### PR TITLE
feat(protocol-designer): add moveToWell command creator

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -21,8 +21,8 @@ import type {
   FilePipette,
   FileLabware,
   FileModule,
-  Command,
 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import type { ModuleEntity } from '../../step-forms'
 import type { Selector } from '../../types'
 import type { PDProtocolFile } from '../../file-types'

--- a/protocol-designer/src/file-data/types.js
+++ b/protocol-designer/src/file-data/types.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 
 export type FileMetadataFields = $PropertyType<ProtocolFile<{}>, 'metadata'>
 export type FileMetadataFieldAccessors = $Keys<FileMetadataFields>

--- a/protocol-designer/src/file-types.js
+++ b/protocol-designer/src/file-types.js
@@ -4,6 +4,7 @@ import type { RootState as StepformRoot } from './step-forms'
 import type { RootState as DismissRoot } from './dismiss'
 import type { ProtocolFile as ProtocolFileV3 } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type { ProtocolFile as ProtocolFileV4 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { ProtocolFile as ProtocolFileV5 } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 
 export type PDMetadata = {
   // pipetteId to tiprackModel
@@ -29,6 +30,7 @@ export type PDMetadata = {
 export type PDProtocolFile =
   | ProtocolFileV3<PDMetadata>
   | ProtocolFileV4<PDMetadata>
+  | ProtocolFileV5<PDMetadata>
 
 export function getPDMetadata(file: PDProtocolFile): PDMetadata {
   const metadata = file.designerApplication?.data

--- a/protocol-designer/src/step-generation/__tests__/moveToWell.test.js
+++ b/protocol-designer/src/step-generation/__tests__/moveToWell.test.js
@@ -1,0 +1,132 @@
+// @flow
+import { expectTimelineError } from '../__utils__/testMatchers'
+import { moveToWell } from '../commandCreators/atomic/moveToWell'
+import { thermocyclerPipetteCollision } from '../utils'
+import {
+  getRobotStateWithTipStandard,
+  makeContext,
+  getSuccessResult,
+  getErrorResult,
+  DEFAULT_PIPETTE,
+  SOURCE_LABWARE,
+} from '../__fixtures__'
+import type { RobotState } from '../'
+
+jest.mock('../utils/thermocyclerPipetteCollision')
+
+const mockThermocyclerPipetteCollision: JestMockFn<
+  [
+    $PropertyType<RobotState, 'modules'>,
+    $PropertyType<RobotState, 'labware'>,
+    string
+  ],
+  boolean
+> = thermocyclerPipetteCollision
+
+describe('moveToWell', () => {
+  let robotStateWithTip
+  let invariantContext
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should return a moveToWell command given only the required params', () => {
+    const params = {
+      pipette: DEFAULT_PIPETTE,
+      labware: SOURCE_LABWARE,
+      well: 'A1',
+    }
+
+    const result = moveToWell(params, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        command: 'moveToWell',
+        params,
+      },
+    ])
+  })
+
+  it('should apply the optional params to the command', () => {
+    const params = {
+      pipette: DEFAULT_PIPETTE,
+      labware: SOURCE_LABWARE,
+      well: 'A1',
+      offset: { x: 1, y: 2, z: 3 },
+      minimumZHeight: 5,
+      forceDirect: true,
+    }
+
+    const result = moveToWell(params, invariantContext, robotStateWithTip)
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        command: 'moveToWell',
+        params,
+      },
+    ])
+  })
+
+  it('should return an error if pipette does not exist', () => {
+    const result = moveToWell(
+      {
+        pipette: 'badPipette',
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+
+    expectTimelineError(getErrorResult(result).errors, 'PIPETTE_DOES_NOT_EXIST')
+  })
+
+  it('should return error if labware does not exist', () => {
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: 'problematicLabwareId',
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'LABWARE_DOES_NOT_EXIST',
+    })
+  })
+
+  it('should return an error when moving to well in a thermocycler with pipette collision', () => {
+    mockThermocyclerPipetteCollision.mockImplementationOnce(
+      (
+        modules: $PropertyType<RobotState, 'modules'>,
+        labware: $PropertyType<RobotState, 'labware'>,
+        labwareId: string
+      ) => {
+        expect(modules).toBe(robotStateWithTip.modules)
+        expect(labware).toBe(robotStateWithTip.labware)
+        expect(labwareId).toBe(SOURCE_LABWARE)
+        return true
+      }
+    )
+    const result = moveToWell(
+      {
+        pipette: DEFAULT_PIPETTE,
+        labware: SOURCE_LABWARE,
+        well: 'A1',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'THERMOCYCLER_LID_CLOSED',
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/commandCreators/atomic/moveToWell.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/moveToWell.js
@@ -1,0 +1,75 @@
+// @flow
+import * as errorCreators from '../../errorCreators'
+import {
+  modulePipetteCollision,
+  thermocyclerPipetteCollision,
+} from '../../utils'
+import type { MoveToWellParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
+import type { CommandCreator, CommandCreatorError } from '../../types'
+
+/** Move to specified well of labware, with optional offset and pathing options. */
+export const moveToWell: CommandCreator<MoveToWellParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { pipette, labware, well, offset, minimumZHeight, forceDirect } = args
+
+  const actionName = 'moveToWell'
+  const errors: Array<CommandCreatorError> = []
+
+  // TODO(2020-07-30, IL): the below is duplicated or at least similar
+  // across aspirate/dispense/blowout, we can probably DRY it up
+  const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
+
+  if (!pipetteSpec) {
+    errors.push(errorCreators.pipetteDoesNotExist({ actionName, pipette }))
+  }
+
+  if (!labware || !prevRobotState.labware[labware]) {
+    errors.push(errorCreators.labwareDoesNotExist({ actionName, labware }))
+  }
+
+  if (
+    modulePipetteCollision({
+      pipette,
+      labware,
+      invariantContext,
+      prevRobotState,
+    })
+  ) {
+    errors.push(errorCreators.modulePipetteCollisionDanger())
+  }
+
+  if (
+    thermocyclerPipetteCollision(
+      prevRobotState.modules,
+      prevRobotState.labware,
+      labware
+    )
+  ) {
+    errors.push(errorCreators.thermocyclerLidClosed())
+  }
+
+  if (errors.length > 0) {
+    return { errors }
+  }
+
+  const commands = [
+    {
+      command: 'moveToWell',
+      params: {
+        pipette,
+        labware,
+        well,
+        offset,
+        forceDirect,
+        minimumZHeight,
+      },
+    },
+  ]
+
+  return {
+    commands,
+  }
+}

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -25,7 +25,7 @@ import {
   forSetTemperature,
   forDeactivateTemperature,
 } from './temperatureUpdates'
-import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import type {
   InvariantContext,
   RobotState,
@@ -71,6 +71,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
       break
     case 'touchTip':
     case 'delay':
+    case 'moveToWell':
       // these commands don't have any effects on the state
       break
     case 'temperatureModule/setTargetTemperature':

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -1,10 +1,10 @@
 // @flow
 import type {
   AtomicProfileStep,
-  Command,
   EngageMagnetParams,
   ModuleOnlyParams,
 } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import typeof { THERMOCYCLER_STATE, THERMOCYCLER_PROFILE } from '../constants'
 import type { ProfileItem } from '../form-types'
 import type {

--- a/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
+++ b/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
@@ -1,6 +1,6 @@
 // @flow
 import { getNextRobotStateAndWarnings } from '../getNextRobotStateAndWarnings'
-import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import type {
   InvariantContext,
   RobotState,

--- a/protocol-designer/src/steplist/substepTimeline.js
+++ b/protocol-designer/src/steplist/substepTimeline.js
@@ -4,7 +4,7 @@ import pick from 'lodash/pick'
 import { getWellsForTips } from '../step-generation/utils'
 import { getNextRobotStateAndWarningsSingleCommand } from '../step-generation/getNextRobotStateAndWarnings'
 
-import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import type { Channels } from '@opentrons/components'
 import type {
   CommandCreatorError,

--- a/protocol-designer/src/top-selectors/substep-highlight.js
+++ b/protocol-designer/src/top-selectors/substep-highlight.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect'
 import { getWellNamePerMultiTip } from '@opentrons/shared-data'
 import { getWellSetForMultichannel } from '../utils'
-import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 
 import mapValues from 'lodash/mapValues'
 

--- a/protocol-designer/src/top-selectors/tip-contents/index.js
+++ b/protocol-designer/src/top-selectors/tip-contents/index.js
@@ -19,7 +19,7 @@ import {
 import { selectors as fileDataSelectors } from '../../file-data'
 import type { WellGroup } from '@opentrons/components'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
 import type { OutputSelector } from 'reselect'
 import type { BaseState, Selector } from '../../types'
 

--- a/shared-data/protocol/flowTypes/schemaV5.js
+++ b/shared-data/protocol/flowTypes/schemaV5.js
@@ -1,0 +1,31 @@
+// @flow
+import type { ProtocolFile as V3ProtocolFile } from './schemaV3'
+import type { Command as V4Command, FileModule } from './schemaV4'
+
+export type MoveToWellParams = {|
+  pipette: string,
+  labware: string,
+  well: string,
+  offset?: {
+    x: number,
+    y: number,
+    z: number,
+  },
+  minimumZHeight?: number,
+  forceDirect?: boolean,
+|}
+
+export type Command =
+  | V4Command
+  | {| command: 'moveToWell', params: MoveToWellParams |}
+
+// NOTE: must be kept in sync with '../schemas/5.json'
+export type ProtocolFile<DesignerApplicationData> = {|
+  ...V3ProtocolFile<DesignerApplicationData>,
+  $otSharedSchema: '#/protocol/schemas/5',
+  schemaVersion: 5,
+  modules: {
+    [moduleId: string]: FileModule,
+  },
+  commands: Array<Command>,
+|}


### PR DESCRIPTION
# Overview

Closes #6240

# Changelog

- add `moveToWell` command creator
- add `schemaV5.js` flow types and use that for the `Command` type

# Review requests

- [ ] Unit tests describe all behaviors we care about
- [ ] Should not affect PD -- not hooked up to anything!

# Risk assessment

low, isn't used anywhere yet