### PR TITLE
feat(protocol-designer): confirm when creating a new step when needed

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -57,11 +57,11 @@ const StepCreationButtonComponent = (props: StepButtonComponentProps) => {
   )
 }
 
-type StepButtonItemProps = {
+type StepButtonItemProps = {|
   onClick: () => mixed,
   disabled: boolean,
   stepType: string,
-}
+|}
 
 function StepButtonItem(props: StepButtonItemProps) {
   const { onClick, disabled, stepType } = props
@@ -135,10 +135,9 @@ export const StepCreationButton = () => {
         <ConfirmDeleteStepModal
           onCancelClick={() => setEnqueuedStepType(null)}
           onContinueClick={() => {
-            const s = enqueuedStepType
-            setEnqueuedStepType(null)
-            if (s != null) {
-              addStep(s)
+            if (enqueuedStepType !== null) {
+              addStep(enqueuedStepType)
+              setEnqueuedStepType(null)
             }
           }}
         />


### PR DESCRIPTION
## overview

Serves is its own ticket. I missed a requirement in #5421 where adding a new step while your current step has never been saved should give you the same confirmation modal you'd get if you selected a different step.

I think this also fixes the behavior that has been around a while when you add a step, the "ADD STEP +" menu doesn't close immediately.

## changelog

- Refactor
- Show modal

## review requests

- Different step types should still be enabled/disabled depending on modules (eg "magnet" disabled without magnet module on deck)
- Adding a step closes the menu of steps
- Creating a new step, not saving it, and trying to add another new step should give you the "Are you sure you want to delete this step" modal. Cancel/continue buttons in this modal should work as expected
- The "are you sure you want to delete this step" modal should NOT appear as a response to adding a step when the current step was saved before (ie is not presaved)

Annoyingly I couldn't find a way to use `useConditionalConfirm` here, because each StepButtonItem has its own onClick with its own StepType and `useConditionalConfirm` doesn't handle passing arguments (like `stepType`) down the chain.

## risk assessment

PD only. Medium, affects step creation button