### PR TITLE
feat(api): change attach pipette positions to match leveling blocks

### DIFF
--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -284,8 +284,8 @@ async def position_info(request):
         'positions': {
             'change_pipette': {
                 'target': 'mount',
-                'left': (325, 40, 30),
-                'right': (65, 40, 30)
+                'left': (300, 40, 30),
+                'right': (95, 40, 30)
             },
             'attach_tip': {
                 'target': 'pipette',


### PR DESCRIPTION
This is a small change in the exact positions we move the gantry to for attach
pipette to center the pipettes above the leveling blocks, which enables leveling
flows where the user pulls the pipettes down onto the blocks.

Closes #4679
