### PR TITLE
refactor(api): Lower Touch Tip Minimum Speed

### DIFF
--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -2,7 +2,7 @@ import abc
 
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 3)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 4)
 #: The maximum supported protocol API version in this release
 
 V2_MODULE_DEF_VERSION = types.APIVersion(2, 3)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -419,6 +419,12 @@ class InstrumentContext(CommandPublisher):
         self._hw_manager.hardware.blow_out(self._mount)
         return self
 
+    def _determine_speed(self, speed: float):
+        if self._api_version < APIVersion(2, 4):
+            return clamp_value(speed, 80, 20, 'touch_tip:')
+        else:
+            return clamp_value(speed, 80, 1, 'touch_tip:')
+
     @cmds.publish.both(command=cmds.touch_tip)
     @requires_version(2, 0)
     def touch_tip(self,
@@ -477,7 +483,7 @@ class InstrumentContext(CommandPublisher):
                 where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
             ]
 
-        checked_speed = clamp_value(speed, 80, 20, 'touch_tip:')
+        checked_speed = self._determine_speed(speed)
 
         # If location is a valid well, move to the well first
         if location is None:


### PR DESCRIPTION
## overview

Closes #5453. This PR bumps up the API version to 2.4 to avoid potentially breaking current protocols. Documentation for 2.4 will be added in a separate PR once touch tip revisions are complete.

## changelog

- Cap the minimum speed to 1 mm/s in Python Protocol API version 2.4 and higher.

## review requests

Test on a robot with a regular well plate so you don't have other weird issues associated with touch tip.

## risk assessment

Ensure that the speed for touch tip in 2.3 and lower gets capped at 20 mm/s whereas you can lower the speed all the way to 1 mm/s and see a noticeable difference in speed.
