### PR TITLE
feat(protocol-designer): add profile button tooltips

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.js
@@ -8,6 +8,8 @@ import {
   Icon,
   Tooltip,
   useHoverTooltip,
+  TOOLTIP_TOP,
+  TOOLTIP_TOP_END,
 } from '@opentrons/components'
 import { i18n } from '../../../localization'
 import { getUnsavedForm } from '../../../step-forms/selectors'
@@ -53,8 +55,14 @@ export const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   const deleteProfileCycle = () =>
     dispatch(steplistActions.deleteProfileCycle({ id: cycleItem.id }))
 
-  const [targetProps, tooltipProps] = useHoverTooltip({
-    placement: 'top',
+  const [
+    addStepToCycleTargetProps,
+    addStepToCycleTooltipProps,
+  ] = useHoverTooltip({
+    placement: TOOLTIP_TOP_END,
+  })
+  const [deleteCycleTargetProps, deleteCycleTooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_TOP,
   })
 
   return (
@@ -93,13 +101,16 @@ export const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
             />
           </div>
         )}
-        <div className={styles.add_cycle_step}>
+        <Tooltip {...addStepToCycleTooltipProps}>
+          {i18n.t('tooltip.profile.add_step_to_cycle')}
+        </Tooltip>
+        <div className={styles.add_cycle_step} {...addStepToCycleTargetProps}>
           <OutlineButton onClick={addStepToCycle}>+ Step</OutlineButton>
         </div>
       </div>
-      <div onClick={deleteProfileCycle} {...targetProps}>
-        <Tooltip {...tooltipProps}>
-          {i18n.t('tooltip.step_fields.profileCycle.deleteCycle')}
+      <div onClick={deleteProfileCycle} {...deleteCycleTargetProps}>
+        <Tooltip {...deleteCycleTooltipProps}>
+          {i18n.t('tooltip.profile.delete_cycle')}
         </Tooltip>
         <Icon name="close" className={styles.delete_step_icon} />
       </div>
@@ -115,6 +126,13 @@ export const ProfileItemRows = (props: ProfileItemRowsProps): React.Node => {
   const dispatch = useDispatch()
   const addProfileCycle = () => dispatch(steplistActions.addProfileCycle(null))
   const addProfileStep = () => dispatch(steplistActions.addProfileStep(null))
+
+  const [addCycleTargetProps, addCycleTooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_TOP,
+  })
+  const [addStepTargetProps, addStepTooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_TOP,
+  })
 
   const unsavedForm = useSelector(getUnsavedForm)
   if (!unsavedForm) {
@@ -163,9 +181,29 @@ export const ProfileItemRows = (props: ProfileItemRowsProps): React.Node => {
         </div>
       )}
       {rows}
+      <Tooltip {...addStepTooltipProps}>
+        {i18n.t('tooltip.profile.add_step')}
+      </Tooltip>
+      <Tooltip {...addCycleTooltipProps}>
+        {i18n.t('tooltip.profile.add_cycle')}
+      </Tooltip>
       <div className={styles.profile_button_group}>
-        <OutlineButton onClick={addProfileStep}>+ Step</OutlineButton>
-        <OutlineButton onClick={addProfileCycle}>+ Cycle</OutlineButton>
+        <OutlineButton
+          hoverTooltipHandlers={addStepTargetProps}
+          onClick={addProfileStep}
+        >
+          {i18n.t(
+            'form.step_edit_form.field.thermocyclerProfile.add_step_button'
+          )}
+        </OutlineButton>
+        <OutlineButton
+          hoverTooltipHandlers={addCycleTargetProps}
+          onClick={addProfileCycle}
+        >
+          {i18n.t(
+            'form.step_edit_form.field.thermocyclerProfile.add_cycle_button'
+          )}
+        </OutlineButton>
       </div>
     </>
   )
@@ -261,7 +299,7 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
     durationSeconds: i18n.t('application.units.seconds'),
   }
   const [targetProps, tooltipProps] = useHoverTooltip({
-    placement: 'top',
+    placement: TOOLTIP_TOP,
   })
   const fields = names.map(name => {
     const className = name === 'title' ? styles.title : styles.profile_field
@@ -295,7 +333,7 @@ const ProfileStepRow = (props: ProfileStepRowProps) => {
         {...targetProps}
       >
         <Tooltip {...tooltipProps}>
-          {i18n.t('tooltip.step_fields.profileStepRow.deleteStep')}
+          {i18n.t('tooltip.profile.delete_step')}
         </Tooltip>
         <Icon name="close" className={styles.delete_step_icon} />
       </div>

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -148,7 +148,9 @@
         "volume": "volume",
         "lid_temp": "lid temp",
         "lid_position": "lid position",
-        "lid_closed": "Closed"
+        "lid_closed": "Closed",
+        "add_cycle_button": "+ Cycle",
+        "add_step_button": "+ Step"
       }
     }
   }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -46,12 +46,6 @@
       "disabled": {
         "wait_until_temp": "There is no temperature module on the deck"
       }
-    },
-    "profileStepRow": {
-      "deleteStep": "Delete profile step"
-    },
-    "profileCycle": {
-      "deleteCycle": "Delete cycle and steps"
     }
   },
   "edit_module_card": {
@@ -60,5 +54,12 @@
   },
   "edit_module_modal": {
     "slot_selection": "To enable non-default/unrestricted positioning, go to Settings > App > Experimental settings."
+  },
+  "profile": {
+    "add_cycle": "Add a series of steps that cycle",
+    "add_step": "Add a single non-cycling step",
+    "add_step_to_cycle": "Add a step to the cycle",
+    "delete_step": "Delete profile step",
+    "delete_cycle": "Delete cycle and steps"
   }
 }


### PR DESCRIPTION
# Overview

Closes #6062

# Changelog

- Switch around some i18n organization, keep it snake case
- Add tooltips to TC profile buttons

# Review requests

- [ ] Button copy itself shouldn't be changed for + Step / + Cycle
- [ ] Tooltips on step/cycle buttons should match ticket

- I'm not sure why the tooltip for "+ Step" inside a cycle has its carat :arrow_down_small: off-center, something about the `placement: TOOLTIP_TOP_END`? With `placement: TOOLTIP_TOP` it centers in the row instead of on the button, I'm not sure what we usually would do to have the tooltip become free of the parent layout styling

# Risk assessment

Low, copy only