### PR TITLE
feat(protocol-designer): Style dynamic step fields

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -315,3 +315,46 @@ and when that is implemented.
   font-size: var(--fs-body-1);
   line-height: 2;
 }
+
+.profile_step_labels {
+  @apply --font-form-default;
+
+  display: grid;
+  grid-template-columns: 13.5rem 7.25rem 7.25rem;
+  font-weight: var(--fw-semibold);
+  padding: 1rem 0 0.25rem 0.625rem;
+}
+
+.profile_step_row {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.profile_step_fields {
+  display: flex;
+  align-items: center;
+  border: var(--bd-light);
+  width: 100%;
+  padding: 0.5rem;
+}
+
+.step_input_wrapper {
+  margin-right: 1.5rem;
+  width: 5.75rem;
+
+  &:first-child {
+    width: 12rem;
+  }
+}
+
+.delete_step_icon {
+  color: var(--c-med-gray);
+  width: 1.5rem;
+  margin-top: 0.25rem;
+}
+
+.profile_button_group {
+  padding: 1rem 1.5rem 0;
+  text-align: right;
+}

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileStepRows.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileStepRows.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { InputField, OutlineButton } from '@opentrons/components'
+import { InputField, OutlineButton, Icon } from '@opentrons/components'
+import { i18n } from '../../../localization'
 import { getUnsavedForm } from '../../../step-forms/selectors'
 import * as steplistActions from '../../../steplist/actions'
 import {
@@ -9,6 +10,7 @@ import {
   maskProfileField,
 } from '../../../steplist/fieldLevel'
 import { getDynamicFieldFocusHandlerId } from '../utils'
+import styles from '../StepEditForm.css'
 import type { ProfileStepItem } from '../../../form-types'
 import type { FocusHandlers } from '../types'
 
@@ -68,8 +70,17 @@ export const ProfileStepRows = (props: ProfileStepRowsProps) => {
 
   return (
     <>
+      {rows.length > 0 && (
+        <div className={styles.profile_step_labels}>
+          <div>Name:</div>
+          <div>Temperature:</div>
+          <div>Time:</div>
+        </div>
+      )}
       {rows}
-      <OutlineButton onClick={addProfileStep}>+ Add Step</OutlineButton>
+      <div className={styles.profile_button_group}>
+        <OutlineButton onClick={addProfileStep}>+ Add Step</OutlineButton>
+      </div>
     </>
   )
 }
@@ -83,6 +94,12 @@ type ProfileStepRowProps = {|
 
 const ProfileStepRow = (props: ProfileStepRowProps) => {
   const names = ['title', 'temperature', 'durationMinutes', 'durationSeconds']
+  const units = {
+    title: null,
+    temperature: i18n.t('application.units.degrees'),
+    durationMinutes: i18n.t('application.units.minutes'),
+    durationSeconds: i18n.t('application.units.seconds'),
+  }
   const {
     deleteProfileStep,
     profileStepItem,
@@ -120,21 +137,22 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
       focusHandlers.onFieldFocus(fieldId)
     }
     return (
-      <div
-        key={name}
-        style={{ width: '4rem', display: 'inline-block', margin: '0.5rem' }}
-      >
+      <div key={name} className={styles.step_input_wrapper}>
         <InputField
+          className={styles.step_input}
           error={errorToShow}
+          units={units[name]}
           {...{ name, onChange, onBlur, onFocus, value }}
         />
       </div>
     )
   })
   return (
-    <div>
-      {fields}
-      <div onClick={deleteProfileStep}>X</div>
+    <div className={styles.profile_step_row}>
+      <div className={styles.profile_step_fields}>{fields}</div>
+      <div onClick={deleteProfileStep}>
+        <Icon name="close" className={styles.delete_step_icon} />
+      </div>
     </div>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -80,9 +80,7 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
             {i18n.t('application.stepType.profile_steps')}
           </span>
         </div>
-
         <ProfileStepRows focusHandlers={focusHandlers} />
-
         <div className={styles.section_header}>
           <span className={styles.section_header_text}>
             {i18n.t('application.stepType.ending_hold')}


### PR DESCRIPTION
## overview

This PR closes #5513 by adding adding styling and units to dynamic step fields.

<img width="1164" alt="Screen Shot 2020-06-01 at 2 24 04 PM" src="https://user-images.githubusercontent.com/3430313/83527694-1fa2fd80-a4b6-11ea-8d33-24a474cde42b.png">
<img width="1167" alt="Screen Shot 2020-06-01 at 2 24 15 PM" src="https://user-images.githubusercontent.com/3430313/83527695-203b9400-a4b6-11ea-8103-14db63d7cbae.png">


## changelog

- feat(protocol-designer): Style dynamic step fields

## review requests

Make a TC profile
- [ ] Empty step section contains + Step button
Add a step
- [ ] Fields, labels, units and delete button render correctly
Add several steps
- [ ] Labels only render once at the top

_Note: Obviously there will me another styling pass once we have cycles in place._

## risk assessment
Low PD CSS
