### PR TITLE
Use $APP_DATA_DIR/containers to look for custom containers

### DIFF
--- a/opentrons/containers/persisted_containers.py
+++ b/opentrons/containers/persisted_containers.py
@@ -1,5 +1,5 @@
-import copy
 from collections import OrderedDict
+import copy
 import json
 import numbers
 import os

--- a/opentrons/containers/persisted_containers.py
+++ b/opentrons/containers/persisted_containers.py
@@ -5,8 +5,6 @@ import numbers
 import os
 import pkg_resources
 
-import itertools
-
 from opentrons.containers.placeable import Container, Well
 from opentrons.util import environment
 

--- a/opentrons/containers/persisted_containers.py
+++ b/opentrons/containers/persisted_containers.py
@@ -5,10 +5,30 @@ import numbers
 import os
 import pkg_resources
 
+import itertools
+
 from opentrons.containers.placeable import Container, Well
+from opentrons.util import environment
 
 
 persisted_containers_dict = {}
+persisted_containers_file_list = []
+
+
+def load_persisted_containers_from_file_list(file_list):
+    for file_name in file_list:
+        load_persisted_containers_from_file_path(file_name)
+
+
+def load_all_persisted_containers_from_disk():
+    persisted_containers_file_list.clear()
+    persisted_containers_file_list.extend(
+        [persisted_containers_json_path] + get_custom_container_files()
+    )
+
+    load_persisted_containers_from_file_list(
+        persisted_containers_file_list
+    )
 
 
 def load_persisted_containers_from_file_path(file_path):
@@ -23,19 +43,43 @@ containers_dir_path = pkg_resources.resource_filename(
     'opentrons.config',
     'containers'
 )
+
 persisted_containers_json_path = os.path.join(
     containers_dir_path,
     'default-containers.json'
 )
-load_persisted_containers_from_file_path(persisted_containers_json_path)
+
+
+def get_custom_container_files():
+    """
+    Traverses environment.get_path('CONTAINERS_DIR') to retrieve
+    all .json files
+    """
+    def is_special_file(name):
+        return name.startswith('.')
+
+    res = []
+
+    top = environment.get_path('CONTAINERS_DIR')
+    for root, dirnames, files in os.walk(top):
+        for name in filter(is_special_file, dirnames):
+            dirnames.remove(name)
+
+        res.extend(
+            [
+                os.path.join(root, name) for name in files
+                if not is_special_file(name) and name.endswith('.json')
+            ])
+
+    return res
 
 
 def get_persisted_container(container_name: str) -> Container:
     container_data = persisted_containers_dict.get(container_name)
     if not container_data:
-        raise Exception(
-            ('Container type "{}" not found in file {}')
-            .format(container_name, persisted_containers_json_path)
+        raise ValueError(
+            ('Container type "{}" not found in files: {}')
+            .format(container_name, persisted_containers_file_list)
         )
     return create_container_obj_from_dict(container_data)
 
@@ -146,3 +190,8 @@ def create_container_obj_from_dict(container_data: dict) -> Container:
         container.add(well, well_name, well_coordinates)
 
     return container
+
+
+# Load default persisted containers from API distribution
+# and whatever containers we find in environment.get_path('CONTAINERS_DIR')
+load_all_persisted_containers_from_disk()

--- a/opentrons/util/environment.py
+++ b/opentrons/util/environment.py
@@ -1,0 +1,52 @@
+import os
+
+settings = {}
+
+
+def refresh():
+    """
+    Refresh environment.settings dict
+    """
+    APP_DATA_DIR = os.environ.get('APP_DATA_DIR', os.getcwd())
+    settings.clear()
+
+    settings.update({
+        'APP_DATA_DIR': APP_DATA_DIR,
+        'LOG_DIR': os.path.join(APP_DATA_DIR, 'logs'),
+        'LOG_FILE': os.path.join(APP_DATA_DIR, 'logs', 'api.log'),
+        'CONTAINERS_DIR': os.path.join(APP_DATA_DIR, 'containers'),
+        'CALIBRATIONS_DIR': os.path.join(APP_DATA_DIR, 'calibrations')
+    })
+
+    return settings
+
+
+def get_path(key):
+    """
+    For a given key returns a full path and
+    creates the path if missing. The caller is guaranteed
+    the path exists if exception is not thrown.
+
+    For *_DIR it will create a directory, for *_FILE it will
+    create a directory tree to the file. Throws exception if neither.
+    """
+
+    if key not in settings:
+        raise ValueError(
+            'Key "{}" not found in environment settings'.format(key))
+
+    if key.endswith('_DIR'):
+        path = settings[key]
+    elif key.endswith('_FILE'):
+        path, _ = os.path.split(settings[key])
+    else:
+        raise ValueError(
+            'Expected key suffix as _DIR or _FILE. "{}" received'.format(key))
+
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+    return settings[key]
+
+
+refresh()

--- a/opentrons/util/log.py
+++ b/opentrons/util/log.py
@@ -1,43 +1,42 @@
 import logging
 from logging.config import dictConfig
 
-import os
+from opentrons.util import environment
 
 
-LOG_DIR = os.environ.get('APP_DATA_DIR', os.getcwd())
-LOG_FILENAME = os.path.join(LOG_DIR, 'api.log')
-
+LOG_FILENAME = environment.get_path('LOG_FILE')
 
 logging_config = dict(
-        version=1,
-        formatters={
-            'basic': {
-                'format': '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s]     %(message)s'  #NOQA
-            }
+    version=1,
+    formatters={
+        'basic': {
+            'format': '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s]     %(message)s'  #NOQA
+        }
+    },
+    handlers={
+        'debug': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'basic',
+            'level': logging.DEBUG},
+        'development': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'basic',
+            'level': logging.WARNING},
+        'file': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'basic',
+            'filename': LOG_FILENAME,
+            'maxBytes': 5000000,
+            'level': logging.INFO,
+            'backupCount': 3
         },
-        handlers={
-            'debug': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'basic',
-                'level': logging.DEBUG},
-            'development': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'basic',
-                'level': logging.WARNING},
-            'file': {
-                'class': 'logging.handlers.RotatingFileHandler',
-                'formatter': 'basic',
-                'filename': LOG_FILENAME,
-                'maxBytes': 5000000,
-                'level': logging.INFO,
-                'backupCount': 3
-            },
-        },
-        root={
-            'handlers': ['file'],
-            'level': logging.DEBUG
-        },
-    )
+    },
+    root={
+        'handlers': ['file'],
+        'level': logging.DEBUG
+    }
+)
+
 dictConfig(logging_config)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ config = {
     'install_requires': ['pyserial==3.1.1'],
     'package_data': {
         "opentrons": [
-            "config/containers/legacy_containers.json",
+            "config/containers/default-containers.json",
         ]
     },
     'scripts': [

--- a/tests/opentrons/containers/data/.containers-4.json
+++ b/tests/opentrons/containers/data/.containers-4.json
@@ -1,0 +1,9 @@
+{
+  "containers":{
+    "container-1":{
+      "locations":{
+        "A1":{"x":0, "y":0, "z":0, "depth":0, "diameter":0, "total-liquid-volume":1 }
+      }
+    }
+  }
+}

--- a/tests/opentrons/containers/data/.secret/containers-3.json
+++ b/tests/opentrons/containers/data/.secret/containers-3.json
@@ -1,0 +1,9 @@
+{
+  "containers":{
+    "container-3":{
+      "locations":{
+        "A1":{"x":0, "y":0, "z":0, "depth":0, "diameter":0, "total-liquid-volume":1 }
+      }
+    }
+  }
+}

--- a/tests/opentrons/containers/data/containers-1.json
+++ b/tests/opentrons/containers/data/containers-1.json
@@ -1,0 +1,9 @@
+{
+  "containers":{
+    "container-1":{
+      "locations":{
+        "A1":{"x":0, "y":0, "z":0, "depth":0, "diameter":0, "total-liquid-volume":1 }
+      }
+    }
+  }
+}

--- a/tests/opentrons/containers/data/containers-2.json
+++ b/tests/opentrons/containers/data/containers-2.json
@@ -1,0 +1,9 @@
+{
+  "containers":{
+    "container-2":{
+      "locations":{
+        "A1":{"x":0, "y":0, "z":0, "depth":0, "diameter":0, "total-liquid-volume":1 }
+      }
+    }
+  }
+}

--- a/tests/opentrons/containers/test_persisted_containers.py
+++ b/tests/opentrons/containers/test_persisted_containers.py
@@ -1,18 +1,65 @@
 import unittest
 import json
 from collections import OrderedDict
-
+import os
 from opentrons.containers.placeable import Container, Well
-from opentrons.containers.persisted_containers import (
-    create_container_obj_from_dict,
-    get_persisted_container,
-    load_all_persisted_containers
-)
+from opentrons.containers import persisted_containers
+import shutil
+from opentrons.util import environment
 
 
 class PersistedContainersTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # here we are copying containers from data and
+        # re-defining APP_DATA_DIR. This way we can
+        # load a few more custom containers
+        persisted_containers.persisted_containers_dict.clear()
+        os.environ['APP_DATA_DIR'] = os.path.join(
+            os.path.dirname(__file__),
+            'opentrons-data')
+        environment.refresh()
+
+        source = os.path.join(
+            os.path.dirname(__file__),
+            'data'
+        )
+
+        containers_dir = environment.get_path('CONTAINERS_DIR')
+        shutil.rmtree(containers_dir)
+        shutil.copytree(source, containers_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(environment.get_path('APP_DATA_DIR'))
+        del os.environ['APP_DATA_DIR']
+
+    def test_get_custom_container_files(self):
+
+        persisted_containers.get_custom_container_files()
+
+    def test_load_all_containers(self):
+        persisted_containers.load_all_persisted_containers_from_disk()
+        persisted_containers.get_persisted_container("24-plate")
+        persisted_containers.get_persisted_container("container-1")
+        persisted_containers.get_persisted_container("container-2")
+
+        # Skip container-3 is defined in .secret/containers-3.json.
+        with self.assertRaisesRegexp(
+            ValueError,
+            'Container type "container-3" not found in files: .*'
+        ):
+            persisted_containers.get_persisted_container("container-3")
+
+        # Skip container-4 is defined in .containers-4.json.
+        with self.assertRaisesRegexp(
+            ValueError,
+            'Container type "container-4" not found in files: .*'
+        ):
+            persisted_containers.get_persisted_container("container-4")
+
     def test_load_persisted_container(self):
-        plate = get_persisted_container("24-plate")
+        plate = persisted_containers.get_persisted_container("24-plate")
         self.assertIsInstance(plate, Container)
 
         self.assertIsInstance(plate, Container)
@@ -27,8 +74,9 @@ class PersistedContainersTestCase(unittest.TestCase):
         self.assertEqual(well_2.coordinates(), (13.3 + 0, 17.5 + 19.3, 0))
 
     def test_load_all_persisted_containers(self):
-        all_persisted_containers = load_all_persisted_containers()
-        self.assertEqual(len(all_persisted_containers), 31)
+        all_persisted_containers = \
+            persisted_containers.load_all_persisted_containers()
+        self.assertEqual(len(all_persisted_containers), 33)
 
     def test_create_container_obj_from_dict(self):
         container_data = """{
@@ -61,7 +109,8 @@ class PersistedContainersTestCase(unittest.TestCase):
             object_pairs_hook=OrderedDict
         )
 
-        res_container = create_container_obj_from_dict(container_data)
+        res_container = \
+            persisted_containers.create_container_obj_from_dict(container_data)
         self.assertIsInstance(res_container, Container)
         self.assertEqual(len(res_container), 2)
 

--- a/tests/opentrons/containers/test_persisted_containers.py
+++ b/tests/opentrons/containers/test_persisted_containers.py
@@ -1,10 +1,11 @@
-import unittest
-import json
 from collections import OrderedDict
+import json
 import os
-from opentrons.containers.placeable import Container, Well
-from opentrons.containers import persisted_containers
 import shutil
+import unittest
+
+from opentrons.containers import persisted_containers
+from opentrons.containers.placeable import Container, Well
 from opentrons.util import environment
 
 

--- a/tests/opentrons/util/test_environment.py
+++ b/tests/opentrons/util/test_environment.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+
+from opentrons.util import environment
+
+
+class EnvironmentCase(unittest.TestCase):
+
+    def test_get_path(self):
+        app_data = environment.get_path('APP_DATA_DIR')
+        self.assertTrue(os.path.exists(app_data))
+
+        log_file = environment.get_path('LOG_FILE')
+        log_path, _ = os.path.split(log_file)
+        self.assertTrue(os.path.exists(log_path))
+
+        with self.assertRaisesRegex(
+            ValueError,
+            'Key "APP_DATA" not found in environment settings'
+        ):
+            environment.get_path('APP_DATA')
+
+        environment.settings['INVALID_KEY'] = 'invalid path'
+        with self.assertRaisesRegex(
+            ValueError,
+            'Expected key suffix as _DIR or _FILE. "INVALID_KEY" received'
+        ):
+            environment.get_path('INVALID_KEY')

--- a/tests/opentrons/util/test_environment.py
+++ b/tests/opentrons/util/test_environment.py
@@ -4,7 +4,7 @@ import unittest
 from opentrons.util import environment
 
 
-class EnvironmentCase(unittest.TestCase):
+class EnvironmentTestCase(unittest.TestCase):
 
     def test_get_path(self):
         app_data = environment.get_path('APP_DATA_DIR')

--- a/tests/opentrons/util/test_singleton.py
+++ b/tests/opentrons/util/test_singleton.py
@@ -2,12 +2,12 @@ import unittest
 from opentrons.util.singleton import Singleton
 
 
-class SingletonCase(unittest.TestCase):
+class SingletonTestCase(unittest.TestCase):
 
     class MyClass(object, metaclass=Singleton):
         pass
 
     def test_singleton(self):
-        a = SingletonCase.MyClass()
-        b = SingletonCase.MyClass()
+        a = SingletonTestCase.MyClass()
+        b = SingletonTestCase.MyClass()
         self.assertEqual(a, b)

--- a/tests/opentrons/util/test_trace.py
+++ b/tests/opentrons/util/test_trace.py
@@ -39,8 +39,6 @@ class TraceTestCase(unittest.TestCase):
             'function': 'TraceTestCase.MyClass.event_A',
             'result': 100
         })
-        print(expected_results[-1])
-        print(self.events[-1])
         self.assertDictEqual(expected_results[-1], self.events[-1])
 
         # Test named args


### PR DESCRIPTION
This PR:
* Adds `opentrons.environment` and `get_path()` to track app specific dirs and files, creating respective dirs if necessary
* Changes `persisted_containers` to load default containers and look for custom containers in CONTAINER_DIR ($APP_DATA_DIR/containers) skipping dirs and files that start with `.`
* Adds tests and container files to test custom container functionality