### PR TITLE
add kwargs radius= to .touch_tip(); adds test

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -691,7 +691,7 @@ class Pipette(Instrument):
         return self
 
     # QUEUEABLE
-    def touch_tip(self, location=None, radius=1, enqueue=True):
+    def touch_tip(self, location=None, radius=1.0, enqueue=True):
         """
         Touch the :any:`Pipette` tip to the sides of a well,
         with the intent of removing left-over droplets

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -691,7 +691,7 @@ class Pipette(Instrument):
         return self
 
     # QUEUEABLE
-    def touch_tip(self, location=None, enqueue=True):
+    def touch_tip(self, location=None, radius=1, enqueue=True):
         """
         Touch the :any:`Pipette` tip to the sides of a well,
         with the intent of removing left-over droplets
@@ -707,6 +707,13 @@ class Pipette(Instrument):
             The :any:`Placeable` (:any:`Well`) to perform the touch_tip.
             Can also be a tuple with first item :any:`Placeable`,
             second item relative :any:`Vector`
+
+        radius : float
+            Radius is a floating point number between 0.0 and 1.0, describing
+            the percentage of a well's radius. When radius=1.0,
+            :any:`touch_tip()` will move to 100% of the wells radius. When
+            radius=0.5, :any:`touch_tip()` will move to 50% of the wells
+            radius.
 
         enqueue : bool
             If set to `True` (default), the method will be appended
@@ -738,7 +745,7 @@ class Pipette(Instrument):
             self._associate_placeable(location)
 
         def _do():
-            nonlocal location
+            nonlocal location, radius
 
             # if no location specified, use the previously
             # associated placeable to get Well dimensions
@@ -752,28 +759,28 @@ class Pipette(Instrument):
             self.move_to(
                 (
                     location,
-                    location.from_center(x=1, y=0, z=1) + v_offset
+                    location.from_center(x=radius, y=0, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=-1, y=0, z=1) + v_offset
+                    location.from_center(x=radius * -1, y=0, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=0, y=1, z=1) + v_offset
+                    location.from_center(x=0, y=radius, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)
             self.move_to(
                 (
                     location,
-                    location.from_center(x=0, y=-1, z=1) + v_offset
+                    location.from_center(x=0, y=radius * -1, z=1) + v_offset
                 ),
                 strategy='direct',
                 enqueue=False)

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -1278,6 +1278,7 @@ class PipetteTest(unittest.TestCase):
         self.p200.move_to = mock.Mock()
         self.p200.touch_tip(self.plate[0])
         self.p200.touch_tip(-3)
+        self.p200.touch_tip(-3, radius=0.5)
 
         self.robot.simulate()
 
@@ -1307,8 +1308,23 @@ class PipetteTest(unittest.TestCase):
                 enqueue=False, strategy='direct'),
             mock.call(
                 (self.plate[0], (3.20, 0.00, 7.50)),
-                enqueue=False, strategy='direct')]
+                enqueue=False, strategy='direct'),
+            mock.call(self.plate[0], enqueue=False, strategy='arc'),
+            mock.call(
+                (self.plate[0], (4.80, 3.20, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (1.60, 3.20, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 4.80, 7.50)),
+                enqueue=False, strategy='direct'),
+            mock.call(
+                (self.plate[0], (3.20, 1.60, 7.50)),
+                enqueue=False, strategy='direct')
+        ]
 
+        print(self.p200.move_to.mock_calls)
         self.assertEquals(expected, self.p200.move_to.mock_calls)
 
     def test_mix(self):


### PR DESCRIPTION
Small PR adding a kew-word argument `radius=` to touch-tip commands

```python
pipette.touch_tip(radius=0.5)  # percentage of the well's radius to move within
pipette.touch_tip(radius=1.0)  # default is 1.0 (100%)
```