### PR TITLE
feat(api): Allow move, jog and tip handling for a cal session

### DIFF
--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -5,20 +5,70 @@ import logging
 import shutil
 import tempfile
 import traceback
+import typing
 
 from aiohttp import web
+from aiohttp.web_urldispatcher import UrlDispatcher
 
 from opentrons.config import CONFIG
 from opentrons.hardware_control.threaded_async_lock import ThreadedAsyncLock
 
 from .rpc import RPCServer
-from .http import HTTPServer
-from .endpoints.calibration.session import SessionManager
+from .http import HTTPServer, CalibrationRoutes
 from opentrons.api.routers import MainRouter
 from opentrons.hardware_control import ThreadManager
 
+from .endpoints.calibration.constants import ALLOWED_SESSIONS
+from .endpoints.calibration.session import (
+    SessionManager, CheckCalibrationSession)
+from .endpoints.calibration.util import CalibrationCheckState
+from .endpoints.calibration.models import (
+    CalibrationSessionStatus, LabwareStatus)
 
 log = logging.getLogger(__name__)
+
+
+def _format_links(
+        session: 'CheckCalibrationSession',
+        next: CalibrationCheckState,
+        router: UrlDispatcher) -> typing.Dict:
+    if session.state_machine.requires_move(next):
+        path = router.get('move', '')
+    else:
+        path = router.get(next.name, '')
+
+    params = session.format_params(next.name)
+    if path:
+        url = str(path.url_for(type=session.session_type))
+    else:
+        url = path
+    return {'links': {next.name: {'url': url, 'params': params}}}
+
+
+def status_response(
+        session: 'CheckCalibrationSession',
+        request: web.Request,
+        response: web.Response) -> web.Response:
+
+    current = session.state_machine.current_state.name
+    next = session.state_machine.next_state
+    links = _format_links(session, next, request.app.router)
+
+    lw_status = session.labware_status.values()
+
+    sess_status = CalibrationSessionStatus(
+        instruments=session.pipette_status,
+        currentStep=current,
+        nextSteps=links,
+        labware=[LabwareStatus(**data) for data in lw_status])
+    return web.json_response(text=sess_status.json(), status=response.status)
+
+
+def no_session_error_response(start_url: str, type: str) -> web.Response:
+    error_response = {
+        "message": f"No {type} session exists. Please create one.",
+        "links": {"createSession": {'url': start_url, 'params': {}}}}
+    return web.json_response(error_response, status=404)
 
 
 @web.middleware
@@ -42,6 +92,39 @@ async def error_middleware(request, handler):
     return response
 
 
+@web.middleware
+async def session_middleware(request, handler):
+    """
+    Middleware used for the calibration sub-app. This includes all routes
+    found in the :py:class:`.http:CalibrationRoutes` class.
+
+    *Note* Does NOT include old deck calibration endpoints.
+    """
+
+    session_type = request.match_info['type']
+    session_storage = request.app['com.opentrons.session_manager']
+
+    if session_type not in ALLOWED_SESSIONS:
+        message = f"Session of type {session_type} is not supported."
+        return web.json_response(message, status=403)
+
+    router = request.app.router
+    start_url = str(router.get('sessionStart').url_for(type=session_type))
+    session = session_storage.sessions.get(session_type)
+    if start_url == request.path and request.method == 'POST':
+        response = await handler(request)
+    elif not session:
+        response = no_session_error_response(start_url, session_type)
+    else:
+        response = await handler(request, session)
+
+    if response.text:
+        return response
+    else:
+        session = session_storage.sessions.get(session_type)
+        return status_response(session, request, response)
+
+
 # Support for running using aiohttp CLI.
 # See: https://docs.aiohttp.org/en/stable/web.html#command-line-interface-cli
 def init(hardware: ThreadManager = None,
@@ -56,14 +139,19 @@ def init(hardware: ThreadManager = None,
                      :py:attr:`opentrons.hardware`
     """
     app = web.Application(middlewares=[error_middleware])
+    app['com.opentrons.http'] = HTTPServer(app, CONFIG['log_dir'])
     app['com.opentrons.hardware'] = hardware
     app['com.opentrons.motion_lock'] = ThreadedAsyncLock()
     app['com.opentrons.rpc'] = RPCServer(
         app, MainRouter(
             hardware, lock=app['com.opentrons.motion_lock'], loop=loop))
     app['com.opentrons.response_file_tempdir'] = tempfile.mkdtemp()
-    app['com.opentrons.http'] = HTTPServer(app, CONFIG['log_dir'])
-    app['com.opentrons.session_manager'] = SessionManager()
+    calibration_app = web.Application(middlewares=[session_middleware])
+    calibration_app['com.opentrons.http'] = CalibrationRoutes(calibration_app)
+    calibration_app['com.opentrons.session_manager'] = SessionManager()
+    app.add_subapp('/calibration/', calibration_app)
+
+    app['calibration'] = calibration_app
 
     async def dispose_response_file_tempdir(app):
         temppath = app.get('com.opentrons.response_file_tempdir')

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -1,9 +1,11 @@
 import typing
+from uuid import UUID
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlDispatcher
 
+from .util import CalibrationCheckState
 from .session import CheckCalibrationSession
-from .models import CalibrationSessionStatus, LabwareStatus
+from .models import CalibrationSessionStatus, LabwareStatus, AttachedPipette
 
 ALLOWED_SESSIONS = ['check']
 TypeSession = typing.Tuple[str, typing.Optional[CheckCalibrationSession]]
@@ -16,6 +18,23 @@ def _fetch_type_and_session(request: web.Request) -> TypeSession:
     return session_type, session
 
 
+def _format_links(
+        session: 'CheckCalibrationSession',
+        next: CalibrationCheckState,
+        router: UrlDispatcher) -> typing.Dict:
+    if session.state_machine.requires_move(next):
+        path = router.get('move', '')
+        params = session.format_move_params(next.name)
+    else:
+        path = router.get(next.name, '')
+        params = {}
+    if path:
+        url = str(path.url_for(type=session.session_type))
+    else:
+        url = path
+    return {'links': {next.name: {'url': url, 'params': params}}}
+
+
 def _format_status(
         session: 'CheckCalibrationSession',
         router: UrlDispatcher) -> 'CalibrationSessionStatus':
@@ -23,19 +42,15 @@ def _format_status(
     # pydantic restricts dictionary keys that can be evaluated. Since
     # the session pipettes dictionary has a UUID as a key, we must first
     # convert the UUID to a hex string.
-    instruments = {token.hex: data for token, data in pips.items() if token}
+    instruments = {
+        token.hex: AttachedPipette(**data)
+        for token, data in pips.items() if token}
     current = session.state_machine.current_state.name
     next = session.state_machine.next_state
-    if next:
-        path = router.get(next.name, '')
-        if path:
-            url = str(path.url_for(type=session.session_type))
-        else:
-            url = path
-        links = {'links': {next.name: url}}
-    else:
-        links = {'links': {}}
+    links = _format_links(session, next, router)
+
     lw_status = session.labware_status.values()
+
     status = CalibrationSessionStatus(
         instruments=instruments,
         currentStep=current,
@@ -84,9 +99,10 @@ async def create_session(request):
     if not current_session:
         hardware = request.app['com.opentrons.hardware']
         await hardware.cache_instruments()
+        await hardware.set_lights(rails=True)
+        await hardware.home()
         new_session = CheckCalibrationSession(hardware)
         session_storage.sessions[session_type] = new_session
-
         response = _format_status(new_session, request.app.router)
         return web.json_response(text=response.json(), status=201)
     else:
@@ -117,14 +133,15 @@ async def delete_session(request):
 
 
 async def load_labware(request: web.Request) -> web.Response:
-    _, session = _fetch_type_and_session(request)
+    session_type, session = _fetch_type_and_session(request)
     if not session:
         error_response = {
             "message": f"No {session_type} session exists. Please create one.",
             "links": {"createSession": f"/calibration/{session_type}/session"}}
         return web.json_response(error_response, status=404)
+    session.load_labware_objects()
     response = _format_status(session, request.app.router)
-    return web.json_response(response, status=200)
+    return web.json_response(text=response.json(), status=200)
 
 
 async def move(request: web.Request) -> web.Response:
@@ -136,11 +153,11 @@ async def move(request: web.Request) -> web.Response:
         return web.json_response(error_response, status=404)
     req = await request.json()
     pipette = req.get("pipetteId")
-    position = req.get("location")
-
-    session.move(pipette, position)
+    loc = req.get("location")
+    position = {"locationId": UUID(loc["locationId"]), "offset": loc["offset"]}
+    await session.move(UUID(pipette), position)
     response = _format_status(session, request.app.router)
-    return web.json_response(response, status=200)
+    return web.json_response(text=response.json(), status=200)
 
 
 async def jog(request):
@@ -153,9 +170,9 @@ async def jog(request):
     req = await request.json()
     pipette = req.get("pipetteId")
     vector = req.get("vector")
-    session.jog(pipette, vector)
+    await session.jog(UUID(pipette), vector)
     response = _format_status(session, request.app.router)
-    return web.json_response(response, status=200)
+    return web.json_response(text=response.json(), status=200)
 
 
 async def pick_up_tip(request):
@@ -166,18 +183,18 @@ async def pick_up_tip(request):
             "links": {"createSession": f"/calibration/{session_type}/session"}}
         return web.json_response(error_response, status=404)
     req = await request.json()
-    pipette = req.get("pipetteId")
-    vector = req.get("vector")
-    try:
-        session.pick_up_tip(pipette)
+    pipette = UUID(req.get("pipetteId"))
+    if not session.get_pipette(pipette).has_tip:
+        await session.pick_up_tip(pipette)
         response = _format_status(session, request.app.router)
-        return web.json_response(response, status=200)
-    except AssertionError:
+        return web.json_response(text=response.json(), status=200)
+    else:
+        invalidate_path = f"/calibration/{session_type}/session/invalidateTip"
         error_response = {
             "message": "Tip is already attached.",
             "links": {
                 "dropTip": f"/calibration/{session_type}/session/dropTip",
-                "invalidateTip": f"/calibration/{session_type}/session/invalidateTip"
+                "invalidateTip": invalidate_path
             }
         }
         return web.json_response(error_response, status=409)
@@ -191,10 +208,17 @@ async def invalidate_tip(request):
             "links": {"createSession": f"/calibration/{session_type}/session"}}
         return web.json_response(error_response, status=404)
     req = await request.json()
-    pipette_id = req.get("pipetteId")
-    session.invalidate_tip(pipette_id)
-    response = _format_status(session, request.app.router)
-    return web.json_response(response, status=200)
+    pipette = UUID(req.get("pipetteId"))
+    if session.get_pipette(pipette).has_tip:
+        session.invalidate_tip(pipette)
+        response = _format_status(session, request.app.router)
+        return web.json_response(text=response.json(), status=200)
+    else:
+        error_response = {
+            "message": f"No tip attached to {pipette} pipette.",
+            "links": {
+                "pickUpTip": f"/calibration/{session_type}/session/pickUpTip"}}
+        return web.json_response(error_response, status=409)
 
 
 async def drop_tip(request):
@@ -205,7 +229,14 @@ async def drop_tip(request):
             "links": {"createSession": f"/calibration/{session_type}/session"}}
         return web.json_response(error_response, status=404)
     req = await request.json()
-    pipette = req.get("pipetteId")
-    session.return_tip(pipette)
-    response = _format_status(session, request.app.router)
-    return web.json_response(response, status=200)
+    pipette = UUID(req.get("pipetteId"))
+    if session.get_pipette(pipette).has_tip:
+        await session.return_tip(pipette)
+        response = _format_status(session, request.app.router)
+        return web.json_response(text=response.json(), status=200)
+    else:
+        error_response = {
+            "message": f"No tip attached to {pipette} pipette.",
+            "links": {
+                "pickUpTip": f"/calibration/{session_type}/session/pickUpTip"}}
+        return web.json_response(error_response, status=409)

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -31,7 +31,12 @@ def _format_status(
         instruments=instruments,
         currentStep=current,
         nextSteps=links,
+<<<<<<< HEAD
         labware=[LabwareStatus(**data) for data in lw_status])
+=======
+        sessionToken=session.token,
+        labware=[LabwareStatus(**lw) for lw in session.labware.values()])
+>>>>>>> feat(api): Add labware required to session status
     return status
 
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -1,65 +1,11 @@
-import typing
 from uuid import UUID
 from aiohttp import web
-from aiohttp.web_urldispatcher import UrlDispatcher
 
-from .util import CalibrationCheckState
-from .session import CheckCalibrationSession
-from .models import CalibrationSessionStatus, LabwareStatus, AttachedPipette
-
-ALLOWED_SESSIONS = ['check']
-TypeSession = typing.Tuple[str, typing.Optional[CheckCalibrationSession]]
+from opentrons import types
+from .session import CheckCalibrationSession, TipAttachError
 
 
-def _fetch_type_and_session(request: web.Request) -> TypeSession:
-    session_type = request.match_info['type']
-    session_storage = request.app['com.opentrons.session_manager']
-    session = session_storage.sessions.get(session_type)
-    return session_type, session
-
-
-def _format_links(
-        session: 'CheckCalibrationSession',
-        next: CalibrationCheckState,
-        router: UrlDispatcher) -> typing.Dict:
-    if session.state_machine.requires_move(next):
-        path = router.get('move', '')
-        params = session.format_move_params(next.name)
-    else:
-        path = router.get(next.name, '')
-        params = {}
-    if path:
-        url = str(path.url_for(type=session.session_type))
-    else:
-        url = path
-    return {'links': {next.name: {'url': url, 'params': params}}}
-
-
-def _format_status(
-        session: 'CheckCalibrationSession',
-        router: UrlDispatcher) -> 'CalibrationSessionStatus':
-    pips = session.pipette_status
-    # pydantic restricts dictionary keys that can be evaluated. Since
-    # the session pipettes dictionary has a UUID as a key, we must first
-    # convert the UUID to a hex string.
-    instruments = {
-        token.hex: AttachedPipette(**data)
-        for token, data in pips.items() if token}
-    current = session.state_machine.current_state.name
-    next = session.state_machine.next_state
-    links = _format_links(session, next, router)
-
-    lw_status = session.labware_status.values()
-
-    status = CalibrationSessionStatus(
-        instruments=instruments,
-        currentStep=current,
-        nextSteps=links,
-        labware=[LabwareStatus(**data) for data in lw_status])
-    return status
-
-
-async def get_session(request: web.Request) -> web.Response:
+async def get_session(request: web.Request, session) -> web.Response:
     """
     GET /calibration/check/session
 
@@ -67,17 +13,7 @@ async def get_session(request: web.Request) -> web.Response:
 
     Otherwise, this endpoint will return a 404 with links to the post request.
     """
-    session_type = request.match_info['type']
-    session_storage = request.app['com.opentrons.session_manager']
-    current_session = session_storage.sessions.get(session_type)
-    if current_session:
-        response = _format_status(current_session, request.app.router)
-        return web.json_response(text=response.json(), status=200)
-    else:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+    return web.json_response(status=200)
 
 
 async def create_session(request):
@@ -90,30 +26,25 @@ async def create_session(request):
     :py:class:`.models.CalibrationSessionStatus`
     """
     session_type = request.match_info['type']
-    if session_type not in ALLOWED_SESSIONS:
-        message = f"Session of type {session_type} is not supported."
-        return web.json_response(message, status=403)
-
     session_storage = request.app['com.opentrons.session_manager']
     current_session = session_storage.sessions.get(session_type)
     if not current_session:
-        hardware = request.app['com.opentrons.hardware']
-        await hardware.cache_instruments()
-        await hardware.set_lights(rails=True)
-        await hardware.home()
+        hardware = request.config_dict['com.opentrons.hardware']
+        await CheckCalibrationSession.build(hardware)
         new_session = CheckCalibrationSession(hardware)
         session_storage.sessions[session_type] = new_session
-        response = _format_status(new_session, request.app.router)
-        return web.json_response(text=response.json(), status=201)
+        return web.json_response(status=201)
     else:
+        router = request.app.router
+        path = router.get('sessionExit')
         error_response = {
             "message": f"A {session_type} session exists."
                        "Please delete to proceed.",
-            "links": {"deleteSession": f"/calibration/{session_type}/session"}}
+            "links": {"deleteSession": str(path.url_for(type=session_type))}}
         return web.json_response(error_response, status=409)
 
 
-async def delete_session(request):
+async def delete_session(request: web.Request, session):
     """
     DELETE /calibration/check/session
 
@@ -121,122 +52,92 @@ async def delete_session(request):
     """
     session_type = request.match_info['type']
     session_storage = request.app['com.opentrons.session_manager']
-    current_session = session_storage.sessions.get(session_type)
-    if not current_session:
-        response = {"message": f"A {session_type} session does not exist."}
-        return web.json_response(response, status=404)
-    else:
-        await current_session.delete_session()
-        del session_storage.sessions[session_type]
-        response = {'message': f"Successfully deleted {session_type} session."}
-        return web.json_response(response, status=200)
+
+    await session.delete_session()
+    del session_storage.sessions[session_type]
+    response = {'message': f"Successfully deleted {session_type} session."}
+    return web.json_response(response, status=200)
 
 
-async def load_labware(request: web.Request) -> web.Response:
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def load_labware(request: web.Request, session) -> web.Response:
     session.load_labware_objects()
-    response = _format_status(session, request.app.router)
-    return web.json_response(text=response.json(), status=200)
+    return web.json_response(status=200)
 
 
-async def move(request: web.Request) -> web.Response:
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def move(request: web.Request, session) -> web.Response:
     req = await request.json()
     pipette = req.get("pipetteId")
     loc = req.get("location")
-    position = {"locationId": UUID(loc["locationId"]), "offset": loc["offset"]}
+    position = {
+        "locationId": UUID(loc["locationId"]),
+        "offset": types.Point(*loc["offset"])}
     await session.move(UUID(pipette), position)
-    response = _format_status(session, request.app.router)
-    return web.json_response(text=response.json(), status=200)
+    return web.json_response(status=200)
 
 
-async def jog(request):
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def jog(request: web.Request, session: 'CheckCalibrationSession'):
     req = await request.json()
     pipette = req.get("pipetteId")
     vector = req.get("vector")
-    await session.jog(UUID(pipette), vector)
-    response = _format_status(session, request.app.router)
-    return web.json_response(text=response.json(), status=200)
+    await session.jog(UUID(pipette), types.Point(*vector))
+    return web.json_response(status=200)
 
 
-async def pick_up_tip(request):
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def pick_up_tip(
+        request: web.Request, session: 'CheckCalibrationSession'):
+    session_type = request.match_info['type']
+
     req = await request.json()
     pipette = UUID(req.get("pipetteId"))
-    if not session.get_pipette(pipette).has_tip:
+    try:
         await session.pick_up_tip(pipette)
-        response = _format_status(session, request.app.router)
-        return web.json_response(text=response.json(), status=200)
-    else:
-        invalidate_path = f"/calibration/{session_type}/session/invalidateTip"
+        return web.json_response(status=200)
+    except TipAttachError:
+        router = request.app.router
+        invalidate = router.get('invalidateTip')
+        drop = router.get('dropTip')
         error_response = {
             "message": "Tip is already attached.",
             "links": {
-                "dropTip": f"/calibration/{session_type}/session/dropTip",
-                "invalidateTip": invalidate_path
+                "dropTip": str(drop.url_for(type=session_type)),
+                "invalidateTip": str(invalidate.url_for(type=session_type))
             }
         }
         return web.json_response(error_response, status=409)
 
 
-async def invalidate_tip(request):
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def invalidate_tip(
+        request: web.Request, session: 'CheckCalibrationSession'):
+    session_type = request.match_info['type']
+
     req = await request.json()
     pipette = UUID(req.get("pipetteId"))
-    if session.get_pipette(pipette).has_tip:
-        session.invalidate_tip(pipette)
-        response = _format_status(session, request.app.router)
-        return web.json_response(text=response.json(), status=200)
-    else:
+    try:
+        await session.invalidate_tip(pipette)
+        return web.json_response(status=200)
+    except TipAttachError:
+        router = request.app.router
+        path = router.get('pickUpTip')
         error_response = {
             "message": f"No tip attached to {pipette} pipette.",
             "links": {
-                "pickUpTip": f"/calibration/{session_type}/session/pickUpTip"}}
+                "pickUpTip": str(path.url_for(type=session_type))}}
         return web.json_response(error_response, status=409)
 
 
-async def drop_tip(request):
-    session_type, session = _fetch_type_and_session(request)
-    if not session:
-        error_response = {
-            "message": f"No {session_type} session exists. Please create one.",
-            "links": {"createSession": f"/calibration/{session_type}/session"}}
-        return web.json_response(error_response, status=404)
+async def drop_tip(request: web.Request, session: 'CheckCalibrationSession'):
+    session_type = request.match_info['type']
+
     req = await request.json()
     pipette = UUID(req.get("pipetteId"))
-    if session.get_pipette(pipette).has_tip:
+    try:
         await session.return_tip(pipette)
-        response = _format_status(session, request.app.router)
-        return web.json_response(text=response.json(), status=200)
-    else:
+        return web.json_response(status=200)
+    except TipAttachError:
+        router = request.app.router
+        pickup = router.get('pickUpTip')
         error_response = {
             "message": f"No tip attached to {pipette} pipette.",
             "links": {
-                "pickUpTip": f"/calibration/{session_type}/session/pickUpTip"}}
+                "pickUpTip": str(pickup.url_for(type=session_type))}}
         return web.json_response(error_response, status=409)

--- a/api/src/opentrons/server/endpoints/calibration/constants.py
+++ b/api/src/opentrons/server/endpoints/calibration/constants.py
@@ -1,44 +1,43 @@
-from typing import Dict, Union, List
+from typing import Dict, Set
+from dataclasses import dataclass
 
-ALLOWED_SESSIONS = set(['check'])
+ALLOWED_SESSIONS = {'check'}
 
-LOOKUP_LABWARE: Dict[str, Dict[str, Union[List[str], str]]] = {
-    '10': {
-        'load_name': 'opentrons_96_tiprack_10ul',
-        'alternatives': [
+
+@dataclass
+class LabwareLookUp:
+    load_name: str
+    alternatives: Set[str]
+
+
+LOOKUP_LABWARE: Dict[str, LabwareLookUp] = {
+    '10': LabwareLookUp(
+        load_name='opentrons_96_tiprack_10ul',
+        alternatives={
             'opentrons_96_tiprack_20ul',
             'opentrons_96_filtertiprack_10ul',
-            'opentrons_96_filtertiprack_20ul']
-    },
-    '20': {
-        'load_name': 'opentrons_96_tiprack_20ul',
-        'alternatives': [
+            'opentrons_96_filtertiprack_20ul'}),
+    '20': LabwareLookUp(
+        load_name='opentrons_96_tiprack_20ul',
+        alternatives={
             'opentrons_96_tiprack_20ul',
             'opentrons_96_filtertiprack_10ul',
-            'opentrons_96_filtertiprack_20ul'
-        ]
-    },
-    '50': {
-        'load_name': 'opentrons_96_tiprack_300ul',
-        'alternatives': [
+            'opentrons_96_filtertiprack_20ul'}),
+    '50': LabwareLookUp(
+        load_name='opentrons_96_tiprack_300ul',
+        alternatives={
             'opentrons_96_tiprack_300ul',
-            'opentrons_96_filtertiprack_300ul',
-        ]
-    },
-    '300': {
-        'load_name': 'opentrons_96_tiprack_300ul',
-        'alternatives': [
-            'opentrons_96_tiprack_300ul',
-            'opentrons_96_filtertiprack_300ul',
-        ]
-    },
-    '1000': {
-        'load_name': 'opentrons_96_tiprack_1000ul',
-        'alternatives': [
-            'opentrons_96_tiprack_1000ul',
-            'opentrons_96_filtertiprack_1000ul',
-        ]
-    }
+            'opentrons_96_filtertiprack_300ul'}),
+    '300': LabwareLookUp(
+         load_name='opentrons_96_tiprack_300ul',
+         alternatives={
+             'opentrons_96_tiprack_300ul',
+             'opentrons_96_filtertiprack_300ul'}),
+    '1000': LabwareLookUp(
+          load_name='opentrons_96_tiprack_1000ul',
+          alternatives={
+              'opentrons_96_tiprack_1000ul',
+              'opentrons_96_filtertiprack_1000ul'})
 }
 
 

--- a/api/src/opentrons/server/endpoints/calibration/constants.py
+++ b/api/src/opentrons/server/endpoints/calibration/constants.py
@@ -1,6 +1,6 @@
 from typing import Dict, Union, List
 
-ALLOWED_SESSIONS = ['check']
+ALLOWED_SESSIONS = set(['check'])
 
 LOOKUP_LABWARE: Dict[str, Dict[str, Union[List[str], str]]] = {
     '10': {
@@ -40,3 +40,11 @@ LOOKUP_LABWARE: Dict[str, Dict[str, Union[List[str], str]]] = {
         ]
     }
 }
+
+
+class LabwareLoaded(Exception):
+    pass
+
+
+class TipAttachError(Exception):
+    pass

--- a/api/src/opentrons/server/endpoints/calibration/constants.py
+++ b/api/src/opentrons/server/endpoints/calibration/constants.py
@@ -1,0 +1,42 @@
+from typing import Dict, Union, List
+
+ALLOWED_SESSIONS = ['check']
+
+LOOKUP_LABWARE: Dict[str, Dict[str, Union[List[str], str]]] = {
+    '10': {
+        'load_name': 'opentrons_96_tiprack_10ul',
+        'alternatives': [
+            'opentrons_96_tiprack_20ul',
+            'opentrons_96_filtertiprack_10ul',
+            'opentrons_96_filtertiprack_20ul']
+    },
+    '20': {
+        'load_name': 'opentrons_96_tiprack_20ul',
+        'alternatives': [
+            'opentrons_96_tiprack_20ul',
+            'opentrons_96_filtertiprack_10ul',
+            'opentrons_96_filtertiprack_20ul'
+        ]
+    },
+    '50': {
+        'load_name': 'opentrons_96_tiprack_300ul',
+        'alternatives': [
+            'opentrons_96_tiprack_300ul',
+            'opentrons_96_filtertiprack_300ul',
+        ]
+    },
+    '300': {
+        'load_name': 'opentrons_96_tiprack_300ul',
+        'alternatives': [
+            'opentrons_96_tiprack_300ul',
+            'opentrons_96_filtertiprack_300ul',
+        ]
+    },
+    '1000': {
+        'load_name': 'opentrons_96_tiprack_1000ul',
+        'alternatives': [
+            'opentrons_96_tiprack_1000ul',
+            'opentrons_96_filtertiprack_1000ul',
+        ]
+    }
+}

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Any
 from pydantic import BaseModel, Field, UUID4
 
 from opentrons.hardware_control.types import Axis
@@ -26,7 +26,10 @@ class AttachedPipette(BaseModel):
         Field(None, description="The axis that moves plunger of this pipette")
     pipette_id: Optional[str] =\
         Field(None, description="The serial number of the attached pipette")
-    has_tip: bool
+    has_tip: Optional[bool]=\
+        Field(None, description="Whether a tip is attached.")
+    tiprack_id: Optional[UUID4]=\
+        Field(None, description="Id of tiprack associated with this pip.")
 
     class Config:
         json_encoders = {
@@ -57,7 +60,7 @@ class CalibrationSessionStatus(BaseModel):
     """
     instruments: Dict[str, AttachedPipette]
     currentStep: str = Field(..., description="Current step of session")
-    nextSteps: Dict[str, Dict[str, str]] =\
+    nextSteps: Dict[str, Dict[str, Dict[str, Any]]] =\
         Field(..., description="Next Available Step in Session")
     labware: List[LabwareStatus]
 
@@ -87,7 +90,7 @@ class CalibrationSessionStatus(BaseModel):
                     "currentStep": "sessionStart",
                     "nextSteps": {
                         "links": {
-                            "loadLabware": ""
+                            "loadLabware": {"url": "", "params": {}}
                         }
                     }
 

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -26,6 +26,7 @@ class AttachedPipette(BaseModel):
         Field(None, description="The axis that moves plunger of this pipette")
     pipette_id: Optional[str] =\
         Field(None, description="The serial number of the attached pipette")
+    hasTip: bool
 
     class Config:
         json_encoders = {

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -26,7 +26,7 @@ class AttachedPipette(BaseModel):
         Field(None, description="The axis that moves plunger of this pipette")
     pipette_id: Optional[str] =\
         Field(None, description="The serial number of the attached pipette")
-    hasTip: bool
+    has_tip: bool
 
     class Config:
         json_encoders = {

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -1,11 +1,60 @@
 from typing import Dict, Optional, List, Any
+from functools import partial
 from pydantic import BaseModel, Field, UUID4
+from uuid import UUID
 
 from opentrons.hardware_control.types import Axis
 
 
-def convert_uuid(obj: UUID4):
+def convert_from_uuid(obj: UUID4):
     return obj.hex
+
+
+def convert_to_uuid(obj: str):
+    return UUID(obj)
+
+
+Point = List[float]
+
+# Commonly used Point type description and constraints
+PointField = partial(Field, ...,
+                     description="A point in deck coordinates (x, y, z)",
+                     min_items=3, max_items=3)
+
+
+class Position(BaseModel):
+    locationId: UUID4
+    offset: Point = PointField()
+
+    class Config:
+        json_encoders = {
+            UUID4: convert_to_uuid}
+
+
+class SpecificPipette(BaseModel):
+    pipetteId: UUID4
+
+    class Config:
+        json_encoders = {
+            UUID4: convert_to_uuid}
+
+
+class MoveLocation(BaseModel):
+    pipetteId: UUID4
+    location: Position
+
+    class Config:
+        json_encoders = {
+            UUID4: convert_to_uuid}
+
+
+class JogPosition(BaseModel):
+    pipetteId: UUID4
+    vector: Point = PointField()
+
+    class Config:
+        json_encoders = {
+            UUID4: convert_to_uuid}
 
 
 class AttachedPipette(BaseModel):
@@ -32,7 +81,7 @@ class AttachedPipette(BaseModel):
     class Config:
         json_encoders = {
             Axis: str,
-            UUID4: convert_uuid}
+            UUID4: convert_from_uuid}
 
 
 class LabwareStatus(BaseModel):
@@ -49,7 +98,7 @@ class LabwareStatus(BaseModel):
 
     class Config:
         json_encoders = {
-            UUID4: convert_uuid}
+            UUID4: convert_from_uuid}
 
 
 class CalibrationSessionStatus(BaseModel):
@@ -63,7 +112,7 @@ class CalibrationSessionStatus(BaseModel):
     labware: List[LabwareStatus]
 
     class Config:
-        json_encoders = {UUID4: convert_uuid}
+        json_encoders = {UUID4: convert_from_uuid}
         schema_extra = {
             "examples": [
                 {

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -24,11 +24,9 @@ class AttachedPipette(BaseModel):
         Field(None, description="The axis that moves this pipette up and down")
     plunger_axis: Optional[Axis] =\
         Field(None, description="The axis that moves plunger of this pipette")
-    pipette_id: Optional[str] =\
-        Field(None, description="The serial number of the attached pipette")
-    has_tip: Optional[bool]=\
+    has_tip: Optional[bool] =\
         Field(None, description="Whether a tip is attached.")
-    tiprack_id: Optional[UUID4]=\
+    tiprack_id: Optional[UUID4] =\
         Field(None, description="Id of tiprack associated with this pip.")
 
     class Config:

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -2,6 +2,7 @@ import typing
 from uuid import uuid4, UUID
 from dataclasses import dataclass, asdict
 
+from opentrons.types import Mount, Point
 from opentrons.hardware_control.types import Axis
 
 from .models import AttachedPipette
@@ -59,11 +60,8 @@ class CalibrationSession:
         self._pipettes = self._key_by_uuid(hardware.get_attached_instruments())
         self._hardware = hardware
         self._deck = geometry.Deck()
-<<<<<<< HEAD
         self._slot_options = ['8', '6']
         self._labware_info = self._determine_required_labware()
-=======
->>>>>>> feat(api): Add labware required to session status
 
     def _key_by_uuid(self, new_pipettes: typing.Dict) -> typing.Dict:
         pipette_dict = {}
@@ -118,6 +116,45 @@ class CalibrationSession:
         else:
             raise KeyError("No available slots remaining")
 
+    def _convert_to_mount(self, mount: str) -> Mount:
+        if mount == 'z':
+            return Mount.LEFT
+        else:
+            return Mount.RIGHT
+
+    def _jog(self, pipette: UUID, vector: Point):
+        """
+        General function that can be used by all session types to jog around
+        a specified pipette.
+        """
+        pip = self.get_pipette(pipette)
+        mount = pip['mount_axis']
+        self._hardware.move_rel(self._convert_to_mount(mount), vector)
+
+    def _add_tip(self, pipette: UUID, tip_length: float):
+        self._pipettes[pipette]['hasTip'] = True
+        self._pipettes[pipette]['tipLength'] = tip_length
+
+    def _remove_tip(self, pipette: UUID):
+        self._pipettes[pipette]['hasTip'] = False
+        self._pipettes[pipette]['tipLength'] = 0.0
+
+    def _has_tip(self, pipette: UUID) -> bool:
+        return self._pipettes[pipette]['hasTip']
+
+    def _pick_up_tip(self, pipette: UUID, tiprack: UUID):
+        pip = self.get_pipette(pipette)
+        mount = self._convert_to_mount(pip['mount_axis'])
+        lw_info = self.get_tiprack(tiprack)
+        tip_length = self._deck[lw_info.slot].tip_length
+        self._hardware.pick_up_tip(mount, tip_length)
+        self._add_tip(pipette, tip_length)
+
+    def _return_tip(self, pipette: UUID):
+        pip = self.get_pipette(pipette)
+        mount = self._convert_to_mount(pip['mount_axis'])
+        self._hardware.drop_tip(mount)
+
     async def cache_instruments(self):
         await self.hardware.cache_instruments()
         new_dict = self._key_by_uuid(self.hardware.get_attached_instruments())
@@ -130,6 +167,9 @@ class CalibrationSession:
 
     def get_pipette(self, uuid: UUID) -> 'AttachedPipette':
         return self._pipettes[uuid]
+
+    def get_tiprack(self, uuid: UUID):
+        return self._labware_info[uuid]
 
     @property
     def pipettes(self) -> typing.Dict:
@@ -149,6 +189,7 @@ class CheckCalibrationSession(CalibrationSession):
     def __init__(self, hardware: 'ThreadManager'):
         super().__init__(hardware)
         self.state_machine = CalibrationCheckMachine()
+        self._moves = Moves()
 
     def _load_labware_objects(self):
         """
@@ -160,3 +201,42 @@ class CheckCalibrationSession(CalibrationSession):
         for name, data in self._labware_info.items():
             parent = self._deck.position_for(data.slot)
             self._deck[data.slot] = labware.Labware(data.definition, parent)
+            'You cannot build a labware object during {curr_state} state.'
+        objs = {}
+        for name, data in self._lw_definitions.items():
+            parent = self._deck.position_for(data['slot'])
+            objs[name] = {
+                'object': labware.Labware(data['definition'], parent)}
+        self._lw_definitions.update(**objs)
+        self.state_machine.update_state()
+
+    def pick_up_tip(self, pipette: UUID):
+        curr_state = self.state_machine.current_state.name
+        assert curr_state == 'pickUpTip',\
+            f'You cannot pick up tip during {curr_state} state'
+        self._pick_up_tip(pipette)
+        self.state_machine.update_state()
+
+    def invalidate_tip(self, pipette: UUID):
+        self.state_machine.update_state(self.get_state('invalidateTip'))
+        curr_state = self.state_machine.current_state.name
+        assert curr_state == 'invalidateTip',\
+            f'You cannot remove a tip during {curr_state} state'
+        self._remove_tip(pipette)
+
+    def drop_tip(self, pipette: UUID):
+        curr_state = self.state_machine.current_state.name
+        assert curr_state == 'dropTip',\
+            f'You cannot drop a tip during {curr_state} state'
+        self._remove_tip(pipette)
+        self.state_machine.update_state()
+
+    def move(self, pipette: UUID, position: typing.Dict[str, typing.Union[UUID, typing.List]]):
+        assert position["locationId"] in self._moves.values()
+        pt = Point(position["location"])
+        self._move(pipette, pt)
+        self.state_machine.update_state()
+
+    def jog(self, pipette: UUID, vector: typing.List):
+        self._jog(pipette, Point(vector))
+        self.state_machine.update_state()

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -59,8 +59,11 @@ class CalibrationSession:
         self._pipettes = self._key_by_uuid(hardware.get_attached_instruments())
         self._hardware = hardware
         self._deck = geometry.Deck()
+<<<<<<< HEAD
         self._slot_options = ['8', '6']
         self._labware_info = self._determine_required_labware()
+=======
+>>>>>>> feat(api): Add labware required to session status
 
     def _key_by_uuid(self, new_pipettes: typing.Dict) -> typing.Dict:
         pipette_dict = {}

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -1,11 +1,11 @@
 import typing
 from uuid import uuid4, UUID
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 
 from opentrons.types import Mount, Point
 from opentrons.hardware_control.types import Axis
 
-from .models import AttachedPipette
+# from .models import AttachedPipette
 from .util import CalibrationCheckMachine
 from opentrons.hardware_control import ThreadManager
 from opentrons.protocol_api import labware, geometry
@@ -36,6 +36,33 @@ class SessionManager:
 
 
 @dataclass
+class Pipette:
+    model: typing.Optional[str]
+    name: typing.Optional[str]
+    tip_length: typing.Optional[float]
+    mount_axis: Axis
+    plunger_axis: typing.Optional[Axis]
+    pipette_id: typing.Optional[str]
+    has_tip: bool
+    max_volume: int
+    channels: int
+    tip_overlap: typing.Dict[str, int]
+    return_tip_height: int
+    tiprack_id: typing.Optional[UUID]
+
+
+@dataclass
+class PipetteStatus:
+    model: str
+    name: str
+    tip_length: float
+    mount_axis: Axis
+    plunger_axis: Axis
+    pipette_uuid: Axis
+    has_tip: bool
+
+
+@dataclass
 class LabwareInfo:
     """
     This class purely maps to :py:class:`.models.LabwareStatus` and is
@@ -54,6 +81,18 @@ class LabwareInfo:
     definition: labware.LabwareDefinition
 
 
+@dataclass
+class Moves:
+    """
+    This class is meant to encapsulate the different moves
+    """
+    moveToTipRack: typing.Optional[typing.Dict[UUID, Point]] = field(default_factory=dict)
+    checkPointOne: typing.Optional[typing.Dict[UUID, Point]] = field(default_factory=dict)
+    checkPointTwo: typing.Optional[typing.Dict[UUID, Point]] = field(default_factory=dict)
+    checkPointThree: typing.Optional[typing.Dict[UUID, Point]] = field(default_factory=dict)
+    checkHeight: typing.Optional[typing.Dict[UUID, Point]] = field(default_factory=dict)
+
+
 class CalibrationSession:
     """Class that controls state of the current deck calibration session"""
     def __init__(self, hardware: ThreadManager):
@@ -70,10 +109,16 @@ class CalibrationSession:
             # This is to ensure during testing that two pipettes are
             # attached -- for now.
             assert data, "Please attach pipettes before proceeding"
+            fields = list(Pipette.__dataclass_fields__.keys())
+
+            updated_data = {
+                key: value for key, value in data.items() if key in fields}
             token = uuid4()
-            data['mount_axis'] = Axis.by_mount(mount)
-            data['plunger_axis'] = Axis.of_plunger(mount)
-            pipette_dict[token] = {**data}
+            pipette_dict[token] = Pipette(
+                **updated_data,
+                mount_axis=Axis.by_mount(mount),
+                plunger_axis=Axis.of_plunger(mount),
+                tiprack_id=None)
         return pipette_dict
 
     def _determine_required_labware(self) -> typing.Dict[UUID, LabwareInfo]:
@@ -86,13 +131,16 @@ class CalibrationSession:
         _uuid: typing.Optional[UUID] = None
 
         for id, data in self._pipettes.items():
-            vol = data['max_volume']
+            max_vol = data.max_volume
+            # Gross workaround for the p50 pipette to use a 300ul tiprack.
+            vol = 300 if max_vol == 50 else max_vol
             load_name = LOAD_NAME.format(vol)
             if_labware = None
             if _uuid:
                 if_labware = lw.get(_uuid)
             if _uuid and if_labware and if_labware.loadName == load_name:
                 lw[_uuid].forPipettes.append(id)
+                self._pipettes[id].tiprack_id = _uuid
             else:
                 lw_def = labware.get_labware_definition(load_name)
                 alt_lw = [name.format(vol) for name in ALTERNATIVE_LABWARE]
@@ -108,6 +156,7 @@ class CalibrationSession:
                     version=lw_def['version'],
                     id=new_uuid,
                     definition=lw_def)
+                self._pipettes[id].tiprack_id = new_uuid
         return lw
 
     def _available_slot_options(self) -> str:
@@ -116,8 +165,8 @@ class CalibrationSession:
         else:
             raise KeyError("No available slots remaining")
 
-    def _convert_to_mount(self, mount: str) -> Mount:
-        if mount == 'z':
+    def _convert_to_mount(self, mount: Axis) -> Mount:
+        if mount == Axis.Z:
             return Mount.LEFT
         else:
             return Mount.RIGHT
@@ -128,23 +177,22 @@ class CalibrationSession:
         a specified pipette.
         """
         pip = self.get_pipette(pipette)
-        mount = pip['mount_axis']
-        self._hardware.move_rel(self._convert_to_mount(mount), vector)
+        self._hardware.move_rel(self._convert_to_mount(pip.mount_axis), vector)
 
     def _add_tip(self, pipette: UUID, tip_length: float):
-        self._pipettes[pipette]['hasTip'] = True
-        self._pipettes[pipette]['tipLength'] = tip_length
+        self._pipettes[pipette].hasTip = True
+        self._pipettes[pipette].tip_length = tip_length
 
     def _remove_tip(self, pipette: UUID):
-        self._pipettes[pipette]['hasTip'] = False
-        self._pipettes[pipette]['tipLength'] = 0.0
+        self._pipettes[pipette].hasTip = False
+        self._pipettes[pipette].tip_length = 0.0
 
     def _has_tip(self, pipette: UUID) -> bool:
-        return self._pipettes[pipette]['hasTip']
+        return self._pipettes[pipette].hasTip
 
     def _pick_up_tip(self, pipette: UUID, tiprack: UUID):
         pip = self.get_pipette(pipette)
-        mount = self._convert_to_mount(pip['mount_axis'])
+        mount = self._convert_to_mount(pip.mount_axis)
         lw_info = self.get_tiprack(tiprack)
         tip_length = self._deck[lw_info.slot].tip_length
         self._hardware.pick_up_tip(mount, tip_length)
@@ -152,8 +200,8 @@ class CalibrationSession:
 
     def _return_tip(self, pipette: UUID):
         pip = self.get_pipette(pipette)
-        mount = self._convert_to_mount(pip['mount_axis'])
-        self._hardware.drop_tip(mount)
+        self._hardware.drop_tip(pip.mount_axis)
+        self._remove_tip
 
     async def cache_instruments(self):
         await self.hardware.cache_instruments()
@@ -165,7 +213,7 @@ class CalibrationSession:
     def hardware(self) -> ThreadManager:
         return self._hardware
 
-    def get_pipette(self, uuid: UUID) -> 'AttachedPipette':
+    def get_pipette(self, uuid: UUID) -> Pipette:
         return self._pipettes[uuid]
 
     def get_tiprack(self, uuid: UUID):
@@ -174,6 +222,16 @@ class CalibrationSession:
     @property
     def pipettes(self) -> typing.Dict:
         return self._pipettes
+
+    @property
+    def pipette_status(self) -> typing.Dict:
+        fields = list(PipetteStatus.__dataclass_fields__.keys())
+        to_dict = {}
+        for name, value in self.pipettes.items():
+            data = asdict(value)
+            to_dict[name] = {
+                key: value for key, value in data.items() if key in fields}
+        return to_dict
 
     @property
     def labware_status(self) -> typing.Dict:
@@ -189,54 +247,78 @@ class CheckCalibrationSession(CalibrationSession):
     def __init__(self, hardware: 'ThreadManager'):
         super().__init__(hardware)
         self.state_machine = CalibrationCheckMachine()
+        self.session_type = 'check'
         self._moves = Moves()
+        self._load_labware_objects()
 
     def _load_labware_objects(self):
         """
         A function that takes tiprack information and loads them onto the deck.
         """
-        curr_state = self.state_machine.current_state.name
-        assert curr_state == 'loadLabware',\
-            f'You cannot build a labware object during {curr_state} state.'
+        # curr_state = self.state_machine.current_state.name
+        # assert curr_state == 'loadLabware',\
+        #     f'You cannot build a labware object during {curr_state} state.'
         for name, data in self._labware_info.items():
             parent = self._deck.position_for(data.slot)
             self._deck[data.slot] = labware.Labware(data.definition, parent)
-            'You cannot build a labware object during {curr_state} state.'
-        objs = {}
-        for name, data in self._lw_definitions.items():
-            parent = self._deck.position_for(data['slot'])
-            objs[name] = {
-                'object': labware.Labware(data['definition'], parent)}
-        self._lw_definitions.update(**objs)
-        self.state_machine.update_state()
+            self._moves.moveToTipRack[data.id] = Point(0, 0, 0)
+        # self.state_machine.update_state()
+
+    def _update_tiprack_offset(self, pipette: UUID) -> UUID:
+        pip = self.get_pipette(pipette)
+        tiprack_id = pip.tiprack_id
+        mount = self._convert_to_mount(pip.mount_axis)
+        old_offset = self._moves.moveToTipRack[tiprack_id]
+        self._moves.moveToTipRack[tiprack_id] =\
+            self._hardware.gantry_position(mount) + old_offset
+        return tiprack_id
+
+    async def delete_session(self):
+        for name, data in self.pipettes.items():
+            state1 = self.state_machine.get_state('moveToTipRack')
+            self.state_machine.update_state(state1)
+            position = {
+                "location": Point(0, 0, 0), "locationId": data.tiprack_id}
+            self.move(name, position)
+            state2 = self.state_machine.get_state('dropTip')
+            self.state_machine.update_state(state2)
+            self.return_tip(name)
+        await current_session.hardware.home()
 
     def pick_up_tip(self, pipette: UUID):
+        tiprack_id = self._update_tiprack_offset(pipette)
         curr_state = self.state_machine.current_state.name
         assert curr_state == 'pickUpTip',\
             f'You cannot pick up tip during {curr_state} state'
-        self._pick_up_tip(pipette)
+        self._pick_up_tip(pipette, tiprack_id)
         self.state_machine.update_state()
 
     def invalidate_tip(self, pipette: UUID):
-        self.state_machine.update_state(self.get_state('invalidateTip'))
+        self.state_machine.update_state(self.state_machine.get_state('invalidateTip'))
         curr_state = self.state_machine.current_state.name
         assert curr_state == 'invalidateTip',\
             f'You cannot remove a tip during {curr_state} state'
         self._remove_tip(pipette)
 
-    def drop_tip(self, pipette: UUID):
+    def return_tip(self, pipette: UUID):
         curr_state = self.state_machine.current_state.name
         assert curr_state == 'dropTip',\
             f'You cannot drop a tip during {curr_state} state'
-        self._remove_tip(pipette)
+        self._return_tip(pipette)
         self.state_machine.update_state()
 
-    def move(self, pipette: UUID, position: typing.Dict[str, typing.Union[UUID, typing.List]]):
-        assert position["locationId"] in self._moves.values()
-        pt = Point(position["location"])
-        self._move(pipette, pt)
+    def move(self, pipette: UUID,
+             position: typing.Dict[str, typing.Union[UUID, typing.List]]):
+        curr_state = self.state_machine.current_state.name
+        print(curr_state)
+        get_position = getattr(self._moves, curr_state)
+        print(get_position)
+        print(type(get_position))
+        offset = get_position[position["locationId"]]
+        pt = Point(*position["location"]) + offset
+        self.hardware.move(pipette, pt)
         self.state_machine.update_state()
 
     def jog(self, pipette: UUID, vector: typing.List):
-        self._jog(pipette, Point(vector))
+        self._jog(pipette, Point(*vector))
         self.state_machine.update_state()

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -130,7 +130,7 @@ class CalibrationSession:
             pip_vol = self.get_pipette(mount)['max_volume']
 
             _lookup = LOOKUP_LABWARE[str(pip_vol)]
-            load_name: str = _lookup['load_name']  # type: ignore
+            load_name: str = _lookup.load_name
 
             if_labware = None
             if _uuid:
@@ -139,14 +139,14 @@ class CalibrationSession:
                 lw[_uuid].forPipettes.append(id)
                 self._relate_mount[id]['tiprack_id'] = _uuid
             else:
-                lw_def = labware.get_labware_definition(load_name)  # type: ignore  # NOQA(E501)
+                lw_def = labware.get_labware_definition(load_name)
                 new_uuid: UUID = uuid4()
                 _uuid = new_uuid
                 slot = self._available_slot_options()
                 lw[new_uuid] = LabwareInfo(
-                    alternatives=list(_lookup['alternatives']),
+                    alternatives=list(_lookup.alternatives),
                     forPipettes=[id],
-                    loadName=load_name,  # type: ignore
+                    loadName=load_name,
                     slot=slot,
                     namespace=lw_def['namespace'],
                     version=lw_def['version'],

--- a/api/src/opentrons/server/endpoints/calibration/util.py
+++ b/api/src/opentrons/server/endpoints/calibration/util.py
@@ -25,7 +25,6 @@ check_normal_relationship_dict = {
     CalibrationCheckState.checkPointTwo: CalibrationCheckState.checkPointThree,
     CalibrationCheckState.checkPointThree: CalibrationCheckState.checkHeight,
     CalibrationCheckState.checkHeight: CalibrationCheckState.sessionStart
-
 }
 
 exit = CalibrationCheckState.sessionExit

--- a/api/src/opentrons/server/endpoints/calibration/util.py
+++ b/api/src/opentrons/server/endpoints/calibration/util.py
@@ -130,11 +130,7 @@ class StateMachine(Generic[StateEnumType]):
         return self._iterate_thru_relationships(self.current_state)
 
     def requires_move(self, state: StateEnumType) -> bool:
-        move_state = self._move_relationship.get(state)
-        if move_state:
-            return True
-        else:
-            return False
+        return bool(self._move_relationship.get(state))
 
 
 class CalibrationCheckMachine(StateMachine[CalibrationCheckState]):

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -102,6 +102,26 @@ class HTTPServer(object):
             '/calibration/{type}/session', check.get_session)
         self.app.router.add_post(
             '/calibration/{type}/session', check.create_session)
+        self.app.router.add_post(
+            '/calibration/{type}/session/move', check.move)
+        self.app.router.add_post(
+            '/calibration/{type}/session/loadLabware',
+            check.load_labware,
+            name="loadLabware")
+        self.app.router.add_post(
+            '/calibration/{type}/session/pickUpTip',
+            check.pick_up_tip,
+            name="pickUpTip")
+        self.app.router.add_post(
+            '/calibration/{type}/session/invalidateTip',
+            check.invalidate_tip,
+            name="invalidateTip")
+        self.app.router.add_post(
+            '/calibration/{type}/session/dropTip',
+            check.drop_tip,
+            name="dropTip")
+        self.app.router.add_post(
+            '/calibration/{type}/session/jog', check.jog)
         self.app.router.add_delete(
             '/calibration/{type}/session',
             check.delete_session,

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -98,31 +98,38 @@ class HTTPServer(object):
         )
         self.app.router.add_get(
             '/settings/robot', settings.get_robot_settings)
+
+
+class CalibrationRoutes(object):
+    def __init__(self, app):
+        self.app = app
         self.app.router.add_get(
-            '/calibration/{type}/session', check.get_session)
+            '/{type}/session', check.get_session)
         self.app.router.add_post(
-            '/calibration/{type}/session', check.create_session)
+            '/{type}/session',
+            check.create_session,
+            name="sessionStart")
         self.app.router.add_post(
-            '/calibration/{type}/session/move', check.move, name="move")
+            '/{type}/session/move', check.move, name="move")
         self.app.router.add_post(
-            '/calibration/{type}/session/loadLabware',
+            '/{type}/session/loadLabware',
             check.load_labware,
             name="loadLabware")
         self.app.router.add_post(
-            '/calibration/{type}/session/pickUpTip',
+            '/{type}/session/pickUpTip',
             check.pick_up_tip,
             name="pickUpTip")
         self.app.router.add_post(
-            '/calibration/{type}/session/invalidateTip',
+            '/{type}/session/invalidateTip',
             check.invalidate_tip,
             name="invalidateTip")
         self.app.router.add_post(
-            '/calibration/{type}/session/dropTip',
+            '/{type}/session/dropTip',
             check.drop_tip,
             name="dropTip")
         self.app.router.add_post(
-            '/calibration/{type}/session/jog', check.jog, name="jog")
+            '/{type}/session/jog', check.jog, name="jog")
         self.app.router.add_delete(
-            '/calibration/{type}/session',
+            '/{type}/session',
             check.delete_session,
             name="sessionExit")

--- a/api/src/opentrons/server/http.py
+++ b/api/src/opentrons/server/http.py
@@ -103,7 +103,7 @@ class HTTPServer(object):
         self.app.router.add_post(
             '/calibration/{type}/session', check.create_session)
         self.app.router.add_post(
-            '/calibration/{type}/session/move', check.move)
+            '/calibration/{type}/session/move', check.move, name="move")
         self.app.router.add_post(
             '/calibration/{type}/session/loadLabware',
             check.load_labware,
@@ -121,7 +121,7 @@ class HTTPServer(object):
             check.drop_tip,
             name="dropTip")
         self.app.router.add_post(
-            '/calibration/{type}/session/jog', check.jog)
+            '/calibration/{type}/session/jog', check.jog, name="jog")
         self.app.router.add_delete(
             '/calibration/{type}/session',
             check.delete_session,

--- a/api/tests/opentrons/server/test_calibration_check.py
+++ b/api/tests/opentrons/server/test_calibration_check.py
@@ -1,0 +1,56 @@
+import pytest
+from opentrons import types
+
+from opentrons.server.endpoints.calibration.util import CalibrationCheckState
+
+
+@pytest.fixture
+async def test_setup(async_server, async_client):
+    hw = async_server['com.opentrons.hardware']._backend
+    hw._attached_instruments[types.Mount.LEFT] = {
+        'model': 'p10_single_v1', 'id': 'fake10pip'}
+    hw._attached_instruments[types.Mount.RIGHT] = {
+        'model': 'p300_single_v1', 'id': 'fake300pip'}
+    await async_client.post('/calibration/check/session')
+
+
+async def test_load_labware(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.loadLabware)
+    resp = await async_client.post('/calibration/check/session/loadLabware')
+    text = await resp.json()
+    print(text)
+
+
+async def test_move_to_position(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.move)
+    resp = await async_client.post('/calibration/check/session/move')
+    return None
+
+
+async def test_jog_pipette(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.jog)
+    resp = await async_client.post('/calibration/check/session/jog')
+    return None
+
+
+async def test_pickup_tip(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
+    resp = await async_client.post('/calibration/check/session/pickUpTip')
+    return None
+
+
+async def invalidateTip(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
+    resp = await async_client.post('/calibration/check/session/invalidateTip')
+
+
+async def test_drop_tip(async_client, async_server, test_setup):
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
+    resp = await async_client.post('/calibration/check/session/dropTip')
+    return None

--- a/api/tests/opentrons/server/test_calibration_check.py
+++ b/api/tests/opentrons/server/test_calibration_check.py
@@ -13,8 +13,9 @@ async def test_setup(async_server, async_client):
     hw._attached_instruments[types.Mount.RIGHT] = {
         'model': 'p300_single_v1', 'id': 'fake300pip'}
     resp = await async_client.post('/calibration/check/session')
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    # await sess.hardware.home()
+    cal_app = async_server['calibration']
+    sess = cal_app['com.opentrons.session_manager'].sessions['check']
+
     return await resp.json(), sess
 
 

--- a/api/tests/opentrons/server/test_calibration_check.py
+++ b/api/tests/opentrons/server/test_calibration_check.py
@@ -1,6 +1,7 @@
 import pytest
-from opentrons import types
+from uuid import UUID
 
+from opentrons import types
 from opentrons.server.endpoints.calibration.util import CalibrationCheckState
 
 
@@ -11,46 +12,134 @@ async def test_setup(async_server, async_client):
         'model': 'p10_single_v1', 'id': 'fake10pip'}
     hw._attached_instruments[types.Mount.RIGHT] = {
         'model': 'p300_single_v1', 'id': 'fake300pip'}
-    await async_client.post('/calibration/check/session')
+    resp = await async_client.post('/calibration/check/session')
+    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    # await sess.hardware.home()
+    return await resp.json(), sess
 
 
 async def test_load_labware(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(CalibrationCheckState.loadLabware)
+    _, sess = test_setup
+
     resp = await async_client.post('/calibration/check/session/loadLabware')
     text = await resp.json()
-    print(text)
+
+    # check that URL is for the move endpoint
+    assert text['nextSteps']['links']['moveToTipRack']['url'] ==\
+        '/calibration/check/session/move'
+
+    # check that params exist
+    assert text['nextSteps']['links']['moveToTipRack']['params']
+    assert sess._deck['8']
+    assert sess._deck['8'].name == 'opentrons_96_tiprack_10ul'
+    assert sess._deck['6']
+    assert sess._deck['6'].name == 'opentrons_96_tiprack_300ul'
 
 
 async def test_move_to_position(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(CalibrationCheckState.move)
-    resp = await async_client.post('/calibration/check/session/move')
-    return None
+    _, sess = test_setup
+    # load labware on deck to enable move
+    resp = await async_client.post('/calibration/check/session/loadLabware')
+    status = await resp.json()
+
+    id = list(status['instruments'].keys())[0]
+
+    mount = types.Mount.LEFT
+    tiprack_id = status['instruments'][id]['tiprack_id']
+    # temporarily convert back to UUID to access well location
+    uuid_tiprack = UUID(tiprack_id)
+    uuid_pipette = UUID(id)
+
+    well = sess._moves.moveToTipRack[uuid_tiprack][uuid_pipette]['well']
+
+    pos_dict = {'locationId': tiprack_id, 'offset': [0, 1, 0]}
+    resp = await async_client.post(
+        '/calibration/check/session/move',
+        json={'pipetteId': id, 'location': pos_dict})
+
+    curr_pos = await sess.hardware.gantry_position(mount)
+    assert curr_pos == (well.top()[0] + types.Point(0, 1, 0))
 
 
 async def test_jog_pipette(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
+    status, sess = test_setup
+
     sess.state_machine.update_state(CalibrationCheckState.jog)
-    resp = await async_client.post('/calibration/check/session/jog')
-    return None
+
+    id = list(status['instruments'].keys())[0]
+    mount = types.Mount.LEFT
+
+    old_pos = await sess.hardware.gantry_position(mount)
+    await async_client.post(
+        '/calibration/check/session/jog',
+        json={'pipetteId': id, 'vector': [0, -1, 0]})
+
+    new_pos = await sess.hardware.gantry_position(mount)
+
+    assert (new_pos - old_pos) == types.Point(0, -1, 0)
 
 
 async def test_pickup_tip(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
-    resp = await async_client.post('/calibration/check/session/pickUpTip')
-    return None
+    status, sess = test_setup
+    await async_client.post('/calibration/check/session/loadLabware')
+
+    sess.state_machine.update_state(CalibrationCheckState.jog)
+
+    id = list(status['instruments'].keys())[0]
+    resp = await async_client.post(
+        '/calibration/check/session/pickUpTip',
+        json={'pipetteId': id})
+    text = await resp.json()
+    assert text['instruments'][id]['has_tip'] is True
+    assert text['instruments'][id]['tip_length'] > 0.0
 
 
-async def invalidateTip(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
-    resp = await async_client.post('/calibration/check/session/invalidateTip')
+async def test_invalidate_tip(async_client, async_server, test_setup):
+    status, sess = test_setup
+    await async_client.post('/calibration/check/session/loadLabware')
+
+    sess.state_machine.update_state(CalibrationCheckState.jog)
+    id = list(status['instruments'].keys())[0]
+    resp = await async_client.post(
+        '/calibration/check/session/invalidateTip',
+        json={'pipetteId': id})
+    assert resp.status == 409
+    resp = await async_client.post(
+        '/calibration/check/session/pickUpTip',
+        json={'pipetteId': id})
+    text = await resp.json()
+    assert text['instruments'][id]['has_tip'] is True
+
+    resp = await async_client.post(
+        '/calibration/check/session/invalidateTip',
+        json={'pipetteId': id})
+    text = await resp.json()
+    assert text['instruments'][id]['has_tip'] is False
+    assert resp.status == 200
 
 
 async def test_drop_tip(async_client, async_server, test_setup):
-    sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(CalibrationCheckState.pickUpTip)
-    resp = await async_client.post('/calibration/check/session/dropTip')
-    return None
+    status, sess = test_setup
+    await async_client.post('/calibration/check/session/loadLabware')
+
+    sess.state_machine.update_state(CalibrationCheckState.dropTip)
+    id = list(status['instruments'].keys())[0]
+    resp = await async_client.post(
+        '/calibration/check/session/dropTip',
+        json={'pipetteId': id})
+    assert resp.status == 409
+
+    sess.state_machine.update_state(CalibrationCheckState.jog)
+    resp = await async_client.post(
+        '/calibration/check/session/pickUpTip',
+        json={'pipetteId': id})
+    text = await resp.json()
+    assert text['instruments'][id]['has_tip'] is True
+
+    sess.state_machine.update_state(CalibrationCheckState.dropTip)
+    resp = await async_client.post(
+        '/calibration/check/session/dropTip',
+        json={'pipetteId': id})
+    assert resp.status == 200
+    text = await resp.json()
+    assert text['instruments'][id]['has_tip'] is False

--- a/api/tests/opentrons/server/test_calibration_check_integration.py
+++ b/api/tests/opentrons/server/test_calibration_check_integration.py
@@ -44,8 +44,6 @@ async def test_integrated_calibration_check(async_client, test_setup):
     next_data, url = _interpret_status_results(
         status, 'moveToTipRack', curr_pip)
 
-    print(url)
-    print(next_data)
     resp = await async_client.post(url, json=next_data)
     status = await resp.json()
     assert list(status['nextSteps']['links'].keys())[0] == 'jog'

--- a/api/tests/opentrons/server/test_calibration_check_integration.py
+++ b/api/tests/opentrons/server/test_calibration_check_integration.py
@@ -1,0 +1,59 @@
+import pytest
+
+from opentrons import types
+
+
+@pytest.fixture
+async def test_setup(async_server, async_client):
+    hw = async_server['com.opentrons.hardware']._backend
+    hw._attached_instruments[types.Mount.LEFT] = {
+        'model': 'p10_single_v1', 'id': 'fake10pip'}
+    hw._attached_instruments[types.Mount.RIGHT] = {
+        'model': 'p300_multi_v1', 'id': 'fake300pip'}
+
+
+def _interpret_status_results(status, next_step, curr_pip):
+    next_request = status['nextSteps']['links'][next_step]
+    next_data = next_request.get('params', {})
+    next_url = next_request.get('url', '')
+    if next_url == '/calibration/check/session/move':
+        formatted_data = {
+            'pipetteId': curr_pip, 'location': next_data[curr_pip]}
+        return formatted_data, next_url
+    next_data['pipetteId'] = curr_pip
+    return next_data, next_url
+
+
+def _get_pipette(instruments, pip_name):
+    for name, data in instruments.items():
+        if pip_name == data['model']:
+            return name
+    return ''
+
+
+async def test_integrated_calibration_check(async_client, test_setup):
+    curr_pip = None
+    # TODO: Add in next move steps once they are completed
+    resp = await async_client.post('/calibration/check/session')
+
+    status = await resp.json()
+
+    assert list(status['nextSteps']['links'].keys())[0] == 'loadLabware'
+    curr_pip = _get_pipette(status['instruments'], 'p300_multi_v1')
+
+    next_data, url = _interpret_status_results(status, 'loadLabware', curr_pip)
+
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'moveToTipRack'
+    next_data, url = _interpret_status_results(
+        status, 'moveToTipRack', curr_pip)
+
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'jog'
+
+    next_data, url = _interpret_status_results(status, 'jog', curr_pip)
+    await async_client.post(url, json=next_data)
+
+    await async_client.delete('/calibration/check/session')

--- a/api/tests/opentrons/server/test_calibration_check_integration.py
+++ b/api/tests/opentrons/server/test_calibration_check_integration.py
@@ -16,12 +16,7 @@ def _interpret_status_results(status, next_step, curr_pip):
     next_request = status['nextSteps']['links'][next_step]
     next_data = next_request.get('params', {})
     next_url = next_request.get('url', '')
-    if next_url == '/calibration/check/session/move':
-        formatted_data = {
-            'pipetteId': curr_pip, 'location': next_data[curr_pip]}
-        return formatted_data, next_url
-    next_data['pipetteId'] = curr_pip
-    return next_data, next_url
+    return next_data[curr_pip], next_url
 
 
 def _get_pipette(instruments, pip_name):
@@ -49,6 +44,8 @@ async def test_integrated_calibration_check(async_client, test_setup):
     next_data, url = _interpret_status_results(
         status, 'moveToTipRack', curr_pip)
 
+    print(url)
+    print(next_data)
     resp = await async_client.post(url, json=next_data)
     status = await resp.json()
     assert list(status['nextSteps']['links'].keys())[0] == 'jog'

--- a/api/tests/opentrons/server/test_calibration_session.py
+++ b/api/tests/opentrons/server/test_calibration_session.py
@@ -26,8 +26,8 @@ async def test_start_session(async_client, test_setup):
     assert list(text.keys()) ==\
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text["currentStep"] == "sessionStart"
-    assert text["nextSteps"] == {"links": {"loadLabware": ""}}
-    print(text["labware"])
+    assert text["nextSteps"] ==\
+        {"links": {"loadLabware": "/calibration/check/session/loadLabware"}}
 
     first_lw = text["labware"][0]
     second_lw = text["labware"][1]
@@ -53,18 +53,11 @@ async def test_check_session(async_client, test_setup):
     text2 = await resp.json()
     assert text == text2
 
-<<<<<<< HEAD
     assert list(text2.keys()) ==\
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text2["currentStep"] == "sessionStart"
-    assert text2["nextSteps"] == {"links": {"loadLabware": ""}}
-=======
-    assert text["sessionToken"] == text2["sessionToken"]
-    assert list(text.keys()) ==\
-        ["instruments", "currentStep", "nextSteps", "sessionToken", "labware"]
-    assert text["currentStep"] == "sessionStart"
-    assert text["nextSteps"] == {"links": {"loadLabware": ""}}
->>>>>>> feat(api): Add labware required to session status
+    assert text2["nextSteps"] ==\
+        {"links": {"loadLabware": "/calibration/check/session/loadLabware"}}
 
 
 async def test_delete_session(async_client, async_server, test_setup):

--- a/api/tests/opentrons/server/test_calibration_session.py
+++ b/api/tests/opentrons/server/test_calibration_session.py
@@ -27,6 +27,7 @@ async def test_start_session(async_client, test_setup):
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text["currentStep"] == "sessionStart"
     assert text["nextSteps"] == {"links": {"loadLabware": ""}}
+    print(text["labware"])
 
     first_lw = text["labware"][0]
     second_lw = text["labware"][1]
@@ -52,10 +53,18 @@ async def test_check_session(async_client, test_setup):
     text2 = await resp.json()
     assert text == text2
 
+<<<<<<< HEAD
     assert list(text2.keys()) ==\
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text2["currentStep"] == "sessionStart"
     assert text2["nextSteps"] == {"links": {"loadLabware": ""}}
+=======
+    assert text["sessionToken"] == text2["sessionToken"]
+    assert list(text.keys()) ==\
+        ["instruments", "currentStep", "nextSteps", "sessionToken", "labware"]
+    assert text["currentStep"] == "sessionStart"
+    assert text["nextSteps"] == {"links": {"loadLabware": ""}}
+>>>>>>> feat(api): Add labware required to session status
 
 
 async def test_delete_session(async_client, async_server, test_setup):

--- a/api/tests/opentrons/server/test_calibration_session.py
+++ b/api/tests/opentrons/server/test_calibration_session.py
@@ -3,7 +3,7 @@ import enum
 
 from opentrons import types
 
-from opentrons.server.endpoints.calibration import util
+from opentrons.server.endpoints.calibration import util, constants
 
 
 @pytest.fixture
@@ -105,6 +105,9 @@ async def test_create_lw_object(async_client, test_setup):
     assert sess._deck['8'].name == 'opentrons_96_tiprack_10ul'
     assert sess._deck['6']
     assert sess._deck['6'].name == 'opentrons_96_tiprack_300ul'
+
+    with pytest.raises(constants.LabwareLoaded):
+        sess.load_labware_objects()
 
 
 def test_state_machine():

--- a/api/tests/opentrons/server/test_calibration_session.py
+++ b/api/tests/opentrons/server/test_calibration_session.py
@@ -27,7 +27,10 @@ async def test_start_session(async_client, test_setup):
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text["currentStep"] == "sessionStart"
     assert text["nextSteps"] ==\
-        {"links": {"loadLabware": "/calibration/check/session/loadLabware"}}
+        {'links': {
+            'loadLabware': {
+                'params': {}, 'url': '/calibration/check/session/loadLabware'}
+                }}
 
     first_lw = text["labware"][0]
     second_lw = text["labware"][1]
@@ -57,7 +60,10 @@ async def test_check_session(async_client, test_setup):
         ["instruments", "currentStep", "nextSteps", "labware"]
     assert text2["currentStep"] == "sessionStart"
     assert text2["nextSteps"] ==\
-        {"links": {"loadLabware": "/calibration/check/session/loadLabware"}}
+        {'links': {
+            'loadLabware': {
+                'params': {}, 'url': '/calibration/check/session/loadLabware'}
+                }}
 
 
 async def test_delete_session(async_client, async_server, test_setup):
@@ -78,11 +84,8 @@ async def test_create_lw_object(async_client, async_server, test_setup):
     # Create a session
     await async_client.post('/calibration/check/session')
     sess = async_server['com.opentrons.session_manager'].sessions['check']
-    sess.state_machine.update_state(sess.state_machine.current_state)
-    assert sess.state_machine.current_state ==\
-        util.CalibrationCheckState.loadLabware
-
-    sess._load_labware_objects()
+    sess.state_machine.update_state()
+    sess.load_labware_objects()
     assert sess._deck['8']
     assert sess._deck['8'].name == 'opentrons_96_tiprack_10ul'
     assert sess._deck['6']
@@ -125,14 +128,14 @@ def test_state_machine():
     state5 = sm.get_state('DecideToDoWork')
 
     assert sm.current_state.name == state1.name
-    sm.update_state(state1)
+    sm.update_state()
     assert sm.current_state.name == state2.name
-    sm.update_state(state2)
+    sm.update_state()
     assert sm.current_state.name == state1.name
-    sm.update_state(state1)
     sm.update_state(state3)
+    sm.update_state()
     assert sm.current_state.name == state4.name
-    sm.update_state(state4)
+    sm.update_state()
     assert sm.current_state.name == state5.name
-    sm.update_state(state5)
+    sm.update_state()
     assert sm.current_state.name == state1.name


### PR DESCRIPTION
## overview

Closes #5096. This PR lays the final ground work for the follow-up tickets in deck cal check. It adds functionality for pick up tip, drop tip, move.

## changelog

- Added in two more fields in an attached pipette status
- Add a parameter value for any move action which requires a saved offset
- Add in state updates to all endpoint facing methods from `CalibrationCheckSession`
- Ported the pipette info over to a dataclass
- Adds more tests in, including an incomplete integration test -- will finish once the other location PRs are done.

## review requests

Please play around with the endpoints in postman. I just need to fix-up jogging on the tiny client I made, then I will post it here.

Does state handling seem OK? Should I add in more states, or are the current states sufficient.

## risk assessment

Ensure no behavior for previously existing behavior is different.
