### PR TITLE
fix(api): fix server crash due to unresponsive motor controller at boot

### DIFF
--- a/api/src/opentrons/main.py
+++ b/api/src/opentrons/main.py
@@ -93,8 +93,9 @@ async def _do_fw_update(driver, new_fw_path, new_fw_ver):
 
 async def check_for_smoothie_update():
     driver = SmoothieDriver_3_0_0(robot_configs.load())
-    driver.connect()
+
     try:
+        driver.connect()
         fw_version = driver.get_fw_version()
     except Exception as e:
         # The most common reason for this exception (aside from hardware


### PR DESCRIPTION
## overview

Bug report + fix

#5165 made changes to the motor controller board version check / automatic update routine. One of those changes resulted in an unguarded `driver.connect` call. This method raises can raise if the motor controller board is unresponsive, resulting in a server crash rather than the desired boot with virtual smoothie

## changelog

- fix(api): fix server crash due to unresponsive motor controller at boot

## review requests

- [ ] Robots with attached motor controller boards continue to boot
- [ ] Robots without attached motor controller boards (e.g. with board missing) can successfully boot

## risk assessment

Any change to the boot path is inherently risky, but this is a tiny change (moving an unguarded line of code into a `try` block).

If the checklist in **review requests** is completed I think we've covered our bases
