### PR TITLE
fix(app): fix cal check tip rack images at large window sizes

### DIFF
--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -162,11 +162,13 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 14rem;
+  height: 15rem;
 }
 
 .tiprack_image {
   width: 100%;
+  max-height: 15rem;
+  max-width: 15.25rem;
 }
 
 .tiprack_display_name {


### PR DESCRIPTION
## overview

Fix issue where tip rack images in robot calibration check introduction screen overstepped their bounding border at larger window sizes of the run app (as seen in UAT).

## changelog

applied some max height and width restrictions for the image and its container.

## risk assessment

None