### PR TITLE
Remove unnecessary socket events

### DIFF
--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -432,7 +432,8 @@ class CNCDriver(object):
             },
             'class': type(self.connection).__name__
         }
-        trace.EventBroker.get_instance().notify(arguments)
+        if type(self.connection).__name__ != "VirtualSmoothie":
+            trace.EventBroker.get_instance().notify(arguments)
         return (True, self.SMOOTHIE_SUCCESS)
 
     def flip_coordinates(self, coordinates, mode='absolute'):

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -13,7 +13,7 @@ from opentrons.util.vector import Vector
 from opentrons.util.log import get_logger
 from opentrons.drivers import virtual_smoothie
 from opentrons.helpers import helpers
-from opentrons.util.trace import traceable
+# from opentrons.util.trace import traceable
 from opentrons.util.singleton import Singleton
 
 
@@ -744,7 +744,6 @@ class Robot(object, metaclass=Singleton):
             })
             if mode == "live":
                 trace.EventBroker.get_instance().notify(cmd_run_event)
-                
             try:
                 self.can_pop_command.wait()
                 if command.description:

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -742,8 +742,8 @@ class Robot(object, metaclass=Singleton):
                 'command_index': i,
                 'commands_total': len(self._commands)
             })
-            if mode == "live":
-                trace.EventBroker.get_instance().notify(cmd_run_event)
+            # if mode == "live":
+            trace.EventBroker.get_instance().notify(cmd_run_event)
             try:
                 self.can_pop_command.wait()
                 if command.description:

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -530,7 +530,7 @@ class Robot(object, metaclass=Singleton):
         """
         self._driver.set_head_speed(rate)
 
-    @traceable('move-to')
+    # @traceable('move-to')
     def move_to(self, location, instrument=None, strategy='arc', **kwargs):
         """
         Move an instrument to a coordinate, container or a coordinate within
@@ -742,7 +742,9 @@ class Robot(object, metaclass=Singleton):
                 'command_index': i,
                 'commands_total': len(self._commands)
             })
-            trace.EventBroker.get_instance().notify(cmd_run_event)
+            if mode == "live":
+                trace.EventBroker.get_instance().notify(cmd_run_event)
+                
             try:
                 self.can_pop_command.wait()
                 if command.description:


### PR DESCRIPTION
This PR removes socket events that are unused by the frontend, as they are slowing notifications and other socket based events down on the app. I disabled socket events for the virtual smoothie and only emitted `move-to` events when the connection is live.