### PR TITLE
fix(api): fix load tip length calibration exception handling

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -80,7 +80,7 @@ def _get_tip_length_data(
         tip_length_data =\
             io.read_cal_file(str(pip_tip_length_path))
         return tip_length_data[labware_hash]
-    except (FileNotFoundError, AttributeError):
+    except (FileNotFoundError, KeyError):
         raise local_types.TipLengthCalNotFound(
             f'Tip length of {labware_load_name} has not been '
             f'calibrated for this pipette: {pip_id} and cannot'

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1055,7 +1055,7 @@ class Pipette(CommandPublisher):
             if ff.enable_tip_length_calibration() and self.pipette_id:
                 tip_length_cal = load_tip_length_calibration(
                     self.pipette_id, location)
-                self._tip_length(tip_length_cal['tipLength'])
+                self._tip_length = tip_length_cal['tipLength']
             self._add_tip(length=self._tip_length)
             # neighboring tips tend to get stuck in the space between
             # the volume chamber and the drop-tip sleeve on p1000.

--- a/api/src/opentrons/legacy_api/instruments/pipette.py
+++ b/api/src/opentrons/legacy_api/instruments/pipette.py
@@ -1055,7 +1055,7 @@ class Pipette(CommandPublisher):
             if ff.enable_tip_length_calibration() and self.pipette_id:
                 tip_length_cal = load_tip_length_calibration(
                     self.pipette_id, location)
-                self._tip_length = tip_length_cal['tipLength']
+                self._tip_length(tip_length_cal['tipLength'])
             self._add_tip(length=self._tip_length)
             # neighboring tips tend to get stuck in the space between
             # the volume chamber and the drop-tip sleeve on p1000.


### PR DESCRIPTION
# Overview
When a pipette attempts to pick up a tip during simulation from a tiprack whose tip length has not been calibrated, a KeyError exception is raised and the protocol cannot be opened. This is not the desired behavior. The protocol should load the default tip length from the tiprack definition instead.

This PR fixes the faulty exception handling in `modify._get_tip_length_data()`, which should catch the `KeyError` instead of the `AttributeError`.


<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
