### PR TITLE
feat(api, app): add state change information to rpc

### DIFF
--- a/api/src/opentrons/api/dev_types.py
+++ b/api/src/opentrons/api/dev_types.py
@@ -1,0 +1,17 @@
+from typing_extensions import Literal, TypedDict
+
+State = Literal[
+    'loaded', 'running', 'finished', 'stopped', 'paused', 'error', None]
+
+
+class StateInfo(TypedDict, total=False):
+    message: str
+    #: A message associated with the state change by the system for display
+    changedAt: float
+    #: The time at which the state changed, relative to the startTime
+    estimatedDuration: float
+    #: If relevant for the state (e.g. 'paused' caused by a delay() call) the
+    #: duration estimated for the state
+    userMessage: str
+    #: If provided by the mechanism that changed the state, a message from the
+    #: user

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -585,7 +585,7 @@ class Session(object):
         else:
             self.stateInfo.pop('message', None)
         if duration:
-            self.stateInfo.pop('estimatedDuration', None)
+            self.stateInfo['estimatedDuration'] = duration
         else:
             self.stateInfo.pop('estimatedDuration', None)
         if self.startTime:

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -533,7 +533,8 @@ def pause(msg):
     return make_command(
         name=command_types.PAUSE,
         payload={
-            'text': text
+            'text': text,
+            'userMessage': msg,
         }
     )
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 import base64
 
+from opentrons.api import session
 from opentrons.api.session import (
     _accumulate, _dedupe)
 from tests.opentrons.conftest import state
@@ -130,6 +131,21 @@ def test_set_state(run_session):
 
     with pytest.raises(ValueError):
         run_session.set_state('impossible-state')
+
+
+def test_set_state_info(run_session, monkeypatch):
+    assert run_session.stateInfo == {}
+    run_session.set_state('paused',
+                          reason='test1',
+                          user_message='cool message',
+                          duration=10)
+    assert run_session.stateInfo == {'message': 'test1',
+                                     'userMessage': 'cool message',
+                                     'estimatedDuration': 10}
+    run_session.startTime = 300
+    monkeypatch.setattr(session, 'now', lambda: 350)
+    run_session.set_state('running')
+    assert run_session.stateInfo == {'changedAt': 50}
 
 
 def test_error_append(run_session):

--- a/app/src/components/RunLog/CommandList.js
+++ b/app/src/components/RunLog/CommandList.js
@@ -7,11 +7,12 @@ import { SessionAlert } from './SessionAlert'
 import { Portal } from '../portal'
 import styles from './styles.css'
 
-import type { SessionStatus } from '../../robot'
+import type { SessionStatus, SessionStatusInfo } from '../../robot'
 
 export type CommandListProps = {|
   commands: Array<any>,
   sessionStatus: SessionStatus,
+  sessionStatusInfo: SessionStatusInfo,
   showSpinner: boolean,
   onResetClick: () => mixed,
 |}
@@ -23,7 +24,13 @@ export class CommandList extends React.Component<CommandListProps> {
   }
 
   render() {
-    const { commands, sessionStatus, showSpinner, onResetClick } = this.props
+    const {
+      commands,
+      sessionStatus,
+      sessionStatusInfo,
+      showSpinner,
+      onResetClick,
+    } = this.props
     const makeCommandToTemplateMapper = depth => command => {
       const {
         id,
@@ -88,6 +95,7 @@ export class CommandList extends React.Component<CommandListProps> {
         {!showSpinner && (
           <SessionAlert
             sessionStatus={sessionStatus}
+            sessionStatusInfo={sessionStatusInfo}
             onResetClick={onResetClick}
             className={styles.alert}
           />

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -13,7 +13,7 @@ const buildPause = (message: ?string): string =>
   `Run paused${buildPauseMessage(message)}`
 
 const buildPauseUserMessage = (message: ?string) =>
-  message && <div className={styles.pauseUserMessage}>{message}</div>
+  message && <div className={styles.pause_user_message}>{message}</div>
 
 export type SessionAlertProps = {|
   sessionStatus: SessionStatus,

--- a/app/src/components/RunLog/SessionAlert.js
+++ b/app/src/components/RunLog/SessionAlert.js
@@ -3,16 +3,27 @@ import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { AlertItem } from '@opentrons/components'
 import { getSessionError } from '../../robot/selectors'
-import type { SessionStatus } from '../../robot'
+import type { SessionStatus, SessionStatusInfo } from '../../robot'
+import styles from './styles.css'
+
+const buildPauseMessage = (message: ?string): string =>
+  message ? `: ${message}` : ''
+
+const buildPause = (message: ?string): string =>
+  `Run paused${buildPauseMessage(message)}`
+
+const buildPauseUserMessage = (message: ?string) =>
+  message && <div className={styles.pauseUserMessage}>{message}</div>
 
 export type SessionAlertProps = {|
   sessionStatus: SessionStatus,
+  sessionStatusInfo: SessionStatusInfo,
   className?: string,
   onResetClick: () => mixed,
 |}
 
 export function SessionAlert(props: SessionAlertProps) {
-  const { sessionStatus, className, onResetClick } = props
+  const { sessionStatus, sessionStatusInfo, className, onResetClick } = props
   const sessionError = useSelector(getSessionError)
 
   switch (sessionStatus) {
@@ -36,8 +47,10 @@ export function SessionAlert(props: SessionAlertProps) {
           className={className}
           type="info"
           icon={{ name: 'pause-circle' }}
-          title="Run paused"
-        />
+          title={buildPause(sessionStatusInfo.message)}
+        >
+          {buildPauseUserMessage(sessionStatusInfo.userMessage)}
+        </AlertItem>
       )
 
     case 'stopped':

--- a/app/src/components/RunLog/index.js
+++ b/app/src/components/RunLog/index.js
@@ -9,7 +9,7 @@ import {
 import { CommandList } from './CommandList'
 
 import type { State, Dispatch } from '../../types'
-import type { SessionStatus } from '../../robot'
+import type { SessionStatus, SessionStatusInfo } from '../../robot'
 import type { CommandListProps } from './CommandList'
 
 export { ConfirmCancelModal } from './ConfirmCancelModal'
@@ -17,6 +17,7 @@ export { ConfirmCancelModal } from './ConfirmCancelModal'
 type SP = {|
   commands: Array<any>,
   sessionStatus: SessionStatus,
+  sessionStatusInfo: SessionStatusInfo,
   showSpinner: boolean,
 |}
 
@@ -33,6 +34,7 @@ function mapStateToProps(state: State): SP {
   return {
     commands: robotSelectors.getCommands(state),
     sessionStatus: robotSelectors.getSessionStatus(state),
+    sessionStatusInfo: robotSelectors.getSessionStatusInfo(state),
     showSpinner:
       robotSelectors.getCancelInProgress(state) ||
       robotSelectors.getSessionLoadInProgress(state),

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -2,6 +2,14 @@
 /* stylelint-disable selector-class-pattern, font-family-no-missing-generic-family-keyword  */
 @import '@opentrons/components';
 
+.pauseUserMessage {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  font-style: italic;
+  overflow-y: scroll;
+  max-height: 4rem;
+}
+
 .run_page {
   position: relative;
 }

--- a/app/src/components/RunLog/styles.css
+++ b/app/src/components/RunLog/styles.css
@@ -2,7 +2,7 @@
 /* stylelint-disable selector-class-pattern, font-family-no-missing-generic-family-keyword  */
 @import '@opentrons/components';
 
-.pauseUserMessage {
+.pause_user_message {
   margin-left: 0.5rem;
   margin-right: 0.5rem;
   font-style: italic;

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -457,10 +457,8 @@ export function client(dispatch) {
       message: apiSession.stateInfo?.message ?? null,
       userMessage: apiSession.stateInfo?.userMessage ?? null,
       changedAt: apiSession.stateInfo?.changedAt ?? null,
-      estimatedDuration:
-        apiSession.stateInfo?.estimatedDuration ?? null,
+      estimatedDuration: apiSession.stateInfo?.estimatedDuration ?? null,
     }
-
 
     // both light and full updates may have the errors list
     if (apiSession.errors) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -453,22 +453,14 @@ export function client(dispatch) {
       clearRunTimerInterval()
     }
 
-    if (apiSession.stateInfo) {
-      update.statusInfo = {
-        message: apiSession.stateInfo?.message ?? null,
-        userMessage: apiSession.stateInfo?.userMessage ?? null,
-        changedAt: apiSession.stateInfo?.changedAt ?? null,
-        estimatedDuration:
-          apiSession.stateInfo?.estimatedDuration ?? null,
-      }
-    } else {
-      update.statusInfo = {
-        message: null,
-        userMessage: null,
-        changedAt: null,
-        estimatedDuration: null,
-      }
+    update.statusInfo = {
+      message: apiSession.stateInfo?.message ?? null,
+      userMessage: apiSession.stateInfo?.userMessage ?? null,
+      changedAt: apiSession.stateInfo?.changedAt ?? null,
+      estimatedDuration:
+        apiSession.stateInfo?.estimatedDuration ?? null,
     }
+
 
     // both light and full updates may have the errors list
     if (apiSession.errors) {

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -453,6 +453,22 @@ export function client(dispatch) {
       clearRunTimerInterval()
     }
 
+    if (apiSession.stateInfo) {
+      update.stateInfo = pick(apiSession.stateInfo, [
+        'message',
+        'userMessage',
+        'changedAt',
+        'estimatedDuration',
+      ])
+    } else {
+      update.stateInfo = {
+        message: null,
+        userMessage: null,
+        changedAt: null,
+        estimatedDuration: null,
+      }
+    }
+
     // both light and full updates may have the errors list
     if (apiSession.errors) {
       update.errors = apiSession.errors.map(e => ({

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -456,7 +456,7 @@ export function client(dispatch) {
     if (apiSession.stateInfo) {
       update.statusInfo = {
         message: apiSession.stateInfo?.message ?? null,
-        userMessage: apiSession.stateInfo?.message ?? null,
+        userMessage: apiSession.stateInfo?.userMessage ?? null,
         changedAt: apiSession.stateInfo?.changedAt ?? null,
         estimatedDuration:
           apiSession.stateInfo?.estimatedDuration ?? null,

--- a/app/src/robot/api-client/client.js
+++ b/app/src/robot/api-client/client.js
@@ -454,14 +454,15 @@ export function client(dispatch) {
     }
 
     if (apiSession.stateInfo) {
-      update.stateInfo = pick(apiSession.stateInfo, [
-        'message',
-        'userMessage',
-        'changedAt',
-        'estimatedDuration',
-      ])
+      update.statusInfo = {
+        message: apiSession.stateInfo?.message ?? null,
+        userMessage: apiSession.stateInfo?.message ?? null,
+        changedAt: apiSession.stateInfo?.changedAt ?? null,
+        estimatedDuration:
+          apiSession.stateInfo?.estimatedDuration ?? null,
+      }
     } else {
-      update.stateInfo = {
+      update.statusInfo = {
         message: null,
         userMessage: null,
         changedAt: null,

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -12,6 +12,7 @@ import type {
   Mount,
   Slot,
   SessionStatus,
+  SessionStatusInfo,
 } from '../types'
 
 import type { InvalidProtocolFileAction } from '../../protocol/types'
@@ -25,6 +26,7 @@ type Request = {
 export type SessionState = {
   sessionRequest: Request,
   state: SessionStatus,
+  stateInfo: SessionStatusInfo,
   errors: Array<{|
     timestamp: number,
     line: number,
@@ -72,6 +74,12 @@ const INITIAL_STATE: SessionState = {
   // loading a protocol
   sessionRequest: { inProgress: false, error: null },
   state: '',
+  stateInfo: {
+    message: null,
+    changedAt: null,
+    estimatedDuration: null,
+    userMessage: null,
+  },
   errors: [],
   protocolCommands: [],
   protocolCommandsById: {},
@@ -196,6 +204,7 @@ function handleSessionUpdate(
   return {
     ...state,
     state: sessionState,
+    stateInfo: action.payload.stateInfo,
     remoteTimeCompensation,
     startTime,
     protocolCommandsById,

--- a/app/src/robot/reducer/session.js
+++ b/app/src/robot/reducer/session.js
@@ -26,7 +26,7 @@ type Request = {
 export type SessionState = {
   sessionRequest: Request,
   state: SessionStatus,
-  stateInfo: SessionStatusInfo,
+  statusInfo: SessionStatusInfo,
   errors: Array<{|
     timestamp: number,
     line: number,
@@ -74,7 +74,7 @@ const INITIAL_STATE: SessionState = {
   // loading a protocol
   sessionRequest: { inProgress: false, error: null },
   state: '',
-  stateInfo: {
+  statusInfo: {
     message: null,
     changedAt: null,
     estimatedDuration: null,
@@ -204,7 +204,7 @@ function handleSessionUpdate(
   return {
     ...state,
     state: sessionState,
-    stateInfo: action.payload.stateInfo,
+    statusInfo: action.payload.statusInfo,
     remoteTimeCompensation,
     startTime,
     protocolCommandsById,

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -22,6 +22,7 @@ import type {
   LabwareCalibrationStatus,
   LabwareType,
   SessionStatus,
+  SessionStatusInfo,
   SessionModule,
   TiprackByMountMap,
 } from './types'
@@ -81,6 +82,10 @@ export function getUploadError(state: State): ?{ message: string } {
 
 export function getSessionStatus(state: State): SessionStatus {
   return session(state).state
+}
+
+export function getSessionStatusInfo(state: State): SessionStatusInfo {
+  return session(state).stateInfo
 }
 
 export function getSessionIsLoaded(state: State): boolean {

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -85,7 +85,7 @@ export function getSessionStatus(state: State): SessionStatus {
 }
 
 export function getSessionStatusInfo(state: State): SessionStatusInfo {
-  return session(state).stateInfo
+  return session(state).statusInfo
 }
 
 export function getSessionIsLoaded(state: State): boolean {

--- a/app/src/robot/test/__fixtures__/session.js
+++ b/app/src/robot/test/__fixtures__/session.js
@@ -7,6 +7,12 @@ export function MockSession() {
     commands: [],
     command_log: {},
     state: 'loaded',
+    stateInfo: {
+      message: null,
+      userMessage: null,
+      changedAt: null,
+      estimatedDuration: null,
+    },
     instruments: [],
     containers: [],
 

--- a/app/src/robot/test/__fixtures__/session.js
+++ b/app/src/robot/test/__fixtures__/session.js
@@ -7,12 +7,7 @@ export function MockSession() {
     commands: [],
     command_log: {},
     state: 'loaded',
-    stateInfo: {
-      message: null,
-      userMessage: null,
-      changedAt: null,
-      estimatedDuration: null,
-    },
+    stateInfo: {},
     instruments: [],
     containers: [],
 

--- a/app/src/robot/test/__fixtures__/session.js
+++ b/app/src/robot/test/__fixtures__/session.js
@@ -21,3 +21,24 @@ export function MockSession() {
     refresh: jest.fn(),
   }
 }
+
+
+export function MockSessionNoStateInfo() {
+   return {
+    name: 'MOCK SESSION',
+    protocol_text: '# mock protocol text',
+    commands: [],
+    command_log: {},
+    state: 'loaded',
+    instruments: [],
+    containers: [],
+
+    modules: [],
+
+    run: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    stop: jest.fn(),
+    refresh: jest.fn(),
+  }
+}

--- a/app/src/robot/test/__fixtures__/session.js
+++ b/app/src/robot/test/__fixtures__/session.js
@@ -22,9 +22,8 @@ export function MockSession() {
   }
 }
 
-
 export function MockSessionNoStateInfo() {
-   return {
+  return {
     name: 'MOCK SESSION',
     protocol_text: '# mock protocol text',
     commands: [],

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -751,7 +751,7 @@ describe('api client', () => {
           userMessage: null,
           changedAt: null,
           estimatedDuration: null,
-        }
+        },
       }
       const expected = actions.sessionUpdate(actionInput, expect.any(Number))
 
@@ -764,7 +764,7 @@ describe('api client', () => {
       const update = {
         state: 'running',
         startTime: 2,
-        lastCommand: null
+        lastCommand: null,
       }
 
       const actionInput = {
@@ -774,7 +774,7 @@ describe('api client', () => {
           userMessage: null,
           changedAt: null,
           estimatedDuration: null,
-        }
+        },
       }
       const expected = actions.sessionUpdate(actionInput, expect.any(Number))
 
@@ -788,9 +788,11 @@ describe('api client', () => {
         state: 'running',
         startTime: 2,
         lastCommand: null,
-        stateInfo: {message: 'hi and hello football fans',
-                    userMessage: 'whos ready for some FOOTBALL',
-                    changedAt: 2}
+        stateInfo: {
+          message: 'hi and hello football fans',
+          userMessage: 'whos ready for some FOOTBALL',
+          changedAt: 2,
+        },
       }
 
       const actionInput = {
@@ -802,7 +804,7 @@ describe('api client', () => {
           userMessage: 'whos ready for some FOOTBALL',
           changedAt: 2,
           estimatedDuration: null,
-        }
+        },
       }
       const expected = actions.sessionUpdate(actionInput, expect.any(Number))
 
@@ -810,7 +812,6 @@ describe('api client', () => {
         .then(() => sendNotification('session', update))
         .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
     })
-
   })
 
   describe('calibration', () => {

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -739,9 +739,72 @@ describe('api client', () => {
         state: 'running',
         startTime: 1,
         lastCommand: null,
-        statusInfo: { message: null, userMessage: null, changedAt: null, estimatedDuration: null},
+        stateInfo: {},
       }
-      const expected = actions.sessionUpdate(update, expect.any(Number))
+
+      const actionInput = {
+        state: 'running',
+        startTime: 1,
+        lastCommand: null,
+        statusInfo: {
+          message: null,
+          userMessage: null,
+          changedAt: null,
+          estimatedDuration: null,
+        }
+      }
+      const expected = actions.sessionUpdate(actionInput, expect.any(Number))
+
+      return sendConnect()
+        .then(() => sendNotification('session', update))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    it('handles SESSION_UPDATEs with no stateInfo', () => {
+      const update = {
+        state: 'running',
+        startTime: 2,
+        lastCommand: null
+      }
+
+      const actionInput = {
+        ...update,
+        statusInfo: {
+          message: null,
+          userMessage: null,
+          changedAt: null,
+          estimatedDuration: null,
+        }
+      }
+      const expected = actions.sessionUpdate(actionInput, expect.any(Number))
+
+      return sendConnect()
+        .then(() => sendNotification('session', update))
+        .then(() => expect(dispatch).toHaveBeenCalledWith(expected))
+    })
+
+    it('handles SESSION_UPDATEs with values in stateInfo', () => {
+      const update = {
+        state: 'running',
+        startTime: 2,
+        lastCommand: null,
+        stateInfo: {message: 'hi and hello football fans',
+                    userMessage: 'whos ready for some FOOTBALL',
+                    changedAt: 2}
+      }
+
+      const actionInput = {
+        state: 'running',
+        startTime: 2,
+        lastCommand: null,
+        statusInfo: {
+          message: 'hi and hello football fans',
+          userMessage: 'whos ready for some FOOTBALL',
+          changedAt: 2,
+          estimatedDuration: null,
+        }
+      }
+      const expected = actions.sessionUpdate(actionInput, expect.any(Number))
 
       return sendConnect()
         .then(() => sendNotification('session', update))

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -353,7 +353,7 @@ describe('api client', () => {
         {
           name: session.name,
           state: session.state,
-          stateInfo: {
+          statusInfo: {
             message: null,
             userMessage: null,
             changedAt: null,
@@ -696,12 +696,7 @@ describe('api client', () => {
         state: 'running',
         startTime: 1,
         lastCommand: null,
-        stateInfo: {
-          message: null,
-          userMessage: null,
-          changedAt: null,
-          estimatedDuration: null,
-        },
+        statusInfo: { message: null, userMessage: null, changedAt: null, estimatedDuration: null},
       }
       const expected = actions.sessionUpdate(update, expect.any(Number))
 

--- a/app/src/robot/test/api-client.test.js
+++ b/app/src/robot/test/api-client.test.js
@@ -353,6 +353,12 @@ describe('api client', () => {
         {
           name: session.name,
           state: session.state,
+          stateInfo: {
+            message: null,
+            userMessage: null,
+            changedAt: null,
+            estimatedDuration: null,
+          },
           protocolText: session.protocol_text,
           protocolCommands: [],
           protocolCommandsById: {},
@@ -686,7 +692,17 @@ describe('api client', () => {
     })
 
     it('sends SESSION_UPDATE if session notification has lastCommand', () => {
-      const update = { state: 'running', startTime: 1, lastCommand: null }
+      const update = {
+        state: 'running',
+        startTime: 1,
+        lastCommand: null,
+        stateInfo: {
+          message: null,
+          userMessage: null,
+          changedAt: null,
+          estimatedDuration: null,
+        },
+      }
       const expected = actions.sessionUpdate(update, expect.any(Number))
 
       return sendConnect()

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -16,6 +16,12 @@ describe('robot reducer - session', () => {
       // loading a protocol
       sessionRequest: { inProgress: false, error: null },
       state: '',
+      stateInfo: {
+        message: null,
+        userMessage: null,
+        changedAt: null,
+        estimatedDuration: null,
+      },
       errors: [],
       protocolCommands: [],
       protocolCommandsById: {},

--- a/app/src/robot/test/session-reducer.test.js
+++ b/app/src/robot/test/session-reducer.test.js
@@ -16,7 +16,7 @@ describe('robot reducer - session', () => {
       // loading a protocol
       sessionRequest: { inProgress: false, error: null },
       state: '',
-      stateInfo: {
+      statusInfo: {
         message: null,
         userMessage: null,
         changedAt: null,

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -158,15 +158,15 @@ export type ConnectionStatus =
   | DISCONNECTING
 
 export type SessionStatusInfo = {|
-  message: ?string,
-  changedAt: ?number,
-  estimatedDuration: ?number,
-  userMessage: ?string,
+  message: string | null,
+  changedAt: number | null,
+  estimatedDuration: number | null,
+  userMessage: string | null,
 |}
 
 export type SessionUpdate = {|
   state: SessionStatus,
-  stateInfo: SessionStatusInfo,
+  statusInfo: SessionStatusInfo,
   startTime: ?number,
   lastCommand: ?{|
     id: number,

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -157,8 +157,16 @@ export type ConnectionStatus =
   | CONNECTED
   | DISCONNECTING
 
+export type SessionStatusInfo = {|
+  message: ?string,
+  changedAt: ?number,
+  estimatedDuration: ?number,
+  userMessage: ?string,
+|}
+
 export type SessionUpdate = {|
   state: SessionStatus,
+  stateInfo: SessionStatusInfo,
   startTime: ?number,
   lastCommand: ?{|
     id: number,


### PR DESCRIPTION
This adds an extra structure of StateInfo to the RPC session that
transmits information like the reason behind a state change to the app.

As a first pass at using it, it also displays the message from a
protocol pause in the pause alert box.

## Testing
- On a robot with this commit, make sure that if you put a `protocol_context.pause()` (or `robot.pause()` in your protocol the message shows up in the alert box
- On a robot without this commit, make sure pausing still works and shows the old reason-less result box

This is a precursor and set of new functionality for adding the rest of the window switch pausing; displaying the user pause message is just a good example of what it can do.