### PR TITLE
feat(protocol-designer): add move to slot command creator

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/isValidSlot.test.js
+++ b/protocol-designer/src/step-generation/__tests__/isValidSlot.test.js
@@ -1,0 +1,17 @@
+// @flow
+import { isValidSlot } from '../utils/isValidSlot'
+
+describe('isValidSlot', () => {
+  ;['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'].forEach(
+    slot => {
+      it(`should return true when slot is ${slot}`, () => {
+        expect(isValidSlot(slot)).toBe(true)
+      })
+    }
+  )
+  ;['-1', '0', '13'].forEach(slot => {
+    it(`should return false when slot is ${slot}`, () => {
+      expect(isValidSlot(slot)).toBe(false)
+    })
+  })
+})

--- a/protocol-designer/src/step-generation/__tests__/moveToSlot.test.js
+++ b/protocol-designer/src/step-generation/__tests__/moveToSlot.test.js
@@ -1,0 +1,86 @@
+// @flow
+import {
+  DEFAULT_PIPETTE,
+  makeContext,
+  getRobotStateWithTipStandard,
+  getErrorResult,
+  getSuccessResult,
+} from '../__fixtures__'
+import { moveToSlot } from '../commandCreators/atomic/moveToSlot'
+import { expectTimelineError } from '../__utils__/testMatchers'
+
+describe('moveToSlot', () => {
+  let invariantContext
+  let robotStateWithTip
+  let params
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+
+    params = {
+      pipette: DEFAULT_PIPETTE,
+      slot: '1',
+    }
+  })
+  it('should return a moveToSlot command without optional params', () => {
+    const result = moveToSlot(params, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        command: 'moveToSlot',
+        params,
+      },
+    ])
+  })
+  it('should return a moveToSlot command with optional params', () => {
+    const optionalParams = {
+      offset: {
+        x: 1,
+        y: 2,
+        z: 3,
+      },
+      minimumZHeight: 1,
+      forceDirect: true,
+    }
+    const combinedParams = {
+      ...params,
+      ...optionalParams,
+    }
+    const result = moveToSlot(
+      combinedParams,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        command: 'moveToSlot',
+        params: combinedParams,
+      },
+    ])
+  })
+  it('should return an invalid slot error when attempting to move to an invalid slot', () => {
+    const result = moveToSlot(
+      {
+        ...params,
+        slot: 'whack slot',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+    expectTimelineError(getErrorResult(result).errors, 'INVALID_SLOT')
+  })
+  it('should return an invalid pipette error when using an invalid pipette', () => {
+    const result = moveToSlot(
+      {
+        ...params,
+        pipette: 'badPipette',
+      },
+      invariantContext,
+      robotStateWithTip
+    )
+
+    expectTimelineError(getErrorResult(result).errors, 'PIPETTE_DOES_NOT_EXIST')
+  })
+})

--- a/protocol-designer/src/step-generation/commandCreators/atomic/moveToSlot.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/moveToSlot.js
@@ -1,0 +1,49 @@
+// @flow
+
+import * as errorCreators from '../../errorCreators'
+import { isValidSlot } from '../../utils/isValidSlot'
+
+import type { MoveToSlotParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
+import type { CommandCreator, CommandCreatorError } from '../../types'
+
+export const moveToSlot: CommandCreator<MoveToSlotParams> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { pipette, slot, offset, minimumZHeight, forceDirect } = args
+
+  const actionName = 'moveToSlot'
+  const errors: Array<CommandCreatorError> = []
+
+  const pipetteData = prevRobotState.pipettes[pipette]
+
+  if (!pipetteData) {
+    errors.push(errorCreators.pipetteDoesNotExist({ actionName, pipette }))
+  }
+
+  if (!isValidSlot(slot)) {
+    errors.push(errorCreators.invalidSlot({ actionName, slot }))
+  }
+
+  const commands = [
+    {
+      command: 'moveToSlot',
+      params: {
+        pipette,
+        slot,
+        offset,
+        minimumZHeight,
+        forceDirect,
+      },
+    },
+  ]
+
+  if (errors.length > 0) {
+    return { errors }
+  }
+
+  return {
+    commands,
+  }
+}

--- a/protocol-designer/src/step-generation/errorCreators.js
+++ b/protocol-designer/src/step-generation/errorCreators.js
@@ -37,6 +37,17 @@ export function pipetteDoesNotExist(args: {|
   }
 }
 
+export function invalidSlot(args: {|
+  actionName: string,
+  slot: string,
+|}): CommandCreatorError {
+  const { actionName, slot } = args
+  return {
+    message: `Attempted to ${actionName} with slot "${slot}", this is not a valid slot"`,
+    type: 'INVALID_SLOT',
+  }
+}
+
 export function labwareDoesNotExist(args: {|
   actionName: string,
   labware: string,

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -316,6 +316,7 @@ export type ErrorType =
   | 'TIP_VOLUME_EXCEEDED'
   | 'MISSING_TEMPERATURE_STEP'
   | 'THERMOCYCLER_LID_CLOSED'
+  | 'INVALID_SLOT'
 
 export type CommandCreatorError = {|
   message: string,

--- a/protocol-designer/src/step-generation/utils/isValidSlot.js
+++ b/protocol-designer/src/step-generation/utils/isValidSlot.js
@@ -1,0 +1,8 @@
+import * as deckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard'
+// @flow
+export const isValidSlot = (slot: string): boolean => {
+  const slots: Array<string> = deckDef.locations.orderedSlots.map(
+    slotDef => slotDef.id
+  )
+  return slots.includes(slot)
+}

--- a/shared-data/protocol/flowTypes/schemaV3.js
+++ b/shared-data/protocol/flowTypes/schemaV3.js
@@ -61,7 +61,8 @@ export type MoveToSlotParams = {|
     y: number,
     z: number,
   |},
-  minimumZHeight: number,
+  minimumZHeight?: number,
+  forceDirect?: boolean,
 |}
 
 export type DelayParams = {|


### PR DESCRIPTION
# Overview

This PR closes #6221 by adding a move to slot command creator. Note, this isn't actually being used, delay offset will use `moveToWell` instead. We just figured that since we were half way through making this command creator, and because `moveToSlot` is part of the v3 executor + schema, we should PR this.

# Changelog

- Add move to slot command creator

# Review requests
Code review (including tests, i wasn't exactly sure which errors to be checking for so cases might be missing)

# Risk assessment
Low