### PR TITLE
chore(docs): note that api 2.3 released in beta

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -97,7 +97,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.2     |          3.16.0             |
 +-------------+-----------------------------+
-|     2.3     |          3.17.0             |
+|     2.3     |          3.17.0 beta 0      |
 +-------------+-----------------------------+
 
 Changes in API Versions

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -97,7 +97,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.2     |          3.16.0             |
 +-------------+-----------------------------+
-|     2.3     |          3.17.0 beta 0      |
+|     2.3     |          3.17.0 (In Beta)   |
 +-------------+-----------------------------+
 
 Changes in API Versions


### PR DESCRIPTION
Make sure we don't confuse people by referencing a version that doesn't exist