### PR TITLE
chore(api): fix tempdeck simulate freeze

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -48,9 +48,8 @@ class Poller(Thread):
         while not self._stop_event.wait(TEMP_POLL_INTERVAL_SECS):
             self._driver_ref.update_temperature()
 
-    def join(self):
+    def stop(self):
         self._stop_event.set()
-        super().join()
 
 
 class TempDeck(mod_abc.AbstractModule):
@@ -223,6 +222,7 @@ class TempDeck(mod_abc.AbstractModule):
         TempDecks
         """
         if self._poller:
+            self._poller.stop()
             self._poller.join()
         if not self._driver.is_connected():
             self._driver.connect(self._port)
@@ -232,7 +232,7 @@ class TempDeck(mod_abc.AbstractModule):
 
     def __del__(self):
         if hasattr(self, '_poller') and self._poller:
-            self._poller.join()
+            self._poller.stop()
 
     async def prep_for_update(self) -> str:
         model = self._device_info and self._device_info.get('model')
@@ -241,6 +241,7 @@ class TempDeck(mod_abc.AbstractModule):
                                     "Please contact Opentrons Support.")
 
         if self._poller:
+            self.poller.stop()
             self._poller.join()
         del self._poller
         self._poller = None

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -241,7 +241,7 @@ class TempDeck(mod_abc.AbstractModule):
                                     "Please contact Opentrons Support.")
 
         if self._poller:
-            self.poller.stop()
+            self._poller.stop()
             self._poller.join()
         del self._poller
         self._poller = None

--- a/robot-server/tests/service/routers/test_modules.py
+++ b/robot-server/tests/service/routers/test_modules.py
@@ -38,6 +38,7 @@ def tempdeck():
     yield t
 
     # Have to stop the poller
+    t._poller.stop()
     t._poller.join()
 
 


### PR DESCRIPTION
This fixes an interesting edge case brought about by doing something
that is in retrospect wrong with the temperature module poller thread.

When you start a thread with daemon=True, then any threads that thread
creates will inherit daemon=True. We make the threadmanager threads
daemonic. That means the poller threads are typically daemonic. This is
usually fine!

However, when you are creating them in a short lived program - like
opentrons_simulate - it's not fine. Python programs end when all
non-daemonic threads are done. The remaining daemonic threads are
terminated, at some point during the interpreter shutdown, messily.

join() doesn't work by magic - it has internal locking around the
thread's running state. When the interpreter kills a daemonic thread, it
doesn't necessarily handle that locking cleanly, because it doesn't have
to - it's a daemonic thread that's getting killed.

So if you have a daemonic thread remaining after program execution -
which the poller is because it's created from ThreadManager's thread,
which is daemonic, and that's inherited - and if you try to join that
thread during some other execution context that happens sometime during
interpreter shutdown, like the cyclic garbage collector cleaning up and
triggering object __del__ methods, then you could get a race between
join() in the __del__ and the interpreter killing the daemonic thread,
and you lock up.

The solution: don't do that! Separate the "set the quit flag" and
"join" concepts in the poller; only join() when you actually need to -
when you need to wait until the poller thread exits before doing
something else - and in the case of __del__, just set the flag (in case
we're not daemonic) and let the thread end naturally.

Closes #5561

## Testing
Simulate a protocol that loads a temperature module (doesn't have to use it or anything) and run `opentrons_simulate` on it. It should quit normally

## Risk Assessment
Low - this is in the tempdeck code that is used in a couple places, but it is a small refactor of exiting behavior.

## Test Protocol
```
import opentrons

metadata = {'apiLevel': '2.3'}

def run(ctx: opentrons.protocol_api.ProtocolContext):
    tr = ctx.load_labware('opentrons_96_filtertiprack_10ul', '1')
    instr = ctx.load_instrument('p10_multi', 'left', tip_racks=[tr])
    td = ctx.load_module('temperature module', '3')
    tdp = td.load_labware('opentrons_96_aluminumblock_biorad_wellplate_200ul')
    ctx.pause()
    #td.set_temperature(30)
    ctx.pause()
    #td.deactivate()
    instr.pick_up_tip()
    instr.aspirate(10, tdp['A1'])
    instr.dispense(10, tdp['A2'])
    instr.drop_tip()
```