### PR TITLE
fix(api): return rail lights to original state post cal-check

### DIFF
--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -302,7 +302,8 @@ COMPARISON_STATE_MAP: typing.Dict[CalibrationCheckState, ComparisonParams] = {
 
 
 class CheckCalibrationSession(CalibrationSession, StateMachine):
-    def __init__(self, hardware: 'ThreadManager', lights_on_before: bool = False):
+    def __init__(self, hardware: 'ThreadManager',
+                 lights_on_before: bool = False):
         CalibrationSession.__init__(self, hardware, lights_on_before)
         StateMachine.__init__(self, states=[s for s in CalibrationCheckState],
                               transitions=CHECK_TRANSITIONS,

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -302,8 +302,8 @@ COMPARISON_STATE_MAP: typing.Dict[CalibrationCheckState, ComparisonParams] = {
 
 
 class CheckCalibrationSession(CalibrationSession, StateMachine):
-    def __init__(self, hardware: 'ThreadManager'):
-        CalibrationSession.__init__(self, hardware)
+    def __init__(self, hardware: 'ThreadManager', lights_on_before: bool = False):
+        CalibrationSession.__init__(self, hardware, lights_on_before)
         StateMachine.__init__(self, states=[s for s in CalibrationCheckState],
                               transitions=CHECK_TRANSITIONS,
                               initial_state="sessionStarted")
@@ -388,7 +388,8 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                 except (CalibrationException, AssertionError):
                     pass
         await self.hardware.home()
-        await self.hardware.set_lights(rails=False)
+        if not self._lights_on_before:
+            await self.hardware.set_lights(rails=False)
 
     def _get_preparing_state_mount(self) -> typing.Optional[Mount]:
         pip = None

--- a/api/src/opentrons/calibration/session.py
+++ b/api/src/opentrons/calibration/session.py
@@ -35,8 +35,9 @@ HEIGHT_SAFETY_BUFFER = Point(0, 0, 5.0)
 
 class CalibrationSession:
     """Class that controls state of the current robot calibration session"""
-    def __init__(self, hardware: ThreadManager):
+    def __init__(self, hardware: ThreadManager, lights_on_before: bool = False):
         self._hardware = hardware
+        self._lights_on_before = lights_on_before
         self._deck = geometry.Deck()
         self._pip_info_by_mount = self._get_pip_info_by_mount(
                 hardware.get_attached_instruments())
@@ -55,10 +56,11 @@ class CalibrationSession:
 
     @classmethod
     async def build(cls, hardware: ThreadManager):
+        lights_on = hardware.get_lights()['rails']
         await hardware.cache_instruments()
         await hardware.set_lights(rails=True)
         await hardware.home()
-        return cls(hardware=hardware)
+        return cls(hardware=hardware, lights_on_before=lights_on)
 
     @staticmethod
     def _get_pip_info_by_mount(

--- a/api/src/opentrons/calibration/session.py
+++ b/api/src/opentrons/calibration/session.py
@@ -35,7 +35,8 @@ HEIGHT_SAFETY_BUFFER = Point(0, 0, 5.0)
 
 class CalibrationSession:
     """Class that controls state of the current robot calibration session"""
-    def __init__(self, hardware: ThreadManager, lights_on_before: bool = False):
+    def __init__(self, hardware: ThreadManager,
+                 lights_on_before: bool = False):
         self._hardware = hardware
         self._lights_on_before = lights_on_before
         self._deck = geometry.Deck()

--- a/api/tests/opentrons/calibration/check/test_check_calibration_session.py
+++ b/api/tests/opentrons/calibration/check/test_check_calibration_session.py
@@ -256,6 +256,26 @@ def test_session_started(check_calibration_session):
            session.CalibrationCheckState.sessionStarted
 
 
+async def test_lights_from_off(check_calibration_session):
+    # lights were off before starting session
+    assert check_calibration_session._lights_on_before is False
+    # lights are on after starting session
+    assert check_calibration_session._hardware.get_lights()['rails'] is True
+    await check_calibration_session.delete_session()
+    # lights should be off after deleting session
+    assert check_calibration_session._hardware.get_lights()['rails'] is False
+
+
+async def test_lights_from_on(check_calibration_session):
+    # lights were on before starting session
+    check_calibration_session._lights_on_before = True
+    # lights were still on after starting session
+    assert check_calibration_session._hardware.get_lights()['rails'] is True
+    await check_calibration_session.delete_session()
+    # lights should still be on after deleting session
+    assert check_calibration_session._hardware.get_lights()['rails'] is True
+
+
 async def test_pick_up_tip_sets_current(check_calibration_session_shared_tips):
     sess = check_calibration_session_shared_tips
     await sess.trigger_transition(


### PR DESCRIPTION
## Overview

If the lights were on when you started your calibration check session, they will continue to be on when you exit the session. Conversely, if your lights were off prior to checking calibration, they will turn on for the check and return to "off" once you exit the calibration check session.

## review requests

Try starting and exiting a check session with the lights on and off respectively. 

## risk assessment

Minimal risk, mostly a nice to have design change
