### PR TITLE
fix(api): do not swallow smoothie errors with certain patterns

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -930,11 +930,15 @@ class SmoothieDriver_3_0_0:
             # is locking at a higher level like in APIv2.
             self._reset_from_error()
             error_axis = se.ret_code.strip()[-1]
-            if GCODES['HOME'] not in command and error_axis in 'XYZABC':
-                log.warning(
-                    f"alarm/error in {se.ret_code}, homing {error_axis}")
-                self.home(error_axis)
-                raise SmoothieError(se.ret_code, command)
+            if GCODES['HOME'] not in command:
+                if error_axis in 'XYZABC':
+                    log.warning(
+                        f"alarm/error in {se.ret_code}, homing {error_axis}")
+                    self.home(error_axis)
+                else:
+                    log.warning(f"alarm/error in probe, homing")
+                    self.home()
+            raise SmoothieError(se.ret_code, command)
 
     def _send_command_unsynchronized(self,
                                      command,


### PR DESCRIPTION
In 628c6c47c79a656f9babd552784a96d99deb4852 the line that reraised the error
that was being handled was accidentally moved into the part of the code that
automatically homes after a smoothie error. This code meant that if an error
occurred
- during a home, or
- with a message that didn't end in a valid axis name (as most of them don't)
the error would get swallowed and the machine would continue on.

This is ready for review and test but please do not merge it until we know if we're doing a hotfix.