### PR TITLE
fix(api): verify the structure of v2 protocol ast

### DIFF
--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -89,7 +89,7 @@ def _parse_python(
     protocol = compile(parsed, filename=ast_filename, mode='exec')
     version = get_version(metadata, parsed)
 
-    if version > APIVersion(2, 0):
+    if version >= APIVersion(2, 0):
         _validate_v2_ast(parsed)
 
     result = PythonProtocol(

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -15,13 +15,30 @@ import jsonschema  # type: ignore
 
 from opentrons.config import feature_flags as ff
 from opentrons.system.shared_data import load_shared_data
-from .types import Protocol, PythonProtocol, JsonProtocol, Metadata, APIVersion
+from .types import (Protocol, PythonProtocol, JsonProtocol,
+                    Metadata, APIVersion, MalformedProtocolError)
 from .bundle import extract_bundle
 
 MODULE_LOG = logging.getLogger(__name__)
 
 # match e.g. "2.0" but not "hi", "2", "2.0.1"
 API_VERSION_RE = re.compile(r'^(\d+)\.(\d+)$')
+
+
+def _validate_v2_ast(protocol_ast: ast.Module):
+    defs = [fdef for fdef in protocol_ast.body
+            if isinstance(fdef, ast.FunctionDef)]
+    rundefs = [fdef for fdef in defs
+               if fdef.name == 'run']
+    # There must be precisely 1 one run function
+    if len(rundefs) > 1:
+        lines = [str(d.lineno) for d in rundefs]
+        linestr = ', '.join(lines)
+        raise MalformedProtocolError(
+            f'More than one run function is defined (lines {linestr})')
+    if not rundefs:
+        raise MalformedProtocolError(
+            "No function 'run(ctx)' defined")
 
 
 def version_from_string(vstr: str) -> APIVersion:
@@ -71,6 +88,9 @@ def _parse_python(
     metadata = extract_metadata(parsed)
     protocol = compile(parsed, filename=ast_filename, mode='exec')
     version = get_version(metadata, parsed)
+
+    if version > APIVersion(2, 0):
+        _validate_v2_ast(parsed)
 
     result = PythonProtocol(
         text=protocol_contents,

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -40,3 +40,29 @@ class BundleContents(NamedTuple):
     bundled_labware: Dict[str, Dict[str, Any]]
     bundled_data: Dict[str, bytes]
     bundled_python: Dict[str, str]
+
+
+PROTOCOL_MALFORMED = """
+
+A Python protocol for the OT2 must define a function called 'run' that takes a
+single argument: the protocol context to call functions on. For instance, a run
+function might look like this:
+
+def run(ctx):
+    ctx.comment('hello, world')
+
+This function is called by the robot when the robot executes the protol.
+This function is not present in the current protocol and must be added.
+"""
+
+
+class MalformedProtocolError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self):
+        return self.message + PROTOCOL_MALFORMED
+
+    def __repr__(self):
+        return '<{}: {}>'.format(self.__class__.__name__, self.message)

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -55,12 +55,15 @@ async def test_async_notifications(main_router):
 
 @pytest.mark.parametrize(
     'proto_with_error', [
-        'metadata={"apiLevel": "2.0"}; blah',
+        '''
+metadata={"apiLevel": "2.0"}
+blah
+def run(ctx): pass''',
         'metadata={"apiLevel": "1.0"}; blah',
     ])
 def test_load_protocol_with_error(session_manager, hardware,
                                   proto_with_error):
-    with pytest.raises(Exception) as e:
+    with pytest.raises(NameError) as e:
         session = session_manager.create(
             name='<blank>', contents=proto_with_error)
         assert session is None

--- a/api/tests/opentrons/protocol_api/test_execute.py
+++ b/api/tests/opentrons/protocol_api/test_execute.py
@@ -19,17 +19,20 @@ def test_api2_runfunc():
     def two_with_default(a, b=2):
         pass
 
-    assert execute._runfunc_ok(two_with_default) == two_with_default
+    # making sure this doesn't raise
+    execute._runfunc_ok(two_with_default)
 
     def one_with_default(a=2):
         pass
 
-    assert execute._runfunc_ok(one_with_default) == one_with_default
+    # shouldn't raise
+    execute._runfunc_ok(one_with_default)
 
     def starargs(*args):
         pass
 
-    assert execute._runfunc_ok(starargs) == starargs
+    # shouldn't raise
+    execute._runfunc_ok(starargs)
 
 
 @pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
@@ -41,13 +44,6 @@ def test_execute_ok(protocol, protocol_file, loop):
 
 def test_bad_protocol(loop):
     ctx = ProtocolContext(loop)
-    no_run = parse('''
-metadata={"apiLevel": "2.0"}
-print("hi")
-''')
-    with pytest.raises(execute.MalformedProtocolError) as e:
-        execute.run_protocol(no_run, context=ctx)
-        assert "No function 'run" in str(e.value)
 
     no_args = parse('''
 metadata={"apiLevel": "2.0"}

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -10,7 +10,8 @@ from opentrons.protocols.parse import (extract_metadata,
                                        version_from_metadata)
 from opentrons.protocols.types import (JsonProtocol,
                                        PythonProtocol,
-                                       APIVersion)
+                                       APIVersion,
+                                       MalformedProtocolError)
 
 
 def test_extract_metadata():
@@ -295,3 +296,22 @@ def test_extra_contents(
                    extra_data=extra_data)
     assert parsed.extra_labware == bundled_labware
     assert parsed.bundled_data == extra_data
+
+
+# noqa(E122)
+@pytest.mark.parametrize('bad_protocol', [
+    '''
+from opentrons import robot
+metadata={"apiLevel": "2.0"}
+print("hi")''',
+    '''
+def run(ctx):
+  pass
+
+def run(blahblah):
+  pass
+    '''
+])
+def test_bad_structure(bad_protocol):
+    with pytest.raises(MalformedProtocolError):
+        parse(bad_protocol)

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -74,6 +74,7 @@ metadata = {
   }
 
 p = instruments.P10_Single(mount='right')
+def run(ctx): pass
 """, APIVersion(2, 0)),
     ("""
 from opentrons import types
@@ -305,6 +306,7 @@ from opentrons import robot
 metadata={"apiLevel": "2.0"}
 print("hi")''',
     '''
+metadata = {"apiLevel": "2.0"}
 def run(ctx):
   pass
 


### PR DESCRIPTION
V2 protocols have to have a basic minimum structure: a single run
function that can be called with a single positional argument, e.g.
run(ctx). We have been checking this in
protocol_api.execute._runfunc_ok, on the exec'd protocol by using the
inspect module and looking at the exec'd globals.

The problem with this is if somebody uploads a protocol that doesn't
match this, we won't catch it until after we exec the protocol. We do
allow protocols that do work at module scope (e.g. script-style), but
that's also what v1 protocols look like. So if someone had a v1 protocol
that they had mistakenly or absent-mindedly told the system was a v2
protocol in the metadata, like this:

from opentrons import robot

metadata = {"apiLevel": "2.3"}

robot.comment("Hello, world!")

then that protocol will execute during the exec, and you won't get a
good error.

The way to get around this is to verify the structure from the AST,
before we call exec(). That AST is parsed in protocols.parse. So we move
the basic structure checking there, looking for a function definition
with the right name.

This keeps the argument checking in the protocol_api.execute module
though for reasons of excessive complexity: it's quite a bit simpler to
check the structure of a function's arguments using the inspect module
on a live object than it is to parse the wonderful glory of python's
function signature AST with its four or five separate kinds of argument.

## Risk Assessment and Testing

This shouldn't be that risky since it only changes one place: protocol upload. That said, our users can upload some weird and wild protocols, so try a lot of them, like
- v1 protocols that have their metadata set to an apiv2 api level
- normal v2 protocols
- protocols that should be v2 protocols but don't have a run function or a typo'd run function
