### PR TITLE
fix(robot-server): Fixup failing tests in robot-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ test-py-windows:
 .PHONY: test-py
 test-py: test-py-windows
 	$(MAKE) -C update-server test
+	$(MAKE) -C robot-server test
 
 .PHONY: test-js
 test-js:

--- a/robot-server/robot_server/service/session/session_status.py
+++ b/robot-server/robot_server/service/session/session_status.py
@@ -36,7 +36,7 @@ def _create_calibration_check_session_details(
             model=v.model,
             name=v.name,
             tip_length=v.tip_length,
-            mount=v.mount,
+            mount=str(v.mount),
             has_tip=v.has_tip,
             rank=v.rank,
             tiprack_id=v.tiprack_id)
@@ -47,7 +47,7 @@ def _create_calibration_check_session_details(
                 alternatives=data.alternatives,
                 slot=data.slot,
                 id=data.id,
-                forMounts=data.forMounts,
+                forMounts=[str(m) for m in data.forMounts],
                 loadName=data.loadName,
                 namespace=data.namespace,
                 version=data.version) for data in

--- a/robot-server/tests/service/routers/test_session.py
+++ b/robot-server/tests/service/routers/test_session.py
@@ -38,7 +38,7 @@ def session_details():
 @pytest.fixture
 def mock_cal_session(hardware, loop):
 
-    mock_instrs = {
+    mock_pipette_info_by_mount = {
         types.Mount.LEFT: PipetteInfo(
             tiprack_id=None,
             critical_point=None,
@@ -52,7 +52,7 @@ def mock_cal_session(hardware, loop):
             mount=types.Mount.RIGHT
         )
     }
-    other_instrs = {
+    mock_hw_pipettes = {
         types.Mount.LEFT: {
             'model': 'p10_single_v1',
             'has_tip': False,
@@ -70,8 +70,8 @@ def mock_cal_session(hardware, loop):
     }
 
     CheckCalibrationSession._get_pip_info_by_mount =\
-        MagicMock(return_value=mock_instrs)
-    CheckCalibrationSession.pipettes = other_instrs
+        MagicMock(return_value=mock_pipette_info_by_mount)
+    CheckCalibrationSession.pipettes = mock_hw_pipettes
 
     m = CheckCalibrationSession(hardware)
 

--- a/robot-server/tests/service/session/test_session_status.py
+++ b/robot-server/tests/service/session/test_session_status.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from opentrons.types import Mount

--- a/robot-server/tests/service/session/test_session_status.py
+++ b/robot-server/tests/service/session/test_session_status.py
@@ -5,27 +5,28 @@ from opentrons.types import Mount
 from opentrons.server.endpoints.calibration.session import \
     CheckCalibrationSession, PipetteStatus, LabwareInfo
 
-from robot_server.service.session.session_status import create_session_details
+from robot_server.service.session.session_status import\
+    _create_calibration_check_session_details
 
 
 def test_create_session_response(hardware):
-    session = CheckCalibrationSession(hardware)
+    session = MagicMock(spec=CheckCalibrationSession)
 
-    pip1id = uuid4()
-    pip2id = uuid4()
     pip1st = PipetteStatus(name="pip1", model="model1", tip_length=1.0,
                            mount=Mount.RIGHT, has_tip=False,
-                           tiprack_id=uuid4())
+                           tiprack_id=uuid4(), rank='first')
     pip2st = PipetteStatus(name="pip2", model="model2", tip_length=2.0,
-                           mount=Mount.LEFT, has_tip=True, tiprack_id=None)
+                           mount=Mount.LEFT, has_tip=True,
+                           tiprack_id=None, rank='second')
 
     pipettes = {
-        pip1id: pip1st,
-        pip2id: pip2st
+        Mount.RIGHT: pip1st,
+        Mount.LEFT: pip2st
     }
 
     session.pipette_status = MagicMock()
     session.pipette_status.return_value = pipettes
+    session.current_state_name = 'fakeStateName'
 
     labware = {
         uuid4(): LabwareInfo(alternatives=["a", "b"],
@@ -38,14 +39,11 @@ def test_create_session_response(hardware):
                              definition={})
     }
 
-    path = 'opentrons.server.endpoints.calibration.' \
-           'session.CheckCalibrationSession.labware_status'
-    with patch(path, new_callable=PropertyMock) as p:
-        p.return_value = labware
-        response = create_session_details(session)
+    session.labware_status = labware
+    response = _create_calibration_check_session_details(session)
 
     assert response.dict() == {
-        'currentStep': 'sessionStarted',
+        'currentStep': 'fakeStateName',
         'comparisonsByStep': {},
         'instruments': {
             str(k): {
@@ -54,12 +52,13 @@ def test_create_session_response(hardware):
                 'tip_length': v.tip_length,
                 'tiprack_id': v.tiprack_id,
                 'has_tip': v.has_tip,
-                'mount': v.mount,
+                'mount': str(v.mount),
+                'rank': v.rank
             } for k, v in pipettes.items()
         },
         'labware': [{
             'alternatives': lw.alternatives,
-            'forMounts': lw.forMounts,
+            'forMounts': [str(m) for m in lw.forMounts],
             'loadName': lw.loadName,
             'slot': lw.slot,
             'namespace': lw.namespace,


### PR DESCRIPTION
## overview

Robot-server tests were not running in CI which caused us to fail to notice that tests were not passing.

## changelog

- Fixup failling tests
- Add robot server tests to run when `make test-py` is called

## review requests

Ensure tests still look ok.

## risk assessment
None, just tests
