### PR TITLE
feat(protocol-designer): adjust disposal volume and path reset patches for air gap

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -250,6 +250,10 @@ const clampAirGapVolume = (
       minAirGapVolume,
       maxAirGapVolume
     )
+
+    if (clampedAirGapVolume === Number(patchedAspirateAirgapVolume))
+      return patch
+
     return {
       ...patch,
       aspirate_airGap_volume: String(clampedAirGapVolume),
@@ -546,8 +550,8 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch => updatePatchPathField(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
-    chainPatch => clampDisposalVolume(chainPatch, rawForm, pipetteEntities),
     chainPatch => clampAirGapVolume(chainPatch, rawForm, pipetteEntities),
+    chainPatch => clampDisposalVolume(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchMixFields(chainPatch, rawForm),
     chainPatch => updatePatchBlowoutFields(chainPatch, rawForm),
   ])

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -66,10 +66,16 @@ export function getMaxDisposalVolumeForMultidispense(
     rawForm.path === 'multiDispense',
     `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${rawForm.path}`
   )
-  const volume = Number(rawForm.volume)
   const pipetteEntity = pipetteEntities[rawForm.pipette]
   const pipetteCapacity = getPipetteCapacity(pipetteEntity)
-  return round(pipetteCapacity - volume * 2, DISPOSAL_VOL_DIGITS)
+
+  const volume = Number(rawForm.volume)
+  const airGapChecked = rawForm['aspirate_airGap_checkbox']
+  let airGapVolume = airGapChecked
+    ? Number(rawForm['aspirate_airGap_volume'])
+    : 0
+  airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
+  return round(pipetteCapacity - volume * 2 - airGapVolume, DISPOSAL_VOL_DIGITS)
 }
 
 // Ensures that 2x volume can fit in pipette
@@ -79,7 +85,6 @@ export function volumeInCapacityForMulti(
   rawForm: FormData,
   pipetteEntities: PipetteEntities
 ): boolean {
-  const volume = Number(rawForm.volume)
   assert(
     rawForm.pipette in pipetteEntities,
     `volumeInCapacityForMulti expected pipette ${rawForm.pipette} to be in pipetteEntities`
@@ -87,7 +92,18 @@ export function volumeInCapacityForMulti(
   const pipetteEntity = pipetteEntities[rawForm.pipette]
   const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
 
-  return volume > 0 && pipetteCapacity > 0 && volume * 2 <= pipetteCapacity
+  const volume = Number(rawForm.volume)
+  const airGapChecked = rawForm['aspirate_airGap_checkbox']
+  let airGapVolume = airGapChecked
+    ? Number(rawForm['aspirate_airGap_volume'])
+    : 0
+  airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
+
+  return (
+    volume > 0 &&
+    pipetteCapacity > 0 &&
+    volume * 2 + airGapVolume <= pipetteCapacity
+  )
 }
 
 type GetDefaultWellsArgs = {


### PR DESCRIPTION
# Overview

This PR closes #6022 by taking air gap volume into account for multi dispense disposal volume + path reset. 

Pairing credit to @IanLondon 

# Changelog
- Adjust disposal volume and path reset patches for air gap

# Review requests
- Code review (including tests)

- Make sure that when you increase the air gap volume, the max disposal volume decreases (via clamping) by the same amount. Max disposal volume should be  Pipette capacity - 2*volume - airgap volume.  

- Make sure that when you increase the air gap volume enough such that 2*volume + airgap volume does not fit in the tip, the path gets reset from multi dispense to single

# Risk assessment
Low
