### PR TITLE
fix(protocol-designer): auto add TC module id to TC steps

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -13,6 +13,7 @@ import {
   getModuleType,
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   rootReducer as labwareDefsRootReducer,
@@ -623,6 +624,13 @@ export const savedStepForms = (
         if (
           savedForm.stepType === 'magnet' &&
           action.payload.type === MAGNETIC_MODULE_TYPE
+        ) {
+          return { ...savedForm, moduleId }
+        }
+        // same logic applies to Thermocycler
+        if (
+          savedForm.stepType === 'thermocycler' &&
+          action.payload.type === THERMOCYCLER_MODULE_TYPE
         ) {
           return { ...savedForm, moduleId }
         }

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -757,9 +757,9 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       )
     })
     describe('existing steps', () => {
-      let prevRootStateWithMagStep
+      let prevRootStateWithMagAndTCSteps
       beforeEach(() => {
-        prevRootStateWithMagStep = {
+        prevRootStateWithMagAndTCSteps = {
           savedStepForms: {
             ...makePrevRootState().savedStepForms,
             ...{
@@ -768,10 +768,16 @@ describe('savedStepForms reducer: initial deck setup step', () => {
                 moduleId: 'magdeckId',
               },
             },
+            ...{
+              TC_step_form_id: {
+                stepType: 'thermocycler',
+                moduleId: 'TCId',
+              },
+            },
           },
         }
       })
-      const testCases = [
+      const magneticStepCases = [
         {
           testName: 'create mag mod -> override mag step module id',
           action: {
@@ -813,10 +819,61 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         },
       ]
 
-      testCases.forEach(({ testName, action, expectedModuleId }) => {
+      const TCStepCases = [
+        {
+          testName: 'create TC -> override TC step module id',
+          action: {
+            type: 'CREATE_MODULE',
+            payload: {
+              id: 'NewTCId',
+              slot: SPAN7_8_10_11_SLOT,
+              type: THERMOCYCLER_MODULE_TYPE,
+              model: 'someTCModel',
+            },
+          },
+          expectedModuleId: 'NewTCId',
+        },
+        {
+          testName: 'create temp mod -> DO NOT override TC step module id',
+          action: {
+            type: 'CREATE_MODULE',
+            payload: {
+              id: 'tempdeckId',
+              slot: '1',
+              type: TEMPERATURE_MODULE_TYPE,
+              model: 'someTempModel',
+            },
+          },
+          expectedModuleId: 'TCId',
+        },
+        {
+          testName: 'create magnetic mod -> DO NOT override TC step module id',
+          action: {
+            type: 'CREATE_MODULE',
+            payload: {
+              id: 'newMagdeckId',
+              slot: '1',
+              type: MAGNETIC_MODULE_TYPE,
+              model: 'someMagModel',
+            },
+          },
+          expectedModuleId: 'TCId',
+        },
+      ]
+
+      magneticStepCases.forEach(({ testName, action, expectedModuleId }) => {
         it(testName, () => {
-          const result = savedStepForms(prevRootStateWithMagStep, action)
-          expect(result.mag_step_form_id.moduleId).toBe(expectedModuleId)
+          const result = savedStepForms(prevRootStateWithMagAndTCSteps, action)
+          if (action.payload.type)
+            expect(result.mag_step_form_id.moduleId).toBe(expectedModuleId)
+        })
+      })
+
+      TCStepCases.forEach(({ testName, action, expectedModuleId }) => {
+        it(testName, () => {
+          const result = savedStepForms(prevRootStateWithMagAndTCSteps, action)
+          if (action.payload.type)
+            expect(result.TC_step_form_id.moduleId).toBe(expectedModuleId)
         })
       })
     })


### PR DESCRIPTION
## overview
This PR closes #5942 by automagically adding TC module ids to saved TC steps.

## review requests
Code review, look at tests

- Make a protocol with TC
- Add a TC step
- Delete TC

- [ ] Verify that there are timeline errors
- Re add TC
- [ ] Verify timeline errors go away
## risk assessment
Low, fixing bug behind FF
