### PR TITLE
feat(api): Allow Non-Full plate Thermocycler Configuration

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -73,7 +73,15 @@ BAD_PAIRS = [('1', '12'),
              ('4', '12'),
              ('12', '4'),
              ('4', '9'),
-             ('9, 4')]
+             ('9, 4'),
+             ('4', '8'),
+             ('8', '4'),
+             ('1', '8'),
+             ('8', '1'),
+             ('4', '11'),
+             ('11', '4'),
+             ('1', '11'),
+             ('11', '1')]
 
 
 def should_dodge_thermocycler(
@@ -388,7 +396,9 @@ class Deck(UserDict):
             with the given item.
         """
         def get_item_covered_slot_keys(sk, i):
-            if isinstance(i, ThermocyclerGeometry):
+            if isinstance(i, ThermocyclerGeometry) and i.is_semi_configuration:
+                return(set([7, 10]))
+            elif isinstance(i, ThermocyclerGeometry):
                 return(set([7, 8, 10, 11]))
             elif i is not None:
                 return set([sk])

--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -396,10 +396,8 @@ class Deck(UserDict):
             with the given item.
         """
         def get_item_covered_slot_keys(sk, i):
-            if isinstance(i, ThermocyclerGeometry) and i.is_semi_configuration:
-                return(set([7, 10]))
-            elif isinstance(i, ThermocyclerGeometry):
-                return(set([7, 8, 10, 11]))
+            if isinstance(i, ThermocyclerGeometry):
+                return i.covered_slots
             elif i is not None:
                 return set([sk])
             else:

--- a/api/src/opentrons/protocol_api/module_geometry.py
+++ b/api/src/opentrons/protocol_api/module_geometry.py
@@ -277,6 +277,10 @@ class ThermocyclerGeometry(ModuleGeometry):
                                      :py:class:`ModuleGeometry` instance. The
                                      :py:class:`ModuleGeometry` will
                                      conform to this level.
+        :param configuration: Used to specify the slot configuration of
+                              the Thermocycler. It should by of type
+                              :py:class:`.ThermocyclerConfiguration` and can
+                              either be FULL or SEMI.
         """
         super().__init__(
             display_name, model, module_type, offset, overall_height,
@@ -548,6 +552,11 @@ def load_module(
                                  :py:class:`ModuleGeometry` will
                                  conform to this level. If not specified,
                                  defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
+    :param configuration: Used to specify the slot configuration of
+                        the Thermocycler. Only Valid in Python API
+                        Version 2.4 and later. If you wish to use
+                        the non-full plate configuration, you must
+                        pass in the key word value `semi`
     """
     api_level = api_level or MAX_SUPPORTED_VERSION
     defn = _load_module_definition(api_level, model)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -399,7 +399,7 @@ class ProtocolContext(CommandPublisher):
     def load_module(
             self, module_name: str,
             location: Optional[types.DeckLocation] = None,
-            configuration: str = None) -> ModuleTypes:
+            semi_configuration: bool = False) -> ModuleTypes:
         """ Load a module onto the deck given its name.
 
         This is the function to call to use a module in your protocol, like
@@ -419,9 +419,11 @@ class ProtocolContext(CommandPublisher):
                          location. You do not have to specify a location
                          when loading a Thermocycler - it will always be
                          in Slot 7.
-        :param configuration: Used to specify the slot configuration of
-                              the Thermocycler. Only Valid in Python API
-                              Version 2.4 and later.
+        :param semi_configuration: Used to specify the slot configuration of
+                                   the Thermocycler. Only Valid in Python API
+                                   Version 2.4 and later. True if semi
+                                   configuration for thermocycler,
+                                   False otherwise.
         :type location: str or int or None
         :returns ModuleContext: The loaded and initialized
                                 :py:class:`ModuleContext`.
@@ -430,12 +432,16 @@ class ProtocolContext(CommandPublisher):
         resolved_type = resolve_module_type(resolved_model)
         resolved_location = self._deck_layout.resolve_module_location(
             resolved_type, location)
+        if self._api_version < APIVersion(2, 4) and semi_configuration:
+            self._log.warning(
+                f'You have specified API {self._api_version}, but you are'
+                'using thermocycler parameters only available in 2.4')
         geometry = load_module(
             resolved_model,
             self._deck_layout.position_for(
                 resolved_location),
-            self._api_version,
-            configuration)
+            self._api_version, semi_configuration)
+
         hc_mod_instance = None
         mod_class = {
             ModuleType.MAGNETIC: MagneticModuleContext,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -398,7 +398,8 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 0)
     def load_module(
             self, module_name: str,
-            location: Optional[types.DeckLocation] = None) -> ModuleTypes:
+            location: Optional[types.DeckLocation] = None,
+            configuration: str = None) -> ModuleTypes:
         """ Load a module onto the deck given its name.
 
         This is the function to call to use a module in your protocol, like
@@ -418,6 +419,9 @@ class ProtocolContext(CommandPublisher):
                          location. You do not have to specify a location
                          when loading a Thermocycler - it will always be
                          in Slot 7.
+        :param configuration: Used to specify the slot configuration of
+                              the Thermocycler. Only Valid in Python API
+                              Version 2.4 and later.
         :type location: str or int or None
         :returns ModuleContext: The loaded and initialized
                                 :py:class:`ModuleContext`.
@@ -430,7 +434,8 @@ class ProtocolContext(CommandPublisher):
             resolved_model,
             self._deck_layout.position_for(
                 resolved_location),
-            self._api_version)
+            self._api_version,
+            configuration)
         hc_mod_instance = None
         mod_class = {
             ModuleType.MAGNETIC: MagneticModuleContext,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -23,7 +23,7 @@ from .module_contexts import (
     ModuleContext, MagneticModuleContext, TemperatureModuleContext,
     ThermocyclerContext)
 from .util import (AxisMaxSpeeds, HardwareManager,
-                   requires_version, HardwareToManage)
+                   requires_version, HardwareToManage, APIVersionError)
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -399,7 +399,7 @@ class ProtocolContext(CommandPublisher):
     def load_module(
             self, module_name: str,
             location: Optional[types.DeckLocation] = None,
-            semi_configuration: bool = False) -> ModuleTypes:
+            configuration: str = None) -> ModuleTypes:
         """ Load a module onto the deck given its name.
 
         This is the function to call to use a module in your protocol, like
@@ -419,11 +419,11 @@ class ProtocolContext(CommandPublisher):
                          location. You do not have to specify a location
                          when loading a Thermocycler - it will always be
                          in Slot 7.
-        :param semi_configuration: Used to specify the slot configuration of
-                                   the Thermocycler. Only Valid in Python API
-                                   Version 2.4 and later. True if semi
-                                   configuration for thermocycler,
-                                   False otherwise.
+        :param configuration: Used to specify the slot configuration of
+                              the Thermocycler. Only Valid in Python API
+                              Version 2.4 and later. If you wish to use
+                              the non-full plate configuration, you must
+                              pass in the key word value `semi`
         :type location: str or int or None
         :returns ModuleContext: The loaded and initialized
                                 :py:class:`ModuleContext`.
@@ -432,15 +432,16 @@ class ProtocolContext(CommandPublisher):
         resolved_type = resolve_module_type(resolved_model)
         resolved_location = self._deck_layout.resolve_module_location(
             resolved_type, location)
-        if self._api_version < APIVersion(2, 4) and semi_configuration:
-            self._log.warning(
+        if self._api_version < APIVersion(2, 4) and configuration:
+            raise APIVersionError(
                 f'You have specified API {self._api_version}, but you are'
                 'using thermocycler parameters only available in 2.4')
+
         geometry = load_module(
             resolved_model,
             self._deck_layout.position_for(
                 resolved_location),
-            self._api_version, semi_configuration)
+            self._api_version, configuration)
 
         hc_mod_instance = None
         mod_class = {

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -370,7 +370,9 @@ def test_module_load_v1(v1_module_name):
     assert mod.highest_z == high_z + 3
     assert mod.location.point == (offset + Point(1, 2, 3))
     mod2 = module_geometry.load_module_from_definition(
-        module_defs[v1_module_name], Location(Point(3, 2, 1), 'test2'))
+        module_defs[v1_module_name],
+        Location(Point(3, 2, 1), 'test2'),
+        module_geometry.ThermocyclerConfiguration.FULL)
     assert mod2.highest_z == high_z + 1
     assert mod2.location.point == (offset + Point(3, 2, 1))
 

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -433,3 +433,19 @@ def test_module_compatibility(get_module_fixture, monkeypatch):
         DummyEnum('compatibleGenerationV1'),
         DummyEnum('incompatibleGenerationV1')
     )
+
+
+def test_thermocycler_semi_plate_configuration(loop):
+    ctx = papi.ProtocolContext(loop)
+    labware_name = 'nest_96_wellplate_100ul_pcr_full_skirt'
+    mod = ctx.load_module('thermocycler', configuration='semi')
+    assert mod._geometry.labware_offset == Point(-23.28, 82.56, 97.8)
+
+    tc_labware = mod.load_labware(labware_name)
+
+    other_labware = ctx.load_labware(labware_name, 2)
+    without_first_two_cols = other_labware.wells()[16::]
+    for tc_well, other_well in zip(tc_labware.wells(), without_first_two_cols):
+        tc_well_name = tc_well.display_name.split()[0]
+        other_well_name = other_well.display_name.split()[0]
+        assert tc_well_name == other_well_name

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -438,7 +438,7 @@ def test_module_compatibility(get_module_fixture, monkeypatch):
 def test_thermocycler_semi_plate_configuration(loop):
     ctx = papi.ProtocolContext(loop)
     labware_name = 'nest_96_wellplate_100ul_pcr_full_skirt'
-    mod = ctx.load_module('thermocycler', semi_configuration=True)
+    mod = ctx.load_module('thermocycler', configuration='semi')
     assert mod._geometry.labware_offset == Point(-23.28, 82.56, 97.8)
 
     tc_labware = mod.load_labware(labware_name)

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -438,7 +438,7 @@ def test_module_compatibility(get_module_fixture, monkeypatch):
 def test_thermocycler_semi_plate_configuration(loop):
     ctx = papi.ProtocolContext(loop)
     labware_name = 'nest_96_wellplate_100ul_pcr_full_skirt'
-    mod = ctx.load_module('thermocycler', configuration='semi')
+    mod = ctx.load_module('thermocycler', semi_configuration=True)
     assert mod._geometry.labware_offset == Point(-23.28, 82.56, 97.8)
 
     tc_labware = mod.load_labware(labware_name)


### PR DESCRIPTION
## overview

Closes #5464. This PR adds in support for a "semi" thermocycler configuration which can support up to 80 samples.

## changelog

- Add in more 'bad locations' in geometry to avoid when a thermocycler is loaded onto the deck
- Add in a parameter to the `load_module` method called `configuration` that allows you to specify the non-full plate configuration by setting the value to `semi`
- Modify the thermocycler offset when the semi configuration is specified
- Modify the wells you can access on the plate (this will get a little confusing when you access stuff by index; should we do a weird hack to fix that?)

## review requests

Please test the following listed in risk assessment using this protocol:
```
def run(ctx):
	tc = ctx.load_module('thermocycler', configuration='semi')
	tc_lw = tc.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
	tiprack = ctx.load_labware('opentrons_96_tiprack_1000ul', 1)
         pip = ctx.load_instrument('p1000_single_gen2', 'right', tip_racks=[tiprack])

	slot_11_lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 11)

	pip.transfer(200, slot_11_lw['A1'], tc_lw['A4'])
```

## risk assessment

Low/Medium. We should test a few different things:
- [ ] Add in a labware to slot 8 or 11 and perform an action that will cause the robot to move either to this location or from this location to slots 1 or 4.
- [ ] Check that you cannot access columns 1 or 2 by name
- [ ] Check that you can move through columns/rows as normal on the thermocycler without collision
