### PR TITLE
refactor(api): load new tip length calibration if ff set

### DIFF
--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -126,8 +126,7 @@ class Pipette:
                         cp)
             info_str += 'model offset: {} + instrument offset: {}'\
                 .format(mod_offset_xy, instr)
-            if tip_length:
-                info_str += ' - tip_length: {}'.format(tip_length)
+            info_str += ' - tip_length: {}'.format(tip_length)
             info_str += ')'
             self._log.debug(info_str)
 

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 from opentrons.types import Point
 from opentrons.config import pipette_config
+from opentrons.config.feature_flags import enable_tip_length_calibration
 from .types import CriticalPoint
 from opentrons_shared_data.pipette import name_for_model
 
@@ -110,21 +111,26 @@ class Pipette:
         mod_and_tip = Point(mod_offset_xy[0],
                             mod_offset_xy[1],
                             mod_offset_xy[2] - tip_length)
-        cp = mod_and_tip + self._instrument_offset._replace(z=0)
+
+        if enable_tip_length_calibration():
+            instr = self._instrument_offset
+        else:
+            instr = self._instrument_offset._replace(z=0)
+
+        cp = mod_and_tip + instr
+
         if self._log.isEnabledFor(logging.DEBUG):
-            mo = 'model offset: {} + '.format(self.model_offset)\
-                if cp_type != CriticalPoint.XY_CENTER else ''
-            info_str = 'cp: {}{}: {}=({}instr offset xy: {}'\
-                .format(cp_type, '(from override)' if cp_override else '',
-                        cp, mo,
-                        self._instrument_offset._replace(z=0))
-            if cp_type == CriticalPoint.TIP:
-                info_str += '- current_tip_length: {}=(true tip length: {}'\
-                    ' - inst z: {}) (z only)'.format(
-                        self.current_tip_length, self._current_tip_length,
-                        self._instrument_offset.z)
+            info_str = 'cp: {}{}: {} (from: '\
+                .format(cp_type,
+                        ' (from override)' if cp_override else '',
+                        cp)
+            info_str += 'model offset: {} + instrument offset: {}'\
+                .format(mod_offset_xy, instr)
+            if tip_length:
+                info_str += ' - tip_length: {}'.format(tip_length)
             info_str += ')'
             self._log.debug(info_str)
+
         return cp
 
     @property
@@ -135,8 +141,11 @@ class Pipette:
     @property
     def current_tip_length(self) -> float:
         """ The length of the current tip attached (0.0 if no tip) """
-        return (self._current_tip_length
-                - self._instrument_offset.z)
+        if enable_tip_length_calibration():
+            return self._current_tip_length
+        else:
+            return (self._current_tip_length
+                    - self._instrument_offset.z)
 
     @property
     def current_tiprack_diameter(self) -> float:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import logging
 from typing import (Any, Dict, List, Tuple, Sequence, TYPE_CHECKING, Union)
 
@@ -5,9 +6,12 @@ from typing import (Any, Dict, List, Tuple, Sequence, TYPE_CHECKING, Union)
 from opentrons import types, commands as cmds, hardware_control as hc
 from opentrons.commands import CommandPublisher
 from opentrons.hardware_control.types import CriticalPoint
+from opentrons.config.feature_flags import enable_tip_length_calibration
+from opentrons.calibration_storage import get
+from opentrons.calibration_storage.types import TipLengthCalNotFound
 from .util import (
     FlowRates, PlungerSpeeds, Clearances,
-    clamp_value, requires_version, build_edges)
+    clamp_value, requires_version, build_edges, first_parent)
 from opentrons.protocols.types import APIVersion
 from .labware import (
     filter_tipracks_to_start, Labware, OutOfTipsError, quirks_from_any_parent,
@@ -1341,10 +1345,25 @@ class InstrumentContext(CommandPublisher):
         return '{} on {} mount'.format(self.hw_pipette['display_name'],
                                        self._mount.name.lower())
 
+    @lru_cache(maxsize=12)
     def _tip_length_for(self, tiprack: Labware) -> float:
         """ Get the tip length, including overlap, for a tip from this rack """
-        tip_overlap = self.hw_pipette['tip_overlap'].get(
-            tiprack.uri,
-            self.hw_pipette['tip_overlap']['default'])
-        tip_length = tiprack.tip_length
-        return tip_length - tip_overlap
+
+        def _build_length_from_overlap() -> float:
+            tip_overlap = self.hw_pipette['tip_overlap'].get(
+                tiprack.uri,
+                self.hw_pipette['tip_overlap']['default'])
+            tip_length = tiprack.tip_length
+            return tip_length - tip_overlap
+
+        if not enable_tip_length_calibration():
+            return _build_length_from_overlap()
+        else:
+            try:
+                parent = first_parent(tiprack) or ''
+                return get.load_tip_length_calibration(
+                    self.hw_pipette['pipette_id'],
+                    tiprack._definition,
+                    parent)['tipLength']
+            except TipLengthCalNotFound:
+                return _build_length_from_overlap()

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -205,6 +205,13 @@ async def old_aspiration(monkeypatch):
         'useOldAspirationFunctions', False)
 
 
+@pytest.fixture
+async def use_tip_length_cal(monkeypatch):
+    await config.advanced_settings.set_adv_setting(
+        'enableTipLengthCalibration', True)
+    yield
+    await config.advanced_settings.set_adv_setting(
+        'enableTipLengthCalibration', False)
 # -----end feature flag fixtures-----------
 
 


### PR DESCRIPTION
If the robot-side feature flag use_tip_length_calibration is set, we
will use the new tip length calibration data in the protocol api and the
hardware controller (so, APIv2 only for now).

Loading tip length calibration data requires knowing about both the
pipette id and the labware, which means it's not a natural fit for just
the opentrons.protocol_api.labware module. The place where both of those
data are present is in the InstrumentContext, which features a
tip_length_for method used by everything that cares about tip length
that is a perfect place to add the loading.

In addition to the instrument_context change, the new tip length data is
actually used slightly differently. Previously, tip length calibration
was folded into the instrument offset in the z coordinate there. That
means that when applying the instrument offset to critical point
computation, applying the z or not depends on whether there's a tip.

Now that tip length calibration is separate, that's not true, so if the
feature flag is on the entire instrument offset can be added to the
critical point.

Unfortunately, this means things won't work quite right when you toggle
on the feature flag unless you zero out the instrument offset z part.

Closes #6186 
