### PR TITLE
feat(protocol-designer): Add validation to profile settings and end hold

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -285,12 +285,19 @@ describe('createPresavedStepForm', () => {
       lidIsActive: false,
       lidTargetTemp: null,
       lidOpen: null,
+      profileVolume: null,
+      profileTargetLidTemp: null,
       orderedProfileItems: [],
       profileItemsById: {},
+      blockIsActiveHold: false,
+      blockTargetTempHold: null,
+      lidIsActiveHold: false,
+      lidTargetTempHold: null,
+      lidOpenHold: null,
     })
   })
 
-  it('should set a default thermocycler module for thermocycler step, and populate TC state when previously saved TC state', () => {
+  it('should populate TC state when previously saved TC state', () => {
     const args = {
       ...defaultArgs,
       savedStepForms: {
@@ -304,8 +311,15 @@ describe('createPresavedStepForm', () => {
           lidIsActive: true,
           lidTargetTemp: 45,
           lidOpen: true,
+          profileVolume: null,
+          profileTargetLidTemp: null,
           orderedProfileItems: [],
           profileItemsById: {},
+          blockIsActiveHold: false,
+          blockTargetTempHold: null,
+          lidIsActiveHold: false,
+          lidTargetTempHold: null,
+          lidOpenHold: null,
         },
       },
       orderedStepIds: ['prevStepId'],
@@ -325,8 +339,15 @@ describe('createPresavedStepForm', () => {
       lidIsActive: true,
       lidTargetTemp: 45,
       lidOpen: true,
+      profileVolume: null,
+      profileTargetLidTemp: null,
       orderedProfileItems: [],
       profileItemsById: {},
+      blockIsActiveHold: false,
+      blockTargetTempHold: null,
+      lidIsActiveHold: false,
+      lidTargetTempHold: null,
+      lidOpenHold: null,
     })
   })
 })

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -191,6 +191,25 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
+  profileTargetLidTemp: {
+    getErrors: composeErrors(
+      temperatureRangeFieldValue(MIN_TC_LID_TEMP, MAX_TC_LID_TEMP)
+    ),
+  },
+  blockTargetTempHold: {
+    getErrors: composeErrors(
+      temperatureRangeFieldValue(MIN_TC_BLOCK_TEMP, MAX_TC_BLOCK_TEMP)
+    ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
+  lidTargetTempHold: {
+    getErrors: composeErrors(
+      temperatureRangeFieldValue(MIN_TC_LID_TEMP, MAX_TC_LID_TEMP)
+    ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
 }
 
 const profileFieldHelperMap: { [string]: StepFieldHelpers } = {

--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -11,6 +11,7 @@ import {
   PAUSE_UNTIL_RESUME,
   PAUSE_UNTIL_TIME,
   PAUSE_UNTIL_TEMP,
+  THERMOCYCLER_PROFILE,
 } from '../../constants'
 import type { StepFieldName } from '../../form-types'
 
@@ -33,6 +34,10 @@ export type FormErrorKey =
   | 'TARGET_TEMPERATURE_REQUIRED'
   | 'BLOCK_TEMPERATURE_REQUIRED'
   | 'LID_TEMPERATURE_REQUIRED'
+  | 'PROFILE_VOLUME_REQUIRED'
+  | 'PROFILE_LID_TEMPERATURE_REQUIRED'
+  | 'BLOCK_TEMPERATURE_HOLD_REQUIRED'
+  | 'LID_TEMPERATURE_HOLD_REQUIRED'
 
 export type FormError = {
   title: string,
@@ -95,13 +100,21 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
     title: 'Temperature is required',
     dependentFields: ['setTemperature', 'targetTemperature'],
   },
-  BLOCK_TEMPERATURE_REQUIRED: {
-    title: 'Temperature is required',
-    dependentFields: ['blockIsActive', 'blockTargetTemp'],
+  PROFILE_VOLUME_REQUIRED: {
+    title: 'Volume is required',
+    dependentFields: ['thermocyclerFormType', 'profileVolume'],
   },
-  LID_TEMPERATURE_REQUIRED: {
+  PROFILE_LID_TEMPERATURE_REQUIRED: {
     title: 'Temperature is required',
-    dependentFields: ['lidIsActive', 'lidTargetTemp'],
+    dependentFields: ['thermocyclerFormType', 'profileTargetLidTemp'],
+  },
+  BLOCK_TEMPERATURE_HOLD_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['blockIsActiveHold', 'blockTargetTempHold'],
+  },
+  LID_TEMPERATURE_HOLD_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['lidIsActiveHold', 'lidTargetTempHold'],
   },
 }
 
@@ -225,6 +238,24 @@ export const targetTemperatureRequired = (
     : null
 }
 
+export const profileVolumeRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { thermocyclerFormType, profileVolume } = fields
+  return thermocyclerFormType === THERMOCYCLER_PROFILE && !profileVolume
+    ? FORM_ERRORS.PROFILE_VOLUME_REQUIRED
+    : null
+}
+
+export const profileTargetLidTempRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { thermocyclerFormType, profileTargetLidTemp } = fields
+  return thermocyclerFormType === THERMOCYCLER_PROFILE && !profileTargetLidTemp
+    ? FORM_ERRORS.PROFILE_LID_TEMPERATURE_REQUIRED
+    : null
+}
+
 export const blockTemperatureRequired = (
   fields: HydratedFormData
 ): FormError | null => {
@@ -240,6 +271,24 @@ export const lidTemperatureRequired = (
   const { lidIsActive, lidTargetTemp } = fields
   return lidIsActive === true && !lidTargetTemp
     ? FORM_ERRORS.LID_TEMPERATURE_REQUIRED
+    : null
+}
+
+export const blockTemperatureHoldRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { blockIsActiveHold, blockTargetTempHold } = fields
+  return blockIsActiveHold === true && !blockTargetTempHold
+    ? FORM_ERRORS.BLOCK_TEMPERATURE_HOLD_REQUIRED
+    : null
+}
+
+export const lidTemperatureHoldRequired = (
+  fields: HydratedFormData
+): FormError | null => {
+  const { lidIsActiveHold, lidTargetTempHold } = fields
+  return lidIsActiveHold === true && !lidTargetTempHold
+    ? FORM_ERRORS.LID_TEMPERATURE_HOLD_REQUIRED
     : null
 }
 

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -102,8 +102,15 @@ export function getDefaultsForStepType(
         lidIsActive: false,
         lidTargetTemp: null,
         lidOpen: null,
+        profileVolume: null,
+        profileTargetLidTemp: null,
         orderedProfileItems: [],
         profileItemsById: {},
+        blockIsActiveHold: false,
+        blockTargetTempHold: null,
+        lidIsActiveHold: false,
+        lidTargetTempHold: null,
+        lidOpenHold: null,
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
@@ -15,6 +15,11 @@ const updatePatchOnBlockChange = (patch: FormPatch, rawForm: FormData) => {
       ...patch,
       ...getDefaultFields('blockTargetTemp'),
     }
+  } else if (fieldHasChanged(rawForm, patch, 'blockIsActiveHold')) {
+    return {
+      ...patch,
+      ...getDefaultFields('blockTargetTempHold'),
+    }
   }
   return patch
 }
@@ -24,6 +29,11 @@ const updatePatchOnLidChange = (patch: FormPatch, rawForm: FormData) => {
     return {
       ...patch,
       ...getDefaultFields('lidTargetTemp'),
+    }
+  } else if (fieldHasChanged(rawForm, patch, 'lidIsActiveHold')) {
+    return {
+      ...patch,
+      ...getDefaultFields('lidTargetTempHold'),
     }
   }
   return patch

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -14,6 +14,10 @@ import {
   targetTemperatureRequired,
   blockTemperatureRequired,
   lidTemperatureRequired,
+  profileVolumeRequired,
+  profileTargetLidTempRequired,
+  blockTemperatureHoldRequired,
+  lidTemperatureHoldRequired,
 } from './errors'
 import {
   composeWarnings,
@@ -83,7 +87,14 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
     getErrors: composeErrors(targetTemperatureRequired, moduleIdRequired),
   },
   thermocycler: {
-    getErrors: composeErrors(blockTemperatureRequired, lidTemperatureRequired),
+    getErrors: composeErrors(
+      blockTemperatureRequired,
+      lidTemperatureRequired,
+      profileVolumeRequired,
+      profileTargetLidTempRequired,
+      blockTemperatureHoldRequired,
+      lidTemperatureHoldRequired
+    ),
   },
 }
 


### PR DESCRIPTION
## overview

This Pr closes #5520 closes #5753 by adding validation to the profile settings and ending hold state sections of TC profile form. While I was in there I added the default values so I could reset the ending hold temperatures on toggle change.

## changelog

- feat(protocol-designer): Add validation to profile settings and end hold

## review requests

- [ ] Form validates as expected

_Note: this PR does not cover resetting everything when you change between state and profile_

## risk assessment

Low PD only behind a FF