### PR TITLE
fix(api): allow protocol delay to be cancelled

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -215,7 +215,13 @@ class API(HardwareAPILike):
     async def delay(self, duration_s: int):
         """ Delay execution by pausing and sleeping.
         """
-        await self._backend.delay(duration_s)
+        self.pause()
+        if not self.is_simulator:
+            async def sleep_for_seconds(seconds: int):
+                await asyncio.sleep(seconds)
+            delay_task = self._loop.create_task(sleep_for_seconds(duration_s))
+            await self._execution_manager.register_cancellable_task(delay_task)
+        self.resume()
 
     async def cache_instruments(self,
                                 require:

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -242,6 +242,8 @@ class Controller:
         """
         return self._smoothie_driver.probe_axis(axis, distance)
 
+    # NOTE: this function is here for legacy support, delays are now
+    # handled at the hardware control api level
     async def delay(self, duration_s: int):
         """ Pause and sleep
         """

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -242,15 +242,6 @@ class Controller:
         """
         return self._smoothie_driver.probe_axis(axis, distance)
 
-    # NOTE: this function is here for legacy support, delays are now
-    # handled at the hardware control api level
-    async def delay(self, duration_s: int):
-        """ Pause and sleep
-        """
-        self.pause()
-        await asyncio.sleep(duration_s)
-        self.resume()
-
     def __del__(self):
         if hasattr(self, '_module_watcher'):
             loop = asyncio.get_event_loop()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -275,6 +275,8 @@ class Simulator:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position
 
+    # NOTE: this function is here for legacy support, delays are now
+    # handled at the hardware control api level
     async def delay(self, duration_s: int):
         """ Pause and unpause, but without the actual delay """
         self.pause()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -274,10 +274,3 @@ class Simulator:
     def probe(self, axis: str, distance: float) -> Dict[str, float]:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position
-
-    # NOTE: this function is here for legacy support, delays are now
-    # handled at the hardware control api level
-    async def delay(self, duration_s: int):
-        """ Pause and unpause, but without the actual delay """
-        self.pause()
-        self.resume()

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from opentrons import execute, types
-from opentrons.hardware_control import controller
+from opentrons.hardware_control import controller, api
 from opentrons.protocol_api.execute import ExceptionInProtocolError
 
 HERE = Path(__file__).parent
@@ -23,7 +23,7 @@ def mock_get_attached_instr(monkeypatch, virtual_smoothie_env):
     monkeypatch.setattr(controller.Controller,
                         'get_attached_instruments',
                         gai_mock)
-    monkeypatch.setattr(controller.Controller, 'delay', dummy_delay)
+    monkeypatch.setattr(api.API, 'delay', dummy_delay)
     gai_mock.return_value = {types.Mount.RIGHT: {'model': None, 'id': None},
                              types.Mount.LEFT: {'model': None, 'id': None}}
     return gai_mock


### PR DESCRIPTION
Fix bug where protocol delays were not able to be cancelled. Move delay responsibility up to the
hardware control api level.

Closes #5400

## review requests

- run both JSON and python protocols where last step is a delay
- confirm cancelling during delay works
- confirm delay still completes as expected if not cancelled

## risk assessment

relative small scope, as this only effects the delay function, but it effects its usage across all sources.
