### PR TITLE
uses container slot to help filter for current container

### DIFF
--- a/app-src/src/components/Placeable.vue
+++ b/app-src/src/components/Placeable.vue
@@ -32,7 +32,7 @@
       },
       placeable () {
         let placeable = this.instrument().placeables.filter((p) => {
-          return p.label === this.params().placeable
+          return p.label === this.params().placeable && p.slot === this.params().slot
         })[0]
         let sanitized = ['point', 'tiprack', 'trough', 'tuberack'].filter((el) =>
           placeable.type.includes(el)


### PR DESCRIPTION
Removes bug from UI where calibrating placeables with same name doesn't create checkmarks next to the correct container.