### PR TITLE
feat(protocol-designer): add initial step to new tc cycles

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -144,14 +144,15 @@ export const unsavedForm = (
         )
         return unsavedFormState
       }
-      const id = uuid()
+      const cycleId = uuid()
+      const profileStepId = uuid()
 
       return {
         ...unsavedFormState,
-        orderedProfileItems: [...unsavedFormState.orderedProfileItems, id],
+        orderedProfileItems: [...unsavedFormState.orderedProfileItems, cycleId],
         profileItemsById: {
           ...unsavedFormState.profileItemsById,
-          [id]: createInitialProfileCycle(id),
+          [cycleId]: createInitialProfileCycle(cycleId, profileStepId),
         },
       }
     }

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1213,7 +1213,12 @@ describe('unsavedForm reducer', () => {
     const action = { type: 'ADD_PROFILE_CYCLE', payload: null }
 
     const id = 'newCycleId'
-    mockUuid.mockReturnValue(id)
+    const profileStepId = 'newProfileStepId'
+    // NOTE: because we're using uuid() to create multiple different ids,
+    // this test is sensitive to the order that uuid is called in and
+    // assumes it's first for cycle id, then next for profile step id
+    mockUuid.mockReturnValueOnce(id)
+    mockUuid.mockReturnValueOnce(profileStepId)
 
     const state = {
       unsavedForm: {
@@ -1228,7 +1233,7 @@ describe('unsavedForm reducer', () => {
       stepType: 'thermocycler',
       orderedProfileItems: [id],
       profileItemsById: {
-        [id]: createInitialProfileCycle(id),
+        [id]: createInitialProfileCycle(id, profileStepId),
       },
     })
   })

--- a/protocol-designer/src/step-forms/utils/createInitialProfileItems.js
+++ b/protocol-designer/src/step-forms/utils/createInitialProfileItems.js
@@ -2,13 +2,6 @@
 import { PROFILE_CYCLE, PROFILE_STEP } from '../../form-types'
 import type { ProfileStepItem, ProfileCycleItem } from '../../form-types'
 
-export const createInitialProfileCycle = (id: string): ProfileCycleItem => ({
-  id,
-  type: PROFILE_CYCLE,
-  repetitions: '',
-  steps: [],
-})
-
 export const createInitialProfileStep = (id: string): ProfileStepItem => ({
   type: PROFILE_STEP,
   id,
@@ -16,4 +9,14 @@ export const createInitialProfileStep = (id: string): ProfileStepItem => ({
   temperature: '',
   durationMinutes: '',
   durationSeconds: '',
+})
+
+export const createInitialProfileCycle = (
+  cycleId: string,
+  profileStepId: string
+): ProfileCycleItem => ({
+  id: cycleId,
+  type: PROFILE_CYCLE,
+  repetitions: '',
+  steps: [createInitialProfileStep(profileStepId)],
 })


### PR DESCRIPTION
# Overview

Closes #6064

# Changelog

- New TC cycles start out with an initial step

# Review requests

- [ ] Code review
- [ ] Adding a new cycle with "+ CYCLE" in a TC Profile step should populate the cycle with a new empty profile step
- [ ] Can delete the step in the cycle as normal

# Risk assessment

- low, still under FF, unit tested, PD-only