### PR TITLE
Drop tip uses offset from bottom

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -91,6 +91,10 @@ class Pipette(Instrument):
         self.trash_container = trash_container
         self.tip_racks = tip_racks
 
+        # default mm above tip to execute drop-tip
+        # this gives room for the drop-tip mechanism to work
+        self._drop_tip_offset = 15
+
         self.reset_tip_tracking()
 
         self.robot = Robot.get_instance()
@@ -920,7 +924,7 @@ class Pipette(Instrument):
 
             if isinstance(location, Placeable):
                 # give space for the drop-tip mechanism
-                location = location.bottom(10)
+                location = location.bottom(self._drop_tip_offset)
 
             self._associate_placeable(location)
             self.current_tip_home_well = None

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -245,7 +245,11 @@ class PipetteTest(unittest.TestCase):
 
         self.assertEqual(
             current_pos,
-            Vector({'x': 161.0, 'y': 116.7, 'z': 13.0})
+            Vector({
+                'x': 161.0,
+                'y': 116.7,
+                'z': 3.0 + self.p200._drop_tip_offset
+            })
         )
 
     def test_empty_aspirate(self):
@@ -664,6 +668,8 @@ class PipetteTest(unittest.TestCase):
                 mock.call(
                     self.tiprack1[0].bottom(), enqueue=False, strategy='arc'),
                 mock.call(
-                    self.trash.bottom(10), enqueue=False, strategy='arc')
+                    self.trash.bottom(self.p200._drop_tip_offset),
+                    enqueue=False,
+                    strategy='arc')
             ]
         )

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -238,14 +238,14 @@ class PipetteTest(unittest.TestCase):
 
         self.p200.calibrate_position(location)
 
-        self.p200.drop_tip(location)
+        self.p200.drop_tip(self.plate[0])
         self.robot.run()
 
         current_pos = self.robot._driver.get_head_position()['current']
 
         self.assertEqual(
             current_pos,
-            Vector({'x': 144.3, 'y': 97.0, 'z': 3.0})
+            Vector({'x': 161.0, 'y': 116.7, 'z': 13.0})
         )
 
     def test_empty_aspirate(self):
@@ -639,17 +639,17 @@ class PipetteTest(unittest.TestCase):
         self.p200.pick_up_tip()
         self.p200.return_tip()
 
+        expected = [
+            mock.call(self.tiprack1[0], enqueue=True),
+            mock.call(self.tiprack1[1], enqueue=True)
+        ]
+
         self.assertEqual(
-            self.p200.drop_tip.mock_calls,
-            [
-                mock.call(self.tiprack1[0], enqueue=True),
-                mock.call(self.tiprack1[1], enqueue=True)
-            ]
-        )
+            self.p200.drop_tip.mock_calls, expected)
 
     def build_move_to_bottom(self, well):
         return mock.call(
-            well.bottom(), strategy='arc', enqueue=False)
+            well.bottom(), enqueue=False, strategy='arc')
 
     def test_drop_tip_to_trash(self):
         self.p200.move_to = mock.Mock()
@@ -661,7 +661,9 @@ class PipetteTest(unittest.TestCase):
         self.assertEqual(
             self.p200.move_to.mock_calls,
             [
-                self.build_move_to_bottom(self.tiprack1[0]),
-                self.build_move_to_bottom(self.trash)
+                mock.call(
+                    self.tiprack1[0].bottom(), enqueue=False, strategy='arc'),
+                mock.call(
+                    self.trash.bottom(10), enqueue=False, strategy='arc')
             ]
         )


### PR DESCRIPTION
This PR adds `Pipette._drop_tip_offset`, which is used as a default Z offset when doing a `drop_tip()`. This is needed to give room for the drop-tip mechanism on pipettes.