### PR TITLE
fix(api): do not check used tips after pickup

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -725,8 +725,17 @@ class Labware(DeckItem):
         num_tips = min(len(target_column) - well_idx, num_channels)
         target_wells = target_column[well_idx: well_idx + num_tips]
 
-        assert all([well.has_tip for well in target_wells]),\
-            '{} is out of tips'.format(str(self))
+        # In API version 2.2, we no longer reset the tip tracker when a tip
+        # is dropped back into a tiprack well. This fixes a behavior where
+        # subsequent transfers would reuse the dirty tip. However, sometimes
+        # the user explicitly wants to use a dirty tip, and this check would
+        # raise an exception if they tried to do so.
+        # An extension of work here is to have separate tip trackers for
+        # dirty tips and non-present tips; but until then, we can avoid the
+        # exception.
+        if self._api_version < APIVersion(2, 2):
+            assert all([well.has_tip for well in target_wells]),\
+                '{} is out of tips'.format(str(self))
 
         for well in target_wells:
             well.has_tip = False

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -5,6 +5,7 @@ import pytest
 from opentrons.protocol_api import labware, MAX_SUPPORTED_VERSION
 from opentrons.system.shared_data import load_shared_data
 from opentrons.types import Point, Location
+from opentrons.protocols.types import APIVersion
 
 test_data = {
     'circular_well_json': {
@@ -289,6 +290,18 @@ def test_select_next_tip():
     assert next_five == well_list[16]
     next_eight = tiprack.next_tip(8)
     assert next_eight == well_list[16]
+
+    # you can reuse tips infinitely on api level 2.2
+    tiprack.use_tips(well_list[0])
+    tiprack.use_tips(well_list[0])
+
+    # you can't on api level 2.1 or previous
+    early_tr = labware.Labware(labware_def,
+                               Location(Point(0, 0, 0), 'Test Slot'),
+                               api_level=APIVersion(2, 1))
+    early_tr.use_tips(well_list[0])
+    with pytest.raises(AssertionError):
+        early_tr.use_tips(well_list[0])
 
 
 def test_previous_tip():


### PR DESCRIPTION
In api version 2.2, we stopped re-adding tips to the tip tracker after
return_tip to prevent subsequent automatic tip pickup (like calling
pick_up_tip without arguments, or the behavior in
transfer/consolidate/distribute calls) from re-using the tip that might
now be dirty.

However, at the end of pick_up_tip, the system tries to mark tips as
used and raises an error if any of the tips to be marked have been used.

The fix is to remove this check, since it is only relevant in the case
where pick_up_tip is called with a specific location argument, and in
that case we should assume the user really wants the behavior of reusing
the tip.

The root cause is that our tip tracker is about tracking tip presence,
not tip dirtiness. The behavior fixed in 2.2 was because of this: we
were only caring that the tip was physically back in the rack, so we
could reuse it. We now overload the tip tracker's results with tip
dirtiness and tip presence, and that needs to change.

Until that time, this fix should ensure the proper behavior.

Closes #5059

