### PR TITLE
fix(api): Save v2 labware in api v1 with URIs

### DIFF
--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -42,8 +42,10 @@ def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
         return local_types.UriDetails(
             namespace=info[0], load_name=info[1], version=int(info[2]))
     else:
+        # Here we are assuming that the 'uri' passed in is actually
+        # the loadname, though sometimes it may be an empty string.
         return local_types.UriDetails(
-            namespace='', load_name='', version=1)
+            namespace='', load_name=uri, version=1)
 
 
 def uri_from_details(namespace: str, load_name: str,

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -37,9 +37,13 @@ def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
     """
     Unpack a labware URI to get the namespace, loadname and version
     """
-    info = uri.split(delimiter)
-    return local_types.UriDetails(
-        namespace=info[0], load_name=info[1], version=int(info[2]))
+    if uri:
+        info = uri.split(delimiter)
+        return local_types.UriDetails(
+            namespace=info[0], load_name=info[1], version=int(info[2]))
+    else:
+        return local_types.UriDetails(
+            namespace='', load_name='', version=1)
 
 
 def uri_from_details(namespace: str, load_name: str,

--- a/api/src/opentrons/legacy_api/containers/__init__.py
+++ b/api/src/opentrons/legacy_api/containers/__init__.py
@@ -221,11 +221,12 @@ def _look_up_offsets(labware_hash):
         return Point(x=0, y=0, z=0)
 
 
-def save_new_offsets(labware_hash, delta):
+def save_new_offsets(labware_hash, delta, definition):
     calibration_path = CONFIG['labware_calibration_offsets_dir_v2']
     if not calibration_path.exists():
         calibration_path.mkdir(parents=True, exist_ok=True)
     old_delta = _look_up_offsets(labware_hash)
+    uri = cal_helpers.uri_from_definition(definition)
 
     # Note that the next line looks incorrect (like it's letting the prior
     # value leak into the new one). That's sort of correct, but this actually
@@ -245,7 +246,7 @@ def save_new_offsets(labware_hash, delta):
     labware_offset_path = calibration_path / '{}.json'.format(labware_hash)
     calibration_data = modify._helper_offset_data_format(
         str(labware_offset_path), new_delta)
-    modify._add_to_index_offset_file('', '', '', labware_hash)
+    modify._add_to_index_offset_file('', '', uri, labware_hash)
     io.save_to_file(labware_offset_path, calibration_data)
 
 
@@ -271,6 +272,7 @@ def load_new_labware_def(definition):
     container_name = definition['parameters']['loadName']
     log.info(f"Container name {container_name}, hash {labware_hash}")
     container.properties['labware_hash'] = labware_hash
+    container.properties['definition'] = definition
     container.properties['type'] = container_name
     lw_quirks = definition['parameters'].get('quirks', [])
     if definition['parameters']['isMagneticModuleCompatible']:

--- a/api/src/opentrons/legacy_api/robot/robot.py
+++ b/api/src/opentrons/legacy_api/robot/robot.py
@@ -1109,7 +1109,10 @@ class Robot(CommandPublisher):
             entry._coordinates = entry._coordinates + delta
 
         if save and container.properties.get('labware_hash'):
-            save_new_offsets(container.properties['labware_hash'], delta)
+            save_new_offsets(
+                container.properties['labware_hash'],
+                delta,
+                container.properties['definition'])
         elif save and new_container_name:
             database.save_new_container(container, new_container_name)
         elif save:


### PR DESCRIPTION
# Overview

Not enough information was being saved in api v1 for new labware definitions in order for the calibration to carry over properly to api v2 protocols/be displayed in the app.

# Changelog
- Get the uri for the labware definition
- pass in the labware definition to the save function
- Make the uri details function slightly more robust so it won't fail if no URI exists for some reason

# Limitations
There is not an easy way for us to get the proper names of the temp deck + mag deck to save the calibrations accordingly.

That means that any calibrations saved in api v1 for modules will _not_ translate to api v2, and also will _not_ show up in the app for api v1.

An unrelated limitation is on the temperature module GEN1 vs GEN2. Although the calibrations should be the same, the system is saving them as two separate calibrations. We will document this to hopefully prevent confusion.

# Review requests

Test on a robot with your own protocol, or [these two](https://github.com/Opentrons/opentrons/files/5059105/Archive.zip)
. Make sure you can see calibrations for the tip rack in api v2 after calibrating in api v1 -- the reverse should be true as well.

# Risk assessment

Low as this feature hasn't been released yet.
