### PR TITLE
feat(test): add test id to Pipette Select component

### DIFF
--- a/components/src/instrument/PipetteSelect.js
+++ b/components/src/instrument/PipetteSelect.js
@@ -27,6 +27,8 @@ export type PipetteSelectProps = {|
   tabIndex?: number,
   /** classes to apply to the top-level component */
   className?: string,
+  /** custom id to be applied. likely to be used as a data test id for e2e testing */
+  id?: string,
 |}
 
 // TODO(mc, 2019-10-14): i18n
@@ -48,7 +50,13 @@ const specToOption = ({ name, displayName }: PipetteNameSpecs) => ({
 })
 
 export const PipetteSelect = (props: PipetteSelectProps): React.Node => {
-  const { tabIndex, className, enableNoneOption, nameBlacklist = [] } = props
+  const {
+    tabIndex,
+    className,
+    enableNoneOption,
+    id,
+    nameBlacklist = [],
+  } = props
   const whitelist = ({ value }: SelectOption) => {
     return !nameBlacklist.some(n => n === value)
   }
@@ -75,6 +83,7 @@ export const PipetteSelect = (props: PipetteSelectProps): React.Node => {
       value={value}
       defaultValue={defaultValue}
       tabIndex={tabIndex}
+      id={id}
       onChange={option => {
         // TODO(mc, 2020-02-03):  change to `option?.value ?? null`
         // when we enable that babel functionality

--- a/protocol-designer/cypress/support/commands.js
+++ b/protocol-designer/cypress/support/commands.js
@@ -46,25 +46,19 @@ Cypress.Commands.add('openFilePage', () => {
 //
 // Pipette Page Actions
 //
-// TODO(SA 2020/04/14): Update this command to use better pipette selectors
-Cypress.Commands.add('choosePipettes', (left, right) => {
-  cy.contains('Left Pipette')
-    .next()
-    .contains('None')
-    .click()
-  cy.contains('Left Pipette')
-    .next()
-    .contains(left)
-    .click()
-  cy.contains('Right Pipette')
-    .next()
-    .contains('None')
-    .click()
-  cy.contains('Right Pipette')
-    .next()
-    .contains(right)
-    .click()
-})
+Cypress.Commands.add(
+  'choosePipettes',
+  (left_pipette_name, right_pipette_name) => {
+    cy.get('[id="PipetteSelect_left"]')
+      .click()
+      .contains(left_pipette_name)
+      .click()
+    cy.get('[id="PipetteSelect_right"]')
+      .click()
+      .contains(right_pipette_name)
+      .click()
+  }
+)
 
 Cypress.Commands.add('selectTipRacks', (left, right) => {
   if (left) {

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.js
@@ -106,6 +106,7 @@ export function PipetteFields(props: Props) {
           onSetFieldValue(targetToClear, null)
           onSetFieldTouched(targetToClear, false)
         }}
+        id={`PipetteSelect_${mount}`}
       />
     )
   }


### PR DESCRIPTION
## overview

This PR adds an id prop to the `PipetteSelect` component, which is then used by a cypress test helper.

The reason I added this as a prop is because there was no other clear identifier I could use for e2e tests in the `PipetteSelect` component as it stood.

I used `id` rather than `test-id` because `id` already in the `Select` component's props (which is what `PipetteSelect` actually renders.

Partially addresses #5724. Also related: #4898

While this is a small PR, I'm expecting opinions, so please share thoughts. 
## changelog

  - Add optional id prop to PipetteSelect component
  - Change cypress pipette helper to use new id

## review requests
Not even sure here, make sure this makes sense to you, and that you feel I added the id in the right place. 

## risk assessment
Low, adding an additional prop for testing. 
