### PR TITLE
feat(protocol-designer): do not default select TC state form

### DIFF
--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -10,6 +10,7 @@ const tipRackWithoutUnit = 'Opentrons 96 Tip Rack 300'
 const sidePanel = '[class*="SidePanel__panel_contents"]'
 const deckMap = '[class*="DeckSetup"]'
 const designPageModal = '#main-page-modal-portal-root'
+const thermocyclerFormOption = '[class*="StepEditForm__tc_step_option"]'
 const thermocyclerToggleGroups = '[class*="toggle_form_group"]'
 const temperatureFieldInput = '[class*="toggle_temperature_field"] input'
 const thermocyclerWellBlock = 'TC Well'
@@ -180,6 +181,11 @@ describe('Protocols with Modules', () => {
           .contains('thermocycler')
           .should('exist')
         // Verify acceptable block temperature range
+        cy.get(thermocyclerFormOption)
+          .first()
+          .within(() => {
+            cy.get('input[type="radio"]').check({ force: true })
+          })
         cy.get(thermocyclerToggleGroups + ':first-child').within(() => {
           cy.get('input[type="checkbox"]').click({ force: true })
           cy.get(temperatureFieldInput)
@@ -232,19 +238,37 @@ describe('Protocols with Modules', () => {
         cy.contains('deactivated').should('exist')
       })
 
-      // Add another Thermocycler State Step
-      cy.addStep('thermocycler')
+      // Verify thermocycler block settings
+      cy.get('[data-test="StepItem_1"]')
+        .children()
+        .first()
+        .click()
       cy.get(designPageModal).within(() => {
-        // Verify thermocycler block settings
+        cy.get(thermocyclerFormOption)
+          .first()
+          .within(() => {
+            cy.get('input[type="radio"]').check({ force: true })
+          })
         cy.get(thermocyclerToggleGroups + ':first-child').within(() => {
           cy.get('input[type="checkbox"][checked]').should('exist')
           cy.get(temperatureFieldInput + '[value="50"]').should('exist')
         })
+
         // Verify acceptable lid temperature range
         cy.get(thermocyclerToggleGroups + ':nth-child(2)').within(() => {
           cy.get('input[type="checkbox"][checked]').should('exist')
           cy.get(temperatureFieldInput + '[value="50"]').should('exist')
         })
+      })
+
+      // Add another Thermocycler State Step
+      cy.addStep('thermocycler')
+      cy.get(designPageModal).within(() => {
+        cy.get(thermocyclerFormOption)
+          .first()
+          .within(() => {
+            cy.get('input[type="radio"]').check({ force: true })
+          })
         // Close Lid
         cy.get(thermocyclerToggleGroups + ':last-child').within(() => {
           cy.get('input[type="checkbox"]').click({ force: true })

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -355,6 +355,7 @@ describe('createPresavedStepForm', () => {
           stepDetails: '',
           stepName: 'thermocycler',
           stepType: 'thermocycler',
+          thermocyclerFormType: null,
         })
       })
     })

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -355,7 +355,6 @@ describe('createPresavedStepForm', () => {
           stepDetails: '',
           stepName: 'thermocycler',
           stepType: 'thermocycler',
-          thermocyclerFormType: 'thermocyclerState',
         })
       })
     })

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -94,6 +94,7 @@ export function getDefaultsForStepType(
       }
     case 'thermocycler':
       return {
+        thermocyclerFormType: null,
         moduleId: null,
         blockIsActive: false,
         blockTargetTemp: null,

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -6,7 +6,6 @@ import {
   DEFAULT_WELL_ORDER_FIRST_OPTION,
   DEFAULT_WELL_ORDER_SECOND_OPTION,
   FIXED_TRASH_ID,
-  THERMOCYCLER_STATE,
 } from '../../constants'
 import type { StepType, StepFieldName } from '../../form-types'
 
@@ -95,7 +94,6 @@ export function getDefaultsForStepType(
       }
     case 'thermocycler':
       return {
-        thermocyclerFormType: THERMOCYCLER_STATE,
         moduleId: null,
         blockIsActive: false,
         blockTargetTemp: null,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
@@ -15,7 +15,7 @@ const updatePatchOnThermocyclerFormType = (
 ) => {
   // Profile => State
   if (
-    rawForm['thermocyclerFormType'] &&
+    rawForm['thermocyclerFormType'] !== null &&
     fieldHasChanged(rawForm, patch, 'thermocyclerFormType')
   ) {
     return {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.js
@@ -14,7 +14,10 @@ const updatePatchOnThermocyclerFormType = (
   rawForm: FormData
 ) => {
   // Profile => State
-  if (fieldHasChanged(rawForm, patch, 'thermocyclerFormType')) {
+  if (
+    rawForm['thermocyclerFormType'] &&
+    fieldHasChanged(rawForm, patch, 'thermocyclerFormType')
+  ) {
     return {
       ...patch,
       ...getDefaultFields(


### PR DESCRIPTION
# Overview

This PR cloes #6097 by removing the default TC state form selection from the TC form.

# Changelog

- Do not default select TC state form

# Review requests

Make a protocol with TC
Create a TC step
No form should be auto selected

# Risk assessment
Low
