### PR TITLE
refactor(api): Make idle plunger current dependent on pipette model

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -43,7 +43,8 @@ pipette_config = namedtuple(
         'blow_out_flow_rate',
         'max_travel',
         'home_position',
-        'steps_per_mm'
+        'steps_per_mm',
+        'idle_current'
     ]
 )
 
@@ -67,6 +68,8 @@ Z_OFFSET_P10 = -13  # longest single-channel pipette
 Z_OFFSET_P50 = 0
 Z_OFFSET_P300 = 0
 Z_OFFSET_P1000 = 20  # shortest single-channel pipette
+
+LOW_CURRENT_DEFAULT = 0.05
 
 
 def model_config() -> Dict[str, Any]:
@@ -199,7 +202,8 @@ def load(pipette_model: str, pipette_id: str = None) -> pipette_config:
             cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
         max_travel=smoothie_configs['travelDistance'],
         home_position=smoothie_configs['homePosition'],
-        steps_per_mm=smoothie_configs['stepsPerMM']
+        steps_per_mm=smoothie_configs['stepsPerMM'],
+        idle_current=cfg.get('idleCurrent', LOW_CURRENT_DEFAULT)
     )
 
     return res

--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -75,3 +75,6 @@ class SimulatingDriver:
 
     def configure_splits_for(self, config):
         pass
+
+    def set_dwelling_current(self, settings):
+        pass

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -301,6 +301,7 @@ class API(HardwareAPILike):
                 home_pos = p.config.home_position
                 max_travel = p.config.max_travel
                 steps_mm = p.config.steps_per_mm
+                idle_current = p.config.idle_current
                 if 'needsUnstick' in p.config.quirks:
                     splits[plunger_axis.name.upper()] = MoveSplit(
                         split_distance=1,
@@ -326,6 +327,7 @@ class API(HardwareAPILike):
                 home_pos = self._config.default_pipette_configs['homePosition']
                 max_travel = self._config.default_pipette_configs['maxTravel']
                 steps_mm = self._config.default_pipette_configs['stepsPerMM']
+                idle_current = self._config.low_current[plunger_axis.name]
 
             self._backend._smoothie_driver.update_steps_per_mm(
                 {plunger_axis.name: steps_mm})
@@ -333,6 +335,8 @@ class API(HardwareAPILike):
                 mount_axis.name, {'home': home_pos})
             self._backend._smoothie_driver.update_pipette_config(
                 plunger_axis.name, {'max_travel': max_travel})
+            self._backend._smoothie_driver.set_dwelling_current(
+                {plunger_axis.name: idle_current})
             self._backend._smoothie_driver.configure_splits_for(splits)
         mod_log.info("Instruments found: {}".format(
             self._attached_instruments))

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -312,15 +312,18 @@ class Robot(CommandPublisher):
                 home_pos = cfg.home_position
                 max_travel = cfg.max_travel
                 steps_mm = cfg.steps_per_mm
+                idle_current = cfg.idle_current
             else:
                 home_pos = self.config.default_pipette_configs['homePosition']
                 max_travel = self.config.default_pipette_configs['maxTravel']
                 steps_mm = self.config.default_pipette_configs['stepsPerMM']
+                idle_current = self.config.low_current[plunger_axis]
 
             self._driver.update_steps_per_mm({plunger_axis: steps_mm})
             self._driver.update_pipette_config(mount_axis, {'home': home_pos})
             self._driver.update_pipette_config(
                 plunger_axis, {'max_travel': max_travel})
+            self._driver.set_dwelling_current({plunger_axis: idle_current})
             self._driver.configure_splits_for(splits)
 
             if model_value:

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -1607,6 +1607,7 @@
         "min": 0,
         "max": 100
       },
+      "idleCurrent": 0.3,
       "quirks": []
     },
     "p50_single_v1": {
@@ -4005,6 +4006,7 @@
         "max": 100
       },
       "returnTipHeight": 0.4,
+      "idleCurrent": 0.3,
       "quirks": ["needsUnstick"]
     },
     "p1000_single_v1": {

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -118,6 +118,7 @@
               "type": "object",
               "value": { "$ref": "#/definitions/positiveNumber" }
             },
+            "idleCurrent": { "$ref": "#/definitions/editConfigurations" },
             "returnTipHeight": { "$ref": "#/definitions/returnTipHeightRange" },
             "tipOverlap": {
               "type": "object",

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -11,6 +11,11 @@
       "minimum": 0.25,
       "maximum": 1.25
     },
+    "idleCurrentRange": {
+      "type": "number",
+      "minimum": 0.01,
+      "maximum": 1.0
+    },
     "xyzArray": {
       "type": "array",
       "description": "Array of 3 numbers, [x, y, z]",
@@ -118,7 +123,7 @@
               "type": "object",
               "value": { "$ref": "#/definitions/positiveNumber" }
             },
-            "idleCurrent": { "$ref": "#/definitions/editConfigurations" },
+            "idleCurrent": { "$ref": "#/definitions/idleCurrentRange" },
             "returnTipHeight": { "$ref": "#/definitions/returnTipHeightRange" },
             "tipOverlap": {
               "type": "object",


### PR DESCRIPTION
## overview

Closes #5346 and Closes #5347. Now the idle current can be added to a pipette model spec, if necessary, and used in place of the default idle current. If no new idle current is specified, the default is used.

## changelog

- Add an optional key to pipette model specs called `idleCurrent`
- The default currents from `robot_settings` are used until a pipette is detected, in which case the idle current is pulled from the pipette configs.

## review requests

Implementation OK? Anymore tests I should add?

## risk assessment

This PR should only modify the dwelling current on GEN2 multis. Ensure that only GEN2 multis are having their current changed by checking the `idle_current` attribute from pipette config. A GEN2 Multi should have 0.3A as its idle current, and anything else should be 0.05. You can use this protocol:
```
from opentrons.types import Mount

def run(ctx):
	ctx.load_labware('opentrons_96_filtertiprack_20ul', '1')
	m20 = ctx.load_instrument('p20_multi_gen2', 'left', tip_racks=tips20m)

	instr = m20._hw_manager.hardware._attached_instruments[Mount.LEFT]
	ctx.comment(f"My low current is {instr.config.idle_current}")

``` 