### PR TITLE
chore: refactor python makefiles

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,5 +1,8 @@
 # opentrons api makefile
 
+include ../scripts/push.mk
+include ../scripts/python.mk
+
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
 
@@ -13,21 +16,13 @@ SHX := npx shx
 firmware = $(wildcard smoothie/*.hex)
 
 # python and pipenv config
-pipenv_envvars := $(and $(CI),PIPENV_IGNORE_VIRTUALENVS=1)
-python := $(pipenv_envvars) pipenv run python
-pip := $(pipenv_envvars) pipenv run pip
-pytest := $(pipenv_envvars) pipenv run py.test
 sphinx_build := $(pipenv_envvars) pipenv run sphinx-build
-pipenv_opts := --dev
-pipenv_opts += $(and $(CI),--keep-outdated --clear)
-wheel_opts := $(if $(or $(CI),$(V),$(VERBOSE)),,-q)
 
 
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-wheel_file = dist/opentrons-$(shell $(python) ../scripts/python_build_utils.py api normalize_version)-py2.py3-none-any.whl
-wheel_pattern := dist/opentrons-%-py2.py3-none-any.whl
+wheel_file = dist/$(call python_get_wheelname,api,opentrons)
 
 # These variables are for simulating python protocols
 sim_log_level ?= info
@@ -46,11 +41,11 @@ pypi_username ?=
 pypi_password ?=
 
 # Host key location for buildroot robot
-br_ssh_key ?= ~/.ssh/robot_key
+br_ssh_key ?= $(default_ssh_key)
 # Pubkey location for buildroot robot to install with install-key
 br_ssh_pubkey ?= $(br_ssh_key).pub
 # Other SSH args for buildroot robots
-ssh_opts ?= -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
+ssh_opts ?= $(default_ssh_opts)
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 
@@ -85,7 +80,7 @@ clean: docs-clean
 uninstall:
 	$(pipenv_envvars)	pipenv --rm
 
-$(wheel_pattern): setup.py $(ot_sources)
+dist/opentrons-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(clean_cmd)
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build
@@ -142,17 +137,11 @@ local-shell:
 
 .PHONY: push-no-restart
 push-no-restart: wheel
-	scp -i $(br_ssh_key) $(ssh_opts) $(wheel_file) root@$(host):/data/
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/opentrons*.whl && mount -o remount,ro / ; } ;\
-mount -o remount,rw / &&\
-cd /usr/lib/python3.7/site-packages &&\
-unzip -o /data/opentrons-*.whl && cleanup || cleanup"
+	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
 
 .PHONY: push
 push: push-no-restart
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
-"systemctl restart jupyter-notebook && systemctl restart opentrons-robot-server"
+	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),"jupyter-notebook opentrons-robot-server")
 
 .PHONY: simulate
 simulate:

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -1,5 +1,8 @@
 # opentrons robot server makefile
 
+include ../scripts/push.mk
+include ../scripts/python.mk
+
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
 
@@ -12,20 +15,10 @@ SHX := npx shx
 # Path of source package
 SRC_PATH = robot_server
 
-# python and pipenv config
-pipenv_envvars := $(and $(CI),PIPENV_IGNORE_VIRTUALENVS=1)
-python := $(pipenv_envvars) pipenv run python
-pip := $(pipenv_envvars) pipenv run pip
-pytest := $(pipenv_envvars) pipenv run py.test
-pipenv_opts := --dev
-pipenv_opts += $(and $(CI),--keep-outdated --clear)
-wheel_opts := $(if $(or $(CI),$(V),$(VERBOSE)),,-q)
-
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-wheel_file = dist/robotserver-$(shell $(python) ../scripts/python_build_utils.py robot-server normalize_version)-py2.py3-none-any.whl
-wheel_pattern := dist/robotserver-%-py2.py3-none-any.whl
+wheel_file = dist/$(call python_get_wheelname,robot-server,robotserver)
 
 
 # These variables can be overriden when make is invoked to customize the
@@ -36,11 +29,11 @@ tests ?= tests
 test_opts ?=  --cov=$(SRC_PATH) --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 
 # Host key location for buildroot robot
-br_ssh_key ?= ~/.ssh/robot_key
+br_ssh_key ?= $(default_ssh_key)
 # Pubkey location for buildroot robot to install with install-key
 br_ssh_pubkey ?= $(br_ssh_key).pub
 # Other SSH args for buildroot robots
-ssh_opts ?= -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
+ssh_opts ?= $(default_ssh_opts)
 
 # Source discovery
 # For the python sources
@@ -67,7 +60,7 @@ clean:
 uninstall:
 	$(pipenv_envvars)	pipenv --rm
 
-$(wheel_pattern): setup.py $(ot_sources)
+dist/robotserver-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(clean_cmd)
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build
@@ -95,15 +88,9 @@ local-shell:
 
 .PHONY: push
 push: wheel
-	scp -i $(br_ssh_key) $(ssh_opts) $(wheel_file) root@$(host):/data/
-	scp -i $(br_ssh_key) $(ssh_opts) ./opentrons-robot-server.service root@$(host):/data/
-	ssh -i $(br_ssh_key) $(ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/robotserver*.whl && mount -o remount,ro / && systemctl daemon-reload && systemctl start opentrons-robot-server; } ;\
-systemctl stop opentrons-robot-server &&\
-mount -o remount,rw / &&\
-cp /data/opentrons-robot-server.service /etc/systemd/system/ &&\
-cd /usr/lib/python3.7/site-packages &&\
-unzip -o /data/robotserver*.whl && cleanup || cleanup"
+	$(call push-python-package,$(host),$(br_ssh_key),$(ssh_opts),$(wheel_file))
+	$(call push-systemd-unit,$(host),$(br_ssh_key),$(ssh_opts),./opentrons-robot-server.service)
+	$(call restart-service,$(host),$(br_ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: install-key
 install-key:

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -1,0 +1,45 @@
+# utilities for pushing things to robots in a reusable fashion
+
+find_robot=$(shell yarn run -s discovery find -i 169.254 fd00 -c "[fd00:0:cafe:fefe::1]")
+default_ssh_key := ~/.ssh/robot_key
+default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
+
+# push-command: execute a push to the robot of a particular python
+# package.
+#
+# argument 1 is the host to push to
+# argument 2 is the identity key to use
+# argument 3 is any further ssh options, quoted
+# argument 4 is the path to the wheel file
+
+define push-python-package
+scp -i $(2) $(3) "$(4)" root@$(1):/data/$(notdir $(4))
+ssh -i $(2) $(3) root@$(1) \
+"function cleanup () { rm -f /data/$(notdir $(4)) && mount -o remount,ro / ; } ;\
+mount -o remount,rw / &&\
+cd /usr/lib/python3.7/site-packages &&\
+unzip -o /data/$(notdir $(4)) && cleanup || cleanup"
+endef
+
+# restart-service: ssh to a robot and restart one of its systemd units
+#
+# argument 1 is the host to push to
+# argument 2 is the identity key to use
+# argument 3 is any further ssh options, quoted
+# argument 4 is the service name
+
+define restart-service
+ssh -i "$(2)" $(3)  root@$(1) \
+"systemctl restart $(4)"
+endef
+
+# push-systemd-unit: move a systemd unit file to the robot
+# 
+# argument 1 is the host to push to
+# argument 2 is the identity key to use
+# argument 3 is any further ssh options, quoted
+# argument 4 is the unit file path
+define push-systemd-unit
+	scp -i $(2) $(3) "$(4)" root@$(1):/data/
+	ssh -i $(2) $(3) root@$(1) "mv /data/$(notdir $(4)) /etc/systemd/system/ && systemctl daemon-reload"
+endef

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -1,0 +1,23 @@
+pipenv_envvars := $(and $(CI),PIPENV_IGNORE_VIRTUALENVS=1)
+python := $(pipenv_envvars) pipenv run python
+pip := $(pipenv_envvars) pipenv run pip
+pytest := $(pipenv_envvars) pipenv run py.test
+
+pipenv_opts := --dev
+pipenv_opts += $(and $(CI),--keep-outdated --clear)
+wheel_opts := $(if $(or $(CI),$(V),$(VERBOSE)),,-q)
+
+# get the python package version
+# (evaluates to that string)
+# paramter 1: name of the project (aka api, robot-server, etc)
+define python_package_version
+$(shell $(python) ../scripts/python_build_utils.py $(1) normalize_version)
+endef
+
+
+# get the name of the wheel that setup.py will build
+# parameter 1: the name of the project (aka api, robot-server, etc)
+# parameter 2: the name of the python package (aka opentrons, robot_server, etc)
+define python_get_wheelname
+$(2)-$(call python_package_version,$(1))-py2.py3-none-any.whl
+endef

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,4 +1,7 @@
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
+include ../scripts/push.mk
+include ../scripts/python.mk
+
 SHELL := bash
 
 PATH := $(shell cd .. && yarn bin):$(PATH)
@@ -7,24 +10,16 @@ SHX := npx shx
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
 PATH := $(shell cd .. && yarn bin):$(PATH)
 
-pipenv_envvars := $(and $(CI),PIPENV_IGNORE_VIRTUALENVS=1)
-python := $(pipenv_envvars) pipenv run python
-pipenv_opts := --dev
-pipenv_opts += $(and $(CI),--keep-outdated)
 
 port ?= 34000
 tests ?= tests
 test_opts ?=
-wheel_file = dist/*.whl
+wheel_file = $(python_get_wheelname,update-server,otupdate)
 # Host key location for buildroot robot
-br_ssh_key ?= ~/.ssh/robot_key
+br_ssh_key ?= $(default_ssh_key)
 # Other SSH args for buildroot robots
-br_ssh_opts ?= -o stricthostkeychecking=no
-# Host key for push-key uploading
-pubkey ?= br_ssh_key
+br_ssh_opts ?= $(default_ssh_opts)
 
-# make bootstrap wheel file (= rather than := to expand at every use)
-wheel_file = $(wildcard dist/otupdate-*.whl)
 
 .PHONY: install
 install:
@@ -74,12 +69,6 @@ restart:
 
 .PHONY: push
 push: wheel
-	scp -i $(br_ssh_key) $(br_ssh_opts) $(wheel_file) root@$(host):/data/
-	scp -i $(br_ssh_key) $(br_ssh_opts) ./opentrons-update-server.service root@$(host):/data/
-	ssh -i $(br_ssh_key) $(br_ssh_opts) root@$(host) \
-"function cleanup () { rm -f /data/otupdate*.whl && mount -o remount,ro / && systemctl daemon-reload && systemctl start opentrons-update-server; } ;\
-systemctl stop opentrons-update-server &&\
-mount -o remount,rw / &&\
-cp /data/opentrons-update-server.service /etc/systemd/system/ &&\
-cd /usr/lib/python3.7/site-packages &&\
-unzip -o /data/otupdate-*.whl && cleanup || cleanup"
+	$(call push-python-package,$(host),$(br_ssh_key),$(br_ssh_opts),$(wheel_file))
+	$(call push-systemd-unit,$(host),$(br_ssh_key),$(br_ssh_opts),$(./opentrons-update-server.service))
+	$(call restart-service,$(host),$(br_ssh_key),$(br_ssh_opts),opentrons-update-server)


### PR DESCRIPTION
Pull out common code from python makefiles because it's getting a bit
ridiculous.

python definitions and useful macros are in scripts/python.mk; push
stuff in push.mk

## Testing
Push some stuff, most other functionality is covered by CI