### PR TITLE
fix(api): remove unnecessary pipette movement during mix

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -319,7 +319,7 @@ class API(HardwareAPILike):
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
                    'tip_length', 'model', 'blow_out_flow_rate',
-                   'working_volume', 'tip_overlap']
+                   'working_volume', 'tip_overlap', 'bottom']
         instruments: Dict[top_types.Mount, Pipette.DictType] = {
             top_types.Mount.LEFT: {},
             top_types.Mount.RIGHT: {}
@@ -603,6 +603,21 @@ class API(HardwareAPILike):
                 z_ax: self._current_position[z_ax] + offset[2] + cp.z,
                 plunger_ax: self._current_position[plunger_ax]
             }
+
+    async def plunger_position(
+            self,
+            mount: top_types.Mount,
+            refresh: bool = False) -> float:
+        """ Return the current position of the plunger
+
+        This ignores the gantry position and returns a float
+
+        `refresh` if set to True, update the cached position using the
+        smoothie driver (see :py:meth:`current_position`).
+        """
+        cur_pos = await self.current_position(mount, refresh=refresh)
+        plunger_ax = Axis.of_plunger(mount)
+        return cur_pos[plunger_ax]
 
     async def gantry_position(
             self,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -319,7 +319,7 @@ class API(HardwareAPILike):
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
                    'tip_length', 'model', 'blow_out_flow_rate',
-                   'working_volume', 'tip_overlap']
+                   'working_volume', 'tip_overlap', 'available_volume']
         instruments: Dict[top_types.Mount, Pipette.DictType] = {
             top_types.Mount.LEFT: {},
             top_types.Mount.RIGHT: {}

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -319,7 +319,7 @@ class API(HardwareAPILike):
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
                    'tip_length', 'model', 'blow_out_flow_rate',
-                   'working_volume', 'tip_overlap', 'bottom']
+                   'working_volume', 'tip_overlap']
         instruments: Dict[top_types.Mount, Pipette.DictType] = {
             top_types.Mount.LEFT: {},
             top_types.Mount.RIGHT: {}
@@ -338,6 +338,7 @@ class API(HardwareAPILike):
                 instr, instr.config.dispense_flow_rate, 'dispense')
             instruments[mount]['blow_out_speed'] = self._plunger_speed(
                 instr, instr.config.blow_out_flow_rate, 'dispense')
+            instruments[mount]['ready_to_aspirate'] = instr.ready_to_aspirate
         return instruments
 
     attached_instruments = property(fget=get_attached_instruments)
@@ -972,7 +973,6 @@ class API(HardwareAPILike):
         if this_pipette.current_volume == 0\
            and not this_pipette.ready_to_aspirate:
             raise RuntimeError('Pipette not ready to aspirate')
-        this_pipette.ready_to_aspirate = False
 
         if volume is None:
             asp_vol = this_pipette.available_volume
@@ -1097,6 +1097,7 @@ class API(HardwareAPILike):
             raise
         finally:
             this_pipette.set_current_volume(0)
+            this_pipette.ready_to_aspirate = False
 
     async def pick_up_tip(self,
                           mount,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -605,21 +605,6 @@ class API(HardwareAPILike):
                 plunger_ax: self._current_position[plunger_ax]
             }
 
-    async def plunger_position(
-            self,
-            mount: top_types.Mount,
-            refresh: bool = False) -> float:
-        """ Return the current position of the plunger
-
-        This ignores the gantry position and returns a float
-
-        `refresh` if set to True, update the cached position using the
-        smoothie driver (see :py:meth:`current_position`).
-        """
-        cur_pos = await self.current_position(mount, refresh=refresh)
-        plunger_ax = Axis.of_plunger(mount)
-        return cur_pos[plunger_ax]
-
     async def gantry_position(
             self,
             mount: top_types.Mount,

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -217,6 +217,7 @@ class Pipette:
     def as_dict(self) -> 'Pipette.DictType':
         config_dict = self.config._asdict()
         config_dict.update({'current_volume': self.current_volume,
+                            'available_volume': self.available_volume,
                             'name': self.name,
                             'model': self.model,
                             'pipette_id': self.pipette_id,

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -34,7 +34,6 @@ class Pipette:
         self._current_tiprack_diameter = 0.0
         self._fallback_tip_length = self._config.tip_length
         self._tip_overlap_map = self._config.tip_overlap
-        self._bottom = self._config.bottom
         self._has_tip = False
         self._pipette_id = pipette_id
         pip_type = 'multi' if self._config.channels > 1 else 'single'

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -34,6 +34,7 @@ class Pipette:
         self._current_tiprack_diameter = 0.0
         self._fallback_tip_length = self._config.tip_length
         self._tip_overlap_map = self._config.tip_overlap
+        self._bottom = self._config.bottom
         self._has_tip = False
         self._pipette_id = pipette_id
         pip_type = 'multi' if self._config.channels > 1 else 'single'

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -107,6 +107,11 @@ class InstrumentContext(CommandPublisher):
         self.starting_tip = None
 
     @property  # type: ignore
+    @requires_version(2, 3)
+    def _plunger_position(self):
+        return self._hw_manager.hardware.plunger_position(self._mount)
+
+    @property  # type: ignore
     @requires_version(2, 0)
     def default_speed(self) -> float:
         """ The speed at which the robot's gantry moves.
@@ -194,7 +199,9 @@ class InstrumentContext(CommandPublisher):
             # Make sure we're at the top of the labware and clear of any
             # liquid to prepare the pipette for aspiration
             if isinstance(dest.labware, Well):
-                self.move_to(dest.labware.top())
+                if self._api_version < APIVersion(2, 3) or \
+                        self._plunger_position < self.hw_pipette['bottom']:
+                    self.move_to(dest.labware.top())
             else:
                 # TODO(seth,2019/7/29): This should be a warning exposed via
                 # rpc to the runapp

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -212,11 +212,13 @@ class InstrumentContext(CommandPublisher):
         elif dest != self._ctx.location_cache:
             self.move_to(dest)
 
+        c_vol = self.hw_pipette['available_volume'] if not volume else volume
+
         cmds.do_publish(self.broker, cmds.aspirate, self.aspirate,
-                        'before', None, None, self, volume, dest, rate)
+                        'before', None, None, self, c_vol, dest, rate)
         self._hw_manager.hardware.aspirate(self._mount, volume, rate)
         cmds.do_publish(self.broker, cmds.aspirate, self.aspirate,
-                        'after', self, None, self, volume, dest, rate)
+                        'after', self, None, self, c_vol, dest, rate)
         return self
 
     @requires_version(2, 0)
@@ -293,14 +295,16 @@ class InstrumentContext(CommandPublisher):
                 " method that moves to a location (such as move_to or "
                 "aspirate) must previously have been called so the robot "
                 "knows where it is.")
+
+        c_vol = self.hw_pipette['current_volume'] if not volume else volume
+
         cmds.do_publish(self.broker, cmds.dispense, self.dispense,
-                        'before', None, None, self, volume, loc, rate)
+                        'before', None, None, self, c_vol, loc, rate)
         self._hw_manager.hardware.dispense(self._mount, volume, rate)
         cmds.do_publish(self.broker, cmds.dispense, self.dispense,
-                        'after', self, None, self, volume, loc, rate)
+                        'after', self, None, self, c_vol, loc, rate)
         return self
 
-    @cmds.publish.both(command=cmds.mix)
     @requires_version(2, 0)
     def mix(self,
             repetitions: int = 1,
@@ -346,12 +350,20 @@ class InstrumentContext(CommandPublisher):
         if not self.hw_pipette['has_tip']:
             raise hc.NoTipAttachedError('Pipette has no tip. Aborting mix()')
 
+        c_vol = self.hw_pipette['available_volume'] if not volume else volume
+
+        cmds.do_publish(self.broker, cmds.mix, self.mix,
+                        'before', None, None,
+                        self, repetitions, c_vol, location)
         self.aspirate(volume, location, rate)
         while repetitions - 1 > 0:
             self.dispense(volume, rate=rate)
             self.aspirate(volume, rate=rate)
             repetitions -= 1
         self.dispense(volume, rate=rate)
+        cmds.do_publish(self.broker, cmds.mix, self.mix,
+                        'after', None, None,
+                        self, repetitions, c_vol, location)
         return self
 
     @cmds.publish.both(command=cmds.blow_out)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -54,7 +54,7 @@ instrument_keys = sorted([
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
     'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume',
-    'tip_overlap', 'ready_to_aspirate'])
+    'tip_overlap', 'ready_to_aspirate', 'available_volume'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -54,7 +54,7 @@ instrument_keys = sorted([
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
     'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume',
-    'tip_overlap', 'bottom'])
+    'tip_overlap', 'ready_to_aspirate'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -54,7 +54,7 @@ instrument_keys = sorted([
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
     'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume',
-    'tip_overlap'])
+    'tip_overlap', 'bottom'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -367,11 +367,11 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
     instr.aspirate(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
-    assert fake_move.call_args_list[-1] ==\
+    assert len(fake_move.call_args_list) == 1
+    assert fake_move.call_args_list[0] ==\
         mock.call(
             Mount.RIGHT, dest_point, critical_point=None, speed=400,
             max_speeds={})
-    assert len(fake_move.call_args_list) == 1
     fake_move.reset_mock()
     ctx._hw_manager.hardware._obj_to_adapt\
                             ._attached_instruments[Mount.RIGHT]\
@@ -379,6 +379,20 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
 
     instr.aspirate(2.0)
     fake_move.assert_not_called()
+
+    instr.blow_out()
+    fake_move.reset_mock()
+    instr.aspirate(2.0)
+    assert len(fake_move.call_args_list) == 2
+    # reset plunger at the top of the well after blowout
+    assert fake_move.call_args_list[0] ==\
+        mock.call(
+            Mount.RIGHT, dest_lw.top().point, critical_point=None,
+            speed=400, max_speeds={})
+    assert fake_move.call_args_list[1] ==\
+        mock.call(
+            Mount.RIGHT, dest_point, critical_point=None,
+            speed=400, max_speeds={})
 
 
 def test_dispense(loop, get_labware_def, monkeypatch):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -358,9 +358,6 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
     assert 'aspirating' in ','.join([cmd.lower() for cmd in ctx.commands()])
 
     fake_hw_aspirate.assert_called_once_with(Mount.RIGHT, 2.0, 1.0)
-    assert fake_move.call_args_list[-2] ==\
-        mock.call(Mount.RIGHT, lw.wells()[0].top().point,
-                  critical_point=None, speed=400, max_speeds={})
     assert fake_move.call_args_list[-1] ==\
         mock.call(Mount.RIGHT, lw.wells()[0].bottom().point,
                   critical_point=None, speed=400, max_speeds={})
@@ -370,14 +367,11 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
     instr.aspirate(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
-    assert fake_move.call_args_list[-2] ==\
-        mock.call(Mount.RIGHT, lw.wells()[0].top().point,
-                  critical_point=None, speed=400, max_speeds={})
     assert fake_move.call_args_list[-1] ==\
         mock.call(
             Mount.RIGHT, dest_point, critical_point=None, speed=400,
             max_speeds={})
-    assert len(fake_move.call_args_list) == 2
+    assert len(fake_move.call_args_list) == 1
     fake_move.reset_mock()
     ctx._hw_manager.hardware._obj_to_adapt\
                             ._attached_instruments[Mount.RIGHT]\


### PR DESCRIPTION
## overview
In APIv2, the pipette would move above the well between each aspirate-dispense repetitions during mix. The original logic for this movement is to reset the plunger position above liquid level after a blow-out command, to avoid over-aspiration in the subsequent `aspirate`. 

However, we currently evaluate the necessity of this action by checking the current volume of the pipette: if the volume is equal to 0, the pipette is always moved above the top of the well. Instead, we should check the plunger position and only move the pipette when the position is below the `bottom` position.

closes #4640 

## changelog
- add a check for the plunger position in `aspirate` to avoid unnecessary pipette movement
- include the pipette bottom position in the pipette config dictionary for easy access in the protocol API
- add function in hardware control API to return the current plunger position
- bump max API version to 2.3

## review requests
Run the following protocol in API version 2.2 and 2.3 and see that:
- in v2.2, the pipette moves out of the well before each aspirate
- in v2.3, the pipette only moves out of the well after blowout
```
pip.pick_up_tip()
pip.mix(repetitions=3)
pip.blow_out()
pip.mix(repetitions=3)
pip.return_tip()
```