### PR TITLE
fix(app): fix tip probe button in apiV1 protocols

### DIFF
--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -61,14 +61,15 @@ export function Pipettes(props: Props): React.Node {
       />
       {robotName &&
         !!currentPipette &&
-        !!tipRackDef &&
         (ff.enableCalibrationOverhaul ? (
-          <CalibrateTipLengthControl
-            mount={currentPipette.mount}
-            robotName={robotName}
-            hasCalibrated={currentPipette.probed}
-            tipRackDefinition={tipRackDef}
-          />
+          !!tipRackDef ? (
+            <CalibrateTipLengthControl
+              mount={currentPipette.mount}
+              robotName={robotName}
+              hasCalibrated={currentPipette.probed}
+              tipRackDefinition={tipRackDef}
+            />
+          ) : null
         ) : (
           <TipProbe {...currentPipette} />
         ))}


### PR DESCRIPTION
# Overview

Fix bug that @nusrat813 identified in QA, where tip probe button would not render for apiV1 protocols.

# Review requests

 - [ ] Should be able to tip probe with an apiV1 protocol

# Risk assessment

low
