### PR TITLE
fix(api): fix recent change breaking api server init

### DIFF
--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -141,7 +141,7 @@ def run(hardware, **kwargs):  # noqa(C901)
 
     log.info("API server version:  {}".format(__version__))
     if not os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"):
-        loop.run_until_complete(initialize_robot(loop, hardware))
+        initialize_robot(loop, hardware)
         if ff.use_protocol_api_v2():
             loop.run_until_complete(hardware.cache_instruments())
         if not ff.disable_home_on_boot():


### PR DESCRIPTION
A recent commit broke server initialization by passing
initialize_robot() into asyncio.loop.run_until_complete, but it's a
synchronous function.
