### PR TITLE
fix(api): Fix determine thresholds function

### DIFF
--- a/api/src/opentrons/server/endpoints/calibration/helper_classes.py
+++ b/api/src/opentrons/server/endpoints/calibration/helper_classes.py
@@ -53,6 +53,9 @@ class DeckCalibrationError(Enum):
     BAD_INSTRUMENT_OFFSET = auto()
     BAD_DECK_TRANSFORM = auto()
 
+    def __str__(self):
+        return self.name
+
 
 class PipetteRank(str, Enum):
     """The rank in the order of pipettes to use within flow"""

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -705,7 +705,11 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             template_dict['vector'] = [0, 0, 0]
         return template_dict
 
-    def _determine_threshold(self, state: CalibrationCheckState):
+    def _determine_threshold(self, state: CalibrationCheckState) -> Point:
+        """
+        Helper function used to determine the threshold for comparison
+        based on the state currently being compared and the pipette.
+        """
         first_pipette = [
             CalibrationCheckState.comparingFirstPipetteHeight,
             CalibrationCheckState.comparingFirstPipettePointOne,

--- a/api/src/opentrons/server/endpoints/calibration/session.py
+++ b/api/src/opentrons/server/endpoints/calibration/session.py
@@ -705,14 +705,14 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             template_dict['vector'] = [0, 0, 0]
         return template_dict
 
-    def _determine_threshold(self):
+    def _determine_threshold(self, state: CalibrationCheckState):
         first_pipette = [
-            CalibrationCheckState.joggingFirstPipetteToHeight,
-            CalibrationCheckState.joggingFirstPipetteToPointOne,
-            CalibrationCheckState.joggingFirstPipetteToPointTwo,
-            CalibrationCheckState.joggingFirstPipetteToPointThree,
+            CalibrationCheckState.comparingFirstPipetteHeight,
+            CalibrationCheckState.comparingFirstPipettePointOne,
+            CalibrationCheckState.comparingFirstPipettePointTwo,
+            CalibrationCheckState.comparingFirstPipettePointThree,
         ]
-        if self.current_state_name in first_pipette:
+        if state in first_pipette:
             pip = self._get_pipette_by_rank(PipetteRank.first)
         else:
             pip = self._get_pipette_by_rank(PipetteRank.second)
@@ -722,19 +722,19 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             pipette_type = str(self.pipettes[pip.mount]['model'])
         is_p1000 = pipette_type.startswith('p1000')
         height_states = [
-            CalibrationCheckState.joggingFirstPipetteToHeight,
-            CalibrationCheckState.joggingSecondPipetteToHeight]
+            CalibrationCheckState.comparingFirstPipetteHeight,
+            CalibrationCheckState.comparingSecondPipetteHeight]
         cross_states = [
-            CalibrationCheckState.joggingFirstPipetteToPointOne,
-            CalibrationCheckState.joggingFirstPipetteToPointTwo,
-            CalibrationCheckState.joggingFirstPipetteToPointThree,
-            CalibrationCheckState.joggingSecondPipetteToPointOne
+            CalibrationCheckState.comparingFirstPipettePointOne,
+            CalibrationCheckState.comparingFirstPipettePointTwo,
+            CalibrationCheckState.comparingFirstPipettePointThree,
+            CalibrationCheckState.comparingSecondPipettePointOne
         ]
-        if is_p1000 and self.current_state_name in cross_states:
+        if is_p1000 and state in cross_states:
             return Point(2.7, 2.7, 0.0)
-        elif is_p1000 and self.current_state_name in height_states:
+        elif is_p1000 and state in height_states:
             return Point(0.0, 0.0, 1)
-        elif self.current_state_name in cross_states:
+        elif state in cross_states:
             return Point(1.79, 1.64, 0.0)
         else:
             return Point(0.0, 0.0, 0.8)
@@ -750,7 +750,7 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             jogged_pt = self._saved_points.get(getattr(CalibrationCheckState,
                                                        jogged_state), None)
 
-            threshold_vector = self._determine_threshold()
+            threshold_vector = self._determine_threshold(jogged_state)
             if (ref_pt is not None and jogged_pt is not None):
                 diff_magnitude = None
                 if threshold_vector.z == 0.0:


### PR DESCRIPTION
## overview
@b-cooper found some bugs in the determine threshold function such that it was only ever incorrectly returning the Z height vector.

## changelog
- Ensure that the deck calibration transform error is returning its name rather than value when cast as a string
- Use the correct state name to check against for a given threshold vector
- Pass in the state name rather than using the current state name, as the function that calls this method is manually checking states.

## review requests

Check that everything looks fine, test on a robot if you have time.

## risk assessment
Just some small fixups, should not outright change the behavior but it would be good to test on a robot nonetheless
