### PR TITLE
feat(api): Allow moves to crosses and slot 5

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -358,11 +358,11 @@ class Deck(UserDict):
 
     def get_calibration_position(self, id: str) -> CalibrationPosition:
         calibration_position = next(
-            (pos for pos in self.calibration_positions if pos['id'] == id),
+            (pos for pos in self.calibration_positions if pos.id == id),
             None)
         if not calibration_position:
-            pos_ids = [pos['id'] for pos in self.calibration_positions]
-            raise ValueError(f'calibration position {pos_name} '
+            pos_ids = [pos.id for pos in self.calibration_positions]
+            raise ValueError(f'calibration position {id} '
                              'could not be found, '
                              f'valid calibration position ids are: {pos_ids}')
         return calibration_position

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -28,6 +28,7 @@ class CalibrationPosition:
     position: List[float]
     displayName: str
 
+
 class LabwareHeightError(Exception):
     pass
 

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -2,6 +2,7 @@ from collections import UserDict
 import functools
 import logging
 import json
+from dataclasses import dataclass
 from typing import Any, List, Optional, Set, Tuple, Dict
 
 from opentrons import types
@@ -11,11 +12,21 @@ from .labware import (Labware, Well,
                       quirks_from_any_parent)
 from .definitions import DeckItem
 from .module_geometry import ThermocyclerGeometry, ModuleGeometry, ModuleType
-from .types import CalibrationPosition
 
 
 MODULE_LOG = logging.getLogger(__name__)
 
+
+@dataclass
+class CalibrationPosition:
+    """
+    A point on the deck of a robot that is used to calibrate
+    aspects of the robot's movement system as defined by
+    opentrons/shared-data/deck/schemas/2.json
+    """
+    id: str
+    position: List[float]
+    displayName: str
 
 class LabwareHeightError(Exception):
     pass
@@ -354,7 +365,8 @@ class Deck(UserDict):
 
     @property
     def calibration_positions(self) -> List[CalibrationPosition]:
-        return self._definition['locations']['calibrationPoints']
+        raw_positions = self._definition['locations']['calibrationPoints']
+        return [CalibrationPosition(**pos) for pos in raw_positions]
 
     def get_calibration_position(self, id: str) -> CalibrationPosition:
         calibration_position = next(

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -5,12 +5,13 @@ import json
 from typing import Any, List, Optional, Set, Tuple, Dict
 
 from opentrons import types
+from opentrons.hardware_control.types import CriticalPoint
+from opentrons.system.shared_data import load_shared_data
 from .labware import (Labware, Well,
                       quirks_from_any_parent)
 from .definitions import DeckItem
 from .module_geometry import ThermocyclerGeometry, ModuleGeometry, ModuleType
-from opentrons.hardware_control.types import CriticalPoint
-from opentrons.system.shared_data import load_shared_data
+from .types import CalibrationPosition
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -352,19 +353,18 @@ class Deck(UserDict):
         return self._definition['locations']['orderedSlots']
 
     @property
-    def calibration_positions(self) -> List[Dict]:
+    def calibration_positions(self) -> List[CalibrationPosition]:
         return self._definition['locations']['calibrationPoints']
 
-    def get_calibration_position(self, pos_name: str):
-        positions = list(filter(lambda pos: 'C' in pos['id'],
-                                self.calibration_positions))
+    def get_calibration_position(self, id: str) -> CalibrationPosition:
         calibration_position = next(
-            (pos for pos in positions if pos['id'].startswith(pos_name)),
+            (pos for pos in self.calibration_positions if pos['id'] == id),
             None)
         if not calibration_position:
-            pos_ids = [pos['id'] for pos in positions]
-            raise ValueError(f'position {pos_name} could not be found,'
-                             f'valid deck slots are: {pos_ids}')
+            pos_ids = [pos['id'] for pos in self.calibration_positions]
+            raise ValueError(f'calibration position {pos_name} '
+                             'could not be found, '
+                             f'valid calibration position ids are: {pos_ids}')
         return calibration_position
 
     def get_collisions_for_item(self,

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -351,6 +351,22 @@ class Deck(UserDict):
         """ Return the definition of the loaded robot deck. """
         return self._definition['locations']['orderedSlots']
 
+    @property
+    def calibration_positions(self) -> List[Dict]:
+        return self._definition['locations']['calibrationPoints']
+
+    def get_calibration_position(self, pos_name: str):
+        positions = list(filter(lambda pos: 'C' in pos['id'],
+                                self.calibration_positions))
+        calibration_position = next(
+            (pos for pos in positions if pos['id'].startswith(pos_name)),
+            None)
+        if not calibration_position:
+            pos_ids = [pos['id'] for pos in positions]
+            raise ValueError(f'position {pos_name} could not be found,'
+                             f'valid deck slots are: {pos_ids}')
+        return calibration_position
+
     def get_collisions_for_item(self,
                                 slot_key: types.DeckLocation,
                                 item: DeckItem) -> Dict[types.DeckLocation,

--- a/api/src/opentrons/protocol_api/types.py
+++ b/api/src/opentrons/protocol_api/types.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
+from dataclasses import dataclass
 from .labware import Labware
 from .contexts import InstrumentContext, ProtocolContext, \
     MagneticModuleContext, TemperatureModuleContext
@@ -16,3 +17,16 @@ PipetteHandler = Callable[[Instruments, LoadedLabware, Any], None]
 MagneticModuleHandler = Callable[[MagneticModuleContext, Any], None]
 
 TemperatureModuleHandler = Callable[[TemperatureModuleContext, Any], None]
+
+# Deck definition types
+
+@dataclass
+class CalibrationPosition:
+    """
+    A point on the deck of a robot that is used to calibrate
+    aspects of the robot's movement system as defined by
+    opentrons/shared-data/deck/schemas/2.json
+    """
+    id: str
+    position: List[float]
+    displayName: str

--- a/api/src/opentrons/protocol_api/types.py
+++ b/api/src/opentrons/protocol_api/types.py
@@ -20,6 +20,7 @@ TemperatureModuleHandler = Callable[[TemperatureModuleContext, Any], None]
 
 # Deck definition types
 
+
 @dataclass
 class CalibrationPosition:
     """

--- a/api/src/opentrons/protocol_api/types.py
+++ b/api/src/opentrons/protocol_api/types.py
@@ -1,5 +1,4 @@
-from typing import Any, Callable, Dict, List
-from dataclasses import dataclass
+from typing import Any, Callable, Dict
 from .labware import Labware
 from .contexts import InstrumentContext, ProtocolContext, \
     MagneticModuleContext, TemperatureModuleContext
@@ -17,17 +16,3 @@ PipetteHandler = Callable[[Instruments, LoadedLabware, Any], None]
 MagneticModuleHandler = Callable[[MagneticModuleContext, Any], None]
 
 TemperatureModuleHandler = Callable[[TemperatureModuleContext, Any], None]
-
-# Deck definition types
-
-
-@dataclass
-class CalibrationPosition:
-    """
-    A point on the deck of a robot that is used to calibrate
-    aspects of the robot's movement system as defined by
-    opentrons/shared-data/deck/schemas/2.json
-    """
-    id: str
-    position: List[float]
-    displayName: str

--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -8,121 +8,20 @@ import traceback
 import typing
 
 from aiohttp import web
-from aiohttp.web_urldispatcher import UrlDispatcher
 
 from opentrons.config import CONFIG
 from opentrons.hardware_control.threaded_async_lock import ThreadedAsyncLock
-
-from .rpc import RPCServer
-from .http import HTTPServer, CalibrationRoutes
 from opentrons.api.routers import MainRouter
 from opentrons.hardware_control import ThreadManager
 
-from .endpoints.calibration.constants import (
-    ALLOWED_SESSIONS, LabwareLoaded, TipAttachError)
-from .endpoints.calibration.session import (
-    SessionManager, CheckCalibrationSession)
-from .endpoints.calibration.util import CalibrationCheckState
-from .endpoints.calibration.models import (
-    CalibrationSessionStatus, LabwareStatus)
+from .rpc import RPCServer
+from .http import HTTPServer, CalibrationRoutes
+
+from .endpoints.calibration.session import SessionManager as CalSessionManager
+from .endpoints.calibration.middlewares import \
+        session_middleware as cal_session_middleware
 
 log = logging.getLogger(__name__)
-
-
-def _format_links(
-        session: 'CheckCalibrationSession',
-        next: CalibrationCheckState,
-        router: UrlDispatcher) -> typing.Dict:
-    if session.state_machine.requires_move(next):
-        path = router.get('move', '')
-    else:
-        path = router.get(next.name, '')
-
-    params = session.format_params(next.name)
-    if path:
-        url = str(path.url_for(type=session.session_type))
-    else:
-        url = path
-    return {'links': {next.name: {'url': url, 'params': params}}}
-
-
-def _determine_error_message(
-        request: web.Request,
-        router: UrlDispatcher, type: str, pipette: str) -> typing.Dict:
-    """
-    Helper function to determine the exact error messaging for any
-    TipAttachError thrown by a calibration session.
-    """
-    invalidate = router['invalidateTip'].url_for(type=type)
-    drop = router['dropTip'].url_for(type=type)
-    pickup = router['pickUpTip'].url_for(type=type)
-    if request.path == pickup:
-        msg = f"Tip is already attached to {pipette} pipette."
-        links = {
-            "dropTip": str(drop),
-            "invalidateTip": str(invalidate)
-        }
-    elif request.path == drop or request.path == invalidate:
-        msg = f"No tip attached to {pipette} pipette."
-        links = {"pickUpTip": str(pickup)}
-    else:
-        msg = "Conflict with server."
-        links = {}
-    return {"message": msg, "links": links}
-
-
-def status_response(
-        session: 'CheckCalibrationSession',
-        request: web.Request,
-        response: web.Response) -> web.Response:
-
-    current = session.state_machine.current_state.name
-    next = session.state_machine.next_state
-    links = _format_links(session, next, request.app.router)
-
-    lw_status = session.labware_status.values()
-
-    sess_status = CalibrationSessionStatus(
-        instruments=session.pipette_status,
-        currentStep=current,
-        nextSteps=links,
-        labware=[LabwareStatus(**data) for data in lw_status])
-    return web.json_response(text=sess_status.json(), status=response.status)
-
-
-def no_session_error_response(start_url: str, type: str) -> web.Response:
-    error_response = {
-        "message": f"No {type} session exists. Please create one.",
-        "links": {"createSession": {'url': start_url, 'params': {}}}}
-    return web.json_response(error_response, status=404)
-
-
-async def misc_error_handling(
-        request: web.Request,
-        session: 'CheckCalibrationSession',
-        handler: typing.Callable) -> web.Response:
-    """
-    Miscellaneous error handling for calibration sessions. Specifically, it
-    handles all responses that might require a 409 error response.
-    """
-    try:
-        response = await handler(request, session)
-    except (TipAttachError, LabwareLoaded) as e:
-        router = request.app.router
-        if isinstance(e, TipAttachError):
-            type = request.match_info['type']
-            req = await request.json()
-
-            error_response = _determine_error_message(
-                request, router, type, req.get('pipetteId', ''))
-        else:
-            next = session.state_machine.next_state
-            links = _format_links(session, next, router)
-            error_response = {
-                "message": "Labware Already Loaded.",
-                **links}
-        response = web.json_response(error_response, status=409)
-    return response
 
 
 @web.middleware
@@ -147,40 +46,6 @@ async def error_middleware(
     return response
 
 
-@web.middleware
-async def session_middleware(
-        request: web.Request, handler: typing.Callable) -> web.Response:
-    """
-    Middleware used for the calibration sub-app. This includes all routes
-    found in the :py:class:`.http:CalibrationRoutes` class.
-
-    *Note* Does NOT include old deck calibration endpoints.
-    """
-
-    session_type = request.match_info['type']
-    session_storage = request.app['com.opentrons.session_manager']
-
-    if session_type not in ALLOWED_SESSIONS:
-        message = f"Session of type {session_type} is not supported."
-        return web.json_response(message, status=403)
-
-    router = request.app.router
-    start_url = str(router.get('sessionStart').url_for(type=session_type))
-    session = session_storage.sessions.get(session_type)
-    if start_url == request.path and request.method == 'POST':
-        response = await handler(request)
-    elif not session:
-        response = no_session_error_response(start_url, session_type)
-    else:
-        response = await misc_error_handling(request, session, handler)
-
-    if response.text:
-        return response
-    else:
-        session = session_storage.sessions.get(session_type)
-        return status_response(session, request, response)
-
-
 # Support for running using aiohttp CLI.
 # See: https://docs.aiohttp.org/en/stable/web.html#command-line-interface-cli
 def init(hardware: ThreadManager = None,
@@ -202,9 +67,9 @@ def init(hardware: ThreadManager = None,
         app, MainRouter(
             hardware, lock=app['com.opentrons.motion_lock'], loop=loop))
     app['com.opentrons.response_file_tempdir'] = tempfile.mkdtemp()
-    calibration_app = web.Application(middlewares=[session_middleware])
+    calibration_app = web.Application(middlewares=[cal_session_middleware])
     calibration_app['com.opentrons.http'] = CalibrationRoutes(calibration_app)
-    calibration_app['com.opentrons.session_manager'] = SessionManager()
+    calibration_app['com.opentrons.session_manager'] = CalSessionManager()
     app.add_subapp('/calibration/', calibration_app)
 
     app['calibration'] = calibration_app

--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -177,6 +177,7 @@ async def session_middleware(
     if response.text:
         return response
     else:
+        session = session_storage.sessions.get(session_type)
         return status_response(session, request, response)
 
 

--- a/api/src/opentrons/server/__init__.py
+++ b/api/src/opentrons/server/__init__.py
@@ -177,7 +177,6 @@ async def session_middleware(
     if response.text:
         return response
     else:
-        session = session_storage.sessions.get(session_type)
         return status_response(session, request, response)
 
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -20,7 +20,8 @@ async def create_session(request):
     """
     POST /calibration/check/session
 
-    If a session exists, this endpoint will return the current status.
+    If a session exists, this endpoint will return a 409 with links to delete.
+    If none exists, this will create a session and return its status.
 
     The status message is in the shape of:
     :py:class:`.models.CalibrationSessionStatus`

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -67,9 +67,18 @@ async def load_labware(request: web.Request, session) -> web.Response:
 async def move(request: web.Request, session) -> web.Response:
     req = await request.json()
     moveloc = MoveLocation(**req)
-    location = {
-        "locationId": moveloc.location.locationId,
-        "offset": types.Point(*moveloc.location.offset)}
+    if req.get('offset'):
+        # using getattr to avoid error raised by Union of deck position and
+        # tiprack position having different attributes.
+        offset = getattr(moveloc.location, 'offset')
+        location = {
+            "locationId": moveloc.location.locationId,
+            "offset": types.Point(offset)}
+    else:
+        position = getattr(moveloc.location, 'position')
+        location = {
+            "locationId": moveloc.location.locationId,
+            "position": types.Point(*position)}
     await session.move(moveloc.pipetteId, location)
     return web.json_response(status=200)
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -67,13 +67,13 @@ async def load_labware(request: web.Request, session) -> web.Response:
 async def move(request: web.Request, session) -> web.Response:
     req = await request.json()
     moveloc = MoveLocation(**req)
-    if req.get('offset'):
+    if hasattr(moveloc.location, 'offset'):
         # using getattr to avoid error raised by Union of deck position and
         # tiprack position having different attributes.
         offset = getattr(moveloc.location, 'offset')
         location = {
             "locationId": moveloc.location.locationId,
-            "offset": types.Point(offset)}
+            "offset": types.Point(*offset)}
     else:
         position = getattr(moveloc.location, 'position')
         location = {

--- a/api/src/opentrons/server/endpoints/calibration/middlewares.py
+++ b/api/src/opentrons/server/endpoints/calibration/middlewares.py
@@ -1,0 +1,137 @@
+import typing
+from aiohttp import web
+from aiohttp.web_urldispatcher import UrlDispatcher
+from .session import CheckCalibrationSession
+from .models import CalibrationSessionStatus, LabwareStatus
+from .constants import ALLOWED_SESSIONS, LabwareLoaded, TipAttachError
+from .util import CalibrationCheckState
+
+
+def _format_links(
+        session: 'CheckCalibrationSession',
+        next: CalibrationCheckState,
+        router: UrlDispatcher) -> typing.Dict:
+    if session.state_machine.requires_move(next):
+        path = router.get('move', '')
+    else:
+        path = router.get(next.name, '')
+
+    params = session.format_params(next.name)
+    if path:
+        url = str(path.url_for(type=session.session_type))
+    else:
+        url = path
+    return {'links': {next.name: {'url': url, 'params': params}}}
+
+
+def _determine_error_message(
+        request: web.Request,
+        router: UrlDispatcher, type: str, pipette: str) -> typing.Dict:
+    """
+    Helper function to determine the exact error messaging for any
+    TipAttachError thrown by a calibration session.
+    """
+    invalidate = router['invalidateTip'].url_for(type=type)
+    drop = router['dropTip'].url_for(type=type)
+    pickup = router['pickUpTip'].url_for(type=type)
+    if request.path == pickup:
+        msg = f"Tip is already attached to {pipette} pipette."
+        links = {
+            "dropTip": str(drop),
+            "invalidateTip": str(invalidate)
+        }
+    elif request.path == drop or request.path == invalidate:
+        msg = f"No tip attached to {pipette} pipette."
+        links = {"pickUpTip": str(pickup)}
+    else:
+        msg = "Conflict with server."
+        links = {}
+    return {"message": msg, "links": links}
+
+
+def status_response(
+        session: 'CheckCalibrationSession',
+        request: web.Request,
+        response: web.Response) -> web.Response:
+
+    current = session.state_machine.current_state.name
+    next = session.state_machine.next_state
+    links = _format_links(session, next, request.app.router)
+
+    lw_status = session.labware_status.values()
+
+    sess_status = CalibrationSessionStatus(
+        instruments=session.pipette_status,
+        currentStep=current,
+        nextSteps=links,
+        labware=[LabwareStatus(**data) for data in lw_status])
+    return web.json_response(text=sess_status.json(), status=response.status)
+
+
+def no_session_error_response(start_url: str, type: str) -> web.Response:
+    error_response = {
+        "message": f"No {type} session exists. Please create one.",
+        "links": {"createSession": {'url': start_url, 'params': {}}}}
+    return web.json_response(error_response, status=404)
+
+
+async def misc_error_handling(
+        request: web.Request,
+        session: 'CheckCalibrationSession',
+        handler: typing.Callable) -> web.Response:
+    """
+    Miscellaneous error handling for calibration sessions. Specifically, it
+    handles all responses that might require a 409 error response.
+    """
+    try:
+        response = await handler(request, session)
+    except (TipAttachError, LabwareLoaded) as e:
+        router = request.app.router
+        if isinstance(e, TipAttachError):
+            type = request.match_info['type']
+            req = await request.json()
+
+            error_response = _determine_error_message(
+                request, router, type, req.get('pipetteId', ''))
+        else:
+            next = session.state_machine.next_state
+            links = _format_links(session, next, router)
+            error_response = {
+                "message": "Labware Already Loaded.",
+                **links}
+        response = web.json_response(error_response, status=409)
+    return response
+
+
+@web.middleware
+async def session_middleware(
+        request: web.Request, handler: typing.Callable) -> web.Response:
+    """
+    Middleware used for the calibration sub-app. This includes all routes
+    found in the :py:class:`.http:CalibrationRoutes` class.
+
+    *Note* Does NOT include old deck calibration endpoints.
+    """
+
+    session_type = request.match_info['type']
+    session_storage = request.app['com.opentrons.session_manager']
+
+    if session_type not in ALLOWED_SESSIONS:
+        message = f"Session of type {session_type} is not supported."
+        return web.json_response(message, status=403)
+
+    router = request.app.router
+    start_url = str(router.get('sessionStart').url_for(type=session_type))
+    session = session_storage.sessions.get(session_type)
+    if start_url == request.path and request.method == 'POST':
+        response = await handler(request)
+    elif not session:
+        response = no_session_error_response(start_url, session_type)
+    else:
+        response = await misc_error_handling(request, session, handler)
+
+    if response.text:
+        return response
+    else:
+        session = session_storage.sessions.get(session_type)
+        return status_response(session, request, response)

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, Union
 from functools import partial
 from pydantic import BaseModel, Field, UUID4
 from uuid import UUID
@@ -22,9 +22,18 @@ PointField = partial(Field, ...,
                      min_items=3, max_items=3)
 
 
-class Position(BaseModel):
+class TiprackPosition(BaseModel):
     locationId: UUID4
     offset: Point = PointField()
+
+    class Config:
+        json_encoders = {
+            UUID4: convert_to_uuid}
+
+
+class DeckPosition(BaseModel):
+    locationId: UUID4
+    position: Point = PointField()
 
     class Config:
         json_encoders = {
@@ -41,7 +50,7 @@ class SpecificPipette(BaseModel):
 
 class MoveLocation(BaseModel):
     pipetteId: UUID4
-    location: Position
+    location: Union[TiprackPosition, DeckPosition]
 
     class Config:
         json_encoders = {

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -167,7 +167,7 @@ class CalibrationSession:
                      checkHeight=height)
 
     def _build_cross_dict(self, pos_id: str) -> typing.Dict:
-        cross_coords = self._deck.get_calibration_position(pos_id)['position']
+        cross_coords = self._deck.get_calibration_position(pos_id).position
         return {'position': Point(*cross_coords), 'locationId': uuid4()}
 
     def _build_height_dict(self, slot: str) -> typing.Dict:

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -157,18 +157,18 @@ class CalibrationSession:
         return lw
 
     def _build_deck_moves(self) -> Moves:
-        checkone = self._build_cross_dict('1')
-        checktwo = self._build_cross_dict('3')
-        checkthree = self._build_cross_dict('7')
+        checkone = self._build_cross_dict('1BLC')
+        checktwo = self._build_cross_dict('3BRC')
+        checkthree = self._build_cross_dict('7TLC')
         height = self._build_height_dict('5')
         return Moves(checkPointOne=checkone,
                      checkPointTwo=checktwo,
                      checkPointThree=checkthree,
                      checkHeight=height)
 
-    def _build_cross_dict(self, slot: str) -> typing.Dict:
-        pos = self._deck.get_calibration_position(slot)['position']
-        return {'position': Point(*pos), 'locationId': uuid4()}
+    def _build_cross_dict(self, pos_id: str) -> typing.Dict:
+        cross_coords = self._deck.get_calibration_position(pos_id)['position']
+        return {'position': Point(*cross_coords), 'locationId': uuid4()}
 
     def _build_height_dict(self, slot: str) -> typing.Dict:
         pos = Point(*self._deck.get_slot_center(slot))

--- a/api/src/opentrons/server/endpoints/calibration/util.py
+++ b/api/src/opentrons/server/endpoints/calibration/util.py
@@ -29,7 +29,8 @@ check_normal_relationship_dict = {
     CalibrationCheckState.checkPointOne: CalibrationCheckState.checkPointTwo,
     CalibrationCheckState.checkPointTwo: CalibrationCheckState.checkPointThree,
     CalibrationCheckState.checkPointThree: CalibrationCheckState.checkHeight,
-    CalibrationCheckState.checkHeight: CalibrationCheckState.sessionStart
+    CalibrationCheckState.checkHeight: CalibrationCheckState.dropTip,
+    CalibrationCheckState.dropTip: CalibrationCheckState.moveToTipRack
 }
 
 exit = CalibrationCheckState.sessionExit

--- a/api/tests/opentrons/server/test_calibration_check_integration.py
+++ b/api/tests/opentrons/server/test_calibration_check_integration.py
@@ -49,6 +49,87 @@ async def test_integrated_calibration_check(async_client, test_setup):
     assert list(status['nextSteps']['links'].keys())[0] == 'jog'
 
     next_data, url = _interpret_status_results(status, 'jog', curr_pip)
-    await async_client.post(url, json=next_data)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'pickUpTip'
+
+    next_data, url = _interpret_status_results(status, 'pickUpTip', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointOne'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointOne', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointTwo'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointTwo', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointThree'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointThree', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkHeight'
+
+    next_data, url = _interpret_status_results(status, 'checkHeight', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'dropTip'
+
+    next_data, url = _interpret_status_results(status, 'dropTip', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'moveToTipRack'
+
+    curr_pip = _get_pipette(status['instruments'], 'p10_single_v1')
+
+    next_data, url = _interpret_status_results(
+        status, 'moveToTipRack', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'jog'
+
+    next_data, url = _interpret_status_results(status, 'jog', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'pickUpTip'
+
+    next_data, url = _interpret_status_results(status, 'pickUpTip', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointOne'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointOne', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointTwo'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointTwo', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkPointThree'
+
+    next_data, url = _interpret_status_results(
+        status, 'checkPointThree', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'checkHeight'
+
+    next_data, url = _interpret_status_results(status, 'checkHeight', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'dropTip'
+
+    next_data, url = _interpret_status_results(status, 'dropTip', curr_pip)
+    resp = await async_client.post(url, json=next_data)
+    status = await resp.json()
+    assert list(status['nextSteps']['links'].keys())[0] == 'moveToTipRack'
 
     await async_client.delete('/calibration/check/session')


### PR DESCRIPTION
## overview

Closes #5099 and closes #5098. This PR enables the calibration session to move to all three crosses on the deck (1,3,7) and the left of slot 5 to check the height.

## changelog

- Add a method in `geometry.py` to grab the cross information from the ot deck json definition. 
-  Move the `_moves` attribute to the top level session -- since deck calibration session will also be using these points
-  Add in a different move input that is in the shape of `{'location': {'locationId', 'position'}, 'pipetteId'}`. Now, move takes in two different input shapes depending on the state.
- Expand on the integration test to check an entire deck check flow with two pipettes (*note* this test will be changed once the session has control over the active pipette again.)

## review requests

The state machine needs a little more work I think -- it's gross having to check whether the `moveToTiprack` state is active or not to prevent the state from moving forward when returning tip to the tiprack.

## risk assessment

This only adds onto the deck calibration check project. Some things were moved around to account for some future proofing, but the session should still work as intended.