### PR TITLE
feat(api): Support pipette pairing for pickup and drop tip

### DIFF
--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -1,7 +1,8 @@
 import asyncio
 from contextlib import contextmanager, ExitStack
 import logging
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import (Any, Dict, List, Optional,
+                    Tuple, TYPE_CHECKING, Union, Sequence)
 try:
     import aionotify  # type: ignore
 except OSError:
@@ -108,8 +109,11 @@ class Controller:
             args = tuple()
         return self._smoothie_driver.home(*args)
 
-    def fast_home(self, axis: str, margin: float) -> Dict[str, float]:
-        return self._smoothie_driver.fast_home(axis, margin)
+    def fast_home(
+            self, axes: Sequence[str],
+            margin: float) -> Dict[str, float]:
+        converted_axes = ''.join(axes)
+        return self._smoothie_driver.fast_home(converted_axes, margin)
 
     def get_attached_instruments(
             self, expected: Dict[Mount, Union['PipetteModel', 'PipetteName']])\

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -15,7 +15,7 @@ from opentrons.types import Mount
 
 from . import modules
 from .execution_manager import ExecutionManager
-from .types import BoardRevision
+from .types import BoardRevision, Axis
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
@@ -141,13 +141,14 @@ class Controller:
                 'id': found_id}
         return to_return
 
-    def set_active_current(self, axis, amp):
+    def set_active_current(self, axis_currents: Dict[Axis, float]):
         """
         This method sets only the 'active' current, i.e., the current for an
         axis' movement. Smoothie driver automatically resets the current for
         pipette axis to a low current (dwelling current) after each move
         """
-        self._smoothie_driver.set_active_current({axis.name: amp})
+        self._smoothie_driver.set_active_current(
+            {axis.name: amp for axis, amp in axis_currents.items()})
 
     @contextmanager
     def save_current(self):

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import logging
 from threading import Event
-from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Union
+from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Union, Sequence
 from contextlib import contextmanager
 from opentrons import types
 from opentrons.config.pipette_config import (config_models,
@@ -157,7 +157,8 @@ class Simulator:
                                    for ax in checked_axes})
         return self._position
 
-    def fast_home(self, axis: str, margin: float) -> Dict[str, float]:
+    def fast_home(
+            self, axis: Sequence[str], margin: float) -> Dict[str, float]:
         for ax in axis:
             self._position[ax] = _HOME_POSITION[ax]
             self._engaged_axes[ax] = True

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -13,7 +13,7 @@ from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 
 from . import modules
 from .execution_manager import ExecutionManager
-from .types import BoardRevision
+from .types import BoardRevision, Axis
 
 
 if TYPE_CHECKING:
@@ -158,8 +158,9 @@ class Simulator:
         return self._position
 
     def fast_home(self, axis: str, margin: float) -> Dict[str, float]:
-        self._position[axis] = _HOME_POSITION[axis]
-        self._engaged_axes[axis] = True
+        for ax in axis:
+            self._position[ax] = _HOME_POSITION[ax]
+            self._engaged_axes[ax] = True
         return self._position
 
     def get_attached_instruments(
@@ -232,7 +233,7 @@ class Simulator:
                     'id': None}
         return to_return
 
-    def set_active_current(self, axis, amp):
+    def set_active_current(self, axis_currents: Dict[Axis, float]):
         pass
 
     async def watch_modules(self, register_modules: 'RegisterModules'):

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -191,6 +191,13 @@ class PipettePair(enum.Enum):
             return top_types.Mount.RIGHT
 
 
+class HardwareAction(enum.Enum):
+    DROPTIP = enum.auto()
+
+    def __str__(self):
+        return self.name
+
+
 class ExecutionCancelledError(RuntimeError):
     pass
 
@@ -200,4 +207,12 @@ class MustHomeError(RuntimeError):
 
 
 class NoTipAttachedError(RuntimeError):
+    pass
+
+
+class TipAttachedError(RuntimeError):
+    pass
+
+
+class PairedPipetteConfigValueError(RuntimeError):
     pass

--- a/api/tests/opentrons/hardware_control/test_paired_pipettes.py
+++ b/api/tests/opentrons/hardware_control/test_paired_pipettes.py
@@ -15,9 +15,9 @@ def dummy_instruments():
             'name': 'p300_single_gen2'
         },
         types.Mount.RIGHT: {
-            'model': 'p300_single_v2.0',
+            'model': 'p20_single_v2.0',
             'id': 'fake2',
-            'name': 'p300_single_gen2',
+            'name': 'p20_single_gen2',
         }
     }
     return dummy_instruments_attached
@@ -100,7 +100,7 @@ async def test_pick_up_tip(
                        Axis.Z: 218.0,     # Z retracts after pick_up
                        Axis.A: 218.0,
                        Axis.B: -14.5,
-                       Axis.C: -14.5}
+                       Axis.C: -8.5}
     await hw_api.move_to(mount, tip_position)
 
     # Note: pick_up_tip without a tip_length argument requires the pipette on
@@ -158,9 +158,10 @@ async def test_tip_action_currents(
 
     tip_length = 25.0
     await hardware_api.pick_up_tip(mount, tip_length)
+
     expected_call_list = [
         mock.call({'C': 1.0, 'B': 1.0}),
-        mock.call({'A': 0.125, 'Z': 0.125}),
+        mock.call({'A': 0.1, 'Z': 0.125}),
         mock.call({
             'X': 1.25, 'Y': 1.25, 'Z': 0.8,
             'A': 0.8, 'B': 0.05, 'C': 0.05})]
@@ -171,7 +172,7 @@ async def test_tip_action_currents(
 
     expected_call_list = [
         mock.call({'C': 1.0, 'B': 1.0}),
-        mock.call({'C': 1.25, 'B': 1.25}),
+        mock.call({'C': 1.0, 'B': 1.25}),
         mock.call({'C': 1.0, 'B': 1.0}),
         mock.call({'C': 1.0, 'B': 1.0})]
     assert mock_active_current.call_args_list == expected_call_list


### PR DESCRIPTION
# Overview

Closes #6275. This PR adds pipette pairing support to the pick up and drop tip methods of the hardware controller.

# Changelog

- Add tests for pick up and drop tip + checking current is set correctly
- Modify set active current to take in multiple axes
- Modify retract to allow for different types of axes and to support pipette pairing
- Modify `_move_plunger` to support pipette pairing 

# Review requests

Code look OK? Are the tests sufficient?

# Risk assessment

Low, new feature that is not being utilized currently.
