### PR TITLE
Move to slot using max dimensions

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -288,6 +288,9 @@ class Placeable(object):
         if reference in self._max_dimensions:
             return self._max_dimensions[reference]
 
+        if not self.has_children():
+            return (0, 0, 0)
+
         # Collect all furthermost child coordinates
         child_coordinates = [
             child.from_center(x=1, y=1, z=1, reference=reference)

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -85,9 +85,9 @@ class CNCDriver(object):
 
     ot_version = None
     ot_one_dimensions = {
-        'hood': Vector(400, 250, 120),
-        'one_pro': Vector(400, 400, 120),
-        'one_standard': Vector(400, 400, 120)
+        'hood': Vector(400, 250, 100),
+        'one_pro': Vector(400, 400, 100),
+        'one_standard': Vector(400, 400, 100)
     }
 
     def __init__(self):

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -114,8 +114,8 @@ class OpenTronsTest(unittest.TestCase):
 
         coords = self.motor.get_head_position()
         expected_coords = {
-            'target': (0, 400, 120),
-            'current': (0, 400, 120)
+            'target': (0, 400, 100),
+            'current': (0, 400, 100)
         }
         self.assertDictEqual(coords, expected_coords)
 
@@ -132,8 +132,8 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.move_head(x=100)
         coords = self.motor.get_head_position()
         expected_coords = {
-            'target': (100, 400, 120),
-            'current': (100, 400, 120)
+            'target': (100, 400, 100),
+            'current': (100, 400, 100)
         }
         self.assertDictEqual(coords, expected_coords)
 

--- a/tests/opentrons/labware/test_crud_calibrations.py
+++ b/tests/opentrons/labware/test_crud_calibrations.py
@@ -32,6 +32,7 @@ class CrudCalibrationsTestCase(unittest.TestCase):
         self.assertDictEqual(self.p200.calibration_data, {})
 
         self.p200 = instruments.Pipette(name="p200", axis="a")
+        self.p200.delete_calibration_data()
         self.assertDictEqual(self.p200.calibration_data, {})
 
         self.p200 = instruments.Pipette(name="p200", axis="b")


### PR DESCRIPTION
Small PR, where `Placeable.max_dimensions()` returns `Vector(0, 0, 0)` if it has no children