### PR TITLE
Fixes to transfer and wells

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -597,6 +597,12 @@ class Container(Placeable):
             return new_wells[0]
         return new_wells
 
+    def get(self, *args, **kwargs):
+        """
+        Passes all arguments to Wells() and returns result
+        """
+        return self.wells(*args, **kwargs)
+
     def _parse_wells_to_and_length(self, *args, **kwargs):
         start = args[0] if len(args) else 0
         stop = kwargs.get('to', None)

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -614,6 +614,7 @@ class Container(Placeable):
             for i in range(3)
             for w in self.get_children_list()
         ]
+        total_kids = len(self.get_children_list())
 
         if isinstance(start, str):
             start = self.get_index_from_name(start)
@@ -627,13 +628,13 @@ class Container(Placeable):
                 stop -= 1
                 step = step * -1 if step > 0 else step
             return WellSeries(
-                wrapped_wells[start + 96:stop + 96:step])
+                wrapped_wells[start + total_kids:stop + total_kids:step])
         else:
             if length < 0:
                 length *= -1
                 step = step * -1 if step > 0 else step
             return WellSeries(
-                wrapped_wells[start + 96::step][:length])
+                wrapped_wells[start + total_kids::step][:length])
 
 
 class WellSeries(Container):

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -1589,10 +1589,6 @@ class Pipette(Instrument):
                 self._add_tip_during_transfer(tips, **kwargs)
                 self._aspirate_during_transfer(
                     aspirate['volume'], aspirate['location'], **kwargs)
-                if air_gap:
-                    self.air_gap(air_gap, enqueue=enqueue)
-                if should_touch_tip is not False:
-                    self.touch_tip(touch_tip, enqueue=enqueue)
 
             if dispense:
                 self._dispense_during_transfer(
@@ -1628,10 +1624,19 @@ class Pipette(Instrument):
         rate = kwargs.get('rate', 1)
         mix_before = kwargs.get('mix', kwargs.get('mix_before', (0, 0)))
         air_gap = kwargs.get('air_gap', 0)
+        should_touch_tip = kwargs.get('touch_tip', False)
+        if isinstance(should_touch_tip, (int, float, complex)):
+            touch_tip = should_touch_tip
+        else:
+            touch_tip = -1
 
         if self.current_volume == 0:
             self._mix_during_transfer(mix_before, loc, **kwargs)
         self.aspirate(vol, loc, rate=rate, enqueue=enqueue)
+        if air_gap:
+            self.air_gap(air_gap, enqueue=enqueue)
+        if should_touch_tip is not False:
+            self.touch_tip(touch_tip, enqueue=enqueue)
 
     def _dispense_during_transfer(self, vol, loc, **kwargs):
         """

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -1535,8 +1535,10 @@ class Pipette(Instrument):
             # SPECIAL CASE: if using multi-channel pipette,
             # and the source or target is a WellSeries
             # then avoid iterating through it's Wells
-            s = [s] if isinstance(s, WellSeries) else s
-            t = [t] if isinstance(t, WellSeries) else t
+            if isinstance(s, WellSeries) and not isinstance(s[0], WellSeries):
+                s = [s] if isinstance(s, WellSeries) else s
+            if isinstance(t, WellSeries) and not isinstance(t[0], WellSeries):
+                t = [t] if isinstance(t, WellSeries) else t
 
         # create list of volumes, sources, and targets of equal length
         s, t = helpers._create_source_target_lists(s, t, **kwargs)

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -218,7 +218,6 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(c.wells('A1', to='H1', step=2), expected)
         self.assertWellSeriesEqual(c.get('A1', to='H1', step=2), expected)
 
-
         expected = c.wells(
             'A3', 'G2', 'E2', 'C2', 'A2', 'G1', 'E1', 'C1', 'A1')
         self.assertWellSeriesEqual(c.wells('A3', to='A1', step=2), expected)

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -200,22 +200,29 @@ class PlaceableTestCase(unittest.TestCase):
 
         expected = [c[n] for n in ['A1', 'B2', 'C3']]
         self.assertWellSeriesEqual(c.wells('A1', 'B2', 'C3'), expected)
+        self.assertWellSeriesEqual(c.get('A1', 'B2', 'C3'), expected)
 
         expected = [c.cols[0][0], c.cols[0][5]]
         self.assertWellSeriesEqual(c.cols['A'].wells('1', '6'), expected)
+        self.assertWellSeriesEqual(c.cols['A'].get('1', '6'), expected)
 
         expected = [c.cols[0][0], c.cols[0][5]]
         self.assertWellSeriesEqual(c.cols['A'].wells(['1', '6']), expected)
+        self.assertWellSeriesEqual(c.cols['A'].get('1', '6'), expected)
 
         expected = c.wells('A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1')
         self.assertWellSeriesEqual(c.wells('A1', to='H1'), expected)
+        self.assertWellSeriesEqual(c.get('A1', to='H1'), expected)
 
         expected = c.wells('A1', 'C1', 'E1', 'G1')
         self.assertWellSeriesEqual(c.wells('A1', to='H1', step=2), expected)
+        self.assertWellSeriesEqual(c.get('A1', to='H1', step=2), expected)
+
 
         expected = c.wells(
             'A3', 'G2', 'E2', 'C2', 'A2', 'G1', 'E1', 'C1', 'A1')
         self.assertWellSeriesEqual(c.wells('A3', to='A1', step=2), expected)
+        self.assertWellSeriesEqual(c.get('A3', to='A1', step=2), expected)
 
         expected = c.wells('A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1')
         self.assertWellSeriesEqual(c.wells('A1', length=8), expected)

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -629,67 +629,75 @@ class PipetteTest(unittest.TestCase):
         # pprint(self.robot.commands())
         expected = [
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well A1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well B1'],
             ['dispensing', '30', 'Well B1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well B1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well C1'],
             ['dispensing', '30', 'Well C1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well C1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well D1'],
             ['dispensing', '30', 'Well D1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well D1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well E1'],
             ['dispensing', '30', 'Well E1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well E1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well F1'],
             ['dispensing', '30', 'Well F1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well F1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well G1'],
             ['dispensing', '30', 'Well G1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well G1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well H1'],
             ['dispensing', '30', 'Well H1'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop'],
             ['pick'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['aspirating', '30', 'Well H1'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['dispensing', '10', 'Well A2'],
             ['dispensing', '30', 'Well A2'],
-            ['blow', 'in place'],
+            ['blow'],
             ['touch'],
             ['drop']
         ]
@@ -905,10 +913,10 @@ class PipetteTest(unittest.TestCase):
         # pprint(self.robot.commands())
         expected = [
             ['pick'],
-            ['air gap'], ['moving'], ['aspirating', '20'],
             ['aspirating', '120', 'Well A1'],
+            ['air gap'], ['moving'], ['aspirating', '20'],
+            ['dispensing', '20', 'Well B1'],
             ['dispensing', '120', 'Well B1'],
-            ['blow', 'in place'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
@@ -925,16 +933,14 @@ class PipetteTest(unittest.TestCase):
             self.plate[2],
             air_gap=20
         )
-        from pprint import pprint
-        print('\n\n***\n')
-        pprint(self.robot.commands())
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
         expected = [
             ['pick'],
-            ['air gap'], ['moving to'], ['aspirating', '20'],
             ['aspirating', '60', 'Well A1'],
             ['aspirating', '60', 'Well B1'],
             ['dispensing', '120', 'Well C1'],
-            ['blow', 'in place'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
@@ -951,14 +957,17 @@ class PipetteTest(unittest.TestCase):
             self.plate[0:2],
             air_gap=20
         )
-        # from pprint import pprint
-        # print('\n\n***\n')
-        # pprint(self.robot.commands())
+        from pprint import pprint
+        print('\n\n***\n')
+        pprint(self.robot.commands())
         expected = [
             ['pick'],
-            ['air gap'], ['moving to'], ['aspirating', '20'],
             ['aspirating', '130', 'Well C1'],
+            ['air gap'], ['moving to'], ['aspirating', '20'],
+            ['dispensing', '20'],
             ['dispensing', '60', 'Well A1'],
+            ['air gap'], ['moving to'], ['aspirating', '20'],
+            ['dispensing', '20'],
             ['dispensing', '60', 'Well B1'],
             ['blow', 'point'],
             ['drop']
@@ -983,9 +992,12 @@ class PipetteTest(unittest.TestCase):
         # pprint(self.robot.commands())
         expected = [
             ['pick'],
-            ['air gap'], ['moving to'], ['aspirating', '20'],
             ['aspirating', '140', 'Well C1'],
+            ['air gap'], ['moving to'], ['aspirating', '20'],
+            ['dispensing', '20', 'Well A1'],
             ['dispensing', '60', 'Well A1'],
+            ['air gap'], ['moving to'], ['aspirating', '20'],
+            ['dispensing', '20', 'Well B1'],
             ['dispensing', '60', 'Well B1'],
             ['blow', 'point'],
             ['drop']


### PR DESCRIPTION
Address small bugs found within `Placeable.wells()` and `Pipette.transfer()`

- `Placeable.wells()` now works with `WellSeries`
- `Pipette.transfer()` source/destination arguments for multi-channel can be `WellSeries` of `WellSeries`
- `Placeable.wells()` had was using a hardcoded length of 96 to wrap around container. Now it's based on actual length of that `Container`