### PR TITLE
test(protocol-designer): mock file-saver while using cypress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # opentrons platform travis config
 cache: false
 
+addons:
+  chrome: stable
+
 stages:
   - test
   - name: app

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -124,8 +124,8 @@ describe('Protocol fixtures migrate and match snapshots', () => {
           cy.window()
             .its('__lastSavedFileBlob__')
             .should('be.a', 'blob')
-            .then(blob => blob.text())
-            .then(blobText => {
+            .should(async blob => {
+              const blobText = await blob.text()
               const savedFile = JSON.parse(blobText)
               const expectedFile = cloneDeep(expectedExportProtocol)
 

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -121,29 +121,35 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               .click()
           }
 
-          cy.window().then(async window => {
-            const blobText = await window.__lastSavedFileBlob__.text()
-            const savedFile = cloneDeep(JSON.parse(blobText))
-            const expectedFile = cloneDeep(expectedExportProtocol)
-            const fileName = window.__lastSavedFileName__
+          cy.window()
+            .its('__lastSavedFileBlob__')
+            .should('be.a', 'blob')
+            .then(blob => blob.text())
+            .then(blobText => {
+              const savedFile = JSON.parse(blobText)
+              const expectedFile = cloneDeep(expectedExportProtocol)
 
-            assert.match(
-              savedFile.designerApplication.version,
-              /^4\.0\.\d+$/,
-              'designerApplication.version is 4.0.x'
-            )
-            ;[savedFile, expectedFile].forEach(f => {
-              // Homogenize fields we don't want to compare
-              f.metadata.lastModified = 123
-              f.designerApplication.data._internalAppBuildDate = 'Foo Date'
-              f.designerApplication.version = 'x.x.x'
+              assert.match(
+                savedFile.designerApplication.version,
+                /^4\.0\.\d+$/,
+                'designerApplication.version is 4.0.x'
+              )
+              ;[savedFile, expectedFile].forEach(f => {
+                // Homogenize fields we don't want to compare
+                f.metadata.lastModified = 123
+                f.designerApplication.data._internalAppBuildDate = 'Foo Date'
+                f.designerApplication.version = 'x.x.x'
+              })
+
+              expectDeepEqual(assert, savedFile, expectedFile)
             })
 
-            expectDeepEqual(assert, savedFile, expectedFile)
-            expect(fileName).to.equal(
-              `${expectedFile.metadata.protocolName}.json`
+          cy.window()
+            .its('__lastSavedFileName__')
+            .should(
+              'equal',
+              `${expectedExportProtocol.metadata.protocolName}.json`
             )
-          })
         })
       })
     }

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -121,23 +121,28 @@ describe('Protocol fixtures migrate and match snapshots', () => {
               .click()
           }
 
-          cy.window().then(window => {
-            const savedFile = cloneDeep(window.__lastSavedFile__)
-            const expected = cloneDeep(expectedExportProtocol)
+          cy.window().then(async window => {
+            const blobText = await window.__lastSavedFileBlob__.text()
+            const savedFile = cloneDeep(JSON.parse(blobText))
+            const expectedFile = cloneDeep(expectedExportProtocol)
+            const fileName = window.__lastSavedFileName__
 
             assert.match(
               savedFile.designerApplication.version,
               /^4\.0\.\d+$/,
               'designerApplication.version is 4.0.x'
             )
-            ;[savedFile, expected].forEach(f => {
+            ;[savedFile, expectedFile].forEach(f => {
               // Homogenize fields we don't want to compare
               f.metadata.lastModified = 123
               f.designerApplication.data._internalAppBuildDate = 'Foo Date'
               f.designerApplication.version = 'x.x.x'
             })
 
-            expectDeepEqual(assert, savedFile, expected)
+            expectDeepEqual(assert, savedFile, expectedFile)
+            expect(fileName).to.equal(
+              `${expectedFile.metadata.protocolName}.json`
+            )
           })
         })
       })

--- a/protocol-designer/cypress/mocks/file-saver.js
+++ b/protocol-designer/cypress/mocks/file-saver.js
@@ -1,0 +1,6 @@
+// mock for 'file-saver' npm module
+
+export const saveAs = (blob, fileName) => {
+  global.__lastSavedFileBlob__ = blob
+  global.__lastSavedFileName__ = fileName
+}

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -43,13 +43,7 @@ const saveFile = (downloadData: $PropertyType<Props, 'downloadData'>) => {
   const blob = new Blob([JSON.stringify(downloadData.fileData)], {
     type: 'application/json',
   })
-  if (process.env.CYPRESS === '1') {
-    // HACK(IL, 2020-04-02): can't figure out a better way to do this yet
-    // https://docs.cypress.io/faq/questions/using-cypress-faq.html#Can-my-tests-interact-with-Redux-Vuex-data-store
-    global.__lastSavedFile__ = downloadData.fileData
-  } else {
-    saveAs(blob, downloadData.fileName)
-  }
+  saveAs(blob, downloadData.fileName)
 }
 
 type WarningContent = {|

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -37,6 +37,13 @@ const envVars = passThruEnvVars.reduce(
   { ...envVarsWithDefaults }
 )
 
+const testAliases =
+  process.env.CYPRESS === '1'
+    ? {
+        'file-saver': path.resolve(__dirname, 'cypress/mocks/file-saver.js'),
+      }
+    : {}
+
 console.log(`PD version: ${OT_PD_VERSION || 'UNKNOWN!'}`)
 
 module.exports = merge(baseConfig, {
@@ -78,4 +85,8 @@ module.exports = merge(baseConfig, {
     }),
     new ScriptExtHtmlWebpackPlugin({ defaultAttribute: 'defer' }),
   ],
+
+  resolve: {
+    alias: testAliases,
+  },
 })


### PR DESCRIPTION
## overview

Same deal as #5932 but for PD

Closes #5457

## changelog

- mock file-saver for cypress, using webpack
- define Chrome version in Travis (`stable`) instead of using implicitly-defined one (it's out-of-date)

## review requests

- PD should allow you to download files (branch build, or `make dev`)
- E2E tests should still pass (if running with `yarn cypress open`, you need to run `make -C protocol-designer dev CYPRESS=1`. Which is already the case on `edge`, just implemented differently)

## risk assessment

Medium, but easy to check. If I messed something up, PD would not save files.