### PR TITLE
ci(travis): remove deprecated "sudo: false"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 # opentrons platform travis config
-sudo: false
-
 cache:
   pip: true
   yarn: true


### PR DESCRIPTION
## overview

remove `sudo: false` b/c Travis deprecated container-based Linux
infrastructure in December so it's just cruft now
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

I thought we did this already but I guess not?

## changelog

* remove `sudo: false` from .travis.yml

## review requests

:construction_worker_man: