### PR TITLE
refactor(app): Change legacy definition to N/A and add to the calibration

### DIFF
--- a/app/src/components/CalibratePanel/CalibrationData.js
+++ b/app/src/components/CalibratePanel/CalibrationData.js
@@ -8,13 +8,21 @@ import type { LabwareCalibrationData } from '../../calibration/labware/types'
 const NOT_CALIBRATED = 'Not yet calibrated'
 const UPDATED_DATA = 'Updated data'
 const EXISTING_DATA = 'Existing data'
+const LEGACY_DEFINITION = 'Calibration Data N/A'
 
 export function CalibrationData(props: {|
   calibrationData: LabwareCalibrationData | null,
   calibratedThisSession: boolean,
+  legacy: boolean,
 |}): React.Node {
-  const { calibrationData, calibratedThisSession } = props
-  if (calibrationData === null) {
+  const { calibrationData, calibratedThisSession, legacy } = props
+  if (legacy) {
+    return (
+      <Text as="i" marginTop={SPACING_2}>
+        {LEGACY_DEFINITION}
+      </Text>
+    )
+  } else if (calibrationData === null) {
     return (
       <Text as="i" marginTop={SPACING_2}>
         {NOT_CALIBRATED}

--- a/app/src/components/CalibratePanel/LabwareListItem.js
+++ b/app/src/components/CalibratePanel/LabwareListItem.js
@@ -26,6 +26,7 @@ export function LabwareListItem(props: LabwareListItemProps): React.Node {
     slot,
     calibratorMount,
     isTiprack,
+    isLegacy,
     confirmed,
     isDisabled,
     onClick,
@@ -87,6 +88,7 @@ export function LabwareListItem(props: LabwareListItemProps): React.Node {
               <CalibrationData
                 calibrationData={calibrationData}
                 calibratedThisSession={confirmed}
+                legacy={isLegacy}
               />
             </div>
           </div>

--- a/app/src/components/CalibratePanel/__tests__/CalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/CalibrationData.test.js
@@ -9,11 +9,16 @@ describe('CalibrationData', () => {
 
   beforeEach(() => {
     render = (props = {}) => {
-      const { calibrationData = null, calibratedThisSession = false } = props
+      const {
+        calibrationData = null,
+        calibratedThisSession = false,
+        legacy = false,
+      } = props
       return mount(
         <CalibrationData
           calibrationData={calibrationData}
           calibratedThisSession={calibratedThisSession}
+          legacy={legacy}
         />
       )
     }
@@ -46,5 +51,12 @@ describe('CalibrationData', () => {
       calibratedThisSession: true,
     })
     expect(wrapper.text().includes('Updated data')).toBe(true)
+  })
+
+  it('displays calibration data n/a when labware is legacy', () => {
+    const wrapper = render({
+      legacy: true,
+    })
+    expect(wrapper.text().includes('Calibration Data N/A')).toBe(true)
   })
 })

--- a/app/src/components/FileInfo/ProtocolLabwareList.js
+++ b/app/src/components/FileInfo/ProtocolLabwareList.js
@@ -23,7 +23,7 @@ import type { LabwareSummary } from '../../calibration/types'
 const TYPE = 'Type'
 const QUANTITY = 'Quantity'
 const CALIBRATION_DATA = 'Calibration Data'
-const LEGACY_DEFINITION = 'Legacy definition'
+const LEGACY_DEFINITION = 'N/A'
 const NOT_CALIBRATED = 'Not yet calibrated'
 const CALIBRATION_DESCRIPTION = 'Calibrated offset from labware origin point'
 

--- a/app/src/components/FileInfo/__tests__/ProtocolLabwareList.test.js
+++ b/app/src/components/FileInfo/__tests__/ProtocolLabwareList.test.js
@@ -92,7 +92,7 @@ describe('ProtocolLabwareList Component', () => {
       item2.containsAllMatchingElements([
         <Text>V1 Labware</Text>,
         <Text>x 3</Text>,
-        <Text>Legacy definition</Text>,
+        <Text>N/A</Text>,
       ])
     ).toBe(true)
     /* eslint-enable react/jsx-key */


### PR DESCRIPTION
# Overview
The surface labware feature is only meant to work with v2 labware definitions. [Some discussions](https://opentrons.slack.com/archives/CSCPS8A64/p1597169911100700) on slack led to [modified designs](https://opentrons.slack.com/archives/CSCPS8A64/p1597170862109800) for legacy labware for api v1 protocols.

# Changelog

- Change instances of `legacy definition` -> `N/A` on the file info page
- Add the phrase `Calibration Data N/A` to the calibration page

# Review requests

Please test on a robot.

# Risk assessment

Low, changing text.
