### PR TITLE
feat(protocol-designer): add atomic thermocyclerRunProfile command creator

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
@@ -11,6 +11,7 @@ import { thermocyclerOpenLid } from '../commandCreators/atomic/thermocyclerOpenL
 import { getSuccessResult } from '../__fixtures__'
 
 import type {
+  AtomicProfileStep,
   ModuleOnlyParams,
   TemperatureParams,
   TCProfileParams,
@@ -24,14 +25,9 @@ const getRobotInitialState = (): any => {
 // neither should InvariantContext
 const invariantContext: any = {}
 
-type ProfileItem = $ElementType<
-  $PropertyType<TCProfileParams, 'profile'>,
-  number // Using arrays, we don't statically know the size of the array, so `number` is the key
->
-
 const module: $PropertyType<ModuleOnlyParams, 'module'> = 'someTCModuleId'
 const temperature: $PropertyType<TemperatureParams, 'temperature'> = 42
-const holdTime: $PropertyType<ProfileItem, 'holdTime'> = 10
+const holdTime: $PropertyType<AtomicProfileStep, 'holdTime'> = 10
 const volume: $PropertyType<TCProfileParams, 'volume'> = 10
 const profile = [{ temperature, holdTime }]
 

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerAtomicCommands.test.js
@@ -5,9 +5,16 @@ import { thermocyclerAwaitBlockTemperature } from '../commandCreators/atomic/the
 import { thermocyclerAwaitLidTemperature } from '../commandCreators/atomic/thermocyclerAwaitLidTemperature'
 import { thermocyclerDeactivateBlock } from '../commandCreators/atomic/thermocyclerDeactivateBlock'
 import { thermocyclerDeactivateLid } from '../commandCreators/atomic/thermocyclerDeactivateLid'
+import { thermocyclerRunProfile } from '../commandCreators/atomic/thermocyclerRunProfile'
 import { thermocyclerCloseLid } from '../commandCreators/atomic/thermocyclerCloseLid'
 import { thermocyclerOpenLid } from '../commandCreators/atomic/thermocyclerOpenLid'
 import { getSuccessResult } from '../__fixtures__'
+
+import type {
+  ModuleOnlyParams,
+  TemperatureParams,
+  TCProfileParams,
+} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import type { CommandCreator } from '../types'
 
 const getRobotInitialState = (): any => {
@@ -17,8 +24,16 @@ const getRobotInitialState = (): any => {
 // neither should InvariantContext
 const invariantContext: any = {}
 
-const module = 'someTCModuleId'
-const temperature = 42
+type ProfileItem = $ElementType<
+  $PropertyType<TCProfileParams, 'profile'>,
+  number // Using arrays, we don't statically know the size of the array, so `number` is the key
+>
+
+const module: $PropertyType<ModuleOnlyParams, 'module'> = 'someTCModuleId'
+const temperature: $PropertyType<TemperatureParams, 'temperature'> = 42
+const holdTime: $PropertyType<ProfileItem, 'holdTime'> = 10
+const volume: $PropertyType<TCProfileParams, 'volume'> = 10
+const profile = [{ temperature, holdTime }]
 
 describe('thermocycler atomic commands', () => {
   // NOTE(IL, 2020-05-11): splitting these into different arrays based on type of args
@@ -73,6 +88,14 @@ describe('thermocycler atomic commands', () => {
     },
   ]
 
+  const testCasesRunProfile = [
+    {
+      commandCreator: thermocyclerRunProfile,
+      expectedType: 'thermocycler/runProfile',
+      params: { module, profile, volume },
+    },
+  ]
+
   const testParams = <P>({
     commandCreator,
     params,
@@ -101,4 +124,5 @@ describe('thermocycler atomic commands', () => {
   testCasesSetBlock.forEach(testParams)
   testCasesWithTempParam.forEach(testParams)
   testCasesModuleOnly.forEach(testParams)
+  testCasesRunProfile.forEach(testParams)
 })

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerRunProfile.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerRunProfile.js
@@ -1,0 +1,23 @@
+// @flow
+import type { TCProfileParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerRunProfile: CommandCreator<TCProfileParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { module, profile, volume } = args
+  return {
+    commands: [
+      {
+        command: 'thermocycler/runProfile',
+        params: {
+          module,
+          profile,
+          volume,
+        },
+      },
+    ],
+  }
+}

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -23,6 +23,12 @@ export type EngageMagnetParams = {|
 
 export type TemperatureParams = {| module: string, temperature: number |}
 
+export type TCProfileParams = {|
+  module: string,
+  profile: Array<{| temperature: number, holdTime: number |}>,
+  volume: number,
+|}
+
 export type ModuleOnlyParams = {| module: string |}
 
 export type ThermocyclerSetTargetBlockTemperatureArgs = {|

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -23,9 +23,10 @@ export type EngageMagnetParams = {|
 
 export type TemperatureParams = {| module: string, temperature: number |}
 
+export type AtomicProfileStep = {| holdTime: number, temperature: number |}
 export type TCProfileParams = {|
   module: string,
-  profile: Array<{| temperature: number, holdTime: number |}>,
+  profile: Array<AtomicProfileStep>,
   volume: number,
 |}
 
@@ -98,11 +99,7 @@ export type Command =
   | {| command: 'thermocycler/deactivateLid', params: ModuleOnlyParams |}
   | {|
       command: 'thermocycler/runProfile',
-      params: {|
-        module: string,
-        profile: Array<{| temperature: number, holdTime: number |}>,
-        volume: number,
-      |},
+      params: TCProfileParams,
     |}
   | {| command: 'thermocycler/awaitProfileComplete', params: ModuleOnlyParams |}
 


### PR DESCRIPTION
## overview

This PR closes #5839 by adding a `thermocyclerRunProfile` atomic command creator. 

Note: this isn't being used yet, will be used by `thermocyclerProfileStep` in #5835


## changelog

  - Add atomic thermocyclerRunProfile command creator

## review requests
Code review

## risk assessment
Very low, adding a command creator that is not being used yet
