### PR TITLE
fix(protocol-designer): Remove errant p tag

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -80,9 +80,9 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
             {i18n.t('application.stepType.profile_steps')}
           </span>
         </div>
-        <p>
-          <ProfileStepRows focusHandlers={focusHandlers} />
-        </p>
+
+        <ProfileStepRows focusHandlers={focusHandlers} />
+
         <div className={styles.section_header}>
           <span className={styles.section_header_text}>
             {i18n.t('application.stepType.ending_hold')}


### PR DESCRIPTION
## overview

This PR fixes a bug where I accidentally wrapped the dynamic fields in a `<p>` tag. Probably left over from placeholder text.

## changelog

- fix(protocol-designer): Remove errant p tag

## review requests

- [ ] No more console errors in TC profile form

## risk assessment

Low, PD single element