### PR TITLE
fix(app) truncate module temps

### DIFF
--- a/app/src/components/ModuleControls/TemperatureData.js
+++ b/app/src/components/ModuleControls/TemperatureData.js
@@ -20,13 +20,13 @@ export const TemperatureData = ({
     <div className={styles.data_row}>
       <p className={styles.inline_labeled_value}>Current:</p>
       <p className={styles.inline_labeled_value}>{`${
-        current != null ? current : '-'
+        current != null ? Math.trunc(current) : '-'
       } °C`}</p>
     </div>
     <div className={styles.data_row}>
       <p className={styles.inline_labeled_value}>Target:</p>
       <p className={styles.inline_labeled_value}>{`${
-        target != null ? target : '-'
+        target != null ? Math.trunc(target) : '-'
       } °C`}</p>
     </div>
   </div>


### PR DESCRIPTION
We display temperature as only integer values, and that's something that should be enforced in the view layer.

## Risk Assessment
Low, just about displaying values set in the protocol