### PR TITLE
feat(protocol-designer): add new air gap fields

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -105,20 +105,22 @@ export const SourceDestFields = (props: Props): React.Node => {
             />
             {getMixFields()}
             {getDelayFields()}
-            <CheckboxRowField
-              disabled
-              tooltipComponent={i18n.t('tooltip.not_in_beta')}
-              name="aspirate_airGap_checkbox"
-              label={i18n.t('form.step_edit_form.field.airGap.label')}
-              className={styles.small_field}
-            >
-              <TextField
+            {!delayEnabled && (
+              <CheckboxRowField
                 disabled
-                name="aspirate_airGap_volume"
-                units={i18n.t('application.units.microliter')}
-                {...focusHandlers}
-              />
-            </CheckboxRowField>
+                tooltipComponent={i18n.t('tooltip.not_in_beta')}
+                name="aspirate_airGap_checkbox"
+                label={i18n.t('form.step_edit_form.field.airGap.label')}
+                className={styles.small_field}
+              >
+                <TextField
+                  disabled
+                  name="aspirate_airGap_volume"
+                  units={i18n.t('application.units.microliter')}
+                  {...focusHandlers}
+                />
+              </CheckboxRowField>
+            )}
           </React.Fragment>
         )}
         {prefix === 'dispense' && (
@@ -151,6 +153,26 @@ export const SourceDestFields = (props: Props): React.Node => {
             <BlowoutLocationField
               name="blowout_location"
               className={styles.full_width}
+              {...focusHandlers}
+            />
+          </CheckboxRowField>
+        )}
+
+        {delayEnabled && (
+          <CheckboxRowField
+            tooltipComponent={i18n.t(
+              `tooltip.step_fields.defaults.${addFieldNamePrefix(
+                'airGap_checkbox'
+              )}`
+            )}
+            name={addFieldNamePrefix('airGap_checkbox')}
+            label={i18n.t('form.step_edit_form.field.airGap.label')}
+            className={styles.small_field}
+          >
+            <TextField
+              className={styles.small_field}
+              name={addFieldNamePrefix('airGap_volume')}
+              units={i18n.t('application.units.microliter')}
               {...focusHandlers}
             />
           </CheckboxRowField>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -158,7 +158,7 @@ export const SourceDestFields = (props: Props): React.Node => {
           </CheckboxRowField>
         )}
 
-        {delayEnabled && (
+        {prefix === 'aspirate' && delayEnabled && (
           <CheckboxRowField
             tooltipComponent={i18n.t(
               `tooltip.step_fields.defaults.${addFieldNamePrefix(

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -58,8 +58,8 @@ describe('SourceDestFields', () => {
         expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
         expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
         expect(checkboxes.at(2).prop('name')).toBe('aspirate_delay_checkbox')
-        expect(checkboxes.at(3).prop('name')).toBe('aspirate_airGap_checkbox')
-        expect(checkboxes.at(4).prop('name')).toBe('aspirate_touchTip_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('aspirate_touchTip_checkbox')
+        expect(checkboxes.at(4).prop('name')).toBe('aspirate_airGap_checkbox')
       })
     })
     describe('When air gap/delay FF is off', () => {

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -16,7 +16,6 @@
   "step_fields": {
     "defaults": {
       "aspirate_airGap_checkbox": "Aspirate air before moving to destination well",
-      "dispense_airGap_checkbox": "Aspirate air after dispense, before moving to next destination",
       "aspirate_flowRate": "The speed at which the pipette aspirates",
       "dispense_flowRate": "The speed at which the pipette dispenses",
       "aspirate_mix_checkbox": "Pipette up and down before aspirating",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -15,6 +15,8 @@
 
   "step_fields": {
     "defaults": {
+      "aspirate_airGap_checkbox": "Aspirate air before moving to destination well",
+      "dispense_airGap_checkbox": "Aspirate air after dispense, before moving to next destination",
       "aspirate_flowRate": "The speed at which the pipette aspirates",
       "dispense_flowRate": "The speed at which the pipette dispenses",
       "aspirate_mix_checkbox": "Pipette up and down before aspirating",


### PR DESCRIPTION
# Overview

Closes #6005 

~and addresses static UI part of #6147~ (nope we're punting Delay > Air gap)

# Changelog


# Review requests

Should look like this 
![image](https://user-images.githubusercontent.com/11590381/88199949-72c24280-cc13-11ea-81d8-9c9e0707b966.png)


- [ ] With air gap FF on: make sure this is correct, compare to Figma. Check tooltips too!
- [ ] With air gap FF off: make sure it still matches prod (no visible change, including tooltips)

# Risk assessment

Low if correctly under FF