### PR TITLE
fix(api): respect port in tools arghandler

### DIFF
--- a/api/src/opentrons/tools/args_handler.py
+++ b/api/src/opentrons/tools/args_handler.py
@@ -16,6 +16,6 @@ def root_argparser(description: str = None):
 def build_driver(
         port: str = None)\
         -> Tuple[adapters.SynchronousAdapter, SmoothieDriver_3_0_0]:
-    hardware = ThreadManager(API.build_hardware_controller).sync
+    hardware = ThreadManager(API.build_hardware_controller, None, port).sync
     driver = hardware._backend._smoothie_driver
     return hardware, driver


### PR DESCRIPTION
The central args handler for our tools scripts didn't actually pass its
port argument when building its hardware controller which breaks a lot
of smoothie connections on non-linux.

## Risk Estimation

Tools only. Test them though please