### PR TITLE
feat(api): Allow user specified multi-channel control

### DIFF
--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -5,9 +5,10 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from opentrons.types import Point
 from opentrons.config import pipette_config
-from .types import CriticalPoint
+from .types import CriticalPoint, CriticalPointMultiChannel
 
 mod_log = logging.getLogger(__name__)
+CP_TYPE = Union[CriticalPointMultiChannel, CriticalPoint]
 
 
 class Pipette:
@@ -73,7 +74,7 @@ class Pipette:
     def pipette_id(self) -> Optional[str]:
         return self._pipette_id
 
-    def critical_point(self, cp_override: CriticalPoint = None) -> Point:
+    def critical_point(self, cp_override: CP_TYPE = None) -> Point:
         """
         The vector from the pipette's origin to its critical point. The
         critical point for a pipette is the end of the nozzle if no tip is
@@ -97,6 +98,13 @@ class Pipette:
             mod_offset_xy = [
                 0, -self.model_offset[1], self.model_offset[2]]
             cp_type = CriticalPoint.FRONT_NOZZLE
+        elif isinstance(cp_override, CriticalPointMultiChannel):
+            mod_offset_xy = [
+                0,
+                cp_override.spacing_value(self.model_offset[1]),
+                self.model_offset[2]]
+            # Channel override should only be used to determine XY offset,
+            # the critical point should still either be tip or nozzle.
         else:
             mod_offset_xy = self.model_offset
         mod_and_tip = Point(mod_offset_xy[0],

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import enum
 import logging
-from typing import Tuple
+from typing import Tuple, Type, TypeVar
 from opentrons import types as top_types
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -96,7 +96,75 @@ class CriticalPoint(enum.Enum):
     """
     The end of the front-most nozzle of a multipipette with a tip attached.
     Only relevant when a multichannel pipette is present.
+    NOTE: This member is now deprecated in favor of utilizing the
+    CriticalPointMultiChannel class.
     """
+
+
+CPMultiChannel = TypeVar('CPMultiChannel', bound='CriticalPointMultiChannel')
+
+
+class CriticalPointMultiChannel(enum.Enum):
+    """
+    This class is meant to encapsulate the critical point of an individual
+    channel on the multi-channel pipette. This will allow for more
+    fine-tuned movement of the multi-channel, including picking up tips
+    with only certain channels.
+    """
+    CHANNEL_1 = enum.auto()
+    """
+    The "first" channel of a multi-channel pipette. This is the backmost
+    channel of a multi-channel pipette. It is closest to the back
+    of the robot.
+    """
+    CHANNEL_2 = enum.auto()
+    """
+    The "second" channel of a multi-channel pipette.
+    """
+    CHANNEL_3 = enum.auto()
+    """
+    The "third" channel of a multi-channel pipette.
+    """
+    CHANNEL_4 = enum.auto()
+    """
+    The "fourth" channel of a multi-channel pipette. This is one of the middle
+    channels of the multi-channel pipette.
+    """
+    CHANNEL_5 = enum.auto()
+    """
+    The "fifth" channel of a multi-channel pipette. This is one of the middle
+    channels of the multi-channel pipette.
+    """
+    CHANNEL_6 = enum.auto()
+    """
+    The "sixth" channel of a multi-channel pipette.
+    """
+    CHANNEL_7 = enum.auto()
+    """
+    The "seventh" channel of a multi-channel pipette.
+    """
+    CHANNEL_8 = enum.auto()
+    """
+    The "eighth" channel of a multi-channel pipette. This is the channel
+    closest to the front of the robot.
+    """
+
+    @classmethod
+    def get_channel(cls: Type[CPMultiChannel], channel: str) -> CPMultiChannel:
+        for m in cls.__members__.values():
+            if m.value == int(channel):
+                return m
+        raise AttributeError(f'Channel {channel} does not exist.')
+
+    def spacing_value(self, offset: int) -> int:
+        return offset - (self.value - 1) * 9
+
+    @property
+    def amount_of_channels(self) -> int:
+        return 8 - self.value
+
+    def __str__(self):
+        return self.name
 
 
 class ExecutionState(enum.Enum):

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, asdict, field, fields
 from opentrons.protocol_api.labware import Well
 from opentrons.types import Mount, Point, Location
 from opentrons.hardware_control.pipette import Pipette
-from opentrons.hardware_control.types import Axis
+from opentrons.hardware_control.types import Axis, CriticalPointMultiChannel
 
 from .constants import LOOKUP_LABWARE, TipAttachError
 from .util import StateMachine, WILDCARD
@@ -121,7 +121,11 @@ class CalibrationSession:
             assert data, "Please attach pipettes before proceeding"
 
             token = uuid4()
-            pipette_dict[token] = {'mount': mount, 'tiprack_id': None}
+            cp = None
+            if data['channels'] == 8:
+                cp = CriticalPointMultiChannel.CHANNEL_8
+            pipette_dict[token] = {
+                'mount': mount, 'tiprack_id': None, 'critical_point': cp}
         return pipette_dict
 
     def _determine_required_labware(self) -> typing.Dict[UUID, LabwareInfo]:
@@ -426,19 +430,19 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         A function that takes tiprack information and loads them onto the deck.
         """
         full_dict = {}
+        prev_lw = None
         for name, data in self._labware_info.items():
             parent = self._deck.position_for(data.slot)
             lw = labware.Labware(data.definition, parent)
             self._deck[data.slot] = lw
             build_dict = {}
             for id in data.forPipettes:
-                mount = self._get_mount(id)
-                pip = self.get_pipette(mount)
-                well_name = 'H1' if pip['channels'] == 8 else 'A1'
+                well_name = 'B1' if prev_lw == lw else 'A1'
                 well = lw.wells_by_name()[well_name]
                 build_dict[id] = PreparingPipetteMoveOffset(
                     offset=Point(0, 0, 10), well=well
                 )
+                prev_lw = lw
             full_dict[data.id] = build_dict
         self._moves.preparingPipette = full_dict
 
@@ -567,12 +571,14 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         mount = self._get_mount(pipette_id)
         from_pt = await self.hardware.gantry_position(mount)
         from_loc = Location(from_pt, None)
+        cp = self._relate_mount[pipette_id]['critical_point']
 
         max_height = self.hardware.get_instrument_max_height(mount)
         moves = geometry.plan_moves(from_loc, request_position,
                                     self._deck, max_height)
         for move in moves:
-            await self.hardware.move_to(mount, move[0], move[1])
+            await self.hardware.move_to(
+                mount, move[0], move[1], critical_point=cp)
 
     async def _jog_pipette(self, pipette_id: UUID, vector: Point, **kwargs):
         mount = self._get_mount(pipette_id)


### PR DESCRIPTION
## overview

This is a feature added in for deck calibration check. You can now specify the channel in which you want to control the multi-channel with. In example, you might want to pick up a tip with only the 8th channel of the pipette (one closest to the front) and perform some actions with that. This feature is only available in API V2.4 and higher.

## changelog

- Add in another critical point Enum class specifically for multichannel pipettes
- Add in some helper methods on the enum class to determine the correct offset for the pipette and the number of channels being used.
- Pass in the new critical point enum both for `instrument_context.py` and `session.py` in the deck calibration check session

## review requests

Should we document this as a feature, or let it fly under the radar until we feel comfortable releasing it?

Here is a protocol for testing:
```
metadata={"apiLevel": "2.4"}

def run(ctx):
    # mod = ctx.load_module('magnetic module', 1)
    tc_lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 6)
    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 4)
    pip = ctx.load_instrument('p300_multi_gen2', 'left', tip_racks=[tiprack])
    # tiprack2 = ctx.load_labware('opentrons_96_tiprack_1000ul', 5)
    # pip2 = ctx.load_instrument('p1000_single_gen2', 'right', tip_racks=[tiprack2])

    slot_11_lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)

    pip.default_channel = '7'
    pip.pick_up_tip()
    ctx.comment(f"{pip.default_channel}")
    pip.transfer(200, slot_11_lw['A1'], tc_lw['A4'], new_tip='never')
    pip.touch_tip(tc_lw['A12'])
    pip.return_tip()
    ctx.pause()

    # pip.default_channel = '2'
    pip.pick_up_tip()
    ctx.comment(f"{pip.default_channel}")
    pip.touch_tip(slot_11_lw['A1'])
    ctx.pause()
    pip.touch_tip(slot_11_lw['A2'])
    pip.return_tip()
```

## risk assessment

Low/Medium. There were some small changes made in instrument context that should be fairly low risk. We should test the following:

- [ ] Single-Channels still behave as normal. Attempts to setting the `default_channel` should result in an error when uploaded to the app
- [ ] Multi-channels without setting `default_channel` still behave as normal (i.e. tip tracking still works, and it moves to all locations with the back nozzle over Row A of the labware)
- [ ] Setting `default_channel` to 8 -> 1 results in the pipette moving channels from the front of the robot to the back of the robot respectively
- [ ] Multi-Channel tip tracking still works as expected when using this new setting. So, if you are moving channel 8 around, the robot should first pick up a tip from `A1` then move to `B1` etc.
