### PR TITLE
refactor(app): add skeleton of tip length calibration view layer

### DIFF
--- a/app/src/calibration/__fixtures__/index.js
+++ b/app/src/calibration/__fixtures__/index.js
@@ -8,7 +8,10 @@ import {
   CHECK_STEP_COMPARING_SECOND_PIPETTE_POINT_ONE,
   CHECK_TRANSFORM_TYPE_UNKNOWN,
 } from '../constants'
-import type { RobotCalibrationCheckSessionDetails } from '../api-types'
+import type {
+  RobotCalibrationCheckSessionDetails,
+  TipLengthCalibrationSessionDetails,
+} from '../api-types'
 
 export const badZComparison = {
   differenceVector: [0, 0, 4],
@@ -66,6 +69,48 @@ export const mockRobotCalibrationCheckSessionDetails: RobotCalibrationCheckSessi
     [CHECK_STEP_COMPARING_SECOND_PIPETTE_HEIGHT]: goodZComparison,
     [CHECK_STEP_COMPARING_SECOND_PIPETTE_POINT_ONE]: goodXYComparison,
   },
+  labware: [
+    {
+      alternatives: ['fake_tiprack_load_name'],
+      slot: '8',
+      id: 'abc123_labware_uuid',
+      forMounts: ['left'],
+      loadName: 'opentrons_96_tiprack_300ul',
+      namespace: 'opentrons',
+      version: 1,
+    },
+    {
+      alternatives: ['fake_other_tiprack_load_name'],
+      slot: '6',
+      id: 'def456_labware_uuid',
+      forMounts: ['right'],
+      loadName: 'opentrons_96_tiprack_20ul',
+      namespace: 'opentrons',
+      version: 1,
+    },
+  ],
+}
+
+export const mockTipLengthCalibrationSessionDetails: TipLengthCalibrationSessionDetails = {
+  instruments: {
+    left: {
+      model: 'fake_pipette_model',
+      name: 'fake_pipette_name',
+      tip_length: 42,
+      mount: 'left',
+      tiprack_id: 'abc123_labware_uuid',
+      rank: 'first',
+    },
+    right: {
+      model: 'fake_pipette_model',
+      name: 'fake_pipette_name',
+      tip_length: 42,
+      mount: 'right',
+      tiprack_id: 'def456_labware_uuid',
+      rank: 'second',
+    },
+  },
+  currentStep: 'sessionStarted',
   labware: [
     {
       alternatives: ['fake_tiprack_load_name'],

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -26,6 +26,13 @@ import typeof {
   CHECK_TRANSFORM_TYPE_INSTRUMENT_OFFSET,
   CHECK_TRANSFORM_TYPE_UNKNOWN,
   CHECK_TRANSFORM_TYPE_DECK,
+  TIP_LENGTH_STEP_SESSION_STARTED,
+  TIP_LENGTH_STEP_LABWARE_LOADED,
+  TIP_LENGTH_STEP_MEASURING_NOZZLE_OFFSET,
+  TIP_LENGTH_STEP_PREPARING_PIPETTE,
+  TIP_LENGTH_STEP_INSPECTING_TIP,
+  TIP_LENGTH_STEP_MEASURING_TIP_OFFSET,
+  TIP_LENGTH_STEP_CALIBRATION_COMPLETE,
 } from './constants'
 
 /* Robot Calibration Check Types */
@@ -107,3 +114,10 @@ export type TipLengthCalibrationStep =
   | TIP_LENGTH_STEP_INSPECTING_TIP
   | TIP_LENGTH_STEP_MEASURING_TIP_OFFSET
   | TIP_LENGTH_STEP_CALIBRATION_COMPLETE
+
+// TODO: update this type once the session details settle
+export type TipLengthCalibrationSessionDetails = {|
+  instruments: { [mount: string]: RobotCalibrationCheckInstrument, ... },
+  currentStep: TipLengthCalibrationStep,
+  labware: Array<RobotCalibrationCheckLabware>,
+|}

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -28,6 +28,8 @@ import typeof {
   CHECK_TRANSFORM_TYPE_DECK,
 } from './constants'
 
+/* Robot Calibration Check Types */
+
 export type RobotCalibrationCheckStep =
   | CHECK_STEP_SESSION_STARTED
   | CHECK_STEP_LABWARE_LOADED
@@ -94,3 +96,14 @@ export type RobotCalibrationCheckSessionDetails = {|
   },
   labware: Array<RobotCalibrationCheckLabware>,
 |}
+
+/* Tip Length Calibration Types */
+
+export type TipLengthCalibrationStep =
+  | TIP_LENGTH_STEP_SESSION_STARTED
+  | TIP_LENGTH_STEP_LABWARE_LOADED
+  | TIP_LENGTH_STEP_MEASURING_NOZZLE_OFFSET
+  | TIP_LENGTH_STEP_PREPARING_PIPETTE
+  | TIP_LENGTH_STEP_INSPECTING_TIP
+  | TIP_LENGTH_STEP_MEASURING_TIP_OFFSET
+  | TIP_LENGTH_STEP_CALIBRATION_COMPLETE

--- a/app/src/calibration/constants.js
+++ b/app/src/calibration/constants.js
@@ -1,5 +1,7 @@
 // @flow
 
+/* Robot Calibration Check Constants */
+
 export const CHECK_STEP_SESSION_STARTED: 'sessionStarted' = 'sessionStarted'
 export const CHECK_STEP_LABWARE_LOADED: 'labwareLoaded' = 'labwareLoaded'
 export const CHECK_STEP_PREPARING_FIRST_PIPETTE: 'preparingFirstPipette' =
@@ -66,3 +68,18 @@ export const checkCommands = {
 export const CHECK_TRANSFORM_TYPE_INSTRUMENT_OFFSET = 'BAD_INSTRUMENT_OFFSET'
 export const CHECK_TRANSFORM_TYPE_UNKNOWN = 'UNKNOWN'
 export const CHECK_TRANSFORM_TYPE_DECK = 'BAD_DECK_TRANSFORM'
+
+/* Tip Length Calibration Constants */
+
+export const TIP_LENGTH_STEP_SESSION_STARTED: 'sessionStarted' =
+  'sessionStarted'
+export const TIP_LENGTH_STEP_LABWARE_LOADED: 'labwareLoaded' = 'labwareLoaded'
+export const TIP_LENGTH_STEP_MEASURING_NOZZLE_OFFSET: 'measuringNozzleOffset' =
+  'measuringNozzleOffset'
+export const TIP_LENGTH_STEP_PREPARING_PIPETTE: 'preparingPipette' =
+  'preparingPipette'
+export const TIP_LENGTH_STEP_INSPECTING_TIP: 'inspectingTip' = 'inspectingTip'
+export const TIP_LENGTH_STEP_MEASURING_TIP_OFFSET: 'measuringTipOffset' =
+  'measuringTipOffset'
+export const TIP_LENGTH_STEP_CALIBRATION_COMPLETE: 'calibrationComplete' =
+  'calibrationComplete'

--- a/app/src/calibration/index.js
+++ b/app/src/calibration/index.js
@@ -4,6 +4,8 @@ import type {
   RobotCalibrationCheckStep,
   RobotCalibrationCheckComparison,
   RobotCalibrationCheckSessionDetails,
+  TipLengthCalibrationStep,
+  TipLengthCalibrationSessionDetails,
 } from './api-types'
 export * from './constants'
 
@@ -11,4 +13,6 @@ export type {
   RobotCalibrationCheckStep,
   RobotCalibrationCheckComparison,
   RobotCalibrationCheckSessionDetails,
+  TipLengthCalibrationStep,
+  TipLengthCalibrationSessionDetails,
 }

--- a/app/src/components/CalibrateTipLength/CompleteConfirmation.js
+++ b/app/src/components/CalibrateTipLength/CompleteConfirmation.js
@@ -1,0 +1,30 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import { Icon, PrimaryButton, IconButton } from '@opentrons/components'
+import styles from './styles.css'
+import type { CalibrateTipLengthChildProps } from './types'
+
+const COMPLETE_HEADER = 'Tip length calibration complete'
+const COMPLETE_BODY =
+  'Remove Calibration Block from the deck and select where to dispose of tip.'
+const RETURN_TIP = 'Return tip to tip rack'
+
+export function CompleteConfirmation(
+  props: CalibrateTipLengthChildProps
+): React.Node {
+  const exitSession = () => {
+    console.log('TODO: wire up command')
+    // props.exitSession()
+  }
+  return (
+    <>
+      <div className={styles.modal_icon_wrapper}>
+        <Icon name="check-circle" className={styles.success_status_icon} />
+        <h3>{COMPLETE_HEADER}</h3>
+      </div>
+      <div className={styles.complete_summary}>{COMPLETE_BODY}</div>
+      <PrimaryButton onClick={exitSession}>{RETURN_TIP}</PrimaryButton>
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/CompleteConfirmation.js
+++ b/app/src/components/CalibrateTipLength/CompleteConfirmation.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
-import cx from 'classnames'
-import { Icon, PrimaryButton, IconButton } from '@opentrons/components'
+import { Icon, PrimaryButton } from '@opentrons/components'
 import styles from './styles.css'
 import type { CalibrateTipLengthChildProps } from './types'
 

--- a/app/src/components/CalibrateTipLength/DeckSetup.js
+++ b/app/src/components/CalibrateTipLength/DeckSetup.js
@@ -17,6 +17,7 @@ import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefini
 
 import type { RobotCalibrationCheckLabware } from '../../calibration/api-types'
 import { getLatestLabwareDef } from '../../getLabware'
+import type { CalibrateTipLengthChildProps } from './types'
 import styles from './styles.css'
 
 const DECK_SETUP_WITH_BLOCK_PROMPT =
@@ -29,12 +30,17 @@ type DeckSetupProps = {|
   labware: Array<RobotCalibrationCheckLabware>,
   proceed: () => mixed,
 |}
-export function DeckSetup(props: DeckSetupProps): React.Node {
-  const { labware, proceed } = props
+export function DeckSetup(props: CalibrateTipLengthChildProps): React.Node {
   const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
 
-  // TODO: get real has_block value from tip length calibration session
+  // TODO: get real has_block value and labware from tip length calibration session
   const has_block = true
+  const labware = {}
+
+  const proceed = () => {
+    console.log('TODO: wire up command')
+    // props.sendSessionCommand('loadLabware')
+  }
 
   return (
     <>

--- a/app/src/components/CalibrateTipLength/DeckSetup.js
+++ b/app/src/components/CalibrateTipLength/DeckSetup.js
@@ -55,7 +55,7 @@ export function DeckSetup(props: CalibrateTipLengthChildProps): React.Node {
       </div>
       <div className={styles.deck_map_wrapper}>
         <RobotWorkSpace
-          deckLayerBlacklist={[
+          deckLayerBlocklist={[
             'fixedBase',
             'doorStops',
             'metalFrame',

--- a/app/src/components/CalibrateTipLength/DeckSetup.js
+++ b/app/src/components/CalibrateTipLength/DeckSetup.js
@@ -15,7 +15,6 @@ import {
 } from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 
-import type { RobotCalibrationCheckLabware } from '../../calibration/api-types'
 import { getLatestLabwareDef } from '../../getLabware'
 import type { CalibrateTipLengthChildProps } from './types'
 import styles from './styles.css'
@@ -26,10 +25,6 @@ const DECK_SETUP_NO_BLOCK_PROMPT =
   'Place full tip rack on the deck within the designated slot as illustrated below.'
 const DECK_SETUP_BUTTON_TEXT = 'Confirm placement and continue'
 
-type DeckSetupProps = {|
-  labware: Array<RobotCalibrationCheckLabware>,
-  proceed: () => mixed,
-|}
 export function DeckSetup(props: CalibrateTipLengthChildProps): React.Node {
   const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
 

--- a/app/src/components/CalibrateTipLength/DeckSetup.js
+++ b/app/src/components/CalibrateTipLength/DeckSetup.js
@@ -19,9 +19,11 @@ import type { RobotCalibrationCheckLabware } from '../../calibration/api-types'
 import { getLatestLabwareDef } from '../../getLabware'
 import styles from './styles.css'
 
-const DECK_SETUP_PROMPT =
-  'Place full tip rack(s) on the deck, in their designated slots, as illustrated below.'
-const DECK_SETUP_BUTTON_TEXT = 'Confirm tip rack placement and continue'
+const DECK_SETUP_WITH_BLOCK_PROMPT =
+  'Place full tip rack and Calibration Block on the deck within their designated slots as illustrated below.'
+const DECK_SETUP_NO_BLOCK_PROMPT =
+  'Place full tip rack on the deck within the designated slot as illustrated below.'
+const DECK_SETUP_BUTTON_TEXT = 'Confirm placement and continue'
 
 type DeckSetupProps = {|
   labware: Array<RobotCalibrationCheckLabware>,
@@ -30,10 +32,18 @@ type DeckSetupProps = {|
 export function DeckSetup(props: DeckSetupProps): React.Node {
   const { labware, proceed } = props
   const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
+
+  // TODO: get real has_block value from tip length calibration session
+  const has_block = true
+
   return (
     <>
       <div className={styles.prompt}>
-        <p className={styles.prompt_text}>{DECK_SETUP_PROMPT}</p>
+        {has_block ? (
+          <p className={styles.prompt_text}>{DECK_SETUP_WITH_BLOCK_PROMPT}</p>
+        ) : (
+          <p className={styles.prompt_text}>{DECK_SETUP_NO_BLOCK_PROMPT}</p>
+        )}
         <OutlineButton
           className={styles.prompt_button}
           onClick={proceed}
@@ -44,13 +54,14 @@ export function DeckSetup(props: DeckSetupProps): React.Node {
       </div>
       <div className={styles.deck_map_wrapper}>
         <RobotWorkSpace
-          deckLayerBlocklist={[
+          deckLayerBlacklist={[
             'fixedBase',
             'doorStops',
             'metalFrame',
             'removalHandle',
             'removableDeckOutline',
             'screwHoles',
+            'calibrationMarkings',
           ]}
           deckDef={deckDef}
           viewBox={`-46 -10 ${488} ${390}`} // TODO: put these in variables
@@ -63,6 +74,9 @@ export function DeckSetup(props: DeckSetupProps): React.Node {
                 if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
                 const labwareForSlot = labware.find(l => l.slot === slotId)
                 const labwareDef = getLatestLabwareDef(labwareForSlot?.loadName)
+
+                // TODO: also render calibration block if present
+
                 return labwareDef ? (
                   <TiprackRender
                     key={slotId}

--- a/app/src/components/CalibrateTipLength/InspectingTip.js
+++ b/app/src/components/CalibrateTipLength/InspectingTip.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react'
+import { PrimaryButton } from '@opentrons/components'
+import type { CalibrateTipLengthChildProps } from './types'
+import styles from './styles.css'
+
+const CONFIRM_TIP_BODY = 'Did pipette pick up tips successfully?'
+const CONFIRM_TIP_YES_BUTTON_TEXT = 'Yes, continue'
+const CONFIRM_TIP_NO_BUTTON_TEXT = 'No, try again'
+
+export function InspectingTip(props: CalibrateTipLengthChildProps): React.Node {
+  const invalidateTip = () => {
+    console.log('TODO: wire up command')
+    // props.sendSessionCommand('invalidateTip')
+  }
+  const confirmTip = () => {
+    console.log('TODO: wire up command')
+    // props.sendSessionCommand('confirmTip')
+  }
+  return (
+    <div className={styles.tip_pick_up_confirmation_wrapper}>
+      <p className={styles.pick_up_tip_confirmation_body}>{CONFIRM_TIP_BODY}</p>
+      <PrimaryButton
+        className={styles.pick_up_tip_confirmation_button}
+        onClick={invalidateTip}
+      >
+        {CONFIRM_TIP_NO_BUTTON_TEXT}
+      </PrimaryButton>
+      <PrimaryButton
+        className={styles.pick_up_tip_confirmation_button}
+        onClick={confirmTip}
+      >
+        {CONFIRM_TIP_YES_BUTTON_TEXT}
+      </PrimaryButton>
+    </div>
+  )
+}

--- a/app/src/components/CalibrateTipLength/Introduction.js
+++ b/app/src/components/CalibrateTipLength/Introduction.js
@@ -1,0 +1,62 @@
+// @flow
+import * as React from 'react'
+import { SecondaryButton, Link } from '@opentrons/components'
+
+import styles from './styles.css'
+
+const INTRO_TIP_LENGTH_CAL_HEADER = 'Tip length calibration'
+const INTRO_TIP_LENGTH_CAL_BODY =
+  'The Tip Probe feature of the robot is no longer being used. We’ve replaced it with a new process that allows the robot to measure the length of a tip relative to how it fits on the nozzle of the pipette. The data is saved per pipette model, so that each pipette model can save unique tip length data.'
+const PREREQS = 'To perform this new calibration process, you will require a'
+const CALIBRATION_BLOCK = 'Calibration Block.'
+const IF_NO_BLOCK = 'If you do not have a Calibration Block please'
+const CONTACT_US = 'contact us'
+const TO_RECEIVE = 'to receive one.'
+const ALTERNATIVE =
+  'While you wait for the block to arrive, you may opt in to using the flat surface on the Trash Bin of your robot instead.'
+const HAVE_BLOCK = 'I have a calibration block'
+const USE_TRASH = 'Use trash bin for now'
+
+const SUPPORT_URL = 'https://www.opentrons.com/contact-support'
+
+type IntroductionProps = {||}
+export function Introduction(props: IntroductionProps): React.Node {
+  return (
+    <>
+      <div className={styles.modal_header}>
+        <h3>{INTRO_TIP_LENGTH_CAL_HEADER}</h3>
+      </div>
+      <p className={styles.complete_body}>{INTRO_TIP_LENGTH_CAL_BODY}</p>
+      <div>
+        <div>
+          <p>
+            {PREREQS}
+            &nbsp;
+            <b>{CALIBRATION_BLOCK}</b>
+          </p>
+          <p>
+            {IF_NO_BLOCK}
+            &nbsp;
+            <Link href={SUPPORT_URL} external>
+              {CONTACT_US}
+            </Link>
+            &nbsp;
+            {TO_RECEIVE}
+          </p>
+          <p>{ALTERNATIVE}</p>
+        </div>
+        <div>{/*  TODO: insert image of calibration block here */}</div>
+      </div>
+      <div className={styles.button_row}>
+        <SecondaryButton onClick={() => console.log('TODO: handle use block')}>
+          {HAVE_BLOCK}
+        </SecondaryButton>
+        <SecondaryButton
+          onClick={() => console.log('TODO: handle use trash edge')}
+        >
+          {USE_TRASH}
+        </SecondaryButton>
+      </div>
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/Introduction.js
+++ b/app/src/components/CalibrateTipLength/Introduction.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react'
-import { SecondaryButton, Link } from '@opentrons/components'
+import { Link, OutlineButton } from '@opentrons/components'
 
 import styles from './styles.css'
+import type { CalibrateTipLengthChildProps } from './types'
 
 const INTRO_TIP_LENGTH_CAL_HEADER = 'Tip length calibration'
 const INTRO_TIP_LENGTH_CAL_BODY =
@@ -19,8 +20,7 @@ const USE_TRASH = 'Use trash bin for now'
 
 const SUPPORT_URL = 'https://www.opentrons.com/contact-support'
 
-type IntroductionProps = {||}
-export function Introduction(props: IntroductionProps): React.Node {
+export function Introduction(props: CalibrateTipLengthChildProps): React.Node {
   return (
     <>
       <div className={styles.modal_header}>
@@ -48,14 +48,14 @@ export function Introduction(props: IntroductionProps): React.Node {
         <div>{/*  TODO: insert image of calibration block here */}</div>
       </div>
       <div className={styles.button_row}>
-        <SecondaryButton onClick={() => console.log('TODO: handle use block')}>
+        <OutlineButton onClick={() => console.log('TODO: handle use block')}>
           {HAVE_BLOCK}
-        </SecondaryButton>
-        <SecondaryButton
+        </OutlineButton>
+        <OutlineButton
           onClick={() => console.log('TODO: handle use trash edge')}
         >
           {USE_TRASH}
-        </SecondaryButton>
+        </OutlineButton>
       </div>
     </>
   )

--- a/app/src/components/CalibrateTipLength/MeasureNozzle.js
+++ b/app/src/components/CalibrateTipLength/MeasureNozzle.js
@@ -1,0 +1,73 @@
+// @flow
+import * as React from 'react'
+import { PrimaryButton } from '@opentrons/components'
+
+import { JogControls } from '../JogControls'
+import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
+import styles from './styles.css'
+import type { CalibrateTipLengthProps } from './types'
+
+// TODO: fill with real video assets keyed by mount and then channels
+const assetMap = {}
+
+const HEADER = 'Save the nozzle z-axis'
+const JOG_UNTIL = 'Jog pipette until tip is'
+const JUST_BARELY = 'just barely'
+const TOUCHING = 'touching the deck in'
+const SLOT_5 = 'slot 5'
+const SAVE_NOZZLE_Z_AXIS = 'Save nozzle z-axis'
+
+export function MeasureNozzle(props: CalibrateTipLengthProps): React.Node {
+  // TODO: get real isMulti and mount from the session
+  const isMulti = false
+  const mount = 'left'
+
+  const demoAsset = React.useMemo(
+    () => mount && assetMap[mount][isMulti ? 'multi' : 'single'],
+    [mount, isMulti]
+  )
+
+  const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
+    console.log('TODO: jog with params', axis, dir, step)
+  }
+
+  return (
+    <>
+      <div className={styles.modal_header}>
+        <h3>{HEADER}</h3>
+      </div>
+      <div className={styles.tip_pick_up_demo_wrapper}>
+        <p className={styles.tip_pick_up_demo_body}>
+          {JOG_UNTIL}
+          <b>&nbsp;{JUST_BARELY}&nbsp;</b>
+          {TOUCHING}
+          <b>&nbsp;{SLOT_5}.&nbsp;</b>
+        </p>
+        <div className={styles.step_check_video_wrapper}>
+          <video
+            key={demoAsset}
+            className={styles.step_check_video}
+            autoPlay={true}
+            loop={true}
+            controls={false}
+          >
+            {/* TODO: insert assets <source src={demoAsset} /> */}
+          </video>
+        </div>
+      </div>
+      <div className={styles.tip_pick_up_controls_wrapper}>
+        <JogControls jog={jog} stepSizes={[0.1, 1]} axes={['z']} />
+      </div>
+      <div className={styles.button_row}>
+        <PrimaryButton
+          onClick={() => {
+            console.log('TODO: save nozzle offset')
+          }}
+          className={styles.command_button}
+        >
+          {SAVE_NOZZLE_Z_AXIS}
+        </PrimaryButton>
+      </div>
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/MeasureNozzle.js
+++ b/app/src/components/CalibrateTipLength/MeasureNozzle.js
@@ -8,7 +8,10 @@ import styles from './styles.css'
 import type { CalibrateTipLengthChildProps } from './types'
 
 // TODO: fill with real video assets keyed by mount and then channels
-const assetMap = {}
+const assetMap = {
+  left: {},
+  right: {},
+}
 
 const HEADER = 'Save the nozzle z-axis'
 const JOG_UNTIL = 'Jog the robot until nozzle is'

--- a/app/src/components/CalibrateTipLength/MeasureTip.js
+++ b/app/src/components/CalibrateTipLength/MeasureTip.js
@@ -8,7 +8,10 @@ import styles from './styles.css'
 import type { CalibrateTipLengthChildProps } from './types'
 
 // TODO: fill with real video assets keyed by mount and then channels
-const assetMap = {}
+const assetMap = {
+  left: {},
+  right: {},
+}
 
 const HEADER = 'Save the tip length'
 const JOG_UNTIL = 'Jog the robot until tip is'

--- a/app/src/components/CalibrateTipLength/MeasureTip.js
+++ b/app/src/components/CalibrateTipLength/MeasureTip.js
@@ -10,15 +10,15 @@ import type { CalibrateTipLengthChildProps } from './types'
 // TODO: fill with real video assets keyed by mount and then channels
 const assetMap = {}
 
-const HEADER = 'Save the nozzle z-axis'
-const JOG_UNTIL = 'Jog the robot until nozzle is'
+const HEADER = 'Save the tip length'
+const JOG_UNTIL = 'Jog the robot until tip is'
 const JUST_BARELY = 'just barely'
 // TODO: check copy here, should be touching the calibration block if present
 // and the top of the trash if not
 const TOUCHING = 'touching the deck in'
-const SAVE_NOZZLE_Z_AXIS = 'Save nozzle z-axis'
+const SAVE_NOZZLE_Z_AXIS = 'Save the tip length'
 
-export function MeasureNozzle(props: CalibrateTipLengthChildProps): React.Node {
+export function MeasureTip(props: CalibrateTipLengthChildProps): React.Node {
   // TODO: get real isMulti and mount and slotName from the session
   const isMulti = false
   const mount = 'left'

--- a/app/src/components/CalibrateTipLength/TipPickUp.js
+++ b/app/src/components/CalibrateTipLength/TipPickUp.js
@@ -1,0 +1,110 @@
+// @flow
+import * as React from 'react'
+import { PrimaryButton } from '@opentrons/components'
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+
+import type { RobotCalibrationCheckLabware } from '../../calibration/api-types'
+import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
+import { getLatestLabwareDef } from '../../getLabware'
+import { JogControls } from '../JogControls'
+import type { CalibrateTipLengthChildProps } from './types'
+import styles from './styles.css'
+
+// TODO: put these assets in a shared location?
+import multiDemoAsset from '../CheckCalibration/videos/A1-Multi-Channel-SEQ.webm'
+import singleDemoAsset from '../CheckCalibration/videos/A1-Single-Channel-SEQ.webm'
+
+const TIP_PICK_UP_HEADER = 'Position pipette over '
+const TIP_PICK_UP_BUTTON_TEXT = 'Pick up tip'
+
+const SINGLE_JOG_UNTIL_AT = 'Jog pipette until nozzle is centered above the'
+const MULTI_JOG_UNTIL_AT = 'Jog pipette until the channel nozzle'
+const CLOSEST = 'closest'
+const TO_YOU_IS_CENTERED = 'to you is centered above the'
+const POSITION = 'position'
+const AND = 'and'
+const FLUSH = 'flush'
+const WITH_TOP_OF_TIP = 'with the top of the tip.'
+const TIP_WELL_NAME = 'A1'
+
+const ASSET_MAP = {
+  multi: multiDemoAsset,
+  single: singleDemoAsset,
+}
+export function TipPickUp(props: CalibrateTipLengthChildProps): React.Node {
+  // TODO: get real isMulti and tiprack from the session
+  const tiprack = {}
+  const isMulti = true
+
+  const tiprackDef = React.useMemo(
+    () => getLatestLabwareDef(tiprack?.loadName),
+    [tiprack]
+  )
+
+  const demoAsset = ASSET_MAP[isMulti ? 'multi' : 'single']
+
+  const jogUntilAbove = isMulti ? (
+    <>
+      {MULTI_JOG_UNTIL_AT}
+      <b>&nbsp;{CLOSEST}&nbsp;</b>
+      {TO_YOU_IS_CENTERED}
+    </>
+  ) : (
+    SINGLE_JOG_UNTIL_AT
+  )
+
+  const pickUpTip = () => {
+    console.log('TODO: wire up command')
+    // props.sendSessionCommand('pickUpTip')
+  }
+
+  const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
+    console.log('TODO: wire up jog with params', axis, dir, step)
+    // props.sendSessionCommand('jog',{
+    //   vector: formatJogVector(axis, direction, step),
+    // }, {})
+  }
+
+  return (
+    <>
+      <div className={styles.modal_header}>
+        <h3>
+          {TIP_PICK_UP_HEADER}
+          {tiprackDef
+            ? getLabwareDisplayName(tiprackDef).replace('µL', 'uL')
+            : null}
+        </h3>
+      </div>
+      <div className={styles.tip_pick_up_demo_wrapper}>
+        <p className={styles.tip_pick_up_demo_body}>
+          {jogUntilAbove}
+          <b>{` ${TIP_WELL_NAME} `}</b>
+          {POSITION}
+          <br />
+          {AND}
+          <b>{` ${FLUSH} `}</b>
+          {WITH_TOP_OF_TIP}
+        </p>
+        <div className={styles.step_check_video_wrapper}>
+          <video
+            key={demoAsset}
+            className={styles.step_check_video}
+            autoPlay={true}
+            loop={true}
+            controls={false}
+          >
+            <source src={demoAsset} />
+          </video>
+        </div>
+      </div>
+      <div className={styles.tip_pick_up_controls_wrapper}>
+        <JogControls jog={jog} />
+      </div>
+      <div className={styles.button_row}>
+        <PrimaryButton onClick={pickUpTip} className={styles.command_button}>
+          {TIP_PICK_UP_BUTTON_TEXT}
+        </PrimaryButton>
+      </div>
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/TipPickUp.js
+++ b/app/src/components/CalibrateTipLength/TipPickUp.js
@@ -3,7 +3,6 @@ import * as React from 'react'
 import { PrimaryButton } from '@opentrons/components'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 
-import type { RobotCalibrationCheckLabware } from '../../calibration/api-types'
 import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
 import { getLatestLabwareDef } from '../../getLabware'
 import { JogControls } from '../JogControls'

--- a/app/src/components/CalibrateTipLength/UncalibratedInfo.js
+++ b/app/src/components/CalibrateTipLength/UncalibratedInfo.js
@@ -1,63 +1,34 @@
 // @flow
 import * as React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { PrimaryButton } from '@opentrons/components'
-import { ClearDeckAlertModal } from '../ClearDeckAlertModal'
 import { CalibrationInfoContent } from '../CalibrationInfoContent'
-
-import { actions as robotActions } from '../../robot'
-
-import { getDeckPopulated } from '../../robot/selectors'
-
-import type { Dispatch } from '../../types'
 import type { CalibrateTipLengthProps } from './types'
 
 const IS_CALIBRATED = 'Pipette tip height is calibrated'
 const IS_NOT_CALIBRATED = 'Pipette tip height is not calibrated'
+const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
+const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
+const CONTINUE = 'Continue to labware setup'
 
 export function UncalibratedInfo(props: CalibrateTipLengthProps): React.Node {
   const { mount, probed } = props
   const [showClearDeck, setShowClearDeck] = React.useState(false)
   const dispatch = useDispatch<Dispatch>()
-  const deckPopulated = useSelector(getDeckPopulated)
-
-  const moveToFront = () => {
-    dispatch(robotActions.moveToFront(mount))
-    setShowClearDeck(false)
-  }
 
   const handleStart = () => {
-    if (deckPopulated === true || deckPopulated === null) {
-      setShowClearDeck(true)
-    } else {
-      moveToFront()
-    }
+    console.log('TODO: start tip length cal session')
   }
-
-  const message = !probed ? IS_NOT_CALIBRATED : IS_CALIBRATED
-
-  const buttonText = !probed ? 'Calibrate Tip' : 'Recalibrate Tip'
 
   const leftChildren = (
     <div>
-      <p>{message}</p>
-      <PrimaryButton onClick={handleStart}>{buttonText}</PrimaryButton>
+      <p>{!probed ? IS_NOT_CALIBRATED : IS_CALIBRATED}</p>
+      <PrimaryButton onClick={handleStart}>
+        {!probed ? CALIBRATE_TIP_LENGTH : RECALIBRATE_TIP_LENGTH}
+      </PrimaryButton>
     </div>
   )
 
-  return (
-    <>
-      <CalibrationInfoContent leftChildren={leftChildren} />
-      {showClearDeck && (
-        <ClearDeckAlertModal
-          continueText={'Move pipette to front'}
-          cancelText={'Cancel'}
-          onContinueClick={moveToFront}
-          onCancelClick={() => setShowClearDeck(false)}
-          removeTrash
-        />
-      )}
-    </>
-  )
+  return <CalibrationInfoContent leftChildren={leftChildren} />
 }

--- a/app/src/components/CalibrateTipLength/UncalibratedInfo.js
+++ b/app/src/components/CalibrateTipLength/UncalibratedInfo.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import { useDispatch } from 'react-redux'
 
 import { PrimaryButton } from '@opentrons/components'
 import { CalibrationInfoContent } from '../CalibrationInfoContent'
@@ -10,7 +9,6 @@ const IS_CALIBRATED = 'Pipette tip height is calibrated'
 const IS_NOT_CALIBRATED = 'Pipette tip height is not calibrated'
 const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
 const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
-const CONTINUE = 'Continue to labware setup'
 
 export function UncalibratedInfo(
   props: CalibrateTipLengthChildProps

--- a/app/src/components/CalibrateTipLength/UncalibratedInfo.js
+++ b/app/src/components/CalibrateTipLength/UncalibratedInfo.js
@@ -1,0 +1,63 @@
+// @flow
+import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { PrimaryButton } from '@opentrons/components'
+import { ClearDeckAlertModal } from '../ClearDeckAlertModal'
+import { CalibrationInfoContent } from '../CalibrationInfoContent'
+
+import { actions as robotActions } from '../../robot'
+
+import { getDeckPopulated } from '../../robot/selectors'
+
+import type { Dispatch } from '../../types'
+import type { CalibrateTipLengthProps } from './types'
+
+const IS_CALIBRATED = 'Pipette tip height is calibrated'
+const IS_NOT_CALIBRATED = 'Pipette tip height is not calibrated'
+
+export function UncalibratedInfo(props: CalibrateTipLengthProps): React.Node {
+  const { mount, probed } = props
+  const [showClearDeck, setShowClearDeck] = React.useState(false)
+  const dispatch = useDispatch<Dispatch>()
+  const deckPopulated = useSelector(getDeckPopulated)
+
+  const moveToFront = () => {
+    dispatch(robotActions.moveToFront(mount))
+    setShowClearDeck(false)
+  }
+
+  const handleStart = () => {
+    if (deckPopulated === true || deckPopulated === null) {
+      setShowClearDeck(true)
+    } else {
+      moveToFront()
+    }
+  }
+
+  const message = !probed ? IS_NOT_CALIBRATED : IS_CALIBRATED
+
+  const buttonText = !probed ? 'Calibrate Tip' : 'Recalibrate Tip'
+
+  const leftChildren = (
+    <div>
+      <p>{message}</p>
+      <PrimaryButton onClick={handleStart}>{buttonText}</PrimaryButton>
+    </div>
+  )
+
+  return (
+    <>
+      <CalibrationInfoContent leftChildren={leftChildren} />
+      {showClearDeck && (
+        <ClearDeckAlertModal
+          continueText={'Move pipette to front'}
+          cancelText={'Cancel'}
+          onContinueClick={moveToFront}
+          onCancelClick={() => setShowClearDeck(false)}
+          removeTrash
+        />
+      )}
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/UncalibratedInfo.js
+++ b/app/src/components/CalibrateTipLength/UncalibratedInfo.js
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 
 import { PrimaryButton } from '@opentrons/components'
 import { CalibrationInfoContent } from '../CalibrationInfoContent'
-import type { CalibrateTipLengthProps } from './types'
+import type { CalibrateTipLengthChildProps } from './types'
 
 const IS_CALIBRATED = 'Pipette tip height is calibrated'
 const IS_NOT_CALIBRATED = 'Pipette tip height is not calibrated'
@@ -12,10 +12,10 @@ const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
 const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
 const CONTINUE = 'Continue to labware setup'
 
-export function UncalibratedInfo(props: CalibrateTipLengthProps): React.Node {
-  const { mount, probed } = props
-  const [showClearDeck, setShowClearDeck] = React.useState(false)
-  const dispatch = useDispatch<Dispatch>()
+export function UncalibratedInfo(
+  props: CalibrateTipLengthChildProps
+): React.Node {
+  const { probed } = props
 
   const handleStart = () => {
     console.log('TODO: start tip length cal session')

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
@@ -8,7 +8,6 @@ import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefini
 import * as Sessions from '../../../sessions'
 import * as Calibration from '../../../calibration'
 import { mockTipLengthCalibrationSessionAttributes } from '../../../sessions/__fixtures__'
-import { mockTipLengthCalibrationSessionDetails } from '../../../calibration/__fixtures__'
 
 import { CalibrateTipLength } from '../index'
 import { Introduction } from '../Introduction'
@@ -18,9 +17,6 @@ import { TipPickUp } from '../TipPickUp'
 import { InspectingTip } from '../InspectingTip'
 import { MeasureTip } from '../MeasureTip'
 import { CompleteConfirmation } from '../CompleteConfirmation'
-
-import type { State } from '../../../types'
-import { SESSION_TYPE_TIP_LENGTH_CALIBRATION } from '../../../sessions'
 
 jest.mock('@opentrons/components/src/deck/getDeckDefinitions')
 jest.mock('../../../sessions/selectors')
@@ -32,15 +28,15 @@ type CalibrateTipLengthSpec = {
   ...
 }
 
-const getRobotSessionOfType: JestMockFn<
-  [State, string, Sessions.SessionType],
-  $Call<
-    typeof Sessions.getRobotSessionOfType,
-    State,
-    string,
-    Sessions.SessionType
-  >
-> = Sessions.getRobotSessionOfType
+// const getRobotSessionOfType: JestMockFn<
+//   [State, string, Sessions.SessionType],
+//   $Call<
+//     typeof Sessions.getRobotSessionOfType,
+//     State,
+//     string,
+//     Sessions.SessionType
+//   >
+// > = Sessions.getRobotSessionOfType
 
 const mockGetDeckDefinitions: JestMockFn<
   [],
@@ -51,12 +47,13 @@ describe('CalibrateTipLength', () => {
   let mockStore
   let render
   let dispatch
-  let mockTipLengthSession: Sessions.TipLengthCalibrationSession | null = null
+  let mockTipLengthSession: Sessions.TipLengthCalibrationSession = {
+    id: 'fake_session_id',
+    ...mockTipLengthCalibrationSessionAttributes,
+  }
 
-  const mockCloseCalibrationCheck = jest.fn()
-
-  const getBackButton = wrapper =>
-    wrapper.find({ title: 'exit' }).find('button')
+  // const getBackButton = wrapper =>
+  //   wrapper.find({ title: 'exit' }).find('button')
 
   const POSSIBLE_CHILDREN = [
     Introduction,
@@ -89,17 +86,12 @@ describe('CalibrateTipLength', () => {
     }
     mockGetDeckDefinitions.mockReturnValue({})
 
-    render = (
-      currentStep: Calibration.TipLengthCalibrationStep = 'sessionStarted'
-    ) => {
-      mockTipLengthSession = {
-        id: 'fake_session_id',
-        ...mockTipLengthCalibrationSessionAttributes,
-        details: {
-          ...mockTipLengthCalibrationSessionAttributes.details,
-          currentStep,
-        },
-      }
+    mockTipLengthSession = {
+      id: 'fake_session_id',
+      ...mockTipLengthCalibrationSessionAttributes,
+    }
+
+    render = () => {
       return mount(
         <CalibrateTipLength
           robotName="robot-name"
@@ -122,7 +114,14 @@ describe('CalibrateTipLength', () => {
 
   SPECS.forEach(spec => {
     it(`renders correct contents when currentStep is ${spec.currentStep}`, () => {
-      const wrapper = render(spec.currentStep)
+      mockTipLengthSession = {
+        ...mockTipLengthSession,
+        details: {
+          ...mockTipLengthSession.details,
+          currentStep: spec.currentStep,
+        },
+      }
+      const wrapper = render()
 
       POSSIBLE_CHILDREN.forEach(child => {
         if (child === spec.component) {

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
@@ -33,8 +33,13 @@ type CalibrateTipLengthSpec = {
 }
 
 const getRobotSessionOfType: JestMockFn<
-  [State, string, string],
-  $Call<typeof Sessions.getRobotSessionOfType, State, string, string>
+  [State, string, Sessions.SessionType],
+  $Call<
+    typeof Sessions.getRobotSessionOfType,
+    State,
+    string,
+    Sessions.SessionType
+  >
 > = Sessions.getRobotSessionOfType
 
 const mockGetDeckDefinitions: JestMockFn<

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrationTipLength.test.js
@@ -1,0 +1,175 @@
+// @flow
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
+
+import * as Sessions from '../../../sessions'
+import * as Calibration from '../../../calibration'
+import { mockRobotCalibrationCheckSessionDetails } from '../../../calibration/__fixtures__'
+
+import { CalibrateTipLength } from '../index'
+import { Introduction } from '../Introduction'
+import { DeckSetup } from '../DeckSetup'
+import { MeasureNozzle } from '../MeasureNozzle'
+import { TipPickUp } from '../TipPickUp'
+import { InspectingTip } from '../InspectingTip'
+import { MeasureTip } from '../MeasureTip'
+import { CompleteConfirmation } from '../CompleteConfirmation'
+
+import type { State } from '../../../types'
+
+jest.mock('@opentrons/components/src/deck/getDeckDefinitions')
+jest.mock('../../../sessions/selectors')
+
+type CalibrateTipLengthSpec = {
+  component: React.AbstractComponent<any>,
+  childProps?: {},
+  currentStep: Calibration.RobotCalibrationCheckStep,
+  ...
+}
+
+const getRobotSessionOfType: JestMockFn<
+  [State, string, string],
+  $Call<typeof Sessions.getRobotSessionOfType, State, string, string>
+> = Sessions.getRobotSessionOfType
+
+const mockGetDeckDefinitions: JestMockFn<
+  [],
+  $Call<typeof getDeckDefinitions, any>
+> = getDeckDefinitions
+
+describe('CalibrateTipLength', () => {
+  let mockStore
+  let render
+  let dispatch
+
+  const mockCloseCalibrationCheck = jest.fn()
+
+  const getBackButton = wrapper =>
+    wrapper.find({ title: 'exit' }).find('button')
+
+  const POSSIBLE_CHILDREN = [
+    Introduction,
+    DeckSetup,
+    MeasureNozzle,
+    TipPickUp,
+    InspectingTip,
+    MeasureTip,
+    CompleteConfirmation,
+  ]
+
+  const SPECS: Array<CalibrateTipLengthSpec> = [
+    { component: Introduction, currentStep: 'sessionStarted' },
+    { component: DeckSetup, currentStep: 'labwareLoaded' },
+    { component: MeasureNozzle, currentStep: 'measuringNozzleOffset' },
+    { component: InspectingTip, currentStep: 'inspectingTip' },
+    { component: TipPickUp, currentStep: 'preparingPipette' },
+    { component: MeasureTip, currentStep: 'measuringTipOffset' },
+    { component: CompleteConfirmation, currentStep: 'calibrationComplete' },
+  ]
+
+  beforeEach(() => {
+    dispatch = jest.fn()
+    mockStore = {
+      subscribe: () => {},
+      getState: () => ({
+        robotApi: {},
+      }),
+      dispatch,
+    }
+    mockGetDeckDefinitions.mockReturnValue({})
+
+    render = () => {
+      return mount(
+        <ChecTipLengthk
+          robotName="robot-name"
+          closeCalibrationCheck={mockCloseCalibrationCheck}
+        />,
+        {
+          wrappingComponent: Provider,
+          wrappingComponentProps: { store: mockStore },
+        }
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('fetches robot cal check session on mount if session in state', () => {
+    getRobotSessionOfType.mockReturnValue({
+      id: 'fake_check_session_id',
+      sessionType: Sessions.SESSION_TYPE_CALIBRATION_CHECK,
+      details: mockRobotCalibrationCheckSessionDetails,
+    })
+    render()
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...Sessions.fetchSession('robot-name', 'fake_check_session_id'),
+        meta: { requestId: expect.any(String) },
+      })
+    )
+  })
+
+  it('creates robot cal check session on mount if no session already in state', () => {
+    getRobotSessionOfType.mockReturnValue(null)
+    render()
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...Sessions.createSession(
+          'robot-name',
+          Sessions.SESSION_TYPE_CALIBRATION_CHECK
+        ),
+        meta: { requestId: expect.any(String) },
+      })
+    )
+  })
+
+  SPECS.forEach(spec => {
+    it(`renders correct contents when currentStep is ${spec.currentStep}`, () => {
+      getRobotSessionOfType.mockReturnValue({
+        id: 'fake_check_session_id',
+        sessionType: Sessions.SESSION_TYPE_CALIBRATION_CHECK,
+        details: {
+          ...mockRobotCalibrationCheckSessionDetails,
+          currentStep: spec.currentStep,
+        },
+      })
+      const wrapper = render()
+
+      POSSIBLE_CHILDREN.forEach(child => {
+        if (child === spec.component) {
+          expect(wrapper.exists(child)).toBe(true)
+        } else {
+          expect(wrapper.exists(child)).toBe(false)
+        }
+      })
+    })
+  })
+
+  it('calls deleteRobotCalibrationCheckSession on exit click', () => {
+    getRobotSessionOfType.mockReturnValue({
+      id: 'fake_check_session_id',
+      sessionType: Sessions.SESSION_TYPE_CALIBRATION_CHECK,
+      details: mockRobotCalibrationCheckSessionDetails,
+    })
+    const wrapper = render()
+
+    act(() => {
+      getBackButton(wrapper).invoke('onClick')()
+    })
+    wrapper.update()
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...Sessions.deleteSession('robot-name', 'fake_check_session_id'),
+        meta: { requestId: expect.any(String) },
+      })
+    )
+    expect(mockCloseCalibrationCheck).toHaveBeenCalled()
+  })
+})

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -2,6 +2,12 @@
 // TipProbe controls
 import * as React from 'react'
 
+import type {
+  SessionCommandString,
+  SessionCommandData,
+} from '../../sessions/types'
+import * as Sessions from '../../sessions'
+import { useDispatchApiRequest } from '../../robot-api'
 import { CalibrationInfoBox } from '../CalibrationInfoBox'
 
 import { UncalibratedInfo } from './UncalibratedInfo'
@@ -13,10 +19,13 @@ import { InspectingTip } from './InspectingTip'
 import { MeasureTip } from './MeasureTip'
 import { CompleteConfirmation } from './CompleteConfirmation'
 
-import type { CalibrateTipLengthProps } from './types'
+import type {
+  CalibrateTipLengthParentProps,
+  CalibrateTipLengthChildProps,
+} from './types'
 
 const PANEL_BY_STEP: {
-  [string]: React.ComponentType<CalibrateTipLengthProps>,
+  [string]: React.ComponentType<CalibrateTipLengthChildProps>,
 } = {
   sessionStarted: Introduction,
   labwareLoaded: DeckSetup,
@@ -26,16 +35,41 @@ const PANEL_BY_STEP: {
   measuringTipOffset: MeasureTip,
   calibrationComplete: CompleteConfirmation,
 }
-export function CalibrateTipLength(props: CalibrateTipLengthProps): React.Node {
+export function CalibrateTipLength(
+  props: CalibrateTipLengthParentProps
+): React.Node {
   const { mount, probed } = props
+  // TODO: get real session
+  const tipLengthCalSession = {}
+  // TODO: get real currentStep from session
   const currentStep = ''
+  const robotName = ''
+
   const title = `${mount} pipette calibration`
   const Panel = PANEL_BY_STEP[currentStep]
 
+  const [dispatchRequest, requestIds] = useDispatchApiRequest()
+
+  function sendCommand(
+    command: SessionCommandString,
+    data: SessionCommandData = {}
+  ) {
+    tipLengthCalSession.id &&
+      dispatchRequest(
+        Sessions.createSessionCommand(robotName, tipLengthCalSession.id, {
+          command,
+          data,
+        })
+      )
+  }
   return (
     <>
       <CalibrationInfoBox confirmed={probed} title={title}>
-        {Panel ? <Panel {...props} /> : <UncalibratedInfo />}
+        {Panel ? (
+          <Panel {...props} sendSessionCommand={sendCommand} />
+        ) : (
+          <UncalibratedInfo {...props} sendSessionCommand={sendCommand} />
+        )}
       </CalibrationInfoBox>
     </>
   )

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -38,11 +38,11 @@ const PANEL_BY_STEP: {
 export function CalibrateTipLength(
   props: CalibrateTipLengthParentProps
 ): React.Node {
-  const { mount, probed } = props
+  const { mount, probed, session } = props
   // TODO: get real session
-  const tipLengthCalSession = {}
+  const tipLengthCalSession = session || {}
   // TODO: get real currentStep from session
-  const currentStep = ''
+  const currentStep = session?.details?.currentStep || ''
   const robotName = ''
 
   const title = `${mount} pipette calibration`

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -5,11 +5,27 @@ import * as React from 'react'
 import { CalibrationInfoBox } from '../CalibrationInfoBox'
 
 import { UncalibratedInfo } from './UncalibratedInfo'
+import { Introduction } from './Introduction'
+import { DeckSetup } from './DeckSetup'
+import { MeasureNozzle } from './MeasureNozzle'
+import { TipPickUp } from './TipPickUp'
+import { InspectingTip } from './InspectingTip'
+import { MeasureTip } from './MeasureTip'
+import { CompleteConfirmation } from './CompleteConfirmation'
+
 import type { CalibrateTipLengthProps } from './types'
 
 const PANEL_BY_STEP: {
   [string]: React.ComponentType<CalibrateTipLengthProps>,
-} = {}
+} = {
+  sessionStarted: Introduction,
+  labwareLoaded: DeckSetup,
+  measuringNozzleOffset: MeasureNozzle,
+  preparingPipette: TipPickUp,
+  inspectingTip: InspectingTip,
+  measuringTipOffset: MeasureTip,
+  calibrationComplete: CompleteConfirmation,
+}
 export function CalibrateTipLength(props: CalibrateTipLengthProps): React.Node {
   const { mount, probed } = props
   const currentStep = ''

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -48,7 +48,7 @@ export function CalibrateTipLength(
   const title = `${mount} pipette calibration`
   const Panel = PANEL_BY_STEP[currentStep]
 
-  const [dispatchRequest, requestIds] = useDispatchApiRequest()
+  const [dispatchRequest] = useDispatchApiRequest()
 
   function sendCommand(
     command: SessionCommandString,

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -1,5 +1,5 @@
 // @flow
-// TipProbe controls
+// Tip Length Calibration Orchestration Component
 import * as React from 'react'
 
 import type {

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -1,0 +1,26 @@
+// @flow
+// TipProbe controls
+import * as React from 'react'
+
+import { CalibrationInfoBox } from '../CalibrationInfoBox'
+
+import { UncalibratedInfo } from './UncalibratedInfo'
+import type { CalibrateTipLengthProps } from './types'
+
+const PANEL_BY_STEP: {
+  [string]: React.ComponentType<CalibrateTipLengthProps>,
+} = {}
+export function CalibrateTipLength(props: CalibrateTipLengthProps): React.Node {
+  const { mount, probed } = props
+  const currentStep = ''
+  const title = `${mount} pipette calibration`
+  const Panel = PANEL_BY_STEP[currentStep]
+
+  return (
+    <>
+      <CalibrationInfoBox confirmed={probed} title={title}>
+        {Panel ? <Panel {...props} /> : <UncalibratedInfo />}
+      </CalibrationInfoBox>
+    </>
+  )
+}

--- a/app/src/components/CalibrateTipLength/styles.css
+++ b/app/src/components/CalibrateTipLength/styles.css
@@ -1,0 +1,294 @@
+@import '@opentrons/components';
+
+.success_status_icon {
+  width: 2.5rem;
+  margin-right: 0.75rem;
+  color: var(--c-success);
+}
+
+.modal_header {
+  display: flex;
+  text-transform: uppercase;
+}
+
+.modal_icon_wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.terminal_modal_contents,
+.modal_contents {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  max-width: 48rem;
+  min-height: 14rem;
+  padding: 1rem;
+}
+
+.terminal_modal_contents {
+  padding: 2rem 3.5rem;
+}
+
+.complete_summary {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  margin: 2rem 0;
+}
+
+.summary_section {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  height: 3rem;
+  width: 10.25rem;
+  padding: 0.75rem;
+  margin-right: 1rem;
+  border-radius: var(--bd-radius-default);
+  border-width: var(--bd-width-default);
+  border-style: solid;
+}
+
+.summary_section:last-child {
+  margin-right: 0;
+}
+
+.summary_icon {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.copy_icon {
+  height: 2rem;
+  width: 2rem;
+  margin-bottom: 2rem;
+}
+
+.error_explanation {
+  @apply --font-body-2-dark;
+
+  margin: 0.75rem 0;
+}
+
+.padded_contents_wrapper {
+  margin: 1rem 3rem;
+}
+
+.button_row {
+  width: 100%;
+  display: flex;
+}
+
+.button_stack {
+  margin: 1rem 0;
+}
+
+.button_stack > button {
+  margin: 0.5rem 0;
+}
+
+.continue_button {
+  margin: 2rem 5rem;
+}
+
+.required_tipracks_wrapper {
+  width: 100%;
+  display: flex;
+}
+
+.required_tiprack {
+  width: 50%;
+  border: 1px solid var('--c-med-gray');
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 1rem 0;
+}
+
+.required_tiprack:not(:last-child) {
+  margin-right: 0.625rem;
+}
+
+.tiprack_image_container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 15rem;
+}
+
+.tiprack_image {
+  width: 100%;
+  max-height: 15rem;
+  max-width: 15.25rem;
+}
+
+.tiprack_display_name {
+  font-size: var('--fs-body-2');
+}
+
+/*
+TODO: BC 2020-04-01 consider abstracting this to a shared place
+ these styles were mostly copped from PD's VIEW MEASUREMENTs button
+ ideally these would both use the same component
+*/
+.tiprack_measurements_link {
+  padding: 1rem 0.5rem;
+  flex: 0.6;
+  text-transform: uppercase;
+  text-align: center;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  font-size: var('--fs-body-2');
+
+  &:hover {
+    background-color: var(--c-bg-hover);
+  }
+}
+
+.tipracks_note_header {
+  text-transform: uppercase;
+}
+
+.tipracks_note_body {
+  font-size: var('--fs-body-1');
+}
+
+/* end copped styles */
+
+.prompt {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.prompt_text {
+  @apply --font-header-light;
+
+  font-weight: normal;
+  margin: 0.5rem 0;
+  text-align: center;
+}
+
+.prompt_button {
+  display: block;
+  width: auto;
+  margin: 0.5rem 0 1rem 0;
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
+
+.page_content_dark {
+  display: flex;
+  padding: 1rem;
+  flex-direction: column;
+  align-items: center;
+  background-color: transparent;
+  height: 100%;
+}
+
+.deck_map_wrapper {
+  flex: 1 1 0;
+  align-self: stretch;
+  display: flex;
+  background-color: var(--c-bg-light);
+  border-radius: 6px;
+}
+
+.deck_map {
+  flex: 1;
+}
+
+.labware_ui_wrapper {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.labware_ui_content {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.name_overlay {
+  font-size: 0.5rem;
+  color: var(--c-font-light);
+  background-color: color-mod(var(--c-black) alpha(0.75));
+  padding: 0.25rem;
+  border-radius: 0 0 3px 3px;
+}
+
+.display_name {
+  @apply --truncate;
+
+  font-weight: var(--fw-semibold);
+  color: var(--c-font-light);
+  text-transform: uppercase;
+}
+
+.tip_pick_up_demo_wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border: 2px solid var(--c-lightest-gray);
+  padding: 1rem 0;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.tip_pick_up_demo_body {
+  @apply --font-body-2-dark;
+
+  margin: 0 1rem;
+}
+
+.command_button {
+  margin: 0 5rem;
+}
+
+.tip_pick_up_confirmation_wrapper {
+  align-self: stretch;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 1rem;
+}
+
+.pick_up_tip_confirmation_body {
+  margin: 1rem 0;
+}
+
+.pick_up_tip_confirmation_button {
+  margin-top: 1rem;
+  width: 80%;
+}
+
+.step_check_video_wrapper {
+  margin-top: 1rem;
+}
+
+.step_check_video {
+  max-width: 100%;
+  max-height: 15rem;
+}
+
+.loading_spinner {
+  width: 7.5rem;
+  margin-bottom: 3rem;
+}

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -1,6 +1,5 @@
 // @flow
 import type { Mount } from '@opentrons/components'
-import type { Pipette } from '../../robot'
 import type {
   SessionCommandString,
   SessionCommandData,

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -3,11 +3,13 @@ import type { Pipette } from '../../robot'
 import type {
   SessionCommandString,
   SessionCommandData,
+  Session,
 } from '../../sessions/types'
 
 export type CalibrateTipLengthParentProps = {|
   ...Pipette,
   robotName: string | null,
+  session: Session,
 |}
 
 export type CalibrateTipLengthChildProps = {|

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -2,11 +2,3 @@
 import type { Pipette } from '../../robot'
 
 export type CalibrateTipLengthProps = Pipette
-
-export type TipProbeState =
-  | 'unprobed'
-  | 'moving-to-front'
-  | 'waiting-for-tip'
-  | 'probing'
-  | 'waiting-for-remove-tip'
-  | 'done'

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -1,0 +1,12 @@
+// @flow
+import type { Pipette } from '../../robot'
+
+export type CalibrateTipLengthProps = Pipette
+
+export type TipProbeState =
+  | 'unprobed'
+  | 'moving-to-front'
+  | 'waiting-for-tip'
+  | 'probing'
+  | 'waiting-for-remove-tip'
+  | 'done'

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -1,4 +1,19 @@
 // @flow
 import type { Pipette } from '../../robot'
+import type {
+  SessionCommandString,
+  SessionCommandData,
+} from '../../sessions/types'
 
-export type CalibrateTipLengthProps = Pipette
+export type CalibrateTipLengthParentProps = {|
+  ...Pipette,
+  robotName: string | null,
+|}
+
+export type CalibrateTipLengthChildProps = {|
+  ...CalibrateTipLengthParentProps,
+  sendSessionCommand: (
+    command: SessionCommandString,
+    data: SessionCommandData
+  ) => void,
+|}

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Mount } from '@opentrons/components'
 import type { Pipette } from '../../robot'
 import type {
   SessionCommandString,
@@ -7,7 +8,9 @@ import type {
 } from '../../sessions/types'
 
 export type CalibrateTipLengthParentProps = {|
-  ...Pipette,
+  isMulti: boolean,
+  mount: Mount,
+  probed: boolean,
   robotName: string | null,
   session: Session,
 |}

--- a/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
@@ -32,8 +32,13 @@ type CheckCalibrationSpec = {
 }
 
 const getRobotSessionOfType: JestMockFn<
-  [State, string, string],
-  $Call<typeof Sessions.getRobotSessionOfType, State, string, string>
+  [State, string, Sessions.SessionType],
+  $Call<
+    typeof Sessions.getRobotSessionOfType,
+    State,
+    string,
+    Sessions.SessionType
+  >
 > = Sessions.getRobotSessionOfType
 
 const mockGetDeckDefinitions: JestMockFn<

--- a/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
@@ -8,7 +8,6 @@ import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefini
 
 import * as Sessions from '../../../sessions'
 import * as Calibration from '../../../calibration'
-import { mockRobotCalibrationCheckSessionDetails } from '../../../calibration/__fixtures__'
 
 import { CheckCalibration } from '../index'
 import { Introduction } from '../Introduction'
@@ -102,17 +101,12 @@ describe('CheckCalibration', () => {
     }
     mockGetDeckDefinitions.mockReturnValue({})
 
-    render = (
-      currentStep: Calibration.RobotCalibrationCheckStep = 'sessionStarted'
-    ) => {
-      mockCalibrationCheckSession = {
-        id: 'fake_check_session_id',
-        ...mockCalibrationCheckSessionAttributes,
-        details: {
-          ...mockCalibrationCheckSessionAttributes.details,
-          currentStep,
-        },
-      }
+    mockCalibrationCheckSession = {
+      id: 'fake_check_session_id',
+      ...mockCalibrationCheckSessionAttributes,
+    }
+
+    render = () => {
       return mount(
         <CheckCalibration
           robotName="robot-name"
@@ -157,8 +151,16 @@ describe('CheckCalibration', () => {
 
   SPECS.forEach(spec => {
     it(`renders correct contents when currentStep is ${spec.currentStep}`, () => {
-      const wrapper = render(spec.currentStep)
+      mockCalibrationCheckSession = {
+        ...mockCalibrationCheckSession,
+        details: {
+          ...mockCalibrationCheckSession.details,
+          currentStep: spec.currentStep,
+        },
+      }
       getRobotSessionOfType.mockReturnValue(mockCalibrationCheckSession)
+
+      const wrapper = render()
 
       POSSIBLE_CHILDREN.forEach(child => {
         if (child === spec.component) {
@@ -171,8 +173,8 @@ describe('CheckCalibration', () => {
   })
 
   it('calls deleteRobotCalibrationCheckSession on exit click', () => {
-    const wrapper = render()
     getRobotSessionOfType.mockReturnValue(mockCalibrationCheckSession)
+    const wrapper = render()
 
     act(() => {
       getBackButton(wrapper).invoke('onClick')()

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -55,7 +55,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
   const pending = requestStatus === PENDING
 
   const robotCalCheckSession = useSelector((state: State) => {
-    const session = Sessions.getRobotSessionOfType(
+    const session: Sessions.CalibrationCheckSession | null = Sessions.getRobotSessionOfType<Sessions.CalibrationCheckSession>(
       state,
       robotName,
       Sessions.SESSION_TYPE_CALIBRATION_CHECK

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -55,12 +55,18 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
   const pending = requestStatus === PENDING
 
   const robotCalCheckSession = useSelector((state: State) => {
-    const session: Sessions.CalibrationCheckSession | null = Sessions.getRobotSessionOfType<Sessions.CalibrationCheckSession>(
+    const session: Sessions.Session | null = Sessions.getRobotSessionOfType(
       state,
       robotName,
       Sessions.SESSION_TYPE_CALIBRATION_CHECK
     )
-    return session ?? {}
+    if (
+      session &&
+      session.sessionType === Sessions.SESSION_TYPE_CALIBRATION_CHECK
+    ) {
+      return session
+    }
+    return {}
   })
   const { currentStep, labware, instruments, comparisonsByStep } =
     robotCalCheckSession.details || {}

--- a/app/src/config/constants.js
+++ b/app/src/config/constants.js
@@ -8,6 +8,7 @@ export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'enableBundleUpload',
   'enableRobotCalCheck',
+  'enableTipLengthCal',
 ]
 
 // action type constants

--- a/app/src/config/schema-types.js
+++ b/app/src/config/schema-types.js
@@ -11,6 +11,7 @@ export type DevInternalFlag =
   | 'allPipetteConfig'
   | 'enableBundleUpload'
   | 'enableRobotCalCheck'
+  | 'enableTipLengthCal'
 
 export type FeatureFlags = $Shape<{|
   [DevInternalFlag]: boolean | void,

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -7,6 +7,8 @@ import { selectors as robotSelectors } from '../../robot'
 import { PIPETTE_MOUNTS, fetchPipettes } from '../../pipettes'
 import { getConnectedRobot } from '../../discovery'
 import { getFeatureFlags } from '../../config'
+import { mockSession } from '../../sessions/__fixtures__'
+import { mockTipLengthCalibrationSessionDetails } from '../../calibration/__fixtures__'
 
 import { Page } from '../../components/Page'
 import { TipProbe } from '../../components/TipProbe'
@@ -44,6 +46,12 @@ export function Pipettes(props: Props): React.Node {
 
   const currentPipette = pipettes.find(p => p.mount === currentMount) || null
 
+  // TODO: get real session
+  const tipLengthCalibrationSession = {
+    ...mockSession,
+    details: mockTipLengthCalibrationSessionDetails,
+  }
+
   return (
     <Page titleBarProps={{ title: <SessionHeader /> }}>
       <PipetteTabs currentMount={currentMount} />
@@ -57,7 +65,13 @@ export function Pipettes(props: Props): React.Node {
       />
       {!!currentPipette &&
         (ff.enableTipLengthCal ? (
-          <CalibrateTipLength {...currentPipette} robotName={robotName} />
+          <CalibrateTipLength
+            mount={currentPipette.mount}
+            isMulti={currentPipette.channels > 1}
+            probed={currentPipette.probed}
+            robotName={robotName}
+            session={tipLengthCalibrationSession}
+          />
         ) : (
           <TipProbe {...currentPipette} />
         ))}

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -3,12 +3,12 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
+import * as Sessions from '../../sessions'
 import { selectors as robotSelectors } from '../../robot'
 import { PIPETTE_MOUNTS, fetchPipettes } from '../../pipettes'
 import { getConnectedRobot } from '../../discovery'
 import { getFeatureFlags } from '../../config'
-import { mockSession } from '../../sessions/__fixtures__'
-import { mockTipLengthCalibrationSessionDetails } from '../../calibration/__fixtures__'
+import { mockTipLengthCalibrationSessionAttributes } from '../../sessions/__fixtures__'
 
 import { Page } from '../../components/Page'
 import { TipProbe } from '../../components/TipProbe'
@@ -47,9 +47,9 @@ export function Pipettes(props: Props): React.Node {
   const currentPipette = pipettes.find(p => p.mount === currentMount) || null
 
   // TODO: get real session
-  const tipLengthCalibrationSession = {
-    ...mockSession,
-    details: mockTipLengthCalibrationSessionDetails,
+  const tipLengthCalibrationSession: Sessions.TipLengthCalibrationSession = {
+    ...mockTipLengthCalibrationSessionAttributes,
+    id: 'fake_session_id',
   }
 
   return (

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -57,7 +57,7 @@ export function Pipettes(props: Props): React.Node {
       />
       {!!currentPipette &&
         (ff.enableTipLengthCal ? (
-          <CalibrateTipLength {...currentPipette} />
+          <CalibrateTipLength {...currentPipette} robotName={robotName} />
         ) : (
           <TipProbe {...currentPipette} />
         ))}

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -6,9 +6,11 @@ import { useSelector, useDispatch } from 'react-redux'
 import { selectors as robotSelectors } from '../../robot'
 import { PIPETTE_MOUNTS, fetchPipettes } from '../../pipettes'
 import { getConnectedRobot } from '../../discovery'
+import { getFeatureFlags } from '../../config'
 
 import { Page } from '../../components/Page'
 import { TipProbe } from '../../components/TipProbe'
+import { CalibrateTipLength } from '../../components/CalibrateTipLength'
 import {
   PipetteTabs,
   Pipettes as PipettesContents,
@@ -25,6 +27,7 @@ export function Pipettes(props: Props): React.Node {
   const { mount } = props.match.params
   const dispatch = useDispatch<Dispatch>()
   const robot = useSelector(getConnectedRobot)
+  const ff = useSelector(getFeatureFlags)
   const robotName = robot?.name || null
   const tipracksByMount = useSelector(robotSelectors.getTipracksByMount)
   const pipettes = useSelector(robotSelectors.getPipettes)
@@ -52,7 +55,12 @@ export function Pipettes(props: Props): React.Node {
           changePipetteUrl,
         }}
       />
-      {!!currentPipette && <TipProbe {...currentPipette} />}
+      {!!currentPipette &&
+        (ff.enableTipLengthCal ? (
+          <CalibrateTipLength {...currentPipette} />
+        ) : (
+          <TipProbe {...currentPipette} />
+        ))}
     </Page>
   )
 }

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -5,7 +5,10 @@ import {
   makeResponseFixtures,
   mockV2ErrorResponse,
 } from '../../robot-api/__fixtures__'
-import { mockRobotCalibrationCheckSessionDetails } from '../../calibration/__fixtures__'
+import {
+  mockRobotCalibrationCheckSessionDetails,
+  mockTipLengthCalibrationSessionDetails,
+} from '../../calibration/__fixtures__'
 
 import type { ResponseFixtures } from '../../robot-api/__fixtures__'
 import type { RobotApiV2ErrorResponseBody } from '../../robot-api/types'
@@ -16,13 +19,18 @@ import * as Constants from '../constants'
 export const mockSessionId: string = 'fake_session_id'
 export const mockOtherSessionId: string = 'other_fake_session_id'
 
-export const mockSessionAttributes: Types.SessionResponseAttributes = {
+export const mockCalibrationCheckSessionAttributes: Types.CalibrationCheckSessionResponseAttributes = {
   sessionType: Constants.SESSION_TYPE_CALIBRATION_CHECK,
   details: mockRobotCalibrationCheckSessionDetails,
 }
 
+export const mockTipLengthCalibrationSessionAttributes: Types.TipLengthCalibrationSessionResponseAttributes = {
+  sessionType: Constants.SESSION_TYPE_TIP_LENGTH_CALIBRATION,
+  details: mockTipLengthCalibrationSessionDetails,
+}
+
 export const mockSession: Types.Session = {
-  ...mockSessionAttributes,
+  ...mockCalibrationCheckSessionAttributes,
   id: mockSessionId,
 }
 
@@ -41,7 +49,7 @@ export const mockSessionResponse: Types.SessionResponse = {
   data: {
     id: mockSessionId,
     type: 'Session',
-    attributes: mockSessionAttributes,
+    attributes: mockCalibrationCheckSessionAttributes,
   },
 }
 
@@ -50,12 +58,12 @@ export const mockMultiSessionResponse: Types.MultiSessionResponse = {
     {
       id: mockSessionId,
       type: 'Session',
-      attributes: mockSessionAttributes,
+      attributes: mockCalibrationCheckSessionAttributes,
     },
     {
       id: mockOtherSessionId,
       type: 'Session',
-      attributes: mockSessionAttributes,
+      attributes: mockCalibrationCheckSessionAttributes,
     },
   ],
 }

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -250,11 +250,11 @@ const SPECS: Array<ReducerSpec> = [
       'frumious-bandersnatch': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockTipLengthCalibrationSessionAttributes,
             id: 'existing_fake_session_id',
           },
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockTipLengthCalibrationSessionAttributes,
             id: Fixtures.mockSessionId,
           },
         },
@@ -264,7 +264,7 @@ const SPECS: Array<ReducerSpec> = [
       'frumious-bandersnatch': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockTipLengthCalibrationSessionAttributes,
             id: 'existing_fake_session_id',
           },
         },
@@ -288,11 +288,11 @@ const SPECS: Array<ReducerSpec> = [
       'detestable-moss': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: 'existing_fake_session_id',
           },
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: Fixtures.mockSessionId,
           },
         },
@@ -302,7 +302,7 @@ const SPECS: Array<ReducerSpec> = [
       'detestable-moss': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: 'existing_fake_session_id',
           },
         },

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -177,7 +177,7 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           fake_stale_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: 'fake_stale_session_id',
           },
         },
@@ -212,11 +212,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: 'existing_fake_session_id',
           },
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: Fixtures.mockSessionId,
           },
         },
@@ -226,7 +226,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionAttributes,
+            ...Fixtures.mockCalibrationCheckSessionAttributes,
             id: 'existing_fake_session_id',
           },
         },

--- a/app/src/sessions/__tests__/selectors.test.js
+++ b/app/src/sessions/__tests__/selectors.test.js
@@ -33,14 +33,15 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+            [Fixtures.mockSessionId]:
+              Fixtures.mockCalibrationCheckSessionAttributes,
           },
         },
       },
     },
     args: ['germanium-cobweb'],
     expected: {
-      [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+      [Fixtures.mockSessionId]: Fixtures.mockCalibrationCheckSessionAttributes,
     },
   },
   {
@@ -50,7 +51,8 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+            [Fixtures.mockSessionId]:
+              Fixtures.mockCalibrationCheckSessionAttributes,
           },
         },
       },
@@ -65,13 +67,14 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+            [Fixtures.mockSessionId]:
+              Fixtures.mockCalibrationCheckSessionAttributes,
           },
         },
       },
     },
     args: ['germanium-cobweb', Fixtures.mockSessionId],
-    expected: Fixtures.mockSessionAttributes,
+    expected: Fixtures.mockCalibrationCheckSessionAttributes,
   },
   {
     name:
@@ -81,7 +84,8 @@ const SPECS: Array<SelectorSpec> = [
       sessions: {
         'germanium-cobweb': {
           robotSessions: {
-            [Fixtures.mockSessionId]: Fixtures.mockSessionAttributes,
+            [Fixtures.mockSessionId]:
+              Fixtures.mockCalibrationCheckSessionAttributes,
           },
         },
       },
@@ -98,7 +102,7 @@ const SPECS: Array<SelectorSpec> = [
         'germanium-cobweb': {
           robotSessions: {
             [Fixtures.mockSessionId]: {
-              ...Fixtures.mockSessionAttributes,
+              ...Fixtures.mockCalibrationCheckSessionAttributes,
               sessionType: 'FakeUntrackedSessionType',
             },
           },
@@ -117,7 +121,7 @@ const SPECS: Array<SelectorSpec> = [
         'germanium-cobweb': {
           robotSessions: {
             [Fixtures.mockSessionId]: {
-              ...Fixtures.mockSessionAttributes,
+              ...Fixtures.mockCalibrationCheckSessionAttributes,
               sessionType: 'FakeUntrackedSessionType',
             },
           },

--- a/app/src/sessions/constants.js
+++ b/app/src/sessions/constants.js
@@ -51,5 +51,7 @@ export const CREATE_SESSION_COMMAND_SUCCESS: 'sessions:CREATE_SESSION_COMMAND_SU
 export const CREATE_SESSION_COMMAND_FAILURE: 'sessions:CREATE_SESSION_COMMAND_FAILURE' =
   'sessions:CREATE_SESSION_COMMAND_FAILURE'
 
-export const SESSION_TYPE_CALIBRATION_CHECK = 'calibrationCheck'
-export const SESSION_TYPE_TIP_LENGTH_CALIBRATION = 'tipLengthCalibration'
+export const SESSION_TYPE_CALIBRATION_CHECK: 'calibrationCheck' =
+  'calibrationCheck'
+export const SESSION_TYPE_TIP_LENGTH_CALIBRATION: 'tipLengthCalibration' =
+  'tipLengthCalibration'

--- a/app/src/sessions/constants.js
+++ b/app/src/sessions/constants.js
@@ -52,3 +52,4 @@ export const CREATE_SESSION_COMMAND_FAILURE: 'sessions:CREATE_SESSION_COMMAND_FA
   'sessions:CREATE_SESSION_COMMAND_FAILURE'
 
 export const SESSION_TYPE_CALIBRATION_CHECK = 'calibrationCheck'
+export const SESSION_TYPE_TIP_LENGTH_CALIBRATION = 'tipLengthCalibration'

--- a/app/src/sessions/index.js
+++ b/app/src/sessions/index.js
@@ -5,7 +5,13 @@ export * from './constants'
 export * from './selectors'
 import type {
   Session,
+  SessionType,
   CalibrationCheckSession,
   TipLengthCalibrationSession,
 } from './types'
-export type { Session, CalibrationCheckSession, TipLengthCalibrationSession }
+export type {
+  Session,
+  SessionType,
+  CalibrationCheckSession,
+  TipLengthCalibrationSession,
+}

--- a/app/src/sessions/index.js
+++ b/app/src/sessions/index.js
@@ -3,3 +3,9 @@
 export * from './actions'
 export * from './constants'
 export * from './selectors'
+import type {
+  Session,
+  CalibrationCheckSession,
+  TipLengthCalibrationSession,
+} from './types'
+export type { Session, CalibrationCheckSession, TipLengthCalibrationSession }

--- a/app/src/sessions/index.js
+++ b/app/src/sessions/index.js
@@ -1,14 +1,16 @@
 // @flow
-// sessions constants, actions, and selectors
-export * from './actions'
-export * from './constants'
-export * from './selectors'
+// sessions constants, actions, selectors, and types
 import type {
   Session,
   SessionType,
   CalibrationCheckSession,
   TipLengthCalibrationSession,
 } from './types'
+
+export * from './actions'
+export * from './constants'
+export * from './selectors'
+
 export type {
   Session,
   SessionType,

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -52,7 +52,6 @@ export const getAnalyticsPropsForRobotSessionById: (
       initialModelsByMount
     )
     const initialStepData: $Shape<Types.CalibrationCheckAnalyticsData> = {}
-    // $FlowFixMe (bc, 2020-6-10) we know that this property exists in a session of this type, but flow doesn't
     const normalizedStepData = Object.keys(comparisonsByStep).reduce(
       (
         acc: Types.CalibrationCheckAnalyticsData,

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -18,11 +18,11 @@ export const getRobotSessionById: (
   return (getRobotSessions(state, robotName) || {})[sessionId] ?? null
 }
 
-export const getRobotSessionOfType: (
+export function getRobotSessionOfType<T: Types.Session>(
   state: State,
   robotName: string,
   sessionType: Types.SessionType
-) => Types.Session | null = (state, robotName, sessionType) => {
+): T | null {
   const sessionsById = getRobotSessions(state, robotName) || {}
   const foundSessionId =
     Object.keys(sessionsById).find(
@@ -40,6 +40,7 @@ export const getAnalyticsPropsForRobotSessionById: (
   if (!session) return null
 
   if (session.sessionType === Constants.SESSION_TYPE_CALIBRATION_CHECK) {
+    // $FlowFixMe (bc, 2020-6-10) we know that this property exists in a session of this type, but flow doesn't
     const { instruments, comparisonsByStep } = session.details
     const initialModelsByMount: $Shape<Types.AnalyticsModelsByMount> = {}
     const modelsByMount: Types.AnalyticsModelsByMount = Object.keys(
@@ -52,6 +53,7 @@ export const getAnalyticsPropsForRobotSessionById: (
       initialModelsByMount
     )
     const initialStepData: $Shape<Types.CalibrationCheckAnalyticsData> = {}
+    // $FlowFixMe (bc, 2020-6-10) we know that this property exists in a session of this type, but flow doesn't
     const normalizedStepData = Object.keys(comparisonsByStep).reduce(
       (
         acc: Types.CalibrationCheckAnalyticsData,

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -18,11 +18,11 @@ export const getRobotSessionById: (
   return (getRobotSessions(state, robotName) || {})[sessionId] ?? null
 }
 
-export function getRobotSessionOfType<T: Types.Session>(
+export function getRobotSessionOfType(
   state: State,
   robotName: string,
   sessionType: Types.SessionType
-): T | null {
+): Types.Session | null {
   const sessionsById = getRobotSessions(state, robotName) || {}
   const foundSessionId =
     Object.keys(sessionsById).find(
@@ -40,7 +40,6 @@ export const getAnalyticsPropsForRobotSessionById: (
   if (!session) return null
 
   if (session.sessionType === Constants.SESSION_TYPE_CALIBRATION_CHECK) {
-    // $FlowFixMe (bc, 2020-6-10) we know that this property exists in a session of this type, but flow doesn't
     const { instruments, comparisonsByStep } = session.details
     const initialModelsByMount: $Shape<Types.AnalyticsModelsByMount> = {}
     const modelsByMount: Types.AnalyticsModelsByMount = Object.keys(

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -17,6 +17,7 @@ import typeof {
   CREATE_SESSION_COMMAND_SUCCESS,
   CREATE_SESSION_COMMAND_FAILURE,
   SESSION_TYPE_CALIBRATION_CHECK,
+  SESSION_TYPE_TIP_LENGTH_CALIBRATION,
 } from './constants'
 
 import type {
@@ -27,7 +28,9 @@ import type {
 import * as Calibration from '../calibration'
 
 // The available session types
-export type SessionType = SESSION_TYPE_CALIBRATION_CHECK
+export type SessionType =
+  | SESSION_TYPE_CALIBRATION_CHECK
+  | SESSION_TYPE_TIP_LENGTH_CALIBRATION
 
 // The details associated with available session types
 type SessionDetails = Calibration.RobotCalibrationCheckSessionDetails

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -56,16 +56,6 @@ export type SessionResponseAttributes =
   | CalibrationCheckSessionResponseAttributes
   | TipLengthCalibrationSessionResponseAttributes
 
-export type Session = {|
-  id: string,
-  +sessionType:
-    | SESSION_TYPE_CALIBRATION_CHECK
-    | SESSION_TYPE_TIP_LENGTH_CALIBRATION,
-  +details:
-    | Calibration.TipLengthCalibrationSessionDetails
-    | Calibration.RobotCalibrationCheckSessionDetails,
-|}
-
 export type CalibrationCheckSession = {|
   ...CalibrationCheckSessionResponseAttributes,
   id: string,
@@ -75,6 +65,8 @@ export type TipLengthCalibrationSession = {|
   ...TipLengthCalibrationSessionResponseAttributes,
   id: string,
 |}
+
+export type Session = CalibrationCheckSession | TipLengthCalibrationSession
 
 export type SessionCommandAttributes = {|
   command: SessionCommandString,

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -33,20 +33,46 @@ export type SessionType =
   | SESSION_TYPE_TIP_LENGTH_CALIBRATION
 
 // The details associated with available session types
-type SessionDetails = Calibration.RobotCalibrationCheckSessionDetails
+type SessionDetails =
+  | Calibration.RobotCalibrationCheckSessionDetails
+  | Calibration.TipLengthCalibrationSessionDetails
 export type SessionCommandString = $Values<typeof Calibration.checkCommands>
 
 // TODO(al, 2020-05-11): data should be properly typed with all
 // known command types
 export type SessionCommandData = { ... }
 
-export type SessionResponseAttributes = {|
-  sessionType: SessionType,
-  details: SessionDetails,
+export type CalibrationCheckSessionResponseAttributes = {|
+  sessionType: SESSION_TYPE_CALIBRATION_CHECK,
+  details: Calibration.RobotCalibrationCheckSessionDetails,
 |}
 
+export type TipLengthCalibrationSessionResponseAttributes = {|
+  sessionType: SESSION_TYPE_TIP_LENGTH_CALIBRATION,
+  details: Calibration.TipLengthCalibrationSessionDetails,
+|}
+
+export type SessionResponseAttributes =
+  | CalibrationCheckSessionResponseAttributes
+  | TipLengthCalibrationSessionResponseAttributes
+
 export type Session = {|
-  ...SessionResponseAttributes,
+  id: string,
+  +sessionType:
+    | SESSION_TYPE_CALIBRATION_CHECK
+    | SESSION_TYPE_TIP_LENGTH_CALIBRATION,
+  +details:
+    | Calibration.TipLengthCalibrationSessionDetails
+    | Calibration.RobotCalibrationCheckSessionDetails,
+|}
+
+export type CalibrationCheckSession = {|
+  ...CalibrationCheckSessionResponseAttributes,
+  id: string,
+|}
+
+export type TipLengthCalibrationSession = {|
+  ...TipLengthCalibrationSessionResponseAttributes,
   id: string,
 |}
 

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -32,10 +32,6 @@ export type SessionType =
   | SESSION_TYPE_CALIBRATION_CHECK
   | SESSION_TYPE_TIP_LENGTH_CALIBRATION
 
-// The details associated with available session types
-type SessionDetails =
-  | Calibration.RobotCalibrationCheckSessionDetails
-  | Calibration.TipLengthCalibrationSessionDetails
 export type SessionCommandString = $Values<typeof Calibration.checkCommands>
 
 // TODO(al, 2020-05-11): data should be properly typed with all


### PR DESCRIPTION
## overview

Build out the infrastructure of the new tip length calibration flow. Add views and todos, as well as
a simple test for the top level component.

## changelog

- add support for new session type to sessions data layer module
- create feature flag `enableTipLengthCal`
- put entry point to tip length cal in place of tip probe behind new feature flag
- create orchestration component for view layer of tip length flow
- create all corresponding children components with relevant guts copied over from cal check flow, and gaps to fill described in TODO comments (all components are as of yet un-styled)

## review requests

- Make sure calibration check still behaves as expected, some of it's session data layer was changed to allow for this new session type.
- There is no way to navigate to the majority of the child screens until further wired-up, for now, ensuring that the feature flag behaves as expected is good

## risk assessment
 
minor risk associated with the changing of moving parts that Robot Calibration Check session relies on, otherwise everything new is behind a dev feature flag

