### PR TITLE
feat(api): add module def schema v2 and v2 defs

### DIFF
--- a/shared-data/js/__tests__/moduleSpecsSchema.test.js
+++ b/shared-data/js/__tests__/moduleSpecsSchema.test.js
@@ -1,18 +1,31 @@
 import Ajv from 'ajv'
-import moduleSpecsSchema from '../../module/schemas/1.json'
-import moduleSpecs from '../../module/definitions/1.json'
+import moduleSpecsSchemaV1 from '../../module/schemas/1.json'
+import moduleSpecsV1 from '../../module/definitions/1.json'
+import moduleSpecsSchemaV2 from '../../module/schemas/2.json'
+import moduleSpecsV2 from '../../module/definitions/2.json'
 
 const ajv = new Ajv({
   allErrors: true,
   jsonPointers: true,
 })
 
-const validateModuleSpecs = ajv.compile(moduleSpecsSchema)
+const validateModuleSpecsV1 = ajv.compile(moduleSpecsSchemaV1)
+const validateModuleSpecsV2 = ajv.compile(moduleSpecsSchemaV2)
 
 describe('validate all module specs with schema', () => {
-  test('ensure all module specs match the JSON schema', () => {
-    const valid = validateModuleSpecs(moduleSpecs)
-    const validationErrors = validateModuleSpecs.errors
+  test('ensure V1 module specs match the V1 JSON schema', () => {
+    const valid = validateModuleSpecsV1(moduleSpecsV1)
+    const validationErrors = validateModuleSpecsV1.errors
+
+    if (validationErrors) {
+      console.log(JSON.stringify(validationErrors, null, 4))
+    }
+    expect(validationErrors).toBe(null)
+    expect(valid).toBe(true)
+  })
+  test('ensure V2 module specs match the V2 JSON schema', () => {
+    const valid = validateModuleSpecsV2(moduleSpecsV2)
+    const validationErrors = validateModuleSpecsV2.errors
 
     if (validationErrors) {
       console.log(JSON.stringify(validationErrors, null, 4))

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -1,6 +1,6 @@
 // @flow
 import type { ModuleType } from './types'
-import moduleSpecs from '../module/definitions/1.json'
+import moduleSpecs from '../module/definitions/2.json'
 
 // use a name like 'magdeck' to get displayName for app
 export function getModuleDisplayName(name: ModuleType): string {

--- a/shared-data/module/definitions/2.json
+++ b/shared-data/module/definitions/2.json
@@ -15,10 +15,10 @@
       "y": 2.75
     },
     "displayName": "Magnetic Module",
-    "loadName": "magdeck",
+    "loadNames": ["magdeck", "magnetic module"],
     "quirks": [],
     "slotTransforms": {},
-    "compatibleLoadNames": ["magdeckGen2"]
+    "compatibleWith": []
   },
   "tempdeck": {
     "labwareOffset": {
@@ -35,10 +35,10 @@
       "y": 8.75
     },
     "displayName": "Temperature Module",
-    "loadName": "tempdeck",
+    "loadNames": ["tempdeck", "temperature module"],
     "quirks": [],
     "slotTransforms": {},
-    "compatibleLoadNames": ["tempdeckGen2"]
+    "compatibleWith": ["#/tempdeckGen2"]
   },
   "thermocycler": {
     "labwareOffset": {
@@ -56,10 +56,10 @@
       "y": 64.93
     },
     "displayName": "Thermocycler Module",
-    "loadName": "thermocycler",
+    "loadNames": ["thermocycler", "thermocycler module"],
     "quirks": [],
     "slotTransforms": {},
-    "compatibleLoadNames": []
+    "compatibleWith": []
   },
   "magdeckGen2": {
     "labwareOffset": {
@@ -76,7 +76,7 @@
       "y": 2.75
     },
     "displayName": "Magnetic Module GEN2",
-    "loadName": "magdeckGen2",
+    "loadNames": ["magdeckgen2", "magnetic module gen2"],
     "quirks": [],
     "slotTransforms": {
       "ot2_standard": {
@@ -89,9 +89,20 @@
         "9": {
           "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
         }
+      },
+      "ot2_short_trash": {
+        "3": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "6": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "9": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        }
       }
     },
-    "compatibleLoadNames": ["magdeck"]
+    "compatibleWith": []
   },
   "tempdeckGen2": {
     "labwareOffset": {
@@ -108,19 +119,32 @@
       "y": 8.75
     },
     "displayName": "Temperature Module GEN2",
-    "loadName": "tempdeckGen2",
+    "loadNames": ["tempdeckGen2", "temperature module gen2"],
     "quirks": [],
     "slotTransforms": {
-      "3": {
-        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      "ot2_standard": {
+        "3": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "6": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "9": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        }
       },
-      "6": {
-        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
-      },
-      "9": {
-        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      "ot2_short_trash": {
+        "3": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "6": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        },
+        "9": {
+          "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+        }
       }
     },
-    "compatibleLoadNames": ["tempdeck"]
+    "compatibleWith": ["#/tempdeck"]
   }
 }

--- a/shared-data/module/definitions/2.json
+++ b/shared-data/module/definitions/2.json
@@ -1,0 +1,126 @@
+{
+  "$otSharedSchema": "module/schemas/2",
+  "magdeck": {
+    "labwareOffset": {
+      "x": 0.125,
+      "y": -0.125,
+      "z": 82.25
+    },
+    "dimensions": {
+      "bareOverallHeight": 110.152,
+      "overLabwareHeight": 4.052
+    },
+    "calibrationPoint": {
+      "x": 124.875,
+      "y": 2.75
+    },
+    "displayName": "Magnetic Module",
+    "loadName": "magdeck",
+    "quirks": [],
+    "slotTransforms": {},
+    "compatibleLoadNames": ["magdeckGen2"]
+  },
+  "tempdeck": {
+    "labwareOffset": {
+      "x": -0.15,
+      "y": -0.15,
+      "z": 80.09
+    },
+    "dimensions": {
+      "bareOverallHeight": 84,
+      "overLabwareHeight": 0
+    },
+    "calibrationPoint": {
+      "x": 12.0,
+      "y": 8.75
+    },
+    "displayName": "Temperature Module",
+    "loadName": "tempdeck",
+    "quirks": [],
+    "slotTransforms": {},
+    "compatibleLoadNames": ["tempdeckGen2"]
+  },
+  "thermocycler": {
+    "labwareOffset": {
+      "x": 0,
+      "y": 82.56,
+      "z": 97.8
+    },
+    "dimensions": {
+      "bareOverallHeight": 98.0,
+      "overLabwareHeight": 0.0,
+      "lidHeight": 37.7
+    },
+    "calibrationPoint": {
+      "x": 14.4,
+      "y": 64.93
+    },
+    "displayName": "Thermocycler Module",
+    "loadName": "thermocycler",
+    "quirks": [],
+    "slotTransforms": {},
+    "compatibleLoadNames": []
+  },
+  "magdeckGen2": {
+    "labwareOffset": {
+      "x": -1.175,
+      "y": -0.125,
+      "z": 82.25
+    },
+    "dimensions": {
+      "bareOverallHeight": 110.152,
+      "overLabwareHeight": 4.052
+    },
+    "calibrationPoint": {
+      "x": 124.875,
+      "y": 2.75
+    },
+    "displayName": "Magnetic Module GEN2",
+    "loadName": "magdeckGen2",
+    "quirks": [],
+    "slotTransforms": {
+      "ot2_standard": {
+        "3": {
+          "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+        },
+        "6": {
+          "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+        },
+        "9": {
+          "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+        }
+      }
+    },
+    "compatibleLoadNames": ["magdeck"]
+  },
+  "tempdeckGen2": {
+    "labwareOffset": {
+      "x": -1.45,
+      "y": -0.15,
+      "z": 80.09
+    },
+    "dimensions": {
+      "bareOverallHeight": 84,
+      "overLabwareHeight": 0
+    },
+    "calibrationPoint": {
+      "x": 11.7,
+      "y": 8.75
+    },
+    "displayName": "Temperature Module GEN2",
+    "loadName": "tempdeckGen2",
+    "quirks": [],
+    "slotTransforms": {
+      "3": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      }
+    },
+    "compatibleLoadNames": ["tempdeck"]
+  }
+}

--- a/shared-data/module/schemas/2.json
+++ b/shared-data/module/schemas/2.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "coordinates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" }
+      }
+    },
+    "affineTransform": {
+      "description": "A 3x3 row-major matrix describing an affine transform to apply to the labwareOffset and calibrationPoint coordinates of the module (in certain circumstances, e.g. per slot)",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "array",
+        "minItems": 3,
+        "maxItems": 3,
+        "items": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "description": "Module specifications",
+  "type": "object",
+  "$comment": "Example key: 'magdeck'",
+  "required": ["$otSharedSchema"],
+  "properties": {
+    "$otSharedSchema": {
+      "type": "string",
+      "description": "The path to a valid Opentrons shared schema relative to the shared-data directory, without its extension. For instance, #/module/schemas/2 is a reference to this schema."
+    }
+  },
+  "patternProperties": {
+    "^[^$].*": {
+      "type": "object",
+      "required": [
+        "labwareOffset",
+        "dimensions",
+        "calibrationPoint",
+        "displayName",
+        "loadName",
+        "quirks",
+        "slotTransforms",
+        "compatibleLoadNames"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "labwareOffset": { "$ref": "#/definitions/coordinates" },
+        "dimensions": {
+          "type": "object",
+          "required": ["bareOverallHeight", "overLabwareHeight"],
+          "properties": {
+            "bareOverallHeight": { "type": "number" },
+            "overLabwareHeight": { "type": "number" },
+            "lidHeight": { "type": "number" }
+          }
+        },
+        "calibrationPoint": { "$ref": "#/definitions/coordinates" },
+        "displayName": { "type": "string" },
+        "loadName": { "type": "string" },
+        "quirks": {
+          "type": "array",
+          "description": "List of quirks for a given module",
+          "items": {
+            "type": "string"
+          }
+        },
+        "slotTransforms": {
+          "type": "object",
+          "description": "Per-deckmap sets of per-slot transforms, properties should be ids of decks such as \"ot2_standard\". Transforms for a deck not explicitly listed are the identity.",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "patternProperties:": {
+                "^([1-9]|10|11)$": {
+                  "type": "object",
+                  "description": "Holds 2-D affine transforms that should be applied to top level keys plus the special property $image for applying to images images. If any top level key has no corresponding entry, it is an identity transform. If the transform applies to an entity specifying a 3D position, it should be applied only to the x and y.",
+                  "patternProperties": {
+                    ".*": {
+                      "type": "object",
+                      "description": "The keys identify transforms that apply to different sections of the module definition. Most will be top level keys of the module def (for instance, \"labwareOffset\") but there may also be additional meta keys for values that are not in the def",
+                      "patternProperties": {
+                        ".*": { "$ref": "#/definitions/affineTransform" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "compatibleLoadNames": {
+          "description": "Array of compatible load names. If this module is specified in a protocol and is not present, other modules with compatible load names are allowed to be substituted.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/shared-data/module/schemas/2.json
+++ b/shared-data/module/schemas/2.json
@@ -44,10 +44,10 @@
         "dimensions",
         "calibrationPoint",
         "displayName",
-        "loadName",
+        "loadNames",
         "quirks",
         "slotTransforms",
-        "compatibleLoadNames"
+        "compatibleWith"
       ],
       "additionalProperties": false,
       "properties": {
@@ -63,7 +63,13 @@
         },
         "calibrationPoint": { "$ref": "#/definitions/coordinates" },
         "displayName": { "type": "string" },
-        "loadName": { "type": "string" },
+        "loadNames": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "A name that can be used to load this module within a protocol. These must be interpreted non-case-sensitively."
+          }
+        },
         "quirks": {
           "type": "array",
           "description": "List of quirks for a given module",
@@ -95,10 +101,12 @@
             }
           }
         },
-        "compatibleLoadNames": {
-          "description": "Array of compatible load names. If this module is specified in a protocol and is not present, other modules with compatible load names are allowed to be substituted.",
+        "compatibleWith": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string",
+            "description": "A JSON path to a compatilbe module definition, e.g. one that may be loaded in place of this one with no behavior changes implied"
+          }
         }
       }
     }


### PR DESCRIPTION
This lets us specify gen2 modules along with equivalencies between gen2 and gen1
of the same model, as well as transforms on a per-slot basis.

Also adds gen2 versions of the temperature and magnetic modules.

Closes #4222

## Testing
- make sure the schema and data seem good
- audit the positions generated by applying the transforms (by hand sadly) and make sure they're correct.