### PR TITLE
Driver head speed no connection

### DIFF
--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -480,7 +480,12 @@ class CNCDriver(object):
         if not axis_to_home:
             return
 
-        res = self.send_command(self.HOME + axis_to_home)
+        res = None
+        try:
+            res = self.send_command(self.HOME + axis_to_home)
+        except Exception:
+            raise RuntimeWarning(
+                'HOMING ERROR: Check switches are being pressed and connected')
         if res == b'ok':
             # the axis aren't necessarily set to 0.0
             # values after homing, so force it

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -595,9 +595,7 @@ class CNCDriver(object):
             self.saved_settings['state']['head_speed'] = str(self.head_speed)
             with open(CONFIG_FILE_PATH, 'w') as configfile:
                 self.saved_settings.write(configfile)
-        kwargs = {"F": self.head_speed}
-        res = self.send_command(self.SET_SPEED, **kwargs)
-        return res == b'ok'
+        return True
 
     def set_plunger_speed(self, rate, axis):
         if axis.lower() not in 'ab':

--- a/opentrons/drivers/motor.py
+++ b/opentrons/drivers/motor.py
@@ -24,12 +24,6 @@ CONFIG_DIR_PATH = os.environ.get('APP_DATA_DIR', os.getcwd())
 CONFIG_DIR_PATH = os.path.join(CONFIG_DIR_PATH, 'smoothie')
 CONFIG_FILE_PATH = os.path.join(CONFIG_DIR_PATH, 'smoothie-config.ini')
 
-JSON_ERROR = None
-if sys.version_info > (3, 4):
-    JSON_ERROR = ValueError
-else:
-    JSON_ERROR = json.decoder.JSONDecodeError
-
 log = get_logger(__name__)
 
 
@@ -574,7 +568,7 @@ class CNCDriver(object):
                 # the uppercase axis are the "target" values
                 coords['target'][letter] = response_dict.get(letter.upper(), 0)
 
-        except JSON_ERROR:
+        except ValueError:
             log.critical("Error parsing JSON string from smoothie board:")
             log.critical(res)
 

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -95,6 +95,11 @@ class OpenTronsTest(unittest.TestCase):
         res = self.motor.get_connected_port()
         self.assertEquals(res, None)
 
+    def test_get_dimensions(self):
+        self.motor.ot_version = None
+        res = self.motor.get_dimensions()
+        self.assertEquals(res, Vector(400.00, 400.00, 100.00))
+
     def test_pause_resume(self):
         self.motor.home()
 

--- a/tests/opentrons/drivers/test_motor.py
+++ b/tests/opentrons/drivers/test_motor.py
@@ -3,6 +3,7 @@ from threading import Thread
 import unittest
 
 from opentrons import Robot
+from opentrons.util.vector import Vector
 
 
 class OpenTronsTest(unittest.TestCase):


### PR DESCRIPTION
…serial

Small PR address a couple issues in smoothie driver:

1. `set_head_speed` no longer attempts to write to port, was unnecessary and required app to be connected when calling `robot.head_speed()`
2. Serial timeouts occurring during a call to `home()` will raise a RuntimeError explicitly saying the error was most likely caused by a homing switch being disconnected or misaligned