### PR TITLE
fix(app): Add tip rack name to tip probe wizard instructions

### DIFF
--- a/app/src/components/TipProbe/AttachTipPanel.js
+++ b/app/src/components/TipProbe/AttachTipPanel.js
@@ -1,38 +1,47 @@
 // @flow
 import * as React from 'react'
-import { connect } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import CalibrationInfoContent from '../CalibrationInfoContent'
 import { PrimaryButton } from '@opentrons/components'
 
-import { actions as robotActions } from '../../robot'
+import {
+  actions as robotActions,
+  selectors as robotSelectors,
+} from '../../robot'
 import attachSingle from '../../img/attach_tip_single.png'
 import attachMulti from '../../img/attach_tip_multi.png'
 
 import type { Dispatch } from '../../types'
 import type { TipProbeProps } from './types'
 
-type OP = TipProbeProps
+type Props = TipProbeProps
 
-type DP = {| onProbeTipClick: () => void |}
+export default function AttachTipPanel(props: Props) {
+  const { mount, channels } = props
+  const dispatch = useDispatch<Dispatch>()
+  const tipracksByMount = useSelector(robotSelectors.getTipracksByMount)
+  const tiprack = tipracksByMount[mount]
+  const tiprackName =
+    tiprack?.definition?.metadata.displayName || tiprack?.name || null
 
-type Props = { ...OP, ...DP }
-
-export default connect<Props, OP, {||}, DP, _, _>(
-  null,
-  mapDispatchToProps
-)(AttachTipPanel)
-
-function AttachTipPanel(props: Props) {
-  const { volume, channels, onProbeTipClick } = props
+  // $FlowFixMe: robotActions.probeTip is not typed
+  const handleTipProbe = () => dispatch(robotActions.probeTip(mount))
 
   const leftChildren = (
     <div>
       <p>
-        Place a spare
-        <em>{` ${volume} μL `}</em>
-        tip on pipette before continuing
+        Place a spare tip
+        {tiprackName !== null && (
+          <>
+            {' from'}
+            <br />
+            <strong>{tiprackName}</strong>
+            <br />{' '}
+          </>
+        )}
+        on pipette before continuing
       </p>
-      <PrimaryButton onClick={onProbeTipClick}>
+      <PrimaryButton onClick={handleTipProbe}>
         Confirm Tip Attached
       </PrimaryButton>
     </div>
@@ -48,15 +57,4 @@ function AttachTipPanel(props: Props) {
       rightChildren={rightChildren}
     />
   )
-}
-
-function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  const mount = ownProps.mount
-
-  return {
-    onProbeTipClick: () => {
-      // $FlowFixMe: robotActions.probeTip is not typed
-      dispatch(robotActions.probeTip(mount))
-    },
-  }
 }

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -3,17 +3,17 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 import cx from 'classnames'
 
-import type { PipettesState } from '../../robot-api'
-import type { Pipette, Labware } from '../../robot'
 import { constants as robotConstants } from '../../robot'
-
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import { InstrumentGroup, AlertItem } from '@opentrons/components'
 import styles from './styles.css'
 
+import type { PipettesState } from '../../robot-api'
+import type { Pipette, TiprackByMountMap } from '../../robot'
+
 type Props = {|
   pipettes: Array<Pipette>,
-  labware: Array<Labware>,
+  tipracksByMount: TiprackByMountMap,
   currentPipette: ?Pipette,
   actualPipettes: ?PipettesState,
   changePipetteUrl: string,
@@ -27,7 +27,7 @@ export default function Pipettes(props: Props) {
   const {
     currentPipette,
     pipettes,
-    labware,
+    tipracksByMount,
     actualPipettes,
     changePipetteUrl,
   } = props
@@ -35,9 +35,7 @@ export default function Pipettes(props: Props) {
 
   const infoByMount = PIPETTE_MOUNTS.reduce((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
-    const tiprack = labware.find(
-      lw => lw.isTiprack && lw.calibratorMount === mount
-    )
+    const tiprack = tipracksByMount[mount]
     const pipetteConfig = pipette?.modelSpecs
     const actualPipetteConfig = getPipetteModelSpecs(
       actualPipettes?.[mount]?.model || ''

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -16,7 +16,7 @@ import SessionHeader from '../../components/SessionHeader'
 
 import type { ContextRouter } from 'react-router'
 import type { State, Dispatch } from '../../types'
-import type { Pipette, Labware } from '../../robot'
+import type { Pipette, TiprackByMountMap } from '../../robot'
 import type { PipettesState } from '../../robot-api'
 import type { Robot } from '../../discovery'
 
@@ -24,7 +24,7 @@ type OP = ContextRouter
 
 type SP = {|
   pipettes: Array<Pipette>,
-  labware: Array<Labware>,
+  tipracksByMount: TiprackByMountMap,
   currentPipette: ?Pipette,
   actualPipettes: ?PipettesState,
   _robot: ?Robot,
@@ -48,7 +48,7 @@ export default connect<Props, OP, SP, {||}, State, Dispatch>(
 function CalibratePipettesPage(props: Props) {
   const {
     pipettes,
-    labware,
+    tipracksByMount,
     actualPipettes,
     currentPipette,
     fetchPipettes,
@@ -69,7 +69,7 @@ function CalibratePipettesPage(props: Props) {
         <Pipettes
           {...{
             pipettes,
-            labware,
+            tipracksByMount,
             currentPipette,
             actualPipettes,
             changePipetteUrl,
@@ -101,14 +101,14 @@ function mapStateToProps(state: State, ownProps: OP): SP {
   const { mount } = ownProps.match.params
   const _robot = getConnectedRobot(state)
   const pipettes = robotSelectors.getPipettes(state)
-  const labware = robotSelectors.getLabware(state)
+  const tipracksByMount = robotSelectors.getTipracksByMount(state)
   const currentPipette = pipettes.find(p => p.mount === mount)
   const actualPipettes = _robot && getPipettesState(state, _robot.name)
 
   return {
     _robot,
     pipettes,
-    labware,
+    tipracksByMount,
     actualPipettes,
     currentPipette,
   }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -21,6 +21,7 @@ import type {
   LabwareType,
   SessionStatus,
   SessionModule,
+  TiprackByMountMap,
 } from './types'
 
 const calibration = (state: State) => state.robot.calibration
@@ -420,8 +421,7 @@ export const getUnconfirmedLabware = createSelector(
   labware => labware.filter(lw => lw.type && !lw.confirmed)
 )
 
-// $FlowFixMe: (mc, 2019-04-17): untyped RPC state selector
-export const getTipracks = createSelector(
+export const getTipracks: State => Array<Labware> = createSelector(
   getLabware,
   labware => labware.filter(lw => lw.type && lw.isTiprack)
 )
@@ -468,3 +468,14 @@ export function getOffsetUpdateInProgress(state: State): boolean {
 
   return request.type === 'UPDATE_OFFSET' && request.inProgress
 }
+
+// return a tiprack used by the pipette on each mount for calibration processes
+export const getTipracksByMount: (
+  state: State
+) => TiprackByMountMap = createSelector(
+  getTipracks,
+  tipracks => ({
+    left: tipracks.find(tr => tr.calibratorMount === 'left') || null,
+    right: tipracks.find(tr => tr.calibratorMount === 'right') || null,
+  })
+)

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -25,6 +25,7 @@ const {
   getUnconfirmedTipracks,
   getUnconfirmedLabware,
   getNextLabware,
+  getTipracksByMount,
   getModulesBySlot,
   getModules,
   getDeckPopulated,
@@ -694,6 +695,31 @@ describe('robot selectors', () => {
         calibration: 'unconfirmed',
         confirmed: false,
         definition: null,
+      })
+    })
+
+    test('getTipracksByMount', () => {
+      expect(getTipracksByMount(state)).toEqual({
+        left: {
+          slot: '2',
+          type: 'm',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left',
+          definition: null,
+        },
+        right: {
+          slot: '1',
+          type: 's',
+          isTiprack: true,
+          isMoving: true,
+          calibration: 'moving-to-slot',
+          confirmed: false,
+          calibratorMount: 'right',
+          definition: null,
+        },
       })
     })
   })

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -163,3 +163,8 @@ export type SessionUpdate = {
     handledAt: number,
   },
 }
+
+export type TiprackByMountMap = {|
+  left: Labware | null,
+  right: Labware | null,
+|}


### PR DESCRIPTION
## overview

This PR is a followup to fully address #2444 (which was marked closed by #3644). It turns out the previous fix missed some additional text in the wizard itself that was still showing the old, incorrect "suggested tip type".

This PR makes the same change that 3644 made to the pipette summary area inside the wizard itself.

![2019-08-26 15 17 41](https://user-images.githubusercontent.com/2963448/63716743-b7cbd200-c814-11e9-8831-77efc72853fc.gif)

## changelog

- fix(app): Add tip rack name to tip probe wizard instructions

## review requests

- [ ] Shows labware v2 display names
- [ ] Falls back to labware v1 load names

