### PR TITLE
fix(api): don't stomp other loggers in log config

### DIFF
--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -11,6 +11,7 @@ def _balena_config(level_value: int) -> Dict[str, Any]:
     api_log_filename = CONFIG['api_log_file']
     return {
         'version': 1,
+        'disable_existing_loggers': False,
         'formatters': {
             'basic': {
                 'format':
@@ -68,6 +69,7 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
     # either
     return {
         'version': 1,
+        'disable_existing_loggers': False,
         'formatters': {
             'message_only': {
                 'format': '%(message)s'


### PR DESCRIPTION
A recent robot-server PR deferred API loading until after the server is
up, which is a great change but means that the API-side logging
configuration now stomps on the robot server's logging configuration, so
robot server messages are not logged.

This commit removes the stomping and the robot server's logs should now
be visible again.

## Testing
Push this and make sure you can see robot server logs