### PR TITLE
fix(app): fix labware list uniqueing logic for file info page

### DIFF
--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -402,7 +402,7 @@ describe('labware calibration selectors', () => {
         ({
           type: wellPlate96Def.parameters.loadName,
           definition: wellPlate96Def,
-          slot: '3',
+          slot: '4',
         }: $Shape<ProtocolLabware>),
       ])
       getModulesBySlot.mockReturnValue({})

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -73,11 +73,7 @@ export const getUniqueProtocolLabwareSummaries: (
   ) => {
     const uniqueLabware = uniqWith<BaseProtocolLabware>(
       baseLabwareList,
-      (labwareA, labwareB) => {
-        const { definition: _defA, ...labwareIdentityA } = labwareA
-        const { definition: _defB, ...labwareIdentityB } = labwareB
-        return isEqual(labwareIdentityA, labwareIdentityB)
-      }
+      matchesLabwareIdentity
     )
 
     return uniqueLabware.map(lw => {

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -1,7 +1,6 @@
 // @flow
 import { createSelector } from 'reselect'
 import head from 'lodash/head'
-import isEqual from 'lodash/isEqual'
 import uniqWith from 'lodash/uniqWith'
 
 import {


### PR DESCRIPTION
# Overview

This repairs the logic within the getUniqueProtocolLabwareList selector that determines whether two
labware will share calibration data. The unit test meant to check for this was also slightly wrong
which has now been repaired.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Review requests

- upload a protocol  like this one, which has a labware that is both duplicated on the deck and on a module; the deck versions should collapse into one record on the FileInfo page, and the module instance should be it's own row.

```
metadata={"apiLevel": "2.5"}

def run(ctx):
	tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_10ul', '1')
	tiprack2 = ctx.load_labware('opentrons_96_filtertiprack_200ul', '2')

	thermocycler = ctx.load_module('thermocycler')
	reaction_plate = thermocycler.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')

	plate1 = ctx.load_labware('nest_96_wellplate_100ul_pcr_full_skirt', '5')
	plate2 = ctx.load_labware('nest_96_wellplate_100ul_pcr_full_skirt', '4')

	pip = ctx.load_instrument('p300_single', mount='right', tip_racks=[tiprack2])

	pip.transfer(100, plate1.wells('A1'), reaction_plate.wells('A1'))

	pip.transfer(100, plate1.wells('A1'), [plate2[well].top() for well in ['A1', 'B1','C1', 'D1','E1', 'F1','G1','H1']])
```

# Risk assessment

low