### PR TITLE
refactor(robot-server): deck cal - select pipette and tip rack

### DIFF
--- a/robot-server/robot_server/robot/calibration/constants.py
+++ b/robot-server/robot_server/robot/calibration/constants.py
@@ -35,9 +35,9 @@ TIP_RACK_LOOKUP_BY_MAX_VOL: Dict[str, LabwareLookUp] = {
             FILTERTIPRACK_10,
             FILTERTIPRACK_20}),
     '20': LabwareLookUp(
-        load_name=TIPRACK_10,
+        load_name=TIPRACK_20,
         alternatives={
-            TIPRACK_20,
+            TIPRACK_10,
             FILTERTIPRACK_10,
             FILTERTIPRACK_20}),
     '50': LabwareLookUp(

--- a/robot-server/robot_server/robot/calibration/constants.py
+++ b/robot-server/robot_server/robot/calibration/constants.py
@@ -35,7 +35,7 @@ TIP_RACK_LOOKUP_BY_MAX_VOL: Dict[str, LabwareLookUp] = {
             FILTERTIPRACK_10,
             FILTERTIPRACK_20}),
     '20': LabwareLookUp(
-        load_name=TIPRACK_20,
+        load_name=TIPRACK_10,
         alternatives={
             TIPRACK_20,
             FILTERTIPRACK_10,

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, call
+from typing import List, Tuple
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 from robot_server.robot.calibration.deck.user_flow import \
@@ -38,6 +39,34 @@ def mock_hw(hardware):
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
     return hardware
+
+
+pipette_combos: List[Tuple[List[str], Mount]] = [
+    (['p20_multi_v2.1', 'p20_multi_v2.1'], Mount.RIGHT),
+    (['p20_single_v2.1', 'p20_multi_v2.1'], Mount.LEFT),
+    (['p20_multi_v2.1', 'p300_single_v2.1'], Mount.LEFT),
+    (['p300_multi_v2.1', 'p1000_single_v2.1'], Mount.LEFT),
+    (['p1000_single_v2.1', ''], Mount.LEFT),
+    (['', 'p300_multi_v2.1'], Mount.RIGHT)
+]
+
+
+@pytest.mark.parametrize('pipettes,target_mount', pipette_combos)
+def test_user_flow_select_pipette(pipettes, target_mount, hardware):
+    pip, pip2 = None, None
+    if pipettes[0]:
+        pip = pipette.Pipette(pipettes[0],
+                              {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                              'testId')
+    if pipettes[1]:
+        pip2 = pipette.Pipette(pipettes[1],
+                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                               'testId2')
+    hardware._attached_instruments = {Mount.LEFT: pip, Mount.RIGHT: pip2}
+
+    uf = DeckCalibrationUserFlow(hardware=hardware)
+    assert uf._hw_pipette == \
+        hardware._attached_instruments[target_mount]
 
 
 @pytest.fixture

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -123,7 +123,7 @@ async def test_return_tip(mock_user_flow):
     # should move to return tip
     move_calls = [
         call(
-            mount=Mount.LEFT,
+            mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
             critical_point=uf._get_critical_point()
         ),


### PR DESCRIPTION
closes #6254


# Overview
This PR selects the pipette and its appropriate tiprack for deck calibration.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- fixed labware lookup dictionary so that a P20 pipette can use a 10 uL tiprack as an alternative

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Still a WIP: The changes here only allow the pipette to use the default tip rack based on `TIP_RACK_LOOKUP_BY_MAX_VOL`. Would like to discuss more on letting user select a different tiprack
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
