### PR TITLE
chore(api): add util to plot session state machines

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -173,3 +173,7 @@ deploy: wheel
 .PHONY: term
 term:
 	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host)
+
+.PHONY: plot-session
+plot-session:
+	$(python) util/plot_session.py calibration_check calibration_check.pdf

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -25,6 +25,7 @@ twine = "==2.0.0"
 typing-extensions = "*"
 wheel = "==0.30.0"
 "e1839a8" = {editable = true, path = "."}
+graphviz = "*"
 
 [packages]
 aiohttp = "==3.4.4"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9885184e1e180327642bd5d22997c4459a2b1405e77f2e0ab873fbf6b2978ddb"
+            "sha256": "0159d23270003bf0932bcfe9695406af4fbe2f76ed7b1afd42e6d70170af59e6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -110,25 +110,25 @@
         },
         "multidict": {
             "hashes": [
-                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
-                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
-                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
-                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
-                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
-                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
-                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
-                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
-                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
-                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
-                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
-                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
-                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
-                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
-                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
-                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
-                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
+                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
+                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
+                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
+                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
+                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
+                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
+                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
+                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
+                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
+                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
+                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
+                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
+                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
+                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
+                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
+                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
-            "version": "==4.7.5"
+            "version": "==4.7.6"
         },
         "numpy": {
             "hashes": [
@@ -302,12 +302,12 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
             ],
             "index": "pypi",
             "markers": "sys_platform == 'win32'",
-            "version": "==1.3.0"
+            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -325,10 +325,10 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:cc8da25076a1fe56c3ac63671e2194458e0c4d9c7becfd52ca251650d517903c",
-                "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"
+                "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f",
+                "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
             ],
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "certifi": {
             "hashes": [
@@ -414,6 +414,14 @@
             "editable": true,
             "path": "."
         },
+        "graphviz": {
+            "hashes": [
+                "sha256:cb0e878f90378489f17aab140b68e64e44b79e4cb59a530c8863d84bf2e2e5f5",
+                "sha256:e104ba036c8aef84320ec80560e544cd3cad68c9f90394b4e2b87bc44ab09791"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
+        },
         "idna": {
             "hashes": [
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
@@ -498,32 +506,32 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+                "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
+                "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
-            "version": "==8.2.0"
+            "version": "==8.3.0"
         },
         "multidict": {
             "hashes": [
-                "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
-                "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35",
-                "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928",
-                "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969",
-                "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e",
-                "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78",
-                "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1",
-                "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136",
-                "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8",
-                "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2",
-                "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e",
-                "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4",
-                "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5",
-                "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd",
-                "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab",
-                "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20",
-                "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"
+                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
+                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
+                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
+                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
+                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
+                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
+                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
+                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
+                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
+                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
+                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
+                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
+                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
+                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
+                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
+                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
+                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
             ],
-            "version": "==4.7.5"
+            "version": "==4.7.6"
         },
         "mypy": {
             "hashes": [
@@ -604,10 +612,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "pkginfo": {
             "hashes": [
@@ -632,10 +640,10 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pydocstyle": {
             "hashes": [
@@ -714,10 +722,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
-            "version": "==2019.3"
+            "version": "==2020.1"
         },
         "pyyaml": {
             "hashes": [
@@ -737,10 +745,10 @@
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:1b6d8dd1673a0b293766b4106af766b6eff3654605f9c4f239e65de6076bc222",
-                "sha256:e67d64242f0174a63c3b727801a2fff4c1f38ebe5d71d95ff7ece081945a6cd4"
+                "sha256:cbe9db71defedd2428a1589cdc545f9bd98e59297449f69d721ef8f1cfced68d",
+                "sha256:cc4957a803106e820d05d14f71033092537a22daa4f406dfbdd61177e0936376"
             ],
-            "version": "==25.0"
+            "version": "==26.0"
         },
         "requests": {
             "hashes": [
@@ -822,10 +830,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:00339634a22c10a7a22476ee946bbde2dbe48d042ded784e4d88e0236eca5d81",
-                "sha256:ea9e3fd6bd9a37e8783d75bfc4c1faf3c6813da6bd1c3e776488b41ec683af94"
+                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
+                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
             ],
-            "version": "==4.45.0"
+            "version": "==4.46.0"
         },
         "twine": {
             "hashes": [

--- a/api/src/opentrons/legacy_api/containers/placeable.py
+++ b/api/src/opentrons/legacy_api/containers/placeable.py
@@ -45,7 +45,7 @@ def location_to_list(loc):
         else:
             loc = [
                 unpack_location(l)[0]
-                for l in loc
+                for l in loc  # noqa(E741)
             ]
 
     if isinstance(loc, WellSeries):

--- a/api/src/opentrons/protocol_api/transfers.py
+++ b/api/src/opentrons/protocol_api/transfers.py
@@ -578,7 +578,7 @@ class TransferPlan:
         yield from self._new_tip_action()
 
     Target = TypeVar('Target')
-    @staticmethod
+    @staticmethod  # noqa(E301)
     def _expand_for_volume_constraints(
             volumes: Iterator[float],
             targets: Iterator[Target],

--- a/api/src/opentrons/server/rpc.py
+++ b/api/src/opentrons/server/rpc.py
@@ -285,7 +285,7 @@ class RPCServer(object):
             try:
                 line_msg = ' [line ' + [
                     l.split(',')[0].strip()
-                    for l in trace.split('line')
+                    for l in trace.split('line')  # noqa(E741)
                     if '<module>' in l][0] + ']'
             except Exception:
                 line_msg = ''

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -368,7 +368,7 @@ def format_runlog(runlog: List[Mapping[str, Any]]) -> str:
             to_ret.extend(
                 ['\t' * command['level']
                  + f'{l.levelname} ({l.module}): {l.msg}' % l.args
-                 for l in command['logs']])
+                 for l in command['logs']])  # noqa(E741)
     return '\n'.join(to_ret)
 
 

--- a/api/src/opentrons/tools/factory_test.py
+++ b/api/src/opentrons/tools/factory_test.py
@@ -31,7 +31,7 @@ def _find_storage_device():
     if os.path.ismount(USB_MOUNT_FILEPATH) is False:
         sdn1_devices = [
             '/dev/sd{}1'.format(l)
-            for l in 'abcdefgh'
+            for l in 'abcdefgh'  # noqa(E741)
             if os.path.exists('/dev/sd{}1'.format(l))
         ]
         if len(sdn1_devices) == 0:

--- a/api/tests/opentrons/protocol_api/test_execute_v4.py
+++ b/api/tests/opentrons/protocol_api/test_execute_v4.py
@@ -21,6 +21,7 @@ from opentrons.protocol_api import MagneticModuleContext, \
     ProtocolContext, execute
 from opentrons.protocol_api.constants import JsonCommand
 
+
 # autouse set to True to setup/teardown mock after each run
 @pytest.fixture(autouse=True)
 def mockObj():

--- a/api/util/plot_session.py
+++ b/api/util/plot_session.py
@@ -1,0 +1,78 @@
+import argparse
+from typing import Dict
+
+import graphviz as gv
+
+from opentrons.server.endpoints import calibration
+
+
+def build_calibration_check_plot(
+        wildcard_separate: bool,
+        plot_actions: bool) -> gv.Digraph:
+    d = gv.Digraph('Calibration Check Session')
+    for state in calibration.session.CalibrationCheckState:
+        d.node(state.name, state.value)
+    all_states = [s.name for s in calibration.session.CalibrationCheckState]
+    if wildcard_separate:
+        d.node('*', 'wildcard')
+    for edgespec in calibration.session.CHECK_TRANSITIONS:
+        fs = edgespec['from_state']
+        if isinstance(fs, calibration.session.CalibrationCheckState):
+            fs_s = [fs.name]
+        elif wildcard_separate:
+            fs_s = [fs]
+        else:
+            fs_s = all_states
+        ts = edgespec['to_state']
+
+        kws: Dict[str, str] = {}
+        if plot_actions:
+            if edgespec.get('before'):
+                kws['before'] = edgespec['before']
+            if edgespec.get('after'):
+                kws['after'] = edgespec['after']
+        label = r'\n'.join([edgespec['trigger'].name]
+                           + [rf'{k}: {v}' for k, v in kws.items()])
+        for f in fs_s:
+            d.edge(f, ts, label=label)
+    return d
+
+
+def build_argparser(
+        parent: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
+    if not parent:
+        parent = argparse.ArgumentParser(
+            description='Build plots of sessions')
+    parent.add_argument('session', metavar='SESSION',
+                        choices=['calibration_check'],
+                        help='The session to check')
+    parent.add_argument('output', metavar='OUTFILE',
+                        type=argparse.FileType('wb'),
+                        default='session.pdf',
+                        nargs='?',
+                        help='Where to store the file')
+    parent.add_argument(
+        '-w', '--wildcard-integrated',
+        action='store_true',
+        help='Integrate wildcard-based edges into the graph. This will give '
+             'a better idea of the true shape but can be very hard to read.')
+    parent.add_argument(
+        '-a', '--actions',
+        action='store_true',
+        help='Add labels for before/after actions to edges'
+    )
+    parent.add_argument(
+        '-f', '--format',
+        type=str,
+        default='pdf',
+        help='Select output format (one of https://www.graphviz.org/doc/info/output.html)')
+    return parent
+
+if __name__ == '__main__':
+    parser = build_argparser()
+    args = parser.parse_args()
+    if args.session == 'calibration_check':
+        graph = build_calibration_check_plot(not args.wildcard_integrated,
+                                             args.actions)
+        graph.format = args.format
+        args.output.write(graph.pipe())


### PR DESCRIPTION
This will parse the calibration check session (and eventually later
sessions) and produce a nice pdf graph if you have graphviz installed.
This can be useful for, for instance, noticing if there's a state that's
never used because it has no edge (hint hint).

To use, update your pipenv and install graphviz from somewhere (on
linux, your package manager; on OSX, homebrew; on windows, who knows)
and make sure its `dot` utility is on your path.

Example:
![calibration_check](https://user-images.githubusercontent.com/3091648/82492036-8df9c000-9ab3-11ea-91a5-b260db17e722.png)
