### PR TITLE
refactor(api): special moves to unstick some pipettes after idle

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -72,3 +72,6 @@ class SimulatingDriver:
 
     def update_steps_per_mm(self, data):
         pass
+
+    def configure_splits_for(self, config):
+        pass

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -4830,5 +4830,10 @@
     "defaultBlowOutFlowRate",
     "quirks"
   ],
-  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip", "needsUnstick"]
+  "validQuirks": [
+    "pickupTipShake",
+    "dropTipShake",
+    "doubleDropTip",
+    "needsUnstick"
+  ]
 }

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1607,7 +1607,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": []
+      "quirks": ["needsUnstick"]
     },
     "p50_single_v1": {
       "name": "p50_single",
@@ -4004,7 +4004,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": []
+      "quirks": ["needsUnstick"]
     },
     "p1000_single_v1": {
       "name": "p1000_single",
@@ -4830,5 +4830,5 @@
     "defaultBlowOutFlowRate",
     "quirks"
   ],
-  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip"]
+  "validQuirks": ["pickupTipShake", "dropTipShake", "doubleDropTip", "needsUnstick"]
 }


### PR DESCRIPTION
Certain pipette models build up static friction when idle. We configure the
smoothie driver to keep track of when those pipettes move, and when it commands
a move or home generate a special motion command to unstick those pipette axes.

Closes #4816

Sample motion commands:

- From a home determined to need unsticking: `b'M907B1.5 G4P0.005 G0F60 G91 G0B1 G90 G0F24000\r\n\r\n'`
- A move determined to need unsticking: `'G0F60 M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005 G0C1 G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C20.3 G0C20'` (the original move here would be to +20; backlash compensation adds the 20.3, and the move is split into two segments at different speeds and currents, with the move to 1 being the unstick)