### PR TITLE
Persist containers create

### DIFF
--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from opentrons.containers.persisted_containers import get_persisted_container
 from opentrons.containers.persisted_containers import list_container_names
 from opentrons.containers.placeable import (
@@ -9,6 +12,7 @@ from opentrons.containers.placeable import (
     unpack_location
 )
 from opentrons.containers.calibrator import apply_calibration
+from opentrons.util import environment
 
 __all__ = [
     get_persisted_container,
@@ -44,22 +48,54 @@ def list():
     return list_container_names()
 
 
-def create(slot, grid, spacing, diameter, depth, name=None):
+def create(slot, grid, spacing, diameter, depth, volume=0, name=None):
     columns, rows = grid
     col_spacing, row_spacing = spacing
     custom_container = Container()
     properties = {
         'type': 'custom',
         'radius': diameter / 2,
-        'height': depth
+        'height': depth,
+        'total-liquid-volume': volume
     }
 
     for r in range(rows):
         for c in range(columns):
             well = Well(properties=properties)
-            name = chr(c + ord('A')) + str(1 + r)
+            well_name = chr(c + ord('A')) + str(1 + r)
             coordinates = (c * col_spacing, r * row_spacing, 0)
-            custom_container.add(well, name, coordinates)
+            custom_container.add(well, well_name, coordinates)
     from opentrons import Robot
+    if name is None:
+        name = 'custom_{0}x{1}'.format(columns, rows)
+    else:
+        json_container = container_to_json(c, name)
+        update_container_create_file(json_container)
     Robot.get_instance().deck[slot].add(custom_container, name)
     return custom_container
+
+
+def container_to_json(c, name):
+    locations = {}
+    for w in c:
+        x, y, z = w.coordinates()
+        locations[w.get_name()] = {
+            'x': x, 'y': y, 'z': z,
+            'depth': w.z_size(),
+            'diameter': w.x_size(),
+            'total-liquid-volume': 0
+        }
+    return {name: {'locations': locations}}
+
+
+def update_container_create_file(data):
+    container_file_path = environment.get_path('CONTAINERS_FILE')
+    if not os.path.isfile(container_file_path):
+        with open(container_file_path, 'w') as f:
+            f.write(json.dumps({'containers': {}}))
+    with open(container_file_path, 'r+') as f:
+        old_data = json.load(f)
+        old_data['containers'].update(data)
+        f.seek(0)
+        f.write(json.dumps(old_data))
+        f.truncate()

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import json
 import os
 
@@ -69,14 +70,14 @@ def create(slot, grid, spacing, diameter, depth, volume=0, name=None):
     if name is None:
         name = 'custom_{0}x{1}'.format(columns, rows)
     else:
-        json_container = container_to_json(c, name)
+        json_container = container_to_json(custom_container, name)
         update_container_create_file(json_container)
     Robot.get_instance().deck[slot].add(custom_container, name)
     return custom_container
 
 
 def container_to_json(c, name):
-    locations = {}
+    locations = OrderedDict()
     for w in c:
         x, y, z = w.coordinates()
         locations[w.get_name()] = {
@@ -97,5 +98,5 @@ def update_container_create_file(data):
         old_data = json.load(f)
         old_data['containers'].update(data)
         f.seek(0)
-        f.write(json.dumps(old_data))
+        f.write(json.dumps(old_data, indent=4))
         f.truncate()

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -71,7 +71,7 @@ def create(slot, grid, spacing, diameter, depth, volume=0, name=None):
         name = 'custom_{0}x{1}'.format(columns, rows)
     else:
         json_container = container_to_json(custom_container, name)
-        update_container_create_file(json_container)
+        save_custom_container(json_container)
     Robot.get_instance().deck[slot].add(custom_container, name)
     return custom_container
 
@@ -89,7 +89,7 @@ def container_to_json(c, name):
     return {name: {'locations': locations}}
 
 
-def update_container_create_file(data):
+def save_custom_container(data):
     container_file_path = environment.get_path('CONTAINERS_FILE')
     if not os.path.isfile(container_file_path):
         with open(container_file_path, 'w') as f:

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -84,7 +84,7 @@ def container_to_json(c, name):
             'x': x, 'y': y, 'z': z,
             'depth': w.z_size(),
             'diameter': w.x_size(),
-            'total-liquid-volume': 0
+            'total-liquid-volume': w.max_volume()
         }
     return {name: {'locations': locations}}
 

--- a/opentrons/containers/__init__.py
+++ b/opentrons/containers/__init__.py
@@ -55,7 +55,7 @@ def create(slot, grid, spacing, diameter, depth, volume=0, name=None):
     custom_container = Container()
     properties = {
         'type': 'custom',
-        'radius': diameter / 2,
+        'diameter': diameter,
         'height': depth,
         'total-liquid-volume': volume
     }

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -274,6 +274,12 @@ class Placeable(object):
             self.z_size()
         )
 
+    def max_volume(self):
+        """
+        Returns placeable's maximum liquid volume in uL
+        """
+        return self.properties['total-liquid-volume']
+
     def x_size(self):
         """
         Returns placeable's size along X axis

--- a/opentrons/util/environment.py
+++ b/opentrons/util/environment.py
@@ -15,6 +15,9 @@ def refresh():
         'LOG_DIR': os.path.join(APP_DATA_DIR, 'logs'),
         'LOG_FILE': os.path.join(APP_DATA_DIR, 'logs', 'api.log'),
         'CONTAINERS_DIR': os.path.join(APP_DATA_DIR, 'containers'),
+        'CONTAINERS_FILE':
+            os.path.join(
+                APP_DATA_DIR, 'containers', '_containers_create.json'),
         'CALIBRATIONS_DIR': os.path.join(APP_DATA_DIR, 'calibrations'),
         'CALIBRATIONS_FILE':
             os.path.join(APP_DATA_DIR, 'calibrations', 'calibrations.json'),

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -29,6 +29,7 @@ class ContainerTestCase(unittest.TestCase):
         import os
         import json
         from opentrons import Robot
+        container_name = 'plate_for_testing_containers_create'
         p = containers.create(
             slot='A1',
             grid=(8, 12),
@@ -36,7 +37,7 @@ class ContainerTestCase(unittest.TestCase):
             diameter=4,
             depth=8,
             volume=1000,
-            name='platez')
+            name=container_name)
         self.assertEquals(len(p), 96)
         self.assertEquals(len(p.rows), 12)
         self.assertEquals(len(p.cols), 8)
@@ -49,7 +50,7 @@ class ContainerTestCase(unittest.TestCase):
 
         Robot.get_instance().reset()
         persisted_containers.load_all_persisted_containers_from_disk()
-        p = containers.load('platez', 'A1')
+        p = containers.load(container_name, 'A1')
         self.assertEquals(len(p), 96)
         self.assertEquals(len(p.rows), 12)
         self.assertEquals(len(p.cols), 8)

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -31,6 +31,7 @@ class ContainerTestCase(unittest.TestCase):
             spacing=(9, 9),
             diameter=4,
             depth=8,
+            volume=1000,
             name='platez')
         self.assertEquals(len(p), 96)
         self.assertEquals(len(p.rows), 12)
@@ -38,10 +39,13 @@ class ContainerTestCase(unittest.TestCase):
         self.assertEquals(
             p.get_parent(), Robot.get_instance().deck['A1'])
         self.assertEquals(p['C3'], p[18])
+        self.assertEquals(p['C3'].max_volume(), 1000)
+        for i, w in enumerate(p):
+            self.assertEquals(w, p[i])
 
     def test_containers_list(self):
         res = containers.list()
-        self.assertEquals(len(res), 38)
+        self.assertTrue(len(res))
 
     def test_bad_unpack_containers(self):
         self.assertRaises(

--- a/tests/opentrons/containers/test_containers.py
+++ b/tests/opentrons/containers/test_containers.py
@@ -56,7 +56,6 @@ class ContainerTestCase(unittest.TestCase):
         self.assertEquals(
             p.get_parent(), Robot.get_instance().deck['A1'])
         self.assertEquals(p['C3'], p[18])
-        print(p['C3'].properties['total-liquid-volume'])
         self.assertEquals(p['C3'].max_volume(), 1000)
         for i, w in enumerate(p):
             self.assertEquals(w, p[i])


### PR DESCRIPTION
When a custom `Container` is created using `containers.create()`, it is saved as a JSON container within the file specified by environment variable `CONTAINERS_FILE`.

If no `name =` is specified when using `containers.create()`, it will **not be saved** to the file.