### PR TITLE
refactor(api): Add in an index file to keep track of labware calibrations

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import json
 from dataclasses import dataclass
-from typing import Any, List, Optional, Set, Tuple, Dict
+from typing import Any, List, Optional, Tuple, Dict
 
 from opentrons import types
 from opentrons.hardware_control.types import CriticalPoint
@@ -13,6 +13,7 @@ from .labware import (Labware, Well,
                       quirks_from_any_parent)
 from .definitions import DeckItem
 from .module_geometry import ThermocyclerGeometry, ModuleGeometry, ModuleType
+from .util import first_parent
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -49,27 +50,6 @@ def split_loc_labware(
         return loc.labware.parent, loc.labware
     else:
         return None, None
-
-
-def first_parent(loc: types.LocationLabware) -> Optional[str]:
-    """ Return the topmost parent of this location. It should be
-    either a string naming a slot or a None if the location isn't
-    associated with a slot """
-
-    # cycle-detecting recursive climbing
-    seen: Set[types.LocationLabware] = set()
-
-    # internal function to have the cycle detector different per call
-    def _fp_recurse(location: types.LocationLabware):
-        if location in seen:
-            raise RuntimeError('Cycle in labware parent')
-        seen.add(location)
-        if location is None or isinstance(location, str):
-            return location
-        else:
-            return first_parent(location.parent)
-
-    return _fp_recurse(loc)
 
 
 BAD_PAIRS = [('1', '12'),

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -494,15 +494,14 @@ def test_add_index_file(labware_name, index_file_dir):
     lw_uri = labware.uri_from_definition(definition)
 
     str_parent = labware._get_parent_identifier(lw.parent)
+    slot = '1'
     if str_parent:
-        slot = lw.parent.parent
         mod_dict = {str_parent: f'{slot}-{str_parent}'}
     else:
-        slot = lw.parent
         mod_dict = {}
     blob = {
-            "id": f'{labware_hash}{str_parent}',
-            "slot": slot,
+            "id": f'{labware_hash}',
+            "slot": f'{labware_hash}{str_parent}',
             "module": mod_dict
         }
 

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -5,8 +5,10 @@ import pytest
 from opentrons.protocol_api import (
     labware, MAX_SUPPORTED_VERSION, module_geometry)
 from opentrons.system.shared_data import load_shared_data
+from opentrons import config
 from opentrons.types import Point, Location
 from opentrons.protocols.types import APIVersion
+from opentrons.protocol_api.geometry import Deck
 
 test_data = {
     'circular_well_json': {
@@ -29,6 +31,14 @@ test_data = {
         'z': 22
     }
 }
+
+
+@pytest.fixture
+def index_file_dir(tmpdir):
+    config.CONFIG['labware_calibration_offsets_dir_v2'] = tmpdir
+    # config.reload()
+    yield tmpdir
+    config.reload()
 
 
 def test_well_init():
@@ -465,3 +475,37 @@ def test_uris():
     assert labware.uri_from_definition(defn) == uri
     lw = labware.Labware(defn, Location(Point(0, 0, 0), 'Test Slot'))
     assert lw.uri == uri
+
+
+@pytest.mark.parametrize(
+    'labware_name', [
+        'nest_96_wellplate_2ml_deep',
+        'corning_384_wellplate_112ul_flat',
+        'geb_96_tiprack_1000ul',
+        'nest_12_reservoir_15ml'])
+def test_add_index_file(labware_name, index_file_dir):
+    deck = Deck()
+    parent = deck.position_for(1)
+    definition = labware.get_labware_definition(labware_name)
+    lw = labware.Labware(definition, parent)
+    labware_hash = labware._hash_labware_def(lw._definition)
+    labware._add_to_index_offset_file(lw, labware_hash)
+
+    lw_uri = labware.uri_from_definition(definition)
+
+    str_parent = labware._get_parent_identifier(lw.parent)
+    if str_parent:
+        slot = lw.parent.parent
+        mod_dict = {str_parent: f'{slot}-{str_parent}'}
+    else:
+        slot = lw.parent
+        mod_dict = {}
+    blob = {
+            "id": f'{labware_hash}{str_parent}',
+            "slot": slot,
+            "module": mod_dict
+        }
+
+    lw_path = index_file_dir / 'index.json'
+    info = labware._read_file(lw_path)
+    assert info[lw_uri] == blob

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -50,7 +50,9 @@ minimalLabwareDef = {
         "xDimension": 1.0,
         "yDimension": 2.0,
         "zDimension": 3.0
-    }
+    },
+    "namespace": "opentrons",
+    "version": 1
 }
 
 


### PR DESCRIPTION
## overview

Closes #5580. This PR adds in an `index.json` file into the calibration offsets directory. The file then stores look-up information for each labware calibration file.

This is to ensure easy look-up 

## changelog
- Add a test to check that the contents of the index file 
- Add in a function that gets called either during load calibration or save calibration which will update the index file _if_ that labware has not been seen before.

## review requests
Check that everything seems Ok. Should we store any other information in the file itself?

## risk assessment
Low. Currently this file is only being created in the background, it never actually gets used anywhere. The main problem would be if you tried to use a labware definition that did not have all of the expected keys. Since the main pathway we support is uploading labware via the app, I would expect that this is a rare problem.



