### PR TITLE
adds Pipette.air_gap(vol, height)

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -360,6 +360,10 @@ class Pipette(Instrument):
             self.motor.speed(speed)
             self.motor.move(destination)
 
+        # if volume is specified as 0uL, then do nothing
+        if volume is 0:
+            return self
+
         _description = "Aspirating {0}uL at {1}".format(
             volume,
             (humanize_location(location) if location else '<In Place>')
@@ -471,6 +475,10 @@ class Pipette(Instrument):
 
             self.motor.speed(speed)
             self.motor.move(destination)
+
+        # if volume is specified as 0uL, then do nothing
+        if volume is 0:
+            return self
 
         _description = "Dispensing {0}uL at {1}".format(
             volume,
@@ -728,6 +736,70 @@ class Pipette(Instrument):
             setup=_setup,
             description=_description,
             enqueue=enqueue)
+
+        return self
+
+    # QUEUEABLE
+    def air_gap(self, volume=None, height=None, enqueue=True):
+        """
+        Pull air into the :any:`Pipette` current tip
+
+        Notes
+        -----
+        If no `location` is passed, the pipette will touch_tip
+        from it's current position.
+
+        Parameters
+        ----------
+        volume : number
+            The amount in uL to aspirate air into the tube.
+            (Default will use all remaining volume in tip)
+
+        height : number
+            The number of millimiters to move above the current Placeable
+            to perform and air-gap aspirate
+            (Default will be 10mm above current Placeable)
+
+        Returns
+        -------
+
+        This instance of :class:`Pipette`.
+
+        Examples
+        --------
+        ..
+        >>> p200 = instruments.Pipette(axis='a', max_volume=200)
+        >>> p200.aspirate(50, plate[0]) # doctest: +ELLIPSIS
+        <opentrons.instruments.pipette.Pipette object at ...>
+        >>> p200.air_gap(50) # doctest: +ELLIPSIS
+        <opentrons.instruments.pipette.Pipette object at ...>
+        """
+
+        def _setup():
+            pass
+
+        def _do():
+            pass
+
+        # if volumes is specified as 0uL, do nothing
+        if volume is 0:
+            return self
+
+        _description = 'Air gap'
+        self.create_command(
+            do=_do,
+            setup=_setup,
+            description=_description,
+            enqueue=enqueue)
+
+        if height is None:
+            height = 20
+
+        location = self.previous_placeable.top(height)
+        # "move_to" separate from aspirate command
+        # so "_position_for_aspirate" isn't executed
+        self.move_to(location, enqueue=enqueue)
+        self.aspirate(volume, enqueue=enqueue)
 
         return self
 

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -504,6 +504,16 @@ class PipetteTest(unittest.TestCase):
         self.p200.air_gap(10, 10)
         self.assertEquals(self.p200.current_volume, 60)
 
+        self.p200.dispense()
+        self.p200.aspirate(50, self.plate[2])
+        self.p200.air_gap(0)
+        self.assertEquals(self.p200.current_volume, 50)
+
+    def test_pipette_home(self):
+        self.p200.motor.home = mock.Mock()
+        self.p200.home()
+        self.assertEquals(len(self.robot.commands()), 1)
+
     def test_mix_with_named_args(self):
         self.p200.current_volume = 100
         self.p200.aspirate = mock.Mock()

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -489,6 +489,21 @@ class PipetteTest(unittest.TestCase):
             ]
         )
 
+    def test_air_gap(self):
+        self.p200.aspirate(50, self.plate[0])
+        self.p200.air_gap()
+        self.assertEquals(self.p200.current_volume, 200)
+
+        self.p200.dispense()
+        self.p200.aspirate(50, self.plate[1])
+        self.p200.air_gap(10)
+        self.assertEquals(self.p200.current_volume, 60)
+
+        self.p200.dispense()
+        self.p200.aspirate(50, self.plate[2])
+        self.p200.air_gap(10, 10)
+        self.assertEquals(self.p200.current_volume, 60)
+
     def test_mix_with_named_args(self):
         self.p200.current_volume = 100
         self.p200.aspirate = mock.Mock()


### PR DESCRIPTION
Small PR, creates a pipette command `Pipette.air_gap()`, which takes two optional arguments: `volume` and `height`.

- `Pipette.air_gap()` will automatically move 20mm above the current well, and then aspirate air until the tip is full
- `Pipette.air_gap(10)` will automatically move 20mm above the current well, and then aspirate 10uL of air
- `Pipette.air_gap(10, 7)` will move 7mm above the current well, and then aspirate 10uL of air