### PR TITLE
feat(protocol-designer): Add profiles settings to TC profile form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -306,3 +306,12 @@ and when that is implemented.
 .toggle_temperature_field {
   margin-top: 0.125rem;
 }
+
+.profile_settings_group {
+  margin-right: 1rem;
+}
+
+.profile_settings_lid {
+  font-size: var(--fs-body-1);
+  line-height: 2;
+}

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 
-import { i18n } from '../../../../localization'
 import { FormGroup } from '@opentrons/components'
+import { i18n } from '../../../../localization'
 import { TextField } from '../../fields'
 
 import styles from '../../StepEditForm.css'

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.js
@@ -1,0 +1,52 @@
+// @flow
+import * as React from 'react'
+
+import { i18n } from '../../../../localization'
+import { FormGroup } from '@opentrons/components'
+import { TextField } from '../../fields'
+
+import styles from '../../StepEditForm.css'
+
+import type { FocusHandlers } from '../../types'
+
+type Props = {| focusHandlers: FocusHandlers |}
+
+export const ProfileSettings = (props: Props) => {
+  const { focusHandlers } = props
+
+  return (
+    <div className={styles.form_row}>
+      <FormGroup
+        label={i18n.t('form.step_edit_form.field.thermocyclerProfile.volume')}
+        className={styles.profile_settings_group}
+      >
+        <TextField
+          name="profileVolume"
+          className={styles.small_field}
+          units={i18n.t('application.units.microliter')}
+          {...focusHandlers}
+        />
+      </FormGroup>
+      <FormGroup
+        label={i18n.t('form.step_edit_form.field.thermocyclerProfile.lid_temp')}
+        className={styles.profile_settings_group}
+      >
+        <TextField
+          name="profileTargetLidTemp"
+          className={styles.small_field}
+          units={i18n.t('application.units.degrees')}
+          {...focusHandlers}
+        />
+      </FormGroup>
+      <FormGroup
+        label={i18n.t(
+          'form.step_edit_form.field.thermocyclerProfile.lid_position'
+        )}
+      >
+        <p className={styles.profile_settings_lid}>
+          {i18n.t('form.step_edit_form.field.thermocyclerProfile.lid_closed')}
+        </p>
+      </FormGroup>
+    </div>
+  )
+}

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -13,6 +13,7 @@ import {
   RadioGroupField,
 } from '../../fields'
 import { StateFields } from './StateFields'
+import { ProfileSettings } from './ProfileSettings'
 import styles from '../../StepEditForm.css'
 
 import type { FormData } from '../../../../form-types'
@@ -62,14 +63,26 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
           ]}
           {...focusHandlers}
         />
-        <div>-----TODO BELOW-----</div>
-        <ProfileStepRows focusHandlers={focusHandlers} />
       </div>
 
       <ConditionalOnField
         name={'thermocyclerFormType'}
         condition={val => val === THERMOCYCLER_PROFILE}
       >
+        <div className={styles.section_header}>
+          <span className={styles.section_header_text}>
+            {i18n.t('application.stepType.profile_settings')}
+          </span>
+        </div>
+        <ProfileSettings focusHandlers={focusHandlers} />
+        <div className={styles.section_header}>
+          <span className={styles.section_header_text}>
+            {i18n.t('application.stepType.profile_steps')}
+          </span>
+        </div>
+        <p>
+          <ProfileStepRows focusHandlers={focusHandlers} />
+        </p>
         <div className={styles.section_header}>
           <span className={styles.section_header_text}>
             {i18n.t('application.stepType.ending_hold')}

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -6,6 +6,8 @@
     "magnet": "magnet",
     "temperature": "temperature",
     "thermocycler": "thermocycler",
+    "profile_settings": "profile settings",
+    "profile_steps": "profile steps",
     "ending_hold": "ending hold"
   },
   "units": {

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -143,6 +143,12 @@
           "toggleOff": "Closed",
           "toggleOn": "Open"
         }
+      },
+      "thermocyclerProfile": {
+        "volume": "volume",
+        "lid_temp": "lid temp",
+        "lid_position": "lid position",
+        "lid_closed": "Closed"
       }
     }
   }


### PR DESCRIPTION
## overview

This PR addresses #5513 By adding the Profile Setting fields to the TC profile form. It also wraps the WIP TC profile step work in the Profile Steps section. Stopping this PR to avoid a monster PR and tangling with other coders' work.

<img width="915" alt="Screen Shot 2020-05-29 at 9 42 33 AM" src="https://user-images.githubusercontent.com/3430313/83267347-13efc800-a192-11ea-87a8-e1c4075e4767.png">


## changelog

- feat(protocol-designer): Add profiles settings to TC profile form

## review requests

- [ ] Settings section form field names are OK
- [ ] TC step dynamic fields work as they do on edge

## risk assessment

Low. PD behind a FF