### PR TITLE
feat(protocol-designer): add TC profile deck visualization

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.js
@@ -1,21 +1,19 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { connect } from 'react-redux'
 import { RobotCoordsForeignDiv } from '@opentrons/components'
 import type { DeckSlot } from '@opentrons/shared-data'
 
-import type { BaseState } from '../../../types'
 import { START_TERMINAL_ITEM_ID, type TerminalItemId } from '../../../steplist'
 import type { LabwareOnDeck } from '../../../step-forms'
-import { getHoveredStepLabware } from '../../../ui/steps'
 import { BlockedSlot } from './BlockedSlot'
 import { BrowseLabware } from './BrowseLabware'
 import { EditLabware } from './EditLabware'
 import { LabwareName } from './LabwareName'
+import { LabwareHighlight } from './LabwareHighlight'
 import styles from './LabwareOverlays.css'
 
-type OP = {|
+type LabwareControlsProps = {|
   labwareOnDeck: LabwareOnDeck,
   selectedTerminalItemId: ?TerminalItemId,
   slot: DeckSlot,
@@ -24,18 +22,11 @@ type OP = {|
   swapBlocked: boolean,
 |}
 
-type SP = {|
-  highlighted: boolean,
-|}
-
-type Props = { ...OP, ...SP }
-
-const LabwareControlsComponent = (props: Props) => {
+export const LabwareControls = (props: LabwareControlsProps): React.Node => {
   const {
     labwareOnDeck,
     slot,
     selectedTerminalItemId,
-    highlighted,
     setHoveredLabware,
     setDraggedLabware,
     swapBlocked,
@@ -54,7 +45,7 @@ const LabwareControlsComponent = (props: Props) => {
           }),
         }}
       >
-        {highlighted && <div className={styles.highlighted_border_div} />}
+        <LabwareHighlight labwareOnDeck={labwareOnDeck} />
         {canEdit ? (
           <EditLabware
             labwareOnDeck={labwareOnDeck}
@@ -76,16 +67,3 @@ const LabwareControlsComponent = (props: Props) => {
     </>
   )
 }
-
-const mapStateToProps = (state: BaseState, ownProps: OP): SP => ({
-  highlighted: getHoveredStepLabware(state).includes(ownProps.labwareOnDeck.id),
-})
-
-export const LabwareControls: React.AbstractComponent<OP> = connect<
-  Props,
-  OP,
-  SP,
-  {||},
-  _,
-  _
->(mapStateToProps)(LabwareControlsComponent)

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.js
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import cx from 'classnames'
+import { useSelector } from 'react-redux'
+import { Icon } from '@opentrons/components'
+import { getHoveredStepLabware, getHoveredStepId } from '../../../ui/steps'
+import { getSavedStepForms } from '../../../step-forms/selectors'
+import { THERMOCYCLER_PROFILE } from '../../../constants'
+
+import styles from './LabwareOverlays.css'
+import type { LabwareOnDeck } from '../../../step-forms'
+
+type LabwareHighlightProps = {|
+  labwareOnDeck: LabwareOnDeck,
+|}
+
+export const LabwareHighlight = (props: LabwareHighlightProps): React.Node => {
+  const { labwareOnDeck } = props
+  const highlighted = useSelector(getHoveredStepLabware).includes(
+    labwareOnDeck.id
+  )
+
+  let isTcProfile = false
+  const form = useSelector(getSavedStepForms)
+  const hoveredStepId = useSelector(getHoveredStepId)
+  const formData = hoveredStepId ? form[hoveredStepId] : null
+
+  if (
+    formData &&
+    formData.stepType === 'thermocycler' &&
+    formData['thermocyclerFormType'] === THERMOCYCLER_PROFILE
+  ) {
+    isTcProfile = true
+  }
+  if (highlighted) {
+    return (
+      <div
+        className={cx(styles.highlighted_border_div, {
+          [styles.highlight_fill]: isTcProfile,
+        })}
+      >
+        {isTcProfile && (
+          <Icon className={styles.thermocycler_icon} name={'ot-thermocycler'} />
+        )}
+      </div>
+    )
+  }
+  return null
+}

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
@@ -108,7 +108,7 @@
 
 .thermocycler_icon {
   height: 60%;
-  color: var(--c-selected-dark)
+  color: var(--c-selected-dark);
 }
 
 .blocked_slot_background {

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
@@ -99,6 +99,18 @@
   border-radius: 0.5rem;
 }
 
+.highlight_fill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: color-mod(var(--c-highlight) alpha(0.5));
+}
+
+.thermocycler_icon {
+  height: 60%;
+  color: var(--c-selected-dark)
+}
+
 .blocked_slot_background {
   fill: rgba(200, 115, 0, 0.75);
   stroke: var(--c-red);


### PR DESCRIPTION
## overview
Pairing credit to @IanLondon! 

This PR closes #5523 by adding TC profile deck visualization when hovering on profile steps. 

Note -- we turned `LabwareControls` into a dumb, non connected component, and moved all store logic into a new component called `LabwareHighlight`
## changelog
  - Add TC profile deck visualization

## review requests

- [ ] Make a TC profile step and make sure it matches the design (labware has blue background fill, TC icon rendered inside of labware)

- [ ] Make a TC state step, only the border of the labware should be lighted (no fill, and no TC icon)

## risk assessment
Low
