### PR TITLE
test(shared-data): remove applicationData from non-PD JSON fixture

### DIFF
--- a/shared-data/protocol/fixtures/4/testThermocyclerModuleV4.json
+++ b/shared-data/protocol/fixtures/4/testThermocyclerModuleV4.json
@@ -8,43 +8,6 @@
     "subcategory": null,
     "tags": []
   },
-  "designerApplication": {
-    "name": "opentrons/protocol-designer",
-    "version": "4.0.1",
-    "data": {
-      "_internalAppBuildDate": "Wed, 29 Apr 2020 15:30:24 GMT",
-      "defaultValues": {
-        "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
-        "touchTip_mmFromTop": -1,
-        "blowout_mmFromTop": 0
-      },
-      "pipetteTiprackAssignments": {
-        "de8061b0-8a4a-11ea-b2bb-0d8365e806c3": "opentrons/opentrons_96_tiprack_20ul/1"
-      },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
-      "ingredients": {},
-      "ingredLocations": {},
-      "savedStepForms": {
-        "__INITIAL_DECK_SETUP_STEP__": {
-          "stepType": "manualIntervention",
-          "id": "__INITIAL_DECK_SETUP_STEP__",
-          "labwareLocationUpdate": {
-            "trashId": "12",
-            "de82f9c0-8a4a-11ea-b2bb-0d8365e806c3:opentrons/opentrons_96_tiprack_20ul/1": "1",
-            "e5860500-8a4a-11ea-b2bb-0d8365e806c3:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "someThermocyclerModuleId"
-          },
-          "pipetteLocationUpdate": {
-            "de8061b0-8a4a-11ea-b2bb-0d8365e806c3": "left"
-          },
-          "moduleLocationUpdate": {
-            "someThermocyclerModuleId": "span7_8_10_11"
-          }
-        }
-      },
-      "orderedStepIds": []
-    }
-  },
   "robot": { "model": "OT-2 Standard" },
   "pipettes": {
     "de8061b0-8a4a-11ea-b2bb-0d8365e806c3": {


### PR DESCRIPTION
# Overview

This fixture has `applicationData` written as if it was a PD protocol. But this should be a JSON fixture, not a PD fixture. It's confusing because if you open this file in PD, PD will treat it as a protocol with no steps, and re-saving it yields a protocol with no commands. The fixture itself has commands, but no PD metadata (savedStepForms) that PD needs to generate commands.

Instead, this PR removes the extraneous `applicationData` data so PD won't be able to open this fixture, just like all the other fixtures.

# Changelog


# Review requests

- Code review
- CI should still pass

# Risk assessment

None (if CI passes), just change to a fixture