### PR TITLE
fix(api): proper hardware controller teardown

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1662,3 +1662,7 @@ class API(HardwareAPILike):
             self._config.gantry_calibration,
             (0, 0, max_height))
         return transformed_z
+
+    def clean_up(self):
+        """ Get the API ready to stop cleanly. """
+        self._backend.clean_up()

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -290,3 +290,6 @@ class Simulator:
     def probe(self, axis: str, distance: float) -> Dict[str, float]:
         self._position[axis.upper()] = self._position[axis.upper()] + distance
         return self._position
+
+    def clean_up(self):
+        pass

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -11,8 +11,7 @@ mod_log = logging.getLogger(__name__)
 
 def _handle_loop_exception(loop: asyncio.AbstractEventLoop,
                            context: Dict[str, Any]):
-    mod_log.error(f"Caught exception: {context['exception']}:"
-                  f" {context['message']}")
+    mod_log.error(f"Caught exception: {context}")
 
 
 def use_or_initialize_loop(loop: Optional[asyncio.AbstractEventLoop]


### PR DESCRIPTION
opentrons_execute was printing an exception when it stopped, because we
weren't properly tearing down the module watcher and were relying on the
interpreter to do so - not great. We now explicitly tear down the
hardware control stack.

When we tear down the hardware controller, we cancel some running tasks.
When you cancel a running task, it pends a CancelledException, but the
task needs to execute on the next loop spin, so we need to spin the
loop. This is the complex annoying logic in
thread_manager.__getattribute__.

Closes #5728

## Testing

Run opentrons_execute and make sure you don't get an exception at the end, and it doesn't hang. Run opentrons_simulate and make sure it doesn't hang. 

## Risk Assessment

Low - the above cases are the only times we actually do teardowns.