### PR TITLE
Pipette commands more readable

### DIFF
--- a/opentrons/containers/placeable.py
+++ b/opentrons/containers/placeable.py
@@ -100,7 +100,7 @@ class Placeable(object):
         """
         Return full path to the :Placeable: for debugging
         """
-        return '/'.join([str(i) for i in reversed(self.get_trace())])
+        return ''.join([str(i) for i in reversed(self.get_trace())])
 
     def __str__(self):
         if not self.parent:
@@ -695,9 +695,16 @@ class WellSeries(Container):
         """
         self.offset = offset
 
+    def __repr__(self):
+        """
+        Return full path to the :Placeable: for debugging
+        """
+        return str(self)
+
     def __str__(self):
-        return '<Series: {}>'.format(
-            ' '.join([str(well) for well in self.values]))
+        return '<{0}: {1}>'.format(
+            self.__class__.__name__,
+            ''.join([str(well) for well in self.values]))
 
     def __getattr__(self, name):
         # getstate/setstate are used by pickle and are not implemented by

--- a/opentrons/instruments/pipette.py
+++ b/opentrons/instruments/pipette.py
@@ -392,9 +392,9 @@ class Pipette(Instrument):
         if volume is 0:
             return self
 
-        _description = "Aspirating {0}uL at {1}".format(
+        _description = "Aspirating {0} {1}".format(
             volume,
-            (humanize_location(location) if location else '<In Place>')
+            ('at ' + humanize_location(location) if location else '')
         )
         self.create_command(
             do=_do,
@@ -508,9 +508,9 @@ class Pipette(Instrument):
         if volume is 0:
             return self
 
-        _description = "Dispensing {0}uL at {1}".format(
+        _description = "Dispensing {0} {1}".format(
             volume,
-            (humanize_location(location) if location else '<In Place>')
+            ('at ' + humanize_location(location) if location else '')
         )
         self.create_command(
             do=_do,
@@ -682,8 +682,8 @@ class Pipette(Instrument):
             self.move_to(location, strategy='arc', enqueue=False)
             self.motor.move(self._get_plunger_position('blow_out'))
 
-        _description = "Blow_out at {}".format(
-            humanize_location(location) if location else '<In Place>'
+        _description = "Blowing out {}".format(
+            'at ' + humanize_location(location) if location else ''
         )
         self.create_command(
             do=_do,
@@ -996,8 +996,8 @@ class Pipette(Instrument):
             self.robot.move_head(z=tip_plunge + 1, mode='relative')
             self.robot.move_head(z=-tip_plunge, mode='relative')
 
-        _description = "Picking up tip from {0}".format(
-            (humanize_location(location) if location else '<In Place>')
+        _description = "Picking up tip {0}".format(
+            ('from ' + humanize_location(location) if location else '')
         )
         self.create_command(
             do=_do,
@@ -1078,8 +1078,8 @@ class Pipette(Instrument):
 
             self.motor.move(self._get_plunger_position('bottom'))
 
-        _description = "Drop_tip at {}".format(
-            (humanize_location(location) if location else '<In Place>')
+        _description = "Drop_tip {}".format(
+            ('at ' + humanize_location(location) if location else '')
         )
 
         self.create_command(

--- a/opentrons/robot/robot.py
+++ b/opentrons/robot/robot.py
@@ -151,7 +151,7 @@ class Robot(object, metaclass=Singleton):
     >>> p200.aspirate(200, plate[0]) # doctest: +ELLIPSIS
     <opentrons.instruments.pipette.Pipette object at ...>
     >>> robot.commands()
-    ['Aspirating 200uL at <Deck>/<Slot A1>/<Container plate>/<Well A1>']
+    ['Aspirating 200 at <Deck><Slot A1><Container plate><Well A1>']
     >>> robot.simulate()
     []
     """

--- a/tests/opentrons/labware/test_pipette.py
+++ b/tests/opentrons/labware/test_pipette.py
@@ -408,13 +408,13 @@ class PipetteTest(unittest.TestCase):
             ['dispensing', '30', 'Well E1'],
             ['dispensing', '30', 'Well F1'],
             ['dispensing', '30', 'Well G1'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
             ['drop'],
             ['pick'],
             ['aspirating', '70', 'Well A1'],
             ['dispensing', '30', 'Well H1'],
             ['dispensing', '30', 'Well A2'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
@@ -430,9 +430,9 @@ class PipetteTest(unittest.TestCase):
             self.plate[1:9],
             new_tip='never'
         )
-        # from pprint import pprint
-        # print('\n\n***\n')
-        # pprint(self.robot.commands())
+        from pprint import pprint
+        print('\n\n***\n')
+        pprint(self.robot.commands())
         expected = [
             ['aspirating', '190', 'Well A1'],
             ['dispensing', '30', 'Well B1'],
@@ -441,11 +441,11 @@ class PipetteTest(unittest.TestCase):
             ['dispensing', '30', 'Well E1'],
             ['dispensing', '30', 'Well F1'],
             ['dispensing', '30', 'Well G1'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
             ['aspirating', '70', 'Well A1'],
             ['dispensing', '30', 'Well H1'],
             ['dispensing', '30', 'Well A2'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))
         for i, c in enumerate(self.robot.commands()):
@@ -949,14 +949,14 @@ class PipetteTest(unittest.TestCase):
             ['dispensing', '30', 'Well C2'],
             ['dispensing', '40', 'Well D2'],
             ['dispensing', '50', 'Well E2'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
             ['aspirating', '140', 'Well A1'],
             ['dispensing', '60', 'Well F2'],
             ['dispensing', '70', 'Well G2'],
-            ['blow_out', 'point'],
+            ['blow', 'point'],
             ['aspirating', '80', 'Well A1'],
             ['dispensing', '80', 'Well H2'],
-            ['blow_out', 'in place'],
+            ['blow'],
             ['drop']
         ]
         self.assertEqual(len(self.robot.commands()), len(expected))


### PR DESCRIPTION
Makes the output of `robot.commands()` slightly more readable, no more `"<In Place>"` when it's actually going to a tiprack, etc.