### PR TITLE
fix(robot-server): prevent nmcli connection states from causing a 500 response

### DIFF
--- a/robot-server/robot_server/service/models/networking.py
+++ b/robot-server/robot_server/service/models/networking.py
@@ -13,13 +13,6 @@ class ConnectivityStatus(str, Enum):
     unknown = "unknown"
 
 
-class ConnectionState(str, Enum):
-    connected = "connected"
-    connecting = "connecting"
-    disconnected = "disconnected"
-    unavailable = "unavailable"
-
-
 class ConnectionType(str, Enum):
     wifi = "wifi"
     ethernet = "ethernet"
@@ -40,9 +33,10 @@ class InterfaceStatus(BaseModel):
     gatewayAddress: str = \
         Field(None,
               description="The address of the configured gateway")
-    state: ConnectionState = \
+    state: str = \
         Field(...,
-              description="The state of the connection")
+              description="The state of the connection. (i.e. connected, "
+                          "disconnected, connection failed)")
     type: ConnectionType = \
         Field(...,
               description="What kind of interface this is")

--- a/robot-server/tests/service/routers/test_networking.py
+++ b/robot-server/tests/service/routers/test_networking.py
@@ -27,7 +27,7 @@ def test_networking_status(api_client, monkeypatch):
             'macAddress': 'B8:27:EB:39:C0:9A',
             # test missing output gets mapped to None
             'gatewayAddress': None,
-            'state': 'connected',
+            'state': 'connecting (configuring)',
             'type': 'ethernet'
         }
     }


### PR DESCRIPTION
## overview

Remove enum ConnectionState for modeling nmcli's connection state. The only benefit we had from this is documenting all the potential values in a response. Changed it to str and fill and extend the description of the field.

## changelog

Change type of field to str

## risk assessment

None. Bug fix.

closes #5698 