### PR TITLE
feat(robot-server): session life cycle tavern tests

### DIFF
--- a/robot-server/robot_server/service/routers/session.py
+++ b/robot-server/robot_server/service/routers/session.py
@@ -45,7 +45,9 @@ def get_session(manager: SessionManager,
 @router.post("/sessions",
              description="Create a session",
              response_model_exclude_unset=True,
-             response_model=session.SessionResponse)
+             response_model=session.SessionResponse,
+             status_code=http_status_codes.HTTP_201_CREATED,
+             )
 async def create_session_handler(
         create_request: SessionCreateRequest,
         session_manager: SessionManager = Depends(get_session_manager),

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -1,0 +1,41 @@
+---
+test_name: Session Lifecycle
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Create a session
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: check
+    response:
+      status_code: 201
+      save:
+        json:
+          session_id: data.id
+
+  - name: Get the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 200
+
+  - name: Delete the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: DELETE
+    response:
+      status_code: 200
+
+  - name: Fail to get the deleted session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 404

--- a/robot-server/tests/service/routers/test_session.py
+++ b/robot-server/tests/service/routers/test_session.py
@@ -143,7 +143,7 @@ def test_create_session(api_client, patch_build_session):
             },
         }
     }
-    assert response.status_code == 200
+    assert response.status_code == 201
     # Clean up
     get_session_manager().sessions.clear()
 


### PR DESCRIPTION
## overview

Add a simple tavern test that creates, fetches, deletes, then fails to get a session.

Provides an example of using the `save` feature of tavern. Where a returned value is used in subsequent stages of a test (session_id).

## changelog

- Add test
- Change POST /sessions to return 201 instead of 200

## risk assessment

None