### PR TITLE
refactor(protocol-designer): Update confirm unsaved step deletion modals

### DIFF
--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -6,7 +6,7 @@ import { AlertModal } from './AlertModal'
 import type { AlertModalProps } from './AlertModal'
 
 export type ContinueModalProps = {|
-  ...$Diff<AlertModalProps, { buttons?: mixed }>,
+  ...$Diff<AlertModalProps, { buttons: mixed }>,
   onCancelClick: () => mixed,
   onContinueClick: () => mixed,
 |}
@@ -19,13 +19,10 @@ const CONTINUE = 'Continue'
  */
 export function ContinueModal(props: ContinueModalProps): React.Node {
   const { onCancelClick, onContinueClick, ...passThruProps } = props
-  const buttonOverride = props.buttons && props.buttons.length > 0
-  const buttons = buttonOverride
-    ? props.buttons
-    : [
-        { title: CANCEL, children: CANCEL, onClick: onCancelClick },
-        { title: CONTINUE, children: CONTINUE, onClick: onContinueClick },
-      ]
+  const buttons = [
+    { title: CANCEL, children: CANCEL, onClick: onCancelClick },
+    { title: CONTINUE, children: CONTINUE, onClick: onContinueClick },
+  ]
 
   return (
     <AlertModal

--- a/components/src/modals/ContinueModal.js
+++ b/components/src/modals/ContinueModal.js
@@ -6,7 +6,7 @@ import { AlertModal } from './AlertModal'
 import type { AlertModalProps } from './AlertModal'
 
 export type ContinueModalProps = {|
-  ...$Diff<AlertModalProps, { buttons: mixed }>,
+  ...$Diff<AlertModalProps, { buttons?: mixed }>,
   onCancelClick: () => mixed,
   onContinueClick: () => mixed,
 |}
@@ -19,10 +19,13 @@ const CONTINUE = 'Continue'
  */
 export function ContinueModal(props: ContinueModalProps): React.Node {
   const { onCancelClick, onContinueClick, ...passThruProps } = props
-  const buttons = [
-    { title: CANCEL, children: CANCEL, onClick: onCancelClick },
-    { title: CONTINUE, children: CONTINUE, onClick: onContinueClick },
-  ]
+  const buttonOverride = props.buttons && props.buttons.length > 0
+  const buttons = buttonOverride
+    ? props.buttons
+    : [
+        { title: CANCEL, children: CANCEL, onClick: onCancelClick },
+        { title: CONTINUE, children: CONTINUE, onClick: onContinueClick },
+      ]
 
   return (
     <AlertModal

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -8,6 +8,7 @@ import {
   useHoverTooltip,
   TOOLTIP_RIGHT,
   TOOLTIP_FIXED,
+  AlertModal,
 } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
@@ -20,7 +21,7 @@ import {
   selectors as stepFormSelectors,
   getIsModuleOnDeck,
 } from '../step-forms'
-import { ConfirmDeleteStepModal } from './modals/ConfirmDeleteStepModal'
+import { Portal } from './portals/MainPageModalPortal'
 import { stepIconsByType, type StepType } from '../form-types'
 import styles from './listButtons.css'
 
@@ -133,17 +134,31 @@ export const StepCreationButton = (): React.Node => {
   return (
     <>
       {enqueuedStepType !== null && (
-        <ConfirmDeleteStepModal
-          heading="Unsaved step form"
-          alertOverlay
-          onCancelClick={() => setEnqueuedStepType(null)}
-          onContinueClick={() => {
-            if (enqueuedStepType !== null) {
-              addStep(enqueuedStepType)
-              setEnqueuedStepType(null)
-            }
-          }}
-        />
+        <Portal>
+          <AlertModal
+            heading="Unsaved step form"
+            alertOverlay
+            buttons={[
+              {
+                children: 'Continue',
+                onClick: () => setEnqueuedStepType(null),
+              },
+              {
+                children: 'Delete Step',
+                onClick: () => {
+                  if (enqueuedStepType !== null) {
+                    addStep(enqueuedStepType)
+                    setEnqueuedStepType(null)
+                  }
+                },
+              },
+            ]}
+          >
+            <p style={{ lineHeight: 1.5 }}>
+              {i18n.t('modal.delete_step.body')}
+            </p>
+          </AlertModal>
+        </Portal>
       )}
       <StepCreationButtonComponent
         expanded={expanded}

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -134,6 +134,8 @@ export const StepCreationButton = (): React.Node => {
     <>
       {enqueuedStepType !== null && (
         <ConfirmDeleteStepModal
+          heading="Unsaved step form"
+          alertOverlay
           onCancelClick={() => setEnqueuedStepType(null)}
           onContinueClick={() => {
             if (enqueuedStepType !== null) {

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -227,6 +227,8 @@ const StepEditFormManager = (props: StepEditFormManagerProps) => {
       )}
       {showConfirmCancelModal && (
         <ConfirmDeleteStepModal
+          heading="Unsaved Step form"
+          alertOverlay
           close
           onCancelClick={cancelClose}
           onContinueClick={confirmClose}

--- a/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
+++ b/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
@@ -10,32 +10,12 @@ type Props = {|
   close?: boolean,
 |}
 
-const CANCEL = 'Cancel'
-const DELETE_STEP = 'Delete Step'
-
 export function ConfirmDeleteStepModal(props: Props): React.Node {
   const { close, ...continueModalProps } = props
-
-  const buttons = close
-    ? []
-    : [
-        { title: CANCEL, children: CANCEL, onClick: props.onCancelClick },
-        {
-          title: DELETE_STEP,
-          children: DELETE_STEP,
-          onClick: props.onContinueClick,
-        },
-      ]
   return (
     <Portal>
-      <ContinueModal
-        className={modalStyles.modal}
-        {...continueModalProps}
-        buttons={buttons}
-      >
-        {close
-          ? i18n.t('modal.close_step.body')
-          : i18n.t('modal.delete_step.body')}
+      <ContinueModal className={modalStyles.modal} {...continueModalProps}>
+        <p>{i18n.t('modal.close_step.body')}</p>
       </ContinueModal>
     </Portal>
   )

--- a/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
+++ b/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
@@ -10,11 +10,29 @@ type Props = {|
   close?: boolean,
 |}
 
+const CANCEL = 'Cancel'
+const DELETE_STEP = 'Delete Step'
+
 export function ConfirmDeleteStepModal(props: Props): React.Node {
   const { close, ...continueModalProps } = props
+
+  const buttons = close
+    ? []
+    : [
+        { title: CANCEL, children: CANCEL, onClick: props.onCancelClick },
+        {
+          title: DELETE_STEP,
+          children: DELETE_STEP,
+          onClick: props.onContinueClick,
+        },
+      ]
   return (
     <Portal>
-      <ContinueModal className={modalStyles.modal} {...continueModalProps}>
+      <ContinueModal
+        className={modalStyles.modal}
+        {...continueModalProps}
+        buttons={buttons}
+      >
         {close
           ? i18n.t('modal.close_step.body')
           : i18n.t('modal.delete_step.body')}

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -64,10 +64,10 @@
     "body": "Update your pipette and tiprack selection. Please note, this may affect your existing protocol steps."
   },
   "close_step": {
-    "body": "Are you sure you want to close this step? Any unsaved changes will be lost."
+    "body": "You have not saved this step form. If you continue without saving this step will be deleted."
   },
   "delete_step": {
-    "body": "Are you sure you want to delete this step?"
+    "body": "You have not saved this step form. If you navigate away without saving, this step will be deleted."
   },
   "global_step_changes": {
     "heading": "Are you sure you want to make this change?",


### PR DESCRIPTION
## overview

closes #5762 by updating the Pristine Step Deletion Modal. It also adds an optional buttons override prop to the cancel continue modal (to update button text)

## changelog

- refactor(protocol-designer): Update confirm unsaved step deletion modals

## review requests

- [ ] Clicking off an unsaved step (creating another new step) -> modal has updated text, header, and button text
- [ ] Clicking close on an unsaved step -> modal has updated text and header

## risk assessment
Low, but please confirm i didn't break any other cancel/continue modals
