### PR TITLE
feat(protocol-designer): add TC announcement modal

### DIFF
--- a/protocol-designer/src/components/modals/AnnouncementModal/AnnouncementModal.css
+++ b/protocol-designer/src/components/modals/AnnouncementModal/AnnouncementModal.css
@@ -28,6 +28,14 @@
   padding-right: 19.294%;
 }
 
+.thermocycler_diagram_row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 2rem;
+  padding: 0 25%;
+}
+
 .modules_diagram {
   width: 100%;
   height: 100%;

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -37,4 +37,27 @@ export const announcements: Array<Announcement> = [
       </>
     ),
   },
+  {
+    announcementKey: 'thermocyclerSupport',
+    image: (
+      <div className={styles.thermocycler_diagram_row}>
+        <img
+          className={styles.modules_diagram}
+          src={require('../../../images/modules/thermocycler.jpg')}
+        />
+      </div>
+    ),
+    heading: "We've updated the Protocol Designer",
+    message: (
+      <>
+        <p>Protocol Designer Beta now includes support for the Thermocycler!</p>
+        <p>
+          Note: Protocols with modules{' '}
+          <strong>may require an app and robot update to run</strong>. You will
+          need to have the OT-2 app and robot on the latest versions (
+          <strong>3.18 or higher</strong>).
+        </p>
+      </>
+    ),
+  },
 ]


### PR DESCRIPTION
## overview

Closes #5887

## changelog


## review requests

![image](https://user-images.githubusercontent.com/11590381/84512411-f0e70d00-ac95-11ea-8aa0-e30ea694f669.png)

- [ ] Should match design above -- EXCEPT, it should be 3.18 not 3.17
- [ ] If you've already seen the old modal, you should still see this new modal when PD starts
- [ ] If you've never seen the previous modal, you shouldn't be shown that one. Just this new one

## risk assessment

low, PD only