### PR TITLE
feat(protocol-designer): do not display calibration blocks

### DIFF
--- a/protocol-designer/src/labware-defs/utils.js
+++ b/protocol-designer/src/labware-defs/utils.js
@@ -2,6 +2,7 @@
 import groupBy from 'lodash/groupBy'
 import {
   getLabwareDefURI,
+  PD_DO_NOT_LIST,
   type LabwareDefinition2,
 } from '@opentrons/shared-data'
 import type { LabwareDefByDefURI } from './types'
@@ -24,9 +25,11 @@ export function getAllDefinitions(): LabwareDefByDefURI {
   // also, more convenient & performant to make a map {labwareDefURI: def} not an array
   if (!_definitions) {
     _definitions = definitionsContext.keys().reduce((acc, filename) => {
-      const def = definitionsContext(filename)
+      const def: LabwareDefinition2 = definitionsContext(filename)
       const labwareDefURI = getLabwareDefURI(def)
-      return { ...acc, [labwareDefURI]: def }
+      return PD_DO_NOT_LIST.includes(def.parameters.loadName)
+        ? acc
+        : { ...acc, [labwareDefURI]: def }
     }, {})
   }
 

--- a/shared-data/js/getLabware.js
+++ b/shared-data/js/getLabware.js
@@ -36,6 +36,13 @@ export const LABWAREV2_DO_NOT_LIST = [
   'opentrons_calibrationblock_short_side_left',
   'opentrons_calibrationblock_short_side_right',
 ]
+// NOTE(sa, 2020-7-14): in PD we do not want to list calibration blocks
+// but we still might want the rest of the labware in LABWAREV2_DO_NOT_LIST
+// because of legacy protocols that might use them
+export const PD_DO_NOT_LIST = [
+  'opentrons_calibrationblock_short_side_left',
+  'opentrons_calibrationblock_short_side_right',
+]
 
 export function getLabwareV1Def(labwareName: string): ?LabwareDefinition1 {
   const labware: ?LabwareDefinition1 = definitions[labwareName]


### PR DESCRIPTION
# Overview

This PR closes #6117 by removing calibration blocks from the labware def object in PD.

# Changelog
- Remove calibration blocks from the labware def object in PD.

# Review requests
Create a protocol, go to the deckmap and try to add labware. Under aluminum blocks, there should be no calibration blocks listed

# Risk assessment
Low
