### PR TITLE
feat(protocol-designer): add profile step numbers to TC side bar

### DIFF
--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -230,6 +230,14 @@
   text-transform: uppercase;
 }
 
+.align_left {
+  text-align: left;
+}
+
+.align_right {
+  text-align: right;
+}
+
 /* TODO: similar to .substep_header .step_subitem_channel_row */
 .profile_substep_header {
   display: flex;
@@ -299,10 +307,14 @@
 
 .cycle_step_row {
   border-right: 2px solid var(--c-med-gray);
-  width: 12rem;
+  width: 13.4rem;
   display: flex;
   justify-content: space-between;
   padding: 1em 1.25rem 1rem 0;
+
+  & > * {
+    flex: 1;
+  }
 }
 
 .cycle_repetitions {

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -225,23 +225,37 @@ const CollapsibleSubstep = (props: CollapsibleSubstepProps) => {
 
 const renderSubstepInfo = (substeps: ThermocyclerProfileSubstepItem) => {
   let stepNumber = 1
-  return substeps.meta?.rawProfileItems.map(item => {
-    const prevStepNumber = stepNumber
-    if (item.type === PROFILE_CYCLE) {
-      stepNumber += item.steps.length
-      return (
-        <ProfileCycleSubstepGroup cycle={item} stepNumber={prevStepNumber} />
-      )
-    }
-    stepNumber++
-    return (
-      <ProfileStepSubstepRow
-        step={item}
-        stepNumber={prevStepNumber}
-        repetitionsDisplay="1"
-      />
-    )
-  })
+  const substepInfo: Array<
+    | React.Element<typeof ProfileCycleSubstepGroup>
+    | React.Element<typeof ProfileStepSubstepRow>
+  > = []
+
+  substeps.meta &&
+    substeps.meta.rawProfileItems.forEach(item => {
+      const prevStepNumber = stepNumber
+      if (item.type === PROFILE_CYCLE) {
+        stepNumber += item.steps.length
+        substepInfo.push(
+          <ProfileCycleSubstepGroup
+            cycle={item}
+            stepNumber={prevStepNumber}
+            key={prevStepNumber}
+          />
+        )
+      } else {
+        stepNumber++
+        substepInfo.push(
+          <ProfileStepSubstepRow
+            step={item}
+            stepNumber={prevStepNumber}
+            repetitionsDisplay="1"
+            key={prevStepNumber}
+          />
+        )
+      }
+    })
+
+  return substepInfo
 }
 
 export const StepItemContents = (props: StepItemContentsProps): React.Node => {

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -30,6 +30,7 @@ import type {
 import type {
   SubstepIdentifier,
   SubstepItemData,
+  ThermocyclerProfileSubstepItem,
   WellIngredientNames,
 } from '../../steplist/types'
 
@@ -126,12 +127,13 @@ const makeDurationText = (
 
 type ProfileStepSubstepRowProps = {|
   step: ProfileStepItem,
+  stepNumber: number,
   repetitionsDisplay: ?string,
 |}
 export const ProfileStepSubstepRow = (
   props: ProfileStepSubstepRowProps
 ): React.Node => {
-  const { repetitionsDisplay } = props
+  const { repetitionsDisplay, stepNumber } = props
   const { temperature, durationMinutes, durationSeconds } = props.step
   return (
     // TODO IMMEDIATELY: rename .step_subitem_channel_row class to more generic name
@@ -141,7 +143,8 @@ export const ProfileStepSubstepRow = (
         styles.profile_step_substep_row
       )}
     >
-      <span className={styles.profile_step_substep_column}>
+      <span className={styles.profile_step_substep_column}>{stepNumber}</span>
+      <span className={styles.align_left}>
         {makeTemperatureText(temperature)}
       </span>
       <span
@@ -160,20 +163,24 @@ export const ProfileStepSubstepRow = (
 }
 
 // this is a row under a cycle under a substep
-type ProfileCycleRowProps = {| step: ProfileStepItem |}
+type ProfileCycleRowProps = {| step: ProfileStepItem, stepNumber: number |}
 const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
-  const { step } = props
+  const { step, stepNumber } = props
   return (
     <div className={styles.cycle_step_row}>
+      <span>{stepNumber}</span>
       <span>{makeTemperatureText(step.temperature)}</span>
-      <span>
+      <span className={styles.align_right}>
         {makeDurationText(step.durationMinutes, step.durationSeconds)}
       </span>
     </div>
   )
 }
 
-type ProfileCycleSubstepGroupProps = {| cycle: ProfileCycleItem |}
+type ProfileCycleSubstepGroupProps = {|
+  cycle: ProfileCycleItem,
+  stepNumber: number,
+|}
 export const ProfileCycleSubstepGroup = (
   props: ProfileCycleSubstepGroupProps
 ): React.Node => {
@@ -182,7 +189,11 @@ export const ProfileCycleSubstepGroup = (
     <div className={styles.profile_substep_cycle}>
       <div className={styles.cycle_group}>
         {steps.map((step, index) => (
-          <ProfileCycleRow key={index} step={step} />
+          <ProfileCycleRow
+            key={index}
+            stepNumber={props.stepNumber + index}
+            step={step}
+          />
         ))}
       </div>
       <div className={styles.cycle_repetitions}>{`${repetitions}x`}</div>
@@ -210,6 +221,27 @@ const CollapsibleSubstep = (props: CollapsibleSubstepProps) => {
       {!contentCollapsed && props.children}
     </>
   )
+}
+
+const renderSubstepInfo = (substeps: ThermocyclerProfileSubstepItem) => {
+  let stepNumber = 1
+  return substeps.meta?.rawProfileItems.map(item => {
+    const prevStepNumber = stepNumber
+    if (item.type === PROFILE_CYCLE) {
+      stepNumber += item.steps.length
+      return (
+        <ProfileCycleSubstepGroup cycle={item} stepNumber={prevStepNumber} />
+      )
+    }
+    stepNumber++
+    return (
+      <ProfileStepSubstepRow
+        step={item}
+        stepNumber={prevStepNumber}
+        repetitionsDisplay="1"
+      />
+    )
+  })
 }
 
 export const StepItemContents = (props: StepItemContentsProps): React.Node => {
@@ -289,6 +321,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
           }
         >
           <li className={cx(styles.profile_substep_header, styles.uppercase)}>
+            <span className={styles.profile_step_substep_column} />
             <span className={styles.profile_step_substep_column}>
               block temp
             </span>
@@ -302,18 +335,7 @@ export const StepItemContents = (props: StepItemContentsProps): React.Node => {
             </span>
             <span className={styles.profile_step_substep_column}>cycles</span>
           </li>
-          {substeps.meta?.rawProfileItems.map((item, index) => {
-            if (item.type === PROFILE_CYCLE) {
-              return <ProfileCycleSubstepGroup cycle={item} key={index} />
-            }
-            return (
-              <ProfileStepSubstepRow
-                step={item}
-                key={index}
-                repetitionsDisplay="1"
-              />
-            )
-          })}
+          {renderSubstepInfo(substeps)}
         </CollapsibleSubstep>
 
         <CollapsibleSubstep


### PR DESCRIPTION
# Overview

This PR closes #6059 by adding step numbers to the TC side bar

# Changelog

- Add profile step numbers to TC side bar

# Review requests
- Code review, I did some funny stuff
- Make a TC profile step with cycles + steps, in the sidebar step number should now show up

Make sure you test with a combo of cycles + steps to make sure the numbers render correctly

# Risk assessment
Low
