### PR TITLE
feat(protocol-designer): only show one labware name in sidebar tooltip

### DIFF
--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.js
@@ -11,22 +11,15 @@ import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 
-type AspirateDispenseHeaderProps = {
+type AspirateDispenseHeaderProps = {|
   sourceLabwareNickname: ?string,
-  sourceLabwareDefDisplayName: ?string,
   destLabwareNickname: ?string,
-  destLabwareDefDisplayName: ?string,
-}
+|}
 
 export function AspirateDispenseHeader(
   props: AspirateDispenseHeaderProps
 ): React.Node {
-  const {
-    sourceLabwareNickname,
-    sourceLabwareDefDisplayName,
-    destLabwareNickname,
-    destLabwareDefDisplayName,
-  } = props
+  const { sourceLabwareNickname, destLabwareNickname } = props
 
   const [sourceTargetProps, sourceTooltipProps] = useHoverTooltip({
     placement: 'bottom-start',
@@ -47,17 +40,11 @@ export function AspirateDispenseHeader(
       </li>
 
       <Tooltip {...sourceTooltipProps}>
-        <LabwareTooltipContents
-          labwareNickname={sourceLabwareNickname}
-          labwareDefDisplayName={sourceLabwareDefDisplayName}
-        />
+        <LabwareTooltipContents labwareNickname={sourceLabwareNickname} />
       </Tooltip>
 
       <Tooltip {...destTooltipProps}>
-        <LabwareTooltipContents
-          labwareNickname={destLabwareNickname}
-          labwareDefDisplayName={destLabwareDefDisplayName}
-        />
+        <LabwareTooltipContents labwareNickname={destLabwareNickname} />
       </Tooltip>
 
       <PDListItem

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.js
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.js
@@ -2,23 +2,16 @@
 import * as React from 'react'
 import styles from './StepItem.css'
 
-type LabwareTooltipContentsProps = {
+type LabwareTooltipContentsProps = {|
   labwareNickname: ?string,
-  labwareDefDisplayName: ?string,
-}
+|}
 export const LabwareTooltipContents = (
   props: LabwareTooltipContentsProps
 ): React.Node => {
-  const { labwareNickname, labwareDefDisplayName } = props
+  const { labwareNickname } = props
   return (
     <div className={styles.labware_tooltip_contents}>
       <p className={styles.labware_name}>{labwareNickname}</p>
-      {labwareDefDisplayName && (
-        <React.Fragment>
-          <div className={styles.labware_spacer} />
-          <p>{labwareDefDisplayName}</p>
-        </React.Fragment>
-      )}
     </div>
   )
 }

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.js
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.js
@@ -13,7 +13,7 @@ export const LabwareTooltipContents = (
   return (
     <div className={styles.labware_tooltip_contents}>
       <p className={styles.labware_name}>{labwareNickname}</p>
-      {labwareNickname && (
+      {labwareDefDisplayName && (
         <React.Fragment>
           <div className={styles.labware_spacer} />
           <p>{labwareDefDisplayName}</p>

--- a/protocol-designer/src/components/steplist/MixHeader.js
+++ b/protocol-designer/src/components/steplist/MixHeader.js
@@ -6,15 +6,14 @@ import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 
-type Props = {
+type Props = {|
   volume: ?string,
   times: ?string,
   labwareNickname: ?string,
-  labwareDisplayName: ?string,
-}
+|}
 
 export function MixHeader(props: Props): React.Node {
-  const { volume, times, labwareNickname, labwareDisplayName } = props
+  const { volume, times, labwareNickname } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',
     strategy: TOOLTIP_FIXED,
@@ -22,9 +21,7 @@ export function MixHeader(props: Props): React.Node {
   return (
     <>
       <Tooltip {...tooltipProps}>
-        <LabwareTooltipContents
-          {...{ labwareNickname, labwareDefDisplayName: labwareDisplayName }}
-        />
+        <LabwareTooltipContents {...{ labwareNickname }} />
       </Tooltip>
 
       <PDListItem className={styles.step_subitem}>

--- a/protocol-designer/src/components/steplist/MixHeader.js
+++ b/protocol-designer/src/components/steplist/MixHeader.js
@@ -10,11 +10,11 @@ type Props = {
   volume: ?string,
   times: ?string,
   labwareNickname: ?string,
-  labwareDefDisplayName: ?string,
+  labwareDisplayName: ?string,
 }
 
 export function MixHeader(props: Props): React.Node {
-  const { volume, times, labwareNickname, labwareDefDisplayName } = props
+  const { volume, times, labwareNickname, labwareDisplayName } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',
     strategy: TOOLTIP_FIXED,
@@ -23,7 +23,7 @@ export function MixHeader(props: Props): React.Node {
     <>
       <Tooltip {...tooltipProps}>
         <LabwareTooltipContents
-          {...{ labwareNickname, labwareDefDisplayName }}
+          {...{ labwareNickname, labwareDefDisplayName: labwareDisplayName }}
         />
       </Tooltip>
 

--- a/protocol-designer/src/components/steplist/ModuleStepItems.js
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.js
@@ -36,7 +36,6 @@ type Props = {|
   action?: string,
   moduleType: ModuleRealType,
   actionText: string,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: ?string,
   children?: React.Node,
@@ -57,10 +56,7 @@ export const ModuleStepItems = (props: Props): React.Node => {
         </li>
       )}
       <Tooltip {...tooltipProps}>
-        <LabwareTooltipContents
-          labwareNickname={props.labwareNickname}
-          labwareDefDisplayName={props.labwareDisplayName}
-        />
+        <LabwareTooltipContents labwareNickname={props.labwareNickname} />
       </Tooltip>
       <ModuleStepItemRow
         label={props.labwareNickname}

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -109,7 +109,6 @@ export type StepItemContentsProps = {|
   substeps: ?SubstepItemData,
 
   ingredNames: WellIngredientNames,
-  labwareDefDisplayNamesById: { [labwareId: string]: ?string },
   labwareNicknamesById: { [labwareId: string]: string },
 
   highlightSubstep: SubstepIdentifier => mixed,
@@ -122,17 +121,6 @@ const makeDurationText = (
 ): string => {
   const minutesText = Number(durationMinutes) > 0 ? `${durationMinutes}m ` : ''
   return `${minutesText}${durationSeconds || 0}s`
-}
-
-const getSingleLabwareNameProps = (
-  labwareNickname?: ?string,
-  labwareDisplayName?: ?string
-) => {
-  // Only display one name per labware
-  // Nickname if a labware has one, labware type if labware has no nickname
-  labwareNickname = labwareNickname || ''
-  labwareDisplayName = labwareNickname ? '' : labwareDisplayName
-  return { labwareNickname, labwareDisplayName }
 }
 
 type ProfileStepSubstepRowProps = {|
@@ -229,7 +217,6 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
     stepType,
     substeps,
     ingredNames,
-    labwareDefDisplayNamesById,
     labwareNicknamesById,
     highlightSubstep,
     hoveredSubstep,
@@ -247,7 +234,6 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
   if (substeps && substeps.substepType === 'magnet') {
     return (
       <ModuleStepItems
-        labwareDisplayName={substeps.labwareDisplayName}
         labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t(`modules.actions.action`)}
@@ -268,10 +254,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         action={i18n.t(`modules.actions.go_to`)}
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
-        {...getSingleLabwareNameProps(
-          substeps.labwareNickname,
-          substeps.labwareDisplayName
-        )}
+        labwareNickname={substeps.labwareNickname}
       />
     )
   }
@@ -286,10 +269,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         action={i18n.t(`modules.actions.profile`)}
         actionText={i18n.t(`modules.actions.cycling`)}
         moduleType={THERMOCYCLER_MODULE_TYPE}
-        {...getSingleLabwareNameProps(
-          substeps.labwareNickname,
-          substeps.labwareDisplayName
-        )}
+        labwareNickname={substeps.labwareNickname}
       >
         <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
         <CollapsibleSubstep
@@ -342,10 +322,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
             actionText={makeTemperatureText(substeps.blockTargetTempHold)}
             moduleType={THERMOCYCLER_MODULE_TYPE}
             hideHeader
-            {...getSingleLabwareNameProps(
-              substeps.labwareNickname,
-              substeps.labwareDisplayName
-            )}
+            labwareNickname={substeps.labwareNickname}
           />
           <ModuleStepItemRow
             label={`Lid (${substeps.lidOpenHold ? 'open' : 'closed'})`}
@@ -367,10 +344,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         action={i18n.t(`modules.actions.hold`)}
         actionText={blockTemperature}
         moduleType={THERMOCYCLER_MODULE_TYPE}
-        {...getSingleLabwareNameProps(
-          substeps.labwareNickname,
-          substeps.labwareDisplayName
-        )}
+        labwareNickname={substeps.labwareNickname}
       >
         <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
       </ModuleStepItems>
@@ -386,10 +360,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         action={i18n.t('modules.actions.await_temperature')}
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
-        {...getSingleLabwareNameProps(
-          substeps.labwareNickname,
-          substeps.labwareDisplayName
-        )}
+        labwareNickname={substeps.labwareNickname}
       />
     )
   }
@@ -405,11 +376,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
       <AspirateDispenseHeader
         key="moveLiquid-header"
         sourceLabwareNickname={labwareNicknamesById[sourceLabwareId]}
-        sourceLabwareDefDisplayName={
-          labwareDefDisplayNamesById[sourceLabwareId]
-        }
         destLabwareNickname={labwareNicknamesById[destLabwareId]}
-        destLabwareDefDisplayName={labwareDefDisplayNamesById[destLabwareId]}
       />
     )
   }
@@ -421,10 +388,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         key="mix-header"
         volume={rawForm.volume}
         times={rawForm.times}
-        {...getSingleLabwareNameProps(
-          labwareNicknamesById[mixLabwareId],
-          labwareDefDisplayNamesById[mixLabwareId]
-        )}
+        labwareNickname={labwareNicknamesById[mixLabwareId]}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -124,6 +124,17 @@ const makeDurationText = (
   return `${minutesText}${durationSeconds || 0}s`
 }
 
+const getSingleLabwareNameProps = (
+  labwareNickname?: ?string,
+  labwareDisplayName?: ?string
+) => {
+  // Only display one name per labware
+  // Nickname if a labware has one, labware type if labware has no nickname
+  labwareNickname = labwareNickname || ''
+  labwareDisplayName = labwareNickname ? '' : labwareDisplayName
+  return { labwareNickname, labwareDisplayName }
+}
+
 type ProfileStepSubstepRowProps = {|
   step: ProfileStepItem,
   repetitionsDisplay: ?string,
@@ -253,12 +264,14 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
 
     return (
       <ModuleStepItems
-        labwareDisplayName={substeps.labwareDisplayName}
-        labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t(`modules.actions.go_to`)}
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
+        {...getSingleLabwareNameProps(
+          substeps.labwareNickname,
+          substeps.labwareDisplayName
+        )}
       />
     )
   }
@@ -269,12 +282,14 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
 
     return (
       <ModuleStepItems
-        labwareDisplayName={substeps.labwareDisplayName}
-        labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t(`modules.actions.profile`)}
         actionText={i18n.t(`modules.actions.cycling`)}
         moduleType={THERMOCYCLER_MODULE_TYPE}
+        {...getSingleLabwareNameProps(
+          substeps.labwareNickname,
+          substeps.labwareDisplayName
+        )}
       >
         <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
         <CollapsibleSubstep
@@ -324,11 +339,13 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
           }
         >
           <ModuleStepItems
-            labwareDisplayName={substeps.labwareDisplayName}
-            labwareNickname={substeps.labwareNickname}
             actionText={makeTemperatureText(substeps.blockTargetTempHold)}
             moduleType={THERMOCYCLER_MODULE_TYPE}
             hideHeader
+            {...getSingleLabwareNameProps(
+              substeps.labwareNickname,
+              substeps.labwareDisplayName
+            )}
           />
           <ModuleStepItemRow
             label={`Lid (${substeps.lidOpenHold ? 'open' : 'closed'})`}
@@ -346,12 +363,14 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
 
     return (
       <ModuleStepItems
-        labwareDisplayName={substeps.labwareDisplayName}
-        labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t(`modules.actions.hold`)}
         actionText={blockTemperature}
         moduleType={THERMOCYCLER_MODULE_TYPE}
+        {...getSingleLabwareNameProps(
+          substeps.labwareNickname,
+          substeps.labwareDisplayName
+        )}
       >
         <ModuleStepItemRow label={lidLabelText} value={lidTemperature} />
       </ModuleStepItems>
@@ -363,12 +382,14 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
 
     return (
       <ModuleStepItems
-        labwareDisplayName={substeps.labwareDisplayName}
-        labwareNickname={substeps.labwareNickname}
         message={substeps.message}
         action={i18n.t('modules.actions.await_temperature')}
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
+        {...getSingleLabwareNameProps(
+          substeps.labwareNickname,
+          substeps.labwareDisplayName
+        )}
       />
     )
   }
@@ -400,8 +421,10 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
         key="mix-header"
         volume={rawForm.volume}
         times={rawForm.times}
-        labwareNickname={labwareNicknamesById[mixLabwareId]}
-        labwareDefDisplayName={labwareDefDisplayNamesById[mixLabwareId]}
+        {...getSingleLabwareNameProps(
+          labwareNicknamesById[mixLabwareId],
+          labwareDefDisplayNamesById[mixLabwareId]
+        )}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/__tests__/ModuleStepItems.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/ModuleStepItems.test.js
@@ -10,7 +10,6 @@ beforeEach(() => {
     action: 'action',
     moduleType: MAGNETIC_MODULE_TYPE,
     actionText: 'engage',
-    labwareDisplayName: 'magnet module',
     labwareNickname: 'maggie',
     message: 'my magnet module',
   }

--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
@@ -32,15 +32,11 @@ describe('StepItemContents', () => {
         substeps: {
           substepType: stepType,
           engage: true,
-          labwareDisplayName: 'magnet display',
           labwareNickname: 'magnet nickname',
           message: 'message',
         },
         labwareNicknamesById: {
           magnetId: 'magnet nickname',
-        },
-        labwareDefDisplayNamesById: {
-          magnetId: 'magnet display',
         },
       }
     })
@@ -78,9 +74,6 @@ describe('StepItemContents', () => {
         labwareNicknamesById: {
           temperatureId: 'temperature nickname',
         },
-        labwareDefDisplayNamesById: {
-          temperatureId: 'temperature display',
-        },
       }
     })
 
@@ -88,7 +81,6 @@ describe('StepItemContents', () => {
       temperatureProps.substeps = {
         substepType: stepType,
         temperature: 45,
-        labwareDisplayName: 'temperature display',
         labwareNickname: 'temperature nickname',
         message: 'message',
       }
@@ -102,7 +94,6 @@ describe('StepItemContents', () => {
       temperatureProps.substeps = {
         substepType: stepType,
         temperature: null,
-        labwareDisplayName: 'temperature display',
         labwareNickname: 'temperature nickname',
         message: 'message',
       }
@@ -116,13 +107,11 @@ describe('StepItemContents', () => {
       temperatureProps.substeps = {
         substepType: stepType,
         temperature: null,
-        labwareDisplayName: 'temperature display',
         labwareNickname: 'temperature nickname',
         message: 'message',
       }
       const wrapper = shallow(<StepItemContents {...temperatureProps} />)
       const component = wrapper.find(ModuleStepItems)
-      expect(component.prop('labwareDisplayName')).toEqual('')
       expect(component.prop('labwareNickname')).toEqual('temperature nickname')
     })
   })
@@ -144,9 +133,6 @@ describe('StepItemContents', () => {
         labwareNicknamesById: {
           temperatureId: 'temperature nickname',
         },
-        labwareDefDisplayNamesById: {
-          temperatureId: 'temperature display',
-        },
       }
     })
 
@@ -154,7 +140,6 @@ describe('StepItemContents', () => {
       awaitTemperatureProps.substeps = {
         substepType: stepType,
         temperature: 45,
-        labwareDisplayName: 'temperature display',
         labwareNickname: 'temperature nickname',
         message: 'message',
       }
@@ -163,7 +148,6 @@ describe('StepItemContents', () => {
       expect(component).toHaveLength(1)
       expect(component.prop('action')).toEqual('pause until')
       expect(component.prop('actionText')).toEqual('45 °C')
-      expect(component.prop('labwareDisplayName')).toEqual('')
       expect(component.prop('labwareNickname')).toEqual('temperature nickname')
     })
   })
@@ -185,9 +169,6 @@ describe('StepItemContents', () => {
         labwareNicknamesById: {
           temperatureId: 'tc nickname',
         },
-        labwareDefDisplayNamesById: {
-          temperatureId: 'tc display',
-        },
       }
     })
 
@@ -197,7 +178,6 @@ describe('StepItemContents', () => {
         blockTargetTemp: 55,
         lidTargetTemp: 45,
         lidOpen: false,
-        labwareDisplayName: 'tc display',
         labwareNickname: 'tc nickname',
         message: 'message',
       }
@@ -205,7 +185,6 @@ describe('StepItemContents', () => {
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
 
-      expect(component.prop('labwareDisplayName')).toEqual('')
       expect(component.prop('labwareNickname')).toEqual('tc nickname')
       expect(component.prop('message')).toEqual('message')
       expect(component.prop('action')).toEqual('hold')

--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
@@ -111,6 +111,20 @@ describe('StepItemContents', () => {
       expect(component).toHaveLength(1)
       expect(component.prop('actionText')).toEqual('deactivated')
     })
+
+    it('only renders the labware nickname', () => {
+      temperatureProps.substeps = {
+        substepType: stepType,
+        temperature: null,
+        labwareDisplayName: 'temperature display',
+        labwareNickname: 'temperature nickname',
+        message: 'message',
+      }
+      const wrapper = shallow(<StepItemContents {...temperatureProps} />)
+      const component = wrapper.find(ModuleStepItems)
+      expect(component.prop('labwareDisplayName')).toEqual('')
+      expect(component.prop('labwareNickname')).toEqual('temperature nickname')
+    })
   })
 
   describe('awaitTemperature step type', () => {
@@ -136,7 +150,7 @@ describe('StepItemContents', () => {
       }
     })
 
-    it('module is rendered with temperature', () => {
+    it('module is rendered with temperature and only labware nick name', () => {
       awaitTemperatureProps.substeps = {
         substepType: stepType,
         temperature: 45,
@@ -149,6 +163,8 @@ describe('StepItemContents', () => {
       expect(component).toHaveLength(1)
       expect(component.prop('action')).toEqual('pause until')
       expect(component.prop('actionText')).toEqual('45 °C')
+      expect(component.prop('labwareDisplayName')).toEqual('')
+      expect(component.prop('labwareNickname')).toEqual('temperature nickname')
     })
   })
 
@@ -175,7 +191,7 @@ describe('StepItemContents', () => {
       }
     })
 
-    it('module is rendered with temperature and lid state', () => {
+    it('module is rendered with temperature and lid state and only labware nick name', () => {
       thermocyclerStateProps.substeps = {
         substepType: stepType,
         blockTargetTemp: 55,
@@ -189,7 +205,7 @@ describe('StepItemContents', () => {
       const component = wrapper.find(ModuleStepItems)
       expect(component).toHaveLength(1)
 
-      expect(component.prop('labwareDisplayName')).toEqual('tc display')
+      expect(component.prop('labwareDisplayName')).toEqual('')
       expect(component.prop('labwareNickname')).toEqual('tc nickname')
       expect(component.prop('message')).toEqual('message')
       expect(component.prop('action')).toEqual('hold')

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -1,19 +1,14 @@
 // @flow
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import mapValues from 'lodash/mapValues'
 import { useConditionalConfirm } from '@opentrons/components'
-import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import { selectors as uiLabwareSelectors } from '../ui/labware'
 import * as substepSelectors from '../top-selectors/substeps'
 import * as timelineWarningSelectors from '../top-selectors/timelineWarnings'
 import { selectors as labwareIngredSelectors } from '../labware-ingred/selectors'
 import { selectors as dismissSelectors } from '../dismiss'
-import {
-  selectors as stepFormSelectors,
-  type LabwareEntity,
-} from '../step-forms'
+import { selectors as stepFormSelectors } from '../step-forms'
 import {
   getCollapsedSteps,
   getHoveredSubstep,
@@ -65,16 +60,11 @@ export const ConnectedStepItem = (props: Props): React.Node => {
   const labwareNicknamesById = useSelector(
     uiLabwareSelectors.getLabwareNicknamesById
   )
-  const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )
   const formHasChanges = useSelector(
     stepFormSelectors.getCurrentFormHasUnsavedChanges
-  )
-  const labwareDefDisplayNamesById = mapValues(
-    labwareEntities,
-    (l: LabwareEntity) => getLabwareDisplayName(l.def)
   )
 
   // Actions
@@ -121,7 +111,6 @@ export const ConnectedStepItem = (props: Props): React.Node => {
     substeps,
 
     ingredNames,
-    labwareDefDisplayNamesById,
     labwareNicknamesById,
 
     highlightSubstep,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -337,7 +337,7 @@ export function generateSubsteps(
   robotState: ?RobotState,
   stepId: string,
   labwareNamesByModuleId: {
-    [moduleId: string]: ?{ nickname: ?string, displayName: string },
+    [moduleId: string]: { nickname: string },
   }
 ): ?SubstepItemData {
   if (!robotState) {
@@ -392,7 +392,6 @@ export function generateSubsteps(
     return {
       substepType: 'magnet',
       engage: stepArgs.commandCreatorFnName === 'engageMagnet',
-      labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
     }
@@ -410,7 +409,6 @@ export function generateSubsteps(
     return {
       substepType: 'temperature',
       temperature: temperature,
-      labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
     }
@@ -420,7 +418,6 @@ export function generateSubsteps(
     return {
       substepType: 'awaitTemperature',
       temperature: stepArgs.temperature,
-      labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
     }
@@ -440,7 +437,6 @@ export function generateSubsteps(
     return {
       substepType: THERMOCYCLER_PROFILE,
       blockTargetTempHold,
-      labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       lidOpenHold,
       lidTargetTempHold,
@@ -455,7 +451,6 @@ export function generateSubsteps(
   if (stepArgs.commandCreatorFnName === THERMOCYCLER_STATE) {
     return {
       substepType: THERMOCYCLER_STATE,
-      labwareDisplayName: labwareNames?.displayName,
       labwareNickname: labwareNames?.nickname,
       blockTargetTemp: stepArgs.blockTargetTemp,
       lidTargetTemp: stepArgs.lidTargetTemp,

--- a/protocol-designer/src/steplist/generateSubsteps.js
+++ b/protocol-designer/src/steplist/generateSubsteps.js
@@ -337,7 +337,7 @@ export function generateSubsteps(
   robotState: ?RobotState,
   stepId: string,
   labwareNamesByModuleId: {
-    [moduleId: string]: { nickname: string },
+    [moduleId: string]: ?{ nickname: string },
   }
 ): ?SubstepItemData {
   if (!robotState) {

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.js
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.js
@@ -17,16 +17,13 @@ describe('generateSubsteps', () => {
 
     labwareNamesByModuleId = {
       magnet123: {
-        displayName: 'magnet module',
-        nickname: null,
+        nickname: 'mag nickname',
       },
       tempId: {
-        displayName: 'temperature module',
-        nickname: null,
+        nickname: 'temp nickname',
       },
       thermocyclerModuleId: {
-        displayName: 'tc labware',
-        nickname: 'tc labware nickname',
+        nickname: 'tc nickname',
       },
     }
     robotState = makeInitialRobotState({
@@ -510,8 +507,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual({
       substepType: 'magnet',
       engage: true,
-      labwareDisplayName: 'magnet module',
-      labwareNickname: null,
+      labwareNickname: 'mag nickname',
       message: null,
     })
   })
@@ -537,8 +533,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual({
       substepType: 'magnet',
       engage: false,
-      labwareDisplayName: 'magnet module',
-      labwareNickname: null,
+      labwareNickname: 'mag nickname',
       message: null,
     })
   })
@@ -565,8 +560,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual({
       substepType: 'temperature',
       temperature: 45,
-      labwareDisplayName: 'temperature module',
-      labwareNickname: null,
+      labwareNickname: 'temp nickname',
       message: null,
     })
   })
@@ -593,8 +587,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual({
       substepType: 'temperature',
       temperature: 0,
-      labwareDisplayName: 'temperature module',
-      labwareNickname: null,
+      labwareNickname: 'temp nickname',
       message: null,
     })
   })
@@ -620,8 +613,7 @@ describe('generateSubsteps', () => {
     expect(result).toEqual({
       substepType: 'temperature',
       temperature: null,
-      labwareDisplayName: 'temperature module',
-      labwareNickname: null,
+      labwareNickname: 'temp nickname',
       message: null,
     })
   })
@@ -647,8 +639,7 @@ describe('generateSubsteps', () => {
     )
     expect(result).toEqual({
       substepType: THERMOCYCLER_STATE,
-      labwareDisplayName: 'tc labware',
-      labwareNickname: 'tc labware nickname',
+      labwareNickname: 'tc nickname',
       blockTargetTemp: 44,
       lidTargetTemp: 66,
       lidOpen: false,

--- a/protocol-designer/src/steplist/types.js
+++ b/protocol-designer/src/steplist/types.js
@@ -107,7 +107,6 @@ export type SourceDestSubstepItem =
 export type MagnetSubstepItem = {|
   substepType: 'magnet',
   engage: boolean,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: string,
 |}
@@ -115,7 +114,6 @@ export type MagnetSubstepItem = {|
 export type TemperatureSubstepItem = {|
   substepType: 'temperature',
   temperature: number | null,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: string,
 |}
@@ -128,7 +126,6 @@ export type PauseSubstepItem = {|
 export type AwaitTemperatureSubstepItem = {|
   substepType: 'awaitTemperature',
   temperature: number,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   message?: string,
 |}
@@ -136,7 +133,6 @@ export type AwaitTemperatureSubstepItem = {|
 export type ThermocyclerProfileSubstepItem = {|
   substepType: THERMOCYCLER_PROFILE,
   blockTargetTempHold: number | null,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   lidOpenHold: boolean,
   lidTargetTempHold: number | null,
@@ -149,7 +145,6 @@ export type ThermocyclerProfileSubstepItem = {|
 
 export type ThermocyclerStateSubstepItem = {|
   substepType: THERMOCYCLER_STATE,
-  labwareDisplayName: ?string,
   labwareNickname: ?string,
   blockTargetTemp: number | null,
   lidTargetTemp: number | null,

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -19,9 +19,9 @@ import {
 import type { Options } from '@opentrons/components'
 import type { Selector } from '../../types'
 
-export const getLabwareNamesByModuleId: Selector<{
-  [moduleId: string]: ?{ nickname: ?string, displayName: string },
-}> = createSelector(
+export const getLabwareNamesByModuleId: Selector<{|
+  [moduleId: string]: { nickname: string },
+|}> = createSelector(
   getInitialDeckSetup,
   getLabwareNicknamesById,
   (initialDeckSetup, nicknamesById) =>

--- a/protocol-designer/src/ui/modules/selectors.js
+++ b/protocol-designer/src/ui/modules/selectors.js
@@ -20,7 +20,7 @@ import type { Options } from '@opentrons/components'
 import type { Selector } from '../../types'
 
 export const getLabwareNamesByModuleId: Selector<{|
-  [moduleId: string]: { nickname: string },
+  [moduleId: string]: ?{ nickname: string },
 |}> = createSelector(
   getInitialDeckSetup,
   getLabwareNicknamesById,


### PR DESCRIPTION
# Overview

This PR closes #6061 by only showing one labware name for mix, temperature, and TC steps.

# Changelog
- Only show one labware name in sidebar tooltip for TC + temp + mix steps

# Review requests

Code review, I did some funny stuff

- [ ] Make a mix step, in the sidebar when you hover over labware there should only be one labware name
- [ ] Make a temperature step, in the sidebar when you hover over labware there should only be one labware name
- [ ] Make a TC step, in the sidebar when you hover over labware there should only be one labware name

For TC steps, validate this behavior for ending hold too

# Risk assessment
Low, just modifying tooltip text