### PR TITLE
refactor(api): Separate out pipette tolerances further in cal check

### DIFF
--- a/api/src/opentrons/calibration/check/constants.py
+++ b/api/src/opentrons/calibration/check/constants.py
@@ -1,0 +1,24 @@
+from opentrons.types import Point
+
+
+MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
+
+# Add in a 2mm buffer to tiprack thresholds on top of
+# the max acceptable range for a given pipette based
+# on calibration research data.
+DEFAULT_OK_TIP_PICK_UP_VECTOR = Point(3.79, 3.64, 2.8)
+P1000_OK_TIP_PICK_UP_VECTOR = Point(4.7, 4.7, 2.8)
+
+
+# The tolerances below are absolute values that a pipette
+# might be off due to things that cannot be controlled
+# such as tip straightness or slight changes betweeen
+# tip length. Please review the Motion research for
+# further information.
+PIPETTE_TOLERANCES = {
+    'p1000_crosses': Point(2.7, 2.7, 0.0),
+    'p1000_height': Point(0.0, 0.0, 1.0),
+    'p300_crosses': Point(1.8, 1.8, 0.0),
+    'p20_crosses': Point(1.4, 1.4, 0.0),
+    'other_height': Point(0.0, 0.0, 0.8)
+}

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -540,6 +540,8 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         if pip and pip.mount:
             pipette_type = str(self.pipettes[pip.mount]['model'])
         is_p1000 = pipette_type.startswith('p1000')
+        is_p20 = \
+            pipette_type.startswith('p20') or pipette_type.startswith('p10')
         height_states = [
             CalibrationCheckState.comparingFirstPipetteHeight,
             CalibrationCheckState.comparingSecondPipetteHeight]
@@ -552,9 +554,11 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
         if is_p1000 and state in cross_states:
             return Point(2.7, 2.7, 0.0)
         elif is_p1000 and state in height_states:
-            return Point(0.0, 0.0, 1)
+            return Point(0.0, 0.0, 1.0)
+        elif is_p20 and state in cross_states:
+            return Point(1.4, 1.4, 0.0)
         elif state in cross_states:
-            return Point(1.79, 1.64, 0.0)
+            return Point(1.8, 1.8, 0.0)
         else:
             return Point(0.0, 0.0, 0.8)
 

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -16,6 +16,11 @@ from opentrons.calibration.helper_classes import (
 from opentrons.hardware_control import ThreadManager
 from opentrons.protocol_api import labware
 
+from .constants import (PIPETTE_TOLERANCES,
+                        P1000_OK_TIP_PICK_UP_VECTOR,
+                        DEFAULT_OK_TIP_PICK_UP_VECTOR,
+                        MOVE_TO_TIP_RACK_SAFETY_BUFFER)
+
 MODULE_LOG = logging.getLogger(__name__)
 
 """
@@ -267,15 +272,6 @@ CHECK_TRANSITIONS: typing.List[typing.Dict[str, typing.Any]] = [
         "to_state": CalibrationCheckState.badCalibrationData
     }
 ]
-
-
-MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
-
-# Add in a 2mm buffer to tiprack thresholds on top of
-# the max acceptable range for a given pipette based
-# on calibration research data.
-DEFAULT_OK_TIP_PICK_UP_VECTOR = Point(3.79, 3.64, 2.8)
-P1000_OK_TIP_PICK_UP_VECTOR = Point(4.7, 4.7, 2.8)
 
 
 @dataclass
@@ -538,10 +534,11 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
 
         pipette_type = ''
         if pip and pip.mount:
-            pipette_type = str(self.pipettes[pip.mount]['model'])
-        is_p1000 = pipette_type.startswith('p1000')
-        is_p20 = \
-            pipette_type.startswith('p20') or pipette_type.startswith('p10')
+            pipette_type = str(self.pipettes[pip.mount]['name'])
+
+        is_p1000 = pipette_type in ['p1000_single_gen2', 'p1000_single']
+        is_p20 = pipette_type in \
+            ['p20_single_gen2', 'p10_single', 'p20_multi_gen2', 'p10_multi']
         height_states = [
             CalibrationCheckState.comparingFirstPipetteHeight,
             CalibrationCheckState.comparingSecondPipetteHeight]
@@ -552,15 +549,15 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
             CalibrationCheckState.comparingSecondPipettePointOne
         ]
         if is_p1000 and state in cross_states:
-            return Point(2.7, 2.7, 0.0)
+            return PIPETTE_TOLERANCES['p1000_crosses']
         elif is_p1000 and state in height_states:
-            return Point(0.0, 0.0, 1.0)
+            return PIPETTE_TOLERANCES['p1000_height']
         elif is_p20 and state in cross_states:
-            return Point(1.4, 1.4, 0.0)
+            return PIPETTE_TOLERANCES['p20_crosses']
         elif state in cross_states:
-            return Point(1.8, 1.8, 0.0)
+            return PIPETTE_TOLERANCES['p300_crosses']
         else:
-            return Point(0.0, 0.0, 0.8)
+            return PIPETTE_TOLERANCES['other_height']
 
     def _is_instr_offset_diff(
             self,


### PR DESCRIPTION
We have further split out pipette tolerances into 3 separate use cases:
1. P1000s
2. p20/p10s
3. p300/p50s

The XY values are different for use case 2/3, but the height check will remain the same.