### PR TITLE
fix(api): call module functions across threads

### DIFF
--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -4,13 +4,65 @@ import threading
 import logging
 import asyncio
 import functools
+from typing import Generic, TypeVar, Any
 from .adapters import SynchronousAdapter
+from .modules.mod_abc import AbstractModule
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 class ThreadManagerException(Exception):
     pass
+
+
+async def call_coroutine_threadsafe(
+        loop: asyncio.AbstractEventLoop,
+        coro, *args, **kwargs) -> asyncio.Future:
+    fut = asyncio.run_coroutine_threadsafe(coro(*args, **kwargs), loop)
+    wrapped = asyncio.wrap_future(fut)
+    return await wrapped
+
+
+WrappedObj = TypeVar('WrappedObj')
+
+
+class CallBridger(Generic[WrappedObj]):
+    def __init__(
+            self,
+            wrapped_obj: WrappedObj,
+            loop: asyncio.AbstractEventLoop) -> None:
+        self.wrapped_obj = wrapped_obj
+        self._loop = loop
+
+    def __getattribute__(self, attr_name: str) -> Any:
+        # Almost every attribute retrieved from us will be for people actually
+        # looking for an attribute of the managed object, so check there first.
+        managed_obj = object.__getattribute__(self, 'wrapped_obj')
+        loop = object.__getattribute__(self, '_loop')
+        try:
+            attr = getattr(managed_obj, attr_name)
+        except AttributeError:
+            # Maybe this actually was for us? Let’s find it
+            return object.__getattribute__(self, attr_name)
+
+        if asyncio.iscoroutinefunction(attr):
+            # Return coroutine result of async function
+            # executed in managed thread to calling thread
+
+            @functools.wraps(attr)
+            async def wrapper(*args, **kwargs):
+                return await call_coroutine_threadsafe(
+                    loop, attr, *args, **kwargs)
+
+            return wrapper
+
+        elif asyncio.iscoroutine(attr):
+            # Return awaitable coroutine properties run in managed thread/loop
+            fut = asyncio.run_coroutine_threadsafe(attr, loop)
+            wrapped = asyncio.wrap_future(fut)
+            return wrapped
+
+        return attr
 
 
 # TODO: BC 2020-02-25 instead of overwriting __get_attribute__ in this class
@@ -40,7 +92,7 @@ class ThreadManager():
     >>> api_single_thread.sync.home() # call as blocking sync
     """
 
-    def __init__(self, builder, *args, **kwargs) -> None:
+    def __init__(self, builder, *args, **kwargs):
         """ Build the ThreadManager.
 
         :param builder: The API function to use
@@ -92,16 +144,16 @@ class ThreadManager():
             loop.call_soon_threadsafe(loop.stop)
         except Exception:
             pass
+        object.__getattribute__(self, 'wrap_module').cache_clear()
         object.__getattribute__(self, '_thread').join()
 
     def __del__(self):
         self.clean_up()
 
-    @staticmethod
-    async def call_coroutine_threadsafe(loop, coro, *args, **kwargs):
-        fut = asyncio.run_coroutine_threadsafe(coro(*args, **kwargs), loop)
-        wrapped = asyncio.wrap_future(fut)
-        return await wrapped
+    @functools.lru_cache(8)
+    def wrap_module(
+            self, module: AbstractModule) -> CallBridger[AbstractModule]:
+        return CallBridger(module, self._loop)
 
     def __getattribute__(self, attr_name):
         # Almost every attribute retrieved from us will be for people actually
@@ -117,13 +169,20 @@ class ThreadManager():
         if asyncio.iscoroutinefunction(attr):
             # Return coroutine result of async function
             # executed in managed thread to calling thread
-            return functools.partial(self.call_coroutine_threadsafe,
-                                     loop,
-                                     attr)
+
+            @functools.wraps(attr)
+            async def wrapper(*args, **kwargs):
+                return await call_coroutine_threadsafe(
+                    loop, attr, *args, **kwargs)
+
+            return wrapper
         elif asyncio.iscoroutine(attr):
             # Return awaitable coroutine properties run in managed thread/loop
             fut = asyncio.run_coroutine_threadsafe(attr, loop)
-            wrapped = asyncio.wrap_future(fut, loop=asyncio.get_event_loop())
+            wrapped = asyncio.wrap_future(fut)
             return wrapped
+
+        if attr_name == 'attached_modules':
+            return [self.wrap_module(mod) for mod in attr]
 
         return attr

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -155,7 +155,7 @@ class ThreadManager:
     @functools.lru_cache(8)
     def wrap_module(
             self, module: AbstractModule) -> CallBridger[AbstractModule]:
-        return CallBridger(module, self._loop)
+        return CallBridger(module, object.__getattribute__(self, '_loop'))
 
     def __getattribute__(self, attr_name):
         # hardware_control.api.API.attached_modules is the only hardware

--- a/api/src/opentrons/legacy_api/modules/tempdeck.py
+++ b/api/src/opentrons/legacy_api/modules/tempdeck.py
@@ -140,7 +140,7 @@ class TempDeck(commands.CommandPublisher):
                 self._driver.connect(self._port)
             self._device_info = self._driver.get_device_info()
             self._poll_stop_event = Event()
-            Thread(target=self._poll_temperature).start()
+            Thread(target=self._poll_temperature, daemon=True).start()
         else:
             # Sanity check Should never happen, because connect should never
             # be called without a port on Module

--- a/api/tests/opentrons/protocol_api/test_util.py
+++ b/api/tests/opentrons/protocol_api/test_util.py
@@ -4,7 +4,7 @@ from opentrons.protocol_api.util import HardwareManager, AxisMaxSpeeds
 from opentrons.hardware_control import API, adapters, types, ThreadManager
 
 
-def test_hw_manager(loop):
+async def test_hw_manager(loop):
     # When built without an input it should build its own adapter
     mgr = HardwareManager(None)
     adapter = mgr.hardware
@@ -17,8 +17,8 @@ def test_hw_manager(loop):
 
     # When built with a hardware API input it should wrap it with a new
     # synchronous adapter and not build its own API
-    mgr = HardwareManager(
-        API.build_hardware_simulator(loop=loop))
+    sim = await API.build_hardware_simulator(loop=loop)
+    mgr = HardwareManager(sim)
     assert isinstance(mgr.hardware, adapters.SynchronousAdapter)
     passed = mgr.hardware
     # When disconnecting from a real external adapter, it should create


### PR DESCRIPTION
Moving to the threadmanager broke the case of calling module functions
through the threadmanager, since the module objects would be returned
directly.

They are now wrapped in CallBridger objects that have the
`__getattribute__` override the same as thread managers but don't do the
actual thread managing. This is LRU cached so we don't build a bunch of
them.

## Testing
- Make sure that the module cards both in the pipettes and modules page and in protocol work
- Note that sending module commands when a protocol is paused does not (and should not) work; #5209 will disable module commands when the protocol is paused. Module commands from the protocol run page should only be tested when the protocol is not running.