### PR TITLE
feat(protocol-designer): add TC run profile state updater

### DIFF
--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -14,6 +14,7 @@ import {
   forThermocyclerDeactivateLid,
   forThermocyclerSetTargetBlockTemperature,
   forThermocyclerSetTargetLidTemperature,
+  forThermocyclerRunProfile,
   forThermocyclerCloseLid,
   forThermocyclerOpenLid,
 } from './thermocyclerUpdates'
@@ -145,6 +146,12 @@ function _getNextRobotStateAndWarningsSingleCommand(
       )
       break
     case 'thermocycler/runProfile':
+      forThermocyclerRunProfile(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
+      break
     case 'thermocycler/awaitProfileComplete':
       console.warn(`NOT IMPLEMENTED: ${command.command}`)
       break

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
@@ -1,8 +1,10 @@
 // @flow
+import last from 'lodash/last'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import { getModuleState } from '../robotStateSelectors'
 import type {
   ModuleOnlyParams,
+  TCProfileParams,
   TemperatureParams,
   ThermocyclerSetTargetBlockTemperatureArgs,
 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
@@ -116,4 +118,17 @@ export const forThermocyclerOpenLid = (
 
   const moduleState = _getThermocyclerModuleState(robotState, module)
   moduleState.lidOpen = true
+}
+
+export const forThermocyclerRunProfile = (
+  params: TCProfileParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  const { module, profile } = params
+  const { robotState } = robotStateAndWarnings
+
+  const moduleState = _getThermocyclerModuleState(robotState, module)
+
+  moduleState.blockTargetTemp = last(profile).temperature
 }


### PR DESCRIPTION
## overview

This PR closes #5837 by adding a robot state updater for `thermocycler/runProfile`

Note, I plugged in the state updater to `getNextRobotStateAndWarnings , but the UI isn't hooked up yet so it's not being used.

## review requests
Code review

## risk assessment
Very low, not being used yet and behind FF