### PR TITLE
RuntimeError raised if versions incompatible

### DIFF
--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -155,7 +155,18 @@ class CNCDriver(object):
         self.reset_port()
         log.debug("Connected to {}".format(device))
         compatible = self.versions_compatible()
-        return all(compatible.values())
+        if not all(compatible.values()):
+            raise RuntimeError(
+                'This Robot\'s versions are incompatible with the API: '
+                'firmware={firmware}, '
+                'config={config}, '
+                'ot_version={ot_version}'.format(
+                    firmware=self.firmware_version,
+                    config=self.config_version,
+                    ot_version=self.ot_version
+                )
+            )
+        return self.calm_down()
 
     def is_connected(self):
         return self.connection and self.connection.isOpen()
@@ -166,8 +177,6 @@ class CNCDriver(object):
         self.flush_port()
 
         self.turn_off_feedback()
-
-        return self.calm_down()
 
     def pause(self):
         self.can_move.clear()

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -37,13 +37,17 @@ class OpenTronsTest(unittest.TestCase):
             'ot_version': True
         })
         self.robot.disconnect()
-        self.robot.connect(options={
-            'firmware': 'v2.0.0',
-            'config': {
-                'version': 'v3.1.2',
-                'ot_version': 'hoodie'
+
+        kwargs = {
+            'options': {
+                'firmware': 'v2.0.0',
+                'config': {
+                    'version': 'v3.1.2',
+                    'ot_version': 'hoodie'
+                }
             }
-        })
+        }
+        self.assertRaises(RuntimeError, self.robot.connect, **kwargs)
         res = self.motor.versions_compatible()
         self.assertEquals(res, {
             'firmware': False,

--- a/tests/opentrons/labware/test_magbead.py
+++ b/tests/opentrons/labware/test_magbead.py
@@ -11,14 +11,7 @@ class MagbeadTest(unittest.TestCase):
     def setUp(self):
         self.robot = Robot.reset_for_tests()
         options = {
-            'limit_switches': False,
-            'firmware': 'v1.0.5',
-            'config': {
-                'ot_version': 'one_pro',
-                'version': 'v1.0.3',        # config version
-                'alpha_steps_per_mm': 80.0,
-                'beta_steps_per_mm': 80.0
-            }
+            'limit_switches': False
         }
         self.robot.connect(options=options)
         self.robot.home()

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -13,18 +13,8 @@ class PipetteTest(unittest.TestCase):
 
     def setUp(self):
         self.robot = Robot.reset_for_tests()
-        options = {
-            'limit_switches': True,
-            'firmware': 'v1.0.5',
-            'config': {
-                'ot_version': 'one_pro',
-                'version': 'v1.0.3',        # config version
-                'alpha_steps_per_mm': 80.0,
-                'beta_steps_per_mm': 80.0
-            }
-        }
         myport = self.robot.VIRTUAL_SMOOTHIE_PORT
-        self.robot.connect(port=myport, options=options)
+        self.robot.connect(port=myport)
         self.robot.home()
 
         self.trash = containers.load('point', 'A1')

--- a/tests/opentrons/performance/test_performance.py
+++ b/tests/opentrons/performance/test_performance.py
@@ -16,18 +16,7 @@ class PerformanceTest(unittest.TestCase):
     def protocol(self):
         robot = Robot.get_instance()
         robot.get_serial_ports_list()
-
-        options = {
-            'limit_switches': True,
-            'firmware': 'v1.0.5',
-            'config': {
-                'ot_version': 'one_pro',
-                'version': 'v1.0.3',        # config version
-                'alpha_steps_per_mm': 80.0,
-                'beta_steps_per_mm': 80.0
-            }
-        }
-        robot.connect(options=options)
+        robot.connect()
         robot.home()
 
         tiprack = containers.load(


### PR DESCRIPTION
This is a small PR, allowing `driver.connect()` to raise a `RuntimeError` if the connected robot's versions are incompatible with the current version of the API