### PR TITLE
feat(api): support gen2 modules

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -76,9 +76,20 @@ class Module:
     def __init__(self, module, context=None):
         self.id = id(module)
         if isinstance(module, module_geometry.ModuleGeometry):
-            self.name = module.load_name
+            _lookup = {
+                module_geometry.ModuleType.MAGNETIC: 'magdeck',
+                module_geometry.ModuleType.TEMPERATURE: 'tempdeck',
+                module_geometry.ModuleType.THERMOCYCLER: 'thermocycler'}
+            self.name = _lookup[module.module_type]
+            self.model = module.model.value
             self.slot = module.parent
         else:
             self.name = module.get_name()
+            _lookup = {
+                'tempdeck': 'temperatureModuleV1',
+                'magdeck': 'magneticModuleV1',
+                'thermocycler': 'thermocyclerModuleV1'
+            }
+            self.model = _lookup[module.get_name()]
             self.slot = module.parent.get_name()
         self._context = context

--- a/api/src/opentrons/app/models/control.py
+++ b/api/src/opentrons/app/models/control.py
@@ -76,10 +76,15 @@ class Module(BaseModel):
     """An object identifying a module"""
     name: str = \
         Field(...,
-              description="A machine readable identifying name for a module", )
+              description="A machine readable identifying name for a module. "
+                          "Deprecated. Prefer moduleModel", )
     displayName: str = \
         Field(...,
-              description="A human-presentable name of the module", )
+              description="A human-presentable name of the module. Deprecated."
+                          " Prefer lookup in the def", )
+    moduleModel: str = \
+        Field(...,
+              description="The model of the module (e.g. magneticModuleV1)")
     port: str = \
         Field(...,
               description="The virtual port to which the module is attached", )
@@ -88,9 +93,15 @@ class Module(BaseModel):
               description="The unique serial number of the module", )
     model: str = \
         Field(...,
-              description="The model identifier (i.e. the part number)", )
+              description="The model identifier (i.e. the part number). "
+                          "Deprecated. Prefer revision", )
+    revision: str = \
+        Field(...,
+              description="The hardware identifier (i.e. the part number)")
     fwVersion: str = \
         Field(..., description="The current firmware version", )
+    hasAvailableUpdate: bool = \
+        Field(..., description="If set, a module update is available")
     status: str = \
         Field(...,
               description="A human-readable module-specific status", )
@@ -116,11 +127,14 @@ class Modules(BaseModel):
                         {
                             "name": "magdeck",
                             "displayName": "Magnetic Module",
+                            "moduleModel": "magneticModuleV1",
                             "port": "tty01_magdeck",
                             "serial": "MDV2313121",
-                            "model": "V23",
+                            "model": "mag_deck_v4.0",
+                            "revision": "mag_deck_v4.0",
                             "fwVersion": "2.1.3",
                             "status": "engaged",
+                            "hasAvailableUpdate": True,
                             "data": {
                                 "engaged": True,
                                 "height": 10
@@ -136,9 +150,12 @@ class Modules(BaseModel):
                         {
                             "name": "tempdeck",
                             "displayName": "Temperature Module",
+                            "moduleModel": "temperatureModuleV1",
+                            "revision": "temp_deck_v10",
                             "port": "tty2_tempdeck",
                             "serial": "TDV10231231",
-                            "model": "V10",
+                            "model": "temp_deck_v10",
+                            "hasAvailableUpdate": False,
                             "fwVersion": "1.2.0",
                             "status": "cooling",
                             "data": {
@@ -156,9 +173,12 @@ class Modules(BaseModel):
                         {
                             "name": "thermocycler",
                             "displayName": "Thermocycler",
+                            "revision": "thermocycler_v10",
+                            "moduleModel": "thermocyclerModuleV1",
                             "port": "tty3_thermocycler",
                             "serial": "TCV1006052018",
-                            "model": "V10",
+                            "model": "thermocycler_v10",
+                            "hasAvailableUpdate": True,
                             "fwVersion": "1.0.0",
                             "status": "cooling",
                             "data": {

--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -106,7 +106,7 @@ def _parse_key_from_substring(substring) -> str:
                 substring))
 
 
-def _parse_device_information(device_info_string) -> dict:
+def _parse_device_information(device_info_string) -> Dict[str, str]:
     '''
     Parse the magnetic module's device information response.
     Example response from magnetic module:
@@ -265,7 +265,7 @@ class MagDeck:
             return str(e)
         return ''
 
-    def get_device_info(self) -> dict:
+    def get_device_info(self) -> Dict[str, str]:
         '''
         Queries Temp-Deck for it's build version, model, and serial number
 
@@ -282,10 +282,7 @@ class MagDeck:
         Example input from Temp-Deck's serial response:
             "serial:aa11bb22 model:aa11bb22 version:aa11bb22"
         '''
-        try:
-            return self._recursive_get_info(DEFAULT_COMMAND_RETRIES)
-        except (MagDeckError, SerialException, SerialNoResponse) as e:
-            return {'error': str(e)}
+        return self._recursive_get_info(DEFAULT_COMMAND_RETRIES)
 
     def enter_programming_mode(self) -> str:
         '''

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -1,13 +1,34 @@
 import asyncio
-from typing import Union
+import logging
+from typing import Mapping, Optional, Union
 from opentrons.drivers.mag_deck import MagDeck as MagDeckDriver
 from opentrons.drivers.mag_deck.driver import mag_locks
 from ..execution_manager import ExecutionManager
 from . import update, mod_abc, types
 
+log = logging.getLogger('__name__')
+
 LABWARE_ENGAGE_HEIGHT = {'biorad-hardshell-96-PCR': 18}    # mm
 MAX_ENGAGE_HEIGHT = 45  # mm from home position
 OFFSET_TO_LABWARE_BOTTOM = 5
+
+FIRST_GEN2_REVISION = 20
+
+
+def _model_from_revision(revision: Optional[str]) -> str:
+    """ Defines the revision -> model mapping """
+    if not revision or 'v' not in revision:
+        log.error(f'bad revision: {revision}')
+        return 'magneticModuleV1'
+    try:
+        revision_num = float(revision.split('v')[-1])  # type: ignore
+    except (ValueError, TypeError):
+        log.exception('bad revision: {revision}')
+        return 'magneticModuleV1'
+    if revision_num < FIRST_GEN2_REVISION:
+        return 'magneticModuleV1'
+    else:
+        return 'magneticModuleV2'
 
 
 class MissingDevicePortError(Exception):
@@ -25,32 +46,32 @@ class SimulatingDriver:
     def home(self):
         pass
 
-    def move(self, location):
+    def move(self, location: float):
         self._height = location
 
-    def get_device_info(self):
+    def get_device_info(self) -> Mapping[str, str]:
         return {'serial': 'dummySerialMD',
                 'model': 'dummyModelMD',
                 'version': 'dummyVersionMD'}
 
-    def connect(self, port):
+    def connect(self, port: str):
         pass
 
-    def disconnect(self, port=None):
+    def disconnect(self, port: str = None):
         pass
 
     def enter_programming_mode(self):
         pass
 
     @property
-    def plate_height(self):
+    def plate_height(self) -> float:
         return self._height
 
     @property
-    def mag_position(self):
+    def mag_position(self) -> float:
         return self._height
 
-    def is_connected(self):
+    def is_connected(self) -> bool:
         return True
 
 
@@ -78,9 +99,8 @@ class MagDeck(mod_abc.AbstractModule):
     def name(cls) -> str:
         return 'magdeck'
 
-    @classmethod
-    def display_name(cls) -> str:
-        return 'Magnetic Deck'
+    def model(self) -> str:
+        return _model_from_revision(self._device_info.get('model'))
 
     @classmethod
     def bootloader(cls) -> types.UploadFunction:
@@ -103,6 +123,7 @@ class MagDeck(mod_abc.AbstractModule):
                          simulating=simulating,
                          loop=loop,
                          execution_manager=execution_manager)
+        self._device_info: Mapping[str, str] = {}
         if mag_locks.get(port):
             self._driver = mag_locks[port][1]
         else:
@@ -116,7 +137,7 @@ class MagDeck(mod_abc.AbstractModule):
         self._driver.probe_plate()
         # return if successful or not?
 
-    async def engage(self, height):
+    async def engage(self, height: float):
         """
         Move the magnet to a specific height, in mm from home position
         """
@@ -135,11 +156,11 @@ class MagDeck(mod_abc.AbstractModule):
         await self.engage(0.0)
 
     @property
-    def current_height(self):
+    def current_height(self) -> float:
         return self._driver.mag_position
 
     @property
-    def device_info(self):
+    def device_info(self) -> Mapping[str, str]:
         """
         Returns a dict:
             { 'serial': 'abc123', 'model': '8675309', 'version': '9001' }
@@ -147,21 +168,21 @@ class MagDeck(mod_abc.AbstractModule):
         return self._device_info
 
     @property
-    def status(self):
+    def status(self) -> str:
         if self.current_height > 0:
             return 'engaged'
         else:
             return 'disengaged'
 
     @property
-    def engaged(self):
+    def engaged(self) -> bool:
         if self.current_height > 0:
             return True
         else:
             return False
 
     @property
-    def live_data(self):
+    def live_data(self) -> types.LiveData:
         return {
             'status': self.status,
             'data': {
@@ -171,22 +192,22 @@ class MagDeck(mod_abc.AbstractModule):
         }
 
     @property
-    def port(self):
+    def port(self) -> str:
         return self._port
 
     @property
-    def is_simulated(self):
+    def is_simulated(self) -> bool:
         return isinstance(self._driver, SimulatingDriver)
 
     @property
-    def interrupt_callback(self):
+    def interrupt_callback(self) -> types.InterruptCallback:
         return lambda x: None
 
     @property
-    def loop(self):
+    def loop(self) -> asyncio.AbstractEventLoop:
         return self._loop
 
-    def set_loop(self, loop):
+    def set_loop(self, loop: asyncio.AbstractEventLoop):
         self._loop = loop
 
     # Internal Methods

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -3,11 +3,11 @@ import asyncio
 import logging
 import re
 from pkg_resources import parse_version
-from typing import Dict, Optional
+from typing import Mapping, Optional
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.hardware_control.util import use_or_initialize_loop
 from ..execution_manager import ExecutionManager
-from .types import BundledFirmware, UploadFunction, InterruptCallback
+from .types import BundledFirmware, UploadFunction, InterruptCallback, LiveData
 
 mod_log = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class AbstractModule(abc.ABC):
         self._port = port
         self._loop = use_or_initialize_loop(loop)
         self._execution_manager = execution_manager
-        self._device_info = None
+        self._device_info: Mapping[str, str]
         self._bundled_fw: Optional[BundledFirmware] = self.get_bundled_fw()
 
     def get_bundled_fw(self) -> Optional[BundledFirmware]:
@@ -64,8 +64,8 @@ class AbstractModule(abc.ABC):
 
     def has_available_update(self) -> bool:
         """ Return whether a newer firmware file is available """
-        if self._device_info is not None and self._bundled_fw:
-            device_version = parse_version(self._device_info.get('version'))
+        if self._device_info and self._bundled_fw:
+            device_version = parse_version(self._device_info['version'])
             available_version = parse_version(self._bundled_fw.version)
             return available_version > device_version
         return False
@@ -87,13 +87,13 @@ class AbstractModule(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def device_info(self) -> Dict[str, str]:
+    def device_info(self) -> Mapping[str, str]:
         """ Return a dict of the module's static information (serial, etc)"""
         pass
 
     @property
     @abc.abstractmethod
-    def live_data(self) -> Dict[str, str]:
+    def live_data(self) -> LiveData:
         """ Return a dict of the module's dynamic information """
         pass
 
@@ -131,16 +131,15 @@ class AbstractModule(abc.ABC):
     def bundled_fw(self):
         return self._bundled_fw
 
-    @classmethod
     @abc.abstractmethod
-    def name(cls) -> str:
-        """ A name for this kind of module. """
+    def model(self) -> str:
+        """ A name for this specific module, matching module defs """
         pass
 
     @classmethod
     @abc.abstractmethod
-    def display_name(cls) -> str:
-        """ A user-facing name for this kind of module. """
+    def name(cls) -> str:
+        """ A shortname used for looking up firmware, among other things """
         pass
 
     @classmethod

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -1,12 +1,35 @@
 import asyncio
+import logging
 from threading import Thread, Event
-from typing import Union
+from typing import Mapping, Union, Optional
 from opentrons.drivers.temp_deck import TempDeck as TempDeckDriver
 from opentrons.drivers.temp_deck.driver import temp_locks
 from ..execution_manager import ExecutionManager
 from . import update, mod_abc, types
 
+log = logging.getLogger(__name__)
+
 TEMP_POLL_INTERVAL_SECS = 1
+
+FIRST_GEN2_REVISION = 20
+
+
+def _model_from_revision(revision: Optional[str]) -> str:
+    """ Defines the revision -> model mapping"""
+    if not revision or 'v' not in revision:
+        log.error(f'bad revision: {revision}')
+        return 'temperatureModuleV1'
+    try:
+        revision_num = float(revision.split('v')[-1])  # type: ignore
+    except (ValueError, TypeError):
+        # none or corrupt
+        log.exception('no revision')
+        return 'temperatureModuleV1'
+
+    if revision_num < FIRST_GEN2_REVISION:
+        return 'temperatureModuleV1'
+    else:
+        return 'temperatureModuleV2'
 
 
 class MissingDevicePortError(Exception):
@@ -19,11 +42,11 @@ class SimulatingDriver:
         self._active = False
         self._port = None
 
-    async def set_temperature(self, celsius):
+    async def set_temperature(self, celsius: float):
         self._target_temp = celsius
         self._active = True
 
-    def legacy_set_temperature(self, celsius):
+    def legacy_set_temperature(self, celsius: float):
         self._target_temp = celsius
         self._active = True
 
@@ -34,10 +57,10 @@ class SimulatingDriver:
     def update_temperature(self):
         pass
 
-    def connect(self, port):
+    def connect(self, port: str):
         self._port = port
 
-    def is_connected(self):
+    def is_connected(self) -> bool:
         return True
 
     def disconnect(self):
@@ -47,25 +70,25 @@ class SimulatingDriver:
         pass
 
     @property
-    def temperature(self):
+    def temperature(self) -> float:
         return self._target_temp
 
     @property
-    def target(self):
+    def target(self) -> Optional[float]:
         return self._target_temp if self._active else None
 
     @property
-    def status(self):
+    def status(self) -> str:
         return 'holding at target' if self._active else 'idle'
 
-    def get_device_info(self):
+    def get_device_info(self) -> Mapping[str, str]:
         return {'serial': 'dummySerialTD',
                 'model': 'dummyModelTD',
                 'version': 'dummyVersionTD'}
 
 
 class Poller(Thread):
-    def __init__(self, driver):
+    def __init__(self, driver: TempDeckDriver):
         self._driver_ref = driver
         self._stop_event = Event()
         super().__init__(target=self._poll_temperature,
@@ -106,12 +129,11 @@ class TempDeck(mod_abc.AbstractModule):
     def name(cls) -> str:
         return 'tempdeck'
 
-    @classmethod
-    def display_name(cls) -> str:
-        return 'Temperature Deck'
+    def model(self) -> str:
+        return _model_from_revision(self._device_info.get('model'))
 
     @classmethod
-    def bootloader(cls) -> types.UploadFunction:
+    def bootloader(cls) -> mod_abc.UploadFunction:
         return update.upload_via_avrdude
 
     @staticmethod
@@ -131,6 +153,7 @@ class TempDeck(mod_abc.AbstractModule):
                          simulating=simulating,
                          loop=loop,
                          execution_manager=execution_manager)
+        self._device_info: Mapping[str, str] = {}
         if temp_locks.get(port):
             self._driver = temp_locks[port][1]
         else:
@@ -138,7 +161,7 @@ class TempDeck(mod_abc.AbstractModule):
 
         self._poller = None
 
-    async def set_temperature(self, celsius):
+    async def set_temperature(self, celsius: float):
         """
         Set temperature in degree Celsius
         Range: 4 to 95 degree Celsius (QA tested).
@@ -157,11 +180,11 @@ class TempDeck(mod_abc.AbstractModule):
         self._driver.deactivate()
 
     @property
-    def device_info(self):
+    def device_info(self) -> Mapping[str, str]:
         return self._device_info
 
     @property
-    def live_data(self):
+    def live_data(self) -> types.LiveData:
         return {
             'status': self.status,
             'data': {
@@ -171,34 +194,34 @@ class TempDeck(mod_abc.AbstractModule):
         }
 
     @property
-    def temperature(self):
+    def temperature(self) -> float:
         return self._driver.temperature
 
     @property
-    def target(self):
+    def target(self) -> float:
         return self._driver.target
 
     @property
-    def status(self):
+    def status(self) -> str:
         return self._driver.status
 
     @property
-    def port(self):
+    def port(self) -> str:
         return self._port
 
     @property
-    def is_simulated(self):
+    def is_simulated(self) -> bool:
         return isinstance(self._driver, SimulatingDriver)
 
     @property
-    def interrupt_callback(self):
+    def interrupt_callback(self) -> types.InterruptCallback:
         return lambda x: None
 
     @property
-    def loop(self):
+    def loop(self) -> asyncio.AbstractEventLoop:
         return self._loop
 
-    def set_loop(self, loop):
+    def set_loop(self, loop: asyncio.AbstractEventLoop):
         self._loop = loop
 
     async def _connect(self):

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -136,12 +136,11 @@ class Thermocycler(mod_abc.AbstractModule):
         return mod
 
     @classmethod
-    def name(cls):
+    def name(cls) -> str:
         return 'thermocycler'
 
-    @classmethod
-    def display_name(cls):
-        return 'Thermocycler'
+    def model(self) -> str:
+        return 'thermocyclerModuleV1'
 
     @classmethod
     def bootloader(cls) -> types.UploadFunction:

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
-from typing import Dict, NamedTuple, Callable, Any, Tuple, Awaitable
+from typing import (
+    Dict, NamedTuple, Callable, Any, Tuple, Awaitable, Mapping, Union)
 from pathlib import Path
 
 ThermocyclerStep = Dict[str, float]
@@ -10,6 +11,8 @@ UploadFunction = Callable[[str, str, Dict[str, Any]],
                           Awaitable[Tuple[bool, str]]]
 
 ModuleAtPort = namedtuple('ModuleAtPort', ('port', 'name'))
+
+LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]
 
 
 class BundledFirmware(NamedTuple):
@@ -31,3 +34,10 @@ class UnsupportedModuleError(Exception):
 
 class AbsentModuleError(Exception):
     pass
+
+
+class ModuleInfo(NamedTuple):
+    model: str        # A module model such as "magneticModuleV2"
+    fw_version: str   # The version of the firmware
+    hw_revision: str  # the revision of the hardware
+    serial: str       # the serial number

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -1,8 +1,12 @@
 import abc
+
 from ..protocols import types
 
 MAX_SUPPORTED_VERSION = types.APIVersion(2, 3)
 #: The maximum supported protocol API version in this release
+
+V2_MODULE_DEF_VERSION = types.APIVersion(2, 3)
+#: The first API version in which we prefer the v2 module defs
 
 
 class DeckItem(abc.ABC):

--- a/api/src/opentrons/protocol_api/module_geometry.py
+++ b/api/src/opentrons/protocol_api/module_geometry.py
@@ -7,23 +7,82 @@ objects on the deck (as opposed to calling commands on them, which is handled
 by :py:mod:`.module_contexts`)
 """
 
+from enum import Enum
+import functools
 import json
-from typing import Any, Dict, Optional, Union
+import logging
+import re
+from typing import Any, Dict, Mapping, Optional, Type, TypeVar, Union
+
+import numpy as np  # type: ignore
+import jsonschema  # type: ignore
 
 from opentrons.system.shared_data import load_shared_data
-from opentrons.types import Location, Point
+from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.types import APIVersion
-from .definitions import MAX_SUPPORTED_VERSION, DeckItem
+from .definitions import MAX_SUPPORTED_VERSION, DeckItem, V2_MODULE_DEF_VERSION
 from .labware import Labware
 
 
-ModuleDefinitionV1 = Dict[str, Any]
-ModuleDefinitionV2 = Dict[str, Any]
-ModuleDefinition = Union[ModuleDefinitionV1, ModuleDefinitionV2]
+E = TypeVar('E', bound='_ProvideLookup')
+
+
+class _ProvideLookup(Enum):
+    @classmethod
+    def from_str(cls: Type[E], typename: str) -> 'E':
+        for m in cls.__members__.values():
+            if m.value == typename:
+                return m
+        raise AttributeError(f'No such module type {typename}')
+
+
+class ModuleType(_ProvideLookup):
+    THERMOCYCLER: str = 'thermocyclerModuleType'
+    TEMPERATURE: str = 'temperatureModuleType'
+    MAGNETIC: str = 'magneticModuleType'
+
+
+class MagneticModuleModel(_ProvideLookup):
+    MAGNETIC_V1: str = 'magneticModuleV1'
+    MAGNETIC_V2: str = 'magneticModuleV2'
+
+
+class TemperatureModuleModel(_ProvideLookup):
+    TEMPERATURE_V1: str = 'temperatureModuleV1'
+    TEMPERATURE_V2: str = 'temperatureModuleV2'
+
+
+class ThermocyclerModuleModel(_ProvideLookup):
+
+    @classmethod
+    def from_str(cls: Type['ThermocyclerModuleModel'],
+                 typename: str) -> 'ThermocyclerModuleModel':
+        return super().from_str(typename)
+
+    THERMOCYCLER_V1: str = 'thermocyclerModuleV1'
+
+
+ModuleModel = Union[
+    MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel]
+
+
+def module_model_from_string(model_string: str) -> ModuleModel:
+    for model_enum in {
+            MagneticModuleModel,
+            TemperatureModuleModel,
+            ThermocyclerModuleModel}:
+        try:
+            return model_enum.from_str(model_string)  # type: ignore
+        except AttributeError:
+            pass
+    raise AttributeError(f"No such module model {model_string}")
+
+
+log = logging.getLogger(__name__)
 
 
 class NoSuchModuleError(Exception):
-    def __init__(self, message: str, requested_module: str) -> None:
+    def __init__(self, message: str, requested_module: ModuleModel) -> None:
         self.message = message
         self.requested_module = requested_module
         super().__init__()
@@ -40,31 +99,20 @@ class ModuleGeometry(DeckItem):
     the labware mounted on top of it).
     """
 
-    @classmethod
-    def resolve_module_name(cls, module_name: str):
-        alias_map = {
-            'magdeck': 'magdeck',
-            'magnetic module': 'magdeck',
-            'tempdeck': 'tempdeck',
-            'temperature module': 'tempdeck',
-            'thermocycler': 'thermocycler',
-            'thermocycler module': 'thermocycler'
-        }
-        lower_name = module_name.lower()
-        resolved_name = alias_map.get(lower_name, None)
-        if not resolved_name:
-            raise ValueError(f'{module_name} is not a valid module load name')
-        return resolved_name
-
     @property
     def separate_calibration(self) -> bool:
         # If a module is the parent of a labware it affects calibration
         return True
 
     def __init__(self,
-                 definition: dict,
+                 display_name: str,
+                 model: ModuleModel,
+                 module_type: ModuleType,
+                 offset: Point,
+                 overall_height: float,
+                 height_over_labware: float,
                  parent: Location,
-                 api_level: APIVersion = None) -> None:
+                 api_level: APIVersion) -> None:
         """
         Create a Module for tracking the position of a module.
 
@@ -76,9 +124,15 @@ class ModuleGeometry(DeckItem):
         this would be to correct the :py:class:`.Location` so that the
         calibrated labware is targeted accurately in both positions.
 
-        :param definition: A dict containing all the data required to define
-                           the geometry of the module.
-        :type definition: dict
+        :param display_name: A human-readable display name of only the module
+                             (for instance, "Thermocycler Module" - not
+                             including parents or location)
+        :param model: The model of module this represents
+        :param offset: The offset from the slot origin at which labware loaded
+                       on this module should be placed
+        :param overall_height: The height of the module without labware
+        :param height_over_labware: The height of this module over the top of
+                                    the labware
         :param parent: A location representing location of the front left of
                        the outside of the module (usually the front-left corner
                        of a slot on the deck).
@@ -86,28 +140,17 @@ class ModuleGeometry(DeckItem):
         :param APIVersion api_level: the API version to set for the loaded
                                      :py:class:`ModuleGeometry` instance. The
                                      :py:class:`ModuleGeometry` will
-                                     conform to this level. If not specified,
-                                     defaults to
-                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
+                                     conform to this level.
         """
-        if not api_level:
-            api_level = MAX_SUPPORTED_VERSION
-        if api_level > MAX_SUPPORTED_VERSION:
-            raise RuntimeError(
-                f'API version {api_level} is not supported by this '
-                f'robot software. Please either reduce your requested API '
-                f'version or update your robot.')
         self._api_version = api_level
         self._parent = parent
-        self._display_name = "{} on {}".format(definition["displayName"],
-                                               str(parent.labware))
-        self._load_name = definition["loadName"]
-        self._offset = Point(definition["labwareOffset"]["x"],
-                             definition["labwareOffset"]["y"],
-                             definition["labwareOffset"]["z"])
-        self._height = definition["dimensions"]["bareOverallHeight"]\
-            + self._parent.point.z
-        self._over_labware = definition["dimensions"]["overLabwareHeight"]
+        self._module_type = module_type
+        self._display_name = "{} on {}".format(
+            display_name, str(parent.labware))
+        self._model = model
+        self._offset = offset
+        self._height = overall_height + self._parent.point.z
+        self._over_labware = height_over_labware
         self._labware: Optional[Labware] = None
         self._location = Location(
             point=self._offset + self._parent.point,
@@ -127,11 +170,20 @@ class ModuleGeometry(DeckItem):
         self._labware = None
 
     @property
-    def load_name(self):
-        return self._load_name
+    def model(self) -> ModuleModel:
+        return self._model
 
     @property
-    def parent(self):
+    def load_name(self) -> str:
+        return self.model.value
+
+    @property
+    def module_type(self) -> ModuleType:
+        """ The Moduletype """
+        return self._module_type
+
+    @property
+    def parent(self) -> LocationLabware:
         return self._parent.labware
 
     @property
@@ -161,15 +213,54 @@ class ModuleGeometry(DeckItem):
         else:
             return self._height
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self._display_name
 
 
 class ThermocyclerGeometry(ModuleGeometry):
-    def __init__(self, definition: Dict[str, Any], parent: Location,
-                 api_level: APIVersion = None) -> None:
-        super().__init__(definition, parent, api_level)
-        self._lid_height = definition["dimensions"]["lidHeight"]
+    def __init__(self,
+                 display_name: str,
+                 model: ModuleModel,
+                 module_type: ModuleType,
+                 offset: Point,
+                 overall_height: float,
+                 height_over_labware: float,
+                 lid_height: float,
+                 parent: Location,
+                 api_level: APIVersion) -> None:
+        """
+        Create a Module for tracking the position of a module.
+
+        Note that modules do not currently have a concept of calibration apart
+        from calibration of labware on top of the module. The practical result
+        of this is that if the module parent :py:class:`.Location` is
+        incorrect, then acorrect calibration of one labware on the deck would
+        be incorrect on the module, and vice-versa. Currently, the way around
+        this would be to correct the :py:class:`.Location` so that the
+        calibrated labware is targeted accurately in both positions.
+
+        :param display_name: A human-readable display name of only the module
+                             (for instance, "Thermocycler Module" - not
+                             including parents or location)
+        :param model: The model of module this represents
+        :param offset: The offset from the slot origin at which labware loaded
+                       on this module should be placed
+        :param overall_height: The height of the module without labware
+        :param height_over_labware: The height of this module over the top of
+                                    the labware
+        :param parent: A location representing location of the front left of
+                       the outside of the module (usually the front-left corner
+                       of a slot on the deck).
+        :type parent: :py:class:`.Location`
+        :param APIVersion api_level: the API version to set for the loaded
+                                     :py:class:`ModuleGeometry` instance. The
+                                     :py:class:`ModuleGeometry` will
+                                     conform to this level.
+        """
+        super().__init__(
+            display_name, model, module_type, offset, overall_height,
+            height_over_labware, parent, api_level)
+        self._lid_height = lid_height
         self._lid_status = 'open'   # Needs to reflect true status
         # TODO: BC 2019-07-25 add affordance for "semi" configuration offset
         # to be from a flag in context, according to drawings, the only
@@ -213,6 +304,102 @@ class ThermocyclerGeometry(ModuleGeometry):
         return self._labware
 
 
+def _load_from_v1(definition: Dict[str, Any],
+                  parent: Location,
+                  api_level: APIVersion) -> ModuleGeometry:
+    """ Load a module geometry from a v1 definition.
+
+    The definition should be schema checked before being passed to this
+    function; all definitions passed here are assumed to be valid.
+    """
+    mod_name = definition['loadName']
+    model_lookup: Mapping[str, ModuleModel] = {
+        'thermocycler': ThermocyclerModuleModel.THERMOCYCLER_V1,
+        'magdeck': MagneticModuleModel.MAGNETIC_V1,
+        'tempdeck': TemperatureModuleModel.TEMPERATURE_V1}
+    type_lookup = {
+        'thermocycler': ModuleType.THERMOCYCLER,
+        'tempdeck': ModuleType.TEMPERATURE,
+        'magdeck': ModuleType.MAGNETIC
+    }
+    model = model_lookup[mod_name]
+    offset = Point(definition["labwareOffset"]["x"],
+                   definition["labwareOffset"]["y"],
+                   definition["labwareOffset"]["z"])
+    overall_height = definition["dimensions"]["bareOverallHeight"]\
+
+    height_over_labware = definition["dimensions"]["overLabwareHeight"]
+
+    if model in ThermocyclerModuleModel:
+        lid_height = definition['dimensions']['lidHeight']
+        mod: ModuleGeometry = \
+            ThermocyclerGeometry(definition["displayName"],
+                                 model,
+                                 type_lookup[mod_name],
+                                 offset,
+                                 overall_height,
+                                 height_over_labware,
+                                 lid_height,
+                                 parent,
+                                 api_level)
+    else:
+        mod = ModuleGeometry(definition['displayName'],
+                             model,
+                             type_lookup[mod_name],
+                             offset,
+                             overall_height,
+                             height_over_labware,
+                             parent, api_level)
+    return mod
+
+
+def _load_from_v2(definition: Dict[str, Any],
+                  parent: Location,
+                  api_level: APIVersion) -> ModuleGeometry:
+    """ Load a module geometry from a v2 definition.
+
+    The definition should be schema checked before being passed to this
+     function; all definitions passed here are assumed to be valid.
+    """
+    pre_transform = np.array((definition['labwareOffset']['x'],
+                              definition['labwareOffset']['y'],
+                              1))
+    par = parent.labware
+
+    # this needs to change to look up the current deck type if/when we add
+    # that notion
+    xforms_ser = definition['slotTransforms']\
+        .get('ot2_standard', {})\
+        .get(par, {'labwareOffset': [[1, 0, 0], [0, 1, 0], [0, 0, 1]]})
+    xform_ser = xforms_ser['labwareOffset']
+
+    # apply the slot transform if any
+    xform = np.array(xform_ser)
+    xformed = np.dot(xform, pre_transform)
+    opts = {
+        'parent': parent,
+        'api_level': api_level,
+        'offset': Point(xformed[0],
+                        xformed[1],
+                        definition['labwareOffset']['z']),
+        'overall_height': definition['dimensions']['bareOverallHeight'],
+        'height_over_labware': definition['dimensions']['overLabwareHeight'],
+        'model': module_model_from_string(definition['model']),
+        'module_type': ModuleType.from_str(definition['moduleType']),
+        'display_name': definition['displayName']
+    }
+    if definition['moduleType'] in {
+            ModuleType.MAGNETIC.value,
+            ModuleType.TEMPERATURE.value}:
+        return ModuleGeometry(**opts)
+    elif definition['moduleType'] == ModuleType.THERMOCYCLER.value:
+        return ThermocyclerGeometry(
+            lid_height=definition['dimensions']['lidHeight'],
+            **opts)
+    else:
+        raise RuntimeError(f'Unknown module type {definition["moduleType"]}')
+
+
 def load_module_from_definition(
         definition: Dict[str, Any],
         parent: Location,
@@ -233,35 +420,85 @@ def load_module_from_definition(
                                  defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     api_level = api_level or MAX_SUPPORTED_VERSION
-    mod_name = definition['loadName']
+    schema = definition.get("$otSharedSchema")
+    if not schema:
+        # v1 definitions don't have schema versions
+        return _load_from_v1(definition, parent, api_level)
+    if schema == 'module/schemas/2':
+        schema_doc = json.loads(load_shared_data("module/schemas/2.json"))
+        try:
+            jsonschema.validate(definition, schema_doc)
+        except jsonschema.ValidationError:
+            log.exception("Failed to validate module def schema")
+            raise RuntimeError('The specified module definition is not valid.')
+        return _load_from_v2(definition, parent, api_level)
+    elif isinstance(schema, str):
+        maybe_schema = re.match('^module/schemas/([0-9]+)$', schema)
+        if maybe_schema:
+            raise RuntimeError(
+                f"Module definitions of schema version {maybe_schema.group(1)}"
+                " are not supported in this robot software release.")
+    log.error(f"Bad module definition (schema specifier {schema})")
+    raise RuntimeError(
+        f'The specified module definition is not valid.')
 
-    if mod_name == 'thermocycler':
-        mod: ModuleGeometry = \
-                ThermocyclerGeometry(definition, parent, api_level)
-    else:
-        mod = ModuleGeometry(definition, parent, api_level)
-    # TODO: calibration
-    return mod
+
+def _load_v1_module_def(module_model: ModuleModel) -> Dict[str, Any]:
+    v1names = {MagneticModuleModel.MAGNETIC_V1: 'magdeck',
+               TemperatureModuleModel.TEMPERATURE_V1: 'tempdeck',
+               ThermocyclerModuleModel.THERMOCYCLER_V1: 'thermocycler'}
+    try:
+        name = v1names[module_model]
+    except KeyError:
+        raise NoSuchModuleError(
+            f'Could not find module {module_model.value}',
+            module_model)
+    return json.loads(load_shared_data('module/definitions/1.json'))[name]
 
 
-def _load_module_definition(api_level: APIVersion) -> Dict[str, Any]:
+def _load_v2_module_def(module_model: ModuleModel) -> Dict[str, Any]:
+    try:
+        return json.loads(
+            load_shared_data(
+                f'module/definitions/2/{module_model.value}.json'))
+    except OSError:
+        raise NoSuchModuleError(
+            f'Could not find the module {module_model.value}.',
+            module_model)
+
+
+@functools.lru_cache(maxsize=128)
+def _load_module_definition(api_level: APIVersion,
+                            module_model: ModuleModel) -> Dict[str, Any]:
     """
     Load the appropriate module definition for this api version
     """
-    return json.loads(load_shared_data('module/definitions/1.json'))
+    if api_level < V2_MODULE_DEF_VERSION:
+        try:
+            return _load_v1_module_def(module_model)
+        except NoSuchModuleError:
+            try:
+                dname = _load_v2_module_def(module_model)['displayName']
+            except NoSuchModuleError:
+                dname = module_model.value
+            raise NoSuchModuleError(
+                f'API version {api_level} does not support the module '
+                f'{dname}. Please use at least version '
+                f'{V2_MODULE_DEF_VERSION} to use this module.', module_model)
+    else:
+        return _load_v2_module_def(module_model)
 
 
 def load_module(
-        name: str,
+        model: ModuleModel,
         parent: Location,
         api_level: APIVersion = None) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a definition looked up
     by name.
 
-    :param name: A string to use for looking up the definition. The string
-                 must be present as a top-level key in
-                 module/definitions/{moduleDefinitionVersion}.json.
+    :param model: The module model to use. This should be one of the strings
+                  returned by :py:func:`ModuleGeometry.resolve_module_model`
     :param parent: A :py:class:`.Location` representing the location where
                    the front and left most point of the outside of the module
                    is (often the front-left corner of a slot on the deck).
@@ -272,5 +509,39 @@ def load_module(
                                  defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
     """
     api_level = api_level or MAX_SUPPORTED_VERSION
-    defn = _load_module_definition(api_level)
-    return load_module_from_definition(defn[name], parent, api_level)
+    defn = _load_module_definition(api_level, model)
+    return load_module_from_definition(defn, parent, api_level)
+
+
+def resolve_module_model(module_name: str) -> ModuleModel:
+    """ Turn any of the supported load names into module model names """
+    alias_map: Mapping[str, ModuleModel] = {
+        'magdeck': MagneticModuleModel.MAGNETIC_V1,
+        'magnetic module': MagneticModuleModel.MAGNETIC_V1,
+        'magnetic module gen2': MagneticModuleModel.MAGNETIC_V2,
+        'tempdeck': TemperatureModuleModel.TEMPERATURE_V1,
+        'temperature module': TemperatureModuleModel.TEMPERATURE_V1,
+        'temperature module gen2': TemperatureModuleModel.TEMPERATURE_V2,
+        'thermocycler': ThermocyclerModuleModel.THERMOCYCLER_V1,
+        'thermocycler module': ThermocyclerModuleModel.THERMOCYCLER_V1,
+    }
+    lower_name = module_name.lower()
+    resolved_name = alias_map.get(lower_name, None)
+    if not resolved_name:
+        raise ValueError(f'{module_name} is not a valid module load name.\n'
+                         'Valid names (ignoring case): '
+                         '"' + '", "'.join(alias_map.keys()) + '"')
+    return resolved_name
+
+
+def resolve_module_type(module_model: ModuleModel) -> ModuleType:
+    return ModuleType.from_str(_load_module_definition(
+        V2_MODULE_DEF_VERSION, module_model)['moduleType'])
+
+
+def models_compatible(model_a: ModuleModel, model_b: ModuleModel) -> bool:
+    """ Check if two module models may be considered the same """
+    if model_a == model_b:
+        return True
+    return model_b.value in _load_module_definition(
+        V2_MODULE_DEF_VERSION, model_a)['compatibleWith']

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -96,16 +96,16 @@ async def get_attached_modules(request):
     {
         "modules": [
             {
+                # module model name for lookups in module defs
+                "model": "string"
                 # machine readable identifying name of module
                 "name": "string",
-                # human-presentable name of module
-                "displayName": "string",
                 # module system port pat
                 "port": "string",
                 # unique serial number
                 "serial": "string",
-                # model identifier (i.e. part number)
-                "model": "string",
+                # revision identifier (i.e. part number)
+                "revision": "string",
                 # current firmware version
                 "fwVersion": "string",
                 # human readable status
@@ -127,11 +127,13 @@ async def get_attached_modules(request):
     hw_mods = hw.attached_modules
     module_data = [
         {
-            'name': mod.name(),
-            'displayName': mod.display_name(),
-            'port': mod.port,
+            'name': mod.name(),  # TODO: legacy, remove
+            'displayName': mod.name(),  # TODO: legacy, remove
+            'model': mod.device_info.get('model'),  # TODO legacy, remove
+            'moduleModel': mod.model(),
+            'port': mod.port,  # /dev/ttyS0
             'serial': mod.device_info.get('serial'),
-            'model': mod.device_info.get('model'),
+            'revision': mod.device_info.get('model'),
             'fwVersion': mod.device_info.get('version'),
             'hasAvailableUpdate': mod.has_available_update(),
             **mod.live_data

--- a/api/src/opentrons/server/openapi.json
+++ b/api/src/opentrons/server/openapi.json
@@ -1293,14 +1293,26 @@
                       "items": {
                         "description": "An object identifying a module",
                         "type": "object",
-                        "required": ["name", "displayName", "port", "serial", "model", "fwVersion", "status", "data"],
+                        "required": ["model", "moduleModel", "name", "displayName", "port", "serial", "revision", "fwVersion", "status", "data", "hasAvailableUpdate"],
                         "properties": {
+                          "hasAvailableUpdate": {
+                            "description": "if set, a module update is available",
+                            "type": "boolean"
+                          },
                           "name": {
-                            "description": "A machine readable identifying name for a module",
+                            "description": "A machine readable identifying name for a module. Provided for backcompatibility. Prefer use of moduleModel",
+                            "type": "string"
+                          },
+                          "moduleModel": {
+                            "description": "The model of the module, suitable for looking up the definition (e.g. magneticModuleV1)",
                             "type": "string"
                           },
                           "displayName": {
-                            "description": "A human-presentable name of the module",
+                            "description": "A human readable description of the module. Provided for backcompatibility. Prefer looking up the display name in the module definition",
+                            "type": "string"
+                          },
+                          "model": {
+                            "description": "The old name of the module hardware revision (e.g. temp_deck_v4.0). Provided for backcompatibility. Prefer use of revision",
                             "type": "string"
                           },
                           "port": {
@@ -1311,8 +1323,8 @@
                             "description": "The unique serial number of the module",
                             "type": "string"
                           },
-                          "model": {
-                            "description": "The model identifier (i.e. the part number)",
+                          "revision": {
+                            "description": "The hardware revision identifier (i.e. the part number)",
                             "type": "string"
                           },
                           "fwVersion": {
@@ -1341,12 +1353,15 @@
                     "value": {
                       "modules": [
                         {
+                          "model": "mag_deck_v4.0",
                           "name": "magdeck",
-                          "displayName": "Magnetic Module",
+                          "moduleModel": "magneticModuleV1",
+                          "displayName": "magdeck",
                           "port": "tty01_magdeck",
                           "serial": "MDV2313121",
-                          "model": "V23",
+                          "revision": "mag_deck_v4.0",
                           "fwVersion": "2.1.3",
+                          "hasAvailableUpdate": true,
                           "status": "engaged",
                           "data": {
                             "engaged": true,
@@ -1357,17 +1372,20 @@
                     }
                   },
                   "tempDeckAttached": {
-                    "description": "With a Temperature Module attached",
+                    "description": "With a Temperature Module GEN2 attached",
                     "value": {
                       "modules": [
                         {
+                          "moduleModel": "temperatureModuleV2",
+                          "model": "temp_deck_v20",
                           "name": "tempdeck",
-                          "displayName": "Temperature Module",
+                          "displayName": "tempdeck",
                           "port": "tty2_tempdeck",
-                          "serial": "TDV10231231",
-                          "model": "V10",
+                          "serial": "TDV20231231",
+                          "revision": "temp_deck_v20",
                           "fwVersion": "1.2.0",
                           "status": "cooling",
+                          "hasAvailableUpdate": false,
                           "data": {
                             "currentTemp": 25,
                             "targetTemp": 10
@@ -1381,12 +1399,15 @@
                     "value": {
                       "modules": [
                         {
+                          "model": "thermocycler_v10",
+                          "moduleModel": "thermocyclerModuleV1",
+                          "displayName": "thermocycler",
                           "name": "thermocycler",
-                          "displayName": "Thermocycler",
                           "port": "tty3_thermocycler",
                           "serial": "TCV1006052018",
-                          "model": "V10",
+                          "model": "thermocycler_v10",
                           "fwVersion": "1.0.0",
+                          "hasAvailableUpdate": false,
                           "status": "cooling",
                           "data": {
                             "lid": "closed",
@@ -1448,12 +1469,6 @@
                   "magneticModule": {
                     "description": "Specifying a Magnetic Module",
                     "value": {
-                      "name": "magdeck",
-                      "displayName": "Magnetic Module",
-                      "port": "tty01_magdeck",
-                      "serial": "MDV2313121",
-                      "model": "V23",
-                      "fwVersion": "2.1.3",
                       "status": "engaged",
                       "data": {
                         "engaged": true,
@@ -1464,12 +1479,6 @@
                   "tempDeck": {
                     "description": "Specifying a Temperature Module",
                     "value": {
-                      "name": "tempdeck",
-                      "displayName": "Temperature Module",
-                      "port": "tty2_tempdeck",
-                      "serial": "TDV10231231",
-                      "model": "V10",
-                      "fwVersion": "1.2.0",
                       "status": "cooling",
                       "data": {
                         "currentTemp": 25,
@@ -1480,12 +1489,6 @@
                   "thermocycler": {
                     "description": "Specifying a Thermocycler",
                     "value": {
-                      "name": "thermocycler",
-                      "displayName": "Thermocycler",
-                      "port": "tty3_thermocycler",
-                      "serial": "TCV1006052018",
-                      "model": "V10",
-                      "fwVersion": "1.0.0",
                       "status": "cooling",
                       "data": {
                         "lid": "closed",

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -38,6 +38,9 @@ class Point(NamedTuple):
         return '({}, {}, {})'.format(self.x, self.y, self.z)
 
 
+LocationLabware = Union['Labware', 'Well', str, 'ModuleGeometry', None]
+
+
 class Location(NamedTuple):
     """ A location to target as a motion.
 
@@ -65,7 +68,7 @@ class Location(NamedTuple):
        of each item.
     """
     point: Point
-    labware: 'Union[Labware, Well, str, ModuleGeometry, None]'
+    labware: LocationLabware
 
     def move(self, point: Point) -> 'Location':
         """

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -354,6 +354,8 @@ def run(ctx):
     assert 'p300_single_v1' in [pip.name for pip in session.instruments]
     assert 'p10_multi_v1' in [pip.name for pip in session.instruments]
     assert 'magdeck' in [mod.name for mod in session.modules]
+    assert 'magneticModuleV1' in [mod.model for mod in session.modules]
+    assert 'temperatureModuleV1' in [mod.model for mod in session.modules]
     assert 'tempdeck' in [mod.name for mod in session.modules]
 
     v1proto = '''
@@ -386,6 +388,7 @@ left.drop_tip()
     session3 = main_router.session_manager.create('dummy-pipette_v1',
                                                   v1proto)
     assert ['p300_single_v1'] == [pip.name for pip in session3.instruments]
+    assert ['temperatureModuleV1'] == [mod.model for mod in session3.modules]
     assert ['tempdeck'] == [mod.name for mod in session3.modules]
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -539,6 +539,16 @@ def get_json_protocol_fixture():
 
 
 @pytest.fixture
+def get_module_fixture():
+    def _get_module_fixture(fixture_name):
+        with open(pathlib.Path(__file__).parent
+                  / '..' / '..' / '..' / 'shared-data' / 'module' / 'fixtures'
+                  / '2' / f'{fixture_name}.json', 'rb') as f:
+            return json.loads(f.read().decode('utf-8'))
+    return _get_module_fixture
+
+
+@pytest.fixture
 def get_bundle_fixture():
     def get_std_labware(loadName, version=1):
         with open(

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -13,6 +13,7 @@ import asyncio
 from threading import Lock
 from opentrons.drivers import serial_communication
 from opentrons.drivers.temp_deck import TempDeck
+from opentrons.drivers import utils
 
 
 @pytest.fixture
@@ -208,8 +209,8 @@ def test_fail_get_device_info(monkeypatch, temp_deck):
 
     monkeypatch.setattr(temp_deck, '_send_command', _mock_send_command)
 
-    res = temp_deck.get_device_info()
-    assert 'error' in res
+    with pytest.raises(utils.ParseError):
+        temp_deck.get_device_info()
 
 
 def test_dfu_command(monkeypatch, temp_deck):

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -39,3 +39,14 @@ async def test_sim_state_update(loop):
     assert mag.status == 'engaged'
     await mag.deactivate()
     assert mag.status == 'disengaged'
+
+
+async def test_revision_model_parsing(loop):
+    mag = await modules.build('', 'magdeck', True, lambda x: None, loop=loop,
+                              execution_manager=ExecutionManager(loop=loop))
+    mag._device_info['model'] = 'mag_deck_v1.1'
+    assert mag.model() == 'magneticModuleV1'
+    mag._device_info['model'] = 'mag_deck_v20'
+    assert mag.model() == 'magneticModuleV2'
+    del mag._device_info['model']
+    assert mag.model() == 'magneticModuleV1'

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -66,3 +66,16 @@ async def test_poller(monkeypatch, loop):
     assert temp._poller.is_alive()
     await asyncio.sleep(tempdeck.TEMP_POLL_INTERVAL_SECS * 1.1)
     assert hit
+
+
+async def test_revision_model_parsing(loop):
+    mag = await modules.build('', 'tempdeck', True, lambda x: None, loop=loop,
+                              execution_manager=ExecutionManager(loop=loop))
+    mag._device_info['model'] = 'temp_deck_v20'
+    assert mag.model() == 'temperatureModuleV2'
+    mag._device_info['model'] = 'temp_deck_v4.0'
+    assert mag.model() == 'temperatureModuleV1'
+    del mag._device_info['model']
+    assert mag.model() == 'temperatureModuleV1'
+    mag._device_info['model'] = 'temp_deck_v1.1'
+    assert mag.model() == 'temperatureModuleV1'

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 from unittest import mock
+import pytest
 try:
     import aionotify
 except OSError:
@@ -8,6 +9,7 @@ except OSError:
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import ModuleAtPort
 from opentrons.hardware_control.modules.types import BundledFirmware
+from opentrons.hardware_control.modules import tempdeck, magdeck
 
 
 async def test_get_modules_simulating():
@@ -181,3 +183,32 @@ async def test_get_bundled_fw(monkeypatch, tmpdir):
         version='3.2.1', path=dummy_md_file)
     assert api.attached_modules[2].bundled_fw == BundledFirmware(
         version='0.1.2', path=dummy_tc_file)
+
+
+@pytest.mark.parametrize(
+    'revision,model',
+    [
+        ('mag_deck_v1.1', 'magneticModuleV1'),
+        ('mag_deck_v20', 'magneticModuleV2'),
+        ('', 'magneticModuleV1'),
+        ('asdasdadvasdasd', 'magneticModuleV1'),
+        (None, 'magneticModuleV1')
+    ])
+def test_magnetic_module_revision_parsing(revision, model):
+    assert magdeck._model_from_revision(revision) == model
+
+
+@pytest.mark.parametrize(
+    'revision,model',
+    [
+        ('temp_deck_v1.1', 'temperatureModuleV1'),
+        ('temp_deck_v3.0', 'temperatureModuleV1'),
+        ('temp_deck_v4.0', 'temperatureModuleV1'),
+        ('temp_deck_v15', 'temperatureModuleV1'),
+        ('temp_deck_v20', 'temperatureModuleV2'),
+        ('', 'temperatureModuleV1'),
+        ('v', 'temperatureModuleV1'),
+        (None, 'temperatureModuleV1')
+    ])
+def test_temperature_module_revision_parsing(revision, model):
+    assert tempdeck._model_from_revision(revision) == model

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -90,7 +90,8 @@ async def test_get_modules(
             loop=loop)
     monkeypatch.setattr(API, 'attached_modules', [magdeck])
     keys = sorted(['name', 'port', 'serial', 'model', 'fwVersion',
-                   'displayName', 'status', 'data', 'hasAvailableUpdate'])
+                   'status', 'data', 'hasAvailableUpdate', 'revision',
+                   'moduleModel', 'displayName'])
     resp = await async_client.get('/modules')
     body = await resp.json()
     assert resp.status == 200

--- a/shared-data/module/fixtures/2/compatibleGenerationV1.json
+++ b/shared-data/module/fixtures/2/compatibleGenerationV1.json
@@ -1,0 +1,45 @@
+{
+  "$otSharedSchema": "module/schemas/2",
+  "moduleType": "compatibleModuleType",
+  "model": "compatibleGenerationV1",
+  "labwareOffset": {
+    "x": -1.45,
+    "y": -0.15,
+    "z": 80.09
+  },
+  "dimensions": {
+    "bareOverallHeight": 84,
+    "overLabwareHeight": 0
+  },
+  "calibrationPoint": {
+    "x": 11.7,
+    "y": 8.75
+  },
+  "displayName": "Compatible Across Generations",
+  "quirks": [],
+  "slotTransforms": {
+    "ot2_standard": {
+      "3": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      }
+    },
+    "ot2_short_trash": {
+      "3": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      }
+    }
+  },
+  "compatibleWith": ["compatibleGenerationV2"]
+}

--- a/shared-data/module/fixtures/2/compatibleGenerationV2.json
+++ b/shared-data/module/fixtures/2/compatibleGenerationV2.json
@@ -1,0 +1,45 @@
+{
+  "$otSharedSchema": "module/schemas/2",
+  "moduleType": "compatibleModuleType",
+  "model": "compatibleGenerationV2",
+  "labwareOffset": {
+    "x": -1.45,
+    "y": -0.15,
+    "z": 80.09
+  },
+  "dimensions": {
+    "bareOverallHeight": 84,
+    "overLabwareHeight": 0
+  },
+  "calibrationPoint": {
+    "x": 11.7,
+    "y": 8.75
+  },
+  "displayName": "Compatible Across Generations GEN2",
+  "quirks": [],
+  "slotTransforms": {
+    "ot2_standard": {
+      "3": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, -0.3], [0, 1, 0], [0, 0, 1]]
+      }
+    },
+    "ot2_short_trash": {
+      "3": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, -0.15], [0, 1, 0], [0, 0, 1]]
+      }
+    }
+  },
+  "compatibleWith": ["compatibleGenerationV1"]
+}

--- a/shared-data/module/fixtures/2/incompatibleGenerationV1.json
+++ b/shared-data/module/fixtures/2/incompatibleGenerationV1.json
@@ -1,0 +1,22 @@
+{
+  "$otSharedSchema": "module/schemas/2",
+  "moduleType": "incompatibleGenerationType",
+  "model": "incompatibleGenerationV1",
+  "labwareOffset": {
+    "x": 0.125,
+    "y": -0.125,
+    "z": 82.25
+  },
+  "dimensions": {
+    "bareOverallHeight": 110.152,
+    "overLabwareHeight": 4.052
+  },
+  "calibrationPoint": {
+    "x": 124.875,
+    "y": 2.75
+  },
+  "displayName": "Incompatible Across Generations",
+  "quirks": [],
+  "slotTransforms": {},
+  "compatibleWith": []
+}

--- a/shared-data/module/fixtures/2/incompatibleGenerationV2.json
+++ b/shared-data/module/fixtures/2/incompatibleGenerationV2.json
@@ -1,0 +1,45 @@
+{
+  "$otSharedSchema": "module/schemas/2",
+  "moduleType": "incompatibleGenerationType",
+  "model": "incompatibleGenerationV2",
+  "labwareOffset": {
+    "x": -1.175,
+    "y": -0.125,
+    "z": 82.25
+  },
+  "dimensions": {
+    "bareOverallHeight": 110.152,
+    "overLabwareHeight": 4.052
+  },
+  "calibrationPoint": {
+    "x": 124.875,
+    "y": 2.75
+  },
+  "displayName": "Incompatible Across Generations GEN2",
+  "quirks": [],
+  "slotTransforms": {
+    "ot2_standard": {
+      "3": {
+        "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, 0.25], [0, 1, 0], [0, 0, 1]]
+      }
+    },
+    "ot2_short_trash": {
+      "3": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "6": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      },
+      "9": {
+        "labwareOffset": [[-1, 0, 0.3], [0, 1, 0], [0, 0, 1]]
+      }
+    }
+  },
+  "compatibleWith": []
+}


### PR DESCRIPTION
This is the beginnings of the work to handle gen2 modules in the protocol API. It has (most of the commits from) the split module schemas pr worked in, which I'll rebase out later. 

This builds on the changes in #4954 and #4805 that introduced the gen2 module schemas and things supporting them.

## New Terms
This PR introduces (unfortunately) some new, confusing language around modules. The way it works is that

- *module revision*: a string sourced from the module eeprom (generated from the module serial on the production line). These look like "tempdeck_v15" or "tempdeck_v20". They are not systematically defined, are by and large impossible to change in the field, and are abstracted as low as possible. This was what was previously put in the "model" field of the modules response.
- *module model*: a string (and flow type constant, and enum member) that denotes a user-visible differentiation between modules. For instance, these are `temperatureModuleV1` or `magneticModuleV2`. For now, these align with generations. These don't necessarily mean that different module models are interoperable or not. 
- *module type*: a string (and flow type constant, and enum member) that denotes a "kind" of module. This is `magneticModuleType` or `thermocyclerModuleType` or similar. This is a similar group of module that behaves similarly to each other - for instance, multiple models share a type.

These are all notable separate from the concept of display names or python protocol api load names. The display names are encoded in the defs and passed around; we try not to care about them. The module load names are defined only in python code, so we can change them without affecting other systems and also so they can be things like "magnetic module" or "tempdeck" for backwards compatibility.

This also implies that we need functionality similar to the `requested_as` patch for gen2 pipettes, where even if the api does the work to ensure different models look the same to the app, the app needs to know what they actually are to make sense of them. This isn't implemented yet.

## HTTP and RPC API Changes

This all comes together so that `GET /modules` might return this:
```{"modules": [{"name": "tempdeck", "moduleModel": "temperatureModuleV2", "port": "/dev/ot_module_tempdeck0", "serial": "TDV20P20191102B04", "revision": "temp_deck_v20", "model": "temp_deck_v20", "displayName": "tempdeck", "fwVersion": "v2.0.0", "hasAvailableUpdate": true, "status": "idle", "data": {"currentTemp": 27.0, "targetTemp": null}}]}```

(no keys have been deleted; we added moduleModel to contain the new model, and revision to handle the hardware revision)

The structure of the RPC object on a protocol session has a `model` as well as a `name`, which is unchanged. The app can then look up compatibility:

```
{
  modulesBySlot: {
    '3': {
      id: 1923687216,
      model: 'temperatureModuleV1',
      name: 'tempdeck',
      slot: '3',
      _id: 1934364816
    }
  }
}
```

## Protocol API Public-Facing Changes
Adds Gen2 module support to protocol API version 2.3. If you try to load a module with a gen2 model before that, it will yell at you (specifically).

## Testing

This isn't integrated into the run app yet, but because it just adds more keys to the endpoints it should still be testable. In general, the app won't know the difference between the models, so all the things we can test either happen at runtime or are simulation errors. 

- [ ] A version 2.3 python protocol that requests "magnetic module gen2" will work with a gen2 magnetic module; if you have a gen1 magnetic module connected, you will get an error at runtime (after the robot homes)
- [ ] A version 2.3 python protocol that requests "magdeck" or "magnetic module" will work with a gen1 magnetic module; if you have a gen2 connected, you get an error at runtime
- [ ] A version 2.3 python protocol that requests "temperature module gen2", "temperature module", or "tempdeck" will work with any kind of physical tempdeck (check gen1 and gen2). No runtime or simulating errors.
- [ ] If you put something garbled into `load_module` it lists valid module identifiers
- [ ] A version 2.2 (or 2.1, or 2.0) python protocol that requests a "temperature module gen2" or "magnetic module gen2" will helpfully inform you that you have to set version 2.3 to use those
- [ ] A version 2.2 protocol that requests a "temperature module" or "tempdeck" still connects to a gen1 tempdeck, and also works with a gen2
- [ ] A version 2.2 protocol that requests a "magnetic module" or "magdeck" connects to a gen1 magdeck, and gives you a runtime error if a gen2 tempdeck is connected
- [ ] `curl (ip):31950/modules` has the new `revision` and `moduleModel` keys, and they're correct (`revision` is the same as `model`; `moduleModel` is appropriately set). `name` and `displayName` should also still be there
- [ ] a poke at the redux state for modules shows the new `model` tag (doesn't matter whether the protocol is 2.3 or 2.2 or which module is selected). It should also be there for v1 modules.