### PR TITLE
Delay takes minutes kwarg

### DIFF
--- a/opentrons/instruments/magbead.py
+++ b/opentrons/instruments/magbead.py
@@ -95,7 +95,7 @@ class Magbead(Instrument):
 
         return self
 
-    def delay(self, seconds, enqueue=True):
+    def delay(self, seconds=0, minutes=0, enqueue=True):
         """
         Pause the robot for a given number of seconds
 
@@ -116,7 +116,11 @@ class Magbead(Instrument):
         def _do():
             self.motor.wait(seconds)
 
-        _description = "Delaying Magbead for {} seconds".format(seconds)
+        minutes += int(seconds / 60)
+        seconds = int(seconds % 60)
+        _description = "Delaying {} minutes and {} seconds".format(
+            minutes, seconds)
+        seconds += (minutes * 60)
         self.create_command(
             do=_do,
             setup=_setup,

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -1294,7 +1294,7 @@ class Pipette(Instrument):
         return self
 
     # QUEUEABLE
-    def delay(self, seconds, enqueue=True):
+    def delay(self, seconds=0, minutes=0, enqueue=True):
         """
         Parameters
         ----------
@@ -1308,13 +1308,19 @@ class Pipette(Instrument):
             :any:`run` or :any:`simulate`. If set to `False`, the
             method will skip the command queue and execute immediately
         """
+
         def _setup():
             pass
 
         def _do():
+            nonlocal seconds
             self.motor.wait(seconds)
 
-        _description = "Delaying {} seconds".format(seconds)
+        minutes += int(seconds / 60)
+        seconds = seconds % 60
+        _description = "Delaying {} minutes and {} seconds".format(
+            minutes, seconds)
+        seconds += float(minutes * 60)
         self.create_command(
             do=_do,
             setup=_setup,

--- a/tests/opentrons/labware/test_magbead.py
+++ b/tests/opentrons/labware/test_magbead.py
@@ -42,8 +42,9 @@ class MagbeadTest(unittest.TestCase):
 
     def test_magbead_delay(self):
         self.magbead.engage()
-        self.magbead.delay(2.2)
+        self.magbead.delay(2)
         self.magbead.disengage()
+        self.magbead.delay(minutes=2)
         self.robot.run()
 
         calls = self.robot._driver.set_mosfet.mock_calls
@@ -51,5 +52,5 @@ class MagbeadTest(unittest.TestCase):
         self.assertEquals(calls, expected)
 
         calls = self.robot._driver.wait.mock_calls
-        expected = [mock.call(2.2)]
+        expected = [mock.call(2), mock.call(120)]
         self.assertEquals(calls, expected)

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -374,7 +374,7 @@ class PipetteTest(unittest.TestCase):
             self.robot._commands[-1].description,
             "Delaying 0 minutes and 1 seconds")
 
-        robot.clear_commands()
+        self.robot.clear_commands()
         self.p200.delay(seconds=12, minutes=10)
 
         self.assertEqual(

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -372,7 +372,14 @@ class PipetteTest(unittest.TestCase):
 
         self.assertEqual(
             self.robot._commands[-1].description,
-            "Delaying 1 seconds")
+            "Delaying 0 minutes and 1 seconds")
+
+        robot.clear_commands()
+        self.p200.delay(seconds=12, minutes=10)
+
+        self.assertEqual(
+            self.robot._commands[-1].description,
+            "Delaying 10 minutes and 12 seconds")
 
     def test_set_speed(self):
         self.p200.set_speed(aspirate=100)


### PR DESCRIPTION
`pipette.delay(10)` will delay for 10 seconds

`pipette.delay(10, 2)` will delay for 2 minutes and 10 seconds

`pipette.delay(minutes=10)` will delay for 10  minutes

`pipette.delay(seconds=120)` will delay for 2 minutes (120 seconds)

`pipette.delay(seconds=10, minutes=2)` will delay for 2 minutes and 10 seconds

`pipette.delay(minutes=2, seconds=10)` will delay for 2 minutes and 10 seconds