### PR TITLE
feat(api):  Use 10mm/s-equivalent flow rates for GEN2 singles in API Version 2.6

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -25,6 +25,7 @@ wheel = "==0.30.0"
 "e1839a8" = {editable = true, path = "."}
 "c445fee" = {editable = true, path = "./../shared-data/python"}
 pytest-aiohttp = "*"
+typeguard = "*"
 
 [packages]
 aionotify = "==0.2.0"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c8fb0a38bb1c91229f5bb28055568700ecb2ba8348694ce87b66343a16c0203e"
+            "sha256": "2fbc7974bf12d750a036a23a697fe3a9b63bc6cea7479dcd608c7226e9b31d8a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -677,10 +677,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7",
-                "sha256:7810e627bcf9d983a99d9ff8a0c09674400fd2927eddabeadf153c14a2ec8656"
+                "sha256:1a336d2b829be50e46b84668691e0a2719f26c97c62846298dd5ae2937e4d5cf",
+                "sha256:564d632ea2b9cb52979f7956e093e831c28d441c11751682f84c86fc46e4fd21"
             ],
-            "version": "==4.47.0"
+            "version": "==4.48.2"
         },
         "twine": {
             "hashes": [
@@ -716,6 +716,14 @@
             ],
             "version": "==1.4.1"
         },
+        "typeguard": {
+            "hashes": [
+                "sha256:529ef3d88189cc457f4340388028412f71be8091c2c943465146d4170fb67288",
+                "sha256:e258567e62d28f9a51d4f7c71f491154e9ef0889286ad2f37e3e22e4f668b21b"
+            ],
+            "index": "pypi",
+            "version": "==2.9.1"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
@@ -727,10 +735,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "version": "==1.25.9"
+            "version": "==1.25.10"
         },
         "urwid": {
             "hashes": [
@@ -763,25 +771,25 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce",
-                "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6",
-                "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce",
-                "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae",
-                "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d",
-                "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f",
-                "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b",
-                "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b",
-                "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb",
-                "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462",
-                "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea",
-                "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70",
-                "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1",
-                "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a",
-                "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b",
-                "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080",
-                "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"
+                "sha256:040b237f58ff7d800e6e0fd89c8439b841f777dd99b4a9cca04d6935564b9409",
+                "sha256:17668ec6722b1b7a3a05cc0167659f6c95b436d25a36c2d52db0eca7d3f72593",
+                "sha256:3a584b28086bc93c888a6c2aa5c92ed1ae20932f078c46509a66dce9ea5533f2",
+                "sha256:4439be27e4eee76c7632c2427ca5e73703151b22cae23e64adb243a9c2f565d8",
+                "sha256:48e918b05850fffb070a496d2b5f97fc31d15d94ca33d3d08a4f86e26d4e7c5d",
+                "sha256:9102b59e8337f9874638fcfc9ac3734a0cfadb100e47d55c20d0dc6087fb4692",
+                "sha256:9b930776c0ae0c691776f4d2891ebc5362af86f152dd0da463a6614074cb1b02",
+                "sha256:b3b9ad80f8b68519cc3372a6ca85ae02cc5a8807723ac366b53c0f089db19e4a",
+                "sha256:bc2f976c0e918659f723401c4f834deb8a8e7798a71be4382e024bcc3f7e23a8",
+                "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6",
+                "sha256:c52ce2883dc193824989a9b97a76ca86ecd1fa7955b14f87bf367a61b6232511",
+                "sha256:ce584af5de8830d8701b8979b18fcf450cef9a382b1a3c8ef189bedc408faf1e",
+                "sha256:da456eeec17fa8aa4594d9a9f27c0b1060b6a75f2419fe0c00609587b2695f4a",
+                "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb",
+                "sha256:df89642981b94e7db5596818499c4b2219028f2a528c9c37cc1de45bf2fd3a3f",
+                "sha256:f18d68f2be6bf0e89f1521af2b1bb46e66ab0018faafa81d70f358153170a317",
+                "sha256:f379b7f83f23fe12823085cd6b906edc49df969eb99757f58ff382349a3303c6"
             ],
-            "version": "==1.4.2"
+            "version": "==1.5.1"
         },
         "zipp": {
             "hashes": [

--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -13,7 +13,7 @@ The examples in this section would be added to the following:
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.4'}
+    metadata = {'apiLevel': '2.6'}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack = protocol.load_labware('corning_96_wellplate_360ul_flat', 2)
@@ -515,7 +515,7 @@ You can turn the robot rail lights on or off in the protocol using :py:meth:`.Pr
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.5'}
+    metadata = {'apiLevel': '2.6'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # turn on robot rail lights

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -435,25 +435,43 @@ Defaults
 
 **p20_single_gen2**
 
-- Aspirate Default: 3.78 µL/s
-- Dispense Default: 3.78 µL/s
-- Blow Out Default: 3.78 µL/s
+- Aspirate Default:
+    - On API Version 2.5 and previous: 3.78 µL/s
+    - On API Version 2.6 and subsequent: 7.56 µL/s
+- Dispense Default:
+    - On API Version 2.5 and previous: 3.78 µL/s
+    - On API Version 2.6 and subsequent: 7.56 µL/s
+- Blow Out Default:
+    - On API Version 2.5 and previous: 3.78 µL/s
+    - On API Version 2.6 and subsequent: 7.56 µL/s
 - Minimum Volume: 1 µL
 - Maximum Volume: 20 µL
 
 **p300_single_gen2**
 
-- Aspirate Default: 46.43 µL/s
-- Dispense Default: 46.43 µL/s
-- Blow Out Default: 46.43 µL/s
+- Aspirate Default:
+    - On API Version 2.5 and previous: 46.43 µL/s
+    - On API Version 2.6 and subsequent: 92.86 µL/s
+- Dispense Default:
+    - On API Version 2.5 and previous: 46.43 µL/s
+    - On API Version 2.6 and subsequent: 92.86 µL/s
+- Blow Out Default:
+    - On API Version 2.5 and previous: 46.43 µL/s
+    - On API Version 2.6 and subsequent: 92.86 µL/s
 - Minimum Volume: 20 µL
 - Maximum Volume: 300 µL
 
 **p1000_single_gen2**
 
-- Aspirate Default: 137.35 µL/s
-- Dispense Default: 137.35 µL/s
-- Blow Out Default: 137.35 µL/s
+- Aspirate Default:
+    - On API Version 2.5 and previous: 137.35 µL/s
+    - On API Version 2.6 and subsequent: 274.7 µL/s
+- Dispense Default:
+    - On API Version 2.5 and previous: 137.35 µL/s
+    - On API Version 2.6 and subsequent: 274.7 µL/s
+- Blow Out Default:
+    - On API Version 2.5 and previous: 137.35 µL/s
+    - On API Version 2.6 and subsequent: 274.7 µL/s
 - Minimum Volume: 100 µL
 - Maximum Volume: 1000 µL
 

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -62,7 +62,7 @@ For instance, to aspirate from the first column of a 96-well plate you would wri
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.5'}
+    metadata = {'apiLevel': '2.6'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # Load a tiprack for 300uL tips
@@ -101,7 +101,7 @@ F, H, J, L, N, and P).
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '2.5'}
+    metadata = {'apiLevel': '2.6'}
 
     def run(protocol: protocol_api.ProtocolContext):
         # Load a tiprack for 300uL tips

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -103,6 +103,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.5     |          3.19.0             |
 +-------------+-----------------------------+
+|     2.5     |          3.20.0             |
++-------------+-----------------------------+
 
 Changes in API Versions
 -----------------------
@@ -153,3 +155,12 @@ Version 2.5
     - :py:meth:`.ProtocolContext.set_rail_lights`: turns robot rail lights on or off
     - :py:obj:`.ProtocolContext.rail_lights_on`: describes whether or not the rail lights are on
     - :py:obj:`.ProtocolContext.door_closed`: describes whether the robot door is closed
+
+
+Version 2.6
++++++++++++
+
+- GEN2 Single pipettes now default to flow rates equivalent to 10 mm/s plunger
+  speeds
+    - Protocols that manually configure pipette flow rates will be unaffected
+    - For a comparison between API Versions, see :ref:`defaults`

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -103,7 +103,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.5     |          3.19.0             |
 +-------------+-----------------------------+
-|     2.5     |          3.20.0             |
+|     2.6     |          3.20.0             |
 +-------------+-----------------------------+
 
 Changes in API Versions

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -53,6 +53,9 @@ class PipetteConfig:
     home_position: float
     steps_per_mm: float
     idle_current: float
+    default_blow_out_flow_rates: Dict[str, float]
+    default_aspirate_flow_rates: Dict[str, float]
+    default_dispense_flow_rates: Dict[str, float]
 
 
 # Notes:
@@ -196,7 +199,16 @@ def load(
         max_travel=smoothie_configs['travelDistance'],
         home_position=smoothie_configs['homePosition'],
         steps_per_mm=smoothie_configs['stepsPerMM'],
-        idle_current=cfg.get('idleCurrent', LOW_CURRENT_DEFAULT)
+        idle_current=cfg.get('idleCurrent', LOW_CURRENT_DEFAULT),
+        default_blow_out_flow_rates=cfg['defaultBlowOutFlowRate'].get(
+            'valuesByApiLevel',
+            {'2.0': cfg['defaultBlowOutFlowRate']['value']}),
+        default_dispense_flow_rates=cfg['defaultDispenseFlowRate'].get(
+            'valuesByApiLevel',
+            {'2.0': cfg['defaultDispenseFlowRate']['value']}),
+        default_aspirate_flow_rates=cfg['defaultAspirateFlowRate'].get(
+            'valuesByApiLevel',
+            {'2.0': cfg['defaultAspirateFlowRate']['value']}),
     )
 
     return res

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -2,10 +2,10 @@
 # and are only relevant for static typechecking. this file should only
 # be imported if typing.TYPE_CHECKING is True
 import asyncio
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from opentrons_shared_data.pipette.dev_types import (
-    PipetteModel
+    PipetteModel, PipetteName, ChannelCount
 )
 
 from .modules import ModuleAtPort
@@ -33,3 +33,37 @@ DoorStateNotificationType = Literal[HardwareEventType.DOOR_SWITCH_CHANGE]
 class AttachedInstrument(TypedDict):
     model: Optional[PipetteModel]
     id: Optional[str]
+
+
+EIGHT_CHANNELS = Literal[8]
+ONE_CHANNEL = Literal[1]
+
+
+class PipetteDict(TypedDict):
+    name: PipetteName
+    model: PipetteModel
+    pipette_id: str
+    display_name: str
+    min_volume: float
+    max_volume: float
+    channels: ChannelCount
+    aspirate_flow_rate: float
+    dispense_flow_rate: float
+    blow_out_flow_rate: float
+    aspirate_speed: float
+    dispense_speed: float
+    blow_out_speed: float
+    current_volume: float
+    tip_length: float
+    working_volume: float
+    tip_overlap: Dict[str, float]
+    available_volume: float
+    return_tip_height: float
+    default_aspirate_flow_rates: Dict[str, float]
+    default_dispense_flow_rates: Dict[str, float]
+    default_blow_out_flow_rates: Dict[str,  float]
+    default_aspirate_speeds: Dict[str, float]
+    default_dispense_speeds: Dict[str, float]
+    default_blow_out_speeds: Dict[str, float]
+    ready_to_aspirate: bool
+    has_tip: bool

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -52,6 +52,12 @@ class Pipette:
                        .format(model, self._instrument_offset))
         self.ready_to_aspirate = False
         #: True if ready to aspirate
+        self._aspirate_flow_rate\
+            = self._config.default_aspirate_flow_rates['2.0']
+        self._dispense_flow_rate\
+            = self._config.default_dispense_flow_rates['2.0']
+        self._blow_out_flow_rate\
+            = self._config.default_blow_out_flow_rates['2.0']
 
     def update_instrument_offset(self, new_offset: Point):
         self._log.info("updated instrument offset to {}".format(new_offset))
@@ -156,6 +162,36 @@ class Pipette:
         self._current_tiprack_diameter = diameter
 
     @property
+    def aspirate_flow_rate(self) -> float:
+        """ Current active flow rate (not config value)"""
+        return self._aspirate_flow_rate
+
+    @aspirate_flow_rate.setter
+    def aspirate_flow_rate(self, new_flow_rate: float):
+        assert new_flow_rate > 0
+        self._aspirate_flow_rate = new_flow_rate
+
+    @property
+    def dispense_flow_rate(self) -> float:
+        """ Current active flow rate (not config value)"""
+        return self._dispense_flow_rate
+
+    @dispense_flow_rate.setter
+    def dispense_flow_rate(self, new_flow_rate: float):
+        assert new_flow_rate > 0
+        self._dispense_flow_rate = new_flow_rate
+
+    @property
+    def blow_out_flow_rate(self) -> float:
+        """ Current active flow rate (not config value)"""
+        return self._blow_out_flow_rate
+
+    @blow_out_flow_rate.setter
+    def blow_out_flow_rate(self, new_flow_rate: float):
+        assert new_flow_rate > 0
+        self._blow_out_flow_rate = new_flow_rate
+
+    @property
     def working_volume(self) -> float:
         """ The working volume of the pipette """
         return self._working_volume
@@ -238,5 +274,8 @@ class Pipette:
                             'model': self.model,
                             'pipette_id': self.pipette_id,
                             'has_tip': self.has_tip,
-                            'working_volume': self.working_volume})
+                            'working_volume': self.working_volume,
+                            'aspirate_flow_rate':  self.aspirate_flow_rate,
+                            'dispense_flow_rate': self.dispense_flow_rate,
+                            'blow_out_flow_rate': self.blow_out_flow_rate})
         return config_dict

--- a/api/src/opentrons/protocol_api/definitions.py
+++ b/api/src/opentrons/protocol_api/definitions.py
@@ -2,7 +2,7 @@ import abc
 
 from ..protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 5)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 6)
 #: The maximum supported protocol API version in this release
 
 V2_MODULE_DEF_VERSION = types.APIVersion(2, 3)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -96,6 +96,7 @@ class InstrumentContext(CommandPublisher):
         self._speeds = PlungerSpeeds(self)
         self._starting_tip: Union[Well, None] = None
         self.requested_as = requested_as
+        self._flow_rates.set_defaults(self._api_version)
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -3,7 +3,8 @@ from collections import UserDict
 import functools
 import logging
 from dataclasses import dataclass, field, astuple
-from typing import Any, Callable, Optional, TYPE_CHECKING, Union, List, Set
+from typing import (Any, Callable, Dict, Optional,
+                    TYPE_CHECKING, Union, List, Set)
 
 from opentrons import types as top_types
 from opentrons.protocols.types import APIVersion
@@ -160,6 +161,25 @@ class FlowRates:
             mount=self._instr._mount,
             blow_out=_assert_gzero(
                 new_val, 'flow rate should be a numerical value in ul/s'))
+
+
+def _find_value_for_api_version(for_version: APIVersion,
+                                values: Dict[str, float]) -> float:
+    """
+    Parse a dict that looks like
+    {"2.0": 5,
+    "2.5": 4}
+    (aka the flow rate values from pipette config) and return the value for
+    the highest api level that is at or underneath ``for_version``
+    """
+    sorted_versions = sorted({APIVersion.from_string(k): v
+                              for k, v in values.items()})
+    last = values[str(sorted_versions[0])]
+    for version in sorted_versions:
+        if version > for_version:
+            break
+        last = values[str(version)]
+    return last
 
 
 class PlungerSpeeds:

--- a/api/src/opentrons/protocol_api/util.py
+++ b/api/src/opentrons/protocol_api/util.py
@@ -129,6 +129,14 @@ class FlowRates:
                  instr: 'InstrumentContext') -> None:
         self._instr = instr
 
+    def set_defaults(self, api_level: APIVersion):
+        self.aspirate = _find_value_for_api_version(
+            api_level, self._instr.hw_pipette['default_aspirate_flow_rates'])
+        self.dispense = _find_value_for_api_version(
+            api_level, self._instr.hw_pipette['default_dispense_flow_rates'])
+        self.blow_out = _find_value_for_api_version(
+            api_level, self._instr.hw_pipette['default_blow_out_flow_rates'])
+
     @property
     def aspirate(self) -> float:
         return self._instr.hw_pipette['aspirate_flow_rate']

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -13,6 +13,15 @@ class APIVersion(NamedTuple):
     major: int
     minor: int
 
+    @classmethod
+    def from_string(cls, inp: str) -> 'APIVersion':
+        parts = inp.split('.')
+        if len(parts) != 2:
+            raise ValueError(inp)
+        intparts = [int(p) for p in parts]
+
+        return cls(major=intparts[0], minor=intparts[1])
+
     def __str__(self):
         return f'{self.major}.{self.minor}'
 

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -120,3 +120,37 @@ def test_tip_overlap(config_model):
                           'testId')
     assert pip.config.tip_overlap\
         == pipette_config.configs[config_model]['tipOverlap']
+
+
+def test_flow_rate_setting():
+    pip = pipette.Pipette('p300_single_v2.0',
+                          {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          'testId')
+    # pipettes should load settings from config at init time
+    assert pip.aspirate_flow_rate\
+        == pip.config.default_aspirate_flow_rates['2.0']
+    assert pip.dispense_flow_rate\
+        == pip.config.default_dispense_flow_rates['2.0']
+    assert pip.blow_out_flow_rate\
+        == pip.config.default_blow_out_flow_rates['2.0']
+    # changing flow rates with normal property access shouldn't touch
+    # config or other flow rates
+    config = pip.config
+    pip.aspirate_flow_rate = 2
+    assert pip.aspirate_flow_rate == 2
+    assert pip.dispense_flow_rate\
+        == pip.config.default_dispense_flow_rates['2.0']
+    assert pip.blow_out_flow_rate\
+        == pip.config.default_blow_out_flow_rates['2.0']
+    assert pip.config is config
+    pip.dispense_flow_rate = 3
+    assert pip.aspirate_flow_rate == 2
+    assert pip.dispense_flow_rate == 3
+    assert pip.blow_out_flow_rate\
+        == pip.config.default_blow_out_flow_rates['2.0']
+    assert pip.config is config
+    pip.blow_out_flow_rate = 4
+    assert pip.aspirate_flow_rate == 2
+    assert pip.dispense_flow_rate == 3
+    assert pip.blow_out_flow_rate == 4
+    assert pip.config is config

--- a/api/tests/opentrons/protocol_api/test_util.py
+++ b/api/tests/opentrons/protocol_api/test_util.py
@@ -6,7 +6,7 @@ from opentrons.protocols.types import APIVersion
 from opentrons.protocol_api.labware import Labware, get_labware_definition
 from opentrons.protocol_api.geometry import Deck
 from opentrons.protocol_api.util import (
-    HardwareManager, AxisMaxSpeeds, build_edges)
+    HardwareManager, AxisMaxSpeeds, build_edges, _find_value_for_api_version)
 from opentrons.hardware_control import API, adapters, types, ThreadManager
 
 
@@ -166,3 +166,15 @@ def test_build_edges_right_pipette(loop):
     res2 = build_edges(
         test_lw2['A12'], 1.0, APIVersion(2, 4), Mount.RIGHT, ctx._deck_layout)
     assert res2 == right_pip_edges
+
+
+@pytest.mark.parametrize('data,level,desired', [
+    ({'2.0': 5}, APIVersion(2, 0), 5),
+    ({'2.0': 5}, APIVersion(2, 5), 5),
+    ({'2.6': 4, '2.0': 5}, APIVersion(2, 1), 5),
+    ({'2.6': 4, '2.0': 5}, APIVersion(2, 6), 4),
+    ({'2.0': 5, '2.6': 4}, APIVersion(2, 3), 5),
+    ({'2.0': 5, '2.6': 4}, APIVersion(2, 6), 4)
+])
+def test_find_value_for_api_version(data, level, desired):
+    assert _find_value_for_api_version(level, data) == desired

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -22,7 +22,7 @@ stages:
         system_version: 0.0.0
         protocol_api_version:
           - 2
-          - 5
+          - 6
         links:
           apiLog: /logs/api.log
           serialLog: /logs/serial.log


### PR DESCRIPTION
(target is that other pr because it's based on it)

## Intro
Hardware changes to the test protocol for GEN2 single pipettes mean we can (and must, since this is the new way they're tested) double the flow rates across the board for GEN2 single pipettes to values equivalent to 10mm/s plunger speeds.

This data change is. set in #6279 .  This PR reads the data correctly in the api, creates a new protocol API version, and uses the new data to set the faster flow rates for protocols that request API Version 2.6.

## Changelog
- Add typeguard to API dev dependencies and use it for checking the `attached_instruments` results, which cuts down on some noise in tests and makes sure the new TypedDict specifying the result of `attached_instruments` stays synced to the implementation
- Load the new data in pipette config, use it in the hardware controller pipette, and expose it up the stack
- Use the new data to set appropriate flow rates in protocols when `InstrumentContext`s are built
- Refactor the hardware pipette and its owners to store flow rates in instance members and modify them there rather than poking the config every time

## Review Requests
- Does this look sane?

## Testing
- Run some protocols, with and without Gen2 Singles,  on 2.6 and below. Verify that smoothie logs look right, and nothing's broken (I need to do this myself also - I put this PR up early so we can get eyes on it).

Closes #5968 