### PR TITLE
Container slices with strings

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -86,7 +86,17 @@ class Placeable(object):
         Returns placeable by name or index
         If slice is given, returns a list
         """
-        if isinstance(name, int) or isinstance(name, slice):
+        if isinstance(name, slice):
+            if isinstance(name.start, str):
+                s = self.get_children_list().index(
+                    self.get_child_by_name(name.start))
+                name = slice(s, name.stop, name.step)
+            if isinstance(name.stop, str):
+                s = self.get_children_list().index(
+                    self.get_child_by_name(name.stop))
+                name = slice(name.start, s, name.step)
+            return self.get_children_list()[name]
+        elif isinstance(name, int):
             return self.get_children_list()[name]
         elif isinstance(name, str):
             return self.get_child_by_name(name)
@@ -589,10 +599,22 @@ class WellSeries(Placeable):
             ' '.join([str(well) for well in self.values]))
 
     def __getitem__(self, index):
-        if isinstance(index, str):
+        if isinstance(index, slice):
+            if isinstance(index.start, str):
+                s = list(self.values).index(
+                    self.items[index.start])
+                index = slice(s, index.stop, index.step)
+            if isinstance(index.stop, str):
+                s = list(self.values).index(
+                    self.items[index.stop])
+                index = slice(index.start, s, index.step)
+            return list(self.values)[index]
+        elif isinstance(index, int):
+            return list(self.values)[index]
+        elif isinstance(index, str):
             return self.items[index]
         else:
-            return list(self.values)[index]
+            raise TypeError('Expected int, slice or str')
 
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -87,15 +87,7 @@ class Placeable(object):
         If slice is given, returns a list
         """
         if isinstance(name, slice):
-            if isinstance(name.start, str):
-                s = self.get_children_list().index(
-                    self.get_child_by_name(name.start))
-                name = slice(s, name.stop, name.step)
-            if isinstance(name.stop, str):
-                s = self.get_children_list().index(
-                    self.get_child_by_name(name.stop))
-                name = slice(name.start, s, name.step)
-            return self.get_children_list()[name]
+            return self.get_children_from_slice(name)
         elif isinstance(name, int):
             return self.get_children_list()[name]
         elif isinstance(name, str):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -246,6 +246,25 @@ class Placeable(object):
         """
         return self.children_by_name.get(name)
 
+    def get_index_by_name(self, name):
+        """
+        Retrieves child's name by index
+        """
+        return self.get_children_list().index(
+            self.get_child_by_name(name))
+
+    def get_children_from_slice(self, s):
+        """
+        Retrieves list of children within slice
+        """
+        if isinstance(s.start, str):
+            s = slice(
+                self.get_index_by_name(s.start), s.stop, s.step)
+        if isinstance(s.stop, str):
+            s = slice(
+                s.start, self.get_index_by_name(s.stop), s.step)
+        return self.get_children_list()[s]
+
     def has_children(self):
         """
         Returns *True* if :Placeable: has children
@@ -600,15 +619,7 @@ class WellSeries(Placeable):
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            if isinstance(index.start, str):
-                s = list(self.values).index(
-                    self.items[index.start])
-                index = slice(s, index.stop, index.step)
-            if isinstance(index.stop, str):
-                s = list(self.values).index(
-                    self.items[index.stop])
-                index = slice(index.start, s, index.step)
-            return list(self.values)[index]
+            return self.get_children_from_slice(index)
         elif isinstance(index, int):
             return list(self.values)[index]
         elif isinstance(index, str):
@@ -622,3 +633,22 @@ class WellSeries(Placeable):
         if name in ('__getstate__', '__setstate__'):
             raise AttributeError()
         return getattr(self.values[self.offset], name)
+
+    def get_index_by_name(self, name):
+        """
+        Retrieves child's name by index
+        """
+        return list(self.values).index(
+            self.items[name])
+
+    def get_children_from_slice(self, s):
+        """
+        Retrieves list of children within slice
+        """
+        if isinstance(s.start, str):
+            s = slice(
+                self.get_index_by_name(s.start), s.stop, s.step)
+        if isinstance(s.stop, str):
+            s = slice(
+                s.start, self.get_index_by_name(s.stop), s.step)
+        return list(self.values)[s]

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -173,3 +173,79 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertListEqual(c.rows['4':'8'], c.rows[3:7])
         self.assertListEqual(c.cols['B':'E'], c.cols[1:4])
         self.assertListEqual(c.cols['B']['1':'7'], c.cols[1][0:6])
+
+    def test_wells(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertEquals(c.well(0), c[0])
+        self.assertEquals(c.well('A2'), c['A2'])
+        self.assertEquals(c.wells(0), c[0])
+        self.assertListEqual(c.wells(), c[0:])
+
+        expected = [c[n] for n in ['A1', 'B2', 'C3']]
+        self.assertListEqual(c.wells('A1', 'B2', 'C3'), expected)
+
+        expected = [c.cols[0][0], c.cols[0][5]]
+        self.assertListEqual(c.cols['A'].wells('1', '6'), expected)
+
+    def test_range(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.range(0, 96),
+            c[0:96])
+        self.assertListEqual(
+            c.range(2, 12, 3),
+            c[2:12:3])
+        self.assertListEqual(
+            c.range('A3'),
+            c[0:16])
+        self.assertListEqual(
+            c.range('A1', 'A3'),
+            c['A1':'A3'])
+        self.assertListEqual(
+            c.cols.range('A', 'D'),
+            c.cols['A':'D'])
+        self.assertListEqual(
+            c.cols['A'].range('2', '7'),
+            c.cols['A']['2':'7'])
+        self.assertListEqual(
+            c.cols.range('A', 'D', 2),
+            c.cols['A':'D':2])
+        self.assertListEqual(
+            c.cols['A'].range('2', '7', 2),
+            c.cols['A']['2':'7':2])
+
+    def test_group(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.group('A1', 'H1'),
+            c.range('A1', 'A2'))
+
+        self.assertListEqual(
+            c.cols.group('A', 'C'),
+            c.cols.range('A', 'D'))
+
+        self.assertListEqual(
+            c.cols['A'].group('1', '3'),
+            c.cols['A'].range('1', '4'))
+
+    def test_chain(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.chain('A1', 8),
+            c[0:8])
+
+        self.assertListEqual(
+            c.chain('C3', 8),
+            c['C3':'C4'])
+
+        self.assertListEqual(
+            c.cols.chain('A', 3),
+            c.cols.range('A', 'D'))
+
+        self.assertListEqual(
+            c.cols['A'].chain('1', 3),
+            c.cols['A'].range('1', '4'))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -16,7 +16,7 @@ class PlaceableTestCase(unittest.TestCase):
         for i in range(0, wells):
             well = Well(properties={'radius': radius, 'height': height})
             row, col = divmod(i, cols)
-            name = chr(row + ord('A')) + str(1 + col)
+            name = chr(col + ord('A')) + str(1 + row)
             coordinates = (col * spacing[0] + offset[0],
                            row * spacing[1] + offset[1],
                            0)
@@ -40,7 +40,7 @@ class PlaceableTestCase(unittest.TestCase):
     def test_next(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
         well = c['A1']
-        expected = c.get_child_by_name('A2')
+        expected = c.get_child_by_name('B1')
 
         self.assertEqual(next(well), expected)
 
@@ -48,7 +48,7 @@ class PlaceableTestCase(unittest.TestCase):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
 
         self.assertEqual(c[3], c.get_child_by_name('B2'))
-        self.assertEqual(c[1], c.get_child_by_name('A2'))
+        self.assertEqual(c[1], c.get_child_by_name('B1'))
 
     def test_named_well(self):
         deck = Deck()
@@ -165,3 +165,11 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertEqual(
             plate['A1'].top(10),
             (plate['A1'], Vector(5, 5, 20)))
+
+    def test_slice_with_strings(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+        self.assertListEqual(c['A1':'A2'], c[0:8])
+        self.assertListEqual(c['A12':], c.rows[-1][0:])
+        self.assertListEqual(c.rows['4':'8'], c.rows[3:7])
+        self.assertListEqual(c.cols['B':'E'], c.cols[1:4])
+        self.assertListEqual(c.cols['B']['1':'7'], c.cols[1][0:6])


### PR DESCRIPTION
Modifies `Placeable` such that it will accept `slice`s that use strings for their start and stop positions.

Example:
```python
plate[0:4] == plate['A1':'E1']
plate[0:8] == plate['A1':'A2']
plate.rows[2][0:4] == plate.rows['3']['A':'E']
plate.cols[2][1:6] == plate.cols['C']['2':'7']
```