### PR TITLE
feat(protocol-designer): Add number maskers to tc duration fields

### DIFF
--- a/protocol-designer/src/constants.js
+++ b/protocol-designer/src/constants.js
@@ -102,6 +102,9 @@ export const MAX_TC_BLOCK_TEMP = 99
 export const MIN_TC_LID_TEMP = 37
 export const MAX_TC_LID_TEMP = 110
 
+export const MIN_TC_DURATION_SECONDS = 0
+export const MAX_TC_DURATION_SECONDS = 60
+
 // Temperature statuses
 export const TEMPERATURE_DEACTIVATED: 'TEMPERATURE_DEACTIVATED' =
   'TEMPERATURE_DEACTIVATED'

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -224,11 +224,7 @@ const profileFieldHelperMap: { [string]: StepFieldHelpers } = {
     castValue: Number,
   },
   durationMinutes: {
-    maskValue: composeMaskers(
-      maskToFloat,
-      onlyPositiveNumbers,
-      trimDecimals(1)
-    ),
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
   durationSeconds: {

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -223,6 +223,18 @@ const profileFieldHelperMap: { [string]: StepFieldHelpers } = {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },
+  durationMinutes: {
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
+    castValue: Number,
+  },
+  durationSeconds: {
+    maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
+    castValue: Number,
+  },
   // profile cycle fields
   repetitions: {
     getErrors: composeErrors(requiredField),

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -26,6 +26,8 @@ import {
   MAX_TC_BLOCK_TEMP,
   MIN_TC_LID_TEMP,
   MAX_TC_LID_TEMP,
+  MIN_TC_DURATION_SECONDS,
+  MAX_TC_DURATION_SECONDS,
 } from '../../constants'
 import type { StepFieldName } from '../../form-types'
 import type { LabwareEntity, PipetteEntity } from '../../step-forms'
@@ -228,6 +230,10 @@ const profileFieldHelperMap: { [string]: StepFieldHelpers } = {
     castValue: Number,
   },
   durationSeconds: {
+    getErrors: composeErrors(
+      minFieldValue(MIN_TC_DURATION_SECONDS),
+      maxFieldValue(MAX_TC_DURATION_SECONDS)
+    ),
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),
     castValue: Number,
   },


### PR DESCRIPTION
## overview

This PR closes #5737 by adding the missing number maskers to durationMinutes and durationSeconds fields in TC profile steps/cycles.

## changelog

feat(protocol-designer): Add number maskers to tc duration fields

## review requests

- [ ] Minutes field is floats only, 1 decimal point allowed
- [ ] Seconds is masked to integers
- [ ] No other validation from the ticket is missing

## risk assessment

Low PD behind a FF
