### PR TITLE
feat(protocol-designer): Implement presaved step form for TC state

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -4,6 +4,8 @@ import {
   MAGNETIC_MODULE_V2,
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V2,
+  THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import {
@@ -54,6 +56,12 @@ beforeEach(() => {
           id: 'someTemperatureModuleId',
           type: TEMPERATURE_MODULE_TYPE,
           model: TEMPERATURE_MODULE_V2,
+          slot: '3',
+        },
+        someThermocyclerModuleId: {
+          id: 'someTemperatureModuleId',
+          type: THERMOCYCLER_MODULE_TYPE,
+          model: THERMOCYCLER_MODULE_V1,
           slot: '3',
         },
       },
@@ -254,6 +262,22 @@ describe('createPresavedStepForm', () => {
       setTemperature: null,
       targetTemperature: null,
       stepName: 'temperature',
+      stepDetails: '',
+    })
+  })
+
+  it('should set a default thermocycler module when a Thermocycler step is added', () => {
+    const args = {
+      ...defaultArgs,
+      stepType: 'thermocycler',
+    }
+
+    expect(createPresavedStepForm(args)).toEqual({
+      id: stepId,
+      stepType: 'thermocycler',
+      moduleId: 'someThermocyclerModuleId',
+      // TODO add TC Default fields once rebased
+      stepName: 'thermocycler',
       stepDetails: '',
     })
   })

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -276,9 +276,15 @@ describe('createPresavedStepForm', () => {
       id: stepId,
       stepType: 'thermocycler',
       moduleId: 'someThermocyclerModuleId',
-      // TODO add TC Default fields once rebased
+      // TC Default field
       stepName: 'thermocycler',
       stepDetails: '',
+      thermocyclerFormType: 'thermocyclerState',
+      blockIsActive: false,
+      blockTargetTemp: null,
+      lidIsActive: false,
+      lidTargetTemp: null,
+      lidOpen: null,
     })
   })
 })

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.js
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.js
@@ -6,6 +6,7 @@ import {
   getNextDefaultMagnetAction,
   getNextDefaultPipetteId,
   getNextDefaultTemperatureModuleId,
+  getNextDefaultThermocyclerModuleId,
   handleFormChange,
 } from '../../steplist/formLevel'
 import {
@@ -140,6 +141,27 @@ const _patchTemperatureModuleId = (args: {|
   return null
 }
 
+const _patchThermocyclerModuleId = (args: {|
+  initialDeckSetup: InitialDeckSetup,
+  orderedStepIds: OrderedStepIdsState,
+  savedStepForms: SavedStepFormState,
+  stepType: StepType,
+|}): FormUpdater => () => {
+  const { initialDeckSetup, orderedStepIds, savedStepForms, stepType } = args
+
+  const hasThermocyclerModuleId = stepType === 'thermocycler'
+
+  if (hasThermocyclerModuleId) {
+    const moduleId = getNextDefaultThermocyclerModuleId(
+      savedStepForms,
+      orderedStepIds,
+      initialDeckSetup.modules
+    )
+    return { moduleId }
+  }
+  return null
+}
+
 export const createPresavedStepForm = ({
   initialDeckSetup,
   labwareEntities,
@@ -176,11 +198,19 @@ export const createPresavedStepForm = ({
     stepType,
   })
 
+  const updateThermocyclerModuleId = _patchThermocyclerModuleId({
+    initialDeckSetup,
+    orderedStepIds,
+    savedStepForms,
+    stepType,
+  })
+
   // finally, compose and apply all the updaters in order,
   // passing the applied result from one updater as the input of the next
   return [
     updateDefaultPipette,
     updateTemperatureModuleId,
+    updateThermocyclerModuleId,
     updateMagneticModuleId,
   ].reduce<FormData>(
     (acc, updater: FormUpdater) => {

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -100,6 +100,7 @@ export function getDefaultsForStepType(
         blockIsActive: false,
         blockTargetTemp: null,
         lidIsActive: false,
+        lidTargetTemp: null,
         lidOpen: null,
       }
     default:

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultTemperatureModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultTemperatureModuleId.test.js
@@ -8,7 +8,7 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
-import { getNextDefaultTemperatureModuleId } from '..'
+import { getNextDefaultTemperatureModuleId } from '../getNextDefaultTemperatureModuleId'
 
 const getThermocycler = () => ({
   id: 'tcId',
@@ -55,13 +55,6 @@ describe('getNextDefaultTemperatureModuleId', () => {
         expected: 'tempId',
       },
       {
-        testMsg: 'thermocycler only: use tc',
-        equippedModulesById: {
-          tcId: getThermocycler(),
-        },
-        expected: 'tcId',
-      },
-      {
         testMsg: 'only mag module present: return null',
         equippedModulesById: {
           magId: getMag(),
@@ -85,7 +78,7 @@ describe('getNextDefaultTemperatureModuleId', () => {
       })
     })
   })
-  // TODO (ka 2019-12-20): Add in tests for existing temperature form steps once wired up
+
   describe('previous forms', () => {
     const testCases = [
       {

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultThermocyclerModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultThermocyclerModuleId.test.js
@@ -10,58 +10,62 @@ import {
 import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
 import { getNextDefaultThermocyclerModuleId } from '../getNextDefaultThermocyclerModuleId'
 
+const getThermocycler = () => ({
+  id: 'tcId',
+  type: THERMOCYCLER_MODULE_TYPE,
+  model: THERMOCYCLER_MODULE_V1,
+  slot: '_span781011',
+  moduleState: {
+    type: THERMOCYCLER_MODULE_TYPE,
+    blockTargetTemp: null,
+    lidTargetTemp: null,
+    lidOpen: null,
+  },
+})
+
+const getMag = () => ({
+  id: 'magId',
+  type: MAGNETIC_MODULE_TYPE,
+  model: MAGNETIC_MODULE_V1,
+  slot: '_span781011',
+  moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
+})
+
+const getTemp = () => ({
+  id: 'tempId',
+  type: TEMPERATURE_MODULE_TYPE,
+  model: TEMPERATURE_MODULE_V1,
+  slot: '3',
+  moduleState: {
+    type: TEMPERATURE_MODULE_TYPE,
+    status: TEMPERATURE_DEACTIVATED,
+    targetTemperature: null,
+  },
+})
+
 describe('getNextDefaultThermocyclerModuleId', () => {
   describe('NO previous forms', () => {
     const testCases = [
       {
         testMsg: 'temp and TC module present: use TC',
         equippedModulesById: {
-          tempId: {
-            id: 'tempId',
-            type: TEMPERATURE_MODULE_TYPE,
-            model: TEMPERATURE_MODULE_V1,
-            slot: '3',
-            moduleState: {
-              type: TEMPERATURE_MODULE_TYPE,
-              status: TEMPERATURE_DEACTIVATED,
-              targetTemperature: null,
-            },
-          },
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
-          },
+          tempId: getTemp(),
+          tcId: getThermocycler(),
         },
         expected: 'tcId',
       },
       {
-        testMsg: 'thermocycler only: use tc',
+        testMsg: 'only TC module present: use TC',
         equippedModulesById: {
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: {
-              type: THERMOCYCLER_MODULE_TYPE,
-            },
-          },
+          tcId: getThermocycler(),
         },
         expected: 'tcId',
       },
+
       {
         testMsg: 'only mag module present: return null',
         equippedModulesById: {
-          magId: {
-            id: 'magId',
-            type: MAGNETIC_MODULE_TYPE,
-            model: MAGNETIC_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
-          },
+          magId: getMag(),
         },
         expected: null,
       },
@@ -88,24 +92,8 @@ describe('getNextDefaultThermocyclerModuleId', () => {
       {
         testMsg: 'temp and tc present, last step was tc: use tc mod',
         equippedModulesById: {
-          tempId: {
-            id: 'tempId',
-            type: TEMPERATURE_MODULE_TYPE,
-            model: TEMPERATURE_MODULE_V1,
-            slot: '3',
-            moduleState: {
-              type: TEMPERATURE_MODULE_TYPE,
-              status: TEMPERATURE_DEACTIVATED,
-              targetTemperature: null,
-            },
-          },
-          tcId: {
-            id: 'tcId',
-            type: THERMOCYCLER_MODULE_TYPE,
-            model: THERMOCYCLER_MODULE_V1,
-            slot: '_span781011',
-            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
-          },
+          tempId: getTemp(),
+          tcId: getThermocycler(),
         },
         savedForms: {
           tempStepId: {
@@ -125,7 +113,7 @@ describe('getNextDefaultThermocyclerModuleId', () => {
         expected: 'tcId',
       },
       {
-        testMsg: 'temp and mag present, last step was mag step: return null',
+        testMsg: 'temp and mag present return null',
         equippedModulesById: {
           magId: {
             id: 'magId',

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultThermocyclerModuleId.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/__tests__/getNextDefaultThermocyclerModuleId.test.js
@@ -1,0 +1,188 @@
+// @flow
+import {
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  MAGNETIC_MODULE_V1,
+  TEMPERATURE_MODULE_V1,
+  THERMOCYCLER_MODULE_V1,
+} from '@opentrons/shared-data'
+import { TEMPERATURE_DEACTIVATED } from '../../../../constants'
+import { getNextDefaultThermocyclerModuleId } from '../getNextDefaultThermocyclerModuleId'
+
+describe('getNextDefaultThermocyclerModuleId', () => {
+  describe('NO previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'temp and TC module present: use TC',
+        equippedModulesById: {
+          tempId: {
+            id: 'tempId',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: TEMPERATURE_MODULE_V1,
+            slot: '3',
+            moduleState: {
+              type: TEMPERATURE_MODULE_TYPE,
+              status: TEMPERATURE_DEACTIVATED,
+              targetTemperature: null,
+            },
+          },
+          tcId: {
+            id: 'tcId',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: THERMOCYCLER_MODULE_V1,
+            slot: '_span781011',
+            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
+          },
+        },
+        expected: 'tcId',
+      },
+      {
+        testMsg: 'thermocycler only: use tc',
+        equippedModulesById: {
+          tcId: {
+            id: 'tcId',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: THERMOCYCLER_MODULE_V1,
+            slot: '_span781011',
+            moduleState: {
+              type: THERMOCYCLER_MODULE_TYPE,
+            },
+          },
+        },
+        expected: 'tcId',
+      },
+      {
+        testMsg: 'only mag module present: return null',
+        equippedModulesById: {
+          magId: {
+            id: 'magId',
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: '_span781011',
+            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
+          },
+        },
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, equippedModulesById, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultThermocyclerModuleId(
+          savedForms,
+          orderedStepIds,
+          equippedModulesById
+        )
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'temp and tc present, last step was tc: use tc mod',
+        equippedModulesById: {
+          tempId: {
+            id: 'tempId',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: TEMPERATURE_MODULE_V1,
+            slot: '3',
+            moduleState: {
+              type: TEMPERATURE_MODULE_TYPE,
+              status: TEMPERATURE_DEACTIVATED,
+              targetTemperature: null,
+            },
+          },
+          tcId: {
+            id: 'tcId',
+            type: THERMOCYCLER_MODULE_TYPE,
+            model: THERMOCYCLER_MODULE_V1,
+            slot: '_span781011',
+            moduleState: { type: THERMOCYCLER_MODULE_TYPE },
+          },
+        },
+        savedForms: {
+          tempStepId: {
+            id: 'tempStepId',
+            stepType: 'temperature',
+            stepName: 'temperature',
+            moduleId: 'tempId',
+          },
+          tcStepId: {
+            id: 'tcStepId',
+            stepType: THERMOCYCLER_MODULE_TYPE,
+            stepName: THERMOCYCLER_MODULE_TYPE,
+            moduleId: 'tcId',
+          },
+        },
+        orderedStepIds: ['tempStepId', 'tcStepId'],
+        expected: 'tcId',
+      },
+      {
+        testMsg: 'temp and mag present, last step was mag step: return null',
+        equippedModulesById: {
+          magId: {
+            id: 'magId',
+            type: MAGNETIC_MODULE_TYPE,
+            model: MAGNETIC_MODULE_V1,
+            slot: '_span781011',
+            moduleState: { type: MAGNETIC_MODULE_TYPE, engaged: false },
+          },
+          tempId: {
+            id: 'tempId',
+            type: TEMPERATURE_MODULE_TYPE,
+            model: TEMPERATURE_MODULE_V1,
+            slot: '3',
+            moduleState: {
+              type: TEMPERATURE_MODULE_TYPE,
+              status: TEMPERATURE_DEACTIVATED,
+              targetTemperature: null,
+            },
+          },
+        },
+        savedForms: {
+          tempStepId: {
+            id: 'tempStepId',
+            stepType: 'temperature',
+            stepName: 'temperature',
+            moduleId: 'tempId',
+          },
+          magStepId: {
+            id: 'magStepId',
+            stepType: 'magnet',
+            stepName: 'magnet',
+            moduleId: 'magdeckId',
+          },
+        },
+        orderedStepIds: ['tempStepId', 'magStepId'],
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(
+      ({
+        testMsg,
+        savedForms = {},
+        equippedModulesById,
+        orderedStepIds = [],
+        expected,
+      }) => {
+        it(testMsg, () => {
+          const result = getNextDefaultThermocyclerModuleId(
+            savedForms,
+            orderedStepIds,
+            equippedModulesById
+          )
+
+          expect(result).toBe(expected)
+        })
+      }
+    )
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultTemperatureModuleId.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultTemperatureModuleId.js
@@ -1,31 +1,18 @@
 // @flow
 import findKey from 'lodash/findKey'
-import last from 'lodash/last'
+
 import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
 
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
-
-const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
-  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
 
 export function getNextDefaultTemperatureModuleId(
   savedForms: { [StepIdType]: FormData },
   orderedStepIds: Array<StepIdType>,
   equippedModulesById: { [moduleId: string]: ModuleOnDeck }
 ): string | null {
-  const prevModuleSteps = orderedStepIds
-    .map(stepId => savedForms[stepId])
-    .filter(form => form && form.moduleId)
-
-  const lastModuleStep = last(prevModuleSteps)
-
-  // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
-  // should we simplify this to only return temperature modules?
-  const nextDefaultModule: string | null =
-    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
+  return (
     findKey(equippedModulesById, m => m.type === TEMPERATURE_MODULE_TYPE) ||
     null
-
-  return nextDefaultModule || null
+  )
 }

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultTemperatureModuleId.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultTemperatureModuleId.js
@@ -1,0 +1,31 @@
+// @flow
+import findKey from 'lodash/findKey'
+import last from 'lodash/last'
+import { TEMPERATURE_MODULE_TYPE } from '@opentrons/shared-data'
+
+import type { ModuleOnDeck } from '../../../step-forms'
+import type { StepIdType, FormData } from '../../../form-types'
+
+const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
+  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
+
+export function getNextDefaultTemperatureModuleId(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>,
+  equippedModulesById: { [moduleId: string]: ModuleOnDeck }
+): string | null {
+  const prevModuleSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.moduleId)
+
+  const lastModuleStep = last(prevModuleSteps)
+
+  // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
+  // should we simplify this to only return temperature modules?
+  const nextDefaultModule: string | null =
+    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
+    findKey(equippedModulesById, m => m.type === TEMPERATURE_MODULE_TYPE) ||
+    null
+
+  return nextDefaultModule || null
+}

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultThermocyclerModuleId.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultThermocyclerModuleId.js
@@ -1,29 +1,17 @@
 // @flow
 import findKey from 'lodash/findKey'
-import last from 'lodash/last'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import type { ModuleOnDeck } from '../../../step-forms'
 import type { StepIdType, FormData } from '../../../form-types'
-
-const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
-  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
 
 export function getNextDefaultThermocyclerModuleId(
   savedForms: { [StepIdType]: FormData },
   orderedStepIds: Array<StepIdType>,
   equippedModulesById: { [moduleId: string]: ModuleOnDeck }
 ): string | null {
-  const prevModuleSteps = orderedStepIds
-    .map(stepId => savedForms[stepId])
-    .filter(form => form && form.moduleId)
-
-  const lastModuleStep = last(prevModuleSteps)
-
-  const nextDefaultModule: string | null =
-    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
+  return (
     findKey(equippedModulesById, m => m.type === THERMOCYCLER_MODULE_TYPE) ||
     null
-
-  return nextDefaultModule || null
+  )
 }

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultThermocyclerModuleId.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/getNextDefaultThermocyclerModuleId.js
@@ -1,0 +1,29 @@
+// @flow
+import findKey from 'lodash/findKey'
+import last from 'lodash/last'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+
+import type { ModuleOnDeck } from '../../../step-forms'
+import type { StepIdType, FormData } from '../../../form-types'
+
+const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
+  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
+
+export function getNextDefaultThermocyclerModuleId(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>,
+  equippedModulesById: { [moduleId: string]: ModuleOnDeck }
+): string | null {
+  const prevModuleSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.moduleId)
+
+  const lastModuleStep = last(prevModuleSteps)
+
+  const nextDefaultModule: string | null =
+    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
+    findKey(equippedModulesById, m => m.type === THERMOCYCLER_MODULE_TYPE) ||
+    null
+
+  return nextDefaultModule || null
+}

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultModuleId/index.js
@@ -1,35 +1,4 @@
-// @flow
-import findKey from 'lodash/findKey'
-import last from 'lodash/last'
-import {
-  TEMPERATURE_MODULE_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
-} from '@opentrons/shared-data'
+import { getNextDefaultTemperatureModuleId } from './getNextDefaultTemperatureModuleId'
+import { getNextDefaultThermocyclerModuleId } from './getNextDefaultThermocyclerModuleId'
 
-import type { ModuleOnDeck } from '../../../step-forms'
-import type { StepIdType, FormData } from '../../../form-types'
-
-const isLastStepTemp = (lastModuleStep: FormData = {}): boolean =>
-  !!(lastModuleStep.moduleId && lastModuleStep.stepType === 'temperature')
-
-export function getNextDefaultTemperatureModuleId(
-  savedForms: { [StepIdType]: FormData },
-  orderedStepIds: Array<StepIdType>,
-  equippedModulesById: { [moduleId: string]: ModuleOnDeck }
-): string | null {
-  const prevModuleSteps = orderedStepIds
-    .map(stepId => savedForms[stepId])
-    .filter(form => form && form.moduleId)
-
-  const lastModuleStep = last(prevModuleSteps)
-
-  // TODO (ka 2019-12-20): Since we are hiding the thermocylcer module as an option for now,
-  // should we simplify this to only return temperature modules?
-  const nextDefaultModule: string | null =
-    (isLastStepTemp(lastModuleStep) && lastModuleStep.moduleId) ||
-    findKey(equippedModulesById, m => m.type === TEMPERATURE_MODULE_TYPE) ||
-    findKey(equippedModulesById, m => m.type === THERMOCYCLER_MODULE_TYPE) ||
-    null
-
-  return nextDefaultModule || null
-}
+export { getNextDefaultTemperatureModuleId, getNextDefaultThermocyclerModuleId }

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -30,7 +30,10 @@ export { createBlankForm } from './createBlankForm'
 export { getDefaultsForStepType } from './getDefaultsForStepType'
 export { getDisabledFields } from './getDisabledFields'
 export { getNextDefaultPipetteId } from './getNextDefaultPipetteId'
-export { getNextDefaultTemperatureModuleId } from './getNextDefaultModuleId'
+export {
+  getNextDefaultTemperatureModuleId,
+  getNextDefaultThermocyclerModuleId,
+} from './getNextDefaultModuleId'
 export { getNextDefaultMagnetAction } from './getNextDefaultMagnetAction'
 export { getNextDefaultEngageHeight } from './getNextDefaultEngageHeight'
 export { stepFormToArgs } from './stepFormToArgs'


### PR DESCRIPTION
## overview

This PR closes #5596 by adding TC state fields to createPresavedStepForm and updating tests accordingly. It also caught a missing default field for TC state after the rebase.

## changelog

- feat(protocol-designer): Implement presaved step form for TC state

## review requests

I kept the `GetDefaultModuleId/` folder but split temp and tc ids into separate files/tests within.  

- [ ] Code looks sane

## risk assessment

Low PD behind a FF