### PR TITLE
feat(protocol-designer): Add step grouping and styles for tc cycles

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -320,9 +320,9 @@ and when that is implemented.
   @apply --font-form-default;
 
   display: grid;
-  grid-template-columns: 13.5rem 7.25rem 7.25rem;
+  grid-template-columns: 14.5rem 7.25rem 7.25rem;
   font-weight: var(--fw-semibold);
-  padding: 1rem 0 0.25rem 0.625rem;
+  padding: 1rem 0 0.25rem 2.125rem;
 }
 
 .profile_step_number {

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -337,6 +337,10 @@ and when that is implemented.
   display: flex;
   align-items: center;
   padding: 0.25rem 0;
+
+  &.cycle {
+    padding: 0;
+  }
 }
 
 .profile_step_fields {
@@ -345,6 +349,11 @@ and when that is implemented.
   border: var(--bd-light);
   width: 100%;
   padding: 0.5rem;
+}
+
+.profile_cycle_fields {
+  width: 31.5rem;
+  border: none;
 }
 
 .step_input_wrapper {
@@ -363,7 +372,73 @@ and when that is implemented.
   cursor: pointer;
 }
 
+.profile_cycle_wrapper {
+  display: flex;
+  width: 100%;
+}
+
+.cycle_steps {
+  display: flex;
+}
+
+.cycle_row {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  border-right: 1px solid var(--c-light-gray);
+  padding: 0;
+  margin-top: 0.25rem;
+  margin-right: 0.75rem;
+
+  &::before {
+    content: '';
+    background: var(--c-light-gray);
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 1px;
+    width: 1rem;
+  }
+
+  &::after {
+    content: '';
+    background: var(--c-light-gray);
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 1px;
+    width: 1rem;
+  }
+}
+
+.profile_cycle_group {
+  border: var(--bd-light);
+  width: 100%;
+  padding-right: 0.5rem;
+}
+
+.cycle_step_delete {
+  height: 3rem;
+
+  & > .delete_step_icon {
+    margin-top: 0.75rem;
+  }
+}
+
+.cycles_field {
+  margin-top: 1rem;
+}
+
+.add_cycle_step {
+  text-align: right;
+  margin: 0.75rem 0 1rem;
+}
+
 .profile_button_group {
   padding: 1rem 1.5rem 0;
   text-align: right;
+
+  & :first-child {
+    margin-right: 1.5rem;
+  }
 }

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
@@ -60,21 +60,22 @@ export const ProfileCycleRow = (props: ProfileCycleRowProps) => {
   return (
     <div className={styles.profile_cycle_wrapper}>
       <div className={styles.profile_cycle_group}>
-        <div className={styles.cycle_steps}>
-          <div className={styles.cycle_row}>
-            {cycleItem.steps.map((stepItem, index) => {
-              return (
-                <ProfileStepRow
-                  profileStepItem={stepItem}
-                  focusHandlers={focusHandlers}
-                  key={stepItem.id}
-                  stepNumber={stepOffset + index}
-                  isCycle
-                />
-              )
-            })}
-          </div>
-          {cycleItem.steps.length > 0 && (
+        {cycleItem.steps.length > 0 && (
+          <div className={styles.cycle_steps}>
+            <div className={styles.cycle_row}>
+              {cycleItem.steps.map((stepItem, index) => {
+                return (
+                  <ProfileStepRow
+                    profileStepItem={stepItem}
+                    focusHandlers={focusHandlers}
+                    key={stepItem.id}
+                    stepNumber={stepOffset + index}
+                    isCycle
+                  />
+                )
+              })}
+            </div>
+
             <ProfileField
               name="repetitions"
               focusHandlers={focusHandlers}
@@ -90,8 +91,8 @@ export const ProfileCycleRow = (props: ProfileCycleRowProps) => {
                 )
               }
             />
-          )}
-        </div>
+          </div>
+        )}
         <div className={styles.add_cycle_step}>
           <OutlineButton onClick={addStepToCycle}>+ Step</OutlineButton>
         </div>

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -18,7 +18,8 @@
     "seconds": "s",
     "minutes": "m",
     "hours": "h",
-    "degrees": "°C"
+    "degrees": "°C",
+    "cycles": "cycles"
   },
   "version": "Protocol Designer Version",
   "beta": "beta",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -49,6 +49,9 @@
     },
     "profileStepRow": {
       "deleteStep": "Delete profile step"
+    },
+    "profileCycle": {
+      "deleteCycle": "Delete cycle and steps"
     }
   },
   "edit_module_card": {


### PR DESCRIPTION
## overview


closes #5516 
closes #5517 
closes #5518 

^ functionality was covered in previous PRs. This one styles and groups the steps within the cycles and adds a tooltip to the delete cycles button.

<img width="908" alt="Screen Shot 2020-06-08 at 11 40 51 AM" src="https://user-images.githubusercontent.com/3430313/84056015-a1e26480-a983-11ea-8164-ef6df6c36184.png">

## changelog

- feat(protocol-designer):Add step grouping and styles for tc cycles
- add delete cycles tooltip
- add conditional styling for `ProfileStepRow` based on` isCycle` prop

## review requests

- [ ] Tooltip is correct (delete cycles)
- [ ] Layout matches design
- [ ] Functionality of cycle creation/validation is unaffected

## risk assessment
Low PD only mainly divs and CSS