### PR TITLE
fix(protocol-designer): Lighten TC hover overlay

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareOverlays.css
@@ -103,7 +103,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: color-mod(var(--c-highlight) alpha(0.5));
+  background-color: color-mod(var(--c-highlight) alpha(0.25));
 }
 
 .thermocycler_icon {


### PR DESCRIPTION
## overview

closes #5912 by lightening the hover overlay alpha for TC cycle

## changelog

- fix(protocol-designer): Lighten TC hover overlay

## review requests

- [ ] Overlay is lighter, TC icon has higher contrast

## risk assessment

Low one line of CSS