### PR TITLE
fix(api): correctly set api level in session sim

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -363,16 +363,11 @@ class Session(object):
                      for mod in self._hardware.attached_modules],
                     strict_attached_instruments=False)
                 sim.home()
-                self._simulating_ctx = ProtocolContext(
+                self._simulating_ctx = ProtocolContext.build_using(
+                    self._protocol,
                     loop=self._loop,
                     hardware=sim,
-                    broker=self._broker,
-                    bundled_labware=getattr(
-                        self._protocol, 'bundled_labware', None),
-                    bundled_data=getattr(
-                        self._protocol, 'bundled_data', None),
-                    extra_labware=getattr(
-                        self._protocol, 'extra_labware', {}))
+                    broker=self._broker)
                 run_protocol(self._protocol,
                              context=self._simulating_ctx)
             else:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -367,7 +367,8 @@ class Session(object):
                     self._protocol,
                     loop=self._loop,
                     hardware=sim,
-                    broker=self._broker)
+                    broker=self._broker,
+                    extra_labware=getattr(self._protocol, 'extra_labware', {}))
                 run_protocol(self._protocol,
                              context=self._simulating_ctx)
             else:
@@ -493,10 +494,6 @@ class Session(object):
                     self._protocol,
                     loop=self._loop,
                     broker=self._broker,
-                    bundled_labware=getattr(
-                        self._protocol, 'bundled_labware', None),
-                    bundled_data=getattr(
-                        self._protocol, 'bundled_data', None),
                     extra_labware=getattr(self._protocol, 'extra_labware', {}))
                 ctx.connect(self._hardware)
                 ctx.home()


### PR DESCRIPTION
We create a new protocol context for every simulation run to avoid state
leaking in between simulations. Unfortunately, when we create the new
protocol context we weren't doing it quite right - we were manually
specifying some kwargs instead of using
ProtocolContext.build_using(protocol). That means that some things
weren't specified. Now they are.

Closes #5060
