### PR TITLE
feat(protocol-designer): reverse multi channel substep arrows in sidebar

### DIFF
--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.js
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.js
@@ -87,7 +87,7 @@ export class MultiChannelSubstep extends React.PureComponent<
             className={styles.inner_carat}
             onClick={this.handleToggleCollapsed}
           >
-            <Icon name={collapsed ? 'chevron-up' : 'chevron-down'} />
+            <Icon name={collapsed ? 'chevron-down' : 'chevron-up'} />
           </span>
         </PDListItem>
 


### PR DESCRIPTION
## overview

This PR addresses https://opentrons.slack.com/archives/CSCLVUW3C/p1592327680039700 by reversing the accordion arrow directions in the sidebar for multi channel substeps to match TC profile substeps (see #5911)

## review requests
Make a protocol with a multichannel pipette and save a transfer step
In the sidebar, make sure:

- [ ]  when the step is collapsed, the arrow points down
- [ ]  when the step is expanded, the arrow points up


## risk assessment
Very low