### PR TITLE
feat(shared-data): add labware definitions for calibration block

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
@@ -25,26 +25,14 @@
     {
       "metadata": {
         "displayName": "Opentrons Calibration Block - Short Side",
-        "displayCategory": "other",
         "wellBottomShape": "flat"
-      },
-      "brand": {
-        "brand": "Opentrons",
-        "brandId": [],
-        "links": []
       },
       "wells": ["A1"]
     },
     {
       "metadata": {
         "displayName": "Opentrons Calibration Block - Tall Side",
-        "displayCategory": "other",
         "wellBottomShape": "flat"
-      },
-      "brand": {
-        "brand": "Opentrons",
-        "brandId": [],
-        "links": []
       },
       "wells": ["A2"]
     }

--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
@@ -33,9 +33,7 @@
         "brandId": [],
         "links": []
       },
-      "wells": [
-        "A1"
-      ]
+      "wells": ["A1"]
     },
     {
       "metadata": {
@@ -48,9 +46,7 @@
         "brandId": [],
         "links": []
       },
-      "wells": [
-        "A2"
-      ]
+      "wells": ["A2"]
     }
   ],
   "brand": {
@@ -75,14 +71,7 @@
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_calibrationblock_short_side_left"
   },
-  "ordering": [
-    [
-      "A1"
-    ],
-    [
-      "A2"
-    ]
-  ],
+  "ordering": [["A1"], ["A2"]],
   "namespace": "opentrons",
   "version": 1,
   "schemaVersion": 2,

--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_left/1.json
@@ -1,0 +1,94 @@
+{
+  "wells": {
+    "A1": {
+      "totalLiquidVolume": 0,
+      "xDimension": 63.88,
+      "yDimension": 85.5,
+      "shape": "rectangular",
+      "depth": 0,
+      "x": 31.94,
+      "y": 42.75,
+      "z": 33
+    },
+    "A2": {
+      "totalLiquidVolume": 0,
+      "xDimension": 63.88,
+      "yDimension": 85.5,
+      "shape": "rectangular",
+      "depth": 0,
+      "x": 95.81,
+      "y": 42.75,
+      "z": 62.5
+    }
+  },
+  "groups": [
+    {
+      "metadata": {
+        "displayName": "Opentrons Calibration Block - Short Side",
+        "displayCategory": "other",
+        "wellBottomShape": "flat"
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": []
+      },
+      "wells": [
+        "A1"
+      ]
+    },
+    {
+      "metadata": {
+        "displayName": "Opentrons Calibration Block - Tall Side",
+        "displayCategory": "other",
+        "wellBottomShape": "flat"
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": []
+      },
+      "wells": [
+        "A2"
+      ]
+    }
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons Calibration Block - Short Side: Left",
+    "displayCategory": "aluminumBlock",
+    "displayVolumeUnits": "mL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.75,
+    "yDimension": 85.5,
+    "zDimension": 62.5
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_calibrationblock_short_side_left"
+  },
+  "ordering": [
+    [
+      "A1"
+    ],
+    [
+      "A2"
+    ]
+  ],
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
@@ -1,0 +1,94 @@
+{
+  "wells": {
+    "A1": {
+      "totalLiquidVolume": 0,
+      "xDimension": 63.88,
+      "yDimension": 85.5,
+      "shape": "rectangular",
+      "depth": 0,
+      "x": 31.94,
+      "y": 42.75,
+      "z": 62.5
+    },
+    "A2": {
+      "totalLiquidVolume": 0,
+      "xDimension": 63.88,
+      "yDimension": 85.5,
+      "shape": "rectangular",
+      "depth": 0,
+      "x": 95.81,
+      "y": 42.75,
+      "z": 33
+    }
+  },
+  "groups": [
+    {
+      "metadata": {
+        "displayName": "Opentrons Calibration Block - Tall Side",
+        "displayCategory": "other",
+        "wellBottomShape": "flat"
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": []
+      },
+      "wells": [
+        "A1"
+      ]
+    },
+    {
+      "metadata": {
+        "displayName": "Opentrons Calibration Block - Short Side",
+        "displayCategory": "other",
+        "wellBottomShape": "flat"
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": []
+      },
+      "wells": [
+        "A2"
+      ]
+    }
+  ],
+  "brand": {
+    "brand": "Opentrons",
+    "brandId": [],
+    "links": []
+  },
+  "metadata": {
+    "displayName": "Opentrons Calibration Block - Short Side: Right",
+    "displayCategory": "aluminumBlock",
+    "displayVolumeUnits": "mL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.75,
+    "yDimension": 85.5,
+    "zDimension": 62.5
+  },
+  "parameters": {
+    "format": "irregular",
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "opentrons_calibrationblock_short_side_right"
+  },
+  "ordering": [
+    [
+      "A1"
+    ],
+    [
+      "A2"
+    ]
+  ],
+  "namespace": "opentrons",
+  "version": 1,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  }
+}

--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
@@ -33,9 +33,7 @@
         "brandId": [],
         "links": []
       },
-      "wells": [
-        "A1"
-      ]
+      "wells": ["A1"]
     },
     {
       "metadata": {
@@ -48,9 +46,7 @@
         "brandId": [],
         "links": []
       },
-      "wells": [
-        "A2"
-      ]
+      "wells": ["A2"]
     }
   ],
   "brand": {
@@ -75,14 +71,7 @@
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_calibrationblock_short_side_right"
   },
-  "ordering": [
-    [
-      "A1"
-    ],
-    [
-      "A2"
-    ]
-  ],
+  "ordering": [["A1"], ["A2"]],
   "namespace": "opentrons",
   "version": 1,
   "schemaVersion": 2,

--- a/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
+++ b/shared-data/labware/definitions/2/opentrons_calibrationblock_short_side_right/1.json
@@ -25,26 +25,14 @@
     {
       "metadata": {
         "displayName": "Opentrons Calibration Block - Tall Side",
-        "displayCategory": "other",
         "wellBottomShape": "flat"
-      },
-      "brand": {
-        "brand": "Opentrons",
-        "brandId": [],
-        "links": []
       },
       "wells": ["A1"]
     },
     {
       "metadata": {
         "displayName": "Opentrons Calibration Block - Short Side",
-        "displayCategory": "other",
         "wellBottomShape": "flat"
-      },
-      "brand": {
-        "brand": "Opentrons",
-        "brandId": [],
-        "links": []
       },
       "wells": ["A2"]
     }


### PR DESCRIPTION
# Overview
This PR adds two irregular labware definitions for the Opentrons Calibration Block, representing the two different orientation that the block can be situated inside a slot:
* `opentrons_calibrationblock_short_side_left`: short side on the left of the slot
* `opentrons_calibrationblock_short_side_right`: short side on the right of the slot

Each of these definitions consists of two wells - both have different z-offsets (tall side: 62.5 mm, short side: 33.0 mm) and a depth of 0mm.

The following generates the `opentrons_calibrationblock_short_side_right` using the labware creator tool:
```
const opt = {
  namespace: 'opentrons',
  metadata: {
    displayName: 'Opentrons Calibration Block - Short: Right',
    displayCategory: 'aluminumBlock',
    displayVolumeUnits: 'mL',
    tags: [],
  },
  parameters: {
    format: 'irregular',
    isTiprack: false,
    isMagneticModuleCompatible: false,
  },
  dimensions: {
    xDimension: 127.75,
    yDimension: 85.5,
    zDimension: 62.5,
  },
  offset: [{ x: 31.94, y: 42.75, z: 62.5 }, { x: 95.81, y: 42.75, z: 33.0 }],
  grid: [{ row: 1, column: 1 }, { row: 1, column: 1 }],
  spacing: [{ row: 0, column: 0 }, { row: 0, column: 0 }],
  well: [
    {
      totalLiquidVolume: 0,
      xDimension: 63.88,
      yDimension: 85.5,
      shape: 'rectangular',
      depth: 0,
    },
    {
      totalLiquidVolume: 0,
      xDimension: 63.88,
      yDimension: 85.5,
      shape: 'rectangular',
      depth: 0,
    },
  ],
  gridStart: [
    { rowStart: 'A', colStart: '1', rowStride: 1, colStride: 1 },
    { rowStart: 'A', colStart: '2', rowStride: 1, colStride: 1 },
  ],
  group: [
    {
      metadata: {
        displayName: 'Opentrons Calibration Block - Short Side'
        wellBottomShape: 'flat',
      },
    },
    {
      metadata: {
        displayName: 'Opentrons Calibration Block - Tall Side'
        wellBottomShape: 'flat',
      },
    },
  ],
  brand: {
    brand: 'Opentrons',
    brandId: [],
    links: [],
  },
}

// load name will need to be edited manually
const lw = sharedData.createIrregularLabware(opt)
```

closes #5618



# Risk assessment
low, since this is a new feature and is intended to be used during calibration only
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
