### PR TITLE
refactor(*): replace black/whitelist where usage has no technical purpose

### DIFF
--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -661,11 +661,11 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                                        self.current_state_name).position,
                                None)
 
-        saved_z_whitelist = \
+        saved_z_allowlist = \
             [CalibrationCheckState.joggingFirstPipetteToPointOne,
              CalibrationCheckState.joggingFirstPipetteToPointTwo,
              CalibrationCheckState.joggingFirstPipetteToPointThree]
-        if self.current_state_name in saved_z_whitelist:
+        if self.current_state_name in saved_z_allowlist:
             saved_height =\
                 self._saved_points[getattr(CalibrationCheckState,
                                            'comparingFirstPipetteHeight')]

--- a/api/src/opentrons/calibration/util.py
+++ b/api/src/opentrons/calibration/util.py
@@ -162,9 +162,9 @@ class StateMachine:
         return getattr(self, method_name) if method_name else None
 
     def _bind_cb_kwarg(self, key, value):
-        cb_whitelist = ['before', 'after']
+        cb_allowlist = ['before', 'after']
         if key in enum_to_set(CallbackKeys):
-            if key in cb_whitelist and isinstance(value, list):
+            if key in cb_allowlist and isinstance(value, list):
                 to_return = []
                 for m in value:
                     to_return.append(self._get_cb(m))

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -809,9 +809,9 @@ def _get_parent_identifier(
 
 def _hash_labware_def(labware_def: 'LabwareDefinition') -> str:
     # remove keys that do not affect run
-    blacklist = ['metadata', 'brand', 'groups']
+    blocklist = ['metadata', 'brand', 'groups']
     def_no_metadata = {
-        k: v for k, v in labware_def.items() if k not in blacklist}
+        k: v for k, v in labware_def.items() if k not in blocklist}
     sorted_def_str = json.dumps(
         def_no_metadata, sort_keys=True, separators=(',', ':'))
     return sha256(sorted_def_str.encode('utf-8')).hexdigest()

--- a/app-shell/src/discovery.js
+++ b/app-shell/src/discovery.js
@@ -108,6 +108,6 @@ function filterServicesToPersist(services: Array<Service>) {
   const candidateOverrides = getOverrides('discovery.candidates')
   if (!candidateOverrides) return client.services
 
-  const blacklist = [].concat(candidateOverrides)
-  return client.services.filter(s => blacklist.every(ip => ip !== s.ip))
+  const blocklist = [].concat(candidateOverrides)
+  return client.services.filter(s => blocklist.every(ip => ip !== s.ip))
 }

--- a/app/src/components/CheckCalibration/DeckSetup.js
+++ b/app/src/components/CheckCalibration/DeckSetup.js
@@ -44,7 +44,7 @@ export function DeckSetup(props: DeckSetupProps): React.Node {
       </div>
       <div className={styles.deck_map_wrapper}>
         <RobotWorkSpace
-          deckLayerBlacklist={[
+          deckLayerBlocklist={[
             'fixedBase',
             'doorStops',
             'metalFrame',

--- a/app/src/components/DeckMap/index.js
+++ b/app/src/components/DeckMap/index.js
@@ -49,7 +49,7 @@ type SP = {|
 
 type Props = {| ...OP, ...SP, ...DP |}
 
-const deckSetupLayerBlacklist = [
+const deckSetupLayerBlocklist = [
   'calibrationMarkings',
   'fixedBase',
   'doorStops',
@@ -70,7 +70,7 @@ function DeckMapComponent(props: Props) {
   } = props
   return (
     <RobotWorkSpace
-      deckLayerBlacklist={deckSetupLayerBlacklist}
+      deckLayerBlocklist={deckSetupLayerBlocklist}
       deckDef={deckDef}
       viewBox={`-46 -10 ${488} ${390}`} // TODO: put these in variables
       className={className}

--- a/components/src/deck/Deck.js
+++ b/components/src/deck/Deck.js
@@ -131,16 +131,16 @@ function renderLabware(
 
 export type DeckFromDataProps = {|
   def: DeckDefinition,
-  layerBlacklist: Array<string>,
+  layerBlocklist: Array<string>,
 |}
 
 export class DeckFromData extends React.PureComponent<DeckFromDataProps> {
   render(): React.Node {
-    const { def, layerBlacklist } = this.props
+    const { def, layerBlocklist } = this.props
     return (
       <g>
         {map(def.layers, (layer: DeckLayer, layerId: string) => {
-          if (layerBlacklist.includes(layerId)) return null
+          if (layerBlocklist.includes(layerId)) return null
           return (
             <g id={layerId} key={layerId}>
               <path

--- a/components/src/deck/RobotWorkSpace.js
+++ b/components/src/deck/RobotWorkSpace.js
@@ -11,7 +11,7 @@ export type RobotWorkSpaceProps = {|
   viewBox?: string,
   className?: string,
   children?: RobotWorkSpaceRenderProps => React.Node,
-  deckLayerBlacklist?: Array<string>,
+  deckLayerBlocklist?: Array<string>,
 |}
 
 type GetRobotCoordsFromDOMCoords = $PropertyType<
@@ -20,7 +20,7 @@ type GetRobotCoordsFromDOMCoords = $PropertyType<
 >
 
 export function RobotWorkSpace(props: RobotWorkSpaceProps): React.Node {
-  const { children, deckDef, deckLayerBlacklist = [], viewBox } = props
+  const { children, deckDef, deckLayerBlocklist = [], viewBox } = props
   const wrapperRef: {| current: Element | null |} = React.useRef(null)
 
   // NOTE: getScreenCTM in Chrome a DOMMatrix type,
@@ -63,7 +63,7 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): React.Node {
       ref={wrapperRef}
     >
       {deckDef && (
-        <DeckFromData def={deckDef} layerBlacklist={deckLayerBlacklist} />
+        <DeckFromData def={deckDef} layerBlocklist={deckLayerBlocklist} />
       )}
       {children && children({ deckSlotsById, getRobotCoordsFromDOMCoords })}
     </svg>

--- a/components/src/instrument/PipetteSelect.js
+++ b/components/src/instrument/PipetteSelect.js
@@ -20,7 +20,7 @@ export type PipetteSelectProps = {|
   /** react-select change handler */
   onPipetteChange: (pipetteName: string | null) => mixed,
   /** list of pipette names to omit */
-  nameBlacklist?: Array<string>,
+  nameBlocklist?: Array<string>,
   /** whether or not "None" shows up as the default option */
   enableNoneOption?: boolean,
   /** input tabIndex */
@@ -55,13 +55,13 @@ export const PipetteSelect = (props: PipetteSelectProps): React.Node => {
     className,
     enableNoneOption,
     id,
-    nameBlacklist = [],
+    nameBlocklist = [],
   } = props
-  const whitelist = ({ value }: SelectOption) => {
-    return !nameBlacklist.some(n => n === value)
+  const allowlist = ({ value }: SelectOption) => {
+    return !nameBlocklist.some(n => n === value)
   }
-  const gen2Options = specsByCategory[GEN2].map(specToOption).filter(whitelist)
-  const gen1Options = specsByCategory[GEN1].map(specToOption).filter(whitelist)
+  const gen2Options = specsByCategory[GEN2].map(specToOption).filter(allowlist)
+  const gen1Options = specsByCategory[GEN1].map(specToOption).filter(allowlist)
   const groupedOptions = [
     ...(enableNoneOption ? [OPTION_NONE] : []),
     ...(gen2Options.length > 0 ? [{ options: gen2Options }] : []),

--- a/components/src/instrument/PipetteSelect.md
+++ b/components/src/instrument/PipetteSelect.md
@@ -10,7 +10,7 @@ const [state, setState] = React.useState({ pipetteName: null })
     setState({ pipetteName })
   }}
   pipetteName={state.pipetteName}
-  nameBlacklist={['p20_multi_gen2', 'p300_multi_gen2']}
+  nameBlocklist={['p20_multi_gen2', 'p300_multi_gen2']}
 />
 ```
 

--- a/components/src/instrument/__tests__/PipetteSelect.test.js
+++ b/components/src/instrument/__tests__/PipetteSelect.test.js
@@ -62,7 +62,7 @@ describe('PipetteSelect', () => {
     ])
   })
 
-  it('can blacklist pipettes by name', () => {
+  it('can omit pipettes by name', () => {
     const pipetteSpecs: Array<PipetteNameSpecs> = getAllPipetteNames(
       'maxVolume',
       'channels'
@@ -71,14 +71,14 @@ describe('PipetteSelect', () => {
       .filter(Boolean)
 
     const gen2Specs = pipetteSpecs.filter(s => s.displayCategory === GEN2)
-    const nameBlacklist = pipetteSpecs
+    const nameBlocklist = pipetteSpecs
       .filter(s => s.displayCategory === GEN1)
       .map(s => s.name)
 
     const wrapper = shallow(
       <PipetteSelect
         onPipetteChange={jest.fn()}
-        nameBlacklist={nameBlacklist}
+        nameBlocklist={nameBlocklist}
       />
     )
 

--- a/labware-library/src/definitions.js
+++ b/labware-library/src/definitions.js
@@ -43,7 +43,7 @@ function _getAllDefs(): Array<LabwareDefinition2> {
 }
 
 let allLoadNames: Array<string> | null = null
-// ALL unique load names, not just the non-blacklisted ones
+// ALL unique load names, not just the allowed ones
 export function getAllLoadNames(): Array<string> {
   if (!allLoadNames) {
     allLoadNames = uniq(_getAllDefs().map(def => def.parameters.loadName))
@@ -52,7 +52,7 @@ export function getAllLoadNames(): Array<string> {
 }
 
 let allDisplayNames: Array<string> | null = null
-// ALL unique display names, not just the non-blacklisted ones
+// ALL unique display names, not just the allowed ones
 export function getAllDisplayNames(): Array<string> {
   if (!allDisplayNames) {
     allDisplayNames = uniq(_getAllDefs().map(def => def.metadata.displayName))

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.js
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.js
@@ -48,7 +48,7 @@ import type { LabwareDefByDefURI } from '../../labware-defs'
 
 import styles from './DeckSetup.css'
 
-const DECK_LAYER_BLACKLIST = [
+const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
   'fixedBase',
   'doorStops',
@@ -375,7 +375,7 @@ export const DeckSetup = (props: Props): React.Node => {
         {props.drilledDown && <BrowseLabwareModal />}
         <div ref={wrapperRef} className={styles.deck_wrapper}>
           <RobotWorkSpace
-            deckLayerBlacklist={DECK_LAYER_BLACKLIST}
+            deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
             deckDef={deckDef}
             viewBox={`${VIEWBOX_MIN_X} ${VIEWBOX_MIN_Y} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
             className={styles.robot_workspace}

--- a/protocol-designer/src/utils/labwareModuleCompatibility.js
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.js
@@ -10,7 +10,7 @@ import type { LabwareDefinition2, ModuleRealType } from '@opentrons/shared-data'
 import type { LabwareDefByDefURI } from '../labware-defs'
 import type { LabwareOnDeck } from '../step-forms'
 // NOTE: this does not distinguish btw versions. Standard labware only (assumes namespace is 'opentrons')
-const COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE: {
+const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: {
   [ModuleRealType]: $ReadOnlyArray<string>,
 } = {
   [TEMPERATURE_MODULE_TYPE]: [
@@ -55,12 +55,12 @@ export const getLabwareIsCompatible = (
   moduleType: ModuleRealType
 ): boolean => {
   assert(
-    moduleType in COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE,
-    `expected ${moduleType} in labware<>module compatibility whitelist`
+    moduleType in COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE,
+    `expected ${moduleType} in labware<>module compatibility allowlist`
   )
-  const whitelist =
-    COMPATIBLE_LABWARE_WHITELIST_BY_MODULE_TYPE[moduleType] || []
-  return whitelist.includes(def.parameters.loadName)
+  const allowlist =
+    COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[moduleType] || []
+  return allowlist.includes(def.parameters.loadName)
 }
 
 export const getLabwareIsCustom = (

--- a/protocol-library-kludge/src/URLDeck.js
+++ b/protocol-library-kludge/src/URLDeck.js
@@ -29,7 +29,7 @@ type UrlData = {
 
 const DECK_DEF = getDeckDefinitions()['ot2_standard']
 
-const DECK_LAYER_BLACKLIST = [
+const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',
   'fixedBase',
   'doorStops',
@@ -70,7 +70,7 @@ export class URLDeck extends React.Component<{||}> {
     return (
       <RobotWorkSpace
         deckDef={DECK_DEF}
-        deckLayerBlacklist={DECK_LAYER_BLACKLIST}
+        deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
         viewBox={`-35 -35 ${488} ${390}`} // TODO: put these in variables
         className={styles.url_deck}
       >

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -51,10 +51,10 @@ export function getIsTiprack(labwareDef: LabwareDefinition2): boolean {
 // NOTE: these labware definitions in _SHORT_MM_LABWARE_DEF_LOADNAMES
 // were written in "short mm" = 0.5mm, but
 // we will write all future definitions in actual mm.
-// These whitelisted labware also have engage heights measured from home switch
+// These allowed labware also have engage heights measured from home switch
 // instead of from labware bottom, which is why we add ENGAGE_HEIGHT_OFFSET.
 //
-// Ideally instead of using this whitelist, we would publish a new version
+// Ideally instead of using this allow-list, we would publish a new version
 // of these definitions with corrected labware heights. However, we don't
 // support labware versioning well enough yet.
 const _SHORT_MM_LABWARE_DEF_LOADNAMES = [


### PR DESCRIPTION
## overview

We're quite late to this particular party, but our codebase has a few instances of the terms "blacklist" and "whitelist" to mean "block these items" and "allow these items", respectively. This PR replaces the terms with the more accurate "blocklist" and "allowlist" respectively, per the recommendation of the IETF.

These terms, while extremely common in technical systems, are metaphorical rather than technical, and reinforce the "black == bad, white == good" tropes that exist pretty widely in our society. For a more detailed discussion of the subject, please see this [RFC on "Terminology, Power and Offensive Language" from the IETF](https://tools.ietf.org/id/draft-knodel-terminology-01.html#rfc.section.1.2).

## changelog

- refactor(*): replace black/whitelist where usage has no technical purpose
    - "blacklist" was replaced with the more technically accurate "blocklist"
    - "whitelist" was replaced with the more technically accurate "allowlist"
    - Happily enough, these replacement terms have the same number of characters as the old terms

## review requests

I had to keep one instance of "whitelist" in place because it is used as part of the [options API of a development dependency](https://github.com/liady/webpack-node-externals#optionswhitelist-). I have submitted [an upstream PR](https://github.com/liady/webpack-node-externals/pull/75) for that but obviously that could take some time to trickle down.

## risk assessment

Low. None of these usages were externally facing, and all checks are still passing. For smoke test purposes, the following flows/systems were touched:

- Deck cal check
- Protocol API labware loading
- The App's robot discovery cache
- Deck map rendering in the App and PD
- Pipette select components in the App and PD