### PR TITLE
feat(protocol-designer): add 'mini' command creators for TC

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
@@ -1,0 +1,104 @@
+// @flow
+import { thermocyclerSetTargetBlockTemperature } from '../commandCreators/atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerSetTargetLidTemperature } from '../commandCreators/atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerAwaitBlockTemperature } from '../commandCreators/atomic/thermocyclerAwaitBlockTemperature'
+import { thermocyclerAwaitLidTemperature } from '../commandCreators/atomic/thermocyclerAwaitLidTemperature'
+import { thermocyclerDeactivateBlock } from '../commandCreators/atomic/thermocyclerDeactivateBlock'
+import { thermocyclerDeactivateLid } from '../commandCreators/atomic/thermocyclerDeactivateLid'
+import { thermocyclerCloseLid } from '../commandCreators/atomic/thermocyclerCloseLid'
+import { thermocyclerOpenLid } from '../commandCreators/atomic/thermocyclerOpenLid'
+import { getSuccessResult } from '../__fixtures__'
+import type { CommandCreator } from '../types'
+
+const getRobotInitialState = (): any => {
+  // This particular state shouldn't matter for these command creators
+  return {}
+}
+// neither should InvariantContext
+const invariantContext: any = {}
+
+const module = 'someTCModuleId'
+const temperature = 42
+
+describe('thermocycler atomic commands', () => {
+  // NOTE(IL, 2020-05-11): splitting these into different arrays based on type of args
+  // the command creator takes, so tests are type-safe
+
+  const testCasesSetBlock = [
+    {
+      commandCreator: thermocyclerSetTargetBlockTemperature,
+      expectedType: 'thermocycler/setTargetBlockTemperature',
+      params: { module, temperature },
+    },
+  ]
+
+  const testCasesWithTempParam = [
+    {
+      commandCreator: thermocyclerSetTargetLidTemperature,
+      expectedType: 'thermocycler/setTargetLidTemperature',
+      params: { module, temperature },
+    },
+    {
+      commandCreator: thermocyclerAwaitBlockTemperature,
+      expectedType: 'thermocycler/awaitBlockTemperature',
+      params: { module, temperature },
+    },
+    {
+      commandCreator: thermocyclerAwaitLidTemperature,
+      expectedType: 'thermocycler/awaitLidTemperature',
+      params: { module, temperature },
+    },
+  ]
+
+  const testCasesModuleOnly = [
+    {
+      commandCreator: thermocyclerDeactivateBlock,
+      expectedType: 'thermocycler/deactivateBlock',
+      params: { module },
+    },
+    {
+      commandCreator: thermocyclerDeactivateLid,
+      expectedType: 'thermocycler/deactivateLid',
+      params: { module },
+    },
+    {
+      commandCreator: thermocyclerCloseLid,
+      expectedType: 'thermocycler/closeLid',
+      params: { module },
+    },
+    {
+      commandCreator: thermocyclerOpenLid,
+      expectedType: 'thermocycler/openLid',
+      params: { module },
+    },
+  ]
+
+  const testParams = <P>({
+    commandCreator,
+    params,
+    expectedType,
+  }: {|
+    commandCreator: CommandCreator<P>,
+    params: P,
+    expectedType: string,
+  |}) => {
+    it('...', () => {
+      const robotInitialState = getRobotInitialState()
+
+      const result = commandCreator(params, invariantContext, robotInitialState)
+
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        {
+          command: expectedType,
+          params,
+        },
+      ])
+    })
+  }
+
+  // run all the test testCases
+  testCasesSetBlock.forEach(testParams)
+  testCasesWithTempParam.forEach(testParams)
+  testCasesModuleOnly.forEach(testParams)
+})

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
@@ -82,7 +82,7 @@ describe('thermocycler atomic commands', () => {
     params: P,
     expectedType: string,
   |}) => {
-    it('...', () => {
+    it(`creates a single "${expectedType}" command with the given params`, () => {
       const robotInitialState = getRobotInitialState()
 
       const result = commandCreator(params, invariantContext, robotInitialState)

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitBlockTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitBlockTemperature.js
@@ -1,0 +1,21 @@
+// @flow
+import type { TemperatureParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerAwaitBlockTemperature: CommandCreator<TemperatureParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/awaitBlockTemperature',
+        params: {
+          module: args.module,
+          temperature: args.temperature,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitLidTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitLidTemperature.js
@@ -1,0 +1,21 @@
+// @flow
+import type { TemperatureParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerAwaitLidTemperature: CommandCreator<TemperatureParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/awaitLidTemperature',
+        params: {
+          module: args.module,
+          temperature: args.temperature,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerCloseLid.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerCloseLid.js
@@ -1,0 +1,20 @@
+// @flow
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerCloseLid: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/closeLid',
+        params: {
+          module: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerDeactivateBlock.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerDeactivateBlock.js
@@ -1,0 +1,20 @@
+// @flow
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerDeactivateBlock: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/deactivateBlock',
+        params: {
+          module: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerDeactivateLid.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerDeactivateLid.js
@@ -1,0 +1,20 @@
+// @flow
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerDeactivateLid: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/deactivateLid',
+        params: {
+          module: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerOpenLid.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerOpenLid.js
@@ -1,0 +1,20 @@
+// @flow
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerOpenLid: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/openLid',
+        params: {
+          module: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerSetTargetBlockTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerSetTargetBlockTemperature.js
@@ -1,0 +1,27 @@
+// @flow
+import type { ThermocyclerSetTargetBlockTemperatureArgs } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerSetTargetBlockTemperature: CommandCreator<ThermocyclerSetTargetBlockTemperatureArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  if (args.volume !== undefined) {
+    console.warn(
+      `'volume' param not implemented for thermocycler/setTargetBlockTemperature, should not be set!`
+    )
+  }
+  return {
+    commands: [
+      {
+        command: 'thermocycler/setTargetBlockTemperature',
+        params: {
+          module: args.module,
+          temperature: args.temperature,
+          // NOTE(IL, 2020-05-11): 'volume' param supported in schema but not implemented, so don't use it
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerSetTargetLidTemperature.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerSetTargetLidTemperature.js
@@ -1,0 +1,21 @@
+// @flow
+import type { TemperatureParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerSetTargetLidTemperature: CommandCreator<TemperatureParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/setTargetLidTemperature',
+        params: {
+          module: args.module,
+          temperature: args.temperature,
+        },
+      },
+    ],
+  }
+}

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -25,6 +25,12 @@ export type TemperatureParams = {| module: string, temperature: number |}
 
 export type ModuleOnlyParams = {| module: string |}
 
+export type ThermocyclerSetTargetBlockTemperatureArgs = {|
+  module: string,
+  temperature: number,
+  volume?: number,
+|}
+
 export type Command =
   | {|
       command: 'aspirate' | 'dispense' | 'airGap',
@@ -66,7 +72,7 @@ export type Command =
     |}
   | {|
       command: 'thermocycler/setTargetBlockTemperature',
-      params: {| module: string, temperature: number, volume: number |},
+      params: ThermocyclerSetTargetBlockTemperatureArgs,
     |}
   | {|
       command: 'thermocycler/setTargetLidTemperature',


### PR DESCRIPTION
## overview

Closes #5598 

## changelog

- add 8 mini/simple command creators needed to make TC Step command creator

## review requests

- Not much to test, just code review

PS noticed that for `thermocycler/setTargetBlockTemperature`, the `volume` param (optional in v4 schema) was marked as required in the flow type, so this PR corrects the flow type to match the schema by making it optional.

Also, it turns out we're not going to support this particular `volume` param in PD yet (and also we don't support this parameter in the executor, it will throw "not implemented"), so `thermocyclerSetTargetBlockTemperature` fn also doesn't implement it. This is mostly just as a reminder for future development.

## risk assessment

low/no, PD only & not yet used