### PR TITLE
fix(api): Fix return tip behavior in check session

### DIFF
--- a/api/src/opentrons/calibration/check/models.py
+++ b/api/src/opentrons/calibration/check/models.py
@@ -4,8 +4,6 @@ from typing import Dict, Optional, List, Any, Tuple
 from functools import partial
 from pydantic import BaseModel, Field
 
-from opentrons.calibration.helper_classes import DeckCalibrationError
-
 
 OffsetVector = Tuple[float, float, float]
 
@@ -77,7 +75,7 @@ class ComparisonStatus(BaseModel):
     differenceVector: OffsetVector = OffsetVectorField()
     thresholdVector:  OffsetVector = OffsetVectorField()
     exceedsThreshold: bool
-    transformType: DeckCalibrationError
+    transformType: str
 
 
 class CalibrationSessionStatus(BaseModel):

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -717,7 +717,7 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             'cannot drop tip on second mount, pipette not present'
         state_name = CalibrationCheckState.inspectingSecondTip
         return_pt = self._saved_points[getattr(CalibrationCheckState,
-                                        state_name)]
+                                       state_name)]
         loc = Location(return_pt, None)
         await self._move(second_pip.mount, loc)
         await self._drop_tip(second_pip.mount)

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -630,9 +630,11 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         if self.current_state_name ==\
                 CalibrationCheckState.comparingFirstPipetteHeight:
             buffer = HEIGHT_SAFETY_BUFFER
+        current_point = self.hardware.gantry_position(
+            first_pip.mount, critical_point=first_pip.critical_point)
         self._saved_points[getattr(CalibrationCheckState,
                                    self.current_state_name)] = \
-            await self.hardware.gantry_position(first_pip.mount) + buffer
+            await current_point + buffer
 
     async def _register_point_second_pipette(self):
         second_pip = self._get_pipette_by_rank(PipetteRank.second)
@@ -641,9 +643,12 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         if self.current_state_name ==\
                 CalibrationCheckState.comparingSecondPipetteHeight:
             buffer = HEIGHT_SAFETY_BUFFER
+        current_point = self.hardware.gantry_position(
+            second_pip.mount, critical_point=second_pip.critical_point
+        )
         self._saved_points[getattr(CalibrationCheckState,
                                    self.current_state_name)] = \
-            await self.hardware.gantry_position(second_pip.mount) + buffer
+            await current_point + buffer
 
     async def _move_first_pipette(self):
         first_pip = self._get_pipette_by_rank(PipetteRank.first)

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -102,7 +102,6 @@ CHECK_TRANSITIONS: typing.List[typing.Dict[str, typing.Any]] = [
         "from_state": CalibrationCheckState.inspectingFirstTip,
         "to_state": CalibrationCheckState.badCalibrationData,
         "condition": "_is_tip_pick_up_dangerous",
-        "after": "_return_first_tip"
     },
     {
         "trigger": CalibrationCheckTrigger.confirm_tip_attached,
@@ -215,7 +214,6 @@ CHECK_TRANSITIONS: typing.List[typing.Dict[str, typing.Any]] = [
         "from_state": CalibrationCheckState.inspectingSecondTip,
         "to_state": CalibrationCheckState.badCalibrationData,
         "condition": "_is_tip_pick_up_dangerous",
-        "after": "_return_second_tip"
     },
     {
         "trigger": CalibrationCheckTrigger.confirm_tip_attached,
@@ -706,8 +704,10 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         first_pip = self._get_pipette_by_rank(PipetteRank.first)
         assert first_pip, \
             'cannot drop tip on first mount, pipette not present'
-        state_name = CalibrationCheckState.preparingFirstPipette
-        loc = Location(getattr(self._moves, state_name).position, None)
+        state_name = CalibrationCheckState.inspectingFirstTip
+        return_pt = self._saved_points[getattr(CalibrationCheckState,
+                                       state_name)]
+        loc = Location(return_pt, None)
         await self._move(first_pip.mount, loc)
         await self._drop_tip(first_pip.mount)
 
@@ -715,7 +715,9 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         second_pip = self._get_pipette_by_rank(PipetteRank.second)
         assert second_pip, \
             'cannot drop tip on second mount, pipette not present'
-        state_name = CalibrationCheckState.preparingSecondPipette
-        loc = Location(getattr(self._moves, state_name).position, None)
+        state_name = CalibrationCheckState.inspectingSecondTip
+        return_pt = self._saved_points[getattr(CalibrationCheckState,
+                                        state_name)]
+        loc = Location(return_pt, None)
         await self._move(second_pip.mount, loc)
         await self._drop_tip(second_pip.mount)

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -704,10 +704,14 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         first_pip = self._get_pipette_by_rank(PipetteRank.first)
         assert first_pip, \
             'cannot drop tip on first mount, pipette not present'
+        mount = first_pip.mount
+        z_value = float(self.pipettes[mount]['tip_length']) * 0.5
         state_name = CalibrationCheckState.inspectingFirstTip
+
         return_pt = self._saved_points[getattr(CalibrationCheckState,
                                        state_name)]
-        loc = Location(return_pt, None)
+        account_for_tip = return_pt - Point(0, 0, z_value)
+        loc = Location(account_for_tip, None)
         await self._move(first_pip.mount, loc)
         await self._drop_tip(first_pip.mount)
 
@@ -715,9 +719,12 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         second_pip = self._get_pipette_by_rank(PipetteRank.second)
         assert second_pip, \
             'cannot drop tip on second mount, pipette not present'
+        mount = second_pip.mount
+        z_value = float(self.pipettes[mount]['tip_length']) * 0.5
         state_name = CalibrationCheckState.inspectingSecondTip
         return_pt = self._saved_points[getattr(CalibrationCheckState,
                                        state_name)]
-        loc = Location(return_pt, None)
+        account_for_tip = return_pt - Point(0, 0, z_value)
+        loc = Location(account_for_tip, None)
         await self._move(second_pip.mount, loc)
         await self._drop_tip(second_pip.mount)

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -620,7 +620,7 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                     ComparisonStatus(differenceVector=(jogged_pt - ref_pt),
                                      thresholdVector=threshold_vector,
                                      exceedsThreshold=exceeds,
-                                     transformType=tform_type)
+                                     transformType=str(tform_type))
         return comparisons
 
     async def _register_point_first_pipette(self):

--- a/robot-server/robot_server/service/session/session_status.py
+++ b/robot-server/robot_server/service/session/session_status.py
@@ -53,10 +53,17 @@ def _create_calibration_check_session_details(
                 version=data.version) for data in
             session.labware_status.values()
         ]
-
+    comparisons = {
+        k: calibration_models.ComparisonStatus(
+            differenceVector=v.differenceVector,
+            thresholdVector=v.thresholdVector,
+            exceedsThreshold=v.exceedsThreshold,
+            transformType=str(v.transformType)
+        )
+        for k, v in session.get_comparisons_by_step().items()}
     return calibration_models.CalibrationSessionStatus(
         instruments=instruments,
         currentStep=session.current_state_name,
-        comparisonsByStep=session.get_comparisons_by_step(),
+        comparisonsByStep=comparisons,
         labware=labware,
     )

--- a/robot-server/robot_server/service/session/session_status.py
+++ b/robot-server/robot_server/service/session/session_status.py
@@ -53,17 +53,10 @@ def _create_calibration_check_session_details(
                 version=data.version) for data in
             session.labware_status.values()
         ]
-    comparisons = {
-        k: calibration_models.ComparisonStatus(
-            differenceVector=v.differenceVector,
-            thresholdVector=v.thresholdVector,
-            exceedsThreshold=v.exceedsThreshold,
-            transformType=str(v.transformType)
-        )
-        for k, v in session.get_comparisons_by_step().items()}
+
     return calibration_models.CalibrationSessionStatus(
         instruments=instruments,
         currentStep=session.current_state_name,
-        comparisonsByStep=comparisons,
+        comparisonsByStep=session.get_comparisons_by_step(),
         labware=labware,
     )


### PR DESCRIPTION
## overview

During user tests yesterday, there appeared to be a bug in the tip handling section of bad deck calibration after tip pick up. First, the tip returned to the wrong location in the tiprack and second, the robot should actually _drop_ tip on this step.

## changelog

- Remove return tip from the bad calibration data state after picking up tip
- Fix return tip such that it returns to the jogged location for the tiprack rather than the initial location

## review requests
Check that code flow makes sense.

## risk assessment

Low. Fixing a pre-existing bug.
