### PR TITLE
containers.create() for making custom containers

### DIFF
--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -54,8 +54,8 @@ def create(slot, grid, spacing, diameter, depth, name=None):
         'height': depth
     }
 
-    for c in range(columns):
-        for r in range(rows):
+    for r in range(rows):
+        for c in range(columns):
             well = Well(properties=properties)
             name = chr(c + ord('A')) + str(1 + r)
             coordinates = (c * col_spacing, r * row_spacing, 0)

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -61,5 +61,5 @@ def create(slot, grid, spacing, diameter, depth, name=None):
             coordinates = (c * col_spacing, r * row_spacing, 0)
             custom_container.add(well, name, coordinates)
     from opentrons import robot
-    robot._deck[slot].add(custom_container, name)
+    robot.deck[slot].add(custom_container, name)
     return custom_container

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -60,6 +60,6 @@ def create(slot, grid, spacing, diameter, depth, name=None):
             name = chr(c + ord('A')) + str(1 + r)
             coordinates = (c * col_spacing, r * row_spacing, 0)
             custom_container.add(well, name, coordinates)
-    from opentrons import robot
-    robot.deck[slot].add(custom_container, name)
+    from opentrons import Robot
+    Robot.get_instance().deck[slot].add(custom_container, name)
     return custom_container

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -42,3 +42,24 @@ def load(container_name, slot, label=None):
 
 def list():
     return list_container_names()
+
+
+def create(slot, grid, spacing, diameter, depth, name=None):
+    columns, rows = grid
+    col_spacing, row_spacing = spacing
+    custom_container = Container()
+    properties = {
+        'type': 'custom',
+        'radius': diameter / 2,
+        'height': depth
+    }
+
+    for c in range(columns):
+        for r in range(rows):
+            well = Well(properties=properties)
+            name = chr(c + ord('A')) + str(1 + r)
+            coordinates = (c * col_spacing, r * row_spacing, 0)
+            custom_container.add(well, name, coordinates)
+    from opentrons import robot
+    robot._deck[slot].add(custom_container, name)
+    return custom_container

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -1,7 +1,7 @@
 import unittest
 import math
 
-from opentrons import containers
+from opentrons import containers, robot
 from opentrons.containers.placeable import (
     Container,
     Well,
@@ -22,6 +22,19 @@ class ContainerTestCase(unittest.TestCase):
                            0)
             c.add(well, name, coordinates)
         return c
+
+    def test_containers_create(self):
+        p = containers.create(
+            slot='A1',
+            grid=(8, 12),
+            spacing=(9, 9),
+            diameter=4,
+            depth=8,
+            name='platez')
+        self.assertEquals(len(p), 96)
+        self.assertEquals(len(p.rows), 12)
+        self.assertEquals(len(p.cols), 8)
+        self.assertEquals(p.get_parent(), robot._deck['A1'])
 
     def test_containers_list(self):
         res = containers.list()

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -35,6 +35,7 @@ class ContainerTestCase(unittest.TestCase):
         self.assertEquals(len(p.rows), 12)
         self.assertEquals(len(p.cols), 8)
         self.assertEquals(p.get_parent(), robot._deck['A1'])
+        self.assertEquals(p['C3'], p[18])
 
     def test_containers_list(self):
         res = containers.list()

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -34,7 +34,7 @@ class ContainerTestCase(unittest.TestCase):
         self.assertEquals(len(p), 96)
         self.assertEquals(len(p.rows), 12)
         self.assertEquals(len(p.cols), 8)
-        self.assertEquals(p.get_parent(), robot._deck['A1'])
+        self.assertEquals(p.get_parent(), robot.deck['A1'])
         self.assertEquals(p['C3'], p[18])
 
     def test_containers_list(self):

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -1,7 +1,7 @@
 import unittest
 import math
 
-from opentrons import containers, robot
+from opentrons import containers
 from opentrons.containers.placeable import (
     Container,
     Well,
@@ -24,6 +24,7 @@ class ContainerTestCase(unittest.TestCase):
         return c
 
     def test_containers_create(self):
+        from opentrons import Robot
         p = containers.create(
             slot='A1',
             grid=(8, 12),
@@ -34,7 +35,8 @@ class ContainerTestCase(unittest.TestCase):
         self.assertEquals(len(p), 96)
         self.assertEquals(len(p.rows), 12)
         self.assertEquals(len(p.cols), 8)
-        self.assertEquals(p.get_parent(), robot.deck['A1'])
+        self.assertEquals(
+            p.get_parent(), Robot.get_instance().deck['A1'])
         self.assertEquals(p['C3'], p[18])
 
     def test_containers_list(self):


### PR DESCRIPTION
```python
custom_plate = containers.create(
    slot='A1',
    grid=(8, 4),
    spacing=(9, 9),
    diameter=4,
    depth=8,
    name='my-fancy-plate'
)

for well in custom_plate:
    print(well)
```
outputs the following
```
<Well A1>
<Well B1>
<Well C1>
<Well D1>
<Well E1>
<Well F1>
<Well G1>
<Well H1>
<Well A2>
<Well B2>
<Well C2>
<Well D2>
<Well E2>
<Well F2>
<Well G2>
<Well H2>
<Well A3>
<Well B3>
<Well C3>
<Well D3>
<Well E3>
<Well F3>
<Well G3>
<Well H3>
<Well A4>
<Well B4>
<Well C4>
<Well D4>
<Well E4>
<Well F4>
<Well G4>
<Well H4>
```