### PR TITLE
refactor(robot-server): Expose the labware hash in the http endpoint for labware calibrations

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -71,8 +71,7 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
                     calibration=calibration,
                     parent=_format_parent(data),
                     labware_id=key,
-                    uri=data['uri']
-                ))
+                    uri=data['uri']))
     return all_calibrations
 
 

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -58,7 +58,7 @@ class LabwareCalibration(BaseModel):
         Field(...,
               description="The module associated with this offset or an empty"
                           " string if the offset is associated with a slot")
-    labwareId: str =\
+    definitionHash: str =\
         Field(...,
               description="The sha256 hash of key labware definition details")
 

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -58,6 +58,9 @@ class LabwareCalibration(BaseModel):
         Field(...,
               description="The module associated with this offset or an empty"
                           " string if the offset is associated with a slot")
+    labwareId: str =\
+        Field(...,
+              description="The sha256 hash of key labware definition details")
 
     class Config:
         schema_extra = {

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -52,7 +52,8 @@ def _format_calibrations(
             loadName=details.load_name,
             namespace=details.namespace,
             version=details.version,
-            parent=parent_info)
+            parent=parent_info,
+            labwareId=calInfo.labware_id)
         formatted_calibrations.append(
                 lw_models.ResponseDataModel.create(
                     attributes=formatted_cal,

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -53,7 +53,7 @@ def _format_calibrations(
             namespace=details.namespace,
             version=details.version,
             parent=parent_info,
-            labwareId=calInfo.labware_id)
+            definitionHash=calInfo.labware_id)
         formatted_calibrations.append(
                 lw_models.ResponseDataModel.create(
                     attributes=formatted_cal,

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -38,6 +38,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -46,6 +47,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -54,6 +56,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -62,6 +65,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -70,6 +74,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 
@@ -98,6 +103,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 ---
@@ -126,6 +132,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -134,6 +141,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -142,6 +150,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -150,6 +159,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -158,6 +168,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
+              labwareId: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 ---

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -38,7 +38,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -47,7 +47,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -56,7 +56,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -65,7 +65,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -74,7 +74,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 
@@ -103,7 +103,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 ---
@@ -132,7 +132,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -141,7 +141,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -150,7 +150,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -159,7 +159,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
           - attributes:
@@ -168,7 +168,7 @@ stages:
               parent: !anystr
               namespace: 'opentrons'
               version: 1
-              labwareId: !anystr
+              definitionHash: !anystr
             id: !anystr
             type: 'LabwareCalibration'
 ---

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -33,7 +33,7 @@ def test_access_individual_labware(api_client, grab_id):
         'namespace': 'opentrons',
         'version': 1,
         'parent': '',
-        'labwareId': calibration_id}
+        'definitionHash': calibration_id}
 
     resp = api_client.get(f'/labware/calibrations/{calibration_id}')
     assert resp.status_code == 200

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -32,7 +32,8 @@ def test_access_individual_labware(api_client, grab_id):
         'loadName': 'opentrons_96_tiprack_10ul',
         'namespace': 'opentrons',
         'version': 1,
-        'parent': ''}
+        'parent': '',
+        'labwareId': calibration_id}
 
     resp = api_client.get(f'/labware/calibrations/{calibration_id}')
     assert resp.status_code == 200


### PR DESCRIPTION
# Overview

One of the requirements for fixing a bug found in surface labware calibrations. Due to how we're saving calibrations by hash, and how PD protocols embedded labware definitions into protocols, we ended up with a mismatch in hashes. For now, we should match labware per hash value rather than namespace, loadname and version.

# Changelog
- add `labwareId` to the calibration response

# Review requests

Do you like the name?

# Risk assessment

Low, just adding an extra value being sent over http.

