### PR TITLE
refactor(app): calcheck: save report to file

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "core-js": "3.2.1",
     "date-fns": "2.10.0",
     "events": "3.0.0",
+    "file-saver": "2.0.1",
     "formik": "2.1.4",
     "history": "4.7.2",
     "lodash": "4.17.15",

--- a/app/src/components/CheckCalibration/CompleteConfirmation.js
+++ b/app/src/components/CheckCalibration/CompleteConfirmation.js
@@ -47,11 +47,9 @@ export function CompleteConfirmation(
     (p: RobotCalibrationCheckInstrument) =>
       p.rank === Calibration.CHECK_PIPETTE_RANK_SECOND
   )
-  const [
-    firstComparisonsByStep,
-    secondComparisonsByStep,
-  ] = partition(Object.keys(comparisonsByStep), compStep =>
-    Calibration.FIRST_PIPETTE_COMPARISON_STEPS.includes(compStep)
+  const [firstComparisonsByStep, secondComparisonsByStep] = partition(
+    Object.keys(comparisonsByStep),
+    compStep => Calibration.FIRST_PIPETTE_COMPARISON_STEPS.includes(compStep)
   ).map(stepNames => pick(comparisonsByStep, stepNames))
 
   return (

--- a/app/src/components/CheckCalibration/__tests__/CompleteConfirmation.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CompleteConfirmation.test.js
@@ -7,6 +7,14 @@ import * as Fixtures from '../../../calibration/__fixtures__'
 import * as Calibration from '../../../calibration'
 import type { RobotCalibrationCheckComparisonsByStep } from '../../../calibration'
 import { CompleteConfirmation } from '../CompleteConfirmation'
+import { saveAs } from 'file-saver'
+
+jest.mock('file-saver')
+
+const mockSaveAs: JestMockFn<
+  [Blob, string],
+  $Call<typeof saveAs, Blob, string>
+> = saveAs
 
 const mockSessionDetails = Fixtures.mockRobotCalibrationCheckSessionDetails
 
@@ -18,6 +26,11 @@ describe('CompleteConfirmation', () => {
   const getExitButton = wrapper =>
     wrapper
       .find('PrimaryButton[children="Drop tip in trash and exit"]')
+      .find('button')
+
+  const getSaveButton = wrapper =>
+    wrapper
+      .find('OutlineButton[children="Download JSON summary"]')
       .find('button')
 
   beforeEach(() => {
@@ -89,5 +102,12 @@ describe('CompleteConfirmation', () => {
     wrapper.update()
 
     expect(mockExit).toHaveBeenCalled()
+  })
+
+  it('saves the calibration report when the button is clicked', () => {
+    const wrapper = render()
+    act(() => getSaveButton(wrapper).invoke('onClick')())
+    wrapper.update()
+    expect(mockSaveAs).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Adds a new dependency (file-saver, the same thing as in labware library and protocol designer) to the app and uses it to allow users to save their calibration check reports to file rather than copy to clipboard.


## Testing

This is a built in chrome thing so it should just work on all OSs, but let's give it a test on windows, linux, and mac.

## Risk Assessment

None really, this is one button in calibration check.