### PR TITLE
fix(protocol-designer): ensure all tc temps are awaited

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
@@ -56,6 +56,12 @@ describe('thermocyclerProfileStep', () => {
           },
         },
         {
+          command: 'thermocycler/awaitProfileComplete',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
           command: 'thermocycler/openLid',
           params: {
             module: 'thermocyclerId',
@@ -109,6 +115,12 @@ describe('thermocyclerProfileStep', () => {
             module: 'thermocyclerId',
             profile: [{ temperature: 61, holdTime: 99 }],
             volume: 42,
+          },
+        },
+        {
+          command: 'thermocycler/awaitProfileComplete',
+          params: {
+            module: 'thermocyclerId',
           },
         },
         {

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
@@ -41,6 +41,13 @@ describe('thermocyclerProfileStep', () => {
           },
         },
         {
+          command: 'thermocycler/awaitLidTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 55,
+          },
+        },
+        {
           command: 'thermocycler/runProfile',
           params: {
             module: 'thermocyclerId',
@@ -56,6 +63,13 @@ describe('thermocyclerProfileStep', () => {
         },
         {
           command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/awaitBlockTemperature',
           params: {
             module: 'thermocyclerId',
             temperature: 4,
@@ -105,6 +119,13 @@ describe('thermocyclerProfileStep', () => {
         },
         {
           command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/awaitBlockTemperature',
           params: {
             module: 'thermocyclerId',
             temperature: 4,

--- a/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerStateStep.test.js
@@ -112,56 +112,8 @@ describe('thermocyclerStateStep', () => {
             temperature: 10,
           },
         },
-      ],
-    },
-    {
-      testMsg:
-        'should decativate the block when diff includes deactivateBlockTemperature',
-      thermocyclerStateArgs: {
-        module: thermocyclerId,
-        commandCreatorFnName: 'thermocyclerState',
-        blockTargetTemp: null,
-        lidTargetTemp: null,
-        lidOpen: false,
-      },
-      ...getStateAndContextTempTCModules({
-        temperatureModuleId,
-        thermocyclerId,
-      }),
-      thermocyclerStateDiff: {
-        ...getInitialDiff(),
-        deactivateBlockTemperature: true,
-      },
-      expected: [
         {
-          command: 'thermocycler/deactivateBlock',
-          params: {
-            module: thermocyclerId,
-          },
-        },
-      ],
-    },
-    {
-      testMsg:
-        'should set the lid temperature when diff includes setLidTemperature',
-      thermocyclerStateArgs: {
-        module: thermocyclerId,
-        commandCreatorFnName: 'thermocyclerState',
-        blockTargetTemp: null,
-        lidTargetTemp: 10,
-        lidOpen: false,
-      },
-      ...getStateAndContextTempTCModules({
-        temperatureModuleId,
-        thermocyclerId,
-      }),
-      thermocyclerStateDiff: {
-        ...getInitialDiff(),
-        setLidTemperature: true,
-      },
-      expected: [
-        {
-          command: 'thermocycler/setTargetLidTemperature',
+          command: 'thermocycler/awaitBlockTemperature',
           params: {
             module: thermocyclerId,
             temperature: 10,
@@ -217,6 +169,75 @@ describe('thermocyclerStateStep', () => {
       expected: [
         {
           command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+        {
+          command: 'thermocycler/awaitLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should decativate the block when diff includes deactivateBlockTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: null,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        deactivateBlockTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/deactivateBlock',
+          params: {
+            module: thermocyclerId,
+          },
+        },
+      ],
+    },
+    {
+      testMsg:
+        'should set the lid temperature when diff includes setLidTemperature',
+      thermocyclerStateArgs: {
+        module: thermocyclerId,
+        commandCreatorFnName: 'thermocyclerState',
+        blockTargetTemp: null,
+        lidTargetTemp: 10,
+        lidOpen: false,
+      },
+      ...getStateAndContextTempTCModules({
+        temperatureModuleId,
+        thermocyclerId,
+      }),
+      thermocyclerStateDiff: {
+        ...getInitialDiff(),
+        setLidTemperature: true,
+      },
+      expected: [
+        {
+          command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+        {
+          command: 'thermocycler/awaitLidTemperature',
           params: {
             module: thermocyclerId,
             temperature: 10,
@@ -299,6 +320,13 @@ describe('thermocyclerStateStep', () => {
           },
         },
         {
+          command: 'thermocycler/awaitBlockTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 10,
+          },
+        },
+        {
           command: 'thermocycler/deactivateLid',
           params: {
             module: thermocyclerId,
@@ -306,6 +334,13 @@ describe('thermocyclerStateStep', () => {
         },
         {
           command: 'thermocycler/setTargetLidTemperature',
+          params: {
+            module: thermocyclerId,
+            temperature: 20,
+          },
+        },
+        {
+          command: 'thermocycler/awaitLidTemperature',
           params: {
             module: thermocyclerId,
             temperature: 20,

--- a/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitProfileComplete.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/thermocyclerAwaitProfileComplete.js
@@ -1,0 +1,20 @@
+// @flow
+import type { ModuleOnlyParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { CommandCreator } from '../../types'
+
+export const thermocyclerAwaitProfileComplete: CommandCreator<ModuleOnlyParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  return {
+    commands: [
+      {
+        command: 'thermocycler/awaitProfileComplete',
+        params: {
+          module: args.module,
+        },
+      },
+    ],
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
@@ -2,8 +2,9 @@
 import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { thermocyclerStateGetter } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
-import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerAwaitLidTemperature } from '../atomic/thermocyclerAwaitLidTemperature'
 import { thermocyclerRunProfile } from '../atomic/thermocyclerRunProfile'
+import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
 import { thermocyclerStateStep } from './thermocyclerStateStep'
 import type {
   CommandCreator,
@@ -36,6 +37,12 @@ export const thermocyclerProfileStep: CommandCreator<ThermocyclerProfileStepArgs
   if (profileTargetLidTemp !== thermocyclerState.lidTargetTemp) {
     commandCreators.push(
       curryCommandCreator(thermocyclerSetTargetLidTemperature, {
+        module: moduleId,
+        temperature: profileTargetLidTemp,
+      })
+    )
+    commandCreators.push(
+      curryCommandCreator(thermocyclerAwaitLidTemperature, {
         module: moduleId,
         temperature: profileTargetLidTemp,
       })

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
@@ -5,6 +5,7 @@ import * as errorCreators from '../../errorCreators'
 import { thermocyclerAwaitLidTemperature } from '../atomic/thermocyclerAwaitLidTemperature'
 import { thermocyclerRunProfile } from '../atomic/thermocyclerRunProfile'
 import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerAwaitProfileComplete } from '../atomic/thermocyclerAwaitProfileComplete'
 import { thermocyclerStateStep } from './thermocyclerStateStep'
 import type {
   CommandCreator,
@@ -54,6 +55,12 @@ export const thermocyclerProfileStep: CommandCreator<ThermocyclerProfileStepArgs
       module: moduleId,
       profile: profileSteps,
       volume: profileVolume,
+    })
+  )
+
+  commandCreators.push(
+    curryCommandCreator(thermocyclerAwaitProfileComplete, {
+      module: moduleId,
     })
   )
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerStateStep.js
@@ -3,12 +3,14 @@ import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { thermocyclerStateDiff } from '../../utils/thermocyclerStateDiff'
 import { thermocyclerStateGetter } from '../../robotStateSelectors'
 import * as errorCreators from '../../errorCreators'
-import { thermocyclerDeactivateBlock } from '../atomic/thermocyclerDeactivateBlock'
-import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerAwaitBlockTemperature } from '../atomic/thermocyclerAwaitBlockTemperature'
+import { thermocyclerAwaitLidTemperature } from '../atomic/thermocyclerAwaitLidTemperature'
 import { thermocyclerCloseLid } from '../atomic/thermocyclerCloseLid'
-import { thermocyclerOpenLid } from '../atomic/thermocyclerOpenLid'
-import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
+import { thermocyclerDeactivateBlock } from '../atomic/thermocyclerDeactivateBlock'
 import { thermocyclerDeactivateLid } from '../atomic/thermocyclerDeactivateLid'
+import { thermocyclerOpenLid } from '../atomic/thermocyclerOpenLid'
+import { thermocyclerSetTargetBlockTemperature } from '../atomic/thermocyclerSetTargetBlockTemperature'
+import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
 import type {
   CommandCreator,
   CurriedCommandCreator,
@@ -35,6 +37,8 @@ export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = 
     deactivateLidTemperature,
   } = thermocyclerStateDiff(thermocyclerState, args)
 
+  const { blockTargetTemp, lidTargetTemp } = args
+
   const commandCreators: Array<CurriedCommandCreator> = []
 
   if (lidOpen) {
@@ -56,11 +60,17 @@ export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = 
     )
   }
 
-  if (args.blockTargetTemp !== null && setBlockTemperature) {
+  if (blockTargetTemp !== null && setBlockTemperature) {
     commandCreators.push(
       curryCommandCreator(thermocyclerSetTargetBlockTemperature, {
         module: args.module,
-        temperature: args.blockTargetTemp,
+        temperature: blockTargetTemp,
+      })
+    )
+    commandCreators.push(
+      curryCommandCreator(thermocyclerAwaitBlockTemperature, {
+        module: args.module,
+        temperature: blockTargetTemp,
       })
     )
   }
@@ -73,11 +83,17 @@ export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = 
     )
   }
 
-  if (args.lidTargetTemp !== null && setLidTemperature) {
+  if (lidTargetTemp !== null && setLidTemperature) {
     commandCreators.push(
       curryCommandCreator(thermocyclerSetTargetLidTemperature, {
         module: args.module,
-        temperature: args.lidTargetTemp,
+        temperature: lidTargetTemp,
+      })
+    )
+    commandCreators.push(
+      curryCommandCreator(thermocyclerAwaitLidTemperature, {
+        module: args.module,
+        temperature: lidTargetTemp,
       })
     )
   }

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -10,13 +10,14 @@ import { forEngageMagnet, forDisengageMagnet } from './magnetUpdates'
 import {
   forThermocyclerAwaitBlockTemperature,
   forThermocyclerAwaitLidTemperature,
+  forThermocyclerAwaitProfileComplete,
+  forThermocyclerCloseLid,
   forThermocyclerDeactivateBlock,
   forThermocyclerDeactivateLid,
+  forThermocyclerOpenLid,
+  forThermocyclerRunProfile,
   forThermocyclerSetTargetBlockTemperature,
   forThermocyclerSetTargetLidTemperature,
-  forThermocyclerRunProfile,
-  forThermocyclerCloseLid,
-  forThermocyclerOpenLid,
 } from './thermocyclerUpdates'
 
 import {
@@ -153,7 +154,11 @@ function _getNextRobotStateAndWarningsSingleCommand(
       )
       break
     case 'thermocycler/awaitProfileComplete':
-      console.warn(`NOT IMPLEMENTED: ${command.command}`)
+      forThermocyclerAwaitProfileComplete(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
       break
 
     default:

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/thermocyclerUpdates.js
@@ -72,6 +72,14 @@ export const forThermocyclerAwaitLidTemperature = (
   // nothing to be done
 }
 
+export const forThermocyclerAwaitProfileComplete = (
+  params: ModuleOnlyParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  // nothing to be done
+}
+
 export const forThermocyclerDeactivateBlock = (
   params: ModuleOnlyParams,
   invariantContext: InvariantContext,


### PR DESCRIPTION
## overview

Oops this was an oversight when we wrote the TC command creators. What should happen is: all setTarget(Lid|Block)Temperature commands should be immediately followed by a corresponding await(Lid|Block)Temperature command. The JSON commands are written in an async vocabulary, but we don't yet support actually async behavior, so the executor will raise an error if you give it commands where `[(set TC temp X), (anything besides await temp X)]`

## changelog


## review requests

- Make some TC state + profile protocols, inspect commands, every "set temp" should be immediately followed by an "await temp" command
- Upload to a robot (or `make -C api dev` for a fake robot). The executor should no longer fail when you upload TC protocols

## risk assessment

low, PD only under FF, is bugfix