### PR TITLE
fix(robot-server): session commands with empty data field should be accepted

### DIFF
--- a/robot-server/robot_server/service/models/__init__.py
+++ b/robot-server/robot_server/service/models/__init__.py
@@ -4,3 +4,7 @@ from pydantic import BaseModel, Field
 class V1BasicResponse(BaseModel):
     """A response with a human readable message"""
     message: str = Field(..., description="A human-readable message")
+
+
+class EmptyModel(BaseModel):
+    pass

--- a/robot-server/robot_server/service/models/session.py
+++ b/robot-server/robot_server/service/models/session.py
@@ -6,6 +6,8 @@ from opentrons.server.endpoints.calibration import \
     models as calibration_models
 from opentrons.server.endpoints.calibration.session import \
     CalibrationCheckTrigger
+
+from robot_server.service.models import EmptyModel
 from robot_server.service.models.json_api.response import ResponseDataModel,\
     ResponseModel
 from robot_server.service.models.json_api.request import RequestDataModel,\
@@ -29,7 +31,7 @@ class SessionCommands(str, Enum):
     exit = CalibrationCheckTrigger.exit.value
     reject_calibration = CalibrationCheckTrigger.reject_calibration.value
 
-    def __new__(cls, value, model=type(None)):
+    def __new__(cls, value, model=EmptyModel):
         """Create a string enum with the expected model"""
         obj = str.__new__(cls, value)
         obj._value_ = value
@@ -42,8 +44,8 @@ class SessionCommands(str, Enum):
 
 
 SessionCommandTypes = typing.Union[
-    None,
     calibration_models.JogPosition,
+    EmptyModel
 ]
 
 

--- a/robot-server/tests/service/models/test_session.py
+++ b/robot-server/tests/service/models/test_session.py
@@ -1,0 +1,23 @@
+import pytest
+from robot_server.service.models import session
+
+
+def test_command_type_validation_jog():
+    c = session.SessionCommand(**{'command': session.SessionCommands.jog,
+                                  'data': {'vector': [1, 2, 3]}})
+    assert c.data == session.calibration_models.JogPosition(vector=(1, 2, 3,))
+
+
+def test_command_type_validation_jog_fail():
+    with pytest.raises(ValueError):
+        session.SessionCommand(**{'command': session.SessionCommands.jog,
+                                  'data': {}})
+
+
+def test_command_type_empty():
+    """Test that we create command correctly for
+     commands that have no added data."""
+    c = session.SessionCommand(
+        **{'command': session.SessionCommands.prepare_pipette,
+           'data': {}})
+    assert c.data == session.EmptyModel()

--- a/robot-server/tests/service/routers/test_session.py
+++ b/robot-server/tests/service/routers/test_session.py
@@ -309,7 +309,7 @@ def command(command_type: str, body: typing.Optional[BaseModel]):
             "type": "SessionCommand",
             "attributes": {
                 "command": command_type,
-                "data": body.dict(exclude_unset=True) if body else None
+                "data": body.dict(exclude_unset=True) if body else {}
             }
         }
     }
@@ -386,7 +386,7 @@ def test_session_command_create_no_body(api_client,
         'data': {
             'attributes': {
                 'command': 'loadLabware',
-                'data': None,
+                'data': {},
                 'status': 'accepted'
             },
             'type': 'SessionCommand',


### PR DESCRIPTION
## overview

Session command data is mandatory. Should be an empty dict for commands that have no added data.

## changelog

Added EmptyModel as last entry in command type union. This is the default type for commands which have no added attributes in their `data` field. 

## review requests


## risk assessment

Bug fix