### PR TITLE
fix(protocol-designer): fix TC profile step lid label text

### DIFF
--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -264,9 +264,6 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
   }
 
   if (substeps && substeps.substepType === THERMOCYCLER_PROFILE) {
-    const lidTemperature = makeTemperatureText(substeps.profileTargetLidTemp)
-    const lidLabelText = makeLidLabelText(substeps.lidOpenHold)
-
     return (
       <ModuleStepItems
         labwareDisplayName={substeps.labwareDisplayName}
@@ -276,7 +273,11 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         actionText={i18n.t(`modules.actions.cycling`)}
         moduleType={THERMOCYCLER_MODULE_TYPE}
       >
-        <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
+        <ModuleStepItemRow
+          // NOTE: for TC Profile, lid label text always says "closed" bc Profile runs with lid closed.
+          label={makeLidLabelText(false)}
+          value={makeTemperatureText(substeps.profileTargetLidTemp)}
+        />
         <CollapsibleSubstep
           headerContent={
             <span
@@ -331,7 +332,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
             hideHeader
           />
           <ModuleStepItemRow
-            label={`Lid (${substeps.lidOpenHold ? 'open' : 'closed'})`}
+            label={makeLidLabelText(substeps.lidOpenHold)}
             value={makeTemperatureText(substeps.lidTargetTempHold)}
           />
         </CollapsibleSubstep>


### PR DESCRIPTION
# Overview

Closes #6060

# Changelog


# Review requests

- [ ] TC Profile should always say `Lid (closed)` at the top.
- [ ] TC Profile step item's "Ending Hold" section should show `Lid (open / closed)` depending on what the hold state is in the form
- [ ] No changes to TC State step (should always show `Lid (open / closed)` depending on what the lid state is in the form

# Risk assessment

Low, PD only, still under FF, copy change