### PR TITLE
feat(protocol-designer): implement robot state updaters for TC State atomic commands

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerUpdates.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerUpdates.test.js
@@ -1,0 +1,197 @@
+// @flow
+import merge from 'lodash/merge'
+import {
+  THERMOCYCLER_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V1,
+} from '@opentrons/shared-data'
+import { SPAN7_8_10_11_SLOT } from '../../constants'
+import {
+  forThermocyclerSetTargetBlockTemperature as _forThermocyclerSetTargetBlockTemperature,
+  forThermocyclerSetTargetLidTemperature as _forThermocyclerSetTargetLidTemperature,
+  forThermocyclerAwaitBlockTemperature as _forThermocyclerAwaitBlockTemperature,
+  forThermocyclerAwaitLidTemperature as _forThermocyclerAwaitLidTemperature,
+  forThermocyclerDeactivateBlock as _forThermocyclerDeactivateBlock,
+  forThermocyclerDeactivateLid as _forThermocyclerDeactivateLid,
+  forThermocyclerCloseLid as _forThermocyclerCloseLid,
+  forThermocyclerOpenLid as _forThermocyclerOpenLid,
+} from '../getNextRobotStateAndWarnings/thermocyclerUpdates'
+import {
+  makeImmutableStateUpdater,
+  type ImmutableStateUpdater,
+} from '../__utils__'
+import { makeContext, getInitialRobotStateStandard } from '../__fixtures__'
+import type {
+  ModuleOnlyParams,
+  TemperatureParams,
+  ThermocyclerSetTargetBlockTemperatureArgs,
+} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
+
+const forThermocyclerSetTargetBlockTemperature = makeImmutableStateUpdater(
+  _forThermocyclerSetTargetBlockTemperature
+)
+const forThermocyclerSetTargetLidTemperature = makeImmutableStateUpdater(
+  _forThermocyclerSetTargetLidTemperature
+)
+const forThermocyclerAwaitBlockTemperature = makeImmutableStateUpdater(
+  _forThermocyclerAwaitBlockTemperature
+)
+const forThermocyclerAwaitLidTemperature = makeImmutableStateUpdater(
+  _forThermocyclerAwaitLidTemperature
+)
+const forThermocyclerDeactivateBlock = makeImmutableStateUpdater(
+  _forThermocyclerDeactivateBlock
+)
+const forThermocyclerDeactivateLid = makeImmutableStateUpdater(
+  _forThermocyclerDeactivateLid
+)
+const forThermocyclerCloseLid = makeImmutableStateUpdater(
+  _forThermocyclerCloseLid
+)
+const forThermocyclerOpenLid = makeImmutableStateUpdater(
+  _forThermocyclerOpenLid
+)
+
+const moduleId = 'thermocyclerModuleId'
+
+let invariantContext
+let lidOpenRobotState
+
+beforeEach(() => {
+  invariantContext = makeContext()
+  invariantContext.moduleEntities[moduleId] = {
+    id: moduleId,
+    type: THERMOCYCLER_MODULE_TYPE,
+    model: THERMOCYCLER_MODULE_V1,
+  }
+  lidOpenRobotState = getInitialRobotStateStandard(invariantContext)
+  lidOpenRobotState.modules[moduleId] = {
+    slot: SPAN7_8_10_11_SLOT,
+    moduleState: {
+      type: THERMOCYCLER_MODULE_TYPE,
+      lidOpen: true,
+      lidTargetTemp: null,
+      blockTargetTemp: null,
+    },
+  }
+})
+
+type TestCase<P> = {|
+  params: P,
+  expectedUpdate: $Shape<ThermocyclerModuleState>,
+  moduleStateBefore: $Shape<ThermocyclerModuleState>,
+  fn: ImmutableStateUpdater<P>,
+  testName: string,
+|}
+type TestCases<P> = Array<TestCase<P>>
+describe('thermocycler state updaters', () => {
+  const blockTempTestCase: TestCases<ThermocyclerSetTargetBlockTemperatureArgs> = [
+    {
+      params: { module: moduleId, temperature: 42 },
+      moduleStateBefore: { blockTargetTemp: null },
+      expectedUpdate: { blockTargetTemp: 42 },
+      fn: forThermocyclerSetTargetBlockTemperature,
+      testName:
+        'forThermocyclerSetBlockTemperature should update the block temp',
+    },
+  ]
+
+  const temperatureParamsCases: TestCases<TemperatureParams> = [
+    {
+      params: { module: moduleId, temperature: 42 },
+      moduleStateBefore: { lidTargetTemp: null },
+      expectedUpdate: { lidTargetTemp: 42 },
+      fn: forThermocyclerSetTargetLidTemperature,
+      testName:
+        'forThermocyclerSetTargetLidTemperature should update the lid temp',
+    },
+    {
+      params: { module: moduleId, temperature: 42 },
+      moduleStateBefore: {
+        lidTargetTemp: 41,
+        blockTargetTemp: 42,
+        lidOpen: true,
+      },
+      expectedUpdate: { lidTargetTemp: 41, blockTargetTemp: 42, lidOpen: true },
+      fn: forThermocyclerAwaitBlockTemperature,
+      testName: 'forThermocyclerAwaitBlockTemperature should do nothing',
+    },
+    {
+      params: { module: moduleId, temperature: 41 },
+      moduleStateBefore: {
+        lidTargetTemp: 41,
+        blockTargetTemp: 42,
+        lidOpen: true,
+      },
+      expectedUpdate: { lidTargetTemp: 41, blockTargetTemp: 42, lidOpen: true },
+      fn: forThermocyclerAwaitLidTemperature,
+      testName: 'forThermocyclerAwaitLidTemperature should do nothing',
+    },
+  ]
+
+  const moduleOnlyParamsCases: TestCases<ModuleOnlyParams> = [
+    {
+      params: { module: moduleId },
+      moduleStateBefore: { blockTargetTemp: 42 },
+      expectedUpdate: { blockTargetTemp: null },
+      fn: forThermocyclerDeactivateBlock,
+      testName:
+        'forThermocyclerDeactivateBlock should set blockTargetTemp to null',
+    },
+    {
+      params: { module: moduleId },
+      moduleStateBefore: { lidTargetTemp: 42 },
+      expectedUpdate: { lidTargetTemp: null },
+      fn: forThermocyclerDeactivateLid,
+      testName: 'forThermocyclerDeactivateLid should set lidTargetTemp to null',
+    },
+    {
+      params: { module: moduleId },
+      moduleStateBefore: { lidOpen: true },
+      expectedUpdate: { lidOpen: false },
+      fn: forThermocyclerCloseLid,
+      testName: 'forThermocyclerCloseLid should set lidOpen to false',
+    },
+    {
+      params: { module: moduleId },
+      moduleStateBefore: { lidOpen: false },
+      expectedUpdate: { lidOpen: true },
+      fn: forThermocyclerOpenLid,
+      testName: 'forThermocyclerOpenLid should set lidOpen to true',
+    },
+  ]
+
+  const runTest = <P>({
+    params,
+    moduleStateBefore,
+    expectedUpdate,
+    fn,
+    testName,
+  }: TestCase<P>) => {
+    it(testName, () => {
+      const prevRobotState = merge({}, lidOpenRobotState, {
+        modules: { [moduleId]: { moduleState: moduleStateBefore } },
+      })
+      const result = fn(params, invariantContext, prevRobotState)
+
+      expect(result).toMatchObject({
+        robotState: {
+          modules: {
+            [moduleId]: {
+              slot: SPAN7_8_10_11_SLOT,
+              moduleState: {
+                ...lidOpenRobotState.modules[moduleId].moduleState,
+                ...expectedUpdate,
+              },
+            },
+          },
+        },
+        warnings: [],
+      })
+    })
+  }
+
+  blockTempTestCase.forEach(runTest)
+  temperatureParamsCases.forEach(runTest)
+  moduleOnlyParamsCases.forEach(runTest)
+})

--- a/protocol-designer/src/step-generation/__utils__/makeImmutableStateUpdater.js
+++ b/protocol-designer/src/step-generation/__utils__/makeImmutableStateUpdater.js
@@ -2,13 +2,13 @@
 import produce from 'immer'
 import type { RobotState, RobotStateAndWarnings, InvariantContext } from '../'
 
-type ImmutableStateUpdater<P> = (
+export type ImmutableStateUpdater<P> = (
   params: P,
   invariantContext: InvariantContext,
   robotState: RobotState
 ) => RobotStateAndWarnings
 
-type MutableStateUpdater<P> = (
+export type MutableStateUpdater<P> = (
   params: P,
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -8,6 +8,17 @@ import { forDropTip } from './forDropTip'
 import { forPickUpTip } from './forPickUpTip'
 import { forEngageMagnet, forDisengageMagnet } from './magnetUpdates'
 import {
+  forThermocyclerAwaitBlockTemperature,
+  forThermocyclerAwaitLidTemperature,
+  forThermocyclerDeactivateBlock,
+  forThermocyclerDeactivateLid,
+  forThermocyclerSetTargetBlockTemperature,
+  forThermocyclerSetTargetLidTemperature,
+  forThermocyclerCloseLid,
+  forThermocyclerOpenLid,
+} from './thermocyclerUpdates'
+
+import {
   forAwaitTemperature,
   forSetTemperature,
   forDeactivateTemperature,
@@ -78,13 +89,61 @@ function _getNextRobotStateAndWarningsSingleCommand(
       )
       break
     case 'thermocycler/setTargetBlockTemperature':
+      forThermocyclerSetTargetBlockTemperature(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/setTargetLidTemperature':
+      forThermocyclerSetTargetLidTemperature(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/awaitBlockTemperature':
+      forThermocyclerAwaitBlockTemperature(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/awaitLidTemperature':
+      forThermocyclerAwaitLidTemperature(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/deactivateBlock':
+      forThermocyclerDeactivateBlock(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/deactivateLid':
+      forThermocyclerDeactivateLid(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/closeLid':
+      forThermocyclerCloseLid(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/openLid':
+      forThermocyclerOpenLid(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/runProfile':
     case 'thermocycler/awaitProfileComplete':
       console.warn(`NOT IMPLEMENTED: ${command.command}`)

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
@@ -1,0 +1,119 @@
+// @flow
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { getModuleState } from '../robotStateSelectors'
+import type {
+  ModuleOnlyParams,
+  TemperatureParams,
+  ThermocyclerSetTargetBlockTemperatureArgs,
+} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type {
+  InvariantContext,
+  RobotStateAndWarnings,
+  RobotState,
+} from '../types'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
+
+const _getThermocyclerModuleState = (
+  robotState: RobotState,
+  module: string
+): ThermocyclerModuleState => {
+  const moduleState = getModuleState(robotState, module)
+  if (moduleState.type === THERMOCYCLER_MODULE_TYPE) {
+    return moduleState
+  } else {
+    console.error(
+      `Thermocycler state updater expected ${module} moduleState to be thermocycler, but it was ${moduleState.type}`
+    )
+    // return some object instead of an error :/
+    const fallback: any = {}
+    return fallback
+  }
+}
+
+export const forThermocyclerSetTargetBlockTemperature = (
+  params: ThermocyclerSetTargetBlockTemperatureArgs,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module, temperature } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.blockTargetTemp = temperature
+}
+
+export const forThermocyclerSetTargetLidTemperature = (
+  params: TemperatureParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module, temperature } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.lidTargetTemp = temperature
+}
+
+export const forThermocyclerAwaitBlockTemperature = (
+  params: TemperatureParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  // nothing to be done
+}
+
+export const forThermocyclerAwaitLidTemperature = (
+  params: TemperatureParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  // nothing to be done
+}
+
+export const forThermocyclerDeactivateBlock = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.blockTargetTemp = null
+}
+
+export const forThermocyclerDeactivateLid = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.lidTargetTemp = null
+}
+
+export const forThermocyclerCloseLid = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.lidOpen = false
+}
+
+export const forThermocyclerOpenLid = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+  moduleState.lidOpen = true
+}

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -139,10 +139,11 @@ export function getModuleState(
   robotState: RobotState,
   module: string
 ): $PropertyType<ModuleTemporalProperties, 'moduleState'> {
-  console.warn(
-    module in robotState.modules,
-    `getModuleState expected module id "${module}"`
-  )
+  if (!(module in robotState.modules)) {
+    console.warn(
+      `getModuleState expected module id "${module}" to be in robot state`
+    )
+  }
 
   return robotState.modules[module]?.moduleState
 }


### PR DESCRIPTION
## overview

Closes #5611 

## changelog

- Add "getNextRobotStateAndWarnings" state updaters for TC State atomic commands (that's all the TC atomic commands except for runProfile + awaitProfile)

## review requests

- Sanity check. It's a lot of boilerplate

## risk assessment

low, new fns not used yet