### PR TITLE
feat(app): Allow :mount in /calibrate/instruments to be optional

### DIFF
--- a/app/src/components/TipProbe/index.js
+++ b/app/src/components/TipProbe/index.js
@@ -1,14 +1,8 @@
 // @flow
-// TipProbe container
+// TipProbe controls
 import * as React from 'react'
-import {connect} from 'react-redux'
 
-import {
-  selectors as robotSelectors,
-  type InstrumentCalibrationStatus,
-  type Mount,
-  type Channels
-} from '../../robot'
+import type {Instrument, InstrumentCalibrationStatus} from '../../robot'
 
 import CalibrationInfoBox from '../CalibrationInfoBox'
 import UnprobedPanel from './UnprobedPanel'
@@ -17,22 +11,12 @@ import AttachTipPanel from './AttachTipPanel'
 import RemoveTipPanel from './RemoveTipPanel'
 import ContinuePanel from './ContinuePanel'
 
-type OwnProps = {
-  mount: Mount,
-  confirmTipProbeUrl: string,
+type Props = Instrument & {
+  confirmTipProbeUrl: string
 }
-
-type StateProps = {
-  calibration: InstrumentCalibrationStatus,
-  channels: Channels,
-  volume: number,
-  probed: boolean,
-}
-
-type TipProbeProps = OwnProps & StateProps
 
 const PANEL_BY_CALIBRATION: {
-  [InstrumentCalibrationStatus]: React.ComponentType<TipProbeProps>
+  [InstrumentCalibrationStatus]: React.ComponentType<Props>
 } = {
   'unprobed': UnprobedPanel,
   'preparing-to-probe': InstrumentMovingPanel,
@@ -42,23 +26,7 @@ const PANEL_BY_CALIBRATION: {
   'probed': ContinuePanel
 }
 
-export default connect(mapStateToProps)(TipProbe)
-
-function mapStateToProps (state, ownProps: OwnProps): StateProps {
-  const instruments = robotSelectors.getInstruments(state)
-  const currentInstrument = instruments
-    .find((inst) => inst.mount === ownProps.mount)
-
-  // TODO(mc, 2018-01-22): this should never happen; refactor so this
-  //   check isn't necessary
-  if (!currentInstrument || !currentInstrument.calibration) {
-    throw new Error('no currentInstrument or has no calibration status')
-  }
-
-  return currentInstrument
-}
-
-function TipProbe (props: TipProbeProps) {
+export default function TipProbe (props: Props) {
   const {mount, probed, calibration} = props
   const title = `${mount} pipette calibration`
 

--- a/app/src/components/setup-instruments/InstrumentTabs.js
+++ b/app/src/components/setup-instruments/InstrumentTabs.js
@@ -1,30 +1,29 @@
 // @flow
 // instrument tabs bar container
 // used for left/right pipette selection during pipette calibration
+import * as React from 'react'
 
-import {connect} from 'react-redux'
-import {PageTabs, type PageTabProps} from '@opentrons/components'
-import {
-  constants as robotConstants,
-  selectors as robotSelectors,
-  type Mount
-} from '../../robot'
+import type {Instrument} from '../../robot'
+import {constants as robotConstants} from '../../robot'
 
-export default connect(mapStateToProps)(PageTabs)
+import {PageTabs} from '@opentrons/components'
 
-type OwnProps = {
-  mount: Mount
+type Props = {
+  instruments: Array<Instrument>,
+  currentInstrument: ?Instrument
 }
 
-function mapStateToProps (state, ownProps: OwnProps): PageTabProps {
-  const instruments = robotSelectors.getInstruments(state)
+export default function InstrumentTabs (props: Props) {
+  const {instruments, currentInstrument} = props
 
   const pages = robotConstants.INSTRUMENT_MOUNTS.map((mount) => ({
     title: mount,
     href: `/calibrate/instruments/${mount}`,
-    isActive: mount === ownProps.mount,
+    isActive: currentInstrument != null && mount === currentInstrument.mount,
     isDisabled: !instruments.some((inst) => inst.mount === mount)
   }))
 
-  return {pages}
+  return (
+    <PageTabs pages={pages} />
+  )
 }

--- a/app/src/components/setup-instruments/Instruments.js
+++ b/app/src/components/setup-instruments/Instruments.js
@@ -1,30 +1,25 @@
 // @flow
 import * as React from 'react'
-import {connect} from 'react-redux'
 import capitalize from 'lodash/capitalize'
 
-// import type InstrumentInfoProps from './InstrumentInfo'
-import {InstrumentGroup, InstrumentInfo} from '@opentrons/components'
+import type {Instrument} from '../../robot'
+import {constants as robotConstants} from '../../robot'
 
-import {
-  constants as robotConstants,
-  selectors as robotSelectors
-} from '../../robot'
+import {InstrumentGroup} from '@opentrons/components'
 
-type OwnProps = {
-  mount: ?string
+type Props = {
+  instruments: Array<Instrument>,
+  currentInstrument: ?Instrument
 }
 
-type StateProps = {
-  instruments: Array<React.ElementProps<typeof InstrumentInfo>>
-}
+export default function Instruments (props: Props) {
+  const {currentInstrument, instruments: allInstruments} = props
+  const currentMount = currentInstrument
+    ? currentInstrument.mount
+    : null
 
-export default connect(mapStateToProps)(InstrumentGroup)
-
-function mapStateToProps (state, ownProps: OwnProps): StateProps {
-  const currentMount = ownProps.mount
-  const allInstruments = robotSelectors.getInstruments(state)
-
+  // TODO(mc, 2018-03-07): refactor when InstrumentGroup switches to object
+  //   of instruments keyed by mount instead of array
   const instruments = robotConstants.INSTRUMENT_MOUNTS.map((mount) => {
     const inst = allInstruments.find((i) => i.mount === mount)
     const isDisabled = !inst || mount !== currentMount
@@ -45,5 +40,7 @@ function mapStateToProps (state, ownProps: OwnProps): StateProps {
     }
   })
 
-  return {instruments}
+  return (
+    <InstrumentGroup instruments={instruments} />
+  )
 }

--- a/app/src/pages/Calibrate.js
+++ b/app/src/pages/Calibrate.js
@@ -11,8 +11,14 @@ export default function Calibrate (props: ContextRouter) {
 
   return (
     <Switch>
-      <Route path={`${path}/instruments/:mount`} component={SetupInstruments} />
-      <Route path={`${path}/labware/:slot`} component={SetupDeck} />
+      <Route
+        path={`${path}/instruments/:mount?`}
+        component={SetupInstruments}
+      />
+      <Route
+        path={`${path}/labware/:slot`}
+        component={SetupDeck}
+      />
     </Switch>
   )
 }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -3,6 +3,7 @@
 import padStart from 'lodash/padStart'
 import sortBy from 'lodash/sortBy'
 import {createSelector} from 'reselect'
+import type {ContextRouter} from 'react-router'
 
 import type {State} from '../types'
 
@@ -319,7 +320,7 @@ export function getLabwareBySlot (state: State) {
 export const getLabware = createSelector(
   getLabwareBySlot,
   (state: State) => calibration(state).confirmedBySlot,
-  (state: State) => getCalibrationRequest(state),
+  getCalibrationRequest,
   (labwareBySlot, confirmedBySlot, calibrationRequest): Labware[] => {
     return Object.keys(labwareBySlot)
       .filter(isSlot)
@@ -419,3 +420,11 @@ export function getOffsetUpdateInProgress (state: State): boolean {
 export function getJogDistance (state: State): number {
   return calibration(state).jogDistance
 }
+
+// get current instrument selector factory
+// to be used by a react-router Route component
+export const makeGetCurrentInstrument = () => createSelector(
+  (_, props: ContextRouter) => props.match.params.mount,
+  getInstruments,
+  (mount, instruments) => instruments.find((i) => i.mount === mount)
+)


### PR DESCRIPTION
## overview

In advance of upcoming changes to the Calibrate page and Calibrate SidePanel (TODO: tickets for those changes?), this PR updates the page URL to allow the selected pipette to be optional. This is a non-user facing change to improve the app's architecture and increase reliability.

To be followed up with an equivalent PR for making `:slot` optional in `/calibrate/labware/:slot`

## changelog

- Added a `makeGetCurrentInstrument` selector factory for smart route components to get the current instrument from the route params in their props
- Updated the `SetupInstruments` page to be a smart component that pulls the instrument list and currentInstrument from state/props
    - Also updated the page to gracefully handle a missing instrument (no more UI crashes during non-hot reloads)
- Updated children of `SetupInstruments` to be entirely props based (or at least not need to use `mapStateToProps`) since `SetupInstruments` now pulls everything needed from redux

## review requests

The original plan was to remove routes entirely from the labware and instrument selection, but given our recent nav hierarchy consolidation (#984) and after talking with @pantslakz, it seems like the behavior of the SidePanel is evolving in a way where clicking on the `SidePanel` `ListItem`s simply change the view (without triggering robot actions). This means that routes start to make sense again.

Rather than proceed with the route removal, @Kadee80 and I elected to evolve the route-based solution to something more reliable. This means a smaller change-set to worry about, and most of these changes still help if we end up deciding to move to a completely state-based solution for calibration selection after all.

There should not be any behavior regressions from `edge` on this one, so if possible, running this side-by-side with a prod build could be helpful.

### example test plan

I was able to run through this procedure without problem on `sunset` bot 🌆 

1. Load a protocol
2. Click big tab to select pipette
3. Click "Calibrate Tip"
4. Verify correct pipette moves
5. Click pipette in "Pipette Calibration" list
6. Click "Calibrate Tip"
7. Verify correct pipette moves

### known issues

* SidePanel list highlighting is still not working
    * Confirmed that NavLink active selection _is_ working, though
    * We just need to add `activeClassName` styling, which didn't feel super in-scope for this PR
