### PR TITLE
refactor(app): Remove info icon from the file info page for calibration data

### DIFF
--- a/app/src/components/FileInfo/ProtocolLabwareList.js
+++ b/app/src/components/FileInfo/ProtocolLabwareList.js
@@ -5,14 +5,12 @@ import {
   useHoverTooltip,
   Box,
   Flex,
-  Icon,
   Text,
   Tooltip,
   ALIGN_FLEX_END,
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   LINE_HEIGHT_COPY,
-  SIZE_1,
   SPACING_2,
   SPACING_3,
   SPACING_AUTO,
@@ -63,7 +61,6 @@ export function ProtocolLabwareList(
         <Text {...QUANTITY_COL_STYLE}>{QUANTITY}</Text>
         <Flex {...CAL_DATA_COL_STYLE} {...calDescTooltipTargetProps}>
           <Text>{CALIBRATION_DATA}</Text>
-          <Icon size={SIZE_1} name="information" marginLeft={SPACING_2} />
           <Tooltip {...calDescTooltipProps}>{CALIBRATION_DESCRIPTION}</Tooltip>
         </Flex>
       </Flex>

--- a/app/src/components/FileInfo/__tests__/ProtocolLabwareList.test.js
+++ b/app/src/components/FileInfo/__tests__/ProtocolLabwareList.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { mount } from 'enzyme'
 
-import { Icon, Tooltip, Text } from '@opentrons/components'
+import { Tooltip, Text } from '@opentrons/components'
 import { ProtocolLabwareList } from '../ProtocolLabwareList'
 
 const LABWARE = [
@@ -52,7 +52,6 @@ describe('ProtocolLabwareList Component', () => {
         <Text>Type</Text>,
         <Text>Quantity</Text>,
         <Text>Calibration Data</Text>,
-        <Icon name="information" />,
         <Tt>Calibrated offset from labware origin point</Tt>,
       ])
     ).toBe(true)


### PR DESCRIPTION
Designs posted in [HMG slack](https://opentrons.slack.com/archives/CSCPS8A64/p1594847378304900) specified that the icon next to the calibration data title be removed.

This PR takes care of that.