### PR TITLE
feat(app): Display robot and protocol api versions

### DIFF
--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -23,7 +23,7 @@ type Props = {
   lastUpdated: ?number,
   method: ?string,
   description: ?string,
-  apiLevel: ?number,
+  apiLevel: ?[number, number],
 }
 
 const INFO_TITLE = 'Information'

--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -39,7 +39,7 @@ function InformationCard(props: Props) {
   const lastUpdated = props.lastUpdated
     ? moment(props.lastUpdated).format(DATE_FORMAT)
     : '-'
-
+  const formattedApiLevel = apiLevel ? `${apiLevel[0]}.${apiLevel[1]}` : null
   return (
     <React.Fragment>
       <InfoSection title={INFO_TITLE}>
@@ -63,7 +63,7 @@ function InformationCard(props: Props) {
           <SectionContentHalf>
             <LabeledValue
               label="Protocol API Version"
-              value={apiLevel || '-'}
+              value={formattedApiLevel || '-'}
             />
           </SectionContentHalf>
         </CardRow>
@@ -84,6 +84,6 @@ function mapStateToProps(state: State): $Exact<Props> {
     lastUpdated: getProtocolLastUpdated(state),
     method: getProtocolMethod(state),
     description: getProtocolDescription(state),
-    apiLevel: robotSelectors.getApiLevel(state)[0],
+    apiLevel: robotSelectors.getApiLevel(state),
   }
 }

--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -10,7 +10,7 @@ import {
   getProtocolMethod,
   getProtocolDescription,
 } from '../../protocol'
-import { selectors as robotSelectors } from '../../robot'
+
 import { LabeledValue } from '@opentrons/components'
 import InfoSection from './InfoSection'
 import { SectionContentHalf, CardRow } from '../layout'
@@ -23,23 +23,22 @@ type Props = {
   lastUpdated: ?number,
   method: ?string,
   description: ?string,
-  apiLevel: ?[number, number],
 }
 
 const INFO_TITLE = 'Information'
 const DESCRIPTION_TITLE = 'Description'
 const DATE_FORMAT = 'DD MMM Y, hh:mmA'
 
-export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(
+export default connect<Props, {||}, _, {||}, _, _>(mapStateToProps)(
   InformationCard
 )
 
 function InformationCard(props: Props) {
-  const { name, author, method, description, apiLevel } = props
+  const { name, author, method, description } = props
   const lastUpdated = props.lastUpdated
     ? moment(props.lastUpdated).format(DATE_FORMAT)
     : '-'
-  const formattedApiLevel = apiLevel ? `${apiLevel[0]}.${apiLevel[1]}` : null
+
   return (
     <React.Fragment>
       <InfoSection title={INFO_TITLE}>
@@ -59,14 +58,6 @@ function InformationCard(props: Props) {
             <LabeledValue label="Creation Method" value={method || '-'} />
           </SectionContentHalf>
         </CardRow>
-        <CardRow>
-          <SectionContentHalf>
-            <LabeledValue
-              label="Protocol API Version"
-              value={formattedApiLevel || '-'}
-            />
-          </SectionContentHalf>
-        </CardRow>
       </InfoSection>
       {description && (
         <InfoSection title={DESCRIPTION_TITLE}>
@@ -84,6 +75,5 @@ function mapStateToProps(state: State): $Exact<Props> {
     lastUpdated: getProtocolLastUpdated(state),
     method: getProtocolMethod(state),
     description: getProtocolDescription(state),
-    apiLevel: robotSelectors.getApiLevel(state),
   }
 }

--- a/app/src/components/FileInfo/InformationCard.js
+++ b/app/src/components/FileInfo/InformationCard.js
@@ -10,6 +10,7 @@ import {
   getProtocolMethod,
   getProtocolDescription,
 } from '../../protocol'
+import { selectors as robotSelectors } from '../../robot'
 import { LabeledValue } from '@opentrons/components'
 import InfoSection from './InfoSection'
 import { SectionContentHalf, CardRow } from '../layout'
@@ -22,6 +23,7 @@ type Props = {
   lastUpdated: ?number,
   method: ?string,
   description: ?string,
+  apiLevel: ?number,
 }
 
 const INFO_TITLE = 'Information'
@@ -33,7 +35,7 @@ export default connect<Props, {||}, _, _, _, _>(mapStateToProps)(
 )
 
 function InformationCard(props: Props) {
-  const { name, author, method, description } = props
+  const { name, author, method, description, apiLevel } = props
   const lastUpdated = props.lastUpdated
     ? moment(props.lastUpdated).format(DATE_FORMAT)
     : '-'
@@ -49,12 +51,22 @@ function InformationCard(props: Props) {
             <LabeledValue label="Organization/Author" value={author || '-'} />
           </SectionContentHalf>
         </CardRow>
-        <SectionContentHalf>
-          <LabeledValue label="Last Updated" value={lastUpdated} />
-        </SectionContentHalf>
-        <SectionContentHalf>
-          <LabeledValue label="Creation Method" value={method || '-'} />
-        </SectionContentHalf>
+        <CardRow>
+          <SectionContentHalf>
+            <LabeledValue label="Last Updated" value={lastUpdated} />
+          </SectionContentHalf>
+          <SectionContentHalf>
+            <LabeledValue label="Creation Method" value={method || '-'} />
+          </SectionContentHalf>
+        </CardRow>
+        <CardRow>
+          <SectionContentHalf>
+            <LabeledValue
+              label="Protocol API Version"
+              value={apiLevel || '-'}
+            />
+          </SectionContentHalf>
+        </CardRow>
       </InfoSection>
       {description && (
         <InfoSection title={DESCRIPTION_TITLE}>
@@ -72,5 +84,6 @@ function mapStateToProps(state: State): $Exact<Props> {
     lastUpdated: getProtocolLastUpdated(state),
     method: getProtocolMethod(state),
     description: getProtocolDescription(state),
+    apiLevel: robotSelectors.getApiLevel(state)[0],
   }
 }

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -24,7 +24,7 @@ import {
   useInterval,
 } from '@opentrons/components'
 
-import { CardContentThird } from '../layout'
+import { CardRow, CardContentThird } from '../layout'
 
 import type { Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
@@ -38,7 +38,7 @@ const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
-const MAX_API_VERSION_LABEL = 'Max API Version'
+const MAX_PROTOCOL_API_VERSION_LABEL = 'Max Protocol API Version'
 
 const UPDATE_SERVER_UNAVAILABLE =
   "Unable to update because your robot's update server is not responding"
@@ -46,6 +46,8 @@ const OTHER_ROBOT_UPDATING =
   'Unable to update because your app is currently updating a different robot'
 const NO_UPDATE_FILES =
   'No robot update files found for this version of the app; please check again later'
+
+const DEFAULT_MAX_API_VERSION = '1.0'
 
 const UPDATE_RECHECK_DELAY_MS = 60000
 
@@ -63,10 +65,7 @@ export default function InformationCard(props: Props) {
   const buildrootRobot = useSelector(getBuildrootRobot)
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
-  const protocolApiVersion = getRobotProtocolApiVersion(robot)
-  const formattedProtocolApiVersion = protocolApiVersion
-    ? `${protocolApiVersion[0]}.${protocolApiVersion[1]}`
-    : null
+  const maxApiVersion = getRobotProtocolApiVersion(robot)
 
   const updateFilesUnavailable = updateType === null
   const updateServerUnavailable = !serverOk
@@ -89,46 +88,42 @@ export default function InformationCard(props: Props) {
 
   return (
     <Card title={TITLE}>
-      <div>
-        <CardContentThird>
+      <CardContentThird>
+        <CardRow>
           <LabeledValue label={NAME_LABEL} value={displayName} />
-        </CardContentThird>
-        <CardContentThird>
+        </CardRow>
+        <LabeledValue
+          label={FIRMWARE_VERSION_LABEL}
+          value={firmwareVersion || 'Unknown'}
+        />
+      </CardContentThird>
+      <CardContentThird>
+        <CardRow>
           <LabeledValue
             label={SERVER_VERSION_LABEL}
             value={version || 'Unknown'}
           />
-        </CardContentThird>
-        <CardContentThird>
-          <HoverTooltip tooltipComponent={updateButtonTooltip}>
-            {hoverTooltipHandlers => (
-              <div {...hoverTooltipHandlers}>
-                <OutlineButton
-                  Component={Link}
-                  to={updateUrl}
-                  disabled={updateDisabled}
-                >
-                  {updateButtonText}
-                </OutlineButton>
-              </div>
-            )}
-          </HoverTooltip>
-        </CardContentThird>
-      </div>
-      <div>
-        <CardContentThird>
-          <LabeledValue
-            label={FIRMWARE_VERSION_LABEL}
-            value={firmwareVersion || 'Unknown'}
-          />
-        </CardContentThird>
-        <CardContentThird overrideLast>
-          <LabeledValue
-            label={MAX_API_VERSION_LABEL}
-            value={formattedProtocolApiVersion || 'Unknown'}
-          />
-        </CardContentThird>
-      </div>
+        </CardRow>
+        <LabeledValue
+          label={MAX_PROTOCOL_API_VERSION_LABEL}
+          value={maxApiVersion || DEFAULT_MAX_API_VERSION}
+        />
+      </CardContentThird>
+      <CardContentThird>
+        <HoverTooltip tooltipComponent={updateButtonTooltip}>
+          {hoverTooltipHandlers => (
+            <div {...hoverTooltipHandlers}>
+              <OutlineButton
+                Component={Link}
+                to={updateUrl}
+                disabled={updateDisabled}
+              >
+                {updateButtonText}
+              </OutlineButton>
+            </div>
+          )}
+        </HoverTooltip>
+      </CardContentThird>
     </Card>
   )
 }

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -65,8 +65,6 @@ export default function InformationCard(props: Props) {
   const firmwareVersion = getRobotFirmwareVersion(robot)
   const protocolApiVersion = getRobotProtocolApiVersion(robot)
 
-  console.log(robot.health)
-
   const updateFilesUnavailable = updateType === null
   const updateServerUnavailable = !serverOk
   const otherRobotUpdating = Boolean(buildrootRobot && buildrootRobot !== robot)

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -64,6 +64,9 @@ export default function InformationCard(props: Props) {
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
   const protocolApiVersion = getRobotProtocolApiVersion(robot)
+  const formattedProtocolApiVersion = protocolApiVersion
+    ? `${protocolApiVersion[0]}.${protocolApiVersion[1]}`
+    : null
 
   const updateFilesUnavailable = updateType === null
   const updateServerUnavailable = !serverOk
@@ -122,7 +125,7 @@ export default function InformationCard(props: Props) {
         <CardContentThird overrideLast>
           <LabeledValue
             label={MAX_API_VERSION_LABEL}
-            value={protocolApiVersion || 'Unknown'}
+            value={formattedProtocolApiVersion || 'Unknown'}
           />
         </CardContentThird>
       </div>

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -4,7 +4,11 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
 
-import { getRobotApiVersion, getRobotFirmwareVersion } from '../../discovery'
+import {
+  getRobotApiVersion,
+  getRobotFirmwareVersion,
+  getRobotProtocolApiVersion,
+} from '../../discovery'
 
 import {
   getBuildrootRobot,
@@ -20,7 +24,7 @@ import {
   useInterval,
 } from '@opentrons/components'
 
-import { CardContentQuarter } from '../layout'
+import { CardContentThird } from '../layout'
 
 import type { Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
@@ -34,6 +38,7 @@ const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
+const MAX_API_VERSION_LABEL = 'Max API Version'
 
 const UPDATE_SERVER_UNAVAILABLE =
   "Unable to update because your robot's update server is not responding"
@@ -56,9 +61,11 @@ export default function InformationCard(props: Props) {
 
   const { displayName, serverOk } = robot
   const buildrootRobot = useSelector(getBuildrootRobot)
-
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
+  const protocolApiVersion = getRobotProtocolApiVersion(robot)
+
+  console.log(robot.health)
 
   const updateFilesUnavailable = updateType === null
   const updateServerUnavailable = !serverOk
@@ -81,36 +88,46 @@ export default function InformationCard(props: Props) {
 
   return (
     <Card title={TITLE}>
-      <CardContentQuarter>
-        <LabeledValue label={NAME_LABEL} value={displayName} />
-      </CardContentQuarter>
-      <CardContentQuarter>
-        <LabeledValue
-          label={SERVER_VERSION_LABEL}
-          value={version || 'Unknown'}
-        />
-      </CardContentQuarter>
-      <CardContentQuarter>
-        <LabeledValue
-          label={FIRMWARE_VERSION_LABEL}
-          value={firmwareVersion || 'Unknown'}
-        />
-      </CardContentQuarter>
-      <CardContentQuarter>
-        <HoverTooltip tooltipComponent={updateButtonTooltip}>
-          {hoverTooltipHandlers => (
-            <div {...hoverTooltipHandlers}>
-              <OutlineButton
-                Component={Link}
-                to={updateUrl}
-                disabled={updateDisabled}
-              >
-                {updateButtonText}
-              </OutlineButton>
-            </div>
-          )}
-        </HoverTooltip>
-      </CardContentQuarter>
+      <div>
+        <CardContentThird>
+          <LabeledValue label={NAME_LABEL} value={displayName} />
+        </CardContentThird>
+        <CardContentThird>
+          <LabeledValue
+            label={SERVER_VERSION_LABEL}
+            value={version || 'Unknown'}
+          />
+        </CardContentThird>
+        <CardContentThird>
+          <HoverTooltip tooltipComponent={updateButtonTooltip}>
+            {hoverTooltipHandlers => (
+              <div {...hoverTooltipHandlers}>
+                <OutlineButton
+                  Component={Link}
+                  to={updateUrl}
+                  disabled={updateDisabled}
+                >
+                  {updateButtonText}
+                </OutlineButton>
+              </div>
+            )}
+          </HoverTooltip>
+        </CardContentThird>
+      </div>
+      <div>
+        <CardContentThird>
+          <LabeledValue
+            label={FIRMWARE_VERSION_LABEL}
+            value={firmwareVersion || 'Unknown'}
+          />
+        </CardContentThird>
+        <CardContentThird overrideLast>
+          <LabeledValue
+            label={MAX_API_VERSION_LABEL}
+            value={protocolApiVersion || 'Unknown'}
+          />
+        </CardContentThird>
+      </div>
     </Card>
   )
 }

--- a/app/src/components/layout/CardContentThird.js
+++ b/app/src/components/layout/CardContentThird.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import styles from './styles.css'
+
+type Props = {
+  children: React.Node,
+  className?: string,
+  overrideLast?: boolean,
+}
+export default function CardContentThird(props: Props) {
+  return (
+    <div
+      className={cx(styles.card_content_third, props.className, {
+        [styles.override_last]: props.overrideLast,
+      })}
+    >
+      {props.children}
+    </div>
+  )
+}

--- a/app/src/components/layout/CardContentThird.js
+++ b/app/src/components/layout/CardContentThird.js
@@ -3,18 +3,14 @@ import * as React from 'react'
 import cx from 'classnames'
 import styles from './styles.css'
 
-type Props = {
+export type CardContentThirdProps = {|
   children: React.Node,
   className?: string,
-  overrideLast?: boolean,
-}
-export default function CardContentThird(props: Props) {
+|}
+
+export function CardContentThird(props: CardContentThirdProps) {
   return (
-    <div
-      className={cx(styles.card_content_third, props.className, {
-        [styles.override_last]: props.overrideLast,
-      })}
-    >
+    <div className={cx(styles.card_content_third, props.className)}>
       {props.children}
     </div>
   )

--- a/app/src/components/layout/index.js
+++ b/app/src/components/layout/index.js
@@ -4,6 +4,7 @@ import CardRow from './CardRow'
 import CardColumn from './CardColumn'
 import CardContentFull from './CardContentFull'
 import CardContentHalf from './CardContentHalf'
+import CardContentThird from './CardContentThird'
 import CardContentQuarter from './CardContentQuarter'
 import CardContentFlex from './CardContentFlex'
 import SectionContentFull from './SectionContentFull'
@@ -15,6 +16,7 @@ export {
   CardColumn,
   CardContentFull,
   CardContentHalf,
+  CardContentThird,
   CardContentQuarter,
   CardContentFlex,
   SectionContentFull,

--- a/app/src/components/layout/index.js
+++ b/app/src/components/layout/index.js
@@ -1,24 +1,12 @@
 // @flow
-import CardContainer from './CardContainer'
-import CardRow from './CardRow'
-import CardColumn from './CardColumn'
-import CardContentFull from './CardContentFull'
-import CardContentHalf from './CardContentHalf'
-import CardContentThird from './CardContentThird'
-import CardContentQuarter from './CardContentQuarter'
-import CardContentFlex from './CardContentFlex'
-import SectionContentFull from './SectionContentFull'
-import SectionContentHalf from './SectionContentHalf'
-
-export {
-  CardContainer,
-  CardRow,
-  CardColumn,
-  CardContentFull,
-  CardContentHalf,
-  CardContentThird,
-  CardContentQuarter,
-  CardContentFlex,
-  SectionContentFull,
-  SectionContentHalf,
-}
+// TODO(mc, 2019-11-26): flex box these and also no default exports
+export { default as CardContainer } from './CardContainer'
+export { default as CardRow } from './CardRow'
+export { default as CardColumn } from './CardColumn'
+export { default as CardContentFull } from './CardContentFull'
+export { default as CardContentHalf } from './CardContentHalf'
+export * from './CardContentThird'
+export { default as CardContentQuarter } from './CardContentQuarter'
+export { default as CardContentFlex } from './CardContentFlex'
+export { default as SectionContentFull } from './SectionContentFull'
+export { default as SectionContentHalf } from './SectionContentHalf'

--- a/app/src/components/layout/styles.css
+++ b/app/src/components/layout/styles.css
@@ -68,10 +68,6 @@
     text-align: right;
     padding: 1rem;
   }
-
-  &.override_last {
-    text-align: left;
-  }
 }
 
 .card_content_flex {

--- a/app/src/components/layout/styles.css
+++ b/app/src/components/layout/styles.css
@@ -57,6 +57,23 @@
   }
 }
 
+.card_content_third {
+  display: inline-block;
+  font-size: 0;
+  vertical-align: top;
+  width: calc(1 / 3 * 100%);
+  padding: 1rem 0 1rem 1rem;
+
+  &:last-child {
+    text-align: right;
+    padding: 1rem;
+  }
+
+  &.override_last {
+    text-align: left;
+  }
+}
+
 .card_content_flex {
   display: flex;
   justify-content: space-between;

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -418,7 +418,7 @@ describe('discovery selectors', () => {
         health: { protocol_api_version: [2, 0] },
       },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: [2, 0],
+      expected: '2.0',
     },
     {
       name: 'getRobotProtocolApiVersion returns null if no healths',

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -410,14 +410,15 @@ describe('discovery selectors', () => {
       expected: null,
     },
     {
-      name: 'getRobotProtocolApiVersion returns first health.protocol_api_version',
+      name:
+        'getRobotProtocolApiVersion returns first health.protocol_api_version',
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: {
-        serverHealth: {  },
+        serverHealth: {},
         health: { protocol_api_version: [2, 0] },
       },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: 2,
+      expected: [2, 0],
     },
     {
       name: 'getRobotProtocolApiVersion returns null if no healths',

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -396,7 +396,7 @@ describe('discovery selectors', () => {
     },
     {
       name:
-        'getRobotFirmwareVersion returns serverHealth.smoothieVersion if no halth',
+        'getRobotFirmwareVersion returns serverHealth.smoothieVersion if no health',
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: { serverHealth: { smoothieVersion: '4.5.6' }, health: null },
       selector: discovery.getRobotFirmwareVersion,
@@ -407,6 +407,23 @@ describe('discovery selectors', () => {
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: { serverHealth: null, health: null },
       selector: discovery.getRobotFirmwareVersion,
+      expected: null,
+    },
+    {
+      name: 'getRobotProtocolApiVersion returns first health.protocol_api_version',
+      // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
+      state: {
+        serverHealth: {  },
+        health: { protocol_api_version: [2, 0] },
+      },
+      selector: discovery.getRobotProtocolApiVersion,
+      expected: 2,
+    },
+    {
+      name: 'getRobotProtocolApiVersion returns null if no healths',
+      // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
+      state: { serverHealth: null, health: null },
+      selector: discovery.getRobotProtocolApiVersion,
       expected: null,
     },
   ]

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -150,3 +150,8 @@ export const getRobotApiVersion = (robot: AnyRobot): ?string =>
 export const getRobotFirmwareVersion = (robot: AnyRobot): ?string =>
   (robot.health && robot.health.fw_version) ||
   (robot.serverHealth && robot.serverHealth.smoothieVersion)
+
+export const getRobotProtocolApiVersion = (robot: AnyRobot): ?number =>
+  robot.health &&
+  robot.health.protocol_api_version &&
+  robot.health.protocol_api_version[0]

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -151,5 +151,6 @@ export const getRobotFirmwareVersion = (robot: AnyRobot): ?string =>
   (robot.health && robot.health.fw_version) ||
   (robot.serverHealth && robot.serverHealth.smoothieVersion)
 
-export const getRobotProtocolApiVersion = (robot: AnyRobot): Array<number> =>
-  robot.health && robot.health.protocol_api_version
+export const getRobotProtocolApiVersion = (
+  robot: AnyRobot
+): ?[number, number] => robot.health && robot.health.protocol_api_version

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -151,6 +151,7 @@ export const getRobotFirmwareVersion = (robot: AnyRobot): ?string =>
   (robot.health && robot.health.fw_version) ||
   (robot.serverHealth && robot.serverHealth.smoothieVersion)
 
-export const getRobotProtocolApiVersion = (
-  robot: AnyRobot
-): ?[number, number] => robot.health && robot.health.protocol_api_version
+export const getRobotProtocolApiVersion = (robot: AnyRobot): string | null => {
+  const maxApiVersion = robot.health?.protocol_api_version
+  return maxApiVersion ? maxApiVersion.join('.') : null
+}

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -151,7 +151,5 @@ export const getRobotFirmwareVersion = (robot: AnyRobot): ?string =>
   (robot.health && robot.health.fw_version) ||
   (robot.serverHealth && robot.serverHealth.smoothieVersion)
 
-export const getRobotProtocolApiVersion = (robot: AnyRobot): ?number =>
-  robot.health &&
-  robot.health.protocol_api_version &&
-  robot.health.protocol_api_version[0]
+export const getRobotProtocolApiVersion = (robot: AnyRobot): Array<number> =>
+  robot.health && robot.health.protocol_api_version

--- a/app/src/protocol/__tests__/reducer.test.js
+++ b/app/src/protocol/__tests__/reducer.test.js
@@ -1,6 +1,6 @@
 // protocol state reducer tests
 
-import { protocolReducer } from '..'
+import { protocolReducer } from '../reducer'
 
 describe('protocolReducer', () => {
   test('initial state', () => {

--- a/app/src/protocol/__tests__/selectors.test.js
+++ b/app/src/protocol/__tests__/selectors.test.js
@@ -172,13 +172,17 @@ const SPECS = [
   {
     name: 'getProtocolMethod if nothing loaded',
     selector: protocol.getProtocolMethod,
-    state: { protocol: { file: null, contents: null, data: null } },
+    state: {
+      robot: { session: { apiLevel: [1, 0] } },
+      protocol: { file: null, contents: null, data: null },
+    },
     expected: null,
   },
   {
     name: 'getProtocolMethod if file not yet read',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: { file: { name: 'proto.py' }, contents: null, data: null },
     },
     expected: null,
@@ -187,18 +191,20 @@ const SPECS = [
     name: 'getProtocolMethod if non-JSON file has been read',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: {
         file: { name: 'proto.py' },
         contents: 'fizzbuzz',
         data: null,
       },
     },
-    expected: 'Opentrons API',
+    expected: 'Python Protocol API v1.0',
   },
   {
     name: 'getProtocolMethod if JSON file read but no data',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: {
         file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
@@ -211,6 +217,7 @@ const SPECS = [
     name: 'getProtocolMethod if JSON file read but no name in data',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: {
         file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
@@ -223,6 +230,7 @@ const SPECS = [
     name: 'getProtocolMethod if JSON file read with name in data',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: {
         file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
@@ -234,12 +242,13 @@ const SPECS = [
         },
       },
     },
-    expected: 'Opentrons Protocol Designer',
+    expected: 'Protocol Designer',
   },
   {
     name: 'getProtocolMethod if JSON file read with name and version in data',
     selector: protocol.getProtocolMethod,
     state: {
+      robot: { session: { apiLevel: [1, 0] } },
       protocol: {
         file: { name: 'proto.json', type: 'json' },
         contents: 'fizzbuzz',
@@ -247,12 +256,12 @@ const SPECS = [
           metadata: {},
           'designer-application': {
             'application-name': 'opentrons/protocol-designer',
-            'application-version': 'v1.2.3',
+            'application-version': '1.2.3',
           },
         },
       },
     },
-    expected: 'Opentrons Protocol Designer v1.2.3',
+    expected: 'Protocol Designer v1.2.3',
   },
 ]
 

--- a/app/src/protocol/index.js
+++ b/app/src/protocol/index.js
@@ -3,28 +3,13 @@
 import {
   fileToProtocolFile,
   parseProtocolData,
-  filenameToType,
   fileIsBinary,
 } from './protocol-data'
 
-import type { Action, ThunkAction } from '../types'
-import type { ProtocolState, ProtocolFile } from './types'
+import type { ThunkAction } from '../types'
+import type { OpenProtocolAction, UploadProtocolAction } from './types'
 
-export * from './types'
 export * from './selectors'
-
-type OpenProtocolAction = {|
-  type: 'protocol:OPEN',
-  payload: {| file: ProtocolFile |},
-|}
-
-type UploadProtocolAction = {|
-  type: 'protocol:UPLOAD',
-  payload: {| contents: string, data: $PropertyType<ProtocolState, 'data'> |},
-  meta: {| robot: true |},
-|}
-
-export type ProtocolAction = OpenProtocolAction | UploadProtocolAction
 
 const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
   let binary = ''
@@ -69,39 +54,4 @@ export function openProtocol(file: File): ThunkAction {
     }
     return dispatch(openAction)
   }
-}
-
-const INITIAL_STATE = { file: null, contents: null, data: null }
-
-export function protocolReducer(
-  state: ProtocolState = INITIAL_STATE,
-  action: Action
-): ProtocolState {
-  switch (action.type) {
-    case 'protocol:OPEN':
-      return { ...INITIAL_STATE, ...action.payload }
-
-    case 'protocol:UPLOAD':
-      return { ...state, ...action.payload }
-
-    case 'robot:SESSION_RESPONSE': {
-      const { name, metadata, protocolText: contents } = action.payload
-      const file =
-        !state.file || name !== state.file.name
-          ? { name, type: filenameToType(name), lastModified: null }
-          : state.file
-      const data =
-        !state.data ||
-        (typeof contents === 'string' && contents !== state.contents)
-          ? parseProtocolData(file, contents, metadata)
-          : state.data
-
-      return { file, contents, data }
-    }
-
-    case 'robot:DISCONNECT_RESPONSE':
-      return INITIAL_STATE
-  }
-
-  return state
 }

--- a/app/src/protocol/reducer.js
+++ b/app/src/protocol/reducer.js
@@ -1,0 +1,40 @@
+// @flow
+import { filenameToType, parseProtocolData } from './protocol-data'
+
+import type { Action } from '../types'
+import type { ProtocolState } from './types'
+
+const INITIAL_STATE: ProtocolState = { file: null, contents: null, data: null }
+
+export function protocolReducer(
+  state: ProtocolState = INITIAL_STATE,
+  action: Action
+): ProtocolState {
+  switch (action.type) {
+    case 'protocol:OPEN':
+      return { ...INITIAL_STATE, ...action.payload }
+
+    case 'protocol:UPLOAD':
+      return { ...state, ...action.payload }
+
+    case 'robot:SESSION_RESPONSE': {
+      const { name, metadata, protocolText: contents } = action.payload
+      const file =
+        !state.file || name !== state.file.name
+          ? { name, type: filenameToType(name), lastModified: null }
+          : state.file
+      const data =
+        !state.data ||
+        (typeof contents === 'string' && contents !== state.contents)
+          ? parseProtocolData(file, contents, metadata)
+          : state.data
+
+      return { file, contents, data }
+    }
+
+    case 'robot:DISCONNECT_RESPONSE':
+      return INITIAL_STATE
+  }
+
+  return state
+}

--- a/app/src/protocol/types.js
+++ b/app/src/protocol/types.js
@@ -18,8 +18,25 @@ export type ProtocolFile = {
   lastModified: ?number,
 }
 
-export type ProtocolState = {
-  file: ?ProtocolFile,
-  contents: ?string,
-  data: ?ProtocolData,
-}
+// action types
+
+export type OpenProtocolAction = {|
+  type: 'protocol:OPEN',
+  payload: {| file: ProtocolFile |},
+|}
+
+export type UploadProtocolAction = {|
+  type: 'protocol:UPLOAD',
+  payload: {| contents: string, data: ProtocolData | null |},
+  meta: {| robot: true |},
+|}
+
+export type ProtocolAction = OpenProtocolAction | UploadProtocolAction
+
+// state types
+
+export type ProtocolState = $ReadOnly<{|
+  file: ProtocolFile | null,
+  contents: string | null,
+  data: ProtocolData | null,
+|}>

--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -33,7 +33,7 @@ import { configReducer } from './config'
 import { discoveryReducer } from './discovery/reducer'
 
 // protocol state
-import { protocolReducer } from './protocol'
+import { protocolReducer } from './protocol/reducer'
 
 // custom labware state
 import { customLabwareReducer } from './custom-labware/reducer'

--- a/app/src/robot/actions.js
+++ b/app/src/robot/actions.js
@@ -3,7 +3,7 @@
 import { _NAME as NAME } from './constants'
 
 import type { Error } from '../types'
-import type { ProtocolData } from '../protocol'
+import type { ProtocolData } from '../protocol/types'
 import type { Mount, Slot, Axis, Direction, SessionUpdate } from './types'
 
 // TODO(mc, 2017-11-22): rename this function to actionType

--- a/app/src/types.js
+++ b/app/src/types.js
@@ -20,7 +20,7 @@ import type { RobotState, Action as RobotAction } from './robot'
 import type { ShellState, ShellAction } from './shell/types'
 import type { Config, ConfigAction } from './config/types'
 import type { DiscoveryState, DiscoveryAction } from './discovery/types'
-import type { ProtocolState, ProtocolAction } from './protocol'
+import type { ProtocolState, ProtocolAction } from './protocol/types'
 import type {
   CustomLabwareState,
   CustomLabwareAction,

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -7,6 +7,7 @@ export type HealthResponse = {
   fw_version: string,
   system_version?: string,
   logs?: Array<string>,
+  protocol_api_version?: Array<number>,
 }
 
 export type Capability =

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -7,7 +7,7 @@ export type HealthResponse = {
   fw_version: string,
   system_version?: string,
   logs?: Array<string>,
-  protocol_api_version?: Array<number>,
+  protocol_api_version?: [number, number],
 }
 
 export type Capability =


### PR DESCRIPTION
## overview

This PR closes #4362 by displaying the max supported API version in the robot info card and the API version specified in the protocol on the file info page.

<img width="1136" alt="Screenshot 2019-11-26 14 27 01" src="https://user-images.githubusercontent.com/2963448/69672703-a8079800-1066-11ea-9e08-2234e0fc823c.png">

<img width="1136" alt="Screenshot 2019-11-26 14 25 04" src="https://user-images.githubusercontent.com/2963448/69672707-a938c500-1066-11ea-8970-7f9996bd4d04.png">

## changelog

- feat(app): Display robot and protocol api versions

## review requests

This touches types in discovery client (adds protocol_api_version to HealthResponse). Please double check my work!

- [ ] Layout seems sane
- [ ] Copy for the labels is correct
- [ ] RobotInfo correctly displays the max supported api version 
- [ ] FileInfo correctly displays the protocol specified api version 

