### PR TITLE
fix(api): Only move to max safe height in between labwares during calibration

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -7,6 +7,7 @@ from opentrons.config import feature_flags as ff
 from opentrons.broker import Broker
 from opentrons.types import Point, Mount, Location
 from opentrons.protocol_api import labware
+from opentrons.protocols.types import APIVersion
 from opentrons.hardware_control import CriticalPoint
 
 from .models import Container
@@ -157,7 +158,8 @@ class CalibrationManager:
         self._set_state('moving')
         if instrument._context:
             with instrument._context.temp_connect(self._hardware):
-                instrument._context.location_cache = None
+                if instrument._context.api_version < APIVersion(2, 2):
+                    instrument._context.location_cache = None
                 inst.drop_tip(_well0(container._container))
         else:
             inst.drop_tip(_well0(container._container))

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -197,7 +197,7 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         display_name=ensure_value(cfg, 'displayName', MUTABLE_CONFIGS),
         name=cfg.get('name'),
         back_compat_names=cfg.get('backCompatNames', []),
-        return_tip_height=cfg.get('returnTipHeight'),
+        return_tip_height=cfg.get('returnTipHeight', 0.5),
         blow_out_flow_rate=ensure_value(
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
         max_travel=smoothie_configs['travelDistance'],

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1289,6 +1289,16 @@ class InstrumentContext(CommandPublisher):
 
         return self
 
+    def _determine_drop_target(self, location: Well):
+        if self.api_version < APIVersion(2, 2):
+            bot = location.bottom()
+            return bot._replace(point=bot.point._replace(z=bot.point.z + 10))
+        else:
+            tr = location.parent
+            assert tr.is_tiprack
+            z_height = self.return_height * self._tip_length_for(tr)
+            return location.top(-z_height + 10)
+
     @requires_version(2, 0)
     def drop_tip(  # noqa(C901)
             self,
@@ -1347,9 +1357,7 @@ class InstrumentContext(CommandPublisher):
             if 'fixedTrash' in quirks_from_any_parent(location):
                 target = location.top()
             else:
-                bot = location.bottom()
-                target = bot._replace(
-                    point=bot.point._replace(z=bot.point.z + 10))
+                target = self._determine_drop_target(location)
         elif not location:
             target = self.trash_container.wells()[0].top()
         else:
@@ -1883,6 +1891,12 @@ class InstrumentContext(CommandPublisher):
 
     @property  # type: ignore
     @requires_version(2, 0)
+    def return_height(self) -> int:
+        """ The height to return a tip to its tiprack. """
+        return self.hw_pipette.get('returnTipHeight', 0.5)
+
+    @property  # type: ignore
+    @requires_version(2, 0)
     def well_bottom_clearance(self) -> 'Clearances':
         """ The distance above the bottom of a well to aspirate or dispense.
 
@@ -1991,10 +2005,10 @@ class ModuleContext(CommandPublisher):
         .. versionadded:: 2.1
         :returns: The initialized and loaded labware object.
         """
-        if self._ctx.api_version < APIVersion(2, 1) and\
+        if self.api_version < APIVersion(2, 1) and\
                 (label or namespace or version):
             MODULE_LOG.warning(
-                f'You have specified API {self._ctx.api_version}, but you '
+                f'You have specified API {self.api_version}, but you '
                 'are trying to utilize new load_labware parameters in 2.1')
         lw = load(name, self._geometry.location,
                   label, namespace, version,


### PR DESCRIPTION
## overview

A few reports have been made about customers experiencing hard limit errors during labware calibration -- specifically during a return tip/drop tip move. Previously, labware calibration expected to use the max safe height when performing any move around the deck including movements to the same labware.

Instead if the robot is returning tips to a tiprack it is already positioned over, the robot will use a direct move to the drop off location.

## changelog
- Remove location cache being set to `None` in `drop_tip` during labware calibration
- Calculate the position of the tip using the top of the well and a pipette's return tip height


## review requests

Feel free to test out this protocol on the robot. Switch between version 2.2 and 2.1/0 to see that behavior still remains the same.

```
metadata={"apiLevel": "2.2"}

def run(ctx):
	tiprack2 = ctx.load_labware('opentrons_96_tiprack_1000ul', '2')
	tiprack1 = ctx.load_labware('opentrons_96_tiprack_300ul', '1')

	plate1 = ctx.load_labware('corning_96_wellplate_360ul_flat', '3')
	plate2 = ctx.load_labware('corning_96_wellplate_360ul_flat', '4')

	pip = ctx.load_instrument('p50_single', mount='right', tip_racks=[tiprack1])
	pip2 = ctx.load_instrument('p1000_single', mount='left', tip_racks=[tiprack2])


	pip.transfer(50, plate1.wells(), plate2.wells())

	pip2.transfer(50, plate2.wells(), plate1.wells())
```
