### PR TITLE
fix(api): fix APIv1 GPIO ctl for cmdline and jupyter protocol execution

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -132,6 +132,18 @@ class GPIOCharDev:
         self.set_reset_pin(True)
         await asyncio.sleep(0.25)
 
+    def setup_v1(self):
+        # TODO: AA 07-08-2020 remove when legacy API is deprecated
+        MODULE_LOG.info("Setting up GPIOs for APIv1")
+        self.set_audio_enable(True)
+        # smoothieware programming pins, must be in a known state (HIGH)
+        self.set_halt_pin(True)
+        self.set_isp_pin(True)
+        self.set_reset_pin(False)
+        time.sleep(0.25)
+        self.set_reset_pin(True)
+        time.sleep(0.25)
+
     def set_high(self, output_pin: GPIOPin):
         self.lines[output_pin.name].set_value(1)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When the robot server is running, protocols executed in Jupyter or using `opentrons_execute` would not have control over the GPIOs. Currently, a warning with a workaround is shown if the protocol is in APIv2. However, there is no indication given to the user of why GPIO controls are not working when they are running a v1 protocol.

This PR fixes the issue by surfacing the same warning as v2 and actually implementing the workaround for v1 protocols.

closes #6045

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- adds a new `info` message right before GPIO chardev is being built in APIv1
- allowed GPIO chip access during `robot.connect`
  - this automatically surfaces the following warning when a v1 protocol is executed in Jupyter or via opentrons_execute:
`Failed to initialize character device, will not be able to control gpios (lights, button, smoothie
    kill, smoothie reset). If you need to control gpios, first stop the robot server with systemctl stop 
    opentrons-robot-server. Until you restart the server with systemctl start opentrons-robot-server,
    you will be unable to control the robot using the Opentrons app.`
    
  - if the GPIOs are not held by the robot server, the resulting `GPIOCharDev` (not the simulator) will be set as the `robot._driver.gpio_chardev`
- added `setup_v1` function in gpio.py so robot can setup GPIO pins without being async 

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Not sure if adding `GPIOCharDev.setup_v1` is the best way to tackle the problem, any suggestions? 

Test this PR by executing `robot.turn_on_rail_lights()` in Jupyter and using `opentrons_execute`:
1. before killing the robot server, a warning should be shown that the GPIO char dev has failed to initialized
2. after killing the server, no warning and the robot lights should turn on
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low - this PR only affects APIv1 protocols when the robot server is stopped
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
