### PR TITLE
feat(api): cache_instruments when creating simulator.

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -177,6 +177,7 @@ class API(HardwareAPILike):
                             strict_attached_instruments)
         await backend.setup_gpio_chardev()
         api_instance = cls(backend, loop=checked_loop, config=config)
+        await api_instance.cache_instruments()
         await backend.watch_modules(
                 register_modules=api_instance.register_modules)
         return api_instance


### PR DESCRIPTION
## overview

For parity with hardware, call cache_instruments after creating simulator. 

## risk assessment

None