### PR TITLE
fix(api): make sure we move plunger to bottom after home

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -456,6 +456,36 @@ class API(HardwareAPILike):
             axes = [Axis.by_mount(mount)]
         await self.home(axes)
 
+    async def _do_plunger_home(
+            self,
+            axis: Axis = None,
+            mount: top_types.Mount = None,
+            acquire_lock: bool = True):
+        assert axis or mount, 'specify either axis or mount'
+        if axis:
+            checked_axis = axis
+            checked_mount = Axis.to_mount(checked_axis)
+        if mount:
+            checked_mount = mount
+            checked_axis = Axis.of_plunger(checked_mount)
+        instr = self._attached_instruments[checked_mount]
+        if not instr:
+            return
+        async with contextlib.AsyncExitStack() as stack:
+            if acquire_lock:
+                await stack.enter_async_context(self._motion_lock)
+            with self._backend.save_current():
+                self._backend.set_active_current(
+                    checked_axis, instr.config.plunger_current)
+                smoothie_pos = self._backend.home([checked_axis.name.upper()])
+                smoothie_pos.update(self._backend.update_position())
+                # either we were passed False for our acquire_lock and we
+                # should pass it on, or we acquired the lock above and
+                # shouldn't do it again
+                await self._move_plunger(checked_mount,
+                                         instr.config.bottom,
+                                         acquire_lock=False)
+
     async def home_plunger(self, mount: top_types.Mount):
         """
         Home the plunger motor for a mount, and then return it to the 'bottom'
@@ -464,11 +494,8 @@ class API(HardwareAPILike):
         :param mount: the mount associated with the target plunger
         :type mount: :py:class:`.top_types.Mount`
         """
-        instr = self._attached_instruments[mount]
-        if instr:
-            await self.home([Axis.of_plunger(mount)])
-            await self._move_plunger(mount,
-                                     instr.config.bottom)
+        await self._do_plunger_home(mount=mount,
+                                    acquire_lock=True)
 
     async def home(self, axes: List[Axis] = None):
         """ Home the entire robot and initialize current position.
@@ -484,27 +511,12 @@ class API(HardwareAPILike):
         plungers = [ax for ax in checked_axes
                     if ax not in Axis.gantry_axes()]
 
-        def _current_with_fallback(mount: top_types.Mount) -> float:
-            attached = self._attached_instruments[mount]
-            if attached:
-                return attached.config.plunger_current
-            else:
-                return self._config.high_current[Axis.of_plunger(mount).name]
-
-        smoothie_plungers = {
-            ax: _current_with_fallback(Axis.to_mount(ax))
-            for ax in plungers
-        }
         async with self._motion_lock:
             if smoothie_gantry:
                 smoothie_pos.update(self._backend.home(smoothie_gantry))
-            if smoothie_plungers:
-                for smoothie_plunger, current in smoothie_plungers.items():
-                    self._backend.set_active_current(
-                        smoothie_plunger, current)
-                    self._backend.home([smoothie_plunger.name.upper()])
-                    smoothie_pos.update(self._backend.update_position())
-            self._current_position = self._deck_from_smoothie(smoothie_pos)
+                self._current_position = self._deck_from_smoothie(smoothie_pos)
+            for plunger in plungers:
+                await self._do_plunger_home(axis=plunger, acquire_lock=False)
 
     async def add_tip(
             self,
@@ -730,7 +742,8 @@ class API(HardwareAPILike):
         self._last_moved_mount = mount
 
     async def _move_plunger(self, mount: top_types.Mount, dist: float,
-                            speed: float = None):
+                            speed: float = None,
+                            acquire_lock: bool = True):
         z_axis = Axis.by_mount(mount)
         pl_axis = Axis.of_plunger(mount)
         all_axes_pos = OrderedDict(
@@ -742,11 +755,13 @@ class API(HardwareAPILike):
               self._current_position[z_axis]),
              (pl_axis, dist))
         )
-        await self._move(all_axes_pos, speed, False)
+        await self._move(all_axes_pos, speed, False,
+                         acquire_lock=acquire_lock)
 
     async def _move(self, target_position: 'OrderedDict[Axis, float]',
                     speed: float = None, home_flagged_axes: bool = True,
-                    max_speeds: Dict[Axis, float] = None):
+                    max_speeds: Dict[Axis, float] = None,
+                    acquire_lock: bool = True):
         """ Worker function to apply robot motion.
 
         Robot motion means the kind of motions that are relevant to the robot,
@@ -811,7 +826,9 @@ class API(HardwareAPILike):
                                 bounds[ax.name][0], bounds[ax.name][1]))
         checked_maxes = max_speeds or {}
         str_maxes = {ax.name: val for ax, val in checked_maxes.items()}
-        async with self._motion_lock:
+        async with contextlib.AsyncExitStack() as stack:
+            if acquire_lock:
+                await stack.enter_async_context(self._motion_lock)
             try:
                 self._backend.move(smoothie_pos, speed=speed,
                                    home_flagged_axes=home_flagged_axes,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -461,7 +461,8 @@ class API(HardwareAPILike):
             axis: Axis = None,
             mount: top_types.Mount = None,
             acquire_lock: bool = True):
-        assert axis or mount, 'specify either axis or mount'
+        assert (axis is not None) ^ (mount is not None),\
+            'specify either axis or mount'
         if axis:
             checked_axis = axis
             checked_mount = Axis.to_mount(checked_axis)

--- a/api/tests/opentrons/server/test_control_endpoints.py
+++ b/api/tests/opentrons/server/test_control_endpoints.py
@@ -1,13 +1,13 @@
 import json
-from copy import deepcopy
 
 import pytest
+from unittest import mock
 
 from opentrons import types
 from opentrons.legacy_api import modules as legacy_modules
-from opentrons.hardware_control import API, ExecutionManager
+from opentrons.hardware_control import (
+    API, ExecutionManager, types as hwtypes)
 
-from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
 from opentrons.config import pipette_config
 
 
@@ -228,44 +228,51 @@ async def test_get_cached_pipettes(async_server, async_client, monkeypatch):
     assert json.loads(text2) == expected2
 
 
-async def test_disengage_axes(async_client, monkeypatch):
-    def mock_send(self, command, timeout=None):
+async def test_disengage_axes(async_client, mocked_hw):
+
+    async def _mock_dummy(*args, **kwargs):
         pass
 
-    monkeypatch.setattr(
-        SmoothieDriver_3_0_0, '_send_command', mock_send)
+    mocked_hw.disengage_axes.side_effect = _mock_dummy
+    res = await async_client.post('/motors/disengage',
+                                  json={'axes': ['x', 'a', 'b']})
+    assert res.status == 200
+    mocked_hw.disengage_axes.assert_called_once_with(
+        [hwtypes.Axis.X, hwtypes.Axis.A, hwtypes.Axis.B])
+    mocked_hw.reset_mock()
+    mocked_hw.disengage_axes.side_effect = _mock_dummy
+    res2 = await async_client.post('/motors/disengage',
+                                   json={'axes': ['asdaf', 'acasc', 'b']})
+    assert res2.status == 400
+    body = await res2.json()
+    assert 'invalid' in body['message'].lower()
+    mocked_hw.disengage_axes.assert_not_called()
 
-    alltrue = {
-        "x": {"enabled": True},
-        "y": {"enabled": True},
-        "z": {"enabled": True},
-        "a": {"enabled": True},
-        "b": {"enabled": True},
-        "c": {"enabled": True}}
+
+async def test_engaged_axes(async_client, mocked_hw):
+    pm = mock.PropertyMock()
+    type(mocked_hw).engaged_axes = pm
+    pm.return_value = {
+        hwtypes.Axis.X: True,
+        hwtypes.Axis.Y: False,
+        hwtypes.Axis.Z: True,
+        hwtypes.Axis.A: True,
+        hwtypes.Axis.B: False,
+        hwtypes.Axis.C: True}
+
+    should_return = {
+        'x': {'enabled': True},
+        'y': {'enabled': False},
+        'z': {'enabled': True},
+        'a': {'enabled': True},
+        'b': {'enabled': False},
+        'c': {'enabled': True}
+    }
     res0 = await async_client.get('/motors/engaged')
     result0 = await res0.text()
     assert res0.status == 200
-    assert json.loads(result0) == alltrue
-
-    postres = await async_client.post(
-        '/motors/disengage', json={'axes': ['X', 'b']})
-    assert postres.status == 200
-
-    xbfalse = deepcopy(alltrue)
-    xbfalse["x"]["enabled"] = False
-    xbfalse["b"]["enabled"] = False
-    res1 = await async_client.get('/motors/engaged')
-    result1 = await res1.text()
-    assert res1.status == 200
-    assert json.loads(result1) == xbfalse
-
-    resp = await async_client.post('/robot/home',
-                                   json={'target': 'robot'})
-    assert resp.status == 200
-    res2 = await async_client.get('/motors/engaged')
-    result2 = await res2.text()
-    assert res2.status == 200
-    assert json.loads(result2) == alltrue
+    assert json.loads(result0) == should_return
+    pm.assert_called_once()
 
 
 async def test_robot_info(async_client):


### PR DESCRIPTION
This commit make a new function _do_plunger_home which homes a plunger
on a mount, if it exists, and then moves that plunger to its configured
bottom. This is now used both by API.home_plunger (which was where this
behavior was before) but also by a call to API.home() that involves
pipettes, ensuring that plungers are always moved to the bottom after
they are homed.

Closes #5164, #5071 

## Testing
- Home a bunch, with and without pipettes attached and detected

## Risk Assessment
This change has a broad impact (it will happen anywhere the plungers are homed, which as any of our users can annoyedly tell you is a lot of places) but the actual risk involved is fairly low - we're still homing the pipette, just moving it to the bottom now. Note that this won't happen in fast home, so drop tip behavior shouldn't change.

Let's run a couple protocols, run a couple change pipette flows, that sort of thing. Try it on at least a gen1 and a gen2 (which ones don't really matter).