### PR TITLE
fix(protocol-designer): ensure pipettes are removed when nuked

### DIFF
--- a/protocol-designer/src/pipettes/thunks.js
+++ b/protocol-designer/src/pipettes/thunks.js
@@ -32,7 +32,7 @@ export const editPipettes = (payload: EditPipettesFields) =>
         const nextPipetteModel = pipetteFields.pipetteModel
         const nextTiprackModel = isEmpty(pipetteFields.tiprackModel) ? null : pipetteFields.tiprackModel
         const nextPipette: ?PipetteData = nextPipetteModel ? createPipette(mount, nextPipetteModel, nextTiprackModel) : null
-        return nextPipette ? {...acc, [mount]: nextPipette} : acc
+        return {...acc, [mount]: nextPipette}
       },
       {}
     )


### PR DESCRIPTION
We are changing the saved step forms when you edit your pipettes, the intended behavior included
updating the removed pipette references to null, although that action was not being dispatched if a
mount was set to null from a previously used mount.

Closes #2809 