### PR TITLE
fix(app): fix clunky text wrapping for multi tip pick up in cal check

### DIFF
--- a/app/src/components/CheckCalibration/TipPickUp.js
+++ b/app/src/components/CheckCalibration/TipPickUp.js
@@ -113,9 +113,7 @@ export function TipPickUp(props: TipPickUpProps): React.Node {
             <p className={styles.tip_pick_up_demo_body}>
               {jogUntilAbove}
               <b>&nbsp;{tipRackWellName}&nbsp;</b>
-              {POSITION}
-              <br />
-              {AND}
+              {`${POSITION} ${AND}`}
               <b>&nbsp;{FLUSH}&nbsp;</b>
               {WITH_TOP_OF_TIP}
             </p>


### PR DESCRIPTION
# Overview

Let dynamic copy in cal check tip pick up flow naturally to avoid clunk text wrapping with multi channel text.  


Before:

![Screen Shot 2020-06-29 at 5 31 21 PM](https://user-images.githubusercontent.com/4731953/86028077-7c370100-b9ff-11ea-939f-672403568664.png)


After:

<img width="606" alt="Screen Shot 2020-06-29 at 11 57 36 AM" src="https://user-images.githubusercontent.com/4731953/86028333-c4eeba00-b9ff-11ea-91c5-e971083c67a3.png">
