### PR TITLE
Methods for creating WellSeries

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -603,26 +603,29 @@ class Container(Placeable):
             last = self.get_index_from_name(last)
         if last < first and step > 0:
             step *= -1
-        child_list = [w for w in self.__getitem__(slice(first, last, step))]
+        child_list = [w for w in self.range(first, last, step)]
         if abs(last - first) % abs(step) == 0:
             child_list.append(self[last])
         return WellSeries(child_list)
 
-    def chain(self, first, length=None, step=1):
+    def chain(self, index, length=None, step=1):
         """
         Returns WellSeries of child Wells of the specified "length",
         starting at the "first" well, and iterating using "step"
         """
-        if isinstance(first, str):
-            first = self.get_index_from_name(first)
+        if isinstance(index, str):
+            index = self.get_index_from_name(index)
         if length is None:
-            length = len(self)
+            length = len(self) - index
         if length < 0:
-            length *= -1
+            length = abs(length)
             if step > 0:
                 step *= -1
-        return WellSeries(self.__getitem__(
-            slice(first, first + (length * step), step)))
+        child_wells = []
+        while len(child_wells) < length:
+            child_wells.append(self[index])
+            index = (index + step) % len(self)
+        return WellSeries(child_wells)
 
 
 class WellSeries(Container):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -60,7 +60,6 @@ class Placeable(object):
         self._max_dimensions = {}
 
         self.parent = parent
-        self.name = None
 
         if properties is None:
             properties = {}
@@ -133,13 +132,9 @@ class Placeable(object):
         """
         Returns Placeable's name withing the parent
         """
-        if self.name:
-            return str(self.name)
-        elif self.parent:
-            self.name = self.parent.children_by_reference[self]
-            return self.name
-        else:
+        if not self.parent:
             return None
+        return self.parent.children_by_reference[self]
 
     def get_type(self):
         """

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -86,7 +86,17 @@ class Placeable(object):
         Returns placeable by name or index
         If slice is given, returns a list
         """
-        if isinstance(name, int) or isinstance(name, slice):
+        if isinstance(name, slice):
+            if isinstance(name.start, str):
+                s = self.get_children_list().index(
+                    self.get_child_by_name(name.start))
+                name = slice(s, name.stop, name.step)
+            if isinstance(name.stop, str):
+                s = self.get_children_list().index(
+                    self.get_child_by_name(name.stop))
+                name = slice(name.start, s, name.step)
+            return self.get_children_list()[name]
+        elif isinstance(name, int):
             return self.get_children_list()[name]
         elif isinstance(name, str):
             return self.get_child_by_name(name)
@@ -589,10 +599,22 @@ class WellSeries(Placeable):
             ' '.join([str(well) for well in self.values]))
 
     def __getitem__(self, index):
-        if isinstance(index, str):
+        if isinstance(index, slice):
+            if isinstance(index.start, str):
+                s = list(self.values).index(
+                    self.items[index.start])
+                index = slice(s, index.stop, index.step)
+            if isinstance(index.stop, str):
+                s = list(self.values).index(
+                    self.items[index.stop])
+                index = slice(index.start, s, index.step)
+            return list(self.values)[index]
+        elif isinstance(index, int):
+            return list(self.values)[index]
+        elif isinstance(index, str):
             return self.items[index]
         else:
-            return list(self.values)[index]
+            raise TypeError('Expected int, slice or str')
 
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -596,13 +596,15 @@ class Container(Placeable):
             last = self.get_index_from_name(last)
         return self.__getitem__(slice(first, last + 1, step))
 
-    def chain(self, first, length=1, step=1):
+    def chain(self, first, length=None, step=1):
         """
         Returns list of child Wells of the specified "length",
         starting at the "first" well, and iterating using "step"
         """
         if isinstance(first, str):
             first = self.get_index_from_name(first)
+        if length is None:
+            length = len(self)
         return self.__getitem__(slice(first, first + (length * step), step))
 
 

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -101,25 +101,6 @@ class Placeable(object):
             plate('A1~4')  # same as `plate.chain('A1', 4)`
         '''
 
-        def _parse_arguments(method, character, args):
-            vals = [n.strip() for n in args[0].split(character)]
-            if len(vals) < 2:
-                raise ValueError()
-            if vals[0] not in self.children_by_name:
-                raise KeyError()
-            if method == 'chain':
-                if vals[1]:
-                    vals[1] = int(vals[1])
-                else:
-                    del vals[1]
-            elif len(vals) > 1:
-                for v in vals[1:]:
-                    if v not in self.children_by_name:
-                        raise KeyError()
-            if method != 'wells' and len(vals) == 2 and len(args) >= 2:
-                vals.append(args[1])
-            return vals
-
         methods = {
             'chain': '~',
             'group': '-',
@@ -127,11 +108,30 @@ class Placeable(object):
         }
         for meth, l in methods.items():
             try:
-                a = _parse_arguments(meth, l, args)
+                a = self._parse_string_arguments(meth, l, args)
                 return getattr(self, meth)(*a)
             except Exception:
                 pass
         raise ValueError()
+
+    def _parse_string_arguments(self, method, character, args):
+        vals = [n.strip() for n in args[0].split(character)]
+        if len(vals) < 2:
+            raise ValueError()
+        if vals[0] not in self.children_by_name:
+            raise KeyError()
+        if method == 'chain':
+            if vals[1]:
+                vals[1] = int(vals[1])
+            else:
+                del vals[1]
+        elif len(vals) > 1:
+            for v in vals[1:]:
+                if v not in self.children_by_name:
+                    raise KeyError()
+        if method != 'wells' and len(vals) == 2 and len(args) >= 2:
+            vals.append(args[1])
+        return vals
 
     def __getitem__(self, name):
         """

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -742,11 +742,11 @@ class WellSeries(Container):
         return self.items.get(name)
 
     def trim(self, *args):
-        new = []
-        for w in self.get_children_list():
-            new.append(w.__call__(*args))
-        self.__init__(new, name=self.name)
-        return self
+        new = [
+            w.__call__(*args)
+            for w in self.get_children_list()
+        ]
+        return WellSeries(new, name=self.name)
 
     def flatten(self, *args):
         new = []
@@ -756,5 +756,4 @@ class WellSeries(Container):
                     new.append(w)
             else:
                 new.append(series)
-        self.__init__(new)
-        return self
+        return WellSeries(new)

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -132,8 +132,9 @@ class Placeable(object):
         """
         Returns Placeable's name withing the parent
         """
-        if not self.parent:
+        if self.parent is None:
             return None
+
         return self.parent.children_by_reference[self]
 
     def get_type(self):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -108,10 +108,10 @@ class Placeable(object):
             self.__class__.__name__, self.get_name())
 
     def __iter__(self):
-        return iter(self.children_by_reference.keys())
+        return iter(self.get_children_list())
 
     def __len__(self):
-        return len(self.children_by_name)
+        return len(self.get_children_list())
 
     def __bool__(self):
         return True
@@ -619,7 +619,7 @@ class WellSeries(Container):
 
     Default well index can be overriden using :set_offset:
     """
-    def __init__(self, wells, name='<Series>'):
+    def __init__(self, wells, name=None):
         if isinstance(wells, dict):
             self.items = wells
             self.values = list(wells.values())
@@ -635,25 +635,9 @@ class WellSeries(Container):
         """
         self.offset = offset
 
-    def __iter__(self):
-        return iter(self.values)
-
     def __str__(self):
         return '<Series: {}>'.format(
             ' '.join([str(well) for well in self.values]))
-
-    def __getitem__(self, index):
-        if isinstance(index, slice):
-            return self.get_children_from_slice(index)
-        elif isinstance(index, int):
-            return self.get_children_list()[index]
-        elif isinstance(index, str):
-            return self.items[index]
-        else:
-            raise TypeError('Expected int, slice or str')
-
-    def __len__(self):
-        return len(self.values)
 
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by
@@ -663,14 +647,12 @@ class WellSeries(Container):
         return getattr(self.values[self.offset], name)
 
     def get_name(self):
+        if self.name is None:
+            return str(self)
         return str(self.name)
 
     def get_children_list(self):
         return list(self.values)
 
-    def get_index_from_name(self, name):
-        """
-        Retrieves child's name by index
-        """
-        return self.get_children_list().index(
-            self.items[name])
+    def get_child_by_name(self, name):
+        return self.items[name]

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -60,6 +60,7 @@ class Placeable(object):
         self._max_dimensions = {}
 
         self.parent = parent
+        self.name = None
 
         if properties is None:
             properties = {}
@@ -132,10 +133,13 @@ class Placeable(object):
         """
         Returns Placeable's name withing the parent
         """
-        if self.parent is None:
+        if self.name:
+            return str(self.name)
+        elif self.parent:
+            self.name = self.parent.children_by_reference[self]
+            return self.name
+        else:
             return None
-
-        return self.parent.children_by_reference[self]
 
     def get_type(self):
         """
@@ -203,6 +207,7 @@ class Placeable(object):
 
         child._coordinates = Vector(coordinates)
         child.parent = self
+        child.name = name
         self.children_by_name[name] = child
         self.children_by_reference[child] = name
 
@@ -658,6 +663,9 @@ class WellSeries(Container):
         if name in ('__getstate__', '__setstate__'):
             raise AttributeError()
         return getattr(self.values[self.offset], name)
+
+    def get_name(self):
+        return '<Series>'
 
     def get_children_list(self):
         return list(self.values)

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -120,14 +120,14 @@ class Placeable(object):
             raise ValueError()
 
         if method is 'chain':
-            assert self.children_by_name[vals[0]]
+            assert self.get_child_by_name(vals[0])
             try:
                 vals[1] = int(vals[1])
             except ValueError:
                 vals = vals[:1]
         else:
             for v in vals:
-                assert self.children_by_name[v]
+                assert self.get_child_by_name(v)
 
         if (method is 'wells' or len(vals) is 2) and len(args) > 1:
             vals.extend(args[1:])

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -87,15 +87,7 @@ class Placeable(object):
         If slice is given, returns a list
         """
         if isinstance(name, slice):
-            if isinstance(name.start, str):
-                s = self.get_children_list().index(
-                    self.get_child_by_name(name.start))
-                name = slice(s, name.stop, name.step)
-            if isinstance(name.stop, str):
-                s = self.get_children_list().index(
-                    self.get_child_by_name(name.stop))
-                name = slice(name.start, s, name.step)
-            return self.get_children_list()[name]
+            return self.get_children_from_slice(name)
         elif isinstance(name, int):
             return self.get_children_list()[name]
         elif isinstance(name, str):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -582,13 +582,13 @@ class Container(Placeable):
 
     def range(self, *args):
         """
-        Returns list of child Wells using slice
+        Returns WellSeries of child Wells using slice
         """
-        return WellSeries(self.__getitem__(slice(*args)))
+        return self.__getitem__(slice(*args))
 
     def group(self, first, last, step=1):
         """
-        Returns list of child Wells, similar to range
+        Returns WellSeries of child Wells, similar to range
         but specify last instead of stop
         """
         if isinstance(last, str):
@@ -597,7 +597,7 @@ class Container(Placeable):
 
     def chain(self, first, length=None, step=1):
         """
-        Returns list of child Wells of the specified "length",
+        Returns WellSeries of child Wells of the specified "length",
         starting at the "first" well, and iterating using "step"
         """
         if isinstance(first, str):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -587,7 +587,7 @@ class Container(Placeable):
         """
         return self.__getitem__(slice(*args))
 
-    def group(self, first, last, step=None):
+    def group(self, first, last, step=1):
         """
         Returns list of child Wells, similar to range
         but specify last instead of stop
@@ -596,16 +596,14 @@ class Container(Placeable):
             last = self.get_index_from_name(last)
         return self.__getitem__(slice(first, last + 1, step))
 
-    def chain(self, first, length=None, step=None):
+    def chain(self, first, length=1, step=1):
         """
-        Returns list of child Wells, similar to range
-        but specify last instead of stop
+        Returns list of child Wells of the specified "length",
+        starting at the "first" well, and iterating using "step"
         """
         if isinstance(first, str):
             first = self.get_index_from_name(first)
-        if length is None:
-            length = len(self) - first
-        return self.__getitem__(slice(first, first + length, step))
+        return self.__getitem__(slice(first, first + (length * step), step))
 
 
 class WellSeries(Container):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -118,19 +118,19 @@ class Placeable(object):
         vals = [n.strip() for n in args[0].split(character)]
         if len(vals) < 2:
             raise ValueError()
-        if vals[0] not in self.children_by_name:
-            raise KeyError()
-        if method == 'chain':
-            if vals[1]:
+
+        if method is 'chain':
+            assert self.children_by_name[vals[0]]
+            try:
                 vals[1] = int(vals[1])
-            else:
-                del vals[1]
-        elif len(vals) > 1:
-            for v in vals[1:]:
-                if v not in self.children_by_name:
-                    raise KeyError()
-        if method != 'wells' and len(vals) == 2 and len(args) >= 2:
-            vals.append(args[1])
+            except ValueError:
+                vals = vals[:1]
+        else:
+            for v in vals:
+                assert self.children_by_name[v]
+
+        if (method is 'wells' or len(vals) is 2) and len(args) > 1:
+            vals.extend(args[1:])
         return vals
 
     def __getitem__(self, name):

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -203,7 +203,6 @@ class Placeable(object):
 
         child._coordinates = Vector(coordinates)
         child.parent = self
-        child.name = name
         self.children_by_name[name] = child
         self.children_by_reference[child] = name
 

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -246,6 +246,25 @@ class Placeable(object):
         """
         return self.children_by_name.get(name)
 
+    def get_index_by_name(self, name):
+        """
+        Retrieves child's name by index
+        """
+        return self.get_children_list().index(
+            self.get_child_by_name(name))
+
+    def get_children_from_slice(self, s):
+        """
+        Retrieves list of children within slice
+        """
+        if isinstance(s.start, str):
+            s = slice(
+                self.get_index_by_name(s.start), s.stop, s.step)
+        if isinstance(s.stop, str):
+            s = slice(
+                s.start, self.get_index_by_name(s.stop), s.step)
+        return self.get_children_list()[s]
+
     def has_children(self):
         """
         Returns *True* if :Placeable: has children
@@ -600,15 +619,7 @@ class WellSeries(Placeable):
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            if isinstance(index.start, str):
-                s = list(self.values).index(
-                    self.items[index.start])
-                index = slice(s, index.stop, index.step)
-            if isinstance(index.stop, str):
-                s = list(self.values).index(
-                    self.items[index.stop])
-                index = slice(index.start, s, index.step)
-            return list(self.values)[index]
+            return self.get_children_from_slice(index)
         elif isinstance(index, int):
             return list(self.values)[index]
         elif isinstance(index, str):
@@ -622,3 +633,22 @@ class WellSeries(Placeable):
         if name in ('__getstate__', '__setstate__'):
             raise AttributeError()
         return getattr(self.values[self.offset], name)
+
+    def get_index_by_name(self, name):
+        """
+        Retrieves child's name by index
+        """
+        return list(self.values).index(
+            self.items[name])
+
+    def get_children_from_slice(self, s):
+        """
+        Retrieves list of children within slice
+        """
+        if isinstance(s.start, str):
+            s = slice(
+                self.get_index_by_name(s.start), s.stop, s.step)
+        if isinstance(s.stop, str):
+            s = slice(
+                s.start, self.get_index_by_name(s.stop), s.step)
+        return list(self.values)[s]

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -569,17 +569,16 @@ class Container(Placeable):
         """
         Returns well by :name:
         """
-        return self.wells(name)
+        return self.__getitem__(name)
 
     def wells(self, *args):
         """
         Returns child Well or list of child Wells
         """
-        if len(args) > 1:
+        if len(args) > 0:
             return [self.__getitem__(n) for n in args]
-        elif len(args) == 0:
+        else:
             return self.get_children_list()
-        return self.__getitem__(args[0])
 
     def range(self, *args):
         """
@@ -605,7 +604,8 @@ class Container(Placeable):
             first = self.get_index_from_name(first)
         if length is None:
             length = len(self)
-        return self.__getitem__(slice(first, first + (length * step), step))
+        return self.__getitem__(
+            slice(first, first + (length * step), step))
 
 
 class WellSeries(Container):
@@ -668,15 +668,3 @@ class WellSeries(Container):
         """
         return self.get_children_list().index(
             self.items[name])
-
-    def get_children_from_slice(self, s):
-        """
-        Retrieves list of children within slice
-        """
-        if isinstance(s.start, str):
-            s = slice(
-                self.get_index_from_name(s.start), s.stop, s.step)
-        if isinstance(s.stop, str):
-            s = slice(
-                s.start, self.get_index_from_name(s.stop), s.step)
-        return self.get_children_list()[s]

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -110,7 +110,8 @@ class Placeable(object):
     def _parse_string_arguments(self, c):
         methods = {
             'chain': '~',
-            'group': '-'
+            'group': '-',
+            'range': ':'
         }
         step_char = ':'
         for m, l in methods.items():

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -27,6 +27,24 @@ class ContainerTestCase(unittest.TestCase):
         res = containers.list()
         self.assertEquals(len(res), 37)
 
+    def test_bad_unpack_containers(self):
+        self.assertRaises(
+            ValueError, containers.placeable.unpack_location, 1)
+
+    def test_iterate_without_parent(self):
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        self.assertRaises(
+            Exception, next, c)
+
+    def test_remove_child(self):
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        c.remove_child('A2')
+        self.assertEquals(len(c), 3)
+
+    def test_back_container_getitem(self):
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        self.assertRaises(TypeError, c.__getitem__, (1, 1))
+
     def test_iterator(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
         res = [well.coordinates() for well in c]

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -23,6 +23,14 @@ class PlaceableTestCase(unittest.TestCase):
             c.add(well, name, coordinates)
         return c
 
+    def assertWellSeriesEqual(self, w1, w2):
+        if hasattr(w1, '__len__') and hasattr(w2, '__len__'):
+            self.assertEqual(len(w1), len(w2))
+            for i in range(len(w1)):
+                self.assertEquals(w1[i], w2[i])
+        else:
+            self.assertEquals(w1, w2)
+
     def test_get_name(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
         expected = '<Well A1>'
@@ -168,88 +176,88 @@ class PlaceableTestCase(unittest.TestCase):
 
     def test_slice_with_strings(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
-        self.assertListEqual(c['A1':'A2'], c[0:8])
-        self.assertListEqual(c['A12':], c.rows[-1][0:])
-        self.assertListEqual(c.rows['4':'8'], c.rows[3:7])
-        self.assertListEqual(c.cols['B':'E'], c.cols[1:4])
-        self.assertListEqual(c.cols['B']['1':'7'], c.cols[1][0:6])
+        self.assertWellSeriesEqual(c['A1':'A2'], c[0:8])
+        self.assertWellSeriesEqual(c['A12':], c.rows[-1][0:])
+        self.assertWellSeriesEqual(c.rows['4':'8'], c.rows[3:7])
+        self.assertWellSeriesEqual(c.cols['B':'E'], c.cols[1:4])
+        self.assertWellSeriesEqual(c.cols['B']['1':'7'], c.cols[1][0:6])
 
     def test_wells(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
 
-        self.assertEquals(c.well(0), c[0])
-        self.assertEquals(c.well('A2'), c['A2'])
-        self.assertEquals(c.wells(0), [c[0]])
-        self.assertListEqual(c.wells(), c[0:])
+        self.assertWellSeriesEqual(c.well(0), c[0])
+        self.assertWellSeriesEqual(c.well('A2'), c['A2'])
+        self.assertWellSeriesEqual(c.wells(0), [c[0]])
+        self.assertWellSeriesEqual(c.wells(), c[0:])
 
         expected = [c[n] for n in ['A1', 'B2', 'C3']]
-        self.assertListEqual(c.wells('A1', 'B2', 'C3'), expected)
+        self.assertWellSeriesEqual(c.wells('A1', 'B2', 'C3'), expected)
 
         expected = [c.cols[0][0], c.cols[0][5]]
-        self.assertListEqual(c.cols['A'].wells('1', '6'), expected)
+        self.assertWellSeriesEqual(c.cols['A'].wells('1', '6'), expected)
 
     def test_range(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.range(0, 96),
             c[0:96])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.range(2, 12, 3),
             c[2:12:3])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.range('A3'),
             c[0:16])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.range('A1', 'A3'),
             c['A1':'A3'])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols.range('A', 'D'),
             c.cols['A':'D'])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols['A'].range('2', '7'),
             c.cols['A']['2':'7'])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols.range('A', 'D', 2),
             c.cols['A':'D':2])
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols['A'].range('2', '7', 2),
             c.cols['A']['2':'7':2])
 
     def test_group(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.group('A1', 'H1'),
             c.range('A1', 'A2'))
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols.group('A', 'C'),
             c.cols.range('A', 'D'))
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols['A'].group('1', '3'),
             c.cols['A'].range('1', '4'))
 
     def test_chain(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.chain('A1', 8),
             c[0:8])
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.chain('C3', 8),
             c['C3':'C4'])
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols.chain('A', 3),
             c.cols.range('A', 'D'))
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols['A'].chain('1', 3),
             c.cols['A'].range('1', '4'))
 
-        self.assertListEqual(
+        self.assertWellSeriesEqual(
             c.cols['A'].chain('1', 3, 3),
             c.cols['A'].range('1', '8', 3))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -333,6 +333,12 @@ class PlaceableTestCase(unittest.TestCase):
             plate('A1,B3,C8'),
             plate.wells('A1', 'B3', 'C8'))
 
+        self.assertWellSeriesEqual(
+            plate('A1,B3', 'C8'),
+            plate.wells('A1', 'B3', 'C8'))
+
+        self.assertRaises(Exception, plate, 'A1,B23')
+
         # CHAIN ~
 
         self.assertWellSeriesEqual(

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -27,11 +27,15 @@ class PlaceableTestCase(unittest.TestCase):
         if hasattr(w1, '__len__') and hasattr(w2, '__len__'):
             if len(w1) != len(w2):
                 print(w1)
-                print('{} != {}'.format(len(w1), len(w2)))
+                print('lengths: {} and {}'.format(len(w1), len(w2)))
                 print(w2)
                 assert False
             for i in range(len(w1)):
-                self.assertEquals(w1[i], w2[i])
+                if w1[i] != w2[i]:
+                    print(w1)
+                    print('lengths: {} and {}'.format(len(w1), len(w2)))
+                    print(w2)
+                    assert False
         else:
             self.assertEquals(w1, w2)
 
@@ -396,3 +400,16 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             plate.cols('A', 'C'),
             plate.cols('A-H')('A~2:2'))
+
+    def test_well_series_trim(self):
+        plate = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        grid = plate.cols('A-B', 'E').trim('1~3:2')
+        expected = plate('A1,A3,A5,B1,B3,B5,E1,E3,E5')
+        count = 0
+        self.assertEquals(len(grid), 3)
+        for c in grid:
+            for w in c:
+                self.assertEqual(w, expected[count])
+                count += 1
+        self.assertWellSeriesEqual(grid.flatten(), expected)

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -315,7 +315,7 @@ class PlaceableTestCase(unittest.TestCase):
     def test_string_syntax(self):
         plate = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
 
-        # WELLS
+        # WELLS ,
 
         self.assertWellSeriesEqual(
             plate(),
@@ -327,6 +327,10 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertWellSeriesEqual(
             plate('A1', 'B3', 'C8'),
+            plate.wells('A1', 'B3', 'C8'))
+
+        self.assertWellSeriesEqual(
+            plate('A1,B3,C8'),
             plate.wells('A1', 'B3', 'C8'))
 
         # CHAIN ~

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -173,3 +173,79 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertListEqual(c.rows['4':'8'], c.rows[3:7])
         self.assertListEqual(c.cols['B':'E'], c.cols[1:4])
         self.assertListEqual(c.cols['B']['1':'7'], c.cols[1][0:6])
+
+    def test_wells(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertEquals(c.well(0), c[0])
+        self.assertEquals(c.well('A2'), c['A2'])
+        self.assertEquals(c.wells(0), c[0])
+        self.assertListEqual(c.wells(), c[0:])
+
+        expected = [c[n] for n in ['A1', 'B2', 'C3']]
+        self.assertListEqual(c.wells('A1', 'B2', 'C3'), expected)
+
+        expected = [c.cols[0][0], c.cols[0][5]]
+        self.assertListEqual(c.cols['A'].wells('1', '6'), expected)
+
+    def test_range(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.range(0, 96),
+            c[0:96])
+        self.assertListEqual(
+            c.range(2, 12, 3),
+            c[2:12:3])
+        self.assertListEqual(
+            c.range('A3'),
+            c[0:16])
+        self.assertListEqual(
+            c.range('A1', 'A3'),
+            c['A1':'A3'])
+        self.assertListEqual(
+            c.cols.range('A', 'D'),
+            c.cols['A':'D'])
+        self.assertListEqual(
+            c.cols['A'].range('2', '7'),
+            c.cols['A']['2':'7'])
+        self.assertListEqual(
+            c.cols.range('A', 'D', 2),
+            c.cols['A':'D':2])
+        self.assertListEqual(
+            c.cols['A'].range('2', '7', 2),
+            c.cols['A']['2':'7':2])
+
+    def test_group(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.group('A1', 'H1'),
+            c.range('A1', 'A2'))
+
+        self.assertListEqual(
+            c.cols.group('A', 'C'),
+            c.cols.range('A', 'D'))
+
+        self.assertListEqual(
+            c.cols['A'].group('1', '3'),
+            c.cols['A'].range('1', '4'))
+
+    def test_chain(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        self.assertListEqual(
+            c.chain('A1', 8),
+            c[0:8])
+
+        self.assertListEqual(
+            c.chain('C3', 8),
+            c['C3':'C4'])
+
+        self.assertListEqual(
+            c.cols.chain('A', 3),
+            c.cols.range('A', 'D'))
+
+        self.assertListEqual(
+            c.cols['A'].chain('1', 3),
+            c.cols['A'].range('1', '4'))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -383,6 +383,18 @@ class PlaceableTestCase(unittest.TestCase):
             plate.wells('A1', 'C1', 'E1', 'G1', 'D6', 'F2', 'D2', 'B2'),
             plate('A1-H1:2', 'D6', 'F2~3:-2'))
 
+        self.assertWellSeriesEqual(
+            plate.wells('A1', 'C1', 'E1', 'G1'),
+            plate('A1:A2:2'))
+
+        self.assertWellSeriesEqual(
+            plate.wells('H1', 'F1', 'D1', 'B1'),
+            plate('H1:A1:2'))
+
+        self.assertWellSeriesEqual(
+            plate.wells('H1', 'F1', 'D1', 'B1'),
+            plate('H1:A1:-2'))
+
         # COLUMNS and ROWS
 
         self.assertWellSeriesEqual(

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -250,9 +250,14 @@ class PlaceableTestCase(unittest.TestCase):
             c.chain('A3'),
             c['A3':])
 
+        print('\n\n\n\n FUCK \n\n\n')
         self.assertWellSeriesEqual(
             c.chain('C3', 8),
             c['C3':'C4'])
+
+        self.assertWellSeriesEqual(
+            c.chain('C3', 4, -1),
+            c.wells('C3', 'B3', 'A3', 'H2'))
 
         self.assertWellSeriesEqual(
             c.cols.chain('A', 3),

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -247,6 +247,10 @@ class PlaceableTestCase(unittest.TestCase):
             c[0:8])
 
         self.assertWellSeriesEqual(
+            c.chain('A3'),
+            c['A3':])
+
+        self.assertWellSeriesEqual(
             c.chain('C3', 8),
             c['C3':'C4'])
 

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -249,3 +249,7 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertListEqual(
             c.cols['A'].chain('1', 3),
             c.cols['A'].range('1', '4'))
+
+        self.assertListEqual(
+            c.cols['A'].chain('1', 3, 3),
+            c.cols['A'].range('1', '8', 3))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -27,7 +27,7 @@ class PlaceableTestCase(unittest.TestCase):
         if hasattr(w1, '__len__') and hasattr(w2, '__len__'):
             if len(w1) != len(w2):
                 print(w1)
-                print('!=')
+                print('{} != {}'.format(len(w1), len(w2)))
                 print(w2)
                 assert False
             for i in range(len(w1)):
@@ -289,6 +289,10 @@ class PlaceableTestCase(unittest.TestCase):
             c.wells('C3', 'A3', 'G2', 'E2'))
 
         self.assertWellSeriesEqual(
+            c.chain('B1', -4),
+            c.wells('B1', 'A1', 'H12', 'G12'))
+
+        self.assertWellSeriesEqual(
             c.cols.chain('A', 3),
             c.cols.range('A', 'D'))
 
@@ -299,3 +303,11 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             c.cols['A'].chain('1', 3, 3),
             c.cols['A'].range('1', '8', 3))
+
+        self.assertWellSeriesEqual(
+            c.cols['A'].chain('7', -3, 3),
+            c.cols['A'].wells('7', '4', '1'))
+
+        self.assertWellSeriesEqual(
+            c.cols['A'].chain('4', -3, 3),
+            c.cols['A'].wells('4', '1', '10'))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -334,8 +334,8 @@ class PlaceableTestCase(unittest.TestCase):
             plate.wells('A1', 'B3', 'C8'))
 
         self.assertWellSeriesEqual(
-            plate('A1,B3', 'C8'),
-            plate.wells('A1', 'B3', 'C8'))
+            plate('A1,B3', 'C8', 'F2'),
+            plate.wells('A1', 'B3', 'C8', 'F2'))
 
         self.assertRaises(Exception, plate, 'A1,B23')
 
@@ -351,11 +351,11 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertWellSeriesEqual(
             plate.chain('A2', 3, 3),
-            plate('A2~3', 3))
+            plate('A2~3:3'))
 
         self.assertWellSeriesEqual(
             plate.chain('A2', 3, -3),
-            plate('A2~-3', -3))
+            plate('A2~-3:-3'))
 
         # GROUP -
 
@@ -373,7 +373,11 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertWellSeriesEqual(
             plate.group('A1', 'H1', 2),
-            plate('A1-H1', 2))
+            plate('A1-H1:2'))
+
+        self.assertWellSeriesEqual(
+            plate.wells('A1', 'C1', 'E1', 'G1', 'D6', 'F2', 'D2', 'B2'),
+            plate('A1-H1:2', 'D6', 'F2~3:-2'))
 
         # COLUMNS and ROWS
 
@@ -391,4 +395,4 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertWellSeriesEqual(
             plate.cols('A', 'C'),
-            plate.cols('A-H')('A~2', 2))
+            plate.cols('A-H')('A~2:2'))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -179,7 +179,7 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertEquals(c.well(0), c[0])
         self.assertEquals(c.well('A2'), c['A2'])
-        self.assertEquals(c.wells(0), c[0])
+        self.assertEquals(c.wells(0), [c[0]])
         self.assertListEqual(c.wells(), c[0:])
 
         expected = [c[n] for n in ['A1', 'B2', 'C3']]

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -16,7 +16,7 @@ class PlaceableTestCase(unittest.TestCase):
         for i in range(0, wells):
             well = Well(properties={'radius': radius, 'height': height})
             row, col = divmod(i, cols)
-            name = chr(row + ord('A')) + str(1 + col)
+            name = chr(col + ord('A')) + str(1 + row)
             coordinates = (col * spacing[0] + offset[0],
                            row * spacing[1] + offset[1],
                            0)
@@ -40,7 +40,7 @@ class PlaceableTestCase(unittest.TestCase):
     def test_next(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
         well = c['A1']
-        expected = c.get_child_by_name('A2')
+        expected = c.get_child_by_name('B1')
 
         self.assertEqual(next(well), expected)
 
@@ -48,7 +48,7 @@ class PlaceableTestCase(unittest.TestCase):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
 
         self.assertEqual(c[3], c.get_child_by_name('B2'))
-        self.assertEqual(c[1], c.get_child_by_name('A2'))
+        self.assertEqual(c[1], c.get_child_by_name('B1'))
 
     def test_named_well(self):
         deck = Deck()
@@ -165,3 +165,11 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertEqual(
             plate['A1'].top(10),
             (plate['A1'], Vector(5, 5, 20)))
+
+    def test_slice_with_strings(self):
+        c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+        self.assertListEqual(c['A1':'A2'], c[0:8])
+        self.assertListEqual(c['A12':], c.rows[-1][0:])
+        self.assertListEqual(c.rows['4':'8'], c.rows[3:7])
+        self.assertListEqual(c.cols['B':'E'], c.cols[1:4])
+        self.assertListEqual(c.cols['B']['1':'7'], c.cols[1][0:6])

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -25,7 +25,11 @@ class PlaceableTestCase(unittest.TestCase):
 
     def assertWellSeriesEqual(self, w1, w2):
         if hasattr(w1, '__len__') and hasattr(w2, '__len__'):
-            self.assertEqual(len(w1), len(w2))
+            if len(w1) != len(w2):
+                print(w1)
+                print('!=')
+                print(w2)
+                assert False
             for i in range(len(w1)):
                 self.assertEquals(w1[i], w2[i])
         else:
@@ -223,6 +227,12 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             c.cols['A'].range('2', '7', 2),
             c.cols['A']['2':'7':2])
+        self.assertWellSeriesEqual(
+            c.cols['A'].range('7', '2', 2),
+            c.cols['A'].wells('7', '5', '3'))
+        self.assertWellSeriesEqual(
+            c.cols['A'].range('7', '2', -2),
+            c.cols['A'].wells('7', '5', '3'))
 
     def test_group(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
@@ -230,6 +240,18 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             c.group('A1', 'H1'),
             c.range('A1', 'A2'))
+
+        self.assertWellSeriesEqual(
+            c.group('A1', 'H1', 2),
+            c.range('A1', 'A2', 2))
+
+        self.assertWellSeriesEqual(
+            c.group('H1', 'B1'),
+            c.range('H1', 'A1'))
+
+        self.assertWellSeriesEqual(
+            c.group('H1', 'A1', -2),
+            c.range('H1', 'A1', -2))
 
         self.assertWellSeriesEqual(
             c.cols.group('A', 'C'),
@@ -250,7 +272,6 @@ class PlaceableTestCase(unittest.TestCase):
             c.chain('A3'),
             c['A3':])
 
-        print('\n\n\n\n FUCK \n\n\n')
         self.assertWellSeriesEqual(
             c.chain('C3', 8),
             c['C3':'C4'])
@@ -258,6 +279,14 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             c.chain('C3', 4, -1),
             c.wells('C3', 'B3', 'A3', 'H2'))
+
+        self.assertWellSeriesEqual(
+            c.chain('C3', -4),
+            c.wells('C3', 'B3', 'A3', 'H2'))
+
+        self.assertWellSeriesEqual(
+            c.chain('C3', -4, 2),
+            c.wells('C3', 'A3', 'G2', 'E2'))
 
         self.assertWellSeriesEqual(
             c.cols.chain('A', 3),

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -311,3 +311,56 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             c.cols['A'].chain('4', -3, 3),
             c.cols['A'].wells('4', '1', '10'))
+
+    def test_string_syntax(self):
+        plate = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
+
+        # WELLS
+
+        self.assertWellSeriesEqual(
+            plate(),
+            plate)
+
+        self.assertWellSeriesEqual(
+            plate('A1'),
+            [plate['A1']])
+
+        self.assertWellSeriesEqual(
+            plate('A1', 'B3', 'C8'),
+            plate.wells('A1', 'B3', 'C8'))
+
+        # CHAIN ~
+
+        self.assertWellSeriesEqual(
+            plate.chain('A1', -8),
+            plate('A1~-8'))
+
+        self.assertWellSeriesEqual(
+            plate.chain('A2'),
+            plate('A2~'))
+
+        self.assertWellSeriesEqual(
+            plate.chain('A2', 3, 3),
+            plate('A2~3', 3))
+
+        self.assertWellSeriesEqual(
+            plate.chain('A2', 3, -3),
+            plate('A2~-3', -3))
+
+        # GROUP -
+
+        self.assertWellSeriesEqual(
+            plate.group('C1', 'H8'),
+            plate('C1-H8'))
+
+        self.assertWellSeriesEqual(
+            plate.group(2, 1),
+            plate('C1-B1'))
+
+        self.assertWellSeriesEqual(
+            plate.group('A1', 'H1'),
+            plate('A1-H1'))
+
+        self.assertWellSeriesEqual(
+            plate.group('A1', 'H1', 2),
+            plate('A1-H1', 2))

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -374,3 +374,21 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(
             plate.group('A1', 'H1', 2),
             plate('A1-H1', 2))
+
+        # COLUMNS and ROWS
+
+        self.assertWellSeriesEqual(
+            plate.cols.wells('C', 'D', 'H'),
+            plate.cols('C,D,H'))
+
+        self.assertWellSeriesEqual(
+            plate.cols.chain('C', 3),
+            plate.cols('C~3'))
+
+        self.assertWellSeriesEqual(
+            plate.cols.group('C', 'H'),
+            plate.cols('C-H'))
+
+        self.assertWellSeriesEqual(
+            plate.cols('A', 'C'),
+            plate.cols('A-H')('A~2', 2))


### PR DESCRIPTION
Use a `Container` to create custom `WellSeries`
Here's the most abstracted part. Read the rest of the PR to see what it's build on top of:

All examples use:
```python
plate = containers.load('96-flat', 'A1')
```

#### Get separate wells using `,` (comma)
```python
plate('A1')                # -> [A1]
plate('A1', 'B1', 'D2')    # -> [A1, B1, D2]
plate('A1,B2,D5')          # -> [A1, B2, D5]
plate('A1,B2', 'D5')       # -> [A1, B2, D5]
```
#### Create a range of wells using `:` (colon)
```python
plate('A1:E1')             # -> [A1, B1, C1, D1]
plate('E1:A1')             # -> [E1, D1, C1, B1]
plate('A1:E1:2')           # -> [A1, C1]
```
#### Create a group of wells using `-` (dash)
```python
plate('A1-E1')             # -> [A1, B1, C1, D1, E1]
plate('E1-A1')             # -> [E1, D1, C1, B1, A1]
plate('A1-E1:2')           # -> [A1, C1, E1]
```
#### Create a chain of wells using `~` (tilde)
```python
plate('A2~5')              # -> [A2, B2, C2, D2, E2]
plate('A2~5:-1')           # -> [A2, H1, G1, F1, E1]
plate('A2~5:2')            # -> [A2, C2, E2, G2, A3]
```
#### Arguments can be mixed and matched
```python
plate('A1-C1,H3,H12~3:-1')     # -> [A1, B1, C1, H3, H12, G12, F12]
```
#### All options also work with `.rows` and `.cols`
```python
plate.cols('A-C,H')     # -> [Column-A, Column-B, Column-C, Column-H]
```

#### Using Strings within Slices
Returns a `WellSeries`
```python
plate['A1':'A2'] 
# -> [A1, B1, C1, D1, E1, F1, G1, H1]
plate['A1':'A2':3] 
# -> [A1, D1, G1]
plate.cols['A':'D']
# -> [Column-A, Column-B, Column-C]
plate.cols['A']['1':'4']
# -> [A1, A2, A3]
```

#### Container.wells(name_1, name_2, ... )
##### Container.well(name)

Returns either `Well` or `WellSeries` containing all specified `Well`s
```python
plate.well('A1')
# -> A1
plate.wells('A1')
# -> [A1]
plate.wells('A1', 'A2', 'H12')
# -> [A1, A2, H12]
```

#### Container.range(start, stop, step)

Splits a container into a `WellSeries` using `slice`
```python
plate.range('A1', 'A2')
# -> [A1, B1, C1, D1, E1, F1, G1, H1]
plate.range('H1', 'A1')
# -> [H1, G1, F1, E1, D1, C1, B1]
plate.range('A1', 'A2', 3)
# -> [A1, D1, G1]
plate.range('H1', 'B1', 2)
# -> [H1, F1, D1]
plate.range('H1', 'B1', -2)
# -> [H1, F1, D1]
plate.cols.range('A', 'D')
# -> [Column-A, Column-B, Column-C]
plate.cols['A'].range('1', '4')
# -> [A1, A2, A3]
```

#### Container.group(first, last, step)
Splits a container into a `WellSeries` by specifying the first well and the last well to be included
```python
plate.group('A1', 'H1')
# -> [A1, B1, C1, D1, E1, F1, G1, H1]
plate.group('A1', 'H1')
# -> [H1, G1, F1, E1, D1, C1, B1, A1]
plate.group('A1', 'H1', 3)
# -> [A1, D1, G1]
plate.group('H1', 'B1', 2)
# -> [H1, F1, D1, B1]
plate.group('H1', 'B1', -2)
# -> [H1, F1, D1, B1]
plate.cols.group('A', 'D')
# -> [Column-A, Column-B, Column-C, Column-D]
plate.cols['A'].group('1', '4')
# -> [A1, A2, A3, A4]
```

#### Container.chain(first, length, step)
Splits a container into a `WellSeries` by specifying the first well and the total number of wells to be included.
```python
plate.chain('A1', 8)
# -> [A1, B1, C1, D1, E1, F1, G1, H1]
plate.chain('H1', -8)
# -> [H1, G1, F1, E1, D1, C1, B1, A1]
plate.chain('H1', 8, -1)
# -> [H1, G1, F1, E1, D1, C1, B1, A1]
plate.chain('H1', -8, -1)
# -> [H1, G1, F1, E1, D1, C1, B1, A1]
plate.chain('A1', 8, 3)
# -> [A1, D1, G1, B2, E2, H2, C3, F3]
plate.chain('D11')
# -> [D11, E11, F11, G11, H11, A12, B12, C12, D12, E12, F12, G12, H12]
plate.cols.chain('A', 4)
# -> [Column-A, Column-B, Column-C, Column-D]
plate.cols['A'].chain('1', 4)
# -> [A1, A2, A3, A4]
```