### PR TITLE
fix(protocol-designer): Update TC timeline text alignment

### DIFF
--- a/protocol-designer/src/components/steplist/StepItem.css
+++ b/protocol-designer/src/components/steplist/StepItem.css
@@ -266,10 +266,6 @@
 
 .profile_step_substep_column {
   text-align: right;
-
-  &:first-child {
-    text-align: left;
-  }
 }
 
 .profile_center_column {
@@ -315,6 +311,21 @@
   & > * {
     flex: 1;
   }
+}
+
+.profile_step_number {
+  padding-right: 2rem;
+  max-width: 3rem;
+  text-align: right;
+}
+
+.profile_step_time {
+  padding-right: 2.125rem;
+}
+
+.profile_block_temp {
+  padding-right: 3rem;
+  text-align: right;
 }
 
 .cycle_repetitions {

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -142,14 +142,22 @@ export const ProfileStepSubstepRow = (
         styles.profile_step_substep_row
       )}
     >
-      <span className={styles.profile_step_substep_column}>{stepNumber}</span>
-      <span className={styles.align_left}>
+      <span
+        className={cx(
+          styles.profile_step_substep_column,
+          styles.profile_step_number
+        )}
+      >
+        {stepNumber}
+      </span>
+      <span className={styles.profile_block_temp}>
         {makeTemperatureText(temperature)}
       </span>
       <span
         className={cx(
           styles.profile_step_substep_column,
-          styles.profile_center_column
+          styles.profile_center_column,
+          styles.profile_step_time
         )}
       >
         {makeDurationText(durationMinutes, durationSeconds)}
@@ -167,8 +175,10 @@ const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   const { step, stepNumber } = props
   return (
     <div className={styles.cycle_step_row}>
-      <span>{stepNumber}</span>
-      <span>{makeTemperatureText(step.temperature)}</span>
+      <span className={styles.profile_step_number}>{stepNumber}</span>
+      <span className={styles.profile_block_temp}>
+        {makeTemperatureText(step.temperature)}
+      </span>
       <span className={styles.align_right}>
         {makeDurationText(step.durationMinutes, step.durationSeconds)}
       </span>


### PR DESCRIPTION
# Overview

closes #6138 by fixing the whacky text column alignments in TC cycles/steps. put a dollar in the _just_ jar for this one

# Changelog

- fix(protocol-designer): Update TC timeline text alignment

# Review requests
http://sandbox.designer.opentrons.com/pd_tc-timeline-text-alignment/

Should look like the picture. You will need to make a profile with double digit amount of steps to check.

<img width="308" alt="Screen Shot 2020-07-23 at 1 14 50 PM" src="https://user-images.githubusercontent.com/3430313/88318494-ca7ead80-cce8-11ea-91d9-7e7cece7a0ad.png">


# Risk assessment

Low CSS only
