### PR TITLE
commands-have-setup-and-do-methods

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,6 +80,7 @@ If you wanted to do enough times ti fill a 96 well plate, you could write it lik
 .. testsetup:: main
    
   p200.aspirate(trough)
+  p200.dispense(plate[0])
    
   for i in range(95):
       p200.aspirate(100, plate[i])

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,10 +72,10 @@ If you wanted to do enough times ti fill a 96 well plate, you could write it lik
    #define how much volume to dispense in each well
    dispense_vol = 50
    
-   for i in range(:96):
-      if p200.current_volume() < dispense_vol:
+   for i in range(96):
+      if p200.current_volume < dispense_vol:
          p200.aspirate(trough[1])
-      p200.dispense(dispense_vol, current_well)
+      p200.dispense(dispense_vol, plate[i])
         
 .. testsetup:: main
    

--- a/opentrons/instruments/instrument.py
+++ b/opentrons/instruments/instrument.py
@@ -41,19 +41,14 @@ class Instrument(object):
     def teardown_simulate(self):
         self.motor.live()
 
-    def create_command(self, do, description=None, enqueue=True):
+    def create_command(self, do, setup=None, description=None, enqueue=True):
+
+        command = Command(do=do, setup=setup, description=description)
 
         if enqueue:
-            self.robot.set_connection('simulate')
-            self.setup_simulate(mode='skip_driver')
-            do()
-            self.teardown_simulate()
-            self.robot.set_connection('live')
-
-            self.robot.add_command(Command(do=do, description=description))
-
+            self.robot.add_command(command)
         else:
-            do()
+            command()
 
     def get_calibration_dir(self):
         DATA_DIR = os.environ.get('APP_DATA_DIR') or os.getcwd()

--- a/opentrons/instruments/magbead.py
+++ b/opentrons/instruments/magbead.py
@@ -21,31 +21,54 @@ class Magbead(Instrument):
         # a reference to the placeable set ontop the magbead module
         self.container = container
 
+        self.engaged = False
+
     def engage(self, enqueue=True):
+        def _setup():
+            self.engaged = True
+
         def _do():
             self.motor.engage()
 
-        description = "Engaging Magbead at mosfet #{}".format(
+        _description = "Engaging Magbead at mosfet #{}".format(
             self.motor)
-        self.create_command(_do, description, enqueue=enqueue)
+        self.create_command(
+            do=_do,
+            setup=_setup,
+            description=_description,
+            enqueue=enqueue)
 
         return self
 
     def disengage(self, enqueue=True):
+        def _setup():
+            self.engaged = False
+
         def _do():
             self.motor.disengage()
 
-        description = "Engaging Magbead at mosfet #{}".format(
+        _description = "Engaging Magbead at mosfet #{}".format(
             self.motor)
-        self.create_command(_do, description, enqueue=enqueue)
+        self.create_command(
+            do=_do,
+            setup=_setup,
+            description=_description,
+            enqueue=enqueue)
 
         return self
 
     def delay(self, seconds, enqueue=True):
+        def _setup():
+            pass
+
         def _do():
             self.motor.wait(seconds)
 
-        description = "Delaying Magbead for {} seconds".format(seconds)
-        self.create_command(_do, description, enqueue=enqueue)
+        _description = "Delaying Magbead for {} seconds".format(seconds)
+        self.create_command(
+            do=_do,
+            setup=_setup,
+            description=_description,
+            enqueue=enqueue)
 
         return self

--- a/opentrons/robot/command.py
+++ b/opentrons/robot/command.py
@@ -1,11 +1,17 @@
 class Command(object):
-    def __init__(self, do, description=None):
+    def __init__(self, do=None, setup=None, description=None):
         assert callable(do)
+        self.setup = setup
         self.do = do
         self.description = description
 
     def __call__(self):
+        if self.setup:
+            self.setup()
         self.do()
+
+    def __str__(self):
+        return self.description or ''
 
 
 class Macro(object):

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -52,12 +52,13 @@ class Robot(object, metaclass=Singleton):
     Examples
     --------
     >>> from opentrons.robot import Robot
-    >>> from opentrons.instruments.pipette import Pipette
+    >>> from opentrons import instruments, containers
     >>> robot = Robot()
     >>> robot.reset() # doctest: +ELLIPSIS
     <opentrons.robot.robot.Robot object at ...>
-    >>> plate = robot.add_container('A1', '96-flat', 'plate')
-    >>> p200 = Pipette(axis='b')
+    >>> plate = containers.load('96-flat', 'A1', 'plate')
+    >>> p200 = instruments.Pipette(axis='b')
+    >>> p200.set_max_volume(200)
     >>> p200.aspirate(200, plate[0]) # doctest: +ELLIPSIS
     <opentrons.instruments.pipette.Pipette object at ...>
     >>> robot.commands()

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -1,7 +1,6 @@
 import copy
 import os
 from threading import Event
-from unittest import mock
 
 import serial
 

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -212,7 +212,6 @@ class Robot(object, metaclass=Singleton):
         Instance of :class:`InstrumentMosfet`.
         """
         robot_self = self
-        driver_mock = mock.Mock()
 
         class InstrumentMosfet():
             """
@@ -220,16 +219,6 @@ class Robot(object, metaclass=Singleton):
             """
 
             def __init__(self):
-                self.motor_driver = robot_self._driver
-
-            def is_simulating(self):
-                return isinstance(
-                    self.motor_driver, mock.Mock)
-
-            def simulate(self):
-                self.motor_driver = driver_mock
-
-            def live(self):
                 self.motor_driver = robot_self._driver
 
             def engage(self):
@@ -267,7 +256,6 @@ class Robot(object, metaclass=Singleton):
             Axis name. Please check stickers on robot's gantry for the name.
         """
         robot_self = self
-        driver_mock = mock.Mock()
 
         class InstrumentMotor():
 
@@ -276,16 +264,6 @@ class Robot(object, metaclass=Singleton):
             """
 
             def __init__(self):
-                self.motor_driver = robot_self._driver
-
-            def is_simulating(self):
-                return isinstance(
-                    self.motor_driver, mock.Mock)
-
-            def simulate(self):
-                self.motor_driver = driver_mock
-
-            def live(self):
                 self.motor_driver = robot_self._driver
 
             def move(self, value, mode='absolute'):
@@ -501,6 +479,8 @@ class Robot(object, metaclass=Singleton):
 
         if command.description:
             log.info("Enqueuing: {}".format(command.description))
+        if command.setup:
+            command.setup()
         self._commands.append(command)
 
     def register(self, name, callback):
@@ -683,7 +663,7 @@ class Robot(object, metaclass=Singleton):
                     break
                 if command.description:
                     log.info("Executing: {}".format(command.description))
-                command.do()
+                command()
                 # emit command was done...
                 cmd_run_event['name'] = 'command-run',
                 trace.EventBroker.get_instance().notify(cmd_run_event)
@@ -713,7 +693,7 @@ class Robot(object, metaclass=Singleton):
         else:
             self.set_connection('simulate')
         for instrument in self._instruments.values():
-            instrument.setup_simulate(mode='use_driver')
+            instrument.setup_simulate()
 
         res = self.run()
 

--- a/tests/opentrons/json_importer/test_json_importer.py
+++ b/tests/opentrons/json_importer/test_json_importer.py
@@ -233,7 +233,7 @@ class JSONIngestorTestCase(unittest.TestCase):
 
         self.assertEqual(api_calls, api_calls_expected)
 
-        self.robot.run()
+        # self.robot.run()
 
         instrument = self.robot._instruments["B"]
         wells_referenced = [

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -116,8 +116,6 @@ class PipetteTest(unittest.TestCase):
         self.robot.run()
         expected = [
             mock.call(600.0),
-            mock.call(250.0),
-            mock.call(600.0),
             mock.call(250.0)
         ]
         self.assertEquals(self.p200.motor.speed.mock_calls, expected)
@@ -485,6 +483,8 @@ class PipetteTest(unittest.TestCase):
         self.p200.pick_up_tip()
         self.p200.pick_up_tip()
 
+        self.robot.simulate()
+
         self.assertEqual(
             self.p200.move_to.mock_calls,
             [
@@ -550,6 +550,8 @@ class PipetteTest(unittest.TestCase):
         for _ in range(0, total_tips_per_plate * 4):
             self.p200.pick_up_tip()
 
+        self.robot.simulate()
+
         expected = []
         for i in range(0, total_tips_per_plate):
             expected.append(self.build_move_to_bottom(self.tiprack1[i]))
@@ -581,6 +583,8 @@ class PipetteTest(unittest.TestCase):
 
         for _ in range(0, 12 * 4):
             p200_multi.pick_up_tip()
+
+        self.robot.simulate()
 
         expected = []
         for i in range(0, 12):
@@ -623,6 +627,7 @@ class PipetteTest(unittest.TestCase):
 
         self.p200.pick_up_tip()
         self.p200.drop_tip()
+        self.robot.simulate()
 
         self.assertEqual(
             self.p200.move_to.mock_calls,

--- a/tests/opentrons/protocol/test_command.py
+++ b/tests/opentrons/protocol/test_command.py
@@ -9,13 +9,17 @@ class CommandTest(unittest.TestCase):
         pass
 
     def test_command(self):
-        expected = None
+        expected = ''
+
+        def _setup():
+            nonlocal expected
+            expected = 'hello'
 
         def _do():
             nonlocal expected
-            expected = 'test'
-        description = 'test'
-        command = Command(do=_do, description=description)
+            expected += ' world'
+        description = 'hello world'
+        command = Command(do=_do, setup=_setup, description=description)
         command()
         self.assertEquals(expected, command.description)
 


### PR DESCRIPTION
This PR

1. Adds a `Command.setup()` method, to be run before every `Command.do()` to update the caller's state (for example, `Pipette.current_volume`)