### PR TITLE
fix(update-server): Fix hash in SSH key upload confirmation response

### DIFF
--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -148,7 +148,7 @@ async def add(request: web.Request) -> web.Response:
             ak.write(f'{pubkey}\n')
 
     return web.json_response(
-            data={'message': 'Added key {hashval}',
+            data={'message': f'Added key {hashval}',
                   'key_md5': hashval},
             status=201)
 


### PR DESCRIPTION
## overview

When you send a POST request to upload a new SSH key, the robot responds with a message `Added key {hashval}.` Presumably the actual hash was intended to be substituted there, but the message was accidentally written as a regular string instead of an f-string.

## changelog

- Trivial 1-character change to fix the f-string.
