### PR TITLE
refactor(robot-server): deck calibraton - tip pick up and invalidate tip

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -6,13 +6,13 @@ from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import ThreadManager, CriticalPoint
 from opentrons.hardware_control.pipette import Pipette
-from opentrons.hardware_control.util import plan_arc
 from opentrons.protocol_api import geometry, labware
 from opentrons.types import Mount, Point, Location
 from robot_server.service.session.models import (
     CalibrationCommand, DeckCalibrationCommand)
 from robot_server.robot.calibration.constants import (
     SHORT_TRASH_DECK, STANDARD_DECK)
+import robot_server.robot.calibration.util as uf
 from .constants import (
     DeckCalibrationState as State,
     TIP_RACK_SLOT,
@@ -189,55 +189,16 @@ class DeckCalibrationUserFlow:
             return tip_length - tip_overlap
 
     async def pick_up_tip(self):
-        saved_default = None
-        if self._hw_pipette.config.channels > 1:
-            # reduce pick up current for multichannel pipette picking up 1 tip
-            saved_default = self._hw_pipette.config.pick_up_current
-            self._hw_pipette.update_config_item('pick_up_current', 0.1)
-
-        # grab position of active nozzle for ref when returning tip later
-        self._tip_origin_pt = await self._hardware.gantry_position(
-            self._mount, critical_point=self._get_critical_point())
-
-        tip_length = self._get_tip_length()
-        await self._hardware.pick_up_tip(self._mount, tip_length)
-
-        if saved_default:
-            self._hw_pipette.update_config_item('pick_up_current',
-                                                saved_default)
+        await uf.pick_up_tip(self, tip_length=self._get_tip_length())
 
     async def invalidate_tip(self):
-        await self._return_tip()
-        await self.move_to_tip_rack()
+        await uf.invalidate_tip(self)
 
     async def _return_tip(self):
-        if self._tip_origin_pt and self._hw_pipette.has_tip:
-            tip_length = self._get_tip_length()
-            coeff = self._hw_pipette.config.return_tip_height
-            to_pt = self._tip_origin_pt - Point(0, 0, tip_length * coeff)
-            cp = self._get_critical_point()
-            await self._hardware.move_to(mount=self._mount,
-                                         abs_position=to_pt,
-                                         critical_point=cp)
-            await self._hardware.drop_tip(self._mount)
-            self._tip_origin_pt = None
+        await uf.return_tip(self, tip_length=self._get_tip_length())
 
     async def _move(self, to_loc: Location):
-        from_pt = await self._get_current_point()
-        from_loc = Location(from_pt, None)
-        cp = self._get_critical_point()
-
-        max_height = self._hardware.get_instrument_max_height(self._mount)
-
-        safe = geometry.safe_height(
-            from_loc, to_loc, self._deck, max_height)
-        moves = plan_arc(from_pt, to_loc.point, safe,
-                         origin_cp=None,
-                         dest_cp=cp)
-        for move in moves:
-            await self._hardware.move_to(mount=self._mount,
-                                         abs_position=move[0],
-                                         critical_point=move[1])
+        await uf.move(self, to_loc)
 
     async def exit_session(self):
         await self._return_tip()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -1,9 +1,12 @@
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
+from opentrons.calibration_storage import get
+from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import ThreadManager, CriticalPoint
 from opentrons.hardware_control.pipette import Pipette
+from opentrons.hardware_control.util import plan_arc
 from opentrons.protocol_api import geometry, labware
 from opentrons.types import Mount, Point, Location
 from robot_server.service.session.models import (
@@ -50,10 +53,13 @@ class DeckCalibrationUserFlow:
         deck_load_name = SHORT_TRASH_DECK if ff.short_fixed_trash() \
             else STANDARD_DECK
         self._deck = geometry.Deck(load_name=deck_load_name)
-        self._initialize_deck()
+        self._tip_rack = self._get_tip_rack_lw()
+        self._deck[TIP_RACK_SLOT] = self._tip_rack
 
         self._current_state = State.sessionStarted
         self._state_machine = DeckCalibrationStateMachine()
+
+        self._tip_origin_pt: Optional[Point] = None
 
         self._command_map: COMMAND_MAP = {
             CalibrationCommand.load_labware: self.load_labware,
@@ -99,17 +105,13 @@ class DeckCalibrationUserFlow:
     def _select_target_pipette(self) -> Tuple[Pipette, Mount]:
         # TODO: select pipette for deck calibration
         # return pipette and mount
-        return self._hardware._attached_instruments[Mount.RIGHT], Mount.RIGHT
+        return self._hardware._attached_instruments[Mount.LEFT], Mount.LEFT
 
     def _get_tip_rack_lw(self) -> labware.Labware:
         # TODO: select tiprack based on chosen pipette model
         return labware.load(
             "opentrons_96_tiprack_10ul",
             self._deck.position_for(TIP_RACK_SLOT))
-
-    def _initialize_deck(self):
-        tip_rack_lw = self._get_tip_rack_lw()
-        self._deck[TIP_RACK_SLOT] = tip_rack_lw
 
     async def handle_command(self,
                              name: Any,
@@ -133,7 +135,7 @@ class DeckCalibrationUserFlow:
             f'from {self._current_state} to {next_state}')
 
     def _get_critical_point(self) -> CriticalPoint:
-        return CriticalPoint.FRONT_NOZZLE
+        return CriticalPoint.NOZZLE
         # TODO: uncomment the following after _select_target_pipette
         # is complette:
         # return (CriticalPoint.FRONT_NOZZLE if
@@ -173,18 +175,69 @@ class DeckCalibrationUserFlow:
     async def save_offset(self):
         pass
 
+    def _get_tip_length(self) -> float:
+        try:
+            return get.load_tip_length_calibration(
+                self._hw_pipette.pipette_id,  # type: ignore
+                self._tip_rack._definition,
+                '')['tipLength']
+        except TipLengthCalNotFound:
+            tip_overlap = self._hw_pipette.config.tip_overlap.get(
+                self._tip_rack.uri,
+                self._hw_pipette.config.tip_overlap['default'])
+            tip_length = self._tip_rack.tip_length
+            return tip_length - tip_overlap
+
     async def pick_up_tip(self):
-        pass
+        saved_default = None
+        if self._hw_pipette.config.channels > 1:
+            # reduce pick up current for multichannel pipette picking up 1 tip
+            saved_default = self._hw_pipette.config.pick_up_current
+            self._hw_pipette.update_config_item('pick_up_current', 0.1)
+
+        # grab position of active nozzle for ref when returning tip later
+        self._tip_origin_pt = await self._hardware.gantry_position(
+            self._mount, critical_point=self._get_critical_point())
+
+        tip_length = self._get_tip_length()
+        await self._hardware.pick_up_tip(self._mount, tip_length)
+
+        if saved_default:
+            self._hw_pipette.update_config_item('pick_up_current',
+                                                saved_default)
 
     async def invalidate_tip(self):
         await self._return_tip()
         await self.move_to_tip_rack()
 
     async def _return_tip(self):
-        pass
+        if self._tip_origin_pt and self._hw_pipette.has_tip:
+            tip_length = self._get_tip_length()
+            coeff = self._hw_pipette.config.return_tip_height
+            to_pt = self._tip_origin_pt - Point(0, 0, tip_length * coeff)
+            cp = self._get_critical_point()
+            await self._hardware.move_to(mount=self._mount,
+                                         abs_position=to_pt,
+                                         critical_point=cp)
+            await self._hardware.drop_tip(self._mount)
+            self._tip_origin_pt = None
 
-    async def _move(self, *args):
-        pass
+    async def _move(self, to_loc: Location):
+        from_pt = await self._get_current_point()
+        from_loc = Location(from_pt, None)
+        cp = self._get_critical_point()
+
+        max_height = self._hardware.get_instrument_max_height(self._mount)
+
+        safe = geometry.safe_height(
+            from_loc, to_loc, self._deck, max_height)
+        moves = plan_arc(from_pt, to_loc.point, safe,
+                         origin_cp=None,
+                         dest_cp=cp)
+        for move in moves:
+            await self._hardware.move_to(mount=self._mount,
+                                         abs_position=move[0],
+                                         critical_point=move[1])
 
     async def exit_session(self):
         await self._return_tip()

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -1,10 +1,21 @@
-from typing import Set, Dict, Any, Union
+import contextlib
+from typing import Set, Dict, Any, Union, TYPE_CHECKING
+
+from opentrons.hardware_control import Pipette
+from opentrons.hardware_control.util import plan_arc
+from opentrons.protocol_api import geometry
+from opentrons.types import Point, Location
+
 from robot_server.service.errors import RobotServerError
 from robot_server.service.session.models import CommandDefinition
 from .constants import STATE_WILDCARD
 from .errors import CalibrationError
 from .tip_length.constants import TipCalibrationState
 from .deck.constants import DeckCalibrationState
+
+if TYPE_CHECKING:
+    from .deck.user_flow import DeckCalibrationUserFlow
+    from .tip_length.user_flow import TipCalibrationUserFlow
 
 ValidState = Union[TipCalibrationState, DeckCalibrationState]
 
@@ -57,3 +68,75 @@ class SimpleStateMachine:
             return fs_to_state
         else:
             return None
+
+
+CalibrationUserFlow = Union[
+    'DeckCalibrationUserFlow', 'TipCalibrationUserFlow']
+
+
+async def invalidate_tip(user_flow: CalibrationUserFlow):
+    await user_flow._return_tip()
+    await user_flow.move_to_tip_rack()
+
+
+@contextlib.contextmanager
+def save_default_pick_up_current(instr: Pipette):
+    # reduce pick up current for multichannel pipette picking up 1 tip
+    saved_default = instr.config.pick_up_current
+    instr.update_config_item('pick_up_current', 0.1)
+
+    try:
+        yield
+    finally:
+        instr.update_config_item('pick_up_current', saved_default)
+
+
+async def pick_up_tip(user_flow: CalibrationUserFlow, tip_length: float):
+    # grab position of active nozzle for ref when returning tip later
+    user_flow._tip_origin_pt = await user_flow._hardware.gantry_position(
+        user_flow._mount, critical_point=user_flow._get_critical_point())
+
+    with contextlib.ExitStack() as stack:
+        if user_flow._hw_pipette.config.channels > 1:
+            stack.enter_context(
+                save_default_pick_up_current(user_flow._hw_pipette))
+
+        await user_flow._hardware.pick_up_tip(user_flow._mount, tip_length)
+
+
+async def return_tip(user_flow: CalibrationUserFlow, tip_length: float):
+    """
+    Move pipette with tip to tip rack well, such that
+    the tip is inside the well, but not so deep that
+    the tip rack will block the sheath from ejecting fully.
+    Each pipette config contains a coefficient to apply to an
+    attached tip's length to determine proper z offset
+    """
+    if user_flow._tip_origin_pt and user_flow._hw_pipette.has_tip:
+        coeff = user_flow._hw_pipette.config.return_tip_height
+        to_pt = user_flow._tip_origin_pt - Point(0, 0, tip_length * coeff)
+        cp = user_flow._get_critical_point()
+        await user_flow._hardware.move_to(mount=user_flow._mount,
+                                          abs_position=to_pt,
+                                          critical_point=cp)
+        await user_flow._hardware.drop_tip(user_flow._mount)
+        user_flow._tip_origin_pt = None
+
+
+async def move(user_flow: CalibrationUserFlow, to_loc: Location):
+    from_pt = await user_flow._get_current_point()
+    from_loc = Location(from_pt, None)
+    cp = user_flow._get_critical_point()
+
+    max_height = user_flow._hardware.get_instrument_max_height(
+        user_flow._mount)
+
+    safe = geometry.safe_height(
+        from_loc, to_loc, user_flow._deck, max_height)
+    moves = plan_arc(from_pt, to_loc.point, safe,
+                     origin_cp=None,
+                     dest_cp=cp)
+    for move in moves:
+        await user_flow._hardware.move_to(mount=user_flow._mount,
+                                          abs_position=move[0],
+                                          critical_point=move[1])

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 from robot_server.robot.calibration.deck.user_flow import \
@@ -14,7 +14,7 @@ def mock_hw(hardware):
                               'multi': [0, 0, 0]
                           },
                           'testId')
-    hardware._attached_instruments = {Mount.RIGHT: pip}
+    hardware._attached_instruments = {Mount.RIGHT: pip, Mount.LEFT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
     async def async_mock(*args, **kwargs):
@@ -44,3 +44,38 @@ def mock_hw(hardware):
 def mock_user_flow(mock_hw):
     m = DeckCalibrationUserFlow(hardware=mock_hw)
     yield m
+
+
+async def test_move_to_tip_rack(mock_user_flow):
+    uf = mock_user_flow
+    await uf.move_to_tip_rack()
+    cur_pt = await uf._get_current_point()
+    assert cur_pt == uf._tip_rack.wells()[0].top().point + Point(0, 0, 10)
+
+
+async def test_pick_up_tip(mock_user_flow):
+    uf = mock_user_flow
+    assert uf._tip_origin_pt is None
+    await uf.move_to_tip_rack()
+    cur_pt = await uf._get_current_point()
+    await uf.pick_up_tip()
+    assert uf._tip_origin_pt == cur_pt
+
+
+async def test_return_tip(mock_user_flow):
+    uf = mock_user_flow
+    uf._tip_origin_pt = Point(1, 1, 1)
+    uf._hw_pipette._has_tip = True
+    z_offset = uf._hw_pipette.config.return_tip_height * \
+        uf._get_tip_length()
+    await uf._return_tip()
+    # should move to return tip
+    move_calls = [
+        call(
+            mount=Mount.LEFT,
+            abs_position=Point(1, 1, 1 - z_offset),
+            critical_point=uf._get_critical_point()
+        ),
+    ]
+    uf._hardware.move_to.assert_has_calls(move_calls)
+    uf._hardware.drop_tip.assert_called()

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -62,6 +62,28 @@ async def test_pick_up_tip(mock_user_flow):
     assert uf._tip_origin_pt == cur_pt
 
 
+async def test_save_default_pick_up_current(mock_hw):
+    # make sure pick up current for multi-channels is
+    # modified during tip pick up
+    pip = pipette.Pipette("p20_multi_v2.1",
+                          {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          'testid')
+    mock_hw._attached_instruments[Mount.LEFT] = pip
+    uf = DeckCalibrationUserFlow(hardware=mock_hw)
+
+    def mock_update_config_item(*args, **kwargs):
+        pass
+
+    uf._hw_pipette.update_config_item = MagicMock(
+        side_effect=mock_update_config_item)
+    default_current = pip.config.pick_up_current
+    update_config_calls = [
+        call('pick_up_current', 0.1),
+        call('pick_up_current', default_current)]
+    await uf.pick_up_tip()
+    uf._hw_pipette.update_config_item.assert_has_calls(update_config_calls)
+
+
 async def test_return_tip(mock_user_flow):
     uf = mock_user_flow
     uf._tip_origin_pt = Point(1, 1, 1)


### PR DESCRIPTION
closes #6256

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fills in the preparing pipette flow for deck calibration.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- updated `pick_up_tip`, `return_tip`
- implemented `_get_tip_length` by trying to get the new tip length calibration data; use the default tip length if not found
- added tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low, behind a feature flag
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
