### PR TITLE
fix(app): fix tiprack in tip probe instructions when tipracks are shared

### DIFF
--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -584,12 +584,19 @@ export function client(dispatch) {
         })
         .map(t => t._id)
 
+      // ensure IDs are actually present in containers list
+      // RPC API as of 3.16 may return bogus tipracks in pipette tipracks list
+      const tipRacks = union(
+        tipRacksFromInstrument,
+        tipRacksFromContainers
+      ).filter(id => containers.some(c => c._id === id))
+
       update.pipettesByMount[mount] = {
         _id,
         mount,
         name,
         channels,
-        tipRacks: union(tipRacksFromInstrument, tipRacksFromContainers),
+        tipRacks,
         requestedAs: requested_as,
       }
     }

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -479,8 +479,20 @@ export const getTipracksByMount: (
   state: State
 ) => TiprackByMountMap = createSelector(
   getTipracks,
-  tipracks => ({
-    left: tipracks.find(tr => tr.calibratorMount === 'left') || null,
-    right: tipracks.find(tr => tr.calibratorMount === 'right') || null,
-  })
+  getPipettesByMount,
+  (tipracks, pipettesMap) => {
+    return PIPETTE_MOUNTS.reduce<TiprackByMountMap>(
+      (tiprackMap, mount) => {
+        const byCalibrator = tipracks.find(tr => tr.calibratorMount === mount)
+        const byTiprackList = tipracks.find(tr =>
+          (pipettesMap[mount]?.tipRacks ?? []).includes(tr._id)
+        )
+
+        tiprackMap[mount] = byCalibrator ?? byTiprackList ?? null
+
+        return tiprackMap
+      },
+      { left: null, right: null }
+    )
+  }
 )

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -468,6 +468,8 @@ describe('api client', () => {
         },
       ]
 
+      session.containers = [{ _id: 3 }, { _id: 4 }, { _id: 5 }]
+
       return sendConnect().then(() =>
         expect(dispatch).toHaveBeenCalledWith(expected)
       )
@@ -555,7 +557,9 @@ describe('api client', () => {
           mount: 'right',
           name: 'p50',
           channels: 8,
-          tip_racks: [],
+          // guard against bogus tipracks in this array, which RPC API has been
+          // observed doing as of 3.16
+          tip_racks: [{ _id: 888 }],
           requested_as: 'foo',
         },
         {
@@ -563,7 +567,7 @@ describe('api client', () => {
           mount: 'left',
           name: 'p200',
           channels: 1,
-          tip_racks: [],
+          tip_racks: [{ _id: 999 }],
           requested_as: 'bar',
         },
       ]
@@ -581,9 +585,9 @@ describe('api client', () => {
         },
       ]
 
-      return sendConnect().then(() =>
+      return sendConnect().then(() => {
         expect(dispatch).toHaveBeenCalledWith(expected)
-      )
+      })
     })
 
     it('maps api modules to modules by slot', () => {

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -742,7 +742,7 @@ describe('robot selectors', () => {
       })
     })
 
-    it('getTipracksByMount', () => {
+    it('returns tipracks by calibratorMount with getTipracksByMount', () => {
       expect(getTipracksByMount(state)).toEqual({
         left: {
           slot: '2',
@@ -760,6 +760,65 @@ describe('robot selectors', () => {
           isTiprack: true,
           isMoving: true,
           calibration: 'moving-to-slot',
+          confirmed: false,
+          calibratorMount: 'right',
+          definition: null,
+        },
+      })
+    })
+
+    it('uses tiprack lists from pipettes in getTipracksByMount if no calibratorMount', () => {
+      state = makeState({
+        session: {
+          labwareBySlot: {
+            1: {
+              _id: 1,
+              slot: '1',
+              type: 's',
+              isTiprack: true,
+              calibratorMount: 'right',
+            },
+            2: {
+              _id: 2,
+              slot: '2',
+              type: 'm',
+              isTiprack: true,
+              calibratorMount: 'right',
+            },
+          },
+          pipettesByMount: {
+            left: { name: 'p200', mount: 'left', tipRacks: [2] },
+            right: { name: 'p50', mount: 'right', tipRacks: [1, 2] },
+          },
+        },
+        calibration: {
+          labwareBySlot: {},
+          confirmedBySlot: {},
+          calibrationRequest: { type: '', inProgress: false, error: null },
+          probedByMount: {},
+          tipOnByMount: {},
+        },
+      })
+
+      expect(getTipracksByMount(state)).toEqual({
+        left: {
+          _id: 2,
+          slot: '2',
+          type: 'm',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'right',
+          definition: null,
+        },
+        right: {
+          _id: 1,
+          slot: '1',
+          type: 's',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
           confirmed: false,
           calibratorMount: 'right',
           definition: null,


### PR DESCRIPTION
## overview

#5311 was a leftover from the fact that the RPC state is really not designed to allow sharing tipracks. This PR plugs up a few holes on the client side to get the tip-probe UI working properly if the two pipettes share a single tiprack:

- Ensure bogus tiprack objects that the RPC server reports in the pipettes' tip rack lists are filterd out
- Ensure the `tiprackByMount` selector falls back to looking at the pipettes' tip rack lists if the mount itself isn't listed as the `calibratorMount` for any tipracks

Closes #5311 

## changelog

- fix(app): fix tiprack in tip probe instructions when tipracks are shared

## review requests

Please smoke test for:

- [ ] Independent tipracks continue to work
- [ ] Shared tipracks now work properly

Note: If a single pipette interacts with multiple tipracks of _different_ types, the rendered UI will be technically deterministic, but unpredictable from a user standpoint. I don't believe we support this use case, and even if we did, it would require some dramatic re-working of the existing UI.

## risk assessment

Medium:

- All changes are covered by unit tests (👍)
- RPC is buggy and hard to reason with (👎)
