### PR TITLE
fix(labware-library): fix test protocol well order bug

### DIFF
--- a/labware-library/cypress/fixtures/TestLabwareProtocol.py
+++ b/labware-library/cypress/fixtures/TestLabwareProtocol.py
@@ -113,6 +113,7 @@ def run(protocol: protocol_api.ProtocolContext):
     # go to bottom last. (If there is more than one well, use the last well first
     # because the pipette is already at the last well at this point)
     for well_loc in reversed(well_locs):
+        well = test_labware.well(well_loc)
         set_speeds(RATE)
         pipette.move_to(well.bottom())
         protocol.pause("Moved to the bottom of the well")

--- a/labware-library/src/labware-creator/labwareTestProtocol.js
+++ b/labware-library/src/labware-creator/labwareTestProtocol.js
@@ -164,6 +164,7 @@ def run(protocol: protocol_api.ProtocolContext):
     # go to bottom last. (If there is more than one well, use the last well first
     # because the pipette is already at the last well at this point)
     for well_loc in reversed(well_locs):
+        well = test_labware.well(well_loc)
         set_speeds(RATE)
         pipette.move_to(well.bottom())
         protocol.pause("Moved to the bottom of the well")


### PR DESCRIPTION
# Overview

Serves as its own bug ticket

Previously, the last part of the protocol ("moved to the bottom of the well") would keep going to one well over & over. For example: it would go to `H12, H12` instead of `H12, A1`.

Now it should correctly follow the test guide PDF.

# Changelog

- Fix test protocol well order in labware creator .py protocol

# Review requests

- [ ] Confirm bug is fixed

# Risk assessment

Low. As far as I can figure, this won't break anything that users are relying on right now -- they're expecting the pipette to go to A1 at the end as the test guide states, and it's going to the wrong place. This changes the labware definition test protocol and not actual liquid handling protocols.