### PR TITLE
fix(api): make probe failures raise the actual error

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -133,6 +133,20 @@ class SmoothieAlarm(Exception):
         return f'SmoothieAlarm: {self.command} returned {self.ret_code}'
 
 
+class TipProbeError(SmoothieAlarm):
+    def __init__(self, ret_code: str = None, command: str = None) -> None:
+        self.ret_code = ret_code
+        self.command = command
+        super().__init__(ret_code, command)
+
+    def __repr__(self):
+        return f'<TipProbeError: {self.ret_code} from {self.command}'
+
+    def __str__(self):
+        return 'Tip probe could not complete: the switch was never touched. '\
+            'This may be because there is no tip on the pipette.'
+
+
 class ParseError(Exception):
     pass
 
@@ -1698,8 +1712,12 @@ class SmoothieDriver_3_0_0:
             self.engaged_axes[axis] = True
             command = GCODES['PROBE'] + axis.upper() + str(probing_distance)
             log.debug("probe_axis: {}".format(command))
-            self._send_command(
-                command=command, timeout=DEFAULT_MOVEMENT_TIMEOUT)
+            try:
+                self._send_command(
+                    command=command, ack_timeout=DEFAULT_MOVEMENT_TIMEOUT)
+            except SmoothieAlarm:
+                log.exception("Tip probe failure")
+                raise
             self.update_position(self.position)
             return self.position
         else:

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1715,9 +1715,10 @@ class SmoothieDriver_3_0_0:
             try:
                 self._send_command(
                     command=command, ack_timeout=DEFAULT_MOVEMENT_TIMEOUT)
-            except SmoothieAlarm:
+            except SmoothieError as se:
                 log.exception("Tip probe failure")
-                raise
+                if 'probe' in str(se).lower():
+                    raise TipProbeError(se.ret_code, se.command)
             self.update_position(self.position)
             return self.position
         else:


### PR DESCRIPTION
After c42d4dc62 (#4980), smoothie responses with downstream errors of halts (like the warnings
about having to home, or the "alarm lock" status condition) are
swallowed to make sure that the actual hard halt fault condition is
raised to the appropriate level, which makes it possible to separate
cancel behavior from actual error handling.

This coincidentally swallowed the error that happened when the user runs
a tip probe without a tip and the probe times out - even though there's
a special error code. That's because the tip probe execution timeout was
too low, and so the driver would time out and never read the actual
failure and only get the downstream errors (which would then be
swallowed).

The fix is to lengthen the timeout of the tip probe so the actual error
is raised.

While we're at it, make the error message human readable (and not
contain the word "smoothie")

Closes #5008

<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

<!--
  Describe any requests for your reviewers here.
-->
