### PR TITLE
Shorten imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Below is a short protocol that will pick up a tip and use it to move 100ul volum
 .. code-block:: python
 
   # First, import opentrons API modules
-  from opentrons.robot import Robot
+  from opentrons import Robot
   from opentrons import containers, instruments
 
   # Initialized Robot variable

--- a/docs/hello_world.md
+++ b/docs/hello_world.md
@@ -1,7 +1,7 @@
 # Hello, Opentrons API
 
 ```python
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons import containers, instruments
 
 robot = Robot.get_instance()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@
 
 .. testsetup:: index_main
 
-  from opentrons.robot import Robot
+  from opentrons import Robot
   from opentrons import containers, instruments
 
   robot = Robot()
@@ -36,7 +36,7 @@
 
 .. testsetup:: index_long
   
-  from opentrons.robot import Robot
+  from opentrons import Robot
   Robot().reset()
 
 Opentrons API: Simple Biology Lab Protocol Coding
@@ -85,7 +85,7 @@ Below is a short protocol that will pick up a tip and use it to move 100ul volum
 .. testcode:: index_long
 
   # First, import opentrons API modules
-  from opentrons.robot import Robot
+  from opentrons import Robot
   from opentrons import containers, instruments
 
   # Initialized Robot variable

--- a/docs/source/tips_and_tricks.rst
+++ b/docs/source/tips_and_tricks.rst
@@ -7,7 +7,7 @@ The following examples assume the containers and pipettes:
 
 .. testsetup:: tips_main
 
-  from opentrons.robot import Robot
+  from opentrons import Robot
   from opentrons import containers, instruments
   robot = Robot()
   robot.reset()
@@ -22,24 +22,24 @@ The following examples assume the containers and pipettes:
 
 .. testsetup:: tips_demo
   
-  from opentrons.robot import Robot
+  from opentrons import Robot
   Robot().reset()
 
 .. testcleanup:: tips_main
   
-  import opentrons
-  from opentrons.robot import Robot
-  del opentrons.robot.robot.Singleton._instances[Robot]
+  from opentrons.util import singleton
+  from opentrons import Robot
+  del singleton.Singleton._instances[Robot]
 
 .. testcleanup:: tips_demo
   
-  import opentrons
-  from opentrons.robot import Robot
-  del opentrons.robot.robot.Singleton._instances[Robot]
+  from opentrons.util import singleton
+  from opentrons import Robot
+  del singleton.Singleton._instances[Robot]
 
 .. testcode:: tips_demo
 
-  from opentrons.robot import Robot
+  from opentrons import Robot
   from opentrons import containers, instruments
 
   robot = Robot()

--- a/docs/source/well_access.rst
+++ b/docs/source/well_access.rst
@@ -1,0 +1,182 @@
+.. _well_access:
+
+=====================
+Container Well Access
+=====================
+
+There are many ways to do the same thing in python, so we're going to show you several ways to call container locations, as well as how to access and loop through wells.
+
+Rows vs. Columns
+-------------------------------
+
+The OT-One deck and containers are all set up with the same coordinate system - numbered rows and lettered columns.
+
+--Insert diagrams showing rows, columns and well order (left to right etc.)
+
+
+Accessing Wells
+-------------------------------
+
+Coordinates
+^^^^^^^^^^^
+
+Wells can be called via their string ['A1'], or their well number [0].  In python, number ranges start with 0, and end at **ask katie for better python description**
+
+.. code-block:: python
+
+  plate[0] # A1
+  plate[1] # B1
+  plate[94] # G12
+  plate[95] # H12
+
+You can also split the coordinates for the rows and columns and use either .rows or .cols.
+
+.. testsetup:: main
+
+  from opentrons.robot import Robot
+  from opentrons import containers, instruments
+  robot = Robot()
+  robot.reset()
+  robot.connect('Virtual Smoothie')
+
+  tiprack = containers.load('tiprack-200ul', 'A1')
+  p200rack = containers.load('tiprack-200ul', 'A2', 'p200rack')
+  plate = containers.load('96-flat', 'B1')
+  plate1 = containers.load('96-flat', 'B2', 'plate1')
+  trough = containers.load('trough-12row', 'C1')
+  trash = containers.load('point', 'C2')
+      
+  p200 = instruments.Pipette(axis="b", max_volume=1000)
+  p1000 = instruments.Pipette(axis="b", max_volume=1000)
+
+.. testcode:: main
+
+  plate.rows[0][0] # A1
+  plate.cols[0][0] # A1
+
+  plate.rows[0][1] # B1
+  plate.cols[1][0] # A2
+
+
+Rows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also call entire rows at once, which is especially useful when you are using an 8-channel pipette.  Simply use the .rows attribute after your container.  You can use an integer or a character.
+
+.. testcode:: main
+
+  plate.rows[0] # row 1
+  plate.rows['1']
+
+  plate.rows[1] # row 2
+  plate.rows['2']
+
+  plate.rows[11] # row 12
+  plate.rows['12']
+
+Columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Similar to .rows, except .cols.
+
+.. testcode:: main
+
+  plate.cols[0] # column A
+  plate.cols['A']
+
+  plate.cols[1] # column B
+  plate.cols['B']
+
+  plate.cols[7] # column H
+  plate.cols['H'] 
+
+
+Iterating Wells
+-------------------------------
+
+There are many wells to iterate through a plate, well by well, row by row, col by col, or skipping around.  We will show you examples of how to do all of these.
+
+.. tip::
+
+  **range** (*start, stop, step*)
+  
+  * **start -** starting number of the sequence
+  * **stop -** generate numbers up to, but not including this number
+  * **step -** difference between all numbers in the sequence
+
+Entire Plate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each of these examples shows how to mix every well in a plate, either by specifying a range, or a list of wells.
+
+.. testcode:: main
+
+  for i in range(96):
+    p200.mix(3, 100, plate[i])
+  
+  for well in plate:
+    p200.mix(3, 100, well)
+
+Each of these loops accesses each well in the plate in order, and mixes at each location.
+
+Entire Row
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This loop iterates through all wells in the first row (A1, B1, C1 etc.). 
+
+.. testcode:: main
+
+  for well in plate.rows[0]:
+    p200.mix(3, 100, well)
+
+Entire Column
+^^^^^^^^^^^^^
+
+This loop iterates through all wells in the first column.
+
+.. testcode:: main
+
+  for well in plate.cols['A']:
+    p200.mix(3, 100, well)
+
+Other Examples
+--------------
+
+Odds & Evens
+^^^^^^^^^^^^
+
+In order to access every other row, you can utilize the third parameter in range and add a step count to your loop.  A step of 2 skips every other number, giving you all the odds or all the evens (see below) depending on the start of your range.
+
+.. testcode:: main
+
+  for i in range(1, 12, 2):
+      well = plate1.rows[i]
+      tip = p200rack.rows[i]
+      p200.pick_up_tip(tip).aspirate(200, trough['A1']).dispense(well).drop_tip(tip)
+
+  # Or a bit more Pythonic
+  for well in plate1.rows[1:12:2]:
+      tip = p200rack.rows[i]
+      p200.pick_up_tip(tip).aspirate(200, trough['A1']).dispense(well).drop_tip(tip)
+
+You can alter this step to be any integer and get access to every n wells.
+
+Chaining
+^^^^^^^^
+
+Skipping around multiple chains is easy, once you have the right tools.  There are some python functions that are not inherent to the API, but that can be imported to make your life easier.  You can import the chain function when you import the opentrons API at the start of your python notebook.
+**ask katie for python import explanation**
+
+.. testcode:: main
+
+  from itertools import chain
+
+The chain functinos allows you to link two sets of locations together, in this case, two different columns.  The loop will iterate through all wells in column A and column E, while skipping columns BCDFGH.
+
+.. testcode:: main
+
+  dest_iter = chain(plate1.cols['A'], plate1.cols['E'])
+
+  for well in trough[:12]:
+      p1000.aspirate(600, well)
+      p1000.dispense(300, next(dest_iter))
+      p1000.dispense(300, next(dest_iter))

--- a/opentrons/__init__.py
+++ b/opentrons/__init__.py
@@ -1,7 +1,9 @@
 from opentrons.robot.robot import Robot
 from opentrons.robot.command import Command
 
-__all__ = [Robot, Command]
+robot = Robot()
+
+__all__ = [Robot, Command, robot]
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -32,7 +32,7 @@ def load(container_name, slot, label=None):
     >>> containers.load('non-existent-type', 'A2') # doctest: +ELLIPSIS
     Exception: Container type "non-existent-type" not found in file ...
     """
-    from opentrons.robot import Robot
+    from opentrons import Robot
     if not label:
         label = container_name
     protocol = Robot.get_instance()

--- a/opentrons/instruments/instrument.py
+++ b/opentrons/instruments/instrument.py
@@ -5,7 +5,7 @@ import sys
 
 from opentrons.util.vector import (Vector, VectorEncoder)
 from opentrons.robot.command import Command
-from opentrons.robot import Robot
+from opentrons import Robot
 
 
 JSON_ERROR = None

--- a/opentrons/json_importer/json_importer.py
+++ b/opentrons/json_importer/json_importer.py
@@ -4,7 +4,7 @@ import os
 
 from opentrons import containers
 from opentrons import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.util import vector
 
 

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -52,7 +52,7 @@ class Robot(object, metaclass=Singleton):
 
     Examples
     --------
-    >>> from opentrons.robot import Robot
+    >>> from opentrons import Robot
     >>> from opentrons import instruments, containers
     >>> robot = Robot()
     >>> robot.reset() # doctest: +ELLIPSIS
@@ -449,7 +449,7 @@ class Robot(object, metaclass=Singleton):
 
         Examples
         --------
-        >>> from opentrons.robot import Robot
+        >>> from opentrons import Robot
         >>> robot.connect('Virtual Smoothie')
         True
         >>> robot.home()
@@ -524,7 +524,7 @@ class Robot(object, metaclass=Singleton):
 
         Examples
         --------
-        >>> from opentrons.robot import Robot
+        >>> from opentrons import Robot
         >>> robot.reset() # doctest: +ELLIPSIS
         <opentrons.robot.robot.Robot object at ...>
         >>> robot.connect('Virtual Smoothie')
@@ -677,7 +677,7 @@ class Robot(object, metaclass=Singleton):
         Examples
         --------
         ..
-        >>> from opentrons.robot import Robot
+        >>> from opentrons import Robot
         >>> from opentrons.instruments.pipette import Pipette
         >>> robot.reset() # doctest: +ELLIPSIS
         <opentrons.robot.robot.Robot object at ...>

--- a/tests/opentrons/containers/test_grid.py
+++ b/tests/opentrons/containers/test_grid.py
@@ -2,7 +2,7 @@ import unittest
 
 from opentrons import containers
 from opentrons import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 
 
 class GridTestCase(unittest.TestCase):

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -1,7 +1,7 @@
 from threading import Thread
 import unittest
 
-from opentrons.robot import Robot
+from opentrons import Robot
 
 
 class OpenTronsTest(unittest.TestCase):

--- a/tests/opentrons/helpers/test_calibration.py
+++ b/tests/opentrons/helpers/test_calibration.py
@@ -4,7 +4,7 @@ import unittest
 
 from opentrons import instruments
 from opentrons import containers
-from opentrons.robot import Robot
+from opentrons import Robot
 
 from opentrons.helpers.helpers import import_calibration_file
 

--- a/tests/opentrons/integration/move_robot.py
+++ b/tests/opentrons/integration/move_robot.py
@@ -2,7 +2,7 @@ import os
 
 from opentrons import containers
 from opentrons.labware import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.drivers.motor import CNCDriver
 
 from helpers.calibration import import_json_calibration

--- a/tests/opentrons/integration/test_protocol.py
+++ b/tests/opentrons/integration/test_protocol.py
@@ -1,7 +1,7 @@
 import unittest
 from opentrons import containers
 
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.containers.placeable import Container, Deck
 from opentrons import instruments
 

--- a/tests/opentrons/json_importer/test_import_all_protocols.py
+++ b/tests/opentrons/json_importer/test_import_all_protocols.py
@@ -3,7 +3,7 @@ import json
 import os
 import unittest
 
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.json_importer import JSONProtocolProcessor
 
 

--- a/tests/opentrons/json_importer/test_json_importer.py
+++ b/tests/opentrons/json_importer/test_json_importer.py
@@ -3,7 +3,7 @@ import json
 import unittest
 from unittest import mock
 
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.json_importer import (
     JSONProtocolProcessor,
     JSONProcessorRuntimeError,

--- a/tests/opentrons/labware/test_crud_calibrations.py
+++ b/tests/opentrons/labware/test_crud_calibrations.py
@@ -1,6 +1,6 @@
 import unittest
 
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons import containers, instruments
 from opentrons.util.vector import Vector
 

--- a/tests/opentrons/labware/test_magbead.py
+++ b/tests/opentrons/labware/test_magbead.py
@@ -3,7 +3,7 @@ from unittest import mock
 from opentrons import containers
 
 from opentrons import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 
 
 class MagbeadTest(unittest.TestCase):

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -3,7 +3,7 @@ from unittest import mock
 from opentrons import containers
 
 from opentrons import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.util.vector import Vector
 
 from opentrons.containers.placeable import unpack_location, Container, Well

--- a/tests/opentrons/performance/test_performance.py
+++ b/tests/opentrons/performance/test_performance.py
@@ -3,7 +3,7 @@ import time
 
 from opentrons import containers
 from opentrons import instruments
-from opentrons.robot import Robot
+from opentrons import Robot
 from opentrons.helpers.helpers import import_calibration_json
 
 from opentrons.util.trace import EventBroker


### PR DESCRIPTION
Instead of

```python
from opentrons.robot import Robot
robot = Robot()
robot.run()
```

you can write

```python
from opentrons import robot
robot.run()
```

Thanks @andySigler @SimplyAhmazing 