### PR TITLE
fix(api): swallow hard-halt-related errors and hold lock in session.stop()

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -6,6 +6,7 @@ import logging
 from time import time, sleep
 from typing import List, Dict, Any
 from uuid import uuid4
+from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieAlarm
 from opentrons import robot
 from opentrons.broker import Broker
 from opentrons.commands import tree, types as command_types
@@ -531,6 +532,8 @@ class Session(object):
                 sleep(0.1)
             self.set_state('finished')
             self._hw_iface().home()
+        except SmoothieAlarm:
+            log.info("Protocol cancelled")
         except Exception as e:
             log.exception("Exception during run:")
             self.error_append(e)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -443,7 +443,8 @@ class Session(object):
 
     def stop(self):
         self._hw_iface().halt()
-        self._hw_iface().stop()
+        with self._motion_lock:
+            self._hw_iface().stop()
         self.set_state('stopped')
         return self
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1042,12 +1042,12 @@ class SmoothieDriver_3_0_0:
                 raise SmoothieError(ret_code)
         else:
             if is_alarm or is_error:
-                # these two errors happen when we're recovering from a hard halt.
-                # in that case, some try/finallys above us may send further commands.
-                # smoothie responds to those commands with errors like these. if we
-                # raise exceptions here, they overwrite the original exception
-                # and we don't properly handle it. This hack to get around this is
-                # really bad!
+                # these two errors happen when we're recovering from a hard
+                # halt. in that case, some try/finallys above us may send
+                # further commands. smoothie responds to those commands with
+                # errors like these. if we raise exceptions here, they
+                # overwrite the original exception and we don't properly
+                #  handle it. This hack to get around this is really bad!
                 if 'alarm lock' not in ret_code.lower()\
                    and 'after halt you should home' not in ret_code.lower():
                     log.error(f"alarm/error outside hard halt: {ret_code}")

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1042,7 +1042,16 @@ class SmoothieDriver_3_0_0:
                 raise SmoothieError(ret_code)
         else:
             if is_alarm or is_error:
-                raise SmoothieError(ret_code)
+                # these two errors happen when we're recovering from a hard halt.
+                # in that case, some try/finallys above us may send further commands.
+                # smoothie responds to those commands with errors like these. if we
+                # raise exceptions here, they overwrite the original exception
+                # and we don't properly handle it. This hack to get around this is
+                # really bad!
+                if 'alarm lock' not in ret_code.lower()\
+                   and 'after halt you should home' not in ret_code.lower():
+                    log.error(f"alarm/error outside hard halt: {ret_code}")
+                    raise SmoothieError(ret_code)
 
     def _remove_unwanted_characters(self, command: str, response: str) -> str:
         # smoothieware can enter a weird state, where it repeats back

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -462,6 +462,7 @@ class API(HardwareAPILike):
         """
         self._log.info("Halting")
         self._backend.hard_halt()
+        self._call_on_attached_modules("cancel")
 
     async def stop(self):
         """
@@ -473,7 +474,6 @@ class API(HardwareAPILike):
         """
         self._backend.halt()
         self._log.info("Recovering from halt")
-        self._call_on_attached_modules("cancel")
         await self.reset()
         await self.home()
 

--- a/api/src/opentrons/protocol_api/execute.py
+++ b/api/src/opentrons/protocol_api/execute.py
@@ -4,6 +4,8 @@ import traceback
 import sys
 from typing import Any, Callable
 
+from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieAlarm
+
 from .contexts import ProtocolContext
 from . import execute_v3
 
@@ -104,6 +106,9 @@ def _run_python(
     new_globs.update(new_locs)
     try:
         exec('run(context)', new_globs, new_locs)
+    except SmoothieAlarm:
+        # this is a protocol cancel and shouldn't have special logging
+        raise
     except Exception as e:
         exc_type, exc_value, tb = sys.exc_info()
         try:


### PR DESCRIPTION
- Don't raise smoothieerrors for smoothie return strings like "alarm lock" or "after halt you should home" because they only happen when there's another previous error, and since they happen in an exception context they end up replacing the original SmoothieAlarm exception with a SmoothieError, which can be caught in many more circumstances, like in fast_home.
- Hold the motion lock for the call to hardware control stop(), to make sure that it doesn't happen until the call to session.run() has ended. This prevents a race condition where the halt() and stop() calls could happen in between the protocol run's smoothie calls, meaning that the
smoothie error response would be caught by the reset command instead of the protocol. The subsequent command would just look like a warning, so it wouldn't bubble up and the protocol wouldn't be cancelled.

Closes #4979


## Testing
- Cancel protocols. Try it on both API v1 and API v2; try it when waiting for a module command; try to get it right after the tip is dropped and the ejector shroud starts moving up.