### PR TITLE
refactor(robot-server): Improve error handling in TipLengthCalibration

### DIFF
--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -52,5 +52,4 @@ class TipCalibrationStateMachine:
         if next_state:
             return next_state
         else:
-            raise StateTransitionError(f"Cannot call {command} command "
-                                       f"from {from_state}.")
+            raise StateTransitionError(command, from_state)

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -13,13 +13,13 @@ from robot_server.robot.calibration.constants import (
     SHORT_TRASH_DECK,
     STANDARD_DECK
 )
-from robot_server.robot.calibration.tip_length.state_machine import (
+from .state_machine import (
     TipCalibrationStateMachine
 )
-from robot_server.robot.calibration.tip_length.util import (
-    TipCalibrationError as Error
+from .util import (
+    TipCalibrationException as Error, TipCalibrationErrors as Errors
 )
-from robot_server.robot.calibration.tip_length.constants import (
+from .constants import (
     TipCalibrationState as State,
     TRASH_WELL,
     TIP_RACK_SLOT,
@@ -28,7 +28,7 @@ from robot_server.robot.calibration.tip_length.constants import (
     MOVE_TO_REF_POINT_SAFETY_BUFFER,
     TRASH_REF_POINT_OFFSET
 )
-from robot_server.robot.calibration.tip_length.models import (
+from .models import (
     RequiredLabware,
     AttachedPipette
 )
@@ -58,10 +58,10 @@ class TipCalibrationUserFlow():
         self._has_calibration_block = has_calibration_block
         self._hw_pipette = self._hardware._attached_instruments[mount]
         if not self._hw_pipette:
-            raise Error(f'No pipette found on {mount} mount,'
-                        'cannot run tip length calibration')
+            raise Error(Errors.NO_PIPETTE, mount)
         self._tip_origin_pt: Optional[Point] = None
         self._nozzle_height_at_reference: Optional[float] = None
+
 
         deck_load_name = SHORT_TRASH_DECK if ff.short_fixed_trash() \
             else STANDARD_DECK
@@ -230,7 +230,8 @@ class TipCalibrationUserFlow():
                                 self._deck.position_for(TIP_RACK_SLOT))
         else:
             raise Error(
-                    f'No tiprack found for pipette {self._hw_pipette.model}')
+                Errors.NO_KNOWN_TIPRACK,
+                self._hw_pipette.model)
 
     def _get_alt_tip_racks(self) -> Set[str]:
         pip_vol = self._hw_pipette.config.max_volume

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -62,7 +62,6 @@ class TipCalibrationUserFlow():
         self._tip_origin_pt: Optional[Point] = None
         self._nozzle_height_at_reference: Optional[float] = None
 
-
         deck_load_name = SHORT_TRASH_DECK if ff.short_fixed_trash() \
             else STANDARD_DECK
         self._deck = geometry.Deck(load_name=deck_load_name)

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -17,7 +17,7 @@ from .state_machine import (
     TipCalibrationStateMachine
 )
 from .util import (
-    TipCalibrationException as Error, TipCalibrationErrors as Errors
+    TipCalibrationException as ErrorExc, TipCalibrationError as Error
 )
 from .constants import (
     TipCalibrationState as State,
@@ -58,7 +58,7 @@ class TipCalibrationUserFlow():
         self._has_calibration_block = has_calibration_block
         self._hw_pipette = self._hardware._attached_instruments[mount]
         if not self._hw_pipette:
-            raise Error(Errors.NO_PIPETTE, mount)
+            raise ErrorExc(Error.NO_PIPETTE, mount)
         self._tip_origin_pt: Optional[Point] = None
         self._nozzle_height_at_reference: Optional[float] = None
 
@@ -229,8 +229,8 @@ class TipCalibrationUserFlow():
             return labware.load(tr_lookup.load_name,
                                 self._deck.position_for(TIP_RACK_SLOT))
         else:
-            raise Error(
-                Errors.NO_KNOWN_TIPRACK,
+            raise ErrorExc(
+                Error.NO_KNOWN_TIPRACK,
                 self._hw_pipette.model)
 
     def _get_alt_tip_racks(self) -> Set[str]:

--- a/robot-server/robot_server/robot/calibration/tip_length/util.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/util.py
@@ -7,7 +7,7 @@ from robot_server.service.errors import RobotServerError
 from robot_server.service.json_api.errors import Error
 
 
-class TipCalibrationErrors(Enum):
+class TipCalibrationError(Enum):
     NO_PIPETTE = (
         HTTPStatus.FORBIDDEN,
         'No Pipette Attached',
@@ -20,7 +20,7 @@ class TipCalibrationErrors(Enum):
 
 
 class TipCalibrationException(RobotServerError):
-    def __init__(self, whicherror: TipCalibrationErrors, *fmt_args):
+    def __init__(self, whicherror: TipCalibrationError, *fmt_args):
         super().__init__(
             whicherror.value[0],
             Error(
@@ -38,7 +38,7 @@ class StateTransitionError(RobotServerError):
             HTTPStatus.CONFLICT,
             Error(
                 id='TipLengthCalibration.StateTransitionError',
-                status=str(HTTPStatus.Conflict),
+                status=str(HTTPStatus.CONFLICT),
                 title='Illegal State Transition',
                 detail=f'The action {action} may not occur in the state '
                        f'{state}')

--- a/robot-server/robot_server/robot/calibration/tip_length/util.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/util.py
@@ -1,13 +1,48 @@
+from enum import Enum
+
+from http import HTTPStatus
 from typing import Set, Dict, Any
 from robot_server.robot.calibration.tip_length.constants import WILDCARD
+from robot_server.service.errors import RobotServerError
+from robot_server.service.json_api.errors import Error
 
 
-class TipCalibrationError(Exception):
-    pass
+class TipCalibrationErrors(Enum):
+    NO_PIPETTE = (
+        HTTPStatus.FORBIDDEN,
+        'No Pipette Attached',
+        'No pipette present on {} mount')
+    NO_KNOWN_TIPRACK = (
+        HTTPStatus.NOT_IMPLEMENTED,
+        'No Tiprack For Pipette',
+        'No known tipracks for pipette model {}'
+    )
 
 
-class StateTransitionError(Exception):
-    pass
+class TipCalibrationException(RobotServerError):
+    def __init__(self, whicherror: TipCalibrationErrors, *fmt_args):
+        super().__init__(
+            whicherror.value[0],
+            Error(
+                id=str(whicherror),
+                status=str(whicherror.value[0]),
+                title=whicherror.value[1],
+                detail=whicherror.value[2].format(*fmt_args)
+            )
+        )
+
+
+class StateTransitionError(RobotServerError):
+    def __init__(self, action, state):
+        super().__init__(
+            HTTPStatus.CONFLICT,
+            Error(
+                id='TipLengthCalibration.StateTransitionError',
+                status=str(HTTPStatus.Conflict),
+                title='Illegal State Transition',
+                detail=f'The action {action} may not occur in the state '
+                       f'{state}')
+            )
 
 
 TransitionMap = Dict[Any, Set[Dict[Any, Any]]]

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -5,10 +5,8 @@ from robot_server.robot.calibration.tip_length.user_flow import \
 from robot_server.robot.calibration.tip_length.models import \
     TipCalibrationSessionStatus, SessionCreateParams
 from robot_server.robot.calibration.session import CalibrationException
-from robot_server.robot.calibration.tip_length.util import StateTransitionError
 from robot_server.service.session.errors import (SessionCreationException,
-                                                 CommandExecutionException,
-                                                 CommandExecutionConflict)
+                                                 CommandExecutionException)
 from robot_server.service.session.command_execution import \
      CallableExecutor, Command, CompletedCommand, CommandQueue, CommandExecutor
 
@@ -23,8 +21,6 @@ class TipLengthCalibrationCommandExecutor(CallableExecutor):
     async def execute(self, command: Command) -> CompletedCommand:
         try:
             return await super().execute(command)
-        except StateTransitionError as e:
-            raise CommandExecutionConflict(e)
         except (CalibrationException, AssertionError) as e:
             raise CommandExecutionException(e)
 


### PR DESCRIPTION
We want to avoid expected-error casing raising 500 ISEs by raising
unhandled exceptions. To that end,

- TLC-specific exceptions now inherit from RobotServerError
- Those exceptions properly fill out the json api error details
- That includes ID, and the general-case TipLengthCalibrationException
  (renamed from TipLengthCalibrationError to deconflict with the new
  enum) is based around a specific enum of possible handled error cases
