### PR TITLE
Well bottom() and top() with radius/degrees

### DIFF
--- a/api/opentrons/containers/placeable.py
+++ b/api/opentrons/containers/placeable.py
@@ -403,7 +403,7 @@ class Placeable(object):
         """
         return self.from_center(x=0.0, y=0.0, z=0.0, reference=reference)
 
-    def bottom(self, z=0, reference=None):
+    def bottom(self, z=0, radius=0, degrees=0, reference=None):
         """
         Returns (:Placeable, :Vector:) tuple where :Vector:
         corresponds to the bottom of a :Placeable:
@@ -411,10 +411,14 @@ class Placeable(object):
         If :reference: :Placeable: is provided, returns
         the :Vector: within :reference: coordinate system
         """
-        coordinates = self.from_center(x=0, y=0, z=-1, reference=reference)
+        coordinates = self.from_center(
+            r=radius,
+            theta=(degrees / 180) * math.pi,
+            h=-1,
+            reference=reference)
         return (self, coordinates + (0, 0, z))
 
-    def top(self, z=0, reference=None):
+    def top(self, z=0, radius=0, degrees=0, reference=None):
         """
         Returns (:Placeable, :Vector:) tuple where :Vector:
         corresponds to the top of a :Placeable:
@@ -423,7 +427,11 @@ class Placeable(object):
         the :Vector: within :reference: coordinate system
         """
 
-        coordinates = self.from_center(x=0, y=0, z=1, reference=reference)
+        coordinates = self.from_center(
+            r=radius,
+            theta=(degrees / 180) * math.pi,
+            h=1,
+            reference=reference)
         return (self, coordinates + (0, 0, z))
 
     def from_center(self, x=None, y=None, z=None, r=None,

--- a/api/tests/opentrons/containers/test_placeable.py
+++ b/api/tests/opentrons/containers/test_placeable.py
@@ -225,6 +225,20 @@ class PlaceableTestCase(unittest.TestCase):
             plate['A1'].top(10),
             (plate['A1'], Vector(5, 5, 20)))
 
+        self.assertEqual(
+            plate['A1'].bottom(10, radius=1.0, degrees=90),
+            (plate['A1'], Vector(5, 10, 10)))
+        self.assertEqual(
+            plate['A1'].top(10, radius=1.0, degrees=90),
+            (plate['A1'], Vector(5, 10, 20)))
+
+        self.assertEqual(
+            plate['A1'].bottom(10, radius=0.5, degrees=270),
+            (plate['A1'], Vector(5, 2.5, 10.00)))
+        self.assertEqual(
+            plate['A1'].top(10, radius=0.5, degrees=270),
+            (plate['A1'], Vector(5, 2.5, 20.00)))
+
     def test_slice_with_strings(self):
         c = self.generate_plate(96, 8, (9, 9), (16, 11), 2.5, 40)
         self.assertWellSeriesEqual(c['A1':'A2'], c[0:8])


### PR DESCRIPTION
Small PR, adds `radius=` and `degrees=` optional kwargs to `Placeable.bottom()` and `Placeable.top()`