### PR TITLE
adds optional height argument to touch_tip()

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -691,8 +691,12 @@ class Pipette(Instrument):
         >>> p200.dispense(plate[1]).touch_tip() # doctest: +ELLIPSIS
         <opentrons.instruments.pipette.Pipette object at ...>
         """
+        height_offset = 0
         def _setup():
-            nonlocal location
+            nonlocal location, height_offset
+            if isinstance(location, (int, float, complex)):
+                height_offset = location
+                location = self.previous_placeable
             self._associate_placeable(location)
 
         def _do():
@@ -706,19 +710,31 @@ class Pipette(Instrument):
                 location = self.previous_placeable
 
             self.move_to(
-                (location, location.from_center(x=1, y=0, z=1)),
+                (
+                    location,
+                    location.from_center(x=1, y=0, z=1) + (0, 0, height_offset)
+                ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
-                (location, location.from_center(x=-1, y=0, z=1)),
+                (
+                    location,
+                    location.from_center(x=-1, y=0, z=1) + (0, 0, height_offset)
+                ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
-                (location, location.from_center(x=0, y=1, z=1)),
+                (
+                    location,
+                    location.from_center(x=0, y=1, z=1) + (0, 0, height_offset)
+                ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
-                (location, location.from_center(x=0, y=-1, z=1)),
+                (
+                    location,
+                    location.from_center(x=0, y=-1, z=1) + (0, 0, height_offset)
+                ),
                 strategy='direct',
                 enqueue=False)
 

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -692,6 +692,7 @@ class Pipette(Instrument):
         <opentrons.instruments.pipette.Pipette object at ...>
         """
         height_offset = 0
+
         def _setup():
             nonlocal location, height_offset
             if isinstance(location, (int, float, complex)):
@@ -709,31 +710,33 @@ class Pipette(Instrument):
             else:
                 location = self.previous_placeable
 
+            v_offset = (0, 0, height_offset)
+
             self.move_to(
                 (
                     location,
-                    location.from_center(x=1, y=0, z=1) + (0, 0, height_offset)
+                    location.from_center(x=1, y=0, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=-1, y=0, z=1) + (0, 0, height_offset)
+                    location.from_center(x=-1, y=0, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=0, y=1, z=1) + (0, 0, height_offset)
+                    location.from_center(x=0, y=1, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=0, y=-1, z=1) + (0, 0, height_offset)
+                    location.from_center(x=0, y=-1, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -461,6 +461,46 @@ class PipetteTest(unittest.TestCase):
             ]
         )
 
+    def test_touch_tip(self):
+        self.p200.move_to = mock.Mock()
+        self.p200.touch_tip(self.plate[0])
+        self.p200.touch_tip(-3)
+
+        self.robot.simulate()
+
+        from pprint import pprint
+        pprint(self.p200.move_to.mock_calls)
+
+        expected = [
+            mock.call(self.plate[0], enqueue=False, strategy='arc'),
+            mock.call(
+                (self.plate[0], (6.40, 3.20, 10.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (0.00, 3.20, 10.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 6.40, 10.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 0.00, 10.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(self.plate[0], enqueue=False, strategy='arc'),
+            mock.call(
+                (self.plate[0], (6.40, 3.20, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (0.00, 3.20, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 6.40, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 0.00, 7.50)),
+                enqueue=False, strategy='direct')]
+
+        self.assertEquals(expected, self.p200.move_to.mock_calls)
+
     def test_mix(self):
         # It is necessary to aspirate before it is mocked out
         # so that you have liquid


### PR DESCRIPTION
Small PR, adding optional height argument to `Pipette.touch_tip()`

```python
pipette.touch_tip(plate['A1'])  # normal touch_tip at plate A1
pipette.touch_tip(-3)           # will be 3mm below the top of the previous well
```