### PR TITLE
refactor(api): Add move splitting capability to driver move

### DIFF
--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -1,0 +1,14 @@
+""" Type definitions for modules in this tree """
+
+from typing import Dict, NamedTuple
+
+
+class MoveSplit(NamedTuple):
+    split_distance: float
+    split_current: float
+    split_speed: float
+    after_time: float
+
+
+MoveSplits = Dict[str, MoveSplit]
+#: Dict mapping axes to their split parameters

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -1,6 +1,6 @@
-
 import logging
-from typing import Optional, Mapping
+import time
+from typing import Dict, Optional, Mapping, Sequence
 
 log = logging.getLogger(__name__)
 
@@ -117,3 +117,27 @@ def parse_device_information(
         if key not in res:
             raise ParseError(error_msg)
     return res
+
+
+class AxisMoveTimestamp:
+    """ Keeps track of the last time axes were known to move """
+
+    def __init__(self, axis_iter: Sequence[str]):
+        self._moved_at: Dict[str, Optional[float]] = {
+            ax: None for ax in axis_iter
+        }
+
+    def mark_moved(self, axis_iter: Sequence[str]):
+        """ Indicate that a set of axes just moved """
+        now = time.monotonic()
+        self._moved_at.update({ax: now for ax in axis_iter})
+
+    def time_since_moved(self) -> Mapping[str, Optional[float]]:
+        """ Get a mapping of the time since each known axis moved """
+        now = time.monotonic()
+        return {ax: now-val if val else None
+                for ax, val, in self._moved_at.items()}
+
+    def reset_moved(self, axis_iter: Sequence[str]):
+        """ Reset the clocks for a set of axes """
+        self._moved_at.update({ax: None for ax in axis_iter})

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -63,15 +63,13 @@ class Controller:
              home_flagged_axes: bool = True, speed: float = None,
              axis_max_speeds: Dict[str, float] = None):
         with ExitStack() as cmstack:
-            if speed:
-                cmstack.enter_context(
-                    self._smoothie_driver.restore_speed(speed))
             if axis_max_speeds:
                 cmstack.enter_context(
                     self._smoothie_driver.restore_axis_max_speed(
                         axis_max_speeds))
             self._smoothie_driver.move(
-                target_position, home_flagged_axes=home_flagged_axes)
+                target_position, home_flagged_axes=home_flagged_axes,
+                speed=speed)
 
     def home(self, axes: List[str] = None) -> Dict[str, float]:
         if axes:

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -275,7 +275,7 @@ def test_plunger_commands(smoothie, monkeypatch):
         'C': 5.55})
     expected = [
         # Set active axes high
-        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'], # noqa(E501)
         ['M400'],
         # Set plunger current low
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005'],
@@ -312,11 +312,13 @@ def test_set_active_current(smoothie, monkeypatch):
     smoothie.set_active_current({'B': 0.42, 'C': 0.42})
     smoothie.home('BC')
     expected = [
-        ['M907 A2 B2 C2 X2 Y2 Z2 G4P0.005 G0A0B0C0X0Y0Z0'],  # move all
+        # move all
+        ['M907 A2 B2 C2 X2 Y2 Z2 G4P0.005 G0A0B0C0X0Y0Z0'],
         ['M400'],
         ['M907 A2 B0 C0 X2 Y2 Z2 G4P0.005'],  # disable BC axes
         ['M400'],
-        ['M907 A0 B2 C2 X0 Y0 Z0 G4P0.005 G0B1.3C1.3 G0B1C1'],  # move BC
+        # move BC
+        ['M907 A0 B2 C2 X0 Y0 Z0 G4P0.005 G0B1.3C1.3 G0B1C1'],
         ['M400'],
         ['M907 A0 B0 C0 X0 Y0 Z0 G4P0.005'],  # disable BC axes
         ['M400'],
@@ -685,7 +687,7 @@ def test_clear_limit_switch(smoothie, monkeypatch):
 
     assert [c.strip() for c in cmd_list] == [
         # attempt to move and fail
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',  # noqa(E501)
         # recover from failure
         'M999',
         'M400',
@@ -884,7 +886,8 @@ def test_unstick_axes(robot, smoothie):
     expected = [
         'M203.1 B1 C1',  # slow them down
         'M119',  # get the switch status
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B-1C-1',  # move
+        # move
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B-1C-1',
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',  # set plunger current
         'M203.1 A125 B40 C40 X600 Y400 Z125'  # return to normal speed
     ]
@@ -897,7 +900,7 @@ def test_unstick_axes(robot, smoothie):
     expected = [
         'M203.1 A1 X1 Y1 Z1',  # slow them down
         'M119',  # get the switch status
-        'M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0A-1X-1Y-1Z-1',
+        'M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0A-1X-1Y-1Z-1',  # noqa(E501)
         'M203.1 A125 B40 C40 X600 Y400 Z125'  # return to normal speed
     ]
 
@@ -922,7 +925,8 @@ def test_unstick_axes(robot, smoothie):
     expected = [
         'M203.1 B1 C1',  # set max-speeds
         'M119',  # get switch status
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B-2',  # MOVE B
+        # MOVE B
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0B-2',
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',  # low current B
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G28.2C',  # HOME C
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',  # low current C
@@ -1009,8 +1013,8 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         split_moves={'X': driver_3_0.MoveSplit(
             split_distance=50, split_current=1.5, split_speed=0.5)})
     assert command_log\
-        == ['M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X50 '
-            'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X100']
+        == ['G0F30 M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X50 '
+            'G0F24000 M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X100']
     command_log.clear()
     # move splits that are longer than the move get eaten both in -
     smoothie.move(
@@ -1018,8 +1022,8 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         split_moves={'X': driver_3_0.MoveSplit(
             split_distance=50, split_current=1.5, split_speed=0.5)})
     assert command_log\
-        == ['M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X75 '
-            'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X75']
+        == ['G0F30 M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X75 '
+            'G0F24000 M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X75']
 
     command_log.clear()
     # and in +
@@ -1028,8 +1032,8 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         split_moves={'X': driver_3_0.MoveSplit(
             split_distance=30, split_current=1.5, split_speed=0.5)})
     assert command_log\
-        == ['M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X100 '
-            'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X100']
+        == ['G0F30 M907 A0.1 B0.05 C0.05 X1.5 Y0.3 Z0.1 G4P0.005 G0X100 '
+            'G0F24000 M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X100']
 
     # if backlash is involved, it's added on top
     # prep by moving to 0
@@ -1038,8 +1042,8 @@ def test_move_splitting(smoothie, robot, monkeypatch):
     smoothie.move({'C': 20}, split_moves={'C': driver_3_0.MoveSplit(
         split_distance=1, split_current=2.0, split_speed=1)})
     assert command_log[0:1]\
-        == ['M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005 G0C1 '
-            'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 G0C20']
+        == ['G0F60 M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005 G0C1 '
+            'G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 G0C20']  # noqa(E501)
 
     # if backlash is involved, the backlash target should be the limit
     # for the split move
@@ -1052,5 +1056,29 @@ def test_move_splitting(smoothie, robot, monkeypatch):
     # current. when the driver is used with the rest of the robot or hardware
     # control stack it uses the higher currents
     assert command_log[0:1]\
-        == ['M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 '
-            'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 G0C20']
+        == ['G0F60 M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 '
+            'G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 G0C20']  # noqa(E501)
+
+
+def test_per_move_speed(smoothie, robot, monkeypatch):
+    smoothie.simulating = False
+    command_log = []
+
+    def send_command_logger(command, timeout=12000.0, ack_timeout=5.0):
+        nonlocal command_log
+        command_log.append(command)
+
+    monkeypatch.setattr(smoothie, '_send_command', send_command_logger)
+
+    # no speed argument: use combined speed
+    smoothie.move({'X': 100})
+
+    assert command_log[0]\
+        == 'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4P0.005 G0X100'
+
+    command_log.clear()
+
+    # specify speed: both set and reset
+    smoothie.move({'Y': 100}, speed=100)
+    assert command_log[0]\
+        == 'G0F6000 M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4P0.005 G0Y100 G0F24000'  # noqa(E501)


### PR DESCRIPTION
This is in service of unsticking frozen plunger axes.

When multi pipettes of certain models sit idle for too long, their plunger o
rings create more friction the next time they try to move. To move the o rings,
we have to move a short distance slowly with a higher current before continuing
the rest of the motion.

While this could happen at a higher level, implementing this as splitting up a
move commanded for other reasons lets us more easily share the logic between the
v1 and v2 hardware handling code. Now, the hardware handling code has to check
how long since the plunger last moved and command the split if necessary (or, if
the parameters for the split end up meaning that not that much time elapses
during the slow move, just do it every time in some contexts).

Closes #4674

## Testing
Check out the implementation and the tests and perhaps run it on a robot; at this point however the code isn't used anywhere