### PR TITLE
refactor(api): split geometry.plan_moves

### DIFF
--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -1,7 +1,10 @@
 """ Utility functions and classes for the hardware controller"""
 import asyncio
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Tuple
+
+from .types import CriticalPoint
+from opentrons.types import Point
 
 mod_log = logging.getLogger(__name__)
 
@@ -17,3 +20,21 @@ def use_or_initialize_loop(loop: Optional[asyncio.AbstractEventLoop]
     checked_loop = loop or asyncio.get_event_loop()
     checked_loop.set_exception_handler(_handle_loop_exception)
     return checked_loop
+
+
+def plan_arc(
+        origin_point: Point,
+        dest_point: Point,
+        z_height: float,
+        origin_cp: CriticalPoint = None,
+        dest_cp: CriticalPoint = None,
+        extra_waypoints: List[Tuple[float, float]] = None)\
+        -> List[Tuple[Point, Optional[CriticalPoint]]]:
+
+    assert z_height >= max(origin_point.z, dest_point.z)
+    checked_wp = extra_waypoints or []
+    return [(origin_point._replace(z=z_height), origin_cp)]\
+        + [(Point(x=wp[0], y=wp[1], z=z_height), dest_cp)
+           for wp in checked_wp]\
+        + [(dest_point._replace(z=z_height), dest_cp),
+           (dest_point, dest_cp)]

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -1,0 +1,70 @@
+from typing import List
+
+from opentrons.hardware_control.util import plan_arc
+from opentrons.hardware_control.types import CriticalPoint
+from opentrons.types import Point
+
+import pytest
+
+
+def check_arc_basic(arc: List[Point], from_pt: Point, to_pt: Point):
+    """ Check the tests that should always be true for different-well moves
+    - we should always go only up, then only xy, then only down
+    - we should have three moves
+    """
+    # first move should move only up
+    assert arc[0]._replace(z=0) == from_pt._replace(z=0)
+    # second move should move only in xy
+    assert arc[0].z == arc[1].z
+    # second-to-last move should always end at the dest in xy
+    # so the last move is z-only
+    assert arc[-2]._replace(z=0) == to_pt._replace(z=0)
+    # final move should arrive precisely at the dest
+    assert arc[-1] == to_pt
+    # first move should be up
+    assert arc[0].z >= from_pt.z
+    # last move should be down
+    assert arc[-2].z >= to_pt.z
+
+
+@pytest.mark.parametrize(
+    argnames=['from_pt', 'to_pt', 'z_height'],
+    argvalues=[
+        [Point(10, 20, 30), Point(10, 30, 30), 100],
+        [Point(10, 20, 30), Point(10, 30, 40), 100],
+        [Point(10, 20, 40), Point(10, 30, 30), 40],
+        [Point(10, 20, 30), Point(10, 30, 40), 40]])
+def test_basic_arcs(from_pt, to_pt, z_height):
+    check_arc_basic([a[0] for a in plan_arc(from_pt, to_pt, z_height)],
+                    from_pt, to_pt)
+
+
+def test_arc_with_waypoint():
+    from_pt = Point(20, 20, 40)
+    to_pt = Point(0, 0, 10)
+    arc = plan_arc(from_pt, to_pt,
+                   50,
+                   extra_waypoints=[(5, 10), (20, 30)])
+    check_arc_basic([a[0] for a in arc], from_pt, to_pt)
+    assert arc[1][0].x == 5
+    assert arc[1][0].y == 10
+    assert arc[1][0].z == 50
+    assert arc[2][0].x == 20
+    assert arc[2][0].y == 30
+    assert arc[2][0].z == 50
+
+
+def test_cp_blending():
+    from_pt = Point(10, 10, 10)
+    to_pt = Point(0, 0, 10)
+    arc = plan_arc(from_pt, to_pt, 50, None, CriticalPoint.XY_CENTER)
+    check_arc_basic([a[0] for a in arc], from_pt, to_pt)
+    assert arc[0][1] is None
+    assert arc[1][1] is CriticalPoint.XY_CENTER
+    assert arc[2][1] is CriticalPoint.XY_CENTER
+
+    arc2 = plan_arc(from_pt, to_pt, 50, CriticalPoint.TIP, None)
+    check_arc_basic([a[0] for a in arc], from_pt, to_pt)
+    assert arc2[0][1] == CriticalPoint.TIP
+    assert arc2[1][1] is None
+    assert arc2[2][1] is None

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -2,7 +2,7 @@ import pytest
 
 from opentrons.types import Location, Point
 from opentrons.protocol_api.geometry import (
-    Deck, plan_moves, first_parent, should_dodge_thermocycler)
+    Deck, plan_moves, safe_height, first_parent, should_dodge_thermocycler)
 from opentrons.protocol_api import labware, module_geometry
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_api.definitions import MAX_SUPPORTED_VERSION
@@ -333,25 +333,25 @@ def test_instr_max_height():
     # the max instrument achievable height, we use the max instrument
     # height as the safe height
     instr_max_height = trough.wells()[0].top().point.z + 1
-    moves1 = plan_moves(
+    height = safe_height(
         trough.wells()[0].top(), trough2.wells()[0].top(),
         deck, round(instr_max_height, 2), 7.0, 15.0)
-    assert moves1[0][0].z == round(instr_max_height, 2)
+    assert height == round(instr_max_height, 2)
 
     # if the highest deck height is > 10 mm below the max instrument
     # height, we use the lw_z_margin instead
     instr_max_height = trough.wells()[0].top().point.z + 30
-    moves2 = plan_moves(
+    height2 = safe_height(
         trough.wells()[0].top(), trough2.wells()[0].top(),
         deck, round(instr_max_height, 2), 7.0, 15.0)
-    assert moves2[0][0].z ==\
+    assert height2 ==\
         round(trough.wells()[0].top().point.z, 2) + 15.0
 
     # it fails if the highest deck height is less than 1 mm below
     # the max instr achievable height
     instr_max_height = trough.wells()[0].top().point.z
     with pytest.raises(Exception):
-        plan_moves(
+        safe_height(
             trough.wells()[0].top(), trough2.wells()[0].top(),
             deck, round(instr_max_height, 2), 7.0, 15.0)
 


### PR DESCRIPTION
# overview

opentrons.protocol_api.geometry.plan_moves is a helper function
responsible for planning arc moves that always go high enough to avoid
labware, possibly avoid thermocyclers, and switch critical points. It did all of
- Understand the deck enough to know what "high enough" means, including
constraints like "not too high for the instrument"
- Understand protocol api semantics enough to know when an arc move is
actually necessary, and issue direct moves if possible
- Understand the deck enough to know how to dodge thermocyclers
- Understand hardware enough to switch critical points
- Understand labware semantics enough to figure out which critical
points to use

It was also long enough to need a mccabe exception in the linter.

Because it was in geometry, anything in the rest of the system that
wanted to move in an arc either needed to import the protocol api
subsystem or roll its own arcs.

This splits plan_moves up into three components:
- plan_moves is a one-size-fits-all entrypoint for callers that do know
all about decks and everything (like the protocol api). It calls the
other components and still does all of the above... but with a lot of
work done in helpers to avoid the complexity. The parts it does on its
own are deciding if avoiding the thermocycler is necessary, and issuing
direct moves if possible, and figuring out which critical points to use
- geometry.safe_height implements the "understand the deck enough to
figure out a safe height" part of the stack, which can now be called
independently without involving all the rest of the stuff
- hardware_control.util.plan_arc, which takes an origin point + cp, a
destination point + cp, and a z height and does the part of actually
generating the moves and blending between the two requested critical
points. It also takes a list of internal waypoints, which
geometry.plan_moves provides for dodging the thermocycler

The API to the protocol api is unchanged, but now other components of
the system can build their own arc moves with similar logic but choosing
their own components. For instance (and in an upcoming PR), deck
calibration check can use these components to build arc moves with
proper z heights (using safe_height()) but specifying all critical
points (using hardware_control.util.plan_arc() directly without using
geometry.plan_moves).

## review requests

Check out the changes! Test them on your robot

## Testing/Risk Assessment

Though the behavior should be unchanged (and all previously-written tests for `plan_moves` still pass without changes) technically this is used by a lot of stuff in the protocol api. We should run some protocols and calibrate labware make sure they move ok.
