### PR TITLE
feat(protocol-designer): apply delays to aspirates/dispenses in a mix 

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -42,20 +42,24 @@ function tripleMix(
   } = {}
 ) {
   const { delayAfterAspirate, delayAfterDispense } = delayParams
-  return [
-    aspirateHelper(well, volume, params),
-    ...(delayAfterAspirate ? delayWithOffset(well, params.labware) : []),
-    dispenseHelper(well, volume, params),
-    ...(delayAfterDispense ? delayWithOffset(well, params.labware) : []),
-    aspirateHelper(well, volume, params),
-    ...(delayAfterAspirate ? delayWithOffset(well, params.labware) : []),
-    dispenseHelper(well, volume, params),
-    ...(delayAfterDispense ? delayWithOffset(well, params.labware) : []),
-    aspirateHelper(well, volume, params),
-    ...(delayAfterAspirate ? delayWithOffset(well, params.labware) : []),
-    dispenseHelper(well, volume, params),
-    ...(delayAfterDispense ? delayWithOffset(well, params.labware) : []),
+
+  const delayCommand = [
+    {
+      command: 'delay',
+      params: { wait: 12 },
+    },
   ]
+
+  return [...Array(3)].reduce(
+    (acc, _) => [
+      ...acc,
+      aspirateHelper(well, volume, params),
+      ...(delayAfterAspirate ? delayCommand : []),
+      dispenseHelper(well, volume, params),
+      ...(delayAfterDispense ? delayCommand : []),
+    ],
+    []
+  )
 }
 
 let invariantContext

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -357,17 +357,22 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     )
     const res = getSuccessResult(result)
 
+    const delayCommand = {
+      command: 'delay',
+      params: { wait: 12 },
+    }
+
     const mixCommandsWithDelay = [
       // mix 1
       aspirateHelper('A1', 50),
-      ...delayWithOffset('A1', SOURCE_LABWARE),
+      delayCommand,
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
       // mix 2
       aspirateHelper('A1', 50),
-      ...delayWithOffset('A1', SOURCE_LABWARE),
+      delayCommand,
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -562,6 +567,11 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     )
     const res = getSuccessResult(result)
 
+    const delayCommand = {
+      command: 'delay',
+      params: { wait: 12 },
+    }
+
     const mixCommandsWithDelay = [
       // mix 1
       aspirateHelper('A1', 50),
@@ -569,14 +579,14 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      ...delayWithOffset('A1', SOURCE_LABWARE),
+      delayCommand,
       // mix 2
       aspirateHelper('A1', 50),
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      ...delayWithOffset('A1', SOURCE_LABWARE),
+      delayCommand,
     ]
     expect(res.commands).toEqual([
       ...mixCommandsWithDelay,

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -338,6 +338,56 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       dispenseHelper('A5', 100),
     ])
   })
+  it('should delay after mix aspirate and regular aspirate', () => {
+    const distributeArgs: DistributeArgs = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
+      volume: 100,
+      aspirateDelay: { seconds: 12, mmFromBottom: 14 },
+      mixBeforeAspirate: { times: 2, volume: 50 },
+      disposalVolume: 0,
+    }
+
+    const result = distribute(
+      distributeArgs,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+
+    const mixCommandsWithDelay = [
+      // mix 1
+      aspirateHelper('A1', 50),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      dispenseHelper('A1', 50, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      // mix 2
+      aspirateHelper('A1', 50),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      dispenseHelper('A1', 50, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+    ]
+
+    expect(res.commands).toEqual([
+      ...mixCommandsWithDelay,
+      aspirateHelper('A1', 300),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      dispenseHelper('A2', 100),
+      dispenseHelper('A3', 100),
+      dispenseHelper('A4', 100),
+
+      ...mixCommandsWithDelay,
+      aspirateHelper('A1', 100),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      dispenseHelper('A5', 100),
+    ])
+  })
 
   it('should touch tip after aspirate', () => {
     const distributeArgs: DistributeArgs = {
@@ -489,6 +539,58 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       ...delayWithOffset('A4', DEST_LABWARE),
 
       aspirateHelper('A1', 100),
+      dispenseHelper('A5', 100),
+      ...delayWithOffset('A5', DEST_LABWARE),
+    ])
+  })
+  it('should delay after mix dispense AND regular dispense', () => {
+    const distributeArgs: DistributeArgs = {
+      ...mixinArgs,
+      sourceWell: 'A1',
+      destWells: ['A2', 'A3', 'A4', 'A5'],
+      changeTip: 'never',
+      volume: 100,
+      dispenseDelay: { seconds: 12, mmFromBottom: 14 },
+      mixBeforeAspirate: { times: 2, volume: 50 },
+      disposalVolume: 0,
+    }
+
+    const result = distribute(
+      distributeArgs,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
+
+    const mixCommandsWithDelay = [
+      // mix 1
+      aspirateHelper('A1', 50),
+      dispenseHelper('A1', 50, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      // mix 2
+      aspirateHelper('A1', 50),
+      dispenseHelper('A1', 50, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+    ]
+    expect(res.commands).toEqual([
+      ...mixCommandsWithDelay,
+      aspirateHelper('A1', 300),
+      dispenseHelper('A2', 100),
+      ...delayWithOffset('A2', DEST_LABWARE),
+      dispenseHelper('A3', 100),
+      ...delayWithOffset('A3', DEST_LABWARE),
+      dispenseHelper('A4', 100),
+      ...delayWithOffset('A4', DEST_LABWARE),
+
+      ...mixCommandsWithDelay,
+      aspirateHelper('A1', 100),
+
       dispenseHelper('A5', 100),
       ...delayWithOffset('A5', DEST_LABWARE),
     ])

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -512,6 +512,49 @@ describe('advanced options', () => {
         dispenseHelper('B1', 50),
       ])
     })
+    it('should delay after mix aspirate and regular aspirate', () => {
+      advArgs = {
+        ...advArgs,
+        volume: 350,
+        mixBeforeAspirate: {
+          volume: 250,
+          times: 2,
+        },
+        aspirateDelay: { seconds: 12, mmFromBottom: 14 },
+      }
+
+      // mixes will include the delays after aspirating
+      const mixCommandsWithDelays = [
+        // mix 1
+        aspirateHelper('A1', 250),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('A1', 250, {
+          labware: SOURCE_LABWARE,
+          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+        }),
+        // mix 2
+        aspirateHelper('A1', 250),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('A1', 250, {
+          labware: SOURCE_LABWARE,
+          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+        }),
+      ]
+
+      const result = transfer(advArgs, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        ...mixCommandsWithDelays,
+        aspirateHelper('A1', 300),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('B1', 300),
+
+        ...mixCommandsWithDelays,
+        aspirateHelper('A1', 50),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('B1', 50),
+      ])
+    })
 
     it('should delay after aspirate', () => {
       advArgs = {
@@ -573,6 +616,56 @@ describe('advanced options', () => {
         aspirateHelper('A1', 50),
         dispenseHelper('B1', 50),
         ...mixCommands,
+      ])
+    })
+    it('should delay after mix dispense and after dispense', () => {
+      advArgs = {
+        ...advArgs,
+        volume: 350,
+        mixInDestination: {
+          volume: 250,
+          times: 2,
+        },
+        dispenseDelay: { seconds: 12, mmFromBottom: 14 },
+      }
+
+      // mixes will include the delays after aspirating
+      const mixCommandsWithDelays = [
+        // mix 1
+        aspirateHelper('B1', 250, {
+          labware: DEST_LABWARE,
+          offsetFromBottomMm: DISPENSE_OFFSET_FROM_BOTTOM_MM,
+        }),
+        dispenseHelper('B1', 250, {
+          labware: DEST_LABWARE,
+          offsetFromBottomMm: DISPENSE_OFFSET_FROM_BOTTOM_MM,
+        }),
+        ...delayWithOffset('B1', DEST_LABWARE),
+        // mix 2
+        aspirateHelper('B1', 250, {
+          labware: DEST_LABWARE,
+          offsetFromBottomMm: DISPENSE_OFFSET_FROM_BOTTOM_MM,
+        }),
+        dispenseHelper('B1', 250, {
+          labware: DEST_LABWARE,
+        }),
+        ...delayWithOffset('B1', DEST_LABWARE),
+      ]
+
+      const result = transfer(advArgs, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        aspirateHelper('A1', 300),
+        dispenseHelper('B1', 300),
+        // delay after dispense
+        ...delayWithOffset('B1', DEST_LABWARE),
+        ...mixCommandsWithDelays,
+
+        aspirateHelper('A1', 50),
+        dispenseHelper('B1', 50),
+        // delay after dispense
+        ...delayWithOffset('B1', DEST_LABWARE),
+        ...mixCommandsWithDelays,
       ])
     })
 

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -523,18 +523,23 @@ describe('advanced options', () => {
         aspirateDelay: { seconds: 12, mmFromBottom: 14 },
       }
 
+      const delayCommand = {
+        command: 'delay',
+        params: { wait: 12 },
+      }
+
       // mixes will include the delays after aspirating
       const mixCommandsWithDelays = [
         // mix 1
         aspirateHelper('A1', 250),
-        ...delayWithOffset('A1', SOURCE_LABWARE),
+        delayCommand,
         dispenseHelper('A1', 250, {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
         }),
         // mix 2
         aspirateHelper('A1', 250),
-        ...delayWithOffset('A1', SOURCE_LABWARE),
+        delayCommand,
         dispenseHelper('A1', 250, {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -629,6 +634,11 @@ describe('advanced options', () => {
         dispenseDelay: { seconds: 12, mmFromBottom: 14 },
       }
 
+      const delayCommand = {
+        command: 'delay',
+        params: { wait: 12 },
+      }
+
       // mixes will include the delays after aspirating
       const mixCommandsWithDelays = [
         // mix 1
@@ -640,7 +650,7 @@ describe('advanced options', () => {
           labware: DEST_LABWARE,
           offsetFromBottomMm: DISPENSE_OFFSET_FROM_BOTTOM_MM,
         }),
-        ...delayWithOffset('B1', DEST_LABWARE),
+        delayCommand,
         // mix 2
         aspirateHelper('B1', 250, {
           labware: DEST_LABWARE,
@@ -649,7 +659,7 @@ describe('advanced options', () => {
         dispenseHelper('B1', 250, {
           labware: DEST_LABWARE,
         }),
-        ...delayWithOffset('B1', DEST_LABWARE),
+        delayCommand,
       ]
 
       const result = transfer(advArgs, invariantContext, robotStateWithTip)

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -73,6 +73,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     dispenseDelay,
     dispenseFlowRateUlSec,
     dispenseOffsetFromBottomMm,
+    mixFirstAspirate,
+    mixInDestination,
   } = args
 
   const maxWellsPerChunk = Math.floor(
@@ -164,17 +166,19 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ]
         : []
 
-      const mixBeforeCommands = args.mixFirstAspirate
+      const mixBeforeCommands = mixFirstAspirate
         ? mixUtil({
             pipette: args.pipette,
             labware: args.sourceLabware,
             well: sourceWellChunk[0],
-            volume: args.mixFirstAspirate.volume,
-            times: args.mixFirstAspirate.times,
+            volume: mixFirstAspirate.volume,
+            times: mixFirstAspirate.times,
             aspirateOffsetFromBottomMm,
             dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
+            aspirateDelay,
+            dispenseDelay,
           })
         : []
 
@@ -193,17 +197,19 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           })
         : []
 
-      const mixAfterCommands = args.mixInDestination
+      const mixAfterCommands = mixInDestination
         ? mixUtil({
             pipette: args.pipette,
             labware: args.destLabware,
             well: args.destWell,
-            volume: args.mixInDestination.volume,
-            times: args.mixInDestination.times,
+            volume: mixInDestination.volume,
+            times: mixInDestination.times,
             aspirateOffsetFromBottomMm: dispenseOffsetFromBottomMm,
             dispenseOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
+            aspirateDelay,
+            dispenseDelay,
           })
         : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -177,8 +177,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
-            aspirateDelay,
-            dispenseDelay,
+            aspirateDelaySeconds: aspirateDelay?.seconds,
+            dispenseDelaySeconds: dispenseDelay?.seconds,
           })
         : []
 
@@ -208,8 +208,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             dispenseOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
-            aspirateDelay,
-            dispenseDelay,
+            aspirateDelaySeconds: aspirateDelay?.seconds,
+            dispenseDelaySeconds: dispenseDelay?.seconds,
           })
         : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -236,8 +236,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
             dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
-            aspirateDelay,
-            dispenseDelay,
+            aspirateDelaySeconds: aspirateDelay?.seconds,
+            dispenseDelaySeconds: dispenseDelay?.seconds,
           })
         : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -236,6 +236,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
             dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
+            aspirateDelay,
+            dispenseDelay,
           })
         : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -172,8 +172,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                 dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
                 aspirateFlowRateUlSec,
                 dispenseFlowRateUlSec,
-                aspirateDelay,
-                dispenseDelay,
+                aspirateDelaySeconds: aspirateDelay?.seconds,
+                dispenseDelaySeconds: dispenseDelay?.seconds,
               })
             : []
 
@@ -235,8 +235,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                 dispenseOffsetFromBottomMm,
                 aspirateFlowRateUlSec,
                 dispenseFlowRateUlSec,
-                aspirateDelay,
-                dispenseDelay,
+                aspirateDelaySeconds: aspirateDelay?.seconds,
+                dispenseDelaySeconds: dispenseDelay?.seconds,
               })
             : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -172,6 +172,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                 dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
                 aspirateFlowRateUlSec,
                 dispenseFlowRateUlSec,
+                aspirateDelay,
+                dispenseDelay,
               })
             : []
 
@@ -233,6 +235,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                 dispenseOffsetFromBottomMm,
                 aspirateFlowRateUlSec,
                 dispenseFlowRateUlSec,
+                aspirateDelay,
+                dispenseDelay,
               })
             : []
 


### PR DESCRIPTION
# Overview

This PR closes #6306 by applying delays to aspirates/dispenses that pertain to mixes. 

Also sorta related to #6019.

# Changelog

- Apply delays to aspirates/dispenses in a mix 

# Review requests
 - code review
 - make sure my tests cover each case (delay and mix together for `transfer`, `consolidate`, and `distribute`)

# Risk assessment
Low-ish, I touched the compound command creators, but everything is well tested. 