### PR TITLE
feat(app, components): Support gen2 modules

### DIFF
--- a/app/src/components/CalibrateLabware/ProceedToRun.js
+++ b/app/src/components/CalibrateLabware/ProceedToRun.js
@@ -11,7 +11,7 @@ import type { Dispatch } from '../../types'
 import pcrSealSrc from '../../img/place_pcr_seal.png'
 import { Portal } from '../portal'
 import styles from './styles.css'
-import { THERMOCYCLER } from '../../modules'
+import { THERMOCYCLER_MODULE_TYPE, getModuleType } from '../../modules'
 
 const IS_HOMING_MESSAGE = 'Returning tip and homing robot'
 
@@ -28,7 +28,12 @@ export function ProceedToRun(props: ProceedToRunProps) {
   const [runPrepModalOpen, setRunPrepModalOpen] = useState(false)
 
   useEffect(() => {
-    if (some(sessionModules, mod => mod.name === THERMOCYCLER)) {
+    if (
+      some(
+        sessionModules,
+        mod => getModuleType(mod.model) === THERMOCYCLER_MODULE_TYPE
+      )
+    ) {
       setMustPrepForRun(true)
     }
   }, [sessionModules])

--- a/app/src/components/CalibratePanel/LabwareList.js
+++ b/app/src/components/CalibratePanel/LabwareList.js
@@ -48,10 +48,10 @@ function LabwareListComponent(props: Props) {
         <LabwareListItem
           {...lw}
           key={lw.slot}
-          moduleName={
+          moduleModel={
             modulesBySlot &&
             modulesBySlot[lw.slot] &&
-            modulesBySlot[lw.slot].name
+            modulesBySlot[lw.slot].model
           }
           isDisabled={disabled}
           onClick={() => setLabware(lw)}

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -5,17 +5,18 @@ import cx from 'classnames'
 import {
   getLabwareDisplayName,
   getModuleDisplayName,
-  type ModuleType,
+  getModuleType,
+  THERMOCYCLER_MODULE_TYPE,
+  type ModuleModel,
 } from '@opentrons/shared-data'
 import { ListItem, HoverTooltip } from '@opentrons/components'
 import styles from './styles.css'
 
 import type { Labware } from '../../robot'
-import { THERMOCYCLER } from '../../modules'
 
 export type LabwareListItemProps = {|
   ...Labware,
-  moduleName?: ModuleType,
+  moduleModel?: ModuleModel,
   isDisabled: boolean,
   onClick: () => mixed,
 |}
@@ -31,17 +32,17 @@ export function LabwareListItem(props: LabwareListItemProps) {
     isDisabled,
     onClick,
     definition,
-    moduleName,
+    moduleModel,
   } = props
 
   const url = `/calibrate/labware/${slot}`
   const iconName = confirmed ? 'check-circle' : 'checkbox-blank-circle-outline'
   const displayName = definition ? getLabwareDisplayName(definition) : type
   let displaySlot = `Slot ${slot}`
-  if (moduleName === THERMOCYCLER) {
+  if (moduleModel && getModuleType(moduleModel) === THERMOCYCLER_MODULE_TYPE) {
     displaySlot = 'Slots 7, 8, 10, & 11'
   }
-  const moduleDisplayName = moduleName && getModuleDisplayName(moduleName)
+  const moduleDisplayName = moduleModel && getModuleDisplayName(moduleModel)
 
   return (
     <ListItem
@@ -72,7 +73,7 @@ export function LabwareListItem(props: LabwareListItemProps) {
               </span>
             )}
             <div className={styles.slot_contents_names}>
-              {moduleName && (
+              {moduleModel && (
                 <span className={styles.module_name}>{moduleDisplayName}</span>
               )}
               <span className={styles.labware_item_name}>{displayName}</span>

--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -90,7 +90,7 @@ function DeckMapComponent(props: Props) {
                   })`}
                 >
                   <ModuleItem
-                    name={moduleInSlot.name}
+                    name={moduleInSlot.model}
                     mode={moduleInSlot.mode || 'default'}
                   />
                 </g>
@@ -133,7 +133,7 @@ function mapStateToProps(state: State, ownProps: OP): SP {
     modulesBySlot = mapValues(
       robotSelectors.getModulesBySlot(state),
       module => {
-        const present = !missingModules.some(mm => mm.name === module.name)
+        const present = !missingModules.some(mm => mm.model === module.model)
         return { ...module, mode: present ? 'present' : 'missing' }
       }
     )

--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -90,7 +90,7 @@ function DeckMapComponent(props: Props) {
                   })`}
                 >
                   <ModuleItem
-                    name={moduleInSlot.model}
+                    model={moduleInSlot.model}
                     mode={moduleInSlot.mode || 'default'}
                   />
                 </g>

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -3,7 +3,10 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 
-import { getModuleDisplayName } from '@opentrons/shared-data'
+import {
+  getModuleDisplayName,
+  checkModuleCompatibility,
+} from '@opentrons/shared-data'
 import { selectors as robotSelectors } from '../../robot'
 import { getAttachedModules } from '../../modules'
 
@@ -41,8 +44,10 @@ function ProtocolModulesCardComponent(props: Props) {
   if (modules.length < 1) return null
 
   const moduleInfo = modules.map(module => {
-    const displayName = getModuleDisplayName(module.name)
-    const modulesMatch = actualModules.some(m => m.name === module.name)
+    const displayName = getModuleDisplayName(module.model)
+    const modulesMatch = actualModules.some(m =>
+      checkModuleCompatibility(m.model, module.model)
+    )
 
     return { ...module, displayName, modulesMatch }
   })

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -15,6 +15,9 @@ import { SectionContentHalf } from '../layout'
 import { InstrumentItem } from './InstrumentItem'
 import { MissingItemWarning } from './MissingItemWarning'
 
+import { Icon } from '@opentrons/components'
+import styles from './styles.css'
+
 import type { State, Dispatch } from '../../types'
 import type { SessionModule } from '../../robot/types'
 import type { Robot } from '../../discovery/types'
@@ -33,6 +36,8 @@ type DP = {| dispatch: Dispatch |}
 type Props = {| ...OP, ...SP, ...DP |}
 
 const TITLE = 'Required Modules'
+const inexactModuleSupportArticle =
+  'https://support.opentrons.com/en/articles/3450143-gen2-pipette-compatibility'
 
 export const ProtocolModulesCard = connect<Props, OP, SP, DP, _, _>(
   mapStateToProps
@@ -44,28 +49,50 @@ function ProtocolModulesCardComponent(props: Props) {
   if (modules.length < 1) return null
 
   const moduleInfo = modules.map(module => {
-    const matching = actualModules.find(
-      m => checkModuleCompatibility(m.model, module.model))
-    const displayName = matching ? getModuleDisplayName(matching.model) : getModuleDisplayName(module.model)
-    return { ...module, displayName: displayName, modulesMatch: matching !== undefined}
+    const matching = actualModules.find(m =>
+      checkModuleCompatibility(m.model, module.model)
+    )
+    const displayName = matching
+      ? getModuleDisplayName(matching.model)
+      : getModuleDisplayName(module.model)
+    const modulesMatch = matching
+      ? matching.model === module.model
+        ? 'match'
+        : 'inexact_match'
+      : 'incompatible'
+    return { ...module, displayName, modulesMatch }
   })
 
-  const modulesMatch = moduleInfo.every(m => m.modulesMatch)
+  const modulesMatch = moduleInfo.every(m => m.modulesMatch !== 'incompatible')
+  const someInexact = moduleInfo.some(m => m.modulesMatch === 'inexact_match')
 
   return (
     <InfoSection title={TITLE}>
       <SectionContentHalf>
         {moduleInfo.map(m => (
-          <InstrumentItem
-            key={m.slot}
-            compatibility={m.modulesMatch ? 'match' : 'incompatible'}
-          >
+          <InstrumentItem key={m.slot} compatibility={m.modulesMatch}>
             {m.displayName}{' '}
           </InstrumentItem>
         ))}
       </SectionContentHalf>
       {!modulesMatch && (
         <MissingItemWarning instrumentType="module" url={attachModulesUrl} />
+      )}
+      {modulesMatch && someInexact && (
+        <SectionContentHalf className={styles.soft_warning}>
+          <div className={styles.warning_info_wrapper}>
+            <Icon name="information" className={styles.info_icon} />
+            <span>Inexact module match,</span>
+            <a
+              href={inexactModuleSupportArticle}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              &nbsp; learn more
+            </a>
+            <span>.</span>
+          </div>
+        </SectionContentHalf>
       )}
     </InfoSection>
   )

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -44,12 +44,10 @@ function ProtocolModulesCardComponent(props: Props) {
   if (modules.length < 1) return null
 
   const moduleInfo = modules.map(module => {
-    const displayName = getModuleDisplayName(module.model)
-    const modulesMatch = actualModules.some(m =>
-      checkModuleCompatibility(m.model, module.model)
-    )
-
-    return { ...module, displayName, modulesMatch }
+    const matching = actualModules.find(
+      m => checkModuleCompatibility(m.model, module.model))
+    const displayName = matching ? getModuleDisplayName(matching.model) : getModuleDisplayName(module.model)
+    return { ...module, displayName: displayName, modulesMatch: matching !== undefined}
   })
 
   const modulesMatch = moduleInfo.every(m => m.modulesMatch)

--- a/app/src/components/ModuleControls/TemperatureControl.js
+++ b/app/src/components/ModuleControls/TemperatureControl.js
@@ -15,7 +15,7 @@ import type {
   TemperatureModule,
   ModuleCommand,
 } from '../../modules/types'
-import { THERMOCYCLER } from '../../modules'
+import { THERMOCYCLER_MODULE_TYPE } from '../../modules'
 import { getModuleDisplayName } from '@opentrons/shared-data'
 
 const CONNECT_FOR_CONTROL = 'Connect to robot to control modules'
@@ -41,7 +41,7 @@ export const TemperatureControl = ({
 
   const hasTarget =
     module.status !== 'idle' ||
-    (module.name === THERMOCYCLER && module.data.lidTarget != null)
+    (module.type === THERMOCYCLER_MODULE_TYPE && module.data.lidTarget != null)
 
   const handleClick = () => {
     if (hasTarget) {
@@ -66,8 +66,8 @@ export const TemperatureControl = ({
     setPrimaryTempValue(null)
     setSecondaryTempValue(null)
   }
-  const isThermocycler = module.name === THERMOCYCLER
-  const displayName = getModuleDisplayName(module.name)
+  const isThermocycler = module.type === THERMOCYCLER_MODULE_TYPE
+  const displayName = getModuleDisplayName(module.model)
   const alertHeading = `Set ${displayName} Temp`
   const alertBody = `Pre heat or cool ${displayName}.`
   const primaryFieldLabel = `Set ${isThermocycler ? 'Base' : ''} Temp:`

--- a/app/src/components/ModuleControls/index.js
+++ b/app/src/components/ModuleControls/index.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 
 import { TemperatureControl } from './TemperatureControl'
-import { THERMOCYCLER, useSendModuleCommand } from '../../modules'
+import { THERMOCYCLER_MODULE_TYPE, useSendModuleCommand } from '../../modules'
 import { TemperatureData } from './TemperatureData'
 import styles from './styles.css'
 
@@ -26,10 +26,12 @@ export function ModuleControls(props: Props) {
           current={mod.data.currentTemp}
           target={mod.data.targetTemp}
           title={
-            mod.name === THERMOCYCLER ? 'Base Temperature:' : 'Temperature:'
+            mod.type === THERMOCYCLER_MODULE_TYPE
+              ? 'Base Temperature:'
+              : 'Temperature:'
           }
         />
-        {mod.name === THERMOCYCLER && (
+        {mod.type === THERMOCYCLER_MODULE_TYPE && (
           <TemperatureData
             className={styles.temp_data_item}
             current={mod.data.lidTemp}

--- a/app/src/components/ModuleItem/ModuleImage.js
+++ b/app/src/components/ModuleItem/ModuleImage.js
@@ -3,12 +3,14 @@ import * as React from 'react'
 
 import styles from './styles.css'
 
+import type { ModuleModel } from '@opentrons/shared-data'
+
 type Props = {|
-  name: string,
+  model: ModuleModel,
 |}
 
 export function ModuleImage(props: Props) {
-  const imgSrc = getModuleImg(props.name)
+  const imgSrc = getModuleImg(props.model)
 
   return (
     <div className={styles.module_image_wrapper}>
@@ -17,12 +19,14 @@ export function ModuleImage(props: Props) {
   )
 }
 
-function getModuleImg(name: string) {
-  return MODULE_IMGS[name]
+function getModuleImg(model: ModuleModel) {
+  return MODULE_IMGS[model]
 }
 
-const MODULE_IMGS = {
-  tempdeck: require('./images/module-temp@3x.png'),
-  magdeck: require('./images/module-mag@3x.png'),
-  thermocycler: require('./images/module-thermo@3x.png'),
+const MODULE_IMGS: { [ModuleModel]: mixed } = {
+  temperatureModuleV1: require('./images/module-temp@3x.png'),
+  temperatureModuleV2: require('./images/module-temp@3x.png'),
+  magneticModuleV1: require('./images/module-mag@3x.png'),
+  magneticModuleV2: require('./images/module-mag@3x.png'),
+  thermocyclerModuleV1: require('./images/module-thermo@3x.png'),
 }

--- a/app/src/components/ModuleItem/ModuleInfo.js
+++ b/app/src/components/ModuleItem/ModuleInfo.js
@@ -12,8 +12,8 @@ type Props = {|
 |}
 
 export function ModuleInfo(props: Props) {
-  const { name, serial, status, fwVersion } = props.module
-  const displayName = getModuleDisplayName(name)
+  const { model, serial, status, fwVersion } = props.module
+  const displayName = getModuleDisplayName(model)
 
   return (
     <div className={styles.module_info}>

--- a/app/src/components/ModuleItem/index.js
+++ b/app/src/components/ModuleItem/index.js
@@ -7,7 +7,10 @@ import { ModuleUpdate } from './ModuleUpdate'
 import { ModuleControls } from '../ModuleControls'
 import styles from './styles.css'
 import type { AttachedModule } from '../../modules/types'
-import { TEMPDECK, THERMOCYCLER } from '../../modules'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '../../modules'
 
 type Props = {|
   module: AttachedModule,
@@ -21,7 +24,7 @@ export function ModuleItem(props: Props) {
   return (
     <div className={styles.module_item}>
       <div className={styles.module_content}>
-        <ModuleImage name={module.name} />
+        <ModuleImage model={module.model} />
         <ModuleInfo module={module} />
         <ModuleUpdate
           hasAvailableUpdate={!!module.hasAvailableUpdate}
@@ -29,7 +32,10 @@ export function ModuleItem(props: Props) {
           moduleId={module.serial}
         />
       </div>
-      {(module.name === THERMOCYCLER || module.name === TEMPDECK) && (
+      {module.type === THERMOCYCLER_MODULE_TYPE && (
+        <ModuleControls module={module} canControl={canControl} />
+      )}
+      {module.type === TEMPERATURE_MODULE_TYPE && (
         <ModuleControls module={module} canControl={canControl} />
       )}
     </div>

--- a/app/src/components/ModuleLiveStatusCards/MagDeckCard.js
+++ b/app/src/components/ModuleLiveStatusCards/MagDeckCard.js
@@ -16,7 +16,7 @@ type Props = {|
 
 export const MagDeckCard = ({ module, isCardExpanded, toggleCard }: Props) => (
   <StatusCard
-    title={getModuleDisplayName(module.name)}
+    title={getModuleDisplayName(module.model)}
     isCardExpanded={isCardExpanded}
     toggleCard={toggleCard}
   >

--- a/app/src/components/ModuleLiveStatusCards/TempDeckCard.js
+++ b/app/src/components/ModuleLiveStatusCards/TempDeckCard.js
@@ -30,7 +30,7 @@ export const TempDeckCard = ({
   toggleCard,
 }: Props) => (
   <StatusCard
-    title={getModuleDisplayName(module.name)}
+    title={getModuleDisplayName(module.model)}
     isCardExpanded={isCardExpanded}
     toggleCard={toggleCard}
   >

--- a/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
+++ b/app/src/components/ModuleLiveStatusCards/ThermocyclerCard.js
@@ -107,7 +107,7 @@ export const ThermocyclerCard = ({
     currentStepIndex != null
   return (
     <StatusCard
-      title={getModuleDisplayName(module.name)}
+      title={getModuleDisplayName(module.model)}
       isCardExpanded={isCardExpanded}
       toggleCard={toggleCard}
     >

--- a/app/src/components/ModuleLiveStatusCards/index.js
+++ b/app/src/components/ModuleLiveStatusCards/index.js
@@ -3,9 +3,9 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 
 import {
-  THERMOCYCLER,
-  TEMPDECK,
-  MAGDECK,
+  THERMOCYCLER_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
   useSendModuleCommand,
   getAttachedModulesForConnectedRobot,
 } from '../../modules'
@@ -38,8 +38,8 @@ export const ModuleLiveStatusCards = () => {
   return (
     <>
       {modules.map((module, index) => {
-        switch (module.name) {
-          case TEMPDECK:
+        switch (module.type) {
+          case TEMPERATURE_MODULE_TYPE:
             return (
               <TempDeckCard
                 key={module.serial}
@@ -50,7 +50,7 @@ export const ModuleLiveStatusCards = () => {
                 isProtocolActive={isProtocolActive}
               />
             )
-          case THERMOCYCLER:
+          case THERMOCYCLER_MODULE_TYPE:
             return (
               <ThermocyclerCard
                 key={module.serial}
@@ -61,7 +61,7 @@ export const ModuleLiveStatusCards = () => {
                 isProtocolActive={isProtocolActive}
               />
             )
-          case MAGDECK:
+          case MAGNETIC_MODULE_TYPE:
             return (
               <MagDeckCard
                 key={module.serial}

--- a/app/src/components/PrepareModules/index.js
+++ b/app/src/components/PrepareModules/index.js
@@ -8,7 +8,11 @@ import {
   Icon,
 } from '@opentrons/components'
 
-import { THERMOCYCLER, sendModuleCommand } from '../../modules'
+import {
+  THERMOCYCLER_MODULE_TYPE,
+  sendModuleCommand,
+  getModuleType,
+} from '../../modules'
 import { DeckMap } from '../DeckMap'
 import { Portal } from '../portal'
 import styles from './styles.css'
@@ -36,7 +40,7 @@ export function PrepareModules(props: Props) {
 
   const handleOpenLidClick = () => {
     modules
-      .filter(mod => mod.name === THERMOCYCLER)
+      .filter(mod => getModuleType(mod.model) === THERMOCYCLER_MODULE_TYPE)
       .forEach(mod =>
         dispatch(sendModuleCommand(robotName, mod.serial, 'open'))
       )

--- a/app/src/components/ReviewDeck/index.js
+++ b/app/src/components/ReviewDeck/index.js
@@ -11,7 +11,7 @@ import {
   selectors as robotSelectors,
 } from '../../robot'
 import secureTCLatchSrc from '../../img/secure_tc_latch.png'
-import { THERMOCYCLER } from '../../modules'
+import { THERMOCYCLER_MODULE_TYPE, getModuleType } from '../../modules'
 
 import { Portal } from '../portal'
 import { DeckMap } from '../DeckMap'
@@ -32,7 +32,7 @@ export function ReviewDeck(props: ReviewDeckProps) {
 
   const mustPrepNestedLabware = some(
     sessionModules,
-    mod => mod.name === THERMOCYCLER
+    mod => getModuleType(mod.model) === THERMOCYCLER_MODULE_TYPE
   )
 
   const currentLabware = allLabware.find(lw => lw.slot === slot)

--- a/app/src/modules/__fixtures__/index.js
+++ b/app/src/modules/__fixtures__/index.js
@@ -1,10 +1,11 @@
 // @flow
 
 import * as Types from '../types'
+import * as ApiTypes from '../api-types'
 
 export const mockRobot = { name: 'robot', ip: '127.0.0.1', port: 31950 }
 
-export const mockTemperatureModule: Types.TemperatureModule = {
+export const mockApiTemperatureModuleLegacy: ApiTypes.ApiTemperatureModuleLegacy = {
   name: 'tempdeck',
   displayName: 'Temperature Deck',
   port: '/dev/ot_module_tempdeck0',
@@ -19,7 +20,71 @@ export const mockTemperatureModule: Types.TemperatureModule = {
   },
 }
 
-export const mockMagneticModule: Types.MagneticModule = {
+export const mockApiTemperatureModule: ApiTypes.ApiTemperatureModule = {
+  name: 'tempdeck',
+  displayName: 'tempdeck',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  revision: 'temp_deck_v4.0',
+  moduleModel: 'temperatureModuleV1',
+  model: 'temp_deck_v1.5',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+}
+
+export const mockApiTemperatureModuleGen2: ApiTypes.ApiTemperatureModule = {
+  name: 'tempdeck',
+  displayName: 'tempdeck',
+  model: 'temp_deck_v20',
+  moduleModel: 'temperatureModuleV2',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  revision: 'temp_deck_v20',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+}
+
+export const mockTemperatureModule: Types.TemperatureModule = {
+  model: 'temperatureModuleV1',
+  type: 'temperatureModuleType',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  revision: 'temp_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+}
+
+export const mockTemperatureModuleGen2: Types.TemperatureModule = {
+  model: 'temperatureModuleV2',
+  type: 'temperatureModuleType',
+  port: '/dev/ot_module_tempdeck0',
+  serial: 'abc123',
+  revision: 'temp_deck_v20.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    currentTemp: 25,
+    targetTemp: null,
+  },
+}
+
+export const mockApiMagneticModuleLegacy: ApiTypes.ApiMagneticModuleLegacy = {
   name: 'magdeck',
   displayName: 'Magnetic Deck',
   port: '/dev/ot_module_magdeck0',
@@ -34,12 +99,111 @@ export const mockMagneticModule: Types.MagneticModule = {
   },
 }
 
-export const mockThermocycler: Types.ThermocyclerModule = {
+export const mockApiMagneticModule: ApiTypes.ApiMagneticModule = {
+  name: 'magdeck',
+  displayName: 'magdeck',
+  model: 'mag_deck_v4.0',
+  moduleModel: 'magneticModuleV1',
+  port: '/dev/ot_module_magdeck0',
+  serial: 'def456',
+  revision: 'mag_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'disengaged',
+  hasAvailableUpdate: true,
+  data: {
+    engaged: false,
+    height: 42,
+  },
+}
+
+export const mockApiMagneticModuleGen2: ApiTypes.ApiMagneticModule = {
+  name: 'magdeck',
+  displayName: 'magdeck',
+  model: 'mag_deck_v20',
+  moduleModel: 'magneticModuleV2',
+  port: '/dev/ot_module_magdeck0',
+  serial: 'def456',
+  revision: 'mag_deck_v20',
+  fwVersion: 'v2.0.0',
+  status: 'disengaged',
+  hasAvailableUpdate: true,
+  data: {
+    engaged: false,
+    height: 42,
+  },
+}
+
+export const mockMagneticModule: Types.MagneticModule = {
+  model: 'magneticModuleV1',
+  type: 'magneticModuleType',
+  port: '/dev/ot_module_magdeck0',
+  serial: 'def456',
+  revision: 'mag_deck_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'disengaged',
+  hasAvailableUpdate: true,
+  data: {
+    engaged: false,
+    height: 42,
+  },
+}
+
+export const mockApiThermocyclerLegacy: ApiTypes.ApiThermocyclerModuleLegacy = {
   name: 'thermocycler',
   displayName: 'Thermocycler',
   port: '/dev/ot_module_thermocycler0',
   serial: 'ghi789',
   model: 'thermocycler_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    lid: 'open',
+    lidTarget: null,
+    lidTemp: null,
+    currentTemp: null,
+    targetTemp: null,
+    holdTime: null,
+    rampRate: null,
+    currentCycleIndex: null,
+    totalCycleCount: null,
+    currentStepIndex: null,
+    totalStepCount: null,
+  },
+}
+
+export const mockApiThermocycler: ApiTypes.ApiThermocyclerModule = {
+  name: 'thermocycler',
+  displayName: 'thermocycler',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'ghi789',
+  model: 'thermocycler_v4.0',
+  moduleModel: 'thermocyclerModuleV1',
+  revision: 'thermocycler_v4.0',
+  fwVersion: 'v2.0.0',
+  status: 'idle',
+  hasAvailableUpdate: true,
+  data: {
+    lid: 'open',
+    lidTarget: null,
+    lidTemp: null,
+    currentTemp: null,
+    targetTemp: null,
+    holdTime: null,
+    rampRate: null,
+    currentCycleIndex: null,
+    totalCycleCount: null,
+    currentStepIndex: null,
+    totalStepCount: null,
+  },
+}
+
+export const mockThermocycler: Types.ThermocyclerModule = {
+  model: 'thermocyclerModuleV1',
+  type: 'thermocyclerModuleType',
+  port: '/dev/ot_module_thermocycler0',
+  serial: 'ghi789',
+  revision: 'thermocycler_v4.0',
   fwVersion: 'v2.0.0',
   status: 'idle',
   hasAvailableUpdate: true,
@@ -71,9 +235,31 @@ export const mockFetchModulesSuccess = {
   ...mockFetchModulesSuccessMeta,
   host: mockRobot,
   body: {
-    modules: [mockTemperatureModule],
+    modules: [
+      mockApiMagneticModule,
+      mockApiTemperatureModule,
+      mockApiThermocycler,
+    ],
   },
 }
+
+export const mockLegacyFetchModulesSuccess = {
+  ...mockFetchModulesSuccessMeta,
+  host: mockRobot,
+  body: {
+    modules: [
+      mockApiMagneticModuleLegacy,
+      mockApiTemperatureModuleLegacy,
+      mockApiThermocyclerLegacy,
+    ],
+  },
+}
+
+export const mockFetchModulesSuccessActionPayloadModules = [
+  mockMagneticModule,
+  mockTemperatureModule,
+  mockThermocycler,
+]
 
 export const mockFetchModulesFailureMeta = {
   method: 'GET',

--- a/app/src/modules/__tests__/actions.test.js
+++ b/app/src/modules/__tests__/actions.test.js
@@ -29,14 +29,14 @@ describe('robot modules actions', () => {
       creator: Actions.fetchModulesSuccess,
       args: [
         'robot-name',
-        Fixtures.mockFetchModulesSuccess.body.modules,
+        Fixtures.mockFetchModulesSuccessActionPayloadModules,
         { requestId: 'abc' },
       ],
       expected: {
         type: 'modules:FETCH_MODULES_SUCCESS',
         payload: {
           robotName: 'robot-name',
-          modules: Fixtures.mockFetchModulesSuccess.body.modules,
+          modules: Fixtures.mockFetchModulesSuccessActionPayloadModules,
         },
         meta: { requestId: 'abc' },
       },

--- a/app/src/modules/__tests__/selectors.test.js
+++ b/app/src/modules/__tests__/selectors.test.js
@@ -82,7 +82,7 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', name: 'thermocycler' },
+        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
       ])
     },
     expected: [
@@ -111,14 +111,41 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', name: 'thermocycler' },
-        { _id: 1, slot: '2', name: 'tempdeck' },
-        { _id: 2, slot: '3', name: 'magdeck' },
+        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
+        { _id: 1, slot: '2', model: 'temperatureModuleV1' },
+        { _id: 2, slot: '3', model: 'magneticModuleV1' },
       ])
     },
     expected: [
-      { _id: 0, slot: '1', name: 'thermocycler' },
-      { _id: 2, slot: '3', name: 'magdeck' },
+      { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
+      { _id: 2, slot: '3', model: 'magneticModuleV1' },
+    ],
+  },
+  {
+    name: 'getMissingModules allows compatible modules of different models',
+    selector: Selectors.getMissingModules,
+    state: {
+      modules: {
+        robotName: {
+          modulesById: {
+            abc123: Fixtures.mockTemperatureModuleGen2,
+            def456: Fixtures.mockMagneticModule,
+          },
+        },
+      },
+    },
+    args: [],
+    before: () => {
+      mockGetConnectedRobotName.mockReturnValue('robotName')
+      mockGetProtocolModules.mockReturnValue([
+        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
+        { _id: 1, slot: '2', model: 'temperatureModuleV1' },
+        { _id: 2, slot: '3', model: 'magneticModuleV2' },
+      ])
+    },
+    expected: [
+      { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
+      { _id: 2, slot: '3', model: 'magneticModuleV2' },
     ],
   },
 ]

--- a/app/src/modules/api-types.js
+++ b/app/src/modules/api-types.js
@@ -1,0 +1,134 @@
+// @flow
+
+import {
+  type MagneticModuleModel,
+  type TemperatureModuleModel,
+  type ThermocyclerModuleModel,
+  typeof TEMPDECK,
+  typeof MAGDECK,
+  typeof THERMOCYCLER,
+  type ModuleModel,
+} from '@opentrons/shared-data'
+
+export type ApiBaseModule = {|
+  displayName: string,
+  serial: string,
+  revision: string,
+  model: string,
+  moduleModel: ModuleModel,
+  fwVersion: string,
+  port: string,
+  hasAvailableUpdate: boolean,
+|}
+
+type ApiBaseModuleLegacy = {|
+  displayName: string,
+  serial: string,
+  model: string,
+  fwVersion: string,
+  port: string,
+  hasAvailableUpdate: boolean,
+|}
+
+export type TemperatureData = {|
+  currentTemp: number,
+  targetTemp: number | null,
+|}
+
+export type MagneticData = {|
+  engaged: boolean,
+  height: number,
+|}
+
+export type ThermocyclerData = {|
+  // TODO(mc, 2019-12-12): in_between comes from the thermocycler firmware and
+  // will be rare in normal operation due to limitations in current revision
+  lid: 'open' | 'closed' | 'in_between',
+  lidTarget: number | null,
+  lidTemp: number | null,
+  currentTemp: number | null,
+  targetTemp: number | null,
+  holdTime: number | null,
+  rampRate: number | null,
+  totalStepCount: number | null,
+  currentStepIndex: number | null,
+  totalCycleCount: number | null,
+  currentCycleIndex: number | null,
+|}
+
+export type TemperatureStatus =
+  | 'idle'
+  | 'holding at target'
+  | 'cooling'
+  | 'heating'
+
+export type ThermocyclerStatus =
+  | 'idle'
+  | 'holding at target'
+  | 'cooling'
+  | 'heating'
+  | 'error'
+
+export type MagneticStatus = 'engaged' | 'disengaged'
+
+export type ApiTemperatureModule = {|
+  ...ApiBaseModule,
+  moduleModel: TemperatureModuleModel,
+  name: TEMPDECK,
+  data: TemperatureData,
+  status: TemperatureStatus,
+|}
+
+export type ApiTemperatureModuleLegacy = {|
+  ...ApiBaseModuleLegacy,
+  name: TEMPDECK,
+  data: TemperatureData,
+  status: TemperatureStatus,
+|}
+
+export type ApiMagneticModule = {|
+  ...ApiBaseModule,
+  moduleModel: MagneticModuleModel,
+  name: MAGDECK,
+  data: MagneticData,
+  status: MagneticStatus,
+|}
+
+export type ApiMagneticModuleLegacy = {|
+  ...ApiBaseModuleLegacy,
+  name: MAGDECK,
+  data: MagneticData,
+  status: MagneticStatus,
+|}
+
+export type ApiThermocyclerModule = {|
+  ...ApiBaseModule,
+  moduleModel: ThermocyclerModuleModel,
+  name: THERMOCYCLER,
+  data: ThermocyclerData,
+  status: ThermocyclerStatus,
+|}
+
+export type ApiThermocyclerModuleLegacy = {|
+  ...ApiBaseModuleLegacy,
+  name: THERMOCYCLER,
+  data: ThermocyclerData,
+  status: ThermocyclerStatus,
+|}
+
+export type ApiAttachedModule =
+  | ApiThermocyclerModule
+  | ApiMagneticModule
+  | ApiTemperatureModule
+
+export type ApiAttachedModuleLegacy =
+  | ApiThermocyclerModuleLegacy
+  | ApiTemperatureModuleLegacy
+  | ApiMagneticModuleLegacy
+
+export type ModuleCommand =
+  | 'set_temperature'
+  | 'set_block_temperature'
+  | 'set_lid_temperature'
+  | 'deactivate'
+  | 'open'

--- a/app/src/modules/constants.js
+++ b/app/src/modules/constants.js
@@ -1,11 +1,15 @@
 // @flow
-import { THERMOCYCLER } from '@opentrons/shared-data'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 
 // common constants
 
-export const PREPARABLE_MODULES = [THERMOCYCLER]
+export const PREPARABLE_MODULE_TYPES = [THERMOCYCLER_MODULE_TYPE]
 
-export { MAGDECK, TEMPDECK, THERMOCYCLER } from '@opentrons/shared-data'
+export {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 // http paths
 

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -85,7 +85,11 @@ describe('fetchModulesEpic', () => {
       expectObservable(output$).toBe('--a', {
         a: Actions.fetchModulesSuccess(
           mockRobot.name,
-          [Fixtures.mockMagneticModule, Fixtures.mockTemperatureModule, Fixtures.mockThermocycler],
+          [
+            Fixtures.mockMagneticModule,
+            Fixtures.mockTemperatureModule,
+            Fixtures.mockThermocycler,
+          ],
           { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
         ),
       })
@@ -105,7 +109,11 @@ describe('fetchModulesEpic', () => {
       expectObservable(output$).toBe('--a', {
         a: Actions.fetchModulesSuccess(
           mockRobot.name,
-          [Fixtures.mockMagneticModule, Fixtures.mockTemperatureModule, Fixtures.mockThermocycler],
+          [
+            Fixtures.mockMagneticModule,
+            Fixtures.mockTemperatureModule,
+            Fixtures.mockThermocycler,
+          ],
           { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
         ),
       })

--- a/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
+++ b/app/src/modules/epic/__tests__/fetchModulesEpic.test.js
@@ -85,7 +85,27 @@ describe('fetchModulesEpic', () => {
       expectObservable(output$).toBe('--a', {
         a: Actions.fetchModulesSuccess(
           mockRobot.name,
-          Fixtures.mockFetchModulesSuccess.body.modules,
+          [Fixtures.mockMagneticModule, Fixtures.mockTemperatureModule, Fixtures.mockThermocycler],
+          { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
+        ),
+      })
+    })
+  })
+
+  it('maps successful legacy response to FETCH_MODULES_SUCCESS', () => {
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      mockFetchRobotApi.mockReturnValue(
+        cold('r', { r: Fixtures.mockLegacyFetchModulesSuccess })
+      )
+
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a-a', { a: {} })
+      const output$ = modulesEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.fetchModulesSuccess(
+          mockRobot.name,
+          [Fixtures.mockMagneticModule, Fixtures.mockTemperatureModule, Fixtures.mockThermocycler],
           { ...meta, response: Fixtures.mockFetchModulesSuccessMeta }
         ),
       })

--- a/app/src/modules/epic/fetchModulesEpic.js
+++ b/app/src/modules/epic/fetchModulesEpic.js
@@ -17,7 +17,11 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 
-import type { MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel } from '@opentrons/shared-data'
+import type {
+  MagneticModuleModel,
+  TemperatureModuleModel,
+  ThermocyclerModuleModel,
+} from '@opentrons/shared-data'
 
 import * as Actions from '../actions'
 import * as Constants from '../constants'

--- a/app/src/modules/epic/fetchModulesEpic.js
+++ b/app/src/modules/epic/fetchModulesEpic.js
@@ -3,6 +3,21 @@ import { ofType } from 'redux-observable'
 
 import { GET } from '../../robot-api/constants'
 import { mapToRobotApiRequest } from '../../robot-api/operators'
+import {
+  MAGDECK,
+  TEMPDECK,
+  THERMOCYCLER,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  TEMPERATURE_MODULE_V1,
+  TEMPERATURE_MODULE_V2,
+  MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
+  THERMOCYCLER_MODULE_V1,
+} from '@opentrons/shared-data'
+
+import type { MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel } from '@opentrons/shared-data'
 
 import * as Actions from '../actions'
 import * as Constants from '../constants'
@@ -14,12 +29,127 @@ import type {
   ResponseToActionMapper,
 } from '../../robot-api/operators'
 
-import type { FetchModulesAction } from '../types'
+import type { FetchModulesAction, AttachedModule } from '../types'
+import type {
+  ApiAttachedModule,
+  ApiAttachedModuleLegacy,
+  TemperatureData,
+  MagneticData,
+  ThermocyclerData,
+  TemperatureStatus,
+  MagneticStatus,
+  ThermocyclerStatus,
+} from '../api-types'
 
 const mapActionToRequest: ActionToRequestMapper<FetchModulesAction> = action => ({
   method: GET,
   path: Constants.MODULES_PATH,
 })
+
+type IdentifierWithData =
+  | {|
+      type: typeof MAGNETIC_MODULE_TYPE,
+      model: MagneticModuleModel,
+      data: MagneticData,
+      status: MagneticStatus,
+    |}
+  | {|
+      type: typeof TEMPERATURE_MODULE_TYPE,
+      model: TemperatureModuleModel,
+      data: TemperatureData,
+      status: TemperatureStatus,
+    |}
+  | {|
+      type: typeof THERMOCYCLER_MODULE_TYPE,
+      model: ThermocyclerModuleModel,
+      data: ThermocyclerData,
+      status: ThermocyclerStatus,
+    |}
+
+const normalizeModuleInfoLegacy = (
+  response: ApiAttachedModuleLegacy
+): IdentifierWithData => {
+  switch (response.name) {
+    case MAGDECK:
+      return {
+        type: MAGNETIC_MODULE_TYPE,
+        model: MAGNETIC_MODULE_V1,
+        data: (response.data: MagneticData),
+        status: (response.status: MagneticStatus),
+      }
+    case TEMPDECK:
+      return {
+        type: TEMPERATURE_MODULE_TYPE,
+        model: TEMPERATURE_MODULE_V1,
+        data: (response.data: TemperatureData),
+        status: (response.status: TemperatureStatus),
+      }
+    case THERMOCYCLER:
+      return {
+        type: THERMOCYCLER_MODULE_TYPE,
+        model: THERMOCYCLER_MODULE_V1,
+        data: (response.data: ThermocyclerData),
+        status: (response.status: ThermocyclerStatus),
+      }
+    default:
+      throw new Error(`bad module name ${response.name}`)
+  }
+}
+
+const normalizeModuleInfoNew = (
+  response: ApiAttachedModule
+): IdentifierWithData => {
+  switch (response.moduleModel) {
+    case MAGNETIC_MODULE_V1:
+    case MAGNETIC_MODULE_V2:
+      return {
+        model: response.moduleModel,
+        type: MAGNETIC_MODULE_TYPE,
+        data: (response.data: MagneticData),
+        status: (response.status: MagneticStatus),
+      }
+    case TEMPERATURE_MODULE_V1:
+    case TEMPERATURE_MODULE_V2:
+      return {
+        model: response.moduleModel,
+        type: TEMPERATURE_MODULE_TYPE,
+        data: (response.data: TemperatureData),
+        status: (response.status: TemperatureStatus),
+      }
+    case THERMOCYCLER_MODULE_V1:
+      return {
+        model: response.moduleModel,
+        type: THERMOCYCLER_MODULE_TYPE,
+        data: (response.data: ThermocyclerData),
+        status: (response.status: ThermocyclerStatus),
+      }
+    default:
+      throw new Error(`bad module model ${response.moduleModel}`)
+  }
+}
+
+const normalizeModuleInfo = (
+  response: ApiAttachedModule | ApiAttachedModuleLegacy
+): IdentifierWithData => {
+  if (response.moduleModel) {
+    return normalizeModuleInfoNew(response)
+  } else {
+    return normalizeModuleInfoLegacy(response)
+  }
+}
+
+const normalizeModuleResponse = (
+  response: ApiAttachedModule
+): AttachedModule => {
+  return {
+    ...normalizeModuleInfo(response),
+    revision: response.revision ? response.revision : response.model,
+    port: response.port,
+    serial: response.serial,
+    fwVersion: response.fwVersion,
+    hasAvailableUpdate: response.hasAvailableUpdate,
+  }
+}
 
 const mapResponseToAction: ResponseToActionMapper<FetchModulesAction> = (
   response,
@@ -27,9 +157,12 @@ const mapResponseToAction: ResponseToActionMapper<FetchModulesAction> = (
 ) => {
   const { host, body, ...responseMeta } = response
   const meta = { ...originalAction.meta, response: responseMeta }
-
   return response.ok
-    ? Actions.fetchModulesSuccess(host.name, body.modules, meta)
+    ? Actions.fetchModulesSuccess(
+        host.name,
+        body.modules.map(normalizeModuleResponse),
+        meta
+      )
     : Actions.fetchModulesFailure(host.name, body, meta)
 }
 

--- a/app/src/modules/selectors.js
+++ b/app/src/modules/selectors.js
@@ -1,14 +1,21 @@
 // @flow
 import { createSelector } from 'reselect'
 import sortBy from 'lodash/sortBy'
-import countBy from 'lodash/countBy'
 
 import { selectors as RobotSelectors } from '../robot'
 import * as Types from './types'
 
 import type { State } from '../types'
 import type { SessionModule } from '../robot/types'
-import { PREPARABLE_MODULES, THERMOCYCLER } from './constants'
+import { PREPARABLE_MODULE_TYPES } from './constants'
+import {
+  THERMOCYCLER_MODULE_TYPE,
+  getModuleType,
+  checkModuleCompatibility,
+} from '@opentrons/shared-data'
+import type { ModuleModel } from '@opentrons/shared-data'
+
+export { getModuleType } from '@opentrons/shared-data'
 
 export const getAttachedModules: (
   state: State,
@@ -27,7 +34,8 @@ export const getAttachedModulesForConnectedRobot = (
 }
 
 const isModulePrepared = (module: Types.AttachedModule): boolean => {
-  if (module.name === THERMOCYCLER) return module.data.lid === 'open'
+  if (module.type === THERMOCYCLER_MODULE_TYPE)
+    return module.data.lid === 'open'
   return false
 }
 
@@ -38,14 +46,14 @@ export const getUnpreparedModules: (
   RobotSelectors.getModules,
   (attachedModules, protocolModules) => {
     const preparableSessionModules = protocolModules
-      .filter(m => PREPARABLE_MODULES.includes(m.name))
-      .map(m => m.name)
+      .filter(m => PREPARABLE_MODULE_TYPES.includes(getModuleType(m.model)))
+      .map(m => m.model)
 
     // return actual modules that are both
     // a) required to be prepared by the session
     // b) not prepared according to isModulePrepared
     return attachedModules.filter(
-      m => preparableSessionModules.includes(m.name) && !isModulePrepared(m)
+      m => preparableSessionModules.includes(m.model) && !isModulePrepared(m)
     )
   }
 )
@@ -56,17 +64,18 @@ export const getMissingModules: (
   getAttachedModulesForConnectedRobot,
   RobotSelectors.getModules,
   (attachedModules, protocolModules) => {
-    const requiredCountMap: { [string]: number } = countBy(
-      protocolModules,
-      'name'
+    const compatibleCount: { [ModuleModel]: number } = Object.fromEntries(
+      protocolModules.map(pmod => {
+        const compatible = attachedModules
+          .map((amod): Types.AttachedModule | null => {
+            return checkModuleCompatibility(amod.model, pmod.model)
+              ? amod
+              : null
+          })
+          .filter(a => a !== null)
+        return [pmod.model, compatible.length]
+      })
     )
-    const actualCountMap: { [string]: number } = countBy(
-      attachedModules,
-      'name'
-    )
-
-    return protocolModules.filter(
-      m => requiredCountMap[m.name] > (actualCountMap[m.name] || 0)
-    )
+    return protocolModules.filter(m => compatibleCount[m.model] === 0)
   }
 )

--- a/app/src/modules/types.js
+++ b/app/src/modules/types.js
@@ -1,93 +1,56 @@
 // @flow
 
 import type { RobotApiRequestMeta } from '../robot-api/types'
-import typeof { MAGDECK, TEMPDECK, THERMOCYCLER } from './constants'
+import type {
+  TemperatureModuleModel,
+  ThermocyclerModuleModel,
+  MagneticModuleModel,
+} from '@opentrons/shared-data'
+
+import {
+  TEMPERATURE_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import * as ApiTypes from './api-types'
+export * from './api-types'
 
 // common types
 
-type BaseModule = {|
-  displayName: string,
-  model: string,
-  serial: string,
-  fwVersion: string,
-  port: string,
-  hasAvailableUpdate: boolean,
-|}
-
-export type TemperatureData = {|
-  currentTemp: number,
-  targetTemp: number | null,
-|}
-
-export type MagneticData = {|
-  engaged: boolean,
-  height: number,
-|}
-
-export type ThermocyclerData = {|
-  // TODO(mc, 2019-12-12): in_between comes from the thermocycler firmware and
-  // will be rare in normal operation due to limitations in current revision
-  lid: 'open' | 'closed' | 'in_between',
-  lidTarget: number | null,
-  lidTemp: number | null,
-  currentTemp: number | null,
-  targetTemp: number | null,
-  holdTime: number | null,
-  rampRate: number | null,
-  totalStepCount: number | null,
-  currentStepIndex: number | null,
-  totalCycleCount: number | null,
-  currentCycleIndex: number | null,
-|}
-
-export type TemperatureStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
-
-export type ThermocyclerStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
-  | 'error'
-
-export type MagneticStatus = 'engaged' | 'disengaged'
+export type CommonModuleInfo = $Diff<
+  ApiTypes.ApiBaseModule,
+  {| model: mixed, displayName: mixed, moduleModel: mixed |}
+>
 
 export type TemperatureModule = {|
-  ...BaseModule,
-  name: TEMPDECK,
-  data: TemperatureData,
-  status: TemperatureStatus,
+  type: typeof TEMPERATURE_MODULE_TYPE,
+  model: TemperatureModuleModel,
+  status: ApiTypes.TemperatureStatus,
+  data: ApiTypes.TemperatureData,
+  ...CommonModuleInfo,
 |}
 
 export type MagneticModule = {|
-  ...BaseModule,
-  name: MAGDECK,
-  data: MagneticData,
-  status: MagneticStatus,
+  type: typeof MAGNETIC_MODULE_TYPE,
+  model: MagneticModuleModel,
+  status: ApiTypes.MagneticStatus,
+  data: ApiTypes.MagneticData,
+  ...CommonModuleInfo,
 |}
 
 export type ThermocyclerModule = {|
-  ...BaseModule,
-  name: THERMOCYCLER,
-  data: ThermocyclerData,
-  status: ThermocyclerStatus,
+  type: typeof THERMOCYCLER_MODULE_TYPE,
+  model: ThermocyclerModuleModel,
+  status: ApiTypes.ThermocyclerStatus,
+  data: ApiTypes.ThermocyclerData,
+  ...CommonModuleInfo,
 |}
 
 export type AttachedModule =
-  | ThermocyclerModule
-  | MagneticModule
   | TemperatureModule
-
-export type ModuleCommand =
-  | 'set_temperature'
-  | 'set_block_temperature'
-  | 'set_lid_temperature'
-  | 'deactivate'
-  | 'open'
-
+  | MagneticModule
+  | ThermocyclerModule
 // action object types
 
 // fetch modules
@@ -117,7 +80,7 @@ export type SendModuleCommandAction = {|
   payload: {|
     robotName: string,
     moduleId: string,
-    command: ModuleCommand,
+    command: ApiTypes.ModuleCommand,
     args: Array<mixed>,
   |},
   meta: RobotApiRequestMeta,
@@ -128,7 +91,7 @@ export type SendModuleCommandSuccessAction = {|
   payload: {|
     robotName: string,
     moduleId: string,
-    command: ModuleCommand,
+    command: ApiTypes.ModuleCommand,
     returnValue: mixed,
   |},
   meta: RobotApiRequestMeta,
@@ -139,7 +102,7 @@ export type SendModuleCommandFailureAction = {|
   payload: {|
     robotName: string,
     moduleId: string,
-    command: ModuleCommand,
+    command: ApiTypes.ModuleCommand,
     error: {},
   |},
   meta: RobotApiRequestMeta,

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -20,6 +20,7 @@ import { getConnectableRobots } from '../../discovery/selectors'
 import { getProtocolFile } from '../../protocol/selectors'
 import { fileIsBundle, fileIsPython } from '../../protocol/protocol-data'
 import { getCustomLabwareDefinitions } from '../../custom-labware/selectors'
+import { normalizeModuleModel } from '@opentrons/shared-data'
 
 const RUN_TIME_TICK_INTERVAL_MS = 1000
 const NO_INTERVAL = -1
@@ -618,7 +619,11 @@ export function client(dispatch) {
     }
 
     function addApiModuleToModules(apiModule) {
-      update.modulesBySlot[apiModule.slot] = apiModule
+      const { name, ...noName } = apiModule
+      update.modulesBySlot[apiModule.slot] = {
+        ...noName,
+        model: apiModule?.model ?? normalizeModuleModel(apiModule.name),
+      }
     }
   }
 

--- a/app/src/robot/api-types.js
+++ b/app/src/robot/api-types.js
@@ -1,0 +1,40 @@
+// @flow
+//
+import {
+  typeof TEMPDECK,
+  typeof MAGDECK,
+  typeof THERMOCYCLER,
+  type ModuleModel,
+} from '@opentrons/shared-data'
+
+export type Slot =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+
+export type ApiSessionModule = {|
+  // resource ID
+  _id: number,
+  // slot module is installed in
+  slot: Slot,
+  // name identifier of the module
+  name: TEMPDECK | MAGDECK | THERMOCYCLER,
+  model: ModuleModel,
+|}
+
+export type ApiSessionModuleLegacy = {|
+  // resource ID
+  _id: number,
+  // slot module is installed in
+  slot: Slot,
+  // name identifier of the module
+  name: TEMPDECK | MAGDECK | THERMOCYCLER,
+|}

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -361,7 +361,7 @@ export const getLabware: OutputSelector<
             (key === slot ||
               (!isTiprack &&
                 type === lwBySlot[key].type &&
-                modulesBySlot[key]?.name === modulesBySlot[slot]?.name))
+                modulesBySlot[key]?.model === modulesBySlot[slot]?.model))
         )
 
         let calibration: LabwareCalibrationStatus = 'unconfirmed'

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -594,12 +594,12 @@ describe('api client', () => {
             1: {
               _id: 1,
               slot: '1',
-              name: 'tempdeck',
+              model: 'temperatureModuleV1',
             },
             9: {
               _id: 9,
               slot: '9',
-              name: 'magdeck',
+              model: 'magneticModuleV2',
             },
           },
         }),
@@ -616,6 +616,7 @@ describe('api client', () => {
           _id: 9,
           slot: '9',
           name: 'magdeck',
+          model: 'magneticModuleV2',
         },
       ]
 

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,30 +1,19 @@
 // @flow
 // common robot types
-import type {
-  PipetteModelSpecs,
-  PipetteChannels,
-  ModuleType,
-  LabwareDefinition2,
+import {
+  type PipetteModelSpecs,
+  type PipetteChannels,
+  type LabwareDefinition2,
 } from '@opentrons/shared-data'
 import type { Mount } from '@opentrons/components'
+
+import * as ApiTypes from './api-types'
+export * from './api-types'
 
 // TODO Ian 2018-02-27 files that import from here should just import from @opentrons/components directly
 export type { Mount }
 
 export type Channels = PipetteChannels
-
-export type Slot =
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
 
 // jog axes and directions
 // TODO(mc, 2018-05-04): deprecate in favor of types in HTTP API module
@@ -102,8 +91,8 @@ export type StateLabware = {|
   // resource ID
   _id: number,
   // slot labware is installed in
-  slot: Slot,
-  // deck coordinates of labware when not in slot
+  slot: ApiTypes.Slot,
+  // deck coordinates of la<bware when not in slot
   position: ?Array<number>,
   // unique type of the labware
   type: string,
@@ -127,14 +116,7 @@ export type Labware = {|
 
 export type LabwareType = 'tiprack' | 'labware'
 
-export type SessionModule = {|
-  // resource ID
-  _id: number,
-  // slot module is installed in
-  slot: Slot,
-  // name identifier of the module
-  name: ModuleType,
-|}
+export type SessionModule = $Diff<ApiTypes.ApiSessionModule, {| name: mixed |}>
 
 export type SessionStatus =
   | ''

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -4,10 +4,12 @@ import cx from 'classnames'
 
 import {
   getModuleDisplayName,
-  type ModuleType,
-  MAGDECK,
-  TEMPDECK,
-  THERMOCYCLER,
+  type ModuleModel,
+  MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
+  TEMPERATURE_MODULE_V1,
+  TEMPERATURE_MODULE_V2,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 
@@ -17,7 +19,7 @@ import styles from './Module.css'
 
 export type ModuleProps = {|
   /** name of module, eg 'magdeck', 'tempdeck', or 'thermocycler' */
-  name: ModuleType,
+  name: ModuleModel,
   /** display mode: 'default', 'present', 'missing', or 'info' */
   mode: 'default' | 'present' | 'missing' | 'info',
 |}
@@ -34,21 +36,23 @@ export function Module(props: ModuleProps) {
   } = deckDef?.locations?.orderedSlots[0]?.boundingBox
 
   switch (props.name) {
-    case MAGDECK: {
+    case MAGNETIC_MODULE_V1:
+    case MAGNETIC_MODULE_V2: {
       width = 137
       height = 91
       x = -7
       y = 4
       break
     }
-    case TEMPDECK: {
+    case TEMPERATURE_MODULE_V1:
+    case TEMPERATURE_MODULE_V2: {
       width = 196
       height = 91
       x = -66
       y = 4
       break
     }
-    case THERMOCYCLER: {
+    case THERMOCYCLER_MODULE_V1: {
       // TODO: BC 2019-07-24 these are taken from snapshots of the cad file, they should
       // be included in the module spec schema and added to the data
       width = 172

--- a/components/src/deck/Module.js
+++ b/components/src/deck/Module.js
@@ -18,8 +18,8 @@ import { RobotCoordsForeignDiv } from './RobotCoordsForeignDiv'
 import styles from './Module.css'
 
 export type ModuleProps = {|
-  /** name of module, eg 'magdeck', 'tempdeck', or 'thermocycler' */
-  name: ModuleModel,
+  /** module model */
+  model: ModuleModel,
   /** display mode: 'default', 'present', 'missing', or 'info' */
   mode: 'default' | 'present' | 'missing' | 'info',
 |}
@@ -35,7 +35,7 @@ export function Module(props: ModuleProps) {
     yDimension: height,
   } = deckDef?.locations?.orderedSlots[0]?.boundingBox
 
-  switch (props.name) {
+  switch (props.model) {
     case MAGNETIC_MODULE_V1:
     case MAGNETIC_MODULE_V2: {
       width = 137
@@ -76,9 +76,8 @@ export function Module(props: ModuleProps) {
 }
 
 function ModuleItemContents(props: ModuleProps) {
-  // TODO(mc, 2018-07-23): displayName?
-  const { mode, name } = props
-  const displayName = getModuleDisplayName(name)
+  const { mode, model } = props
+  const displayName = getModuleDisplayName(model)
 
   const message =
     mode === 'missing' ? (

--- a/components/src/deck/ModuleNameOverlay.js
+++ b/components/src/deck/ModuleNameOverlay.js
@@ -2,11 +2,11 @@
 // TODO(mc, 2020-02-19): no longer used; remove
 import * as React from 'react'
 
-import { getModuleDisplayName, type ModuleType } from '@opentrons/shared-data'
+import { getModuleDisplayName, type ModuleModel } from '@opentrons/shared-data'
 
 import styles from './Module.css'
 
-export type ModuleNameOverlayProps = {| name: ModuleType |}
+export type ModuleNameOverlayProps = {| name: ModuleModel |}
 
 // TODO (ka 2019-1-7): eventually add option to override with props
 const HEIGHT = 20

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -17,7 +17,6 @@ import type {
   LabwareDefinition2,
   DeckSlot as DeckDefSlot,
   ModuleRealType,
-  ModuleModel,
 } from '@opentrons/shared-data'
 import type { DeckSlot, WellVolumes } from './types'
 // TODO Ian 2018-11-27: import these from components lib, not from this constants file
@@ -105,14 +104,15 @@ export const TEMPERATURE_APPROACHING_TARGET: 'TEMPERATURE_APPROACHING_TARGET' =
 export const MODELS_FOR_MODULE_TYPE: {
   [ModuleRealType]: Array<{|
     name: string,
-    value: ModuleModel,
+    value: string,
     disabled?: boolean,
   |}>,
 } = {
   [MAGNETIC_MODULE_TYPE]: [
     {
       name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V1}`),
-      value: MAGNETIC_MODULE_V1,
+      // downcast required because the module models are now enums rather than strings
+      value: (MAGNETIC_MODULE_V1: string),
     },
     // TODO: IL 2019-01-31 enable this to support Magnetic Module GEN2 in PD
     // { name: i18n.t(`modules.model_display_name.${MAGNETIC_MODULE_V2}`), value: MAGNETIC_MODULE_V2 },
@@ -120,7 +120,8 @@ export const MODELS_FOR_MODULE_TYPE: {
   [TEMPERATURE_MODULE_TYPE]: [
     {
       name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V1}`),
-      value: TEMPERATURE_MODULE_V1,
+      // downcast required because the module models are now enums rather than strings
+      value: (TEMPERATURE_MODULE_V1: string),
     },
     // TODO: IL 2019-01-31 enable this to support Temperature Module GEN2 in PD
     // { name: i18n.t(`modules.model_display_name.${TEMPERATURE_MODULE_V2}`, value: TEMPERATURE_MODULE_V2 },
@@ -128,7 +129,8 @@ export const MODELS_FOR_MODULE_TYPE: {
   [THERMOCYCLER_MODULE_TYPE]: [
     {
       name: i18n.t(`modules.model_display_name.${THERMOCYCLER_MODULE_V1}`),
-      value: THERMOCYCLER_MODULE_V1,
+      // downcast required because the module models are now enums rather than strings
+      value: (THERMOCYCLER_MODULE_V1: string),
     },
   ],
 }

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -8,7 +8,7 @@ import omit from 'lodash/omit'
 import reduce from 'lodash/reduce'
 import {
   getLabwareDefURI,
-  getModuleTypeFromModuleModel,
+  getModuleType,
   MAGNETIC_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
@@ -699,7 +699,7 @@ export const moduleInvariantProperties = handleActions<ModuleEntities, *>(
         file.modules || {}, // TODO: Ian 2019-11-11 this fallback to empty object is for JSONv3 protocols. Once JSONv4 is released, this should be handled in migration in PD
         (fileModule: FileModule, id: string) => ({
           id,
-          type: getModuleTypeFromModuleModel(fileModule.model),
+          type: getModuleType(fileModule.model),
           model: fileModule.model,
         })
       )

--- a/protocol-library-kludge/README.md
+++ b/protocol-library-kludge/README.md
@@ -1,0 +1,15 @@
+# Protocol Library Kludge
+
+This app provides an OT2 deck map component intended to be used in an iframe in Protocol Library.
+
+JSON data to set up labware and modules is passed in through the `data` URL param.
+
+# Example URL Params
+
+## Standard labware + magnetic module
+
+http://localhost:8080/?data=%7B%22labware%22:%7B%221%22:%7B%22labwareType%22:%22biorad_96_wellplate_200ul_pcr%22,%22name%22:%22Bio-Rad%2096%20Well%20Plate%20200%20%C2%B5L%20PCR%20on%20Magnetic%20Module%20on%201%22%7D,%222%22:%7B%22labwareType%22:%22biorad_96_wellplate_200ul_pcr%22,%22name%22:%22output%20plate%20on%202%22%7D,%223%22:%7B%22labwareType%22:%22opentrons_96_tiprack_1000ul%22,%22name%22:%22p1000%20tiprack%20on%203%22%7D,%225%22:%7B%22labwareType%22:%22opentrons_96_tiprack_1000ul%22,%22name%22:%22p1000%20tiprack%20on%205%22%7D,%227%22:%7B%22labwareType%22:%22usascientific_12_reservoir_22ml%22,%22name%22:%22reagent%20reservoir%20on%207%22%7D,%2212%22:%7B%22labwareType%22:%22opentrons_1_trash_1100ml_fixed%22,%22name%22:%22Opentrons%20Fixed%20Trash%20on%2012%22%7D%7D,%22modules%22%3A%7B%221%22%3A%20%22magneticModuleV1%22%7D%7D
+
+## Custom labware
+
+http://localhost:8080/?data=%7B%22labware%22:%7B%221%22:%7B%22labwareType%22:%22generic_96_tiprack_20ul%22,%22name%22:%22Custom%20200%C2%B5L%20Tiprack%20on%201%22%7D,%222%22:%7B%22labwareType%22:%22generic_96_tiprack_200ul%22,%22name%22:%22Custom%20200%C2%B5L%20Tiprack%20on%202%22%7D,%223%22:%7B%22labwareType%22:%22custom_96_tubeholder_500ul%22,%22name%22:%22Custom%20500ul%20Tube%20Holder%20on%203%22%7D,%2212%22:%7B%22labwareType%22:%22opentrons_1_trash_1100ml_fixed%22,%22name%22:%22Opentrons%20Fixed%20Trash%20on%2012%22%7D%7D,%22modules%22:%7B%7D%7D

--- a/protocol-library-kludge/src/URLDeck.js
+++ b/protocol-library-kludge/src/URLDeck.js
@@ -12,7 +12,7 @@ import {
 } from '@opentrons/components'
 import { getLatestLabwareDef, getLegacyLabwareDef } from './getLabware'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
-import type { ModuleType, DeckSlotId } from '@opentrons/shared-data'
+import type { ModuleModel, DeckSlotId } from '@opentrons/shared-data'
 
 // URI-encoded JSON expected as URL param "data" (eg `?data=...`)
 type UrlData = {
@@ -23,7 +23,7 @@ type UrlData = {
     },
   },
   modules: {
-    [DeckSlotId]: ModuleType,
+    [DeckSlotId]: ModuleModel,
   },
 }
 
@@ -78,7 +78,7 @@ export class URLDeck extends React.Component<{||}> {
           Object.keys(deckSlotsById).map((slotId): Node => {
             const slot = deckSlotsById[slotId]
             if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
-            const module = modulesBySlot && modulesBySlot[slotId]
+            const moduleModel = modulesBySlot && modulesBySlot[slotId]
             const labware = labwareBySlot && labwareBySlot[slotId]
             const labwareDefV2 =
               labware && getLatestLabwareDef(labware.labwareType)
@@ -95,23 +95,16 @@ export class URLDeck extends React.Component<{||}> {
             } else {
               labwareDisplayType = labware?.labwareType || null
             }
-            console.log({
-              slot,
-              labware,
-              labwareDefV1,
-              labwareDefV2,
-              labwareDisplayType,
-            })
 
             return (
               <Fragment key={slotId}>
-                {module && (
+                {moduleModel && (
                   <g
                     transform={`translate(${slot.position[0]}, ${
                       slot.position[1]
                     })`}
                   >
-                    <Module name={module} mode={'default'} />
+                    <Module model={moduleModel} mode={'default'} />
                   </g>
                 )}
                 {labware && (

--- a/shared-data/js/__tests__/moduleAccessors.test.js
+++ b/shared-data/js/__tests__/moduleAccessors.test.js
@@ -2,8 +2,9 @@
 
 import {
   getModuleDef2,
-  getModuleTypeFromModuleModel,
+  getModuleType,
   getModuleDisplayName,
+  normalizeModuleModel,
 } from '../modules'
 
 import {
@@ -25,8 +26,8 @@ describe('all valid models work', () => {
       expect(loadedDef?.model).toEqual(model)
     })
     it('valid models have valid module types', () => {
-      expect(getModuleTypeFromModuleModel(model)).toEqual(loadedDef.moduleType)
-      expect(MODULE_TYPES).toContain(getModuleTypeFromModuleModel(model))
+      expect(getModuleType(model)).toEqual(loadedDef.moduleType)
+      expect(MODULE_TYPES).toContain(getModuleType(model))
     })
     it('valid modules have display names that match the def', () => {
       expect(getModuleDisplayName(model)).toEqual(loadedDef.displayName)
@@ -41,7 +42,7 @@ describe('legacy models work too', () => {
     [THERMOCYCLER, THERMOCYCLER_MODULE_V1],
   ]
   legacyEquivs.forEach(([legacy, modern]) => {
-    const fromLegacy = getModuleDef2(legacy)
-    expect(fromLegacy?.model).toEqual(modern)
+    const fromLegacy = normalizeModuleModel(legacy)
+    expect(fromLegacy).toEqual(modern)
   })
 })

--- a/shared-data/js/constants.js
+++ b/shared-data/js/constants.js
@@ -1,5 +1,6 @@
 // @flow
 
+import type { ModuleModel } from './types'
 // constants for dealing with robot coordinate system (eg in labwareTools)
 export const SLOT_LENGTH_MM = 127.76 // along X axis in robot coordinate system
 export const SLOT_WIDTH_MM = 85.48 // along Y axis in robot coordinate system
@@ -39,15 +40,22 @@ export const MAGNETIC_MODULE_TYPE: 'magneticModuleType' = 'magneticModuleType'
 export const THERMOCYCLER_MODULE_TYPE: 'thermocyclerModuleType' =
   'thermocyclerModuleType'
 
-export const MODULE_MODELS = [
-  MAGNETIC_MODULE_V1,
-  MAGNETIC_MODULE_V2,
+export const MAGNETIC_MODULE_MODELS = [MAGNETIC_MODULE_V1, MAGNETIC_MODULE_V2]
+
+export const TEMPERATURE_MODULE_MODELS = [
   TEMPERATURE_MODULE_V1,
   TEMPERATURE_MODULE_V2,
-  THERMOCYCLER_MODULE_V1,
 ]
 
-// offset added to parameters.magneticModuleEngageHeight for displaying reccomended height in PD
+export const THERMOCYCLER_MODULE_MODELS = [THERMOCYCLER_MODULE_V1]
+
+export const MODULE_MODELS: Array<ModuleModel> = [
+  ...MAGNETIC_MODULE_MODELS,
+  ...TEMPERATURE_MODULE_MODELS,
+  ...THERMOCYCLER_MODULE_MODELS,
+]
+
+// offset added to parameters.agneticModuleEngageHeight for displaying reccomended height in PD
 export const ENGAGE_HEIGHT_OFFSET = -4
 
 export const MODULE_TYPES = [

--- a/shared-data/js/modules.js
+++ b/shared-data/js/modules.js
@@ -16,7 +16,7 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from './constants'
 
-import type { ModuleModel, ModuleRealType } from './types'
+import type { ModuleModel, ModuleRealType, ModuleType } from './types'
 
 // The module objects in v2 Module Definitions representing a single module model
 type Coordinates = {|
@@ -50,31 +50,47 @@ export type ModuleDef2 = {|
 // TODO IMMEDIATELY: Phase out code that uses legacy models
 export const getModuleDef2 = (moduleModel: ModuleModel): ModuleDef2 => {
   switch (moduleModel) {
-    case MAGDECK: // TODO IMMEDIATE: Remove when callsites use only new models
-    case MAGNETIC_MODULE_V1: // fallthrough: legacy model
+    case MAGNETIC_MODULE_V1:
       return magneticModuleV1
     case MAGNETIC_MODULE_V2:
       return magneticModuleV2
-    case TEMPDECK: // TODO IMMEDIATE: Remove when callsites use only new models
-    case TEMPERATURE_MODULE_V1: // fallthrough: legacy model
+    case TEMPERATURE_MODULE_V1:
       return temperatureModuleV1
     case TEMPERATURE_MODULE_V2:
       return temperatureModuleV2
-    case THERMOCYCLER: // TODO IMMEDIATE: Remove when callsites use only new models
-    case THERMOCYCLER_MODULE_V1: // fallthrough: legacy model
+    case THERMOCYCLER_MODULE_V1:
       return thermocyclerModuleV1
     default:
       throw new Error(`Invalid module model ${moduleModel}`)
   }
 }
 
-export const getModuleTypeFromModuleModel = (
-  moduleModel: ModuleModel
-): ModuleRealType => {
+export function normalizeModuleModel(legacyModule: ModuleType): ModuleModel {
+  switch (legacyModule) {
+    case TEMPDECK:
+      return TEMPERATURE_MODULE_V1
+    case MAGDECK:
+      return MAGNETIC_MODULE_V1
+    case THERMOCYCLER:
+      return THERMOCYCLER_MODULE_V1
+    default:
+      throw new Error(`Invalid legacy module model ${legacyModule}`)
+  }
+}
+
+export function getModuleType(moduleModel: ModuleModel): ModuleRealType {
   return getModuleDef2(moduleModel).moduleType
 }
 
 // use module model (not type!) to get model-specific displayName for UI
 export function getModuleDisplayName(moduleModel: ModuleModel): string {
   return getModuleDef2(moduleModel).displayName
+}
+
+export function checkModuleCompatibility(
+  modelA: ModuleModel,
+  modelB: ModuleModel
+): boolean {
+  const bDef = getModuleDef2(modelB)
+  return modelA === modelB || bDef.compatibleWith.includes(modelA)
 }

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -1,18 +1,18 @@
 // @flow
 import typeof {
-  MAGNETIC_MODULE_TYPE,
-  TEMPERATURE_MODULE_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
-  // MAGNETIC_MODULE_V1,
-  // MAGNETIC_MODULE_V2,
-  // TEMPERATURE_MODULE_V1,
-  // TEMPERATURE_MODULE_V2,
-  // THERMOCYCLER_MODULE_V1,
-  GEN1,
-  GEN2,
   MAGDECK,
   TEMPDECK,
   THERMOCYCLER,
+  MAGNETIC_MODULE_V1,
+  MAGNETIC_MODULE_V2,
+  TEMPERATURE_MODULE_V1,
+  TEMPERATURE_MODULE_V2,
+  THERMOCYCLER_MODULE_V1,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  GEN1,
+  GEN2,
 } from './constants'
 // TODO Ian 2019-06-04 split this out into eg ../labware/flowTypes/labwareV1.js
 export type WellDefinition = {
@@ -169,13 +169,23 @@ export type ModuleRealType =
   | THERMOCYCLER_MODULE_TYPE
 
 // ModuleModel corresponds to top-level keys in shared-data/module/definitions/2
-export type ModuleModel = string // TODO: IL 2020-02-20 Change to enum type below as soon as callsites are compatible
-// export type ModuleModel =
-//   | MAGNETIC_MODULE_V1
-//   | MAGNETIC_MODULE_V2
-//   | TEMPERATURE_MODULE_V1
-//   | TEMPERATURE_MODULE_V2
-//   | THERMOCYCLER_MODULE_V1
+
+export type MagneticModuleModel = MAGNETIC_MODULE_V1 | MAGNETIC_MODULE_V2
+export type TemperatureModuleModel =
+  | TEMPERATURE_MODULE_V1
+  | TEMPERATURE_MODULE_V2
+export type ThermocyclerModuleModel = THERMOCYCLER_MODULE_V1
+
+export type ModuleModel =
+  | MagneticModuleModel
+  | TemperatureModuleModel
+  | ThermocyclerModuleModel
+
+export type ModuleModelWithLegacy =
+  | ModuleModel
+  | THERMOCYCLER
+  | MAGDECK
+  | TEMPDECK
 
 export type DeckOffset = {|
   x: number,

--- a/shared-data/module/definitions/2/magneticModuleV1.json
+++ b/shared-data/module/definitions/2/magneticModuleV1.json
@@ -15,7 +15,7 @@
     "x": 124.875,
     "y": 2.75
   },
-  "displayName": "Magnetic Module",
+  "displayName": "Magnetic Module GEN1",
   "quirks": [],
   "slotTransforms": {},
   "compatibleWith": []

--- a/shared-data/module/definitions/2/temperatureModuleV1.json
+++ b/shared-data/module/definitions/2/temperatureModuleV1.json
@@ -15,7 +15,7 @@
     "x": 12.0,
     "y": 8.75
   },
-  "displayName": "Temperature Module",
+  "displayName": "Temperature Module GEN1",
   "quirks": [],
   "slotTransforms": {},
   "compatibleWith": ["temperatureModuleV2"]


### PR DESCRIPTION
This PR
- introduces support for gen2 modules by supporting the new structures
of the HTTP and RPC endpoints from the robot (while handling backwards
compatibility)
- Changes most of the app's structure to support the new version 2
schema for module and deck definitions

Closes #4960

## ~Work to bring out of WIP~ Ready for review!
- [x] Alter the protocol-library-kludge stuff
- [x] alter the protocol designer stuff
- [x] test

## Testing
This touches everywhere that used modules, unfortunately, which means we should test
General:
- [ ] Plugging in modules makes the cards show up
- [ ] You get the right cards rendered for the right modules (images are for now the same between gen1 and 2); the names should have gen1 or gen2 except for thermocycler
- [ ] ~The card controls work~ on hold until a pending fix, those controls are broken rn
Protocol file info:
- [ ] Matching modules match
- [ ] Tempdeck gen1 and gen2s work with each other and display an inexact match warning like pipettes (the link goes to the pipettes page for now; the modules page doesn't exist)
- [ ] Magdeck gen1 and gen2s don't
- [ ] They render right on the deck map
- [ ] In the protocol, you can see the cards and controls

## can't merge until
- [ ] tests pass
- [ ] code review pass
- [ ] the url for the module inexact match page is right