### PR TITLE
feat(protocol-designer): add FF for air gap + delay

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -25,6 +25,8 @@ const initialFlags: Flags = {
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ENABLE_THERMOCYCLER:
     process.env.OT_PD_ENABLE_THERMOCYCLER === '1' || false,
+  OT_PD_ENABLE_AIR_GAP_AND_DELAY:
+    process.env.OT_PD_ENABLE_AIR_GAP_AND_DELAY === '1' || false,
 }
 
 // NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -21,3 +21,8 @@ export const getEnableThermocycler: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_THERMOCYCLER
 )
+
+export const getEnableAirGapDelay: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_AIR_GAP_AND_DELAY
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -17,6 +17,7 @@ export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ENABLE_THERMOCYCLER'
+  | 'OT_PD_ENABLE_AIR_GAP_AND_DELAY'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,5 +11,9 @@
   "OT_PD_ENABLE_THERMOCYCLER": {
     "title": "Enable thermocycler module",
     "description": "Allow adding thermocycler modules and steps to protocols."
+  },
+  "OT_PD_ENABLE_AIR_GAP_AND_DELAY": {
+    "title": "Enable Air Gap & Delay",
+    "description": "Allow using the Air Gap and the Delay advanced settings in steps."
   }
 }


### PR DESCRIPTION
# Overview

Closes #6046

# Changelog


# Review requests

- Code looks good
- New toggle should show up in settings page if prerelease mode is enabled, and its state should persist if you refresh the tab

# Risk assessment

Low, PD-only, adding a new FF