### PR TITLE
feat(protocol-designer): add air gap command creator

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/airGap.test.js
+++ b/protocol-designer/src/step-generation/__tests__/airGap.test.js
@@ -1,0 +1,206 @@
+// @flow
+import { getLabwareDefURI } from '@opentrons/shared-data'
+import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import fixture_tiprack_1000_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_1000_ul.json'
+import {
+  getInitialRobotStateStandard,
+  getRobotStateWithTipStandard,
+  makeContext,
+  getSuccessResult,
+  getErrorResult,
+  DEFAULT_PIPETTE,
+  SOURCE_LABWARE,
+} from '../__fixtures__'
+import { airGap } from '../commandCreators/atomic/airGap'
+import { thermocyclerPipetteCollision, modulePipetteCollision } from '../utils'
+
+import type { InvariantContext, RobotState } from '../'
+
+jest.mock('../utils/thermocyclerPipetteCollision')
+jest.mock('../utils/modulePipetteCollision')
+
+const mockThermocyclerPipetteCollision: JestMockFn<
+  [
+    $PropertyType<RobotState, 'modules'>,
+    $PropertyType<RobotState, 'labware'>,
+    string
+  ],
+  boolean
+> = thermocyclerPipetteCollision
+
+const mockModulePipetteCollision: JestMockFn<
+  [
+    {|
+      pipette: ?string,
+      labware: ?string,
+      invariantContext: InvariantContext,
+      prevRobotState: RobotState,
+    |}
+  ],
+  boolean
+> = modulePipetteCollision
+
+describe('airGap', () => {
+  let invariantContext, robotStateNoTip, robotStateWithTip, flowRateAndOffsets
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateNoTip = getInitialRobotStateStandard(invariantContext)
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+    flowRateAndOffsets = {
+      flowRate: 6,
+      offsetFromBottomMm: 5,
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return an air gap command', () => {
+    const params = {
+      ...flowRateAndOffsets,
+      pipette: DEFAULT_PIPETTE,
+      volume: 50,
+      labware: SOURCE_LABWARE,
+      well: 'A1',
+    }
+    const result = airGap({ ...params }, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        command: 'airGap',
+        params,
+      },
+    ])
+  })
+
+  it('should return a no tip error when there is no tip', () => {
+    const params = {
+      ...flowRateAndOffsets,
+      pipette: DEFAULT_PIPETTE,
+      volume: 50,
+      labware: SOURCE_LABWARE,
+      well: 'A1',
+    }
+    const result = airGap({ ...params }, invariantContext, robotStateNoTip)
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'NO_TIP_ON_PIPETTE',
+    })
+  })
+
+  it('should return a volume exceeded error when the air gap volume is above the tip max', () => {
+    invariantContext.pipetteEntities[
+      DEFAULT_PIPETTE
+    ].tiprackDefURI = getLabwareDefURI(fixture_tiprack_10_ul)
+
+    invariantContext.pipetteEntities[
+      DEFAULT_PIPETTE
+    ].tiprackLabwareDef = fixture_tiprack_10_ul
+
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 201,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'TIP_VOLUME_EXCEEDED',
+    })
+  })
+
+  it('should return a TC lid closed error when there is a pipette collision with a TC', () => {
+    mockThermocyclerPipetteCollision.mockImplementationOnce(
+      (
+        modules: $PropertyType<RobotState, 'modules'>,
+        labware: $PropertyType<RobotState, 'labware'>,
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
+        expect(labwareId).toBe(SOURCE_LABWARE)
+        return true
+      }
+    )
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 50,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'THERMOCYCLER_LID_CLOSED',
+    })
+  })
+
+  it('should return a module collision error when there a module collision', () => {
+    mockModulePipetteCollision.mockImplementationOnce(
+      (args: {
+        pipette: ?string,
+        labware: ?string,
+        invariantContext: InvariantContext,
+        prevRobotState: RobotState,
+      }): boolean => {
+        const { pipette, labware, invariantContext, prevRobotState } = args
+        expect(pipette).toEqual(DEFAULT_PIPETTE)
+        expect(labware).toEqual(SOURCE_LABWARE)
+        expect(invariantContext).toEqual(invariantContext)
+        expect(prevRobotState).toEqual(robotStateWithTip)
+        return true
+      }
+    )
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 50,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'MODULE_PIPETTE_COLLISION_DANGER',
+    })
+  })
+
+  it('should return a pipette volume exceeded error when the pipette volume is less than the air gap volume', () => {
+    invariantContext.pipetteEntities[
+      DEFAULT_PIPETTE
+    ].tiprackDefURI = getLabwareDefURI(fixture_tiprack_1000_ul)
+
+    invariantContext.pipetteEntities[
+      DEFAULT_PIPETTE
+    ].tiprackLabwareDef = fixture_tiprack_1000_ul
+
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 301,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'PIPETTE_VOLUME_EXCEEDED',
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/__tests__/airGap.test.js
+++ b/protocol-designer/src/step-generation/__tests__/airGap.test.js
@@ -113,10 +113,7 @@ describe('airGap', () => {
       well: 'A1',
     }
     const result = airGap({ ...params }, invariantContext, robotStateNoTip)
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'NO_TIP_ON_PIPETTE',
-    })
+    expectTimelineError(getErrorResult(result).errors, 'NO_TIP_ON_PIPETTE')
   })
 
   it('should return a volume exceeded error when the air gap volume is above the tip max', () => {
@@ -140,10 +137,7 @@ describe('airGap', () => {
       robotStateWithTip
     )
 
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'TIP_VOLUME_EXCEEDED',
-    })
+    expectTimelineError(getErrorResult(result).errors, 'TIP_VOLUME_EXCEEDED')
   })
 
   it('should return a TC lid closed error when there is a pipette collision with a TC', () => {
@@ -170,10 +164,10 @@ describe('airGap', () => {
       invariantContext,
       robotStateWithTip
     )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'THERMOCYCLER_LID_CLOSED',
-    })
+    expectTimelineError(
+      getErrorResult(result).errors,
+      'THERMOCYCLER_LID_CLOSED'
+    )
   })
 
   it('should return a module collision error when there a module collision', () => {
@@ -203,10 +197,11 @@ describe('airGap', () => {
       invariantContext,
       robotStateWithTip
     )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'MODULE_PIPETTE_COLLISION_DANGER',
-    })
+
+    expectTimelineError(
+      getErrorResult(result).errors,
+      'MODULE_PIPETTE_COLLISION_DANGER'
+    )
   })
 
   it('should return a pipette volume exceeded error when the pipette volume is less than the air gap volume', () => {
@@ -229,9 +224,10 @@ describe('airGap', () => {
       invariantContext,
       robotStateWithTip
     )
-    expect(getErrorResult(result).errors).toHaveLength(1)
-    expect(getErrorResult(result).errors[0]).toMatchObject({
-      type: 'PIPETTE_VOLUME_EXCEEDED',
-    })
+
+    expectTimelineError(
+      getErrorResult(result).errors,
+      'PIPETTE_VOLUME_EXCEEDED'
+    )
   })
 })

--- a/protocol-designer/src/step-generation/__tests__/airGap.test.js
+++ b/protocol-designer/src/step-generation/__tests__/airGap.test.js
@@ -11,6 +11,7 @@ import {
   DEFAULT_PIPETTE,
   SOURCE_LABWARE,
 } from '../__fixtures__'
+import { expectTimelineError } from '../__utils__/testMatchers'
 import { airGap } from '../commandCreators/atomic/airGap'
 import { thermocyclerPipetteCollision, modulePipetteCollision } from '../utils'
 
@@ -71,6 +72,36 @@ describe('airGap', () => {
         params,
       },
     ])
+  })
+
+  it('should return pipette error when using an invalid pipette', () => {
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: 'badPipette',
+        volume: 50,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expectTimelineError(getErrorResult(result).errors, 'PIPETTE_DOES_NOT_EXIST')
+  })
+
+  it('should return a labware error when using invalid labware', () => {
+    const result = airGap(
+      {
+        ...flowRateAndOffsets,
+        pipette: DEFAULT_PIPETTE,
+        volume: 50,
+        labware: 'problematicLabwareId',
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expectTimelineError(getErrorResult(result).errors, 'LABWARE_DOES_NOT_EXIST')
   })
 
   it('should return a no tip error when there is no tip', () => {

--- a/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
@@ -1,0 +1,100 @@
+// @flow
+import * as errorCreators from '../../errorCreators'
+import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
+import {
+  modulePipetteCollision,
+  thermocyclerPipetteCollision,
+} from '../../utils'
+
+import type { AirGapParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
+import type { CommandCreator, CommandCreatorError } from '../../types'
+
+export const airGap: CommandCreator<AirGapParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { pipette, volume, labware, well, offsetFromBottomMm, flowRate } = args
+
+  const actionName = 'aspirate'
+  const errors: Array<CommandCreatorError> = []
+
+  const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
+
+  if (!prevRobotState.tipState.pipettes[pipette]) {
+    errors.push(
+      errorCreators.noTipOnPipette({
+        actionName,
+        pipette,
+        labware,
+        well,
+      })
+    )
+  }
+
+  if (errors.length === 0 && pipetteSpec && pipetteSpec.maxVolume < volume) {
+    errors.push(
+      errorCreators.pipetteVolumeExceeded({
+        actionName,
+        volume,
+        maxVolume: pipetteSpec.maxVolume,
+      })
+    )
+  }
+
+  if (errors.length === 0 && pipetteSpec) {
+    const tipMaxVolume = getPipetteWithTipMaxVol(pipette, invariantContext)
+    if (tipMaxVolume < volume) {
+      errors.push(
+        errorCreators.tipVolumeExceeded({
+          actionName,
+          volume,
+          maxVolume: tipMaxVolume,
+        })
+      )
+    }
+  }
+
+  if (
+    thermocyclerPipetteCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (
+    modulePipetteCollision({
+      pipette,
+      labware,
+      invariantContext,
+      prevRobotState,
+    })
+  ) {
+    errors.push(errorCreators.modulePipetteCollisionDanger())
+  }
+
+  if (errors.length > 0) {
+    return { errors }
+  }
+
+  const commands = [
+    {
+      command: 'airGap',
+      params: {
+        pipette,
+        volume,
+        labware,
+        well,
+        offsetFromBottomMm,
+        flowRate,
+      },
+    },
+  ]
+
+  return {
+    commands,
+  }
+}

--- a/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
@@ -21,6 +21,14 @@ export const airGap: CommandCreator<AirGapParams> = (
 
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
 
+  if (!pipetteSpec) {
+    errors.push(errorCreators.pipetteDoesNotExist({ actionName, pipette }))
+  }
+
+  if (!labware || !prevRobotState.labware[labware]) {
+    errors.push(errorCreators.labwareDoesNotExist({ actionName, labware }))
+  }
+
   if (!prevRobotState.tipState.pipettes[pipette]) {
     errors.push(
       errorCreators.noTipOnPipette({

--- a/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/airGap.js
@@ -16,7 +16,7 @@ export const airGap: CommandCreator<AirGapParams> = (
 ) => {
   const { pipette, volume, labware, well, offsetFromBottomMm, flowRate } = args
 
-  const actionName = 'aspirate'
+  const actionName = 'airGap'
   const errors: Array<CommandCreatorError> = []
 
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec


### PR DESCRIPTION
# Overview

This PR closes #6053 by adding an air gap command creator.
# Changelog


Example changelog:
- Add air gap command creator

# Review requests
It's not hooked up yet so really just a thorough code review.

- try to think through any errors that might occur, I took all from `aspirate` and I can't think of any others
- make sure unit tests cover all error cases

# Risk assessment

Low
