### PR TITLE
refactor(api): Remove diagonal movement from touch tip

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -6,7 +6,8 @@ from opentrons import types, commands as cmds, hardware_control as hc
 from opentrons.commands import CommandPublisher
 from opentrons.hardware_control.types import CriticalPoint
 from .util import (
-    FlowRates, PlungerSpeeds, Clearances, clamp_value, requires_version)
+    FlowRates, PlungerSpeeds, Clearances,
+    clamp_value, requires_version, build_edges)
 from opentrons.protocols.types import APIVersion
 from .labware import (
     filter_tipracks_to_start, Labware, OutOfTipsError, quirks_from_any_parent,
@@ -425,36 +426,6 @@ class InstrumentContext(CommandPublisher):
         else:
             return clamp_value(speed, 80, 1, 'touch_tip:')
 
-    def _build_edges(
-            self, where: Well, offset: float,
-            radius: float = 1.0) -> List[types.Point]:
-        # Determine the touch_tip edges/points
-        offset_pt = types.Point(0, 0, offset)
-        if self._api_version < APIVersion(2, 4):
-            edge_list = [
-                # right edge
-                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
-                # left edge
-                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
-                # back edge
-                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-                # front edge
-                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
-            ]
-        else:
-            edge_list = [
-                # right edge
-                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
-                # left edge
-                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
-                where.center().point + offset_pt,
-                # back edge
-                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-                # front edge
-                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
-            ]
-        return edge_list
-
     @cmds.publish.both(command=cmds.touch_tip)
     @requires_version(2, 0)
     def touch_tip(self,
@@ -521,7 +492,7 @@ class InstrumentContext(CommandPublisher):
             raise TypeError(
                 'location should be a Well, but it is {}'.format(location))
 
-        for edge in self._build_edges(location, v_offset, radius):
+        for edge in build_edges(location, v_offset, self._api_version, radius):
             self._hw_manager.hardware.move_to(self._mount, edge, checked_speed)
         return self
 

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -586,7 +586,7 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     speed = 60                  # default speed
     edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].center().point - z_offset,
+             lw.wells()[0]._from_center_cartesian(0, 0, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -533,6 +533,36 @@ def test_mix(loop, monkeypatch):
 
 
 def test_touch_tip_default_args(loop, monkeypatch):
+    ctx = papi.ProtocolContext(loop, api_version=APIVersion(2, 3))
+    ctx.home()
+    lw = ctx.load_labware(
+        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
+    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
+                                tip_racks=[tiprack])
+
+    instr.pick_up_tip()
+    total_hw_moves = []
+
+    async def fake_hw_move(self, mount, abs_position, speed=None,
+                           critical_point=None, max_speeds=None):
+        nonlocal total_hw_moves
+        total_hw_moves.append((abs_position, speed))
+
+    instr.aspirate(10, lw.wells()[0])
+    monkeypatch.setattr(API, 'move_to', fake_hw_move)
+    instr.touch_tip()
+    z_offset = Point(0, 0, 1)   # default z offset of 1mm
+    speed = 60                  # default speed
+    edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
+    for i in range(1, 5):
+        assert total_hw_moves[i] == (edges[i - 1], speed)
+
+
+def test_touch_tip_new_default_args(loop, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
     lw = ctx.load_labware(
@@ -556,6 +586,7 @@ def test_touch_tip_default_args(loop, monkeypatch):
     speed = 60                  # default speed
     edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].center().point - z_offset,
              lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):


### PR DESCRIPTION
## overview

Closes #5451. This PR adds in an extra move to touch tip which first moves to the center before switching directions the pipette is moving in.

## changelog

- Change the edge list for touch tip to have an extra move to the center
- Add an extra test to verify this change only exists in API v2.4

## review requests

Check that the diagonal behavior when moving from left/right -> top/bottom is removed in api version 2.4.

## risk assessment

Low, just ensure that the behavior changes between version 2.3 and 2.4.
