### PR TITLE
feat(api): add start set temperature to api

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -29,6 +29,7 @@ Modules
 -------
 .. autoclass:: opentrons.protocol_api.contexts.TemperatureModuleContext
    :members:
+   :exclude-members: start_set_temperature
    :inherited-members:
 
 .. autoclass:: opentrons.protocol_api.contexts.MagneticModuleContext

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -121,6 +121,18 @@ class TempDeck:
             await asyncio.sleep(0.1)
         return ''
 
+    def start_set_temperature(self, celsius) -> str:
+        self.run_flag.wait()
+        celsius = round(float(celsius),
+                        utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
+        try:
+            self._send_command(
+                '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
+        except (TempDeckError, SerialException, SerialNoResponse) as e:
+            return str(e)
+        self._temperature.update({'target': celsius})
+        return ''
+
     # NOTE: only present to support apiV1 non-blocking by default behavior
     def legacy_set_temperature(self, celsius) -> str:
         self.run_flag.wait()

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -125,11 +125,8 @@ class TempDeck:
         self.run_flag.wait()
         celsius = round(float(celsius),
                         utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
-        try:
-            self._send_command(
+        self._send_command(
                 '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
-        except (TempDeckError, SerialException, SerialNoResponse) as e:
-            return str(e)
         self._temperature.update({'target': celsius})
         return ''
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -46,6 +46,10 @@ class SimulatingDriver:
         self._target_temp = celsius
         self._active = True
 
+    def start_set_temperature(self, celsius):
+        self._target_temp = celsius
+        self._active = True
+
     def legacy_set_temperature(self, celsius: float):
         self._target_temp = celsius
         self._active = True
@@ -173,6 +177,17 @@ class TempDeck(mod_abc.AbstractModule):
         return await self._loop.create_task(
             self._driver.set_temperature(celsius)
         )
+
+    async def start_set_temperature(self, celsius):
+        """
+        Set temperature in degree Celsius
+        Range: 4 to 95 degree Celsius (QA tested).
+        The internal temp range is -9 to 99 C, which is limited by the 2-digit
+        temperature display. Any input outside of this range will be clipped
+        to the nearest limit
+        """
+        await self.wait_for_is_running()
+        return self._driver.start_set_temperature(celsius)
 
     async def deactivate(self):
         """ Stop heating/cooling and turn off the fan """

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -204,6 +204,15 @@ class TemperatureModuleContext(ModuleContext):
         """
         return self._module.set_temperature(celsius)
 
+    def start_set_temperature(self, celsius: float):
+        """ Start setting the target temperature, in C.
+
+        Must be between 4 and 95C based on Opentrons QA.
+
+        :param celsius: The target temperature, in C
+        """
+        return self._module.start_set_temperature(celsius)
+
     @cmds.publish.both(command=cmds.tempdeck_deactivate)
     @requires_version(2, 0)
     def deactivate(self):

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -152,6 +152,27 @@ async def test_fail_set_temp_deck_temperature(monkeypatch, temp_deck):
     assert res == error_msg
 
 
+def test_start_set_temp_deck_temperature(monkeypatch, temp_deck):
+    # Start setting target temperature
+    command_log = []
+
+    def _mock_send_command(command, timeout=None, tag=None):
+        nonlocal command_log
+        command_log += [command]
+        return ''
+
+    monkeypatch.setattr(temp_deck, '_send_command',
+                        _mock_send_command)
+
+    monkeypatch.setattr(temp_deck, '_get_status', lambda: 'holding at target')
+
+    temp_deck.start_set_temperature(99)
+    assert command_log[-1] == 'M104 S99.0'
+
+    temp_deck.start_set_temperature(-9)
+    assert command_log[-1] == 'M104 S-9.0'
+
+
 def test_turn_off_temp_deck(monkeypatch, temp_deck):
 
     command_log = []


### PR DESCRIPTION
## overview

This PR closes #5176 by adding a non blocking start set temperature method to the api. This will not be published to python users, it is intended to be used only by PD for the time being. 

Shoutout to @b-cooper for being super helpful and thinking through all of this with me! 

## changelog
  -  Add non blocking set temperature method to api
## review requests

While `start_set_temperature` shouldn't be used by python users, it can be used to validate that the method does what it is supposed to. You can do a `temp_mod.start_set_temperature(x)` followed by any normal command and see that the runtime will continue executing commands without waiting for the temperature module to reach whatever temperature you specify:

```
def run(protocol: protocol_api.ProtocolContext):

    # labware
    tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '4')
    plate = protocol.load_labware('usascientific_12_reservoir_22ml', '5')
    # tiprack2 = protocol.load_labware('opentrons_96_tiprack_300ul', '4')

    #tempmod
    temp_mod = protocol.load_module('Temperature Module', '10')
    # temp_plate = temp_mod.load_labware('biorad_96_wellplate_200ul_pcr')

    # pipettes
    right_pipette = protocol.load_instrument(
         'p300_single', 'right', tip_racks=[tiprack])

    # the start set temperature will get called and immediate move to the following command
    temp_mod.start_set_temperature(40)

    right_pipette.pick_up_tip()
    right_pipette.aspirate(100, plate['A1'])
    right_pipette.dispense(100, plate['A2'])
```