### PR TITLE
feat(labware-library): make LC test protocol go to bottom last

### DIFF
--- a/labware-library/cypress/fixtures/TestLabwareProtocol.py
+++ b/labware-library/cypress/fixtures/TestLabwareProtocol.py
@@ -45,6 +45,7 @@ def uniq(l):
             res.append(i)
     return res
 
+
 def run(protocol: protocol_api.ProtocolContext):
     tiprack = protocol.load_labware(TIPRACK_LOADNAME, TIPRACK_SLOT)
     pipette = protocol.load_instrument(
@@ -109,6 +110,9 @@ def run(protocol: protocol_api.ProtocolContext):
             pipette.move_to(edge_location)
             protocol.pause(f'Moved to {edge_name} edge')
 
+    # go to bottom last. (If there is more than one well, use the last well first
+    # because the pipette is already at the last well at this point)
+    for well_loc in reversed(well_locs):
         set_speeds(RATE)
         pipette.move_to(well.bottom())
         protocol.pause("Moved to the bottom of the well")

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -96,6 +96,7 @@ def uniq(l):
             res.append(i)
     return res
 
+
 def run(protocol: protocol_api.ProtocolContext):
     tiprack = protocol.load_labware(TIPRACK_LOADNAME, TIPRACK_SLOT)
     pipette = protocol.load_instrument(
@@ -160,6 +161,9 @@ def run(protocol: protocol_api.ProtocolContext):
             pipette.move_to(edge_location)
             protocol.pause(f'Moved to {edge_name} edge')
 
+    # go to bottom last. (If there is more than one well, use the last well first
+    # because the pipette is already at the last well at this point)
+    for well_loc in reversed(well_locs):
         set_speeds(RATE)
         pipette.move_to(well.bottom())
         protocol.pause("Moved to the bottom of the well")


### PR DESCRIPTION
## overview

Closes #4625

## changelog

- if you have more than one well, go to bottom of last well before going to bottom of A1
- update fixture for python protocol

## review requests

PDF for reference: https://github.com/Opentrons/opentrons/files/4221711/Labware.test.Slot.2.pdf (from #4620)

- [ ] Make labware in LC with more than one well. It should work as in the PDF: first go to A1, then the last well, then the bottom of last well, then bottom of A1
- [ ] Make labware in LC with one well. It should work as before (and still conform to PDF): first go to all sides of A1, then go to bottom of A1.


## risk assessment

low, LL only, test protocol change
