### PR TITLE
fix(protocol-designer): Update profile step fields alignment

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -330,7 +330,7 @@ and when that is implemented.
 
   width: 1.5rem;
   text-align: right;
-  padding-right: 0.5rem;
+  padding: 0.5rem 0.5rem 0 0;
 }
 
 .profile_step_row {
@@ -345,7 +345,7 @@ and when that is implemented.
 
 .profile_step_fields {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   border: var(--bd-light);
   width: 100%;
   min-width: 36rem;


### PR DESCRIPTION
## overview

This PR serves as its own ticket. Previously, the profile step fields aligned center, which is fine until an error caption renders and bumps the field alignment. This PR fixes the alignment issues 

<img width="900" alt="Screen Shot 2020-06-17 at 10 22 39 AM" src="https://user-images.githubusercontent.com/3430313/84910505-f624cd00-b084-11ea-8f42-2afcccd66a27.png">

## changelog

- fix(protocol-designer): Update profile step fields alignment

## review requests

Make a TC profile step, enter a bogus number for temperature
- [ ] All fields are still aligned and caption renders below

## risk assessment

Low CSS only
