### PR TITLE
fix(robot-server, api): reject commands while robot is moving

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -34,7 +34,7 @@ def _require_lock(func):
     def decorated(*args, **kwargs):
         self = args[0]
         if self._lock:
-            with self._lock:
+            with self._lock.forbid():
                 return func(*args, **kwargs)
         else:
             return func(*args, **kwargs)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -47,7 +47,7 @@ def _motion_lock(func):
     def decorated(*args, **kwargs):
         self = args[0]
         if self._motion_lock:
-            with self._motion_lock:
+            with self._motion_lock.forbid():
                 return func(*args, **kwargs)
         else:
             return func(*args, **kwargs)
@@ -462,7 +462,7 @@ class Session(object):
 
     def stop(self):
         self._hw_iface().halt()
-        with self._motion_lock:
+        with self._motion_lock.lock():
             try:
                 self._hw_iface().stop()
             except asyncio.CancelledError:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -602,12 +602,6 @@ class Session(RobotBusy):
 
     def run(self):
         if not self.blocked:
-            # Inhibit starting a protocol run while one is running.
-            with self._run_lock:
-                if self._is_running.is_set():
-                    raise RuntimeError("Protocol cannot be started "
-                                       "while already running")
-                self._is_running.set()
             try:
                 self._broker.set_logger(self._run_logger)
                 self._run()
@@ -615,7 +609,6 @@ class Session(RobotBusy):
                 raise
             finally:
                 self._broker.set_logger(self._default_logger)
-                self._is_running.clear()
             return self
         else:
             raise RuntimeError(

--- a/api/src/opentrons/api/util.py
+++ b/api/src/opentrons/api/util.py
@@ -1,0 +1,30 @@
+import functools
+from abc import ABC, abstractmethod
+
+from opentrons.hardware_control import ThreadedAsyncLock
+
+
+class RobotBusy(ABC):
+    @property
+    @abstractmethod
+    def busy_lock(self) -> ThreadedAsyncLock:
+        ...
+
+
+def robot_is_busy(func):
+    """ Decorator to mark a function as putting the robot in a busy
+    state. Simultaneous attempts to call a busy function (from same or
+    separate thread) will result in an exception.
+     Must wrap a class of type RobotBusy.
+
+     :raises ThreadedAsyncForbidden: on call during busy.
+     """
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        self = args[0]
+        if self.busy_lock:
+            with self.busy_lock.forbid():
+                return func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+    return decorated

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -21,12 +21,12 @@ from .types import (HardwareAPILike, CriticalPoint,
 from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
-from .threaded_async_lock import ThreadedAsyncLock
+from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
 
 __all__ = [
     'API', 'Controller', 'Simulator', 'Pipette',
     'SynchronousAdapter', 'HardwareAPILike', 'CriticalPoint',
     'NoTipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
     'ThreadManager', 'ExecutionManager', 'ExecutionState',
-    'ExecutionCancelledError', 'ThreadedAsyncLock'
+    'ExecutionCancelledError', 'ThreadedAsyncLock', 'ThreadedAsyncForbidden'
 ]

--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -41,7 +41,7 @@ class ThreadedAsyncForbidden(Exception):
     is forbidden"""
 
     def __init__(self, msg="Robot is currently moving. Please wait and try "
-                           "again this command"):
+                           "this command again."):
         super().__init__(msg)
 
 

--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -24,7 +24,41 @@ class ThreadedAsyncLock:
     """
 
     def __init__(self):
-        self._thread_lock = threading.RLock()
+        self._thread_lock = threading.Lock()
+
+    def lock(self) -> '_Internal':
+        """Create a context manager that locks access to a code block"""
+        return _Internal(lock=self._thread_lock, forbid=False)
+
+    def forbid(self) -> '_Internal':
+        """Create a context manager that forbids concurrent attempts to
+        access to a code block"""
+        return _Internal(lock=self._thread_lock, forbid=True)
+
+
+class ThreadedAsyncForbidden(Exception):
+    """Exception indicating that lock is acquired and that blocking
+    is forbidden"""
+
+    def __init__(self, msg="Robot is currently moving. Please wait and try "
+                           "again this command"):
+        super().__init__(msg)
+
+
+class _Internal:
+    def __init__(self, lock: threading.Lock, forbid: bool):
+        """
+        The private context manager that interacts with the lock. It can
+        behave in normal locking mode or in `forbid` mode. When `forbid` is
+        True, then trying to acquire a lock that is already acquired will
+        raise ThreadedAsyncForbidden. This forbids blocking on
+         critical sections.
+
+        :param lock: The Lock
+        :param forbid: whether to block or raise an exception
+        """
+        self._thread_lock = lock
+        self._forbid = forbid
 
     async def __aenter__(self):
         pref = f"[ThreadedAsyncLock tid {threading.get_ident()} "\
@@ -32,6 +66,9 @@ class ThreadedAsyncLock:
         log.debug(pref + 'will acquire')
         then = time.perf_counter()
         while not self._thread_lock.acquire(blocking=False):
+            if self._forbid:
+                # Lock is already acquired and blocking is forbidden
+                raise ThreadedAsyncForbidden()
             await asyncio.sleep(0.1)
         now = time.perf_counter()
         log.debug(pref + f'acquired in {now-then}s')
@@ -42,7 +79,11 @@ class ThreadedAsyncLock:
         self._thread_lock.release()
 
     def __enter__(self):
-        self._thread_lock.acquire()
+        if not self._forbid:
+            self._thread_lock.acquire()
+        elif not self._thread_lock.acquire(blocking=False):
+            # Lock is already acquired and blocking is forbidden
+            raise ThreadedAsyncForbidden()
 
     def __exit__(self, exc_type, exc, tb):
         self._thread_lock.release()

--- a/api/src/opentrons/server/endpoints/control.py
+++ b/api/src/opentrons/server/endpoints/control.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 def _motion_lock(func):
     @functools.wraps(func)
     async def decorated(request):
-        async with request.app['com.opentrons.motion_lock']:
+        async with request.app['com.opentrons.motion_lock'].forbid():
             return await func(request)
     return decorated
 

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -27,7 +27,7 @@ async def test_tip_probe_v2(main_router, model, monkeypatch):
 
     monkeypatch.setattr(API, 'update_instrument_offset', fake_update)
     monkeypatch.setattr(main_router.calibration_manager,
-                        'move_to_front', fake_move)
+                        '_move_to_front', fake_move)
 
     tr = labware.load('opentrons_96_tiprack_300ul', Location(Point(), 'test'))
 
@@ -215,6 +215,30 @@ async def test_home_api1(main_router, model):
             model.instrument)
 
         home.assert_called_with()
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
+@pytest.mark.api2_only
+async def test_home_all_api2(main_router, model):
+    with mock.patch.object(model.instrument._context, 'home') as home:
+        main_router.calibration_manager.home_all(
+            model.instrument)
+
+        home.assert_called_once()
+
+        await main_router.wait_until(state('moving'))
+        await main_router.wait_until(state('ready'))
+
+
+@pytest.mark.api1_only
+async def test_home_all_api1(main_router, model):
+    with mock.patch.object(main_router.calibration_manager, '_hardware') as hardware:  # noqa: e501
+        main_router.calibration_manager.home_all(
+            model.instrument)
+
+        hardware.home.assert_called_with()
 
         await main_router.wait_until(state('moving'))
         await main_router.wait_until(state('ready'))

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -6,6 +6,8 @@ import base64
 from opentrons.api import session
 from opentrons.api.session import (
     _accumulate, _dedupe)
+from opentrons.hardware_control import ThreadedAsyncForbidden
+
 from tests.opentrons.conftest import state
 from functools import partial
 from opentrons.protocols.types import APIVersion
@@ -454,7 +456,7 @@ def run(ctx):
     def run_while_running():
         """The entry point to threads that try to run while a protocol is
         running"""
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ThreadedAsyncForbidden):
             session.run()
 
     # Do this twice to prove we run again after completion.

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -33,7 +33,7 @@ from opentrons import config, types
 from opentrons.server import init
 from opentrons.deck_calibration import endpoints
 from opentrons import hardware_control as hc
-from opentrons.hardware_control import API, ThreadManager
+from opentrons.hardware_control import API, ThreadManager, ThreadedAsyncLock
 from opentrons.protocol_api import ProtocolContext
 from opentrons.types import Mount
 from opentrons import (robot as rb,
@@ -374,7 +374,7 @@ def sync_hardware(request, loop, virtual_smoothie_env):
 
 @pytest.fixture
 def main_router(loop, virtual_smoothie_env, hardware):
-    router = MainRouter(hardware, loop)
+    router = MainRouter(hardware=hardware, loop=loop, lock=ThreadedAsyncLock())
     router.wait_until = partial(
         wait_until,
         notifications=router.notifications,

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -150,4 +150,4 @@ async def _do_move(hardware: ThreadManager,
                   critical_point=critical_point)
     # Move to requested z position
     await move_to(mount, target_pos, critical_point=critical_point)
-    return  await gantry_position(mount)
+    return await gantry_position(mount)

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -3,7 +3,8 @@ import asyncio
 from fastapi import APIRouter, Query, Depends
 from starlette import status
 
-from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
+from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock, \
+    ThreadedAsyncForbidden
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 
@@ -58,31 +59,16 @@ async def post_move_robot(
         motion_lock: ThreadedAsyncLock = Depends(get_motion_lock))\
         -> V1BasicResponse:
     """Move the robot"""
-    async with motion_lock:
-        await hardware.cache_instruments()  # type: ignore
-
-        critical_point = None
-        if robot_move_target.target == control.MotionTarget.mount:
-            critical_point = CriticalPoint.MOUNT
-
-        mount = Mount[robot_move_target.mount.upper()]
-        target_pos = Point(*robot_move_target.point)
-
-        # Reset z position
-        await hardware.home_z()  # type: ignore
-
-        gantry_position = hardware.gantry_position  # type: ignore
-        move_to = hardware.move_to  # type: ignore
-
-        pos = await gantry_position(mount, critical_point=critical_point)
-        # Move to requested x, y and current z position
-        await move_to(mount, Point(x=target_pos.x, y=target_pos.y, z=pos.z),
-                      critical_point=critical_point)
-        # Move to requested z position
-        await move_to(mount, target_pos, critical_point=critical_point)
-        pos = await gantry_position(mount)
-
-        return V1BasicResponse(message=f"Move complete. New position: {pos}")
+    try:
+        async with motion_lock.forbid():
+            pos = await _do_move(hardware=hardware,
+                                 robot_move_target=robot_move_target)
+            return V1BasicResponse(
+                message=f"Move complete. New position: {pos}"
+            )
+    except ThreadedAsyncForbidden as e:
+        raise V1HandlerError(status_code=status.HTTP_403_FORBIDDEN,
+                             message=str(e))
 
 
 @router.post("/robot/home",
@@ -94,25 +80,29 @@ async def post_home_robot(
         motion_lock: ThreadedAsyncLock = Depends(get_motion_lock)) \
         -> V1BasicResponse:
     """Home the robot or one of the pipettes"""
-    async with motion_lock:
-        mount = robot_home_target.mount
-        target = robot_home_target.target
+    try:
+        async with motion_lock.forbid():
+            mount = robot_home_target.mount
+            target = robot_home_target.target
 
-        home = hardware.home  # type: ignore
-        home_plunger = hardware.home_plunger  # type: ignore
+            home = hardware.home  # type: ignore
+            home_plunger = hardware.home_plunger  # type: ignore
 
-        if target == control.HomeTarget.pipette and mount:
-            await home([Axis.by_mount(Mount[mount.upper()])])
-            await home_plunger(Mount[mount.upper()])
-            message = f"Pipette on {mount} homed successfully"
-        elif target == control.HomeTarget.robot:
-            await home()
-            message = "Homing robot."
-        else:
-            raise V1HandlerError(message=f"{target} is invalid",
-                                 status_code=status.HTTP_400_BAD_REQUEST)
+            if target == control.HomeTarget.pipette and mount:
+                await home([Axis.by_mount(Mount[mount.upper()])])
+                await home_plunger(Mount[mount.upper()])
+                message = f"Pipette on {mount} homed successfully"
+            elif target == control.HomeTarget.robot:
+                await home()
+                message = "Homing robot."
+            else:
+                raise V1HandlerError(message=f"{target} is invalid",
+                                     status_code=status.HTTP_400_BAD_REQUEST)
 
-        return V1BasicResponse(message=message)
+            return V1BasicResponse(message=message)
+    except ThreadedAsyncForbidden as e:
+        raise V1HandlerError(status_code=status.HTTP_403_FORBIDDEN,
+                             message=str(e))
 
 
 @router.get("/robot/lights",
@@ -134,3 +124,30 @@ async def post_robot_light_state(
         -> control.RobotLightState:
     await hardware.set_lights(rails=robot_light_state.on)  # type: ignore
     return robot_light_state
+
+
+async def _do_move(hardware: ThreadManager,
+                   robot_move_target: control.RobotMoveTarget):
+    """Perform the move"""
+    await hardware.cache_instruments()  # type: ignore
+
+    critical_point = None
+    if robot_move_target.target == control.MotionTarget.mount:
+        critical_point = CriticalPoint.MOUNT
+
+    mount = Mount[robot_move_target.mount.upper()]
+    target_pos = Point(*robot_move_target.point)
+
+    # Reset z position
+    await hardware.home_z()  # type: ignore
+
+    gantry_position = hardware.gantry_position  # type: ignore
+    move_to = hardware.move_to  # type: ignore
+
+    pos = await gantry_position(mount, critical_point=critical_point)
+    # Move to requested x, y and current z position
+    await move_to(mount, Point(x=target_pos.x, y=target_pos.y, z=pos.z),
+                  critical_point=critical_point)
+    # Move to requested z position
+    await move_to(mount, target_pos, critical_point=critical_point)
+    return  await gantry_position(mount)


### PR DESCRIPTION
## overview

Our use of ThreadedAsyncLock via RPC is rather dangerous. It leads to deadlocks and queueing up of commands that cause unexpected protocol runs and motion. 

See https://github.com/Opentrons/opentrons/issues/5810#issuecomment-642196368 for bug root cause explanation.

## changelog

Modified the ThreadedAsyncLock. It now runs in two modes: regular lock and forbid. Lock is normal mutex locking. Forbid will raise an error if trying to acquired the already acquired lock. 

This allows us to reject commands while a long running command is running, thus eliminating deadlocks.

Also, changed to a Lock instead of RLock. RLock was not achieving locking in our async code as all calls are coming an the same thread.

Removed the protocol run Event as the `ThreadedAsyncLock` change in this PR deprecates the run block.

## review requests

To reproduce see: https://github.com/Opentrons/opentrons/issues/5810

I reproduced without a robot using these steps:
- add a 2 second sleep in `CalibrationManager.return_tip`
- start robot server `make dev OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test.json`
- start runapp and connect to local robot server
- load this protocol: 
```
metadata = {"apiLevel": "2.0"}
def run(ctx):
    r_tips_1 = ctx.load_labware('opentrons_96_tiprack_300ul', '2')
    r_pipette = ctx.load_instrument('p300_single', 'right',
                                         tip_racks=[r_tips_1])

    r_pipette.pick_up_tip()
    ctx.pause()
```
- click `start run` immediately after clicking `return tip`

## test plan
- In a V2 protocol, try double clicking buttons in calibration a lot
- In a V1 protocol, try double clicking buttons a lot
- In a V1 and V2 protocol, try double clicking pause and resume
- follow steps in #5810 to prove that bug was fixed.
- Try to move while the robot is home-ing and vice versa. Calls should be rejected.

## risk assessment

Very high. This affects every RPC call. 

closes #5810 
