### PR TITLE
fix(api): db write optimization

### DIFF
--- a/api/src/opentrons/data_storage/database.py
+++ b/api/src/opentrons/data_storage/database.py
@@ -120,7 +120,7 @@ def _load_well_object_from_db(db, well_data):
     x -= (well.x_size() / 2)
     y -= (well.y_size() / 2)
     well_coordinates = (x, y, z)
-    return (well, location, well_coordinates)
+    return well, location, well_coordinates
 
 
 def _list_all_containers_by_name(db):

--- a/api/src/opentrons/data_storage/database.py
+++ b/api/src/opentrons/data_storage/database.py
@@ -45,8 +45,11 @@ def _create_container_obj_in_db(db, container: Container, container_name: str):
     db_queries.create_container(
         db, container_name, **_parse_container_obj(container)
     )
-    for well in iter(container):
-        _create_well_obj_in_db(db, container_name, well)
+
+    well_data = (_parse_well_obj(well) for well in iter(container))
+    well_rows = (db_queries.WellRow(container_name=container_name, **w)
+                 for w in well_data)
+    db_queries.insert_wells_into_db(db, well_rows)
 
 
 def _load_container_object_from_db(db, container_name: str):
@@ -97,7 +100,8 @@ def _delete_container_object_in_db(db, container_name: str):
 def _create_well_obj_in_db(db, container_name: str, well: Well):
     well_data = _parse_well_obj(well)
     db_queries.insert_well_into_db(
-        db_conn=db, container_name=container_name, **well_data
+        db_conn=db,
+        well=db_queries.WellRow(container_name=container_name, **well_data)
     )
 
 

--- a/api/src/opentrons/data_storage/database_migration.py
+++ b/api/src/opentrons/data_storage/database_migration.py
@@ -92,7 +92,7 @@ def _ensure_trash():
     """
     load_all_containers_from_disk()
 
-    to_load = set(['fixed-trash', 'tall-fixed-trash'])
+    to_load = {'fixed-trash', 'tall-fixed-trash'}
     present = set(database.list_all_containers())
     to_update = to_load - present
     log.info(f"_ensure_trash: loading {to_update}")

--- a/api/src/opentrons/data_storage/database_queries.py
+++ b/api/src/opentrons/data_storage/database_queries.py
@@ -1,6 +1,9 @@
-
+import typing
 
 # ------------- Configuration Functions -------------#
+from collections import namedtuple
+
+
 def get_user_version(db_conn):
     with db_conn:
         cursor = db_conn.cursor()
@@ -69,22 +72,35 @@ def delete_container(db_conn, container_name):
 
 
 # ------------- Well Functions -------------#
-def insert_well_into_db(db_conn, container_name, location, x, y, z,
-                        depth, volume, diameter, length, width):
+
+
+WellRow = namedtuple("WellRow", [
+    'container_name',
+    'location',
+    'x',
+    'y',
+    'z',
+    'depth',
+    'volume',
+    'diameter',
+    'length',
+    'width'
+])
+
+
+def insert_well_into_db(db_conn, well: WellRow):
     with db_conn:
         db_conn.execute(
             'INSERT INTO ContainerWells VALUES (?,?,?,?,?,?,?,?,?,?)',
-            (
-                container_name,
-                location,
-                x,
-                y,
-                z,
-                depth,
-                volume,
-                diameter,
-                length,
-                width,)
+            well
+        )
+
+
+def insert_wells_into_db(db_conn, wells: typing.Iterable[WellRow]):
+    with db_conn:
+        db_conn.executemany(
+            'INSERT INTO ContainerWells VALUES (?,?,?,?,?,?,?,?,?,?)',
+            wells
         )
 
 

--- a/api/src/opentrons/data_storage/old_container_loading.py
+++ b/api/src/opentrons/data_storage/old_container_loading.py
@@ -84,8 +84,9 @@ def get_persisted_container(container_name: str) -> Container:
     container_data = persisted_containers_dict.get(container_name)
     if not container_data:
         raise ValueError(
-            ('Container type "{}" not found in files: {}')
-            .format(container_name, containers_file_list)
+            'Container type "{}" not found in files: {}'.format(
+                container_name, containers_file_list
+            )
         )
     return create_container_obj_from_dict(container_data)
 

--- a/api/src/opentrons/data_storage/old_container_loading.py
+++ b/api/src/opentrons/data_storage/old_container_loading.py
@@ -171,9 +171,10 @@ def create_container_obj_from_dict(container_data: dict) -> Container:
             }
     """
     container_data = copy.deepcopy(container_data)
-    origin_offset_x = container_data.get('origin-offset', {}).get('x') or 0
-    origin_offset_y = container_data.get('origin-offset', {}).get('y') or 0
-    origin_offset_z = container_data.get('origin-offset', {}).get('z') or 0
+    origin_offsets = container_data.get('origin-offset', {})
+    origin_offset_x = origin_offsets.get('x', 0)
+    origin_offset_y = origin_offsets.get('y', 0)
+    origin_offset_z = origin_offsets.get('z', 0)
 
     container = Container()
     locations = container_data['locations']


### PR DESCRIPTION
# Overview

Database migration takes a very long time. This attempts to reduce that time by reducing the number of inserts we make.

# Changelog

- added insert_wells_into_db that uses `executemany` to insert a number of rows vs just one.

# Review requests

# How I tested

Ran the the full migration on `edge` and in `api_db_speed`.  Then compared the two databases (steps 9 and 12 should show no differences in the files).  Also, observing that robot-server takes longer to be ready in step 3 than step 6.

```
1. git checkout edge
2. rm ~/.opentrons/opentrons.db
3. make -C robot-server dev
4. mv ~/.opentrons/opentrons.db ~/.opentrons/opentrons_orig.db 
5. git checkout api_db_speed
6. make -C robot-server dev
7. sqlite3 ~/.opentrons/opentrons_orig.db "select * from Containers order by name" > orig.txt
8. sqlite3 ~/.opentrons/opentrons.db "select * from Containers order by name" > new.txt
9. diff new.txt orig.txt
10. sqlite3 ~/.opentrons/opentrons.db "select * from ContainerWells order by container_name" > new.txt
11. sqlite3 ~/.opentrons/opentrons_orig.db "select * from ContainerWells order by container_name" > orig.txt
12. diff orig.txt new.txt

```

# Risk assessment

Low. Only affects database migration.


closes #6029 , #5983 