### PR TITLE
refactor(api): Move to the specified height offset in touch tip before moving to edges

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -487,7 +487,14 @@ class InstrumentContext(CommandPublisher):
             if location.parent.is_tiprack:
                 self._log.warning('Touch_tip being performed on a tiprack. '
                                   'Please re-check your code')
-            self.move_to(location.top())
+
+            if self._api_version < APIVersion(2, 4):
+                to_loc = location.top()
+            else:
+                move_with_z_offset =\
+                    location.top().point + types.Point(0, 0, v_offset)
+                to_loc = types.Location(move_with_z_offset, location)
+            self.move_to(to_loc)
         else:
             raise TypeError(
                 'location should be a Well, but it is {}'.format(location))

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -426,36 +426,6 @@ class InstrumentContext(CommandPublisher):
         else:
             return clamp_value(speed, 80, 1, 'touch_tip:')
 
-    def _build_edges(
-            self, where: Well, offset: float,
-            radius: float = 1.0) -> List[types.Point]:
-        # Determine the touch_tip edges/points
-        offset_pt = types.Point(0, 0, offset)
-        if self._api_version < APIVersion(2, 4):
-            edge_list = [
-                # right edge
-                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
-                # left edge
-                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
-                # back edge
-                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-                # front edge
-                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
-            ]
-        else:
-            edge_list = [
-                # right edge
-                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
-                # left edge
-                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
-                where.center().point + offset_pt,
-                # back edge
-                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-                # front edge
-                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
-            ]
-        return edge_list
-
     @cmds.publish.both(command=cmds.touch_tip)
     @requires_version(2, 0)
     def touch_tip(self,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -426,6 +426,36 @@ class InstrumentContext(CommandPublisher):
         else:
             return clamp_value(speed, 80, 1, 'touch_tip:')
 
+    def _build_edges(
+            self, where: Well, offset: float,
+            radius: float = 1.0) -> List[types.Point]:
+        # Determine the touch_tip edges/points
+        offset_pt = types.Point(0, 0, offset)
+        if self._api_version < APIVersion(2, 4):
+            edge_list = [
+                # right edge
+                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
+                # left edge
+                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
+                # back edge
+                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
+                # front edge
+                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
+            ]
+        else:
+            edge_list = [
+                # right edge
+                where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
+                # left edge
+                where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
+                where.center().point + offset_pt,
+                # back edge
+                where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
+                # front edge
+                where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
+            ]
+        return edge_list
+
     @cmds.publish.both(command=cmds.touch_tip)
     @requires_version(2, 0)
     def touch_tip(self,

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -560,6 +560,11 @@ def test_touch_tip_default_args(loop, monkeypatch):
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
+    # Check that the old api version initial well move has the same z height
+    # as the calculated edges.
+    total_hw_moves.clear()
+    instr.touch_tip(v_offset=1)
+    assert total_hw_moves[0][0].z != total_hw_moves[1][0].z
 
 
 def test_touch_tip_new_default_args(loop, monkeypatch):
@@ -591,6 +596,12 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
+
+    # Check that the new api version initial well move has the same z height
+    # as the calculated edges.
+    total_hw_moves.clear()
+    instr.touch_tip(v_offset=1)
+    assert total_hw_moves[0][0].z == total_hw_moves[1][0].z
 
 
 def test_touch_tip_disabled(loop, monkeypatch, get_labware_fixture):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -586,7 +586,11 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     speed = 60                  # default speed
     edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
+<<<<<<< HEAD
              lw.wells()[0]._from_center_cartesian(0, 0, 1) - z_offset,
+=======
+             lw.wells()[0].center().point - z_offset,
+>>>>>>> refactor(api): Remove diagonal movement from touch tip
              lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -586,11 +586,7 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     speed = 60                  # default speed
     edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
-<<<<<<< HEAD
              lw.wells()[0]._from_center_cartesian(0, 0, 1) - z_offset,
-=======
-             lw.wells()[0].center().point - z_offset,
->>>>>>> refactor(api): Remove diagonal movement from touch tip
              lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
              lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):


### PR DESCRIPTION
## overview

Closes #5452. Previously, touch tip would automatically move to the top of the well without taking into account the height specified by the user. In API v2.4, touch tip will move to the top of the well + offset specified before beginning any edge moves.

## changelog

- Move to the top of the well + offset specified from user in touch tip

## review requests

Test the differences between API v2.3 and API v2.4. See the risk assessment below for further details.

## risk assessment

The risk level on this PR is low to medium. Ensure that the behavior changes between API v2.3 & API v2.4 by:

1. aspirating/dispensing in a well then calling touch_tip() without any arguments.
2. aspirate/dispense in a well then call touch_tip(v_offset=-3). In API v2.3 you should see a difference in height before moving to the edges; in API v2.4 you should not see a difference
