### PR TITLE
refactor(app,robot-server): Slight changes to sessions api

### DIFF
--- a/app/src/reducer.js
+++ b/app/src/reducer.js
@@ -56,7 +56,7 @@ import { systemInfoReducer } from './system-info/reducer'
 // app-wide alerts state
 import { alertsReducer } from './alerts/reducer'
 
-import { robotSessionReducer } from './sessions/reducer'
+import { sessionReducer } from './sessions/reducer'
 
 import type { Reducer } from 'redux'
 import type { State, Action } from './types'
@@ -81,6 +81,6 @@ export const rootReducer: Reducer<State, Action> = combineReducers<_, Action>({
   shell: shellReducer,
   systemInfo: systemInfoReducer,
   alerts: alertsReducer,
-  sessions: robotSessionReducer,
+  sessions: sessionReducer,
   router: connectRouter<_, Action>(history),
 })

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -104,7 +104,6 @@ export type RobotApiV2Error = {|
   id?: string,
   links?: ResourceLinks,
   status?: string,
-  code?: string,
   title?: string,
   detail?: string,
   source?: {|

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -59,11 +59,6 @@ export const mockSessionCommandResponse: Types.SessionCommandResponse = {
     type: 'SessionCommand',
     attributes: mockSessionCommandAttributes,
   },
-  meta: {
-    id: mockSessionId,
-    sessionType: 'calibrationCheck',
-    details: mockRobotCalibrationCheckSessionDetails,
-  },
 }
 
 export const {

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -13,7 +13,7 @@ import type { RobotApiV2ErrorResponseBody } from '../../robot-api/types'
 export const mockSessionId: string = 'fake_session_id'
 export const mockOtherSessionId: string = 'other_fake_session_id'
 
-export const mockSessionData: Types.Session = {
+export const mockSessionAttributes: Types.Session = {
   id: mockSessionId,
   sessionType: 'calibrationCheck',
   details: mockRobotCalibrationCheckSessionDetails,
@@ -24,7 +24,7 @@ export const mockSessionCommand: Types.SessionCommand = {
   data: { someData: 32 },
 }
 
-export const mockSessionCommandData: Types.SessionCommand = {
+export const mockSessionCommandAttributes: Types.SessionCommand = {
   command: 'preparePipette',
   status: 'accepted',
   data: {},
@@ -34,7 +34,7 @@ export const mockSessionResponse: Types.SessionResponse = {
   data: {
     id: mockSessionId,
     type: 'Session',
-    attributes: mockSessionData,
+    attributes: mockSessionAttributes,
   },
 }
 
@@ -43,12 +43,12 @@ export const mockMultiSessionResponse: Types.MultiSessionResponse = {
     {
       id: mockSessionId,
       type: 'Session',
-      attributes: mockSessionData,
+      attributes: mockSessionAttributes,
     },
     {
       id: mockOtherSessionId,
       type: 'Session',
-      attributes: mockSessionData,
+      attributes: mockSessionAttributes,
     },
   ],
 }
@@ -57,7 +57,7 @@ export const mockSessionCommandResponse: Types.SessionCommandResponse = {
   data: {
     id: mockSessionId,
     type: 'SessionCommand',
-    attributes: mockSessionCommandData,
+    attributes: mockSessionCommandAttributes,
   },
   meta: {
     id: mockSessionId,

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -13,18 +13,17 @@ import type { RobotApiV2ErrorResponseBody } from '../../robot-api/types'
 export const mockSessionId: string = 'fake_session_id'
 export const mockOtherSessionId: string = 'other_fake_session_id'
 
-export const mockSessionAttributes: Types.Session = {
-  id: mockSessionId,
+export const mockSessionAttributes: Types.SessionResponseAttributes = {
   sessionType: 'calibrationCheck',
   details: mockRobotCalibrationCheckSessionDetails,
 }
 
-export const mockSessionCommand: Types.SessionCommand = {
+export const mockSessionCommand: Types.SessionCommandAttributes = {
   command: 'jog',
   data: { someData: 32 },
 }
 
-export const mockSessionCommandAttributes: Types.SessionCommand = {
+export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {
   command: 'preparePipette',
   status: 'accepted',
   data: {},

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -31,8 +31,10 @@ const SPECS: Array<ReducerSpec> = [
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          [Fixtures.mockSessionId]:
-            Fixtures.mockSessionResponse.data.attributes,
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: Fixtures.mockSessionId,
+          },
         },
       },
     },
@@ -50,18 +52,24 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id:
-            Fixtures.mockSessionResponse.data.attributes,
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: 'existing_fake_session_id',
+          },
         },
       },
     },
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id:
-            Fixtures.mockSessionResponse.data.attributes,
-          [Fixtures.mockSessionId]:
-            Fixtures.mockSessionResponse.data.attributes,
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: 'existing_fake_session_id',
+          },
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: Fixtures.mockSessionId,
+          },
         },
       },
     },
@@ -82,8 +90,10 @@ const SPECS: Array<ReducerSpec> = [
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          [Fixtures.mockSessionId]:
-            Fixtures.mockSessionResponse.data.attributes,
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: Fixtures.mockSessionId,
+          },
         },
       },
     },
@@ -101,18 +111,24 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id:
-            Fixtures.mockSessionResponse.data.attributes,
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: 'existing_fake_session_id',
+          },
         },
       },
     },
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          [Fixtures.mockSessionId]:
-            Fixtures.mockSessionResponse.data.attributes,
-          existing_fake_session_id:
-            Fixtures.mockSessionResponse.data.attributes,
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: Fixtures.mockSessionId,
+          },
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionResponse.data.attributes,
+            id: 'existing_fake_session_id',
+          },
         },
       },
     },
@@ -194,15 +210,24 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionAttributes,
-          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionAttributes,
+            id: Fixtures.mockSessionId,
+          },
         },
       },
     },
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionAttributes,
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
         },
       },
     },

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -182,60 +182,6 @@ const SPECS: Array<ReducerSpec> = [
     },
   },
   {
-    name: 'handles sessions:CREATE_SESSION_COMMAND_SUCCESS',
-    action: {
-      type: 'sessions:CREATE_SESSION_COMMAND_SUCCESS',
-      payload: {
-        robotName: 'eggplant-parm',
-        sessionId: Fixtures.mockSessionId,
-        ...Fixtures.mockSessionCommandResponse,
-      },
-      meta: {},
-    },
-    state: {
-      'eggplant-parm': {
-        robotSessions: {
-          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
-        },
-      },
-    },
-    expected: {
-      'eggplant-parm': {
-        robotSessions: {
-          [Fixtures.mockSessionId]: Fixtures.mockSessionCommandResponse.meta,
-        },
-      },
-    },
-  },
-  {
-    name: 'handles sessions:CREATE_SESSION_COMMAND_SUCCESS with existing',
-    action: {
-      type: 'sessions:CREATE_SESSION_COMMAND_SUCCESS',
-      payload: {
-        robotName: 'eggplant-parm',
-        sessionId: Fixtures.mockSessionId,
-        ...Fixtures.mockSessionCommandResponse,
-      },
-      meta: {},
-    },
-    state: {
-      'eggplant-parm': {
-        robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionAttributes,
-          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
-        },
-      },
-    },
-    expected: {
-      'eggplant-parm': {
-        robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionAttributes,
-          [Fixtures.mockSessionId]: Fixtures.mockSessionCommandResponse.meta,
-        },
-      },
-    },
-  },
-  {
     name: 'handles sessions:DELETE_SESSION_SUCCESS',
     action: {
       type: 'sessions:DELETE_SESSION_SUCCESS',

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as Fixtures from '../__fixtures__'
-import { robotSessionReducer } from '../reducer'
+import { sessionReducer } from '../reducer'
 
 import type { Action } from '../../types'
 import type { SessionState } from '../types'
@@ -160,7 +160,7 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           fake_stale_session_id: {
-            ...Fixtures.mockSessionData,
+            ...Fixtures.mockSessionAttributes,
             id: 'fake_stale_session_id',
           },
         },
@@ -195,7 +195,7 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
         },
       },
     },
@@ -221,15 +221,15 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionData,
-          [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+          existing_fake_session_id: Fixtures.mockSessionAttributes,
+          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
         },
       },
     },
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionData,
+          existing_fake_session_id: Fixtures.mockSessionAttributes,
           [Fixtures.mockSessionId]: Fixtures.mockSessionCommandResponse.meta,
         },
       },
@@ -248,15 +248,15 @@ const SPECS: Array<ReducerSpec> = [
     state: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionData,
-          [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+          existing_fake_session_id: Fixtures.mockSessionAttributes,
+          [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
         },
       },
     },
     expected: {
       'eggplant-parm': {
         robotSessions: {
-          existing_fake_session_id: Fixtures.mockSessionData,
+          existing_fake_session_id: Fixtures.mockSessionAttributes,
         },
       },
     },
@@ -266,6 +266,6 @@ const SPECS: Array<ReducerSpec> = [
 describe('robotSessionReducer', () => {
   SPECS.forEach(spec => {
     const { name, state, action, expected } = spec
-    it(name, () => expect(robotSessionReducer(state, action)).toEqual(expected))
+    it(name, () => expect(sessionReducer(state, action)).toEqual(expected))
   })
 })

--- a/app/src/sessions/__tests__/selectors.test.js
+++ b/app/src/sessions/__tests__/selectors.test.js
@@ -33,14 +33,14 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
           },
         },
       },
     },
     args: ['germanium-cobweb'],
     expected: {
-      [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+      [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
     },
   },
   {
@@ -50,7 +50,7 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
           },
         },
       },
@@ -65,13 +65,13 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionData,
+            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
           },
         },
       },
     },
     args: ['germanium-cobweb', Fixtures.mockSessionId],
-    expected: Fixtures.mockSessionData,
+    expected: Fixtures.mockSessionAttributes,
   },
 ]
 

--- a/app/src/sessions/actions.js
+++ b/app/src/sessions/actions.js
@@ -125,7 +125,7 @@ export const fetchAllSessionsFailure = (
 export const createSessionCommand = (
   robotName: string,
   sessionId: string,
-  command: Types.SessionCommand
+  command: Types.SessionCommandAttributes
 ): Types.CreateSessionCommandAction => ({
   type: Constants.CREATE_SESSION_COMMAND,
   payload: { robotName, sessionId, command },

--- a/app/src/sessions/constants.js
+++ b/app/src/sessions/constants.js
@@ -2,7 +2,10 @@
 
 export const SESSIONS_PATH: '/sessions' = '/sessions'
 
-export const SESSIONS_COMMANDS_PATH_EXTENSION: 'commands' = 'commands'
+export const SESSIONS_COMMANDS_PATH_EXTENSION: '/commands' = '/commands'
+
+export const SESSIONS_COMMANDS_EXECUTE_PATH_EXTENSION: '/commands/execute' =
+  '/commands/execute'
 
 export const CREATE_SESSION: 'sessions:CREATE_SESSION' =
   'sessions:CREATE_SESSION'

--- a/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
@@ -15,7 +15,7 @@ describe('createSessionCommandEpic', () => {
 
   const expectedRequest = {
     method: 'POST',
-    path: '/sessions/1234/commands',
+    path: '/sessions/1234/commands/execute',
     body: {
       data: {
         type: 'Command',
@@ -29,7 +29,7 @@ describe('createSessionCommandEpic', () => {
     },
   }
 
-  it('calls POST /sessions/1234/commands', () => {
+  it('calls POST /sessions/1234/commands/execute', () => {
     const mocks = setupEpicTestMocks(
       makeTriggerAction,
       Fixtures.mockSessionCommandsSuccess

--- a/app/src/sessions/epic/__tests__/fetchSessionOnCommandResonseEpic.test.js
+++ b/app/src/sessions/epic/__tests__/fetchSessionOnCommandResonseEpic.test.js
@@ -1,0 +1,63 @@
+// @flow
+import { setupEpicTestMocks, runEpicTest } from '../../../robot-api/__utils__'
+
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import { sessionsEpic } from '..'
+
+const makeTriggerCommandResponseSuccessAction = robotName =>
+  Actions.createSessionCommandSuccess(
+    robotName,
+    'mysessionid',
+    Fixtures.mockSessionCommandResponse,
+    {}
+  )
+
+const makeTriggerCommandResponseFailureAction = robotName =>
+  Actions.createSessionCommandFailure(
+    robotName,
+    'mysessionid',
+    Fixtures.mockSessionCommandsFailure.body,
+    {}
+  )
+
+describe('commandResponseSessionEpic', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('dispatches sessions:FETCH_SESSION on sessions:CREATE_SESSION_COMMAND_SUCCESS', () => {
+    const mocks = setupEpicTestMocks(
+      makeTriggerCommandResponseSuccessAction,
+      Fixtures.mockSessionCommandsSuccess
+    )
+
+    runEpicTest(mocks, ({ hot, cold, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s--', { s: mocks.state })
+      const output$ = sessionsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.fetchSession(
+          mocks.robot.name,
+          mocks.action.payload.sessionId
+        ),
+      })
+    })
+  })
+
+  it('does nothing on sessions:CREATE_SESSION_COMMAND_FAILURE', () => {
+    const mocks = setupEpicTestMocks(
+      makeTriggerCommandResponseFailureAction,
+      Fixtures.mockSessionCommandsSuccess
+    )
+
+    runEpicTest(mocks, ({ hot, cold, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s--', { s: mocks.state })
+      const output$ = sessionsEpic(action$, state$)
+
+      expectObservable(output$).toBe('---')
+    })
+  })
+})

--- a/app/src/sessions/epic/createSessionCommandEpic.js
+++ b/app/src/sessions/epic/createSessionCommandEpic.js
@@ -18,7 +18,7 @@ import type { CreateSessionCommandAction } from '../types'
 
 const mapActionToRequest: ActionToRequestMapper<CreateSessionCommandAction> = action => ({
   method: POST,
-  path: `${Constants.SESSIONS_PATH}/${action.payload.sessionId}/${Constants.SESSIONS_COMMANDS_PATH_EXTENSION}`,
+  path: `${Constants.SESSIONS_PATH}/${action.payload.sessionId}${Constants.SESSIONS_COMMANDS_EXECUTE_PATH_EXTENSION}`,
   body: {
     data: {
       type: 'Command',

--- a/app/src/sessions/epic/fetchSessionOnCommandResponseEpic.js
+++ b/app/src/sessions/epic/fetchSessionOnCommandResponseEpic.js
@@ -1,0 +1,20 @@
+// @flow
+import { of } from 'rxjs'
+import { ofType } from 'redux-observable'
+import { switchMap } from 'rxjs/operators'
+
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type { Epic } from '../../types'
+
+export const fetchSessionOnCommandResponseEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType(Constants.CREATE_SESSION_COMMAND_SUCCESS),
+    switchMap(action =>
+      of(
+        Actions.fetchSession(action.payload.robotName, action.payload.sessionId)
+      )
+    )
+  )
+}

--- a/app/src/sessions/epic/index.js
+++ b/app/src/sessions/epic/index.js
@@ -6,6 +6,7 @@ import { fetchAllSessionsEpic } from './fetchAllSessionsEpic'
 import { fetchAllSessionsOnConnectEpic } from './fetchAllSessionsOnConnectEpic'
 import { createSessionCommandEpic } from './createSessionCommandEpic'
 import { deleteSessionEpic } from './deleteSessionEpic'
+import { fetchSessionOnCommandResponseEpic } from './fetchSessionOnCommandResponseEpic'
 
 import type { Epic } from '../../types'
 
@@ -15,5 +16,6 @@ export const sessionsEpic: Epic = combineEpics(
   fetchAllSessionsEpic,
   fetchAllSessionsOnConnectEpic,
   createSessionCommandEpic,
-  deleteSessionEpic
+  deleteSessionEpic,
+  fetchSessionOnCommandResponseEpic
 )

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -13,7 +13,7 @@ const INITIAL_PER_ROBOT_STATE: PerRobotSessionState = {
   robotSessions: null,
 }
 
-export function robotSessionReducer(
+export function sessionReducer(
   state: SessionState = INITIAL_STATE,
   action: Action
 ): SessionState {
@@ -80,9 +80,7 @@ export function robotSessionReducer(
         ...state,
         [robotName]: {
           ...robotState,
-          robotSessions: {
-            ...omit(robotState.robotSessions, sessionState.data.id),
-          },
+          robotSessions: omit(robotState.robotSessions, sessionState.data.id),
         },
       }
     }

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -54,24 +54,6 @@ export function sessionReducer(
       }
     }
 
-    case Constants.CREATE_SESSION_COMMAND_SUCCESS: {
-      const { robotName, sessionId, ...sessionState } = action.payload
-      const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE
-
-      if (!sessionId) return state
-
-      return {
-        ...state,
-        [robotName]: {
-          ...robotState,
-          robotSessions: {
-            ...robotState.robotSessions,
-            [sessionId]: { ...sessionState.meta, id: sessionId },
-          },
-        },
-      }
-    }
-
     case Constants.DELETE_SESSION_SUCCESS: {
       const { robotName, ...sessionState } = action.payload
       const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -37,13 +37,17 @@ export type SessionCommandString = $Values<typeof Calibration.checkCommands>
 // known command types
 export type SessionCommandData = { ... }
 
-export type Session = {|
-  id: string,
+export type SessionResponseAttributes = {|
   sessionType: SessionType,
   details: SessionDetails,
 |}
 
-export type SessionCommand = {|
+export type Session = {|
+  ...SessionResponseAttributes,
+  id: string,
+|}
+
+export type SessionCommandAttributes = {|
   command: SessionCommandString,
   data: SessionCommandData,
   status?: string,
@@ -52,13 +56,13 @@ export type SessionCommand = {|
 export type SessionResponseModel = {|
   id: string,
   type: 'Session',
-  attributes: Session,
+  attributes: SessionResponseAttributes,
 |}
 
 export type SessionCommandResponseModel = {|
   id: string,
   type: 'SessionCommand',
-  attributes: SessionCommand,
+  attributes: SessionCommandAttributes,
 |}
 
 export type SessionResponse = RobotApiV2ResponseBody<SessionResponseModel, {||}>
@@ -152,7 +156,7 @@ export type CreateSessionCommandAction = {|
   payload: {|
     robotName: string,
     sessionId: string,
-    command: SessionCommand,
+    command: SessionCommandAttributes,
   |},
   meta: RobotApiRequestMeta,
 |}

--- a/robot-server/robot_server/service/models/json_api/errors.py
+++ b/robot-server/robot_server/service/models/json_api/errors.py
@@ -29,10 +29,6 @@ class Error(BaseModel):
         Field(None,
               description="the HTTP status code applicable to this problem,"
                           " expressed as a string value.")
-    code: Optional[str] = \
-        Field(None,
-              description="an application-specific error code, expressed"
-                          " as a string value.")
     title: Optional[str] = \
         Field(None,
               description="a short, human-readable summary of the problem"

--- a/robot-server/robot_server/service/models/session.py
+++ b/robot-server/robot_server/service/models/session.py
@@ -97,5 +97,5 @@ CommandRequest = RequestModel[
     RequestDataModel[SessionCommand]
 ]
 CommandResponse = ResponseModel[
-    ResponseDataModel[SessionCommand], Session
+    ResponseDataModel[SessionCommand], dict
 ]

--- a/robot-server/robot_server/service/routers/session.py
+++ b/robot-server/robot_server/service/routers/session.py
@@ -182,17 +182,17 @@ async def get_sessions_handler(
     )
 
 
-@router.post("/sessions/{session_id}/commands",
-             description="Create a command",
+@router.post("/sessions/{session_id}/commands/execute",
+             description="Create and execute a command immediately",
              response_model_exclude_unset=True,
              response_model=session.CommandResponse)
-async def session_command_create_handler(
+async def session_command_execute_handler(
         session_id: str,
         command_request: session.CommandRequest,
         session_manager: SessionManager = Depends(get_session_manager),
 ) -> session.CommandResponse:
     """
-    Process a session command
+    Execute a session command
     """
     session_obj = typing.cast(CheckCalibrationSession,
                               get_session(manager=session_manager,
@@ -218,7 +218,7 @@ async def session_command_create_handler(
         data=ResponseDataModel.create(
             attributes=session.SessionCommand(data=command_data,
                                               command=command,
-                                              status='accepted'),
+                                              status='executed'),
             # TODO have session create id for command for later querying
             resource_id=str(uuid4())
         ),
@@ -234,7 +234,7 @@ def get_valid_session_links(session_id: str, api_router: APIRouter) \
             get_session_handler.__name__,
             session_id=session_id)),
         "POST": ResourceLink(href=api_router.url_path_for(
-            session_command_create_handler.__name__,
+            session_command_execute_handler.__name__,
             session_id=session_id)),
         "DELETE": ResourceLink(href=api_router.url_path_for(
             delete_session_handler.__name__,

--- a/robot-server/robot_server/service/routers/session.py
+++ b/robot-server/robot_server/service/routers/session.py
@@ -222,9 +222,6 @@ async def session_command_create_handler(
             # TODO have session create id for command for later querying
             resource_id=str(uuid4())
         ),
-        meta=session.Session(details=create_session_details(session_obj),
-                             # TODO Get type from session
-                             sessionType=models.SessionType.calibration_check),
         links=get_valid_session_links(session_id, router)
     )
 

--- a/robot-server/tests/service/models/json_api/test_errors.py
+++ b/robot-server/tests/service/models/json_api/test_errors.py
@@ -12,7 +12,6 @@ def errors_wrapper(d):
 valid_error_objects = [
     {'id': 'abc123'},
     {'status': '404'},
-    {'code': '1005'},
     {'title': 'Something went wrong'},
     {'detail': "oh wow, there's a few things we messed up there"},
     {'meta': {'num_errors_today': 10000}},

--- a/robot-server/tests/service/routers/test_session.py
+++ b/robot-server/tests/service/routers/test_session.py
@@ -354,7 +354,6 @@ def test_session_command_create(api_client,
             'type': 'SessionCommand',
             'id': response.json()['data']['id']
         },
-        'meta': session_hardware_info['attributes'],
         'links': {
             'POST': {
                 'href': '/sessions/calibrationCheck/commands',
@@ -392,7 +391,6 @@ def test_session_command_create_no_body(api_client,
             'type': 'SessionCommand',
             'id': response.json()['data']['id']
         },
-        'meta': session_hardware_info['attributes'],
         'links': {
             'POST': {
                 'href': '/sessions/calibrationCheck/commands',

--- a/robot-server/tests/service/routers/test_session.py
+++ b/robot-server/tests/service/routers/test_session.py
@@ -208,7 +208,7 @@ def test_create_session(api_client, patch_build_session,
         'data': session_hardware_info,
         'links': {
             'POST': {
-                'href': '/sessions/calibrationCheck/commands',
+                'href': '/sessions/calibrationCheck/commands/execute',
             },
             'GET': {
                 'href': '/sessions/calibrationCheck',
@@ -272,7 +272,7 @@ def test_get_session(api_client, session_manager_with_session,
         'data': session_hardware_info,
         'links': {
             'POST': {
-                'href': '/sessions/calibrationCheck/commands',
+                'href': '/sessions/calibrationCheck/commands/execute',
             },
             'GET': {
                 'href': '/sessions/calibrationCheck',
@@ -317,7 +317,7 @@ def command(command_type: str, body: typing.Optional[BaseModel]):
 
 def test_session_command_create_no_session(api_client):
     response = api_client.post(
-        "/sessions/1234/commands",
+        "/sessions/1234/commands/execute",
         json=command("jog",
                      JogPosition(vector=(1, 2, 3))))
     assert response.json() == {
@@ -331,12 +331,12 @@ def test_session_command_create_no_session(api_client):
     assert response.status_code == 404
 
 
-def test_session_command_create(api_client,
-                                session_manager_with_session,
-                                mock_cal_session,
-                                session_hardware_info):
+def test_session_command_execute(api_client,
+                                 session_manager_with_session,
+                                 mock_cal_session,
+                                 session_hardware_info):
     response = api_client.post(
-        "/sessions/calibrationCheck/commands",
+        "/sessions/calibrationCheck/commands/execute",
         json=command("jog",
                      JogPosition(vector=(1, 2, 3))))
 
@@ -349,14 +349,14 @@ def test_session_command_create(api_client,
             'attributes': {
                 'command': 'jog',
                 'data': {'vector': [1.0, 2.0, 3.0]},
-                'status': 'accepted'
+                'status': 'executed'
             },
             'type': 'SessionCommand',
             'id': response.json()['data']['id']
         },
         'links': {
             'POST': {
-                'href': '/sessions/calibrationCheck/commands',
+                'href': '/sessions/calibrationCheck/commands/execute',
             },
             'GET': {
                 'href': '/sessions/calibrationCheck',
@@ -369,12 +369,12 @@ def test_session_command_create(api_client,
     assert response.status_code == 200
 
 
-def test_session_command_create_no_body(api_client,
-                                        session_manager_with_session,
-                                        mock_cal_session,
-                                        session_hardware_info):
+def test_session_command_execute_no_body(api_client,
+                                         session_manager_with_session,
+                                         mock_cal_session,
+                                         session_hardware_info):
     response = api_client.post(
-        "/sessions/calibrationCheck/commands",
+        "/sessions/calibrationCheck/commands/execute",
         json=command("loadLabware", None)
     )
 
@@ -386,14 +386,14 @@ def test_session_command_create_no_body(api_client,
             'attributes': {
                 'command': 'loadLabware',
                 'data': {},
-                'status': 'accepted'
+                'status': 'executed'
             },
             'type': 'SessionCommand',
             'id': response.json()['data']['id']
         },
         'links': {
             'POST': {
-                'href': '/sessions/calibrationCheck/commands',
+                'href': '/sessions/calibrationCheck/commands/execute',
             },
             'GET': {
                 'href': '/sessions/calibrationCheck',
@@ -406,9 +406,9 @@ def test_session_command_create_no_body(api_client,
     assert response.status_code == 200
 
 
-def test_session_command_create_raise(api_client,
-                                      session_manager_with_session,
-                                      mock_cal_session):
+def test_session_command_execute_raise(api_client,
+                                       session_manager_with_session,
+                                       mock_cal_session):
 
     async def raiser(*args, **kwargs):
         raise AssertionError("Cannot do it")
@@ -416,7 +416,7 @@ def test_session_command_create_raise(api_client,
     mock_cal_session.trigger_transition.side_effect = raiser
 
     response = api_client.post(
-        "/sessions/calibrationCheck/commands",
+        "/sessions/calibrationCheck/commands/execute",
         json=command("jog",
                      JogPosition(vector=(1, 2, 3))))
 


### PR DESCRIPTION
## overview

To distinguish between enqueuing and executing commands, `POST /sessions/:sid/commands` is renamed to `POST /sessions/:sid/commands/execute`. Enqueuing will coma in the future.

We will not return session details in the `meta` field. Instead, the app will call `GET /sessions/:sid` upon successful command response.

Removed `code` from error schema. Redundant.


## risk assessment

None

closes #5674 
