### PR TITLE
change from legacy to default containers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ config = {
     'install_requires': ['pyserial==3.1.1'],
     'package_data': {
         "opentrons": [
-            "config/containers/legacy_containers.json",
+            "config/containers/default-containers.json",
         ]
     },
     'scripts': [


### PR DESCRIPTION
This PR fixes a bug - we left in legacy containers as data in the pip module, instead of switching it over to default_containers.