### PR TITLE
feat(protocol-designer): add custom tiprack on protocol creation

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -171,7 +171,7 @@ export const LabwareSelectionModal = (props: Props) => {
   )
 
   const labwareByCategory = useMemo(() => {
-    const defs = { ...getOnlyLatestDefs(), ...customLabwareDefs }
+    const defs = getOnlyLatestDefs()
     return reduce<
       LabwareDefByDefURI,
       { [category: string]: Array<LabwareDefinition2> }
@@ -194,17 +194,20 @@ export const LabwareSelectionModal = (props: Props) => {
       },
       {}
     )
-  }, [permittedTipracks, customLabwareDefs])
+  }, [permittedTipracks])
 
   const populatedCategories: { [category: string]: boolean } = useMemo(
     () =>
       orderedCategories.reduce(
-        (acc, category) => ({
-          ...acc,
-          [category]: labwareByCategory[category].some(
-            def => !getLabwareDisabled(def)
-          ),
-        }),
+        (acc, category) =>
+          labwareByCategory[category]
+            ? {
+                ...acc,
+                [category]: labwareByCategory[category].some(
+                  def => !getLabwareDisabled(def)
+                ),
+              }
+            : acc,
         {}
       ),
     [labwareByCategory, getLabwareDisabled]

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -171,7 +171,7 @@ export const LabwareSelectionModal = (props: Props) => {
   )
 
   const labwareByCategory = useMemo(() => {
-    const defs = getOnlyLatestDefs()
+    const defs = { ...getOnlyLatestDefs(), ...customLabwareDefs }
     return reduce<
       LabwareDefByDefURI,
       { [category: string]: Array<LabwareDefinition2> }
@@ -194,7 +194,7 @@ export const LabwareSelectionModal = (props: Props) => {
       },
       {}
     )
-  }, [permittedTipracks])
+  }, [permittedTipracks, customLabwareDefs])
 
   const populatedCategories: { [category: string]: boolean } = useMemo(
     () =>

--- a/protocol-designer/src/components/ProtocolEditor.js
+++ b/protocol-designer/src/components/ProtocolEditor.js
@@ -43,10 +43,9 @@ function ProtocolEditorComponent() {
             <AnnouncementModal />
             <NewFileModal showProtocolFields />
             <FileUploadMessageModal />
-            <LabwareUploadMessageModal />
             {/* TODO: Ian 2018-06-28 All main page modals will go here */}
             <MainPageModalPortalRoot />
-
+            <LabwareUploadMessageModal />
             <ConnectedMainPanel />
           </div>
         </div>

--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -95,10 +95,14 @@
   margin-right: 0.5rem;
 }
 
-.upload_custom_btn {
+.upload_button {
   display: block;
   width: 50%;
   margin: 1.25rem auto;
+}
+
+.upload_button input {
+  display: none;
 }
 
 .protocol_modules_group {

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -1,5 +1,6 @@
 // @flow
-import React, { useMemo } from 'react'
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import {
   DropdownField,
   FormGroup,
@@ -10,13 +11,14 @@ import {
 import { getLabwareDefURI, getLabwareDisplayName } from '@opentrons/shared-data'
 import isEmpty from 'lodash/isEmpty'
 import reduce from 'lodash/reduce'
-
 import { i18n } from '../../../localization'
+import { createCustomTiprackDef } from '../../../labware-defs/actions'
+import { getLabwareDefsByURI } from '../../../labware-defs/selectors'
 import { PipetteDiagram } from './PipetteDiagram'
 import { TiprackDiagram } from './TiprackDiagram'
+
 import styles from './FilePipettesModal.css'
 import formStyles from '../../forms/forms.css'
-import { getOnlyLatestDefs } from '../../../labware-defs/utils'
 
 import type { FormPipettesByMount } from '../../../step-forms'
 
@@ -68,23 +70,24 @@ export function PipetteFields(props: Props) {
     customTipracksEnabled,
   } = props
 
-  const tiprackOptions = useMemo(() => {
-    const defs = getOnlyLatestDefs()
-    return reduce(
-      defs,
-      (acc, def: $Values<typeof defs>) => {
-        if (def.metadata.displayCategory !== 'tipRack') return acc
-        return [
-          ...acc,
-          {
-            name: getLabwareDisplayName(def),
-            value: getLabwareDefURI(def),
-          },
-        ]
-      },
-      []
-    )
-  }, [])
+  const dispatch = useDispatch()
+
+  const allLabware = useSelector(getLabwareDefsByURI)
+
+  const tiprackOptions = reduce(
+    allLabware,
+    (acc, def: $Values<typeof allLabware>) => {
+      if (def.metadata.displayCategory !== 'tipRack') return acc
+      return [
+        ...acc,
+        {
+          name: getLabwareDisplayName(def),
+          value: getLabwareDefURI(def),
+        },
+      ]
+    },
+    []
+  )
 
   const initialTabIndex = props.initialTabIndex || 1
 
@@ -216,11 +219,12 @@ export function PipetteFields(props: Props) {
         </div>
       ) : (
         <div>
-          <OutlineButton
-            className={styles.upload_custom_btn}
-            onClick={() => console.log('TODO: Open Upload Modal')}
-          >
+          <OutlineButton Component="label" className={styles.upload_button}>
             upload custom tip rack
+            <input
+              type="file"
+              onChange={e => dispatch(createCustomTiprackDef(e))}
+            />
           </OutlineButton>
         </div>
       )}

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -220,7 +220,7 @@ export function PipetteFields(props: Props) {
       ) : (
         <div>
           <OutlineButton Component="label" className={styles.upload_button}>
-            upload custom tip rack
+            {i18n.t('button.upload_custom_tip_rack')}
             <input
               type="file"
               onChange={e => dispatch(createCustomTiprackDef(e))}

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -189,7 +189,7 @@ describe('PipetteFields', () => {
     props.customTipracksEnabled = true
     const wrapper = render(props)
     const uploadButton = wrapper.find(OutlineButton).at(0)
-    expect(uploadButton.text()).toMatch('upload custom tip rack')
+    expect(uploadButton.text()).toMatch('Upload custom tip rack')
 
     uploadButton
       .find('input')

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -14,6 +14,7 @@ import { PipetteDiagram } from '../PipetteDiagram'
 import type { LabwareDefByDefURI } from '../../../../labware-defs'
 
 jest.mock('../../../../feature-flags/selectors')
+jest.mock('../../../../labware-defs/selectors')
 jest.mock('../../../../labware-defs/utils.js')
 jest.mock('../TiprackDiagram')
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/__tests__/PipetteFields.test.js
@@ -3,25 +3,37 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
-import { PipetteSelect, DropdownField } from '@opentrons/components'
+import {
+  PipetteSelect,
+  DropdownField,
+  OutlineButton,
+} from '@opentrons/components'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import fixture_tiprack_1000_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
+import { actions as labwareDefActions } from '../../../../labware-defs'
 import { getOnlyLatestDefs } from '../../../../labware-defs/utils'
 import { PipetteFields } from '../PipetteFields'
 import { TiprackDiagram } from '../TiprackDiagram'
 import { PipetteDiagram } from '../PipetteDiagram'
 
 import type { LabwareDefByDefURI } from '../../../../labware-defs'
+import type { ThunkAction } from '../../../../types'
 
 jest.mock('../../../../feature-flags/selectors')
 jest.mock('../../../../labware-defs/selectors')
 jest.mock('../../../../labware-defs/utils.js')
+jest.mock('../../../../labware-defs/actions')
 jest.mock('../TiprackDiagram')
 
 const getOnlyLatestDefsMock: JestMockFn<
   [],
   LabwareDefByDefURI
 > = getOnlyLatestDefs
+
+const createCustomTiprackDefMock: JestMockFn<
+  [SyntheticInputEvent<HTMLInputElement>],
+  ThunkAction<*>
+> = labwareDefActions.createCustomTiprackDef
 
 describe('PipetteFields', () => {
   const leftPipetteKey = 'pipettesByMount.left'
@@ -171,5 +183,18 @@ describe('PipetteFields', () => {
       rightPipette: rightPipette.pipetteName,
       customTipracksEnabled: false,
     })
+  })
+
+  it('allows the user to upload custom tip racks when custom tipracks FF enabled', () => {
+    props.customTipracksEnabled = true
+    const wrapper = render(props)
+    const uploadButton = wrapper.find(OutlineButton).at(0)
+    expect(uploadButton.text()).toMatch('upload custom tip rack')
+
+    uploadButton
+      .find('input')
+      .at(0)
+      .simulate('change')
+    expect(createCustomTiprackDefMock).toHaveBeenCalled()
   })
 })

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -39,12 +39,12 @@ import type {
 } from '../../../step-forms'
 import type { FormikProps } from 'formik/@flow-typed'
 
-type PipetteFieldsData = $Diff<
+export type PipetteFieldsData = $Diff<
   PipetteOnDeck,
   {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
 >
 
-type ModuleCreationArgs = {|
+export type ModuleCreationArgs = {|
   type: ModuleRealType,
   model: string,
   slot: DeckSlot,

--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
@@ -110,7 +110,7 @@ const MessageBody = (props: {| message: LabwareUploadMessage |}) => {
   } else if (message.messageType === 'ONLY_TIPRACK') {
     return (
       <>
-        <p>This labware is not a tiprack. Please upload a tiprack.</p>
+        <p>This labware definition is not a Tip Rack.</p>
       </>
     )
   }

--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
@@ -107,6 +107,12 @@ const MessageBody = (props: {| message: LabwareUploadMessage |}) => {
         </p>
       </>
     )
+  } else if (message.messageType === 'ONLY_TIPRACK') {
+    return (
+      <>
+        <p>This labware is not a tiprack. Please upload a tiprack.</p>
+      </>
+    )
   }
   assert(false, `MessageBody got unhandled messageType: ${message.messageType}`)
   return null

--- a/protocol-designer/src/labware-defs/actions.js
+++ b/protocol-designer/src/labware-defs/actions.js
@@ -10,6 +10,7 @@ import {
   getLabwareDefURI,
   OPENTRONS_LABWARE_NAMESPACE,
 } from '@opentrons/shared-data'
+import { getIsTiprack } from '../../../shared-data/js/getLabware'
 import * as labwareDefSelectors from './selectors'
 import { getAllWellSetsForLabware } from '../utils'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -35,7 +36,7 @@ export type CreateCustomLabwareDef = {|
   |},
 |}
 
-const createCustomLabwareDefAction = (
+export const createCustomLabwareDefAction = (
   payload: $PropertyType<CreateCustomLabwareDef, 'payload'>
 ): CreateCustomLabwareDef => ({
   type: 'CREATE_CUSTOM_LABWARE_DEF',
@@ -90,7 +91,7 @@ const getIsOverwriteMismatched = (
   return !(matchedWellOrdering && matchedMultiUse)
 }
 
-export const createCustomLabwareDef = (
+const _createCustomLabwareDef = (onlyTiprack: boolean) => (
   event: SyntheticInputEvent<HTMLInputElement>
 ): ThunkAction<*> => (dispatch: ThunkDispatch<*>, getState: GetState) => {
   const allLabwareDefs: Array<LabwareDefinition2> = values(
@@ -141,10 +142,15 @@ export const createCustomLabwareDef = (
       console.warn('uploaded labware conforms to schema, but has no well A1!')
     }
     if (!valid || !hasWellA1) {
-      console.debug('validation errors:', validate.errors)
       return dispatch(
         labwareUploadMessage({
           messageType: 'INVALID_JSON_FILE',
+        })
+      )
+    } else if (onlyTiprack && !getIsTiprack(parsedLabwareDef)) {
+      return dispatch(
+        labwareUploadMessage({
+          messageType: 'ONLY_TIPRACK',
         })
       )
     } else if (parsedLabwareDef?.namespace === OPENTRONS_LABWARE_NAMESPACE) {
@@ -226,6 +232,9 @@ export const createCustomLabwareDef = (
   }
   reader.readAsText(file)
 }
+
+export const createCustomLabwareDef = _createCustomLabwareDef(false)
+export const createCustomTiprackDef = _createCustomLabwareDef(true)
 
 type DismissLabwareUploadMessage = {|
   type: 'DISMISS_LABWARE_UPLOAD_MESSAGE',

--- a/protocol-designer/src/labware-defs/types.js
+++ b/protocol-designer/src/labware-defs/types.js
@@ -25,7 +25,10 @@ export type LabwareUploadMessage =
       errorText?: string,
     |}
   | {|
-      messageType: 'EXACT_LABWARE_MATCH' | 'USES_STANDARD_NAMESPACE',
+      messageType:
+        | 'EXACT_LABWARE_MATCH'
+        | 'USES_STANDARD_NAMESPACE'
+        | 'ONLY_TIPRACK',
     |}
   | {|
       ...NameConflictFields,

--- a/protocol-designer/src/load-file/reducers.js
+++ b/protocol-designer/src/load-file/reducers.js
@@ -55,7 +55,6 @@ const unsavedChanges = (
     case 'DELETE_STEP':
     case 'SAVE_STEP_FORM':
     case 'SAVE_FILE_METADATA':
-    case 'CREATE_CUSTOM_LABWARE_DEF':
     case 'REPLACE_CUSTOM_LABWARE_DEF':
     case 'CREATE_MODULE':
     case 'DELETE_MODULE':

--- a/protocol-designer/src/localization/en/button.json
+++ b/protocol-designer/src/localization/en/button.json
@@ -18,5 +18,6 @@
   "swap": "swap",
   "yes": "yes",
   "upload_custom_labware": "Upload custom labware",
+  "upload_custom_tip_rack": "Upload custom tip rack",
   "got_it": "Got It!"
 }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -35,7 +35,8 @@
       "EXACT_LABWARE_MATCH": "Duplicate labware definition",
       "LABWARE_NAME_CONFLICT": "Duplicate labware name",
       "ASK_FOR_LABWARE_OVERWRITE": "Duplicate labware name",
-      "USES_STANDARD_NAMESPACE": "Standard (non-custom) Opentrons labware"
+      "USES_STANDARD_NAMESPACE": "Standard (non-custom) Opentrons labware",
+      "ONLY_TIPRACK": "Must be a tiprack"
     }
   },
   "new_protocol": {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -36,7 +36,7 @@
       "LABWARE_NAME_CONFLICT": "Duplicate labware name",
       "ASK_FOR_LABWARE_OVERWRITE": "Duplicate labware name",
       "USES_STANDARD_NAMESPACE": "Standard (non-custom) Opentrons labware",
-      "ONLY_TIPRACK": "Must be a tiprack"
+      "ONLY_TIPRACK": "Incompatible file type"
     }
   },
   "new_protocol": {


### PR DESCRIPTION
## overview

This PR closes #4736 by enabling the custom tiprack upload button in the protocol creation modal.

## changelog

  - Curried createCustomLabwareDef action to handle both full labware def upload as well as only tiprack upload 
  - Enabled custom tiprack upload button in file creation modal
  - Pulled in custom labware info in labware selection modal in deck map

## review requests
When Enable Custom Tipracks FF is off:
   - You should NOT be able to see the `Upload Custom Tip Rack` button in the protocol creation modal

When Enable Custom Tipracks FF is on: 
  - `Upload Custom Tip Rack` button should be visible in protocol creation modal
  - If uploading a file that is NOT JSON, should see `Incompatible file type` warning modal
  - If uploading a file that is JSON but NOT valid tiprack, should see `Must be tiprack` warning modal @howisthisnamenottakenyet need your exact copy text here
  - If uploading a valid tiprack file that has already been uploaded, should see `Duplicate labware definition` warning modal
  - If uploading a file that is valid tiprack JSON file that has NOT already been uploaded, after the upload you should see the tiprack in both the left and right pipette tiprack dropdown fields. 
  - You should be able to select the tiprack and carry on like normal 
  - In the deck map, you should be able to select the custom tiprack in the labware selection modal under `custom labware`

Since I curried the `createCustomLabwareDef` function, we should also make sure normal custom labware uploads also work.

## risk assessment

Low? This should probably be tested on the robot though since we have no way of knowing that this really works. 
