### PR TITLE
More accurate robot dimensions

### DIFF
--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -85,9 +85,9 @@ class CNCDriver(object):
 
     ot_version = None
     ot_one_dimensions = {
-        'hood': Vector(300, 120, 120),
-        'one_pro': Vector(300, 250, 120),
-        'one_standard': Vector(300, 250, 120)
+        'hood': Vector(400, 250, 120),
+        'one_pro': Vector(400, 400, 120),
+        'one_standard': Vector(400, 400, 120)
     }
 
     def __init__(self):

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -338,7 +338,7 @@ class Robot(object):
         return self._deck.containers()
 
     def get_deck_slot_types(self):
-        return 'acrylic_slots'
+        return 'slots'
 
     def get_slot_offsets(self):
         """
@@ -351,13 +351,13 @@ class Robot(object):
         TODO: figure out actual X and Y offsets (from origin)
         """
         SLOT_OFFSETS = {
-            '3d_printed_slots': {
+            'slots': {
                 'x_offset': 10,
                 'y_offset': 10,
                 'col_offset': 91,
                 'row_offset': 134.5
             },
-            'acrylic_slots': {
+            'slots_legacy': {
                 'x_offset': 10,
                 'y_offset': 10,
                 'col_offset': 96.25,

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -114,8 +114,8 @@ class OpenTronsTest(unittest.TestCase):
 
         coords = self.motor.get_head_position()
         expected_coords = {
-            'target': (0, 250, 120),
-            'current': (0, 250, 120)
+            'target': (0, 400, 120),
+            'current': (0, 400, 120)
         }
         self.assertDictEqual(coords, expected_coords)
 
@@ -132,8 +132,8 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.move_head(x=100)
         coords = self.motor.get_head_position()
         expected_coords = {
-            'target': (100, 250, 120),
-            'current': (100, 250, 120)
+            'target': (100, 400, 120),
+            'current': (100, 400, 120)
         }
         self.assertDictEqual(coords, expected_coords)
 


### PR DESCRIPTION
This PR updates the robot dimensions for each version to closely reflect physical dimensions. This allows:

1. movements made before any calibration has been saved to be more accurate (like move to slot)
2. `limit_switches: True` simulations to more accurately report a limit switch hit