### PR TITLE
fix(app): fix calibrate to trough bottom image for multi pipettes

### DIFF
--- a/app/src/components/CalibrateLabware/instructions-data.js
+++ b/app/src/components/CalibrateLabware/instructions-data.js
@@ -130,7 +130,7 @@ const DIAGRAMS_BOTTOM: {
     },
     multi: {
       one: require('./images/step-1-trough-multi@3x.png'),
-      two: require('./images/step-2-trough-multi@3x.png'),
+      two: require('./images/step-2-trough-bottom@3x.png'),
     },
   },
   tuberack: {


### PR DESCRIPTION
This PR updates the "Calibrate to Bottom" diagram when calibrating reservoirs with a multi-channel pipette. 

Closes #473
