### PR TITLE
feat(protocol-designer): apply delays to pre-wet

### DIFF
--- a/protocol-designer/src/step-generation/__fixtures__/commandFixtures.js
+++ b/protocol-designer/src/step-generation/__fixtures__/commandFixtures.js
@@ -172,6 +172,11 @@ export const makeTouchTipHelper: MakeTouchTipHelper = bakedParams => (
   },
 })
 
+export const delayCommand = (seconds: number): Command => ({
+  command: 'delay',
+  params: { wait: seconds },
+})
+
 export const delayWithOffset = (
   well: string,
   labware: string

--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -505,6 +505,118 @@ describe('consolidate single-channel', () => {
     ])
   })
 
+  it('pre-wet tip should use the aspirate delay when specified', () => {
+    // TODO LATER Ian 2018-02-13 Should it be 2/3 max volume instead?
+    const data = {
+      ...mixinArgs,
+      volume: 150,
+      changeTip: 'once',
+      preWetTip: true,
+      sourceWells: ['A1', 'A2', 'A3', 'A4'],
+      aspirateDelay: { mmFromBottom: 14, seconds: 12 },
+    }
+
+    const preWetVol = data.volume // NOTE same as volume above... for now
+
+    const result = consolidate(data, invariantContext, initialRobotState)
+    const res = getSuccessResult(result)
+
+    // TODO IMMEDIATELY: make this a tiny fixture
+    const delayCommand = {
+      command: 'delay',
+      params: { wait: 12 },
+    }
+
+    expect(res.commands).toEqual([
+      pickUpTipHelper('A1'),
+
+      // pre-wet tip
+      aspirateHelper('A1', preWetVol),
+      delayCommand,
+      dispenseHelper('A1', preWetVol, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      // done pre-wet
+
+      aspirateHelper('A1', 150),
+      ...delayWithOffset('A1', SOURCE_LABWARE),
+      aspirateHelper('A2', 150),
+      ...delayWithOffset('A2', SOURCE_LABWARE),
+      dispenseHelper('B1', 300),
+
+      // pre-wet tip, now with A3
+      aspirateHelper('A3', preWetVol),
+      delayCommand,
+      dispenseHelper('A3', preWetVol, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      // done pre-wet
+
+      aspirateHelper('A3', 150),
+      ...delayWithOffset('A3', SOURCE_LABWARE),
+      aspirateHelper('A4', 150),
+      ...delayWithOffset('A4', SOURCE_LABWARE),
+      dispenseHelper('B1', 300),
+    ])
+  })
+
+  it('pre-wet tip should use the dispense delay when specified', () => {
+    // TODO LATER Ian 2018-02-13 Should it be 2/3 max volume instead?
+    const data = {
+      ...mixinArgs,
+      volume: 150,
+      changeTip: 'once',
+      preWetTip: true,
+      sourceWells: ['A1', 'A2', 'A3', 'A4'],
+      dispenseDelay: { mmFromBottom: 14, seconds: 12 },
+    }
+
+    const preWetVol = data.volume // NOTE same as volume above... for now
+
+    const result = consolidate(data, invariantContext, initialRobotState)
+    const res = getSuccessResult(result)
+
+    // TODO IMMEDIATELY: make this a tiny fixture
+    const delayCommand = {
+      command: 'delay',
+      params: { wait: 12 },
+    }
+
+    expect(res.commands).toEqual([
+      pickUpTipHelper('A1'),
+
+      // pre-wet tip
+      aspirateHelper('A1', preWetVol),
+      dispenseHelper('A1', preWetVol, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      delayCommand,
+      // done pre-wet
+
+      aspirateHelper('A1', 150),
+      aspirateHelper('A2', 150),
+      dispenseHelper('B1', 300),
+      ...delayWithOffset('B1', DEST_LABWARE),
+
+      // pre-wet tip, now with A3
+      aspirateHelper('A3', preWetVol),
+      dispenseHelper('A3', preWetVol, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      delayCommand,
+      // done pre-wet
+
+      aspirateHelper('A3', 150),
+      aspirateHelper('A4', 150),
+      dispenseHelper('B1', 300),
+      ...delayWithOffset('B1', DEST_LABWARE),
+    ])
+  })
+
   it('should delay after aspirate', () => {
     const data = {
       ...mixinArgs,

--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -4,6 +4,7 @@ import {
   ASPIRATE_OFFSET_FROM_BOTTOM_MM,
   blowoutHelper,
   DEFAULT_PIPETTE,
+  delayCommand,
   delayWithOffset,
   DEST_LABWARE,
   DISPENSE_OFFSET_FROM_BOTTOM_MM,
@@ -43,20 +44,13 @@ function tripleMix(
 ) {
   const { delayAfterAspirate, delayAfterDispense } = delayParams
 
-  const delayCommand = [
-    {
-      command: 'delay',
-      params: { wait: 12 },
-    },
-  ]
-
   return [...Array(3)].reduce(
     (acc, _) => [
       ...acc,
       aspirateHelper(well, volume, params),
-      ...(delayAfterAspirate ? delayCommand : []),
+      ...(delayAfterAspirate ? [delayCommand(12)] : []),
       dispenseHelper(well, volume, params),
-      ...(delayAfterDispense ? delayCommand : []),
+      ...(delayAfterDispense ? [delayCommand(12)] : []),
     ],
     []
   )
@@ -521,18 +515,12 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data, invariantContext, initialRobotState)
     const res = getSuccessResult(result)
 
-    // TODO IMMEDIATELY: make this a tiny fixture
-    const delayCommand = {
-      command: 'delay',
-      params: { wait: 12 },
-    }
-
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
 
       // pre-wet tip
       aspirateHelper('A1', preWetVol),
-      delayCommand,
+      delayCommand(12),
       dispenseHelper('A1', preWetVol, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -547,7 +535,7 @@ describe('consolidate single-channel', () => {
 
       // pre-wet tip, now with A3
       aspirateHelper('A3', preWetVol),
-      delayCommand,
+      delayCommand(12),
       dispenseHelper('A3', preWetVol, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -578,12 +566,6 @@ describe('consolidate single-channel', () => {
     const result = consolidate(data, invariantContext, initialRobotState)
     const res = getSuccessResult(result)
 
-    // TODO IMMEDIATELY: make this a tiny fixture
-    const delayCommand = {
-      command: 'delay',
-      params: { wait: 12 },
-    }
-
     expect(res.commands).toEqual([
       pickUpTipHelper('A1'),
 
@@ -593,7 +575,7 @@ describe('consolidate single-channel', () => {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      delayCommand,
+      delayCommand(12),
       // done pre-wet
 
       aspirateHelper('A1', 150),
@@ -607,7 +589,7 @@ describe('consolidate single-channel', () => {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      delayCommand,
+      delayCommand(12),
       // done pre-wet
 
       aspirateHelper('A3', 150),

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -271,6 +271,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
   })
 
   // TODO(IL, 2020-02-28): pre-wet volume is not implemented for distribute! #5122
+  //
+  // TODO(IL, 2020-08-18): don't forget to add delay tests for pre-wet when that is implemented
   it.todo('should pre-wet tip')
   // (() => {
   //   const distributeArgs: DistributeArgs = {

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -3,6 +3,7 @@ import {
   ASPIRATE_OFFSET_FROM_BOTTOM_MM,
   blowoutHelper,
   DEFAULT_PIPETTE,
+  delayCommand,
   delayWithOffset,
   DEST_LABWARE,
   dropTipHelper,
@@ -360,22 +361,17 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     )
     const res = getSuccessResult(result)
 
-    const delayCommand = {
-      command: 'delay',
-      params: { wait: 12 },
-    }
-
     const mixCommandsWithDelay = [
       // mix 1
       aspirateHelper('A1', 50),
-      delayCommand,
+      delayCommand(12),
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
       // mix 2
       aspirateHelper('A1', 50),
-      delayCommand,
+      delayCommand(12),
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -570,11 +566,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
     )
     const res = getSuccessResult(result)
 
-    const delayCommand = {
-      command: 'delay',
-      params: { wait: 12 },
-    }
-
     const mixCommandsWithDelay = [
       // mix 1
       aspirateHelper('A1', 50),
@@ -582,14 +573,14 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      delayCommand,
+      delayCommand(12),
       // mix 2
       aspirateHelper('A1', 50),
       dispenseHelper('A1', 50, {
         labware: SOURCE_LABWARE,
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
-      delayCommand,
+      delayCommand(12),
     ]
     expect(res.commands).toEqual([
       ...mixCommandsWithDelay,

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -434,6 +434,76 @@ describe('advanced options', () => {
       ])
     })
 
+    it('pre-wet tip should use the aspirate delay when specified', () => {
+      advArgs = {
+        ...advArgs,
+        volume: 350,
+        preWetTip: true,
+        aspirateDelay: { mmFromBottom: 14, seconds: 12 },
+      }
+
+      const delayCommand = {
+        command: 'delay',
+        params: { wait: 12 },
+      }
+
+      const result = transfer(advArgs, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        // pre-wet aspirate/dispense
+        aspirateHelper('A1', 300),
+        delayCommand,
+        dispenseHelper('A1', 300, {
+          labware: SOURCE_LABWARE,
+          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+        }),
+
+        // "real" aspirate/dispenses
+        aspirateHelper('A1', 300),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('B1', 300),
+
+        aspirateHelper('A1', 50),
+        ...delayWithOffset('A1', SOURCE_LABWARE),
+        dispenseHelper('B1', 50),
+      ])
+    })
+
+    it('pre-wet tip should use the dispense delay when specified', () => {
+      advArgs = {
+        ...advArgs,
+        volume: 350,
+        preWetTip: true,
+        dispenseDelay: { mmFromBottom: 14, seconds: 12 },
+      }
+
+      const delayCommand = {
+        command: 'delay',
+        params: { wait: 12 },
+      }
+
+      const result = transfer(advArgs, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        // pre-wet aspirate/dispense
+        aspirateHelper('A1', 300),
+        dispenseHelper('A1', 300, {
+          labware: SOURCE_LABWARE,
+          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+        }),
+        delayCommand,
+
+        // "real" aspirate/dispenses
+        aspirateHelper('A1', 300),
+        dispenseHelper('B1', 300),
+        ...delayWithOffset('B1', DEST_LABWARE),
+
+        aspirateHelper('A1', 50),
+        dispenseHelper('B1', 50),
+        ...delayWithOffset('B1', DEST_LABWARE),
+      ])
+    })
+
     it('should touchTip after aspirate on each source well, for every aspirate', () => {
       advArgs = {
         ...advArgs,

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -2,6 +2,7 @@
 import {
   ASPIRATE_OFFSET_FROM_BOTTOM_MM,
   DEFAULT_PIPETTE,
+  delayCommand,
   delayWithOffset,
   DEST_LABWARE,
   DISPENSE_OFFSET_FROM_BOTTOM_MM,
@@ -442,17 +443,12 @@ describe('advanced options', () => {
         aspirateDelay: { mmFromBottom: 14, seconds: 12 },
       }
 
-      const delayCommand = {
-        command: 'delay',
-        params: { wait: 12 },
-      }
-
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
         // pre-wet aspirate/dispense
         aspirateHelper('A1', 300),
-        delayCommand,
+        delayCommand(12),
         dispenseHelper('A1', 300, {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -477,11 +473,6 @@ describe('advanced options', () => {
         dispenseDelay: { mmFromBottom: 14, seconds: 12 },
       }
 
-      const delayCommand = {
-        command: 'delay',
-        params: { wait: 12 },
-      }
-
       const result = transfer(advArgs, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -491,7 +482,7 @@ describe('advanced options', () => {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
         }),
-        delayCommand,
+        delayCommand(12),
 
         // "real" aspirate/dispenses
         aspirateHelper('A1', 300),
@@ -593,23 +584,18 @@ describe('advanced options', () => {
         aspirateDelay: { seconds: 12, mmFromBottom: 14 },
       }
 
-      const delayCommand = {
-        command: 'delay',
-        params: { wait: 12 },
-      }
-
       // mixes will include the delays after aspirating
       const mixCommandsWithDelays = [
         // mix 1
         aspirateHelper('A1', 250),
-        delayCommand,
+        delayCommand(12),
         dispenseHelper('A1', 250, {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
         }),
         // mix 2
         aspirateHelper('A1', 250),
-        delayCommand,
+        delayCommand(12),
         dispenseHelper('A1', 250, {
           labware: SOURCE_LABWARE,
           offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
@@ -704,11 +690,6 @@ describe('advanced options', () => {
         dispenseDelay: { seconds: 12, mmFromBottom: 14 },
       }
 
-      const delayCommand = {
-        command: 'delay',
-        params: { wait: 12 },
-      }
-
       // mixes will include the delays after aspirating
       const mixCommandsWithDelays = [
         // mix 1
@@ -720,7 +701,7 @@ describe('advanced options', () => {
           labware: DEST_LABWARE,
           offsetFromBottomMm: DISPENSE_OFFSET_FROM_BOTTOM_MM,
         }),
-        delayCommand,
+        delayCommand(12),
         // mix 2
         aspirateHelper('B1', 250, {
           labware: DEST_LABWARE,
@@ -729,7 +710,7 @@ describe('advanced options', () => {
         dispenseHelper('B1', 250, {
           labware: DEST_LABWARE,
         }),
-        delayCommand,
+        delayCommand(12),
       ]
 
       const result = transfer(advArgs, invariantContext, robotStateWithTip)

--- a/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/consolidate.js
@@ -194,6 +194,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
             aspirateFlowRateUlSec,
             dispenseFlowRateUlSec,
+            aspirateDelaySeconds: aspirateDelay?.seconds,
+            dispenseDelaySeconds: dispenseDelay?.seconds,
           })
         : []
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -158,6 +158,8 @@ export const transfer: CommandCreator<TransferArgs> = (
                   dispenseOffsetFromBottomMm: aspirateOffsetFromBottomMm,
                   aspirateFlowRateUlSec,
                   dispenseFlowRateUlSec,
+                  aspirateDelaySeconds: aspirateDelay?.seconds,
+                  dispenseDelaySeconds: dispenseDelay?.seconds,
                 })
               : []
 


### PR DESCRIPTION
# Overview

Closes #6021

Pairing credit to @shlokamin 

# Changelog

- delay for pre-wet

# Review requests

- [ ] Mostly just review the tests. Every pre-wet should have aspirate and/or dispense delays when they are included

# Risk assessment

