### PR TITLE
fix(api): Correctly grab slot from labware object

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -315,12 +315,13 @@ class Deck(UserDict):
         depending on the mount you are using and the column you are moving
         to inside of the labware.
         """
-        if not target.parent:
+        slot = first_parent(target)
+        if not slot:
             return False
         if mount is types.Mount.RIGHT:
-            other_labware = self.left_of(target.parent)
+            other_labware = self.left_of(slot)
         else:
-            other_labware = self.right_of(target.parent)
+            other_labware = self.right_of(slot)
 
         return isinstance(other_labware, ModuleGeometry)
 


### PR DESCRIPTION
## overview

Closes #5531. If you are accessing a well on a module, you need to go back 3 levels to actually get the slot name. Use `first_parent` instead to ensure you get the slot name.

## changelog

- Use `first_parent` in geometry.py to ensure that you are pulling the slot name, not the labware (or module in this case).

## review requests

Test on a robot using this protocol:
```
from opentrons.types import Mount
metadata={"apiLevel": "2.4"}
def run(ctx):
	tips20m = ctx.load_labware('opentrons_96_tiprack_10ul', '2')
	m20 = ctx.load_instrument('p20_single_gen2', 'right', tip_racks=[tips20m])
	plate = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', '3')
	# plate1 = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', '6')
	# plate2 = ctx.load_labware_by_name('corning_96_wellplate_360ul_flat', '9')
	magdeck = ctx.load_module('magnetic module gen2', '1')
	mag_plate = magdeck.load_labware('nest_96_wellplate_2ml_deep')
	magdeck.engage()
	m20.pick_up_tip()
	m20.aspirate(10, mag_plate['A1'])
	m20.touch_tip()
```

## risk assessment

Low. Touch tip changes have already been validated for regular labware, we just need to make sure it works with modules now.
