### PR TITLE
fix(api): restore plunger current before move to bottom after drop tip

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -1249,6 +1249,8 @@ class API(HardwareAPILike):
                         plunger_ax.name.upper(), safety_margin)
                     self._current_position = self._deck_from_smoothie(
                         smoothie_pos)
+                self._backend.set_active_current(
+                    plunger_ax, instr.config.plunger_current)
                 await self._move_plunger(mount, bottom)
 
         if 'doubleDropTip' in instr.config.quirks:


### PR DESCRIPTION
This should help with the occasional skips during the move to bottoms after the
post-drop-tip home.
