### PR TITLE
fix(api): home only the axis probing after error

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -58,7 +58,7 @@ DEFAULT_AXES_SPEED = 400
 
 XY_HOMING_SPEED = 80
 
-HOME_SEQUENCE = ['ZA', 'BC', 'X', 'Y']
+HOME_SEQUENCE = ['ZABC', 'X', 'Y']
 AXES = ''.join(HOME_SEQUENCE)
 # Ignore these axis when sending move or home command
 DISABLE_AXES = ''

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -58,7 +58,7 @@ DEFAULT_AXES_SPEED = 400
 
 XY_HOMING_SPEED = 80
 
-HOME_SEQUENCE = ['ZABC', 'X', 'Y']
+HOME_SEQUENCE = ['ZA', 'BC', 'X', 'Y']
 AXES = ''.join(HOME_SEQUENCE)
 # Ignore these axis when sending move or home command
 DISABLE_AXES = ''
@@ -1825,11 +1825,15 @@ class SmoothieDriver_3_0_0:
             log.debug("probe_axis: {}".format(command))
             try:
                 self._send_command(
-                    command=command, ack_timeout=DEFAULT_MOVEMENT_TIMEOUT)
+                    command=command, ack_timeout=DEFAULT_MOVEMENT_TIMEOUT,
+                    suppress_home_after_error=True)
             except SmoothieError as se:
                 log.exception("Tip probe failure")
+                self.home(axis)
                 if 'probe' in str(se).lower():
                     raise TipProbeError(se.ret_code, se.command)
+                else:
+                    raise
             self.update_position(self.position)
             return self.position
         else:


### PR DESCRIPTION
Also, raise all errors and not just ones that match "probe failure" to
the user. This fixes an issue where the default home, which hits all
axes, doesn't know about the required currents for the plunger (since
they're handled elsewhere) and fails; this raised an error that didn't
talk about tip probe, so it got swallowed.
