### PR TITLE
fix(shared-data): fix well bottom shape of nest_96_wellplate_2ml_deep

### DIFF
--- a/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_2ml_deep/1.json
@@ -996,7 +996,7 @@
       "metadata": {
         "displayName": "NEST 96 Deepwell Plate 2mL",
         "displayCategory": "wellPlate",
-        "wellBottomShape": "u"
+        "wellBottomShape": "v"
       },
       "brand": {
         "brand": "NEST",


### PR DESCRIPTION
# Overview

Closes #6171

# Changelog

- changes `nest_96_wellplate_2ml_deep` wellBottomShape from U to V, matching the real labware

# Review requests

- Compare LL to production, should show a V-bottom not U-bottom
- This `wellBottomShape` field truly is only metadata: it's only used for display (specifically, only in LL) and does not affect behavior. Right?

# Risk assessment

Low. Mutates a labware definition, but only mutates a metadata field.