### PR TITLE
Fix appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x" # currently 3.4.3
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
+      PYTHON_VERSION: "3.5.x" # currently 3.5.1
       PYTHON_ARCH: "64"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DESCRIPTION = (
     "The Opentrons API is a simple framework designed to make "
     "writing automated biology lab protocols easy.")
 PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
-INSTALL_REQUIRES = ['dill==0.2.5', 'requests==2.12.4', 'pyserial==3.2.1']
+INSTALL_REQUIRES = ['dill==0.2.5', 'requests==2.12.5', 'pyserial==3.2.1']
 TEST_SUITE = 'nose.collector'
 
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DESCRIPTION = (
     "The Opentrons API is a simple framework designed to make "
     "writing automated biology lab protocols easy.")
 PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
-INSTALL_REQUIRES = ['dill==0.2.5', 'requests==2.12.5', 'pyserial==3.2.1']
+INSTALL_REQUIRES = ['dill==0.2.5', 'requests>=2.12.4', 'pyserial==3.2.1']
 TEST_SUITE = 'nose.collector'
 
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Updates the `setup.py` to require `requests>=2.12.4`, to handle the latests release from requests.