### PR TITLE
fix(app): delete local records of session if id not found 

### DIFF
--- a/app/src/sessions/__tests__/actions.test.js
+++ b/app/src/sessions/__tests__/actions.test.js
@@ -75,10 +75,14 @@ describe('robot session check actions', () => {
     {
       name: 'sessions:DELETE_SESSION_FAILURE',
       creator: Actions.deleteSessionFailure,
-      args: ['robot-name', mockV2ErrorResponse, { requestId: 'abc' }],
+      args: ['robot-name', '1234', mockV2ErrorResponse, { requestId: 'abc' }],
       expected: {
         type: 'sessions:DELETE_SESSION_FAILURE',
-        payload: { robotName: 'robot-name', error: mockV2ErrorResponse },
+        payload: {
+          robotName: 'robot-name',
+          sessionId: '1234',
+          error: mockV2ErrorResponse,
+        },
         meta: { requestId: 'abc' },
       },
     },
@@ -108,10 +112,14 @@ describe('robot session check actions', () => {
     {
       name: 'sessions:FETCH_SESSION_FAILURE',
       creator: Actions.fetchSessionFailure,
-      args: ['robot-name', mockV2ErrorResponse, { requestId: 'abc' }],
+      args: ['robot-name', '1234', mockV2ErrorResponse, { requestId: 'abc' }],
       expected: {
         type: 'sessions:FETCH_SESSION_FAILURE',
-        payload: { robotName: 'robot-name', error: mockV2ErrorResponse },
+        payload: {
+          robotName: 'robot-name',
+          sessionId: '1234',
+          error: mockV2ErrorResponse,
+        },
         meta: { requestId: 'abc' },
       },
     },

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -2,6 +2,7 @@
 import * as Fixtures from '../__fixtures__'
 import { sessionReducer } from '../reducer'
 
+import { mockV2ErrorResponse } from '../../robot-api/__fixtures__'
 import type { Action } from '../../types'
 import type { SessionState } from '../types'
 
@@ -223,6 +224,82 @@ const SPECS: Array<ReducerSpec> = [
     },
     expected: {
       'eggplant-parm': {
+        robotSessions: {
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'handles sessions:DELETE_SESSION_FAILURE',
+    action: {
+      type: 'sessions:DELETE_SESSION_FAILURE',
+      payload: {
+        robotName: 'frumious-bandersnatch',
+        sessionId: Fixtures.mockSessionId,
+        error: mockV2ErrorResponse,
+      },
+      meta: {
+        response: { ...Fixtures.mockDeleteSessionFailureMeta, status: 404 },
+      },
+    },
+    state: {
+      'frumious-bandersnatch': {
+        robotSessions: {
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionAttributes,
+            id: Fixtures.mockSessionId,
+          },
+        },
+      },
+    },
+    expected: {
+      'frumious-bandersnatch': {
+        robotSessions: {
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'handles sessions:FETCH_SESSION_FAILURE',
+    action: {
+      type: 'sessions:FETCH_SESSION_FAILURE',
+      payload: {
+        robotName: 'detestable-moss',
+        sessionId: Fixtures.mockSessionId,
+        error: mockV2ErrorResponse,
+      },
+      meta: {
+        response: { ...Fixtures.mockFetchSessionFailureMeta, status: 404 },
+      },
+    },
+    state: {
+      'detestable-moss': {
+        robotSessions: {
+          existing_fake_session_id: {
+            ...Fixtures.mockSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockSessionAttributes,
+            id: Fixtures.mockSessionId,
+          },
+        },
+      },
+    },
+    expected: {
+      'detestable-moss': {
         robotSessions: {
           existing_fake_session_id: {
             ...Fixtures.mockSessionAttributes,

--- a/app/src/sessions/actions.js
+++ b/app/src/sessions/actions.js
@@ -57,11 +57,12 @@ export const deleteSessionSuccess = (
 
 export const deleteSessionFailure = (
   robotName: string,
+  sessionId: string,
   error: RobotApiV2ErrorResponseBody,
   meta: RobotApiRequestMeta
 ): Types.DeleteSessionFailureAction => ({
   type: Constants.DELETE_SESSION_FAILURE,
-  payload: { robotName, error },
+  payload: { robotName, sessionId, error },
   meta: meta,
 })
 
@@ -86,11 +87,12 @@ export const fetchSessionSuccess = (
 
 export const fetchSessionFailure = (
   robotName: string,
+  sessionId: string,
   error: RobotApiV2ErrorResponseBody,
   meta: RobotApiRequestMeta
 ): Types.FetchSessionFailureAction => ({
   type: Constants.FETCH_SESSION_FAILURE,
-  payload: { robotName, error },
+  payload: { robotName, sessionId, error },
   meta: meta,
 })
 

--- a/app/src/sessions/epic/__tests__/deleteSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/deleteSessionEpic.test.js
@@ -5,7 +5,8 @@ import * as Fixtures from '../../__fixtures__'
 import * as Actions from '../../actions'
 import { sessionsEpic } from '..'
 
-const makeTriggerAction = robotName => Actions.deleteSession(robotName, '1234')
+const makeTriggerAction = robotName =>
+  Actions.deleteSession(robotName, Fixtures.mockSessionId)
 
 describe('deleteSessionEpic', () => {
   afterEach(() => {
@@ -14,10 +15,10 @@ describe('deleteSessionEpic', () => {
 
   const expectedRequest = {
     method: 'DELETE',
-    path: '/sessions/1234',
+    path: `/sessions/${Fixtures.mockSessionId}`,
   }
 
-  it('calls DELETE /sessions/1234', () => {
+  it('calls DELETE /sessions/{id}', () => {
     const mocks = setupEpicTestMocks(
       makeTriggerAction,
       Fixtures.mockDeleteSessionSuccess

--- a/app/src/sessions/epic/__tests__/deleteSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/deleteSessionEpic.test.js
@@ -73,6 +73,7 @@ describe('deleteSessionEpic', () => {
       expectObservable(output$).toBe('--a', {
         a: Actions.deleteSessionFailure(
           mocks.robot.name,
+          Fixtures.mockSessionId,
           { errors: [{ status: 'went bad' }] },
           { ...mocks.meta, response: Fixtures.mockDeleteSessionFailureMeta }
         ),

--- a/app/src/sessions/epic/__tests__/fetchSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/fetchSessionEpic.test.js
@@ -6,7 +6,8 @@ import * as Actions from '../../actions'
 import { sessionsEpic } from '..'
 import { mockRobot } from '../../../robot-api/__fixtures__'
 
-const makeTriggerAction = robotName => Actions.fetchSession(robotName, '1234')
+const makeTriggerAction = robotName =>
+  Actions.fetchSession(robotName, Fixtures.mockSessionId)
 
 describe('fetchSessionEpic', () => {
   afterEach(() => {
@@ -15,10 +16,10 @@ describe('fetchSessionEpic', () => {
 
   const expectedRequest = {
     method: 'GET',
-    path: '/sessions/1234',
+    path: `/sessions/${Fixtures.mockSessionId}`,
   }
 
-  it('calls GET /sessions/1234', () => {
+  it('calls GET /sessions/{id}', () => {
     const mocks = setupEpicTestMocks(
       makeTriggerAction,
       Fixtures.mockFetchSessionSuccess

--- a/app/src/sessions/epic/__tests__/fetchSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/fetchSessionEpic.test.js
@@ -74,6 +74,7 @@ describe('fetchSessionEpic', () => {
       expectObservable(output$).toBe('--a', {
         a: Actions.fetchSessionFailure(
           mocks.robot.name,
+          Fixtures.mockSessionId,
           { errors: [{ status: 'went bad' }] },
           { ...mocks.meta, response: Fixtures.mockFetchSessionFailureMeta }
         ),

--- a/app/src/sessions/epic/deleteSessionEpic.js
+++ b/app/src/sessions/epic/deleteSessionEpic.js
@@ -30,7 +30,12 @@ const mapResponseToAction: ResponseToActionMapper<DeleteSessionAction> = (
 
   return response.ok
     ? Actions.deleteSessionSuccess(host.name, body, meta)
-    : Actions.deleteSessionFailure(host.name, body, meta)
+    : Actions.deleteSessionFailure(
+        host.name,
+        originalAction.payload.sessionId,
+        body,
+        meta
+      )
 }
 
 export const deleteSessionEpic: Epic = (action$, state$) => {

--- a/app/src/sessions/epic/fetchSessionEpic.js
+++ b/app/src/sessions/epic/fetchSessionEpic.js
@@ -30,7 +30,12 @@ const mapResponseToAction: ResponseToActionMapper<FetchSessionAction> = (
 
   return response.ok
     ? Actions.fetchSessionSuccess(host.name, body, meta)
-    : Actions.fetchSessionFailure(host.name, body, meta)
+    : Actions.fetchSessionFailure(
+        host.name,
+        originalAction.payload.sessionId,
+        body,
+        meta
+      )
 }
 
 export const fetchSessionEpic: Epic = (action$, state$) => {

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -67,16 +67,17 @@ export function sessionReducer(
       }
     }
 
+    case Constants.FETCH_SESSION_FAILURE:
     case Constants.DELETE_SESSION_FAILURE: {
-      const { robotName, ...sessionState } = action.payload
+      const { robotName, sessionId } = action.payload
       const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE
+      // if session with this id not found, we should forget this id
       if (action.meta.response.status === 404) {
-        const id = action.meta.response.path.replace('/sessions/', '')
         return {
           ...state,
           [robotName]: {
             ...robotState,
-            robotSessions: omit(robotState.robotSessions, id),
+            robotSessions: omit(robotState.robotSessions, sessionId),
           },
         }
       } else {

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -66,6 +66,23 @@ export function sessionReducer(
         },
       }
     }
+
+    case Constants.DELETE_SESSION_FAILURE: {
+      const { robotName, ...sessionState } = action.payload
+      const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE
+      if (action.meta.response.status === 404) {
+        const id = action.meta.response.path.replace('/sessions/', '')
+        return {
+          ...state,
+          [robotName]: {
+            ...robotState,
+            robotSessions: omit(robotState.robotSessions, id),
+          },
+        }
+      } else {
+        return state
+      }
+    }
   }
 
   return state

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -108,7 +108,11 @@ export type DeleteSessionSuccessAction = {|
 
 export type DeleteSessionFailureAction = {|
   type: DELETE_SESSION_FAILURE,
-  payload: {| robotName: string, error: RobotApiV2ErrorResponseBody |},
+  payload: {|
+    robotName: string,
+    sessionId: string,
+    error: RobotApiV2ErrorResponseBody,
+  |},
   meta: RobotApiRequestMeta,
 |}
 
@@ -126,7 +130,11 @@ export type FetchSessionSuccessAction = {|
 
 export type FetchSessionFailureAction = {|
   type: FETCH_SESSION_FAILURE,
-  payload: {| robotName: string, error: RobotApiV2ErrorResponseBody |},
+  payload: {|
+    robotName: string,
+    sessionId: string,
+    error: RobotApiV2ErrorResponseBody,
+  |},
   meta: RobotApiRequestMeta,
 |}
 


### PR DESCRIPTION
## overview

In order to prevent stale/dangling sessions in redux state despite their non-existence on a given
robot, if we ever receive a 404 not found for a session we're attempting to fetch or delete, we will
remove the local reference to that session and sessionId.

## changelog

Sessions reducer now removes records in response to fetch/delete session failure actions with 404 statuses.

## review requests

Make sure session creation and deletion still behaves as expected.

## risk assessment

Low, the only thing this effects is an edge case that is hard to get into outside of a dev environment 
