### PR TITLE
Chain and cycle for wellseries

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -1,3 +1,4 @@
+import itertools
 import math
 import numbers
 from collections import OrderedDict
@@ -127,6 +128,15 @@ class Placeable(object):
         children = self.parent.get_children_list()
         my_loc = children.index(self)
         return children[my_loc + 1]
+
+    def chain(self, *args):
+        return itertools.chain(self.get_children_list(), *args)
+
+    def iter(self, *args):
+        return iter(self.get_children_list())
+
+    def cycle(self):
+        return itertools.cycle(self.get_children_list())
 
     def get_name(self):
         """

--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -129,13 +129,23 @@ class Placeable(object):
         my_loc = children.index(self)
         return children[my_loc + 1]
 
-    def chain(self, *args):
-        return itertools.chain(self.get_children_list(), *args)
-
-    def iter(self, *args):
+    def iter(self):
+        """
+        Returns an iterable built from this Placeable's children list
+        """
         return iter(self.get_children_list())
 
+    def chain(self, *args):
+        """
+        Returns an itertools.chain built from this Placeable's children list
+        and appending any passed lists with *args
+        """
+        return itertools.chain(self.get_children_list(), *args)
+
     def cycle(self):
+        """
+        Returns an itertools.cycle from this Placeable's children list
+        """
         return itertools.cycle(self.get_children_list())
 
     def get_name(self):

--- a/tests/opentrons/containers/test_placeable.py
+++ b/tests/opentrons/containers/test_placeable.py
@@ -60,6 +60,31 @@ class PlaceableTestCase(unittest.TestCase):
 
         self.assertEqual(next(well), expected)
 
+    def test_cycle(self):
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        cycle_iter = c.cycle()
+        for n in range(3):
+            for i in range(4):
+                self.assertEqual(next(cycle_iter), c[i])
+
+    def test_iter_method(self):
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        cycle_iter = c.iter()
+        for i in range(4):
+            self.assertEqual(next(cycle_iter), c[i])
+
+    def test_chain_method(self):
+        a = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        b = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
+        cycle_iter = a.chain(b, c)
+        for i in range(4):
+            self.assertEqual(next(cycle_iter), a[i])
+        for i in range(4):
+            self.assertEqual(next(cycle_iter), b[i])
+        for i in range(4):
+            self.assertEqual(next(cycle_iter), c[i])
+
     def test_int_index(self):
         c = self.generate_plate(4, 2, (5, 5), (0, 0), 5)
 


### PR DESCRIPTION
Adds methods to `Placeable` for creating iterables, chain, and cycle iterables, built from the `Placeable`'s children list

```python
plate.wells('A1', 'B2', 'C3').iter()
plate.wells('A1', 'B2', 'C3').cycle()
plate.wells('A1', 'B2', 'C3').chain(trough.wells('A1', 'A2'))
```

previously would have been
```python
iter(plate.wells('A1', 'B2', 'C3'))
itertools.cycle(plate.wells('A1', 'B2', 'C3'))
itertools.chain(plate.wells('A1', 'B2', 'C3'), trough.wells('A1', 'A2'))
```