### PR TITLE
fix(app): Remove incorrect data removal warning from change pipette

### DIFF
--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -96,15 +96,7 @@ function ChangePipetteRouter(props: ChangePipetteProps) {
     onContinueClick: props.moveToFront,
   }
   if (!moveRequest.inProgress && !moveRequest.response) {
-    return (
-      <ClearDeckAlertModal {...clearDeckProps}>
-        {props.actualPipette && (
-          <p>
-            Detaching a pipette will also clear its related calibration data
-          </p>
-        )}
-      </ClearDeckAlertModal>
-    )
+    return <ClearDeckAlertModal {...clearDeckProps} />
   }
 
   if (moveRequest.inProgress || homeRequest.inProgress) {


### PR DESCRIPTION
## overview

Tiny bug + fix PR to address some feedback about confusing UX surfaced from a user. When you go to change a pipette, it presents the following warning:

> Detaching a pipette will also clear its related calibration data

This is not accurate. The robot will take no action to clear any sort of settings about this pipette. Best guess is that this message was _trying_ to refer to the fact that you'll probably need to re-do any run-time calibration (tip probe, labware position calibration) you've started for the protocol you have uploaded, if any, but:

- That's got nothing to do with robot data, just that the RPC API isn't good enough for us to have a robust app-side state for runtime calibration
- That message isn't clear if runtime calibration is, in fact, what the message is trying to reference
- Starting runtime calibration with the wrong pipette, changing it, and then have to restart runtime calibration is not a surprising experience, so (IMO) we don't _need_ extra copy

## changelog

- fix(app): Remove incorrect data removal warning from change pipette

## review requests

- [ ] Copy removal makes sense
