### PR TITLE
feat(protocol-designer): Default tc state for to previous saved state

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -287,4 +287,40 @@ describe('createPresavedStepForm', () => {
       lidOpen: null,
     })
   })
+
+  it('should set a default thermocycler module for thermocycler step, and populate TC state when previously saved TC state', () => {
+    const args = {
+      ...defaultArgs,
+      savedStepForms: {
+        prevStepId: {
+          id: 'prevStepId',
+          stepName: 'thermocycler',
+          stepDetails: '',
+          thermocyclerFormType: 'thermocyclerState',
+          blockIsActive: true,
+          blockTargetTemp: 45,
+          lidIsActive: true,
+          lidTargetTemp: 45,
+          lidOpen: true,
+        },
+      },
+      orderedStepIds: ['prevStepId'],
+      stepType: 'thermocycler',
+    }
+
+    expect(createPresavedStepForm(args)).toEqual({
+      id: stepId,
+      stepType: 'thermocycler',
+      moduleId: 'someThermocyclerModuleId',
+      // TC Default field
+      stepName: 'thermocycler',
+      stepDetails: '',
+      thermocyclerFormType: 'thermocyclerState',
+      blockIsActive: true,
+      blockTargetTemp: 45,
+      lidIsActive: true,
+      lidTargetTemp: 45,
+      lidOpen: true,
+    })
+  })
 })

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.js
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.js
@@ -7,6 +7,11 @@ import {
   getNextDefaultPipetteId,
   getNextDefaultTemperatureModuleId,
   getNextDefaultThermocyclerModuleId,
+  getNextDefaultBlockIsActive,
+  getNextDefaultBlockTemperature,
+  getNextDefaultLidIsActive,
+  getNextDefaultLidTemperature,
+  getNextDefaultLidOpen,
   handleFormChange,
 } from '../../steplist/formLevel'
 import {
@@ -141,7 +146,7 @@ const _patchTemperatureModuleId = (args: {|
   return null
 }
 
-const _patchThermocyclerModuleId = (args: {|
+const _patchThermocyclerFields = (args: {|
   initialDeckSetup: InitialDeckSetup,
   orderedStepIds: OrderedStepIdsState,
   savedStepForms: SavedStepFormState,
@@ -149,17 +154,42 @@ const _patchThermocyclerModuleId = (args: {|
 |}): FormUpdater => () => {
   const { initialDeckSetup, orderedStepIds, savedStepForms, stepType } = args
 
-  const hasThermocyclerModuleId = stepType === 'thermocycler'
-
-  if (hasThermocyclerModuleId) {
-    const moduleId = getNextDefaultThermocyclerModuleId(
-      savedStepForms,
-      orderedStepIds,
-      initialDeckSetup.modules
-    )
-    return { moduleId }
+  if (stepType !== 'thermocycler') {
+    return null
   }
-  return null
+
+  const moduleId = getNextDefaultThermocyclerModuleId(
+    savedStepForms,
+    orderedStepIds,
+    initialDeckSetup.modules
+  )
+
+  const blockIsActive = getNextDefaultBlockIsActive(
+    savedStepForms,
+    orderedStepIds
+  )
+
+  const blockTargetTemp = getNextDefaultBlockTemperature(
+    savedStepForms,
+    orderedStepIds
+  )
+
+  const lidIsActive = getNextDefaultLidIsActive(savedStepForms, orderedStepIds)
+
+  const lidTargetTemp = getNextDefaultLidTemperature(
+    savedStepForms,
+    orderedStepIds
+  )
+
+  const lidOpen = getNextDefaultLidOpen(savedStepForms, orderedStepIds)
+  return {
+    moduleId,
+    blockIsActive,
+    blockTargetTemp,
+    lidIsActive,
+    lidTargetTemp,
+    lidOpen,
+  }
 }
 
 export const createPresavedStepForm = ({
@@ -198,7 +228,7 @@ export const createPresavedStepForm = ({
     stepType,
   })
 
-  const updateThermocyclerModuleId = _patchThermocyclerModuleId({
+  const updateThermocyclerModuleId = _patchThermocyclerFields({
     initialDeckSetup,
     orderedStepIds,
     savedStepForms,

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
@@ -31,7 +31,7 @@ describe('getNextDefaultBlockIsActive', () => {
       },
       {
         testMsg: 'returns false when false previously selected',
-        orderedStepIds: ['f', 'f', 'f'],
+        orderedStepIds: ['f', 't', 'f'],
         expected: false,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
@@ -5,7 +5,7 @@ describe('getNextDefaultBlockIsActive', () => {
   describe('no previous forms defaults to false', () => {
     const testCases = [
       {
-        testMsg: 'no previous thermocycler state',
+        testMsg: 'returns false when no previous thermocycler state',
         expected: false,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockIsActive.test.js
@@ -1,0 +1,52 @@
+// @flow
+import { getNextDefaultBlockIsActive } from '../'
+
+describe('getNextDefaultBlockIsActive', () => {
+  describe('no previous forms defaults to false', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous thermocycler state',
+        expected: false,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultBlockIsActive(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'returns true when true previously selected',
+        orderedStepIds: ['t', 'f', 't'],
+        expected: true,
+      },
+      {
+        testMsg: 'returns false when false previously selected',
+        orderedStepIds: ['f', 'f', 'f'],
+        expected: false,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {
+          t: { id: 'moduleId', stepType: 'thermocycler', blockIsActive: true },
+          f: { id: 'moduleId', stepType: 'thermocycler', blockIsActive: false },
+        }
+
+        const result = getNextDefaultBlockIsActive(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockTemperature.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockTemperature.test.js
@@ -1,0 +1,71 @@
+// @flow
+import { getNextDefaultBlockTemperature } from '../'
+
+describe('getNextDefaultBlockTemperature', () => {
+  describe('no previous forms defaults to null', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous thermocycler state',
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultBlockTemperature(
+          savedForms,
+          orderedStepIds
+        )
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg:
+          'returns null when block deactivated and no previous block temp entered',
+        orderedStepIds: ['d'],
+        expected: null,
+      },
+      {
+        testMsg:
+          'returns default when block activated previous selected and previous block temp entered',
+        orderedStepIds: ['a', 'd', 'a'],
+        expected: 40,
+      },
+      {
+        testMsg:
+          'returns default when block deactivated previous selected and previous block temp entered',
+        orderedStepIds: ['d', 'a', 'd'],
+        expected: 40,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {
+          a: {
+            id: 'moduleId',
+            stepType: 'thermocycler',
+            blockIsActive: true,
+            blockTargetTemp: 40,
+          },
+          d: { id: 'moduleId', stepType: 'thermocycler', blockIsActive: false },
+        }
+
+        const result = getNextDefaultBlockTemperature(
+          savedForms,
+          orderedStepIds
+        )
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockTemperature.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultBlockTemperature.test.js
@@ -5,7 +5,7 @@ describe('getNextDefaultBlockTemperature', () => {
   describe('no previous forms defaults to null', () => {
     const testCases = [
       {
-        testMsg: 'no previous thermocycler state',
+        testMsg: 'returns false when no previous thermocycler state',
         expected: null,
       },
     ]
@@ -34,15 +34,8 @@ describe('getNextDefaultBlockTemperature', () => {
         expected: null,
       },
       {
-        testMsg:
-          'returns default when block activated previous selected and previous block temp entered',
-        orderedStepIds: ['a', 'd', 'a'],
-        expected: 40,
-      },
-      {
-        testMsg:
-          'returns default when block deactivated previous selected and previous block temp entered',
-        orderedStepIds: ['d', 'a', 'd'],
+        testMsg: 'block target temp populates with previously saved value',
+        orderedStepIds: ['d', 'a'],
         expected: 40,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidIsActive.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidIsActive.test.js
@@ -1,0 +1,52 @@
+// @flow
+import { getNextDefaultLidIsActive } from '../'
+
+describe('getNextDefaultLidIsActive', () => {
+  describe('no previous forms defaults to false', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous thermocycler state',
+        expected: false,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultLidIsActive(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'returns true when true previously selected',
+        orderedStepIds: ['t', 'f', 't'],
+        expected: true,
+      },
+      {
+        testMsg: 'returns false when false previously selected',
+        orderedStepIds: ['f', 'f', 'f'],
+        expected: false,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {
+          t: { id: 'moduleId', stepType: 'thermocycler', lidIsActive: true },
+          f: { id: 'moduleId', stepType: 'thermocycler', lidIsActive: false },
+        }
+
+        const result = getNextDefaultLidIsActive(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidIsActive.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidIsActive.test.js
@@ -5,7 +5,7 @@ describe('getNextDefaultLidIsActive', () => {
   describe('no previous forms defaults to false', () => {
     const testCases = [
       {
-        testMsg: 'no previous thermocycler state',
+        testMsg: 'returns false when no previous thermocycler state',
         expected: false,
       },
     ]
@@ -31,7 +31,7 @@ describe('getNextDefaultLidIsActive', () => {
       },
       {
         testMsg: 'returns false when false previously selected',
-        orderedStepIds: ['f', 'f', 'f'],
+        orderedStepIds: ['f', 't', 'f'],
         expected: false,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidOpen.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidOpen.test.js
@@ -1,0 +1,52 @@
+// @flow
+import { getNextDefaultLidOpen } from '../'
+
+describe('getNextDefaultLidOpen', () => {
+  describe('no previous forms defaults to null', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous thermocycler state',
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultLidOpen(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg: 'returns true when true previously selected',
+        orderedStepIds: ['t', 'f', 't'],
+        expected: true,
+      },
+      {
+        testMsg: 'returns false when false previously selected',
+        orderedStepIds: ['f', 'f', 'f'],
+        expected: false,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {
+          t: { id: 'moduleId', stepType: 'thermocycler', lidOpen: true },
+          f: { id: 'moduleId', stepType: 'thermocycler', lidOpen: false },
+        }
+
+        const result = getNextDefaultLidOpen(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidOpen.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidOpen.test.js
@@ -5,7 +5,7 @@ describe('getNextDefaultLidOpen', () => {
   describe('no previous forms defaults to null', () => {
     const testCases = [
       {
-        testMsg: 'no previous thermocycler state',
+        testMsg: 'returns null when no previous thermocycler state',
         expected: null,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidTemperature.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidTemperature.test.js
@@ -5,7 +5,7 @@ describe('getNextDefaultLidTemperature', () => {
   describe('no previous forms defaults to null', () => {
     const testCases = [
       {
-        testMsg: 'no previous thermocycler state',
+        testMsg: 'returns null when no previous thermocycler state',
         expected: null,
       },
     ]
@@ -31,15 +31,8 @@ describe('getNextDefaultLidTemperature', () => {
         expected: null,
       },
       {
-        testMsg:
-          'returns default when lid activated previous selected and previous lid temp entered',
-        orderedStepIds: ['a', 'd', 'a'],
-        expected: 40,
-      },
-      {
-        testMsg:
-          'returns default when lid deactivated previous selected and previous lid temp entered',
-        orderedStepIds: ['d', 'a', 'd'],
+        testMsg: 'lid target temp populates with previously saved value',
+        orderedStepIds: ['d', 'a'],
         expected: 40,
       },
     ]

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidTemperature.test.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/__tests__/getNextDefaultLidTemperature.test.js
@@ -1,0 +1,65 @@
+// @flow
+import { getNextDefaultLidTemperature } from '../'
+
+describe('getNextDefaultLidTemperature', () => {
+  describe('no previous forms defaults to null', () => {
+    const testCases = [
+      {
+        testMsg: 'no previous thermocycler state',
+        expected: null,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {}
+        const orderedStepIds = []
+
+        const result = getNextDefaultLidTemperature(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+
+  describe('with previous forms', () => {
+    const testCases = [
+      {
+        testMsg:
+          'returns null when lid deactivated and no previous lid temp entered',
+        orderedStepIds: ['d'],
+        expected: null,
+      },
+      {
+        testMsg:
+          'returns default when lid activated previous selected and previous lid temp entered',
+        orderedStepIds: ['a', 'd', 'a'],
+        expected: 40,
+      },
+      {
+        testMsg:
+          'returns default when lid deactivated previous selected and previous lid temp entered',
+        orderedStepIds: ['d', 'a', 'd'],
+        expected: 40,
+      },
+    ]
+
+    testCases.forEach(({ testMsg, orderedStepIds, expected }) => {
+      it(testMsg, () => {
+        const savedForms = {
+          a: {
+            id: 'moduleId',
+            stepType: 'thermocycler',
+            lidIsActive: true,
+            lidTargetTemp: 40,
+          },
+          d: { id: 'moduleId', stepType: 'thermocycler', lidIsActive: false },
+        }
+
+        const result = getNextDefaultLidTemperature(savedForms, orderedStepIds)
+
+        expect(result).toBe(expected)
+      })
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/index.js
+++ b/protocol-designer/src/steplist/formLevel/getNextDefaultThermocyclerState/index.js
@@ -1,0 +1,92 @@
+// @flow
+import last from 'lodash/last'
+import type { StepIdType, FormData } from '../../../form-types'
+
+export function getNextDefaultBlockIsActive(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): boolean {
+  const prevBlockSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.blockIsActive !== null)
+
+  const lastBlockStep = last(prevBlockSteps)
+
+  const nextDefaultBlockIsActive =
+    (lastBlockStep && lastBlockStep.blockIsActive) || false
+
+  return nextDefaultBlockIsActive
+}
+
+export function getNextDefaultBlockTemperature(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): ?string {
+  const prevBlockSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.blockTargetTemp)
+
+  const lastBlockTempStep = last(prevBlockSteps)
+
+  let nextDefaultBlockTemp: string | null = null
+
+  if (lastBlockTempStep && lastBlockTempStep.blockIsActive) {
+    nextDefaultBlockTemp = lastBlockTempStep.blockTargetTemp
+      ? lastBlockTempStep.blockTargetTemp
+      : null
+  }
+
+  return nextDefaultBlockTemp
+}
+
+export function getNextDefaultLidIsActive(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): boolean {
+  const prevLidSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.lidIsActive !== null)
+
+  const lastLidStep = last(prevLidSteps)
+
+  const nextDefaultLidIsActive =
+    (lastLidStep && lastLidStep.lidIsActive) || false
+
+  return nextDefaultLidIsActive
+}
+
+export function getNextDefaultLidTemperature(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): ?string {
+  const prevLidSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.lidTargetTemp)
+
+  const lastLidTempStep = last(prevLidSteps)
+
+  let nextDefaultLidTemp: string | null = null
+
+  if (lastLidTempStep && lastLidTempStep.lidIsActive) {
+    nextDefaultLidTemp = lastLidTempStep.lidTargetTemp
+      ? lastLidTempStep.lidTargetTemp
+      : null
+  }
+
+  return nextDefaultLidTemp
+}
+
+export function getNextDefaultLidOpen(
+  savedForms: { [StepIdType]: FormData },
+  orderedStepIds: Array<StepIdType>
+): ?boolean {
+  const prevLidSteps = orderedStepIds
+    .map(stepId => savedForms[stepId])
+    .filter(form => form && form.lidOpen !== null)
+
+  const lastLidStep = last(prevLidSteps)
+
+  const nextDefaultLidOpen = lastLidStep ? lastLidStep.lidOpen : null
+
+  return nextDefaultLidOpen
+}

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -34,6 +34,13 @@ export {
 } from './getNextDefaultModuleId'
 export { getNextDefaultMagnetAction } from './getNextDefaultMagnetAction'
 export { getNextDefaultEngageHeight } from './getNextDefaultEngageHeight'
+export {
+  getNextDefaultBlockIsActive,
+  getNextDefaultBlockTemperature,
+  getNextDefaultLidIsActive,
+  getNextDefaultLidTemperature,
+  getNextDefaultLidOpen,
+} from './getNextDefaultThermocyclerState'
 export { stepFormToArgs } from './stepFormToArgs'
 export type { FormError, FormWarning, FormWarningType }
 


### PR DESCRIPTION
##  overview

This PR closes #5577 by adding getters for the defaults for previously saved TC state fields

## changelog

- feat(protocol-designer): Default tc state for to previous saved state
- added/updated tests

## review requests

Code stuff:
- [ ] Test updates are correct
- [ ] New tests cover everything

Make a protocol with multiple TC state steps
- [ ] Block Active/Deactivated populates with previously saved value
- [ ] Block Target Temp populates with previously saved value
- [ ] Lid Active/Deactivated populates with previously saved value
- [ ] LidTarget Temp populates with previously saved value
- [ ] Lid Open/Closed populates with previously saved value

## risk assessment

Low, PD behind a FF