### PR TITLE
refactor(components): add optional data id to Titled List component

### DIFF
--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -13,6 +13,8 @@ export type TitledListProps = {|
   iconName?: ?IconName,
   /** props passed down to icon (`className` and `name` are ignored) */
   iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
+  /** optional ID for the container */
+  id?: string,
   // TODO(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */
   children?: React.Node,
@@ -50,6 +52,7 @@ export function TitledList(props: TitledListProps): React.Node {
     iconName,
     disabled,
     inert,
+    id,
     onCollapseToggle,
     iconProps,
     onMouseEnter,
@@ -92,6 +95,7 @@ export function TitledList(props: TitledListProps): React.Node {
   return (
     <div
       className={className}
+      id={id}
       {...{ onMouseEnter, onMouseLeave, onContextMenu }}
     >
       <div onClick={onClick} className={titleBarClass}>

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -14,7 +14,7 @@ export type TitledListProps = {|
   /** props passed down to icon (`className` and `name` are ignored) */
   iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
   /** optional ID for the container */
-  dataId?: string,
+  'data-test'?: string,
   // TODO(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */
   children?: React.Node,
@@ -52,7 +52,7 @@ export function TitledList(props: TitledListProps): React.Node {
     iconName,
     disabled,
     inert,
-    dataId,
+    'data-test': dataTest,
     onCollapseToggle,
     iconProps,
     onMouseEnter,
@@ -95,7 +95,7 @@ export function TitledList(props: TitledListProps): React.Node {
   return (
     <div
       className={className}
-      data-id={dataId}
+      data-test={dataTest}
       {...{ onMouseEnter, onMouseLeave, onContextMenu }}
     >
       <div onClick={onClick} className={titleBarClass}>

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -14,7 +14,7 @@ export type TitledListProps = {|
   /** props passed down to icon (`className` and `name` are ignored) */
   iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
   /** optional ID for the container */
-  id?: string,
+  dataId?: string,
   // TODO(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */
   children?: React.Node,
@@ -52,7 +52,7 @@ export function TitledList(props: TitledListProps): React.Node {
     iconName,
     disabled,
     inert,
-    id,
+    dataId,
     onCollapseToggle,
     iconProps,
     onMouseEnter,
@@ -95,7 +95,7 @@ export function TitledList(props: TitledListProps): React.Node {
   return (
     <div
       className={className}
-      id={id}
+      data-id={dataId}
       {...{ onMouseEnter, onMouseLeave, onContextMenu }}
     >
       <div onClick={onClick} className={titleBarClass}>

--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -13,7 +13,7 @@ export type TitledListProps = {|
   iconName?: ?IconName,
   /** props passed down to icon (`className` and `name` are ignored) */
   iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
-  /** optional ID for the container */
+  /** optional data test id for the container */
   'data-test'?: string,
   // TODO(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -267,7 +267,7 @@ describe('Protocols with Modules', () => {
 
       // Add Temperature Step w/out Pause
       cy.addStep('temperature')
-      cy.get('[data-id="StepItem_1"]')
+      cy.get('[data-test="StepItem_1"]')
         .contains('temperature')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -320,14 +320,14 @@ describe('Protocols with Modules', () => {
           .contains('pause later')
           .click()
       })
-      cy.get('[data-id="StepItem_1"]').within(() => {
+      cy.get('[data-test="StepItem_1"]').within(() => {
         cy.contains('Temperature module').should('exist')
         cy.contains('Go To', { matchCase: false }).should('exist')
       })
 
       // Add Pause Step until Temp
       cy.addStep('pause')
-      cy.get('[data-id="StepItem_2"]')
+      cy.get('[data-test="StepItem_2"]')
         .contains('pause')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -354,14 +354,14 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_2"]').within(() => {
+      cy.get('[data-test="StepItem_2"]').within(() => {
         cy.contains('Pause Until', { matchCase: false }).should('exist')
         cy.contains('heating up').should('exist')
       })
 
       // Add First Transfer Step
       cy.addStep('transfer')
-      cy.get('[data-id="StepItem_3"]')
+      cy.get('[data-test="StepItem_3"]')
         .contains('transfer')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -408,7 +408,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_3"]').within(() => {
+      cy.get('[data-test="StepItem_3"]').within(() => {
         cy.contains('Aspirate', { matchCase: false }).should('exist')
         cy.contains('Dispense', { matchCase: false }).should('exist')
         cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
@@ -418,7 +418,7 @@ describe('Protocols with Modules', () => {
 
       // Add Engage Magnet Step
       cy.addStep('magnet')
-      cy.get('[data-id="StepItem_4"]')
+      cy.get('[data-test="StepItem_4"]')
         .contains('magnet')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -442,7 +442,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_4"]').within(() => {
+      cy.get('[data-test="StepItem_4"]').within(() => {
         cy.contains('Magnet', { matchCase: false }).should('exist')
         cy.contains('Engage', { matchCase: false }).should('exist')
       })
@@ -465,7 +465,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_5"]')
+      cy.get('[data-test="StepItem_5"]')
         .contains('pause')
         .should('exist')
       cy.get('[data-test="ModuleTag_magneticModuleType"]')
@@ -518,7 +518,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_6"]').within(() => {
+      cy.get('[data-test="StepItem_6"]').within(() => {
         cy.contains('Aspirate', { matchCase: false }).should('exist')
         cy.contains('Dispense', { matchCase: false }).should('exist')
         cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
@@ -535,7 +535,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_7"]')
+      cy.get('[data-test="StepItem_7"]')
         .contains('magnet')
         .should('exist')
 
@@ -554,10 +554,10 @@ describe('Protocols with Modules', () => {
           .contains('Pause protocol now')
           .click()
       })
-      cy.get('[data-id="StepItem_8"]')
+      cy.get('[data-test="StepItem_8"]')
         .contains('Temperature')
         .should('exist')
-      cy.get('[data-id="StepItem_9"]')
+      cy.get('[data-test="StepItem_9"]')
         .contains('pause', { matchCase: false })
         .should('exist')
     })
@@ -568,7 +568,7 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeMagneticModuleType"]').click()
       cy.get('button[name="addMagneticModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('[data-id="StepItem_4"]')
+      cy.get('[data-test="StepItem_4"]')
         .children()
         .first()
         .click()
@@ -580,7 +580,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[data-id="StepItem_7"]').click()
+      cy.get('[data-test="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -608,7 +608,7 @@ describe('Protocols with Modules', () => {
 
       // Verify timeline errors resolved
       cy.openDesignPage()
-      cy.get('[data-id="StepItem_4"]')
+      cy.get('[data-test="StepItem_4"]')
         .children()
         .first()
         .click()
@@ -616,7 +616,7 @@ describe('Protocols with Modules', () => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
       })
-      cy.get('[data-id="StepItem_7"]').click()
+      cy.get('[data-test="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
@@ -627,7 +627,7 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeTemperatureModuleType"]').click()
       cy.get('button[name="addTemperatureModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('[data-id="StepItem_1"]').click()
+      cy.get('[data-test="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -637,7 +637,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[data-id="StepItem_2"]').click()
+      cy.get('[data-test="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -649,7 +649,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[data-id="StepItem_8"]').click()
+      cy.get('[data-test="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -658,7 +658,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[data-id="StepItem_9"]').click()
+      cy.get('[data-test="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -686,7 +686,7 @@ describe('Protocols with Modules', () => {
 
       // Resolve Timeline Errors
       cy.openDesignPage()
-      cy.get('[data-id="StepItem_1"]').click()
+      cy.get('[data-test="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -696,7 +696,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_2"]').click()
+      cy.get('[data-test="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -706,7 +706,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_8"]').click()
+      cy.get('[data-test="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -716,7 +716,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[data-id="StepItem_9"]').click()
+      cy.get('[data-test="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -267,7 +267,7 @@ describe('Protocols with Modules', () => {
 
       // Add Temperature Step w/out Pause
       cy.addStep('temperature')
-      cy.get('[id="StepItem_1"]')
+      cy.get('[data-id="StepItem_1"]')
         .contains('temperature')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -320,14 +320,14 @@ describe('Protocols with Modules', () => {
           .contains('pause later')
           .click()
       })
-      cy.get('[id="StepItem_1"]').within(() => {
+      cy.get('[data-id="StepItem_1"]').within(() => {
         cy.contains('Temperature module').should('exist')
         cy.contains('Go To', { matchCase: false }).should('exist')
       })
 
       // Add Pause Step until Temp
       cy.addStep('pause')
-      cy.get('[id="StepItem_2"]')
+      cy.get('[data-id="StepItem_2"]')
         .contains('pause')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -354,14 +354,14 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_2"]').within(() => {
+      cy.get('[data-id="StepItem_2"]').within(() => {
         cy.contains('Pause Until', { matchCase: false }).should('exist')
         cy.contains('heating up').should('exist')
       })
 
       // Add First Transfer Step
       cy.addStep('transfer')
-      cy.get('[id="StepItem_3"]')
+      cy.get('[data-id="StepItem_3"]')
         .contains('transfer')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -408,7 +408,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_3"]').within(() => {
+      cy.get('[data-id="StepItem_3"]').within(() => {
         cy.contains('Aspirate', { matchCase: false }).should('exist')
         cy.contains('Dispense', { matchCase: false }).should('exist')
         cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
@@ -418,7 +418,7 @@ describe('Protocols with Modules', () => {
 
       // Add Engage Magnet Step
       cy.addStep('magnet')
-      cy.get('[id="StepItem_4"]')
+      cy.get('[data-id="StepItem_4"]')
         .contains('magnet')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -442,7 +442,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_4"]').within(() => {
+      cy.get('[data-id="StepItem_4"]').within(() => {
         cy.contains('Magnet', { matchCase: false }).should('exist')
         cy.contains('Engage', { matchCase: false }).should('exist')
       })
@@ -465,7 +465,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_5"]')
+      cy.get('[data-id="StepItem_5"]')
         .contains('pause')
         .should('exist')
       cy.get('[data-test="ModuleTag_magneticModuleType"]')
@@ -518,7 +518,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_6"]').within(() => {
+      cy.get('[data-id="StepItem_6"]').within(() => {
         cy.contains('Aspirate', { matchCase: false }).should('exist')
         cy.contains('Dispense', { matchCase: false }).should('exist')
         cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
@@ -535,7 +535,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_7"]')
+      cy.get('[data-id="StepItem_7"]')
         .contains('magnet')
         .should('exist')
 
@@ -554,10 +554,10 @@ describe('Protocols with Modules', () => {
           .contains('Pause protocol now')
           .click()
       })
-      cy.get('[id="StepItem_8"]')
+      cy.get('[data-id="StepItem_8"]')
         .contains('Temperature')
         .should('exist')
-      cy.get('[id="StepItem_9"]')
+      cy.get('[data-id="StepItem_9"]')
         .contains('pause', { matchCase: false })
         .should('exist')
     })
@@ -568,7 +568,7 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeMagneticModuleType"]').click()
       cy.get('button[name="addMagneticModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('[id="StepItem_4"]')
+      cy.get('[data-id="StepItem_4"]')
         .children()
         .first()
         .click()
@@ -580,7 +580,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[id="StepItem_7"]').click()
+      cy.get('[data-id="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -608,7 +608,7 @@ describe('Protocols with Modules', () => {
 
       // Verify timeline errors resolved
       cy.openDesignPage()
-      cy.get('[id="StepItem_4"]')
+      cy.get('[data-id="StepItem_4"]')
         .children()
         .first()
         .click()
@@ -616,7 +616,7 @@ describe('Protocols with Modules', () => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
       })
-      cy.get('[id="StepItem_7"]').click()
+      cy.get('[data-id="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
@@ -627,7 +627,7 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeTemperatureModuleType"]').click()
       cy.get('button[name="addTemperatureModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('[id="StepItem_1"]').click()
+      cy.get('[data-id="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -637,7 +637,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[id="StepItem_2"]').click()
+      cy.get('[data-id="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -649,7 +649,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[id="StepItem_8"]').click()
+      cy.get('[data-id="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -658,7 +658,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('[id="StepItem_9"]').click()
+      cy.get('[data-id="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -686,7 +686,7 @@ describe('Protocols with Modules', () => {
 
       // Resolve Timeline Errors
       cy.openDesignPage()
-      cy.get('[id="StepItem_1"]').click()
+      cy.get('[data-id="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -696,7 +696,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_2"]').click()
+      cy.get('[data-id="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -706,7 +706,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_8"]').click()
+      cy.get('[data-id="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -716,7 +716,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('[id="StepItem_9"]').click()
+      cy.get('[data-id="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -2,7 +2,6 @@
 const protocolTitle = 'Modules Test Protocol'
 const tipRack = 'Opentrons 96 Tip Rack 300 µL'
 const tipRackWithoutUnit = 'Opentrons 96 Tip Rack 300'
-const sidePanel = '[class*="SidePanel__panel_contents"]'
 const designPageModal = '#main-page-modal-portal-root'
 const rowLetters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 const defaultTextInput = 'input[type="text"]'
@@ -268,7 +267,7 @@ describe('Protocols with Modules', () => {
 
       // Add Temperature Step w/out Pause
       cy.addStep('temperature')
-      cy.get(sidePanel)
+      cy.get('[id="StepItem_1"]')
         .contains('temperature')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -321,15 +320,14 @@ describe('Protocols with Modules', () => {
           .contains('pause later')
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('2.').should('not.exist')
+      cy.get('[id="StepItem_1"]').within(() => {
         cy.contains('Temperature module').should('exist')
         cy.contains('Go To', { matchCase: false }).should('exist')
       })
 
       // Add Pause Step until Temp
       cy.addStep('pause')
-      cy.get(sidePanel)
+      cy.get('[id="StepItem_2"]')
         .contains('pause')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -356,15 +354,14 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('2.').should('exist')
+      cy.get('[id="StepItem_2"]').within(() => {
         cy.contains('Pause Until', { matchCase: false }).should('exist')
         cy.contains('heating up').should('exist')
       })
 
       // Add First Transfer Step
       cy.addStep('transfer')
-      cy.get(sidePanel)
+      cy.get('[id="StepItem_3"]')
         .contains('transfer')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -411,8 +408,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('3.').should('exist')
+      cy.get('[id="StepItem_3"]').within(() => {
         cy.contains('Aspirate', { matchCase: false }).should('exist')
         cy.contains('Dispense', { matchCase: false }).should('exist')
         cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
@@ -422,7 +418,7 @@ describe('Protocols with Modules', () => {
 
       // Add Engage Magnet Step
       cy.addStep('magnet')
-      cy.get(sidePanel)
+      cy.get('[id="StepItem_4"]')
         .contains('magnet')
         .should('exist')
       cy.get(designPageModal).within(() => {
@@ -446,8 +442,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('4.').should('exist')
+      cy.get('[id="StepItem_4"]').within(() => {
         cy.contains('Magnet', { matchCase: false }).should('exist')
         cy.contains('Engage', { matchCase: false }).should('exist')
       })
@@ -470,9 +465,9 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('5.').should('exist')
-      })
+      cy.get('[id="StepItem_5"]')
+        .contains('pause')
+        .should('exist')
       cy.get('[data-test="ModuleTag_magneticModuleType"]')
         .contains('engaged')
         .should('exist')
@@ -523,6 +518,13 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
+      cy.get('[id="StepItem_6"]').within(() => {
+        cy.contains('Aspirate', { matchCase: false }).should('exist')
+        cy.contains('Dispense', { matchCase: false }).should('exist')
+        cy.contains('Temp Deck Block', { matchCase: false }).should('exist')
+        cy.contains('Mag Deck Well', { matchCase: false }).should('exist')
+        cy.contains('A2:H2').should('exist')
+      })
 
       // Add Disengage Magnet Step
       cy.addStep('magnet')
@@ -533,6 +535,9 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
+      cy.get('[id="StepItem_7"]')
+        .contains('magnet')
+        .should('exist')
 
       // Add Temperature Step w/ Pause
       cy.addStep('temperature')
@@ -549,10 +554,12 @@ describe('Protocols with Modules', () => {
           .contains('Pause protocol now')
           .click()
       })
-      cy.get(sidePanel).within(() => {
-        cy.contains('8.').should('exist')
-        cy.contains('9.').should('exist')
-      })
+      cy.get('[id="StepItem_8"]')
+        .contains('Temperature')
+        .should('exist')
+      cy.get('[id="StepItem_9"]')
+        .contains('pause', { matchCase: false })
+        .should('exist')
     })
 
     it('deletes and replaces modules', () => {
@@ -561,8 +568,9 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeMagneticModuleType"]').click()
       cy.get('button[name="addMagneticModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('h3')
-        .contains('4. magnet', { matchCase: false })
+      cy.get('[id="StepItem_4"]')
+        .children()
+        .first()
         .click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
@@ -572,9 +580,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('h3')
-        .contains('7. magnet', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -602,16 +608,15 @@ describe('Protocols with Modules', () => {
 
       // Verify timeline errors resolved
       cy.openDesignPage()
-      cy.get('h3')
-        .contains('4. magnet', { matchCase: false })
+      cy.get('[id="StepItem_4"]')
+        .children()
+        .first()
         .click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
       })
-      cy.get('h3')
-        .contains('7. magnet', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_7"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer).should('not.exist')
         cy.get('button[disabled]').should('not.exist')
@@ -622,9 +627,7 @@ describe('Protocols with Modules', () => {
       cy.get('button[name="removeTemperatureModuleType"]').click()
       cy.get('button[name="addTemperatureModuleType"]').should('exist')
       cy.openDesignPage()
-      cy.get('h3')
-        .contains('1. temperature', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -634,9 +637,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('h3')
-        .contains('2. pause', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -648,9 +649,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('h3')
-        .contains('8. temperature', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -659,9 +658,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .should('exist')
       })
-      cy.get('h3')
-        .contains('9. pause', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get(alertTitleContainer)
           .contains('error')
@@ -689,9 +686,7 @@ describe('Protocols with Modules', () => {
 
       // Resolve Timeline Errors
       cy.openDesignPage()
-      cy.get('h3')
-        .contains('1. temperature', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_1"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -701,9 +696,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('h3')
-        .contains('2. pause', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_2"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -713,9 +706,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('h3')
-        .contains('8. temperature', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_8"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')
@@ -725,9 +716,7 @@ describe('Protocols with Modules', () => {
           .contains('save', { matchCase: false })
           .click()
       })
-      cy.get('h3')
-        .contains('9. pause', { matchCase: false })
-        .click()
+      cy.get('[id="StepItem_9"]').click()
       cy.get(designPageModal).within(() => {
         cy.get('select').select('TEMP Temp Deck Block')
         cy.get(alertTitleContainer).should('not.exist')

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -88,6 +88,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
       description={Description}
       iconName={error || warning ? 'alert-circle' : iconName}
       iconProps={{ className: iconClassName }}
+      id={`StepItem_${stepNumber}`}
       title={`${stepNumber}. ${props.title ||
         i18n.t(`application.stepType.${stepType}`)}`}
       onClick={selectStep}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -88,7 +88,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
       description={Description}
       iconName={error || warning ? 'alert-circle' : iconName}
       iconProps={{ className: iconClassName }}
-      id={`StepItem_${stepNumber}`}
+      dataId={`StepItem_${stepNumber}`}
       title={`${stepNumber}. ${props.title ||
         i18n.t(`application.stepType.${stepType}`)}`}
       onClick={selectStep}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -88,7 +88,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
       description={Description}
       iconName={error || warning ? 'alert-circle' : iconName}
       iconProps={{ className: iconClassName }}
-      dataId={`StepItem_${stepNumber}`}
+      data-test={`StepItem_${stepNumber}`}
       title={`${stepNumber}. ${props.title ||
         i18n.t(`application.stepType.${stepType}`)}`}
       onClick={selectStep}


### PR DESCRIPTION
# Overview

This PR partially addresses #5725 by adding an optional data-id to the container wrapping the `TitledList` component in component library. I also updated the relevant PD cypress test to use the new data-id as a selector.

# Changelog

- Add optional data-id to `TitledList` component
- Update PD cypress tests to use new data-id in selectors

# Review requests
Code review
E2E tests still pass

# Risk assessment
Low
