### PR TITLE
feat(api): ensure stable load_module order in JSON executor

### DIFF
--- a/api/src/opentrons/protocol_api/execute_v4.py
+++ b/api/src/opentrons/protocol_api/execute_v4.py
@@ -57,9 +57,19 @@ def load_modules_from_json(
         protocol: 'JsonProtocolV4') -> Dict[str, ModuleContext]:
     module_data = protocol['modules']
     modules_by_id = {}
-    for module_id, props in module_data.items():
-        model = props['model']
-        slot = props['slot']
+
+    # the sort order doesn't matter, we just need it to be stable
+    # to ensure `load_module` side-effects are deterministic
+    # (eg, multiple module support)
+    sorted_modules = sorted(
+        module_data.keys(),
+        key=lambda module_id: module_data[module_id]['slot'] +
+        module_data[module_id]['model'])
+
+    for module_id in sorted_modules:
+        module_props = module_data[module_id]
+        model = module_props['model']
+        slot = module_props['slot']
         if slot == TC_SPANNING_SLOT:
             instr = ctx.load_module(model)
         else:

--- a/api/src/opentrons/protocol_api/execute_v4.py
+++ b/api/src/opentrons/protocol_api/execute_v4.py
@@ -62,12 +62,11 @@ def load_modules_from_json(
     # to ensure `load_module` side-effects are deterministic
     # (eg, multiple module support)
     sorted_modules = sorted(
-        module_data.keys(),
-        key=lambda module_id: module_data[module_id]['slot'] +
-        module_data[module_id]['model'])
+        module_data.items(),
+        key=lambda v: v[1]['slot'] +
+        v[1]['model'])
 
-    for module_id in sorted_modules:
-        module_props = module_data[module_id]
+    for module_id, module_props in sorted_modules:
         model = module_props['model']
         slot = module_props['slot']
         if slot == TC_SPANNING_SLOT:


### PR DESCRIPTION
# Overview

In preparation for multi-module support, this PR ensures that the v4 JSON executor calls `load_module` in a stable order, instead of relying on `Dictionary.items` arbitrary order.

# Changelog

- load modules in stable order
- add tests around ordering

# Review requests

- V4 JSON protocols with modules should run as before
- Code review

# Risk assessment

Low, shouldn't affect any existing behaviors, because `load_module` order shouldn't matter yet