### PR TITLE
fix(robot-server): Log uncaught exceptions

### DIFF
--- a/robot-server/robot_server/service/app.py
+++ b/robot-server/robot_server/service/app.py
@@ -115,7 +115,7 @@ async def robot_server_exception_handler(request: Request,
 async def v1_exception_handler(request: Request, exc: V1HandlerError) \
         -> JSONResponse:
     """Catch legacy errors"""
-    log.error(f"V!HandlerError: {exc.status_code}: {exc.message}")
+    log.error(f"V1HandlerError: {exc.status_code}: {exc.message}")
     return JSONResponse(
         status_code=exc.status_code,
         content=V1BasicResponse(message=exc.message).dict()

--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import List, Dict, Any
 
 from pydantic import ValidationError
@@ -18,6 +19,16 @@ class RobotServerError(Exception):
     def __init__(self, status_code: int, error: Error):
         self.status_code = status_code
         self.error = error
+
+
+def build_unhandled_exception_response(exception: Exception) \
+    -> ErrorResponse:
+    error = Error(
+        status=str(HTTPStatus.INTERNAL_SERVER_ERROR.value),
+        detail=f'Unhandled exception: {type(exception)}',
+        title='Internal Server Error'
+    )
+    return ErrorResponse(errors=[error])
 
 
 def transform_http_exception_to_json_api_errors(exception: HTTPException) \

--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -22,7 +22,7 @@ class RobotServerError(Exception):
 
 
 def build_unhandled_exception_response(exception: Exception) \
-    -> ErrorResponse:
+        -> ErrorResponse:
     error = Error(
         status=str(HTTPStatus.INTERNAL_SERVER_ERROR.value),
         detail=f'Unhandled exception: {type(exception)}',

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -47,6 +47,16 @@ def _robot_log_config(log_level: int):
                 'level': log_level,
                 'propagate': False
             },
+            'fastapi': {
+                'handlers': ['robot_server'],
+                'level': log_level,
+                'propagate': False
+            },
+            'starlette':  {
+                'handlers': ['robot_server'],
+                'level': log_level,
+                'propagate': False,
+            }
         }
     }
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -22,6 +22,7 @@ from opentrons.protocol_api.geometry import Deck
 
 test_router = routing.APIRouter()
 
+
 @test_router.get('/alwaysRaise')
 async def always_raise():
     raise RuntimeError
@@ -50,7 +51,7 @@ def api_client(override_hardware) -> TestClient:
 
 
 @pytest.fixture
-def api_client_no_errors(hardware) -> TestClient:
+def api_client_no_errors(override_hardware) -> TestClient:
     """ An API client that won't raise server exceptions.
     Use only to test 500 pages; never use this for other tests. """
     return TestClient(app, raise_server_exceptions=False)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from unittest.mock import MagicMock
 
+from fastapi import routing
 import pytest
 from starlette.testclient import TestClient
 from robot_server.service.app import app
@@ -19,20 +20,40 @@ from opentrons.types import Point
 from opentrons.protocol_api.geometry import Deck
 
 
+test_router = routing.APIRouter()
+
+@test_router.get('/alwaysRaise')
+async def always_raise():
+    raise RuntimeError
+
+app.include_router(test_router)
+
+
 @pytest.fixture
 def hardware():
     return MagicMock(spec=API)
 
 
 @pytest.fixture
-def api_client(hardware) -> TestClient:
+def override_hardware(hardware):
 
     async def get_hardware_override() -> HardwareAPILike:
         """Override for get_hardware dependency"""
         return hardware
 
     app.dependency_overrides[get_hardware] = get_hardware_override
+
+
+@pytest.fixture
+def api_client(override_hardware) -> TestClient:
     return TestClient(app)
+
+
+@pytest.fixture
+def api_client_no_errors(hardware) -> TestClient:
+    """ An API client that won't raise server exceptions.
+    Use only to test 500 pages; never use this for other tests. """
+    return TestClient(app, raise_server_exceptions=False)
 
 
 @pytest.fixture(scope="session")

--- a/robot-server/tests/service/test_app.py
+++ b/robot-server/tests/service/test_app.py
@@ -4,12 +4,27 @@ from http import HTTPStatus
 from robot_server.constants import API_VERSION_HEADER, API_VERSION
 
 
+def test_unhandled_exception_handler(api_client_no_errors):
+    resp = api_client_no_errors.get('/alwaysRaise')
+    text = resp.json()
+    expected = {
+        'errors': [
+            {'title': 'Internal Server Error',
+             'status': '500',
+             'detail': "Unhandled exception: <class 'RuntimeError'>"}
+        ]
+    }
+    assert text == expected
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
 def test_custom_http_exception_handler(api_client):
 
     expected = {
         'message': HTTPStatus.METHOD_NOT_ALLOWED.phrase
     }
     resp = api_client.post('/health')
+
     text = resp.json()
     assert resp.status_code == HTTPStatus.METHOD_NOT_ALLOWED
     assert text == expected

--- a/robot-server/tests/service/test_errors.py
+++ b/robot-server/tests/service/test_errors.py
@@ -46,3 +46,17 @@ def test_transform_http_exception_to_json_api_errors():
             'title': 'Bad Request',
         }]
     }
+
+
+def test_build_unhandled_exception_response():
+    exc = RuntimeError()
+    err = errors.build_unhandled_exception_response(
+        exc
+    ).dict(
+        exclude_unset=True
+    )
+    assert err == {
+        'errors': [{'status': '500',
+                    'detail': "Unhandled exception: <class 'RuntimeError'>",
+                    'title': 'Internal Server Error'}]
+    }


### PR DESCRIPTION
While uncaught exceptions that bubble all the way up to the FastAPI
layer all definitionally bugs and shouldn't be expected in a running
server, we do want to be able to log them and provide nice JSONApi error
results if they do occur. This adds
- An ErrorMiddleware handler to catch all exceptions
- Logs it
- Returns a json error page

It also enables logging for other internal server components.
