### PR TITLE
feat(api): use instrument max achievable height in plan_moves

### DIFF
--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -41,6 +41,7 @@ X_CURRENT_HIGH = 1.25
 Y_CURRENT_LOW = 0.3
 Y_CURRENT_HIGH = 1.25
 
+Z_RETRACT_DISTANCE = 2
 
 HIGH_CURRENT: Dict[str, float] = {
     'X': X_CURRENT_HIGH,
@@ -177,7 +178,8 @@ robot_config = namedtuple(
         'mount_offset',
         'log_level',
         'tip_probe',
-        'default_pipette_configs'
+        'default_pipette_configs',
+        'z_retract_distance'
     ]
 )
 
@@ -290,7 +292,9 @@ def build_config(deck_cal: List[List[float]],
         tip_probe=_build_tip_probe(
             _tip_probe_settings_with_migration(robot_settings)),
         default_pipette_configs=robot_settings.get(
-            'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS)
+            'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS),
+        z_retract_distance=robot_settings.get(
+            'z_retract_distance', Z_RETRACT_DISTANCE),
     )
     return cfg
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1566,7 +1566,7 @@ class API(HardwareAPILike):
     def get_instrument_max_height(
             self,
             mount: top_types.Mount,
-            critical_point: CriticalPoint = None):
+            critical_point: CriticalPoint = None) -> float:
         """Return max achievable height of the attached instrument
         based on the current critical point
         """

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1562,3 +1562,22 @@ class API(HardwareAPILike):
         await self.update_config(instrument_offset=inst_offs)
         pip.update_instrument_offset(new_offset)
         robot_configs.save_robot_settings(self._config)
+
+    def get_instrument_max_height(
+            self,
+            mount: top_types.Mount,
+            critical_point: CriticalPoint = None):
+        """Return max achievable height of the attached instrument
+        based on the current critical point
+        """
+        pip = self._attached_instruments[mount]
+        assert pip
+        cp = self._critical_point_for(mount, critical_point)
+
+        max_height = pip.config.home_position - \
+            self._config.z_retract_distance + cp.z
+
+        _, _, transformed_z = linal.apply_reverse(
+            self._config.gantry_calibration,
+            (0, 0, max_height))
+        return transformed_z

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -130,8 +130,8 @@ def plan_moves(
                     " mm, which is too tall for your current pipette "
                     "configurations. The longest pipette on your robot can "
                     f"only be raised to {instr_max_height} mm above the deck."
-                    " This may be because the labware is correctly defined, "
-                    "incorrectly calibrated, or physically too tall. Please "
+                    " This may be because the labware is incorrectly defined,"
+                    " incorrectly calibrated, or physically too tall. Please "
                     "check your labware definitions and calibrations.")
         from_safety = 0.0  # (ignore since it’s in a max())
 

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -107,6 +107,11 @@ def plan_moves(
             from_safety = from_well.top().point.z + well_z_margin
         else:
             from_safety = from_lw.highest_z + well_z_margin
+        # if we are already at the labware, we know the instr max height would
+        # would tall enough
+        if max(from_safety, to_safety) > instr_max_height:
+            to_safety = instr_max_height
+            from_safety = 0.0  # (ignore since it's in a max())
     else:
         # One of our labwares is invalid so we have to just go above
         # deck.highest_z since we don’t know where we are

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -8,7 +8,7 @@ from opentrons import types
 from .labware import (Labware, Well,
                       quirks_from_any_parent)
 from .definitions import DeckItem
-from .module_geometry import ThermocyclerGeometry, ModuleType
+from .module_geometry import ThermocyclerGeometry, ModuleGeometry, ModuleType
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.system.shared_data import load_shared_data
 
@@ -97,8 +97,6 @@ def plan_moves(
     if to_lw and to_lw == from_lw:
         # If we know the labwares we’re moving from and to, we can calculate
         # a safe z based on their heights
-        # TODO: Remove these awful Well.top() calls when we eliminate the back
-        #       compat wrapper
         if to_well:
             to_safety = to_well.top().point.z + well_z_margin
         else:
@@ -108,7 +106,7 @@ def plan_moves(
         else:
             from_safety = from_lw.highest_z + well_z_margin
         # if we are already at the labware, we know the instr max height would
-        # would tall enough
+        # be tall enough
         if max(from_safety, to_safety) > instr_max_height:
             to_safety = instr_max_height
             from_safety = 0.0  # (ignore since it's in a max())
@@ -121,9 +119,20 @@ def plan_moves(
             if instr_max_height >= (deck.highest_z + minimum_lw_z_margin):
                 to_safety = instr_max_height
             else:
+                tallest_lw = list(filter(
+                    lambda lw: lw.highest_z == deck.highest_z,
+                    [lw for lw in deck.data.values() if lw]))[0]
+                if isinstance(tallest_lw, ModuleGeometry) and\
+                        tallest_lw.labware:
+                    tallest_lw = tallest_lw.labware
                 raise LabwareHeightError(
-                    f"Labware height {deck.highest_z} exceeds the "
-                    f"max pipette achievable height: {instr_max_height}")
+                    f"The {tallest_lw} has a total height of {deck.highest_z}"
+                    " mm, which is too tall for your current pipette "
+                    "configurations. The longest pipette on your robot can "
+                    f"only be raised to {instr_max_height} mm above the deck."
+                    " This may be because the labware is correctly defined, "
+                    "incorrectly calibrated, or physically too tall. Please "
+                    "check your labware definitions and calibrations.")
         from_safety = 0.0  # (ignore since it’s in a max())
 
     safe = max_many(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1095,9 +1095,13 @@ class InstrumentContext(CommandPublisher):
             if isinstance(mod, ThermocyclerContext):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
+        instr_max_height = \
+            self._hw_manager.hardware.get_instrument_max_height(self._mount)
         moves = geometry.plan_moves(from_loc, location, self._ctx.deck,
+                                    instr_max_height,
                                     force_direct=force_direct,
-                                    minimum_z_height=minimum_z_height)
+                                    minimum_z_height=minimum_z_height
+                                    )
         self._log.debug("move_to: {}->{} via:\n\t{}"
                         .format(from_loc, location, moves))
         try:

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -27,6 +27,7 @@ dummy_settings = {
             'multi': [10, 11, 12]
         }
     },
+    'z_retract_distance': 2,
     'tip_length': 999,
     'mount_offset': [-3, -2, -1],
     'serial_speed': 888,


### PR DESCRIPTION
## overview
Currently, the safety height for a pipette to move between labware is strictly determined by adding the default labware z margin (10 mm) to the `deck.highest_z`. Since the P300 Gen2 multis are very tall compared to other models, some widely used module + labware setups (i.e. magnetic module + deep well plate / temperature module + aluminum screw-cap tube block) with a total safe height of ~143 mm can sometimes triggers the P300 Gen2 multis to hit the limit switch.

To solve this problem, we are changing the safety height when dealing with these tall labware configs:
1. add default labware z margin to the deck highest z to get the safety height
2. compare the safety height to the pipette max achievable height
3. if the safety height is greater than the max achievable height but the deck highest Z is at least 1 mm shorter than the max achievable height, use the max achievable height as the safety height instead
4. if the deck highest z is actually taller than the max achievable height, raise a LabwareHeightError

NOTE: We only expect the correct max height to be calculated on the robot because of specific robot calibrations.

-- Update 3/10/2020 4:28PM EST --
Adding a cap to the safety height when moving within the same labware to the max instrument height as well.

closes #5156

## changelog
- added a method to hardware control API to get the instrument max achievable height
- modified safety height to pipette homed height when labware is too tall but still has enough labware z clearance (min: 1 mm) from the max achievable height
- updated and added some appropriate tests

## review requests
Make sure Magnetic Module + Deep Well Plate / Temperature Module + Aluminum Tube Rack would not trigger the Gen2 multis to hit the limit switch