### PR TITLE
Pick-up-tip with N presses

### DIFF
--- a/api/opentrons/drivers/__init__.py
+++ b/api/opentrons/drivers/__init__.py
@@ -67,14 +67,14 @@ def get_serial_ports_list():
         raise EnvironmentError('Unsupported platform')
 
     result = []
-    port_filter = {'usbmodem', 'COM', 'ACM', 'USB'}
+    port_filter = {'usbmodem', 'usbserial', 'COM', 'ACM', 'USB'}
     for port in ports:
         try:
-            if any([f.lower() in port.lower() for f in port_filter]):
-                # s = serial.Serial()
-                # c = connection.Connection(
-                #     s, port=port, baudrate=115200, timeout=0.01)
-                # assert get_version(c) in drivers_by_version
+            if any([f in port for f in port_filter]):
+                s = serial.Serial()
+                c = connection.Connection(
+                    s, port=port, baudrate=115200, timeout=0.01)
+                c.open()
                 result.append(port)
         except Exception as e:
             log.debug(

--- a/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
+++ b/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
@@ -307,7 +307,7 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
         """
         if 'reset or M999' in msg or 'error:' in msg:
             self.calm_down()
-            time.sleep(0.2)  # necessary pause for Smoothie's internal state change
+            time.sleep(0.2)  # pause for Smoothie's internal state change
             self.calm_down()
             error_msg = 'Robot Error: limit switch hit'
             log.debug(error_msg)
@@ -477,7 +477,7 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
 
     def calm_down(self):
         self.connection.serial_pause()
-        res = self.send_command(self.CALM_DOWN, read_after=False)
+        self.send_command(self.CALM_DOWN, read_after=False)
         self.ignore_next_line()
         self.ignore_next_line()
         self.connection.serial_pause()

--- a/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
+++ b/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
@@ -132,9 +132,8 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
 
         self.versions_compatible()
 
-        self.prevent_squeal()
-
         self.calm_down()
+        self.prevent_squeal()
 
     def prevent_squeal(self):
         # TODO: (andy) Smoothieware EDGE has this weird bug,
@@ -308,6 +307,8 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
         """
         if 'reset or M999' in msg or 'error:' in msg:
             self.calm_down()
+            time.sleep(0.2)  # necessary pause for Smoothie's internal state change
+            self.calm_down()
             error_msg = 'Robot Error: limit switch hit'
             log.debug(error_msg)
             raise RuntimeWarning(error_msg)
@@ -475,10 +476,12 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
         })
 
     def calm_down(self):
-        res = self.send_command(self.CALM_DOWN)
-        if res != 'ok':
-            self.wait_for_ok()
-        self.wait_for_ok()
+        self.connection.serial_pause()
+        res = self.send_command(self.CALM_DOWN, read_after=False)
+        self.ignore_next_line()
+        self.ignore_next_line()
+        self.connection.serial_pause()
+        self.connection.flush_input()
 
     def send_halt_command(self):
         self.send_command(self.HALT, read_after=False)
@@ -538,7 +541,7 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
 
     def set_speed(self, *args, **kwargs):
         if len(args) > 0:
-            kwargs.update({'x': args[0], 'y': args[0]})
+            self.speeds.update({'x': args[0], 'y': args[0]})
         self.speeds.update({l: kwargs[l] for l in 'xyzab' if l in kwargs})
         if self.is_connected():
             kwargs = {

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -983,7 +983,7 @@ class Pipette(Instrument):
 
             self.current_volume = 0
 
-            if not presses or not isinstance(presses, (int, float, complex)) or presses < 1:
+            if not isinstance(presses, (int, float, complex)) or presses < 1:
                 presses = 1
 
         def _do():

--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -922,7 +922,7 @@ class Pipette(Instrument):
         return self
 
     # QUEUEABLE
-    def pick_up_tip(self, location=None, enqueue=True):
+    def pick_up_tip(self, location=None, presses=3, enqueue=True):
         """
         Pick up a tip for the Pipette to run liquid-handling commands with
 
@@ -968,7 +968,7 @@ class Pipette(Instrument):
         <opentrons.instruments.pipette.Pipette object at ...>
         """
         def _setup():
-            nonlocal location
+            nonlocal location, presses
             if not location:
                 location = self.get_next_tip()
             self.current_tip(None)
@@ -983,18 +983,22 @@ class Pipette(Instrument):
 
             self.current_volume = 0
 
+            if not presses or not isinstance(presses, (int, float, complex)) or presses < 1:
+                presses = 1
+
         def _do():
-            nonlocal location
+            nonlocal location, presses
 
             if location:
                 self.move_to(location, strategy='arc', enqueue=False)
 
             tip_plunge = 6
 
-            self.robot.move_head(z=tip_plunge, mode='relative')
-            self.robot.move_head(z=-tip_plunge - 1, mode='relative')
-            self.robot.move_head(z=tip_plunge + 1, mode='relative')
-            self.robot.move_head(z=-tip_plunge, mode='relative')
+            for i in range(int(presses) - 1):
+                self.robot.move_head(z=tip_plunge, mode='relative')
+                self.robot.move_head(z=-tip_plunge - 1, mode='relative')
+                self.robot.move_head(z=tip_plunge + 1, mode='relative')
+                self.robot.move_head(z=-tip_plunge, mode='relative')
 
         _description = "Picking up tip {0}".format(
             ('from ' + humanize_location(location) if location else '')

--- a/api/tests/opentrons/labware/test_pipette.py
+++ b/api/tests/opentrons/labware/test_pipette.py
@@ -354,6 +354,24 @@ class PipetteTest(unittest.TestCase):
         current_pos = self.robot._driver.get_head_position()['current']
         self.assertEqual(current_pos, target_pos)
 
+        last_well = self.tiprack1[-1]
+        target_pos = last_well.from_center(
+            x=0, y=0, z=-1,
+            reference=self.robot._deck)
+        self.p200.pick_up_tip(last_well, presses=0)
+        self.robot.run()
+        current_pos = self.robot._driver.get_head_position()['current']
+        self.assertEqual(current_pos, target_pos)
+
+        last_well = self.tiprack1[-1]
+        target_pos = last_well.from_center(
+            x=0, y=0, z=-1,
+            reference=self.robot._deck)
+        self.p200.pick_up_tip(last_well, presses='a')
+        self.robot.run()
+        current_pos = self.robot._driver.get_head_position()['current']
+        self.assertEqual(current_pos, target_pos)
+
     def test_drop_tip(self):
         self.p200.drop_tip()
 


### PR DESCRIPTION
Adds optional kwargs `presses=` to `Pipette.pick_up_tip()`, to set the number of times a tip is pressed on when being picked up. This defaults to `presses=3`, and values below `1` will be ignored.

```python
pipette.pick_up_tip(presses=1)
pipette.aspirate().dispense().return_tip()
```

Also adds some minor adjustment to `SmoothieDriver` to better handle an error received from Smoothie, as well and reinstating port filtering by name when discovering serial ports.