### PR TITLE
feat(protocol-designer): create barebones TC profile substeps

### DIFF
--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -24,10 +24,12 @@
   "actions": {
     "action": "action",
     "await_temperature": "pause until",
+    "cycling": "cycling",
     "disengage": "disengage",
     "engage": "engage",
     "go_to": "go to",
-    "hold": "hold"
+    "hold": "hold",
+    "profile": "profile"
   },
   "block_label": "Block",
   "lid_label": "Lid ({{lidStatus}})",

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -6,6 +6,7 @@ import type {
   ModuleOnlyParams,
 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
 import typeof { THERMOCYCLER_STATE, THERMOCYCLER_PROFILE } from '../constants'
+import type { ProfileItem } from '../form-types'
 import type {
   LabwareTemporalProperties,
   ModuleTemporalProperties,
@@ -213,6 +214,9 @@ export type ThermocyclerProfileStepArgs = {|
   profileSteps: Array<AtomicProfileStep>,
   profileTargetLidTemp: number | null,
   profileVolume: number,
+  meta?: {|
+    rawProfileItems: Array<ProfileItem>,
+  |},
 |}
 
 export type ThermocyclerStateStepArgs = {|

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.js
@@ -135,6 +135,41 @@ describe('thermocyclerFormToArgs', () => {
         ],
         profileTargetLidTemp: 40,
         profileVolume: 4,
+        meta: {
+          rawProfileItems: [
+            {
+              type: 'profileStep',
+              id: 'profileItem1',
+              title: 'Top level step',
+              temperature: '5',
+              durationMinutes: '',
+              durationSeconds: '50',
+            },
+            {
+              id: 'profileItem2',
+              type: 'profileCycle',
+              repetitions: '2',
+              steps: [
+                {
+                  type: 'profileStep',
+                  id: 'item2A',
+                  title: 'Step A in cycle',
+                  temperature: '12',
+                  durationMinutes: '1',
+                  durationSeconds: '2',
+                },
+                {
+                  type: 'profileStep',
+                  id: 'item2B',
+                  title: 'Step B in cycle',
+                  temperature: '99',
+                  durationMinutes: '',
+                  durationSeconds: '45',
+                },
+              ],
+            },
+          ],
+        },
       },
     },
   ]

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/thermocyclerFormToArgs.js
@@ -86,6 +86,11 @@ export const thermocyclerFormToArgs = (
           formData.lidIsActiveHold && formData.lidTargetTempHold !== null
             ? Number(formData.lidTargetTempHold)
             : null,
+        meta: {
+          rawProfileItems: formData.orderedProfileItems.map(
+            itemId => formData.profileItemsById[itemId]
+          ),
+        },
         profileSteps,
         profileTargetLidTemp: Number(formData.profileTargetLidTemp),
         profileVolume: Number(formData.profileVolume),

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -14,7 +14,7 @@ import {
   mix,
   curryCommandCreator,
 } from '../step-generation'
-import { THERMOCYCLER_STATE } from '../constants'
+import { THERMOCYCLER_PROFILE, THERMOCYCLER_STATE } from '../constants'
 
 import type { StepIdType } from '../form-types'
 import type {
@@ -423,6 +423,28 @@ export function generateSubsteps(
       labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
+    }
+  }
+
+  if (stepArgs.commandCreatorFnName === THERMOCYCLER_PROFILE) {
+    const {
+      profileTargetLidTemp,
+      lidOpenHold,
+      profileVolume,
+      message,
+      meta,
+      profileSteps,
+    } = stepArgs
+    return {
+      substepType: THERMOCYCLER_PROFILE,
+      labwareDisplayName: labwareNames?.displayName,
+      labwareNickname: labwareNames?.nickname,
+      profileTargetLidTemp,
+      lidOpenHold,
+      profileVolume,
+      message,
+      meta,
+      profileSteps,
     }
   }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -1,6 +1,10 @@
 // @flow
-import typeof { THERMOCYCLER_STATE } from '../constants'
-import type { CommandCreatorArgs, PauseArgs } from '../step-generation'
+import typeof { THERMOCYCLER_PROFILE, THERMOCYCLER_STATE } from '../constants'
+import type {
+  CommandCreatorArgs,
+  PauseArgs,
+  ThermocyclerProfileStepArgs,
+} from '../step-generation'
 import type { StepIdType } from '../form-types'
 import type { FormError } from './formLevel/errors'
 
@@ -129,6 +133,18 @@ export type AwaitTemperatureSubstepItem = {|
   message?: string,
 |}
 
+export type ThermocyclerProfileSubstepItem = {|
+  substepType: THERMOCYCLER_PROFILE,
+  labwareDisplayName: ?string,
+  labwareNickname: ?string,
+  profileTargetLidTemp: number | null,
+  lidOpenHold: boolean,
+  profileVolume: number,
+  profileSteps: $PropertyType<ThermocyclerProfileStepArgs, 'profileSteps'>,
+  meta: $PropertyType<ThermocyclerProfileStepArgs, 'meta'>,
+  message?: string,
+|}
+
 export type ThermocyclerStateSubstepItem = {|
   substepType: THERMOCYCLER_STATE,
   labwareDisplayName: ?string,
@@ -145,6 +161,7 @@ export type SubstepItemData =
   | MagnetSubstepItem
   | TemperatureSubstepItem
   | AwaitTemperatureSubstepItem
+  | ThermocyclerProfileSubstepItem
   | ThermocyclerStateSubstepItem
 
 export type SubSteps = { [StepIdType]: ?SubstepItemData }


### PR DESCRIPTION
## overview

A starting point for #5522 but to close it we need more UI work

This PR just puts the data that TC Profile substeps will need, into some ugly placeholder divs/spans.

I think we should do the styling and real component design in another PR because the designs look like the multichannel timeline substeps, which are integrated into aspirate-dispense rows and need a significant refactor to be generic enough to reuse for TC Profile.

## changelog

- implement stepFormToArgs for TC Profile
- put that info into placeholder components

## review requests

- Compared to designs linked in #5522, these ugly substeps should have the correct data in the right general location for profile steps even though it's ugly. Block temp, duration, cycles should show up

## risk assessment

low, PD only behind FF