### PR TITLE
Adds to=, length=, and step= to Placeable.Wells()

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -577,15 +577,28 @@ class Container(Placeable):
         """
         return self.__getitem__(name)
 
-    def wells(self, *args):
+    def wells(self, *args, **kwargs):
         """
         Returns child Well or list of child Wells
         """
+        to = kwargs.get('to', None)
+        skip = kwargs.get('skip', 1)
+        length = kwargs.get('length', 1)
+
         new_wells = None
-        if len(args) > 0:
+        if len(args) > 1:
             new_wells = WellSeries([self.well(n) for n in args])
+        elif len(args) is 1:
+            if isinstance(args[0], list):
+                new_wells = WellSeries([self.well(n) for n in args[0]])
+            elif to:
+                stop = self.get_index_from_name(to) + 1
+                new_wells = self[args[0]:stop:skip]
+            else:
+                new_wells = self[args[0]::skip][:length]
         else:
             new_wells = WellSeries(self.get_children_list())
+
         if len(new_wells) is 1:
             return new_wells[0]
         return new_wells

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -203,3 +203,31 @@ class PlaceableTestCase(unittest.TestCase):
 
         expected = [c.cols[0][0], c.cols[0][5]]
         self.assertWellSeriesEqual(c.cols['A'].wells('1', '6'), expected)
+
+        expected = [c.cols[0][0], c.cols[0][5]]
+        self.assertWellSeriesEqual(c.cols['A'].wells(['1', '6']), expected)
+
+        expected = c.wells('A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1')
+        self.assertWellSeriesEqual(c.wells('A1', to='H1'), expected)
+
+        expected = c.wells('A1', 'C1', 'E1', 'G1')
+        self.assertWellSeriesEqual(c.wells('A1', to='H1', step=2), expected)
+
+        expected = c.wells(
+            'A3', 'G2', 'E2', 'C2', 'A2', 'G1', 'E1', 'C1', 'A1')
+        self.assertWellSeriesEqual(c.wells('A3', to='A1', step=2), expected)
+
+        expected = c.wells('A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1')
+        self.assertWellSeriesEqual(c.wells('A1', length=8), expected)
+
+        expected = c.wells('A1', 'C1', 'E1', 'G1', 'A2', 'C2', 'E2', 'G2')
+        self.assertWellSeriesEqual(c.wells('A1', length=8, step=2), expected)
+
+        expected = c.wells('A1', 'H12', 'G12', 'F12')
+        self.assertWellSeriesEqual(c.wells('A1', length=4, step=-1), expected)
+
+        expected = c.wells('A1', 'H12', 'G12', 'F12')
+        self.assertWellSeriesEqual(c.wells('A1', length=-4, step=-1), expected)
+
+        expected = c.wells('A1', 'H12', 'G12', 'F12')
+        self.assertWellSeriesEqual(c.wells('A1', length=-4, step=1), expected)


### PR DESCRIPTION
`plate.wells('A1', to='H1')` returns every well in the first rows (8 total)

`plate.wells('A1', to='H1', step=2)` returns every other well in the first rows (4 total)

`plate.wells('H1', to='A1')` returns every well in the first rows, starting at H1

`plate.wells('A1', length=8)` return a total of 8 wells, starting at well A1

`plate.wells('A1', length=8, step=2)` return a total of 8 wells, starting at well A1, and skipping every other well

`plate.wells('H1', length=8, step=-1)` return a total of 8 wells, starting at well H11, and moving backwards from there