### PR TITLE
Avoid Z collisions with limit switch

### DIFF
--- a/api/opentrons/instruments/pipette.py
+++ b/api/opentrons/instruments/pipette.py
@@ -539,7 +539,7 @@ class Pipette(Instrument):
         # then go inside the location
         if location:
             if isinstance(location, Placeable):
-                location = location.bottom(1)
+                location = location.bottom(min(location.z_size(), 1))
             self.move_to(location, strategy='direct', enqueue=False)
 
     # QUEUEABLE

--- a/api/opentrons/robot/robot.py
+++ b/api/opentrons/robot/robot.py
@@ -603,13 +603,14 @@ class Robot(object, metaclass=Singleton):
 
         _, _, robot_max_z = self._driver.get_dimensions()
         arc_top = min(tallest_z, robot_max_z)
+        arrival_z = min(destination[2], robot_max_z)
 
         self._previous_container = this_container
 
         return [
             {'z': arc_top},
             {'x': destination[0], 'y': destination[1]},
-            {'z': destination[2]}
+            {'z': arrival_z}
         ]
 
     @property

--- a/api/opentrons/server/main.py
+++ b/api/opentrons/server/main.py
@@ -898,13 +898,15 @@ def move_to_plunger_position():
 def aspirate_from_current_position():
     axis = request.json.get("axis")
     try:
-        # this action mimics 1.2 app experience
-        # but should be re-thought to take advantage of API features
+        _, _, robot_max_z = robot._driver.get_dimensions()
+        current_z = robot._driver.get_position()['current']['z']
+        jog_up_distance = min(robot_max_z - current_z, 20)
+
+        robot.move_head(z=jog_up_distance, mode='relative')
         instrument = robot._instruments[axis.upper()]
-        robot.move_head(z=20, mode='relative')
         instrument.motor.move(instrument.positions['blow_out'])
         instrument.motor.move(instrument.positions['bottom'])
-        robot.move_head(z=-20, mode='relative')
+        robot.move_head(z=-jog_up_distance, mode='relative')
         instrument.motor.move(instrument.positions['top'])
     except Exception as e:
         emit_notifications([str(e)], 'danger')


### PR DESCRIPTION
Small PR which adds some safegaurds to avoid ever hitting the Z limit switch. This occurs often when using tall containers and also not calibration to the actual bottom of that container.

- "Aspirate" button in UI will avoid Z switch when moving up
- `robot._create_arc()` will avoid Z switch hit for arc height and for arrival Z position
- `aspirate()` command will only move to `bottom(1)` if the `Well` has height greater than 1