### PR TITLE
fix(api): avoid tc lid when pathing

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -39,7 +39,7 @@ def first_parent(loc: types.LocationLabware) -> Optional[str]:
     either a string naming a slot or a None if the location isn't
     associated with a slot """
 
-    # cycle-detecting recursive climnbing
+    # cycle-detecting recursive climbing
     seen: Set[types.LocationLabware] = set()
 
     # internal function to have the cycle detector different per call


### PR DESCRIPTION
When the thermocycler's lid is closed, you cannot move a pipette over it
- it's simply too tall. To avoid these failures, we have to go around.

This implements that behavior for a specific list of slot-slot moves,
avoiding the thermocycler by moving to the center of slot 5 after
retracting.

Closes #5263
