### PR TITLE
Transfer locations divisible

### DIFF
--- a/opentrons/helpers/helpers.py
+++ b/opentrons/helpers/helpers.py
@@ -1,7 +1,6 @@
 import json
 
 from opentrons.util.vector import Vector
-from opentrons.containers.placeable import Placeable
 
 
 def unpack_coordinates(coordinates):

--- a/opentrons/helpers/helpers.py
+++ b/opentrons/helpers/helpers.py
@@ -223,6 +223,7 @@ def _compress_for_distribute(max_vol, plan, **kwargs):
     temp_dispenses = []
     new_transfer_plan = []
     disposal_vol = kwargs.get('disposal_vol', 0)
+    max_vol = max_vol - disposal_vol
 
     def _append_dispenses():
         nonlocal a_vol, temp_dispenses, new_transfer_plan, source
@@ -250,7 +251,7 @@ def _compress_for_distribute(max_vol, plan, **kwargs):
     for p in plan:
         this_vol = p['aspirate']['volume']
         new_source = p['aspirate']['location']
-        if (new_source is not source) or (this_vol + a_vol > max_vol - disposal_vol):
+        if (new_source is not source) or (this_vol + a_vol > max_vol):
             _append_dispenses()
         source = new_source
         a_vol += this_vol

--- a/opentrons/helpers/helpers.py
+++ b/opentrons/helpers/helpers.py
@@ -112,21 +112,25 @@ def _get_list(n):
 def _create_source_target_lists(s, t, **kwargs):
     s = _get_list(s)
     t = _get_list(t)
+    len_s = len(s)
+    len_t = len(t)
     mode = kwargs.get('mode', 'transfer')
-    if mode == 'transfer':
-        if len(s) != len(t):
-            raise RuntimeError(
-                'Transfer sources/targets must be same length')
-    elif mode == 'distribute':
-        if not (len(t) >= len(s) == 1):
-            raise RuntimeError(
-                'Distribute must have 1 source and multiple targets')
-        s *= len(t)
-    elif mode == 'consolidate':
-        if not (len(s) >= len(t) == 1):
-            raise RuntimeError(
-                'Consolidate must have multiple sources and 1 target')
-        t *= len(s)
+    if len_s < len_t:
+        if mode is 'consolidate':
+            raise ValueError(
+                'Consolidate requires more sources than destinations')
+        if (len_t / len_s) % 1 > 0:
+            raise ValueError(
+                'Source and destination lists must be divisible')
+        s = [source for source in s for i in range(int(len_t / len_s))]
+    elif len_s > len_t:
+        if mode is 'distribute':
+            raise ValueError(
+                'Distribute requires more destinations than sources')
+        if (len_s / len_t) % 1 > 0:
+            raise ValueError(
+                'Source and destination lists must be divisible')
+        t = [dest for dest in t for i in range(int(len_s / len_t))]
     return (s, t)
 
 
@@ -213,7 +217,8 @@ def _compress_for_distribute(max_vol, plan, **kwargs):
     """
     Combines as many dispenses as can fit within the maximum volume
     """
-    source = plan[0]['aspirate']['location']
+    source = None
+    new_source = None
     a_vol = 0
     temp_dispenses = []
     new_transfer_plan = []
@@ -244,8 +249,10 @@ def _compress_for_distribute(max_vol, plan, **kwargs):
 
     for p in plan:
         this_vol = p['aspirate']['volume']
-        if this_vol + a_vol > max_vol - disposal_vol:
+        new_source = p['aspirate']['location']
+        if (new_source is not source) or (this_vol + a_vol > max_vol - disposal_vol):
             _append_dispenses()
+        source = new_source
         a_vol += this_vol
         temp_dispenses.append(p['dispense'])
     _append_dispenses()
@@ -256,13 +263,16 @@ def _compress_for_consolidate(max_vol, plan, **kwargs):
     """
     Combines as many aspirates as can fit within the maximum volume
     """
-    target = plan[0]['dispense']['location']
+    target = None
+    new_target = None
     d_vol = 0
     temp_aspirates = []
     new_transfer_plan = []
 
     def _append_aspirates():
         nonlocal d_vol, temp_aspirates, new_transfer_plan, target
+        if not temp_aspirates:
+            return
         for a in temp_aspirates:
             new_transfer_plan.append({
                 'aspirate': {
@@ -279,8 +289,10 @@ def _compress_for_consolidate(max_vol, plan, **kwargs):
 
     for i, p in enumerate(plan):
         this_vol = p['aspirate']['volume']
-        if this_vol + d_vol > max_vol:
+        new_target = p['dispense']['location']
+        if (new_target is not target) or (this_vol + d_vol > max_vol):
             _append_aspirates()
+        target = new_target
         d_vol += this_vol
         temp_aspirates.append(p['aspirate'])
     _append_aspirates()

--- a/opentrons/helpers/helpers.py
+++ b/opentrons/helpers/helpers.py
@@ -104,8 +104,6 @@ def import_calibration_file(file_name, robot):
 def _get_list(n):
     if not hasattr(n, '__len__') or len(n) == 0 or isinstance(n, tuple):
         n = [n]
-    if isinstance(n, Placeable) and len(n) == 1:
-        n = [n[0]]
     return n
 
 

--- a/opentrons/instruments/__init__.py
+++ b/opentrons/instruments/__init__.py
@@ -4,3 +4,11 @@ from opentrons.instruments.pipette import Pipette
 __all__ = [
     Magbead,
     Pipette]
+
+
+def load(axis, name):
+    pass
+
+
+def create(*args, **kwargs):
+    return Pipette(*args, **kwargs)

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -1147,9 +1147,6 @@ class Pipette(Instrument):
         <opentrons.instruments.pipette.Pipette object at ...>
         """
         kwargs['mode'] = 'distribute'
-        kwargs['new_tip'] = kwargs.get('new_tip', 'once')
-        if kwargs['new_tip'] is 'always':
-            kwargs['new_tip'] = 'once'
         kwargs['mix_after'] = (0, 0)
         if 'disposal_vol' not in kwargs:
             kwargs['disposal_vol'] = self.min_volume
@@ -1176,9 +1173,6 @@ class Pipette(Instrument):
         <opentrons.instruments.pipette.Pipette object at ...>
         """
         kwargs['mode'] = 'consolidate'
-        kwargs['new_tip'] = kwargs.get('new_tip', 'once')
-        if kwargs['new_tip'] is 'always':
-            kwargs['new_tip'] = 'once'
         kwargs['mix_before'] = (0, 0)
         kwargs['air_gap'] = 0
         kwargs['disposal_vol'] = 0
@@ -1277,6 +1271,11 @@ class Pipette(Instrument):
         """
 
         kwargs['mode'] = kwargs.get('mode', 'transfer')
+
+        touch_tip = kwargs.get('touch_tip', False)
+        if touch_tip is True:
+            touch_tip = -1
+        kwargs['touch_tip'] = touch_tip
 
         tip_options = {
             'once': 1,
@@ -1579,11 +1578,7 @@ class Pipette(Instrument):
     def _run_transfer_plan(self, tips, plan, **kwargs):
         enqueue = kwargs.get('enqueue', True)
         air_gap = kwargs.get('air_gap', 0)
-
-        touch_tip = kwargs.get('touch_tip', False)
-        if touch_tip is True:
-            touch_tip = -1
-        kwargs['touch_tip'] = touch_tip
+        touch_tip = kwargs.get('touch_tip', -1)
 
         total_transfers = len(plan)
         for i, step in enumerate(plan):

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -1594,18 +1594,16 @@ class Pipette(Instrument):
             if dispense:
                 self._dispense_during_transfer(
                     dispense['volume'], dispense['location'], **kwargs)
+                if touch_tip or touch_tip is 0:
+                    self.touch_tip(touch_tip, enqueue=enqueue)
                 if step is plan[-1] or plan[i + 1].get('aspirate'):
                     self._blowout_during_transfer(
                         dispense['location'], **kwargs)
-                    if touch_tip or touch_tip is 0:
-                        self.touch_tip(touch_tip, enqueue=enqueue)
                     tips = self._drop_tip_during_transfer(
                         tips, i, total_transfers, **kwargs)
                 else:
                     if air_gap:
                         self.air_gap(air_gap, enqueue=enqueue)
-                    if touch_tip or touch_tip is 0:
-                        self.touch_tip(touch_tip, enqueue=enqueue)
 
     def _add_tip_during_transfer(self, tips, **kwargs):
         """
@@ -1630,10 +1628,10 @@ class Pipette(Instrument):
         if self.current_volume == 0:
             self._mix_during_transfer(mix_before, loc, **kwargs)
         self.aspirate(vol, loc, rate=rate, enqueue=enqueue)
-        if air_gap:
-            self.air_gap(air_gap, enqueue=enqueue)
         if touch_tip or touch_tip is 0:
             self.touch_tip(touch_tip, enqueue=enqueue)
+        if air_gap:
+            self.air_gap(air_gap, enqueue=enqueue)
 
     def _dispense_during_transfer(self, vol, loc, **kwargs):
         """

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -394,7 +394,7 @@ class PipetteTest(unittest.TestCase):
             30,
             self.plate[0],
             self.plate[1:9],
-            new_tip='always'  # should use only 1 tip
+            new_tip='always'
         )
         # from pprint import pprint
         # print('\n\n***\n')
@@ -409,6 +409,8 @@ class PipetteTest(unittest.TestCase):
             ['dispensing', '30', 'Well F1'],
             ['dispensing', '30', 'Well G1'],
             ['blow_out', 'point'],
+            ['drop'],
+            ['pick'],
             ['aspirating', '70', 'Well A1'],
             ['dispensing', '30', 'Well H1'],
             ['dispensing', '30', 'Well A2'],
@@ -512,7 +514,7 @@ class PipetteTest(unittest.TestCase):
             30,
             self.plate[0:8],
             self.plate['A2'],
-            new_tip='always'  # should use only 1 tip
+            new_tip='always'
         )
         # from pprint import pprint
         # print('\n\n***\n')
@@ -526,6 +528,8 @@ class PipetteTest(unittest.TestCase):
             ['aspirating', '30', 'Well E1'],
             ['aspirating', '30', 'Well F1'],
             ['dispensing', '180', 'Well A2'],
+            ['drop'],
+            ['pick'],
             ['aspirating', '30', 'Well G1'],
             ['aspirating', '30', 'Well H1'],
             ['dispensing', '60', 'Well A2'],
@@ -740,6 +744,85 @@ class PipetteTest(unittest.TestCase):
             self.plate[1],
             new_tip='sometimes'
         )
+
+    def test_divisible_locations(self):
+        self.p200.reset()
+        self.p200.transfer(
+            100,
+            self.plate[0:4],
+            self.plate[0:2]
+        )
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
+        expected = [
+            ['pick'],
+            ['aspirating', '100', 'Well A1'],
+            ['dispensing', '100', 'Well A1'],
+            ['aspirating', '100', 'Well B1'],
+            ['dispensing', '100', 'Well A1'],
+            ['aspirating', '100', 'Well C1'],
+            ['dispensing', '100', 'Well B1'],
+            ['aspirating', '100', 'Well D1'],
+            ['dispensing', '100', 'Well B1'],
+            ['drop']
+        ]
+        self.assertEqual(len(self.robot.commands()), len(expected))
+        for i, c in enumerate(self.robot.commands()):
+            for s in expected[i]:
+                self.assertTrue(s.lower() in c.lower())
+        self.robot.clear_commands()
+
+        self.p200.reset()
+        self.p200.consolidate(
+            100,
+            self.plate[0:4],
+            self.plate[0:2]
+        )
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
+        expected = [
+            ['pick'],
+            ['aspirating', '100', 'Well A1'],
+            ['aspirating', '100', 'Well B1'],
+            ['dispensing', '200', 'Well A1'],
+            ['aspirating', '100', 'Well C1'],
+            ['aspirating', '100', 'Well D1'],
+            ['dispensing', '200', 'Well B1'],
+            ['drop']
+        ]
+        self.assertEqual(len(self.robot.commands()), len(expected))
+        for i, c in enumerate(self.robot.commands()):
+            for s in expected[i]:
+                self.assertTrue(s.lower() in c.lower())
+        self.robot.clear_commands()
+
+        self.p200.reset()
+        self.p200.distribute(
+            100,
+            self.plate[0:2],
+            self.plate[0:4],
+            disposal_vol=0
+        )
+        # from pprint import pprint
+        # print('\n\n***\n')
+        # pprint(self.robot.commands())
+        expected = [
+            ['pick'],
+            ['aspirating', '200', 'Well A1'],
+            ['dispensing', '100', 'Well A1'],
+            ['dispensing', '100', 'Well B1'],
+            ['aspirating', '200', 'Well B1'],
+            ['dispensing', '100', 'Well C1'],
+            ['dispensing', '100', 'Well D1'],
+            ['drop']
+        ]
+        self.assertEqual(len(self.robot.commands()), len(expected))
+        for i, c in enumerate(self.robot.commands()):
+            for s in expected[i]:
+                self.assertTrue(s.lower() in c.lower())
+        self.robot.clear_commands()
 
     def test_transfer_volume_control(self):
 

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -635,81 +635,81 @@ class PipetteTest(unittest.TestCase):
             blow_out=True,
             trash=True
         )
-        # from pprint import pprint
-        # print('\n\n***\n')
-        # pprint(self.robot.commands())
+        from pprint import pprint
+        print('\n\n***\n')
+        pprint(self.robot.commands())
         expected = [
             ['pick'],
             ['aspirating', '30', 'Well A1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well B1'],
             ['dispensing', '30', 'Well B1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well B1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well C1'],
             ['dispensing', '30', 'Well C1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well C1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well D1'],
             ['dispensing', '30', 'Well D1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well D1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well E1'],
             ['dispensing', '30', 'Well E1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well E1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well F1'],
             ['dispensing', '30', 'Well F1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well F1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well G1'],
             ['dispensing', '30', 'Well G1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well G1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well H1'],
             ['dispensing', '30', 'Well H1'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop'],
             ['pick'],
             ['aspirating', '30', 'Well H1'],
-            ['air'], ['moving'], ['aspirating', '10'],
             ['touch'],
+            ['air'], ['moving'], ['aspirating', '10'],
             ['dispensing', '10', 'Well A2'],
             ['dispensing', '30', 'Well A2'],
-            ['blow'],
             ['touch'],
+            ['blow'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
@@ -738,10 +738,51 @@ class PipetteTest(unittest.TestCase):
 
         self.assertRaises(
             ValueError,
+            self.p200.consolidate,
+            30,
+            self.plate[0],
+            self.plate[1:3]
+        )
+
+        self.assertRaises(
+            ValueError,
+            self.p200.distribute,
+            30,
+            self.plate[0:2],
+            self.plate[0:5]
+        )
+
+        self.assertRaises(
+            ValueError,
+            self.p200.consolidate,
+            30,
+            self.plate[0:5],
+            self.plate[0:2]
+        )
+
+        self.assertRaises(
+            ValueError,
+            self.p200.distribute,
+            30,
+            self.plate[0:3],
+            self.plate[1]
+        )
+
+        self.assertRaises(
+            ValueError,
             self.p200.transfer,
             30,
             self.plate[0],
             self.plate[1],
+            new_tip='sometimes'
+        )
+
+        self.assertRaises(
+            ValueError,
+            self.p200.transfer,
+            [20, 20, 20, 20],
+            self.plate[0:3],
+            self.plate[1:4],
             new_tip='sometimes'
         )
 
@@ -929,8 +970,9 @@ class PipetteTest(unittest.TestCase):
             (10, 80),
             self.plate[0],
             self.plate.rows[1],
-            touch_tip=False,
+            touch_tip=True,
             blow_out=False,
+            air_gap=20,
             gradient=lambda x: 1.0 - x
         )
         # from pprint import pprint
@@ -939,19 +981,62 @@ class PipetteTest(unittest.TestCase):
         expected = [
             ['pick'],
             ['aspirating', '160', 'Well A1'],
+            ['touch'],
+            ['air'],
+            ['moving', 'A1'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well A2'],
             ['dispensing', '80', 'Well A2'],
+            ['touch'],
+            ['air'],
+            ['moving', 'A2'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well B2'],
             ['dispensing', '70', 'Well B2'],
-            ['blow_out', 'point'],
-            ['aspirating', '190', 'Well A1'],
+            ['touch'],
+            ['blow', 'point'],
+            ['aspirating', '160', 'Well A1'],
+            ['touch'],
+            ['air'],
+            ['moving', 'A1'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well C2'],
             ['dispensing', '60', 'Well C2'],
+            ['touch'],
+            ['air'],
+            ['moving', 'C2'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well D2'],
             ['dispensing', '50', 'Well D2'],
+            ['touch'],
+            ['air'],
+            ['moving', 'D2'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well E2'],
             ['dispensing', '40', 'Well E2'],
+            ['touch'],
+            ['blow'],
+            ['aspirating', '70', 'Well A1'],
+            ['touch'],
+            ['air'],
+            ['moving', 'A1'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well F2'],
             ['dispensing', '30', 'Well F2'],
-            ['blow_out', 'point'],
-            ['aspirating', '40', 'Well A1'],
+            ['touch'],
+            ['air'],
+            ['moving', 'F2'],
+            ['aspirating', '20'],
             ['dispensing', '20', 'Well G2'],
+            ['dispensing', '20', 'Well G2'],
+            ['touch'],
+            ['air'],
+            ['moving', 'G2'],
+            ['aspirating', '20'],
+            ['dispensing', '20', 'Well H2'],
             ['dispensing', '10', 'Well H2'],
-            ['blow_out', 'point'],
+            ['touch'],
+            ['blow'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))


### PR DESCRIPTION
Transfer source and destination lists can be of different lengths, and it will evenly spread the lesser list of wells across the greater list. If the lists aren't evenly divisible, pipette raises an exception.

```python
pipette.transfer(20, plate.wells('A1', 'B1'), plate.wells('C1', 'D1', 'E1', 'F1'))
```
Creates:
  - 20uL from 'A1' to 'C1'
  - 20uL from 'A1' to 'D1'
  - 20uL from 'B1' to 'E1'
  - 20uL from 'B1' to 'F1'