### PR TITLE
feat(protocol-designer): add lid cooling hint

### DIFF
--- a/protocol-designer/src/components/Hints/hints.css
+++ b/protocol-designer/src/components/Hints/hints.css
@@ -12,6 +12,19 @@
   padding-bottom: 2rem;
 }
 
+.numbered_list {
+  margin: 0 2rem 2rem 2rem;
+
+  & > li::before {
+    margin-right: 1rem;
+  }
+
+  & li span {
+    position: relative;
+    left: 1rem;
+  }
+}
+
 .step_description {
   margin-bottom: 1rem;
 

--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -89,6 +89,24 @@ class HintsComponent extends React.Component<Props, State> {
             <p>{i18n.t(`alert.hint.${hintKey}.body`)}</p>
           </>
         )
+      case 'thermocycler_lid_passive_cooling':
+        return (
+          <>
+            <p>
+              {i18n.t(`alert.hint.${hintKey}.body1a`)}
+              <strong>{i18n.t(`alert.hint.${hintKey}.strong_body1`)}</strong>
+              {i18n.t(`alert.hint.${hintKey}.body1b`)}
+            </p>
+            <ol className={styles.numbered_list}>
+              <li>
+                <span>{i18n.t(`alert.hint.${hintKey}.li1`)}</span>
+              </li>
+              <li>
+                <span>{i18n.t(`alert.hint.${hintKey}.li2`)}</span>
+              </li>
+            </ol>
+          </>
+        )
       default:
         return null
     }

--- a/protocol-designer/src/dismiss/selectors.js
+++ b/protocol-designer/src/dismiss/selectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
 import { selectors as stepFormSelectors } from '../step-forms'
-import { getSelectedStepId } from '../ui/steps'
+import { getSelectedStepId } from '../ui/steps/selectors'
 import type { FormWarning } from '../steplist'
 import type { BaseState, Selector } from '../types'
 import type {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -38,6 +38,14 @@
     },
     "change_magnet_module_model": {
       "title": "All existing engage heights will be cleared"
+    },
+    "thermocycler_lid_passive_cooling": {
+      "title": "Lid temperature",
+      "body1a": "Please note that the lid ",
+      "strong_body1": "does not actively cool",
+      "body1b": ". When entering a temperature lower than the previous temperature, keep in mind the following:",
+      "li1": "If the Thermocycler lid is closed it may take a very long time to reach a cooler temperature.",
+      "li2": "If the room temperature in your lab is higher than the temperature you have defined, the lid will never reach it. This will stall your protocol indefinitely."
     }
   },
   "timeline": {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -7,7 +7,7 @@
     "pause": "Enable pause within protocol.",
     "moveLiquid": "Move liquid to and from wells/tubes.",
     "magnet": "Engage or disengage the Magnetic module.",
-    "temperature": "Set temperature command for Temperature and Thermocycler modules.",
+    "temperature": "Set temperature command for Temperature module.",
     "thermocycler": "Program a profile for the Thermocycler module."
   },
 

--- a/protocol-designer/src/top-selectors/timelineFrames.js
+++ b/protocol-designer/src/top-selectors/timelineFrames.js
@@ -5,7 +5,7 @@ import assert from 'assert'
 
 import { selectors as fileDataSelectors } from '../file-data'
 import { selectors as stepFormSelectors } from '../step-forms'
-import { getActiveItem } from '../ui/steps'
+import { getActiveItem } from '../ui/steps/selectors'
 import { START_TERMINAL_ITEM_ID, PRESAVED_STEP_ID } from '../steplist'
 
 import type { Selector } from '../types'

--- a/protocol-designer/src/tutorial/__tests__/selectors.test.js
+++ b/protocol-designer/src/tutorial/__tests__/selectors.test.js
@@ -1,0 +1,75 @@
+// @flow
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { shouldShowCoolingHint as _shouldShowCoolingHint } from '../selectors'
+import type { ThermocyclerModuleState } from '../../step-forms/types'
+// TODO(IL, 2020-05-19): Flow doesn't have type for resultFunc
+const shouldShowCoolingHint: any = _shouldShowCoolingHint
+
+const tcModuleId = 'tcModuleId'
+
+describe('shouldShowCoolingHint', () => {
+  const testCases = [
+    {
+      testName: 'should show the hint when lid temperature is decreasing',
+      prevLidTemp: 75,
+      nextLidTemp: 40,
+      formStepType: 'thermocycler',
+      expected: true,
+    },
+    {
+      testName: 'should not show the hint for non-thermocycler forms',
+      prevLidTemp: 75,
+      nextLidTemp: undefined,
+      formStepType: 'moveLiquid',
+      expected: false,
+    },
+    {
+      testName:
+        'should not show the hint when previous lid temperature is null',
+      prevLidTemp: null,
+      nextLidTemp: 40,
+      formStepType: 'thermocycler',
+      expected: false,
+    },
+    {
+      testName: 'should not show the hint when next lid temperature is null',
+      prevLidTemp: 75,
+      nextLidTemp: null,
+      formStepType: 'thermocycler',
+      expected: false,
+    },
+    {
+      testName: 'should not show the hint when lid temperature is increasing',
+      prevLidTemp: 75,
+      nextLidTemp: 80,
+      formStepType: 'thermocycler',
+      expected: false,
+    },
+  ]
+
+  testCases.forEach(
+    ({ testName, prevLidTemp, nextLidTemp, formStepType, expected }) => {
+      it(testName, () => {
+        const moduleState: ThermocyclerModuleState = {
+          type: THERMOCYCLER_MODULE_TYPE,
+          lidTargetTemp: prevLidTemp,
+          lidOpen: false,
+          blockTargetTemp: null,
+        }
+        const prevTimelineFrame = {
+          robotState: { modules: { [tcModuleId]: { moduleState } } },
+        }
+        const unsavedForm = {
+          stepType: 'thermocycler',
+          moduleId: tcModuleId,
+          lidTargetTemp: nextLidTemp,
+        }
+        const result = shouldShowCoolingHint.resultFunc(
+          prevTimelineFrame,
+          unsavedForm
+        )
+        expect(result).toBe(expected)
+      })
+    }
+  )
+})

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -8,6 +8,7 @@ type HintKey =
   | 'add_liquids_and_labware'
   | 'deck_setup_explanation'
   | 'module_without_labware'
+  | 'thermocycler_lid_passive_cooling'
   // blocking hints
   | 'custom_labware_with_modules'
   | 'export_v4_protocol'

--- a/protocol-designer/src/tutorial/selectors.js
+++ b/protocol-designer/src/tutorial/selectors.js
@@ -1,5 +1,8 @@
 // @flow
 import { createSelector } from 'reselect'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { timelineFrameBeforeActiveItem } from '../top-selectors/timelineFrames'
+import { getUnsavedForm } from '../step-forms/selectors'
 import isEmpty from 'lodash/isEmpty'
 import type { BaseState, Selector } from '../types'
 import type { HintKey } from '.'
@@ -31,4 +34,27 @@ export const getDismissedHints: Selector<Array<HintKey>> = createSelector(
 export const getCanClearHintDismissals: Selector<boolean> = createSelector(
   rootSelector,
   tutorial => !isEmpty(tutorial.dismissedHints)
+)
+
+export const shouldShowCoolingHint: Selector<boolean> = createSelector(
+  timelineFrameBeforeActiveItem,
+  getUnsavedForm,
+  (prevTimelineFrame, unsavedForm) => {
+    if (unsavedForm?.stepType !== 'thermocycler') {
+      return false
+    }
+
+    const { moduleId } = unsavedForm
+    const prevModuleState =
+      prevTimelineFrame.robotState.modules[moduleId]?.moduleState
+    if (prevModuleState && prevModuleState.type === THERMOCYCLER_MODULE_TYPE) {
+      const prevLidTemp = prevModuleState.lidTargetTemp
+      const nextLidTemp = unsavedForm.lidTargetTemp
+      if (prevLidTemp === null || nextLidTemp === null) return false
+      return nextLidTemp < prevLidTemp
+    } else {
+      console.error('expected thermocycler module')
+    }
+    return false
+  }
 )

--- a/protocol-designer/src/ui/steps/actions/thunks/index.js
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.js
@@ -11,7 +11,10 @@ import { uuid } from '../../../../utils'
 import { selectors as labwareIngredsSelectors } from '../../../../labware-ingred/selectors'
 import { getSelectedStepId } from '../../selectors'
 import { addStep } from '../actions'
-import { actions as tutorialActions } from '../../../../tutorial'
+import {
+  actions as tutorialActions,
+  selectors as tutorialSelectors,
+} from '../../../../tutorial'
 
 import * as uiModuleSelectors from '../../../../ui/modules/selectors'
 import type { DuplicateStepAction } from '../types'
@@ -125,6 +128,10 @@ export const saveStepForm = () => (
       'Tried to saveStepForm with falsey unsavedForm. This should never be able to happen.'
     )
     return
+  }
+
+  if (tutorialSelectors.shouldShowCoolingHint(initialState)) {
+    dispatch(tutorialActions.addHint('thermocycler_lid_passive_cooling'))
   }
 
   // save the form


### PR DESCRIPTION
## overview

Closes #5574

## changelog

## review requests

Make a protocol with a TC, set TC lid temp.  Make a following step...
- [ ] that deactivates the lid. Should not show the hint
- [ ] with a higher lid temp. Should not show the hint
- [ ] with a lower lid temp. Should show the hint

Warning! Hints are dismissed for the rest of the session after you see them, so refresh PD for each of the 3 cases to make sure hint isn't simply being masked.

## risk assessment

Low, only PD