### PR TITLE
feat(protocol-designer): lazy load air gap/delay FF from local storage

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -143,7 +143,13 @@ describe('createPresavedStepForm', () => {
         pipette: 'leftPipetteId',
         stepType: 'moveLiquid',
         // default fields
-        ...(airGapEnabled ? { aspirate_airGap_volume: '1' } : {}),
+        ...(airGapEnabled
+          ? {
+              aspirate_airGap_volume: '1',
+              aspirate_delay_seconds: '1',
+              dispense_delay_seconds: '1',
+            }
+          : {}),
         aspirate_flowRate: null,
         aspirate_labware: null,
         aspirate_mix_checkbox: false,

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -10,9 +10,8 @@ import {
 } from '../../constants'
 import type { StepType, StepFieldName } from '../../form-types'
 
-const isAirGapDelayEnabled = getPrereleaseFeatureFlag(
-  'OT_PD_ENABLE_AIR_GAP_AND_DELAY'
-)
+const isAirGapDelayEnabled = () =>
+  getPrereleaseFeatureFlag('OT_PD_ENABLE_AIR_GAP_AND_DELAY')
 // TODO: Ian 2019-01-17 move this somewhere more central - see #2926
 
 export function getDefaultsForStepType(
@@ -69,7 +68,7 @@ export function getDefaultsForStepType(
         blowout_location: FIXED_TRASH_ID,
         preWetTip: false,
 
-        ...(isAirGapDelayEnabled
+        ...(isAirGapDelayEnabled()
           ? { aspirate_delay_seconds: '1', dispense_delay_seconds: '1' }
           : {}),
       }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -219,10 +219,8 @@ const updatePatchOnPipetteChange = (
   return patch
 }
 
-const clearedDisposalVolumeFields = getDefaultFields(
-  'disposalVolume_volume',
-  'disposalVolume_checkbox'
-)
+const getClearedDisposalVolumeFields = () =>
+  getDefaultFields('disposalVolume_volume', 'disposalVolume_checkbox')
 
 const updatePatchDisposalVolumeFields = (
   patch: FormPatch,
@@ -241,7 +239,7 @@ const updatePatchDisposalVolumeFields = (
     // or whenever disposalVolume_checkbox is cleared
     return {
       ...patch,
-      ...clearedDisposalVolumeFields,
+      ...getClearedDisposalVolumeFields(),
     }
   }
 
@@ -321,7 +319,7 @@ const clampDisposalVolume = (
       }
     : {
         ...patch,
-        ...clearedDisposalVolumeFields,
+        ...getClearedDisposalVolumeFields(),
       }
 }
 


### PR DESCRIPTION
# Overview

This PR addresses the local storage getItem error we were getting when PD initially loads. The web worker was trying to fetch from local storage because one of the dependencies in its scope was attempting to hit local storage at module load. This also uncovered a test that was not updated, so I updated it to account for extra fields that needed to be added to pre saved step forms.

# Changelog
- lazy load air gap/delay FF from local storage

# Review requests
Validate that there is no local storage error in the browser console when PD loads
Make sure the default airgap/delay args still show up in the presaved form when the FF is on

# Risk assessment
Low