### PR TITLE
179 s report firmware version mismatch on connect

### DIFF
--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -152,12 +152,10 @@ class CNCDriver(object):
 
     def connect(self, device):
         self.connection = device
-        if self.reset_port():
-            log.debug("Connected to {}".format(device))
-            compatible = self.versions_compatible()
-            return all(compatible.values())
-        else:
-            return False
+        self.reset_port():
+        log.debug("Connected to {}".format(device))
+        compatible = self.versions_compatible()
+        return all(compatible.values())
 
     def is_connected(self):
         return self.connection and self.connection.isOpen()

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -154,9 +154,8 @@ class CNCDriver(object):
         self.connection = device
         self.reset_port()
         log.debug("Connected to {}".format(device))
-        self.calm_down()
-        self.get_ot_version()
-        return self.calm_down()
+        compatible = self.versions_compatible()
+        return all(compatible.values())
 
     def is_connected(self):
         return self.connection and self.connection.isOpen()
@@ -167,6 +166,8 @@ class CNCDriver(object):
         self.flush_port()
 
         self.turn_off_feedback()
+
+        return self.calm_down()
 
     def pause(self):
         self.can_move.clear()

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -152,7 +152,7 @@ class CNCDriver(object):
 
     def connect(self, device):
         self.connection = device
-        self.reset_port():
+        self.reset_port()
         log.debug("Connected to {}".format(device))
         compatible = self.versions_compatible()
         return all(compatible.values())

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -97,9 +97,6 @@ class CNCDriver(object):
         self.head_speed = 3000  # smoothie's default speed in mm/minute
         self.current_commands = []
 
-        self.axis_homed = {
-            'x': False, 'y': False, 'z': False, 'a': False, 'b': False}
-
         self.SMOOTHIE_SUCCESS = 'Succes'
         self.SMOOTHIE_ERROR = 'Received unexpected response from Smoothie'
         self.STOPPED = 'Received a STOP signal and exited from movements'
@@ -165,8 +162,6 @@ class CNCDriver(object):
         return self.connection and self.connection.isOpen()
 
     def reset_port(self):
-        for axis in 'xyzab':
-            self.axis_homed[axis.lower()] = False
         self.connection.close()
         self.connection.open()
         self.flush_port()
@@ -397,7 +392,6 @@ class CNCDriver(object):
             # values after homing, so force it
             pos_args = {}
             for l in axis_to_home:
-                self.axis_homed[l.lower()] = True
                 pos_args[l] = 0
 
             arguments = {'name': 'home', 'axis': axis_to_home}

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -152,10 +152,12 @@ class CNCDriver(object):
 
     def connect(self, device):
         self.connection = device
-        self.reset_port()
-        log.debug("Connected to {}".format(device))
-        compatible = self.versions_compatible()
-        return all(compatible.values())
+        if self.reset_port():
+            log.debug("Connected to {}".format(device))
+            compatible = self.versions_compatible()
+            return all(compatible.values())
+        else:
+            return False
 
     def is_connected(self):
         return self.connection and self.connection.isOpen()

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -145,7 +145,7 @@ class Robot(object):
             'firmware': 'v1.0.5',
             'config': {
                 'ot_version': 'one_pro',
-                'version': 'v1.0.3',        # config version
+                'version': 'v1.0.3b',        # config version
                 'alpha_steps_per_mm': 80.0,
                 'beta_steps_per_mm': 80.0
             }
@@ -439,11 +439,16 @@ class Robot(object):
             'firmware': self._driver.get_firmware_version(),
             'config': self._driver.get_config_version(),
             'robot': self._driver.get_ot_version(),
+            'compatible': self._driver.versions_compatible()
         }
 
     def diagnostics(self):
         # TODO: Store these versions in config
         return {
             'axis_homed': self._driver.axis_homed,
-            'switches': self._driver.get_endstop_switches()
+            'switches': self._driver.get_endstop_switches(),
+            'steps_per_mm': {
+                'x': self._driver.get_steps_per_mm('x'),
+                'y': self._driver.get_steps_per_mm('y')
+            }
         }

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -452,11 +452,20 @@ class Robot(object):
 
     def versions(self):
         # TODO: Store these versions in config
+        compatible = self._driver.versions_compatible()
         return {
-            'firmware': self._driver.get_firmware_version(),
-            'config': self._driver.get_config_version(),
-            'robot': self._driver.get_ot_version(),
-            'compatible': self._driver.versions_compatible()
+            'firmware': {
+                'version': self._driver.get_firmware_version(),
+                'compatible': compatible['firmware']
+            },
+            'config': {
+                'version': self._driver.get_config_version(),
+                'compatible': compatible['config']
+            },
+            'ot_version': {
+                'version': self._driver.get_ot_version(),
+                'compatible': compatible['ot_version']
+            }
         }
 
     def diagnostics(self):

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -27,6 +27,30 @@ class OpenTronsTest(unittest.TestCase):
     def tearDown(self):
         self.motor.disconnect()
 
+    def test_version_compatible(self):
+        self.robot.disconnect()
+        self.robot.connect()
+        res = self.motor.versions_compatible()
+        self.assertEquals(res, {
+            'firmware': True,
+            'config': True,
+            'ot_version': True
+        })
+        self.robot.disconnect()
+        self.robot.connect(options={
+            'firmware': 'v2.0.0',
+            'config': {
+                'version': 'v3.1.2',
+                'ot_version': 'hoodie'
+            }
+        })
+        res = self.motor.versions_compatible()
+        self.assertEquals(res, {
+            'firmware': False,
+            'config': False,
+            'ot_version': False
+        })
+
     def test_message_timeout(self):
         self.assertRaises(RuntimeWarning, self.motor.wait_for_response)
 

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -135,19 +135,11 @@ class OpenTronsTest(unittest.TestCase):
 
     def test_home(self):
 
-        expected = {
-            'x': False, 'y': False, 'z': False, 'a': False, 'b': False}
-        self.assertDictEqual(self.motor.axis_homed, expected)
-
         success = self.motor.home('x', 'y')
         self.assertTrue(success)
 
         success = self.motor.home('ba')
         self.assertTrue(success)
-
-        expected = {
-            'x': True, 'y': True, 'z': False, 'a': True, 'b': True}
-        self.assertDictEqual(self.motor.axis_homed, expected)
 
     def test_limit_hit_exception(self):
         self.motor.home()

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -11,17 +11,7 @@ class RobotTest(unittest.TestCase):
         Robot.reset_for_tests()
         self.robot = Robot.get_instance()
 
-        options = {
-            'limit_switches': True,
-            'firmware': 'v1.0.5',
-            'config': {
-                'ot_version': 'one_pro',
-                'version': 'v1.0.3',        # config version
-                'alpha_steps_per_mm': 80.0,
-                'beta_steps_per_mm': 80.0
-            }
-        }
-        self.robot.connect(options=options)
+        self.robot.connect()
         self.robot.home(now=True)
         self.robot.clear()
 
@@ -107,9 +97,14 @@ class RobotTest(unittest.TestCase):
     def test_versions(self):
         res = self.robot.versions()
         expected = {
-            'config': 'v1.0.3',
+            'config': 'v1.0.3b',
             'firmware': 'v1.0.5',
-            'robot': 'one_pro'
+            'robot': 'one_pro',
+            'compatible': {
+                'firmware': True,
+                'config': True,
+                'ot_version': True
+            }
         }
         self.assertDictEqual(res, expected)
 
@@ -125,6 +120,10 @@ class RobotTest(unittest.TestCase):
                 'z': False,
                 'a': False,
                 'b': False
+            },
+            'steps_per_mm': {
+                'x': 80.0,
+                'y': 80.0
             }
         }
         self.assertDictEqual(res, expected)
@@ -142,6 +141,10 @@ class RobotTest(unittest.TestCase):
                 'z': False,
                 'a': False,
                 'b': False
+            },
+            'steps_per_mm': {
+                'x': 80.0,
+                'y': 80.0
             }
         }
         self.assertDictEqual(res, expected)
@@ -158,6 +161,10 @@ class RobotTest(unittest.TestCase):
                 'z': False,
                 'a': False,
                 'b': False
+            },
+            'steps_per_mm': {
+                'x': 80.0,
+                'y': 80.0
             }
         }
         self.assertDictEqual(res, expected)

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -115,13 +115,17 @@ class RobotTest(unittest.TestCase):
     def test_versions(self):
         res = self.robot.versions()
         expected = {
-            'config': 'v1.0.3b',
-            'firmware': 'v1.0.5',
-            'robot': 'one_pro',
-            'compatible': {
-                'firmware': True,
-                'config': True,
-                'ot_version': True
+            'config': {
+                'version': 'v1.0.3b',
+                'compatible': True
+            },
+            'firmware': {
+                'version': 'v1.0.5',
+                'compatible': True
+            },
+            'ot_version': {
+                'version': 'one_pro',
+                'compatible': True
             }
         }
         self.assertDictEqual(res, expected)

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -44,14 +44,32 @@ class RobotTest(unittest.TestCase):
         self.assertEquals(current, (100, 0, 20))
 
     def test_home(self):
+
+        self.robot.disconnect()
+        self.robot.connect()
+
+        self.assertDictEqual(self.robot.axis_homed, {
+            'x': False, 'y': False, 'z': False, 'a': False, 'b': False
+        })
+
         self.robot.clear()
-        self.robot.home()
+        self.robot.home('xa')
+        self.assertDictEqual(self.robot.axis_homed, {
+            'x': False, 'y': False, 'z': False, 'a': False, 'b': False
+        })
         self.assertEquals(len(self.robot._commands), 1)
         self.robot.run()
+        self.assertDictEqual(self.robot.axis_homed, {
+            'x': True, 'y': False, 'z': False, 'a': True, 'b': False
+        })
 
         self.robot.clear()
         self.robot.home(now=True)
         self.assertEquals(len(self.robot._commands), 0)
+
+        self.assertDictEqual(self.robot.axis_homed, {
+            'x': True, 'y': True, 'z': True, 'a': True, 'b': True
+        })
 
     def test_robot_pause_and_resume(self):
         self.robot.move_to((Deck(), (100, 0, 0)))
@@ -128,6 +146,7 @@ class RobotTest(unittest.TestCase):
         }
         self.assertDictEqual(res, expected)
 
+        self.robot.disconnect()
         self.robot.connect()
         self.assertRaises(RuntimeWarning, self.robot.move_head, x=-199)
         res = self.robot.diagnostics()


### PR DESCRIPTION
This PR:

1. Add driver method for checking smoothieboard version compatibility (for firmware, config file, and `ot_version`), which is checked automatically on `.connect()`
2. `axis_homed` flag moved from driver to Robot
3. version compatibility returned along with version number in `Robot.versions()`