### PR TITLE
fix(api): fix transform type logic in calibration check session

### DIFF
--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -623,7 +623,8 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
                 if exceeds:
                     tform_type = self._get_error_source(comparisons,
                                                         comparison_state)
-                comparisons[getattr(CalibrationCheckState, comparison_state)] = \
+                comparisons[getattr(CalibrationCheckState,
+                                    comparison_state)] = \
                     ComparisonStatus(differenceVector=(jogged_pt - ref_pt),
                                      thresholdVector=threshold_vector,
                                      exceedsThreshold=exceeds,

--- a/api/src/opentrons/calibration/check/session.py
+++ b/api/src/opentrons/calibration/check/session.py
@@ -565,16 +565,16 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
     def _get_error_source(
             self,
             comparisons: typing.Dict[CalibrationCheckState, ComparisonStatus],
-            jogged_state: CalibrationCheckState) -> DeckCalibrationError:
-        is_second_pip = jogged_state in [
-            CalibrationCheckState.joggingSecondPipetteToHeight,
-            CalibrationCheckState.joggingSecondPipetteToPointOne,
+            comparison_state: CalibrationCheckState) -> DeckCalibrationError:
+        is_second_pip = comparison_state in [
+            CalibrationCheckState.comparingSecondPipetteHeight,
+            CalibrationCheckState.comparingSecondPipettePointOne,
         ]
         first_pip_keys = [
-            CalibrationCheckState.joggingFirstPipetteToHeight,
-            CalibrationCheckState.joggingFirstPipetteToPointOne,
-            CalibrationCheckState.joggingFirstPipetteToPointTwo,
-            CalibrationCheckState.joggingFirstPipetteToPointThree,
+            CalibrationCheckState.comparingFirstPipetteHeight,
+            CalibrationCheckState.comparingFirstPipettePointOne,
+            CalibrationCheckState.comparingFirstPipettePointTwo,
+            CalibrationCheckState.comparingFirstPipettePointThree,
         ]
         compared_first = all((k in comparisons) for k in first_pip_keys)
         first_pip_steps_passed = compared_first
@@ -593,15 +593,15 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
     def get_comparisons_by_step(
             self) -> typing.Dict[CalibrationCheckState, ComparisonStatus]:
         comparisons: typing.Dict[CalibrationCheckState, ComparisonStatus] = {}
-        for jogged_state, comp in COMPARISON_STATE_MAP.items():
+        for comparison_state, comp in COMPARISON_STATE_MAP.items():
             ref_pt = self._saved_points.get(getattr(CalibrationCheckState,
                                                     comp.reference_state),
                                             None)
 
             jogged_pt = self._saved_points.get(getattr(CalibrationCheckState,
-                                                       jogged_state), None)
+                                                       comparison_state), None)
 
-            threshold_vector = self._determine_threshold(jogged_state)
+            threshold_vector = self._determine_threshold(comparison_state)
             if (ref_pt is not None and jogged_pt is not None):
                 diff_magnitude = None
                 if threshold_vector.z == 0.0:
@@ -622,8 +622,8 @@ class CheckCalibrationSession(CalibrationSession, StateMachine):
 
                 if exceeds:
                     tform_type = self._get_error_source(comparisons,
-                                                        jogged_state)
-                comparisons[getattr(CalibrationCheckState, jogged_state)] = \
+                                                        comparison_state)
+                comparisons[getattr(CalibrationCheckState, comparison_state)] = \
                     ComparisonStatus(differenceVector=(jogged_pt - ref_pt),
                                      thresholdVector=threshold_vector,
                                      exceedsThreshold=exceeds,


### PR DESCRIPTION
## overview

Fixes cases where second pipette check failures would receive a BAD_DECK_TRANSFORM error source instead of an UNKNOWN (deck or pipette offset) error source

**When first pipette is on the right mount:**
-  All first pipette failures will be attributed to BAD_DECK_TRANSFORM
-  If all first pipette checks succeeded second pipette failures will be attributed to BAD_INSTRUMENT_OFFSET
-  If any first pipette checks failed second pipette failures will be attributed to UNKNOWN

**When first pipette is on the left mount (left only):**
- failures will be attributed to UNKNOWN

## review requests

Confirm the above listed 4 cases occur.

## risk assessment

low,  changes a small amount of logic in place
