### PR TITLE
robot.run and robot.simulate re-raise exceptions instead of adding ro…

### DIFF
--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -766,8 +766,9 @@ class Robot(object, metaclass=Singleton):
                     'name': 'command-failed',
                     'error': str(e)
                 })
-                self.add_warning(str(e))
-                break
+                raise RuntimeError(
+                    'Command #{0} failed (\"{1}\"").\nError: \"{2}\"'.format(
+                        i, command.description, str(e))) from e
 
         return self._runtime_warnings
 

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -62,7 +62,7 @@ class RobotTest(unittest.TestCase):
 
         def _run():
             nonlocal res
-            res = self.robot.run()
+            self.assertRaises(RuntimeError(self.robot.run))
 
         thread = threading.Thread(target=_run)
         thread.start()
@@ -70,9 +70,6 @@ class RobotTest(unittest.TestCase):
         self.robot.stop()
 
         thread.join()
-
-        self.assertEquals(
-            res[-1], 'Received a STOP signal and exited from movements')
 
     def test_calibrated_max_dimension(self):
 

--- a/tests/opentrons/protocol/test_robot.py
+++ b/tests/opentrons/protocol/test_robot.py
@@ -71,6 +71,18 @@ class RobotTest(unittest.TestCase):
 
         thread.join()
 
+    def test_exceptions_during_run(self):
+        p200 = instruments.Pipette(axis='b', name='my-fancy-pancy-pipette')
+
+        def _do():
+            return 'hello' / 3
+
+        p200.create_command(
+            do=_do,
+            enqueue=True)
+
+        self.assertRaises(RuntimeError, self.robot.run)
+
     def test_calibrated_max_dimension(self):
 
         expected = self.robot._deck.max_dimensions(self.robot._deck)


### PR DESCRIPTION
…bot warnings list

Small PR, which simply takes all Exceptions being raised during the running of protocol commands, and re-raises them.

Before, these exceptions were being appended to a list or warnings. However, warnings should be treated as permissible, while exceptions should never be permissible. This is also how the UI is currently treating them, and will fix noted bugs when uploaded protocols that error.