### PR TITLE
refactor(protocol-designer): change pipette select to use data-test instead of data-id

### DIFF
--- a/components/src/instrument/PipetteSelect.js
+++ b/components/src/instrument/PipetteSelect.js
@@ -119,7 +119,7 @@ const PipetteNameItem = (props: PipetteNameSpecs) => {
 
   return (
     <Flex
-      data-id={dataIdFormat(
+      data-test={dataIdFormat(
         'PipetteNameItem',
         volumeClass,
         channels,

--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -44,7 +44,7 @@ describe('Protocols with Modules', () => {
         .next()
         .contains('None')
         .click()
-      cy.get('[data-id="PipetteNameItem_p300MultiChannelGen1"]').click()
+      cy.get('[data-test="PipetteNameItem_p300MultiChannelGen1"]').click()
       cy.selectTipRacks(tipRack, tipRack)
 
       // Add modules


### PR DESCRIPTION
# Overview

This PR changes the `PipetteSelect` component in PD to use `data-test` instead of `data-id` to be consistent with the rest of the monorepo.

# Changelog
- Change PipetteSelect component in PD to use `data-test` instead of `data-id`
- Update cypress test to use `data-test` instead of `data-id`

# Risk assessment
Low
