### PR TITLE
fix(api): get_parent_identifier should get parent identifier

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1081,12 +1081,12 @@ def filter_tipracks_to_start(
         lambda tr: starting_point.parent is not tr, tipracks))
 
 
-def _get_parent_identifier(
-        parent: Union['Well', str, DeckItem, None]) -> str:
+def _get_parent_identifier(labware: 'Labware') -> str:
     """
     Helper function to return whether a labware is on top of a
     module or not.
     """
+    parent = labware.parent
     # TODO (lc, 07-14-2020): Once we implement calibrations per slot,
     # this function should either return a slot using `first_parent` or
     # the module it is attached to.
@@ -1098,7 +1098,7 @@ def _get_parent_identifier(
 
 
 def _get_labware_path(labware: 'Labware'):
-    parent_id = _get_parent_identifier(labware.parent)
+    parent_id = _get_parent_identifier(labware)
     labware_hash = helpers.hash_labware_def(labware._definition)
     return f'{labware_hash}{parent_id}.json'
 

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -11,6 +11,8 @@ from opentrons.calibration_storage import (
 from opentrons.types import Point, Location
 from opentrons.protocols.types import APIVersion
 from opentrons.protocol_api.geometry import Deck
+from opentrons.protocol_api.module_geometry import (
+    ModuleGeometry, MagneticModuleModel, ModuleType)
 
 test_data = {
     'circular_well_json': {
@@ -504,7 +506,7 @@ def test_add_index_file(labware_name, labware_offset_tempdir):
 
     lw_uri = helpers.uri_from_definition(definition)
 
-    str_parent = labware._get_parent_identifier(lw.parent)
+    str_parent = labware._get_parent_identifier(lw)
     slot = '1'
     if str_parent:
         mod_dict = {str_parent: f'{slot}-{str_parent}'}
@@ -548,3 +550,20 @@ def test_delete_one_calibration(set_up_index_file):
     load_names = get_load_names(all_cals)
 
     assert lw_to_delete not in load_names
+
+
+def test_get_parent_identifier():
+    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_def = labware.get_labware_definition(labware_name)
+    lw = labware.Labware(labware_def, Location(Point(0, 0, 0), 'Test Slot'))
+    # slots have no parent identifier
+    assert labware._get_parent_identifier(lw) == ''
+    # modules do
+    mmg = ModuleGeometry('my magdeck',
+                         MagneticModuleModel.MAGNETIC_V1,
+                         ModuleType.MAGNETIC,
+                         Point(0, 0, 0), 10, 10, Location(Point(1, 2, 3), '3'),
+                         APIVersion(2, 4))
+    lw = labware.Labware(labware_def, mmg.location)
+    assert labware._get_parent_identifier(lw)\
+        == MagneticModuleModel.MAGNETIC_V1.value


### PR DESCRIPTION
Previously, it was getting the identifier for its argument directly, and
two callers were using it in two different ways.

Now, it only takes a Labware, and access that Labware's parent. The
incorrect caller is also now correct.

## Testing
The easiest way to test this is to upload a protocol with a labware on a module and check that when you calibrate that labware, its calibration shows up in the runapp (on an `edge` build of the app).