### PR TITLE
refactor(protocol-designer): move SLOT_OCCUPIED error to i18n

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -110,7 +110,10 @@ export const EditModulesModal = (props: EditModulesModalProps) => {
     }
 
     if (hasSlotIssue(selectedSlot)) {
-      errors.selectedSlot = `Slot ${selectedSlot} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue.`
+      errors.selectedSlot = i18n.t(
+        'alert.module_placement.SLOT_OCCUPIED.body',
+        { selectedSlot }
+      )
     } else if (!selectedSlot) {
       // in the event that we remove auto selecting selected slot
       errors.selectedSlot = i18n.t('alert.field.required')
@@ -196,6 +199,8 @@ const EditModulesModalComponent = (props: EditModulesModalComponentProps) => {
   )
 
   const showSlotOption = moduleType !== THERMOCYCLER_MODULE_TYPE
+  // NOTE: selectedSlot error could either be required field (though the field is auto-populated)
+  // or occupied slot error. `slotIssue` is only for occupied slot error.
   const slotIssue =
     errors?.selectedSlot && errors.selectedSlot.includes('occupied')
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -83,7 +83,7 @@
   "module_placement": {
     "SLOT_OCCUPIED": {
       "title": "Cannot place module",
-      "body": "Modules can only be placed in slots that are empty"
+      "body": "Slot {{selectedSlot}} is occupied by another module or by labware incompatible with this module. Remove module or labware from the slot in order to continue."
     }
   },
   "export_warnings": {


### PR DESCRIPTION
## overview

Pretty trivial refactor, just did it b/c Morgan is using i18n as reference for PD errors/warnings and the line we had in i18n wasn't used anywhere, while the line we used wasn't in i18n.

## changelog

## review requests

- In module add/edit modal, trying to place a module in an occupied slot should show the same coiy as before: 
![image](https://user-images.githubusercontent.com/11590381/81427774-407f6980-9129-11ea-8b15-717eea20047e.png)


## risk assessment

low, just refactoring where the copy for this field error is stored