### PR TITLE
feat(app): allow p1000 gen2 to fallback to specced p1000 gen1

### DIFF
--- a/app/src/components/FileInfo/useInstrumentMountInfo.js
+++ b/app/src/components/FileInfo/useInstrumentMountInfo.js
@@ -36,6 +36,9 @@ const { PIPETTE_MOUNTS } = robotConstants
 
 function pipettesAreInexactMatch(protocolInstrName, actualInstrName) {
   switch (protocolInstrName) {
+    case 'p1000_single':
+    case 'p1000_single_gen1':
+      return actualInstrName === 'p1000_single_gen2'
     case 'p300_single':
     case 'p300_single_gen1':
       return actualInstrName === 'p300_single_gen2'

--- a/app/src/components/FileInfo/useInstrumentMountInfo.js
+++ b/app/src/components/FileInfo/useInstrumentMountInfo.js
@@ -38,8 +38,8 @@ function pipettesAreInexactMatch(
   protocolInstrName,
   actualModelSpecs: ?PipetteModelSpecs
 ) {
-  const { backcompatName } = actualModelSpecs || {}
-  return protocolInstrName === backcompatName
+  const { backCompatNames } = actualModelSpecs || {}
+  return backCompatNames && backCompatNames.includes(protocolInstrName)
 }
 
 function useInstrumentMountInfo(
@@ -54,25 +54,21 @@ function useInstrumentMountInfo(
     const protocolInstrument = protocolInstruments.find(i => i.mount === mount)
     const actualInstrument = actualInstruments[mount]
 
-    const actualPipetteConfig = getPipetteModelSpecs(
-      actualInstrument?.model || ''
-    )
+    const actualModelSpecs = getPipetteModelSpecs(actualInstrument?.model || '')
     const requestedDisplayName = protocolInstrument?.requestedAs
       ? getPipetteNameSpecs(protocolInstrument?.requestedAs)?.displayName
       : protocolInstrument?.modelSpecs?.displayName
 
     const protocolInstrName =
       protocolInstrument?.requestedAs || protocolInstrument?.modelSpecs?.name
-    const actualInstrName = actualPipetteConfig?.name
+    const actualInstrName = actualModelSpecs?.name
 
     const perfectMatch = protocolInstrName === actualInstrName
 
     let compatibility: PipetteCompatibility = 'incompatible'
     if (perfectMatch || isEmpty(protocolInstrument)) {
       compatibility = 'match'
-    } else if (
-      pipettesAreInexactMatch(protocolInstrName, actualPipetteConfig)
-    ) {
+    } else if (pipettesAreInexactMatch(protocolInstrName, actualModelSpecs)) {
       compatibility = 'inexact_match'
     }
 
@@ -85,8 +81,8 @@ function useInstrumentMountInfo(
         },
         actual: {
           ...actualInstrument,
-          modelSpecs: actualPipetteConfig,
-          displayName: actualPipetteConfig?.displayName || 'N/A',
+          modelSpecs: actualModelSpecs,
+          displayName: actualModelSpecs?.displayName || 'N/A',
         },
         compatibility,
       },

--- a/app/src/components/FileInfo/useInstrumentMountInfo.js
+++ b/app/src/components/FileInfo/useInstrumentMountInfo.js
@@ -34,20 +34,12 @@ type InstrumentMountInfo = {|
 |}
 const { PIPETTE_MOUNTS } = robotConstants
 
-function pipettesAreInexactMatch(protocolInstrName, actualInstrName) {
-  switch (protocolInstrName) {
-    case 'p1000_single':
-    case 'p1000_single_gen1':
-      return actualInstrName === 'p1000_single_gen2'
-    case 'p300_single':
-    case 'p300_single_gen1':
-      return actualInstrName === 'p300_single_gen2'
-    case 'p10_single':
-    case 'p10_single_gen1':
-      return actualInstrName === 'p20_single_gen2'
-    default:
-      return false
-  }
+function pipettesAreInexactMatch(
+  protocolInstrName,
+  actualModelSpecs: ?PipetteModelSpecs
+) {
+  const { backcompatName } = actualModelSpecs || {}
+  return protocolInstrName === backcompatName
 }
 
 function useInstrumentMountInfo(
@@ -78,7 +70,9 @@ function useInstrumentMountInfo(
     let compatibility: PipetteCompatibility = 'incompatible'
     if (perfectMatch || isEmpty(protocolInstrument)) {
       compatibility = 'match'
-    } else if (pipettesAreInexactMatch(protocolInstrName, actualInstrName)) {
+    } else if (
+      pipettesAreInexactMatch(protocolInstrName, actualPipetteConfig)
+    ) {
       compatibility = 'inexact_match'
     }
 

--- a/app/src/components/FileInfo/useInstrumentMountInfo.js
+++ b/app/src/components/FileInfo/useInstrumentMountInfo.js
@@ -35,7 +35,7 @@ type InstrumentMountInfo = {|
 const { PIPETTE_MOUNTS } = robotConstants
 
 function pipettesAreInexactMatch(
-  protocolInstrName,
+  protocolInstrName: ?string,
   actualModelSpecs: ?PipetteModelSpecs
 ) {
   const { backCompatNames } = actualModelSpecs || {}

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -265,6 +265,6 @@ export type PipetteNameSpecs = {|
 export type PipetteModelSpecs = {
   ...PipetteNameSpecs,
   model: string,
-  backcompatName?: string,
+  backCompatNames?: Array<string>,
   tipLength: { value: number },
 }

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -265,5 +265,6 @@ export type PipetteNameSpecs = {|
 export type PipetteModelSpecs = {
   ...PipetteNameSpecs,
   model: string,
+  backcompatName?: string,
   tipLength: { value: number },
 }


### PR DESCRIPTION
When a robot has an attached P1000 Single GEN2, the and the uploaded protocol has a P1000 Single GEN1 specified, the app should accept the newer actual pipette as an inexact match. This mirrors the case of P300 GEN2 -> P300 GEN1 and P20 GEN2 -> P10 GEN1.

re #3598
