### PR TITLE
fix(api): fix InstrumentContext.home_plunger

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -822,7 +822,7 @@ class InstrumentContext(CommandPublisher):
 
         :returns: This instance.
         """
-        self._hw_manager.hardware.home_plunger(self.mount)
+        self._hw_manager.hardware.home_plunger(self._mount)
         return self
 
     @cmds.publish.both(command=cmds.distribute)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -926,3 +926,10 @@ def test_api_per_call_checking(monkeypatch):
     ctx = papi.ProtocolContext(api_version=APIVersion(2, 0))
     with pytest.raises(papi.util.APIVersionError):
         ctx.disconnect()
+
+
+def test_home_plunger(monkeypatch):
+    ctx = papi.ProtocolContext(api_version=APIVersion(2, 0))
+    ctx.home()
+    instr = ctx.load_instrument('p1000_single', 'left')
+    instr.home_plunger()


### PR DESCRIPTION
InstrumentContext.home_plunger was passing the lower case mount name to
API.home_plunger rather than the mount enum, and appears to always have
done so. Fix the issue and add a test.

Closes #6368 

## Testing
Call `InstrumentContext.home_plunger` and see that it doesn't raise an exception.