### PR TITLE
refactor(js): enable Flow's types-first mode and fix errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,42 +37,9 @@ esproposal.optional_chaining=enable
 ; default value of 19 (16 * 2^19 bytes > 8ish MB) isn't quite enough and can
 ; result in flow crashing with `Unhandled exception: SharedMem.Hash_table_full`
 sharedmemory.hash_table_pow=20
-; TODO(mc, 2020-06-01): prepare for types-first mode by
-; 1. Uncommenting + fixing remaining well_formed_exports items below
-; 2. Replacing `well_formed_exports` options with `types_first=true`
+; enable types-first mode for speed and explicitness
 ; https://flow.org/en/docs/lang/types-first/
-well_formed_exports=true
-well_formed_exports.whitelist=<PROJECT_ROOT>/app
-well_formed_exports.whitelist=<PROJECT_ROOT>/app-shell
-well_formed_exports.whitelist=<PROJECT_ROOT>/components
-well_formed_exports.whitelist=<PROJECT_ROOT>/discovery-client
-well_formed_exports.whitelist=<PROJECT_ROOT>/labware-designer
-well_formed_exports.whitelist=<PROJECT_ROOT>/labware-library
-; well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/analytics
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/components
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/containers
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/dismiss
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/feature-flags
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/file-data
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/labware-defs
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/labware-ingred
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/load-file
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/localization
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/modules
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/navigation
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/networking
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/pipettes
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/step-forms
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/step-generation
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/steplist
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/top-selectors
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/tutorial
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/ui
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/utils
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-designer/src/well-selection
-well_formed_exports.whitelist=<PROJECT_ROOT>/protocol-library-kludge
-well_formed_exports.whitelist=<PROJECT_ROOT>/shared-data
+types_first=true
 
 [strict]
 deprecated-type

--- a/app/src/components/CalibrateLabware/ConfirmModalContents.js
+++ b/app/src/components/CalibrateLabware/ConfirmModalContents.js
@@ -52,7 +52,7 @@ function ConfirmModalContentsComponent(props: Props) {
     case 'picking-up':
     case 'dropping-tip':
     case 'confirming':
-      return <InProgressContents {...props} />
+      return <InProgressContents />
 
     default:
       return null

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk'
 import { makePersistSubscriber, rehydratePersistedAction } from './persist'
 import { fileUploadMessage } from './load-file/actions'
 
+import type { Store } from 'redux'
 import type { BaseState, Action, ThunkDispatch } from './types'
 
 const ReselectTools =
@@ -58,7 +59,11 @@ function getRootReducer() {
   }
 }
 
-export function configureStore() {
+export function configureStore(): Store<
+  BaseState,
+  Action,
+  ThunkDispatch<Action>
+> {
   const reducer = getRootReducer()
 
   const composeEnhancers: any =
@@ -111,5 +116,6 @@ export function configureStore() {
     )
   }
 
+  // $FlowFixMe(mc, 2020-06-09): Flow doesn't like mixture of exact and inexact action types
   return store
 }


### PR DESCRIPTION
## overview

This PR finishes the Flow [Types First](https://flow.org/en/docs/lang/types-first/) migration of our JS codebase and enables the setting. This should result in faster typechecking all around, especially when in lazy mode.

Culmination of work in #5785, #5799, #5800, #5803, #5817, #5824, #5825, #5827, #5833, and #5834.

## changelog

- refactor(js): enable Flow's types-first mode and fix errors

## review requests

Check the "fixes" in this PR carefully! There was an instance in the app of props being passed down unnecessarily into a component that didn't expect any props. Don't know why it wasn't caught sooner, but yeah, hopefully that demonstrates this this is a good typechecking change!

You probably want to make sure your IDE is also using Flow in lazy mode if you haven't done so already! In VSCode, the setting is `"flow.lazyMode": "ide"` (in the UI as "Flow: Lazy Mode")

## risk assessment

Low! Speeds up typechecking, which doesn't affect runtime