### PR TITLE
feat(js): update lodash to 4.17.15

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "events": "3.0.0",
     "formik": "2.1.4",
     "history": "4.7.2",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "mixpanel-browser": "2.22.1",
     "netmask": "1.0.6",
     "path-to-regexp": "3.0.0",

--- a/components/package.json
+++ b/components/package.json
@@ -15,13 +15,13 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons#readme",
   "peerDependencies": {
-    "classnames": "^2.2.5",
-    "lodash": "^4.17.4",
     "react": "16.8.6",
     "react-router-dom": "5.1.1"
   },
   "dependencies": {
     "@popperjs/core": "2.1.1",
+    "classnames": "2.2.5",
+    "lodash": "4.17.15",
     "react-popper": "1.0.0",
     "react-remove-scroll": "1.0.8",
     "react-select": "3.0.8",

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/Opentrons/opentrons#readme",
   "dependencies": {
     "escape-string-regexp": "1.0.5",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "mdns-js": "1.0.1",
     "node-fetch": "2.6.0",
     "stable": "0.1.8",

--- a/labware-library/package.json
+++ b/labware-library/package.json
@@ -24,7 +24,7 @@
     "file-saver": "2.0.1",
     "formik": "2.1.4",
     "jszip": "3.2.2",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "mixpanel-browser": "2.29.1",
     "query-string": "6.2.0",
     "react": "16.8.6",

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -31,7 +31,7 @@
     "formik": "2.1.4",
     "i18next": "11.5.0",
     "immer": "5.1.0",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "query-string": "6.2.0",
     "react": "16.8.6",
     "react-dnd": "6.0.0",

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -23,7 +23,7 @@
     "@opentrons/components": "3.19.0-alpha.0",
     "@opentrons/shared-data": "3.19.0-alpha.0",
     "classnames": "2.2.5",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-hot-loader": "^4.12.19"

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -11,6 +11,6 @@
   "main": "js/index.js",
   "dependencies": {
     "ajv": "6.10.2",
-    "lodash": "4.17.4"
+    "lodash": "4.17.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11795,7 +11795,7 @@ lodash@4.17.15, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.4, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
## overview

Our prev version of lodash has a security alert, this is a patch bump to bring us to the latest lodash version.

Also, this moves the 2 peer dependencies of Components Library into regular dependencies. They're lodash and classnames, not really appropriate for peer deps.

## changelog


## review requests

- code review
- CI passes, smoke test JS projects

## risk assessment

affects all JS projects, but shouldn't be too risky