### PR TITLE
feat(protocol-designer): replace v4 protocol export hint

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -149,20 +149,13 @@ function getWarningContent({
   return null
 }
 
-// TODO (ka 2020-2-26): Update this knowledgebase link when available
 export const v4WarningContent: React.Node = (
   <div>
     <p>
-      {i18n.t(`alert.hint.export_v4_protocol.body1`)}{' '}
-      <strong>{i18n.t(`alert.hint.export_v4_protocol.body2`)}</strong>
-      {i18n.t(`alert.hint.export_v4_protocol.body3`)}
+      {i18n.t(`alert.hint.export_v4_protocol_3_18.body1`)}{' '}
+      <strong>{i18n.t(`alert.hint.export_v4_protocol_3_18.body2`)}</strong>
+      {i18n.t(`alert.hint.export_v4_protocol_3_18.body3`)}
     </p>
-    {/* 
-    <p>
-      <KnowledgeBaseLink to="betaReleases">
-        Learn more about Beta releases here
-      </KnowledgeBaseLink>
-    </p> */}
   </div>
 )
 
@@ -214,7 +207,7 @@ export function FileSidebar(props: Props): React.Node {
 
   const blockingV4ExportHint = useBlockingHint({
     enabled: isV4Protocol && showV4ExportWarning,
-    hintKey: 'export_v4_protocol',
+    hintKey: 'export_v4_protocol_3_18',
     content: v4WarningContent,
     handleCancel: () => setShowV4ExportWarning(false),
     handleContinue: () => {

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
@@ -224,7 +224,7 @@ describe('FileSidebar', () => {
     // Before save button is clicked, enabled should be false
     expect(mockUseBlockingHint).toHaveBeenNthCalledWith(1, {
       enabled: false,
-      hintKey: 'export_v4_protocol',
+      hintKey: 'export_v4_protocol_3_18',
       content: v4WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),
@@ -236,7 +236,7 @@ describe('FileSidebar', () => {
     // After save button is clicked, enabled should be true
     expect(mockUseBlockingHint).toHaveBeenLastCalledWith({
       enabled: true,
-      hintKey: 'export_v4_protocol',
+      hintKey: 'export_v4_protocol_3_18',
       content: v4WarningContent,
       handleCancel: expect.any(Function),
       handleContinue: expect.any(Function),

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -30,10 +30,10 @@
       "title": "Missing labware",
       "body": "Your module has no labware on it. We recommend you add labware before proceeding."
     },
-    "export_v4_protocol": {
+    "export_v4_protocol_3_18": {
       "title": "Robot requirements for running module inclusive JSON protocols",
       "body1": "This protocol utilizes modules and can only run on app and robot server version",
-      "body2": "3.17 or higher",
+      "body2": "3.18 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -11,8 +11,11 @@ type HintKey =
   | 'thermocycler_lid_passive_cooling'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v4_protocol'
+  | 'export_v4_protocol_3_18'
   | 'change_magnet_module_model'
+
+// DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
+// 'export_v4_protocol'
 
 export { actions, rootReducer, selectors }
 


### PR DESCRIPTION
## overview

Closes #5888

## changelog


## review requests

- [ ] With fresh browser state, upon exporting a protocol with modules you should see the 3.18 modal
- [ ] If you dismiss the 3.17 modal with "Don't show me again", upon exporting a protocol with modules you should see the 3.18 modal

## risk assessment

low, PD-only