### PR TITLE
feat(api): load tip length calibration in v1

### DIFF
--- a/api/src/opentrons/legacy_api/api.py
+++ b/api/src/opentrons/legacy_api/api.py
@@ -288,7 +288,8 @@ class InstrumentsWrapper(object):
             min_volume=min_volume,
             max_volume=max_volume,
             blow_out_flow_rate=blow_out_flow_rate,
-            requested_as=original_name)
+            requested_as=original_name,
+            pipette_id=pip_id)
 
     def _create_pipette_from_config(
             self,
@@ -303,7 +304,8 @@ class InstrumentsWrapper(object):
             min_volume=None,
             max_volume=None,
             blow_out_flow_rate=None,
-            requested_as=None):
+            requested_as=None,
+            pipette_id=None):
 
         if aspirate_flow_rate is not None:
             config = replace(config, aspirate_flow_rate=aspirate_flow_rate)
@@ -348,7 +350,8 @@ class InstrumentsWrapper(object):
             quirks=config.quirks,
             fallback_tip_length=config.tip_length,  # TODO move to labware
             blow_out_flow_rate=config.blow_out_flow_rate,
-            requested_as=requested_as)
+            requested_as=requested_as,
+            pipette_id=pipette_id)
 
         return p
 

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import itertools
 import logging
 import json
+from typing import TYPE_CHECKING
 from opentrons.config import CONFIG
 from opentrons.data_storage import database
 from opentrons.util.vector import Vector
@@ -19,6 +20,10 @@ from .placeable import (
 from opentrons.helpers import helpers
 
 from opentrons.protocol_api import labware as new_labware
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api.dev_types import TipLengthCalibration
+
 
 __all__ = [
     'Deck',
@@ -278,3 +283,12 @@ def load_new_labware_def(definition):
             definition['wells'][well_name], saved_offset, lw_quirks)
         container.add(well_obj, well_name, well_pos)
     return container
+
+
+def load_tip_length_calibration(
+        pip_id: str, location) -> 'TipLengthCalibration':
+    placeable, _ = unpack_location(location)
+    lw = placeable.get_parent()
+    return new_labware.get_tip_length_data(
+        pip_id=pip_id, labware_hash=lw.properties['labware_hash'],
+        labware_load_name=lw.properties['type'])

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -974,15 +974,25 @@ def load_tip_length_calibration(
         pip_id: str, labware: Labware) -> 'TipLengthCalibration':
     assert labware._is_tiprack, \
         'cannot load tip length for non-tiprack labware'
+    parent_id = _get_parent_identifier(labware.parent)
+    labware_hash = _hash_labware_def(labware._definition)
+    return get_tip_length_data(
+        pip_id=pip_id,
+        labware_hash=labware_hash + parent_id,
+        labware_load_name=labware.load_name)
+
+
+# TODO: AA - move out of protocol_api
+def get_tip_length_data(
+        pip_id: str, labware_hash: str, labware_load_name: str
+) -> 'TipLengthCalibration':
     try:
         pip_tip_length_path = get_tip_length_cal_path()/f'{pip_id}.json'
-        parent_id = _get_parent_identifier(labware.parent)
-        labware_hash = _hash_labware_def(labware._definition)
         tip_length_data = _read_cal_file(str(pip_tip_length_path))
-        return tip_length_data[labware_hash + parent_id]
+        return tip_length_data[labware_hash]
     except (FileNotFoundError, AttributeError):
         raise TipLengthCalNotFound(
-            f'Tip length of {labware.load_name} has not been '
+            f'Tip length of {labware_load_name} has not been '
             f'calibrated for this pipette: {pip_id} and cannot'
             'be loaded')
 

--- a/api/tests/opentrons/labware/test_pipette_constructors.py
+++ b/api/tests/opentrons/labware/test_pipette_constructors.py
@@ -76,3 +76,4 @@ def test_pipette_contructors(factory, monkeypatch,
     assert blow_out_flow_rate == 25
     assert pipette.min_volume == 7
     assert pipette.max_volume == 8
+    assert pipette.pipette_id == 'FakePip'

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -233,7 +233,7 @@ def test_clear_tip_length_calibration_data(monkeypatch):
     with open(calpath/f'{PIPETTE_ID}.json', 'w') as offset_file:
         test_offset = {
             MOCK_HASH: {
-                'tip_length': 22.0,
+                'tipLength': 22.0,
                 'lastModified': 1
             }
         }


### PR DESCRIPTION
## overview
This PR allows pipette to load tip length from tip length calibration data (implemented in #5820) in Protocol API v1.

closes #5608

## changelog
- added `pipette_id` as a property of the legacy Pipette class
- added `load_tip_length_calibration` in v1
- only load tip length from calibration when feature flag is enabled and 
   pipette ID exists (when it's not simulating) in v1 during pick up tip
- refactored `load_tip_length_calibration` in Protocol API
- updated tests

## risk assessment
low - everything is behind a feature flag
<!--
  Carefully go over your pull request and look at the other parts of the
  codebase it may affect. Look for the possibility, even if you think it's
  small, that your change may affect some other part of the system - for
  instance, changing return tip behavior in protocol may also change the
  behavior of labware calibration.

  Identify the other parts of the system your codebase may affect, so that in
  addition to your own review and testing, other people who may not have
  the system internalized as much as you can focus their attention and testing
  there.
-->
