### PR TITLE
feat(labware-library): use loadname not displayname for LC file

### DIFF
--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -140,6 +140,6 @@ context('File Import', () => {
 
     cy.window()
       .its('__lastSavedFileName__')
-      .should('equal', 'TestPro 15 Well Plate 5 µL.zip')
+      .should('equal', 'testpro_15_wellplate_5ul.zip')
   })
 })

--- a/labware-library/src/labware-creator/index.js
+++ b/labware-library/src/labware-creator/index.js
@@ -485,15 +485,16 @@ export const LabwareCreator = (): React.Node => {
           const { pipetteName } = castValues
           const def = fieldsToLabware(castValues)
           const { displayName } = def.metadata
+          const { loadName } = def.parameters
 
           const zip = new JSZip()
-          zip.file(`${displayName}.json`, JSON.stringify(def, null, 4))
+          zip.file(`${loadName}.json`, JSON.stringify(def, null, 4))
           zip.file(
-            `test_${displayName}.py`,
+            `test_${loadName}.py`,
             labwareTestProtocol({ pipetteName, definition: def })
           )
           zip.generateAsync({ type: 'blob' }).then(blob => {
-            saveAs(blob, `${displayName}.zip`)
+            saveAs(blob, `${loadName}.zip`)
           })
 
           reportEvent({


### PR DESCRIPTION
## overview

Closes #5722

## changelog

## review requests

- Saving labware in LC should use loadname for all file names (the zip, and the zip contents)

## risk assessment

LC-only

I want to make sure there are no user-centric problems with making this change, see https://opentrons.slack.com/archives/CA0K6UV5W/p1592417023078400