### PR TITLE
fix(protocol-designer): unhighlight wells on deselect in well selection

### DIFF
--- a/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
+++ b/protocol-designer/src/components/StepEditForm/WellSelectionInput/WellSelectionModal.js
@@ -63,7 +63,7 @@ class WellSelectionModal extends React.Component<Props, State> {
   }
 
   deselectWells = (wells: Wells) => {
-    this.setState({selectedWells: omit(this.state.selectedWells, Object.keys(wells))})
+    this.setState({selectedWells: omit(this.state.selectedWells, Object.keys(wells)), highlightedWells: {}})
   }
 
   handleSave = () => {


### PR DESCRIPTION
This is a follow up to #2442 aiming to fix a bit of lost functionality.

Closes #2463
