### PR TITLE
refactor(protocol-designer): Add better hierarchy to the profile form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -307,6 +307,10 @@ and when that is implemented.
   margin-top: 0.125rem;
 }
 
+.profile_form {
+  padding-left: 1.75rem;
+}
+
 .profile_settings_group {
   margin-right: 1rem;
 }

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.js
@@ -73,24 +73,26 @@ export const ThermocyclerForm = (props: TCFormProps): React.Element<'div'> => {
         name={'thermocyclerFormType'}
         condition={val => val === THERMOCYCLER_PROFILE}
       >
-        <div className={styles.section_header}>
-          <span className={styles.section_header_text}>
-            {i18n.t('application.stepType.profile_settings')}
-          </span>
+        <div className={styles.profile_form}>
+          <div className={styles.section_header}>
+            <span className={styles.section_header_text}>
+              {i18n.t('application.stepType.profile_settings')}
+            </span>
+          </div>
+          <ProfileSettings focusHandlers={focusHandlers} />
+          <div className={styles.section_header}>
+            <span className={styles.section_header_text}>
+              {i18n.t('application.stepType.profile_steps')}
+            </span>
+          </div>
+          <ProfileItemRows focusHandlers={focusHandlers} />
+          <div className={styles.section_header}>
+            <span className={styles.section_header_text}>
+              {i18n.t('application.stepType.ending_hold')}
+            </span>
+          </div>
+          <StateFields focusHandlers={focusHandlers} isEndingHold />
         </div>
-        <ProfileSettings focusHandlers={focusHandlers} />
-        <div className={styles.section_header}>
-          <span className={styles.section_header_text}>
-            {i18n.t('application.stepType.profile_steps')}
-          </span>
-        </div>
-        <ProfileItemRows focusHandlers={focusHandlers} />
-        <div className={styles.section_header}>
-          <span className={styles.section_header_text}>
-            {i18n.t('application.stepType.ending_hold')}
-          </span>
-        </div>
-        <StateFields focusHandlers={focusHandlers} isEndingHold />
       </ConditionalOnField>
     </div>
   )


### PR DESCRIPTION
# Overview

Closes #6063 by adding an indent to the profile form. Punting on responsive name field in order to get this in before release.

<img width="937" alt="Screen Shot 2020-07-13 at 1 22 05 PM" src="https://user-images.githubusercontent.com/3430313/87334378-8af7da80-c50c-11ea-9055-588bc230978a.png">

# Changelog

- refactor(protocol-designer): Add better hierarchy to the profile form

# Review requests

- [ ] Form is indented for TC profile

# Risk assessment

low, CSS only