### PR TITLE
fix(api): return tips to tipracks from the same height as drop tip

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -97,7 +97,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.2     |          3.16.0             |
 +-------------+-----------------------------+
-
+|     2.3     |          3.17.0             |
++-------------+-----------------------------+
 
 Changes in API Versions
 -----------------------
@@ -118,3 +119,14 @@ Version 2.2
   magnet from the base of the labware. For more, see :ref:`magnetic-module-engage`.
 - Return tip will now use pre-defined heights from hardware testing. For more information, see :ref:`pipette-return-tip`.
 - When using the return tip function, tips are no longer added back into the tip tracker. For more information, see :ref:`pipette-return-tip`.
+
+
+Version 2.3
++++++++++++
+
+- GEN2 Magnetic Modules and GEN2 Temperature Modules are now supported; you can load them with the names ``"magnetic
+  module gen2"`` and ``"temperature module gen2"``, respectively
+- All pipettes will return tips to tipracks from a higher position to avoid
+  possible collisions
+- During a :ref:`mix`, the pipette will no longer move up to clear the liquid in
+  between every dispense and following aspirate

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -332,7 +332,8 @@ class API(HardwareAPILike):
                    'aspirate_flow_rate', 'dispense_flow_rate',
                    'pipette_id', 'current_volume', 'display_name',
                    'tip_length', 'model', 'blow_out_flow_rate',
-                   'working_volume', 'tip_overlap', 'available_volume']
+                   'working_volume', 'tip_overlap', 'available_volume',
+                   'return_tip_height']
         instruments: Dict[top_types.Mount, Pipette.DictType] = {
             top_types.Mount.LEFT: {},
             top_types.Mount.RIGHT: {}

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -678,7 +678,7 @@ class InstrumentContext(CommandPublisher):
         else:
             tr = location.parent
             assert tr.is_tiprack
-            z_height = self.return_height * self._tip_length_for(tr)
+            z_height = self.return_height * tr.tip_length
             return location.top(-z_height)
 
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -679,7 +679,7 @@ class InstrumentContext(CommandPublisher):
             tr = location.parent
             assert tr.is_tiprack
             z_height = self.return_height * self._tip_length_for(tr)
-            return location.top(-z_height + 10)
+            return location.top(-z_height)
 
     @requires_version(2, 0)
     def drop_tip(  # noqa(C901)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -569,7 +569,7 @@ class InstrumentContext(CommandPublisher):
         if not isinstance(loc, Well):
             raise TypeError('Last tip location should be a Well but it is: '
                             '{}'.format(loc))
-        drop_loc = self._determine_drop_tip_target(loc, APIVersion(2, 3))
+        drop_loc = self._determine_drop_target(loc, APIVersion(2, 3))
         self.drop_tip(drop_loc, home_after=home_after)
 
         return self
@@ -669,7 +669,8 @@ class InstrumentContext(CommandPublisher):
 
         return self
 
-    def _determine_drop_target(self, location: Well, version_breakpoint: APIVersion = None):
+    def _determine_drop_target(
+            self, location: Well, version_breakpoint: APIVersion = None):
         version_breakpoint = version_breakpoint or APIVersion(2, 2)
         if self.api_version < version_breakpoint:
             bot = location.bottom()

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -569,9 +569,8 @@ class InstrumentContext(CommandPublisher):
         if not isinstance(loc, Well):
             raise TypeError('Last tip location should be a Well but it is: '
                             '{}'.format(loc))
-        bot = loc.bottom()
-        bot = bot._replace(point=bot.point._replace(z=bot.point.z + 10))
-        self.drop_tip(bot, home_after=home_after)
+        drop_loc = self._determine_drop_tip_target(loc, APIVersion(2, 3))
+        self.drop_tip(drop_loc, home_after=home_after)
 
         return self
 
@@ -670,8 +669,9 @@ class InstrumentContext(CommandPublisher):
 
         return self
 
-    def _determine_drop_target(self, location: Well):
-        if self.api_version < APIVersion(2, 2):
+    def _determine_drop_target(self, location: Well, version_breakpoint: APIVersion = None):
+        version_breakpoint = version_breakpoint or APIVersion(2, 2)
+        if self.api_version < version_breakpoint:
             bot = location.bottom()
             return bot._replace(point=bot.point._replace(z=bot.point.z + 10))
         else:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1276,7 +1276,7 @@ class InstrumentContext(CommandPublisher):
     @requires_version(2, 2)
     def return_height(self) -> int:
         """ The height to return a tip to its tiprack. """
-        return self.hw_pipette.get('returnTipHeight', 0.5)
+        return self.hw_pipette.get('return_tip_height', 0.5)
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -54,7 +54,8 @@ instrument_keys = sorted([
     'dispense_flow_rate', 'pipette_id', 'current_volume', 'display_name',
     'tip_length', 'has_tip', 'model', 'blow_out_flow_rate',
     'blow_out_speed', 'aspirate_speed', 'dispense_speed', 'working_volume',
-    'tip_overlap', 'ready_to_aspirate', 'available_volume'])
+    'tip_overlap', 'ready_to_aspirate', 'available_volume',
+    'return_tip_height'])
 
 
 async def test_cache_instruments(dummy_instruments, loop):

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -4004,7 +4004,7 @@
         "min": 0,
         "max": 100
       },
-      "returnTipHeight": 0.8,
+      "returnTipHeight": 0.4,
       "quirks": ["needsUnstick"]
     },
     "p1000_single_v1": {

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -4004,6 +4004,7 @@
         "min": 0,
         "max": 100
       },
+      "returnTipHeight": 0.8,
       "quirks": ["needsUnstick"]
     },
     "p1000_single_v1": {


### PR DESCRIPTION
Avoids an issue where the ejector would contact the tip rack body, and is probably how it should always have worked. We now drop tip from the same position from `return_tip`.

Added the new behavior (and the new version) to the docs.

Also discovered that we're not properly sending over the return tip height, so fixed that.

Closes #5186

## Risk Analysis

This is a fundamental change to the way we do return tip, so it may affect
- Calibration (returning tips to tipracks) for all pipettes
- Protocol behavior (returning tips) for all pipettes
- Pay special attention to p1000s, which are now actually dropping tips at the right height - they had been defaulting to 50% of the tip height because their `returnTipHeight` configurations hadn't been handled properly
