### PR TITLE
refactor(app): implement remaining deck cal flow components, wire up session

### DIFF
--- a/app/src/components/CalibrateDeck/CompleteConfirmation.js
+++ b/app/src/components/CalibrateDeck/CompleteConfirmation.js
@@ -8,13 +8,14 @@ import {
   ALIGN_FLEX_START,
   DIRECTION_COLUMN,
   SPACING_3,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 import styles from './styles.css'
 import type { CalibrateDeckChildProps } from './types'
 import * as Sessions from '../../sessions'
 
 const COMPLETE_HEADER = 'Deck calibration complete'
-const RETURN_TIP = 'Return tip to tip rack'
+const RETURN_TIP = 'Return tip to tip rack and exit'
 
 export function CompleteConfirmation(
   props: CalibrateDeckChildProps
@@ -24,22 +25,22 @@ export function CompleteConfirmation(
     props.deleteSession()
   }
   return (
-    <>
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        padding={SPACING_3}
-        alignItems={ALIGN_FLEX_START}
-        width="100%"
-      >
-        <Flex alignItems={ALIGN_CENTER}>
-          <Icon name="check-circle" className={styles.success_status_icon} />
-          <h3>{COMPLETE_HEADER}</h3>
-        </Flex>
-
-        <PrimaryButton marginY={SPACING_3} onClick={exitSession}>
-          {RETURN_TIP}
-        </PrimaryButton>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      padding={SPACING_3}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      alignItems={ALIGN_FLEX_START}
+      width="100%"
+      flex={1}
+    >
+      <Flex alignItems={ALIGN_CENTER} marginTop={SPACING_3}>
+        <Icon name="check-circle" className={styles.success_status_icon} />
+        <h3>{COMPLETE_HEADER}</h3>
       </Flex>
-    </>
+
+      <PrimaryButton marginY={SPACING_3} onClick={exitSession}>
+        {RETURN_TIP}
+      </PrimaryButton>
+    </Flex>
   )
 }

--- a/app/src/components/CalibrateDeck/ConfirmClearDeckModal.js
+++ b/app/src/components/CalibrateDeck/ConfirmClearDeckModal.js
@@ -1,0 +1,35 @@
+// @flow
+import * as React from 'react'
+
+import { AlertModal } from '@opentrons/components'
+
+export type ConfirmClearDeckModalProps = {|
+  cancel: () => mixed,
+  confirm: () => mixed,
+|}
+
+const HEADING = 'Clear the deck'
+const CANCEL = 'cancel'
+const CONTINUE = 'continue'
+const WARNING =
+  'Before continuing to calibrate the deck, please remove all labware and modules from the deck.'
+
+export function ConfirmClearDeckModal(
+  props: ConfirmClearDeckModalProps
+): React.Node {
+  const { cancel, confirm } = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        { children: CANCEL, onClick: cancel },
+        { children: CONTINUE, onClick: confirm },
+      ]}
+      alertOverlay
+      iconName={null}
+    >
+      {WARNING}
+    </AlertModal>
+  )
+}

--- a/app/src/components/CalibrateDeck/ConfirmExitModal.js
+++ b/app/src/components/CalibrateDeck/ConfirmExitModal.js
@@ -25,6 +25,7 @@ export function ConfirmExitModal(props: ConfirmExitModalProps): React.Node {
         { children: EXIT, onClick: exit },
       ]}
       alertOverlay
+      iconName={null}
     >
       {WARNING}
     </AlertModal>

--- a/app/src/components/CalibrateDeck/DeckSetup.js
+++ b/app/src/components/CalibrateDeck/DeckSetup.js
@@ -56,7 +56,7 @@ export function DeckSetup(props: CalibrateDeckChildProps): React.Node {
               (slot: $Values<typeof deckSlotsById>, slotId) => {
                 if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
                 const labwareDef =
-                  tipRack?.slot === slotId ? tipRack?.definition : null
+                  String(tipRack?.slot) === slotId ? tipRack?.definition : null
 
                 return labwareDef ? (
                   <CalibrationLabwareRender

--- a/app/src/components/CalibrateDeck/Introduction.js
+++ b/app/src/components/CalibrateDeck/Introduction.js
@@ -13,18 +13,21 @@ import {
   Link,
   PrimaryButton,
   Text,
+  useConditionalConfirm,
 } from '@opentrons/components'
 
 import * as Sessions from '../../sessions'
 import styles from './styles.css'
-import type { CalibrateDeckChildProps } from './types'
 import { labwareImages } from './labwareImages'
 import { getLatestLabwareDef } from '../../getLabware'
+import { Portal } from '../portal'
+import { ConfirmClearDeckModal } from './ConfirmClearDeckModal'
+import type { CalibrateDeckChildProps } from './types'
 
 const LABWARE_LIBRARY_PAGE_PATH = 'https://labware.opentrons.com'
 
-// TODO: IMMEDIATELY insert final copy
-const DECK_CAL_INTRO_BODY = ''
+const DECK_CAL_INTRO_BODY =
+  'Deck calibration ensures positional accuracy so that your robot moves as expected. It will accurately establish the OT-2’s deck orientation relative to the gantry.'
 const DECK_CALIBRATION_INTRO_HEADER = 'deck calibration'
 
 const LABWARE_REQS = 'For this process you will require:'
@@ -35,10 +38,17 @@ const NOTE_BODY =
   'important you perform this calibration using the exact tips specified in your protocol, as the robot uses the corresponding labware definition data to find the tip.'
 const VIEW_TIPRACK_MEASUREMENTS = 'View measurements'
 
-const CONTINUE = 'Continue to deck calibration'
+const CONTINUE = 'Continue to calibrate deck'
 
 export function Introduction(props: CalibrateDeckChildProps): React.Node {
   const { tipRack, sendSessionCommand } = props
+
+  const { showConfirmation, confirm: proceed, cancel } = useConditionalConfirm(
+    () => {
+      sendSessionCommand(Sessions.deckCalCommands.LOAD_LABWARE)
+    },
+    true
+  )
 
   return (
     <>
@@ -64,15 +74,15 @@ export function Introduction(props: CalibrateDeckChildProps): React.Node {
         </Box>
       </Flex>
       <Flex width="100%">
-        <PrimaryButton
-          onClick={() =>
-            sendSessionCommand(Sessions.deckCalCommands.LOAD_LABWARE)
-          }
-          className={styles.continue_button}
-        >
+        <PrimaryButton onClick={proceed} className={styles.continue_button}>
           {CONTINUE}
         </PrimaryButton>
       </Flex>
+      {showConfirmation && (
+        <Portal>
+          <ConfirmClearDeckModal confirm={proceed} cancel={cancel} />
+        </Portal>
+      )}
     </>
   )
 }

--- a/app/src/components/CalibrateDeck/SaveXYPoint.js
+++ b/app/src/components/CalibrateDeck/SaveXYPoint.js
@@ -177,7 +177,7 @@ export function SaveXYPoint(props: CalibrateDeckChildProps): React.Node {
       <div className={styles.tip_pick_up_controls_wrapper}>
         <JogControls jog={jog} stepSizes={[0.1, 1]} axes={['x', 'y']} />
       </div>
-      <Flex width="100%">
+      <Flex width="100%" marginBottom={SPACING_3}>
         <PrimaryButton onClick={savePoint} className={styles.command_button}>
           {buttonText}
         </PrimaryButton>

--- a/app/src/components/CalibrateDeck/SaveZPoint.js
+++ b/app/src/components/CalibrateDeck/SaveZPoint.js
@@ -1,6 +1,17 @@
 // @flow
 import * as React from 'react'
-import { PrimaryButton } from '@opentrons/components'
+import { css } from 'styled-components'
+import {
+  PrimaryButton,
+  Flex,
+  Text,
+  FONT_WEIGHT_SEMIBOLD,
+  FONT_SIZE_HEADER,
+  FONT_SIZE_BODY_2,
+  DIRECTION_ROW,
+  SPACING_3,
+  BORDER_SOLID_LIGHT,
+} from '@opentrons/components'
 
 import * as Sessions from '../../sessions'
 import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
@@ -25,15 +36,16 @@ const assetMap = {
   },
 }
 
-const SAVE_Z_HEADER = 'save z-axis offset'
+const HEADER = 'z-axis in slot 5'
 
 const JOG_UNTIL = 'Jog the pipette until the tip is'
 const JUST_BARELY_TOUCHING = 'barely touching (less than 0.1mm)'
 const DECK_IN = 'the deck in'
 const SLOT_5 = 'slot 5'
 const THEN = 'Then press the'
-const SAVE_POINT = 'save z-axis'
-const TO_SAVE = 'button to save z-axis calibration coordinate.'
+const BUTTON_TEXT = 'remember z-axis and move to slot 1'
+const TO_USE_Z =
+  'button to use this z position for the rest of deck calibration'
 
 export function SaveZPoint(props: CalibrateDeckChildProps): React.Node {
   const { isMulti, mount, sendSessionCommand } = props
@@ -61,40 +73,52 @@ export function SaveZPoint(props: CalibrateDeckChildProps): React.Node {
   return (
     <>
       <div className={styles.modal_header}>
-        <h3>{SAVE_Z_HEADER}</h3>
+        <Text
+          textTransform="uppercase"
+          fontWeight={FONT_WEIGHT_SEMIBOLD}
+          fontSize={FONT_SIZE_HEADER}
+        >
+          {HEADER}
+        </Text>
       </div>
-      <div className={styles.step_check_wrapper}>
-        <div className={styles.step_check_body_wrapper}>
-          <p className={styles.tip_pick_up_demo_body}>
-            {JOG_UNTIL}
-            <b>{` ${JUST_BARELY_TOUCHING} `}</b>
-            {DECK_IN}
-            <b>{` ${SLOT_5}.`}</b>
-            <br />
-            <br />
-            {THEN}
-            <b>{` ${SAVE_POINT} `}</b>
-            {TO_SAVE}
-          </p>
-        </div>
-        <div className={styles.step_check_video_wrapper}>
-          <video
-            key={demoAsset}
-            className={styles.step_check_video}
-            autoPlay={true}
-            loop={true}
-            controls={false}
-          >
-            <source src={demoAsset} />
-          </video>
-        </div>
-      </div>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        padding={SPACING_3}
+        border={BORDER_SOLID_LIGHT}
+        marginTop={SPACING_3}
+      >
+        <Text
+          fontSize={FONT_SIZE_BODY_2}
+          css={css`
+            align-self: center;
+          `}
+        >
+          {JOG_UNTIL}
+          <b>{` ${JUST_BARELY_TOUCHING} `}</b>
+          {DECK_IN}
+          <b>{SLOT_5}.</b>
+          <br />
+          <br />
+          {THEN}
+          <b>{` ${BUTTON_TEXT} `}</b>
+          {TO_USE_Z}.
+        </Text>
+        <video
+          key={demoAsset}
+          className={styles.step_check_video}
+          autoPlay={true}
+          loop={true}
+          controls={false}
+        >
+          <source src={demoAsset} />
+        </video>
+      </Flex>
       <div className={styles.tip_pick_up_controls_wrapper}>
         <JogControls jog={jog} stepSizes={[0.1, 1]} axes={['z']} />
       </div>
       <div className={styles.button_row}>
         <PrimaryButton onClick={savePoint} className={styles.command_button}>
-          {SAVE_POINT}
+          {BUTTON_TEXT}
         </PrimaryButton>
       </div>
     </>

--- a/app/src/components/CalibrateDeck/SaveZPoint.js
+++ b/app/src/components/CalibrateDeck/SaveZPoint.js
@@ -116,11 +116,11 @@ export function SaveZPoint(props: CalibrateDeckChildProps): React.Node {
       <div className={styles.tip_pick_up_controls_wrapper}>
         <JogControls jog={jog} stepSizes={[0.1, 1]} axes={['z']} />
       </div>
-      <div className={styles.button_row}>
+      <Flex width="100%" marginBottom={SPACING_3}>
         <PrimaryButton onClick={savePoint} className={styles.command_button}>
           {BUTTON_TEXT}
         </PrimaryButton>
-      </div>
+      </Flex>
     </>
   )
 }

--- a/app/src/components/CalibrateDeck/__tests__/Introduction.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/Introduction.test.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { mount } from 'enzyme'
-import { act } from 'react-dom/test-utils'
 import { mockDeckCalTipRack } from '../../../sessions/__fixtures__'
 import * as Sessions from '../../../sessions'
 
@@ -15,8 +14,14 @@ describe('Introduction', () => {
 
   const getContinueButton = wrapper =>
     wrapper
-      .find('PrimaryButton[children="Continue to deck calibration"]')
+      .find('PrimaryButton[children="Continue to calibrate deck"]')
       .find('button')
+
+  const getCancelDeckClearButton = wrapper =>
+    wrapper.find('OutlineButton[children="cancel"]').find('button')
+
+  const getConfirmDeckClearButton = wrapper =>
+    wrapper.find('OutlineButton[children="continue"]').find('button')
 
   beforeEach(() => {
     render = (props: $Shape<React.ElementProps<typeof Introduction>> = {}) => {
@@ -45,13 +50,33 @@ describe('Introduction', () => {
     jest.resetAllMocks()
   })
 
-  it('clicking continue proceeds to next step', () => {
+  it('clicking continue launches clear deck warning then confirm proceeds to next step', () => {
     const wrapper = render()
 
-    act(() => getContinueButton(wrapper).invoke('onClick')())
+    expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(false)
+    getContinueButton(wrapper).invoke('onClick')()
     wrapper.update()
+    expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(true)
+
+    getConfirmDeckClearButton(wrapper).invoke('onClick')()
 
     expect(mockSendCommand).toHaveBeenCalledWith(
+      Sessions.deckCalCommands.LOAD_LABWARE
+    )
+  })
+
+  it('clicking continue launches clear deck warning then cancel closes modal', () => {
+    const wrapper = render()
+
+    expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(false)
+    getContinueButton(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(true)
+
+    getCancelDeckClearButton(wrapper).invoke('onClick')()
+
+    expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(false)
+    expect(mockSendCommand).not.toHaveBeenCalledWith(
       Sessions.deckCalCommands.LOAD_LABWARE
     )
   })

--- a/app/src/components/CalibrateDeck/__tests__/SaveXYPoint.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/SaveXYPoint.test.js
@@ -8,6 +8,11 @@ import { mockDeckCalTipRack } from '../../../sessions/__fixtures__'
 import * as Sessions from '../../../sessions'
 import { SaveXYPoint } from '../SaveXYPoint'
 
+const currentStepBySlot = {
+  '1': Sessions.DECK_STEP_SAVING_POINT_ONE,
+  '3': Sessions.DECK_STEP_SAVING_POINT_TWO,
+  '7': Sessions.DECK_STEP_SAVING_POINT_THREE,
+}
 describe('SaveXYPoint', () => {
   let render
 
@@ -47,60 +52,57 @@ describe('SaveXYPoint', () => {
 
   it('displays proper asset', () => {
     const slot1LeftMultiSrc = 'SLOT_1_LEFT_MULTI_X-Y.webm'
-    // TODO: IMMEDIATELY Uncomment all other cases when supported in component
-    // const slot1LeftSingleSrc = 'SLOT_1_LEFT_SINGLE_X-Y.webm'
-    // const slot1RightMultiSrc = 'SLOT_1_RIGHT_MULTI_X-Y.webm'
-    // const slot1RightSingleSrc = 'SLOT_1_RIGHT_SINGLE_X-Y.webm'
-    // const slot3LeftMultiSrc = 'SLOT_3_LEFT_MULTI_X-Y.webm'
-    // const slot3LeftSingleSrc = 'SLOT_3_LEFT_SINGLE_X-Y.webm'
-    // const slot3RightMultiSrc = 'SLOT_3_RIGHT_MULTI_X-Y.webm'
-    // const slot3RightSingleSrc = 'SLOT_3_RIGHT_SINGLE_X-Y.webm'
-    // const slot7LeftMultiSrc = 'SLOT_7_LEFT_MULTI_X-Y.webm'
-    // const slot7LeftSingleSrc = 'SLOT_7_LEFT_SINGLE_X-Y.webm'
-    // const slot7RightMultiSrc = 'SLOT_7_RIGHT_MULTI_X-Y.webm'
-    // const slot7RightSingleSrc = 'SLOT_7_RIGHT_SINGLE_X-Y.webm'
+    const slot1LeftSingleSrc = 'SLOT_1_LEFT_SINGLE_X-Y.webm'
+    const slot1RightMultiSrc = 'SLOT_1_RIGHT_MULTI_X-Y.webm'
+    const slot1RightSingleSrc = 'SLOT_1_RIGHT_SINGLE_X-Y.webm'
+    const slot3LeftMultiSrc = 'SLOT_3_LEFT_MULTI_X-Y.webm'
+    const slot3LeftSingleSrc = 'SLOT_3_LEFT_SINGLE_X-Y.webm'
+    const slot3RightMultiSrc = 'SLOT_3_RIGHT_MULTI_X-Y.webm'
+    const slot3RightSingleSrc = 'SLOT_3_RIGHT_SINGLE_X-Y.webm'
+    const slot7LeftMultiSrc = 'SLOT_7_LEFT_MULTI_X-Y.webm'
+    const slot7LeftSingleSrc = 'SLOT_7_LEFT_SINGLE_X-Y.webm'
+    const slot7RightMultiSrc = 'SLOT_7_RIGHT_MULTI_X-Y.webm'
+    const slot7RightSingleSrc = 'SLOT_7_RIGHT_SINGLE_X-Y.webm'
     const assetMap: { [string]: { [Mount]: { ... }, ... }, ... } = {
       '1': {
         left: {
-          // TODO: IMMEDIATELY Uncomment other channel cases when supported in component
           multi: slot1LeftMultiSrc,
-          // single: slot1LeftSingleSrc,
+          single: slot1LeftSingleSrc,
         },
-        // TODO: IMMEDIATELY Uncomment other mount cases when supported in component
-        // right: {
-        //   multi: slot1RightMultiSrc,
-        //   single: slot1RightSingleSrc,
-        // },
+        right: {
+          multi: slot1RightMultiSrc,
+          single: slot1RightSingleSrc,
+        },
       },
-      // TODO: IMMEDIATELY Uncomment other slot cases when supported in component
-      // '3': {
-      //   left: {
-      //     multi: slot3LeftMultiSrc,
-      //     single: slot3LeftSingleSrc,
-      //   },
-      //   right: {
-      //     multi: slot3RightMultiSrc,
-      //     single: slot3RightSingleSrc,
-      //   },
-      // },
-      // '7': {
-      //   left: {
-      //     multi: slot7LeftMultiSrc,
-      //     single: slot7LeftSingleSrc,
-      //   },
-      //   right: {
-      //     multi: slot7RightMultiSrc,
-      //     single: slot7RightSingleSrc,
-      //   },
-      // },
+      '3': {
+        left: {
+          multi: slot3LeftMultiSrc,
+          single: slot3LeftSingleSrc,
+        },
+        right: {
+          multi: slot3RightMultiSrc,
+          single: slot3RightSingleSrc,
+        },
+      },
+      '7': {
+        left: {
+          multi: slot7LeftMultiSrc,
+          single: slot7LeftSingleSrc,
+        },
+        right: {
+          multi: slot7RightMultiSrc,
+          single: slot7RightSingleSrc,
+        },
+      },
     }
     Object.keys(assetMap).forEach(slotNumber => {
       const xyStep = assetMap[slotNumber]
       Object.keys(xyStep).forEach(mountString => {
         Object.keys(xyStep[mountString]).forEach(channelString => {
           const wrapper = render({
-            mount: mountString,
+            pipMount: mountString,
             isMulti: channelString === 'multi',
+            currentStep: currentStepBySlot[slotNumber],
           })
           expect(getVideo(wrapper).prop('src')).toEqual(
             xyStep[mountString][channelString]

--- a/app/src/components/CalibrateDeck/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/SaveZPoint.test.js
@@ -14,7 +14,9 @@ describe('SaveZPoint', () => {
   const mockDeleteSession = jest.fn()
 
   const getSaveButton = wrapper =>
-    wrapper.find('PrimaryButton[children="save z-axis"]').find('button')
+    wrapper
+      .find('PrimaryButton[children="remember z-axis and move to slot 1"]')
+      .find('button')
 
   const getJogButton = (wrapper, direction) =>
     wrapper.find(`JogButton[name="${direction}"]`).find('button')

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -17,7 +17,6 @@ import type {
   SessionCommandData,
   DeckCalibrationLabware,
 } from '../../sessions/types'
-import { mockDeckCalTipRack } from '../../sessions/__fixtures__/deck-calibration.js'
 import * as Sessions from '../../sessions'
 import { useDispatchApiRequest, getRequestById, PENDING } from '../../robot-api'
 import type { RequestState } from '../../robot-api/types'

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import last from 'lodash/last'
 
+import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import {
   ModalPage,
   SpinnerModalPage,
@@ -14,6 +15,7 @@ import type { State } from '../../types'
 import type {
   SessionCommandString,
   SessionCommandData,
+  DeckCalibrationLabware,
 } from '../../sessions/types'
 import { mockDeckCalTipRack } from '../../sessions/__fixtures__/deck-calibration.js'
 import * as Sessions from '../../sessions'
@@ -62,6 +64,7 @@ const PANEL_STYLE_BY_STEP: {
 }
 export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
   const { session, robotName, closeWizard } = props
+  const { currentStep, instrument, labware } = session?.details || {}
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const dispatch = useDispatch()
 
@@ -102,15 +105,17 @@ export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
     deleteSession()
   }, true)
 
-  if (!session) {
+  const isMulti = React.useMemo(() => {
+    const spec = instrument && getPipetteModelSpecs(instrument.model)
+    return spec ? spec.channels > 1 : false
+  }, [instrument])
+
+  const tipRack: DeckCalibrationLabware | null =
+    (labware && labware.find(l => l.isTiprack)) ?? null
+
+  if (!session || !tipRack) {
     return null
   }
-
-  const { currentStep } = session?.details
-  // TODO: IMMEDIATELY pull actual tipRack, isMulti, and mount from session details
-  const tipRack = mockDeckCalTipRack
-  const isMulti = false
-  const mount = 'left'
 
   const titleBarProps = {
     title: TIP_LENGTH_CALIBRATION_SUBTITLE,
@@ -133,7 +138,7 @@ export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
           deleteSession={deleteSession}
           tipRack={tipRack}
           isMulti={isMulti}
-          mount={mount}
+          mount={instrument?.mount.toLowerCase()}
           currentStep={currentStep}
         />
       </ModalPage>

--- a/app/src/components/RobotSettings/ConfirmStartDeckCalModal.js
+++ b/app/src/components/RobotSettings/ConfirmStartDeckCalModal.js
@@ -13,7 +13,7 @@ const HEADING = 'Are you sure you want to continue?'
 const CANCEL = 'cancel'
 const EXIT = 'continue'
 const WARNING =
-  'Performing a deck calibration will clear your instrument offset calibrations.'
+  'Performing a deck calibration will clear your pipette offset calibrations.'
 
 export function ConfirmStartDeckCalModal(
   props: ConfirmStartDeckCalModalProps

--- a/app/src/components/RobotSettings/ConfirmStartDeckCalModal.js
+++ b/app/src/components/RobotSettings/ConfirmStartDeckCalModal.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from 'react'
+
+import { AlertModal } from '@opentrons/components'
+import styles from './styles.css'
+
+export type ConfirmStartDeckCalModalProps = {|
+  cancel: () => mixed,
+  confirm: () => mixed,
+|}
+
+const HEADING = 'Are you sure you want to continue?'
+const CANCEL = 'cancel'
+const EXIT = 'continue'
+const WARNING =
+  'Performing a deck calibration will clear your instrument offset calibrations.'
+
+export function ConfirmStartDeckCalModal(
+  props: ConfirmStartDeckCalModalProps
+): React.Node {
+  const { cancel, confirm } = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        { children: CANCEL, onClick: cancel },
+        { children: EXIT, onClick: confirm },
+      ]}
+      alertOverlay
+      iconName={null}
+      className={styles.confirm_start_deck_cal_modal}
+    >
+      {WARNING}
+    </AlertModal>
+  )
+}

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -7,6 +7,7 @@ import {
   SecondaryBtn,
   BORDER_SOLID_LIGHT,
   SPACING_2,
+  useConditionalConfirm,
 } from '@opentrons/components'
 
 import { getFeatureFlags } from '../../config'
@@ -20,6 +21,7 @@ import { Portal } from '../portal'
 import { TitledControl } from '../TitledControl'
 import { CalibrateDeck } from '../CalibrateDeck'
 import { DeckCalibrationWarning } from './DeckCalibrationWarning'
+import { ConfirmStartDeckCalModal } from './ConfirmStartDeckCalModal'
 
 type Props = {|
   robotName: string,
@@ -78,8 +80,16 @@ export function DeckCalibrationControl(props: Props): React.Node {
     return null
   })
 
+  const {
+    showConfirmation: showConfirmStart,
+    confirm: confirmStart,
+    cancel: cancelStart,
+  } = useConditionalConfirm(() => {
+    handleStartDeckCalSession()
+  }, true)
+
   const handleButtonClick = ff.enableCalibrationOverhaul
-    ? handleStartDeckCalSession
+    ? confirmStart
     : startLegacyDeckCalibration
 
   return (
@@ -103,6 +113,14 @@ export function DeckCalibrationControl(props: Props): React.Node {
           marginTop={SPACING_2}
         />
       </TitledControl>
+      {showConfirmStart && (
+        <Portal>
+          <ConfirmStartDeckCalModal
+            confirm={confirmStart}
+            cancel={cancelStart}
+          />
+        </Portal>
+      )}
       {showWizard && (
         <Portal>
           <CalibrateDeck

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -85,9 +85,10 @@ describe('ControlsCard', () => {
   it('button launches new deck calibration after confirm if feature flag for calibration overhaul is truthy', () => {
     getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     const wrapper = render()
-    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
     getDeckCalButton(wrapper).invoke('onClick')()
-    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(true)
+    wrapper.update()
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(true)
 
     getConfirmDeckCalButton(wrapper).invoke('onClick')()
 
@@ -103,13 +104,14 @@ describe('ControlsCard', () => {
   it('button launches new deck calibration and cancel closes if feature flag for calibration overhaul is truthy', () => {
     getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     const wrapper = render()
-    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
     getDeckCalButton(wrapper).invoke('onClick')()
-    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(true)
+    wrapper.update()
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(true)
 
     getCancelDeckCalButton(wrapper).invoke('onClick')()
 
-    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
     expect(mockStore.dispatch).not.toHaveBeenCalledWith({
       ...Sessions.ensureSession(
         'robot-name',

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -26,6 +26,12 @@ describe('ControlsCard', () => {
   const getDeckCalButton = wrapper =>
     wrapper.find('TitledControl[title="Calibrate deck"]').find('button')
 
+  const getCancelDeckCalButton = wrapper =>
+    wrapper.find('OutlineButton[children="cancel"]').find('button')
+
+  const getConfirmDeckCalButton = wrapper =>
+    wrapper.find('OutlineButton[children="continue"]').find('button')
+
   beforeEach(() => {
     jest.useFakeTimers()
     mockStore = {
@@ -76,12 +82,35 @@ describe('ControlsCard', () => {
     )
   })
 
-  it('button launches new deck calibration button if feature flag for calibration overhaul is truthy', () => {
+  it('button launches new deck calibration after confirm if feature flag for calibration overhaul is truthy', () => {
     getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     const wrapper = render()
+    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
     getDeckCalButton(wrapper).invoke('onClick')()
+    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(true)
+
+    getConfirmDeckCalButton(wrapper).invoke('onClick')()
 
     expect(mockStore.dispatch).toHaveBeenCalledWith({
+      ...Sessions.ensureSession(
+        'robot-name',
+        Sessions.SESSION_TYPE_DECK_CALIBRATION
+      ),
+      meta: expect.objectContaining({ requestId: expect.any(String) }),
+    })
+  })
+
+  it('button launches new deck calibration and cancel closes if feature flag for calibration overhaul is truthy', () => {
+    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    const wrapper = render()
+    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
+    getDeckCalButton(wrapper).invoke('onClick')()
+    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(true)
+
+    getCancelDeckCalButton(wrapper).invoke('onClick')()
+
+    expect(wrapper.find('ConfirmStartDeckCalModel').exists()).toBe(false)
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith({
       ...Sessions.ensureSession(
         'robot-name',
         Sessions.SESSION_TYPE_DECK_CALIBRATION

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -94,3 +94,7 @@
     margin-right: auto;
   }
 }
+
+.confirm_start_deck_cal_modal {
+  padding: 4rem 2rem;
+}


### PR DESCRIPTION
# Overview

This implements the designs for the remaining components in the new deck calibration flow. It also
wires up the real session instrument and labware throughout the parent and child components. Copy
and styles should match the design spec.

Closes #6350, Closes #6354, Closes #6257, Closes #6255

# Changelog

- Add confirmation modal "Warning pipette offset calibrations will be deleted" before entering the flow
- Add confirmation modal after introduction screen "Clear all labware and modules from the deck"
- Finish styling and copy for `SaveZPoint` component
- Update copy across flow to match designs

# Review requests

- [ ] run through the whole flow and check designs, and correct assets/copy is rendered based on tiprack/pipette combination

# Risk assessment

low, behind feature flag