### PR TITLE
defaults pipette's trash to specify trash[0] when dropping tip

### DIFF
--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -3,7 +3,7 @@ import itertools
 
 from opentrons import containers
 from opentrons.containers.calibrator import Calibrator
-from opentrons.containers.placeable import Placeable, WellSeries
+from opentrons.containers.placeable import Placeable, WellSeries, Container
 from opentrons.containers.placeable import humanize_location
 from opentrons.instruments.instrument import Instrument
 from opentrons.helpers import helpers
@@ -87,6 +87,8 @@ class Pipette(Instrument):
             name = self.__class__.__name__
         self.name = name
 
+        if isinstance(trash_container, Container) and len(trash_container) > 0:
+            trash_container = trash_container[0]
         self.trash_container = trash_container
         self.tip_racks = tip_racks
         self.starting_tip = None

--- a/tests/opentrons/json_importer/test_json_importer.py
+++ b/tests/opentrons/json_importer/test_json_importer.py
@@ -272,6 +272,6 @@ class JSONIngestorTestCase(unittest.TestCase):
             ('.75 mL Tube Rack', 'C1'),  # 1st transfer
             ('.75 mL Tube Rack', 'A1'),  # 2nd transfer
             ('.75 mL Tube Rack', 'C1'),  # 2nd transfer
-            ('B2', 'trash')  # Location of tiprack in trash
+            ('trash', 'A1')  # Location of tiprack in trash
         ]
         self.assertEqual(wells_referenced, wells_referenced_expected)

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -1567,7 +1567,7 @@ class PipetteTest(unittest.TestCase):
                 mock.call(
                     self.tiprack1[0].bottom(), enqueue=False, strategy='arc'),
                 mock.call(
-                    self.trash.bottom(self.p200._drop_tip_offset),
+                    self.trash[0].bottom(self.p200._drop_tip_offset),
                     enqueue=False,
                     strategy='arc')
             ]


### PR DESCRIPTION
Pipette will use that passed `trash_container`'s first well. So that it will be running `.drop_tip(trash[0])` instead of before it was doing `.drop_tip(trash)`. This is required when using a trash container that has dimensions (like container `"trash-box"`)