### PR TITLE
Refactor wait_for_arrival() to include timeout

### DIFF
--- a/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
+++ b/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
@@ -295,6 +295,8 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
     def wait_for_arrival(self, tolerance=0.5):
         target = self.get_target_position()
 
+        prev_max_diff = 0
+        did_move_timestamp = time.time()
         while True:
             self.check_paused_stopped()
             self.connection.serial_pause()
@@ -308,8 +310,16 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
             diff_a = abs(diff.get('a', 0))
             diff_b = abs(diff.get('b', 0))
 
-            if max(diff_head, diff_a, diff_b) < tolerance:
+            max_diff = max(diff_head, diff_a, diff_b)
+
+            if max_diff < tolerance:
                 return
+            if max_diff != prev_max_diff:
+                did_move_timestamp = time.time()
+            prev_max_diff = max_diff
+            if time.time() - did_move_timestamp > 1.0:
+                raise RuntimeError('Expected robot to move, please reconnect')
+
 
     def home(self, *axis):
 

--- a/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
+++ b/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
@@ -320,7 +320,6 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
             if time.time() - did_move_timestamp > 1.0:
                 raise RuntimeError('Expected robot to move, please reconnect')
 
-
     def home(self, *axis):
 
         self.send_halt_command()

--- a/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
+++ b/api/opentrons/drivers/smoothie_drivers/v2_0_0/driver.py
@@ -297,6 +297,7 @@ class SmoothieDriver_2_0_0(SmoothieDriver):
 
         while True:
             self.check_paused_stopped()
+            self.connection.serial_pause()
 
             current = self.get_current_position()
             diff = {}

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -24,21 +24,21 @@ class InstrumentMosfet(object):
     Provides access to MagBead's MOSFET.
     """
 
-    def __init__(self, driver, mosfet_index):
-        self.motor_driver = driver
+    def __init__(self, this_robot, mosfet_index):
+        self.robot = this_robot
         self.mosfet_index = mosfet_index
 
     def engage(self):
         """
         Engages the MOSFET.
         """
-        self.motor_driver.set_mosfet(self.mosfet_index, True)
+        self.robot._driver.set_mosfet(self.mosfet_index, True)
 
     def disengage(self):
         """
         Disengages the MOSFET.
         """
-        self.motor_driver.set_mosfet(self.mosfet_index, False)
+        self.robot._driver.set_mosfet(self.mosfet_index, False)
 
     def wait(self, seconds):
         """
@@ -49,15 +49,15 @@ class InstrumentMosfet(object):
         seconds : int
             Number of seconds to pause for.
         """
-        self.motor_driver.wait(seconds)
+        self.robot._driver.wait(seconds)
 
 
 class InstrumentMotor(object):
     """
     Provides access to Robot's head motor.
     """
-    def __init__(self, driver, axis):
-        self.motor_driver = driver
+    def __init__(self, this_robot, axis):
+        self.robot = this_robot
         self.axis = axis
 
     def move(self, value, mode='absolute'):
@@ -71,7 +71,7 @@ class InstrumentMotor(object):
         mode : {'absolute', 'relative'}
         """
         kwargs = {self.axis: value}
-        self.motor_driver.move_plunger(
+        self.robot._driver.move_plunger(
             mode=mode, **kwargs
         )
 
@@ -79,7 +79,7 @@ class InstrumentMotor(object):
         """
         Home plunger motor.
         """
-        self.motor_driver.home(self.axis)
+        self.robot._driver.home(self.axis)
 
     def wait(self, seconds):
         """
@@ -90,7 +90,7 @@ class InstrumentMotor(object):
         seconds : int
             Number of seconds to pause for.
         """
-        self.motor_driver.wait(seconds)
+        self.robot._driver.wait(seconds)
 
     def speed(self, rate):
         """
@@ -100,7 +100,7 @@ class InstrumentMotor(object):
         ----------
         rate : int
         """
-        self.motor_driver.set_plunger_speed(rate, self.axis)
+        self.robot._driver.set_plunger_speed(rate, self.axis)
         return self
 
 
@@ -296,7 +296,7 @@ class Robot(object, metaclass=Singleton):
 
         motor_obj = self.INSTRUMENT_DRIVERS_CACHE.get(key)
         if not motor_obj:
-            motor_obj = InstrumentMosfet(self._driver, mosfet_index)
+            motor_obj = InstrumentMosfet(self, mosfet_index)
             self.INSTRUMENT_DRIVERS_CACHE[key] = motor_obj
         return motor_obj
 
@@ -314,7 +314,7 @@ class Robot(object, metaclass=Singleton):
 
         motor_obj = self.INSTRUMENT_DRIVERS_CACHE.get(key)
         if not motor_obj:
-            motor_obj = InstrumentMotor(self._driver, axis)
+            motor_obj = InstrumentMotor(self, axis)
             self.INSTRUMENT_DRIVERS_CACHE[key] = motor_obj
         return motor_obj
 

--- a/api/tests/opentrons/drivers/smoothie_drivers/v1_2_0/test_motor.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v1_2_0/test_motor.py
@@ -284,10 +284,11 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.wait_for_arrival()
 
         old_coords = dict(self.motor.connection.serial_port.coordinates)
-        for ax in self.motor.connection.serial_port.coordinates['target'].keys():
-            self.motor.connection.serial_port.coordinates['target'][ax] += 10
+        vs = self.motor.connection.serial_port
+        for ax in vs.coordinates['target'].keys():
+            vs.coordinates['target'][ax] += 10
         self.assertRaises(RuntimeError, self.motor.wait_for_arrival)
-        self.motor.connection.serial_port.coordinates = old_coords
+        vs.coordinates = old_coords
 
     def test_move_relative(self):
         self.motor.home()

--- a/api/tests/opentrons/drivers/smoothie_drivers/v1_2_0/test_motor.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v1_2_0/test_motor.py
@@ -30,6 +30,9 @@ class OpenTronsTest(unittest.TestCase):
 
         self.motor = self.robot._driver
 
+    def test_is_simulating(self):
+        self.assertTrue(self.motor.is_simulating())
+
     def test_reset(self):
         self.motor.reset()
         self.assertFalse(self.motor.is_connected())
@@ -279,6 +282,12 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.move_head(x=200, y=200)
         self.motor.move_head(z=30)
         self.motor.wait_for_arrival()
+
+        old_coords = dict(self.motor.connection.serial_port.coordinates)
+        for ax in self.motor.connection.serial_port.coordinates['target'].keys():
+            self.motor.connection.serial_port.coordinates['target'][ax] += 10
+        self.assertRaises(RuntimeError, self.motor.wait_for_arrival)
+        self.motor.connection.serial_port.coordinates = old_coords
 
     def test_move_relative(self):
         self.motor.home()

--- a/api/tests/opentrons/drivers/smoothie_drivers/v2_0_0/test_motor.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v2_0_0/test_motor.py
@@ -292,10 +292,11 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.wait_for_arrival()
 
         old_coords = dict(self.motor.connection.serial_port.coordinates)
-        for ax in self.motor.connection.serial_port.coordinates['target'].keys():
-            self.motor.connection.serial_port.coordinates['target'][ax] += 10
+        vs = self.motor.connection.serial_port
+        for ax in vs.coordinates['target'].keys():
+            vs.coordinates['target'][ax] += 10
         self.assertRaises(RuntimeError, self.motor.wait_for_arrival)
-        self.motor.connection.serial_port.coordinates = old_coords
+        vs.coordinates = old_coords
 
     def test_move_relative(self):
         self.motor.home()

--- a/api/tests/opentrons/drivers/smoothie_drivers/v2_0_0/test_motor.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v2_0_0/test_motor.py
@@ -29,6 +29,9 @@ class OpenTronsTest(unittest.TestCase):
 
         self.motor = self.robot._driver
 
+    def test_is_simulating(self):
+        self.assertTrue(self.motor.is_simulating())
+
     def test_reset(self):
         self.motor.reset()
         self.assertFalse(self.motor.is_connected())
@@ -287,6 +290,12 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.move_head(x=200, y=200)
         self.motor.move_head(z=30)
         self.motor.wait_for_arrival()
+
+        old_coords = dict(self.motor.connection.serial_port.coordinates)
+        for ax in self.motor.connection.serial_port.coordinates['target'].keys():
+            self.motor.connection.serial_port.coordinates['target'][ax] += 10
+        self.assertRaises(RuntimeError, self.motor.wait_for_arrival)
+        self.motor.connection.serial_port.coordinates = old_coords
 
     def test_move_relative(self):
         self.motor.home()


### PR DESCRIPTION
If no movement after 1 second, exception is raised. Also adds 10ms delay between coordinate polling, reducing burden on serial port.

Includes a patch for a bug in the old firmware (`v1.0.5`) where if limit switch is hit, robot will not move until it's coordinate system has been reset.