### PR TITLE
fix(api, app): Clear instrument offset before performing deck calibration

### DIFF
--- a/api/src/opentrons/deck_calibration/dc_main.py
+++ b/api/src/opentrons/deck_calibration/dc_main.py
@@ -512,6 +512,9 @@ class CLITool:
     def exit(self):
         self.hardware.remove_tip(self._current_mount)
         self.hardware.set_lights(rails=False)
+        msg = ('Please calibrate your pipettes'
+               'before running a protocol')
+        self._update_text_box(msg)
         raise urwid.ExitMainLoop
 
     # Private methods for URWID

--- a/app/src/components/CalibrateDeck/AttachTip.js
+++ b/app/src/components/CalibrateDeck/AttachTip.js
@@ -48,10 +48,6 @@ export function AttachTip(props: AttachTipProps): React.Node {
       <span>
         <p>Remove the Opentrons tip from the pipette.</p>
         <p>
-          Please note that as a result of the new deck calibration data, your
-          prior pipette calibration data is no longer valid.
-        </p>
-        <p>
           In order to effectively use this new deck calibration, please
           calibrate your pipette prior to running your next protocol.
         </p>

--- a/app/src/components/CalibrateDeck/AttachTip.js
+++ b/app/src/components/CalibrateDeck/AttachTip.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import type { CalibrateDeckStartedProps, CalibrationStep } from './types'
-import { PrimaryButton } from '@opentrons/components'
+import { PrimaryButton, Link } from '@opentrons/components'
 
 import styles from './styles.css'
 
@@ -22,6 +22,9 @@ const DIAGRAMS: { [step: CalibrationStep]: { [Channels]: string } } = {
     multi: require('./images/detach-tip-multi@3x.png'),
   },
 }
+
+const PIPETTE_CALIBRATION_URL =
+  'https://support.opentrons.com/en/articles/2687641-get-started-calibrate-pipettes-and-labware'
 
 export function AttachTip(props: AttachTipProps): React.Node {
   const multi = props.pipette.channels === 8
@@ -45,13 +48,23 @@ export function AttachTip(props: AttachTipProps): React.Node {
       <span>
         <p>Remove the Opentrons tip from the pipette.</p>
         <p>
-          You must restart your robot to finish the initial robot calibration
-          process and have the new settings take effect. It may take several
-          minutes for your robot to restart.
+          Please note that as a result of the new deck calibration data, your
+          prior pipette calibration data is no longer valid.
+        </p>
+        <p>
+          In order to effectively use this new deck calibration, please
+          calibrate your pipette prior to running your next protocol.
+        </p>
+        <p>
+          Learn more about pipette calibration &nbsp;
+          <Link href={PIPETTE_CALIBRATION_URL} external>
+            here
+          </Link>
+          &nbsp;
         </p>
       </span>
     )
-    buttonText = 'finish and restart robot'
+    buttonText = 'save deck calibration and exit'
   }
 
   return (

--- a/app/src/components/CalibrateDeck/InstructionsModal.js
+++ b/app/src/components/CalibrateDeck/InstructionsModal.js
@@ -6,7 +6,6 @@ import { Link } from 'react-router-dom'
 import capitalize from 'lodash/capitalize'
 
 import { deckCalibrationCommand as dcCommand } from '../../http-api-client'
-import { restartRobot } from '../../robot-admin'
 
 import { chainActions } from '../../util'
 import { ModalPage, SpinnerModalPage } from '@opentrons/components'
@@ -166,7 +165,6 @@ function mapDispatchToProps(dispatch: Dispatch, ownProps: OP): DP {
   } else {
     actions = [
       dcCommand(robot, { command: 'save transform' }),
-      restartRobot(robot.name),
       push(ownProps.parentUrl),
     ]
   }


### PR DESCRIPTION
# Overview

Closes #5022 by resetting instrument offset for all pipettes any time a new deck calibration begins. Some design changes were also added in the app by following instructions from [this design](https://app.zeplin.io/project/5aa97729db58a2192f10d0d6/screen/5f174015bc047a778385eb90).

# Changelog

- Add messaging in deck cal CLI about re-doing pipette calibration (instrument offset does not get taken into account here because robot settings/deck cal are reset before beginning the program)
- Modify the app according to the design above
- The robot _no longer_ restarts after a deck calibration
- Reset instrument offset in `endpoints.py` and reload the current pip instrument offset to be (0, 0, 0)
- Remove feature flags for v1 in `endpoints.py` as it's no longer relevant

# Review requests

Please check that the code place for resetting instrument offset etc are OK.

# Test Plan

1. Verify the issue with the robot and app on 3.19 or edge
   a. Modify your instrument offset (the value in `/data/robot_settings.json` under `instrument_offset` and the mount and type of pipette you'll use for deck calibration - the output of tip probe) to be bad, for instance having a value of 20 in its z component.
   b. Run deck calibration, trying to do a good job.
   c. verify that after the robot restarts, the deck calibration is obviously incorrect - if you modified the z component of instrument offset, the deck calibration z offset should be very wrong
2. Verify that this PR fixes the issue, after putting this PR on the robot with `make push` and building the app on this pr with `make -C app dev`
   a. Edit `/data/robot_settings.json` and verify that the value under `instrument_offset` for the mount and type of pipette used for deck calibration is still bad and large
   b. Run deck calibration, trying to do a good job
   c. When ending deck calibration, the button should say "save and exit" rather than "save and restart robot". The robot should not restart when you click the button
   d. Edit `/data/robot_settings.json` and verify that the `instrument_offset` for the mount and type of pipette you did deck calibration with is now `(0, 0, 0)`
   e. Edit `/data/gantry_calibration.json` and verify that the deck calibration is not bad in the same way it was in 1c
   f. Run the calibrate-to-crosses protocol used by the labware creator. Run tip probe and check that the pipettes move to the crosses accurately (or as accurately as they normally do).

Let me know if you have any other questions!

# Risk assessment

Medium. There was concern that customers would be confused by the new messaging at the end of the deck calibration program in the app. Please make sure we are OK with this language before merging.
