### PR TITLE
refactor(api): don't unstick p20 multis

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1607,7 +1607,7 @@
         "min": 0,
         "max": 100
       },
-      "quirks": ["needsUnstick"]
+      "quirks": []
     },
     "p50_single_v1": {
       "name": "p50_single",


### PR DESCRIPTION
It's apparently not necessary?!

## Risk assessment

Low, just turns off this one thing