### PR TITLE
fix(app): ensure only one RPC connect request can go out at once

### DIFF
--- a/app/src/components/ConnectPanel/RobotItem.js
+++ b/app/src/components/ConnectPanel/RobotItem.js
@@ -1,43 +1,66 @@
 // @flow
-// item in a RobotList
-import { connect } from 'react-redux'
+// connected component for an item in a RobotList
+import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { withRouter, type ContextRouter } from 'react-router-dom'
 
-import { actions as robotActions } from '../../robot'
-import { getBuildrootUpdateAvailable } from '../../buildroot'
+import {
+  actions as RobotActions,
+  selectors as RobotSelectors,
+} from '../../robot'
+import { getBuildrootUpdateAvailable, UPGRADE } from '../../buildroot'
+import { CONNECTABLE } from '../../discovery'
 import { RobotListItem } from './RobotListItem.js'
 
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
 
-type OP = {| ...ContextRouter, robot: ViewableRobot |}
+export type RobotItemProps = {|
+  robot: ViewableRobot,
+|}
 
-type SP = {| upgradable: boolean, selected: boolean |}
+export const RobotItem = withRouter<_, _>(RobotItemComponent)
 
-type DP = {| connect: () => mixed, disconnect: () => mixed |}
+export function RobotItemComponent(props: {|
+  ...ContextRouter,
+  ...RobotItemProps,
+|}) {
+  const { robot, match } = props
+  const { name, displayName, status, local: isLocal } = robot
+  const isUpgradable = useSelector((state: State) => {
+    return getBuildrootUpdateAvailable(state, robot) === UPGRADE
+  })
+  const isConnectable = status === CONNECTABLE
+  // NOTE(mc, 2020-03-30): redundant && true to satisfy Flow
+  const isConnected = Boolean(robot.connected && true)
+  const isSelected = robot.name === match.params.name
+  const connectInProgress = useSelector(
+    (state: State) => RobotSelectors.getConnectRequest(state).inProgress
+  )
+  const dispatch = useDispatch<Dispatch>()
 
-export type RobotItemProps = {| ...OP, ...SP, ...DP |}
+  const handleToggleConnect = () => {
+    if (!connectInProgress) {
+      const action = isConnected
+        ? RobotActions.disconnect()
+        : RobotActions.connect(name)
 
-export const RobotItem = withRouter<_, _>(
-  connect<RobotItemProps, OP, SP, DP, State, Dispatch>(
-    mapStateToProps,
-    mapDispatchToProps
-  )(RobotListItem)
-)
-
-function mapStateToProps(state: State, ownProps: OP): SP {
-  const { robot } = ownProps
-  const updateType = getBuildrootUpdateAvailable(state, robot)
-
-  return {
-    upgradable: updateType === 'upgrade',
-    selected: ownProps.match.params.name === robot.name,
+      dispatch(action)
+    }
   }
-}
 
-function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
-  return {
-    connect: () => dispatch(robotActions.connect(ownProps.robot.name)),
-    disconnect: () => dispatch(robotActions.disconnect()),
-  }
+  return (
+    <RobotListItem
+      {...{
+        name,
+        displayName,
+        isConnectable,
+        isUpgradable,
+        isSelected,
+        isLocal,
+        isConnected,
+        onToggleConnect: handleToggleConnect,
+      }}
+    />
+  )
 }

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -1,46 +1,55 @@
 // @flow
-// list of robots
+// presentational component for an item in a RobotList
 import * as React from 'react'
 import { NotificationIcon, Icon, ToggleButton } from '@opentrons/components'
 
-import { CONNECTABLE } from '../../discovery'
 import { RobotLink } from './RobotLink'
 import styles from './styles.css'
 
-// circular type dependency, thanks flow
-import type { RobotItemProps } from './RobotItem'
+export type RobotListItemProps = {|
+  name: string,
+  displayName: string,
+  isConnectable: boolean,
+  isUpgradable: boolean,
+  isSelected: boolean,
+  isLocal: boolean,
+  isConnected: boolean,
+  onToggleConnect: () => mixed,
+|}
 
-export function RobotListItem(props: RobotItemProps) {
-  const { robot, selected, upgradable, connect, disconnect } = props
-  const { name, displayName, local, status } = robot
-  // unnecessary existence check to satisfy flow
-  const connected = robot.connected != null && robot.connected === true
-  const connectable = status === CONNECTABLE
-  const onClick = connected ? disconnect : connect
+export function RobotListItem(props: RobotListItemProps) {
+  const {
+    name,
+    displayName,
+    isConnectable,
+    isUpgradable,
+    isSelected,
+    isLocal,
+    isConnected,
+    onToggleConnect,
+  } = props
 
   return (
     <li className={styles.robot_group}>
       <RobotLink url={`/robots/${name}`} className={styles.robot_item}>
         <NotificationIcon
-          name={local ? 'usb' : 'wifi'}
+          name={isLocal ? 'usb' : 'wifi'}
           className={styles.robot_item_icon}
-          childName={upgradable ? 'circle' : null}
+          childName={isUpgradable ? 'circle' : null}
           childClassName={styles.notification}
         />
-
         <p className={styles.link_text}>{displayName}</p>
-
-        {connectable ? (
+        {isConnectable ? (
           <ToggleButton
-            toggledOn={connected}
-            onClick={onClick}
+            toggledOn={isConnected}
+            onClick={onToggleConnect}
             className={styles.robot_item_icon}
           />
         ) : (
           <Icon name="chevron-right" className={styles.robot_item_icon} />
         )}
       </RobotLink>
-      {connectable && selected && (
+      {isConnectable && isSelected && (
         <RobotLink
           url={`/robots/${name}/instruments`}
           className={styles.instrument_item}

--- a/app/src/components/ConnectPanel/__tests__/RobotItem.test.js
+++ b/app/src/components/ConnectPanel/__tests__/RobotItem.test.js
@@ -18,7 +18,7 @@ import type { State } from '../../../types'
 jest.mock('../../../buildroot/selectors')
 jest.mock('../../../robot/selectors')
 
-const getBuildrotUpdateAvailable: JestMockFn<
+const getBuildrootUpdateAvailable: JestMockFn<
   [State, any],
   $Call<typeof Buildroot.getBuildrootUpdateAvailable, State, any>
 > = Buildroot.getBuildrootUpdateAvailable
@@ -54,7 +54,7 @@ describe('ConnectPanel RobotItem', () => {
   }
 
   beforeEach(() => {
-    getBuildrotUpdateAvailable.mockReturnValue(null)
+    getBuildrootUpdateAvailable.mockReturnValue(null)
     getConnectRequest.mockReturnValue({
       inProgress: false,
       error: null,
@@ -106,7 +106,7 @@ describe('ConnectPanel RobotItem', () => {
   })
 
   it('renders an upgradable robot if buildroot upgrade available', () => {
-    getBuildrotUpdateAvailable.mockReturnValue(Buildroot.UPGRADE)
+    getBuildrootUpdateAvailable.mockReturnValue(Buildroot.UPGRADE)
 
     const robot = Fixtures.mockConnectableRobot
     const wrapper = render(robot)
@@ -116,7 +116,7 @@ describe('ConnectPanel RobotItem', () => {
   })
 
   it('renders not upgradable robot if buildroot downgrade available', () => {
-    getBuildrotUpdateAvailable.mockReturnValue(Buildroot.DOWNGRADE)
+    getBuildrootUpdateAvailable.mockReturnValue(Buildroot.DOWNGRADE)
 
     const robot = Fixtures.mockConnectableRobot
     const wrapper = render(robot)

--- a/app/src/components/ConnectPanel/__tests__/RobotItem.test.js
+++ b/app/src/components/ConnectPanel/__tests__/RobotItem.test.js
@@ -1,0 +1,181 @@
+// @flow
+import * as React from 'react'
+import { StaticRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+
+import * as Fixtures from '../../../discovery/__fixtures__'
+import {
+  actions as RobotActions,
+  selectors as RobotSelectors,
+} from '../../../robot'
+import * as Buildroot from '../../../buildroot'
+import { RobotItem } from '../RobotItem'
+import { RobotListItem } from '../RobotListItem'
+
+import type { State } from '../../../types'
+
+jest.mock('../../../buildroot/selectors')
+jest.mock('../../../robot/selectors')
+
+const getBuildrotUpdateAvailable: JestMockFn<
+  [State, any],
+  $Call<typeof Buildroot.getBuildrootUpdateAvailable, State, any>
+> = Buildroot.getBuildrootUpdateAvailable
+
+const getConnectRequest: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getConnectRequest, State>
+> = RobotSelectors.getConnectRequest
+
+describe('ConnectPanel RobotItem', () => {
+  const store = {
+    subscribe: () => {},
+    getState: () => ({ mockState: true }),
+    dispatch: jest.fn(),
+  }
+
+  const render = (robot = Fixtures.mockConnectableRobot, matchParams = {}) => {
+    // TODO(mc, 2020-03-30): upgrade react-router to 5.1 for hooks
+    // grab the wrapped component from react-router::withRouter
+    const Component = (RobotItem: any).WrappedComponent
+
+    const Wrapper = ({ children }: {| children: React.Node |}) => (
+      <Provider store={store}>
+        <StaticRouter location="/" context={{}}>
+          {children}
+        </StaticRouter>
+      </Provider>
+    )
+
+    return mount(<Component robot={robot} match={{ params: matchParams }} />, {
+      wrappingComponent: Wrapper,
+    })
+  }
+
+  beforeEach(() => {
+    getBuildrotUpdateAvailable.mockReturnValue(null)
+    getConnectRequest.mockReturnValue({
+      inProgress: false,
+      error: null,
+      name: '',
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders a RobotListItem with the robot', () => {
+    const robot = Fixtures.mockConnectableRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('name')).toBe(robot.name)
+    expect(item.prop('displayName')).toBe(robot.displayName)
+    expect(item.prop('isConnectable')).toBe(true)
+    expect(item.prop('isConnected')).toBe(false)
+  })
+
+  it('renders a connected robot', () => {
+    const robot = Fixtures.mockConnectedRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isConnectable')).toBe(true)
+    expect(item.prop('isConnected')).toBe(true)
+    expect(item.prop('isSelected')).toBe(false)
+  })
+
+  it('marks item as selected if route matches', () => {
+    const robot = Fixtures.mockConnectedRobot
+    const wrapper = render(robot, { name: robot.name })
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isSelected')).toBe(true)
+  })
+
+  it('renders a reachable but not connectable robot', () => {
+    const robot = Fixtures.mockReachableRobot
+    const wrapper = render(robot, { name: robot.name })
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isConnectable')).toBe(false)
+    expect(item.prop('isConnected')).toBe(false)
+    expect(item.prop('isSelected')).toBe(true)
+  })
+
+  it('renders an upgradable robot if buildroot upgrade available', () => {
+    getBuildrotUpdateAvailable.mockReturnValue(Buildroot.UPGRADE)
+
+    const robot = Fixtures.mockConnectableRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isUpgradable')).toBe(true)
+  })
+
+  it('renders not upgradable robot if buildroot downgrade available', () => {
+    getBuildrotUpdateAvailable.mockReturnValue(Buildroot.DOWNGRADE)
+
+    const robot = Fixtures.mockConnectableRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isUpgradable')).toBe(false)
+  })
+
+  it('renders as local if robot.local', () => {
+    const robot = { ...Fixtures.mockConnectableRobot, local: true }
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isLocal')).toBe(true)
+  })
+
+  it('renders as not local if not robot.local', () => {
+    const robot = { ...Fixtures.mockConnectableRobot, local: false }
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    expect(item.prop('isLocal')).toBe(false)
+  })
+
+  it('dispatches connect on toggleConnect if disconnected', () => {
+    const robot = Fixtures.mockConnectableRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    item.invoke('onToggleConnect')()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      RobotActions.connect(robot.name)
+    )
+  })
+
+  it('dispatches disconnect on toggleConnect if connected', () => {
+    const robot = Fixtures.mockConnectedRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    item.invoke('onToggleConnect')()
+
+    expect(store.dispatch).toHaveBeenCalledWith(RobotActions.disconnect())
+  })
+
+  it('dispatches nothing on toggleConnect if connect request in flight', () => {
+    getConnectRequest.mockReturnValue({
+      inProgress: true,
+      error: null,
+      name: 'foo',
+    })
+
+    const robot = Fixtures.mockConnectedRobot
+    const wrapper = render(robot)
+    const item = wrapper.find(RobotListItem)
+
+    item.invoke('onToggleConnect')()
+
+    expect(store.dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/ConnectPanel/__tests__/RobotListItem.test.js
+++ b/app/src/components/ConnectPanel/__tests__/RobotListItem.test.js
@@ -1,0 +1,113 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import { NotificationIcon, ToggleButton } from '@opentrons/components'
+import { RobotListItem } from '../RobotListItem'
+
+describe('ConnectPanel RobotListItem', () => {
+  const handleToggleConnect = jest.fn()
+
+  const render = ({
+    name = 'robot-name',
+    displayName = 'robot-display-name',
+    isConnectable = false,
+    isUpgradable = false,
+    isSelected = false,
+    isLocal = false,
+    isConnected = false,
+    connectToggleDisabled = false,
+    onToggleConnect = handleToggleConnect,
+  } = {}) => {
+    return shallow(
+      <RobotListItem
+        {...{
+          name,
+          displayName,
+          isConnectable,
+          isUpgradable,
+          isSelected,
+          isLocal,
+          isConnected,
+          onToggleConnect,
+        }}
+      />
+    )
+  }
+
+  it("renders the robot's displayName in a RobotLink", () => {
+    const wrapper = render()
+    const link = wrapper.find('RobotLink[url="/robots/robot-name"]')
+
+    expect(link.find('p').html()).toContain('robot-display-name')
+  })
+
+  it('renders a local notification icon', () => {
+    const wrapper = render({ isLocal: true })
+    const icon = wrapper.find(NotificationIcon)
+
+    expect(icon.prop('name')).toBe('usb')
+    expect(icon.prop('childName')).toBe(null)
+  })
+
+  it('renders a non-local notification icon', () => {
+    const wrapper = render({ isLocal: false })
+    const icon = wrapper.find(NotificationIcon)
+
+    expect(icon.prop('name')).toBe('wifi')
+    expect(icon.prop('childName')).toBe(null)
+  })
+
+  it('renders a notification icon with dot if upgradable', () => {
+    const wrapper = render({ isUpgradable: true })
+    const icon = wrapper.find(NotificationIcon)
+
+    expect(icon.prop('childName')).toBe('circle')
+  })
+
+  it('renders an instruments link if connectable and selected', () => {
+    let wrapper = render({ isConnectable: true, isSelected: true })
+    let link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
+
+    expect(link.find('p').html()).toMatch(/pipettes.+modules/i)
+
+    wrapper = render({ isConnectable: true, isSelected: false })
+    link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
+
+    expect(link).toHaveLength(0)
+
+    wrapper = render({ isConnectable: false, isSelected: true })
+    link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
+
+    expect(link).toHaveLength(0)
+  })
+
+  it('renders a connection toggle button if connectable', () => {
+    const wrapper = render({ isConnectable: true, isSelected: false })
+    const toggle = wrapper.find(ToggleButton)
+
+    toggle.invoke('onClick')()
+    expect(handleToggleConnect).toHaveBeenCalled()
+  })
+
+  it('renders a chevron-right instead of toggle if not connectable', () => {
+    const wrapper = render({ isConnectable: false, isSelected: false })
+    const toggle = wrapper.find(ToggleButton)
+    const chevron = wrapper.find('Icon[name="chevron-right"]')
+
+    expect(toggle).toHaveLength(0)
+    expect(chevron).toHaveLength(1)
+  })
+
+  it('renders a connection toggle depends on isConnected', () => {
+    let wrapper = render({ isConnectable: true, isConnected: false })
+    let toggle = wrapper.find(ToggleButton)
+
+    expect(toggle.prop('toggledOn')).toBe(false)
+
+    wrapper = render({ isConnectable: true, isConnected: true })
+    toggle = wrapper.find(ToggleButton)
+
+    expect(toggle.prop('toggledOn')).toBe(true)
+  })
+})

--- a/app/src/components/RobotSettings/__tests__/StatusCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/StatusCard.test.js
@@ -1,0 +1,141 @@
+// @flow
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+
+import * as Fixtures from '../../../discovery/__fixtures__'
+import {
+  actions as RobotActions,
+  selectors as RobotSelectors,
+} from '../../../robot'
+import { OutlineButton, Icon, LabeledValue } from '@opentrons/components'
+import { StatusCard } from '../StatusCard'
+
+import type { State } from '../../../types'
+import type { ViewableRobot } from '../../../discovery/types'
+
+jest.mock('../../../robot/selectors')
+
+const getSessionStatus: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getSessionStatus, any>
+> = RobotSelectors.getSessionStatus
+
+const getConnectRequest: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getConnectRequest, any>
+> = RobotSelectors.getConnectRequest
+
+describe('RobotSettings StatusCard', () => {
+  const store = {
+    dispatch: jest.fn(),
+    getState: () => ({ mockState: true }),
+    subscribe: () => {},
+  }
+
+  const render = (robot: ViewableRobot = Fixtures.mockConnectableRobot) => {
+    return mount(<StatusCard robot={robot} />, {
+      wrappingComponent: Provider,
+      wrappingComponentProps: { store },
+    })
+  }
+
+  beforeEach(() => {
+    getSessionStatus.mockReturnValue('')
+    getConnectRequest.mockReturnValue({
+      inProgress: false,
+      name: '',
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should have a connect button', () => {
+    const wrapper = render()
+    const button = wrapper.find(OutlineButton)
+
+    expect(button.html()).toContain('connect')
+  })
+
+  it('dispatch connect on connect button click if disconnected', () => {
+    const wrapper = render()
+    const button = wrapper.find(OutlineButton)
+
+    button.invoke('onClick')()
+    expect(store.dispatch).toHaveBeenCalledWith(
+      RobotActions.connect(Fixtures.mockConnectableRobot.name)
+    )
+  })
+
+  it('should have a disconnect button if connected', () => {
+    const wrapper = render(Fixtures.mockConnectedRobot)
+    const button = wrapper.find(OutlineButton)
+
+    expect(button.html()).toContain('disconnect')
+  })
+
+  it('dispatch disconnect on button click if connected', () => {
+    const wrapper = render(Fixtures.mockConnectedRobot)
+    const button = wrapper.find(OutlineButton)
+
+    button.invoke('onClick')()
+    expect(store.dispatch).toHaveBeenCalledWith(RobotActions.disconnect())
+  })
+
+  // TODO(mc, 2020-03-30): add tooltip to button
+  it('connect button should be disabled if robot not connectable', () => {
+    const wrapper = render(Fixtures.mockReachableRobot)
+    const button = wrapper.find(OutlineButton)
+
+    expect(button.prop('disabled')).toBe(true)
+  })
+
+  // TODO(mc, 2020-03-30): add tooltip to button
+  it('connect button should be disabled with if connect in progress', () => {
+    getConnectRequest.mockReturnValue({
+      inProgress: true,
+      name: 'foobar',
+      error: null,
+    })
+
+    const wrapper = render()
+    const button = wrapper.find(OutlineButton)
+
+    expect(button.prop('disabled')).toBe(true)
+  })
+
+  it('connect button should have spinner if connect in progress to same robot', () => {
+    getConnectRequest.mockReturnValue({
+      inProgress: true,
+      name: Fixtures.mockConnectableRobot.name,
+      error: null,
+    })
+
+    const wrapper = render()
+    const button = wrapper.find(OutlineButton)
+    const icon = button.find(Icon)
+    expect(button.prop('disabled')).toBe(true)
+    expect(icon.prop('name')).toBe('ot-spinner')
+    expect(icon.prop('spin')).toBe(true)
+  })
+
+  it('displays unknown session status if not connected', () => {
+    const wrapper = render()
+    const status = wrapper.find(LabeledValue)
+
+    expect(status.html()).toMatch(/unknown/i)
+  })
+
+  // TODO(mc, 2020-03-30): https://github.com/Opentrons/opentrons/issues/1033
+  it('displays RPC session status if connected', () => {
+    getSessionStatus.mockReturnValue('running')
+
+    const wrapper = render(Fixtures.mockConnectedRobot)
+    const status = wrapper.find(LabeledValue)
+
+    expect(status.html()).toMatch(/running/i)
+  })
+})

--- a/app/src/discovery/__fixtures__/index.js
+++ b/app/src/discovery/__fixtures__/index.js
@@ -1,0 +1,64 @@
+// @flow
+
+import { CONNECTABLE, REACHABLE } from '../selectors'
+
+import type { Service, ResolvedRobot, Robot, ReachableRobot } from '../types'
+
+export const mockHealthResponse = {
+  name: 'robot-name',
+  api_version: '0.0.0-mock',
+  fw_version: '0.0.0-mock',
+  system_version: '0.0.0-mock',
+  logs: [],
+  protocol_api_version: [2, 0],
+}
+
+export const mockUpdateServerHealthResponse = {
+  name: 'robot-name',
+  apiServerVersion: '0.0.0-mock',
+  updateServerVersion: '0.0.0-mock',
+  smoothieVersion: '0.0.0-mock',
+  systemVersion: '0.0.0-mock',
+  capabilities: {},
+}
+
+export const mockService: $Exact<Service> = {
+  name: 'robot-name',
+  ip: null,
+  port: 31950,
+  local: true,
+  ok: null,
+  serverOk: null,
+  advertising: null,
+  health: null,
+  serverHealth: null,
+}
+
+export const mockResolvedRobot: ResolvedRobot = {
+  ...mockService,
+  ip: '127.0.0.1',
+  local: true,
+  ok: true,
+  serverOk: true,
+  displayName: 'robot-name',
+}
+
+export const mockConnectableRobot: Robot = {
+  ...mockResolvedRobot,
+  ok: true,
+  health: mockHealthResponse,
+  serverHealth: mockUpdateServerHealthResponse,
+  status: CONNECTABLE,
+  connected: false,
+}
+
+export const mockConnectedRobot: Robot = {
+  ...mockConnectableRobot,
+  connected: true,
+}
+
+export const mockReachableRobot: ReachableRobot = {
+  ...mockResolvedRobot,
+  ok: false,
+  status: REACHABLE,
+}

--- a/app/src/discovery/types.js
+++ b/app/src/discovery/types.js
@@ -27,7 +27,7 @@ export type ResolvedRobot = {|
 
 // fully connectable robot
 export type Robot = {|
-  ...$Exact<ResolvedRobot>,
+  ...ResolvedRobot,
   ok: true,
   health: $NonMaybeType<$PropertyType<Service, 'health'>>,
   status: ConnectableStatus,
@@ -36,7 +36,7 @@ export type Robot = {|
 
 // robot with a known IP (i.e. advertising over mDNS) but unconnectable
 export type ReachableRobot = {|
-  ...$Exact<ResolvedRobot>,
+  ...ResolvedRobot,
   ok: false,
   status: ReachableStatus,
 |}

--- a/app/src/robot/api-client/__tests__/create-sessions.test.js
+++ b/app/src/robot/api-client/__tests__/create-sessions.test.js
@@ -6,12 +6,14 @@ import { actions as RobotActions } from '../../actions'
 import * as ProtocolSelectors from '../../../protocol/selectors'
 import * as DiscoverySelectors from '../../../discovery/selectors'
 import * as LabwareSelectors from '../../../custom-labware/selectors'
+import * as RobotSelectors from '../../selectors'
 import { MockSession } from '../../test/__fixtures__/session'
 
 jest.mock('../../../rpc/client')
 jest.mock('../../../protocol/selectors')
 jest.mock('../../../discovery/selectors')
 jest.mock('../../../custom-labware/selectors')
+jest.mock('../../selectors')
 
 const mockState = { state: true }
 const mockRobot = { name: 'robot-name', ip: '127.0.0.1', port: 31950 }
@@ -43,6 +45,7 @@ describe('RPC API client - session creation', () => {
     RpcClient.mockResolvedValue(mockRpcClient)
     DiscoverySelectors.getConnectableRobots.mockReturnValue([mockRobot])
     LabwareSelectors.getCustomLabwareDefinitions.mockReturnValue([])
+    RobotSelectors.getConnectRequest.mockReturnValue({ inProgress: false })
 
     const _receive = client(mockDispatch)
     const _flush = () => new Promise(resolve => setTimeout(resolve, 0))

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -99,6 +99,7 @@ export function client(dispatch) {
   }
 
   function connect(state, action) {
+    if (selectors.getConnectRequest(state).inProgress) return
     if (rpcClient) disconnect()
 
     const name = action.payload.name

--- a/app/src/robot/constants.js
+++ b/app/src/robot/constants.js
@@ -5,35 +5,30 @@ import type { Mount, Slot } from './types'
 export const _NAME = 'robot'
 
 // connection states
-// TODO(mc, 2018-01-11): remove constant exports in favor of flowtype
-export const DISCONNECTED = 'disconnected'
-export const CONNECTING = 'connecting'
-export const CONNECTED = 'connected'
-export const DISCONNECTING = 'disconnecting'
-export type ConnectionStatus =
-  | 'disconnected'
-  | 'connecting'
-  | 'connected'
-  | 'disconnecting'
+export const DISCONNECTED: 'disconnected' = 'disconnected'
+export const CONNECTING: 'connecting' = 'connecting'
+export const CONNECTED: 'connected' = 'connected'
+export const DISCONNECTING: 'disconnecting' = 'disconnecting'
 
 // session status (api/opentrons/api/session.py::VALID_STATES)
-// TODO(mc, 2018-01-11): remove constant exports in favor of flowtype
-export const RUNNING = 'running'
-export const PAUSED = 'paused'
-export const FINISHED = 'finished'
+export const LOADED: 'loaded' = 'loaded'
+export const RUNNING: 'running' = 'running'
+export const FINISHED: 'finished' = 'finished'
+export const STOPPED: 'stopped' = 'stopped'
+export const PAUSED: 'paused' = 'paused'
+export const ERROR: 'error' = 'error'
 
 // labware confirmation states
 // TODO(mc, 2018-01-11): remove constant exports in favor of types.js
-export const UNCONFIRMED = 'unconfirmed'
-export const MOVING_TO_SLOT = 'moving-to-slot'
-export const OVER_SLOT = 'over-slot'
-export const PICKING_UP = 'picking-up'
-export const HOMING = 'homing'
-export const HOMED = 'homed'
-export const UPDATING = 'updating'
-export const UPDATED = 'updated'
-export const CONFIRMING = 'confirming'
-export const CONFIRMED = 'confirmed'
+export const UNCONFIRMED: 'unconfirmed' = 'unconfirmed'
+export const MOVING_TO_SLOT: 'moving-to-slot' = 'moving-to-slot'
+export const JOGGING: 'jogging' = 'jogging'
+export const DROPPING_TIP: 'dropping-tip' = 'dropping-tip'
+export const OVER_SLOT: 'over-slot' = 'over-slot'
+export const PICKING_UP: 'picking-up' = 'picking-up'
+export const PICKED_UP: 'picked-up' = 'picked-up'
+export const CONFIRMING: 'confirming' = 'confirming'
+export const CONFIRMED: 'confirmed' = 'confirmed'
 
 // deck layout
 export const PIPETTE_MOUNTS: Array<Mount> = ['left', 'right']

--- a/app/src/robot/reducer/connection.js
+++ b/app/src/robot/reducer/connection.js
@@ -68,7 +68,9 @@ function handleConnect(
     payload: { name },
   } = action
 
-  return { ...state, connectRequest: { inProgress: true, error: null, name } }
+  return !state.connectRequest.inProgress
+    ? { ...state, connectRequest: { inProgress: true, error: null, name } }
+    : state
 }
 
 function handleConnectResponse(

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -6,19 +6,19 @@ import { createSelector } from 'reselect'
 import { format } from 'date-fns'
 
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
-import { getLatestLabwareDef } from '../getLabware'
-import { PIPETTE_MOUNTS, DECK_SLOTS } from './constants'
-import { getLabwareDefBySlot } from '../protocol/selectors'
 import { getCustomLabwareDefinitions } from '../custom-labware/selectors'
+import { getLabwareDefBySlot } from '../protocol/selectors'
+import { getLatestLabwareDef } from '../getLabware'
+import * as Constants from './constants'
 
 import type { OutputSelector } from 'reselect'
 import type { State } from '../types'
-import type { ConnectionStatus } from './constants'
 import type {
   Mount,
   Slot,
   Pipette,
   Labware,
+  ConnectionStatus,
   LabwareCalibrationStatus,
   LabwareType,
   SessionStatus,
@@ -33,11 +33,11 @@ const sessionRequest = (state: State) => session(state).sessionRequest
 const cancelRequest = (state: State) => session(state).cancelRequest
 
 export function isMount(target: ?string): boolean {
-  return PIPETTE_MOUNTS.indexOf(target) > -1
+  return Constants.PIPETTE_MOUNTS.indexOf(target) > -1
 }
 
 export function isSlot(target: ?string): boolean {
-  return DECK_SLOTS.indexOf(target) > -1
+  return Constants.DECK_SLOTS.indexOf(target) > -1
 }
 
 export function labwareType(labware: Labware): LabwareType {
@@ -52,22 +52,18 @@ export function getConnectedRobotName(state: State): string | null {
   return connection(state).connectedTo || null
 }
 
-export const getConnectionStatus: OutputSelector<
-  State,
-  void,
-  ConnectionStatus
-> = createSelector(
+export const getConnectionStatus: State => ConnectionStatus = createSelector(
   getConnectedRobotName,
   state => getConnectRequest(state).inProgress,
   state => connection(state).disconnectRequest.inProgress,
   state => connection(state).unexpectedDisconnect,
   (connectedTo, isConnecting, isDisconnecting, unexpectedDisconnect) => {
-    if (unexpectedDisconnect) return 'disconnected'
-    if (!connectedTo && isConnecting) return 'connecting'
-    if (connectedTo && !isDisconnecting) return 'connected'
-    if (connectedTo && isDisconnecting) return 'disconnecting'
+    if (unexpectedDisconnect) return Constants.DISCONNECTED
+    if (!connectedTo && isConnecting) return Constants.CONNECTING
+    if (connectedTo && !isDisconnecting) return Constants.CONNECTED
+    if (connectedTo && isDisconnecting) return Constants.DISCONNECTING
 
-    return 'disconnected'
+    return Constants.DISCONNECTED
   }
 )
 
@@ -237,21 +233,21 @@ export const getPipettes: State => Array<Pipette> = createSelector(
   (state: State) => calibration(state).probedByMount,
   (state: State) => calibration(state).tipOnByMount,
   (pipettesByMount, probedByMount, tipOnByMount): Array<Pipette> => {
-    return PIPETTE_MOUNTS.filter(mount => pipettesByMount[mount] != null).map(
-      mount => {
-        const pipette = pipettesByMount[mount]
-        const probed = probedByMount[mount] || false
-        const tipOn = tipOnByMount[mount] || false
+    return Constants.PIPETTE_MOUNTS.filter(
+      mount => pipettesByMount[mount] != null
+    ).map(mount => {
+      const pipette = pipettesByMount[mount]
+      const probed = probedByMount[mount] || false
+      const tipOn = tipOnByMount[mount] || false
 
-        return {
-          ...pipette,
-          probed,
-          tipOn,
-          modelSpecs: getPipetteModelSpecs(pipette.name) || null,
-          requestedAs: pipette.requestedAs || null,
-        }
+      return {
+        ...pipette,
+        probed,
+        tipOn,
+        modelSpecs: getPipetteModelSpecs(pipette.name) || null,
+        requestedAs: pipette.requestedAs || null,
       }
-    )
+    })
   }
 )
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -91,6 +91,7 @@ describe('api client', () => {
     [NAME]: {
       connection: {
         connectedTo: '',
+        connectRequest: { inProgress: false },
       },
     },
     discovery: {
@@ -213,6 +214,20 @@ describe('api client', () => {
       return sendConnect().then(() =>
         expect(dispatch).toHaveBeenCalledWith(expected)
       )
+    })
+
+    it('will not try to connect multiple RpcClients at one time', () => {
+      const state = {
+        ...STATE,
+        robot: {
+          ...STATE.robot,
+          connection: { connectRequest: { inProgress: true } },
+        },
+      }
+
+      return sendToClient(state, actions.connect(ROBOT_NAME)).then(() => {
+        expect(RpcClient).toHaveBeenCalledTimes(0)
+      })
     })
   })
 

--- a/app/src/robot/test/connection-reducer.test.js
+++ b/app/src/robot/test/connection-reducer.test.js
@@ -37,6 +37,28 @@ describe('robot reducer - connection', () => {
     })
   })
 
+  it('handles CONNECT action if connect already in flight', () => {
+    const state = {
+      connection: {
+        connectedTo: null,
+        connectRequest: {
+          inProgress: true,
+          error: null,
+          name: 'ot',
+        },
+      },
+    }
+    const action = {
+      type: 'robot:CONNECT',
+      payload: { name: 'someone-else' },
+    }
+
+    expect(getState(reducer(state, action))).toEqual({
+      connectedTo: null,
+      connectRequest: { inProgress: true, error: null, name: 'ot' },
+    })
+  })
+
   it('handles CONNECT_RESPONSE success', () => {
     const state = {
       connection: {

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -1,13 +1,38 @@
 // @flow
 // common robot types
-import {
-  type PipetteModelSpecs,
-  type PipetteChannels,
-  type LabwareDefinition2,
+
+import type {
+  PipetteModelSpecs,
+  PipetteChannels,
+  LabwareDefinition2,
 } from '@opentrons/shared-data'
+
 import type { Mount } from '@opentrons/components'
 
+import typeof {
+  DISCONNECTED,
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTING,
+  LOADED,
+  RUNNING,
+  FINISHED,
+  STOPPED,
+  PAUSED,
+  ERROR,
+  UNCONFIRMED,
+  MOVING_TO_SLOT,
+  JOGGING,
+  DROPPING_TIP,
+  OVER_SLOT,
+  PICKING_UP,
+  PICKED_UP,
+  CONFIRMING,
+  CONFIRMED,
+} from './constants'
+
 import * as ApiTypes from './api-types'
+
 export * from './api-types'
 
 // TODO Ian 2018-02-27 files that import from here should just import from @opentrons/components directly
@@ -34,17 +59,16 @@ export type RobotService = {
   port: number,
 }
 
-// TODO(mc, 2018-01-11): collapse a bunch of these into something like MOVING
 export type LabwareCalibrationStatus =
-  | 'unconfirmed'
-  | 'moving-to-slot'
-  | 'jogging'
-  | 'dropping-tip'
-  | 'over-slot'
-  | 'picking-up'
-  | 'picked-up'
-  | 'confirming'
-  | 'confirmed'
+  | UNCONFIRMED
+  | MOVING_TO_SLOT
+  | JOGGING
+  | DROPPING_TIP
+  | OVER_SLOT
+  | PICKING_UP
+  | PICKED_UP
+  | CONFIRMING
+  | CONFIRMED
 
 // protocol command as returned by the API
 export type Command = {
@@ -120,12 +144,18 @@ export type SessionModule = $Diff<ApiTypes.ApiSessionModule, {| name: mixed |}>
 
 export type SessionStatus =
   | ''
-  | 'loaded'
-  | 'running'
-  | 'paused'
-  | 'error'
-  | 'finished'
-  | 'stopped'
+  | LOADED
+  | RUNNING
+  | FINISHED
+  | STOPPED
+  | PAUSED
+  | ERROR
+
+export type ConnectionStatus =
+  | DISCONNECTED
+  | CONNECTING
+  | CONNECTED
+  | DISCONNECTING
 
 export type SessionUpdate = {|
   state: SessionStatus,


### PR DESCRIPTION
## overview

This PR patches a couple weird usability issues with the RPC client/server interaction. The RPC server is a broadcast server; it will issue messages to all connected WebSockets, and it does not care if the same client establishes multiple WebSockets.

On the app end, if the client creates multiple connections to the RPC server, weird things can and do happen in the app state because it's not built to handle this. In lieu of messing around with the RPC server, which is generally too dangerous to touch without good reason / care, this PR adds multiple layers of protection on the client side to prevent multiple RPC connections from being established simultaneously:

1. At the UI level, the two connection buttons will be disabled if there is a connection request in flight
2. At the state level, if a connect action still manages to happen even though the buttons are disabled, the state reducer will throw away any new connect action if there is already a connect in progress
3. At the RPC client worker level, if a connect action manages to make it to the worker even though the buttons are disabled, the client worker will also throw away the action if a connect is already in progress

In addition to the buttons getting disabled, this PR adds a spinner state to the main "connect" button when the request is in-flight. **While the toggle is fully disabled when a request is in flight, I chose not to gray it out.** My reasoning behind this choice was:

- Every single toggle in the list would gray out for a second when the request is in flight, which might look funny
- Clicking on the toggle automatically brings you to the robot page, where you will see the main connect button replaced with a spinner

Closes #5241, closes #5307

### longer term plans

In the long term, the RPC server will be replaced. Clicking the "connect" button will, instead of doing this whole RPC handshake + serialization + deserialization dance, make a single HTTP request to lock the robot control. Further seeding of state once control has been granted will happen in the background over multiple HTTP requests, with the UI gracefully updating as those requests come back

## changelog

- fix(app): ensure only one RPC connect request can go out at once

## review requests

- Try to get the app into a weird connection state! Take a look at 5241 and 5307 for some examples

## risk assessment

**Medium**

- Code that touches RPC functionality is risky because the whole system is risky
- All changes were covered with unit tests
- Existing UI that had no unit tests were given tests for good measure
