### PR TITLE
feat(protocol-designer): add thermocycler command creator

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.js
+++ b/protocol-designer/src/file-data/selectors/commands.js
@@ -152,6 +152,11 @@ const commandCreatorFromStepArgs = (
         StepGeneration.awaitTemperature,
         args
       )
+    case 'thermocyclerState':
+      return StepGeneration.curryCommandCreator(
+        StepGeneration.thermocyclerStateStep,
+        args
+      )
   }
   console.warn(`unhandled commandCreatorFnName: ${args.commandCreatorFnName}`)
   return null

--- a/protocol-designer/src/step-generation/__fixtures__/robotStateFixtures.js
+++ b/protocol-designer/src/step-generation/__fixtures__/robotStateFixtures.js
@@ -240,7 +240,7 @@ export const getRobotInitialStateNoTipsRemain = (
   return robotInitialStateNoTipsRemain
 }
 
-export const getStateAndContextTempMagModules = ({
+export const getStateAndContextTempTCModules = ({
   temperatureModuleId,
   thermocyclerId,
 }: {
@@ -280,7 +280,9 @@ export const getStateAndContextTempMagModules = ({
       slot: SPAN7_8_10_11_SLOT,
       moduleState: {
         type: THERMOCYCLER_MODULE_TYPE,
-        // TODO IL 2020-01-14 create this state when thermocycler state is implemented
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: null,
       },
     },
   }

--- a/protocol-designer/src/step-generation/__tests__/awaitTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/awaitTemperature.test.js
@@ -6,7 +6,7 @@ import {
 } from '../../constants'
 import { awaitTemperature } from '../commandCreators/atomic/awaitTemperature'
 import {
-  getStateAndContextTempMagModules,
+  getStateAndContextTempTCModules,
   robotWithStatusAndTemp,
 } from '../__fixtures__'
 
@@ -27,7 +27,7 @@ describe('awaitTemperature', () => {
   let robotState
 
   beforeEach(() => {
-    const stateAndContext = getStateAndContextTempMagModules({
+    const stateAndContext = getStateAndContextTempTCModules({
       temperatureModuleId,
       thermocyclerId,
     })

--- a/protocol-designer/src/step-generation/__tests__/deactivateTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/deactivateTemperature.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { getStateAndContextTempMagModules } from '../__fixtures__'
+import { getStateAndContextTempTCModules } from '../__fixtures__'
 import { deactivateTemperature } from '../commandCreators/atomic/deactivateTemperature'
 
 const temperatureModuleId = 'temperatureModuleId'
@@ -10,7 +10,7 @@ let invariantContext
 let robotState
 
 beforeEach(() => {
-  const stateAndContext = getStateAndContextTempMagModules({
+  const stateAndContext = getStateAndContextTempTCModules({
     temperatureModuleId,
     thermocyclerId,
   })

--- a/protocol-designer/src/step-generation/__tests__/setTemperature.test.js
+++ b/protocol-designer/src/step-generation/__tests__/setTemperature.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { getStateAndContextTempMagModules } from '../__fixtures__'
+import { getStateAndContextTempTCModules } from '../__fixtures__'
 import { setTemperature } from '../commandCreators/atomic/setTemperature'
 
 const temperatureModuleId = 'temperatureModuleId'
@@ -10,7 +10,7 @@ let invariantContext
 let robotState
 
 beforeEach(() => {
-  const stateAndContext = getStateAndContextTempMagModules({
+  const stateAndContext = getStateAndContextTempTCModules({
     temperatureModuleId,
     thermocyclerId,
   })

--- a/protocol-designer/src/step-generation/__tests__/temperatureUpdates.test.js
+++ b/protocol-designer/src/step-generation/__tests__/temperatureUpdates.test.js
@@ -11,7 +11,7 @@ import {
 } from '../getNextRobotStateAndWarnings/temperatureUpdates'
 import { makeImmutableStateUpdater } from '../__utils__/makeImmutableStateUpdater'
 import {
-  getStateAndContextTempMagModules,
+  getStateAndContextTempTCModules,
   robotWithStatusAndTemp,
 } from '../__fixtures__/robotStateFixtures'
 
@@ -27,7 +27,7 @@ const temperature = 45
 let invariantContext, deactivatedRobot, robotWithTemp, robotState
 
 beforeEach(() => {
-  const stateAndContext = getStateAndContextTempMagModules({
+  const stateAndContext = getStateAndContextTempTCModules({
     temperatureModuleId,
     thermocyclerId,
   })

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
@@ -1,0 +1,344 @@
+// @flow
+import { thermocyclerStateDiff } from '../utils/thermocyclerStateDiff'
+import type { Diff } from '../utils/thermocyclerStateDiff'
+import type { ThermocyclerStateStepArgs } from '../types'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
+import { thermocyclerStateStep } from '../commandCreators/compound/thermocyclerStateStep'
+import {
+  getStateAndContextTempTCModules,
+  getSuccessResult,
+} from '../__fixtures__'
+
+jest.mock('../utils/thermocyclerStateDiff')
+
+const mockThermocyclerStateDiff: JestMockFn<
+  [ThermocyclerModuleState, ThermocyclerStateStepArgs],
+  Diff
+> = thermocyclerStateDiff
+
+const getInitialDiff = () => ({
+  lidOpen: false,
+  lidClosed: false,
+  setBlockTemperature: false,
+  deactivateBlockTemperature: false,
+  setLidTemperature: false,
+  deactivateLidTemperature: false,
+})
+
+const temperatureModuleId = 'temperatureModuleId'
+const thermocyclerId = 'thermocyclerId'
+
+describe('thermocyclerStateStep', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const testCases = [
+    {
+      testMsg: 'should open the lid when diff includes lidOpen',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: true,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        lidOpen: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/openLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg: 'should close the lid when diff includes lidClosed',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        lidClosed: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/closeLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should set the block temperature when diff includes setBlockTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: 10,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        setBlockTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should decativate the block when diff includes deactivateBlockTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        deactivateBlockTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/deactivateBlock',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should set the lid temperature when diff includes setLidTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: 10,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        setLidTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should decativate the block when diff includes deactivateBlockTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        deactivateBlockTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/deactivateBlock',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should set the lid temperature when diff includes setLidTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: 10,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        setLidTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should deactivate the lid when diff includes deactivateLidTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        deactivateLidTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/deactivateLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg: 'should issue commands in the correct order',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: 10,
+        lidTargetTemp: 20,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        lidOpen: true,
+        lidClosed: true,
+        setBlockTemperature: true,
+        deactivateBlockTemperature: true,
+        setLidTemperature: true,
+        deactivateLidTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/openLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+        {
+          command: 'thermocycler/closeLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+        {
+          command: 'thermocycler/deactivateBlock',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+        {
+          command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+        {
+          command: 'thermocycler/deactivateLid',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+        {
+          command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 20,
+          },
+        },
+      ],
+    },
+  ]
+
+  testCases.forEach(
+    ({
+      testMsg,
+      thermocyclerStateArgs,
+      robotState,
+      invariantContext,
+      thermocyclerStateDiff,
+      expected,
+    }) => {
+      it(testMsg, () => {
+        mockThermocyclerStateDiff.mockImplementationOnce((state, args) => {
+          expect(state).toEqual(robotState.modules[thermocyclerId].moduleState)
+          expect(args).toEqual(thermocyclerStateArgs)
+          return thermocyclerStateDiff
+        })
+
+        const result = thermocyclerStateStep(
+          thermocyclerStateArgs,
+          invariantContext,
+          robotState
+        )
+        const { commands } = getSuccessResult(result)
+        expect(commands).toEqual(expected)
+      })
+    }
+  )
+})

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
@@ -1,13 +1,13 @@
 // @flow
 import { thermocyclerStateDiff } from '../utils/thermocyclerStateDiff'
-import type { Diff } from '../utils/thermocyclerStateDiff'
-import type { ThermocyclerStateStepArgs } from '../types'
-import type { ThermocyclerModuleState } from '../../step-forms/types'
 import { thermocyclerStateStep } from '../commandCreators/compound/thermocyclerStateStep'
 import {
   getStateAndContextTempTCModules,
   getSuccessResult,
 } from '../__fixtures__'
+import type { Diff } from '../utils/thermocyclerStateDiff'
+import type { ThermocyclerStateStepArgs } from '../types'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
 
 jest.mock('../utils/thermocyclerStateDiff')
 

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -291,3 +291,12 @@ describe('makeInitialRobotState', () => {
     })
   ).toMatchSnapshot()
 })
+
+describe('getThermocyclerStaterDiff', () => {
+  // getTCStateDiff(prevRobotState, args) //
+  //{lidOpen, lidClosed, setBlockTemperature , deactivateBlockTemperature, setLidTemperature, deactivateLidTemperature}
+  it('returns lidOpen when the lid state has changed to open', () => {})
+  it('returns does NOT return lidOpen when the lid state is unchanged', () => {})
+
+  it('returns setBlockTemperature when the block temperature state has changed to non null value', () => {})
+})

--- a/protocol-designer/src/step-generation/commandCreators/compound/index.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/index.js
@@ -2,6 +2,7 @@
 import { consolidate } from './consolidate'
 import { distribute } from './distribute'
 import { mix } from './mix'
+import { thermocyclerStateStep } from './thermocyclerStateStep'
 import { transfer } from './transfer'
 
-export { consolidate, distribute, mix, transfer }
+export { consolidate, distribute, mix, thermocyclerStateStep, transfer }

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
@@ -1,27 +1,90 @@
 // @flow
-import type { CommandCreator, ThermocyclerStateStepArgs } from '../../types'
-import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerStateDiff } from '../../utils/thermocyclerStateDiff'
+import { thermocyclerStateGetter } from '../../robotStateSelectors'
+import * as errorCreators from '../../errorCreators'
 import { thermocyclerDeactivateBlock } from '../atomic/thermocyclerDeactivateBlock'
-export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = () => {
-  const diff = getTCStateDiff(prevRobotState, args) // {lid: OPEN, blockTemperature: ACTIVATE, lidTemperature: DEACTIVATE}
+import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerCloseLid } from '../atomic/thermocyclerCloseLid'
+import { thermocyclerOpenLid } from '../atomic/thermocyclerOpenLid'
+import type {
+  CommandCreator,
+  CurriedCommandCreator,
+  ThermocyclerStateStepArgs,
+} from '../../types'
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
+import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerDeactivateLid } from '../atomic/thermocyclerDeactivateLid'
 
-  //iterate through map in specific order: open/close => block => lid
+export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const thermocyclerState = thermocyclerStateGetter(prevRobotState, args.module)
 
-  if (diff.lid) {
-    if (diff.lid === 'OPEN') {
-      thermocyclerOpenLid()
-    } else if (diff.lid === 'CLOSE') {
-      thermocyclerCloseLid()
-    } else {
-      console.warn('something went wrong')
-    }
+  if (thermocyclerState === null) {
+    return { errors: [errorCreators.missingModuleError()] }
   }
 
-  if (diff.blockTemperature) {
-    if (diff.blockTemperature === 'ACTIVATE') {
-      thermocyclerSetTargetBlockTemperature(args.thermocyclerBlockTemperature)
-    } else if (diff.blockTemperature === 'DEACTIVATE') {
-      thermocyclerDeactivateBlock(args.thermocyclerBlockTemperature)
-    }
+  const {
+    lidOpen,
+    lidClosed,
+    setBlockTemperature,
+    deactivateBlockTemperature,
+    setLidTemperature,
+    deactivateLidTemperature,
+  } = thermocyclerStateDiff(thermocyclerState, args)
+
+  let commandCreators: Array<CurriedCommandCreator> = []
+
+  if (lidOpen) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerOpenLid, { module: args.module })
+    )
   }
+  if (lidClosed) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerCloseLid, { module: args.module })
+    )
+  }
+
+  if (deactivateBlockTemperature) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerDeactivateBlock, {
+        module: args.module,
+      })
+    )
+  }
+
+  if (args.blockTargetTemp !== null && setBlockTemperature) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerSetTargetBlockTemperature, {
+        module: args.module,
+        temperature: args.blockTargetTemp,
+      })
+    )
+  }
+
+  if (deactivateLidTemperature) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerDeactivateLid, {
+        module: args.module,
+      })
+    )
+  }
+
+  if (args.lidTargetTemp !== null && setLidTemperature) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerSetTargetLidTemperature, {
+        module: args.module,
+        temperature: args.lidTargetTemp,
+      })
+    )
+  }
+
+  return reduceCommandCreators(
+    commandCreators,
+    invariantContext,
+    prevRobotState
+  )
 }

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
@@ -1,0 +1,27 @@
+// @flow
+import type { CommandCreator, ThermocyclerStateStepArgs } from '../../types'
+import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerDeactivateBlock } from '../atomic/thermocyclerDeactivateBlock'
+export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = () => {
+  const diff = getTCStateDiff(prevRobotState, args) // {lid: OPEN, blockTemperature: ACTIVATE, lidTemperature: DEACTIVATE}
+
+  //iterate through map in specific order: open/close => block => lid
+
+  if (diff.lid) {
+    if (diff.lid === 'OPEN') {
+      thermocyclerOpenLid()
+    } else if (diff.lid === 'CLOSE') {
+      thermocyclerCloseLid()
+    } else {
+      console.warn('something went wrong')
+    }
+  }
+
+  if (diff.blockTemperature) {
+    if (diff.blockTemperature === 'ACTIVATE') {
+      thermocyclerSetTargetBlockTemperature(args.thermocyclerBlockTemperature)
+    } else if (diff.blockTemperature === 'DEACTIVATE') {
+      thermocyclerDeactivateBlock(args.thermocyclerBlockTemperature)
+    }
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
@@ -1,4 +1,5 @@
 // @flow
+import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { thermocyclerStateDiff } from '../../utils/thermocyclerStateDiff'
 import { thermocyclerStateGetter } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
@@ -6,14 +7,13 @@ import { thermocyclerDeactivateBlock } from '../atomic/thermocyclerDeactivateBlo
 import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
 import { thermocyclerCloseLid } from '../atomic/thermocyclerCloseLid'
 import { thermocyclerOpenLid } from '../atomic/thermocyclerOpenLid'
+import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerDeactivateLid } from '../atomic/thermocyclerDeactivateLid'
 import type {
   CommandCreator,
   CurriedCommandCreator,
   ThermocyclerStateStepArgs,
 } from '../../types'
-import { curryCommandCreator, reduceCommandCreators } from '../../utils'
-import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
-import { thermocyclerDeactivateLid } from '../atomic/thermocyclerDeactivateLid'
 
 export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = (
   args,

--- a/protocol-designer/src/step-generation/commandCreators/index.js
+++ b/protocol-designer/src/step-generation/commandCreators/index.js
@@ -1,5 +1,11 @@
 // @flow
-export { transfer, mix, consolidate, distribute } from './compound'
+export {
+  transfer,
+  mix,
+  consolidate,
+  distribute,
+  thermocyclerStateStep,
+} from './compound'
 
 export {
   aspirate,

--- a/protocol-designer/src/step-generation/index.js
+++ b/protocol-designer/src/step-generation/index.js
@@ -15,6 +15,7 @@ export {
   mix,
   replaceTip,
   setTemperature,
+  thermocyclerStateStep,
   touchTip,
   transfer,
 } from './commandCreators'

--- a/protocol-designer/src/step-generation/robotStateSelectors.js
+++ b/protocol-designer/src/step-generation/robotStateSelectors.js
@@ -4,9 +4,15 @@ import assert from 'assert'
 import { orderWells } from '../steplist/utils/orderWells.js'
 import min from 'lodash/min'
 import sortBy from 'lodash/sortBy'
-import { getTiprackVolume } from '@opentrons/shared-data'
+import {
+  getTiprackVolume,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from './'
-import type { ModuleTemporalProperties } from '../step-forms'
+import type {
+  ModuleTemporalProperties,
+  ThermocyclerModuleState,
+} from '../step-forms'
 
 export function sortLabwareBySlot(
   labwareState: $PropertyType<RobotState, 'labware'>
@@ -146,4 +152,14 @@ export function getModuleState(
   }
 
   return robotState.modules[module]?.moduleState
+}
+
+export const thermocyclerStateGetter = (
+  robotState: RobotState,
+  moduleId: string
+): ThermocyclerModuleState | null => {
+  const hardwareModule = robotState.modules[moduleId]?.moduleState
+  return hardwareModule && hardwareModule.type === THERMOCYCLER_MODULE_TYPE
+    ? hardwareModule
+    : null
 }

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -344,7 +344,7 @@ export type Timeline = {|
   errors?: ?Array<CommandCreatorError>,
 |}
 
-export type RobotStateAndWarnings = {
+export type RobotStateAndWarnings = {|
   robotState: RobotState,
   warnings: Array<CommandCreatorWarning>,
-}
+|}

--- a/protocol-designer/src/step-generation/utils/thermocyclerStateDiff.js
+++ b/protocol-designer/src/step-generation/utils/thermocyclerStateDiff.js
@@ -1,0 +1,75 @@
+// @flow
+import type { ThermocyclerStateStepArgs } from '../types'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
+
+export type Diff = {
+  lidOpen: boolean,
+  lidClosed: boolean,
+  setBlockTemperature: boolean,
+  deactivateBlockTemperature: boolean,
+  setLidTemperature: boolean,
+  deactivateLidTemperature: boolean,
+}
+
+const getInitialDiff = () => ({
+  lidOpen: false,
+  lidClosed: false,
+  setBlockTemperature: false,
+  deactivateBlockTemperature: false,
+  setLidTemperature: false,
+  deactivateLidTemperature: false,
+})
+
+const getLidOpenDiff = (
+  prevThermocyclerState: ThermocyclerModuleState,
+  args: ThermocyclerStateStepArgs
+) => {
+  if (!prevThermocyclerState.lidOpen && args.lidOpen) {
+    return { lidOpen: true }
+  }
+  return {}
+}
+
+const getLidClosedDiff = (
+  prevThermocyclerState: ThermocyclerModuleState,
+  args: ThermocyclerStateStepArgs
+) => {
+  if (
+    (prevThermocyclerState.lidOpen && args.lidOpen === false) ||
+    (prevThermocyclerState.lidOpen === null && args.lidOpen === false)
+  ) {
+    return { lidClosed: true }
+  }
+  return {}
+}
+
+export const thermocyclerStateDiff = (
+  prevThermocyclerState: ThermocyclerModuleState,
+  args: ThermocyclerStateStepArgs
+): Diff => {
+  const lidOpenDiff = { ...getLidOpenDiff(prevThermocyclerState, args) }
+  const lidClosedDiff = { ...getLidClosedDiff(prevThermocyclerState, args) }
+
+  const blockTempChanged =
+    prevThermocyclerState.blockTargetTemp !== args.blockTargetTemp
+  const blockTempDeactivated = blockTempChanged && args.blockTargetTemp === null
+  const blockTempActivated = blockTempChanged && args.blockTargetTemp !== null
+
+  const lidTempChanged =
+    prevThermocyclerState.lidTargetTemp !== args.lidTargetTemp
+  const lidTempDeactivated = lidTempChanged && args.lidTargetTemp === null
+  const lidTempActivated = lidTempChanged && args.lidTargetTemp !== null
+
+  return {
+    ...getInitialDiff(),
+
+    ...lidOpenDiff,
+    ...lidClosedDiff,
+
+    setBlockTemperature: blockTempActivated,
+    deactivateBlockTemperature: blockTempDeactivated,
+
+    setLidTemperature: lidTempActivated,
+    deactivateLidTemperature: lidTempDeactivated,
+  }
+}

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/index.js
@@ -5,6 +5,7 @@ import { mixFormToArgs } from './mixFormToArgs'
 import { pauseFormToArgs } from './pauseFormToArgs'
 import { magnetFormToArgs } from './magnetFormToArgs'
 import { temperatureFormToArgs } from './temperatureFormToArgs'
+import { thermocyclerFormToArgs } from './thermocyclerFormToArgs'
 import { moveLiquidFormToArgs } from './moveLiquidFormToArgs'
 import type { FormData } from '../../../form-types'
 import type { CommandCreatorArgs } from '../../../step-generation'
@@ -33,6 +34,8 @@ export const stepFormToArgs = (hydratedForm: FormData): StepArgs => {
       return magnetFormToArgs(castForm)
     case 'temperature':
       return temperatureFormToArgs(castForm)
+    case 'thermocycler':
+      return thermocyclerFormToArgs(castForm)
     default:
       console.warn(`stepFormToArgs not implemented for ${castForm.stepType}`)
       return null


### PR DESCRIPTION
## overview

This PR closes #5600 by adding and hooking up the thermocycler command creator. This means that we can now export protocols that use TC steps in PD and they _should_ work on the robot (!!!!!!)

## changelog

  - Added thermocycler command creator
  - Hooked up thermocycler stepformToArgs
  - Added thermocycler module state info to existing fixture

## review requests
Code review, review test coverage

Create a protocol with TC steps and export it. The `commands` generated in the JSON should match the schema. 

Since the JSON protocol *should* work on the robot, we should test this too. 

## risk assessment
Medium. The commands generated by the command creator go all the way down to the executor that lives in the api. We should validate that TC protocols actually do what they should on the robot. 
