### PR TITLE
fix(protocol-designer): Default to Gen1 for TC in edit modules modal

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.js
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.js
@@ -14,6 +14,7 @@ import {
 import {
   THERMOCYCLER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
+  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../localization'
 import {
@@ -95,10 +96,17 @@ export const EditModulesModal = (props: EditModulesModalProps) => {
     return !isLabwareCompatible
   }
 
-  const initialValues = {
-    selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
-    selectedModel: moduleOnDeck?.model || null,
-  }
+  const moduleIsThermocycler = moduleType === THERMOCYCLER_MODULE_TYPE
+
+  let initialValues = moduleIsThermocycler
+    ? {
+        selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
+        selectedModel: THERMOCYCLER_MODULE_V1,
+      }
+    : {
+        selectedSlot: moduleOnDeck?.slot || supportedModuleSlot,
+        selectedModel: moduleOnDeck?.model || null,
+      }
 
   const validator = ({
     selectedModel,


### PR DESCRIPTION
## overview

This PR closes a little bug I noticed last week. We default to Gen1 when adding a TC in the new file modal, but not the edit modules modal. 

closes #5669

## changelog

- fix(protocol-designer): Default to Gen1 for TC in edit modules modal

## review requests

Make a protocol, and add a TC via the `FileSettingsPage`

- [ ] Gen1 is automatically selected for TC
- [ ] No default GEN is selected when adding Mag/Temp modules via the `FileSettingsPage`
- [ ] Previously selected GEN is selected when editing Mag/Temp modules via the `FileSettingsPage`

## risk assessment

Low, small feature edit behind a FF in PD.
