### PR TITLE
Require python 3.5 or above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
 - '3.5'
+- '3.6'
 before_install:
 - openssl aes-256-cbc -K $encrypted_f176ff9ac49f_key -iv $encrypted_f176ff9ac49f_iv -in .pypirc.enc -out $HOME/.pypirc -d
 install:

--- a/opentrons/__init__.py
+++ b/opentrons/__init__.py
@@ -7,9 +7,9 @@ from ._version import get_versions
 
 
 version = sys.version_info[0:2]
-if version != (3, 5):
+if version < (3, 5):
     raise RuntimeError(
-        'opentrons requires Python 3.5, this is {0}.{1}'.format(
+        'opentrons requires Python 3.5 or above, this is {0}.{1}'.format(
             version[0], version[1]))
 
 robot = Robot()


### PR DESCRIPTION
This PR:
* Changes the requirement from Python == 3.5 to Python >= 3.6
* Adds tests for Python 3.5 and 3.6 to travis