### PR TITLE
refactor(protocol-designer): fix TipPositionField-related types

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -38,8 +38,8 @@ type OP = {| fieldName: TipOffsetFields, className?: string |}
 
 type SP = {|
   disabled: boolean,
-  mmFromBottom: number,
-  wellDepthMm: number,
+  mmFromBottom: number | null,
+  wellDepthMm: number | null,
 |}
 
 type Props = { ...OP, ...SP }
@@ -60,10 +60,10 @@ function TipPositionInput(props: Props) {
   const isTouchTipField = getIsTouchTipField(props.fieldName)
 
   let value = ''
-  if (wellDepthMm != null) {
+  if (wellDepthMm !== null) {
     // show default value for field in parens if no mmFromBottom value is selected
     value =
-      mmFromBottom != null
+      mmFromBottom !== null
         ? mmFromBottom
         : getDefaultMmFromBottom({ fieldName, wellDepthMm })
   }
@@ -141,10 +141,8 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
 
   return {
     disabled: rawForm ? getDisabledFields(rawForm).has(fieldName) : false,
-    // $FlowFixMe(mc, 2020-06-05): fix types here and in TipPositionModal
     wellDepthMm,
-    // $FlowFixMe(mc, 2020-06-05): fix types here and in TipPositionModal
-    mmFromBottom: rawForm && rawForm[fieldName],
+    mmFromBottom: rawForm?.[fieldName] ?? null,
   }
 }
 


### PR DESCRIPTION
# Overview

Closes #5830

# Changelog

- refactor TipPositionField files to represent types correctly

# Review requests

This PR shouldn't change any behavior, should be a pure refactor. It's not types-only, but TipPositionModal should act the same as `edge`

- Code review
- Tip position modal should act the same (compare both touch-tip positioning, and asp/disp positioning to edge)

# Risk assessment

Low, should be pure refactor.