### PR TITLE
feat(protocol-designer): air gap default value

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -8,11 +8,19 @@ import {
   THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
+import { getPrereleaseFeatureFlag } from '../../persist'
 import { getStateAndContextTempTCModules } from '../../step-generation/__fixtures__'
 import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
 } from '../utils/createPresavedStepForm'
+
+jest.mock('../../persist')
+
+const mockGetPrereleaseFeatureFlag: JestMockFn<
+  string,
+  boolean
+> = getPrereleaseFeatureFlag
 
 const stepId = 'stepId123'
 const EXAMPLE_ENGAGE_HEIGHT = '18'
@@ -83,6 +91,10 @@ beforeEach(() => {
   }
 })
 
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
 describe('createPresavedStepForm', () => {
   ;[true, false].forEach(hasTempModule => {
     it(`should populate initial values for a new pause step (with ${
@@ -115,48 +127,55 @@ describe('createPresavedStepForm', () => {
     })
   })
 
-  it('should call handleFormChange with a default pipette for "moveLiquid" step', () => {
-    const args = {
-      ...defaultArgs,
-      stepType: 'moveLiquid',
-    }
+  // TODO(IL, 2020-07-28): remove `false` case when 'OT_PD_ENABLE_AIR_GAP_AND_DELAY' FF is removed
+  ;[true, false].forEach(airGapEnabled => {
+    it(`should call handleFormChange with a default pipette for "moveLiquid" step (air gap FF enabled: ${airGapEnabled})`, () => {
+      mockGetPrereleaseFeatureFlag.mockImplementation(
+        ff => ff === 'OT_PD_ENABLE_AIR_GAP_AND_DELAY' && airGapEnabled
+      )
+      const args = {
+        ...defaultArgs,
+        stepType: 'moveLiquid',
+      }
 
-    expect(createPresavedStepForm(args)).toEqual({
-      id: stepId,
-      pipette: 'leftPipetteId',
-      stepType: 'moveLiquid',
-      // default fields
-      aspirate_flowRate: null,
-      aspirate_labware: null,
-      aspirate_mix_checkbox: false,
-      aspirate_mix_times: null,
-      aspirate_mix_volume: null,
-      aspirate_mmFromBottom: 1,
-      aspirate_touchTip_checkbox: false,
-      aspirate_wellOrder_first: 't2b',
-      aspirate_wellOrder_second: 'l2r',
-      aspirate_wells: [],
-      aspirate_wells_grouped: false,
-      blowout_checkbox: false,
-      blowout_location: 'trashId',
-      changeTip: 'always',
-      dispense_flowRate: null,
-      dispense_labware: null,
-      dispense_mix_checkbox: false,
-      dispense_mix_times: null,
-      dispense_mix_volume: null,
-      dispense_mmFromBottom: 0.5,
-      dispense_touchTip_checkbox: false,
-      dispense_wellOrder_first: 't2b',
-      dispense_wellOrder_second: 'l2r',
-      dispense_wells: [],
-      disposalVolume_checkbox: true,
-      disposalVolume_volume: '1',
-      path: 'single',
-      preWetTip: false,
-      stepDetails: '',
-      stepName: 'transfer',
-      volume: null,
+      expect(createPresavedStepForm(args)).toEqual({
+        id: stepId,
+        pipette: 'leftPipetteId',
+        stepType: 'moveLiquid',
+        // default fields
+        ...(airGapEnabled ? { aspirate_airGap_volume: '1' } : {}),
+        aspirate_flowRate: null,
+        aspirate_labware: null,
+        aspirate_mix_checkbox: false,
+        aspirate_mix_times: null,
+        aspirate_mix_volume: null,
+        aspirate_mmFromBottom: 1,
+        aspirate_touchTip_checkbox: false,
+        aspirate_wellOrder_first: 't2b',
+        aspirate_wellOrder_second: 'l2r',
+        aspirate_wells: [],
+        aspirate_wells_grouped: false,
+        blowout_checkbox: false,
+        blowout_location: 'trashId',
+        changeTip: 'always',
+        dispense_flowRate: null,
+        dispense_labware: null,
+        dispense_mix_checkbox: false,
+        dispense_mix_times: null,
+        dispense_mix_volume: null,
+        dispense_mmFromBottom: 0.5,
+        dispense_touchTip_checkbox: false,
+        dispense_wellOrder_first: 't2b',
+        dispense_wellOrder_second: 'l2r',
+        dispense_wells: [],
+        disposalVolume_checkbox: true,
+        disposalVolume_volume: '1',
+        path: 'single',
+        preWetTip: false,
+        stepDetails: '',
+        stepName: 'transfer',
+        volume: null,
+      })
     })
   })
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -443,6 +443,27 @@ function updatePatchMixFields(patch: FormPatch, rawForm: FormData): FormPatch {
   return patch
 }
 
+export function updateAirGapFields(
+  patch: FormPatch,
+  rawForm: FormData,
+  pipetteEntities: PipetteEntities
+): FormPatch {
+  console.log({ patch, pipetteEntities })
+  if (
+    patch.aspirate_airGap_checkbox === true &&
+    typeof rawForm.pipette === 'string' &&
+    rawForm.pipette in pipetteEntities
+  ) {
+    const pipetteSpec = pipetteEntities[rawForm.pipette].spec
+    const airGapVolume = pipetteSpec.minVolume
+    return {
+      ...patch,
+      aspirate_airGap_volume: `${airGapVolume}`,
+    }
+  }
+  return patch
+}
+
 export function updatePatchBlowoutFields(
   patch: FormPatch,
   rawForm: FormData
@@ -500,5 +521,6 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch => clampDisposalVolume(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchMixFields(chainPatch, rawForm),
     chainPatch => updatePatchBlowoutFields(chainPatch, rawForm),
+    chainPatch => updateAirGapFields(chainPatch, rawForm, pipetteEntities),
   ])
 }


### PR DESCRIPTION
# Overview

Closes #6017

Air gap volume will default to the pipette minimum, it will update whenever a pipette is selected.

# Changelog

# Review requests

For Transfer step, air gap should default to the pipette minimum...
- [ ] Initially as soon as you toggle the air gap on so that the field is visible
- [ ] If you change the Pipette in the dropdown, air gap volume should update to the new pipette's min vol
- [ ] If you change the Pipette in the Edit Pipettes modal, air gap volume in all Transfer steps that used the changed pipette

This feature should require the FF to be on. If the FF is off, protocols should not pick up the new `aspirate_airGap_volume` field in any savedStepForms in response to pipette changes.

# Risk assessment

Low if correctly under FF