### PR TITLE
feat(protocol-designer): Add validation to TC state form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -296,9 +296,13 @@ and when that is implemented.
 .toggle_row {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .toggle_field {
   margin-right: 1rem;
+}
+
+.toggle_temperature_field {
+  margin-top: 0.125rem;
 }

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 
 import { i18n } from '../../../../localization'
 import { FormGroup } from '@opentrons/components'
@@ -8,8 +9,9 @@ import { ConditionalOnField, ToggleRowField, TextField } from '../../fields'
 import styles from '../../StepEditForm.css'
 
 import type { FocusHandlers } from '../../types'
+import type { FormData } from '../../../../form-types'
 
-type Props = {| focusHandlers: FocusHandlers |}
+type Props = {| focusHandlers: FocusHandlers, formData: FormData |}
 export const StateFields = (props: Props) => {
   const { focusHandlers } = props
   return (
@@ -36,7 +38,10 @@ export const StateFields = (props: Props) => {
           >
             <TextField
               name="blockTargetTemp"
-              className={styles.small_field}
+              className={cx(
+                styles.small_field,
+                styles.toggle_temperature_field
+              )}
               units={i18n.t('application.units.degrees')}
               {...focusHandlers}
             />
@@ -64,7 +69,10 @@ export const StateFields = (props: Props) => {
           >
             <TextField
               name="lidTargetTemp"
-              className={styles.small_field}
+              className={cx(
+                styles.small_field,
+                styles.toggle_temperature_field
+              )}
               units={i18n.t('application.units.degrees')}
               {...focusHandlers}
             />

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
@@ -9,9 +9,8 @@ import { ConditionalOnField, ToggleRowField, TextField } from '../../fields'
 import styles from '../../StepEditForm.css'
 
 import type { FocusHandlers } from '../../types'
-import type { FormData } from '../../../../form-types'
 
-type Props = {| focusHandlers: FocusHandlers, formData: FormData |}
+type Props = {| focusHandlers: FocusHandlers |}
 export const StateFields = (props: Props) => {
   const { focusHandlers } = props
   return (

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -18,7 +18,7 @@ import type { FocusHandlers } from '../../types'
 type TCFormProps = {| focusHandlers: FocusHandlers, formData: FormData |}
 
 export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
-  const { focusHandlers } = props
+  const { focusHandlers, formData } = props
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -44,7 +44,7 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
           name={'thermocyclerFormType'}
           condition={val => val === THERMOCYCLER_STATE}
         >
-          <StateFields focusHandlers={focusHandlers} />
+          <StateFields focusHandlers={focusHandlers} formData={formData} />
         </ConditionalOnField>
 
         <RadioGroupField

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -18,7 +18,7 @@ import type { FocusHandlers } from '../../types'
 type TCFormProps = {| focusHandlers: FocusHandlers, formData: FormData |}
 
 export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
-  const { focusHandlers, formData } = props
+  const { focusHandlers } = props
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -44,7 +44,7 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
           name={'thermocyclerFormType'}
           condition={val => val === THERMOCYCLER_STATE}
         >
-          <StateFields focusHandlers={focusHandlers} formData={formData} />
+          <StateFields focusHandlers={focusHandlers} />
         </ConditionalOnField>
 
         <RadioGroupField

--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -96,6 +96,12 @@ export const MAX_ENGAGE_HEIGHT_V2 = 19
 export const MIN_TEMP_MODULE_TEMP = 4
 export const MAX_TEMP_MODULE_TEMP = 95
 
+export const MIN_TC_BLOCK_TEMP = 4
+export const MAX_TC_BLOCK_TEMP = 99
+
+export const MIN_TC_LID_TEMP = 37
+export const MAX_TC_LID_TEMP = 110
+
 // Temperature statuses
 export const TEMPERATURE_DEACTIVATED: 'TEMPERATURE_DEACTIVATED' =
   'TEMPERATURE_DEACTIVATED'

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -14,7 +14,7 @@ export type FieldError =
   | 'UNDER_RANGE_MINIMUM'
   | 'OVER_RANGE_MAXIMUM'
   | 'NOT_A_REAL_NUMBER'
-  | 'TEMPERATURE_RANGE_EXEEDED'
+  | 'OUTSIDE_OF_RANGE'
 
 const FIELD_ERRORS: { [FieldError]: string } = {
   REQUIRED: 'This field is required',
@@ -23,7 +23,7 @@ const FIELD_ERRORS: { [FieldError]: string } = {
   UNDER_RANGE_MINIMUM: 'Min is',
   OVER_RANGE_MAXIMUM: 'Max is',
   NOT_A_REAL_NUMBER: 'Must be a number',
-  TEMPERATURE_RANGE_EXEEDED: 'Must be between',
+  OUTSIDE_OF_RANGE: 'Must be between',
 }
 
 // TODO: test these
@@ -57,15 +57,15 @@ export const maxFieldValue = (maximum: number): ErrorChecker => (
     ? null
     : `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
 
-export const rangeFieldValue = (
+export const temperatureRangeFieldValue = (
   minimum: number,
   maximum: number
 ): ErrorChecker => (value: mixed): ?string =>
   value === null || (Number(value) <= maximum && Number(value) >= minimum)
     ? null
-    : `${
-        FIELD_ERRORS.TEMPERATURE_RANGE_EXEEDED
-      } ${minimum} and ${maximum} ${i18n.t('application.units.degrees')}`
+    : `${FIELD_ERRORS.OUTSIDE_OF_RANGE} ${minimum} and ${maximum} ${i18n.t(
+        'application.units.degrees'
+      )}`
 
 export const realNumber: ErrorChecker = (value: mixed) =>
   isNaN(Number(value)) ? FIELD_ERRORS.NOT_A_REAL_NUMBER : null

--- a/protocol-designer/src/steplist/fieldLevel/errors.js
+++ b/protocol-designer/src/steplist/fieldLevel/errors.js
@@ -1,6 +1,6 @@
 // @flow
 import isArray from 'lodash/isArray'
-
+import { i18n } from '../../localization'
 /*******************
  ** Error Messages **
  ********************/
@@ -14,6 +14,7 @@ export type FieldError =
   | 'UNDER_RANGE_MINIMUM'
   | 'OVER_RANGE_MAXIMUM'
   | 'NOT_A_REAL_NUMBER'
+  | 'TEMPERATURE_RANGE_EXEEDED'
 
 const FIELD_ERRORS: { [FieldError]: string } = {
   REQUIRED: 'This field is required',
@@ -22,6 +23,7 @@ const FIELD_ERRORS: { [FieldError]: string } = {
   UNDER_RANGE_MINIMUM: 'Min is',
   OVER_RANGE_MAXIMUM: 'Max is',
   NOT_A_REAL_NUMBER: 'Must be a number',
+  TEMPERATURE_RANGE_EXEEDED: 'Must be between',
 }
 
 // TODO: test these
@@ -54,6 +56,16 @@ export const maxFieldValue = (maximum: number): ErrorChecker => (
   value === null || Number(value) <= maximum
     ? null
     : `${FIELD_ERRORS.OVER_RANGE_MAXIMUM} ${maximum}`
+
+export const rangeFieldValue = (
+  minimum: number,
+  maximum: number
+): ErrorChecker => (value: mixed): ?string =>
+  value === null || (Number(value) <= maximum && Number(value) >= minimum)
+    ? null
+    : `${
+        FIELD_ERRORS.TEMPERATURE_RANGE_EXEEDED
+      } ${minimum} and ${maximum} ${i18n.t('application.units.degrees')}`
 
 export const realNumber: ErrorChecker = (value: mixed) =>
   isNaN(Number(value)) ? FIELD_ERRORS.NOT_A_REAL_NUMBER : null

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -6,7 +6,7 @@ import {
   composeErrors,
   minFieldValue,
   maxFieldValue,
-  rangeFieldValue,
+  temperatureRangeFieldValue,
   realNumber,
 } from './errors'
 import {
@@ -178,13 +178,15 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   },
   blockTargetTemp: {
     getErrors: composeErrors(
-      rangeFieldValue(MIN_TC_BLOCK_TEMP, MAX_TC_BLOCK_TEMP)
+      temperatureRangeFieldValue(MIN_TC_BLOCK_TEMP, MAX_TC_BLOCK_TEMP)
     ),
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
   lidTargetTemp: {
-    getErrors: composeErrors(rangeFieldValue(MIN_TC_LID_TEMP, MAX_TC_LID_TEMP)),
+    getErrors: composeErrors(
+      temperatureRangeFieldValue(MIN_TC_LID_TEMP, MAX_TC_LID_TEMP)
+    ),
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -6,6 +6,7 @@ import {
   composeErrors,
   minFieldValue,
   maxFieldValue,
+  rangeFieldValue,
   realNumber,
 } from './errors'
 import {
@@ -18,7 +19,14 @@ import {
   type ValueMasker,
   type ValueCaster,
 } from './processing'
-import { MIN_TEMP_MODULE_TEMP, MAX_TEMP_MODULE_TEMP } from '../../constants'
+import {
+  MIN_TEMP_MODULE_TEMP,
+  MAX_TEMP_MODULE_TEMP,
+  MIN_TC_BLOCK_TEMP,
+  MAX_TC_BLOCK_TEMP,
+  MIN_TC_LID_TEMP,
+  MAX_TC_LID_TEMP,
+} from '../../constants'
 import type { StepFieldName } from '../../form-types'
 import type { LabwareEntity, PipetteEntity } from '../../step-forms'
 import type { InvariantContext } from '../../step-generation'
@@ -165,6 +173,18 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
       minFieldValue(MIN_TEMP_MODULE_TEMP),
       maxFieldValue(MAX_TEMP_MODULE_TEMP)
     ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
+  blockTargetTemp: {
+    getErrors: composeErrors(
+      rangeFieldValue(MIN_TC_BLOCK_TEMP, MAX_TC_BLOCK_TEMP)
+    ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
+  lidTargetTemp: {
+    getErrors: composeErrors(rangeFieldValue(MIN_TC_LID_TEMP, MAX_TC_LID_TEMP)),
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },

--- a/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
+++ b/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
@@ -1,4 +1,8 @@
-import { minFieldValue, maxFieldValue, rangeFieldValue } from '../errors'
+import {
+  minFieldValue,
+  maxFieldValue,
+  temperatureRangeFieldValue,
+} from '../errors'
 
 describe('errors', () => {
   describe('minFieldValue', () => {
@@ -40,12 +44,12 @@ describe('errors', () => {
     })
   })
 
-  describe('rangeFieldValue', () => {
+  describe('temperatureRangeFieldValue', () => {
     const MIN = 4
     const MAX = 99
     let rangeChecker
     beforeEach(() => {
-      rangeChecker = rangeFieldValue(MIN, MAX)
+      rangeChecker = temperatureRangeFieldValue(MIN, MAX)
     })
     it('returns null when value is null', () => {
       expect(rangeChecker(null)).toBe(null)

--- a/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
+++ b/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
@@ -50,6 +50,12 @@ describe('errors', () => {
     it('returns null when value is null', () => {
       expect(rangeChecker(null)).toBe(null)
     })
+    it('returns null when value is equal to the min', () => {
+      expect(rangeChecker(MIN)).toBe(null)
+    })
+    it('returns null when value passed greater than the min', () => {
+      expect(rangeChecker(MIN + 1)).toBe(null)
+    })
     it('returns null when value is equal to the max', () => {
       expect(rangeChecker(MAX)).toBe(null)
     })

--- a/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
+++ b/protocol-designer/src/steplist/fieldLevel/test/errors.test.js
@@ -1,4 +1,4 @@
-import { minFieldValue, maxFieldValue } from '../errors'
+import { minFieldValue, maxFieldValue, rangeFieldValue } from '../errors'
 
 describe('errors', () => {
   describe('minFieldValue', () => {
@@ -37,6 +37,31 @@ describe('errors', () => {
     })
     it('returns an error text when value passed greater than the max', () => {
       expect(maxChecker(MAX + 1)).toBe(`Max is ${MAX}`)
+    })
+  })
+
+  describe('rangeFieldValue', () => {
+    const MIN = 4
+    const MAX = 99
+    let rangeChecker
+    beforeEach(() => {
+      rangeChecker = rangeFieldValue(MIN, MAX)
+    })
+    it('returns null when value is null', () => {
+      expect(rangeChecker(null)).toBe(null)
+    })
+    it('returns null when value is equal to the max', () => {
+      expect(rangeChecker(MAX)).toBe(null)
+    })
+    it('returns null when value passed less than the max', () => {
+      expect(rangeChecker(MAX - 1)).toBe(null)
+    })
+    it('returns an error text when value passed greater than the max', () => {
+      expect(rangeChecker(MAX + 1)).toBe(`Must be between ${MIN} and ${MAX} °C`)
+    })
+
+    it('returns an error text when value passed less than than the min', () => {
+      expect(rangeChecker(MIN - 1)).toBe(`Must be between ${MIN} and ${MAX} °C`)
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -31,6 +31,8 @@ export type FormErrorKey =
   | 'ENGAGE_HEIGHT_REQUIRED'
   | 'MODULE_ID_REQUIRED'
   | 'TARGET_TEMPERATURE_REQUIRED'
+  | 'BLOCK_TEMPERATURE_REQUIRED'
+  | 'LID_TEMPERATURE_REQUIRED'
 
 export type FormError = {
   title: string,
@@ -92,6 +94,14 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
   TARGET_TEMPERATURE_REQUIRED: {
     title: 'Temperature is required',
     dependentFields: ['setTemperature', 'targetTemperature'],
+  },
+  BLOCK_TEMPERATURE_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['blockIsActive', 'blockTargetTemp'],
+  },
+  LID_TEMPERATURE_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['lidIsActive', 'lidTargetTemp'],
   },
 }
 export type FormErrorChecker = mixed => ?FormError
@@ -211,6 +221,24 @@ export const targetTemperatureRequired = (
   const { setTemperature, targetTemperature } = fields
   return setTemperature === 'true' && !targetTemperature
     ? FORM_ERRORS.TARGET_TEMPERATURE_REQUIRED
+    : null
+}
+
+export const blockTemperatureRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { blockIsActive, blockTargetTemp } = fields
+  return blockIsActive === true && !blockTargetTemp
+    ? FORM_ERRORS.BLOCK_TEMPERATURE_REQUIRED
+    : null
+}
+
+export const lidTemperatureRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { lidIsActive, lidTargetTemp } = fields
+  return lidIsActive === true && !lidTargetTemp
+    ? FORM_ERRORS.LID_TEMPERATURE_REQUIRED
     : null
 }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
@@ -1,0 +1,41 @@
+// @flow
+import pick from 'lodash/pick'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+import { getDefaultsForStepType } from '../getDefaultsForStepType'
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+// TODO: Ian 2019-02-21 import this from a more central place - see #2926
+const getDefaultFields = (...fields: Array<StepFieldName>): FormPatch =>
+  pick(getDefaultsForStepType('thermocycler'), fields)
+
+const updatePatchOnBlockChange = (patch: FormPatch, rawForm: FormData) => {
+  if (fieldHasChanged(rawForm, patch, 'blockIsActive')) {
+    return {
+      ...patch,
+      ...getDefaultFields('blockTargetTemp'),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnLidChange = (patch: FormPatch, rawForm: FormData) => {
+  if (fieldHasChanged(rawForm, patch, 'lidIsActive')) {
+    return {
+      ...patch,
+      ...getDefaultFields('lidTargetTemp'),
+    }
+  }
+  return patch
+}
+
+export function dependentFieldsUpdateThermocycler(
+  originalPatch: FormPatch,
+  rawForm: FormData // raw = NOT hydrated
+): FormPatch {
+  // sequentially modify parts of the patch until it's fully updated
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnBlockChange(chainPatch, rawForm),
+    chainPatch => updatePatchOnLidChange(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.js
@@ -4,6 +4,7 @@ import { dependentFieldsUpdateMix } from './dependentFieldsUpdateMix'
 import { dependentFieldsUpdateMagnet } from './dependentFieldsUpdateMagnet'
 import { dependentFieldsUpdatePause } from './dependentFieldsUpdatePause'
 import { dependentFieldsUpdateTemperature } from './dependentFieldsUpdateTemperature'
+import { dependentFieldsUpdateThermocycler } from './dependentFieldsUpdateThermocycler'
 
 import type { FormData } from '../../../form-types'
 import type { FormPatch } from '../../actions/types'
@@ -46,6 +47,13 @@ export function handleFormChange(
   }
   if (rawForm.stepType === 'temperature') {
     const dependentFieldsPatch = dependentFieldsUpdateTemperature(
+      patch,
+      rawForm
+    )
+    return { ...patch, ...dependentFieldsPatch }
+  }
+  if (rawForm.stepType === 'thermocycler') {
+    const dependentFieldsPatch = dependentFieldsUpdateThermocycler(
       patch,
       rawForm
     )

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -12,6 +12,8 @@ import {
   type FormError,
   moduleIdRequired,
   targetTemperatureRequired,
+  blockTemperatureRequired,
+  lidTemperatureRequired,
 } from './errors'
 import {
   composeWarnings,
@@ -74,6 +76,9 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
   },
   temperature: {
     getErrors: composeErrors(targetTemperatureRequired, moduleIdRequired),
+  },
+  thermocycler: {
+    getErrors: composeErrors(blockTemperatureRequired, lidTemperatureRequired),
   },
 }
 


### PR DESCRIPTION
## overview

This PR closes #5569 by 
- adding a `rangeFieldValue` field level error (if you look at the mockup, this does not follow the other min/max error captions)
- resetting/clearing conditional temperature fields when toggling block/lid between active/deactivated
- adding form level error when either lid or block is active but no temperature has be entered

## changelog

- feat(protocol-designer): Add validation to TC state form
- reset temperature fields when block or lid toggles active state
- add test for `rangeFieldValue` error

## review requests

- Make a protocol with a TC
- Make a TC step
- Toggle block to active
- [ ] Save button is disabled when block is active, but no block target temperature has been entered
- Enter 0 for `blockTargetTemp`
- [ ] Save button is disabled when block is active and out of range number is entered
- [ ] Field level error renders for target temp above or below recommended range
- Enter a valid value for `blockTargetTemp`
- [ ] Save button is enabled, errors do not render
- Toggle lid to active
- [ ] Save button is disabled when block is active, but no lid target temperature has been entered
- Enter 0 for `lidTargetTemp`
- [ ] Save button is disabled when block is active and out of range number is entered
- [ ] Field level error renders for target temp above or below recommended range
- Enter a valid value for `lidTargetTemp`
- [ ] Save button is enabled, errors do not render

Masker checks
- [ ] Can only enter positive whole numbers

## risk assessment
Low PD behind a FF