### PR TITLE
fix(api): use the hash-with-parent for rpc cal hashes

### DIFF
--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -44,7 +44,8 @@ class Container:
             self.position = position
             self.is_legacy = False
             self.is_tiprack = container.is_tiprack
-            self.definition_hash = labware.get_labware_hash(container)
+            self.definition_hash = labware.get_labware_hash_with_parent(
+                container)
         self.instruments = [
             Instrument(instrument)
             for instrument in instruments]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1097,12 +1097,17 @@ def _get_parent_identifier(labware: 'Labware') -> str:
         return ''  # treat all slots as same
 
 
-def get_labware_hash(labware: 'Labware'):
+def get_labware_hash(labware: 'Labware') -> str:
     return helpers.hash_labware_def(labware._definition)
 
 
-def _get_labware_path(labware: 'Labware'):
-    return f'{get_labware_hash(labware)}{_get_parent_identifier(labware)}.json'
+def get_labware_hash_with_parent(labware: 'Labware') -> str:
+    return helpers.hash_labware_def(labware._definition)\
+        + _get_parent_identifier(labware)
+
+
+def _get_labware_path(labware: 'Labware') -> str:
+    return f'{get_labware_hash_with_parent(labware)}.json'
 
 
 def load_from_definition(


### PR DESCRIPTION
The HTTP calibration interface exposes labware hashes with parents included (concatenated), but the rpc was exposing only definition hash, so the app couldn't match the two.

Include the parent in the hash, which lets the app properly display calibration data for labware that is on a module.