### PR TITLE
fix(protocol-designer): ensure lid is closed before calling TC runPro…

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
+++ b/protocol-designer/src/step-generation/__tests__/thermocyclerProfileStep.test.js
@@ -34,6 +34,12 @@ describe('thermocyclerProfileStep', () => {
       },
       expected: [
         {
+          command: 'thermocycler/closeLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
           command: 'thermocycler/setTargetLidTemperature',
           params: {
             module: 'thermocyclerId',
@@ -91,12 +97,142 @@ describe('thermocyclerProfileStep', () => {
     },
     {
       testName:
-        'should generate expected commands, omitting the setTargetLidTemperature when lid temp is already at desired temp',
+        'should omit the setTargetLidTemperature when lid temp is already at desired temp',
+      initialThermocyclerModuleState: {
+        type: THERMOCYCLER_MODULE_TYPE,
+        blockTargetTemp: null,
+        lidTargetTemp: 55,
+        lidOpen: false,
+      },
+      args: {
+        commandCreatorFnName: 'thermocyclerProfile',
+        blockTargetTempHold: 4,
+        lidTargetTempHold: null,
+        lidOpenHold: true,
+        module: thermocyclerId,
+        profileSteps: [{ temperature: 61, holdTime: 99 }],
+        profileTargetLidTemp: 55,
+        profileVolume: 42,
+      },
+      expected: [
+        {
+          command: 'thermocycler/runProfile',
+          params: {
+            module: 'thermocyclerId',
+            profile: [{ temperature: 61, holdTime: 99 }],
+            volume: 42,
+          },
+        },
+        {
+          command: 'thermocycler/awaitProfileComplete',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
+          command: 'thermocycler/openLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
+          command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/awaitBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/deactivateLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+      ],
+    },
+    {
+      testName:
+        'should close the lid before running the profile if the lid open state is null',
       initialThermocyclerModuleState: {
         type: THERMOCYCLER_MODULE_TYPE,
         blockTargetTemp: null,
         lidTargetTemp: 55,
         lidOpen: null,
+      },
+      args: {
+        commandCreatorFnName: 'thermocyclerProfile',
+        blockTargetTempHold: 4,
+        lidTargetTempHold: null,
+        lidOpenHold: true,
+        module: thermocyclerId,
+        profileSteps: [{ temperature: 61, holdTime: 99 }],
+        profileTargetLidTemp: 55,
+        profileVolume: 42,
+      },
+      expected: [
+        {
+          command: 'thermocycler/closeLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
+          command: 'thermocycler/runProfile',
+          params: {
+            module: 'thermocyclerId',
+            profile: [{ temperature: 61, holdTime: 99 }],
+            volume: 42,
+          },
+        },
+        {
+          command: 'thermocycler/awaitProfileComplete',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
+          command: 'thermocycler/openLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+        {
+          command: 'thermocycler/setTargetBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/awaitBlockTemperature',
+          params: {
+            module: 'thermocyclerId',
+            temperature: 4,
+          },
+        },
+        {
+          command: 'thermocycler/deactivateLid',
+          params: {
+            module: 'thermocyclerId',
+          },
+        },
+      ],
+    },
+    {
+      testName:
+        'should omit the closeLid when the lid open state is false before running a profile',
+      initialThermocyclerModuleState: {
+        type: THERMOCYCLER_MODULE_TYPE,
+        blockTargetTemp: null,
+        lidTargetTemp: 55,
+        lidOpen: false,
       },
       args: {
         commandCreatorFnName: 'thermocyclerProfile',

--- a/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/thermocyclerProfileStep.js
@@ -6,6 +6,7 @@ import { thermocyclerAwaitLidTemperature } from '../atomic/thermocyclerAwaitLidT
 import { thermocyclerRunProfile } from '../atomic/thermocyclerRunProfile'
 import { thermocyclerSetTargetLidTemperature } from '../atomic/thermocyclerSetTargetLidTemperature'
 import { thermocyclerAwaitProfileComplete } from '../atomic/thermocyclerAwaitProfileComplete'
+import { thermocyclerCloseLid } from '../atomic/thermocyclerCloseLid'
 import { thermocyclerStateStep } from './thermocyclerStateStep'
 import type {
   CommandCreator,
@@ -34,6 +35,14 @@ export const thermocyclerProfileStep: CommandCreator<ThermocyclerProfileStepArgs
   }
 
   const commandCreators: Array<CurriedCommandCreator> = []
+
+  if (thermocyclerState.lidOpen !== false) {
+    commandCreators.push(
+      curryCommandCreator(thermocyclerCloseLid, {
+        module: moduleId,
+      })
+    )
+  }
 
   if (profileTargetLidTemp !== thermocyclerState.lidTargetTemp) {
     commandCreators.push(


### PR DESCRIPTION
## overview

Another oversight when we wrote the TC command creators. 

Calls to `runProfile` should be preceeded by a call to `closeLid`. This is because before a profile is run, we want the lid to be closed. 

If the lid state (in `robotState`) is explicitly closed, then we omit calls to `closeLid`, similarly to how we don't set the body temp twice if the final profile step matches the body hold temp. 

## review requests

- Make a TC profile step (without first making a state step to close the lid), export the JSON, make sure that the call to `runProfile` is proceeded by a call to `closeLid`
- Make a TC state step to close the lid, then make a TC profile step. export the JSON, and make sure that there is only one (not two) call to `closeLid` before `runProfile`

## risk assessment

low, PD only under FF, is bugfix