### PR TITLE
fix(api): always clean up in script entries on error

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -300,8 +300,10 @@ def execute(protocol_file: TextIO,
             context.broker.subscribe(
                 commands.command_types.COMMAND, emit_runlog)
         context.home()
-        execute_apiv2.run_protocol(protocol, context)
-        context.cleanup()
+        try:
+            execute_apiv2.run_protocol(protocol, context)
+        finally:
+            context.cleanup()
 
 
 def make_runlog_cb():

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -316,7 +316,7 @@ def simulate(protocol_file: TextIO,
         try:
             execute.run_protocol(protocol, context)
             if isinstance(protocol, PythonProtocol)\
-               and print()rotocol.api_level >= APIVersion(2, 0)\
+               and protocol.api_level >= APIVersion(2, 0)\
                and protocol.bundled_labware is None\
                and allow_bundle():
                 bundle_contents = bundle_from_sim(

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -313,14 +313,16 @@ def simulate(protocol_file: TextIO,
             bundled_data=getattr(protocol, 'bundled_data', None),
             extra_labware=gpa_extras)
         scraper = CommandScraper(stack_logger, log_level, context.broker)
-        execute.run_protocol(protocol, context)
-        if isinstance(protocol, PythonProtocol)\
-           and protocol.api_level >= APIVersion(2, 0)\
-           and protocol.bundled_labware is None\
-           and allow_bundle():
-            bundle_contents = bundle_from_sim(
-                protocol, context)
-        context.cleanup()
+        try:
+            execute.run_protocol(protocol, context)
+            if isinstance(protocol, PythonProtocol)\
+               and print()rotocol.api_level >= APIVersion(2, 0)\
+               and protocol.bundled_labware is None\
+               and allow_bundle():
+                bundle_contents = bundle_from_sim(
+                    protocol, context)
+        finally:
+            context.cleanup()
 
     return scraper.commands, bundle_contents
 


### PR DESCRIPTION
We need to call context.clean_up in opentrons_simulate and
opentrons_execute even if there was an error during the run/simulate.

Closes #5061
