### PR TITLE
feat(protocol-designer): add ending hold to TC profile substeps

### DIFF
--- a/protocol-designer/src/components/DeckSetup/ModuleTag.js
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.js
@@ -96,7 +96,7 @@ export const ModuleStatus = ({
         default:
           lidStatus = i18n.t('modules.lid_undefined')
       }
-      const lidText = `Lid (${lidStatus}):`
+      const lidText = `${i18n.t('modules.lid_label', { lidStatus })}:`
 
       return (
         <>

--- a/protocol-designer/src/components/StepEditForm/FormAlerts.js
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.js
@@ -63,7 +63,6 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
       errors: dynamicFieldFormErrors,
       profileItemsById,
     })
-    console.log({ dynamicFieldFormErrors, visibleDynamicFieldFormErrors })
   }
 
   return {

--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -33,13 +33,14 @@ export const ModuleStepItemRow = (
 )
 
 type Props = {|
-  action: string,
+  action?: string,
   moduleType: ModuleRealType,
   actionText: string,
   labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: ?string,
   children?: React.Node,
+  hideHeader?: boolean,
 |}
 
 export const ModuleStepItems = (props: Props): React.Node => {
@@ -49,10 +50,12 @@ export const ModuleStepItems = (props: Props): React.Node => {
   })
   return (
     <>
-      <li className={styles.substep_header}>
-        <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
-        <span>{props.action}</span>
-      </li>
+      {!props.hideHeader && (
+        <li className={styles.substep_header}>
+          <span>{i18n.t(`modules.module_long_names.${props.moduleType}`)}</span>
+          <span>{props.action}</span>
+        </li>
+      )}
       <Tooltip {...tooltipProps}>
         <LabwareTooltipContents
           labwareNickname={props.labwareNickname}

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -100,6 +100,8 @@
 
 .inner_carat {
   @apply --clickable;
+
+  text-align: right;
 }
 
 .highlighted {
@@ -222,4 +224,88 @@
   width: 18.25rem;
   position: absolute;
   cursor: grabbing;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+/* TODO: similar to .substep_header .step_subitem_channel_row */
+.profile_substep_header {
+  display: flex;
+  padding: 1rem 0.5rem;
+  font-size: var(--fs-caption);
+  justify-content: space-between;
+  border-top: 0;
+  border-bottom: 1px var(--c-med-gray) dashed;
+  background-color: var(--c-light-gray);
+}
+
+.profile_substep_cycle {
+  display: flex;
+  padding: 0 0.5rem;
+  justify-content: space-between;
+  border-top: 0;
+  border-bottom: 1px var(--c-med-gray) dashed;
+  background-color: var(--c-light-gray);
+}
+
+.profile_step_substep_row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem;
+}
+
+.profile_step_substep_column {
+  text-align: right;
+
+  &:first-child {
+    text-align: left;
+  }
+}
+
+.profile_center_column {
+  width: 4rem;
+  padding-right: 1rem;
+}
+
+.cycle_group {
+  @apply --font-body-1-dark;
+
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  &::before {
+    content: '';
+    background: var(--c-med-gray);
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 2px;
+    width: 1rem;
+  }
+
+  &::after {
+    content: '';
+    background: var(--c-med-gray);
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 2px;
+    width: 1rem;
+  }
+}
+
+.cycle_step_row {
+  border-right: 2px solid var(--c-med-gray);
+  width: 12rem;
+  display: flex;
+  justify-content: space-between;
+  padding: 1em 1.25rem 1rem 0;
+}
+
+.cycle_repetitions {
+  margin-top: 0.75rem;
+  font-size: var(--fs-body-1);
 }

--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -309,3 +309,8 @@
   margin-top: 0.75rem;
   font-size: var(--fs-body-1);
 }
+
+.collapsible_substep_header {
+  overflow: visible;
+  text-align: left;
+}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -278,7 +278,9 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
         <CollapsibleSubstep
           headerContent={
-            <span>{`Profile steps (${Math.floor(
+            <span
+              className={styles.collapsible_substep_header}
+            >{`Profile steps (${Math.floor(
               sum(
                 substeps.profileSteps.map(atomicStep => atomicStep.holdTime)
               ) / 60
@@ -313,7 +315,13 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
           })}
         </CollapsibleSubstep>
 
-        <CollapsibleSubstep headerContent={<span>Ending hold</span>}>
+        <CollapsibleSubstep
+          headerContent={
+            <span className={styles.collapsible_substep_header}>
+              Ending hold
+            </span>
+          }
+        >
           <ModuleStepItems
             labwareDisplayName={substeps.labwareDisplayName}
             labwareNickname={substeps.labwareNickname}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -11,7 +11,7 @@ import {
 import { THERMOCYCLER_PROFILE, THERMOCYCLER_STATE } from '../../constants'
 import { stepIconsByType, PROFILE_CYCLE } from '../../form-types'
 import { i18n } from '../../localization'
-import { makeTemperatureText } from '../../utils'
+import { makeLidLabelText, makeTemperatureText } from '../../utils'
 import { PDListItem, PDTitledList } from '../lists'
 import { StepDescription } from '../StepDescription'
 import { AspirateDispenseHeader } from './AspirateDispenseHeader'
@@ -140,9 +140,9 @@ export const ProfileStepSubstepRow = (
         styles.profile_step_substep_row
       )}
     >
-      <span
-        className={styles.profile_step_substep_column}
-      >{`${temperature} ${i18n.t('application.units.degrees')}`}</span>
+      <span className={styles.profile_step_substep_column}>
+        {makeTemperatureText(temperature)}
+      </span>
       <span
         className={cx(
           styles.profile_step_substep_column,
@@ -164,9 +164,7 @@ const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   const { step } = props
   return (
     <div className={styles.cycle_step_row}>
-      <span>{`${step.temperature} ${i18n.t(
-        'application.units.degrees'
-      )}`}</span>
+      <span>{makeTemperatureText(step.temperature)}</span>
       <span>
         {makeDurationText(step.durationMinutes, step.durationSeconds)}
       </span>
@@ -266,11 +264,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
 
   if (substeps && substeps.substepType === THERMOCYCLER_PROFILE) {
     const lidTemperature = makeTemperatureText(substeps.profileTargetLidTemp)
-    const lidLabelText = i18n.t(`modules.lid_label`, {
-      lidStatus: i18n.t(
-        substeps.lidOpenHold ? 'modules.lid_open' : 'modules.lid_closed'
-      ),
-    })
+    const lidLabelText = makeLidLabelText(substeps.lidOpenHold)
 
     return (
       <ModuleStepItems
@@ -318,6 +312,20 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
             )
           })}
         </CollapsibleSubstep>
+
+        <CollapsibleSubstep headerContent={<span>Ending hold</span>}>
+          <ModuleStepItems
+            labwareDisplayName={substeps.labwareDisplayName}
+            labwareNickname={substeps.labwareNickname}
+            actionText={makeTemperatureText(substeps.blockTargetTempHold)}
+            moduleType={THERMOCYCLER_MODULE_TYPE}
+            hideHeader
+          />
+          <ModuleStepItemRow
+            label={`Lid (${substeps.lidOpenHold ? 'open' : 'closed'})`}
+            value={makeTemperatureText(substeps.lidTargetTempHold)}
+          />
+        </CollapsibleSubstep>
       </ModuleStepItems>
     )
   }
@@ -325,11 +333,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
   if (substeps && substeps.substepType === THERMOCYCLER_STATE) {
     const blockTemperature = makeTemperatureText(substeps.blockTargetTemp)
     const lidTemperature = makeTemperatureText(substeps.lidTargetTemp)
-    const lidLabelText = i18n.t(`modules.lid_label`, {
-      lidStatus: i18n.t(
-        substeps.lidOpen ? 'modules.lid_open' : 'modules.lid_closed'
-      ),
-    })
+    const lidLabelText = makeLidLabelText(substeps.lidOpen)
 
     return (
       <ModuleStepItems
@@ -346,9 +350,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
   }
 
   if (substeps && substeps.substepType === 'awaitTemperature') {
-    const temperature = `${substeps.temperature} ${i18n.t(
-      'application.units.degrees'
-    )}`
+    const temperature = makeTemperatureText(substeps.temperature)
 
     return (
       <ModuleStepItems

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -428,23 +428,27 @@ export function generateSubsteps(
 
   if (stepArgs.commandCreatorFnName === THERMOCYCLER_PROFILE) {
     const {
-      profileTargetLidTemp,
+      blockTargetTempHold,
       lidOpenHold,
-      profileVolume,
+      lidTargetTempHold,
       message,
       meta,
       profileSteps,
+      profileTargetLidTemp,
+      profileVolume,
     } = stepArgs
     return {
       substepType: THERMOCYCLER_PROFILE,
+      blockTargetTempHold,
       labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
-      profileTargetLidTemp,
       lidOpenHold,
-      profileVolume,
+      lidTargetTempHold,
       message,
       meta,
       profileSteps,
+      profileTargetLidTemp,
+      profileVolume,
     }
   }
 

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -135,14 +135,16 @@ export type AwaitTemperatureSubstepItem = {|
 
 export type ThermocyclerProfileSubstepItem = {|
   substepType: THERMOCYCLER_PROFILE,
+  blockTargetTempHold: number | null,
   labwareDisplayName: ?string,
   labwareNickname: ?string,
-  profileTargetLidTemp: number | null,
   lidOpenHold: boolean,
-  profileVolume: number,
-  profileSteps: $PropertyType<ThermocyclerProfileStepArgs, 'profileSteps'>,
-  meta: $PropertyType<ThermocyclerProfileStepArgs, 'meta'>,
+  lidTargetTempHold: number | null,
   message?: string,
+  meta: $PropertyType<ThermocyclerProfileStepArgs, 'meta'>,
+  profileSteps: $PropertyType<ThermocyclerProfileStepArgs, 'profileSteps'>,
+  profileTargetLidTemp: number | null,
+  profileVolume: number,
 |}
 
 export type ThermocyclerStateSubstepItem = {|

--- a/protocol-designer/src/utils/index.js
+++ b/protocol-designer/src/utils/index.js
@@ -89,7 +89,14 @@ export {
   getWellSetForMultichannel,
 }
 
-export const makeTemperatureText = (temperature: number | null): string =>
+export const makeTemperatureText = (
+  temperature: number | string | null
+): string =>
   temperature === null
     ? i18n.t('modules.status.deactivated')
     : `${temperature} ${i18n.t('application.units.degrees')}`
+
+export const makeLidLabelText = (lidOpen: boolean): string =>
+  i18n.t(`modules.lid_label`, {
+    lidStatus: i18n.t(lidOpen ? 'modules.lid_open' : 'modules.lid_closed'),
+  })


### PR DESCRIPTION
## overview

Builds on top of #5876 to get everything looking like is should for #5522 -- but doesn't close the issue, the last thing will be to refactor the CSS to make it less confusing. However code cleanup aside, from a user perspective this PR should bring us to all the acceptance criteria of #5522, if it doesn't please put an :x:!

## changelog

- Add "Ending hold" section to TC Profile substeps
- Factor out reused copy generation fns

## review requests

- [ ] Copy and design for TC Profile substeps match #5522

## risk assessment

Low, PD under FF