### PR TITLE
feat(protocol-designer): add delay form fields

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -121,9 +121,12 @@ export const SourceDestFields = (props: Props): React.Node => {
             </CheckboxRowField>
           </React.Fragment>
         )}
-        {prefix === 'dispense' && getDelayFields()}
-        {prefix === 'dispense' && getMixFields()}
-
+        {prefix === 'dispense' && (
+          <React.Fragment>
+            {getDelayFields()}
+            {getMixFields()}
+          </React.Fragment>
+        )}
         <CheckboxRowField
           name={addFieldNamePrefix('touchTip_checkbox')}
           tooltipComponent={i18n.t(

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import { i18n } from '../../../../localization'
+import { selectors as featureFlagSelectors } from '../../../../feature-flags'
 
 import type { FocusHandlers } from '../../types'
 
@@ -28,6 +30,7 @@ const makeAddFieldNamePrefix = (prefix: string) => (
 ): StepFieldName => `${prefix}_${fieldName}`
 
 export const SourceDestFields = (props: Props): React.Node => {
+  const delayEnabled = useSelector(featureFlagSelectors.getEnableAirGapDelay)
   const { className, focusHandlers, prefix } = props
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
 
@@ -51,6 +54,28 @@ export const SourceDestFields = (props: Props): React.Node => {
       />
     </CheckboxRowField>
   )
+
+  const getDelayFields = () =>
+    delayEnabled ? (
+      <CheckboxRowField
+        name={addFieldNamePrefix('delay_checkbox')}
+        label={i18n.t('form.step_edit_form.field.delay.label')}
+        className={styles.small_field}
+      >
+        <TextField
+          name={addFieldNamePrefix('delay_seconds')}
+          units={i18n.t('application.units.seconds')}
+          className={styles.small_field}
+          {...focusHandlers}
+        />
+        <TextField
+          name={addFieldNamePrefix('delay_tip_position')}
+          units={i18n.t('application.units.millimeter')}
+          className={styles.small_field}
+          {...focusHandlers}
+        />
+      </CheckboxRowField>
+    ) : null
 
   return (
     <div className={className}>
@@ -76,6 +101,7 @@ export const SourceDestFields = (props: Props): React.Node => {
               className={styles.small_field}
             />
             {mixFields}
+            {getDelayFields()}
             <CheckboxRowField
               disabled
               tooltipComponent={i18n.t('tooltip.not_in_beta')}
@@ -92,7 +118,7 @@ export const SourceDestFields = (props: Props): React.Node => {
             </CheckboxRowField>
           </React.Fragment>
         )}
-
+        {prefix === 'dispense' && getDelayFields()}
         {prefix === 'dispense' && mixFields}
 
         <CheckboxRowField

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -34,7 +34,7 @@ export const SourceDestFields = (props: Props): React.Node => {
   const { className, focusHandlers, prefix } = props
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
 
-  const mixFields = (
+  const getMixFields = () => (
     <CheckboxRowField
       name={addFieldNamePrefix('mix_checkbox')}
       label={i18n.t('form.step_edit_form.field.mix.label')}
@@ -100,7 +100,7 @@ export const SourceDestFields = (props: Props): React.Node => {
               label={i18n.t('form.step_edit_form.field.preWetTip.label')}
               className={styles.small_field}
             />
-            {mixFields}
+            {getMixFields()}
             {getDelayFields()}
             <CheckboxRowField
               disabled
@@ -119,7 +119,7 @@ export const SourceDestFields = (props: Props): React.Node => {
           </React.Fragment>
         )}
         {prefix === 'dispense' && getDelayFields()}
-        {prefix === 'dispense' && mixFields}
+        {prefix === 'dispense' && getMixFields()}
 
         <CheckboxRowField
           name={addFieldNamePrefix('touchTip_checkbox')}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -61,6 +61,9 @@ export const SourceDestFields = (props: Props): React.Node => {
         name={addFieldNamePrefix('delay_checkbox')}
         label={i18n.t('form.step_edit_form.field.delay.label')}
         className={styles.small_field}
+        tooltipComponent={i18n.t(
+          `tooltip.step_fields.defaults.${addFieldNamePrefix('delay_checkbox')}`
+        )}
       >
         <TextField
           name={addFieldNamePrefix('delay_seconds')}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -1,0 +1,108 @@
+// @flow
+import React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { selectors as featureFlagSelectors } from '../../../../feature-flags'
+import { SourceDestFields } from '../MoveLiquidForm/SourceDestFields'
+import { CheckboxRowField } from '../../fields'
+
+import type { BaseState } from '../../../../types'
+import { selectors as stepFormSelectors } from '../../../../step-forms'
+
+jest.mock('../../../../feature-flags')
+jest.mock('../../../../step-forms')
+jest.mock('../../utils')
+
+const getEnableAirGapDelayMock: JestMockFn<[BaseState], ?boolean> =
+  featureFlagSelectors.getEnableAirGapDelay
+
+const getUnsavedFormMock: JestMockFn<[BaseState], any> =
+  stepFormSelectors.getUnsavedForm
+
+describe('SourceDestFields', () => {
+  let store
+  let props
+  beforeEach(() => {
+    props = {
+      focusHandlers: {
+        focusedField: '',
+        dirtyFields: [],
+        onFieldFocus: jest.fn(),
+        onFieldBlur: jest.fn(),
+      },
+      prefix: 'aspirate',
+    }
+    store = {
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+      getState: () => ({}),
+    }
+    getUnsavedFormMock.mockReturnValue({})
+  })
+
+  const render = props =>
+    mount(
+      <Provider store={store}>
+        <SourceDestFields {...props} />
+      </Provider>
+    )
+
+  describe('Aspirate section', () => {
+    describe('When air gap/delay FF is on', () => {
+      beforeEach(() => {
+        getEnableAirGapDelayMock.mockReturnValue(true)
+      })
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
+        expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('aspirate_delay_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('aspirate_airGap_checkbox')
+        expect(checkboxes.at(4).prop('name')).toBe('aspirate_touchTip_checkbox')
+      })
+    })
+    describe('When air gap/delay FF is off', () => {
+      beforeEach(() => {
+        getEnableAirGapDelayMock.mockReturnValue(false)
+      })
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
+        expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('aspirate_airGap_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('aspirate_touchTip_checkbox')
+      })
+    })
+  })
+  describe('Dispense section', () => {
+    describe('When air gap/delay FF is on', () => {
+      beforeEach(() => {
+        getEnableAirGapDelayMock.mockReturnValue(true)
+        props.prefix = 'dispense'
+      })
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('dispense_delay_checkbox')
+        expect(checkboxes.at(1).prop('name')).toBe('dispense_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('dispense_touchTip_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('blowout_checkbox')
+      })
+    })
+    describe('When air gap/delay FF is off', () => {
+      beforeEach(() => {
+        getEnableAirGapDelayMock.mockReturnValue(false)
+        props.prefix = 'dispense'
+      })
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('dispense_mix_checkbox')
+        expect(checkboxes.at(1).prop('name')).toBe('dispense_touchTip_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('blowout_checkbox')
+      })
+    })
+  })
+})

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -58,6 +58,9 @@
           "never": "Use same tip as the previous step."
         }
       },
+      "delay": {
+        "label": "delay"
+      },
       "tip_position": { "label": "tip position" },
       "volume": { "label": "volume per well" },
       "well_order": {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -21,6 +21,8 @@
       "dispense_mix_checkbox": "Pipette up and down after dispensing",
       "aspirate_tipPosition": "Where in the well the pipette aspirates from",
       "dispense_tipPosition": "Where in the well the pipette dispenses to",
+      "aspirate_delay_checkbox": "Delay pipette movement after aspirating",
+      "dispense_delay_checkbox": "Delay pipette movement after dispensing",
 
       "blowout_checkbox": "Where to dispose of remaining volume in tip",
       "blowout_location": "Where to dispose of remaining volume in tip",


### PR DESCRIPTION
# Overview

This PR closes #6006 by adding delay form fields to transfer steps

# Changelog

- Add delay form fields to transfer steps 

# Review requests
- Code review

- [ ] When FF on, delay form field should show up in transfer step under advanced settings (both aspirate and dispense).
- [ ] When FF on, delay form field should have tool tips matching [these](https://www.figma.com/file/0dTEbGNsKYgNwKEW6LLfzJ/Airgap-Delay?node-id=104%3A0)
- [ ] When FF off, delay form field should NOT show up in advanced settings 


# Risk assessment
Low, behind FF