### PR TITLE
swapped add_container args to match containers.load

### DIFF
--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -36,4 +36,4 @@ def load(container_name, slot, label=None):
     if not label:
         label = container_name
     protocol = Robot.get_instance()
-    return protocol.add_container(slot, container_name, label)
+    return protocol.add_container(container_name, slot, label)

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -531,7 +531,7 @@ class Robot(object, metaclass=Singleton):
         True
         >>> robot.home()
         True
-        >>> plate = robot.add_container('A1', '96-flat', 'plate')
+        >>> plate = robot.add_container('96-flat', 'A1', 'plate')
         >>> robot.move_to(plate[0])
         >>> robot.move_to(plate[0].top())
         """
@@ -685,7 +685,7 @@ class Robot(object, metaclass=Singleton):
         True
         >>> robot.home()
         True
-        >>> plate = robot.add_container('A1', '96-flat', 'plate')
+        >>> plate = robot.add_container('96-flat', 'A1', 'plate')
         >>> p200 = Pipette(axis='a')
         >>> robot.move_to(plate[0])
         >>> robot.move_to(plate[0].top())
@@ -855,7 +855,9 @@ class Robot(object, metaclass=Singleton):
 
         return sorted(self._instruments.items())
 
-    def add_container(self, slot, container_name, label):
+    def add_container(self, container_name, slot, label=None):
+        if not label:
+            label = container_name
         container = containers.get_persisted_container(container_name)
         container.properties['type'] = container_name
         self._deck[slot].add(container, label)

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -16,6 +16,22 @@ class RobotTest(unittest.TestCase):
         self.robot.connect()
         self.robot.home(enqueue=False)
 
+    def test_add_container(self):
+        c1 = self.robot.add_container('96-flat', 'A1')
+        res = self.robot.containers()
+        expected = {
+            '96-flat': c1
+        }
+        self.assertEquals(res, expected)
+
+        c2 = self.robot.add_container('96-flat', 'A2', 'my-special-plate')
+        res = self.robot.containers()
+        expected = {
+            '96-flat': c1,
+            'my-special-plate': c2
+        }
+        self.assertEquals(res, expected)
+
     def test_home_after_disconnect(self):
         self.robot.disconnect()
         self.assertRaises(RuntimeError, self.robot.home)


### PR DESCRIPTION
Small PR, making `robot.add_container()` and `containers.load()` have same arg order