### PR TITLE
feat(protocol-designer): show confirm modal before losing form's unsaved changes

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -8,7 +8,6 @@ import {
   useHoverTooltip,
   TOOLTIP_RIGHT,
   TOOLTIP_FIXED,
-  AlertModal,
 } from '@opentrons/components'
 import {
   MAGNETIC_MODULE_TYPE,
@@ -21,6 +20,7 @@ import {
   selectors as stepFormSelectors,
   getIsModuleOnDeck,
 } from '../step-forms'
+import { ConfirmDeleteStepModal } from './modals/ConfirmDeleteStepModal'
 import { Portal } from './portals/MainPageModalPortal'
 import { stepIconsByType, type StepType } from '../form-types'
 import styles from './listButtons.css'
@@ -94,6 +94,9 @@ export const StepCreationButton = (): React.Node => {
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )
+  const formHasChanges = useSelector(
+    stepFormSelectors.getCurrentFormHasUnsavedChanges
+  )
   const modules = useSelector(stepFormSelectors.getInitialDeckSetup).modules
   const isStepTypeEnabled = {
     moveLiquid: true,
@@ -122,7 +125,7 @@ export const StepCreationButton = (): React.Node => {
       onClick={() => {
         setExpanded(false)
 
-        if (currentFormIsPresaved) {
+        if (currentFormIsPresaved || formHasChanges) {
           setEnqueuedStepType(stepType)
         } else {
           addStep(stepType)
@@ -135,29 +138,16 @@ export const StepCreationButton = (): React.Node => {
     <>
       {enqueuedStepType !== null && (
         <Portal>
-          <AlertModal
-            heading="Unsaved step form"
-            alertOverlay
-            buttons={[
-              {
-                children: 'Continue',
-                onClick: () => setEnqueuedStepType(null),
-              },
-              {
-                children: 'Delete Step',
-                onClick: () => {
-                  if (enqueuedStepType !== null) {
-                    addStep(enqueuedStepType)
-                    setEnqueuedStepType(null)
-                  }
-                },
-              },
-            ]}
-          >
-            <p style={{ lineHeight: 1.5 }}>
-              {i18n.t('modal.delete_step.body')}
-            </p>
-          </AlertModal>
+          <ConfirmDeleteStepModal
+            close
+            onCancelClick={() => setEnqueuedStepType(null)}
+            onContinueClick={() => {
+              if (enqueuedStepType !== null) {
+                addStep(enqueuedStepType)
+                setEnqueuedStepType(null)
+              }
+            }}
+          ></ConfirmDeleteStepModal>
         </Portal>
       )}
       <StepCreationButtonComponent

--- a/protocol-designer/src/components/StepEditForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/index.js
@@ -142,14 +142,22 @@ const getDirtyFields = (
 
 type StepEditFormManagerProps = {|
   // TODO(IL, 2020-04-22): use HydratedFormData type see #3161
-  formData: ?FormData,
-  isNewStep: boolean,
   canSave: boolean,
+  formData: ?FormData,
+  formHasChanges: boolean,
+  isNewStep: boolean,
   isPristineSetTempForm: boolean,
 |}
 
 const StepEditFormManager = (props: StepEditFormManagerProps) => {
-  const { canSave, formData, isNewStep, isPristineSetTempForm } = props
+  const {
+    canSave,
+    formData,
+    isNewStep,
+    formHasChanges,
+    isPristineSetTempForm,
+  } = props
+
   const [
     showMoreOptionsModal,
     setShowMoreOptionsModal,
@@ -202,7 +210,7 @@ const StepEditFormManager = (props: StepEditFormManagerProps) => {
     confirm: confirmClose,
     showConfirmation: showConfirmCancelModal,
     cancel: cancelClose,
-  } = useConditionalConfirm(handleClose, isNewStep)
+  } = useConditionalConfirm(handleClose, isNewStep || formHasChanges)
 
   const {
     confirm: confirmAddPauseUntilTempStep,
@@ -264,9 +272,10 @@ const StepEditFormManager = (props: StepEditFormManagerProps) => {
 
 const mapStateToProps = (state: BaseState): StepEditFormManagerProps => {
   return {
-    formData: stepFormSelectors.getHydratedUnsavedForm(state),
-    isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
     canSave: stepFormSelectors.getCurrentFormCanBeSaved(state),
+    formData: stepFormSelectors.getHydratedUnsavedForm(state),
+    formHasChanges: stepFormSelectors.getCurrentFormHasUnsavedChanges(state),
+    isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
     isPristineSetTempForm: stepFormSelectors.getUnsavedFormIsPristineSetTempForm(
       state
     ),

--- a/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
+++ b/protocol-designer/src/components/modals/ConfirmDeleteStepModal.js
@@ -14,8 +14,14 @@ export function ConfirmDeleteStepModal(props: Props): React.Node {
   const { close, ...continueModalProps } = props
   return (
     <Portal>
-      <ContinueModal className={modalStyles.modal} {...continueModalProps}>
-        <p>{i18n.t('modal.close_step.body')}</p>
+      <ContinueModal
+        className={modalStyles.modal}
+        {...(close ? { heading: 'Unsaved Step form' } : null)}
+        {...continueModalProps}
+      >
+        <p>
+          {i18n.t(close ? 'modal.close_step.body' : 'modal.delete_step.body')}
+        </p>
       </ContinueModal>
     </Portal>
   )

--- a/protocol-designer/src/components/steplist/TerminalItem/index.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.js
@@ -7,7 +7,10 @@ import {
   getSelectedTerminalItemId,
   actions as stepsActions,
 } from '../../../ui/steps'
-import { getCurrentFormIsPresaved } from '../../../step-forms/selectors'
+import {
+  getCurrentFormIsPresaved,
+  getCurrentFormHasUnsavedChanges,
+} from '../../../step-forms/selectors'
 import { ConfirmDeleteStepModal } from '../../modals/ConfirmDeleteStepModal'
 import { PDTitledList } from '../../lists'
 import type { TerminalItemId } from '../../../steplist'
@@ -27,6 +30,7 @@ export const TerminalItem = (props: Props): React.Node => {
   const hovered = useSelector(getHoveredTerminalItemId) === id
   const selected = useSelector(getSelectedTerminalItemId) === id
   const currentFormIsPresaved = useSelector(getCurrentFormIsPresaved)
+  const formHasChanges = useSelector(getCurrentFormHasUnsavedChanges)
 
   const dispatch = useDispatch()
 
@@ -37,13 +41,14 @@ export const TerminalItem = (props: Props): React.Node => {
 
   const { confirm, showConfirmation, cancel } = useConditionalConfirm(
     selectItem,
-    currentFormIsPresaved
+    currentFormIsPresaved || formHasChanges
   )
 
   return (
     <>
       {showConfirmation && (
         <ConfirmDeleteStepModal
+          close
           onContinueClick={confirm}
           onCancelClick={cancel}
         />

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -69,6 +69,9 @@ export const ConnectedStepItem = (props: Props): React.Node => {
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )
+  const formHasChanges = useSelector(
+    stepFormSelectors.getCurrentFormHasUnsavedChanges
+  )
   const labwareDefDisplayNamesById = mapValues(
     labwareEntities,
     (l: LabwareEntity) => getLabwareDisplayName(l.def)
@@ -88,7 +91,7 @@ export const ConnectedStepItem = (props: Props): React.Node => {
   // step selection is gated when showConfirmation is true
   const { confirm, showConfirmation, cancel } = useConditionalConfirm(
     selectStep,
-    currentFormIsPresaved
+    currentFormIsPresaved || formHasChanges
   )
 
   const stepItemProps = {
@@ -129,6 +132,7 @@ export const ConnectedStepItem = (props: Props): React.Node => {
     <>
       {showConfirmation && (
         <ConfirmDeleteStepModal
+          close
           onContinueClick={confirm}
           onCancelClick={cancel}
         />

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -80,7 +80,7 @@
     "body": "Update your pipette and tiprack selection. Please note, this may affect your existing protocol steps."
   },
   "close_step": {
-    "body": "You have not saved this step form. If you continue without saving this step will be deleted."
+    "body": "You have unsaved changes in this step form. If you navigate away without saving you will lose these changes."
   },
   "delete_step": {
     "body": "You have not saved this step form. If you navigate away without saving, this step will be deleted."

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -119,6 +119,7 @@ type UnsavedFormActions =
   | CancelStepFormAction
   | SaveStepFormAction
   | DeleteStepAction
+  | DeleteModuleAction
   | SelectTerminalItemAction
   | EditModuleAction
   | SubstituteStepFormPipettesAction
@@ -180,10 +181,11 @@ export const unsavedForm = (
     case 'POPULATE_FORM':
       return action.payload
     case 'CANCEL_STEP_FORM':
-    case 'SELECT_TERMINAL_ITEM':
-    case 'SAVE_STEP_FORM':
+    case 'DELETE_MODULE':
     case 'DELETE_STEP':
     case 'EDIT_MODULE':
+    case 'SAVE_STEP_FORM':
+    case 'SELECT_TERMINAL_ITEM':
       return unsavedFormInitialState
     case 'SUBSTITUTE_STEP_FORM_PIPETTES': {
       // only substitute unsaved step form if its ID is in the start-end range

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -99,12 +99,12 @@ import type {
   ModuleEntities,
 } from '../types'
 import type {
-  CreatePipettesAction,
-  DeletePipettesAction,
-  SubstituteStepFormPipettesAction,
   CreateModuleAction,
-  EditModuleAction,
+  CreatePipettesAction,
   DeleteModuleAction,
+  DeletePipettesAction,
+  EditModuleAction,
+  SubstituteStepFormPipettesAction,
 } from '../actions'
 
 type FormState = FormData | null
@@ -119,6 +119,7 @@ type UnsavedFormActions =
   | CancelStepFormAction
   | SaveStepFormAction
   | DeleteStepAction
+  | CreateModuleAction
   | DeleteModuleAction
   | SelectTerminalItemAction
   | EditModuleAction
@@ -181,6 +182,7 @@ export const unsavedForm = (
     case 'POPULATE_FORM':
       return action.payload
     case 'CANCEL_STEP_FORM':
+    case 'CREATE_MODULE':
     case 'DELETE_MODULE':
     case 'DELETE_STEP':
     case 'EDIT_MODULE':

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -1,6 +1,7 @@
 // @flow
 import type { ElementProps } from 'react'
 import assert from 'assert'
+import isEqual from 'lodash/isEqual'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import { createSelector } from 'reselect'
@@ -384,6 +385,20 @@ const getOrderedSavedForms: Selector<Array<FormData>> = createSelector(
     return orderedStepIds
       .map(stepId => savedStepForms[stepId])
       .filter(form => form && form.id != null) // NOTE: for old protocols where stepId could === 0, need to do != null here
+  }
+)
+
+export const getCurrentFormHasUnsavedChanges: Selector<boolean> = createSelector(
+  getUnsavedForm,
+  getSavedStepForms,
+  (unsavedForm, savedStepForms) => {
+    const id = unsavedForm?.id
+    const savedForm = id != null ? savedStepForms[id] : null
+    if (savedForm == null) {
+      // nonexistent = no unsaved changes
+      return false
+    }
+    return !isEqual(unsavedForm, savedForm)
   }
 )
 

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1166,6 +1166,7 @@ describe('unsavedForm reducer', () => {
 
   const actionTypes = [
     'CANCEL_STEP_FORM',
+    'CREATE_MODULE',
     'DELETE_MODULE',
     'DELETE_STEP',
     'EDIT_MODULE',

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1166,10 +1166,11 @@ describe('unsavedForm reducer', () => {
 
   const actionTypes = [
     'CANCEL_STEP_FORM',
-    'SELECT_TERMINAL_ITEM',
-    'SAVE_STEP_FORM',
+    'DELETE_MODULE',
     'DELETE_STEP',
     'EDIT_MODULE',
+    'SAVE_STEP_FORM',
+    'SELECT_TERMINAL_ITEM',
   ]
   actionTypes.forEach(actionType => {
     it(`should clear the unsaved form when any ${actionType} action is dispatched`, () => {


### PR DESCRIPTION
# Overview

Closes #5472

Also closes #6042, a bug the E2E tests accidentally uncovered due to this feature exposing whether a form has any changes (in a test where a Magnet form shouldn't have any changes, there were changes due to this bug, which failed the E2E tests!)

# Changelog

# Review requests

- Cancelling a previously-saved step form should prompt for confirmation, only if there are changes. This should occur for all 4 methods of cancelling a step form:
- [ ] cancel by clicking Cancel button
- [ ] cancel by clicking another step item
- [ ] cancel by clicking a terminal item
- [ ] cancel by creating a new step

- [ ] If the form doesn't really have changes (either no interaction happened since opening, or whatever you changed you then changed back), then all 4 methods above should not show the confirm modal

- [ ] Deleting a step, with changes or without, should show a modal with unique copy `"You have not saved this step form. If you navigate away without saving, this step will be deleted."`

- [ ] #6042 should be fixed (see ticket)

# Risk assessment

Medium, PD-only