### PR TITLE
chore(api): move tempdeck version check earlier

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -63,8 +63,7 @@ ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
 # and the openapi spec
 ot_openapi := src/opentrons/server/openapi.json
-modules_configs := $(filter %.rules,$(shell $(SHX) find src/opentrons/config/modules))
-ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources) $(modules_configs) $(ot_openapi)
+ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources) $(ot_openapi)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -228,3 +228,14 @@ class TempDeck(mod_abc.AbstractModule):
         self._driver.enter_programming_mode()
         new_port = await update.find_bootloader_port()
         return new_port or self.port
+
+    def has_available_update(self) -> bool:
+        """ Override of abc implementation to suppress update notifications
+        for v1 and v1.1 temperature modules which cannot be updated """
+        if not self._device_info:
+            model = None
+        else:
+            model = self._device_info.get('model')
+        if model in ('temp_deck_v1', 'temp_deck_v1.1', 'temp_deck_v2', None):
+            return False
+        return super().has_available_update()

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -231,11 +231,11 @@ class TempDeck(mod_abc.AbstractModule):
 
     def has_available_update(self) -> bool:
         """ Override of abc implementation to suppress update notifications
-        for v1 and v1.1 temperature modules which cannot be updated """
+        for v1, v1.1, and v2 temperature modules which cannot be updated """
         if not self._device_info:
             model = None
         else:
             model = self._device_info.get('model')
-        if model in ('temp_deck_v1', 'temp_deck_v1.1', 'temp_deck_v2', None):
+        if model in {'temp_deck_v1', 'temp_deck_v1.1', 'temp_deck_v2', None}:
             return False
         return super().has_available_update()

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -93,6 +93,16 @@ async def test_get_modules(
     assert len(body['modules']) == 1
     assert sorted(body['modules'][0].keys()) == keys
     assert 'engaged' in body['modules'][0]['data']
+    tempdeck = await hw._backend.build_module('/dev/ot_module_tempdeck1',
+                                              'tempdeck', lambda x: None)
+    monkeypatch.setattr(hw, 'attached_modules', [tempdeck])
+    for model in ('temp_deck_v1', 'temp_deck_v1.1', 'temp_deck_v2'):
+        tempdeck._device_info['model'] = model
+        resp = await async_client.get('/modules')
+        body = await resp.json()
+        assert resp.status == 200
+        assert len(body['modules']) == 1
+        assert not body['modules'][0]['hasAvailableUpdate']
 
 
 @pytest.fixture


### PR DESCRIPTION
Temperature modules that are too early-version to be updated will now
just not advertise that they can be updated in the first place.

## Testing

- Put a firmware file on the robot with the name `temperature-module@v2.1.0.hex` and connect a v1 (or 1.1, or 2) temperature module to the robot; it should not advertise an available update.