### PR TITLE
feat(protocol-designer): set up tc module state

### DIFF
--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -163,7 +163,11 @@ const TEMPERATURE_MODULE_INITIAL_STATE: TemperatureModuleState = {
 }
 const THERMOCYCLER_MODULE_INITIAL_STATE: ThermocyclerModuleState = {
   type: THERMOCYCLER_MODULE_TYPE,
+  blockTargetTemp: null,
+  lidTargetTemp: null,
+  lidOpen: null,
 }
+
 const _getInitialDeckSetup = (
   initialSetupStep: FormData,
   labwareEntities: LabwareEntities,

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -85,7 +85,12 @@ export type TemperatureModuleState = {|
   status: TemperatureStatus,
   targetTemperature: number | null,
 |}
-export type ThermocyclerModuleState = {| type: THERMOCYCLER_MODULE_TYPE |} // TODO IL 2019-11-18 create this state
+export type ThermocyclerModuleState = {|
+  type: THERMOCYCLER_MODULE_TYPE,
+  blockTargetTemp: number | null, // null means block is deactivated
+  lidTargetTemp: number | null, // null means lid is deactivated
+  lidOpen: boolean | null, // if false, closed. If null, unknown
+|}
 
 export type ModuleTemporalProperties = {|
   slot: DeckSlot,

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultModuleId.test.js
@@ -10,58 +10,61 @@ import {
 import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getNextDefaultTemperatureModuleId } from '..'
 
+const getThermocycler = () => ({
+  id: 'tcId',
+  type: THERMOCYCLER_MODULE_TYPE,
+  model: THERMOCYCLER_MODULE_V1,
+  slot: '_span781011',
+  moduleState: {
+    type: THERMOCYCLER_MODULE_TYPE,
+    blockTargetTemp: null,
+    lidTargetTemp: null,
+    lidOpen: null,
+  },
+})
+
+const getMag = () => ({
+  id: 'magId',
+  type: MAGNETIC_MODULE_TYPE,
+  model: MAGNETIC_MODULE_V1,
+  slot: '_span781011',
+  moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
+})
+
+const getTemp = () => ({
+  id: 'tempId',
+  type: TEMPERATURE_MODULE_TYPE,
+  model: TEMPERATURE_MODULE_V1,
+  slot: '3',
+  moduleState: {
+    type: TEMPERATURE_MODULE_TYPE,
+    status: TEMPERATURE_DEACTIVATED,
+    targetTemperature: null,
+  },
+})
+
 describe('getNextDefaultTemperatureModuleId', () => {
   describe('NO previous forms', () => {
     const testCases = [
       {
         testMsg: 'temp and TC module present: use temp',
         equippedModulesById: {
-          tempId: {
-            id: 'tempId',
-            type: TEMPERATURE_MODULE_TYPE,
-            model: TEMPERATURE_MODULE_V1,
-            slot: '3',
-            moduleState: {
-              type: TEMPERATURE_MODULE_TYPE,
-              status: TEMPERATURE_DEACTIVATED,
-              targetTemperature: null,
-            },
-          },
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
-          },
+          tempId: getTemp(),
+          tcId: getThermocycler(),
         },
         expected: 'tempId',
       },
       {
         testMsg: 'thermocycler only: use tc',
         equippedModulesById: {
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: {
-              type: THERMOCYCLER_MODULE_TYPE,
-            },
-          },
+          tcId: getThermocycler(),
         },
         expected: 'tcId',
       },
       {
         testMsg: 'only mag module present: return null',
         equippedModulesById: {
-          magId: {
-            id: 'magId',
-            type: MAGNETIC_MODULE_TYPE,
-            model: MAGNETIC_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
-          },
+          magId: getMag(),
         },
         expected: null,
       },
@@ -88,24 +91,8 @@ describe('getNextDefaultTemperatureModuleId', () => {
       {
         testMsg: 'temp and tc present, last step was tc: use temp mod',
         equippedModulesById: {
-          tempId: {
-            id: 'tempId',
-            type: TEMPERATURE_MODULE_TYPE,
-            model: TEMPERATURE_MODULE_V1,
-            slot: '3',
-            moduleState: {
-              type: TEMPERATURE_MODULE_TYPE,
-              status: TEMPERATURE_DEACTIVATED,
-              targetTemperature: null,
-            },
-          },
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
-          },
+          tempId: getTemp(),
+          tcId: getThermocycler(),
         },
         savedForms: {
           tempStepId: {
@@ -127,24 +114,8 @@ describe('getNextDefaultTemperatureModuleId', () => {
       {
         testMsg: 'temp and mag present, last step was mag step: use temp mod',
         equippedModulesById: {
-          magId: {
-            id: 'magId',
-            type: MAGNETIC_MODULE_TYPE,
-            model: MAGNETIC_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
-          },
-          tempId: {
-            id: 'tempId',
-            type: TEMPERATURE_MODULE_TYPE,
-            model: TEMPERATURE_MODULE_V1,
-            slot: '3',
-            moduleState: {
-              type: TEMPERATURE_MODULE_TYPE,
-              status: TEMPERATURE_DEACTIVATED,
-              targetTemperature: null,
-            },
-          },
+          magId: getMag(),
+          tempId: getTemp(),
         },
         savedForms: {
           tempStepId: {


### PR DESCRIPTION
## overview

Closes #5609 just setting up flow type of `ThermocyclerModuleState`

## changelog

- add fields to ThermocyclerModuleState
- update related test that had flow errors (and refactor it for less repeated data)

## review requests

- Before I proposed ThermocyclerModuleState as having lidIsActive / blockIsActive fields. I think that's just redundant because if eg lidTemperature is null, that exactly means the lid is deactivated, and if lidTemperature is a number, that exactly means the lid is active and at that temperature. Just wanted to double-check I'm not missing something.

## risk assessment

low, just a typedef change in PD that isn't really used for anything yet