### PR TITLE
fix(api): Ensure position is fully updated after a home

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -543,8 +543,8 @@ class API(HardwareAPILike):
                 for smoothie_plunger, current in smoothie_plungers.items():
                     self._backend.set_active_current(
                         smoothie_plunger, current)
-                    smoothie_pos.update(
-                        self._backend.home([smoothie_plunger.name.upper()]))
+                    self._backend.home([smoothie_plunger.name.upper()])
+                    smoothie_pos.update(self._backend.update_position())
             self._current_position = self._deck_from_smoothie(smoothie_pos)
 
     async def add_tip(


### PR DESCRIPTION
## overview

During movement research, we found that the Y axis was significantly off when only homing the X axis. This is because the smoothie driver performs a move away from the Y home switch and then back towards it half the distance to ensure that an X axis movement doesn't interfere with the switch.

## changelog

- Update the position again in hardware controller after homing.

## review requests

Test on the robot if you want, has already been tested on movement research robot.
*Note* this doesn't fully fix the issue if you're moving from an XY position near the front of the robot because the robot skips steps a little moving to the front in the Y.