### PR TITLE
test(labware-library): mock file-saver while using cypress

### DIFF
--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -137,5 +137,9 @@ context('File Import', () => {
           })
         })
       })
+
+    cy.window()
+      .its('__lastSavedFileName__')
+      .should('equal', 'TestPro 15 Well Plate 5 µL.zip')
   })
 })

--- a/labware-library/cypress/mocks/file-saver.js
+++ b/labware-library/cypress/mocks/file-saver.js
@@ -1,0 +1,6 @@
+// mock for 'file-saver' npm module
+
+export const saveAs = (blob, fileName) => {
+  global.__lastSavedBlobZip__ = blob
+  global.__lastSavedFileName__ = fileName
+}

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -493,13 +493,7 @@ export const LabwareCreator = (): React.Node => {
             labwareTestProtocol({ pipetteName, definition: def })
           )
           zip.generateAsync({ type: 'blob' }).then(blob => {
-            if (global.Cypress) {
-              // HACK(IL, 2020-04-02): can't figure out a better way to do this yet
-              // https://docs.cypress.io/faq/questions/using-cypress-faq.html#Can-my-tests-interact-with-Redux-Vuex-data-store
-              global.__lastSavedBlobZip__ = blob
-            } else {
-              saveAs(blob, `${displayName}.zip`)
-            }
+            saveAs(blob, `${displayName}.zip`)
           })
 
           reportEvent({

--- a/labware-library/webpack.config.js
+++ b/labware-library/webpack.config.js
@@ -30,6 +30,13 @@ const envVars = passThruEnvVars.reduce(
   { ...envVarsWithDefaults }
 )
 
+const testAliases =
+  process.env.CYPRESS === '1'
+    ? {
+        'file-saver': path.resolve(__dirname, 'cypress/mocks/file-saver.js'),
+      }
+    : {}
+
 module.exports = merge(baseConfig, {
   entry: JS_ENTRY,
 
@@ -66,4 +73,8 @@ module.exports = merge(baseConfig, {
       },
     }),
   ],
+
+  resolve: {
+    alias: testAliases,
+  },
 })


### PR DESCRIPTION
## overview

Addresses LC side of #5457. If we like this approach, I'll repeat it for PD's use of `file-saver` to close that issue

Note: I think we have a ticket somewhere for not having mu's in the filenames, but I didn't want to address that in this PR, too separate of a concern to fit in here. Plus now that we have a test for the file name, we can TDD that when we get to it :upside_down_face: 

## changelog

## review requests

- [ ] In the sandbox build (or plain `make -C labware-library dev`), you should be able to save labware files in LC normally
- [ ] Cypress should still pass (3 cases below)

1. in CI
2. with `make -C labware-library test-e2e`
3. with `make -C labware-library dev CYPRESS=1` then when that's running, in another tab, `cd labware-library; yarn cypress open`

## risk assessment

Low, if it goes really wrong this would block file download in LC, but should be easy to prove that this is still working or not (eg try to d/l in sandbox)