### PR TITLE
fixes comment in docs for accessing wells using .rows and .cols

### DIFF
--- a/docs/source/well_access.rst
+++ b/docs/source/well_access.rst
@@ -53,8 +53,8 @@ You can also split the coordinates for the rows and columns and use either ``.ro
   plate.rows[0][0] # A1
   plate.cols[0][0] # A1
 
-  plate.rows[0][1] # B1
-  plate.cols[1][0] # A2
+  plate.rows[0][1] # A2
+  plate.cols[1][0] # B1
 
 
 Rows


### PR DESCRIPTION
Small PR, fixing comment which specifies what well is being referenced when using `.rows` and `.cols`