### PR TITLE
feat(protocol-designer): Add ending hold state fields to TC profile

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.js
@@ -10,9 +10,18 @@ import styles from '../../StepEditForm.css'
 
 import type { FocusHandlers } from '../../types'
 
-type Props = {| focusHandlers: FocusHandlers |}
+type Props = {| focusHandlers: FocusHandlers, isEndingHold?: boolean |}
+
 export const StateFields = (props: Props) => {
-  const { focusHandlers } = props
+  const { focusHandlers, isEndingHold } = props
+
+  // Append 'Hold' to field names if component is used for an ending hold in a TC profile
+  const blockActiveName = isEndingHold ? 'blockIsActiveHold' : 'blockIsActive'
+  const blockTempName = isEndingHold ? 'blockTargetTempHold' : 'blockTargetTemp'
+  const lidActiveName = isEndingHold ? 'lidIsActiveHold' : 'lidIsActive'
+  const lidTempName = isEndingHold ? 'lidTargetTempHold' : 'lidTargetTemp'
+  const lidOpenName = isEndingHold ? 'lidOpenHold' : 'lidOpen'
+
   return (
     <div className={styles.form_row}>
       <FormGroup
@@ -23,7 +32,7 @@ export const StateFields = (props: Props) => {
       >
         <div className={styles.toggle_row}>
           <ToggleRowField
-            name="blockIsActive"
+            name={blockActiveName}
             offLabel={i18n.t(
               'form.step_edit_form.field.thermocyclerState.block.toggleOff'
             )}
@@ -32,11 +41,11 @@ export const StateFields = (props: Props) => {
             )}
           />
           <ConditionalOnField
-            name={'blockIsActive'}
+            name={blockActiveName}
             condition={val => val === true}
           >
             <TextField
-              name="blockTargetTemp"
+              name={blockTempName}
               className={cx(
                 styles.small_field,
                 styles.toggle_temperature_field
@@ -54,7 +63,7 @@ export const StateFields = (props: Props) => {
       >
         <div className={styles.toggle_row}>
           <ToggleRowField
-            name="lidIsActive"
+            name={lidActiveName}
             offLabel={i18n.t(
               'form.step_edit_form.field.thermocyclerState.lid.toggleOff'
             )}
@@ -63,11 +72,11 @@ export const StateFields = (props: Props) => {
             )}
           />
           <ConditionalOnField
-            name={'lidIsActive'}
+            name={lidActiveName}
             condition={val => val === true}
           >
             <TextField
-              name="lidTargetTemp"
+              name={lidTempName}
               className={cx(
                 styles.small_field,
                 styles.toggle_temperature_field
@@ -86,7 +95,7 @@ export const StateFields = (props: Props) => {
         className={styles.toggle_form_group}
       >
         <ToggleRowField
-          name="lidOpen"
+          name={lidOpenName}
           offLabel={i18n.t(
             'form.step_edit_form.field.thermocyclerState.lidPosition.toggleOff'
           )}

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import cx from 'classnames'
 
 import { i18n } from '../../../../localization'
 import {
@@ -49,7 +48,7 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
 
         <RadioGroupField
           name="thermocyclerFormType"
-          className={cx(styles.tc_step_option, styles.disabled)}
+          className={styles.tc_step_option}
           options={[
             {
               name: i18n.t(
@@ -61,6 +60,18 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
           {...focusHandlers}
         />
       </div>
+
+      <ConditionalOnField
+        name={'thermocyclerFormType'}
+        condition={val => val === THERMOCYCLER_PROFILE}
+      >
+        <div className={styles.section_header}>
+          <span className={styles.section_header_text}>
+            {i18n.t('application.stepType.ending_hold')}
+          </span>
+        </div>
+        <StateFields focusHandlers={focusHandlers} isEndingHold />
+      </ConditionalOnField>
     </div>
   )
 }

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -5,7 +5,8 @@
     "pause": "pause",
     "magnet": "magnet",
     "temperature": "temperature",
-    "thermocycler": "thermocycler"
+    "thermocycler": "thermocycler",
+    "ending_hold": "ending hold"
   },
   "units": {
     "millimeter": "mm",


### PR DESCRIPTION
## overview

Closes #5519 by refactoring the `StateFields` component to conditionally change field names based on `isEndingHold` prop.

<img width="938" alt="Screen Shot 2020-05-27 at 3 51 00 PM" src="https://user-images.githubusercontent.com/3430313/83065728-f4418e00-a031-11ea-800c-20ca39e1dcfe.png">


## changelog

- refactor(protocol-designer): Add isEndingHold prop to StateFields
- feat(protocol-designer): Add ending hold state fields to TC profile

## review requests

Make a TC protocol
Add a TC state step
- [ ] Form still saves and expected
- [ ] Field names are correct
Add a TC profile step
- [ ] Ending Hold section renders
- [ ] Field names have `Hold` appended 

_Note: Since this is at the end of a TC profile, prepopulating these form fields with previously saved values does not seem relevant_

## risk assessment

Low PD hidden feature