### PR TITLE
fix(api): fix magdeck engage kwargs logic and offset_to_labware_bottom val for Gen1

### DIFF
--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -12,7 +12,9 @@ log = logging.getLogger('__name__')
 MAX_ENGAGE_HEIGHT = {  # mm from home position
     'magneticModuleV1': 45,
     'magneticModuleV2': 25}
-OFFSET_TO_LABWARE_BOTTOM = 5
+OFFSET_TO_LABWARE_BOTTOM = {
+    'magneticModuleV1': 10,
+    'magneticModuleV2': 5}
 
 FIRST_GEN2_REVISION = 20
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -337,10 +337,12 @@ class MagneticModuleContext(ModuleContext):
         :param offset: An offset relative to the default height for the labware
                        in mm
         """
-        if height:
+        if height is not None:
             dist = height
-        elif height_from_base and self._ctx._api_version >= APIVersion(2, 2):
-            dist = height_from_base + modules.magdeck.OFFSET_TO_LABWARE_BOTTOM
+        elif height_from_base is not None and\
+                self._ctx._api_version >= APIVersion(2, 2):
+            dist = height_from_base +\
+                modules.magdeck.OFFSET_TO_LABWARE_BOTTOM[self._module.model()]
         elif self.labware and self.labware.magdeck_engage_height is not None:
             dist = self._determine_lw_engage_height()
             if offset:

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -387,8 +387,11 @@ def test_magdeck_gen1_labware_props(loop):
         mod.engage(offset=1)
     mod.engage(height=2)
     assert mod._module._driver.plate_height == 2
+    mod.engage(height=0)
+    assert mod._module._driver.plate_height == 0
     mod.engage(height_from_base=2)
-    assert mod._module._driver.plate_height == 2 + OFFSET_TO_LABWARE_BOTTOM
+    assert mod._module._driver.plate_height == 2 +\
+        OFFSET_TO_LABWARE_BOTTOM[mod._module.model()]
 
 
 def test_magdeck_gen2_labware_props(loop):
@@ -398,6 +401,8 @@ def test_magdeck_gen2_labware_props(loop):
     assert mod._module.current_height == 25
     with pytest.raises(ValueError):
         mod.engage(height=25.1)  # max engage height for gen2 is 25 mm
+    mod.engage(height=0)
+    assert mod._module.current_height == 0
 
 
 def test_module_compatibility(get_module_fixture, monkeypatch):


### PR DESCRIPTION
## overview

Currently, the magnetic module wrongly moves to the default labware engage height even if `magdeck.engage(height=0)` (home position) or `magdeck.engage(height_from_base=0)` (flush with the labware base) is called.

Also, the `OFFSET_TO_LABWARE_BOTTOM` for GEN1 should be 10 mm instead of 5 mm.

## changelog
- modify logic so that it won't evaluate `0` as falsy when checking for engage kwargs
- use different `OFFSET_TO_LABWARE_BOTTOM` values for GEN1 and GEN2 modules

## review requests
Magnetic Module Gen1:
- `engage(height=0)`: magnets should be at the home position
- `engage(height_from_base=0)`: magnets should be flush with the labware base at 10 mm

Magnetic Module Gen2:
- `engage(height=0)`: magnets should be at the home position
- `engage(height_from_base=0)`: magnets should be flush with the labware base at 5 mm

## risk assessment
Low risk, only affects magnetic module context