### PR TITLE
style(protocol-designer): decrease click target area for TC form radio buttons

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -31,38 +31,41 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
         </span>
       </div>
       <div className={styles.tc_step_group}>
-        <RadioGroupField
-          name="thermocyclerFormType"
-          className={styles.tc_step_option}
-          options={[
-            {
-              name: i18n.t(
-                'form.step_edit_form.field.thermocyclerAction.options.state'
-              ),
-              value: THERMOCYCLER_STATE,
-            },
-          ]}
-          {...focusHandlers}
-        />
+        <div className={styles.checkbox_row}>
+          <RadioGroupField
+            name="thermocyclerFormType"
+            options={[
+              {
+                name: i18n.t(
+                  'form.step_edit_form.field.thermocyclerAction.options.state'
+                ),
+                value: THERMOCYCLER_STATE,
+              },
+            ]}
+            {...focusHandlers}
+          />
+        </div>
         <ConditionalOnField
           name={'thermocyclerFormType'}
           condition={val => val === THERMOCYCLER_STATE}
         >
           <StateFields focusHandlers={focusHandlers} />
         </ConditionalOnField>
-        <RadioGroupField
-          name="thermocyclerFormType"
-          className={styles.tc_step_option}
-          options={[
-            {
-              name: i18n.t(
-                'form.step_edit_form.field.thermocyclerAction.options.profile'
-              ),
-              value: THERMOCYCLER_PROFILE,
-            },
-          ]}
-          {...focusHandlers}
-        />
+        <div className={styles.checkbox_row}>
+          <RadioGroupField
+            name="thermocyclerFormType"
+            className={styles.tc_step_option}
+            options={[
+              {
+                name: i18n.t(
+                  'form.step_edit_form.field.thermocyclerAction.options.profile'
+                ),
+                value: THERMOCYCLER_PROFILE,
+              },
+            ]}
+            {...focusHandlers}
+          />
+        </div>
       </div>
 
       <ConditionalOnField

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -34,6 +34,7 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
         <div className={styles.checkbox_row}>
           <RadioGroupField
             name="thermocyclerFormType"
+            className={styles.tc_step_option}
             options={[
               {
                 name: i18n.t(


### PR DESCRIPTION
## overview

This PR closes #5885 by decreasing the click target area for TC form radio buttons. I reused the same styles as the pause radio buttons.

## review requests
Open the TC form, make sure radio buttons work, and that the click target is limited to the space that the button and the button text fit in.

## risk assessment
Low
