### PR TITLE
refactor(build): add robot-server to top level push target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,11 @@ push-update-server:
 push: export host=$(usb_host)
 push:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
-	$(MAKE) -C $(API_DIR) push
+	$(MAKE) -C $(API_DIR) push-no-restart
 	sleep 1
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push
+	sleep 1
+	$(MAKE) -C $(ROBOT_SERVER_DIR) push
 
 
 .PHONY: term

--- a/api/Makefile
+++ b/api/Makefile
@@ -141,16 +141,19 @@ dev:
 local-shell:
 	$(pipenv_envvars) pipenv shell
 
-.PHONY: push
-push: wheel
+.PHONY: push-no-restart
+push-no-restart: wheel
 	scp -i $(br_ssh_key) $(ssh_opts) $(wheel_file) root@$(host):/data/
 	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/opentrons*.whl && mount -o remount,ro / && systemctl start opentrons-robot-server; } ;\
-systemctl restart jupyter-notebook &&\
-systemctl stop opentrons-robot-server &&\
+"function cleanup () { rm -f /data/opentrons*.whl && mount -o remount,ro / ; } ;\
 mount -o remount,rw / &&\
 cd /usr/lib/python3.7/site-packages &&\
 unzip -o /data/opentrons-*.whl && cleanup || cleanup"
+
+.PHONY: push
+push: push-no-restart
+	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
+"systemctl restart jupyter-notebook && systemctl restart opentrons-robot-server"
 
 .PHONY: simulate
 simulate:


### PR DESCRIPTION
You can now do `make push` in the root of the repo and it will push the
robot server as well as the api and update server. previously it would
only do api and update, and you'd have to do a separate push to get the
robot server on there.
