### PR TITLE
fix(api): Ensure old calibration index entries are migrated over before displaying data

### DIFF
--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -52,7 +52,7 @@ def delete_offset_file(calibration_id: local_types.CalibrationID):
     try:
         _remove_offset_from_index(calibration_id)
         offset.unlink()
-    except (FileNotFoundError, KeyError):
+    except FileNotFoundError:
         pass
 
 

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -36,7 +36,7 @@ def _remove_offset_from_index(calibration_id: local_types.CalibrationID):
     index_path = offset_path / 'index.json'
     blob = io.read_cal_file(str(index_path))
 
-    del blob[calibration_id]
+    del blob['data'][calibration_id]
     io.save_to_file(index_path, blob)
 
 
@@ -52,7 +52,7 @@ def delete_offset_file(calibration_id: local_types.CalibrationID):
     try:
         _remove_offset_from_index(calibration_id)
         offset.unlink()
-    except FileNotFoundError:
+    except (FileNotFoundError, KeyError):
         pass
 
 

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -60,8 +60,8 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
 
     migration.check_index_version(index_path)
     index_file = io.read_cal_file(str(index_path))
-
-    for key, data in index_file.items():
+    calibration_index = index_file.get('data', {})
+    for key, data in calibration_index.items():
         cal_path = offset_path / f'{key}.json'
         if cal_path.exists():
             cal_blob = io.read_cal_file(str(cal_path))

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -58,6 +58,7 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
     if not index_path.exists():
         return all_calibrations
 
+    migration.check_index_version(index_path)
     index_file = io.read_cal_file(str(index_path))
 
     for key, data in index_file.items():

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -33,23 +33,11 @@ def hash_labware_def(labware_def: 'LabwareDefinition') -> str:
     return sha256(sorted_def_str.encode('utf-8')).hexdigest()
 
 
-def is_uri(key: str) -> bool:
-    uri_split = split_string(key, '/')
-    if len(uri_split) > 1:
-        return True
-    else:
-        return False
-
-
-def split_string(to_split: str, delimiter: str) -> typing.List[str]:
-    return to_split.split(delimiter)
-
-
 def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
     """
     Unpack a labware URI to get the namespace, loadname and version
     """
-    info = split_string(uri, delimiter)
+    info = uri.split(delimiter)
     return local_types.UriDetails(
         namespace=info[0], load_name=info[1], version=int(info[2]))
 

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -33,11 +33,23 @@ def hash_labware_def(labware_def: 'LabwareDefinition') -> str:
     return sha256(sorted_def_str.encode('utf-8')).hexdigest()
 
 
+def is_uri(key: str) -> bool:
+    uri_split = split_string(key, '/')
+    if len(uri_split) > 1:
+        return True
+    else:
+        return False
+
+
+def split_string(to_split: str, delimiter: str) -> typing.List[str]:
+    return to_split.split(delimiter)
+
+
 def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
     """
     Unpack a labware URI to get the namespace, loadname and version
     """
-    info = uri.split(delimiter)
+    info = split_string(uri, delimiter)
     return local_types.UriDetails(
         namespace=info[0], load_name=info[1], version=int(info[2]))
 

--- a/api/src/opentrons/calibration_storage/migration.py
+++ b/api/src/opentrons/calibration_storage/migration.py
@@ -2,6 +2,9 @@ import typing
 from . import file_operators as io, types as local_types
 
 
+MAX_VERSION = 1
+
+
 def check_index_version(index_path: local_types.StrPath):
     index_file = io.read_cal_file(str(index_path))
     version = index_file.get('version', 0)
@@ -30,7 +33,7 @@ def migrate_index_0_to_1(index_path: local_types.StrPath):
     the correct format so users do not lose their calibrations
     """
     index_file = io.read_cal_file(str(index_path))
-    migrated_file: typing.Dict = {}
+    updated_entries: typing.Dict = {}
     for key, data in index_file.items():
         uri = key
         full_hash = data['slot']
@@ -41,10 +44,10 @@ def migrate_index_0_to_1(index_path: local_types.StrPath):
                 'fullParent': full_parent}
         else:
             module = {}
-        migrated_file[full_hash] = {
+        updated_entries[full_hash] = {
             "uri": f'{uri}',
             "slot": full_hash,
             "module": module
             }
-    migrated_file['version'] = 1
+    migrated_file = {'version': 1, 'data': updated_entries}
     io.save_to_file(index_path, migrated_file)

--- a/api/src/opentrons/calibration_storage/migration.py
+++ b/api/src/opentrons/calibration_storage/migration.py
@@ -1,0 +1,53 @@
+import typing
+from . import file_operators as io, helpers, types as local_types
+
+
+def check_index_version(index_path: local_types.StrPath):
+    index_file = io.read_cal_file(str(index_path))
+    version = index_file.get('version', 0)
+    if version == 0:
+        migrate_index_0_to_1(index_path)
+
+
+def migrate_index_0_to_1(index_path: local_types.StrPath):
+    """
+    Previously, the index file was keyed as
+    ```
+    uri: {id: hash,
+          slot: hash+parent,
+          module: {{moduletype}: '{slot}-{moduletype}'}
+    ```
+    Now, the format is saved as
+    ```
+    labware_hash : {
+        uri: uri,
+        slot: hash+parent,
+        module: {
+            parent: {moduletype},
+            fullParent: {slot}-{moduletype}}
+    ```
+    This function ensures any index files are migrated over to
+    the correct format so users do not lose their calibrations
+    """
+    index_file = io.read_cal_file(str(index_path))
+    migrated_file: typing.Dict = {}
+    for key, data in index_file.items():
+        if helpers.is_uri(key):
+            uri = key
+            full_hash = data['slot']
+            if data['module']:
+                parent, full_parent = list(data['module'].items())[0]
+                module = {
+                    'parent': parent,
+                    'fullParent': full_parent}
+            else:
+                module = {}
+            migrated_file[full_hash] = {
+                "uri": f'{uri}',
+                "slot": full_hash,
+                "module": module
+                }
+        else:
+            migrated_file[key] = data
+    migrated_file['version'] = 1
+    io.save_to_file(index_path, migrated_file)

--- a/api/src/opentrons/calibration_storage/migration.py
+++ b/api/src/opentrons/calibration_storage/migration.py
@@ -1,5 +1,5 @@
 import typing
-from . import file_operators as io, helpers, types as local_types
+from . import file_operators as io, types as local_types
 
 
 def check_index_version(index_path: local_types.StrPath):
@@ -32,22 +32,19 @@ def migrate_index_0_to_1(index_path: local_types.StrPath):
     index_file = io.read_cal_file(str(index_path))
     migrated_file: typing.Dict = {}
     for key, data in index_file.items():
-        if helpers.is_uri(key):
-            uri = key
-            full_hash = data['slot']
-            if data['module']:
-                parent, full_parent = list(data['module'].items())[0]
-                module = {
-                    'parent': parent,
-                    'fullParent': full_parent}
-            else:
-                module = {}
-            migrated_file[full_hash] = {
-                "uri": f'{uri}',
-                "slot": full_hash,
-                "module": module
-                }
+        uri = key
+        full_hash = data['slot']
+        if data['module']:
+            parent, full_parent = list(data['module'].items())[0]
+            module = {
+                'parent': parent,
+                'fullParent': full_parent}
         else:
-            migrated_file[key] = data
+            module = {}
+        migrated_file[full_hash] = {
+            "uri": f'{uri}',
+            "slot": full_hash,
+            "module": module
+            }
     migrated_file['version'] = 1
     io.save_to_file(index_path, migrated_file)

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -245,6 +245,7 @@ def save_new_offsets(labware_hash, delta):
     labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     calibration_data = modify._helper_offset_data_format(
         str(labware_offset_path), new_delta)
+    modify._add_to_index_offset_file('', '', '', labware_hash)
     io.save_to_file(labware_offset_path, calibration_data)
 
 

--- a/api/tests/opentrons/calibration_storage/test_migration.py
+++ b/api/tests/opentrons/calibration_storage/test_migration.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import MagicMock
+from opentrons.calibration_storage import get, file_operators as io
+
+OLD_FORMAT = {
+    'opentrons/opentrons_96_tiprack_10ul/1': {
+        'id': 'fakeid1',
+        'slot': 'fakeid1',
+        'module': {}},
+    'opentrons/corning_96_wellplate_360ul_flat/1': {
+        'id': 'fakeid2',
+        'slot': 'fakeid2',
+        'module': {}},
+    'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1': {
+        'id': 'fakeid3',
+        'slot': 'fakeid3temperatureModuleV2',
+        'module': {'temperatureModuleV2': '1-temperatureModuleV2'}}
+        }
+
+NEW_FORMAT = {
+    '030b6589be708e8d9edd1dafc32a48c6558d6a14475f11cb97775504b52184d0': {
+        'uri': 'opentrons/opentrons_96_tiprack_10ul/1',
+        'slot': 'fakeid1',
+        'module': {}},
+    'fakeid2': {
+        'uri': 'opentrons/corning_96_wellplate_360ul_flat/1',
+        'slot': 'fakeid2',
+        'module': {}},
+    'fakeid3temperatureModuleV2': {
+        'uri': 'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1',
+        'slot': 'fakeid3temperatureModuleV2',
+        'module': {
+            'parent': 'temperatureModuleV2',
+            'fullParent': '1-temperatureModuleV2'}}}
+
+
+@pytest.fixture
+def setup(labware_offset_tempdir):
+    offset_dir = labware_offset_tempdir
+    index_path = offset_dir / 'index.json'
+    io.save_to_file(index_path, OLD_FORMAT)
+    return index_path
+
+
+def test_migrate_index_file(setup):
+    index_path = setup
+    get._migrate_index_entries(index_path)
+    data = io.read_cal_file(index_path)
+    data == NEW_FORMAT
+
+
+def test_migration_called(setup):
+    get._migrate_index_entries = MagicMock()
+    get.get_all_calibrations()
+    assert get._migrate_index_entries.called

--- a/api/tests/opentrons/calibration_storage/test_migration.py
+++ b/api/tests/opentrons/calibration_storage/test_migration.py
@@ -1,10 +1,8 @@
 import pytest
 from unittest.mock import MagicMock
 
-from opentrons.protocol_api import labware
 from opentrons.calibration_storage import (
     get, file_operators as io, migration)
-from opentrons.types import Point, Location
 
 OLD_FORMAT = {
     'opentrons/opentrons_96_tiprack_10ul/1': {
@@ -23,20 +21,23 @@ OLD_FORMAT = {
 
 NEW_FORMAT = {
     'version': 1,
-    'fakeid1': {
-        'uri': 'opentrons/opentrons_96_tiprack_10ul/1',
-        'slot': 'fakeid1',
-        'module': {}},
-    'fakeid2': {
-        'uri': 'opentrons/corning_96_wellplate_360ul_flat/1',
-        'slot': 'fakeid2',
-        'module': {}},
-    'fakeid3temperatureModuleV2': {
-        'uri': 'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1',
-        'slot': 'fakeid3temperatureModuleV2',
-        'module': {
-            'parent': 'temperatureModuleV2',
-            'fullParent': '1-temperatureModuleV2'}}}
+    'data': {
+        'fakeid1': {
+            'uri': 'opentrons/opentrons_96_tiprack_10ul/1',
+            'slot': 'fakeid1',
+            'module': {}},
+        'fakeid2': {
+            'uri': 'opentrons/corning_96_wellplate_360ul_flat/1',
+            'slot': 'fakeid2',
+            'module': {}},
+        'fakeid3temperatureModuleV2': {
+            'uri': 'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1',
+            'slot': 'fakeid3temperatureModuleV2',
+            'module': {
+                'parent': 'temperatureModuleV2',
+                'fullParent': '1-temperatureModuleV2'}}
+    }
+}
 
 
 @pytest.fixture
@@ -46,12 +47,6 @@ def setup(labware_offset_tempdir):
     io.save_to_file(index_path, OLD_FORMAT)
     return index_path
 
-@pytest.fixture
-def migration_called(labware_offset_tempdir):
-    parent = Location(Point(0, 0, 0), None)
-    test_labware = labware.load('opentrons_96_tiprack_300ul', parent)
-    labware.save_calibration(test_labware, Point(0, 0, 0))
-    return test_labware
 
 def test_migrate_index_file(setup):
     index_path = setup
@@ -60,11 +55,9 @@ def test_migrate_index_file(setup):
     assert data == NEW_FORMAT
 
 
-def test_migration_called(migration_called):
-    lw = migration_called
+def test_migration_called(setup):
     migration.migrate_index_0_to_1 = MagicMock()
-    path = labware._get_labware_path(lw)
-    get.get_labware_calibration(path)
+    get.get_all_calibrations()
     assert migration.migrate_index_0_to_1.called
     migration.migrate_index_0_to_1.reset_mock()
     assert not migration.migrate_index_0_to_1.called

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -519,7 +519,7 @@ def test_add_index_file(labware_name, labware_offset_tempdir):
 
     lw_path = labware_offset_tempdir / 'index.json'
     info = file_operators.read_cal_file(lw_path)
-    assert info[full_id] == blob
+    assert info['data'][full_id] == blob
 
 
 def test_delete_one_calibration(set_up_index_file):

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -13,7 +13,7 @@ def grab_id(set_up_index_file_temporary_directory):
     index_path = offset_path / 'index.json'
     index_file = file_operators.read_cal_file(str(index_path))
     calibration_id = ''
-    for key, data in index_file.items():
+    for key, data in index_file['data'].items():
         if data['uri'] == uri_to_check:
             calibration_id = key
     return calibration_id


### PR DESCRIPTION
# Overview

Previously the index file was keyed by uri of a given labware. Now, it is keyed by the full labware hash, and a few other structural changes were made for the module key. Due to this being launched with 3.19.0, we need to make sure that everyone's files are migrated to the correct format so that they can use the labware calibration feature properly. 

# Changelog

- Migrate the the old index.json entries so that we still have an acceptable record/mapping of labware calibration to index file + info
- Add tests to ensure migration is getting called + migration correctly reformats entries.

# Review requests
- Feel free to test on a robot. You can utilize this index file:
[index.json.zip](https://github.com/Opentrons/opentrons/files/5037018/index.json.zip)
- Anywhere else we should be migrating?
- Any other tests to add

# Risk assessment

Medium. Although nothing will break per se, users might not see that their calibrations exist if it is in the old format. Please upload protocols with labware that you have already calibrated in the old format.
