### PR TITLE
fix(api): smoothie driver: Limit high currents to moving axes

### DIFF
--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -268,11 +268,11 @@ def test_plunger_commands(smoothie, monkeypatch):
 
     smoothie.move({
         'X': 10.987654321,
-        'Y': 1.12345678,
-        'Z': 2,
-        'A': 3,
-        'B': 4,
-        'C': 5})
+        'Y': 2.12345678,
+        'Z': 2.5,
+        'A': 3.5,
+        'B': 4.25,
+        'C': 5.55})
     expected = [
         # Set active axes high
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],


### PR DESCRIPTION
V1 habitually issues calls to the smoothie driver's move() function that include
only the axes that are going to move (basically because of the mover setup that
underpins motion control in V1). In V2, we have a unified source of control for
motor commands that always sends a full axis spec.

The smoothie driver was setting high currents for all axes specified in the
motion command, whether those axes moved or not. That meant that most of the
time, any command would set all axes to high currents. This is unnecessary,
generates heat, and may overstress the power supply, leading to unexpected skips
in certain high-friction situations.

Instead, use the code we already have to cut down on gcode command length to
determine which axes will actually move and only set those axes to high
currents.

Closes #4714

## Testing

This hits at a kind of low level part of the driver. A good thing to do here is run a short protocol like this:

```python
metadata = {'apiLevel': '2.1'}

def run(ctx):
   # the labware, location, and pipette don't really matter here, use what you have
   tr = ctx.load_labware('opentrons_96_tiprack_300ul', '1')
   plate = ctx.load_labware('corning_96_wellplate_360ul', '2')
   pip = ctx.load_instrument('p300_single_gen2', 'right', tip_racks=[tr])
   pip.pick_up_tip()
   pip.aspirate(100, plate['A1'])
   pip.air_gap(50)
   pip.dispense(plate['A2'])
   pip.blow_out()
   pip.drop_tip()
```

Run the protocol and inspect the smoothie log. Only axes that are moving in a given command should have high current (anything other than the LOW_CURRENT defaults in the robot config).
