### PR TITLE
feat(protocol-designer): add form level errors for missing TC block + lid temperatures

### DIFF
--- a/protocol-designer/src/steplist/formLevel/errors.js
+++ b/protocol-designer/src/steplist/formLevel/errors.js
@@ -108,6 +108,14 @@ const FORM_ERRORS: { [FormErrorKey]: FormError } = {
     title: 'Temperature is required',
     dependentFields: ['thermocyclerFormType', 'profileTargetLidTemp'],
   },
+  LID_TEMPERATURE_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['lidIsActive', 'lidTargetTemp'],
+  },
+  BLOCK_TEMPERATURE_REQUIRED: {
+    title: 'Temperature is required',
+    dependentFields: ['blockIsActive', 'blockTargetTemp'],
+  },
   BLOCK_TEMPERATURE_HOLD_REQUIRED: {
     title: 'Temperature is required',
     dependentFields: ['blockIsActiveHold', 'blockTargetTempHold'],


### PR DESCRIPTION
# Overview

This PR closes #6114 by adding the missing error objects to `FORM_ERRORS` for missing block + lid temperatures

# Changelog

- Add form level errors for missing TC block + lid temps

# Review requests

- [ ] Make a TC state step, toggle the block temp, the form should invalidate until you enter a valid temperature
- [ ] Make a TC state step, toggle the lid temp, the form should invalidate until you enter a valid temperature

# Risk assessment

Low