### PR TITLE
fix(api): don't return defaultdicts for labware accessors

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -408,7 +408,7 @@ class Labware(DeckItem):
                 self._api_version)
             for well in self._ordering]
 
-    def _create_indexed_dictionary(self, group=0):
+    def _create_indexed_dictionary(self, group=0) -> Dict[str, List['Well']]:
         """
         Creates a dict of lists of Wells. Which way the labware is segmented
         determines whether this is a dict of rows or dict of columns. If group
@@ -422,7 +422,8 @@ class Labware(DeckItem):
             match = self._pattern.match(index)
             assert match, 'could not match well name pattern'
             dict_list[match.group(group)].append(well_obj)
-        return dict_list
+        # copy to a non-default-dict
+        return {k: v for k, v in dict_list.items()}
 
     def set_calibration(self, delta: Point):
         """


### PR DESCRIPTION
Labware accessors that return dicts, like columns_by_name or
rows_by_name, were returning defaultdict instances. That means that if
the user accessed a bad key... it would "helpfully" create a new empty
list, and the bad value would be propagated into later calls.

## Risk

Low - this is something that valid protocols don't do!

## Review Requests

Think about whether or not this deserves a new protocol API level.