### PR TITLE
refactor(protocol-designer): add names to edit, add, and delete module buttons in PD

### DIFF
--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -558,15 +558,13 @@ describe('Protocols with Modules', () => {
     it('deletes and replaces modules', () => {
       // Delete Magnetic Module
       cy.openFilePage()
+      cy.get('button[name="removeMagneticModuleType"]').click()
+      cy.get('button[name="addMagneticModuleType"]').should('exist')
       cy.get('h4')
         .contains('Magnetic')
         .parent()
         .within(() => {
-          cy.get('button')
-            .contains('remove')
-            .click()
           cy.contains('Slot 1').should('not.exist')
-          cy.contains('add').should('exist')
         })
       cy.openDesignPage()
       cy.get('h3')
@@ -594,14 +592,7 @@ describe('Protocols with Modules', () => {
 
       // Replace Magnetic Module
       cy.openFilePage()
-      cy.get('h4')
-        .contains('Magnetic')
-        .parent()
-        .within(() => {
-          cy.get('button')
-            .contains('add')
-            .click()
-        })
+      cy.get('button[name="addMagneticModuleType"]').click()
       cy.get(editModuleModal).within(() => {
         cy.get('select[disabled]')
           .contains('Slot 1')
@@ -612,13 +603,13 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
+      cy.get('button[name="removeMagneticModuleType"]').should('exist')
+      cy.get('button[name="editMagneticModuleType"]').should('exist')
       cy.get('h4')
         .contains('Magnetic')
         .parent()
         .within(() => {
           cy.contains('Slot 1').should('exist')
-          cy.contains('remove').should('exist')
-          cy.contains('Edit').should('exist')
         })
 
       // Verify timeline errors resolved
@@ -640,15 +631,13 @@ describe('Protocols with Modules', () => {
 
       // Delete Temperature Module
       cy.openFilePage()
+      cy.get('button[name="removeTemperatureModuleType"]').click()
+      cy.get('button[name="addTemperatureModuleType"]').should('exist')
       cy.get('h4')
         .contains('Temperature')
         .parent()
         .within(() => {
-          cy.get('button')
-            .contains('remove')
-            .click()
           cy.contains('Slot 3').should('not.exist')
-          cy.contains('add').should('exist')
         })
       cy.openDesignPage()
       cy.get('h3')
@@ -702,14 +691,7 @@ describe('Protocols with Modules', () => {
 
       // Replace Temperature Module
       cy.openFilePage()
-      cy.get('h4')
-        .contains('Temperature')
-        .parent()
-        .within(() => {
-          cy.get('button')
-            .contains('add')
-            .click()
-        })
+      cy.get('button[name="addTemperatureModuleType"]').click()
       cy.get(editModuleModal).within(() => {
         cy.get('select[disabled]')
           .contains('Slot 3')
@@ -720,13 +702,13 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
+      cy.get('button[name="removeTemperatureModuleType"]').should('exist')
+      cy.get('button[name="editTemperatureModuleType"]').should('exist')
       cy.get('h4')
         .contains('Temperature')
         .parent()
         .within(() => {
           cy.contains('Slot 3').should('exist')
-          cy.contains('remove').should('exist')
-          cy.contains('Edit').should('exist')
         })
 
       // Resolve Timeline Errors

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -560,12 +560,6 @@ describe('Protocols with Modules', () => {
       cy.openFilePage()
       cy.get('button[name="removeMagneticModuleType"]').click()
       cy.get('button[name="addMagneticModuleType"]').should('exist')
-      cy.get('h4')
-        .contains('Magnetic')
-        .parent()
-        .within(() => {
-          cy.contains('Slot 1').should('not.exist')
-        })
       cy.openDesignPage()
       cy.get('h3')
         .contains('4. magnet', { matchCase: false })
@@ -605,12 +599,6 @@ describe('Protocols with Modules', () => {
       })
       cy.get('button[name="removeMagneticModuleType"]').should('exist')
       cy.get('button[name="editMagneticModuleType"]').should('exist')
-      cy.get('h4')
-        .contains('Magnetic')
-        .parent()
-        .within(() => {
-          cy.contains('Slot 1').should('exist')
-        })
 
       // Verify timeline errors resolved
       cy.openDesignPage()
@@ -633,12 +621,6 @@ describe('Protocols with Modules', () => {
       cy.openFilePage()
       cy.get('button[name="removeTemperatureModuleType"]').click()
       cy.get('button[name="addTemperatureModuleType"]').should('exist')
-      cy.get('h4')
-        .contains('Temperature')
-        .parent()
-        .within(() => {
-          cy.contains('Slot 3').should('not.exist')
-        })
       cy.openDesignPage()
       cy.get('h3')
         .contains('1. temperature', { matchCase: false })
@@ -704,12 +686,6 @@ describe('Protocols with Modules', () => {
       })
       cy.get('button[name="removeTemperatureModuleType"]').should('exist')
       cy.get('button[name="editTemperatureModuleType"]').should('exist')
-      cy.get('h4')
-        .contains('Temperature')
-        .parent()
-        .within(() => {
-          cy.contains('Slot 3').should('exist')
-        })
 
       // Resolve Timeline Errors
       cy.openDesignPage()

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -145,6 +145,7 @@ export function ModuleRow(props: Props) {
             <OutlineButton
               className={styles.module_button}
               onClick={handleEditModule}
+              name={dataIdFormat('edit', type)}
             >
               Edit
             </OutlineButton>
@@ -152,6 +153,7 @@ export function ModuleRow(props: Props) {
           <OutlineButton
             className={styles.module_button}
             onClick={handleAddOrRemove}
+            name={dataIdFormat(addRemoveText, type)}
           >
             {addRemoveText}
           </OutlineButton>
@@ -160,3 +162,6 @@ export function ModuleRow(props: Props) {
     </div>
   )
 }
+
+const dataIdFormat = (action: string, moduleType: ModuleRealType): string =>
+  `${action}${moduleType.charAt(0).toUpperCase()}${moduleType.slice(1)}`

--- a/protocol-designer/src/components/modules/ModuleRow.js
+++ b/protocol-designer/src/components/modules/ModuleRow.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from 'react'
+import { useDispatch } from 'react-redux'
+import upperFirst from 'lodash/upperFirst'
 import {
   LabeledValue,
   OutlineButton,
@@ -8,14 +10,12 @@ import {
   useHoverTooltip,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
-import { useDispatch } from 'react-redux'
 import { actions as stepFormActions } from '../../step-forms'
-
-import { ModuleDiagram } from './ModuleDiagram'
 import {
   SPAN7_8_10_11_SLOT,
   DEFAULT_MODEL_FOR_MODULE_TYPE,
 } from '../../constants'
+import { ModuleDiagram } from './ModuleDiagram'
 import { isModuleWithCollisionIssue } from './utils'
 import styles from './styles.css'
 
@@ -145,7 +145,7 @@ export function ModuleRow(props: Props) {
             <OutlineButton
               className={styles.module_button}
               onClick={handleEditModule}
-              name={dataIdFormat('edit', type)}
+              name={`edit${upperFirst(type)}`}
             >
               Edit
             </OutlineButton>
@@ -153,7 +153,7 @@ export function ModuleRow(props: Props) {
           <OutlineButton
             className={styles.module_button}
             onClick={handleAddOrRemove}
-            name={dataIdFormat(addRemoveText, type)}
+            name={`${addRemoveText}${upperFirst(type)}`}
           >
             {addRemoveText}
           </OutlineButton>
@@ -162,6 +162,3 @@ export function ModuleRow(props: Props) {
     </div>
   )
 }
-
-const dataIdFormat = (action: string, moduleType: ModuleRealType): string =>
-  `${action}${moduleType.charAt(0).toUpperCase()}${moduleType.slice(1)}`


### PR DESCRIPTION
## overview

This PR adds button names to the edit, remove, and add module buttons in PD to be used in e2e tests.

I also removed assertions on checking for slot position because they seemed verbose and unnecessary since we're already checking that correct buttons should exist. I can put them back if anyone feels that they're important though.

Closes out #5724.

## changelog

  - Add button names to the edit, remove, and add module buttons in PD

## review requests
Make sure it this seems reasonable

## risk assessment
Very low, just adding a data-id for testing
