### PR TITLE
Route placeable call args to wells

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -597,6 +597,12 @@ class Container(Placeable):
             return new_wells[0]
         return new_wells
 
+    def __call__(self, *args, **kwargs):
+        """
+        Passes all arguments to Wells() and returns result
+        """
+        return self.wells(*args, **kwargs)
+
     def get(self, *args, **kwargs):
         """
         Passes all arguments to Wells() and returns result

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -201,6 +201,7 @@ class PlaceableTestCase(unittest.TestCase):
         expected = [c[n] for n in ['A1', 'B2', 'C3']]
         self.assertWellSeriesEqual(c.wells('A1', 'B2', 'C3'), expected)
         self.assertWellSeriesEqual(c.get('A1', 'B2', 'C3'), expected)
+        self.assertWellSeriesEqual(c('A1', 'B2', 'C3'), expected)
 
         expected = [c.cols[0][0], c.cols[0][5]]
         self.assertWellSeriesEqual(c.cols['A'].wells('1', '6'), expected)
@@ -209,6 +210,7 @@ class PlaceableTestCase(unittest.TestCase):
         expected = [c.cols[0][0], c.cols[0][5]]
         self.assertWellSeriesEqual(c.cols['A'].wells(['1', '6']), expected)
         self.assertWellSeriesEqual(c.cols['A'].get('1', '6'), expected)
+        self.assertWellSeriesEqual(c.cols('A').get('1', '6'), expected)
 
         expected = c.wells('A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1')
         self.assertWellSeriesEqual(c.wells('A1', to='H1'), expected)

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -220,6 +220,9 @@ class PlaceableTestCase(unittest.TestCase):
         self.assertWellSeriesEqual(c.wells('A1', to='H1', step=2), expected)
         self.assertWellSeriesEqual(c.get('A1', to='H1', step=2), expected)
 
+        expected = c.rows['1':'12':2]
+        self.assertWellSeriesEqual(c.rows('1', to='12', step=2), expected)
+
         expected = c.wells(
             'A3', 'G2', 'E2', 'C2', 'A2', 'G1', 'E1', 'C1', 'A1')
         self.assertWellSeriesEqual(c.wells('A3', to='A1', step=2), expected)


### PR DESCRIPTION
Makes `Placeable` class callable by adding `def __call__()`, which then passes all arguments to `Placeable.wells()` and return results. This allows for the following syntax:

```python
plate.rows('2', to='12')
plate.cols('B', length=3, step=2)
```