### PR TITLE
feat(app): add Wi-Fi disconnect to app

### DIFF
--- a/app/src/config/constants.js
+++ b/app/src/config/constants.js
@@ -6,7 +6,6 @@ export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'enableMultiGEN2',
   'enableBundleUpload',
-  'enableWifiDisconnect',
 ]
 
 // action type constants

--- a/app/src/config/types.js
+++ b/app/src/config/types.js
@@ -11,7 +11,6 @@ export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'enableMultiGEN2'
   | 'enableBundleUpload'
-  | 'enableWifiDisconnect'
 
 export type FeatureFlags = $Shape<{|
   [DevInternalFlag]: boolean | void,

--- a/app/src/networking/__tests__/selectors.test.js
+++ b/app/src/networking/__tests__/selectors.test.js
@@ -1,6 +1,5 @@
 // @flow
 import noop from 'lodash/noop'
-import * as Config from '../../config'
 import * as Discovery from '../../discovery'
 import * as Selectors from '../selectors'
 import * as Constants from '../constants'
@@ -15,11 +14,6 @@ const getRobotApiVersionByName: JestMockFn<
   [State, string],
   $Call<typeof Discovery.getRobotApiVersionByName, State, string>
 > = Discovery.getRobotApiVersionByName
-
-const getFeatureFlags: JestMockFn<
-  [State],
-  $Call<typeof Config.getFeatureFlags, State>
-> = Config.getFeatureFlags
 
 type SelectorSpec = {|
   name: string,
@@ -306,9 +300,7 @@ describe('robot settings selectors', () => {
       expected: [Fixtures.mockEapOption],
     },
     {
-      // TODO(mc, 2020-03-03): remove disconnect feature flag
-      name:
-        'getCanDisconnect returns true if active network, robot >= 3.17, FF on',
+      name: 'getCanDisconnect returns true if active network, robot >= 3.17',
       selector: Selectors.getCanDisconnect,
       state: {
         networking: {
@@ -319,10 +311,6 @@ describe('robot settings selectors', () => {
       },
       args: ['robotName'],
       before: ({ state: mockState }) => {
-        getFeatureFlags.mockImplementation(state => {
-          expect(state).toEqual(mockState)
-          return { enableWifiDisconnect: true }
-        })
         getRobotApiVersionByName.mockImplementation((state, robotName) => {
           expect(state).toEqual(mockState)
           expect(robotName).toEqual('robotName')
@@ -339,7 +327,6 @@ describe('robot settings selectors', () => {
       },
       args: ['robotName'],
       before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({ enableWifiDisconnect: true })
         getRobotApiVersionByName.mockReturnValue('3.17.0')
       },
       expected: false,
@@ -356,7 +343,6 @@ describe('robot settings selectors', () => {
       },
       args: ['robotName'],
       before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({ enableWifiDisconnect: true })
         getRobotApiVersionByName.mockReturnValue('3.17.0')
       },
       expected: false,
@@ -373,7 +359,6 @@ describe('robot settings selectors', () => {
       },
       args: ['robotName'],
       before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({ enableWifiDisconnect: false })
         getRobotApiVersionByName.mockReturnValue('3.16.999')
       },
       expected: false,
@@ -390,44 +375,7 @@ describe('robot settings selectors', () => {
       },
       args: ['robotName'],
       before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({ enableWifiDisconnect: false })
         getRobotApiVersionByName.mockReturnValue(null)
-      },
-      expected: false,
-    },
-    {
-      // TODO(mc, 2020-03-03): remove disconnect feature flag
-      name: 'getCanDisconnect returns true if FF on regardless of version',
-      selector: Selectors.getCanDisconnect,
-      state: {
-        networking: {
-          robotName: {
-            wifiList: [{ ...Fixtures.mockWifiNetwork, active: true }],
-          },
-        },
-      },
-      args: ['robotName'],
-      before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({ enableWifiDisconnect: true })
-        getRobotApiVersionByName.mockReturnValue('3.16.999')
-      },
-      expected: true,
-    },
-    {
-      // TODO(mc, 2020-03-03): remove disconnect feature flag
-      name: 'getCanDisconnect returns false if FF off',
-      selector: Selectors.getCanDisconnect,
-      state: {
-        networking: {
-          robotName: {
-            wifiList: [{ ...Fixtures.mockWifiNetwork, active: true }],
-          },
-        },
-      },
-      args: ['robotName'],
-      before: ({ state: mockState }) => {
-        getFeatureFlags.mockReturnValue({})
-        getRobotApiVersionByName.mockReturnValue('3.17.0')
       },
       expected: false,
     },

--- a/app/src/networking/selectors.js
+++ b/app/src/networking/selectors.js
@@ -5,7 +5,7 @@ import map from 'lodash/map'
 import orderBy from 'lodash/orderBy'
 import uniqBy from 'lodash/uniqBy'
 import { long2ip } from 'netmask'
-// import Semver from 'semver'
+import Semver from 'semver'
 
 import { getFeatureFlags } from '../config'
 import { getRobotApiVersionByName } from '../discovery'
@@ -97,7 +97,7 @@ export const getEapOptions = (
   return state.networking[robotName]?.eapOptions ?? []
 }
 
-// const API_MIN_DISCONNECT_VERSION = '3.17.0'
+const API_MIN_DISCONNECT_VERSION = '3.17.0-alpha.0'
 
 export const getCanDisconnect: (
   state: State,
@@ -108,12 +108,9 @@ export const getCanDisconnect: (
   getFeatureFlags,
   (list, apiVersion, featureFlags) => {
     const active = list.some(nw => nw.active)
-    // TODO(mc, 2020-03-03): replace disconnect feature flag with version check
-    // unit tests are in place to validate this switchover
-    const supportsDisconnect = featureFlags.enableWifiDisconnect
-    // const supportsDisconnect = Semver.valid(apiVersion)
-    //   ? Semver.gte(apiVersion, API_MIN_DISCONNECT_VERSION)
-    //   : false
+    const supportsDisconnect = Semver.valid(apiVersion)
+      ? Semver.gte(apiVersion, API_MIN_DISCONNECT_VERSION)
+      : false
 
     return Boolean(active && supportsDisconnect)
   }


### PR DESCRIPTION
## overview

This PR removes the Wi-Fi disconnect feature flag to promote the feature to release

## changelog

- feat(app): add Wi-Fi disconnect to app

## review requests

- [ ] If you connect a robot that reports an API version of 3.17.0-alpha.0 or higher to Wi-Fi, you should have an option in the Wi-Fi selector to disconnect

## risk assessment

Low

- Functionality that was "hidden" behind the feature flag has been smoke tested
- Version check logic that feature flag side-stepped is unit tested
