### PR TITLE
fix(api): make reading door switch state unblocking

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/dev_types.py
+++ b/api/src/opentrons/drivers/rpi_drivers/dev_types.py
@@ -81,7 +81,7 @@ class GPIODriverLike(Protocol):
     def get_door_state(self) -> DoorState:
         ...
 
-    async def monitor_door_switch_state(
+    def start_door_switch_watcher(
             self, loop: asyncio.AbstractEventLoop,
             update_door_state: Callable[[DoorState], None]):
         ...
@@ -89,5 +89,5 @@ class GPIODriverLike(Protocol):
     def release_line(self, pin: GPIOPin):
         ...
 
-    def quit_monitoring(self):
+    def stop_door_switch_watcher(self, loop: asyncio.AbstractEventLoop):
         ...

--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -247,5 +247,9 @@ class GPIOCharDev:
         self.lines.pop(pin.name)
 
     def stop_door_switch_watcher(self, loop: asyncio.AbstractEventLoop):
-        door_fd = self.lines['window_door_sw'].event_get_fd()
-        loop.remove_reader(door_fd)
+        try:
+            door_fd = self.lines['window_door_sw'].event_get_fd()
+            loop.remove_reader(door_fd)
+        except Exception:
+            MODULE_LOG.exception(
+                "Failed to remove window door switch fd reader")

--- a/api/src/opentrons/drivers/rpi_drivers/types.py
+++ b/api/src/opentrons/drivers/rpi_drivers/types.py
@@ -4,11 +4,6 @@ from typing import List, Optional
 from opentrons.hardware_control.types import BoardRevision
 
 
-class GpioQueueEvent(enum.Enum):
-    EVENT_RECEIVED = enum.auto()
-    QUIT = enum.auto()
-
-
 class PinDir(enum.Enum):
     rev_input = enum.auto()
     input = enum.auto()

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -144,10 +144,9 @@ class API(HardwareAPILike):
             checked_loop.create_task(backend.watch_modules(
                 loop=checked_loop,
                 register_modules=api_instance.register_modules))
-            checked_loop.create_task(
-                backend.gpio_chardev.monitor_door_switch_state(
-                    loop=checked_loop,
-                    update_door_state=api_instance._update_door_state))
+            backend.gpio_chardev.start_door_switch_watcher(
+                loop=checked_loop,
+                update_door_state=api_instance._update_door_state)
             return api_instance
         finally:
             blink_task.cancel()

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -144,7 +144,7 @@ class API(HardwareAPILike):
             checked_loop.create_task(backend.watch_modules(
                 loop=checked_loop,
                 register_modules=api_instance.register_modules))
-            backend.gpio_chardev.start_door_switch_watcher(
+            backend.start_gpio_door_watcher(
                 loop=checked_loop,
                 update_door_state=api_instance._update_door_state)
             return api_instance

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -268,6 +268,6 @@ class Controller:
             try:
                 loop = asyncio.get_event_loop()
                 if not loop.is_closed():
-                    self.gpio_chardev.quit_monitoring()
+                    self.gpio_chardev.stop_door_switch_watcher(loop)
             except RuntimeError:
                 pass

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -76,6 +76,9 @@ class Controller:
         self._board_revision = self.gpio_chardev.board_rev
         await self.gpio_chardev.setup()
 
+    def start_gpio_door_watcher(self, **kargs):
+        self.gpio_chardev.start_door_switch_watcher(**kargs)
+
     def update_position(self) -> Dict[str, float]:
         self._smoothie_driver.update_position()
         return self._smoothie_driver.position

--- a/api/tests/opentrons/hardware_control/test_gpio.py
+++ b/api/tests/opentrons/hardware_control/test_gpio.py
@@ -1,7 +1,7 @@
 import asyncio
 from opentrons import hardware_control as hc
 from opentrons.hardware_control.types import DoorState
-from opentrons.drivers.rpi_drivers.types import gpio_group, GpioQueueEvent
+from opentrons.drivers.rpi_drivers.types import gpio_group
 
 
 async def test_gpio_setup(loop):
@@ -10,32 +10,3 @@ async def test_gpio_setup(loop):
     backend = hc.Controller(config=None)
     await backend.setup_gpio_chardev()
     assert str(backend.board_revision) == '2.1'
-
-
-async def test_gpio_door_state(loop):
-    # API.door_state would change based on the value read from
-    # the window_door_sw pin
-    hw_api = await hc.API.build_hardware_simulator(
-        loop=loop)
-    task = loop.create_task(
-        hw_api._backend.gpio_chardev.monitor_door_switch_state(
-            loop=loop,
-            update_door_state=hw_api._update_door_state))
-    await asyncio.sleep(0.1)
-    gpio_chardev = hw_api._backend.gpio_chardev
-
-    # high -> door is open
-    gpio_chardev.set_low(gpio_group.window_door_sw)
-    gpio_chardev.event_queue.put_nowait(
-        GpioQueueEvent.EVENT_RECEIVED)
-    await asyncio.sleep(0.1)
-    assert hw_api.door_state == DoorState.OPEN
-
-    # low -> door is closed
-    gpio_chardev.set_high(gpio_group.window_door_sw)
-    gpio_chardev.event_queue.put_nowait(
-        GpioQueueEvent.EVENT_RECEIVED)
-    await asyncio.sleep(0.1)
-    assert hw_api.door_state == DoorState.CLOSED
-
-    task.cancel()

--- a/api/tests/opentrons/hardware_control/test_gpio.py
+++ b/api/tests/opentrons/hardware_control/test_gpio.py
@@ -1,7 +1,4 @@
-import asyncio
 from opentrons import hardware_control as hc
-from opentrons.hardware_control.types import DoorState
-from opentrons.drivers.rpi_drivers.types import gpio_group
 
 
 async def test_gpio_setup(loop):


### PR DESCRIPTION
## overview
This PR fixes a bug introduced by #5536, that the GPIOCharDev blocks the protocol execution when trying to read the door switch gpio event.

The current implementation of the GPIO watcher is as follows:
- a reader is used to monitor the file descriptor associated with the door switch pin
- a queue is set up to receive two types of flag:
    A. notifies when the file descriptor has been modified, or
    B. when we want to quit the watcher
- whenever a type **A** flag is received, the actual GPIO line is then read and thus determines the door state

The issue that we saw is that sometimes the queue could receive a dummy item, which calls `line_read` while there is actually nothing to be read in the GPIO line and blocks the loop.

## changelog
- changed the name `monitor_door_switch_state` to `start_door_switch_watcher`
- removed the queue and solely use the file descriptor reader to handle and evaluate the GPIO line event
- since we are no longer monitoring a queue, the `start_door_switch_watcher` does not need to be persistent anymore
- altered `quit_monitoring` to `stop_door_switch_watcher` that removes the file descriptor reader when it's called
- removed the test because we're no longer using asyncio.queue

## risk assessment
low - fixing a new feature that was added in recent PR
