### PR TITLE
407 tip tracking prediction

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -570,7 +570,9 @@ class WellSeries(Placeable):
     """
     def __init__(self, items):
         self.items = items
-        self.values = list(self.items.values())
+        if isinstance(items, dict):
+            items = list(self.items.values())
+        self.values = items
         self.offset = 0
 
     def set_offset(self, offset):

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -181,7 +181,7 @@ class Pipette(Instrument):
         """
         Resets the :any:`Pipette` tip tracking, "refilling" the tip racks
         """
-        self.current_tip_home_well = None
+        self.current_tip(None)
         self.tip_rack_iter = iter([])
 
         if self.has_tip_rack():
@@ -196,6 +196,11 @@ class Pipette(Instrument):
                 iterables = iterables[iterables.index(self.starting_tip):]
 
             self.tip_rack_iter = itertools.chain(iterables)
+
+    def current_tip(self, *args):
+        if len(args) and (isinstance(args[0], Placeable) or args[0] is None):
+            self.current_tip_home_well = args[0]
+        return self.current_tip_home_well
 
     def start_at_tip(self, _tip):
         if isinstance(_tip, Placeable):
@@ -804,11 +809,11 @@ class Pipette(Instrument):
             description=_description,
             enqueue=enqueue)
 
-        if not self.current_tip_home_well:
+        if not self.current_tip():
             self.robot.add_warning(
                 'Pipette has no tip to return, dropping in place')
 
-        self.drop_tip(self.current_tip_home_well, enqueue=enqueue)
+        self.drop_tip(self.current_tip(), enqueue=enqueue)
 
         return self
 
@@ -863,10 +868,10 @@ class Pipette(Instrument):
             if not location:
                 location = self.get_next_tip()
 
-            self.current_tip_home_well = None
+            self.current_tip(None)
             if location:
                 placeable, _ = containers.unpack_location(location)
-                self.current_tip_home_well = placeable
+                self.current_tip(placeable)
 
             if isinstance(location, Placeable):
                 location = location.bottom()
@@ -955,7 +960,7 @@ class Pipette(Instrument):
                 location = location.bottom(self._drop_tip_offset)
 
             self._associate_placeable(location)
-            self.current_tip_home_well = None
+            self.current_tip(None)
 
             self.current_volume = 0
 

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -191,9 +191,7 @@ class Pipette(Instrument):
                 for rack in self.tip_racks:
                     iterables.append(rack.rows)
 
-            self.tip_rack_iter = itertools.cycle(
-                itertools.chain(*iterables)
-            )
+            self.tip_rack_iter = itertools.chain(*iterables)
 
     def _associate_placeable(self, location):
         """
@@ -843,7 +841,11 @@ class Pipette(Instrument):
             if not location:
                 if self.has_tip_rack():
                     # TODO: raise warning/exception if looped back to first tip
-                    location = next(self.tip_rack_iter)
+                    try:
+                        location = next(self.tip_rack_iter)
+                    except StopIteration as e:
+                        raise RuntimeWarning(
+                            '{0} has run out of tips'.format(self.name))
                 else:
                     self.robot.add_warning(
                         'pick_up_tip called with no reference to a tip')

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -88,6 +88,7 @@ class Pipette(Instrument):
 
         self.trash_container = trash_container
         self.tip_racks = tip_racks
+        self.starting_tip = None
 
         # default mm above tip to execute drop-tip
         # this gives room for the drop-tip mechanism to work
@@ -187,11 +188,19 @@ class Pipette(Instrument):
             iterables = self.tip_racks
 
             if self.channels > 1:
-                iterables = []
-                for rack in self.tip_racks:
-                    iterables.append(rack.rows)
+                iterables = [r for rack in self.tip_racks for r in rack.rows]
+            else:
+                iterables = [w for rack in self.tip_racks for w in rack]
 
-            self.tip_rack_iter = itertools.chain(*iterables)
+            if self.starting_tip:
+                iterables = iterables[iterables.index(self.starting_tip):]
+
+            self.tip_rack_iter = itertools.chain(iterables)
+
+    def start_at_tip(self, _tip):
+        if isinstance(_tip, Placeable):
+            self.starting_tip = _tip
+            self.reset_tip_tracking()
 
     def get_next_tip(self):
         next_tip = None

--- a/tests/opentrons/json_importer/protocol_data/lewistanner_auto_pcr.json
+++ b/tests/opentrons/json_importer/protocol_data/lewistanner_auto_pcr.json
@@ -11,13 +11,21 @@
             "labware": "tiprack-10ul",
             "slot": "B1"
         },
+        "p10-rack-ST-2": {
+            "labware": "tiprack-10ul",
+            "slot": "B2"
+        },
+        "p10-rack-ST-3": {
+            "labware": "tiprack-10ul",
+            "slot": "B3"
+        },
         "p200-rack": {
             "labware": "tiprack-200ul",
             "slot": "A2"
         },
         "trash": {
             "labware": "point",
-            "slot": "B2"
+            "slot": "C2"
         },
         "reagents": {
             "labware": "tube-rack-2ml",
@@ -72,6 +80,12 @@
             "tip-racks": [
                 {
                     "container": "p10-rack-ST"
+                },
+                {
+                    "container": "p10-rack-ST-2"
+                },
+                {
+                    "container": "p10-rack-ST-3"
                 }
             ],
             "trash-container": {

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -637,6 +637,11 @@ class PipetteTest(unittest.TestCase):
             expected
         )
 
+    def test_tip_tracking_start_at_tip(self):
+        self.p200.start_at_tip(self.tiprack1['B2'])
+        self.p200.pick_up_tip()
+        self.assertEquals(self.tiprack1['B2'], self.p200.current_tip())
+
     def test_tip_tracking_return(self):
         self.p200.drop_tip = mock.Mock()
 

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -583,7 +583,7 @@ class PipetteTest(unittest.TestCase):
 
         self.p200.move_to = mock.Mock()
 
-        for _ in range(0, total_tips_per_plate * 4):
+        for _ in range(0, total_tips_per_plate * 2):
             self.p200.pick_up_tip()
 
         self.robot.simulate()
@@ -593,15 +593,19 @@ class PipetteTest(unittest.TestCase):
             expected.append(self.build_move_to_bottom(self.tiprack1[i]))
         for i in range(0, total_tips_per_plate):
             expected.append(self.build_move_to_bottom(self.tiprack2[i]))
-        for i in range(0, total_tips_per_plate):
-            expected.append(self.build_move_to_bottom(self.tiprack1[i]))
-        for i in range(0, total_tips_per_plate):
-            expected.append(self.build_move_to_bottom(self.tiprack2[i]))
 
         self.assertEqual(
             self.p200.move_to.mock_calls,
             expected
         )
+
+        # test then when we go over the total number of tips,
+        # Pipette raises a RuntimeWarning
+        self.robot.clear_commands()
+        self.p200.reset()
+        for _ in range(0, total_tips_per_plate * 2):
+            self.p200.pick_up_tip()
+        self.assertRaises(RuntimeWarning, self.p200.pick_up_tip)
 
     def test_tip_tracking_chain_multi_channel(self):
         p200_multi = instruments.Pipette(
@@ -617,16 +621,12 @@ class PipetteTest(unittest.TestCase):
             top=0, bottom=10, blow_out=12, drop_tip=13)
         p200_multi.move_to = mock.Mock()
 
-        for _ in range(0, 12 * 4):
+        for _ in range(0, 12 * 2):
             p200_multi.pick_up_tip()
 
         self.robot.simulate()
 
         expected = []
-        for i in range(0, 12):
-            expected.append(self.build_move_to_bottom(self.tiprack1.rows[i]))
-        for i in range(0, 12):
-            expected.append(self.build_move_to_bottom(self.tiprack2.rows[i]))
         for i in range(0, 12):
             expected.append(self.build_move_to_bottom(self.tiprack1.rows[i]))
         for i in range(0, 12):


### PR DESCRIPTION
This PR adds some requested features to tip tracking:

1. When iterating through tips, the `Pipette` will raise a `RuntimeWarning` if it has run out of tips
2. User can set which tip to start at using `Pipette.start_at_tip(tip)`, where tip is a `Well` inside a tip rack `Container` that's been already attached to the `Pipette` during initialization
3. Adds a method `Pipette.current_tip()` to set and get the current tip on the pipette

```python
pipette = instruments.Pipette(axis='b', tip_racks=[tiprack1, tiprack2])

pipette.start_at_tip(tiprack2['C3'])

pipette.pick_up_tip()  # now has tip tiprack2['C3']
pipette.drop_tip()

while True:
    # will eventually raise RuntimeWarning once all remaining tips have been used
    pipette.pick_up_tip()
    pipette.drop_tip()
```