### PR TITLE
chore(protocol-designer): bump to 4.0.4

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '4.0.3'
+const OT_PD_VERSION = '4.0.4'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
# Overview

4.0.3 will not be released due to #6128 and the issue fixed by #6124. 

This 4.0.4 RC will contain all of 4.0.3, with a fix for the above and also the fixup in #6136

# Changelog

Summarized diff (excluded some stuff that doesn't touch shared-data, protocol-designer, or components):

```
feat(protocol-designer): change default lid open state to false (#6129)
refactor(protocol-designer): Update thermocycler step description (#6136)
fix(comp-lib): Update SlotMap prop names (#6124)
```
# Review requests

:cow: 

# Risk assessment

Just a bump