### PR TITLE
feat(api): define data architecture for tip length calibration in v2

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -484,3 +484,7 @@ CONFIG = load_and_migrate()
 #: The currently loaded config. This should not change for the lifetime
 #: of the program. This is a dict much like os.environ() where the keys
 #: are config element names
+
+
+def get_tip_length_cal_path() -> Path:
+    return CONFIG['tip_length_calibration_dir']

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -185,7 +185,13 @@ CONFIG_ELEMENTS = (
                   'Pipette Config User Overrides',
                   Path('pipettes'),
                   ConfigElementType.DIR,
-                  'The dir where settings overrides for pipettes are stored')
+                  'The dir where settings overrides for pipettes are stored'),
+    ConfigElement('tip_length_calibration_dir',
+                  'Tip Length Calibration Directory',
+                  Path('tip_lengths'),
+                  ConfigElementType.DIR,
+                  'The dir where tip length calibration of each tiprack for '
+                  'each unique pipette is stored')
 )
 #: The available configuration file elements to modify. All of these can be
 #: changed by editing opentrons.json, where the keys are the name elements,

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -162,8 +162,10 @@ settings = [
     SettingDefinition(
         _id='enableTipLengthCalibration',
         title='Enable Tip Length Calibration',
-        description='Extrapolate the length of the tip by comparing '
-                    'the heights '
+        description='Measure the tip length based on each unique pipette, '
+                    'by comparing the heights of the tip and the pipette '
+                    'nozzle. This should not be activated except by '
+                    'developers.'
     )
 ]
 

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -158,6 +158,12 @@ settings = [
                     "Opening the robot door during a run will "
                     "pause your robot only after it has completed its "
                     "current motion."
+    ),
+    SettingDefinition(
+        _id='enableTipLengthCalibration',
+        title='Enable Tip Length Calibration',
+        description='Extrapolate the length of the tip by comparing '
+                    'the heights '
     )
 ]
 
@@ -324,8 +330,18 @@ def _migrate4to5(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate5to6(previous: SettingsMap) -> SettingsMap:
+    """
+    Migration to version 6 of the feature flags file. Adds the
+    enableTipLengthCalibration config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap['enableTipLengthCalibration'] = None
+    return newmap
+
+
 _MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4,
-               _migrate4to5]
+               _migrate4to5, _migrate5to6]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -31,3 +31,7 @@ def use_fast_api() -> bool:
 
 def enable_door_safety_switch():
     return advs.get_setting_with_env_overload('enableDoorSafetySwitch')
+
+
+def enable_tip_length_calibration():
+    return advs.get_setting_with_env_overload('enableTipLengthCalibration')

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import NamedTuple, Dict, Set
 
 from opentrons.config import (robot_configs as rc,
-                              IS_ROBOT)
+                              IS_ROBOT, feature_flags as ff)
 from opentrons.data_storage import database as db
 from opentrons.protocol_api import labware
 
@@ -88,5 +88,8 @@ def reset_tip_probe():
     config = rc.load()
     config = config._replace(
         instrument_offset=rc.build_fallback_instrument_offset({}))
-    config.tip_length.clear()
+    if ff.enable_tip_length_calibration():
+        labware.clear_tip_length_calibration()
+    else:
+        config.tip_length.clear()
     rc.save_robot_settings(config)

--- a/api/src/opentrons/protocol_api/dev_types.py
+++ b/api/src/opentrons/protocol_api/dev_types.py
@@ -129,3 +129,12 @@ JsonV4ThermocyclerDispatch = TypedDict(
             ['ThermocyclerContext', 'ModuleIDParams'], None]
     }
 )
+
+
+# TODO: AA 2020-06-10 move these out of protocol_api
+class TipLengthCalibration(TypedDict):
+    tipLength: float
+    lastModified: str
+
+
+PipTipLengthCalibration = Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/protocol_api/dev_types.py
+++ b/api/src/opentrons/protocol_api/dev_types.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Callable, Dict, TYPE_CHECKING
 
 from typing_extensions import Protocol, TypedDict
@@ -134,7 +135,7 @@ JsonV4ThermocyclerDispatch = TypedDict(
 # TODO: AA 2020-06-10 move these out of protocol_api
 class TipLengthCalibration(TypedDict):
     tipLength: float
-    lastModified: str
+    lastModified: datetime
 
 
 PipTipLengthCalibration = Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -43,11 +43,17 @@ CUSTOM_NAMESPACE = 'custom_beta'
 STANDARD_DEFS_PATH = Path("labware/definitions/2")
 
 
+# TODO: AA 2020-06-10 move these out of protocol_api
 TipLengthCalibration = Dict[str, float]
 PipTipLengthCalibration = Dict[str, TipLengthCalibration]
 
 
 class OutOfTipsError(Exception):
+    pass
+
+
+# TODO: AA 2020-06-10 move out of protocol_api
+class TipLengthCalNotFound(Exception):
     pass
 
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -25,7 +25,7 @@ import jsonschema  # type: ignore
 
 from .util import ModifiedList, requires_version, first_parent
 from opentrons.types import Location, Point
-from opentrons.config import CONFIG
+from opentrons.config import CONFIG, feature_flags as ff
 from opentrons.protocols.types import APIVersion
 from opentrons_shared_data import load_shared_data, get_shared_data_root
 from .definitions import MAX_SUPPORTED_VERSION, DeckItem
@@ -878,6 +878,66 @@ def save_tip_length(labware: Labware, length: float):
     with labware_offset_path.open('w') as f:
         json.dump(calibration_data, f)
     labware.tip_length = length
+
+
+def _get_labware_tip_length_path(labware: Labware):
+    tip_length_path = CONFIG['tip_length_calibration_dir']
+    tip_length_path.mkdir(parents=True, exist_ok=True)
+
+    parent_id = _get_parent_identifier(labware.parent)
+    labware_hash = _hash_labware_def(labware._definition)
+    return tip_length_path/f'{labware_hash}{parent_id}.json'
+
+
+def save_tip_length_calibration(labware: Labware, length: float, pip_id: str):
+    if ff.enable_tip_length_calibration():
+        assert labware._is_tiprack, \
+            'cannot save tip length for non-tiprack labware'
+        pip_tip_length_path = _get_labware_tip_length_path(labware)
+        try:
+            tip_length_data = _read_file(pip_tip_length_path)
+        except FileNotFoundError:
+            tip_length_data = {}
+
+        data = {
+            pip_id: {
+                'tipLength': length,
+                'lastModified': time.time()
+                }
+            }
+        tip_length_data.update(data)
+
+        with pip_tip_length_path.open('w') as f:
+            json.dump(tip_length_data, f)
+
+
+def load_tip_length_calibration(labware: Labware, pip_id: str):
+    if ff.enable_tip_length_calibration():
+        assert labware._is_tiprack, \
+            'cannot load tip length for non-tiprack labware'
+        pip_tip_length_path = _get_labware_tip_length_path(labware)
+        try:
+            tip_length_data = _read_file(pip_tip_length_path)
+            return tip_length_data[pip_id]['tipLength']
+        except (FileNotFoundError, AttributeError):
+            raise FileNotFoundError(
+                f'Tip length of {labware.load_name} has not been '
+                f'calibrated for this pipette: {pip_id} and cannot'
+                'be loaded')
+
+
+def clear_tip_length_calibration():
+    """
+    Delete all tip length calibration files.
+    """
+    tip_length_path = CONFIG['tip_length_calibration_dir']
+    try:
+        targets = [
+            f for f in tip_length_path.iterdir() if f.suffix == '.json']
+        for target in targets:
+            target.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def load_calibration(labware: Labware):

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1006,6 +1006,11 @@ def clear_tip_length_calibration():
 def _read_cal_file(filepath: str) -> dict:
     with open(filepath, 'r') as f:
         calibration_data = json.load(f, cls=DateTimeDecoder)
+    for value in calibration_data.values():
+        if value.get('lastModified'):
+            assert isinstance(value['lastModified'], datetime.datetime), \
+                "invalid decoded value type for lastModified: got " \
+                f"{type(value['lastModified']).__name__}, expected datetime"
     return calibration_data
 
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -1,7 +1,7 @@
 from opentrons.config.advanced_settings import _migrate, _ensure
 
 
-good_file_version = 5
+good_file_version = 6
 good_file_settings = {
     'shortFixedTrash': None,
     'calibrateToBottom': None,
@@ -13,6 +13,7 @@ good_file_settings = {
     'useProtocolApi2': None,
     'useV1HttpApi': None,
     'enableDoorSafetySwitch': None,
+    'enableTipLengthCalibration': None,
 }
 
 
@@ -43,7 +44,8 @@ def test_migrates_versionless_new_config():
       'enableApi1BackCompat': None,
       'useProtocolApi2': None,
       'useV1HttpApi': None,
-      'enableDoorSafetySwitch': None
+      'enableDoorSafetySwitch': None,
+      'enableTipLengthCalibration': None
     }
 
 
@@ -66,7 +68,8 @@ def test_migrates_versionless_old_config():
       'enableApi1BackCompat': None,
       'useProtocolApi2': None,
       'useV1HttpApi': None,
-      'enableDoorSafetySwitch': None
+      'enableDoorSafetySwitch': None,
+      'enableTipLengthCalibration': None
     }
 
 
@@ -101,7 +104,8 @@ def test_migrates_v1_config():
         'useProtocolApi2': None,
         'enableApi1BackCompat': None,
         'useV1HttpApi': None,
-        'enableDoorSafetySwitch': None
+        'enableDoorSafetySwitch': None,
+        'enableTipLengthCalibration': None
     }
 
 
@@ -129,7 +133,8 @@ def test_migrates_v2_config():
         'useProtocolApi2': None,
         'enableApi1BackCompat': None,
         'useV1HttpApi': None,
-        'enableDoorSafetySwitch': None
+        'enableDoorSafetySwitch': None,
+        'enableTipLengthCalibration': None
     }
 
 
@@ -156,7 +161,8 @@ def test_migrates_v3_config():
         'useProtocolApi2': None,
         'enableApi1BackCompat': False,
         'useV1HttpApi': None,
-        'enableDoorSafetySwitch': None
+        'enableDoorSafetySwitch': None,
+        'enableTipLengthCalibration': None
     }
 
 
@@ -184,7 +190,38 @@ def test_migrates_v4_config():
         'useProtocolApi2': None,
         'enableApi1BackCompat': False,
         'useV1HttpApi': False,
-        'enableDoorSafetySwitch': None
+        'enableDoorSafetySwitch': None,
+        'enableTipLengthCalibration': None
+    }
+
+
+def test_migrates_v5_config():
+    settings, version = _migrate({
+        '_version': 5,
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useProtocolApi2': None,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+        'enableApi1BackCompat': False,
+        'useV1HttpApi': False,
+        'enableDoorSafetySwitch': True,
+    })
+    assert version == good_file_version
+    assert settings == {
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': False,
+        'disableHomeOnBoot': True,
+        'useOldAspirationFunctions': True,
+        'disableLogAggregation': False,
+        'useProtocolApi2': None,
+        'enableApi1BackCompat': False,
+        'useV1HttpApi': False,
+        'enableDoorSafetySwitch': True,
+        'enableTipLengthCalibration': None
     }
 
 
@@ -203,5 +240,6 @@ def test_ensures_config():
              'disableLogAggregation': True,
              'useProtocolApi2': None,
              'useV1HttpApi': None,
-             'enableDoorSafetySwitch': None
+             'enableDoorSafetySwitch': None,
+             'enableTipLengthCalibration': None
          }

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -92,7 +92,7 @@ def clear_tlc_calibration(monkeypatch):
         pass
     yield
     try:
-        os.remove(tlc_path(PIPETTE_ID))
+        os.remove(tlc_path('index'))
     except FileNotFoundError:
         pass
 
@@ -174,6 +174,25 @@ def test_save_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
     }
     labware.save_tip_length_calibration(PIPETTE_ID, test_data)
     assert os.path.exists(tlc_path(PIPETTE_ID))
+    # test an index file is also created
+    assert os.path.exists(tlc_path('index'))
+
+
+def test_add_index_file(monkeypatch, clear_tlc_calibration):
+
+    def get_result():
+        with open(tlc_path('index')) as f:
+            result = json.load(f)
+        return result
+
+    labware._append_to_index_tip_length_file('pip_1', 'lw_1')
+    assert get_result() == {'lw_1': ['pip_1']}
+
+    labware._append_to_index_tip_length_file('pip_2', 'lw_1')
+    assert get_result() == {'lw_1': ['pip_1', 'pip_2']}
+
+    labware._append_to_index_tip_length_file('pip_2', 'lw_2')
+    assert get_result() == {'lw_1': ['pip_1', 'pip_2'], 'lw_2': ['pip_2']}
 
 
 def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -124,6 +124,15 @@ def test_save_calibration(monkeypatch, clear_calibration):
     assert calibration_point == Point(1, 1, 1)
 
 
+def test_json_datetime_encoder():
+    fake_time = datetime.datetime.utcnow()
+    original = {'mock_hash': {'tipLength': 25.0, 'lastModified': fake_time}}
+
+    encoded = json.dumps(original, cls=labware.DateTimeEncoder)
+    decoded = json.loads(encoded, cls=labware.DateTimeDecoder)
+    assert decoded == original
+
+
 def test_save_tip_length(monkeypatch, clear_calibration):
     assert not os.path.exists(path(MOCK_HASH))
 
@@ -163,7 +172,7 @@ def test_create_tip_length_calibration_data(monkeypatch):
     expected_data = {
         MOCK_HASH: {
             'tipLength': tip_length,
-            'lastModified': fake_time.strftime("%B %d %Y, %H:%M:%S")
+            'lastModified': fake_time
         }
     }
     result = labware.create_tip_length_data(test_labware, tip_length)

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -60,6 +60,12 @@ stages:
           description: !re_search "Automatically pause protocols when robot door opens"
           restart_required: false
           value: !anything
+        - id: enableTipLengthCalibration
+          old_id: Null
+          title: Enable Tip Length Calibration
+          description: !re_search "Measure the tip length based on each unique pipette"
+          restart_required: false
+          value: !anything
         links: !anydict 
 
 ---


### PR DESCRIPTION
<!--
  Thanks for taking the time to open a pull request! Please make sure you've
  read the "Opening Pull Requests" section of our Contributing Guide:

  https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
This PR defines new data architecture for tip length calibration data.

closes #5606

<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog
- added a robot feature flag `enableTipLengthCalibration`
- added new dir `/data/tip_lengths` to store tip length calibration files
- new `save_tip_length_calibration` method in the protocol api labware module
   - it takes in the labware, tip length and the ID of the pipette that performed the calibration
   - saves the data in a json file with pipette's serial number as the name, looks something like this
```
/data/tip_lengths/PIPETTE_ID_1.json:

{
    LW_HASH_1: {
        tipLength: 22.0,
        lastModified: 1591297770.961788},
    LW_HASH_2: {
        tipLength: 25.0,
        lastModified: 1591297725.123456},
    }
}
```
- added an index file to `/data/tip_lengths` to help access labware -> pipette ID easier
```
{
    LW_HASH_1: [PIPETTE_ID_1],
    LW_HASH_2: [PIPETTE_ID_1, PIPETTE_ID_2]
}
```
- added load and clear calibration methods
- tests to make sure all of the above work

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests
Code sanity
How do we like the structure?
<!--
  Describe any requests for your reviewers here.
-->

## risk assessment
low - methods are currently not hooked up anywhere yet and are all behind a feature flag

<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
