### PR TITLE
fix(protocol-designer): Add scroll to top on export modal display

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -223,6 +223,11 @@ export function FileSidebar(props: Props) {
     },
   })
 
+  const scrollToTop = () => {
+    const editPage = document.getElementById('main-page')
+    if (editPage) editPage.scrollTop = 0
+  }
+
   return (
     <>
       {blockingV4ExportHint}
@@ -271,8 +276,10 @@ export function FileSidebar(props: Props) {
             <PrimaryButton
               onClick={() => {
                 if (hasWarning) {
+                  scrollToTop()
                   setShowExportWarningModal(true)
                 } else if (isV4Protocol) {
+                  scrollToTop()
                   setShowV4ExportWarning(true)
                 } else {
                   saveFile(downloadData)


### PR DESCRIPTION
## overview

closes #5422 by adding a scrollTo Top function on export file button click. 

## changelog

- fix(protocol-designer): Add scroll to top on export modal display

## review requests

scroll to top should work on:

- [ ] protocol has no steps modal
- [ ] unused pipettes or modules modal
- [ ] v4 export modal

## risk assessment

Low. PD bug fix.
