### PR TITLE
refactor(api): split module labware handling

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,4 +1,4 @@
-from opentrons.protocol_api import labware
+from opentrons.protocol_api import module_geometry
 from opentrons.legacy_api.containers import Slot, placeable
 
 
@@ -11,7 +11,7 @@ def _get_parent_slot_legacy(placeable):
 
 
 def _get_parent_slot_and_position(labware_obj):
-    if isinstance(labware_obj.parent, (labware.ModuleGeometry)):
+    if isinstance(labware_obj.parent, (module_geometry.ModuleGeometry)):
         return (labware_obj.parent.parent, labware_obj.parent.labware_offset)
     else:
         return (labware_obj.parent, None)
@@ -75,7 +75,7 @@ class Instrument:
 class Module:
     def __init__(self, module, context=None):
         self.id = id(module)
-        if isinstance(module, labware.ModuleGeometry):
+        if isinstance(module, module_geometry.ModuleGeometry):
             self.name = module.load_name
             self.slot = module.parent
         else:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -14,7 +14,7 @@ from opentrons.protocols.types import PythonProtocol, APIVersion
 from opentrons.protocols.parse import parse
 from opentrons.types import Location, Point
 from opentrons.protocol_api import (ProtocolContext,
-                                    labware)
+                                    labware, module_geometry)
 from opentrons.protocol_api.execute import run_protocol
 from opentrons.hardware_control import adapters, API
 from .models import Container, Instrument, Module
@@ -637,7 +637,7 @@ def _get_parent_module(placeable):
     if not placeable or isinstance(placeable, (Point, str)):
         res = None
     elif isinstance(placeable,
-                    (ModulePlaceable, labware.ModuleGeometry)):
+                    (ModulePlaceable, module_geometry.ModuleGeometry)):
         res = placeable
     elif isinstance(placeable, List):
         res = _get_parent_module(placeable[0].parent)

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -1,4 +1,3 @@
-
 from . import types as command_types
 from opentrons.broker import Broker
 
@@ -10,7 +9,8 @@ from opentrons.legacy_api.containers import (Well as OldWell,
                                              Container as OldContainer,
                                              Slot as OldSlot,
                                              location_to_list)
-from opentrons.protocol_api.labware import Well, Labware, ModuleGeometry
+from opentrons.protocol_api.labware import Well, Labware
+from opentrons.protocol_api.module_geometry import ModuleGeometry
 from opentrons.types import Location
 from opentrons.drivers import utils
 

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,4 +1,28 @@
+import abc
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 2)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 3)
 #: The maximum supported protocol API version in this release
+
+
+class DeckItem(abc.ABC):
+
+    @property  # type: ignore
+    @abc.abstractmethod
+    def highest_z(self):
+        pass
+
+    @highest_z.setter  # type: ignore
+    @abc.abstractmethod
+    def highest_z(self, new_z: float):
+        pass
+
+    @property  # type: ignore
+    @abc.abstractmethod
+    def disambiguate_calibration(self) -> bool:
+        pass
+
+    @property  # type: ignore
+    @abc.abstractmethod
+    def load_name(self) -> str:
+        pass

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -19,7 +19,7 @@ class DeckItem(abc.ABC):
 
     @property  # type: ignore
     @abc.abstractmethod
-    def disambiguate_calibration(self) -> bool:
+    def separate_calibration(self) -> bool:
         pass
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -6,7 +6,9 @@ from typing import Any, List, Optional, Tuple, Dict
 
 from opentrons import types
 from .labware import (Labware, Well,
-                      quirks_from_any_parent, ThermocyclerGeometry, DeckItem)
+                      quirks_from_any_parent)
+from .definitions import DeckItem
+from .module_geometry import ThermocyclerGeometry
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.system.shared_data import load_shared_data
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -328,7 +328,7 @@ class Labware(DeckItem):
         self._highest_z = self._dimensions['zDimension']
 
     @property
-    def disambiguate_calibration(self) -> bool:
+    def separate_calibration(self) -> bool:
         return False
 
     @property  # type: ignore
@@ -801,7 +801,7 @@ class Labware(DeckItem):
 
 def _get_parent_identifier(
         parent: Union[Well, str, DeckItem, None]):
-    if isinstance(parent, DeckItem) and parent.disambiguate_calibration:
+    if isinstance(parent, DeckItem) and parent.separate_calibration:
         # treat a given labware on a given module type as same
         return parent.load_name
     else:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -9,7 +9,8 @@ from opentrons.commands import CommandPublisher
 from opentrons.protocols.types import APIVersion
 
 from .labware import (
-    ModuleGeometry, Labware, load, load_from_definition, ThermocyclerGeometry)
+    Labware, load, load_from_definition)
+from .module_geometry import ModuleGeometry, ThermocyclerGeometry
 from . import geometry
 from .util import requires_version
 

--- a/api/src/opentrons/protocol_api/module_geometry.py
+++ b/api/src/opentrons/protocol_api/module_geometry.py
@@ -57,7 +57,7 @@ class ModuleGeometry(DeckItem):
         return resolved_name
 
     @property
-    def disambiguate_calibration(self) -> bool:
+    def separate_calibration(self) -> bool:
         # If a module is the parent of a labware it affects calibration
         return True
 

--- a/api/src/opentrons/protocol_api/module_geometry.py
+++ b/api/src/opentrons/protocol_api/module_geometry.py
@@ -1,0 +1,276 @@
+""" opentrons.protocol_api.module_geometry: classes and functions for modules
+as deck objects
+
+This module provides things like :py:class:`ModuleGeometry` and
+:py:func:`load_module` to create and manipulate module objects as geometric
+objects on the deck (as opposed to calling commands on them, which is handled
+by :py:mod:`.module_contexts`)
+"""
+
+import json
+from typing import Any, Dict, Optional, Union
+
+from opentrons.system.shared_data import load_shared_data
+from opentrons.types import Location, Point
+from opentrons.protocols.types import APIVersion
+from .definitions import MAX_SUPPORTED_VERSION, DeckItem
+from .labware import Labware
+
+
+ModuleDefinitionV1 = Dict[str, Any]
+ModuleDefinitionV2 = Dict[str, Any]
+ModuleDefinition = Union[ModuleDefinitionV1, ModuleDefinitionV2]
+
+
+class NoSuchModuleError(Exception):
+    def __init__(self, message: str, requested_module: str) -> None:
+        self.message = message
+        self.requested_module = requested_module
+        super().__init__()
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ModuleGeometry(DeckItem):
+    """
+    This class represents an active peripheral, such as an Opentrons Magnetic
+    Module, Temperature Module or Thermocycler Module. It defines the physical
+    geometry of the device (primarily the offset that modifies the position of
+    the labware mounted on top of it).
+    """
+
+    @classmethod
+    def resolve_module_name(cls, module_name: str):
+        alias_map = {
+            'magdeck': 'magdeck',
+            'magnetic module': 'magdeck',
+            'tempdeck': 'tempdeck',
+            'temperature module': 'tempdeck',
+            'thermocycler': 'thermocycler',
+            'thermocycler module': 'thermocycler'
+        }
+        lower_name = module_name.lower()
+        resolved_name = alias_map.get(lower_name, None)
+        if not resolved_name:
+            raise ValueError(f'{module_name} is not a valid module load name')
+        return resolved_name
+
+    @property
+    def disambiguate_calibration(self) -> bool:
+        # If a module is the parent of a labware it affects calibration
+        return True
+
+    def __init__(self,
+                 definition: dict,
+                 parent: Location,
+                 api_level: APIVersion = None) -> None:
+        """
+        Create a Module for tracking the position of a module.
+
+        Note that modules do not currently have a concept of calibration apart
+        from calibration of labware on top of the module. The practical result
+        of this is that if the module parent :py:class:`.Location` is
+        incorrect, then acorrect calibration of one labware on the deck would
+        be incorrect on the module, and vice-versa. Currently, the way around
+        this would be to correct the :py:class:`.Location` so that the
+        calibrated labware is targeted accurately in both positions.
+
+        :param definition: A dict containing all the data required to define
+                           the geometry of the module.
+        :type definition: dict
+        :param parent: A location representing location of the front left of
+                       the outside of the module (usually the front-left corner
+                       of a slot on the deck).
+        :type parent: :py:class:`.Location`
+        :param APIVersion api_level: the API version to set for the loaded
+                                     :py:class:`ModuleGeometry` instance. The
+                                     :py:class:`ModuleGeometry` will
+                                     conform to this level. If not specified,
+                                     defaults to
+                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
+        """
+        if not api_level:
+            api_level = MAX_SUPPORTED_VERSION
+        if api_level > MAX_SUPPORTED_VERSION:
+            raise RuntimeError(
+                f'API version {api_level} is not supported by this '
+                f'robot software. Please either reduce your requested API '
+                f'version or update your robot.')
+        self._api_version = api_level
+        self._parent = parent
+        self._display_name = "{} on {}".format(definition["displayName"],
+                                               str(parent.labware))
+        self._load_name = definition["loadName"]
+        self._offset = Point(definition["labwareOffset"]["x"],
+                             definition["labwareOffset"]["y"],
+                             definition["labwareOffset"]["z"])
+        self._height = definition["dimensions"]["bareOverallHeight"]\
+            + self._parent.point.z
+        self._over_labware = definition["dimensions"]["overLabwareHeight"]
+        self._labware: Optional[Labware] = None
+        self._location = Location(
+            point=self._offset + self._parent.point,
+            labware=self)
+
+    @property
+    def api_version(self) -> APIVersion:
+        return self._api_version
+
+    def add_labware(self, labware: Labware) -> Labware:
+        assert not self._labware,\
+            '{} is already on this module'.format(self._labware)
+        self._labware = labware
+        return self._labware
+
+    def reset_labware(self):
+        self._labware = None
+
+    @property
+    def load_name(self):
+        return self._load_name
+
+    @property
+    def parent(self):
+        return self._parent.labware
+
+    @property
+    def labware(self) -> Optional[Labware]:
+        return self._labware
+
+    @property
+    def location(self) -> Location:
+        """
+        :return: a :py:class:`.Location` representing the top of the module
+        """
+        return self._location
+
+    @property
+    def labware_offset(self) -> Point:
+        """
+        :return: a :py:class:`.Point` representing the transformation
+        between the critical point of the module and the critical
+        point of its contained labware
+        """
+        return self._offset
+
+    @property
+    def highest_z(self) -> float:
+        if self.labware:
+            return self.labware.highest_z + self._over_labware
+        else:
+            return self._height
+
+    def __repr__(self):
+        return self._display_name
+
+
+class ThermocyclerGeometry(ModuleGeometry):
+    def __init__(self, definition: Dict[str, Any], parent: Location,
+                 api_level: APIVersion = None) -> None:
+        super().__init__(definition, parent, api_level)
+        self._lid_height = definition["dimensions"]["lidHeight"]
+        self._lid_status = 'open'   # Needs to reflect true status
+        # TODO: BC 2019-07-25 add affordance for "semi" configuration offset
+        # to be from a flag in context, according to drawings, the only
+        # difference is -23.28mm in the x-axis
+
+    @property
+    def highest_z(self) -> float:
+        # TODO: BC 2019-08-27 this highest_z value represents the distance
+        # from the top of the open TC chassis to the base. Once we have a
+        # more robust collision detection system in place, the collision
+        # model for the TC should change based on it's lid_status
+        # (open or closed). A prerequisite for that check will be
+        # path-specific highest z calculations, as opposed to the current
+        # global check on instrument.move_to. For example: a move from slot 1
+        # to slot 3 should only check the highest z of all deck items between
+        # the source and destination in the x,y plane.
+        return super().highest_z
+
+    @property
+    def lid_status(self) -> str:
+        return self._lid_status
+
+    @lid_status.setter
+    def lid_status(self, status) -> None:
+        self._lid_status = status
+
+    # NOTE: this func is unused until "semi" configuration
+    def labware_accessor(self, labware: Labware) -> Labware:
+        # Block first three columns from being accessed
+        definition = labware._definition
+        definition['ordering'] = definition['ordering'][3::]
+        return Labware(
+            definition, super().location, api_level=self._api_version)
+
+    def add_labware(self, labware: Labware) -> Labware:
+        assert not self._labware,\
+            '{} is already on this module'.format(self._labware)
+        assert self.lid_status != 'closed', \
+            'Cannot place labware in closed module'
+        self._labware = labware
+        return self._labware
+
+
+def load_module_from_definition(
+        definition: Dict[str, Any],
+        parent: Location,
+        api_level: APIVersion = None) -> ModuleGeometry:
+    """
+    Return a :py:class:`ModuleGeometry` object from a specified definition
+    matching the v1 module definition schema
+
+    :param definition: A dict representing the full module definition adhering
+                       to the v1 module schema
+    :param parent: A :py:class:`.Location` representing the location where
+                   the front and left most point of the outside of the module
+                   is (often the front-left corner of a slot on the deck).
+    :param APIVersion api_level: the API version to set for the loaded
+                                 :py:class:`ModuleGeometry` instance. The
+                                 :py:class:`ModuleGeometry` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
+    """
+    api_level = api_level or MAX_SUPPORTED_VERSION
+    mod_name = definition['loadName']
+
+    if mod_name == 'thermocycler':
+        mod: ModuleGeometry = \
+                ThermocyclerGeometry(definition, parent, api_level)
+    else:
+        mod = ModuleGeometry(definition, parent, api_level)
+    # TODO: calibration
+    return mod
+
+
+def _load_module_definition(api_level: APIVersion) -> Dict[str, Any]:
+    """
+    Load the appropriate module definition for this api version
+    """
+    return json.loads(load_shared_data('module/definitions/1.json'))
+
+
+def load_module(
+        name: str,
+        parent: Location,
+        api_level: APIVersion = None) -> ModuleGeometry:
+    """
+    Return a :py:class:`ModuleGeometry` object from a definition looked up
+    by name.
+
+    :param name: A string to use for looking up the definition. The string
+                 must be present as a top-level key in
+                 module/definitions/{moduleDefinitionVersion}.json.
+    :param parent: A :py:class:`.Location` representing the location where
+                   the front and left most point of the outside of the module
+                   is (often the front-left corner of a slot on the deck).
+    :param APIVersion api_level: the API version to set for the loaded
+                                 :py:class:`ModuleGeometry` instance. The
+                                 :py:class:`ModuleGeometry` will
+                                 conform to this level. If not specified,
+                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
+    """
+    api_level = api_level or MAX_SUPPORTED_VERSION
+    defn = _load_module_definition(api_level)
+    return load_module_from_definition(defn[name], parent, api_level)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -10,8 +10,8 @@ from opentrons.config import feature_flags as fflags
 from opentrons.commands import CommandPublisher
 from opentrons.protocols.types import APIVersion, Protocol
 from .labware import (
-    LabwareDefinition, Labware, get_labware_definition, load_from_definition,
-    ModuleGeometry, load_module)
+    LabwareDefinition, Labware, get_labware_definition, load_from_definition)
+from .module_geometry import (ModuleGeometry, load_module)
 from .definitions import MAX_SUPPORTED_VERSION
 from . import geometry
 from .instrument_context import InstrumentContext

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -5,7 +5,8 @@ if TYPE_CHECKING:
     from typing import (Optional,       # noqa(F401) Used for typechecking
                         Tuple)
     from .protocol_api.labware import (  # noqa(F401) Used for typechecking
-        Labware, Well, ModuleGeometry)
+        Labware, Well)
+    from .protocol_api.module_geometry import ModuleGeometry  # noqa(F401)
 
 
 class PipetteNotAttachedError(KeyError):

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -2,7 +2,7 @@ import pytest
 
 from opentrons.types import Location, Point
 from opentrons.protocol_api.geometry import Deck, plan_moves
-from opentrons.protocol_api import labware
+from opentrons.protocol_api import labware, module_geometry
 from opentrons.hardware_control.types import CriticalPoint
 
 labware_name = 'corning_96_wellplate_360ul_flat'
@@ -23,7 +23,7 @@ def test_slot_names():
             del d[slot]
             assert slot in d
             assert d[slot] is None
-            mod = labware.load_module('tempdeck', d.position_for(slot))
+            mod = module_geometry.load_module('tempdeck', d.position_for(slot))
             d[slot] = mod
             assert mod == d[slot]
 
@@ -35,7 +35,7 @@ def test_slot_names():
 def test_slot_collisions():
     d = Deck()
     mod_slot = '7'
-    mod = labware.load_module('thermocycler', d.position_for(mod_slot))
+    mod = module_geometry.load_module('thermocycler', d.position_for(mod_slot))
     d[mod_slot] = mod
     with pytest.raises(ValueError):
         d['7'] = 'not this time boyo'
@@ -61,7 +61,7 @@ def test_highest_z():
     assert deck.highest_z == pytest.approx(lw.wells()[0].top().point.z)
     del deck[1]
     assert deck.highest_z == 0
-    mod = labware.load_module('tempdeck', deck.position_for(8))
+    mod = module_geometry.load_module('tempdeck', deck.position_for(8))
     deck[8] = mod
     assert deck.highest_z == mod.highest_z
     lw = labware.load(labware_name, mod.location)

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from opentrons.protocol_api import labware, MAX_SUPPORTED_VERSION
+from opentrons.protocol_api import (
+    labware, MAX_SUPPORTED_VERSION, module_geometry)
 from opentrons.system.shared_data import load_shared_data
 from opentrons.types import Point, Location
 
@@ -341,7 +342,8 @@ def test_module_load():
     module_defs = json.loads(
         load_shared_data('module/definitions/1.json'))
     for name in module_names:
-        mod = labware.load_module(name, Location(Point(0, 0, 0), 'test'))
+        mod = module_geometry.load_module(
+            name, Location(Point(0, 0, 0), 'test'))
         mod_def = module_defs[name]
         offset = Point(mod_def['labwareOffset']['x'],
                        mod_def['labwareOffset']['y'],
@@ -349,12 +351,12 @@ def test_module_load():
         high_z = mod_def['dimensions']['bareOverallHeight']
         assert mod.highest_z == high_z
         assert mod.location.point == offset
-        mod = labware.load_module(name, Location(Point(1, 2, 3), 'test'))
+        mod = module_geometry.load_module(
+            name, Location(Point(1, 2, 3), 'test'))
         assert mod.highest_z == high_z + 3
         assert mod.location.point == (offset + Point(1, 2, 3))
-        mod2 = labware.load_module_from_definition(mod_def,
-                                                   Location(Point(3, 2, 1),
-                                                            'test2'))
+        mod2 = module_geometry.load_module_from_definition(
+            mod_def, Location(Point(3, 2, 1), 'test2'))
         assert mod2.highest_z == high_z + 1
         assert mod2.location.point == (offset + Point(3, 2, 1))
 
@@ -364,7 +366,8 @@ def test_module_load_labware():
     labware_name = 'corning_96_wellplate_360ul_flat'
     labware_def = labware.get_labware_definition(labware_name)
     for name in module_names:
-        mod = labware.load_module(name, Location(Point(0, 0, 0), 'test'))
+        mod = module_geometry.load_module(
+            name, Location(Point(0, 0, 0), 'test'))
         old_z = mod.highest_z
         lw = labware.load_from_definition(labware_def, mod.location)
         mod.add_labware(lw)


### PR DESCRIPTION
This puts all the module labware stuff (module geometries, loading, etc)
into its own file module_geometry.py. This is both a good idea in
general since it reduces the size of the fairly monstrous labware.py and
also paves the way for future work in loading modules.
