### PR TITLE
refactor(calcheck): display pipette serial numbers in summary

### DIFF
--- a/api/src/opentrons/calibration/check/models.py
+++ b/api/src/opentrons/calibration/check/models.py
@@ -58,6 +58,8 @@ class AttachedPipette(BaseModel):
         Field(None, description="Id of tiprack associated with this pipette.")
     rank: Optional[str] =\
         Field(None, description="Rank in the order of pipettes used for flow")
+    serial: Optional[str] =\
+        Field(None, description="The serial number of the attached pipette")
 
 
 class LabwareStatus(BaseModel):

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -377,6 +377,7 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                 has_tip=bool(hw_pip['has_tip']),
                 tiprack_id=pip_info.tiprack_id,
                 rank=str(pip_info.rank),
+                serial=str(hw_pip['pipette_id']),
             )
             to_dict[mount] = p
         return to_dict

--- a/api/src/opentrons/calibration/helper_classes.py
+++ b/api/src/opentrons/calibration/helper_classes.py
@@ -103,3 +103,4 @@ class PipetteStatus:
     has_tip: bool
     rank: str
     tiprack_id: typing.Optional[UUID]
+    serial: str

--- a/app/src/calibration/__fixtures__/index.js
+++ b/app/src/calibration/__fixtures__/index.js
@@ -48,6 +48,7 @@ export const mockRobotCalibrationCheckSessionDetails: RobotCalibrationCheckSessi
       mount: 'left',
       tiprack_id: 'abc123_labware_uuid',
       rank: 'second',
+      serial: 'fake pipette serial 1',
     },
     right: {
       model: 'fake_pipette_model',
@@ -56,6 +57,7 @@ export const mockRobotCalibrationCheckSessionDetails: RobotCalibrationCheckSessi
       mount: 'right',
       tiprack_id: 'def456_labware_uuid',
       rank: 'first',
+      serial: 'fake pipette serial 2',
     },
   },
   currentStep: 'sessionStarted',
@@ -101,6 +103,7 @@ export const mockTipLengthCalibrationSessionDetails: TipLengthCalibrationSession
       mount: 'left',
       tiprack_id: 'abc123_labware_uuid',
       rank: 'first',
+      serial: 'fake serial 1',
     },
     right: {
       model: 'fake_pipette_model',
@@ -109,6 +112,7 @@ export const mockTipLengthCalibrationSessionDetails: TipLengthCalibrationSession
       mount: 'right',
       tiprack_id: 'def456_labware_uuid',
       rank: 'second',
+      serial: 'fake serial 2',
     },
   },
   currentStep: 'sessionStarted',

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -73,6 +73,7 @@ export type RobotCalibrationCheckInstrument = {|
   mount: string,
   tiprack_id: string,
   rank: RobotCalibrationCheckPipetteRank,
+  serial: string,
 |}
 export type RobotCalibrationCheckLabware = {|
   alternatives: Array<string>,

--- a/app/src/components/CheckCalibration/PipetteComparisons.js
+++ b/app/src/components/CheckCalibration/PipetteComparisons.js
@@ -49,7 +49,8 @@ export function PipetteComparisons(props: PipetteComparisonsProps): React.Node {
     <div className={styles.pipette_data_wrapper}>
       <h5 className={styles.pipette_data_header}>
         {`${pipette.mount.toLowerCase()} ${PIPETTE}: ${displayName}`}
-        {/* <p>{`(TODO: put pipette serial here)`}</p> */}
+        &nbsp;
+        <p className={styles.pipette_serial}>{`(#${pipette.serial})`}</p>
       </h5>
       <table className={styles.pipette_data_table}>
         <thead>

--- a/app/src/components/CheckCalibration/styles.css
+++ b/app/src/components/CheckCalibration/styles.css
@@ -128,6 +128,12 @@
   display: flex;
   text-transform: capitalize;
   margin-bottom: 0.75rem;
+  align-items: baseline;
+}
+
+.pipette_serial {
+  font-size: var(--fs-body-1);
+  font-weight: var(--fw-regular);
 }
 
 .inline_step_status {

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -64,7 +64,8 @@ class CheckSession(BaseSession):
                 mount=str(v.mount),
                 has_tip=v.has_tip,
                 rank=v.rank,
-                tiprack_id=v.tiprack_id)
+                tiprack_id=v.tiprack_id,
+                serial=v.serial)
             for k, v in self._calibration_check.pipette_status().items()
         }
         labware = [

--- a/robot-server/tests/service/session/session_types/test_check_session.py
+++ b/robot-server/tests/service/session/session_types/test_check_session.py
@@ -27,7 +27,7 @@ def mock_cal_session(hardware):
             tiprack_id=None,
             critical_point=None,
             rank=PipetteRank.second,
-            mount=types.Mount.LEFT
+            mount=types.Mount.LEFT,
         ),
         types.Mount.RIGHT: PipetteInfo(
             tiprack_id=None,
@@ -43,14 +43,16 @@ def mock_cal_session(hardware):
             'max_volume': 10,
             'name': 'p10_single',
             'tip_length': 0,
-            'channels': 1},
+            'channels': 1,
+            'pipette_id': 'pipette id 1'},
         types.Mount.RIGHT: {
             'model': 'p300_single_v1',
             'has_tip': False,
             'max_volume': 300,
             'name': 'p300_single',
             'tip_length': 0,
-            'channels': 1}
+            'channels': 1,
+            'pipette_id': 'pipette id 2'}
     }
 
     CheckCalibrationSession._get_pip_info_by_mount =\
@@ -112,7 +114,8 @@ def session_hardware_info(mock_cal_session):
                  'mount': v.mount,
                  'has_tip': v.has_tip,
                  'tiprack_id': v.tiprack_id,
-                 'rank': v.rank}
+                 'rank': v.rank,
+                 'serial': v.serial}
         for k, v in mock_cal_session.pipette_status().items()
     }
     info = {


### PR DESCRIPTION
Add the pipette serial number to the session data and display it in the summary screen.

## Testing
Does it display?

## Risk assessment
None