### PR TITLE
fix(protocol-designer): Correct tc profile fields sizing

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -320,7 +320,7 @@ and when that is implemented.
   @apply --font-form-default;
 
   display: grid;
-  grid-template-columns: 14.5rem 7.25rem 7.25rem;
+  grid-template-columns: 12.5rem 7.25rem 7.25rem;
   font-weight: var(--fw-semibold);
   padding: 1rem 0 0.25rem 2.125rem;
 }
@@ -348,21 +348,25 @@ and when that is implemented.
   align-items: center;
   border: var(--bd-light);
   width: 100%;
+  min-width: 36rem;
   padding: 0.5rem;
 }
 
 .profile_cycle_fields {
-  width: 31.5rem;
+  width: 36rem;
   border: none;
 }
 
 .step_input_wrapper {
   margin-right: 1.5rem;
-  width: 5.75rem;
+}
 
-  &:first-child {
-    width: 12rem;
-  }
+.title {
+  width: 11rem;
+}
+
+.profile_field {
+  width: 5.75rem;
 }
 
 .delete_step_icon {
@@ -415,6 +419,7 @@ and when that is implemented.
   border: var(--bd-light);
   width: 100%;
   padding-right: 0.5rem;
+  padding-left: 0.375rem;
 }
 
 .cycle_step_delete {

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
@@ -263,18 +263,22 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'top',
   })
-  const fields = names.map(name => (
-    <ProfileField
-      key={name}
-      units={units[name]}
-      {...{
-        name,
-        focusHandlers,
-        profileItem: profileStepItem,
-        updateValue: updateStepFieldValue,
-      }}
-    />
-  ))
+  const fields = names.map(name => {
+    const className = name === 'title' ? styles.title : styles.profile_field
+    return (
+      <ProfileField
+        key={name}
+        units={units[name]}
+        className={className}
+        {...{
+          name,
+          focusHandlers,
+          profileItem: profileStepItem,
+          updateValue: updateStepFieldValue,
+        }}
+      />
+    )
+  })
   return (
     <div className={cx(styles.profile_step_row, { [styles.cycle]: isCycle })}>
       <div


### PR DESCRIPTION
## overview

closes #5851 by correcting the profile step `name` field width and aligning labels corrrectly.

<img width="904" alt="Screen Shot 2020-06-10 at 12 38 00 PM" src="https://user-images.githubusercontent.com/3430313/84294715-9031c600-ab17-11ea-90d1-82b2cb62b6df.png">

## changelog

- fix(protocol-designer): Correct tc profile fields sizing

## review requests

- [ ] title/name field is larger than other fields
- [ ] labels align with correct fields

## risk assessment

Low PD CSS
