### PR TITLE
refactor(protocol-designer): Update ModuleRow tooltip and tests

### DIFF
--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -4,7 +4,8 @@ import {
   LabeledValue,
   OutlineButton,
   SlotMap,
-  HoverTooltip,
+  Tooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
 import { useDispatch } from 'react-redux'
@@ -99,6 +100,10 @@ export function ModuleRow(props: Props) {
   const handleEditModule =
     moduleOnDeck && setCurrentModule(type, moduleOnDeck.id)
 
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'bottom',
+  })
+
   return (
     <div>
       <h4 className={styles.row_title}>
@@ -123,22 +128,16 @@ export function ModuleRow(props: Props) {
           {slot && <LabeledValue label="Position" value={slotDisplayName} />}
         </div>
         <div className={styles.slot_map}>
+          {collisionSlots.length > 0 && (
+            <Tooltip {...tooltipProps}>{collisionTooltip}</Tooltip>
+          )}
           {slot && (
-            <HoverTooltip
-              placement="bottom"
-              tooltipComponent={
-                collisionSlots.length > 0 ? collisionTooltip : null
-              }
-            >
-              {hoverTooltipHandlers => (
-                <div {...hoverTooltipHandlers}>
-                  <SlotMap
-                    occupiedSlots={occupiedSlotsForMap}
-                    collisionSlots={collisionSlots}
-                  />
-                </div>
-              )}
-            </HoverTooltip>
+            <div {...targetProps}>
+              <SlotMap
+                occupiedSlots={occupiedSlotsForMap}
+                collisionSlots={collisionSlots}
+              />
+            </div>
           )}
         </div>
         <div className={styles.modules_button_group}>

--- a/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
+++ b/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
@@ -57,7 +57,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(Tooltip)).toHaveLength(1)
+    expect(wrapper.find(Tooltip)).toBeTruthy()
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toEqual(['4'])
   })
 
@@ -72,7 +72,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(Tooltip)).toHaveLength(1)
+    expect(wrapper.find(Tooltip)).toBeTruthy()
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toEqual(['6'])
   })
 

--- a/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
+++ b/protocol-designer/src/components/modules/__tests__/ModuleRow.test.js
@@ -8,7 +8,7 @@ import {
   MAGNETIC_MODULE_V2,
 } from '@opentrons/shared-data'
 import {
-  HoverTooltip,
+  Tooltip,
   SlotMap,
   LabeledValue,
   OutlineButton,
@@ -57,7 +57,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(HoverTooltip).prop('tooltipComponent')).toBeTruthy()
+    expect(wrapper.find(Tooltip)).toHaveLength(1)
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toEqual(['4'])
   })
 
@@ -72,7 +72,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(HoverTooltip).prop('tooltipComponent')).toBeTruthy()
+    expect(wrapper.find(Tooltip)).toHaveLength(1)
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toEqual(['6'])
   })
 
@@ -87,7 +87,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(HoverTooltip).prop('tooltipComponent')).toBeNull()
+    expect(wrapper.find(Tooltip)).toHaveLength(0)
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toHaveLength(0)
   })
 
@@ -101,7 +101,7 @@ describe('ModuleRow', () => {
 
     const wrapper = render(props)
 
-    expect(wrapper.find(HoverTooltip).prop('tooltipComponent')).toBeNull()
+    expect(wrapper.find(Tooltip)).toHaveLength(0)
     expect(wrapper.find(SlotMap).prop('collisionSlots')).toHaveLength(0)
   })
 


### PR DESCRIPTION
## overview

This PR addresses #5411 by updating the ModuleRow SlotMap tooltip component and updating corresponding tests.

## changelog

- refactor(protocol-designer): Update ModuleRow tooltip and tests


## review requests

Make a protocol with a Gen1 and a Gen 2 module and a Gen1 multi channel pipette
- [ ] Slotmap in ModuleRow renders tooltip for module with collision warning
- [ ] Slotmap in ModuleRow DOES NOT render tooltip for module with NO collision warning

## risk assessment

Low, PD tooltip update only
