### PR TITLE
feat(protocol-designer): Add profile step number and delete tooltip

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -322,13 +322,19 @@ and when that is implemented.
   display: grid;
   grid-template-columns: 13.5rem 7.25rem 7.25rem;
   font-weight: var(--fw-semibold);
-  padding: 1rem 0 0.25rem 0.625rem;
+  padding: 1rem 0 0.25rem 1.75rem;
 }
 
 .profile_step_row {
   display: flex;
   align-items: center;
   padding: 0.25rem 0;
+}
+
+.profile_step_number {
+  @apply --font-body-1-dark;
+
+  padding: 0.25rem 0.5rem 0 0;
 }
 
 .profile_step_fields {
@@ -343,7 +349,7 @@ and when that is implemented.
   margin-right: 1.5rem;
   width: 5.75rem;
 
-  &:first-child {
+  &:nth-child(2) {
     width: 12rem;
   }
 }

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileStepRows.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileStepRows.js
@@ -1,7 +1,13 @@
 // @flow
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { InputField, OutlineButton, Icon } from '@opentrons/components'
+import {
+  InputField,
+  OutlineButton,
+  Icon,
+  Tooltip,
+  useHoverTooltip,
+} from '@opentrons/components'
 import { i18n } from '../../../localization'
 import { getUnsavedForm } from '../../../step-forms/selectors'
 import * as steplistActions from '../../../steplist/actions'
@@ -63,6 +69,7 @@ export const ProfileStepRows = (props: ProfileStepRowsProps) => {
           profileStepItem={itemFields}
           updateStepFieldValue={updateStepFieldValue}
           focusHandlers={props.focusHandlers}
+          stepNumber={index}
         />
       </div>
     )
@@ -90,6 +97,7 @@ type ProfileStepRowProps = {|
   profileStepItem: ProfileStepItem,
   updateStepFieldValue: (name: string, value: string) => mixed,
   focusHandlers: FocusHandlers,
+  stepNumber: number,
 |}
 
 const ProfileStepRow = (props: ProfileStepRowProps) => {
@@ -105,7 +113,13 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
     profileStepItem,
     updateStepFieldValue,
     focusHandlers,
+    stepNumber,
   } = props
+
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: 'top',
+  })
+
   const fields = names.map(name => {
     const value = profileStepItem[name]
     const fieldId = getDynamicFieldFocusHandlerId({
@@ -149,8 +163,14 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
   })
   return (
     <div className={styles.profile_step_row}>
-      <div className={styles.profile_step_fields}>{fields}</div>
-      <div onClick={deleteProfileStep}>
+      <div className={styles.profile_step_fields}>
+        <span className={styles.profile_step_number}>{stepNumber + 1}. </span>
+        {fields}
+      </div>
+      <div onClick={deleteProfileStep} {...targetProps}>
+        <Tooltip {...tooltipProps}>
+          {i18n.t('tooltip.step_fields.profileStepRow.deleteStep')}
+        </Tooltip>
         <Icon name="close" className={styles.delete_step_icon} />
       </div>
     </div>

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -46,6 +46,9 @@
       "disabled": {
         "wait_until_temp": "There is no temperature module on the deck"
       }
+    },
+    "profileStepRow": {
+      "deleteStep": "Delete profile step"
     }
   },
   "edit_module_card": {


### PR DESCRIPTION
## overview

Adds numbering and tooltip to profile steps

<img width="953" alt="Screen Shot 2020-06-03 at 11 04 19 AM" src="https://user-images.githubusercontent.com/3430313/83770575-39c41380-a64f-11ea-9d73-6401a01dfad1.png">

## changelog

- feat(protocol-designer): Add profile step number and delete tooltip

## review requests

- [ ] Numbering is correct
- [ ] Delete button Tooltip matches design

_note: I know we will have to revisit numbering once cycles are a thing_

## risk assessment
Low. PD tooltip