### PR TITLE
feat(protocol-designer): clamp air gap volume when tiprack changes

### DIFF
--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -164,7 +164,7 @@ const makeUpdatePipettes = (
   const pipettesWithNewTiprackIdentityMap: SubstitutionMap = pipettesWithNewTipracks.reduce(
     (acc: SubstitutionMap, id: string): SubstitutionMap => {
       return {
-        ...acc, // $FlowFixMe (SA, 2020-09-10): can't assign type of computed id value
+        ...acc,
         ...{ [id]: id },
       }
     },

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -129,7 +129,7 @@ const makeUpdatePipettes = (
     id => !(id in nextPipettes)
   )
 
-  // SubstitutionMap represents a map of oldId => newId
+  // SubstitutionMap represents a map of oldPipetteId => newPipetteId
   // When a pipette's tiprack changes, the ids will be the same
   type SubstitutionMap = { [pipetteId: string]: string }
 

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.js
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import isEmpty from 'lodash/isEmpty'
 import last from 'lodash/last'
+import filter from 'lodash/filter'
 import mapValues from 'lodash/mapValues'
 
 import { uuid } from '../../../utils'
@@ -127,8 +128,13 @@ const makeUpdatePipettes = (
   const pipetteIdsToDelete: Array<string> = Object.keys(prevPipettes).filter(
     id => !(id in nextPipettes)
   )
-  const substitutionMap = pipetteIdsToDelete.reduce(
-    (acc: { [string]: string }, deletedId: string): { [string]: string } => {
+
+  // SubstitutionMap represents a map of oldId => newId
+  // When a pipette's tiprack changes, the ids will be the same
+  type SubstitutionMap = { [pipetteId: string]: string }
+
+  const pipetteReplacementMap: SubstitutionMap = pipetteIdsToDelete.reduce(
+    (acc: SubstitutionMap, deletedId: string): SubstitutionMap => {
       const deletedPipette = prevPipettes[deletedId]
       const replacementId = Object.keys(nextPipettes).find(
         newId => nextPipettes[newId].mount === deletedPipette.mount
@@ -139,6 +145,36 @@ const makeUpdatePipettes = (
     },
     {}
   )
+
+  const pipettesWithNewTipracks: Array<string> = filter(
+    nextPipettes,
+    (nextPipette: $Values<typeof nextPipettes>) => {
+      const newPipetteId = nextPipette.id
+      const tiprackChanged =
+        newPipetteId in prevPipettes &&
+        nextPipette.tiprackDefURI !== prevPipettes[newPipetteId].tiprackDefURI
+      return tiprackChanged
+    }
+  ).map(pipette => pipette.id)
+
+  // this creates an identity map with all pipette ids that have new tipracks
+  // this will be used so that handleFormChange gets called even though the
+  // pipette id itself has not changed (only it's tiprack)
+
+  const pipettesWithNewTiprackIdentityMap: SubstitutionMap = pipettesWithNewTipracks.reduce(
+    (acc: SubstitutionMap, id: string): SubstitutionMap => {
+      return {
+        ...acc, // $FlowFixMe (SA, 2020-09-10): can't assign type of computed id value
+        ...{ [id]: id },
+      }
+    },
+    {}
+  )
+
+  const substitutionMap = {
+    ...pipetteReplacementMap,
+    ...pipettesWithNewTiprackIdentityMap,
+  }
 
   // substitute deleted pipettes with new pipettes on the same mount, if any
   if (!isEmpty(substitutionMap) && orderedStepIds.length > 0) {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -231,8 +231,10 @@ const clampAirGapVolume = (
   rawForm: FormData,
   pipetteEntities: PipetteEntities
 ): FormPatch => {
-  const patchedAspirateAirgapVolume = patch.aspirate_airGap_volume
-  const pipetteId = patch.pipette || rawForm.pipette
+  const patchedAspirateAirgapVolume =
+    patch.aspirate_airGap_volume ?? rawForm?.aspirate_airGap_volume
+
+  const pipetteId = patch.pipette ?? rawForm.pipette
 
   if (
     patchedAspirateAirgapVolume &&

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -286,16 +286,44 @@ describe('air gap volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '-1' }, form)
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
-    it('should update the air gap volume to the pipette capacity - min pipette volume when the air gap volume is too big', () => {
+    it('should update the air gap volume to 0 when the raw form volume is less than 0', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '-1' }
+      )
+      expect(result.aspirate_airGap_volume).toEqual('0')
+    })
+    it('should update the air gap volume to the pipette capacity - min pipette volume when the patch air gap volume is too big', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '100' }, form)
+      expect(result.aspirate_airGap_volume).toEqual('9')
+    })
+    it('should update the air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '9' }
+      )
       expect(result.aspirate_airGap_volume).toEqual('9')
     })
     it('should NOT update when the patch volume is greater than the min pipette volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '2' }, form)
       expect(result.aspirate_airGap_volume).toEqual('2')
     })
+    it('should NOT update when the raw form volume is greater than the min pipette volume', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '2' }
+      )
+      expect(result.aspirate_airGap_volume).toEqual('2')
+    })
     it('should NOT update when the patch volume is equal to the min pipette volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '1' }, form)
+      expect(result.aspirate_airGap_volume).toEqual('1')
+    })
+    it('should NOT update when the raw form volume is equal to the min pipette volume', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '1' }
+      )
       expect(result.aspirate_airGap_volume).toEqual('1')
     })
   })
@@ -318,16 +346,44 @@ describe('air gap volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '-1' }, form)
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
+    it('should update the air gap volume to 0 when the raw form volume is less than 0', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '-1' }
+      )
+      expect(result.aspirate_airGap_volume).toEqual('0')
+    })
     it('should update the air gap volume to the pipette capacity - min pipette volume when the air gap volume is too big', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '100' }, form)
+      expect(result.aspirate_airGap_volume).toEqual('9')
+    })
+    it('should update the air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '9' }
+      )
       expect(result.aspirate_airGap_volume).toEqual('9')
     })
     it('should NOT update when the patch volume is greater than the min pipette volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '2' }, form)
       expect(result.aspirate_airGap_volume).toEqual('2')
     })
+    it('should NOT update when the raw form volume is greater than the min pipette volume', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '2' }
+      )
+      expect(result.aspirate_airGap_volume).toEqual('2')
+    })
     it('should NOT update when the patch volume is equal to the min pipette volume', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '1' }, form)
+      expect(result.aspirate_airGap_volume).toEqual('1')
+    })
+    it('should NOT update when the raw form volume is equal to the min pipette volume', () => {
+      const result = handleFormHelper(
+        {},
+        { ...form, aspirate_airGap_volume: '1' }
+      )
       expect(result.aspirate_airGap_volume).toEqual('1')
     })
   })


### PR DESCRIPTION
# Overview

This PR closes #6264 by clamping air gap volume when a user changes a pipette's tiprack.

Because the tiprack is not part of the raw form, I had to add pipettes that have their tiprack modified to `substitutionMap` in `EditPipettesModal`. This in turn triggers `handleFormChange` to be called with the new pipette, which will trigger the clamping. 

# Changelog
- Clamp air gap volume when tiprack changes

# Review requests
- Make a protocol with a P300 GEN2 Single, and a 300 uL tiprack.
- Create a transfer with the P300, and an air gap of 280 uL. Save the transfer.
- Add a 200uL tiprack, and go to Edit Pipettes to assign that 200uL tiprack to the P300
- Open the transfer form. Air gap volume should already be at 180 (Max now should be 200 - 20 = 180)
- Try to update the Air Gap field. If should prevent you from entering a number higher than the max of 180

Note, you'll get a `Not enough tips to complete action` error, but the air gap should still get clamped down since `handleFormChange` will get called with the new tiprack information 

# Risk assessment
Low, fixing an unreleased bug under a FF