### PR TITLE
feat(api): Add type of deck calibration and remove ability to start the program without pipettes

### DIFF
--- a/api/src/opentrons/server/endpoints/calibration/helper_classes.py
+++ b/api/src/opentrons/server/endpoints/calibration/helper_classes.py
@@ -1,0 +1,53 @@
+import typing
+
+from opentrons.types import Point
+from enum import Enum, auto
+from uuid import uuid4, UUID
+from dataclasses import dataclass
+
+if typing.TYPE_CHECKING:
+    from opentrons.protocol_api.labware import LabwareDefinition
+
+
+@dataclass
+class LabwareInfo:
+    """
+    This class purely maps to :py:class:`.models.LabwareStatus` and is
+    intended to inform a client about the tipracks required for a session.
+
+    :note: The UUID class is utilized here instead of UUID4 for type checking
+    as UUID4 is only valid in pydantic models.
+    """
+    alternatives: typing.List[str]
+    forPipettes: typing.List[UUID]
+    loadName: str
+    slot: str
+    namespace: str
+    version: str
+    id: UUID
+    definition: 'LabwareDefinition'
+
+
+@dataclass
+class CheckMove:
+    position: Point = Point(0, 0, 0)
+    locationId: UUID = uuid4()
+
+
+@dataclass
+class Moves:
+    """A mapping of calibration check state to gantry move parameters"""
+    preparingFirstPipette: CheckMove = CheckMove()
+    preparingSecondPipette: CheckMove = CheckMove()
+    joggingFirstPipetteToHeight: CheckMove = CheckMove()
+    joggingFirstPipetteToPointOne: CheckMove = CheckMove()
+    joggingFirstPipetteToPointTwo: CheckMove = CheckMove()
+    joggingFirstPipetteToPointThree: CheckMove = CheckMove()
+    joggingSecondPipetteToHeight: CheckMove = CheckMove()
+    joggingSecondPipetteToPointOne: CheckMove = CheckMove()
+
+
+class DeckCalibrationError(Enum):
+    UNKNOWN = auto()
+    BAD_INSTRUMENT_OFFSET = auto()
+    BAD_DECK_TRANSFORM = auto()

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -70,6 +70,7 @@ class ComparisonStatus(BaseModel):
     differenceVector: Point = PointField()
     thresholdVector:  Point = PointField()
     exceedsThreshold: bool
+    transformType: Optional[str]
 
 
 class CalibrationSessionStatus(BaseModel):

--- a/api/src/opentrons/server/endpoints/calibration/models.py
+++ b/api/src/opentrons/server/endpoints/calibration/models.py
@@ -5,6 +5,8 @@ from functools import partial
 from pydantic import BaseModel, Field
 from opentrons.types import Mount
 
+from .helper_classes import DeckCalibrationError
+
 
 Point = List[float]
 
@@ -70,7 +72,7 @@ class ComparisonStatus(BaseModel):
     differenceVector: Point = PointField()
     thresholdVector:  Point = PointField()
     exceedsThreshold: bool
-    transformType: Optional[str]
+    transformType: DeckCalibrationError
 
 
 class CalibrationSessionStatus(BaseModel):

--- a/api/tests/opentrons/server/calibration/test_check_calibration_session.py
+++ b/api/tests/opentrons/server/calibration/test_check_calibration_session.py
@@ -253,6 +253,11 @@ async def test_session_started_to_bad_state(check_calibration_session):
         )
 
 
+async def test_session_no_pipettes_error(hardware):
+    with pytest.raises(session.noPipetteException):
+        await session.CheckCalibrationSession.build(hardware)
+
+
 async def test_session_started_to_end_state(check_calibration_session):
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.exit
@@ -284,8 +289,7 @@ async def test_same_size_pips_share_tiprack(
     assert len(sess._labware_info.keys()) == 1
     assert len(next(iter(sess._labware_info.values())).forPipettes) == 2
 
-    # loads tiprack for right mount in 8
-    # and tiprack for left mount in 6
+    # loads tiprack in 8 only
     assert sess._deck['8']
     assert sess._deck['8'].name == 'opentrons_96_tiprack_300ul'
     assert sess._deck['6'] is None

--- a/api/tests/opentrons/server/calibration/test_check_calibration_session.py
+++ b/api/tests/opentrons/server/calibration/test_check_calibration_session.py
@@ -254,7 +254,7 @@ async def test_session_started_to_bad_state(check_calibration_session):
 
 
 async def test_session_no_pipettes_error(hardware):
-    with pytest.raises(session.noPipetteException):
+    with pytest.raises(session.NoPipetteException):
         await session.CheckCalibrationSession.build(hardware)
 
 

--- a/robot-server/robot_server/service/routers/session.py
+++ b/robot-server/robot_server/service/routers/session.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 from starlette import status as http_status_codes
 from fastapi import APIRouter, Query, Depends
 from opentrons.server.endpoints.calibration.session import \
-    CheckCalibrationSession, SessionManager, CalibrationSession
+    (CheckCalibrationSession, SessionManager,
+     CalibrationSession, noPipetteException)
 from opentrons.server.endpoints.calibration.util import StateMachineError
 from opentrons.server.endpoints.calibration import models
 
@@ -61,6 +62,15 @@ async def create_session_handler(
         try:
             # TODO generalize for other kinds of sessions
             new_session = await CheckCalibrationSession.build(hardware)
+        except noPipetteException as e:
+            raise RobotServerError(
+                status_code=http_status_codes.HTTP_403_FORBIDDEN,
+                error=Error(
+                    title="No Pipettes Attached",
+                    detail=f"Failed to create a session of type "
+                           f"'{session_type}': {str(e)}.",
+                )
+            )
         except AssertionError as e:
             raise RobotServerError(
                 status_code=http_status_codes.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## overview
Add in a pathway for the server to communicate what type of calibration path the app should display to the user in the instance of a movement that exceeds thresholds set on each check location. These two pathways are `badInstrumentOffset` or `badDeckTransformCalibration`.

## changelog

- Add in a `noPipettesAttached` error that is raised upon
- Adjust some tests to include pipettes in `robot-server` 
- Add a test to check the no pipettes attached error
- Add in a param on the `ComparisonStatus` model that includes an optional string which could be `badInstrumentOffset` or `badDeckTransformCalibration`.
*Note* will be putting up a separate PR for threshold changes which will include a more comprehensive unit test on the comparisons step function.
 
## review requests
Check over the code, see if there are any extra tests needed.

## risk assessment
Low. Only adding in touch ups to the deck calibration check flow. 

