### PR TITLE
feat(protocol-designer): finish form-level errors for dynamic fields

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -10,7 +10,7 @@ import { selectors as stepFormSelectors } from '../../step-forms'
 import {
   getVisibleFormErrors,
   getVisibleFormWarnings,
-  getVisibleProfileErrors,
+  getVisibleProfileFormLevelErrors,
 } from './utils'
 import type { Dispatch } from 'redux'
 import type { StepIdType } from '../../form-types'
@@ -43,7 +43,7 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
   const formLevelErrors = stepFormSelectors.getFormLevelErrorsForUnsavedForm(
     state
   )
-  const filteredErrors = getVisibleFormErrors({
+  const visibleErrors = getVisibleFormErrors({
     focusedField,
     dirtyFields,
     errors: formLevelErrors,
@@ -51,26 +51,27 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
 
   // deal with special-case dynamic field form-level errors
   const { profileItemsById } = stepFormSelectors.getHydratedUnsavedForm(state)
-  let filteredDynamicFieldFormErrors = []
+  let visibleDynamicFieldFormErrors = []
   if (profileItemsById != null) {
     const dynamicFieldFormErrors = stepFormSelectors.getDynamicFieldFormErrorsForUnsavedForm(
       state
     )
-    filteredDynamicFieldFormErrors = getVisibleProfileErrors({
+    visibleDynamicFieldFormErrors = getVisibleProfileFormLevelErrors({
       focusedField,
       dirtyFields,
       errors: dynamicFieldFormErrors,
       profileItemsById,
     })
+    console.log({ dynamicFieldFormErrors, visibleDynamicFieldFormErrors })
   }
 
   return {
     errors: [
-      ...filteredErrors.map(error => ({
+      ...visibleErrors.map(error => ({
         title: error.title,
         description: error.body || null,
       })),
-      ...filteredDynamicFieldFormErrors.map(error => ({
+      ...visibleDynamicFieldFormErrors.map(error => ({
         title: error.title,
         description: error.body || null,
       })),

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -3,6 +3,7 @@ import assert from 'assert'
 import * as React from 'react'
 import difference from 'lodash/difference'
 import { i18n } from '../../localization'
+import { PROFILE_CYCLE } from '../../form-types'
 import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -110,27 +111,35 @@ export const getDynamicFieldFocusHandlerId = ({
   name: string,
 |}) => `${id}:${name}`
 
-export const getVisibleProfileErrors = (args: {|
+// NOTE: if any fields of a given name are pristine, treat all fields of that name as pristine.
+// (Errors don't currently specify the id, so if we later want to only mask form-level errors
+// for specific profile fields, the field's parent ProfileItem id needs to be included in the error)
+export const getVisibleProfileFormLevelErrors = (args: {|
   focusedField: ?string,
   dirtyFields: Array<string>,
   errors: Array<ProfileFormError>,
   profileItemsById: { [itemId: string]: ProfileItem },
 |}): Array<ProfileFormError> => {
   const { dirtyFields, focusedField, errors, profileItemsById } = args
-  const profileIds = Object.keys(profileItemsById)
+  const profileItemIds = Object.keys(profileItemsById)
 
   return errors.filter(error => {
-    return profileIds.every(itemId => {
-      const fieldsForItem = error.dependentProfileFields.map(
-        fieldName => `${itemId}:${fieldName}` // TODO IMMEDIATELY import util for "hashing" the name + id
-      )
+    return profileItemIds.every(itemId => {
+      const item = profileItemsById[itemId]
+      const steps = item.type === PROFILE_CYCLE ? item.steps : [item]
+      return steps.every(step => {
+        const fieldsForStep = error.dependentProfileFields.map(fieldName =>
+          getDynamicFieldFocusHandlerId({ id: step.id, name: fieldName })
+        )
 
-      const dependentFieldsAreNotFocused = !fieldsForItem.includes(focusedField)
+        const dependentFieldsAreNotFocused = !fieldsForStep.includes(
+          focusedField
+        )
 
-      const dependentProfileFieldsAreDirty =
-        difference(fieldsForItem, dirtyFields).length === 0
-
-      return dependentFieldsAreNotFocused && dependentProfileFieldsAreDirty
+        const dependentProfileFieldsAreDirty =
+          difference(fieldsForStep, dirtyFields).length === 0
+        return dependentFieldsAreNotFocused && dependentProfileFieldsAreDirty
+      })
     })
   })
 }

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -432,7 +432,10 @@ const _dynamicFieldFormErrors = (
 export const _hasFieldLevelErrors = (hydratedForm: FormData): boolean => {
   for (const fieldName in hydratedForm) {
     const value = hydratedForm[fieldName]
-    if (fieldName === 'profileItemsById') {
+    if (
+      hydratedForm.stepType === 'thermocycler' &&
+      fieldName === 'profileItemsById'
+    ) {
       if (getProfileItemsHaveErrors(value)) {
         return true
       }
@@ -448,9 +451,21 @@ export const _hasFieldLevelErrors = (hydratedForm: FormData): boolean => {
 }
 
 // TODO type with hydrated form type
+export const _hasFormLevelErrors = (hydratedForm: FormData): boolean => {
+  if (_formLevelErrors(hydratedForm).length > 0) return true
+
+  if (
+    hydratedForm.stepType === 'thermocycler' &&
+    _dynamicFieldFormErrors(hydratedForm).length > 0
+  ) {
+    return true
+  }
+  return false
+}
+
+// TODO type with hydrated form type
 export const _formHasErrors = (hydratedForm: FormData): boolean => {
-  const hasFormLevelErrors = _formLevelErrors(hydratedForm).length > 0
-  return _hasFieldLevelErrors(hydratedForm) || hasFormLevelErrors
+  return _hasFieldLevelErrors(hydratedForm) || _hasFormLevelErrors(hydratedForm)
 }
 
 export const getInvariantContext: Selector<InvariantContext> = createSelector(

--- a/protocol-designer/src/step-forms/test/selectors.test.js
+++ b/protocol-designer/src/step-forms/test/selectors.test.js
@@ -20,8 +20,11 @@ beforeEach(() => {
 })
 
 describe('_hasFieldLevelErrors', () => {
-  it('should return true if form has "profileItemsById" field and _getProfileItemsHaveErrors returns true', () => {
-    const formData = { profileItemsById: { foo: 'abc' } }
+  it('should return true if form is "thermocycler", has "profileItemsById" field, and _getProfileItemsHaveErrors returns true', () => {
+    const formData = {
+      stepType: 'thermocycler',
+      profileItemsById: { foo: 'abc' },
+    }
     mockGetProfileItemsHaveErrors.mockImplementation(profileItems => {
       expect(profileItems).toEqual(formData.profileItemsById)
       return true


### PR DESCRIPTION
## overview

Closes #5814

## changelog

* Show form-level errors for steps that are inside a cycle (not just top-level steps)
* Disable save when form-level errors are present

## review requests

- [ ] Show error when both minutes and seconds are blank or zero
- [ ] Don't show that error when either minutes or seconds hasn't been blurred
- [ ] Error should prevent save (whether it's visible or not)
- [ ] This should work both in top-level profile steps, and steps in cycles

NOTE: since the errors are not associated with a particular row, when any field of a given name is pristine, all will be treated as pristine. So adding a new step will hide any previously visible errors.

(There's just one error, if you don't have a > 0 mins + seconds)

## risk assessment

low, PD-only and under a FF
