### PR TITLE
fix(api): more specific errors for bad json protocols

### DIFF
--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -308,12 +308,15 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
     else:
         MODULE_LOG.error("labware uploaded instead of protocol")
         raise RuntimeError(
-            'Labware uploaded instead of protocol')
+            'The file you are trying to open is a JSON labware definition, '
+            'and therefore can not be opened here. Please try '
+            'uploading a JSON protocol file instead.')
 
     # this is now either a protocol or something corrupt
     version_num = _get_protocol_schema_version(protocol_json)
     if version_num <= 2:
         raise RuntimeError(
+            'Your protocol could not be opened.\n\n'
             f'JSON protocol version {version_num} is '
             'deprecated. Please upload your protocol into Protocol '
             'Designer and save it to migrate the protocol to a later '
@@ -321,8 +324,11 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
             'definition was specified instead of a protocol.')
     if version_num > 3:
         raise RuntimeError(
-            f'JSON protocol version {version_num} is not supported in this '
-            'robot software version.'
+            'Your protocol could not be opened.\n\n'
+            f'The protocol you are trying to open is a JSONv{version_num} '
+            'protocol and is not supported by your current robot server '
+            'version. Please update your OT-2 App and robot server to the '
+            'latest version and try again.'
         )
     protocol_schema = _get_schema_for_protocol(version_num)
 
@@ -340,8 +346,8 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
     except jsonschema.ValidationError:
         MODULE_LOG.exception("JSON protocol validation failed")
         raise RuntimeError(
-            'Could not parse protocol: does not match schema. This may be a '
-            'corrupted file or a JSON file that is not an Opentrons JSON '
-            'protocol.')
+            'Your protocol could not be opened.\n\n'
+            'This may be a corrupted file or a JSON file that is not an '
+            'Opentrons JSON protocol.')
     else:
         return version_num

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -316,7 +316,6 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
     version_num = _get_protocol_schema_version(protocol_json)
     if version_num <= 2:
         raise RuntimeError(
-            'Your protocol could not be opened.\n\n'
             f'JSON protocol version {version_num} is '
             'deprecated. Please upload your protocol into Protocol '
             'Designer and save it to migrate the protocol to a later '
@@ -324,7 +323,6 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
             'definition was specified instead of a protocol.')
     if version_num > 3:
         raise RuntimeError(
-            'Your protocol could not be opened.\n\n'
             f'The protocol you are trying to open is a JSONv{version_num} '
             'protocol and is not supported by your current robot server '
             'version. Please update your OT-2 App and robot server to the '
@@ -346,7 +344,6 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
     except jsonschema.ValidationError:
         MODULE_LOG.exception("JSON protocol validation failed")
         raise RuntimeError(
-            'Your protocol could not be opened.\n\n'
             'This may be a corrupted file or a JSON file that is not an '
             'Opentrons JSON protocol.')
     else:

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -298,6 +298,19 @@ def _get_schema_for_protocol(version_num: int) -> Dict[Any, Any]:
 
 def validate_json(protocol_json: Dict[Any, Any]) -> int:
     """ Validates a json protocol and returns its schema version """
+    # Check if this is actually a labware
+    labware_schema_v2 = json.loads(load_shared_data(
+        'labware/schemas/2.json').decode('utf-8'))
+    try:
+        jsonschema.validate(protocol_json, labware_schema_v2)
+    except jsonschema.ValidationError:
+        pass
+    else:
+        MODULE_LOG.error("labware uploaded instead of protocol")
+        raise RuntimeError(
+            'Labware uploaded instead of protocol')
+
+    # this is now either a protocol or something corrupt
     version_num = _get_protocol_schema_version(protocol_json)
     if version_num <= 2:
         raise RuntimeError(
@@ -306,25 +319,29 @@ def validate_json(protocol_json: Dict[Any, Any]) -> int:
             'Designer and save it to migrate the protocol to a later '
             'version. This error might mean a labware '
             'definition was specified instead of a protocol.')
+    if version_num > 3:
+        raise RuntimeError(
+            f'JSON protocol version {version_num} is not supported in this '
+            'robot software version.'
+        )
     protocol_schema = _get_schema_for_protocol(version_num)
-    # instruct schema how to resolve all $ref's used in protocol schemas
-    schema_body = load_shared_data(
-        'labware/schemas/2.json').decode('utf-8')
-    labware_schema_v2 = json.loads(schema_body)
 
+    # instruct schema how to resolve all $ref's used in protocol schemas
     resolver = jsonschema.RefResolver(
         protocol_schema.get('$id', ''),
         protocol_schema,
         store={
             "opentronsLabwareSchemaV2": labware_schema_v2
         })
+
     # do the validation
     try:
         jsonschema.validate(protocol_json, protocol_schema, resolver=resolver)
     except jsonschema.ValidationError:
-        MODULE_LOG.exception("Bad protocol uploaded (does not match schema)")
+        MODULE_LOG.exception("JSON protocol validation failed")
         raise RuntimeError(
-            'Could not parse protocol: does not match schema. This error '
-            'might also mean a labware definition was specified instead of '
-            'a protocol.')
-    return version_num
+            'Could not parse protocol: does not match schema. This may be a '
+            'corrupted file or a JSON file that is not an Opentrons JSON '
+            'protocol.')
+    else:
+        return version_num

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -179,12 +179,18 @@ def test_get_protocol_schema_version():
         _get_protocol_schema_version({'protocol-schema': '1.2.3'})
 
 
-def test_validate_json(get_json_protocol_fixture):
+def test_validate_json(get_json_protocol_fixture, get_labware_fixture):
     # valid data that has no schema should fail
     with pytest.raises(RuntimeError, match='deprecated'):
         validate_json({'protocol-schema': '1.0.0'})
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='not supported'):
+        validate_json({'schemaVersion': '4'})
+    labware = get_labware_fixture('fixture_12_trough_v2')
+    with pytest.raises(RuntimeError, match='Labware'):
+        validate_json(labware)
+    with pytest.raises(RuntimeError, match='corrupted'):
         validate_json({'schemaVersion': '3'})
+
     v3 = get_json_protocol_fixture('3', 'testAllAtomicSingleV3')
     assert validate_json(v3) == 3
 

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -183,10 +183,10 @@ def test_validate_json(get_json_protocol_fixture, get_labware_fixture):
     # valid data that has no schema should fail
     with pytest.raises(RuntimeError, match='deprecated'):
         validate_json({'protocol-schema': '1.0.0'})
-    with pytest.raises(RuntimeError, match='not supported'):
+    with pytest.raises(RuntimeError, match='update'):
         validate_json({'schemaVersion': '4'})
     labware = get_labware_fixture('fixture_12_trough_v2')
-    with pytest.raises(RuntimeError, match='Labware'):
+    with pytest.raises(RuntimeError, match='labware'):
         validate_json(labware)
     with pytest.raises(RuntimeError, match='corrupted'):
         validate_json({'schemaVersion': '3'})


### PR DESCRIPTION
Instead of getting a generic error about the protocol being invalid and
maybe a labware, we now

- explicitly check uploaded protocol against the labware schema and tell
you if you accidentally uploaded a labware
- explicitly check json versions and tell you we don't yet support
future ones

Closes #4735
Closes #4515


Uploaded v4 protocol

<img width="575" alt="uploaded v4 protocol" src="https://user-images.githubusercontent.com/3091648/74261145-bf027180-4cc8-11ea-81d3-77baeb42c830.png">

Upload labware:

<img width="512" alt="uploaded labware" src="https://user-images.githubusercontent.com/3091648/74261150-c164cb80-4cc8-11ea-98c5-9322fdbd830b.png">




## Testing

The unit tests cover this more explicitly but try and upload a labware and a v4 protocol and make sure it breaks