### PR TITLE
refactor(app): calcheck: confirm exit modal

### DIFF
--- a/app/src/components/CheckCalibration/CheckHeight.js
+++ b/app/src/components/CheckCalibration/CheckHeight.js
@@ -61,7 +61,7 @@ type CheckHeightProps = {|
   mount: Mount | null,
   isInspecting: boolean,
   comparison: RobotCalibrationCheckComparison,
-  exit: () => void,
+  exit: () => mixed,
   nextButtonText: string,
   comparePoint: () => void,
   goToNextCheck: () => void,
@@ -142,7 +142,7 @@ export function CheckHeight(props: CheckHeightProps): React.Node {
 type CompareZProps = {|
   comparison: RobotCalibrationCheckComparison,
   goToNextCheck: () => void,
-  exit: () => void,
+  exit: () => mixed,
   nextButtonText: string,
 |}
 function CompareZ(props: CompareZProps) {

--- a/app/src/components/CheckCalibration/CheckXYPoint.js
+++ b/app/src/components/CheckCalibration/CheckXYPoint.js
@@ -91,7 +91,7 @@ type CheckXYPointProps = {|
   isInspecting: boolean,
   comparison: RobotCalibrationCheckComparison,
   nextButtonText: string,
-  exit: () => void,
+  exit: () => mixed,
   comparePoint: () => void,
   goToNextCheck: () => void,
   jog: (JogAxis, JogDirection, JogStep) => void,
@@ -177,7 +177,7 @@ export function CheckXYPoint(props: CheckXYPointProps): React.Node {
 type CompareXYProps = {|
   comparison: RobotCalibrationCheckComparison,
   goToNextCheck: () => void,
-  exit: () => void,
+  exit: () => mixed,
   nextButtonText: string,
 |}
 function CompareXY(props: CompareXYProps) {

--- a/app/src/components/CheckCalibration/ConfirmExitModal.js
+++ b/app/src/components/CheckCalibration/ConfirmExitModal.js
@@ -21,8 +21,8 @@ export function ConfirmExitModal(props: ConfirmExitModalProps): React.Node {
     <AlertModal
       heading={HEADING}
       buttons={[
-        { title: 'go back', children: GO_BACK, onClick: back },
-        { title: 'confirm exit', children: EXIT, onClick: exit },
+        { children: GO_BACK, onClick: back },
+        { children: EXIT, onClick: exit },
       ]}
       alertOverlay
     >

--- a/app/src/components/CheckCalibration/ConfirmExitModal.js
+++ b/app/src/components/CheckCalibration/ConfirmExitModal.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react'
+
+import { AlertModal } from '@opentrons/components'
+
+export type ConfirmExitModalProps = {|
+  back: () => mixed,
+  exit: () => mixed,
+|}
+
+const HEADING = 'Are you sure you want to exit?'
+const GO_BACK = 'go back'
+const EXIT = 'confirm exit'
+const WARNING =
+  'Doing so will take you to the summary page and prompt you to drop the tip.'
+
+export function ConfirmExitModal(props: ConfirmExitModalProps): React.Node {
+  const { back, exit } = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        { title: 'go back', children: GO_BACK, onClick: back },
+        { title: 'confirm exit', children: EXIT, onClick: exit },
+      ]}
+      alertOverlay
+    >
+      {WARNING}
+    </AlertModal>
+  )
+}

--- a/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
@@ -16,6 +16,7 @@ import { TipPickUp } from '../TipPickUp'
 import { CheckXYPoint } from '../CheckXYPoint'
 import { CheckHeight } from '../CheckHeight'
 import { CompleteConfirmation } from '../CompleteConfirmation'
+import { ConfirmExitModal } from '../ConfirmExitModal'
 
 import type { State } from '../../../types'
 import { mockCalibrationCheckSessionAttributes } from '../../../sessions/__fixtures__'
@@ -58,6 +59,9 @@ describe('CheckCalibration', () => {
 
   const getBackButton = wrapper =>
     wrapper.find({ title: 'exit' }).find('button')
+
+  const getConfirmExitButton = wrapper =>
+    wrapper.find({ title: 'confirm exit' }).find('button')
 
   const POSSIBLE_CHILDREN = [
     Introduction,
@@ -172,7 +176,7 @@ describe('CheckCalibration', () => {
     })
   })
 
-  it('calls deleteRobotCalibrationCheckSession on exit click', () => {
+  it('pops a confirm exit modal on exit click', () => {
     getRobotSessionOfType.mockReturnValue(mockCalibrationCheckSession)
     const wrapper = render()
 
@@ -180,6 +184,22 @@ describe('CheckCalibration', () => {
       getBackButton(wrapper).invoke('onClick')()
     })
     wrapper.update()
+    expect(wrapper.exists(ConfirmExitModal)).toBe(true)
+    expect(mockCloseCalibrationCheck).not.toHaveBeenCalled()
+  })
+
+  it('calls deleteRobotCalibrationCheckSession when exit is confirmed', () => {
+    getRobotSessionOfType.mockReturnValue(mockCalibrationCheckSession)
+    const wrapper = render()
+
+    act(() => {
+      getBackButton(wrapper).invoke('onClick')()
+    })
+    wrapper.update()
+
+    act(() => {
+      getConfirmExitButton(wrapper).invoke('onClick')()
+    })
 
     expect(mockStore.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
@@ -61,7 +61,10 @@ describe('CheckCalibration', () => {
     wrapper.find({ title: 'exit' }).find('button')
 
   const getConfirmExitButton = wrapper =>
-    wrapper.find({ title: 'confirm exit' }).find('button')
+    wrapper
+      .find(ConfirmExitModal)
+      .find({ children: 'confirm exit' })
+      .find('button')
 
   const POSSIBLE_CHILDREN = [
     Introduction,

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -28,6 +28,7 @@ import { CompleteConfirmation } from './CompleteConfirmation'
 import { CheckXYPoint } from './CheckXYPoint'
 import { CheckHeight } from './CheckHeight'
 import { BadCalibration } from './BadCalibration'
+import { ConfirmExitModal } from './ConfirmExitModal'
 import { formatJogVector } from './utils'
 import styles from './styles.css'
 
@@ -145,6 +146,13 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
     closeCalibrationCheck()
   }
 
+  const [inExitModal, setInExitModal] = React.useState(false)
+
+  const confirmExit = () => {
+    console.log('confirm exit clicked')
+    setInExitModal(true)
+  }
+
   function sendCommand(
     command: SessionCommandString,
     data: SessionCommandData = {}
@@ -171,12 +179,13 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
 
   let stepContents
   let modalContentsClassName = styles.modal_contents
+  let shouldDisplayTitleBarExit = !pending
 
   switch (currentStep) {
     case Calibration.CHECK_STEP_SESSION_STARTED: {
       stepContents = (
         <Introduction
-          exit={exit}
+          exit={confirmExit}
           proceed={() => sendCommand(Calibration.checkCommands.LOAD_LABWARE)}
           labwareLoadNames={labware.map(l => l.loadName)}
         />
@@ -244,7 +253,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
           slotNumber={slotNumber}
           isMulti={isActiveInstrumentMultiChannel}
           mount={activeMount}
-          exit={exit}
+          exit={confirmExit}
           isInspecting={isInspecting}
           comparison={comparison}
           nextButtonText={nextButtonText}
@@ -279,7 +288,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
           isInspecting={isInspecting}
           comparison={comparison}
           nextButtonText={nextButtonText}
-          exit={exit}
+          exit={confirmExit}
           comparePoint={() =>
             sendCommand(Calibration.checkCommands.COMPARE_POINT)
           }
@@ -292,6 +301,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
       break
     }
     case Calibration.CHECK_STEP_BAD_ROBOT_CALIBRATION: {
+      shouldDisplayTitleBarExit = false
       stepContents = <BadCalibration exit={exit} />
       break
     }
@@ -311,6 +321,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
         />
       )
       modalContentsClassName = styles.terminal_modal_contents
+      shouldDisplayTitleBarExit = false
       break
     }
     default: {
@@ -319,15 +330,32 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
   }
 
   return (
-    <ModalPage
-      titleBar={{
-        title: ROBOT_CALIBRATION_CHECK_SUBTITLE,
-        back: { onClick: exit, children: EXIT, title: EXIT },
-      }}
-      contentsClassName={modalContentsClassName}
-    >
-      {pending ? <SpinnerModal /> : stepContents}
-    </ModalPage>
+    <React.Fragment>
+      <ModalPage
+        titleBar={{
+          title: ROBOT_CALIBRATION_CHECK_SUBTITLE,
+          back: {
+            onClick: confirmExit,
+            title: EXIT,
+            children: EXIT,
+            disabled: !shouldDisplayTitleBarExit,
+            className:
+              !shouldDisplayTitleBarExit && styles.suppress_exit_button,
+          },
+        }}
+        contentsClassName={modalContentsClassName}
+      >
+        {pending ? <SpinnerModal /> : stepContents}
+      </ModalPage>
+      {inExitModal && (
+        <ConfirmExitModal
+          exit={exit}
+          back={() => {
+            setInExitModal(false)
+          }}
+        />
+      )}
+    </React.Fragment>
   )
 }
 

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -339,8 +339,9 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
             title: EXIT,
             children: EXIT,
             disabled: !shouldDisplayTitleBarExit,
-            className:
-            (!shouldDisplayTitleBarExit ? styles.suppress_exit_button : undefined),
+            className: !shouldDisplayTitleBarExit
+              ? styles.suppress_exit_button
+              : undefined,
           },
         }}
         contentsClassName={modalContentsClassName}

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -330,7 +330,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
   }
 
   return (
-    <React.Fragment>
+    <>
       <ModalPage
         titleBar={{
           title: ROBOT_CALIBRATION_CHECK_SUBTITLE,
@@ -338,7 +338,6 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
             onClick: confirmExit,
             title: EXIT,
             children: EXIT,
-            disabled: !shouldDisplayTitleBarExit,
             className: !shouldDisplayTitleBarExit
               ? styles.suppress_exit_button
               : undefined,
@@ -356,7 +355,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
           }}
         />
       )}
-    </React.Fragment>
+    </>
   )
 }
 

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -8,6 +8,7 @@ import {
   LEFT,
   RIGHT,
   type Mount,
+  useConditionalConfirm,
 } from '@opentrons/components'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import type { State, Dispatch } from '../../types'
@@ -146,12 +147,11 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
     closeCalibrationCheck()
   }
 
-  const [inExitModal, setInExitModal] = React.useState(false)
-
-  const confirmExit = () => {
-    console.log('confirm exit clicked')
-    setInExitModal(true)
-  }
+  const {
+    showConfirmation: showConfirmExit,
+    confirm: confirmExit,
+    cancel: cancelExit,
+  } = useConditionalConfirm(exit, true)
 
   function sendCommand(
     command: SessionCommandString,
@@ -347,13 +347,8 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
       >
         {pending ? <SpinnerModal /> : stepContents}
       </ModalPage>
-      {inExitModal && (
-        <ConfirmExitModal
-          exit={exit}
-          back={() => {
-            setInExitModal(false)
-          }}
-        />
+      {showConfirmExit && (
+        <ConfirmExitModal exit={confirmExit} back={cancelExit} />
       )}
     </>
   )

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -340,7 +340,7 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
             children: EXIT,
             disabled: !shouldDisplayTitleBarExit,
             className:
-              !shouldDisplayTitleBarExit && styles.suppress_exit_button,
+            (!shouldDisplayTitleBarExit ? styles.suppress_exit_button : undefined),
           },
         }}
         contentsClassName={modalContentsClassName}

--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -1,5 +1,9 @@
 @import '@opentrons/components';
 
+.suppress_exit_button {
+  visibility: hidden
+}
+
 .success_status_icon {
   width: 2.5rem;
   margin-right: 0.75rem;

--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -1,7 +1,7 @@
 @import '@opentrons/components';
 
 .suppress_exit_button {
-  visibility: hidden
+  visibility: hidden;
 }
 
 .success_status_icon {

--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -1,7 +1,7 @@
 @import '@opentrons/components';
 
 .suppress_exit_button {
-  visibility: hidden;
+  display: none;
 }
 
 .success_status_icon {


### PR DESCRIPTION
Add a modal that appears when you click on exit (in most circumstances)
during calibration check that prompts you to confirm the exit.

If the exit button is from a terminal screen, there is no confirmation.

In addition, hide the title bar exit button when it isn't necessary,
most notably when the spinner is displayed.

Note that the exit confirmation should actually lead to a generic
summary screen and not immediately exit, but that screen doesn't exist yet.


## Review Requests
In addition to the general review, let me know if the tests need to be better and also if I should be doing something other than react fragments