### PR TITLE
refactor(app): refetch labware calibration when rpc cal session updates

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1090,7 +1090,10 @@ def _get_parent_identifier(
     # TODO (lc, 07-14-2020): Once we implement calibrations per slot,
     # this function should either return a slot using `first_parent` or
     # the module it is attached to.
+
+    MODULE_LOG.info(f'in get parent identifier {parent}')
     if isinstance(parent, DeckItem) and parent.separate_calibration:
+        MODULE_LOG.info(f'in get parent identifier in if, sep cal {parent.separate_calibration}')
         # treat a given labware on a given module type as same
         return parent.load_name
     else:
@@ -1137,7 +1140,8 @@ def load_from_definition(
 def save_calibration(labware: 'Labware', delta: Point):
     definition = labware._definition
     labware_path = _get_labware_path(labware)
-    parent = _get_parent_identifier(labware)
+    parent = _get_parent_identifier(labware.parent)
+    MODULE_LOG.info(f'in save calibration lp: {labware_path}, parent: {parent}')
     modify.save_labware_calibration(
         labware_path, definition, delta, parent=parent)
     labware.set_calibration(delta)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1090,10 +1090,7 @@ def _get_parent_identifier(
     # TODO (lc, 07-14-2020): Once we implement calibrations per slot,
     # this function should either return a slot using `first_parent` or
     # the module it is attached to.
-
-    MODULE_LOG.info(f'in get parent identifier {parent}')
     if isinstance(parent, DeckItem) and parent.separate_calibration:
-        MODULE_LOG.info(f'in get parent identifier in if, sep cal {parent.separate_calibration}')
         # treat a given labware on a given module type as same
         return parent.load_name
     else:
@@ -1140,8 +1137,7 @@ def load_from_definition(
 def save_calibration(labware: 'Labware', delta: Point):
     definition = labware._definition
     labware_path = _get_labware_path(labware)
-    parent = _get_parent_identifier(labware.parent)
-    MODULE_LOG.info(f'in save calibration lp: {labware_path}, parent: {parent}')
+    parent = _get_parent_identifier(labware)
     modify.save_labware_calibration(
         labware_path, definition, delta, parent=parent)
     labware.set_calibration(delta)

--- a/app/src/calibration/labware/epic/__tests__/fetchLabwareCalibrationOnSessionUpdateEpic.test.js
+++ b/app/src/calibration/labware/epic/__tests__/fetchLabwareCalibrationOnSessionUpdateEpic.test.js
@@ -1,11 +1,6 @@
 // @flow
 import { TestScheduler } from 'rxjs/testing'
 import {
-  setupEpicTestMocks,
-  runEpicTest,
-} from '../../../../robot-api/__utils__'
-import * as Fixtures from '../../__fixtures__'
-import {
   actions as robotActions,
   selectors as robotSelectors,
 } from '../../../../robot'
@@ -16,11 +11,6 @@ import type { State } from '../../../../types'
 
 jest.mock('../../actions')
 jest.mock('../../../../robot/selectors')
-
-const mockFetchLabwareCalibrations: JestMockFn<
-  [State, string],
-  void
-> = (Actions.fetchLabwareCalibrations: any)
 
 const mockGetConnectedRobotName: JestMockFn<
   [State],
@@ -44,7 +34,7 @@ describe('fetch labware calibration on rpc cal session update epic', () => {
     })
 
     testScheduler.run(schedulerArgs => {
-      const { hot, cold, expectObservable, flush } = schedulerArgs
+      const { hot, expectObservable, flush } = schedulerArgs
 
       const action$ = hot('--a', { a: robotActions.updateOffsetResponse() })
       const state$ = hot('s-s', { s: mockState })
@@ -65,7 +55,7 @@ describe('fetch labware calibration on rpc cal session update epic', () => {
     })
 
     testScheduler.run(schedulerArgs => {
-      const { hot, cold, expectObservable, flush } = schedulerArgs
+      const { hot, expectObservable, flush } = schedulerArgs
 
       const action$ = hot('--a', { a: robotActions.confirmTiprackResponse() })
       const state$ = hot('s-s', { s: mockState })

--- a/app/src/calibration/labware/epic/__tests__/fetchLabwareCalibrationOnSessionUpdateEpic.test.js
+++ b/app/src/calibration/labware/epic/__tests__/fetchLabwareCalibrationOnSessionUpdateEpic.test.js
@@ -1,0 +1,80 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+import {
+  setupEpicTestMocks,
+  runEpicTest,
+} from '../../../../robot-api/__utils__'
+import * as Fixtures from '../../__fixtures__'
+import {
+  actions as robotActions,
+  selectors as robotSelectors,
+} from '../../../../robot'
+import * as Actions from '../../actions'
+import { labwareCalibrationEpic } from '..'
+
+import type { State } from '../../../../types'
+
+jest.mock('../../actions')
+jest.mock('../../../../robot/selectors')
+
+const mockFetchLabwareCalibrations: JestMockFn<
+  [State, string],
+  void
+> = (Actions.fetchLabwareCalibrations: any)
+
+const mockGetConnectedRobotName: JestMockFn<
+  [State],
+  string
+> = (robotSelectors.getConnectedRobotName: any)
+
+describe('fetch labware calibration on rpc cal session update epic', () => {
+  beforeEach(() => {
+    mockGetConnectedRobotName.mockReturnValue('robotName')
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('dispatches calibration:FETCH_LABWARE_CALIBRATIONS on robot:UPDATE_OFFSET_SUCCESS', () => {
+    const mockState: State = ({ state: true, mock: true }: any)
+
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+
+    testScheduler.run(schedulerArgs => {
+      const { hot, cold, expectObservable, flush } = schedulerArgs
+
+      const action$ = hot('--a', { a: robotActions.updateOffsetResponse() })
+      const state$ = hot('s-s', { s: mockState })
+      const output$ = labwareCalibrationEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(Actions.fetchLabwareCalibrations).toHaveBeenCalledWith('robotName')
+    })
+  })
+
+  it('dispatches calibration:FETCH_LABWARE_CALIBRATIONS on robot:CONFIRM_TIPRACK_SUCCESS', () => {
+    const mockState: State = ({ state: true, mock: true }: any)
+
+    const testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+
+    testScheduler.run(schedulerArgs => {
+      const { hot, cold, expectObservable, flush } = schedulerArgs
+
+      const action$ = hot('--a', { a: robotActions.confirmTiprackResponse() })
+      const state$ = hot('s-s', { s: mockState })
+      const output$ = labwareCalibrationEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(Actions.fetchLabwareCalibrations).toHaveBeenCalledWith('robotName')
+    })
+  })
+})

--- a/app/src/calibration/labware/epic/fetchLabwareCalibrationsOnSessionUpdateEpic.js
+++ b/app/src/calibration/labware/epic/fetchLabwareCalibrationsOnSessionUpdateEpic.js
@@ -1,0 +1,22 @@
+// @flow
+import { of } from 'rxjs'
+import { ofType } from 'redux-observable'
+import { tap, filter, mergeMap, withLatestFrom } from 'rxjs/operators'
+
+import { getConnectedRobotName } from '../../../robot/selectors'
+import * as Actions from '../actions'
+import type { Epic } from '../../../types'
+
+export const fetchLabwareCalibrationsOnSessionUpdateEpic: Epic = (
+  action$,
+  state$
+) => {
+  return action$.pipe(
+    ofType('robot:UPDATE_OFFSET_SUCCESS', 'robot:CONFIRM_TIPRACK_SUCCESS'),
+    withLatestFrom(state$, (_, s) => getConnectedRobotName(s)),
+    filter(robotName => robotName !== null),
+    mergeMap(robotName => {
+      return of(Actions.fetchLabwareCalibrations(robotName))
+    })
+  )
+}

--- a/app/src/calibration/labware/epic/fetchLabwareCalibrationsOnSessionUpdateEpic.js
+++ b/app/src/calibration/labware/epic/fetchLabwareCalibrationsOnSessionUpdateEpic.js
@@ -1,7 +1,7 @@
 // @flow
 import { of } from 'rxjs'
 import { ofType } from 'redux-observable'
-import { tap, filter, mergeMap, withLatestFrom } from 'rxjs/operators'
+import { filter, mergeMap, withLatestFrom } from 'rxjs/operators'
 
 import { getConnectedRobotName } from '../../../robot/selectors'
 import * as Actions from '../actions'

--- a/app/src/calibration/labware/epic/index.js
+++ b/app/src/calibration/labware/epic/index.js
@@ -2,9 +2,11 @@
 
 import { combineEpics } from 'redux-observable'
 import { fetchLabwareCalibrationsEpic } from './fetchLabwareCalibrationsEpic'
+import { fetchLabwareCalibrationsOnSessionUpdateEpic } from './fetchLabwareCalibrationsOnSessionUpdateEpic'
 
 import type { Epic } from '../../../types'
 
 export const labwareCalibrationEpic: Epic = combineEpics(
-  fetchLabwareCalibrationsEpic
+  fetchLabwareCalibrationsEpic,
+  fetchLabwareCalibrationsOnSessionUpdateEpic
 )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Now that we surface the labware calibration data via the http calls that are implemented in the
modern robot-api module, this places a temporary bridge to trigger the get lw calibrations request
when the legacy rpc calibration session updates a tiprack or labware calibration offset.

# Changelog

- add new epic that listens for labware calibration update actions and dispatches the `calibration:FETCH_LABWARE_CALIBRATIONS` action in response.

# Review requests

- [ ] run labware calibration and change the values for a given labware, they should update immediately in the side panel upon confirming. 

# Risk assessment

low
