### PR TITLE
feat(protocol-designer): implement empty getDisabledFields for tc step

### DIFF
--- a/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
+++ b/protocol-designer/src/steplist/formLevel/getDisabledFields/index.js
@@ -11,9 +11,9 @@ function _getDisabledFields(rawForm: FormData): Set<string> {
     case 'mix':
       return getDisabledFieldsMixForm(rawForm)
     case 'pause':
-      return new Set() // nothing to disabled
     case 'magnet':
-      return new Set()
+    case 'thermocycler':
+      return new Set() // nothing to disabled
     default: {
       console.warn(
         `disabled fields for step type ${rawForm.stepType} not yet implemented!`


### PR DESCRIPTION
## overview

Serves as its own ticket

TC Step doesn't need a getDisabledFields fn at this time, so this removes the console warning about it not being implemented

## changelog

## review requests

The console warning `disabled fields for step type thermocycler not yet implemented!` should no longer show up

## risk assessment

Low, PD only