### PR TITLE
fix(app): fix send check session command without params

### DIFF
--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -140,7 +140,7 @@ export function CheckCalibration(props: CheckCalibrationProps) {
 
   function sendCommand(
     command: SessionCommandString,
-    data: SessionCommandData = {}
+    data: SessionCommandData | null = null
   ) {
     robotCalCheckSession.id &&
       dispatchRequest(

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -35,7 +35,7 @@ export type SessionCommandString = $Values<typeof Calibration.checkCommands>
 
 // TODO(al, 2020-05-11): data should be properly typed with all
 // known command types
-export type SessionCommandData = { ... }
+export type SessionCommandData = { ... } | null
 
 export type Session = {|
   id: string,


### PR DESCRIPTION
## overview

Small fix to the default parameter sent to the the session command endpoint in the case that there are no parameters to pass, we shouldn't pass a `data: {}` key into the body.

This was causing all calls to `sendCommand` from `app/src/components/CheckCalibration/index.js` to fail if no parameters were passed into the session command. The api actually expects no data key at all, if there are no command arguments.

## risk assessment
 minimal, still behind a feature flag, very small fix
