### PR TITLE
refactor(shared-data): allow api level dependent flow rates

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -132,6 +132,12 @@ def load(
                 override['quirks'] = [
                     qname for qname, qval in override['quirks'].items()
                     if qval]
+            for legacy_key in (
+                    'defaultAspirateFlowRate',
+                    'defaultDispenseFlowRate',
+                    'defaultBlowOutFlowRate'):
+                override.pop(legacy_key, None)
+
         except FileNotFoundError:
             save_overrides(pipette_id, {}, pipette_model)
             log.info(
@@ -169,10 +175,8 @@ def load(
             cfg, 'pickUpIncrement', MUTABLE_CONFIGS),
         pick_up_presses=ensure_value(cfg, 'pickUpPresses', MUTABLE_CONFIGS),
         pick_up_speed=ensure_value(cfg, 'pickUpSpeed', MUTABLE_CONFIGS),
-        aspirate_flow_rate=ensure_value(
-            cfg, 'defaultAspirateFlowRate', MUTABLE_CONFIGS),
-        dispense_flow_rate=ensure_value(
-            cfg, 'defaultDispenseFlowRate', MUTABLE_CONFIGS),
+        aspirate_flow_rate=cfg['defaultAspirateFlowRate']['value'],
+        dispense_flow_rate=cfg['defaultDispenseFlowRate']['value'],
         channels=ensure_value(cfg, 'channels', MUTABLE_CONFIGS),
         model_offset=ensure_value(cfg, 'modelOffset', MUTABLE_CONFIGS),
         plunger_current=ensure_value(cfg, 'plungerCurrent', MUTABLE_CONFIGS),
@@ -188,8 +192,7 @@ def load(
         name=cfg['name'],
         back_compat_names=cfg.get('backCompatNames', []),
         return_tip_height=cfg.get('returnTipHeight', 0.5),
-        blow_out_flow_rate=ensure_value(
-            cfg, 'defaultBlowOutFlowRate', MUTABLE_CONFIGS),
+        blow_out_flow_rate=cfg['defaultBlowOutFlowRate']['value'],
         max_travel=smoothie_configs['travelDistance'],
         home_position=smoothie_configs['homePosition'],
         steps_per_mm=smoothie_configs['stepsPerMM'],

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -16,9 +16,6 @@ stages:
           fields: 
             blowout: !anydict
             bottom: !anydict
-            defaultAspirateFlowRate: !anydict
-            defaultBlowOutFlowRate: !anydict
-            defaultDispenseFlowRate: !anydict
             dropTip: !anydict
             dropTipCurrent: !anydict
             dropTipSpeed: !anydict
@@ -52,9 +49,6 @@ stages:
         fields: 
           blowout: !anydict
           bottom: !anydict
-          defaultAspirateFlowRate: !anydict
-          defaultBlowOutFlowRate: !anydict
-          defaultDispenseFlowRate: !anydict
           dropTip: !anydict
           dropTipCurrent: !anydict
           dropTipSpeed: !anydict
@@ -92,10 +86,7 @@ stages:
         fields: 
           blowout: !anydict
           bottom: !anydict
-          defaultAspirateFlowRate: !anydict
-          defaultBlowOutFlowRate: !anydict
-          defaultDispenseFlowRate: !anydict
-          dropTip: 
+          dropTip:
             units: mm
             type: float
             min: -6.0
@@ -154,10 +145,7 @@ stages:
             max: 19.0
             default: 3.5
             value: 3.0
-          defaultAspirateFlowRate: !anydict
-          defaultBlowOutFlowRate: !anydict
-          defaultDispenseFlowRate: !anydict
-          dropTip: !anydict 
+          dropTip: !anydict
           dropTipCurrent: !anydict
           dropTipSpeed: !anydict
           pickUpCurrent: !anydict
@@ -240,10 +228,7 @@ stages:
         fields: 
           blowout: !anydict
           bottom: !anydict
-          defaultAspirateFlowRate: !anydict
-          defaultBlowOutFlowRate: !anydict
-          defaultDispenseFlowRate: !anydict
-          dropTip: 
+          dropTip:
             units: mm
             type: float
             min: -6.0

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -21,16 +21,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
@@ -228,16 +237,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
@@ -435,16 +453,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
@@ -642,16 +669,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
@@ -819,16 +855,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
@@ -911,6 +956,9 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1031,16 +1079,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
@@ -1123,6 +1180,9 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1243,16 +1303,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
@@ -1335,6 +1404,9 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1455,16 +1527,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
@@ -1547,6 +1628,9 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1631,16 +1715,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
@@ -1827,16 +1920,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
@@ -2023,16 +2125,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
@@ -2219,16 +2330,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
@@ -2395,16 +2515,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
@@ -2591,16 +2720,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
@@ -2787,16 +2925,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
@@ -2983,16 +3130,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
@@ -3143,16 +3299,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
@@ -3303,16 +3468,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
@@ -3463,16 +3637,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
@@ -3624,16 +3807,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
@@ -3840,16 +4032,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
@@ -4056,16 +4257,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
@@ -4272,16 +4482,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
@@ -4452,16 +4671,25 @@ Object {
     "max": 2000,
     "min": 50,
     "value": 500,
+    "valuesByApiLevel": Object {
+      "2.0": 500,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 2000,
     "min": 50,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
@@ -4634,16 +4862,25 @@ Object {
     "max": 2000,
     "min": 50,
     "value": 500,
+    "valuesByApiLevel": Object {
+      "2.0": 500,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 2000,
     "min": 50,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
@@ -4816,16 +5053,25 @@ Object {
     "max": 2000,
     "min": 50,
     "value": 500,
+    "valuesByApiLevel": Object {
+      "2.0": 500,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 2000,
     "min": 50,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
@@ -4998,16 +5244,25 @@ Object {
     "max": 2000,
     "min": 50,
     "value": 500,
+    "valuesByApiLevel": Object {
+      "2.0": 500,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 2000,
     "min": 50,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
@@ -5166,16 +5421,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
@@ -5197,16 +5461,25 @@ Object {
     "max": 50,
     "min": 0.001,
     "value": 5,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 50,
     "min": 0.001,
     "value": 10,
+    "valuesByApiLevel": Object {
+      "2.0": 10,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
@@ -5217,6 +5490,9 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
+    "valuesByApiLevel": Object {
+      "2.0": 5,
+    },
   },
 }
 `;
@@ -5228,16 +5504,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
@@ -5259,16 +5544,25 @@ Object {
     "max": 100,
     "min": 0.001,
     "value": 25,
+    "valuesByApiLevel": Object {
+      "2.0": 25,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 100,
     "min": 0.001,
     "value": 50,
+    "valuesByApiLevel": Object {
+      "2.0": 50,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
@@ -5290,16 +5584,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
@@ -5321,16 +5624,25 @@ Object {
     "max": 600,
     "min": 0.001,
     "value": 150,
+    "valuesByApiLevel": Object {
+      "2.0": 150,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 600,
     "min": 0.001,
     "value": 300,
+    "valuesByApiLevel": Object {
+      "2.0": 300,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
@@ -5352,16 +5664,25 @@ Object {
     "max": 2000,
     "min": 50,
     "value": 500,
+    "valuesByApiLevel": Object {
+      "2.0": 500,
+    },
   },
   "defaultBlowOutFlowRate": Object {
     "max": 1000,
     "min": 5,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "defaultDispenseFlowRate": Object {
     "max": 2000,
     "min": 50,
     "value": 1000,
+    "valuesByApiLevel": Object {
+      "2.0": 1000,
+    },
   },
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -956,9 +956,6 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
-    "valuesByApiLevel": Object {
-      "2.0": 5,
-    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1180,9 +1177,6 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
-    "valuesByApiLevel": Object {
-      "2.0": 5,
-    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1404,9 +1398,6 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
-    "valuesByApiLevel": Object {
-      "2.0": 5,
-    },
   },
   "tipLength": Object {
     "max": 100,
@@ -1628,9 +1619,6 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
-    "valuesByApiLevel": Object {
-      "2.0": 5,
-    },
   },
   "tipLength": Object {
     "max": 100,
@@ -5490,9 +5478,6 @@ Object {
     "homePosition": 220,
     "stepsPerMM": 768,
     "travelDistance": 30,
-    "valuesByApiLevel": Object {
-      "2.0": 5,
-    },
   },
 }
 `;

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -5169,9 +5169,6 @@
     "dropTipCurrent",
     "dropTipSpeed",
     "tipLength",
-    "defaultAspirateFlowRate",
-    "defaultDispenseFlowRate",
-    "defaultBlowOutFlowRate",
     "quirks"
   ],
   "validQuirks": [

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -8,22 +8,26 @@
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
-      "max": 50
+      "max": 50,
+      "valuesByApiLevel": {"2.0": 5}
     },
     "defaultDispenseFlowRate": {
       "value": 10,
       "min": 0.001,
-      "max": 50
+      "max": 50,
+      "valuesByApiLevel": {"2.0": 10}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "smoothieConfigs": {
       "stepsPerMM": 768,
       "homePosition": 220,
-      "travelDistance": 30
+      "travelDistance": 30,
+      "valuesByApiLevel": {"2.0": 5}
     }
   },
   "p10_multi": {
@@ -34,17 +38,20 @@
     "defaultAspirateFlowRate": {
       "value": 5,
       "min": 0.001,
-      "max": 50
+      "max": 50,
+      "valuesByApiLevel": {"2.0": 5}
     },
     "defaultDispenseFlowRate": {
       "value": 10,
       "min": 0.001,
-      "max": 50
+      "max": 50,
+      "valuesByApiLevel":  {"2.0": 10}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 8,
     "smoothieConfigs": {
@@ -59,17 +66,26 @@
     "defaultAspirateFlowRate": {
       "value": 3.78,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 3.78,
+        "2.6": 7.56}
     },
     "defaultDispenseFlowRate": {
       "value": 3.78,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 3.78,
+        "2.6": 7.56}
     },
     "defaultBlowOutFlowRate": {
       "value": 3.78,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 3.78,
+        "2.6": 7.56}
     },
     "minVolume": 1,
     "maxVolume": 20,
@@ -86,17 +102,26 @@
     "defaultAspirateFlowRate": {
       "value": 7.6,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 7.6
+      }
     },
     "defaultDispenseFlowRate": {
       "value": 7.6,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 7.6
+      }
     },
     "defaultBlowOutFlowRate": {
       "value": 7.6,
       "min": 0.08,
-      "max": 24
+      "max": 24,
+      "valuesByApiLevel": {
+        "2.0": 7.6
+      }
     },
     "minVolume": 1,
     "maxVolume": 20,
@@ -113,17 +138,20 @@
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
-      "max": 100
+      "max": 100,
+      "valuesByApiLevel": {"2.0":  25}
     },
     "defaultDispenseFlowRate": {
       "value": 50,
       "min": 0.001,
-      "max": 100
+      "max": 100,
+      "valuesByApiLevel": {"2.0": 50}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 1,
     "minVolume": 5,
@@ -140,17 +168,20 @@
     "defaultAspirateFlowRate": {
       "value": 25,
       "min": 0.001,
-      "max": 100
+      "max": 100,
+      "valuesByApiLevel": {"2.0": 25}
     },
     "defaultDispenseFlowRate": {
       "value": 50,
       "min": 0.001,
-      "max": 100
+      "max": 100,
+      "valuesByApiLevel":  {"2.0": 50}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 8,
     "minVolume": 5,
@@ -167,17 +198,20 @@
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
-      "max": 600
+      "max": 600,
+      "valuesByApiLevel": {"2.0": 150}
     },
     "defaultDispenseFlowRate": {
       "value": 300,
       "min": 0.001,
-      "max": 600
+      "max": 600,
+      "valuesByApiLevel": {"2.0": 300}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 1,
     "minVolume": 30,
@@ -194,17 +228,29 @@
     "defaultAspirateFlowRate": {
       "value": 46.43,
       "min": 1,
-      "max": 275
+      "max": 275,
+      "valuesByApiLevel": {
+        "2.0": 46.43,
+        "2.6": 92.86
+      }
     },
     "defaultDispenseFlowRate": {
       "value": 46.43,
       "min": 1,
-      "max": 275.31
+      "max": 275.31,
+      "valuesByApiLevel": {
+        "2.0": 46.43,
+        "2.6": 92.86
+      }
     },
     "defaultBlowOutFlowRate": {
       "value": 46.43,
       "min": 1,
-      "max": 275
+      "max": 275,
+      "valuesByApiLevel": {
+        "2.0": 46.43,
+        "2.6": 92.86
+      }
     },
     "channels": 1,
     "minVolume": 20,
@@ -221,17 +267,26 @@
     "defaultAspirateFlowRate": {
       "value": 94,
       "min": 1,
-      "max": 275
+      "max": 275,
+      "valuesByApiLevel": {
+        "2.0": 94
+      }
     },
     "defaultDispenseFlowRate": {
       "value": 94,
       "min": 1,
-      "max": 275
+      "max": 275,
+      "valuesByApiLevel": {
+        "2.0": 94
+      }
     },
     "defaultBlowOutFlowRate": {
       "value": 94,
       "min": 1,
-      "max": 275
+      "max": 275,
+      "valuesByApiLevel": {
+        "2.0": 94
+      }
     },
     "channels": 8,
     "minVolume": 20,
@@ -248,17 +303,20 @@
     "defaultAspirateFlowRate": {
       "value": 150,
       "min": 0.001,
-      "max": 600
+      "max": 600,
+      "valuesByApiLevel": {"2.0": 150}
     },
     "defaultDispenseFlowRate": {
       "value": 300,
       "min": 0.001,
-      "max": 600
+      "max": 600,
+      "valuesByApiLevel": {"2.0": 300}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 8,
     "minVolume": 30,
@@ -275,17 +333,20 @@
     "defaultAspirateFlowRate": {
       "value": 500,
       "min": 50,
-      "max": 2000
+      "max": 2000,
+      "valuesByApiLevel": {"2.0": 500}
     },
     "defaultDispenseFlowRate": {
       "value": 1000,
       "min": 50,
-      "max": 2000
+      "max": 2000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
-      "max": 1000
+      "max": 1000,
+      "valuesByApiLevel": {"2.0": 1000}
     },
     "channels": 1,
     "minVolume": 100,
@@ -302,17 +363,29 @@
     "defaultAspirateFlowRate": {
       "value": 137.35,
       "min": 3,
-      "max": 812
+      "max": 812,
+      "valuesByApiLevel": {
+        "2.0": 137.35,
+        "2.6": 274.7
+      }
     },
     "defaultDispenseFlowRate": {
       "value": 137.35,
       "min": 3,
-      "max": 812
+      "max": 812,
+      "valuesByApiLevel": {
+        "2.0": 137.35,
+        "2.6": 274.7
+      }
     },
     "defaultBlowOutFlowRate": {
       "value": 137.35,
       "min": 3,
-      "max": 812
+      "max": 812,
+      "valuesByApiLevel": {
+        "2.0": 137.35,
+        "2.6": 274.7
+      }
     },
     "channels": 1,
     "minVolume": 100,

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -9,25 +9,24 @@
       "value": 5,
       "min": 0.001,
       "max": 50,
-      "valuesByApiLevel": {"2.0": 5}
+      "valuesByApiLevel": { "2.0": 5 }
     },
     "defaultDispenseFlowRate": {
       "value": 10,
       "min": 0.001,
       "max": 50,
-      "valuesByApiLevel": {"2.0": 10}
+      "valuesByApiLevel": { "2.0": 10 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "smoothieConfigs": {
       "stepsPerMM": 768,
       "homePosition": 220,
-      "travelDistance": 30,
-      "valuesByApiLevel": {"2.0": 5}
+      "travelDistance": 30
     }
   },
   "p10_multi": {
@@ -39,19 +38,19 @@
       "value": 5,
       "min": 0.001,
       "max": 50,
-      "valuesByApiLevel": {"2.0": 5}
+      "valuesByApiLevel": { "2.0": 5 }
     },
     "defaultDispenseFlowRate": {
       "value": 10,
       "min": 0.001,
       "max": 50,
-      "valuesByApiLevel":  {"2.0": 10}
+      "valuesByApiLevel": { "2.0": 10 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 8,
     "smoothieConfigs": {
@@ -69,7 +68,8 @@
       "max": 24,
       "valuesByApiLevel": {
         "2.0": 3.78,
-        "2.6": 7.56}
+        "2.6": 7.56
+      }
     },
     "defaultDispenseFlowRate": {
       "value": 3.78,
@@ -77,7 +77,8 @@
       "max": 24,
       "valuesByApiLevel": {
         "2.0": 3.78,
-        "2.6": 7.56}
+        "2.6": 7.56
+      }
     },
     "defaultBlowOutFlowRate": {
       "value": 3.78,
@@ -85,7 +86,8 @@
       "max": 24,
       "valuesByApiLevel": {
         "2.0": 3.78,
-        "2.6": 7.56}
+        "2.6": 7.56
+      }
     },
     "minVolume": 1,
     "maxVolume": 20,
@@ -139,19 +141,19 @@
       "value": 25,
       "min": 0.001,
       "max": 100,
-      "valuesByApiLevel": {"2.0":  25}
+      "valuesByApiLevel": { "2.0": 25 }
     },
     "defaultDispenseFlowRate": {
       "value": 50,
       "min": 0.001,
       "max": 100,
-      "valuesByApiLevel": {"2.0": 50}
+      "valuesByApiLevel": { "2.0": 50 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 1,
     "minVolume": 5,
@@ -169,19 +171,19 @@
       "value": 25,
       "min": 0.001,
       "max": 100,
-      "valuesByApiLevel": {"2.0": 25}
+      "valuesByApiLevel": { "2.0": 25 }
     },
     "defaultDispenseFlowRate": {
       "value": 50,
       "min": 0.001,
       "max": 100,
-      "valuesByApiLevel":  {"2.0": 50}
+      "valuesByApiLevel": { "2.0": 50 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 8,
     "minVolume": 5,
@@ -199,19 +201,19 @@
       "value": 150,
       "min": 0.001,
       "max": 600,
-      "valuesByApiLevel": {"2.0": 150}
+      "valuesByApiLevel": { "2.0": 150 }
     },
     "defaultDispenseFlowRate": {
       "value": 300,
       "min": 0.001,
       "max": 600,
-      "valuesByApiLevel": {"2.0": 300}
+      "valuesByApiLevel": { "2.0": 300 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 1,
     "minVolume": 30,
@@ -304,19 +306,19 @@
       "value": 150,
       "min": 0.001,
       "max": 600,
-      "valuesByApiLevel": {"2.0": 150}
+      "valuesByApiLevel": { "2.0": 150 }
     },
     "defaultDispenseFlowRate": {
       "value": 300,
       "min": 0.001,
       "max": 600,
-      "valuesByApiLevel": {"2.0": 300}
+      "valuesByApiLevel": { "2.0": 300 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 8,
     "minVolume": 30,
@@ -334,19 +336,19 @@
       "value": 500,
       "min": 50,
       "max": 2000,
-      "valuesByApiLevel": {"2.0": 500}
+      "valuesByApiLevel": { "2.0": 500 }
     },
     "defaultDispenseFlowRate": {
       "value": 1000,
       "min": 50,
       "max": 2000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "defaultBlowOutFlowRate": {
       "value": 1000,
       "min": 5,
       "max": 1000,
-      "valuesByApiLevel": {"2.0": 1000}
+      "valuesByApiLevel": { "2.0": 1000 }
     },
     "channels": 1,
     "minVolume": 100,

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -18,7 +18,7 @@
       "required": ["2.0"],
       "additionalProperties": false,
       "patternProperties": {
-        "^\\d\\.\\d$": {
+        "^\\d\\.\\d+$": {
           "$ref": "#/definitions/positiveNumber"
         }
       }

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -12,6 +12,15 @@
     "displayCategory": {
       "type": "string",
       "enum": ["GEN1", "GEN2"]
+    },
+    "perApiLevelValues": {
+      "type": "object",
+      "required": ["2.0"],
+      "patternProperties": {
+        "\\d+\\.\\d+": {
+          "$ref": "#/definitions/positiveNumber"
+        }
+      }
     }
   },
 
@@ -34,19 +43,31 @@
       "properties": {
         "channels": { "$ref": "#/definitions/channels" },
         "defaultAspirateFlowRate": {
-          "value": { "$ref": "#/definitions/positiveNumber" },
+          "value": {
+            "$ref": "#/definitions/positiveNumber",
+            "$comment": "This key is deprecated in favor of valuesByApiLevel"
+          },
           "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" }
+          "max": { "$ref": "#/definitions/positiveNumber" },
+          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
         },
         "defaultDispenseFlowRate": {
-          "value": { "$ref": "#/definitions/positiveNumber" },
+          "value": {
+            "$ref": "#/definitions/positiveNumber",
+            "$comment": "This key is deprecated in favor of valuesByApiLevel"
+          },
           "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" }
+          "max": { "$ref": "#/definitions/positiveNumber" },
+          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
         },
         "defaultBlowOutFlowRate": {
-          "value": { "$ref": "#/definitions/positiveNumber" },
+          "value": {
+            "$ref": "#/definitions/positiveNumber",
+            "$comment": "This key is deprecated in favor of valuesByApiLevel"
+          },
           "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" }
+          "max": { "$ref": "#/definitions/positiveNumber" },
+          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
         },
         "displayName": { "type": "string" },
         "displayCategory": { "$ref": "#/definitions/displayCategory" },

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -13,13 +13,27 @@
       "type": "string",
       "enum": ["GEN1", "GEN2"]
     },
-    "perApiLevelValues": {
+    "valuesByApiLevel": {
       "type": "object",
       "required": ["2.0"],
+      "additionalProperties": false,
       "patternProperties": {
-        "\\d+\\.\\d+": {
+        "^\\d\\.\\d$": {
           "$ref": "#/definitions/positiveNumber"
         }
+      }
+    },
+    "configValue": {
+      "type": "object",
+      "required": ["value", "min", "max", "valuesByApiLevel"],
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/positiveNumber",
+          "$comment": "This key is deprecated in favor of valuesByApiLevel"
+        },
+        "min": { "$ref": "#/definitions/positiveNumber" },
+        "max": { "$ref": "#/definitions/positiveNumber" },
+        "valuesByApiLevel": { "$ref": "#/definitions/valuesByApiLevel" }
       }
     }
   },
@@ -43,31 +57,13 @@
       "properties": {
         "channels": { "$ref": "#/definitions/channels" },
         "defaultAspirateFlowRate": {
-          "value": {
-            "$ref": "#/definitions/positiveNumber",
-            "$comment": "This key is deprecated in favor of valuesByApiLevel"
-          },
-          "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" },
-          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
+          "$ref": "#/definitions/configValue"
         },
         "defaultDispenseFlowRate": {
-          "value": {
-            "$ref": "#/definitions/positiveNumber",
-            "$comment": "This key is deprecated in favor of valuesByApiLevel"
-          },
-          "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" },
-          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
+          "$ref": "#/definitions/configValue"
         },
         "defaultBlowOutFlowRate": {
-          "value": {
-            "$ref": "#/definitions/positiveNumber",
-            "$comment": "This key is deprecated in favor of valuesByApiLevel"
-          },
-          "min": { "$ref": "#/definitions/positiveNumber" },
-          "max": { "$ref": "#/definitions/positiveNumber" },
-          "valuesByApiLevel": { "$ref": "#/definitions/perApiLevelValues" }
+          "$ref": "#/definitions/configValue"
         },
         "displayName": { "type": "string" },
         "displayCategory": { "$ref": "#/definitions/displayCategory" },

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -38,6 +38,13 @@ class PipetteConfigElement(TypedDict):
     max: float
 
 
+class PipetteConfigElementWithPerApiLevelValue(TypedDict):
+    value: float
+    min: float
+    max: float
+    valuesByApiLevel: Dict[str, float]
+
+
 # TypedDicts can't be generic sadly
 class PipetteCustomizableConfigElementFloat(TypedDict):
     value: float
@@ -71,9 +78,9 @@ class PipetteNameSpec(TypedDict):
     minVolume: Union[float, int]
     maxVolume: Union[float, int]
     channels: ChannelCount
-    defaultAspirateFlowRate: PipetteConfigElement
-    defaultDispenseFlowRate: PipetteConfigElement
-    defaultBlowOutFlowRate: PipetteConfigElement
+    defaultAspirateFlowRate: PipetteConfigElementWithPerApiLevelValue
+    defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
+    defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
     smoothieConfigs: SmoothieConfigs
 
 


### PR DESCRIPTION
Recent hardware changes allow us to update the default flow rate for
Gen2 Single pipettes to 10mm/s plunger speed (resulting flow rate varies
per pipette class), including retroactively. To avoid changing user
protocols under them, this adds new data for the changed values:
- flow rate values now can be organized in an object keyed with api
levels
- this will eventually supercede the single-value structure
- the api level 2.0 key is the "default", and should be used unless
operating at a higher api level for which there is a superceding value.

## Review requests

- Does this structure look good?  Nothing  uses this data yet (that'll be a follow up pr)
- Do the values for api level 2.0 match the "value" defaults?
- Are the 2.6 values properly twice the 2.0 levels, where they exist?