### PR TITLE
App shell white screen debugging

### DIFF
--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -623,11 +623,12 @@ def _get_unique_containers(instrument):
     """
     unique_containers = set()
     for location in instrument.placeables:
-        if isinstance(location, containers.placeable.WellSeries):
+        while isinstance(location, containers.placeable.WellSeries):
             location = location[0]
         for c in location.get_trace():
             if isinstance(c, containers.placeable.Container):
                 unique_containers.add(c)
+                break
 
     return _sort_containers(list(unique_containers))
 

--- a/app-shell/app/main/updater.js
+++ b/app-shell/app/main/updater.js
@@ -7,7 +7,7 @@ var UPDATE_SERVER_URL = 'http://ot-app-releases-2.herokuapp.com'
 
 function initAutoUpdater () {
   const mainLogger = getLogger('electron-main')
-  mainLogger.info('starting ')
+  mainLogger.info('Initializing Audo Updater')
 
   autoUpdater.on(
     'error',

--- a/app-shell/app/main/util.js
+++ b/app-shell/app/main/util.js
@@ -9,6 +9,7 @@ function waitUntilServerResponds (createWindow, windowUrl) {
       return createWindow()
     })
     .catch((err) => {
+      mainLogger.info('Error while pinging ' + windowUrl)
       mainLogger.info(err)
       setTimeout(() => {
         waitUntilServerResponds(createWindow, windowUrl)


### PR DESCRIPTION
Patches two bugs in App:

1. Flask server correctly parses WellSeries containing WellSeries, so as not to duplicate containers in calibration
2. App-shell calls `BrowserWindow.loadURL()` within a `setTimeout()` to hopefully avoid trouble with Chromium not actually sending that request to Flask