### PR TITLE
fix(api): set default move timeout to 12000 instead of 60

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1338,10 +1338,9 @@ class SmoothieDriver_3_0_0:
                 if home_flagged_axes:
                     self.home_flagged_axes(''.join(list(target.keys())))
                 log.debug("move: {}".format(command))
-                # TODO (andy) a movement's timeout should be calculated by
-                # how long the movement is expected to take. A default timeout
-                # of 30 seconds prevents any movements that take longer
-                self._send_command(command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+                # TODO (hmg) a movement's timeout should be calculated by
+                # how long the movement is expected to take.
+                self._send_command(command, timeout=DEFAULT_EXECUTE_TIMEOUT)
             finally:
                 # dwell pipette motors because they get hot
                 plunger_axis_moved = ''.join(set('BC') & set(target.keys()))


### PR DESCRIPTION
We added a split between ack and execute timeouts, with the execute timeout
being 12000 seconds. But we didn't actually change the places where the timeout
was specified to 30 for some reason. We therefore fixed the timeout issues that
consistently happened when the robot homed with the head far from its home...
but not the ones that happened when users specified a sharply limited speed.

Closes #4755

## Testing
- Run some very slow move commands, like setting the aspirate flow rate to 1ul/s and doing a full volume aspirate on a gen2