### PR TITLE
build(make): name targets "setup"/"teardown" instead of "install"/"uninstall"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ _app_stage_build: &app_stage_build
   language: node_js
   install:
     - pip install --user awscli
-    - make install-js
+    - make setup-js
   before_script:
     # pull API wheel from S3
     - mkdir -p ./api/dist
@@ -50,7 +50,7 @@ jobs:
         - pip install awscli
         - nvm install
         - yarn global add shx@0.2.2 codecov@3.1.0
-        - make install-py
+        - make setup-py
       script:
         - make test-py
         - make lint-py
@@ -88,7 +88,7 @@ jobs:
       # node version pulled from .nvmrc
       language: node_js
       install:
-        - make install-js
+        - make setup-js
       script:
         - make test-js
         - make lint-js
@@ -126,7 +126,7 @@ jobs:
       name: 'JS E2E tests'
       language: node_js
       install:
-        - make install-js
+        - make setup-js
       script:
         - make test-e2e
 
@@ -135,7 +135,7 @@ jobs:
       name: 'JS type checks'
       language: node_js
       install:
-        - make install-js
+        - make setup-js
       script:
         - make check-js
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,14 +165,14 @@ Your computer will need the following tools installed to be able to develop with
 - GNU Make - we use [Makefiles][] to manage our builds
 
 - cURL - used to push development updates to robots
-- On Linux, you will need libsystemd and headers. On Ubuntu, install `systemd-dev` and `python3-dev` before running `make install`.
+- On Linux, you will need libsystemd and headers. On Ubuntu, install `systemd-dev` and `python3-dev` before running `make setup`.
 
 Once you're set up, clone the repository and install all project dependencies:
 
 ```shell
 git clone https://github.com/Opentrons/opentrons.git
 cd opentrons
-make install
+make setup
 ```
 
 In addition, if (and only if) you want to build a PDF version of the Opentrons API documentation, you must install a latex distribution that includes a callable pdflatex. If that is installed, you can do `make -C api docs-pdf`.

--- a/Makefile
+++ b/Makefile
@@ -37,30 +37,30 @@ usb_host=$(shell yarn run -s discovery find -i 169.254 fd00 -c "[fd00:0:cafe:fef
 
 
 # install all project dependencies
-.PHONY: install
-install: install-js install-py
+.PHONY: setup
+setup: setup-js setup-py
 
-.PHONY: install-py
-install-py:
+.PHONY: setup-py
+setup-py:
 	$(OT_PYTHON) -m pip install pipenv==2018.10.9
-	$(MAKE) -C $(API_DIR) install
-	$(MAKE) -C $(UPDATE_SERVER_DIR) install
-	$(MAKE) -C $(ROBOT_SERVER_DIR) install
+	$(MAKE) -C $(API_DIR) setup
+	$(MAKE) -C $(UPDATE_SERVER_DIR) setup
+	$(MAKE) -C $(ROBOT_SERVER_DIR) setup
 	$(MAKE) -C $(SHARED_DATA_DIR) setup-py
 
 # front-end dependecies handled by yarn
-.PHONY: install-js
-install-js:
+.PHONY: setup-js
+setup-js:
 	yarn
 	$(MAKE) -j 1 -C $(APP_SHELL_DIR) setup
 	$(MAKE) -j 1 -C $(SHARED_DATA_DIR) setup-js
-	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) install
+	$(MAKE) -j 1 -C $(DISCOVERY_CLIENT_DIR) setup
 
 # uninstall all project dependencies
 # TODO(mc, 2018-03-22): API uninstall via pipenv --rm in api/Makefile
-.PHONY: uninstall
-uninstall:
-	$(MAKE) -C $(API_DIR) clean uninstall
+.PHONY: teardown
+teardown:
+	$(MAKE) -C $(API_DIR) clean teardown
 	shx rm -rf '**/node_modules'
 
 .PHONY: push-api-balena

--- a/api/Makefile
+++ b/api/Makefile
@@ -65,8 +65,8 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 .PHONY: all
 all: clean wheel
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	$(pipenv_envvars) pipenv sync $(pipenv_opts)
 	$(pipenv_envvars) pipenv run pip freeze
 
@@ -74,8 +74,8 @@ install:
 clean: docs-clean
 	$(clean_cmd)
 
-.PHONY: uninstall
-uninstall:
+.PHONY: teardown
+teardown:
 	$(pipenv_envvars)	pipenv --rm
 
 dist/opentrons-%-py2.py3-none-any.whl: setup.py $(ot_sources)

--- a/api/README.rst
+++ b/api/README.rst
@@ -34,7 +34,7 @@ The Opentrons library has two purposes:
 Setting Up For Development
 --------------------------
 
-First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make install`` in this subdirectory.
+First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory.
 
 The only additional prerequisite concerns building documentation. If you want to build the PDF version of the documentation, you will need an installation of `LaTeX <https://www.latex-project.org/get/>`_ that includes the ``pdflatex`` tool. Note that if you don’t install this, everything will still work - you just won’t get the PDF documentation.
 

--- a/app-shell/README.md
+++ b/app-shell/README.md
@@ -300,11 +300,11 @@ To get started: clone the Opentrons/opentrons repository, set up your computer f
 
 ```shell
 # prerequisite: install dependencies as specified in project setup
-make install
+make setup
 # change into the app-shell directory
 cd app-shell
 # install dependencies
-make install
+make setup
 # launch the electron app in dev mode
 make dev
 ```

--- a/app/Makefile
+++ b/app/Makefile
@@ -19,8 +19,8 @@ discovery_client_dir = ../discovery-client
 .PHONY: all
 all: clean dist
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/app/README.md
+++ b/app/README.md
@@ -18,7 +18,7 @@ To get started: clone the Opentrons/opentrons repository, set up your computer f
 # change into the cloned directory
 cd opentrons
 # prerequisite: install dependencies as specified in project setup
-make install
+make setup
 # launch the dev server / electron app in dev mode
 make -C app dev
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - ps: $env:nodejs_version = Get-Content -Path .nvmrc
   - ps: Install-Product node $env:nodejs_version x64
   # install dev dependencies
-  - cmd: '%MAKE% -j 2 install'
+  - cmd: '%MAKE% -j 2 setup'
   # TODO(mc, 2019-09-09): remove this workaround when this issue is fixed:
   # https://github.com/electron-userland/electron-builder/issues/4092
   - cmd: 'yarn add -DW electron-builder@21.1.2'

--- a/components/Makefile
+++ b/components/Makefile
@@ -15,8 +15,8 @@ port ?= 8081
 .PHONY: all
 all: clean dist
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/discovery-client/Makefile
+++ b/discovery-client/Makefile
@@ -12,8 +12,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 .PHONY: all
 all: clean lib
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/labware-designer/Makefile
+++ b/labware-designer/Makefile
@@ -12,8 +12,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 .PHONY: all
 all: clean dist
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/labware-designer/README.md
+++ b/labware-designer/README.md
@@ -22,8 +22,8 @@ Any labware that does not meet the criteria of 'regular'. A labware is irregular
 
 ## Launching the Tool
 
-First you should make sure that you run `make install` within the `opentrons` top level folder.
-If you are up-to-date on all other directories you can simply run `make install-js` instead.
+First you should make sure that you run `make setup` within the `opentrons` top level folder.
+If you are up-to-date on all other directories you can simply run `make setup-js` instead.
 Next you have two options:
 
 1. From the top level folder type: `make -C labware-designer dev`

--- a/labware-library/README.md
+++ b/labware-library/README.md
@@ -14,7 +14,7 @@ Follow the top-level [contributing guide][contributing] to set your repository u
 
 ```shell
 cd opentrons
-make install
+make setup
 ```
 
 ### common tasks

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -12,8 +12,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 .PHONY: all
 all: clean build
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -12,7 +12,7 @@ Protocol Designer Beta is optimized for [Chrome][chrome] browser. Other browsers
 # from the repo root
 
 # install all dependencies
-make install
+make setup
 
 cd protocol-designer/
 

--- a/protocol-library-kludge/Makefile
+++ b/protocol-library-kludge/Makefile
@@ -12,8 +12,8 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 .PHONY: all
 all: clean dist
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	yarn
 
 .PHONY: clean

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -47,8 +47,8 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 .PHONY: all
 all: clean wheel
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	$(pipenv_envvars) pipenv sync $(pipenv_opts)
 	$(pipenv_envvars) pipenv run pip freeze
 
@@ -56,8 +56,8 @@ install:
 clean:
 	$(clean_cmd)
 
-.PHONY: uninstall
-uninstall:
+.PHONY: teardown
+teardown:
 	$(pipenv_envvars)	pipenv --rm
 
 dist/robotserver-%-py2.py3-none-any.whl: setup.py $(ot_sources)

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -21,7 +21,7 @@ This document is about the structure and purpose of the source code of the HTTP 
 Setting Up For Development
 --------------------------
 
-First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make install`` in this subdirectory.
+First, read the `top-level contributing guide section on setup <https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#environment-and-repository>`_. As that document states, once you have installed the prerequisites you can simply run ``make setup`` in this subdirectory.
 
 
 Configuration

--- a/shared-data/js/scripts/build.js
+++ b/shared-data/js/scripts/build.js
@@ -1,4 +1,4 @@
-// This build script is run by `make install`
+// This build script is run by `make setup`
 
 // Merge all v1 labware files into a single JSON file, build/labware.json,
 // with each filename as a key in the final JSON file.

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -21,8 +21,8 @@ br_ssh_key ?= $(default_ssh_key)
 br_ssh_opts ?= $(default_ssh_opts)
 
 
-.PHONY: install
-install:
+.PHONY: setup
+setup:
 	$(pipenv_envvars) pipenv sync $(pipenv_opts)
 
 .PHONY: dev

--- a/update-server/README.md
+++ b/update-server/README.md
@@ -27,7 +27,7 @@ root of the [Opentrons/opentrons repository](https://github.com/Opentrons/opentr
 To test the update server, open a terminal to this directory and enter:
 
 ```bash
-make install
+make setup
 make test
 make lint
 ```


### PR DESCRIPTION
## overview

This renames, repository-wide:

* `make install` ➡️ `make setup`
  * `make install-js` ➡️ `make setup-js`
  * `make install-py` ➡️ `make setup-py`
* `make uninstall` ➡️ `make teardown`

To match mainstream convention, and to be consistent with [Opentrons/opentrons-modules](https://github.com/Opentrons/opentrons-modules).

Closes #4598.

## changelog

* **Breaking: Renamed build targets, as described above.**
* Made the relevant adjustments to CI scripts.
* Updated all mentions of the target names in readmes and other guides.

## review requests

* This quits `make install` cold-turkey. Do we want a deprecation period, instead? It didn't seem worthwhile to me.

## risk assessment

Low?

It's certainly possible I missed an instance. But this change doesn't affect customers, and if it breaks, it will break loudly.