### PR TITLE
adds robot.comment for printing custom messages during protocol run

### DIFF
--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -478,6 +478,16 @@ class Robot(object, metaclass=Singleton):
             log.info('Executing: Home now')
             return _do()
 
+    def comment(self, description):
+        def _do():
+            pass
+
+        def _setup():
+            pass
+
+        c = Command(do=_do, setup=_setup, description=description)
+        self.add_command(c)
+
     def add_command(self, command):
 
         if command.description:

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -32,6 +32,12 @@ class RobotTest(unittest.TestCase):
         }
         self.assertEquals(res, expected)
 
+    def test_comment(self):
+        self.robot.clear_commands()
+        self.robot.comment('hello')
+        self.assertEquals(len(self.robot.commands()), 1)
+        self.assertEquals(self.robot._commands[0].description, 'hello')
+
     def test_home_after_disconnect(self):
         self.robot.disconnect()
         self.assertRaises(RuntimeError, self.robot.home)


### PR DESCRIPTION
Small PR, adding `robot.comment()` for adding queued descriptions

Example:
```python
robot.comment("starting protocol")
p200.pick_up_tip().aspirate(plate[0]).dispense(plate[1]).return_tip()
robot.comment("finished protocol")
```