### PR TITLE
fix(api): Utilize return tip height from pipette configs

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -197,7 +197,7 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
         display_name=ensure_value(cfg, 'displayName', MUTABLE_CONFIGS),
         name=cfg.get('name'),
         back_compat_names=cfg.get('backCompatNames', []),
-        return_tip_height=cfg.get('returnTipHeight'),
+        return_tip_height=cfg.get('returnTipHeight', 0.5),
         blow_out_flow_rate=ensure_value(
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
         max_travel=smoothie_configs['travelDistance'],


### PR DESCRIPTION
## overview

In PAPI1, a specified return tip height is used based on testing from HW. This number varies based on pipette model. In API V2, however, we use the bottom of the labware + 10 mm which is a bit arbitrary.

Starting in 2.2, the return to tiprack behavior will be the same in that the return location is calculated based on the return tip height value.

## changelog

- Calculate the position of the tip using the top of the well and a pipette's return tip height

## review requests

Play around with tiprack calibration on your robot. You can use this protocol or another that has two pipettes + two tipracks to calibrate. Look out for the behavior of returning the tip to the tiprack and ensure that no crashing occurs. Check 2.2 and <2.2

```
metadata={"apiLevel": "2.2"}

def run(ctx):
	tiprack2 = ctx.load_labware('opentrons_96_tiprack_1000ul', '2')
	tiprack1 = ctx.load_labware('opentrons_96_tiprack_300ul', '1')

	plate1 = ctx.load_labware('corning_96_wellplate_360ul_flat', '3')
	plate2 = ctx.load_labware('corning_96_wellplate_360ul_flat', '4')

	pip = ctx.load_instrument('p50_single', mount='right', tip_racks=[tiprack1])
	pip2 = ctx.load_instrument('p1000_single', mount='left', tip_racks=[tiprack2])


	pip.transfer(50, plate1.wells(), plate2.wells())

	pip2.transfer(50, plate2.wells(), plate1.wells())
```
