### PR TITLE
refactor(app): send events to intercom on calcheck complete

### DIFF
--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -254,3 +254,48 @@ export const mockCalibrationCheckSessionAnalyticsProps = {
     mockRobotCalibrationCheckSessionDetails.comparisonsByStep
       .comparingSecondPipettePointOne.transformType,
 }
+
+export const mockCalibrationCheckSessionIntercomProps = {
+  sessionType: Constants.SESSION_TYPE_CALIBRATION_CHECK,
+  leftPipetteModel:
+    mockRobotCalibrationCheckSessionDetails.instruments.left.model,
+  rightPipetteModel:
+    mockRobotCalibrationCheckSessionDetails.instruments.right.model,
+  succeeded: false,
+  comparingFirstPipetteHeightExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipetteHeight.exceedsThreshold,
+  comparingFirstPipetteHeightErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipetteHeight.transformType,
+  comparingFirstPipettePointOneExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointOne.exceedsThreshold,
+  comparingFirstPipettePointOneErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointOne.transformType,
+  comparingFirstPipettePointTwoExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointTwo.exceedsThreshold,
+  comparingFirstPipettePointTwoErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointTwo.transformType,
+  comparingFirstPipettePointThreeExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointThree.exceedsThreshold,
+  comparingFirstPipettePointThreeErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingFirstPipettePointThree.transformType,
+  comparingSecondPipetteHeightExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingSecondPipetteHeight.exceedsThreshold,
+  comparingSecondPipetteHeightErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingSecondPipetteHeight.transformType,
+  comparingSecondPipettePointOneExceedsThreshold:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingSecondPipettePointOne.exceedsThreshold,
+  comparingSecondPipettePointOneErrorSource:
+    mockRobotCalibrationCheckSessionDetails.comparisonsByStep
+      .comparingSecondPipettePointOne.transformType,
+}

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -261,7 +261,7 @@ export const mockCalibrationCheckSessionIntercomProps = {
     mockRobotCalibrationCheckSessionDetails.instruments.left.model,
   rightPipetteModel:
     mockRobotCalibrationCheckSessionDetails.instruments.right.model,
-  succeeded: false,
+  succeeded: true,
   comparingFirstPipetteHeightExceedsThreshold:
     mockRobotCalibrationCheckSessionDetails.comparisonsByStep
       .comparingFirstPipetteHeight.exceedsThreshold,

--- a/app/src/sessions/__tests__/selectors.test.js
+++ b/app/src/sessions/__tests__/selectors.test.js
@@ -131,6 +131,61 @@ const SPECS: Array<SelectorSpec> = [
     args: ['germanium-cobweb', 'fake_nonexistent_session_id'],
     expected: null,
   },
+  {
+    name:
+      'getIntercomEventPropsForRobotSessionById returns props for check cal session',
+    selector: Selectors.getIntercomEventPropsForRobotSessionById,
+    state: {
+      sessions: {
+        'germanium-cobweb': {
+          robotSessions: {
+            [Fixtures.mockSessionId]:
+              Fixtures.mockCalibrationCheckSessionAttributes,
+          },
+        },
+      },
+    },
+    args: ['germanium-cobweb', Fixtures.mockSessionId],
+    expected: Fixtures.mockCalibrationCheckSessionIntercomProps,
+  },
+  {
+    name:
+      'getIntercomEventPropsForRobotSessionById returns null for untracked session type',
+    selector: Selectors.getIntercomEventPropsForRobotSessionById,
+    state: {
+      sessions: {
+        'germanium-cobweb': {
+          robotSessions: {
+            [Fixtures.mockSessionId]: {
+              ...Fixtures.mockCalibrationCheckSessionAttributes,
+              sessionType: 'FakeUntrackedSessionType',
+            },
+          },
+        },
+      },
+    },
+    args: ['germanium-cobweb', Fixtures.mockSessionId],
+    expected: null,
+  },
+  {
+    name:
+      'getIntercomEventPropsForRobotSessionById returns null if session not found',
+    selector: Selectors.getIntercomEventPropsForRobotSessionById,
+    state: {
+      sessions: {
+        'germanium-cobweb': {
+          robotSessions: {
+            [Fixtures.mockSessionId]: {
+              ...Fixtures.mockCalibrationCheckSessionAttributes,
+              sessionType: 'FakeUntrackedSessionType',
+            },
+          },
+        },
+      },
+    },
+    args: ['germanium-cobweb', 'fake_nonexistent_session_id'],
+    expected: null,
+  },
 ]
 
 describe('sessions selectors', () => {

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -1,6 +1,6 @@
 // @flow
 import type { State } from '../types'
-import { every } from 'lodash'
+import { some } from 'lodash'
 import * as Constants from './constants'
 import * as Types from './types'
 
@@ -113,7 +113,7 @@ const getIntercomPropsFromCalibrationCheck: (
     return val
   }
 
-  const succeeded = every(
+  const succeeded = !some(
     Object.keys(comparisonsByStep).map(k =>
       boolValueOrNull(comparisonsByStep[k].exceedsThreshold)
     )

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -106,16 +106,10 @@ const getIntercomPropsFromCalibrationCheck: (
     },
     initialStepData
   )
-  const boolValueOrNull: (val?: boolean) => boolean = val => {
-    if (val === undefined || val === null) {
-      return false
-    }
-    return val
-  }
 
   const succeeded = !some(
     Object.keys(comparisonsByStep).map(k =>
-      boolValueOrNull(comparisonsByStep[k].exceedsThreshold)
+      Boolean(comparisonsByStep[k].exceedsThreshold)
     )
   )
   return {

--- a/app/src/sessions/selectors.js
+++ b/app/src/sessions/selectors.js
@@ -1,5 +1,6 @@
 // @flow
 import type { State } from '../types'
+import { every } from 'lodash'
 import * as Constants from './constants'
 import * as Types from './types'
 
@@ -30,6 +31,101 @@ export function getRobotSessionOfType(
   return foundSessionId ? sessionsById[foundSessionId] : null
 }
 
+const getMountEventPropsFromCalibrationCheck: (
+  session: Types.CalibrationCheckSession
+) => Types.AnalyticsModelsByMount = session => {
+  const { instruments } = session.details
+  const initialModelsByMount: $Shape<Types.AnalyticsModelsByMount> = {}
+  const modelsByMount: Types.AnalyticsModelsByMount = Object.keys(
+    instruments
+  ).reduce(
+    (acc: Types.AnalyticsModelsByMount, mount: string) => ({
+      ...acc,
+      [`${mount.toLowerCase()}PipetteModel`]: instruments[mount].model,
+    }),
+    initialModelsByMount
+  )
+  return modelsByMount
+}
+
+const getSharedAnalyticsPropsFromCalibrationCheck: (
+  session: Types.CalibrationCheckSession
+) => Types.SharedAnalyticsProps = session => ({
+  sessionType: session.sessionType,
+})
+
+const getAnalyticsPropsFromCalibrationCheck: (
+  session: Types.CalibrationCheckSession
+) => Types.CalibrationCheckSessionAnalyticsProps = session => {
+  const { comparisonsByStep } = session.details
+  const initialStepData: $Shape<Types.CalibrationCheckAnalyticsData> = {}
+  const normalizedStepData = Object.keys(comparisonsByStep).reduce(
+    (
+      acc: Types.CalibrationCheckAnalyticsData,
+      stepName: Types.RobotCalibrationCheckStep
+    ) => {
+      const {
+        differenceVector,
+        thresholdVector,
+        exceedsThreshold,
+        transformType,
+      } = comparisonsByStep[stepName]
+      return {
+        ...acc,
+        [`${stepName}DifferenceVector`]: differenceVector,
+        [`${stepName}ThresholdVector`]: thresholdVector,
+        [`${stepName}ExceedsThreshold`]: exceedsThreshold,
+        [`${stepName}ErrorSource`]: transformType,
+      }
+    },
+    initialStepData
+  )
+  return {
+    ...getSharedAnalyticsPropsFromCalibrationCheck(session),
+    ...getMountEventPropsFromCalibrationCheck(session),
+    ...normalizedStepData,
+  }
+}
+
+const getIntercomPropsFromCalibrationCheck: (
+  session: Types.CalibrationCheckSession
+) => Types.CalibrationCheckSessionIntercomProps = session => {
+  const { comparisonsByStep } = session.details
+  const initialStepData: $Shape<Types.CalibrationCheckIntercomData> = {}
+  const normalizedStepData = Object.keys(comparisonsByStep).reduce(
+    (
+      acc: Types.CalibrationCheckIntercomData,
+      stepName: Types.RobotCalibrationCheckStep
+    ) => {
+      const { exceedsThreshold, transformType } = comparisonsByStep[stepName]
+      return {
+        ...acc,
+        [`${stepName}ExceedsThreshold`]: exceedsThreshold,
+        [`${stepName}ErrorSource`]: transformType,
+      }
+    },
+    initialStepData
+  )
+  const boolValueOrNull: (val?: boolean) => boolean = val => {
+    if (val === undefined || val === null) {
+      return false
+    }
+    return val
+  }
+
+  const succeeded = every(
+    Object.keys(comparisonsByStep).map(k =>
+      boolValueOrNull(comparisonsByStep[k].exceedsThreshold)
+    )
+  )
+  return {
+    ...getSharedAnalyticsPropsFromCalibrationCheck(session),
+    ...getMountEventPropsFromCalibrationCheck(session),
+    ...normalizedStepData,
+    succeeded: succeeded,
+  }
+}
+
 export const getAnalyticsPropsForRobotSessionById: (
   state: State,
   robotName: string,
@@ -39,44 +135,22 @@ export const getAnalyticsPropsForRobotSessionById: (
   if (!session) return null
 
   if (session.sessionType === Constants.SESSION_TYPE_CALIBRATION_CHECK) {
-    const { instruments, comparisonsByStep } = session.details
-    const initialModelsByMount: $Shape<Types.AnalyticsModelsByMount> = {}
-    const modelsByMount: Types.AnalyticsModelsByMount = Object.keys(
-      instruments
-    ).reduce(
-      (acc: Types.AnalyticsModelsByMount, mount: string) => ({
-        ...acc,
-        [`${mount.toLowerCase()}PipetteModel`]: instruments[mount].model,
-      }),
-      initialModelsByMount
-    )
-    const initialStepData: $Shape<Types.CalibrationCheckAnalyticsData> = {}
-    const normalizedStepData = Object.keys(comparisonsByStep).reduce(
-      (
-        acc: Types.CalibrationCheckAnalyticsData,
-        stepName: Types.RobotCalibrationCheckStep
-      ) => {
-        const {
-          differenceVector,
-          thresholdVector,
-          exceedsThreshold,
-          transformType,
-        } = comparisonsByStep[stepName]
-        return {
-          ...acc,
-          [`${stepName}DifferenceVector`]: differenceVector,
-          [`${stepName}ThresholdVector`]: thresholdVector,
-          [`${stepName}ExceedsThreshold`]: exceedsThreshold,
-          [`${stepName}ErrorSource`]: transformType,
-        }
-      },
-      initialStepData
-    )
-    return {
-      sessionType: session.sessionType,
-      ...modelsByMount,
-      ...normalizedStepData,
-    }
+    return getAnalyticsPropsFromCalibrationCheck(session)
+  } else {
+    // the exited session type doesn't report to analytics
+    return null
+  }
+}
+
+export const getIntercomEventPropsForRobotSessionById: (
+  state: State,
+  robotName: string,
+  sessionId: string
+) => Types.SessionIntercomProps | null = (state, robotName, sessionId) => {
+  const session = getRobotSessionById(state, robotName, sessionId)
+  if (!session) return null
+  if (session.sessionType === Constants.SESSION_TYPE_CALIBRATION_CHECK) {
+    return getIntercomPropsFromCalibrationCheck(session)
   } else {
     // the exited session type doesn't report to analytics
     return null

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -296,32 +296,41 @@ export type AnalyticsModelsByMount = {|
   rightPipetteModel?: string,
 |}
 
-type VectorTuple = [number, number, number]
-export type CalibrationCheckAnalyticsData = {|
-  comparingFirstPipetteHeightDifferenceVector?: VectorTuple,
-  comparingFirstPipetteHeightThresholdVector?: VectorTuple,
+export type CalibrationCheckCommonEventData = {|
   comparingFirstPipetteHeightExceedsThreshold?: boolean,
   comparingFirstPipetteHeightErrorSource?: string,
-  comparingFirstPipettePointOneDifferenceVector?: VectorTuple,
-  comparingFirstPipettePointOneThresholdVector?: VectorTuple,
   comparingFirstPipettePointOneExceedsThreshold?: boolean,
   comparingFirstPipettePointOneErrorSource?: string,
-  comparingFirstPipettePointTwoDifferenceVector?: VectorTuple,
-  comparingFirstPipettePointTwoThresholdVector?: VectorTuple,
   comparingFirstPipettePointTwoExceedsThreshold?: boolean,
   comparingFirstPipettePointTwoErrorSource?: string,
-  comparingFirstPipettePointThreeDifferenceVector?: VectorTuple,
-  comparingFirstPipettePointThreeThresholdVector?: VectorTuple,
   comparingFirstPipettePointThreeExceedsThreshold?: boolean,
   comparingFirstPipettePointThreeErrorSource?: string,
-  comparingSecondPipetteHeightDifferenceVector?: VectorTuple,
-  comparingSecondPipetteHeightThresholdVector?: VectorTuple,
   comparingSecondPipetteHeightExceedsThreshold?: boolean,
   comparingSecondPipetteHeightErrorSource?: string,
-  comparingSecondPipettePointOneDifferenceVector?: VectorTuple,
-  comparingSecondPipettePointOneThresholdVector?: VectorTuple,
   comparingSecondPipettePointOneExceedsThreshold?: boolean,
   comparingSecondPipettePointOneErrorSource?: string,
+|}
+
+export type CalibrationCheckIntercomData = {|
+  ...CalibrationCheckCommonEventData,
+  succeeded: boolean,
+|}
+
+type VectorTuple = [number, number, number]
+export type CalibrationCheckAnalyticsData = {|
+  ...CalibrationCheckCommonEventData,
+  comparingFirstPipetteHeightDifferenceVector?: VectorTuple,
+  comparingFirstPipetteHeightThresholdVector?: VectorTuple,
+  comparingFirstPipettePointOneDifferenceVector?: VectorTuple,
+  comparingFirstPipettePointOneThresholdVector?: VectorTuple,
+  comparingFirstPipettePointTwoDifferenceVector?: VectorTuple,
+  comparingFirstPipettePointTwoThresholdVector?: VectorTuple,
+  comparingFirstPipettePointThreeDifferenceVector?: VectorTuple,
+  comparingFirstPipettePointThreeThresholdVector?: VectorTuple,
+  comparingSecondPipetteHeightDifferenceVector?: VectorTuple,
+  comparingSecondPipetteHeightThresholdVector?: VectorTuple,
+  comparingSecondPipettePointOneDifferenceVector?: VectorTuple,
+  comparingSecondPipettePointOneThresholdVector?: VectorTuple,
 |}
 
 export type SharedAnalyticsProps = {|
@@ -334,4 +343,11 @@ export type CalibrationCheckSessionAnalyticsProps = {|
   ...CalibrationCheckAnalyticsData,
 |}
 
+export type CalibrationCheckSessionIntercomProps = {|
+  ...SharedAnalyticsProps,
+  ...AnalyticsModelsByMount,
+  ...CalibrationCheckIntercomData,
+|}
+
 export type SessionAnalyticsProps = CalibrationCheckSessionAnalyticsProps
+export type SessionIntercomProps = CalibrationCheckSessionIntercomProps

--- a/app/src/support/__tests__/epic.test.js
+++ b/app/src/support/__tests__/epic.test.js
@@ -3,18 +3,29 @@
 import { TestScheduler } from 'rxjs/testing'
 import { configInitialized } from '../../config'
 import * as Profile from '../profile'
+import * as Event from '../intercom-event'
 import { supportEpic } from '../epic'
 
 import type { Action, State } from '../../types'
 import type { Config } from '../../config/types'
-import type { SupportConfig, SupportProfileUpdate } from '../types'
+import type {
+  SupportConfig,
+  SupportProfileUpdate,
+  IntercomEvent,
+} from '../types'
 
 jest.mock('../profile')
+jest.mock('../intercom-event')
 
 const makeProfileUpdate: JestMockFn<
   [Action, State],
   SupportProfileUpdate | null
 > = Profile.makeProfileUpdate
+
+const makeIntercomEvent: JestMockFn<[Action, State], IntercomEvent | null> =
+  Event.makeIntercomEvent
+
+const sendEvent: JestMockFn<[IntercomEvent], void> = Event.sendEvent
 
 const initializeProfile: JestMockFn<[SupportConfig], void> =
   Profile.initializeProfile
@@ -23,11 +34,13 @@ const updateProfile: JestMockFn<[SupportProfileUpdate], void> =
   Profile.updateProfile
 
 const MOCK_ACTION: Action = ({ type: 'MOCK_ACTION' }: any)
-const MOCK_STATE: $Shape<{| ...State, config: $Shape<Config> |}> = {
+const MOCK_PROFILE_STATE: $Shape<{| ...State, config: $Shape<Config> |}> = {
   config: {
     support: { userId: 'foo', createdAt: 42, name: 'bar', email: null },
   },
 }
+
+const MOCK_EVENT_STATE: $Shape<{| ...State |}> = {}
 
 describe('support profile epic', () => {
   let testScheduler
@@ -46,27 +59,34 @@ describe('support profile epic', () => {
 
   it('should initialize support profile on config:INITIALIZED', () => {
     testScheduler.run(({ hot, expectObservable, flush }) => {
-      const action$ = hot('-a', { a: configInitialized(MOCK_STATE.config) })
+      const action$ = hot('-a', {
+        a: configInitialized(MOCK_PROFILE_STATE.config),
+      })
       const state$ = hot('--')
       const result$ = supportEpic(action$, state$)
 
       expectObservable(result$, '--')
       flush()
 
-      expect(initializeProfile).toHaveBeenCalledWith(MOCK_STATE.config.support)
+      expect(initializeProfile).toHaveBeenCalledWith(
+        MOCK_PROFILE_STATE.config.support
+      )
     })
   })
 
   it('should do nothing with actions that do not map to a profile update', () => {
     testScheduler.run(({ hot, expectObservable, flush }) => {
       const action$ = hot('-a', { a: MOCK_ACTION })
-      const state$ = hot('s-', { s: MOCK_STATE })
+      const state$ = hot('s-', { s: MOCK_PROFILE_STATE })
       const result$ = supportEpic(action$, state$)
 
       expectObservable(result$, '--')
       flush()
 
-      expect(makeProfileUpdate).toHaveBeenCalledWith(MOCK_ACTION, MOCK_STATE)
+      expect(makeProfileUpdate).toHaveBeenCalledWith(
+        MOCK_ACTION,
+        MOCK_PROFILE_STATE
+      )
     })
   })
 
@@ -76,13 +96,65 @@ describe('support profile epic', () => {
 
     testScheduler.run(({ hot, expectObservable, flush }) => {
       const action$ = hot('-a', { a: MOCK_ACTION })
-      const state$ = hot('s-', { s: MOCK_STATE })
+      const state$ = hot('s-', { s: MOCK_PROFILE_STATE })
       const result$ = supportEpic(action$, state$)
 
       expectObservable(result$)
       flush()
 
       expect(updateProfile).toHaveBeenCalledWith(profileUpdate)
+    })
+  })
+})
+
+describe('support event epic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    makeIntercomEvent.mockReturnValue(null)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should do nothing with actions that do not map to an event', () => {
+    testScheduler.run(({ hot, expectObservable, flush }) => {
+      const action$ = hot('-a', { a: MOCK_ACTION })
+      const state$ = hot('s-', { s: MOCK_EVENT_STATE })
+      const result$ = supportEpic(action$, state$)
+
+      expectObservable(result$, '--')
+      flush()
+
+      expect(makeIntercomEvent).toHaveBeenCalledWith(
+        MOCK_ACTION,
+        MOCK_EVENT_STATE
+      )
+      expect(sendEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should send an event', () => {
+    const eventPayload = {
+      eventName: 'completed-robot-calibration-check',
+      metadata: { someProp: 'value' },
+    }
+    makeIntercomEvent.mockReturnValueOnce(eventPayload)
+
+    testScheduler.run(({ hot, expectObservable, flush }) => {
+      const action$ = hot('-a', { a: MOCK_ACTION })
+      const state$ = hot('s-', { s: MOCK_PROFILE_STATE })
+      const result$ = supportEpic(action$, state$)
+
+      expectObservable(result$)
+      flush()
+
+      expect(sendEvent).toHaveBeenCalledWith(eventPayload)
     })
   })
 })

--- a/app/src/support/__tests__/intercom-binding.test.js
+++ b/app/src/support/__tests__/intercom-binding.test.js
@@ -1,0 +1,116 @@
+// @flow
+
+import * as IntercomBinding from '../intercom-binding'
+import * as Constants from '../constants'
+
+describe('calling the intercom js api', () => {
+  const intercom = jest.fn()
+  beforeEach(() => {
+    global.Intercom = intercom
+    process.env.OT_APP_INTERCOM_ID = 'some-intercom-app-id'
+    IntercomBinding.setUserId('dummy')
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+    delete global.Intercom
+    delete process.env.OT_APP_INTERCOM_ID
+    IntercomBinding.setUserId(null)
+  })
+
+  it('should not boot the intercom api if the global is not present', () => {
+    delete global.Intercom
+    IntercomBinding.bootIntercom({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not update intercom profiles if the global is not present', () => {
+    delete global.Intercom
+    IntercomBinding.updateIntercomProfile({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not send intercom events if the global is not present', () => {
+    delete global.Intercom
+    IntercomBinding.sendIntercomEvent('someEvent', {})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not boot the intercom api with no app id', () => {
+    delete process.env.OT_APP_INTERCOM_ID
+    IntercomBinding.bootIntercom({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not update intercom profiles with no app id', () => {
+    delete process.env.OT_APP_INTERCOM_ID
+    IntercomBinding.updateIntercomProfile({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not send intercom events with no app id', () => {
+    delete process.env.OT_APP_INTERCOM_ID
+    IntercomBinding.sendIntercomEvent('someEvent', {})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not boot the intercom api with no user id', () => {
+    IntercomBinding.setUserId(null)
+    IntercomBinding.bootIntercom({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not update intercom profiles with no user id', () => {
+    IntercomBinding.setUserId(null)
+    IntercomBinding.updateIntercomProfile({})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should not send intercom events with no user id', () => {
+    IntercomBinding.setUserId(null)
+    IntercomBinding.sendIntercomEvent('someDummyEvent', {})
+    expect(intercom).not.toHaveBeenCalled()
+  })
+
+  it('should update its let-bound user id', () => {
+    IntercomBinding.setUserId('dummy-user')
+    IntercomBinding.bootIntercom({ some: 'prop' })
+    expect(intercom).toHaveBeenCalledWith('boot', {
+      user_id: 'dummy-user',
+      some: 'prop',
+    })
+  })
+
+  it('should expose its app id', () => {
+    expect(IntercomBinding.getIntercomAppId()).toEqual('some-intercom-app-id')
+  })
+
+  it('should pass boot args to intercom', () => {
+    IntercomBinding.bootIntercom({ some: 'value', other: 'value' })
+    expect(intercom).toHaveBeenCalledWith('boot', {
+      some: 'value',
+      other: 'value',
+      user_id: 'dummy',
+    })
+  })
+
+  it('should pass update profile args to intercom', () => {
+    IntercomBinding.updateIntercomProfile({ some: 'value', other: 'value' })
+    expect(intercom).toHaveBeenCalledWith('update', {
+      some: 'value',
+      other: 'value',
+      user_id: 'dummy',
+    })
+  })
+
+  it('should pass event args to intercom', () => {
+    IntercomBinding.sendIntercomEvent(
+      Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+      { some: 'metadata' }
+    )
+    expect(intercom).toHaveBeenCalledWith(
+      'trackEvent',
+      Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+      { some: 'metadata' }
+    )
+  })
+})

--- a/app/src/support/__tests__/intercom-event.test.js
+++ b/app/src/support/__tests__/intercom-event.test.js
@@ -1,0 +1,82 @@
+// @flow
+
+import type { IntercomPayload } from '../types'
+import type { State } from '../../types'
+import * as Binding from '../intercom-binding'
+import * as Sessions from '../../sessions'
+import * as SessionTypes from '../../sessions/types'
+import { makeIntercomEvent, sendEvent } from '../intercom-event'
+import * as Constants from '../constants'
+
+jest.mock('../intercom-binding')
+jest.mock('../../sessions/selectors')
+
+const sendIntercomEvent: JestMockFn<[string, IntercomPayload], void> =
+  Binding.sendIntercomEvent
+const getIntercomEventPropsForRobotSessionById: JestMockFn<
+  [State, string, string],
+  SessionTypes.SessionIntercomProps | null
+> = Sessions.getIntercomEventPropsForRobotSessionById
+
+const MOCK_STATE: $Shape<{| ...State |}> = {}
+
+describe('support event tests', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('makeIntercomEvent should ignore unhandled events', () => {
+    const built = makeIntercomEvent(
+      Sessions.createSession(
+        'whocares',
+        Sessions.SESSION_TYPE_CALIBRATION_CHECK,
+        {}
+      ),
+      MOCK_STATE
+    )
+    expect(built).toBeNull()
+  })
+
+  it('makeIntercomEvent should send an event for calibration check complete', () => {
+    const sessionState = {
+      sessionType: 'calibrationCheck',
+      succeeded: false,
+      leftPipetteModel: 'p300_single_v2.0',
+      comparingFirstPipetteHeightExceedsThreshold: true,
+      comparingFirstPipetteHeightErrorSource: 'unknown',
+    }
+    getIntercomEventPropsForRobotSessionById.mockReturnValue(sessionState)
+    const built = makeIntercomEvent(
+      Sessions.deleteSession('silly-robot', 'dummySessionID'),
+      MOCK_STATE
+    )
+    expect(built).toEqual({
+      eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+      metadata: sessionState,
+    })
+  })
+
+  it('makeIntercomEvent should ignore events for which no data can be retrieved', () => {
+    getIntercomEventPropsForRobotSessionById.mockReturnValue(null)
+    const built = makeIntercomEvent(
+      Sessions.deleteSession('silly-robot', 'dummySessionID'),
+      MOCK_STATE
+    )
+    expect(built).toBeNull()
+  })
+
+  it('sendEvent should pass on its arguments', () => {
+    const props = {
+      eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+      metadata: {
+        someKey: true,
+        someOtherKey: 'hi',
+      },
+    }
+    sendEvent(props)
+    expect(sendIntercomEvent).toHaveBeenCalledWith(
+      props.eventName,
+      props.metadata
+    )
+  })
+})

--- a/app/src/support/constants.js
+++ b/app/src/support/constants.js
@@ -3,6 +3,7 @@
 // intercom api calls
 export const INTERCOM_BOOT = 'boot'
 export const INTERCOM_UPDATE = 'update'
+export const INTERCOM_TRACK_EVENT = 'trackEvent'
 
 // support profile property names
 export const PROFILE_APP_VERSION = 'App Version'
@@ -12,3 +13,7 @@ export const PROFILE_ROBOT_SMOOTHIE_VERSION = 'Robot Smoothie Version'
 export const PROFILE_PIPETTE_MODEL_LEFT = 'Pipette Model Left'
 export const PROFILE_PIPETTE_MODEL_RIGHT = 'Pipette Model Right'
 export const PROFILE_FEATURE_FLAG = 'Robot FF'
+
+// supported event names
+export const INTERCOM_EVENT_CALCHECK_COMPLETE: 'completed-robot-calibration-check' =
+  'completed-robot-calibration-check'

--- a/app/src/support/epic.js
+++ b/app/src/support/epic.js
@@ -6,6 +6,8 @@ import { tap, filter, withLatestFrom, ignoreElements } from 'rxjs/operators'
 import * as Cfg from '../config'
 import { initializeProfile, makeProfileUpdate, updateProfile } from './profile'
 
+import { makeIntercomEvent, sendEvent } from './intercom-event'
+
 import type { Epic } from '../types'
 import type { ConfigInitializedAction } from '../config/types'
 
@@ -28,7 +30,17 @@ const updateProfileEpic: Epic = (action$, state$) => {
   )
 }
 
+const sendEventEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    withLatestFrom(state$, makeIntercomEvent),
+    filter(maybeSend => maybeSend !== null),
+    tap(sendEvent),
+    ignoreElements()
+  )
+}
+
 export const supportEpic: Epic = combineEpics(
   initializeSupportEpic,
-  updateProfileEpic
+  updateProfileEpic,
+  sendEventEpic
 )

--- a/app/src/support/intercom-binding.js
+++ b/app/src/support/intercom-binding.js
@@ -1,0 +1,52 @@
+// @flow
+// functions for managing the binding to the Intercom js api
+
+import { createLogger } from '../logger'
+import type { IntercomPayload } from './types'
+import * as Constants from './constants'
+
+const log = createLogger(__filename)
+let userId: string | null = null
+
+export const setUserId = (newUserId: string | null): void => {
+  userId = newUserId
+}
+
+// pulled in from environment at build time
+export const getIntercomAppId = (): ?string => process.env.OT_APP_INTERCOM_ID
+
+const okToCall = (): boolean => {
+  return !!getIntercomAppId() && !!global.Intercom && !!userId
+}
+
+export const bootIntercom = (props: IntercomPayload): void => {
+  if (okToCall()) {
+    const iprops = {
+      ...props,
+      user_id: userId,
+    }
+    log.debug('Booting intercom', props)
+    global.Intercom(Constants.INTERCOM_BOOT, iprops)
+  }
+}
+
+export const updateIntercomProfile = (props: IntercomPayload): void => {
+  if (okToCall()) {
+    const iprops = {
+      ...props,
+      user_id: userId,
+    }
+    log.debug('Updating intercom profile', props)
+    global.Intercom(Constants.INTERCOM_UPDATE, iprops)
+  }
+}
+
+export const sendIntercomEvent = (
+  eventName: string,
+  metadata: IntercomPayload
+): void => {
+  if (okToCall()) {
+    log.debug('Sending intercom event', { eventName, metadata })
+    global.Intercom(Constants.INTERCOM_TRACK_EVENT, eventName, metadata)
+  }
+}

--- a/app/src/support/intercom-event.js
+++ b/app/src/support/intercom-event.js
@@ -1,0 +1,36 @@
+// @flow
+// functions for sending events to intercom, both for enriching user profiles
+// and for triggering contextual support conversations
+import type { Action, State } from '../types'
+import { sendIntercomEvent } from './intercom-binding'
+import type { IntercomEvent } from './types'
+import { INTERCOM_EVENT_CALCHECK_COMPLETE } from './constants'
+import * as Sessions from '../sessions'
+
+export function makeIntercomEvent(
+  action: Action,
+  state: State
+): IntercomEvent | null {
+  switch (action.type) {
+    case Sessions.DELETE_SESSION: {
+      const { robotName, sessionId } = action.payload
+      const eventProps = Sessions.getIntercomEventPropsForRobotSessionById(
+        state,
+        robotName,
+        sessionId
+      )
+      if (eventProps === null) {
+        return null
+      }
+      return {
+        eventName: INTERCOM_EVENT_CALCHECK_COMPLETE,
+        metadata: eventProps,
+      }
+    }
+  }
+  return null
+}
+
+export function sendEvent(event: IntercomEvent): void {
+  sendIntercomEvent(event.eventName, event?.metadata ?? {})
+}

--- a/app/src/support/types.js
+++ b/app/src/support/types.js
@@ -2,8 +2,21 @@
 
 import type { Config } from '../config/types'
 
+import typeof { INTERCOM_EVENT_CALCHECK_COMPLETE } from './constants'
+
+export type IntercomEventName = INTERCOM_EVENT_CALCHECK_COMPLETE
+
 export type SupportConfig = $PropertyType<Config, 'support'>
+
+export type IntercomPayload = $Shape<{|
+  [propertyName: string]: string | number | boolean | null,
+|}>
 
 export type SupportProfileUpdate = $Shape<{|
   [propertyName: string]: string | number | boolean | null,
 |}>
+
+export type IntercomEvent = {|
+  eventName: IntercomEventName,
+  metadata?: IntercomPayload,
+|}


### PR DESCRIPTION
The Intercom js api has the capability to send "events" from the client.
These show up on the user profile upstream and both give more context to
support interactions ("oh, this person is reaching out after doing x
thing") and enable us to pop support interactions or some automated
messaging when the event occurs ("you just did calibration check, would
you mind filling out a form that tells us how much you liked it?"). This
will really help us gather user feedback on newly-released features.

This is a pretty different use case from the previous intercom
integration, which only updated intercom with data the user entered
about themselves (if they choose to). To support this,
- Refactor the actual integration with intercom into its own js file
with its own tests
- Refactor the single callIntercom function into one for each intercom
action since the global intercom api has one of those completely
variable function signatures
- Refactor the profile tests to rely on the bindings
- Add the new event system as a snooper on the redux event stream, like
the analytics

## Risk Assessment

This should have no effect on things outside the intercom integration, but because this has a refactor of the intercom binding that should be tested.

## Testing

### Intercom binding

- Make sure that if you set an intercom app id and enable analytics, intercom still works
- Make sure that if you set an intercom app id but disable analytics, intercom does nothing

### Events
- Start deck calibration check and end it (any time during the check, pass or fail) and make sure you get an event
- make sure the boolean results and error status from deck calibration check get passed to the intercom event