### PR TITLE
refactor(robot-server): Utilize temporary directories for I/O operations

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -327,8 +327,6 @@ def change_quirks(override_quirks, existing, model_configs):
 
 def load_overrides(pipette_id: str) -> Dict[str, Any]:
     overrides = config.CONFIG['pipette_config_overrides_dir']
-    print("OVERRIDES PATH")
-    print(overrides)
     fi = (overrides/f'{pipette_id}.json').open()
     try:
         return json.load(fi)

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -5,7 +5,8 @@ import numbers
 from typing import (Any, Dict, List, Union, Tuple,
                     Sequence, TYPE_CHECKING)
 
-from opentrons.config import feature_flags as ff, CONFIG
+from opentrons import config
+from opentrons.config import feature_flags as ff
 from opentrons_shared_data.pipette import (
     model_config, name_config, fuse_specs)
 
@@ -274,7 +275,7 @@ def save_overrides(pipette_id: str,
     :param model: The model of pipette
     :return: None
     """
-    override_dir = CONFIG['pipette_config_overrides_dir']
+    override_dir = config.CONFIG['pipette_config_overrides_dir']
     model_configs = configs[model]
     model_configs_quirks = {key: True for key in model_configs['quirks']}
     try:
@@ -325,7 +326,9 @@ def change_quirks(override_quirks, existing, model_configs):
 
 
 def load_overrides(pipette_id: str) -> Dict[str, Any]:
-    overrides = CONFIG['pipette_config_overrides_dir']
+    overrides = config.CONFIG['pipette_config_overrides_dir']
+    print("OVERRIDES PATH")
+    print(overrides)
     fi = (overrides/f'{pipette_id}.json').open()
     try:
         return json.load(fi)
@@ -370,7 +373,7 @@ def ensure_value(
 def known_pipettes() -> Sequence[str]:
     """ List pipette IDs for which we have known overrides """
     return [fi.stem
-            for fi in CONFIG['pipette_config_overrides_dir'].iterdir()
+            for fi in config.CONFIG['pipette_config_overrides_dir'].iterdir()
             if fi.is_file() and '.json' in fi.suffixes]
 
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -31,56 +31,43 @@ def api_client(hardware) -> TestClient:
 
 
 @pytest.fixture(scope="session")
-def server_temporary_directory():
+def server_temp_directory():
     new_dir = tempfile.mkdtemp()
-    ## SOLUTION 1: Set API config environment again
-    ## to be the new directory. Reload the configuration
-    ## elements so that infer directory is called again
     os.environ['OT_API_CONFIG_DIR'] = new_dir
     config.reload()
 
-    ## SOLUTION 2: Manually set the pipette config dict
-    ## path to be the 'temporary directory / pipettes'
-    # old_path = config.CONFIG['pipette_config_overrides_dir']
-    # pipette_directory_path = os.path.join(new_dir, 'pipettes')
-    # os.mkdir(pipette_directory_path)
-    # config.CONFIG['pipette_config_overrides_dir'] = pipette_directory_path
     yield new_dir
     shutil.rmtree(new_dir)
 
-    ## SOLUTION 1 clean up
     del os.environ['OT_API_CONFIG_DIR']
-
-    ## SOLUTION 2 clean up
-    # config.CONFIG['pipette_config_overrides_dir'] = old_path
 
 
 @pytest.fixture(scope="session")
-def run_server(server_temporary_directory):
+def run_server(server_temp_directory):
     with subprocess.Popen([sys.executable, "-m", "robot_server.main"],
                           env={'OT_ROBOT_SERVER_DOT_ENV_PATH': "test.env",
-                               'OT_API_CONFIG_DIR': server_temporary_directory},
+                               'OT_API_CONFIG_DIR': server_temp_directory},
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:
         # Wait for a bit to get started
-        time.sleep(5)
+        # Note, we should investigate using
+        # symlinks for the file copy to avoid
+        # having such a long sleep
+        time.sleep(10)
         yield proc
         proc.kill()
 
 
 @pytest.fixture
-def attach_pipettes(server_temporary_directory, monkeypatch):
+def attach_pipettes(server_temp_directory, monkeypatch):
     import json
 
     pipette = {
         "dropTipShake": True,
         "model": "p300_multi_v1"
     }
-    ## SOLUTION 3: Use monkeypatch's set env to set the directory
-    ## environment variable here
-    # monkeypatch.setenv('OT_API_CONFIG_DIR', server_temporary_directory)
 
-    pipette_dir_path = os.path.join(server_temporary_directory, 'pipettes')
+    pipette_dir_path = os.path.join(server_temp_directory, 'pipettes')
     pipette_file_path = os.path.join(pipette_dir_path, 'testpipette01.json')
 
     with open(pipette_file_path, 'w') as pipette_file:

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -50,8 +50,8 @@ def run_server(server_temp_directory):
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:
         # Wait for a bit to get started
-        # Note, we should investigate using
-        # symlinks for the file copy to avoid
+        # TODO (lc, 23-06-2020) We should investigate
+        # using symlinks for the file copy to avoid
         # having such a long sleep
         time.sleep(15)
         yield proc
@@ -59,7 +59,7 @@ def run_server(server_temp_directory):
 
 
 @pytest.fixture
-def attach_pipettes(server_temp_directory, monkeypatch):
+def attach_pipettes(server_temp_directory):
     import json
 
     pipette = {

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -1,6 +1,9 @@
 import subprocess
 import time
 import sys
+import tempfile
+import os
+import shutil
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +11,7 @@ from starlette.testclient import TestClient
 from robot_server.service.app import app
 from robot_server.service.dependencies import get_hardware
 from opentrons.hardware_control import API, HardwareAPILike
+from opentrons import config
 
 
 @pytest.fixture
@@ -27,9 +31,39 @@ def api_client(hardware) -> TestClient:
 
 
 @pytest.fixture(scope="session")
-def run_server():
+def server_temporary_directory():
+    new_dir = tempfile.mkdtemp()
+    ## SOLUTION 1: Set API config environment again
+    ## to be the new directory. Reload the configuration
+    ## elements so that infer directory is called again
+    os.environ['OT_API_CONFIG_DIR'] = new_dir
+    config.reload()
+
+    ## SOLUTION 2: Manually set the pipette config dict
+    ## path to be the 'temporary directory / pipettes'
+    # old_path = config.CONFIG['pipette_config_overrides_dir']
+    # pipette_directory_path = os.path.join(new_dir, 'pipettes')
+    # os.mkdir(pipette_directory_path)
+    # config.CONFIG['pipette_config_overrides_dir'] = pipette_directory_path
+    yield new_dir
+    shutil.rmtree(new_dir)
+
+    ## SOLUTION 1 clean up
+    del os.environ['OT_API_CONFIG_DIR']
+
+    ## SOLUTION 2 clean up
+    # config.CONFIG['pipette_config_overrides_dir'] = old_path
+
+
+@pytest.fixture(scope="session")
+def run_server(server_temporary_directory):
+    # Here we are loading the test.env into the temporary directory, then
+    # adding in the OT_API_CONFIG_DIR environment variable to the subprocess
+    shutil.copy(f'{os.getcwd()}/test.env', server_temporary_directory)
+    with open(f'{server_temporary_directory}/test.env', 'a') as f:
+        f.write(f'OT_API_CONFIG_DIR={server_temporary_directory}')
     with subprocess.Popen([sys.executable, "-m", "robot_server.main"],
-                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': 'test.env'},
+                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': f'{server_temporary_directory}/test.env'},
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:
         # Wait for a bit to get started
@@ -39,16 +73,20 @@ def run_server():
 
 
 @pytest.fixture
-def attach_pipettes():
+def attach_pipettes(server_temporary_directory, monkeypatch):
     import json
-    import os
+
     pipette = {
         "dropTipShake": True,
         "model": "p300_multi_v1"
     }
-    pipette_file_path = os.path.join(
-        os.path.expanduser('~'), '.opentrons/pipettes', 'testpipette01.json'
-    )
+    ## SOLUTION 3: Use monkeypatch's set env to set the directory
+    ## environment variable here
+    # monkeypatch.setenv('OT_API_CONFIG_DIR', server_temporary_directory)
+
+    pipette_dir_path = os.path.join(server_temporary_directory, 'pipettes')
+    pipette_file_path = os.path.join(pipette_dir_path, 'testpipette01.json')
+
     with open(pipette_file_path, 'w') as pipette_file:
         json.dump(pipette, pipette_file)
     yield

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -53,7 +53,7 @@ def run_server(server_temp_directory):
         # Note, we should investigate using
         # symlinks for the file copy to avoid
         # having such a long sleep
-        time.sleep(10)
+        time.sleep(15)
         yield proc
         proc.kill()
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -57,17 +57,13 @@ def server_temporary_directory():
 
 @pytest.fixture(scope="session")
 def run_server(server_temporary_directory):
-    # Here we are loading the test.env into the temporary directory, then
-    # adding in the OT_API_CONFIG_DIR environment variable to the subprocess
-    shutil.copy(f'{os.getcwd()}/test.env', server_temporary_directory)
-    with open(f'{server_temporary_directory}/test.env', 'a') as f:
-        f.write(f'OT_API_CONFIG_DIR={server_temporary_directory}')
     with subprocess.Popen([sys.executable, "-m", "robot_server.main"],
-                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': f'{server_temporary_directory}/test.env'},
+                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': "test.env",
+                               'OT_API_CONFIG_DIR': server_temporary_directory},
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:
         # Wait for a bit to get started
-        time.sleep(2)
+        time.sleep(5)
         yield proc
         proc.kill()
 


### PR DESCRIPTION
This is a small test change made for PR #5811.

Instead of writing directly to the file system we are using a temporary directory. The copy operation takes awhile which is why the value for `time.sleep()` in the `run_server` fixture is so long.

After the first pass on the labware skip calibration project is finished, I can come back to this to see if we can possibly use symlinks or optimize in some other manner to avoid having such a long sleep time. See #5983 for future work.
