### PR TITLE
Split delay and dispense to bottom

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -447,6 +447,9 @@ class Pipette(Instrument):
             if not volume or (self.current_volume - volume < 0):
                 volume = self.current_volume
 
+            if isinstance(location, Placeable):
+                location = location.bottom(1)
+
             self.current_volume -= volume
 
             self._associate_placeable(location)


### PR DESCRIPTION
This PR:

1. Changes `Pipette.dispense()` to default to the bottom of the destination well per user feedback
2. `CNCDriver.wait()` splits delays times by second, so calls to it do not block stop and pause signals
3. Cleans up `CNCDriver` a bit, removing unused code blocks and comments