### PR TITLE
fix(protocol-designer): Update temperature field min sizing TC state

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -14,6 +14,7 @@
 .form_row,
 .checkbox_column {
   margin: 1rem 0;
+  width: auto;
 }
 
 .form_row {
@@ -40,6 +41,7 @@
 
 .small_field {
   width: 5.75rem;
+  min-width: 5.75rem;
 }
 
 .full_width_field {
@@ -289,7 +291,7 @@ and when that is implemented.
 }
 
 .toggle_form_group {
-  width: 20%;
+  min-width: 20%;
   margin: 0 0 1rem 1.75rem;
 }
 


### PR DESCRIPTION
# Overview

This PR serves as a last minute bug fix - temperature fields were shrinking too much for TC state fields. 

<img width="951" alt="Screen Shot 2020-07-13 at 4 39 14 PM" src="https://user-images.githubusercontent.com/3430313/87351470-796ffc00-c527-11ea-8b91-254b584bee47.png">


# Changelog

- Update temperature field min sizing TC state

# Review requests

Make a TC state step, shrink down the screen past 1025 px
- [ ] looks sane above 950px width

# Risk assessment

low, CSS in PD