### PR TITLE
fix(api): cal check: terminal drop tips during delete

### DIFF
--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -417,7 +417,6 @@ CHECK_TRANSITIONS = [
         "trigger": CalibrationCheckTrigger.go_to_next_check,
         "from_state": CalibrationCheckState.comparingFirstPipettePointThree,
         "to_state": CalibrationCheckState.checkComplete,
-        "before": "_trash_first_pipette_tip",
     },
     {
         "trigger": CalibrationCheckTrigger.jog,
@@ -484,7 +483,6 @@ CHECK_TRANSITIONS = [
         "trigger": CalibrationCheckTrigger.go_to_next_check,
         "from_state": CalibrationCheckState.comparingSecondPipettePointOne,
         "to_state": CalibrationCheckState.checkComplete,
-        "before": "_trash_second_pipette_tip",
     },
     {
         "trigger": CalibrationCheckTrigger.exit,
@@ -596,11 +594,12 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                     self._moves.preparingFirstPipette = move
 
     async def delete_session(self):
-        for mount in self._pip_info_by_id.values():
-            try:
-                await self._trash_tip(mount['mount'])
-            except (CalibrationException, AssertionError):
-                pass
+        for pid, mount in self._pip_info_by_id.items():
+            if self._has_tip(pid):
+                try:
+                    await self._trash_tip(mount['mount'])
+                except (CalibrationException, AssertionError):
+                    pass
         await self.hardware.home()
         await self.hardware.set_lights(rails=False)
 

--- a/api/tests/opentrons/server/calibration/test_check_calibration_session.py
+++ b/api/tests/opentrons/server/calibration/test_check_calibration_session.py
@@ -374,7 +374,6 @@ async def test_complete_check_one_pip(check_calibration_session_only_right):
             session.CalibrationCheckTrigger.go_to_next_check)
     assert sess.current_state.name == \
         session.CalibrationCheckState.checkComplete
-    assert sess.get_pipette(sess._first_mount)['has_tip'] is False
 
 
 async def test_complete_check_both_pips(check_calibration_session):
@@ -386,8 +385,6 @@ async def test_complete_check_both_pips(check_calibration_session):
             session.CalibrationCheckTrigger.go_to_next_check)
     assert sess.current_state.name == \
         session.CalibrationCheckState.checkComplete
-    assert sess.get_pipette(sess._first_mount)['has_tip'] is False
-    assert sess.get_pipette(sess._second_mount)['has_tip'] is False
 
 
 # START flow testing both mounts


### PR DESCRIPTION
We always want to drop tips in the trash when we end sessions - whether
we do a smooth exit or not (and perhaps whether another client hops in
or not). We also want those drop tips to happen when we actually exit
the session, not right before the session complete screen (which is
triggered by the checkComplete state).

To accomplish both these goals, remove the state transition hooks when
moving to trashComplete that trigger the drop tip and rely on the
behavior in the session deleter (and refactor it a bit to avoid spurious
moves, since previously you would move around some before _trash_tip
realized there was nothing to drop).
