### PR TITLE
Init pipette with max volume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
   - nosetests --with-coverage
   - pylama
-  - cd docs && make html && cd ..
+  - cd docs && make html && make doctest && cd ..
   - cd scripts && ./doc-deploy.sh && cd ..
 
 env:

--- a/docs/hello_world.md
+++ b/docs/hello_world.md
@@ -15,10 +15,9 @@ plate = containers.load('96-flat', 'B1', 'plate')
     
 p200 = instruments.Pipette(
     axis="b",
+    max_volume=200,
     name="p200"
 )
-
-p200.set_max_volume(200)  # volume calibration, can be called whenever you want
 
 robot.clear_commands()
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,4 +21,4 @@ Pipette
 .. module:: opentrons.instruments
 
 .. autoclass:: Pipette
-   :members: aspirate, dispense, mix, delay, drop_tip, blow_out, touch_tip, pick_up_tip, return_tip, calibrate, calibrate_position, move_to, home, set_speed, set_max_volume
+   :members: aspirate, dispense, mix, delay, drop_tip, blow_out, touch_tip, pick_up_tip, return_tip, calibrate, calibrate_position, move_to, home, set_speed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,10 +28,10 @@
   well_4 = plate[3]
       
   p200 = instruments.Pipette(
-      axis="b"
+      axis="b",
+      max_volume=200
   )
 
-  p200.set_max_volume(200)  # volume calibration, can be called whenever you want
   pipette = p200
 
 .. testsetup:: long
@@ -102,10 +102,10 @@ Below is a short protocol that will pick up a tip and use it to move 100ul volum
   
   # Initialize a pipette    
   p200 = instruments.Pipette(
-      axis="b"
+      axis="b",
+      max_volume=200
   )
 
-  p200.set_max_volume(200)  # volume calibration, can be called whenever you want
   p200.pick_up_tip(tiprack[0])  # pick up tip from position 0 in a tip rack
 
   # loop through 95 wells, transferring to the next

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. testsetup:: main
+.. testsetup:: index_main
 
   from opentrons.robot import Robot
   from opentrons import containers, instruments
@@ -34,7 +34,7 @@
 
   pipette = p200
 
-.. testsetup:: long
+.. testsetup:: index_long
   
   from opentrons.robot import Robot
   Robot().reset()
@@ -49,7 +49,7 @@ The Opentrons API is a simple framework designed to make writing automated biolo
 
 We've designed it in a way we hope is accessible to anyone with basic computer and wetlab skills. As a bench scientist, you should be able to code your automated protocols in a way that reads like a lab notebook. 
 
-.. testcode:: main
+.. testcode:: index_main
    
    pipette.aspirate(tube_1).dispense(tube_2)
 
@@ -57,7 +57,7 @@ That is how you tell the Opentrons robot to aspirate its the maximum volume of t
 
 You string these commands into full protocols that anyone with Opentrons can run. This one way to program the robot to use a p200 pipette to pick up 200ul (its full volume) and dispense 50ul into the first four wells in a 96 well plate called 'plate.'
 
-.. testcode:: main
+.. testcode:: index_main
    
    p200.aspirate(trough[1])
    p200.dispense(50, plate[0])
@@ -67,7 +67,7 @@ You string these commands into full protocols that anyone with Opentrons can run
 
 If you wanted to do enough times to fill a 96 well plate, you could write it like this:
 
-.. testcode:: main
+.. testcode:: index_main
    
    #define how much volume to dispense in each well
    dispense_vol = 50
@@ -82,7 +82,7 @@ Hello World
 
 Below is a short protocol that will pick up a tip and use it to move 100ul volume across all the wells on a plate:
 
-.. testcode:: long
+.. testcode:: index_long
 
   # First, import opentrons API modules
   from opentrons.robot import Robot
@@ -125,7 +125,7 @@ Basic Principles
 
 **Human Readable**: API strikes a balance between human and machine readability of the protocol. Protocol written with Opentrons API sound similar to what the protocol will look in real life. For example:
 
-.. testcode:: main
+.. testcode:: index_main
 
   p200.aspirate(100, plate['A1']).dispense(plate['A2'])
 
@@ -137,7 +137,7 @@ Is exactly what you think it would do:
 **Permissive**: everyone's process is different and we are not trying to impose our way of thinking on you. Instead, our API allows for different ways of expressing your protocol and adding fine details as you need them. 
 For example:
 
-.. testcode:: main
+.. testcode:: index_main
 
   p200.aspirate(100, plate[0]).dispense(plate[1])
 
@@ -145,7 +145,7 @@ while using 0 or 1 instead of 'A1' and 'A2' will do just the same.
 
 or
 
-.. testcode:: main
+.. testcode:: index_main
 
   p200.aspirate(100, plate[0].bottom())
 

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -5,7 +5,7 @@ Opentrons API Tips and Tricks
 
 The following examples assume the containers and pipettes:
 
-.. testsetup:: main
+.. testsetup:: tips_main
 
   from opentrons.robot import Robot
   from opentrons import containers, instruments
@@ -19,13 +19,26 @@ The following examples assume the containers and pipettes:
   trash = containers.load('point', 'C2')
       
   p200 = instruments.Pipette(axis="b")
+  p200.set_max_volume(200)  # volume calibration, can be called whenever you want
 
-.. testcode:: long
+.. testsetup:: tips_demo
   
   from opentrons.robot import Robot
   Robot().reset()
 
-.. testcode:: long
+.. testcleanup:: tips_main
+  
+  import opentrons
+  from opentrons.robot import Robot
+  del opentrons.robot.robot.Singleton._instances[Robot]
+
+.. testcleanup:: tips_demo
+  
+  import opentrons
+  from opentrons.robot import Robot
+  del opentrons.robot.robot.Singleton._instances[Robot]
+
+.. testcode:: tips_demo
 
   from opentrons.robot import Robot
   from opentrons import containers, instruments
@@ -45,7 +58,7 @@ Basics
 Simple Transfer
 ---------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   robot.clear_commands()        # deletes all previously created commands
 
@@ -60,12 +73,12 @@ Running on a Robot
 
 List your serial ports:
 
-.. testcode:: main
+.. testcode:: tips_main
 
   my_ports = robot.get_serial_ports_list()
   print(my_ports)
 
-.. testoutput:: main
+.. testoutput:: tips_main
   :hide:
 
   []
@@ -91,7 +104,7 @@ Pass the port name string into :any:`connect` to connect to a physical robot:
 Home
 ----
 
-.. testcode:: main
+.. testcode:: tips_main
 
   robot.clear_commands()
 
@@ -101,7 +114,7 @@ Home
 
   # this will get enqueued and executed after :meth:``~opentrons.robot.Robot.run`` has been called:
 
-.. testcode:: main
+.. testcode:: tips_main
 
   robot.home('xy', enqueue=True)
   robot.run()
@@ -109,7 +122,7 @@ Home
 Aspirate then dispense in a single well
 ---------------------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.aspirate(100, plate['A1']).dispense()
 
@@ -117,21 +130,21 @@ Aspirate then dispense in a single well
 Transfer from one well to another
 ---------------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.aspirate(100, plate['A1']).dispense(plate['B1'])
 
 Pick up then drop tip at a single location
 ------------------------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.pick_up_tip(tiprack['A1']).drop_tip()
 
 Pick up then drop tip somewhere else
 ------------------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.pick_up_tip(tiprack['A1']).drop_tip(tiprack['B1'])
   p200.pick_up_tip(tiprack['B1']).drop_tip(trash)
@@ -140,30 +153,30 @@ Pick up then drop tip somewhere else
 Mixing at a well
 ----------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.mix(100, plate[0], 3)   # arguments are (volume, location, repetitions)
 
 Iterating through wells
 -----------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   for i in range(96):
       p200.mix(100, plate[i], 3)
 
-.. testcode:: main
+.. testcode:: tips_main
 
   for well in plate:
       p200.mix(100, well, 3)
 
-.. testcode:: main
+.. testcode:: tips_main
 
   for row in plate.rows:
       for well in row:
           p200.mix(100, well, 3)
 
-.. testcode:: main
+.. testcode:: tips_main
 
   for well in plate.cols['A']:
       p200.mix(100, well, 3)
@@ -171,7 +184,7 @@ Iterating through wells
 Distribute to multiple wells
 ----------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.aspirate(100, plate['A1'])
   p200.dispense(30, plate['B1']).dispense(35, plate['B2']).dispense(45, plate['B3'])
@@ -179,7 +192,7 @@ Distribute to multiple wells
 Delay
 -----
 
-.. testcode:: main
+.. testcode:: tips_main
 
   p200.aspirate(110, plate['A1']).delay(2).dispense(10)
   p200.dispense(plate['B2'])
@@ -190,7 +203,7 @@ Advanced Use Cases
 Distribute to entire plate
 --------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   robot.clear_commands()
 
@@ -209,7 +222,7 @@ Distribute to entire plate
 Serial Dilution
 ---------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   # Here we assume a 96-well plate with 12 rows and 8 columns
   # A trough has 8 wells, with liquids corresponding to plates columns
@@ -231,7 +244,7 @@ Serial Dilution
 Plate Mapping
 -------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   sources = {
       'A1': 'water',
@@ -269,7 +282,7 @@ Plate Mapping
 Precision pipetting within a well
 ---------------------------------
 
-.. testcode:: main
+.. testcode:: tips_main
 
   robot.clear_commands()
 

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -18,8 +18,7 @@ The following examples assume the containers and pipettes:
   trough = containers.load('trough-12row', 'C1')
   trash = containers.load('point', 'C2')
       
-  p200 = instruments.Pipette(axis="b")
-  p200.set_max_volume(200)  # volume calibration, can be called whenever you want
+  p200 = instruments.Pipette(axis="b", max_volume=200)
 
 .. testsetup:: tips_demo
   

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -134,9 +134,10 @@ class CNCDriver(object):
             raise EnvironmentError('Unsupported platform')
 
         result = []
+        port_filter = {'usbmodem', 'COM', 'ACM', 'USB'}
         for port in ports:
             try:
-                if 'usbmodem' in port or 'COM' in port:
+                if any([f in port for f in port_filter]):
                     s = serial.Serial(port)
                     s.close()
                     result.append(port)

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -64,9 +64,9 @@ class Pipette(Instrument):
     >>> p1000 = instruments.Pipette(axis='a', max_volume=1000)
     >>> tip_rack_200ul = containers.load('tiprack-200ul', 'A1')
     >>> p200 = instruments.Pipette(
-    >>>     axis='b',
-    >>>     max_volume=200,
-    >>>     tip_racks=[tip_rack_200ul])
+    ...     axis='b',
+    ...     max_volume=200,
+    ...     tip_racks=[tip_rack_200ul])
     """
 
     def __init__(

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -106,7 +106,7 @@ class Pipette(Instrument):
         }
 
         self.min_volume = min_volume
-        self.max_volume = max_volume
+        self.max_volume = max_volume or (min_volume + 1)
 
         self.positions = {
             'top': None,
@@ -133,7 +133,7 @@ class Pipette(Instrument):
 
         # if the user passed an initialization value,
         # overwrite the loaded persisted data with it
-        if max_volume:
+        if isinstance(max_volume, (int, float, complex)) and max_volume > 0:
             self.max_volume = max_volume
             self.update_calibrations()
 

--- a/opentrons/json_importer/json_importer.py
+++ b/opentrons/json_importer/json_importer.py
@@ -217,12 +217,12 @@ class JSONProtocolProcessor(object):
             tool_instance = instruments.Pipette(
                 name=tool_name,
                 axis=tool_config.pop('axis'),
+                max_volume=tool_config.pop('volume'),
                 min_volume=0,
                 channels=(8 if tool_config.pop('multi-channel') else 1),
                 tip_racks=tip_rack_objs,
                 trash_container=trash_obj
             )
-            tool_instance.set_max_volume(tool_config.pop('volume'))
 
             head_obj[tool_name] = {
                 'instance': tool_instance,

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -58,9 +58,7 @@ class Robot(object, metaclass=Singleton):
     >>> robot.reset() # doctest: +ELLIPSIS
     <opentrons.robot.robot.Robot object at ...>
     >>> plate = containers.load('96-flat', 'A1', 'plate')
-    >>> p200 = instruments.Pipette(axis='b')
-    >>> p200.set_max_volume(200) # doctest: +ELLIPSIS
-    <opentrons.instruments.pipette.Pipette object at ...>
+    >>> p200 = instruments.Pipette(axis='b', max_volume=200)
     >>> p200.aspirate(200, plate[0]) # doctest: +ELLIPSIS
     <opentrons.instruments.pipette.Pipette object at ...>
     >>> robot.commands()

--- a/tests/opentrons/containers/test_grid.py
+++ b/tests/opentrons/containers/test_grid.py
@@ -62,11 +62,11 @@ class GridTestCase(unittest.TestCase):
         p200 = instruments.Pipette(
             trash_container=trash,
             tip_racks=[tiprack],
+            max_volume=200,
             min_volume=10,  # These are variable
             axis="b",
             channels=1
         )
-        p200.set_max_volume(200)
         p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
 
         for t, col in enumerate(plate.cols):

--- a/tests/opentrons/integration/move_robot.py
+++ b/tests/opentrons/integration/move_robot.py
@@ -23,12 +23,11 @@ p200 = instruments.Pipette(
     name="p200",
     trash_container=trash,
     tip_racks=[tiprack],
+    max_volume=200,
     min_volume=0.1,  # These are variable
     axis="b",
     channels=1
 )
-
-p200.set_max_volume(200)
 
 json_file_path = os.path.join(
     os.path.dirname(__file__),

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -44,9 +44,11 @@ class PipetteTest(unittest.TestCase):
         self.assertEquals(self.p200._get_plunger_position('drop_tip'), 13)
 
         self.p200.positions['drop_tip'] = None
-        self.assertRaises(RuntimeError, self.p200._get_plunger_position, 'drop_tip')
+        self.assertRaises(
+            RuntimeError, self.p200._get_plunger_position, 'drop_tip')
 
-        self.assertRaises(RuntimeError, self.p200._get_plunger_position, 'roll_out')
+        self.assertRaises(
+            RuntimeError, self.p200._get_plunger_position, 'roll_out')
 
     def test_set_max_volume(self):
 

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -36,6 +36,18 @@ class PipetteTest(unittest.TestCase):
         self.robot.home(enqueue=False)
         _, _, starting_z = self.robot._driver.get_head_position()['current']
 
+    def test_get_plunger_position(self):
+
+        self.assertEquals(self.p200._get_plunger_position('top'), 0)
+        self.assertEquals(self.p200._get_plunger_position('bottom'), 10)
+        self.assertEquals(self.p200._get_plunger_position('blow_out'), 12)
+        self.assertEquals(self.p200._get_plunger_position('drop_tip'), 13)
+
+        self.p200.positions['drop_tip'] = None
+        self.assertRaises(RuntimeError, self.p200._get_plunger_position, 'drop_tip')
+
+        self.assertRaises(RuntimeError, self.p200._get_plunger_position, 'roll_out')
+
     def test_set_max_volume(self):
 
         self.p200.reset()

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -26,15 +26,26 @@ class PipetteTest(unittest.TestCase):
         self.p200 = instruments.Pipette(
             trash_container=self.trash,
             tip_racks=[self.tiprack1, self.tiprack2],
+            max_volume=200,
             min_volume=10,  # These are variable
             axis="b",
             channels=1
         )
 
         self.p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
-        self.p200.set_max_volume(200)
         self.robot.home(enqueue=False)
         _, _, starting_z = self.robot._driver.get_head_position()['current']
+
+    def test_set_max_volume(self):
+
+        self.p200.reset()
+        self.p200.aspirate()
+        self.assertEquals(self.p200.current_volume, 200)
+
+        self.p200.reset()
+        self.p200.set_max_volume(202)
+        self.p200.aspirate()
+        self.assertEquals(self.p200.current_volume, 202)
 
     def test_calibrate_by_position_name(self):
 
@@ -575,6 +586,7 @@ class PipetteTest(unittest.TestCase):
         p200_multi = instruments.Pipette(
             trash_container=self.trash,
             tip_racks=[self.tiprack1, self.tiprack2],
+            max_volume=200,
             min_volume=10,  # These are variable
             axis="b",
             channels=8
@@ -582,7 +594,6 @@ class PipetteTest(unittest.TestCase):
 
         p200_multi.calibrate_plunger(
             top=0, bottom=10, blow_out=12, drop_tip=13)
-        p200_multi.set_max_volume(200)
         p200_multi.move_to = mock.Mock()
 
         for _ in range(0, 12 * 4):

--- a/tests/opentrons/performance/test_performance.py
+++ b/tests/opentrons/performance/test_performance.py
@@ -44,12 +44,11 @@ class PerformanceTest(unittest.TestCase):
             name="p200",
             trash_container=trash,
             tip_racks=[tiprack],
+            max_volume=200,
             min_volume=0.5,
             axis="b",
             channels=1
         )
-
-        p200.set_max_volume(200)
 
         calibration_data = """
         {


### PR DESCRIPTION
This PR:

1. Adds `max_volume` as an initialization value to `Pipette`
2. Removes all mentions of `Pipette.set_max_volume()` from examples, because that method shouldn't be in user protocols, as it's now used primarily as UI route
3. Raises readable exceptions if plunger positions haven't been calibrated yet