### PR TITLE
added Instrument.delete_calibration_data() method for testing

### DIFF
--- a/opentrons/instruments/instrument.py
+++ b/opentrons/instruments/instrument.py
@@ -94,6 +94,14 @@ class Instrument(object):
         calibration['calibration_data'] = self.calibration_data
         return calibration
 
+    def delete_calibration_data(self):
+        self.calibration_data = {}
+        self.max_volume = self.min_volume + 1
+        for key in self.positions.keys():
+            self.positions[key] = None
+
+        self.update_calibrations()
+
     def read_calibrations(self):
         """
         Reads calibration data from file system.

--- a/tests/opentrons/labware/test_crud_calibrations.py
+++ b/tests/opentrons/labware/test_crud_calibrations.py
@@ -44,3 +44,26 @@ class CrudCalibrationsTestCase(unittest.TestCase):
         self.assertTrue('plate' in actual)
         actual = self.p200.calibration_data['A1']['children']['plate']
         self.assertEquals(expected_delta, actual)
+
+    def test_delte_calibrations_data(self):
+
+        self.p200 = instruments.Pipette(name="p200", axis="b")
+
+        expected_delta = {
+            'delta': (1.0, 2.0, 3.0)
+        }
+
+        self.assertTrue('A1' in self.p200.calibration_data)
+        actual = self.p200.calibration_data['A1']['children']
+        self.assertTrue('plate' in actual)
+        actual = self.p200.calibration_data['A1']['children']['plate']
+        self.assertEquals(expected_delta, actual)
+
+        self.p200.delete_calibration_data()
+        self.assertDictEqual(self.p200.calibration_data, {})
+
+        self.p200 = instruments.Pipette(name="p200", axis="b")
+        self.assertDictEqual(self.p200.calibration_data, {})
+        self.assertDictEqual(self.p200.positions, {
+            'top': None, 'bottom': None, 'blow_out': None, 'drop_tip': None
+        })

--- a/tests/opentrons/labware/test_crud_calibrations.py
+++ b/tests/opentrons/labware/test_crud_calibrations.py
@@ -45,7 +45,7 @@ class CrudCalibrationsTestCase(unittest.TestCase):
         actual = self.p200.calibration_data['A1']['children']['plate']
         self.assertEquals(expected_delta, actual)
 
-    def test_delte_calibrations_data(self):
+    def test_delete_calibrations_data(self):
 
         self.p200 = instruments.Pipette(name="p200", axis="b")
 

--- a/tests/opentrons/labware/test_crud_calibrations.py
+++ b/tests/opentrons/labware/test_crud_calibrations.py
@@ -14,6 +14,8 @@ class CrudCalibrationsTestCase(unittest.TestCase):
         self.plate = containers.load('96-flat', 'A1', 'plate')
         self.p200 = instruments.Pipette(name="p200", axis="b")
 
+        self.p200.delete_calibration_data()
+
         well = self.plate[0]
         pos = well.from_center(x=0, y=0, z=0, reference=self.plate)
         self.location = (self.plate, pos)
@@ -22,10 +24,9 @@ class CrudCalibrationsTestCase(unittest.TestCase):
         dest = well_deck_coordinates + Vector(1, 2, 3)
 
         self.robot.move_head(x=dest['x'], y=dest['y'], z=dest['z'])
+        self.p200.calibrate_position(self.location)
 
     def test_save_load_calibration_data(self):
-
-        self.p200.calibrate_position(self.location)
 
         self.p200 = instruments.Pipette(name="p200-diff", axis="b")
         self.assertDictEqual(self.p200.calibration_data, {})


### PR DESCRIPTION
This PR adds a `Instrument.delete_calibration_data()` method, which is most helpful while testing, or on the off chance a user wants to re-calibrate everything