### PR TITLE
feat(protocol-designer): add timeline error when aspirating/dispensing from TC with lid closed

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -64,7 +64,7 @@
       },
       "THERMOCYCLER_LID_CLOSED": {
         "title": "Thermocycler lid is closed",
-        "body": "Use a thermocycler step to open the lid before trying to pipette into it."
+        "body": "Before a pipette can interact with labware in the Thermocycler, the lid must be open. To resolve this error, please add a thermocycler step ahead of the current step, and set the lid status to \"open\"."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -61,6 +61,10 @@
       "MISSING_TEMPERATURE_STEP": {
         "title": "Missing Temperature step",
         "body": "Add a Temperature step prior to this Pause step. The module is not currently changing temperature because it has either been deactivated or is holding a temperature"
+      },
+      "THERMOCYCLER_LID_CLOSED": {
+        "title": "Thermocycler lid is closed",
+        "body": "Use a thermocycler step to open the lid before trying to pipette into it."
       }
     },
     "warning": {

--- a/protocol-designer/src/step-generation/__tests__/aspirate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/aspirate.test.js
@@ -4,7 +4,7 @@ import { aspirate } from '../commandCreators/atomic/aspirate'
 import { getLabwareDefURI } from '@opentrons/shared-data'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
 import fixture_tiprack_1000_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
-import { thermocyclerPipetteCollission } from '../utils/thermocyclerPipetteCollision'
+import { thermocyclerPipetteCollision } from '../utils'
 import {
   getInitialRobotStateStandard,
   getRobotStateWithTipStandard,

--- a/protocol-designer/src/step-generation/__tests__/aspirate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/aspirate.test.js
@@ -19,9 +19,13 @@ import type { RobotState } from '../'
 jest.mock('../utils/thermocyclerPipetteCollision')
 
 const mockThermocyclerPipetteCollission: JestMockFn<
-  [RobotState, string],
+  [
+    $PropertyType<RobotState, 'modules'>,
+    $PropertyType<RobotState, 'labware'>,
+    string
+  ],
   boolean
-> = thermocyclerPipetteCollission
+> = thermocyclerPipetteCollision
 
 describe('aspirate', () => {
   let initialRobotState
@@ -169,10 +173,15 @@ describe('aspirate', () => {
       type: 'LABWARE_DOES_NOT_EXIST',
     })
   })
-  it('aspirate from thermocycler with pipette collision returns an error', () => {
+  it('should return an error when aspirating from thermocycler with pipette collision', () => {
     mockThermocyclerPipetteCollission.mockImplementationOnce(
-      (robotState: RobotState, labwareId: string) => {
-        expect(robotState).toBe(robotStateWithTip)
+      (
+        modules: $PropertyType<RobotState, 'modules'>,
+        labware: $PropertyType<RobotState, 'labware'>,
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
         expect(labwareId).toBe(SOURCE_LABWARE)
         return true
       }

--- a/protocol-designer/src/step-generation/__tests__/aspirate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/aspirate.test.js
@@ -18,7 +18,7 @@ import type { RobotState } from '../'
 
 jest.mock('../utils/thermocyclerPipetteCollision')
 
-const mockThermocyclerPipetteCollission: JestMockFn<
+const mockThermocyclerPipetteCollision: JestMockFn<
   [
     $PropertyType<RobotState, 'modules'>,
     $PropertyType<RobotState, 'labware'>,
@@ -174,7 +174,7 @@ describe('aspirate', () => {
     })
   })
   it('should return an error when aspirating from thermocycler with pipette collision', () => {
-    mockThermocyclerPipetteCollission.mockImplementationOnce(
+    mockThermocyclerPipetteCollision.mockImplementationOnce(
       (
         modules: $PropertyType<RobotState, 'modules'>,
         labware: $PropertyType<RobotState, 'labware'>,

--- a/protocol-designer/src/step-generation/__tests__/dispense.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dispense.test.js
@@ -1,4 +1,5 @@
 // @flow
+import { thermocyclerPipetteCollision } from '../utils'
 import {
   getInitialRobotStateStandard,
   getRobotStateWithTipStandard,
@@ -9,6 +10,18 @@ import {
   SOURCE_LABWARE,
 } from '../__fixtures__'
 import { dispense } from '../commandCreators/atomic/dispense'
+import type { RobotState } from '../'
+
+jest.mock('../utils/thermocyclerPipetteCollision')
+
+const mockThermocyclerPipetteCollission: JestMockFn<
+  [
+    $PropertyType<RobotState, 'modules'>,
+    $PropertyType<RobotState, 'labware'>,
+    string
+  ],
+  boolean
+> = thermocyclerPipetteCollision
 
 describe('dispense', () => {
   let initialRobotState
@@ -19,6 +32,10 @@ describe('dispense', () => {
     invariantContext = makeContext()
     initialRobotState = getInitialRobotStateStandard(invariantContext)
     robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
   describe('tip tracking & commands:', () => {
@@ -68,6 +85,28 @@ describe('dispense', () => {
       expect(res.errors).toHaveLength(1)
       expect(res.errors[0]).toMatchObject({
         type: 'LABWARE_DOES_NOT_EXIST',
+      })
+    })
+
+    it('should return an error when dispensing into thermocycler with pipette collision', () => {
+      mockThermocyclerPipetteCollission.mockImplementationOnce(
+        (
+          modules: $PropertyType<RobotState, 'modules'>,
+          labware: $PropertyType<RobotState, 'labware'>,
+          labwareId: string
+        ) => {
+          expect(modules).toBe(robotStateWithTip.modules)
+          expect(labware).toBe(robotStateWithTip.labware)
+          expect(labwareId).toBe(SOURCE_LABWARE)
+          return true
+        }
+      )
+      const result = dispense(params, invariantContext, robotStateWithTip)
+
+      const res = getErrorResult(result)
+      expect(res.errors).toHaveLength(1)
+      expect(res.errors[0]).toMatchObject({
+        type: 'THERMOCYCLER_LID_CLOSED',
       })
     })
   })

--- a/protocol-designer/src/step-generation/__tests__/dispense.test.js
+++ b/protocol-designer/src/step-generation/__tests__/dispense.test.js
@@ -14,7 +14,7 @@ import type { RobotState } from '../'
 
 jest.mock('../utils/thermocyclerPipetteCollision')
 
-const mockThermocyclerPipetteCollission: JestMockFn<
+const mockThermocyclerPipetteCollision: JestMockFn<
   [
     $PropertyType<RobotState, 'modules'>,
     $PropertyType<RobotState, 'labware'>,
@@ -89,7 +89,7 @@ describe('dispense', () => {
     })
 
     it('should return an error when dispensing into thermocycler with pipette collision', () => {
-      mockThermocyclerPipetteCollission.mockImplementationOnce(
+      mockThermocyclerPipetteCollision.mockImplementationOnce(
         (
           modules: $PropertyType<RobotState, 'modules'>,
           labware: $PropertyType<RobotState, 'labware'>,

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -565,7 +565,7 @@ describe('thermocyclerStateDiff', () => {
   })
 })
 
-describe('thermocyclerPipetteColission', () => {
+describe('thermocyclerPipetteColision', () => {
   const thermocyclerId = 'thermocyclerId'
   const labwareOnTCId = 'labwareOnTCId'
 

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -24,11 +24,7 @@ import {
 } from '../utils/misc'
 import { thermocyclerStateDiff } from '../utils/thermocyclerStateDiff'
 import { FIXED_TRASH_ID } from '../__fixtures__'
-import {
-  makeContext,
-  getRobotStateWithTipStandard,
-} from '../__fixtures__/robotStateFixtures'
-import { thermocyclerPipetteCollission } from '../utils/thermocyclerPipetteCollision'
+import { thermocyclerPipetteCollision } from '../utils'
 import type { RobotState } from '../'
 
 describe('splitLiquid', () => {

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -573,6 +573,7 @@ describe('thermocyclerPipetteColision', () => {
     testMsg: string,
     modules: $PropertyType<RobotState, 'modules'>,
     labware: $PropertyType<RobotState, 'labware'>,
+    labwareId: string,
     expected: boolean,
   |}> = [
     {
@@ -592,6 +593,7 @@ describe('thermocyclerPipetteColision', () => {
       labware: {
         [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
+      labwareId: labwareOnTCId,
       expected: true,
     },
     {
@@ -611,6 +613,7 @@ describe('thermocyclerPipetteColision', () => {
       labware: {
         [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
+      labwareId: labwareOnTCId,
       expected: true,
     },
     {
@@ -630,15 +633,36 @@ describe('thermocyclerPipetteColision', () => {
       labware: {
         [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
+      labwareId: labwareOnTCId,
+      expected: false,
+    },
+    {
+      testMsg:
+        'returns false when labware is not on TC, even when TC lid is closed',
+      modules: {
+        [thermocyclerId]: {
+          slot: '7',
+          moduleState: {
+            type: THERMOCYCLER_MODULE_TYPE,
+            blockTargetTemp: null,
+            lidTargetTemp: null,
+            lidOpen: false,
+          },
+        },
+      },
+      labware: {
+        [labwareOnTCId]: { slot: thermocyclerId },
+      },
+      labwareId: 'someOtherLabwareNotOnTC',
       expected: false,
     },
   ]
 
-  testCases.forEach(({ testMsg, modules, labware, expected }) => {
+  testCases.forEach(({ testMsg, modules, labware, labwareId, expected }) => {
     it(testMsg, () => {
-      expect(
-        thermocyclerPipetteCollision(modules, labware, labwareOnTCId)
-      ).toBe(expected)
+      expect(thermocyclerPipetteCollision(modules, labware, labwareId)).toBe(
+        expected
+      )
     })
   })
 })

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -571,82 +571,74 @@ describe('thermocyclerPipetteColission', () => {
 
   const testCases: Array<{|
     testMsg: string,
-    robotState: RobotState,
+    modules: $PropertyType<RobotState, 'modules'>,
+    labware: $PropertyType<RobotState, 'labware'>,
     expected: boolean,
   |}> = [
     {
       testMsg:
         'returns true when aspirating from labware on TC with lidOpen set to null',
-      robotState: {
-        ...getRobotStateWithTipStandard(makeContext()),
-        modules: {
-          [thermocyclerId]: {
-            slot: '7',
-            moduleState: {
-              type: THERMOCYCLER_MODULE_TYPE,
-              blockTargetTemp: null,
-              lidTargetTemp: null,
-              lidOpen: null,
-            },
+      modules: {
+        [thermocyclerId]: {
+          slot: '7',
+          moduleState: {
+            type: THERMOCYCLER_MODULE_TYPE,
+            blockTargetTemp: null,
+            lidTargetTemp: null,
+            lidOpen: null,
           },
         },
-        labware: {
-          [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
-        },
+      },
+      labware: {
+        [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
       expected: true,
     },
     {
       testMsg:
         'returns true when aspirating from labware on TC with lidOpen set to false',
-      robotState: {
-        ...getRobotStateWithTipStandard(makeContext()),
-        modules: {
-          [thermocyclerId]: {
-            slot: '7',
-            moduleState: {
-              type: THERMOCYCLER_MODULE_TYPE,
-              blockTargetTemp: null,
-              lidTargetTemp: null,
-              lidOpen: false,
-            },
+      modules: {
+        [thermocyclerId]: {
+          slot: '7',
+          moduleState: {
+            type: THERMOCYCLER_MODULE_TYPE,
+            blockTargetTemp: null,
+            lidTargetTemp: null,
+            lidOpen: false,
           },
         },
-        labware: {
-          [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
-        },
+      },
+      labware: {
+        [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
       expected: true,
     },
     {
       testMsg:
         'returns false when aspirating from labware on TC with lidOpen set to true',
-      robotState: {
-        ...getRobotStateWithTipStandard(makeContext()),
-        modules: {
-          [thermocyclerId]: {
-            slot: '7',
-            moduleState: {
-              type: THERMOCYCLER_MODULE_TYPE,
-              blockTargetTemp: null,
-              lidTargetTemp: null,
-              lidOpen: true,
-            },
+      modules: {
+        [thermocyclerId]: {
+          slot: '7',
+          moduleState: {
+            type: THERMOCYCLER_MODULE_TYPE,
+            blockTargetTemp: null,
+            lidTargetTemp: null,
+            lidOpen: true,
           },
         },
-        labware: {
-          [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
-        },
+      },
+      labware: {
+        [labwareOnTCId]: { slot: thermocyclerId }, // when labware is on a module, the slot is the module's id
       },
       expected: false,
     },
   ]
 
-  testCases.forEach(({ testMsg, robotState, expected }) => {
+  testCases.forEach(({ testMsg, modules, labware, expected }) => {
     it(testMsg, () => {
-      expect(thermocyclerPipetteCollission(robotState, labwareOnTCId)).toBe(
-        expected
-      )
+      expect(
+        thermocyclerPipetteCollision(modules, labware, labwareOnTCId)
+      ).toBe(expected)
     })
   })
 })

--- a/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
@@ -2,6 +2,7 @@
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import { modulePipetteCollision } from '../../utils'
+import { thermocyclerPipetteCollission } from '../../utils/thermocyclerPipetteCollision'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type { CommandCreator, CommandCreatorError } from '../../types'
 
@@ -45,6 +46,10 @@ export const aspirate: CommandCreator<AspirateParams> = (
         well,
       })
     )
+  }
+
+  if (thermocyclerPipetteCollission(prevRobotState, labware)) {
+    errors.push(errorCreators.thermocyclerLidClosed())
   }
 
   if (errors.length === 0 && pipetteSpec && pipetteSpec.maxVolume < volume) {

--- a/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
@@ -1,8 +1,10 @@
 // @flow
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
-import { modulePipetteCollision } from '../../utils'
-import { thermocyclerPipetteCollission } from '../../utils/thermocyclerPipetteCollision'
+import {
+  modulePipetteCollision,
+  thermocyclerPipetteCollision,
+} from '../../utils'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type { CommandCreator, CommandCreatorError } from '../../types'
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/aspirate.js
@@ -50,7 +50,13 @@ export const aspirate: CommandCreator<AspirateParams> = (
     )
   }
 
-  if (thermocyclerPipetteCollission(prevRobotState, labware)) {
+  if (
+    thermocyclerPipetteCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
     errors.push(errorCreators.thermocyclerLidClosed())
   }
 

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
@@ -39,6 +39,16 @@ export const dispense: CommandCreator<DispenseParams> = (
     errors.push(errorCreators.labwareDoesNotExist({ actionName, labware }))
   }
 
+  if (
+    thermocyclerPipetteCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
   if (errors.length > 0) {
     return { errors }
   }

--- a/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/dispense.js
@@ -1,6 +1,9 @@
 // @flow
 import * as errorCreators from '../../errorCreators'
-import { modulePipetteCollision } from '../../utils'
+import {
+  modulePipetteCollision,
+  thermocyclerPipetteCollision,
+} from '../../utils'
 import type { DispenseParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type { CommandCreator, CommandCreatorError } from '../../types'
 

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -102,3 +102,10 @@ export const modulePipetteCollisionDanger = (): CommandCreatorError => {
       'Gen 1 8-Channel pipettes cannot access labware or tip racks in slot 4 or 6 because they are adjacent to modules.',
   }
 }
+
+export const thermocyclerLidClosed = (): CommandCreatorError => {
+  return {
+    type: 'THERMOCYCLER_LID_CLOSED',
+    message: 'Attempted to pipette into a thermocycler with the lid closed.',
+  }
+}

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -296,6 +296,7 @@ export type ErrorType =
   | 'PIPETTE_VOLUME_EXCEEDED'
   | 'TIP_VOLUME_EXCEEDED'
   | 'MISSING_TEMPERATURE_STEP'
+  | 'THERMOCYCLER_LID_CLOSED'
 
 export type CommandCreatorError = {|
   message: string,

--- a/protocol-designer/src/step-generation/utils/index.js
+++ b/protocol-designer/src/step-generation/utils/index.js
@@ -3,11 +3,14 @@ import { commandCreatorsTimeline } from './commandCreatorsTimeline'
 import { curryCommandCreator } from './curryCommandCreator'
 import { reduceCommandCreators } from './reduceCommandCreators'
 import { modulePipetteCollision } from './modulePipetteCollision'
+import { thermocyclerPipetteCollision } from './thermocyclerPipetteCollision'
+
 export {
   commandCreatorsTimeline,
   curryCommandCreator,
   reduceCommandCreators,
   modulePipetteCollision,
+  thermocyclerPipetteCollision,
 }
 
 export * from './commandCreatorArgsGetters'

--- a/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
@@ -2,11 +2,11 @@
 import { THERMOCYCLER_MODULE_TYPE } from '../../../../shared-data/js/constants'
 import type { RobotState } from '../'
 
-export const thermocyclerPipetteCollission = (
-  robotState: RobotState,
+export const thermocyclerPipetteCollision = (
+  modules: $PropertyType<RobotState, 'modules'>,
+  labware: $PropertyType<RobotState, 'labware'>,
   labwareId: string
 ): boolean => {
-  const { modules, labware } = robotState
   const labwareSlot: string = labware[labwareId]?.slot
 
   const moduleUnderLabware: ?string =

--- a/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
@@ -1,0 +1,27 @@
+// @flow
+import { THERMOCYCLER_MODULE_TYPE } from '../../../../shared-data/js/constants'
+import type { RobotState } from '../'
+
+export const thermocyclerPipetteCollission = (
+  robotState: RobotState,
+  labwareId: string
+): boolean => {
+  const { modules, labware } = robotState
+  const labwareSlot: string = labware[labwareId]?.slot
+
+  const moduleUnderLabware: ?string =
+    modules &&
+    labwareSlot &&
+    Object.keys(modules).find((moduleId: string) => moduleId === labwareSlot)
+
+  const moduleState =
+    moduleUnderLabware && modules[moduleUnderLabware].moduleState
+
+  const isTCLidClosed: boolean = Boolean(
+    moduleState &&
+      moduleState.type === THERMOCYCLER_MODULE_TYPE &&
+      moduleState.lidOpen !== true
+  )
+
+  return isTCLidClosed
+}

--- a/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
+++ b/protocol-designer/src/step-generation/utils/thermocyclerPipetteCollision.js
@@ -1,5 +1,5 @@
 // @flow
-import { THERMOCYCLER_MODULE_TYPE } from '../../../../shared-data/js/constants'
+import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import type { RobotState } from '../'
 
 export const thermocyclerPipetteCollision = (


### PR DESCRIPTION
## overview

This PR closes #5573 by checking if a thermocycler lid is closed before aspirating/dispensing from it. 

## review requests

**Code/style**

Code review (especially my naming and overall readability, I had to wrestle with flow quite a bit so please make sure stuff makes sense to you)

Check that tests cover what they should

**Functionality**

Make sure that you cannot aspirate or dispense from a TC with the lid closed. Check each of these cases and any more you can think of:

- Create a protocol with a TC and well plate on top of TC
- Add a compatible well plate somewhere else on the deck
- In a transfer step, try to aspirate from the TC
- Save step
- [ ] You should see a timeline error that matches [this](https://projects.invisionapp.com/share/VUWZT27EDJ8#/screens/414817390)

- Add a TC step and open the lid, drag the step to the top
- [ ] The error should go away

- Change the lid state to closed
- Try to aspirate from the other well plate (not on the TC), and dispense into the TC
- [ ] You should see the same timeline error (this checks the case that aspirate is OK but dispense is not)

- Add a TC step and open the lid, drag the step to the top
- [ ] The error should go away

Check the same for mix steps, as this should also work as expected. 

## risk assessment
Low, just adding timeline errors and TC work is behind FF