### PR TITLE
fix(robot-server,api): Bug in deck calibration  

### DIFF
--- a/api/src/opentrons/deck_calibration/endpoints.py
+++ b/api/src/opentrons/deck_calibration/endpoints.py
@@ -36,15 +36,29 @@ class SessionWrapper:
 session_wrapper = SessionWrapper()
 
 
+class DeckCalibrationPoint(str, Enum):
+    """
+    The name of a point relative to deck calibration. The number points are
+    calibration crosses ("1" in slot 1, "2" in slot 3, "3" in slot 7); "safeZ"
+    is a safe height above the deck, "attachTip" is a good place to go for the
+    user to attach a tip.
+    """
+    one = "1"
+    two = "2"
+    three = "3"
+    safeZ = "safeZ"
+    attachTip = "attachTip"
+
+
 def expected_points():
     slot_1_lower_left,\
         slot_3_lower_right,\
         slot_7_upper_left = dots_set()
 
     return {
-        '1': slot_1_lower_left,
-        '2': slot_3_lower_right,
-        '3': slot_7_upper_left}
+        DeckCalibrationPoint.one: slot_1_lower_left,
+        DeckCalibrationPoint.two: slot_3_lower_right,
+        DeckCalibrationPoint.three: slot_7_upper_left}
 
 
 def safe_points() -> Dict[str, Tuple[float, float, float]]:
@@ -64,11 +78,11 @@ def safe_points() -> Dict[str, Tuple[float, float, float]]:
     attach_tip_point = (200, 90, 130)
 
     return {
-        '1': slot_1_safe_point,
-        '2': slot_3_safe_point,
-        '3': slot_7_safe_point,
-        'safeZ': z_pos,
-        'attachTip': attach_tip_point
+        DeckCalibrationPoint.one: slot_1_safe_point,
+        DeckCalibrationPoint.two: slot_3_safe_point,
+        DeckCalibrationPoint.three: slot_7_safe_point,
+        DeckCalibrationPoint.safeZ: z_pos,
+        DeckCalibrationPoint.attachTip: attach_tip_point
     }
 
 
@@ -349,7 +363,7 @@ async def move(data) -> CommandResult:
         raise NoSessionInProgress()
 
     point_name = data.get('point')
-    point = safe_points().get(str(point_name))
+    point = safe_points().get(point_name)
     if point and len(point) == 3:
         if not feature_flags.use_protocol_api_v2():
             pipette = session_wrapper.session.pipettes[

--- a/api/tests/opentrons/deck_calibration/test_endpoints.py
+++ b/api/tests/opentrons/deck_calibration/test_endpoints.py
@@ -17,6 +17,8 @@ from opentrons import types
 # operation, and then these tests should be revised to match expected reality.
 
 # ------------ Function tests (unit) ----------------------
+
+
 async def test_add_and_remove_tip(dc_session, instruments):
     hardware = dc_session.adapter
     hardware.reset()
@@ -402,7 +404,6 @@ async def test_set_and_jog_integration(hardware, monkeypatch):
                              {},
                              {"point": "Z"},
                              {"point": "att"},
-                             {"point": []},
                              {"point": None}
                          ])
 async def test_move_no_point(command_data, dc_session):
@@ -423,6 +424,19 @@ async def test_move_basic(dc_session):
         command='move',
         command_data={
             "point": "attachTip"
+        })
+
+    assert resp.success is True
+    assert resp.message == "Moved to (200, 90, 130)"
+
+
+async def test_move_basic_typed(dc_session):
+    dc_session.current_mount = endpoints.Mount.RIGHT
+    resp = await endpoints.dispatch(
+        token=dc_session.id,
+        command='move',
+        command_data={
+            "point": endpoints.DeckCalibrationPoint.attachTip
         })
 
     assert resp.success is True

--- a/robot-server/robot_server/service/models/deck_calibration.py
+++ b/robot-server/robot_server/service/models/deck_calibration.py
@@ -3,7 +3,8 @@ from enum import Enum
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from opentrons.deck_calibration.endpoints import CalibrationCommand
+from opentrons.deck_calibration.endpoints import CalibrationCommand, \
+    DeckCalibrationPoint
 from robot_server.service.models.control import Mount
 
 
@@ -40,20 +41,6 @@ class DeckStartResponse(BaseModel):
                     "model": "p10_single_v1.5"
                   }
                 }}
-
-
-class DeckCalibrationPoint(str, Enum):
-    """
-    The name of a point relative to deck calibration. The number points are
-    calibration crosses ("1" in slot 1, "2" in slot 3, "3" in slot 7); "safeZ"
-    is a safe height above the deck, "attachTip" is a good place to go for the
-    user to attach a tip.
-    """
-    one = "1"
-    two = "2"
-    three = "3"
-    safeZ = "safeZ"
-    attachTip = "attachTip"
 
 
 class JogAxis(str, Enum):


### PR DESCRIPTION
## overview

Root cause is that the field in api was a str but the fastapi passed in an enum. The str is a key in a dict and the lookup using the enum failed due to a str conversion before lookup.
Solution is to move the enum into the API and have it referenced by fastapi model. Also, remove the str conversion before look up. 


## risk assessment

Bug fix. 

closes #5688