### PR TITLE
fix(protocol-designer): flip the expand/collapse arrow for TC substep accordions

### DIFF
--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -203,7 +203,7 @@ const CollapsibleSubstep = (props: CollapsibleSubstepProps) => {
           className={styles.inner_carat}
           onClick={() => setContentCollapsed(!contentCollapsed)}
         >
-          <Icon name={contentCollapsed ? 'chevron-up' : 'chevron-down'} />
+          <Icon name={contentCollapsed ? 'chevron-down' : 'chevron-up'} />
         </span>
       </PDListItem>
       {!contentCollapsed && props.children}


### PR DESCRIPTION
## overview

This PR closes #5911 by flipping TC substep arrow accordions. 

## review requests
Make a TC profile step
When you view it in the sidebar, the substep arrows should be pointing down when collapsed, and pointing up when expanded (like the top level arrows do)

## risk assessment
Very low, style change behind FF