### PR TITLE
fix(api): fix missing arg in v1 move splitting during cache instr models

### DIFF
--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -300,7 +300,8 @@ class Robot(CommandPublisher):
                     splits[plunger_axis] = MoveSplit(split_distance=1,
                                                      split_current=1.5,
                                                      split_speed=1,
-                                                     after_time=1800)
+                                                     after_time=1800,
+                                                     fullstep=True)
             else:
                 name_value = None
                 home_current = self.config.high_current[plunger_axis]


### PR DESCRIPTION
## overview

This PR fixes a TypeError raised when the robot caches instrument models in PAPIv1 because of a missing arg in `MoveSplit()`, when a GEN2 multi is attached.

## Review Request
Upload a v1 protocol with a GEN2 multi attached, like this:
```python
from opentrons import labware, instruments
tiprack = labware.load('opentrons_96_tiprack_10ul', '1')

plate = labware.load('corning_96_wellplate_360ul_flat', '2')

pip = instruments.P10_Single(mount='left')

pip.pick_up_tip(tiprack.wells(0))
pip.drop_tip()

```