### PR TITLE
fix(api): move splitting: strip step postfix

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1483,7 +1483,7 @@ class SmoothieDriver_3_0_0:
             for ax in split_target.keys():
                 self.current[ax] = cached[ax]
 
-            split_postfix = step_postfix
+            split_postfix = step_postfix.strip()
             split_command = GCODES['MOVE'] + split_command_string
         else:
             split_prefix = ''

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -1061,7 +1061,7 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         == ['M55 M92 C100.0 G4P0.01 '
             'G0F60 M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005',
             'G0C1',
-            ' M54 M92 C3200 G4P0.01',
+            'M54 M92 C3200 G4P0.01',
             'G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 '
             'G0C20.3 G0C20',
             'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005']  # noqa(E501)
@@ -1083,7 +1083,7 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         == ['M55 M92 C100.0 G4P0.01 '
             'G0F60 M907 A0.1 B0.05 C2.0 X0.3 Y0.3 Z0.1 G4P0.005',
             'G0C20.3',
-            ' M54 M92 C3200 G4P0.01',
+            'M54 M92 C3200 G4P0.01',
             'G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 '
             'G0C20.3 G0C20',
             'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005']  # noqa(E501)
@@ -1115,7 +1115,7 @@ def test_move_splitting(smoothie, robot, monkeypatch):
         'M53 M92 B100.0 G4P0.01 G0F30 '
         'M907 A0.1 B1.5 C0.05 X0.3 Y0.3 Z0.1 G4P0.005',
         'G0B51',
-        ' M52 M92 B3200 G4P0.01',
+        'M52 M92 B3200 G4P0.01',
         'G0F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 '
         'G0B100.3 G0B100',
         'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005']


### PR DESCRIPTION
the motor controller board ignores commands that start with a space (?)
and so it wasn't restoring the old steps/mm setting and flipping back
the microstepping switch after moves.


## Testing
This problem is immediately apparent running a protocol with a gen2 multi, for instance
```python
metadata = {
    'apiLevel': '2.3'
}
​​
def run(ctx):
    p300_tiprack = ctx.load_labware('opentrons_96_tiprack_300ul','2','300ul tiprack')
​    p300 = ctx.load_instrument('p300_multi_gen2',mount='right',tip_racks=[p300_tiprack])
​    for index in range(10):
        p300.pick_up_tip()
        p300.return_tip()
```

There will be awful noises and the pipette will probably get a hard limit error. If you install this pr, that won't happen, and everything will be nice and quiet and smooth.

## Risk Assessment

Low - this is a one line (really, one-character) change for situations that only happen in the situation described above.