### PR TITLE
fix(protocol-designer): Rename aspirate/dispense delay tip position fields

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -30,10 +30,10 @@ function getLabwareFieldForPositioningField(
   const fieldMap: { [TipOffsetFields]: StepFieldName } = {
     aspirate_mmFromBottom: 'aspirate_labware',
     aspirate_touchTip_mmFromBottom: 'aspirate_labware',
-    aspirate_delay_tip_position: 'aspirate_labware',
+    aspirate_delay_mmFromBottom: 'aspirate_labware',
     dispense_mmFromBottom: 'dispense_labware',
     dispense_touchTip_mmFromBottom: 'dispense_labware',
-    dispense_delay_tip_position: 'dispense_labware',
+    dispense_delay_mmFromBottom: 'dispense_labware',
     mix_mmFromBottom: 'labware',
     mix_touchTip_mmFromBottom: 'labware',
   }

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.js
@@ -21,11 +21,11 @@ export function getDefaultMmFromBottom(args: {
   switch (fieldName) {
     case 'aspirate_mmFromBottom':
       return DEFAULT_MM_FROM_BOTTOM_ASPIRATE
-    case 'aspirate_delay_tip_position':
+    case 'aspirate_delay_mmFromBottom':
       return DEFAULT_MM_FROM_BOTTOM_ASPIRATE
     case 'dispense_mmFromBottom':
       return DEFAULT_MM_FROM_BOTTOM_DISPENSE
-    case 'dispense_delay_tip_position':
+    case 'dispense_delay_mmFromBottom':
       return DEFAULT_MM_FROM_BOTTOM_DISPENSE
     case 'mix_mmFromBottom':
       // TODO: Ian 2018-11-131 figure out what offset makes most sense for mix

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -72,7 +72,7 @@ export const SourceDestFields = (props: Props): React.Node => {
           {...focusHandlers}
         />
         <TipPositionField
-          fieldName={addFieldNamePrefix('delay_tip_position')}
+          fieldName={addFieldNamePrefix('delay_mmFromBottom')}
         />
       </CheckboxRowField>
     ) : null

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -283,8 +283,8 @@ export type TipOffsetFields =
   | 'mix_mmFromBottom'
   | 'aspirate_touchTip_mmFromBottom'
   | 'dispense_touchTip_mmFromBottom'
-  | 'aspirate_delay_tip_position'
-  | 'dispense_delay_tip_position'
+  | 'aspirate_delay_mmFromBottom'
+  | 'dispense_delay_mmFromBottom'
   | 'mix_touchTip_mmFromBottom'
 
 export function getIsTouchTipField(fieldName: string): boolean {
@@ -298,8 +298,8 @@ export function getIsTouchTipField(fieldName: string): boolean {
 
 export function getIsDelayPositionField(fieldName: string): boolean {
   const delayPositionFields = [
-    'aspirate_delay_tip_position',
-    'dispense_delay_tip_position',
+    'aspirate_delay_mmFromBottom',
+    'dispense_delay_mmFromBottom',
   ]
   return delayPositionFields.includes(fieldName)
 }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -25,8 +25,8 @@
       "aspirate_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
       "dispense_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
       "mix_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
-      "aspirate_delay_tip_position": "Change from where in the well the robot delays after aspirating",
-      "dispense_delay_tip_position": "Change from where in the well the robot delays after dispensing"
+      "aspirate_delay_mmFromBottom": "Change from where in the well the robot delays after aspirating",
+      "dispense_delay_mmFromBottom": "Change from where in the well the robot delays after dispensing"
     },
     "field_label": "Distance from bottom of well"
   },

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -126,13 +126,13 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
   aspirate_delay_seconds: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
   },
-  aspirate_delay_tip_position: {
+  aspirate_delay_mmFromBottom: {
     castValue: Number,
   },
   dispense_delay_seconds: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
   },
-  dispense_delay_tip_position: {
+  dispense_delay_mmFromBottom: {
     castValue: Number,
   },
   pauseHour: {


### PR DESCRIPTION
# Overview

closes #6300 - renames `tip_position` to `mmFromBottom` for aspirate and dispense delay fields.

<img width="959" alt="Screen Shot 2020-08-11 at 1 55 40 PM" src="https://user-images.githubusercontent.com/3430313/89932095-17182300-dbdb-11ea-81ea-2f5dc541112d.png">


# Changelog

- fix(protocol-designer): Rename aspirate/dispense delay tip position fields

# Review requests

Please make sure everything in advanced settings renders as expected

# Risk assessment

Low refactor behind a FF in PD