### PR TITLE
feat(robot-server): Add skeleton of tip calibration session including integration test.

### DIFF
--- a/api/src/opentrons/calibration/check/models.py
+++ b/api/src/opentrons/calibration/check/models.py
@@ -22,6 +22,7 @@ class SessionType(str, Enum):
     null = 'null'
     default = 'default'
     calibration_check = 'calibrationCheck'
+    tip_length_calibration = 'tipLengthCalibration'
 
 
 class SpecificPipette(BaseModel):

--- a/robot-server/robot_server/service/session/manager.py
+++ b/robot-server/robot_server/service/session/manager.py
@@ -9,13 +9,14 @@ from robot_server.service.session.session_types.base_session import BaseSession
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session.models import IdentifierType
 from robot_server.service.session.session_types import NullSession, \
-    CheckSession, SessionMetaData
+    CheckSession, SessionMetaData, TipLengthCalibration
 
 log = logging.getLogger(__name__)
 
 SessionTypeToClass: Dict[SessionType, Type[BaseSession]] = {
     SessionType.null: NullSession,
     SessionType.calibration_check: CheckSession,
+    SessionType.tip_length_calibration: TipLengthCalibration
 }
 
 

--- a/robot-server/robot_server/service/session/session_types/__init__.py
+++ b/robot-server/robot_server/service/session/session_types/__init__.py
@@ -1,3 +1,4 @@
 from .null_session import NullSession  # noqa: W0611
 from .check_session import CheckSession  # noqa: W0611
+from .tip_length_calibration import TipLengthCalibration  # noqa: W0611
 from .base_session import BaseSession, SessionMetaData  # noqa: W0611

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -1,0 +1,48 @@
+from opentrons.calibration.check.models import SessionType
+from opentrons.calibration.tip_length.state_machine import \
+    TipCalibrationStateMachine
+
+from .base_session import BaseSession, SessionMetaData
+from .. import models
+from ..command_execution import CommandQueue, CommandExecutor, \
+    StateMachineExecutor
+from ..configuration import SessionConfiguration
+from ..models import EmptyModel
+
+
+class TipLengthCalibration(BaseSession):
+
+    def __init__(self, configuration: SessionConfiguration,
+                 instance_meta: SessionMetaData,
+                 tip_length_calibration: TipCalibrationStateMachine
+                 ):
+        super().__init__(configuration, instance_meta)
+        self._tip_length_calibration = tip_length_calibration
+        self._command_executor = StateMachineExecutor(
+            self._tip_length_calibration
+        )
+        self._command_queue = CommandQueue()
+
+    @classmethod
+    async def create(cls, configuration: SessionConfiguration,
+                     instance_meta: SessionMetaData) -> 'BaseSession':
+        return cls(configuration=configuration,
+                   instance_meta=instance_meta,
+                   tip_length_calibration=TipCalibrationStateMachine())
+
+    @property
+    def command_executor(self) -> CommandExecutor:
+        return self._command_executor
+
+    @property
+    def command_queue(self) -> CommandQueue:
+        return self._command_queue
+
+    @property
+    def session_type(self) -> SessionType:
+        return SessionType.tip_length_calibration
+
+    def _get_response_details(self) -> models.SessionDetails:
+        # TODO: Create a proper model for the session details. Add it to
+        #   SessionDetails Union
+        return EmptyModel()

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -1,0 +1,64 @@
+---
+test_name: Tip length calibration session full flow
+strict:
+  - json:on
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: Create the session
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: POST
+      json:
+        data:
+          type: Session
+          attributes:
+            sessionType: tipLengthCalibration
+    response:
+      status_code: 201
+      save:
+        json:
+          session_id: data.id
+  - name: Get the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        links: !anydict
+        data:
+          id: "{session_id}"
+          type: Session
+          attributes:
+            sessionType: tipLengthCalibration
+            details: {}
+
+  - name: Load labware
+    request: &post_command
+      url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
+      method: POST
+      json:
+        data:
+          type: SessionCommand
+          attributes:
+            command: loadLabware
+            data: {}
+
+  - name: Delete the session
+    request:
+      url: "{host:s}:{port:d}/sessions/{session_id}"
+      method: DELETE
+    response:
+      status_code: 200
+
+  - name: There are no sessions
+    request:
+      url: "{host:s}:{port:d}/sessions"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data: []
+


### PR DESCRIPTION
## overview

This adds support for tip length calibration session. It allows creation and trigger state transitions.

## changelog

- New SessionType and BaseSession derived class
- Very basic integration test


## risk assessment

None