### PR TITLE
fix(shared-data): do not show calibration block defs in the labware library

### DIFF
--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -33,6 +33,8 @@ export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_1_trash_1100ml_fixed',
   'eppendorf_96_tiprack_1000ul_eptips',
   'eppendorf_96_tiprack_10ul_eptips',
+  'opentrons_calibrationblock_short_side_left',
+  'opentrons_calibrationblock_short_side_right',
 ]
 
 export function getLabwareV1Def(labwareName: string): ?LabwareDefinition1 {


### PR DESCRIPTION


# Overview
This PR hides the calibration block definitions created in #5993 from being shown in the labware library
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
# Changelog
Add calibration block load names to the `LABWARE_DO_NOT_LIST`