### PR TITLE
opentrons module raises exception if python version is not 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-- '3.4'
+- '3.5'
 before_install:
 - openssl aes-256-cbc -K $encrypted_f176ff9ac49f_key -iv $encrypted_f176ff9ac49f_iv -in .pypirc.enc -out $HOME/.pypirc -d
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python35-x64"

--- a/opentrons/__init__.py
+++ b/opentrons/__init__.py
@@ -1,10 +1,21 @@
+import sys
+
 from opentrons.robot.robot import Robot
 from opentrons.robot.command import Command
+
+from ._version import get_versions
+
+
+version = sys.version_info[0:2]
+if version != (3, 5):
+    raise RuntimeError(
+        'opentrons requires Python 3.5, this is {0}.{1}'.format(
+            version[0], version[1]))
 
 robot = Robot()
 
 __all__ = [Robot, Command, robot]
 
-from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions

--- a/tests/opentrons/util/test_vector.py
+++ b/tests/opentrons/util/test_vector.py
@@ -16,7 +16,6 @@ class VectorTestCase(unittest.TestCase):
         self.assertEqual(v3, (1, 2, 3))
         self.assertEqual(v4, Vector(1, 0, 0))
 
-    def test_init(self):
         self.assertRaises(ValueError, Vector)
 
     def test_repr(self):

--- a/tests/opentrons/util/test_vector.py
+++ b/tests/opentrons/util/test_vector.py
@@ -16,6 +16,13 @@ class VectorTestCase(unittest.TestCase):
         self.assertEqual(v3, (1, 2, 3))
         self.assertEqual(v4, Vector(1, 0, 0))
 
+    def test_init(self):
+        self.assertRaises(ValueError, Vector)
+
+    def test_repr(self):
+        v1 = Vector(1, 2, 3)
+        self.assertEquals(str(v1), '(x=1.00, y=2.00, z=3.00)')
+
     def test_add(self):
         v1 = Vector(1, 2, 3)
         v2 = Vector(4, 5, 6)


### PR DESCRIPTION
Small PR, `opentrons` module raises `RuntimeError` if detected python version is not 3.5