### PR TITLE
refactor(api): Move calibration related functions out of the protocol_api

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from opentrons.util import calibration_functions
 from opentrons.config import feature_flags as ff
+from opentrons.calibration_storage import modify
 from opentrons.broker import Broker
 from opentrons.types import Point, Mount, Location
 from opentrons.protocol_api import labware
@@ -295,7 +296,7 @@ class CalibrationManager(RobotBusy):
             else:
                 orig = _well0(container._container)._top().point
             delta = here - orig
-            labware.save_calibration(container._container, delta)
+            modify.save_calibration(container._container, delta)
         else:
             inst.robot.calibrate_container_with_instrument(
                 container=container._container,

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -1,0 +1,63 @@
+from . import types as local_types, file_operators as io
+
+from opentrons.config import get_opentrons_path, get_tip_length_cal_path
+
+OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
+
+
+def clear_calibrations():
+    """
+    Delete all calibration files for labware. This includes deleting tip-length
+    data for tipracks.
+    """
+    calibration_path = OFFSETS_PATH
+    try:
+        targets = [
+            f for f in calibration_path.iterdir() if f.suffix == '.json']
+        for target in targets:
+            target.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _remove_offset_from_index(calibration_id: local_types.CalibrationID):
+    """
+    Helper function to remove an individual offset file.
+
+    :param calibration_id: labware hash
+    :raises FileNotFoundError: If index file does not exist or
+    the specified id is not in the index file.
+    """
+    index_path = OFFSETS_PATH / 'index.json'
+    blob = io._read_file(str(index_path))
+
+    del blob[calibration_id]
+    io.save_to_file(index_path, blob)
+
+
+def delete_offset_file(calibration_id: local_types.CalibrationID):
+    """
+    Given a labware's hash, delete the file and remove it from the index file.
+
+    :param calibration_id: labware hash
+    """
+    offset = OFFSETS_PATH / f'{calibration_id}.json'
+    try:
+        _remove_offset_from_index(calibration_id)
+        offset.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def clear_tip_length_calibration():
+    """
+    Delete all tip length calibration files.
+    """
+    tip_length_path = get_tip_length_cal_path()
+    try:
+        targets = (
+            f for f in tip_length_path.iterdir() if f.suffix == '.json')
+        for target in targets:
+            target.unlink()
+    except FileNotFoundError:
+        pass

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -1,8 +1,6 @@
 from . import types as local_types, file_operators as io
 
-from opentrons.config import get_opentrons_path, get_tip_length_cal_path
-
-OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
+from opentrons import config
 
 
 def clear_calibrations():
@@ -10,7 +8,8 @@ def clear_calibrations():
     Delete all calibration files for labware. This includes deleting tip-length
     data for tipracks.
     """
-    calibration_path = OFFSETS_PATH
+    calibration_path =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
     try:
         targets = [
             f for f in calibration_path.iterdir() if f.suffix == '.json']
@@ -28,7 +27,9 @@ def _remove_offset_from_index(calibration_id: local_types.CalibrationID):
     :raises FileNotFoundError: If index file does not exist or
     the specified id is not in the index file.
     """
-    index_path = OFFSETS_PATH / 'index.json'
+    offset_path =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    index_path = offset_path / 'index.json'
     blob = io._read_file(str(index_path))
 
     del blob[calibration_id]
@@ -41,7 +42,9 @@ def delete_offset_file(calibration_id: local_types.CalibrationID):
 
     :param calibration_id: labware hash
     """
-    offset = OFFSETS_PATH / f'{calibration_id}.json'
+    offset_path =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    offset = offset_path / f'{calibration_id}.json'
     try:
         _remove_offset_from_index(calibration_id)
         offset.unlink()
@@ -53,7 +56,7 @@ def clear_tip_length_calibration():
     """
     Delete all tip length calibration files.
     """
-    tip_length_path = get_tip_length_cal_path()
+    tip_length_path = config.get_tip_length_cal_path()
     try:
         targets = (
             f for f in tip_length_path.iterdir() if f.suffix == '.json')

--- a/api/src/opentrons/calibration_storage/encoder_decoder.py
+++ b/api/src/opentrons/calibration_storage/encoder_decoder.py
@@ -1,0 +1,29 @@
+import json
+import datetime
+
+
+# TODO: AA 2020-06-10 move out of protocol_api
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        return json.JSONEncoder.default(self, obj)
+
+
+# TODO: AA 2020-06-10 move out of protocol_api
+class DateTimeDecoder(json.JSONDecoder):
+    def __init__(self):
+        super().__init__(object_hook=self.dict_to_obj)
+
+    def dict_to_obj(self, d):
+        if isinstance(d, dict):
+            d = {k: self._decode_datetime(v) for k, v in d.items()}
+        return d
+
+    def _decode_datetime(self, obj):
+        try:
+            return datetime.datetime.fromisoformat(obj)
+        except ValueError:
+            return obj
+        except TypeError:
+            return self.dict_to_obj(obj)

--- a/api/src/opentrons/calibration_storage/file_operators.py
+++ b/api/src/opentrons/calibration_storage/file_operators.py
@@ -1,0 +1,31 @@
+import json
+import datetime
+from pathlib import Path
+
+
+def _read_file(filepath: str):
+    # TODO(6/16): We should use tagged unions for
+    # both the calibration and tip length dicts to better
+    # categorize the Typed Dicts used here.
+    # This can be done when the labware endpoints
+    # are refactored to grab tip length calibration
+    # from the correct locations.
+    with open(filepath, 'r') as f:
+        calibration_data = json.load(f)
+    return calibration_data
+
+
+def _read_cal_file(filepath: str, decoder=None) -> dict:
+    with open(filepath, 'r') as f:
+        calibration_data = json.load(f, cls=decoder)
+    for value in calibration_data.values():
+        if value.get('lastModified'):
+            assert isinstance(value['lastModified'], datetime.datetime), \
+                "invalid decoded value type for lastModified: got " \
+                f"{type(value['lastModified']).__name__}, expected datetime"
+    return calibration_data
+
+
+def save_to_file(filepath: Path, data: dict, encoder=None):
+    with filepath.open('w') as f:
+        json.dump(data, f, cls=encoder)

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -1,0 +1,110 @@
+import typing
+
+from opentrons.config import get_opentrons_path, get_tip_length_cal_path
+from opentrons.types import Point
+
+from . import (
+    types as local_types,
+    file_operators as io, helpers,
+    encoder_decoder as ed)
+
+if typing.TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Labware
+
+OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
+
+
+def _format_calibration_type(
+        data: local_types.CalibrationDict) -> local_types.CalibrationTypes:
+    offset = local_types.OffsetData(
+        value=data['default']['offset'],
+        last_modified=data['default']['lastModified']
+    )
+    # TODO(6/16): Tip calibration no longer exists in
+    # the labware calibraiton file. We should
+    # have a follow-up PR to grab tip lengths
+    # based on the loaded pips + labware
+    return local_types.CalibrationTypes(
+            offset=offset,
+            tip_length=local_types.TipLengthData()
+        )
+
+
+def _format_parent(
+        data: local_types.CalibrationIndexDict)\
+            -> local_types.ParentOptions:
+    options = local_types.ParentOptions(slot=data['slot'])
+    if data['module']:
+        options.module = data['module']['parent']
+    return options
+
+
+def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
+    """
+    A helper function that will list all of the given calibrations
+    in a succinct way.
+
+    :return: A list of dictionary objects representing all of the
+    labware calibration files found on the robot.
+    """
+    all_calibrations: typing.List[local_types.CalibrationInformation] = []
+    index_path = OFFSETS_PATH / 'index.json'
+    if not index_path.exists():
+        return all_calibrations
+    index_file = io._read_file(str(index_path))
+    for key, data in index_file.items():
+        cal_path = OFFSETS_PATH / f'{key}.json'
+        if cal_path.exists():
+            cal_blob = io._read_file(str(cal_path))
+            calibration = _format_calibration_type(cal_blob)
+            all_calibrations.append(
+                local_types.CalibrationInformation(
+                    calibration=calibration,
+                    parent=_format_parent(data),
+                    labware_id=key,
+                    uri=data['uri']
+                ))
+    return all_calibrations
+
+
+def get_tip_length_data(
+        pip_id: str, labware_hash: str, labware_load_name: str
+) -> local_types.TipLengthCalibration:
+    try:
+        pip_tip_length_path = get_tip_length_cal_path()/f'{pip_id}.json'
+        tip_length_data =\
+            io._read_cal_file(str(pip_tip_length_path), ed.DateTimeDecoder)
+        return tip_length_data[labware_hash]
+    except (FileNotFoundError, AttributeError):
+        raise local_types.TipLengthCalNotFound(
+            f'Tip length of {labware_load_name} has not been '
+            f'calibrated for this pipette: {pip_id} and cannot'
+            'be loaded')
+
+
+def load_calibration(labware: 'Labware'):
+    """
+    Look up a calibration if it exists and apply it to the given labware.
+    """
+    labware_offset_path =\
+        helpers._get_labware_offset_path(labware, OFFSETS_PATH)
+    if labware_offset_path.exists():
+        calibration_data = io._read_file(str(labware_offset_path))
+        offset_array = calibration_data['default']['offset']
+        offset = Point(x=offset_array[0], y=offset_array[1], z=offset_array[2])
+        labware.set_calibration(offset)
+        if 'tipLength' in calibration_data.keys():
+            tip_length = calibration_data['tipLength']['length']
+            labware.tip_length = tip_length
+
+
+def load_tip_length_calibration(
+        pip_id: str, labware: 'Labware') -> local_types.TipLengthCalibration:
+    assert labware._is_tiprack, \
+        'cannot load tip length for non-tiprack labware'
+    parent_id = helpers._get_parent_identifier(labware.parent)
+    labware_hash = helpers._hash_labware_def(labware._definition)
+    return get_tip_length_data(
+        pip_id=pip_id,
+        labware_hash=labware_hash + parent_id,
+        labware_load_name=labware.load_name)

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -1,0 +1,48 @@
+import typing
+import json
+
+from hashlib import sha256
+from pathlib import Path
+
+from opentrons.protocol_api.definitions import DeckItem
+from . import types as local_types
+
+if typing.TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Well, Labware
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+
+def _get_parent_identifier(
+        parent: typing.Union['Well', str, DeckItem, None]) -> str:
+    if isinstance(parent, DeckItem) and parent.separate_calibration:
+        # treat a given labware on a given module type as same
+        return parent.load_name
+    else:
+        return ''  # treat all slots as same
+
+
+def _get_labware_offset_path(labware: 'Labware', offset_path: Path):
+    offset_path.mkdir(parents=True, exist_ok=True)
+
+    parent_id = _get_parent_identifier(labware.parent)
+    labware_hash = _hash_labware_def(labware._definition)
+    return offset_path/f'{labware_hash}{parent_id}.json'
+
+
+def _hash_labware_def(labware_def: 'LabwareDefinition') -> str:
+    # remove keys that do not affect run
+    blocklist = ['metadata', 'brand', 'groups']
+    def_no_metadata = {
+        k: v for k, v in labware_def.items() if k not in blocklist}
+    sorted_def_str = json.dumps(
+        def_no_metadata, sort_keys=True, separators=(',', ':'))
+    return sha256(sorted_def_str.encode('utf-8')).hexdigest()
+
+
+def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
+    """
+    Unpack a labware URI to get the namespace, loadname and version
+    """
+    info = uri.split(delimiter)
+    return local_types.UriDetails(
+        namespace=info[0], load_name=info[1], version=int(info[2]))

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -1,0 +1,135 @@
+import typing
+import datetime
+import time
+from pathlib import Path
+
+from opentrons.protocol_api.util import first_parent
+from opentrons.config import get_opentrons_path, get_tip_length_cal_path
+
+from . import (
+    file_operators as io,
+    encoder_decoder as ed,
+    types as local_types,
+    helpers)
+
+if typing.TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Labware
+    from opentrons.types import Point
+
+OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
+
+
+def _add_to_index_offset_file(labware: 'Labware', lw_hash: str):
+    """
+    A helper method to create or add to an index file so that calibration
+    files can be looked up by their hash to reveal the labware uri and
+    parent information of a given file.
+
+    :param labware: A labware object
+    :param lw_hash: The labware hash of the calibration
+    """
+    index_file = OFFSETS_PATH / 'index.json'
+    uri = labware.uri
+    if index_file.exists():
+        blob = io._read_file(str(index_file))
+    else:
+        blob = {}
+
+    mod_parent = helpers._get_parent_identifier(labware.parent)
+    slot = first_parent(labware)
+    if mod_parent:
+        mod_dict = {
+            'parent': mod_parent,
+            'fullParent': f'{slot}-{mod_parent}'}
+    else:
+        mod_dict = {}
+    full_id = f'{lw_hash}{mod_parent}'
+    blob[full_id] = {
+            "uri": f'{uri}',
+            "slot": full_id,
+            "module": mod_dict
+        }
+    io.save_to_file(index_file, blob)
+
+
+def save_calibration(labware: 'Labware', delta: 'Point'):
+    """
+    Function to be used whenever an updated delta is found for the first well
+    of a given labware. If an offset file does not exist, create the file
+    using labware id as the filename. If the file does exist, load it and
+    modify the delta and the lastModified fields under the "default" key.
+    """
+    labware_offset_path =\
+        helpers._get_labware_offset_path(labware, OFFSETS_PATH)
+    labware_hash = helpers._hash_labware_def(labware._definition)
+    _add_to_index_offset_file(labware, labware_hash)
+    calibration_data = _helper_offset_data_format(
+        str(labware_offset_path), delta)
+    io.save_to_file(labware_offset_path, calibration_data)
+    labware.set_calibration(delta)
+
+
+def create_tip_length_data(
+        labware: 'Labware',
+        length: float) -> local_types.PipTipLengthCalibration:
+    assert labware._is_tiprack, \
+        'cannot save tip length for non-tiprack labware'
+    parent_id = helpers._get_parent_identifier(labware.parent)
+    labware_hash = helpers._hash_labware_def(labware._definition)
+
+    tip_length_data: local_types.TipLengthCalibration = {
+        'tipLength': length,
+        'lastModified': datetime.datetime.utcnow()
+    }
+
+    data = {labware_hash + parent_id: tip_length_data}
+    return data
+
+
+def _helper_offset_data_format(filepath: str, delta: 'Point') -> dict:
+    if not Path(filepath).is_file():
+        calibration_data = {
+            "default": {
+                "offset": [delta.x, delta.y, delta.z],
+                "lastModified": time.time()
+            }
+        }
+    else:
+        calibration_data = io._read_file(filepath)
+        calibration_data['default']['offset'] = [delta.x, delta.y, delta.z]
+        calibration_data['default']['lastModified'] = time.time()
+    return calibration_data
+
+
+def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
+    index_file = get_tip_length_cal_path()/'index.json'
+    try:
+        index_data = io._read_file(str(index_file))
+    except FileNotFoundError:
+        index_data = {}
+
+    if lw_hash not in index_data:
+        index_data[lw_hash] = [pip_id]
+    elif pip_id not in index_data[lw_hash]:
+        index_data[lw_hash].append(pip_id)
+
+    io.save_to_file(index_file, index_data)
+
+
+def save_tip_length_calibration(
+        pip_id: str, tip_length_cal: local_types.PipTipLengthCalibration):
+    tip_length_dir_path = get_tip_length_cal_path()
+    tip_length_dir_path.mkdir(parents=True, exist_ok=True)
+    pip_tip_length_path = tip_length_dir_path/f'{pip_id}.json'
+
+    for lw_hash in tip_length_cal.keys():
+        _append_to_index_tip_length_file(pip_id, lw_hash)
+
+    try:
+        tip_length_data = io._read_cal_file(str(pip_tip_length_path))
+    except FileNotFoundError:
+        tip_length_data = {}
+
+    tip_length_data.update(tip_length_cal)
+
+    io.save_to_file(pip_tip_length_path, tip_length_data, ed.DateTimeEncoder)

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 
 from opentrons.protocol_api.util import first_parent
-from opentrons.config import get_opentrons_path, get_tip_length_cal_path
+from opentrons import config
 
 from . import (
     file_operators as io,
@@ -16,8 +16,6 @@ if typing.TYPE_CHECKING:
     from opentrons.protocol_api.labware import Labware
     from opentrons.types import Point
 
-OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
-
 
 def _add_to_index_offset_file(labware: 'Labware', lw_hash: str):
     """
@@ -28,7 +26,9 @@ def _add_to_index_offset_file(labware: 'Labware', lw_hash: str):
     :param labware: A labware object
     :param lw_hash: The labware hash of the calibration
     """
-    index_file = OFFSETS_PATH / 'index.json'
+    offset =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    index_file = offset / 'index.json'
     uri = labware.uri
     if index_file.exists():
         blob = io._read_file(str(index_file))
@@ -59,8 +59,10 @@ def save_calibration(labware: 'Labware', delta: 'Point'):
     using labware id as the filename. If the file does exist, load it and
     modify the delta and the lastModified fields under the "default" key.
     """
+    offset_path =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
     labware_offset_path =\
-        helpers._get_labware_offset_path(labware, OFFSETS_PATH)
+        helpers._get_labware_offset_path(labware, offset_path)
     labware_hash = helpers._hash_labware_def(labware._definition)
     _add_to_index_offset_file(labware, labware_hash)
     calibration_data = _helper_offset_data_format(
@@ -102,7 +104,7 @@ def _helper_offset_data_format(filepath: str, delta: 'Point') -> dict:
 
 
 def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
-    index_file = get_tip_length_cal_path()/'index.json'
+    index_file = config.get_tip_length_cal_path()/'index.json'
     try:
         index_data = io._read_file(str(index_file))
     except FileNotFoundError:
@@ -118,7 +120,7 @@ def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
 
 def save_tip_length_calibration(
         pip_id: str, tip_length_cal: local_types.PipTipLengthCalibration):
-    tip_length_dir_path = get_tip_length_cal_path()
+    tip_length_dir_path = config.get_tip_length_cal_path()
     tip_length_dir_path.mkdir(parents=True, exist_ok=True)
     pip_tip_length_path = tip_length_dir_path/f'{pip_id}.json'
 

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -1,0 +1,114 @@
+import typing
+from typing_extensions import TypedDict
+from dataclasses import dataclass
+from datetime import datetime
+
+
+CalibrationID = typing.NewType('CalibrationID', str)
+
+
+class TipLengthCalNotFound(Exception):
+    pass
+
+
+@dataclass
+class UriDetails:
+    namespace: str
+    load_name: str
+    version: int
+
+
+@dataclass
+class OffsetData:
+    """
+    Class to categorize the shape of a
+    given calibration data.
+    """
+    value: typing.List[float]
+    last_modified: typing.Optional[str]
+
+
+@dataclass
+class TipLengthData:
+    """
+    Class to categorize the shape of a
+    given calibration data.
+    """
+    value: typing.Optional[float] = None
+    last_modified: typing.Optional[str] = None
+
+
+@dataclass
+class ParentOptions:
+    """
+    Class to store whether a labware calibration has
+    a module, as well the original parent (slot).
+    As of now, the slot is not saved in association
+    with labware calibrations.
+    """
+    slot: str
+    module: str = ''
+
+
+@dataclass
+class CalibrationTypes:
+    """
+    Class to categorize what calibration
+    data might be stored for a labware.
+    """
+    offset: OffsetData
+    tip_length: TipLengthData
+
+
+@dataclass
+class CalibrationInformation:
+    """
+    Class to store important calibration
+    info for labware.
+    """
+    calibration: CalibrationTypes
+    parent: ParentOptions
+    labware_id: str
+    uri: str
+
+
+class TipLengthCalibration(TypedDict):
+    tipLength: float
+    lastModified: datetime
+
+
+class ModuleDict(TypedDict):
+    parent: str
+    fullParent: str
+
+
+class CalibrationIndexDict(TypedDict):
+    """
+    The dict that is returned from
+    the index.json file.
+    """
+    uri: str
+    slot: str
+    module: ModuleDict
+
+
+class OffsetDict(TypedDict):
+    offset: typing.List[float]
+    lastModified: str
+
+
+class TipLengthDict(TypedDict):
+    length: float
+    lastModified: str
+
+
+class CalibrationDict(TypedDict):
+    """
+    The dict that is returned from a labware
+    offset file.
+    """
+    default: OffsetDict
+    tipLength: TipLengthDict
+
+
+PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, Dict, Set
 from opentrons.config import (robot_configs as rc,
                               IS_ROBOT, feature_flags as ff)
 from opentrons.data_storage import database as db
-from opentrons.protocol_api import labware
+from opentrons.calibration_storage import delete
 
 DATA_BOOT_D = Path('/data/boot.d')
 
@@ -80,7 +80,7 @@ def reset_boot_scripts():
 
 
 def reset_labware_calibration():
-    labware.clear_calibrations()
+    delete.clear_calibrations()
     db.reset()
 
 
@@ -89,7 +89,7 @@ def reset_tip_probe():
     config = config._replace(
         instrument_offset=rc.build_fallback_instrument_offset({}))
     if ff.enable_tip_length_calibration():
-        labware.clear_tip_length_calibration()
+        delete.clear_tip_length_calibration()
     else:
         config.tip_length.clear()
     rc.save_robot_settings(config)

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -20,9 +20,10 @@ from .placeable import (
 from opentrons.helpers import helpers
 
 from opentrons.protocol_api import labware as new_labware
+from opentrons.calibration_storage.get import get_tip_length_data
 
 if TYPE_CHECKING:
-    from opentrons.protocol_api.dev_types import TipLengthCalibration
+    from opentrons.calibration_storage.types import TipLengthCalibration
 
 
 __all__ = [
@@ -289,6 +290,6 @@ def load_tip_length_calibration(
         pip_id: str, location) -> 'TipLengthCalibration':
     placeable, _ = unpack_location(location)
     lw = placeable.get_parent()
-    return new_labware.get_tip_length_data(
+    return get_tip_length_data(
         pip_id=pip_id, labware_hash=lw.properties['labware_hash'],
         labware_load_name=lw.properties['type'])

--- a/api/src/opentrons/protocol_api/constants.py
+++ b/api/src/opentrons/protocol_api/constants.py
@@ -5,5 +5,4 @@ from opentrons.config import get_opentrons_path
 OPENTRONS_NAMESPACE = 'opentrons'
 CUSTOM_NAMESPACE = 'custom_beta'
 STANDARD_DEFS_PATH = Path("labware/definitions/2")
-OFFSETS_PATH = get_opentrons_path('labware_calibration_offsets_dir_v2')
 USER_DEFS_PATH = get_opentrons_path('labware_user_definitions_dir_v2')

--- a/api/src/opentrons/protocol_api/dev_types.py
+++ b/api/src/opentrons/protocol_api/dev_types.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from typing import Callable, Dict, TYPE_CHECKING, List
+from typing import Callable, Dict, TYPE_CHECKING
 
 from typing_extensions import Protocol, TypedDict
 
@@ -130,46 +129,3 @@ JsonV4ThermocyclerDispatch = TypedDict(
             ['ThermocyclerContext', 'ModuleIDParams'], None]
     }
 )
-
-
-# TODO: AA 2020-06-10 move these out of protocol_api
-class TipLengthCalibration(TypedDict):
-    tipLength: float
-    lastModified: datetime
-
-
-class ModuleDict(TypedDict):
-    parent: str
-    fullParent: str
-
-
-class CalibrationIndexDict(TypedDict):
-    """
-    The dict that is returned from
-    the index.json file.
-    """
-    uri: str
-    slot: str
-    module: ModuleDict
-
-
-class OffsetDict(TypedDict):
-    offset: List[float]
-    lastModified: str
-
-
-class TipLengthDict(TypedDict):
-    length: float
-    lastModified: str
-
-
-class CalibrationDict(TypedDict):
-    """
-    The dict that is returned from a labware
-    offset file.
-    """
-    default: OffsetDict
-    tipLength: TipLengthDict
-
-
-PipTipLengthCalibration = Dict[str, TipLengthCalibration]

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -319,7 +319,7 @@ async def test_jog_api1(main_router, model):
 @pytest.mark.api2_only
 async def test_update_container_offset_v2(main_router, model):
     with mock.patch(
-            'opentrons.protocol_api.labware.save_calibration') as call,\
+            'opentrons.calibration_storage.modify.save_calibration') as call,\
             mock.patch.object(API,
                               'gantry_position') as gp:
         gp.return_value = Point(0, 0, 0)

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -30,7 +30,7 @@ def mock_db():
 
 @pytest.fixture()
 def mock_labware():
-    with patch("opentrons.config.reset.labware") as m:
+    with patch("opentrons.config.reset.delete") as m:
         yield m
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -136,6 +136,17 @@ def config_tempdir(tmpdir, template_db):
     yield tmpdir, template_db
 
 
+@pytest.fixture
+def offset_tempdir(tmpdir):
+    os.environ['OT_API_CONFIG_DIR'] = str(tmpdir)
+    config.reload()
+
+    yield config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+
+    del os.environ['OT_API_CONFIG_DIR']
+    config.reload()
+
+
 @pytest.mark.apiv1
 @pytest.fixture(scope='function')
 def offsets_tempdir(tmpdir, template_db):
@@ -165,7 +176,6 @@ def wifi_keys_tempdir():
 
 @pytest.fixture
 def is_robot(monkeypatch):
-    print("in here")
     monkeypatch.setattr(config, 'IS_ROBOT', True)
     yield
     monkeypatch.setattr(config, 'IS_ROBOT', False)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -137,7 +137,7 @@ def config_tempdir(tmpdir, template_db):
 
 
 @pytest.fixture
-def offset_tempdir(tmpdir):
+def labware_offset_tempdir(tmpdir):
     os.environ['OT_API_CONFIG_DIR'] = str(tmpdir)
     config.reload()
 

--- a/api/tests/opentrons/containers/test_containers.py
+++ b/api/tests/opentrons/containers/test_containers.py
@@ -12,6 +12,7 @@ from opentrons.legacy_api.containers import (
     load_new_labware as new_load,
     load_tip_length_calibration
 )
+from opentrons.calibration_storage import delete, modify
 from opentrons.legacy_api.containers.placeable import (
     Container,
     Well,
@@ -250,11 +251,11 @@ def test_load_tip_length_calibration_v1(robot):
             'lastModified': datetime.datetime.utcnow()}
     tip_length_cal = {hash: tip_length_data}
     pip_id = 'fake_id'
-    new_labware.save_tip_length_calibration(
+    modify.save_tip_length_calibration(
         pip_id=pip_id, tip_length_cal=tip_length_cal)
 
     result = load_tip_length_calibration(pip_id, lw.wells('A1'))
 
     assert result == tip_length_data
 
-    new_labware.clear_tip_length_calibration()  # clean up
+    delete.clear_tip_length_calibration()  # clean up

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -157,7 +157,7 @@ def test_force_direct():
     assert different_lw == [(lw2.wells()[0].bottom().point, None)]
 
 
-def test_no_labware_loc(offset_tempdir):
+def test_no_labware_loc(labware_offset_tempdir):
     labware_def = labware.get_labware_definition(labware_name)
 
     deck = Deck()

--- a/api/tests/opentrons/protocol_api/test_geometry.py
+++ b/api/tests/opentrons/protocol_api/test_geometry.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 
 from opentrons.types import Location, Point
 from opentrons.protocol_api.geometry import (
@@ -158,8 +157,7 @@ def test_force_direct():
     assert different_lw == [(lw2.wells()[0].bottom().point, None)]
 
 
-def test_no_labware_loc(monkeypatch, tmpdir):
-    monkeypatch.setattr(labware, 'OFFSETS_PATH', Path(tmpdir))
+def test_no_labware_loc(offset_tempdir):
     labware_def = labware.get_labware_definition(labware_name)
 
     deck = Deck()

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -36,7 +36,7 @@ test_data = {
 
 
 @pytest.fixture
-def set_up_index_file(offset_tempdir):
+def set_up_index_file(labware_offset_tempdir):
     deck = Deck()
     labware_list = [
         'nest_96_wellplate_2ml_deep',
@@ -494,7 +494,7 @@ def test_uris():
         'corning_384_wellplate_112ul_flat',
         'geb_96_tiprack_1000ul',
         'nest_12_reservoir_15ml'])
-def test_add_index_file(labware_name, index_file_dir):
+def test_add_index_file(labware_name, labware_offset_tempdir):
     deck = Deck()
     parent = deck.position_for(1)
     definition = labware.get_labware_definition(labware_name)
@@ -517,7 +517,7 @@ def test_add_index_file(labware_name, index_file_dir):
             "module": mod_dict
         }
 
-    lw_path = index_file_dir / 'index.json'
+    lw_path = labware_offset_tempdir / 'index.json'
     info = file_operators._read_file(lw_path)
     assert info[full_id] == blob
 

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 
@@ -7,7 +6,8 @@ from opentrons.protocol_api import (
     labware, MAX_SUPPORTED_VERSION, module_geometry)
 
 from opentrons_shared_data import load_shared_data
-from opentrons import calibration_storage as storage
+from opentrons.calibration_storage import (
+    modify, helpers, get, delete, file_operators)
 from opentrons.types import Point, Location
 from opentrons.protocols.types import APIVersion
 from opentrons.protocol_api.geometry import Deck
@@ -36,13 +36,7 @@ test_data = {
 
 
 @pytest.fixture
-def index_file_dir(tmpdir, monkeypatch):
-    monkeypatch.setattr(labware, 'OFFSETS_PATH', Path(tmpdir))
-    yield tmpdir
-
-
-@pytest.fixture
-def set_up_index_file(index_file_dir):
+def set_up_index_file(offset_tempdir):
     deck = Deck()
     labware_list = [
         'nest_96_wellplate_2ml_deep',
@@ -53,7 +47,7 @@ def set_up_index_file(index_file_dir):
         parent = deck.position_for(idx+1)
         definition = labware.get_labware_definition(name)
         lw = labware.Labware(definition, parent)
-        storage.modify.save_calibration(lw, Point(0, 0, 0))
+        modify.save_calibration(lw, Point(0, 0, 0))
 
     return labware_list
 
@@ -505,12 +499,12 @@ def test_add_index_file(labware_name, index_file_dir):
     parent = deck.position_for(1)
     definition = labware.get_labware_definition(labware_name)
     lw = labware.Labware(definition, parent)
-    labware_hash = storage.helpers._hash_labware_def(lw._definition)
-    storage.modify._add_to_index_offset_file(lw, labware_hash)
+    labware_hash = helpers._hash_labware_def(lw._definition)
+    modify._add_to_index_offset_file(lw, labware_hash)
 
     lw_uri = labware.uri_from_definition(definition)
 
-    str_parent = storage.get._get_parent_identifier(lw.parent)
+    str_parent = helpers._get_parent_identifier(lw.parent)
     slot = '1'
     if str_parent:
         mod_dict = {str_parent: f'{slot}-{str_parent}'}
@@ -524,13 +518,13 @@ def test_add_index_file(labware_name, index_file_dir):
         }
 
     lw_path = index_file_dir / 'index.json'
-    info = storage.file_operators._read_file(lw_path)
+    info = file_operators._read_file(lw_path)
     assert info[full_id] == blob
 
 
 def test_delete_one_calibration(set_up_index_file):
     lw_to_delete = 'nest_96_wellplate_2ml_deep'
-    all_cals = storage.get.get_all_calibrations()
+    all_cals = get.get_all_calibrations()
     id_saved = ''
 
     def get_load_names(all_cals):
@@ -538,7 +532,7 @@ def test_delete_one_calibration(set_up_index_file):
         load_names = []
         for cal in all_cals:
             uri = cal.uri
-            dets = storage.helpers.details_from_uri(uri)
+            dets = helpers.details_from_uri(uri)
             if dets.load_name == lw_to_delete:
                 id_saved = cal.labware_id
             load_names.append(dets.load_name)
@@ -548,9 +542,9 @@ def test_delete_one_calibration(set_up_index_file):
 
     assert lw_to_delete in load_names
 
-    storage.delete.delete_offset_file(id_saved)
+    delete.delete_offset_file(id_saved)
 
-    all_cals = storage.get.get_all_calibrations()
+    all_cals = get.get_all_calibrations()
     load_names = get_load_names(all_cals)
 
     assert lw_to_delete not in load_names

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -13,6 +13,7 @@ from robot_server.service.dependencies import get_hardware
 from opentrons.hardware_control import API, HardwareAPILike
 from opentrons import config
 
+from opentrons.calibration_storage import delete, modify
 from opentrons.protocol_api import labware
 from opentrons.types import Point
 from opentrons.protocol_api.geometry import Deck
@@ -91,10 +92,8 @@ def attach_pipettes(server_temp_directory):
 
 
 @pytest.fixture
-def set_up_index_file_temporary_directory(server_temp_directory, monkeypatch):
-    temp_path = config.CONFIG['labware_calibration_offsets_dir_v2']
-    monkeypatch.setattr(labware, 'OFFSETS_PATH', temp_path)
-    labware.clear_calibrations()
+def set_up_index_file_temporary_directory(server_temp_directory):
+    delete.clear_calibrations()
     deck = Deck()
     labware_list = [
         'nest_96_wellplate_2ml_deep',
@@ -106,6 +105,4 @@ def set_up_index_file_temporary_directory(server_temp_directory, monkeypatch):
         parent = deck.position_for(idx+1)
         definition = labware.get_labware_definition(name)
         lw = labware.Labware(definition, parent)
-        labware.save_calibration(lw, Point(0, 0, 0))
-        if name == 'opentrons_96_tiprack_10ul':
-            labware.save_tip_length(lw, 30)
+        modify.save_calibration(lw, Point(0, 0, 0))

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -1,15 +1,17 @@
 import pytest
 
-from opentrons.protocol_api import labware
+from opentrons.calibration_storage import file_operators
+from opentrons import config
 
 
 @pytest.fixture
 def grab_id(set_up_index_file_temporary_directory):
     labware_to_access = 'opentrons_96_tiprack_10ul'
     uri_to_check = f'opentrons/{labware_to_access}/1'
-
-    index_path = labware.OFFSETS_PATH / 'index.json'
-    index_file = labware._read_file(str(index_path))
+    offset_path =\
+        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    index_path = offset_path / 'index.json'
+    index_file = file_operators._read_file(str(index_path))
     calibration_id = ''
     for key, data in index_file.items():
         if data['uri'] == uri_to_check:


### PR DESCRIPTION
# Overview
As per comments made in both #5811 and #5820, requests were made to move file operators/calibration functions out of `labware.py` in the `protocol_api` folder.

# Changelog
* Move above functions to a `calibration_storage` folder

# Review requests
Do you like the naming conventions/new structure?

# Risk assessment
very low, just moving code around



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=535469633) by [Unito](https://www.unito.io/learn-more)
