### PR TITLE
feat(api): Added configurable min and max volume to pipettes

### DIFF
--- a/api/opentrons/__init__.py
+++ b/api/opentrons/__init__.py
@@ -63,6 +63,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -75,6 +77,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -83,6 +87,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -95,6 +101,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -103,6 +111,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -115,6 +125,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -123,6 +135,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -135,6 +149,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -143,6 +159,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -155,6 +173,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -163,6 +183,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -175,6 +197,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -183,6 +207,8 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
@@ -195,6 +221,8 @@ class InstrumentsWrapper(object):
             mount=mount,
             trash_container=trash_container,
             tip_racks=tip_racks,
+            min_volume=min_volume,
+            max_volume=max_volume,
             aspirate_flow_rate=aspirate_flow_rate,
             dispense_flow_rate=dispense_flow_rate)
 
@@ -204,13 +232,20 @@ class InstrumentsWrapper(object):
             mount,
             trash_container='',
             tip_racks=[],
+            min_volume=None,
+            max_volume=None,
             aspirate_flow_rate=None,
             dispense_flow_rate=None):
 
-        if aspirate_flow_rate:
+        if aspirate_flow_rate is not None:
             config = config._replace(aspirate_flow_rate=aspirate_flow_rate)
-        if dispense_flow_rate:
+        if dispense_flow_rate is not None:
             config = config._replace(dispense_flow_rate=dispense_flow_rate)
+
+        if min_volume is not None:
+            config._replace(min_volume=min_volume)
+        if max_volume is not None:
+            config._replace(max_volume=max_volume)
 
         p = self.Pipette(
             model_offset=config.model_offset,
@@ -221,6 +256,7 @@ class InstrumentsWrapper(object):
             channels=config.channels,
             aspirate_flow_rate=config.aspirate_flow_rate,
             dispense_flow_rate=config.dispense_flow_rate,
+            min_volume=config.min_volume,
             max_volume=config.max_volume,
             plunger_current=config.plunger_current,
             drop_tip_current=config.drop_tip_current,

--- a/api/opentrons/instruments/pipette_config.py
+++ b/api/opentrons/instruments/pipette_config.py
@@ -21,6 +21,7 @@ pipette_config = namedtuple(
         'model_offset',
         'plunger_current',
         'drop_tip_current',
+        'min_volume',
         'max_volume',
         'tip_length'  # TODO (andy): remove from pipette, move to tip-rack
     ]
@@ -84,6 +85,7 @@ def load(pipette_model: str) -> pipette_config:
             model_offset=cfg.get('modelOffset'),
             plunger_current=cfg.get('plungerCurrent'),
             drop_tip_current=cfg.get('dropTipCurrent'),
+            min_volume=cfg.get('minVolume'),
             max_volume=cfg.get('maxVolume'),
             tip_length=cfg.get('tipLength')
         )

--- a/api/tests/opentrons/data/dinosaur.py
+++ b/api/tests/opentrons/data/dinosaur.py
@@ -27,7 +27,8 @@ p200.distribute(
         'C7', 'D7', 'E7', 'F7', 'G7', 'D8', 'E8', 'F8',
         'G8', 'H8', 'E9', 'F9', 'G9', 'H9', 'F10', 'G11',
         'H12'
-    )
+    ),
+    disposal_vol=0
 )
 
 p200.distribute(
@@ -36,5 +37,6 @@ p200.distribute(
     plate.wells(
         'C3', 'B4', 'A5', 'B5', 'B6', 'A7', 'B7',
         'C8', 'C9', 'D9', 'E10', 'E11', 'F11', 'G12'
-    )
+    ),
+    disposal_vol=0
 )

--- a/shared-data/robot-data/pipette-config.json
+++ b/shared-data/robot-data/pipette-config.json
@@ -15,6 +15,7 @@
     "modelOffset": [0.0, 0.0, -13],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 1,
     "maxVolume": 10,
     "tipLength": 33
   },
@@ -34,6 +35,7 @@
     "modelOffset": [0.0, 0.0, -13],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 1,
     "maxVolume": 10,
     "tipLength": 33
   },
@@ -53,6 +55,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 1,
     "maxVolume": 10,
     "tipLength": 33
   },
@@ -72,6 +75,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 1,
     "maxVolume": 10,
     "tipLength": 33
   },
@@ -91,6 +95,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 5,
     "maxVolume": 50,
     "tipLength": 51.7
   },
@@ -110,6 +115,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 5,
     "maxVolume": 50,
     "tipLength": 51.7
   },
@@ -129,6 +135,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 5,
     "maxVolume": 50,
     "tipLength": 51.7
   },
@@ -148,6 +155,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 5,
     "maxVolume": 50,
     "tipLength": 51.7
   },
@@ -167,6 +175,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 30,
     "maxVolume": 300,
     "tipLength": 51.7
   },
@@ -186,6 +195,7 @@
     "modelOffset": [0.0, 0.0, 0.0],
     "plungerCurrent": 0.3,
     "dropTipCurrent": 0.5,
+    "minVolume": 30,
     "maxVolume": 300,
     "tipLength": 51.7
   },
@@ -205,6 +215,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 30,
     "maxVolume": 300,
     "tipLength": 51.7
   },
@@ -224,6 +235,7 @@
     "modelOffset": [0.0, 31.5, -25.8],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 30,
     "maxVolume": 300,
     "tipLength": 51.7
   },
@@ -243,6 +255,7 @@
     "modelOffset": [0.0, 0.0, 20.0],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 100,
     "maxVolume": 1000,
     "tipLength": 76.7
   },
@@ -262,6 +275,7 @@
     "modelOffset": [0.0, 0.0, 20.0],
     "plungerCurrent": 0.5,
     "dropTipCurrent": 0.5,
+    "minVolume": 100,
     "maxVolume": 1000,
     "tipLength": 76.7
   }


### PR DESCRIPTION
## overview

As a user, I would like to configure the pipette min and max volumes in the constructor of the class. Before, the only way to set the `min_volume` and `max_volume` of a pipette was to patch the pipette instance after it is constructed. This feels hacky and is prone to errors. After this change, you can set pipette min and max volume in the constructor of the class to set these attributes.

Default values of 10% of the max volume were also added in the pipette config.

Closes #2075 

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- `min_volume` and `max_volume` keywords added to pipette constructors
- `"minVolume"` field added to `pipette-config.json`
