### PR TITLE
fix(app): calcheck: fix display of bad deck transform

### DIFF
--- a/app/src/sessions/calibration-check/constants.js
+++ b/app/src/sessions/calibration-check/constants.js
@@ -66,7 +66,7 @@ export const checkCommands = {
 
 export const CHECK_TRANSFORM_TYPE_INSTRUMENT_OFFSET = 'BAD_INSTRUMENT_OFFSET'
 export const CHECK_TRANSFORM_TYPE_UNKNOWN = 'UNKNOWN'
-export const CHECK_TRANSFORM_TYPE_DECK = 'BAD_DECK_CAL_STATUS'
+export const CHECK_TRANSFORM_TYPE_DECK = 'BAD_DECK_TRANSFORM'
 
 export const CHECK_PIPETTE_RANK_FIRST: 'first' = 'first'
 export const CHECK_PIPETTE_RANK_SECOND: 'second' = 'second'


### PR DESCRIPTION
Looks like 2bb54a999d682da246884c87bcf29075058878a3 accidentally changed
the value for a bad deck transform value from the api, might have been
an overzealous find and replace. This value should match the value in
opentrons.calibration.helper_classes

## Testing
- Induce a bad deck cal and make sure it displays the reason instead of "Bad Detected"

## Risk assessment
Low, but check both the individual step outcome and the end of flow summary