### PR TITLE
feat(labware-library): use slot 2 instead of 3 in LC test protocol

### DIFF
--- a/labware-library/cypress/fixtures/TestLabwareProtocol.py
+++ b/labware-library/cypress/fixtures/TestLabwareProtocol.py
@@ -19,7 +19,7 @@ CALIBRATION_CROSS_COORDS = {
     }
 }
 CALIBRATION_CROSS_SLOTS = ['1', '3', '7']
-TEST_LABWARE_SLOT = '3'
+TEST_LABWARE_SLOT = '2'
 
 RATE = 0.25  # % of default speeds
 SLOWER_RATE = 0.1

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -70,7 +70,7 @@ CALIBRATION_CROSS_COORDS = {
     }
 }
 CALIBRATION_CROSS_SLOTS = ['1', '3', '7']
-TEST_LABWARE_SLOT = '3'
+TEST_LABWARE_SLOT = '2'
 
 RATE = 0.25  # % of default speeds
 SLOWER_RATE = 0.1


### PR DESCRIPTION
## overview

Closes #5019

## changelog


## review requests

- Save zip from LC, unzip and run the test protocol. Labware should be in slot 2 instead of 3, protocol should run (if you don't have a robot, you can test that it uploads, or just visually inspect the .py file)

## risk assessment

low, LC only