### PR TITLE
feat(app): display the serials of attached pipettes

### DIFF
--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -24,10 +24,13 @@ const LABEL_BY_MOUNT = {
   right: 'Right pipette',
 }
 
+const SERIAL_NUMBER = 'Serial number'
+
 export function PipetteInfo(props: PipetteInfoProps) {
   const { mount, pipette, changeUrl, settingsUrl } = props
   const label = LABEL_BY_MOUNT[mount]
   const displayName = pipette ? pipette.modelSpecs.displayName : null
+  const serialNumber = pipette ? pipette.id : null
   const channels = pipette ? pipette.modelSpecs.channels : null
   const direction = pipette ? 'change' : 'attach'
 
@@ -37,11 +40,18 @@ export function PipetteInfo(props: PipetteInfoProps) {
 
   return (
     <div className={className}>
-      <LabeledValue
-        label={label}
-        value={(displayName || 'None').replace(/-/, '‑')} // non breaking hyphen
-        valueClassName={styles.pipette_display_name}
-      />
+      <div className={styles.pipette_info_block}>
+        <LabeledValue
+          label={label}
+          value={(displayName || 'None').replace(/-/, '‑')} // non breaking hyphen
+          valueClassName={styles.pipette_info_element}
+        />
+        <LabeledValue
+          label={SERIAL_NUMBER}
+          value={serialNumber || 'None'}
+          valueClassName={styles.pipette_info_element}
+        />
+      </div>
 
       <div className={styles.button_group}>
         <OutlineButton Component={Link} to={changeUrl}>

--- a/app/src/components/InstrumentSettings/styles.css
+++ b/app/src/components/InstrumentSettings/styles.css
@@ -21,7 +21,14 @@
   }
 }
 
-.pipette_display_name {
+.pipette_info_block {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.pipette_info_element {
   width: min-content;
 }
 
@@ -34,6 +41,10 @@
 .right {
   & > div {
     order: 2;
+  }
+
+  & > .pipette_info_block {
+    margin-left: 0.5rem;
   }
 
   & > .image {


### PR DESCRIPTION
Displays serial numbers in the pipette info page.

Closes #4730 

## Review/Testing/Risk

Look it over, this is a display-only change so it really doesn't have any risk

One thing that's kind of ugly is poking extra margin in for the info labels in the right-mount less thing. It's necessary because the serial numbers are long and don't get linebroken, so without that margin a lot of reasonable app sizes will result in no margin between the pipette diagram and the text; but if you put that margin on generally, the text for the left pipette doesn't line up with the Pipettes title in a weird way.