### PR TITLE
refactor(robot-server): tip length calibration: move pip to ref location and save offsets

### DIFF
--- a/robot-server/robot_server/robot/calibration/tip_length/constants.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/constants.py
@@ -16,6 +16,7 @@ class TipCalibrationState(str, Enum):
     WILDCARD = WILDCARD
 
 
+TRASH_WELL = 'A1'
 TIP_RACK_SLOT = '8'
 LEFT_MOUNT_CAL_BLOCK_SLOT = '3'
 LEFT_MOUNT_CAL_BLOCK_LOADNAME = 'opentrons_calibrationblock_short_side_right'
@@ -24,7 +25,7 @@ RIGHT_MOUNT_CAL_BLOCK_SLOT = '1'
 RIGHT_MOUNT_CAL_BLOCK_LOADNAME = 'opentrons_calibrationblock_short_side_left'
 RIGHT_MOUNT_CAL_BLOCK_WELL = 'A2'
 
-TRASH_REF_POINT_OFFSET = Point(26, 33, 0)  # offset from corner of slot 12
+TRASH_REF_POINT_OFFSET = Point(-57.84, -55, 0)  # offset from center of trash
 MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
 MOVE_TO_REF_POINT_SAFETY_BUFFER = Point(0, 0, 5)
 

--- a/robot-server/robot_server/robot/calibration/tip_length/constants.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/constants.py
@@ -19,18 +19,24 @@ class TipCalibrationState(str, Enum):
 TIP_RACK_SLOT = '8'
 LEFT_MOUNT_CAL_BLOCK_SLOT = '3'
 LEFT_MOUNT_CAL_BLOCK_LOADNAME = 'opentrons_calibrationblock_short_side_right'
+LEFT_MOUNT_CAL_BLOCK_WELL = 'A1'
 RIGHT_MOUNT_CAL_BLOCK_SLOT = '1'
 RIGHT_MOUNT_CAL_BLOCK_LOADNAME = 'opentrons_calibrationblock_short_side_left'
+RIGHT_MOUNT_CAL_BLOCK_WELL = 'A2'
 
+TRASH_REF_POINT_OFFSET = Point(25, 25, 0)  # offset from the corner of slot 12
 MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
+MOVE_TO_REF_POINT_SAFETY_BUFFER = Point(0, 0, 5)
 
 CAL_BLOCK_SETUP_BY_MOUNT: Dict[Mount, Dict[str, str]] = {
     Mount.LEFT: {
         'load_name': LEFT_MOUNT_CAL_BLOCK_LOADNAME,
         'slot': LEFT_MOUNT_CAL_BLOCK_SLOT,
+        'well': LEFT_MOUNT_CAL_BLOCK_WELL,
     },
     Mount.RIGHT: {
         'load_name': RIGHT_MOUNT_CAL_BLOCK_LOADNAME,
         'slot': RIGHT_MOUNT_CAL_BLOCK_SLOT,
+        'well': RIGHT_MOUNT_CAL_BLOCK_WELL,
     }
 }

--- a/robot-server/robot_server/robot/calibration/tip_length/constants.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/constants.py
@@ -24,7 +24,7 @@ RIGHT_MOUNT_CAL_BLOCK_SLOT = '1'
 RIGHT_MOUNT_CAL_BLOCK_LOADNAME = 'opentrons_calibrationblock_short_side_left'
 RIGHT_MOUNT_CAL_BLOCK_WELL = 'A2'
 
-TRASH_REF_POINT_OFFSET = Point(25, 25, 0)  # offset from the corner of slot 12
+TRASH_REF_POINT_OFFSET = Point(26, 33, 0)  # offset from corner of slot 12
 MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
 MOVE_TO_REF_POINT_SAFETY_BUFFER = Point(0, 0, 5)
 

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -124,10 +124,10 @@ class TipCalibrationUserFlow():
         return Location(point, None)
 
     async def save_offset(self, *args):
-        if self._current_state == State.labwareLoaded:
+        if self._current_state == State.measuringNozzleOffset:
             cur_pt = await self._hardware.gantry_position(self._mount)
             self._nozzle_z_offset = cur_pt.z
-        elif self._current_state == State.preparingPipette:
+        elif self._current_state == State.measuringTipOffset:
             assert self._hw_pipette.has_tip
             tip_length_offset = await self._calculate_tip_length()
             tip_length_data = modify.create_tip_length_data(

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -1,9 +1,10 @@
 import pytest
 from unittest.mock import MagicMock
 from typing import List, Tuple, Dict, Any
-from opentrons.types import Mount, Point
+from opentrons.types import Location, Mount, Point
 from opentrons.hardware_control import pipette
-from robot_server.service.session.models import CalibrationCommand
+from robot_server.service.session.models import (
+    CalibrationCommand, TipLengthCalibrationCommand)
 from robot_server.robot.calibration.tip_length.user_flow import \
     TipCalibrationUserFlow
 
@@ -65,18 +66,31 @@ def mock_hw(hardware):
                           },
                           'testId')
     hardware._attached_instruments = {Mount.RIGHT: pip}
+    hardware._current_pos = Point(0, 0, 0)
 
     async def async_mock(*args, **kwargs):
         pass
 
-    async def gantry_pos_mock(*args, **kwargs):
-        return Point(0, 0, 0)
+    async def async_mock_move_rel(*args, **kwargs):
+        x = kwargs.get('x', 0)
+        y = kwargs.get('y', 0)
+        z = kwargs.get('z', 0)
+        hardware._current_pos += Point(x, y, z)
 
-    hardware.move_rel = MagicMock(side_effect=async_mock)
+    async def async_mock_move_to(*args, **kwargs):
+        x = kwargs.get('x', 0)
+        y = kwargs.get('y', 0)
+        z = kwargs.get('z', 0)
+        hardware._current_pos = Point(x, y, z)
+
+    async def gantry_pos_mock(*args, **kwargs):
+        return hardware._current_pos
+
+    hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
     hardware.pick_up_tip = MagicMock(side_effect=async_mock)
     hardware.drop_tip = MagicMock(side_effect=async_mock)
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock)
+    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
     return hardware
 
@@ -110,6 +124,10 @@ hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
     (CalibrationCommand.jog, 'measuringNozzleOffset',
      stub_jog_data, 'move_rel'),
     (CalibrationCommand.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
+    (TipLengthCalibrationCommand.move_to_reference_point, 'labwareLoaded',
+     {}, 'gantry_position'),
+    (TipLengthCalibrationCommand.move_to_reference_point, 'preparingPipette',
+     {}, 'gantry_position'),
 ]
 
 # TODO: unit test each command
@@ -143,3 +161,33 @@ def test_load_cal_block(mock_user_flow_all_combos):
     else:
         assert uf._deck['3'].load_name == \
                 'opentrons_calibrationblock_short_side_right'
+
+
+async def test_get_reference_location(mock_user_flow_all_combos):
+    uf = mock_user_flow_all_combos
+    result = uf._get_reference_point()
+    if uf._has_calibration_block:
+        if uf._mount == Mount.LEFT:
+            exp = uf._deck['3'].wells()[0].top().point + Point(0, 0, 5)
+        else:
+            exp = uf._deck['1'].wells()[1].top().point + Point(0, 0, 5)
+    else:
+        height = uf._deck['12'].highest_z + 5
+        exp = uf._deck['12']._offset + Point(25, 25, height)
+    assert result == Location(exp, None)
+
+
+async def test_save_offsets(mock_user_flow):
+    uf = mock_user_flow
+    uf._current_state = 'labwareLoaded'
+    assert uf._nozzle_z_offset is None
+
+    await uf._hardware.move_to(x=10, y=10, z=10)
+    await uf.save_offset()
+    assert uf._nozzle_z_offset == 10
+
+    uf._current_state = 'preparingPipette'
+    uf._hw_pipette._has_tip = True
+    await uf._hardware.move_to(x=10, y=10, z=40)
+    result = await uf._calculate_tip_length()
+    assert result == 30

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from typing import List, Tuple, Dict, Any
-from opentrons.types import Location, Mount, Point
+from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 from robot_server.service.session.models import (
     CalibrationCommand, TipLengthCalibrationCommand)
@@ -168,23 +168,23 @@ async def test_get_reference_location(mock_user_flow_all_combos):
     result = uf._get_reference_point()
     if uf._has_calibration_block:
         if uf._mount == Mount.LEFT:
-            exp = uf._deck['3'].wells()[0].top().point + Point(0, 0, 5)
+            exp = uf._deck['3'].wells()[0].top().move(Point(0, 0, 5))
         else:
-            exp = uf._deck['1'].wells()[1].top().point + Point(0, 0, 5)
+            exp = uf._deck['1'].wells()[1].top().move(Point(0, 0, 5))
     else:
         height = uf._deck['12'].highest_z + 5
-        exp = uf._deck['12']._offset + Point(25, 25, height)
-    assert result == Location(exp, None)
+        exp = uf._deck.position_for('12').move(Point(26, 33, height))
+    assert result == exp
 
 
 async def test_save_offsets(mock_user_flow):
     uf = mock_user_flow
     uf._current_state = 'measuringNozzleOffset'
-    assert uf._nozzle_z_offset is None
+    assert uf._nozzle_height_at_reference is None
 
     await uf._hardware.move_to(x=10, y=10, z=10)
     await uf.save_offset()
-    assert uf._nozzle_z_offset == 10
+    assert uf._nozzle_height_at_reference == 10
 
     uf._current_state = 'measuringTipOffset'
     uf._hw_pipette._has_tip = True

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -179,14 +179,14 @@ async def test_get_reference_location(mock_user_flow_all_combos):
 
 async def test_save_offsets(mock_user_flow):
     uf = mock_user_flow
-    uf._current_state = 'labwareLoaded'
+    uf._current_state = 'measuringNozzleOffset'
     assert uf._nozzle_z_offset is None
 
     await uf._hardware.move_to(x=10, y=10, z=10)
     await uf.save_offset()
     assert uf._nozzle_z_offset == 10
 
-    uf._current_state = 'preparingPipette'
+    uf._current_state = 'measuringTipOffset'
     uf._hw_pipette._has_tip = True
     await uf._hardware.move_to(x=10, y=10, z=40)
     result = await uf._calculate_tip_length()

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -172,8 +172,8 @@ async def test_get_reference_location(mock_user_flow_all_combos):
         else:
             exp = uf._deck['1'].wells()[1].top().move(Point(0, 0, 5))
     else:
-        height = uf._deck['12'].highest_z + 5
-        exp = uf._deck.position_for('12').move(Point(26, 33, height))
+        exp = uf._deck.get_fixed_trash().wells()[0].top().move(
+            Point(-57.84, -55, 5))
     assert result == exp
 
 


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fill out the `move_to_reference_point` and `save_offset` commands for tip length calibration user flow.

closes #5612, closes #5614
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- added safety buffer for reference points (z=5 mm)
- determined the reference points:
    - trash bin location: slot 12 offset + (x=25mm, y=25mm, z=trash's highest Z)
    - calibration block location: 
- updated `CAL_BLOCK_SETUP_BY_MOUNT` by adding well name based on the pipette mount
- save_offset() now saves the `TipCalibrationUserFlow._nozzle_z_offset` during measuringNozzleOffset state,
   which is then used to calculate the tip length during measuingTipOffset
- added more tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
I struggled with mypy and had to ignore the type to pass the check:

user_flow.py: line 115
```
calblock: labware.Labware = self._deck[slot]  # type: ignore
```
I understand that `self._deck[slot]` returns a DeckItem instead of a labware. I just couldn't figure out mypy didn't raise for this:

same file: line 154
```
tiprack: labware.Labware = self._deck[TIP_RACK_SLOT]
```

What am I missing?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low - new changes are behind a feature flag
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
