### PR TITLE
fix(api): Use specified port in tools

### DIFF
--- a/api/src/opentrons/tools/__init__.py
+++ b/api/src/opentrons/tools/__init__.py
@@ -4,13 +4,7 @@ import sys
 
 
 def connect_to_port(hardware):
-    parser = optparse.OptionParser(usage='usage: %prog [options] ')
-    parser.add_option(
-        "-p", "--p", dest="port", default='',
-        type='str', help='serial port of the smoothie'
-    )
 
-    options, _ = parser.parse_args(args=sys.argv, values=None)
     if options.port:
         hardware.connect(options.port)
     else:
@@ -20,15 +14,22 @@ def connect_to_port(hardware):
 driver = opentrons.drivers.smoothie_drivers.SimulatingDriver()
 
 try:
-    if opentrons.config.feature_flags.use_protocol_api_v2():
-        api = opentrons.hardware_control.API
-        adapter = opentrons.hardware_control.adapters
-        hardware = adapter.SynchronousAdapter.build(
-            api.build_hardware_controller)
-        driver = hardware._backend._smoothie_driver
+    api = opentrons.hardware_control.API
+    adapter = opentrons.hardware_control.adapters
+    parser = optparse.OptionParser(usage='usage: %prog [options] ')
+    parser.add_option(
+        "-p", "--p", dest="port", default='',
+        type='str', help='serial port of the smoothie'
+    )
+
+    options, _ = parser.parse_args(args=sys.argv, values=None)
+    if options.port:
+        port = options.port
     else:
-        hardware = opentrons.robot
-        connect_to_port(hardware)
-        driver = hardware._driver
+        port = None
+    hardware = adapter.SynchronousAdapter.build(
+        api.build_hardware_controller, port=port)
+    driver = hardware._backend._smoothie_driver
 except AttributeError:
-    hardware = None
+    hardware = None  # type: ignore
+    driver = None  # type: ignore


### PR DESCRIPTION
When we switched to apiv2 by default, we didn't go through and fix a specific
issue with write_pipette_memory: that it only respected the port argument in
apiv1. This commit fixes that (and removes some obsolete code).


## Testing
Run write_pipette_memory from a laptop host (OS doesn't matter) on a known good hardware setup.