### PR TITLE
fix(api): fix update module firmware

### DIFF
--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -18,14 +18,14 @@ async def update_firmware(
 
         raises an UpdateError with the reason for the failure.
     """
-    cls = type(module)
     flash_port = await module.prep_for_update()
     kwargs: Dict[str, Any] = {
         'stdout': asyncio.subprocess.PIPE,
         'stderr': asyncio.subprocess.PIPE,
         'loop': loop
     }
-    successful, res = await cls.bootloader()(flash_port, firmware_file, kwargs)
+    successful, res = await module.bootloader()(
+        flash_port, firmware_file, kwargs)
     if not successful:
         log.info(f'Bootloader reponse: {res}')
         raise UpdateError(res)


### PR DESCRIPTION
# overview
CallBridger doesn't handle classmethods properly and therefore raises an attribute error when calling the bootloader function during module firmware update.

As discussed with @sfoster1:
this is just a quick fix for this issue and requires a refactor in the future, so that the entire call to hardware_control.modules.update.update happens in the module thread instead of the main thread like it is now.
closes #5314 

## review requests
- Update module firmware using the App and make sure the firmware version gets updated

## risk assessment
Should be low, though hardware_control.modules.update.update is not technically executing in the correct thread right now, and would require a refactor in the future