### PR TITLE
refactor(api): Check tiprack thresholds after tip pickup

### DIFF
--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -66,6 +66,7 @@ async def load_labware(request: web.Request, session) -> web.Response:
 
 async def prepare_pipette(request: web.Request, session) -> web.Response:
     await session.trigger_transition(CalibrationCheckTrigger.prepare_pipette)
+    await session.trigger_transition(CalibrationCheckTrigger.move_to_tiprack)
     return web.json_response(status=200)
 
 

--- a/api/src/opentrons/server/endpoints/calibration/check.py
+++ b/api/src/opentrons/server/endpoints/calibration/check.py
@@ -66,7 +66,6 @@ async def load_labware(request: web.Request, session) -> web.Response:
 
 async def prepare_pipette(request: web.Request, session) -> web.Response:
     await session.trigger_transition(CalibrationCheckTrigger.prepare_pipette)
-    await session.trigger_transition(CalibrationCheckTrigger.move_to_tiprack)
     return web.json_response(status=200)
 
 

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -297,7 +297,7 @@ class CalibrationCheckTrigger(str, Enum):
     reject_calibration = "rejectCalibration"
 
 
-CHECK_TRANSITIONS = [
+CHECK_TRANSITIONS: typing.List[typing.Dict[str, typing.Any]] = [
     {
         "trigger": CalibrationCheckTrigger.load_labware,
         "from_state": CalibrationCheckState.sessionStarted,
@@ -545,7 +545,7 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
     def __init__(self, hardware: 'ThreadManager'):
         CalibrationSession.__init__(self, hardware)
         StateMachine.__init__(self, states=[s for s in CalibrationCheckState],
-                              transitions=CHECK_TRANSITIONS,  # type: ignore
+                              transitions=CHECK_TRANSITIONS,
                               initial_state="sessionStarted")
         self.session_type = 'check'
         self._saved_points: typing.Dict[CalibrationCheckState, Point] = {}

--- a/api/src/opentrons/server/endpoints/calibration/util.py
+++ b/api/src/opentrons/server/endpoints/calibration/util.py
@@ -132,11 +132,13 @@ class StateMachine:
         log.debug(f"trigger_transition for {trigger} "
                   f"in {self.current_state_name}")
         events = self._events.get(trigger, {})
+        # print(events)
         if events and WILDCARD not in events and \
                 self.current_state_name not in events:
             raise StateMachineError(f'cannot trigger event {trigger}'
                                     f' from state {self.current_state_name}')
         try:
+            # print(WILDCARD)
             from_state = WILDCARD if WILDCARD in events \
                 else self.current_state_name
             for transition in events[from_state]:

--- a/api/tests/opentrons/server/calibration/test_check_calibration_session.py
+++ b/api/tests/opentrons/server/calibration/test_check_calibration_session.py
@@ -452,11 +452,11 @@ async def test_load_labware_to_preparing_first_pipette(
     assert curr_pos == tip_pt - types.Point(0, 0, 10)
 
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.joggingFirstPipetteToTiprack
+        session.CalibrationCheckState.preparingFirstPipette
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, OK_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.joggingFirstPipetteToTiprack
+        session.CalibrationCheckState.preparingFirstPipette
 
 
 async def test_preparing_first_pipette_to_bad_calibration(
@@ -466,7 +466,7 @@ async def test_preparing_first_pipette_to_bad_calibration(
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, BAD_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.joggingFirstPipetteToTiprack
+        session.CalibrationCheckState.preparingFirstPipette
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.pick_up_tip)
     await check_calibration_session.trigger_transition(
@@ -581,11 +581,11 @@ async def test_load_labware_to_preparing_second_pipette(
         sess._get_pipette_by_rank(session.PipetteRank.second).mount)
     assert curr_pos == tip_pt - types.Point(0, 0, 10)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.joggingSecondPipetteToTiprack
+        session.CalibrationCheckState.preparingSecondPipette
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, OK_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.joggingSecondPipetteToTiprack
+        session.CalibrationCheckState.preparingSecondPipette
 
 
 async def test_preparing_second_pipette_to_inspecting(
@@ -655,7 +655,7 @@ async def test_right_load_labware_to_preparing_first_pipette(
     await in_preparing_first_pipette(
             check_calibration_session_only_right)
     assert check_calibration_session_only_right.current_state.name == \
-        session.CalibrationCheckState.joggingFirstPipetteToTiprack
+        session.CalibrationCheckState.preparingFirstPipette
 
 
 async def test_right_preparing_first_pipette_to_inspecting(
@@ -749,7 +749,7 @@ async def test_left_load_labware_to_preparing_first_pipette(
         check_calibration_session_only_left):
     await in_preparing_first_pipette(check_calibration_session_only_left)
     assert check_calibration_session_only_left.current_state.name == \
-        session.CalibrationCheckState.joggingFirstPipetteToTiprack
+        session.CalibrationCheckState.preparingFirstPipette
 
 
 async def test_left_preparing_first_pipette_to_inspecting(

--- a/api/tests/opentrons/server/calibration/test_check_calibration_session.py
+++ b/api/tests/opentrons/server/calibration/test_check_calibration_session.py
@@ -89,6 +89,10 @@ async def in_inspecting_first_tip(check_calibration_session):
         check_calibration_session
     )
     await check_calibration_session.trigger_transition(
+        session.CalibrationCheckTrigger.jog,
+        types.Point(0, 0, -0.2)
+    )
+    await check_calibration_session.trigger_transition(
         session.CalibrationCheckTrigger.pick_up_tip,
     )
     return check_calibration_session
@@ -191,6 +195,10 @@ async def in_preparing_second_pipette(check_calibration_session):
 async def in_inspecting_second_tip(check_calibration_session):
     check_calibration_session = await in_preparing_second_pipette(
         check_calibration_session
+    )
+    await check_calibration_session.trigger_transition(
+        session.CalibrationCheckTrigger.jog,
+        types.Point(0, 0, -0.5)
     )
     await check_calibration_session.trigger_transition(
         session.CalibrationCheckTrigger.pick_up_tip,
@@ -444,11 +452,11 @@ async def test_load_labware_to_preparing_first_pipette(
     assert curr_pos == tip_pt - types.Point(0, 0, 10)
 
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.preparingFirstPipette
+        session.CalibrationCheckState.joggingFirstPipetteToTiprack
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, OK_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.preparingFirstPipette
+        session.CalibrationCheckState.joggingFirstPipetteToTiprack
 
 
 async def test_preparing_first_pipette_to_bad_calibration(
@@ -458,9 +466,11 @@ async def test_preparing_first_pipette_to_bad_calibration(
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, BAD_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.preparingFirstPipette
+        session.CalibrationCheckState.joggingFirstPipetteToTiprack
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.pick_up_tip)
+    await check_calibration_session.trigger_transition(
+        session.CalibrationCheckTrigger.confirm_tip_attached)
     assert check_calibration_session.current_state.name == \
         session.CalibrationCheckState.badCalibrationData
 
@@ -571,11 +581,11 @@ async def test_load_labware_to_preparing_second_pipette(
         sess._get_pipette_by_rank(session.PipetteRank.second).mount)
     assert curr_pos == tip_pt - types.Point(0, 0, 10)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.preparingSecondPipette
+        session.CalibrationCheckState.joggingSecondPipetteToTiprack
     await check_calibration_session.trigger_transition(
             session.CalibrationCheckTrigger.jog, OK_DIFF_VECTOR)
     assert check_calibration_session.current_state.name == \
-        session.CalibrationCheckState.preparingSecondPipette
+        session.CalibrationCheckState.joggingSecondPipetteToTiprack
 
 
 async def test_preparing_second_pipette_to_inspecting(
@@ -645,7 +655,7 @@ async def test_right_load_labware_to_preparing_first_pipette(
     await in_preparing_first_pipette(
             check_calibration_session_only_right)
     assert check_calibration_session_only_right.current_state.name == \
-        session.CalibrationCheckState.preparingFirstPipette
+        session.CalibrationCheckState.joggingFirstPipetteToTiprack
 
 
 async def test_right_preparing_first_pipette_to_inspecting(
@@ -739,7 +749,7 @@ async def test_left_load_labware_to_preparing_first_pipette(
         check_calibration_session_only_left):
     await in_preparing_first_pipette(check_calibration_session_only_left)
     assert check_calibration_session_only_left.current_state.name == \
-        session.CalibrationCheckState.preparingFirstPipette
+        session.CalibrationCheckState.joggingFirstPipetteToTiprack
 
 
 async def test_left_preparing_first_pipette_to_inspecting(


### PR DESCRIPTION
## overview

This PR will need to be rebased after #5676 is merged in. According to designs, pick up tip should occur before checking whether the jog to the tiprack was outside of the specified threshold.

## changelog
- Separate out pick up tip into two separate functions instead of trying to determine which pipette to used based on the state name.
- Ensure you are saving the reference point and post-jog point for jogging to the tiprack so you can appropriately compare points.
- Add ability for the state machine to take in multiple side effects before or after a state transition
- Add two side effects on the pick up tip trigger to save the jogged point after picking up tip.

## review requests

Check over the state machine states, see that the logic still makes sense. Test on a robot

## risk assessment

Should be very low. Only re-arranging the order of execution for steps in the state machine.
