### PR TITLE
add containers.list() to see list of all loaded container files

### DIFF
--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -1,4 +1,5 @@
 from opentrons.containers.persisted_containers import get_persisted_container
+from opentrons.containers.persisted_containers import list_container_names
 from opentrons.containers.placeable import (
     Deck,
     Slot,
@@ -37,3 +38,7 @@ def load(container_name, slot, label=None):
         label = container_name
     protocol = Robot.get_instance()
     return protocol.add_container(container_name, slot, label)
+
+
+def list():
+    return list_container_names()

--- a/opentrons/containers/persisted_containers.py
+++ b/opentrons/containers/persisted_containers.py
@@ -82,6 +82,11 @@ def get_persisted_container(container_name: str) -> Container:
     return create_container_obj_from_dict(container_data)
 
 
+def list_container_names():
+    c_list = [n for n in persisted_containers_dict.keys()]
+    return sorted(c_list, key=lambda s: s.lower())
+
+
 def load_all_persisted_containers():
     containers = []
     for container_name, container_data in persisted_containers_dict.items():

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -1,6 +1,7 @@
 import unittest
 import math
 
+from opentrons import containers
 from opentrons.containers.placeable import (
     Container,
     Well,
@@ -21,6 +22,10 @@ class ContainerTestCase(unittest.TestCase):
                            0)
             c.add(well, name, coordinates)
         return c
+
+    def test_containers_list(self):
+        res = containers.list()
+        self.assertEquals(len(res), 30)
 
     def test_iterator(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)


### PR DESCRIPTION
Small PR. Adds a `containers.list()` method, which returns a list of all the loaded container names, in alphabetical order