### PR TITLE
refactor(app): deck cal overhaul save xy point

### DIFF
--- a/app/src/components/CalibrateDeck/SaveXYPoint.js
+++ b/app/src/components/CalibrateDeck/SaveXYPoint.js
@@ -9,6 +9,8 @@ import {
   DIRECTION_ROW,
   SPACING_3,
   BORDER_SOLID_LIGHT,
+  FONT_SIZE_HEADER,
+  FONT_WEIGHT_SEMIBOLD,
 } from '@opentrons/components'
 
 import * as Sessions from '../../sessions'
@@ -131,10 +133,14 @@ export function SaveXYPoint(props: CalibrateDeckChildProps): React.Node {
   return (
     <>
       <div className={styles.modal_header}>
-        <h3>
+        <Text
+          fontSize={FONT_SIZE_HEADER}
+          fontWeight={FONT_WEIGHT_SEMIBOLD}
+          textTransform="uppercase"
+        >
           {SAVE_XY_POINT_HEADER}
           {` ${SLOT} ${slotNumber || ''}`}
-        </h3>
+        </Text>
       </div>
       <Flex
         flexDirection={DIRECTION_ROW}

--- a/app/src/components/CalibrateDeck/SaveXYPoint.js
+++ b/app/src/components/CalibrateDeck/SaveXYPoint.js
@@ -1,10 +1,21 @@
 // @flow
 import * as React from 'react'
-import { PrimaryButton } from '@opentrons/components'
+import { css } from 'styled-components'
+import {
+  PrimaryButton,
+  Flex,
+  Text,
+  FONT_SIZE_BODY_2,
+  DIRECTION_ROW,
+  SPACING_3,
+  BORDER_SOLID_LIGHT,
+} from '@opentrons/components'
 
 import * as Sessions from '../../sessions'
 import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
 import type { CalibrateDeckChildProps } from './types'
+import type { DeckCalibrationStep } from '../../sessions/deck-calibration/types'
+import type { SessionCommandString } from '../../sessions/types'
 import { JogControls } from '../JogControls'
 import { formatJogVector } from './utils'
 import styles from './styles.css'
@@ -55,23 +66,44 @@ const assetMap = {
   },
 }
 
-const SAVE_XY_POINT_HEADER = 'Save X and Y-axis offset in'
+const SAVE_XY_POINT_HEADER = 'Calibrate the X and Y-axis in'
 const SLOT = 'slot'
 const JOG_UNTIL = 'Jog the robot until the tip is'
 const PRECISELY_CENTERED = 'precisely centered'
 const ABOVE_THE_CROSS = 'above the cross in'
 const THEN = 'Then press the'
-const SAVE_POINT = 'save x and y-axis'
-const TO_SAVE =
-  'button to determine how this position compares to the previously-saved x and y-axis calibration coordinates.'
+const TO_SAVE = 'button to calibrate the x and y-axis in'
+
+const BASE_BUTTON_TEXT = 'save calibration'
+const POINT_ONE_BUTTON_TEXT = `${BASE_BUTTON_TEXT} and move to slot 3`
+const POINT_TWO_BUTTON_TEXT = `${BASE_BUTTON_TEXT} and move to slot 7`
+
+const slotNumberByCurrentStep: { [DeckCalibrationStep]: string } = {
+  [Sessions.DECK_STEP_SAVING_POINT_ONE]: '1',
+  [Sessions.DECK_STEP_SAVING_POINT_TWO]: '3',
+  [Sessions.DECK_STEP_SAVING_POINT_THREE]: '7',
+}
+const buttonTextByCurrentStep: { [DeckCalibrationStep]: string } = {
+  [Sessions.DECK_STEP_SAVING_POINT_ONE]: POINT_ONE_BUTTON_TEXT,
+  [Sessions.DECK_STEP_SAVING_POINT_TWO]: POINT_TWO_BUTTON_TEXT,
+  [Sessions.DECK_STEP_SAVING_POINT_THREE]: BASE_BUTTON_TEXT,
+}
+const proceedCommandByCurrentStep: {
+  [DeckCalibrationStep]: SessionCommandString,
+} = {
+  [Sessions.DECK_STEP_SAVING_POINT_ONE]:
+    Sessions.deckCalCommands.MOVE_TO_POINT_TWO,
+  [Sessions.DECK_STEP_SAVING_POINT_TWO]:
+    Sessions.deckCalCommands.MOVE_TO_POINT_THREE,
+  [Sessions.DECK_STEP_SAVING_POINT_THREE]:
+    Sessions.deckCalCommands.MOVE_TO_TIP_RACK,
+}
 
 export function SaveXYPoint(props: CalibrateDeckChildProps): React.Node {
-  const { isMulti, mount, sendSessionCommand } = props
+  const { isMulti, mount, sendSessionCommand, currentStep } = props
 
-  // TODO: IMMEDIATELY figure out whether to map step to slots here or in parent
-  const slotNumber = '1'
-  // TODO: IMMEDIATELY similarly to map step to proceed command here or in parent
-  const proceedCommand = Sessions.deckCalCommands.MOVE_TO_POINT_TWO
+  const slotNumber = slotNumberByCurrentStep[currentStep]
+  const proceedCommand = proceedCommandByCurrentStep[currentStep]
 
   const demoAsset = React.useMemo(
     () =>
@@ -94,6 +126,8 @@ export function SaveXYPoint(props: CalibrateDeckChildProps): React.Node {
     sendSessionCommand(proceedCommand)
   }
 
+  const buttonText = buttonTextByCurrentStep[currentStep] || ''
+
   return (
     <>
       <div className={styles.modal_header}>
@@ -102,40 +136,46 @@ export function SaveXYPoint(props: CalibrateDeckChildProps): React.Node {
           {` ${SLOT} ${slotNumber || ''}`}
         </h3>
       </div>
-      <div className={styles.step_check_wrapper}>
-        <div className={styles.step_check_body_wrapper}>
-          <p className={styles.tip_pick_up_demo_body}>
-            {JOG_UNTIL}
-            <b>{` ${PRECISELY_CENTERED} `}</b>
-            {ABOVE_THE_CROSS}
-            <b>{` ${SLOT} ${slotNumber || ''}`}.</b>
-            <br />
-            <br />
-            {THEN}
-            <b>{` ${SAVE_POINT} `}</b>
-            {TO_SAVE}
-          </p>
-        </div>
-        <div className={styles.step_check_video_wrapper}>
-          <video
-            key={String(demoAsset)}
-            className={styles.step_check_video}
-            autoPlay={true}
-            loop={true}
-            controls={false}
-          >
-            <source src={demoAsset} />
-          </video>
-        </div>
-      </div>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        padding={SPACING_3}
+        border={BORDER_SOLID_LIGHT}
+        marginTop={SPACING_3}
+      >
+        <Text
+          fontSize={FONT_SIZE_BODY_2}
+          css={css`
+            align-self: center;
+          `}
+        >
+          {JOG_UNTIL}
+          <b>{` ${PRECISELY_CENTERED} `}</b>
+          {ABOVE_THE_CROSS}
+          <b>{` ${SLOT} ${slotNumber || ''}`}.</b>
+          <br />
+          <br />
+          {THEN}
+          <b>{` ${buttonText} `}</b>
+          {`${TO_SAVE} ${SLOT} ${slotNumber}`}.
+        </Text>
+        <video
+          key={String(demoAsset)}
+          className={styles.step_check_video}
+          autoPlay={true}
+          loop={true}
+          controls={false}
+        >
+          <source src={demoAsset} />
+        </video>
+      </Flex>
       <div className={styles.tip_pick_up_controls_wrapper}>
         <JogControls jog={jog} stepSizes={[0.1, 1]} axes={['x', 'y']} />
       </div>
-      <div className={styles.button_row}>
+      <Flex width="100%">
         <PrimaryButton onClick={savePoint} className={styles.command_button}>
-          {SAVE_POINT}
+          {buttonText}
         </PrimaryButton>
-      </div>
+      </Flex>
     </>
   )
 }

--- a/app/src/components/CalibrateDeck/__tests__/DeckSetup.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/DeckSetup.test.js
@@ -27,6 +27,7 @@ describe('DeckSetup', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_LABWARE_LOADED,
       } = props
       return mount(
         <DeckSetup
@@ -35,6 +36,7 @@ describe('DeckSetup', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }

--- a/app/src/components/CalibrateDeck/__tests__/Introduction.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/Introduction.test.js
@@ -26,6 +26,7 @@ describe('Introduction', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_SESSION_STARTED,
       } = props
       return mount(
         <Introduction
@@ -34,6 +35,7 @@ describe('Introduction', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }

--- a/app/src/components/CalibrateDeck/__tests__/SaveXYPoint.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/SaveXYPoint.test.js
@@ -14,9 +14,6 @@ describe('SaveXYPoint', () => {
   const mockSendCommand = jest.fn()
   const mockDeleteSession = jest.fn()
 
-  const getSaveButton = wrapper =>
-    wrapper.find('PrimaryButton[children="save x and y-axis"]').find('button')
-
   const getJogButton = (wrapper, direction) =>
     wrapper.find(`JogButton[name="${direction}"]`).find('button')
 
@@ -30,6 +27,7 @@ describe('SaveXYPoint', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_SAVING_POINT_ONE,
       } = props
       return mount(
         <SaveXYPoint
@@ -38,6 +36,7 @@ describe('SaveXYPoint', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }
@@ -140,10 +139,14 @@ describe('SaveXYPoint', () => {
     })
   })
 
-  it('sends save offset command when primary button is clicked', () => {
+  it('sends save offset and move to point two commands when current step is savingPointOne', () => {
     const wrapper = render()
 
-    act(() => getSaveButton(wrapper).invoke('onClick')())
+    act(() =>
+      wrapper
+        .find('PrimaryButton[children="save calibration and move to slot 3"]')
+        .invoke('onClick')()
+    )
     wrapper.update()
 
     expect(mockSendCommand).toHaveBeenCalledWith(
@@ -151,6 +154,44 @@ describe('SaveXYPoint', () => {
     )
     expect(mockSendCommand).toHaveBeenCalledWith(
       Sessions.deckCalCommands.MOVE_TO_POINT_TWO
+    )
+  })
+
+  it('sends save offset and move to point three commands when current step is savingPointTwo', () => {
+    const wrapper = render({ currentStep: Sessions.DECK_STEP_SAVING_POINT_TWO })
+
+    act(() =>
+      wrapper
+        .find('PrimaryButton[children="save calibration and move to slot 7"]')
+        .invoke('onClick')()
+    )
+    wrapper.update()
+
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      Sessions.deckCalCommands.SAVE_OFFSET
+    )
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      Sessions.deckCalCommands.MOVE_TO_POINT_THREE
+    )
+  })
+
+  it('sends save offset and move to tip rack commands when current step is savingPointThree', () => {
+    const wrapper = render({
+      currentStep: Sessions.DECK_STEP_SAVING_POINT_THREE,
+    })
+
+    act(() =>
+      wrapper
+        .find('PrimaryButton[children="save calibration"]')
+        .invoke('onClick')()
+    )
+    wrapper.update()
+
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      Sessions.deckCalCommands.SAVE_OFFSET
+    )
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      Sessions.deckCalCommands.MOVE_TO_TIP_RACK
     )
   })
 })

--- a/app/src/components/CalibrateDeck/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/SaveZPoint.test.js
@@ -29,6 +29,7 @@ describe('SaveZPoint', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_JOGGING_TO_DECK,
       } = props
       return mount(
         <SaveZPoint
@@ -37,6 +38,7 @@ describe('SaveZPoint', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }

--- a/app/src/components/CalibrateDeck/__tests__/TipConfirmation.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/TipConfirmation.test.js
@@ -29,6 +29,7 @@ describe('TipConfirmation', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_INSPECTING_TIP,
       } = props
       return mount(
         <TipConfirmation
@@ -37,6 +38,7 @@ describe('TipConfirmation', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }

--- a/app/src/components/CalibrateDeck/__tests__/TipPickUp.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/TipPickUp.test.js
@@ -27,6 +27,7 @@ describe('TipPickUp', () => {
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
         deleteSession = mockDeleteSession,
+        currentStep = Sessions.DECK_STEP_PREPARING_PIPETTE,
       } = props
       return mount(
         <TipPickUp
@@ -35,6 +36,7 @@ describe('TipPickUp', () => {
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
           deleteSession={deleteSession}
+          currentStep={currentStep}
         />
       )
     }

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -37,28 +37,28 @@ const EXIT = 'exit'
 const PANEL_BY_STEP: {
   [string]: React.ComponentType<CalibrateDeckChildProps>,
 } = {
-  sessionStarted: Introduction,
-  labwareLoaded: DeckSetup,
-  preparingPipette: TipPickUp,
-  inspectingTip: TipConfirmation,
-  joggingToDeck: SaveZPoint,
-  savingPointOne: SaveXYPoint,
-  savingPointTwo: SaveXYPoint,
-  savingPointThree: SaveXYPoint,
-  calibrationComplete: CompleteConfirmation,
+  [Sessions.DECK_STEP_SESSION_STARTED]: Introduction,
+  [Sessions.DECK_STEP_LABWARE_LOADED]: DeckSetup,
+  [Sessions.DECK_STEP_PREPARING_PIPETTE]: TipPickUp,
+  [Sessions.DECK_STEP_INSPECTING_TIP]: TipConfirmation,
+  [Sessions.DECK_STEP_JOGGING_TO_DECK]: SaveZPoint,
+  [Sessions.DECK_STEP_SAVING_POINT_ONE]: SaveXYPoint,
+  [Sessions.DECK_STEP_SAVING_POINT_TWO]: SaveXYPoint,
+  [Sessions.DECK_STEP_SAVING_POINT_THREE]: SaveXYPoint,
+  [Sessions.DECK_STEP_CALIBRATION_COMPLETE]: CompleteConfirmation,
 }
 const PANEL_STYLE_BY_STEP: {
   [string]: string,
 } = {
-  sessionStarted: styles.terminal_modal_contents,
-  labwareLoaded: styles.page_content_dark,
-  preparingPipette: styles.modal_contents,
-  inspectingTip: styles.modal_contents,
-  joggingToDeck: styles.modal_contents,
-  savingPointOne: styles.modal_contents,
-  savingPointTwo: styles.modal_contents,
-  savingPointThree: styles.modal_contents,
-  calibrationComplete: styles.terminal_modal_contents,
+  [Sessions.DECK_STEP_SESSION_STARTED]: styles.terminal_modal_contents,
+  [Sessions.DECK_STEP_LABWARE_LOADED]: styles.page_content_dark,
+  [Sessions.DECK_STEP_PREPARING_PIPETTE]: styles.modal_contents,
+  [Sessions.DECK_STEP_INSPECTING_TIP]: styles.modal_contents,
+  [Sessions.DECK_STEP_JOGGING_TO_DECK]: styles.modal_contents,
+  [Sessions.DECK_STEP_SAVING_POINT_ONE]: styles.modal_contents,
+  [Sessions.DECK_STEP_SAVING_POINT_TWO]: styles.modal_contents,
+  [Sessions.DECK_STEP_SAVING_POINT_THREE]: styles.modal_contents,
+  [Sessions.DECK_STEP_CALIBRATION_COMPLETE]: styles.terminal_modal_contents,
 }
 export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
   const { session, robotName, closeWizard } = props
@@ -134,6 +134,7 @@ export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
           tipRack={tipRack}
           isMulti={isMulti}
           mount={mount}
+          currentStep={currentStep}
         />
       </ModalPage>
       {showConfirmExit && (

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -5,7 +5,10 @@ import type {
   DeckCalibrationSession,
 } from '../../sessions/types'
 
-import type { DeckCalibrationLabware } from '../../sessions/deck-calibration/types'
+import type {
+  DeckCalibrationLabware,
+  DeckCalibrationStep,
+} from '../../sessions/deck-calibration/types'
 
 export type CalibrateDeckParentProps = {|
   robotName: string,
@@ -23,4 +26,5 @@ export type CalibrateDeckChildProps = {|
   tipRack: DeckCalibrationLabware,
   isMulti: boolean,
   mount: string,
+  currentStep: DeckCalibrationStep,
 |}


### PR DESCRIPTION
# Overview

Match designs for saving points one, two, and three in the deck calibration overhaul flow.

Wire up each point to actual server commands. You should now be able to step through the entire flow within the run app (with no robot effects)

Closes #6352

# Changelog

- match styling and copy of `SaveXYPoint` component to designs.  
- add `currentStep` as prop to all the child views so that `SaveXYPoint` can't map different steps to different copy/commands
- build out tests for `SaveXYPoint` component and update other component tests after addition of `currentStep` prop 

# Review requests

- step through the flow and make sure that the screens for jogging to the calibration crosses are up to spec.

# Risk assessment

low, all behind feature flag
