### PR TITLE
fix(api): avoid hitting endstop during retract fast home

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1334,7 +1334,10 @@ class API(HardwareAPILike):
             await self._shake_off_tips_pick_up(mount)
             await self._shake_off_tips_pick_up(mount)
 
-        await self.retract(mount, instr.config.pick_up_distance)
+        retract_target = instr.config.pick_up_distance\
+            + checked_increment * checked_presses\
+            + 2  # tiny little margin to avoid the switch itself
+        await self.retract(mount, retract_target)
 
     def set_current_tiprack_diameter(self, mount, tiprack_diameter):
         instr = self._attached_instruments[mount]


### PR DESCRIPTION
The smoothie fast home command moves to near the home position at normal
speed, swallowing errors, and then issues a home to minimize the amount
of time a possibly-slower home must occur.

However, even though the error is swallowed at the level of the
fast_home, if the move triggers the endstop switch the smoothie would
issue a home before returning the error.

While it's not generally safe to mess around with the retract distance,
in the case of pick up tip - the most common case for retracts after
expected skips - we can confidently add a couple millimeters to the
retract to avoid it.

This should also account for the extra distance moved (and possibly
skipped) for pipettes that have more than one press of pick up tip.

## Testing
- Run a protocol that picks up a tip and calibrate the tiprack really really close
- Check to see that it doesn't home twice (execute 4 total upwards motions)