### PR TITLE
fix(api): fix blocking module tasks

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -128,9 +128,10 @@ class TempDeck(mod_abc.AbstractModule):
         to the nearest limit
         """
         await self.wait_for_is_running()
-        return await self.make_cancellable(
+        task = await self.make_cancellable(
             self._loop.create_task(self._driver.set_temperature(celsius))
         )
+        return await task
 
     async def start_set_temperature(self, celsius):
         """

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -128,9 +128,8 @@ class TempDeck(mod_abc.AbstractModule):
         to the nearest limit
         """
         await self.wait_for_is_running()
-        task = await self.make_cancellable(
-            self._loop.create_task(self._driver.set_temperature(celsius))
-        )
+        task = self._loop.create_task(self._driver.set_temperature(celsius))
+        await self.make_cancellable(task)
         return await task
 
     async def start_set_temperature(self, celsius):

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -126,11 +126,12 @@ class Thermocycler(mod_abc.AbstractModule):
                                            ramp_rate=ramp_rate,
                                            volume=volume)
         if hold_time:
-            await self.make_cancellable(self._loop.create_task(
-                                                self.wait_for_hold()))
+            task = await self.make_cancellable(self._loop.create_task(
+                self.wait_for_hold()))
         else:
-            await self.make_cancellable(self._loop.create_task(
-                                                self.wait_for_temp()))
+            task = await self.make_cancellable(self._loop.create_task(
+                self.wait_for_temp()))
+        await task
 
     async def _execute_cycle_step(self,
                                   step: types.ThermocyclerStep,
@@ -166,17 +167,19 @@ class Thermocycler(mod_abc.AbstractModule):
         self._total_cycle_count = repetitions
         self._total_step_count = len(steps)
 
-        await self.make_cancellable(
-                self._loop.create_task(self._execute_cycles(steps,
-                                                            repetitions,
-                                                            volume)))
+        task = await self.make_cancellable(
+            self._loop.create_task(self._execute_cycles(steps,
+                                                        repetitions,
+                                                        volume)))
+        await task
 
     async def set_lid_temperature(self, temperature: float):
         """ Set the lid temperature in deg Celsius """
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=temperature)
-        await self.make_cancellable(
+        task = await self.make_cancellable(
                 self._loop.create_task(self.wait_for_lid_temp()))
+        await task
 
     async def wait_for_lid_temp(self):
         """

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -126,11 +126,12 @@ class Thermocycler(mod_abc.AbstractModule):
                                            ramp_rate=ramp_rate,
                                            volume=volume)
         if hold_time:
-            task = await self.make_cancellable(self._loop.create_task(
-                self.wait_for_hold()))
+            task = self._loop.create_task(
+                self.wait_for_hold())
         else:
-            task = await self.make_cancellable(self._loop.create_task(
-                self.wait_for_temp()))
+            task = self._loop.create_task(
+                self.wait_for_temp())
+        await self.make_cancellable(task)
         await task
 
     async def _execute_cycle_step(self,
@@ -167,18 +168,19 @@ class Thermocycler(mod_abc.AbstractModule):
         self._total_cycle_count = repetitions
         self._total_step_count = len(steps)
 
-        task = await self.make_cancellable(
-            self._loop.create_task(self._execute_cycles(steps,
-                                                        repetitions,
-                                                        volume)))
+        task = self._loop.create_task(
+            self._execute_cycles(steps,
+                                 repetitions,
+                                 volume))
+        await self.make_cancellable(task)
         await task
 
     async def set_lid_temperature(self, temperature: float):
         """ Set the lid temperature in deg Celsius """
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=temperature)
-        task = await self.make_cancellable(
-                self._loop.create_task(self.wait_for_lid_temp()))
+        task = self._loop.create_task(self.wait_for_lid_temp())
+        await self.make_cancellable(task)
         await task
 
     async def wait_for_lid_temp(self):


### PR DESCRIPTION
When we switch to using make_cancellable, some functions weren't updated
with the correct usage pattern of
- await make_cancallable
- await the task returned by make_cancellable

This led to functions that created and queued the task, but wouldn't
actually wait for it to be done.

Closes #5312

## Testing
- Run a protocol that sets the temperature of a tempdeck and runs a thermocycler profile.
- Make sure the buttons in the app for controlling modules don't spin endlessly on tempdeck set temperature

## Risk Assessment
Low, very specific to modules. I do need help testing though since I don't have a thermocycler.