### PR TITLE
refactor(protocol-designer): fix TC run profile state updater

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerUpdates.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerUpdates.test.js
@@ -170,6 +170,17 @@ describe('thermocycler state updaters', () => {
     {
       params: {
         module: moduleId,
+        profile: [],
+        volume: 10,
+      },
+      moduleStateBefore: {},
+      expectedUpdate: {},
+      fn: forThermocyclerRunProfile,
+      testName: 'forThermocyclerRunProfile should not make any updates',
+    },
+    {
+      params: {
+        module: moduleId,
         profile: [
           { holdTime: 10, temperature: 50 },
           { holdTime: 10, temperature: 30 },

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
@@ -130,5 +130,7 @@ export const forThermocyclerRunProfile = (
 
   const moduleState = _getThermocyclerModuleState(robotState, module)
 
-  moduleState.blockTargetTemp = last(profile).temperature
+  if (profile.length > 0) {
+    moduleState.blockTargetTemp = last(profile).temperature
+  }
 }


### PR DESCRIPTION
## overview
This tiny PR fixes a broken test that resulted from a broken edge merge.

I added a test case to catch the scenario that caused the failure (when there are no TC profile items)

## risk assessment
very low, fixing broken test