### PR TITLE
fix(app, app-shell): use mtime for custom labware date display

### DIFF
--- a/app-shell/src/labware/__tests__/definitions.test.js
+++ b/app-shell/src/labware/__tests__/definitions.test.js
@@ -112,17 +112,17 @@ describe('labware directory utilities', () => {
           {
             filename: files[0],
             data: { name: 'a' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           },
           {
             filename: files[1],
             data: { name: 'b' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           },
           {
             filename: files[2],
             data: { name: 'c' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           },
         ])
       })
@@ -145,13 +145,13 @@ describe('labware directory utilities', () => {
           {
             filename: files[0],
             data: { name: 'a' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           },
-          { filename: files[1], data: null, created: expect.any(Number) },
+          { filename: files[1], data: null, modified: expect.any(Number) },
           {
             filename: files[2],
             data: { name: 'c' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           },
         ])
       })
@@ -175,7 +175,7 @@ describe('labware directory utilities', () => {
             {
               filename: expectedName,
               data: { name: 'a' },
-              created: expect.any(Number),
+              modified: expect.any(Number),
             },
           ])
         })
@@ -203,7 +203,7 @@ describe('labware directory utilities', () => {
           expect(files).toContainEqual({
             filename: expectedName,
             data: { name: 'a' },
-            created: expect.any(Number),
+            modified: expect.any(Number),
           })
         })
     })

--- a/app-shell/src/labware/__tests__/dispatch.test.js
+++ b/app-shell/src/labware/__tests__/dispatch.test.js
@@ -126,10 +126,10 @@ describe('labware module dispatches', () => {
   it('reads and parses definition files', () => {
     const mockDirectoryListing = ['a.json', 'b.json', 'c.json', 'd.json']
     const mockParsedFiles = [
-      { filename: 'a.json', created: 0, data: {} },
-      { filename: 'b.json', created: 1, data: {} },
-      { filename: 'c.json', created: 2, data: {} },
-      { filename: 'd.json', created: 3, data: {} },
+      { filename: 'a.json', modified: 0, data: {} },
+      { filename: 'b.json', modified: 1, data: {} },
+      { filename: 'c.json', modified: 2, data: {} },
+      { filename: 'd.json', modified: 3, data: {} },
     ]
 
     readLabwareDirectory.mockResolvedValueOnce(mockDirectoryListing)
@@ -246,7 +246,7 @@ describe('labware module dispatches', () => {
 
     const mockNewUncheckedFile = {
       filename: '/path/to/labware.json',
-      created: 0,
+      modified: 0,
       data: {},
     }
 

--- a/app-shell/src/labware/__tests__/validation.test.js
+++ b/app-shell/src/labware/__tests__/validation.test.js
@@ -7,41 +7,41 @@ import validLabwareB from '@opentrons/shared-data/labware/fixtures/2/fixture_12_
 describe('validateLabwareFiles', () => {
   it('handles unparseable and invalid labware files', () => {
     const files = [
-      { filename: 'a.json', data: null, created: Date.now() },
-      { filename: 'b.json', data: { baz: 'qux' }, created: Date.now() },
+      { filename: 'a.json', data: null, modified: Date.now() },
+      { filename: 'b.json', data: { baz: 'qux' }, modified: Date.now() },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([
       {
         type: 'INVALID_LABWARE_FILE',
         filename: 'a.json',
-        created: expect.any(Number),
+        modified: expect.any(Number),
       },
       {
         type: 'INVALID_LABWARE_FILE',
         filename: 'b.json',
-        created: expect.any(Number),
+        modified: expect.any(Number),
       },
     ])
   })
 
   it('handles valid labware files', () => {
     const files = [
-      { filename: 'a.json', data: validLabwareA, created: Date.now() },
-      { filename: 'b.json', data: validLabwareB, created: Date.now() },
+      { filename: 'a.json', data: validLabwareA, modified: Date.now() },
+      { filename: 'b.json', data: validLabwareB, modified: Date.now() },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([
       {
         type: 'VALID_LABWARE_FILE',
         filename: 'a.json',
-        created: expect.any(Number),
+        modified: expect.any(Number),
         definition: validLabwareA,
       },
       {
         type: 'VALID_LABWARE_FILE',
         filename: 'b.json',
-        created: expect.any(Number),
+        modified: expect.any(Number),
         definition: validLabwareB,
       },
     ])
@@ -49,29 +49,29 @@ describe('validateLabwareFiles', () => {
 
   it('handles non-unique labware files', () => {
     const files = [
-      { filename: 'a.json', data: validLabwareA, created: 3 },
-      { filename: 'b.json', data: validLabwareB, created: 2 },
-      { filename: 'c.json', data: validLabwareA, created: 1 },
+      { filename: 'a.json', data: validLabwareA, modified: 3 },
+      { filename: 'b.json', data: validLabwareB, modified: 2 },
+      { filename: 'c.json', data: validLabwareA, modified: 1 },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([
       {
         type: 'DUPLICATE_LABWARE_FILE',
         filename: 'a.json',
-        created: 3,
+        modified: 3,
         definition: validLabwareA,
       },
       {
         type: 'VALID_LABWARE_FILE',
         filename: 'b.json',
-        created: 2,
+        modified: 2,
         definition: validLabwareB,
       },
       // oldest duplicate wins and is valid
       {
         type: 'VALID_LABWARE_FILE',
         filename: 'c.json',
-        created: 1,
+        modified: 1,
         definition: validLabwareA,
       },
     ])
@@ -80,14 +80,14 @@ describe('validateLabwareFiles', () => {
   it('handles Opentrons-standard labware files', () => {
     const opentronsDef = { ...validLabwareA, namespace: 'opentrons' }
     const files = [
-      { filename: 'a.json', data: opentronsDef, created: Date.now() },
+      { filename: 'a.json', data: opentronsDef, modified: Date.now() },
     ]
 
     expect(validateLabwareFiles(files)).toEqual([
       {
         type: 'OPENTRONS_LABWARE_FILE',
         filename: 'a.json',
-        created: expect.any(Number),
+        modified: expect.any(Number),
         definition: opentronsDef,
       },
     ])
@@ -100,13 +100,13 @@ describe('validateNewLabwareFile', () => {
     const newFile = {
       filename: 'a.json',
       data: validLabwareA,
-      created: 42,
+      modified: 42,
     }
 
     expect(validateNewLabwareFile(existing, newFile)).toEqual({
       type: 'VALID_LABWARE_FILE',
       filename: 'a.json',
-      created: 42,
+      modified: 42,
       definition: validLabwareA,
     })
   })
@@ -116,20 +116,20 @@ describe('validateNewLabwareFile', () => {
       {
         type: 'VALID_LABWARE_FILE',
         filename: 'a.json',
-        created: 42,
+        modified: 42,
         definition: validLabwareA,
       },
     ]
     const newFile = {
       filename: 'a.json',
       data: validLabwareA,
-      created: 21,
+      modified: 21,
     }
 
     expect(validateNewLabwareFile(existing, newFile)).toEqual({
       type: 'DUPLICATE_LABWARE_FILE',
       filename: 'a.json',
-      created: 21,
+      modified: 21,
       definition: validLabwareA,
     })
   })

--- a/app-shell/src/labware/definitions.js
+++ b/app-shell/src/labware/definitions.js
@@ -41,7 +41,7 @@ export function parseLabwareFiles(
 
     return Promise.all([readTask, statTask]).then(([data, stats]) => ({
       filename: f,
-      created: stats.birthtimeMs,
+      modified: stats.mtimeMs,
       data,
     }))
   })

--- a/app-shell/src/labware/validation.js
+++ b/app-shell/src/labware/validation.js
@@ -33,16 +33,16 @@ export function validateLabwareFiles(
   files: Array<UncheckedLabwareFile>
 ): Array<CheckedLabwareFile> {
   const validated = files.map<CheckedLabwareFile>(file => {
-    const { filename, data, created } = file
+    const { filename, data, modified } = file
 
     // check file against the schema
     const definition = data && validateLabwareDefinition(data)
 
     if (definition === null) {
-      return { filename, created, type: INVALID_LABWARE_FILE }
+      return { filename, modified, type: INVALID_LABWARE_FILE }
     }
 
-    const props = { filename, created, definition }
+    const props = { filename, modified, definition }
 
     return definition.namespace !== 'opentrons'
       ? ({ ...props, type: VALID_LABWARE_FILE }: ValidLabwareFile)
@@ -58,7 +58,7 @@ export function validateLabwareFiles(
 
       // if there are duplicates and this labware isn't the oldest one
       // mark it as a duplicate
-      if (duplicates.length > 1 && sortBy(duplicates, 'created')[0] !== v) {
+      if (duplicates.length > 1 && sortBy(duplicates, 'modified')[0] !== v) {
         return { type: DUPLICATE_LABWARE_FILE, ...props }
       }
     }

--- a/app/src/components/ListLabwareCard/LabwareItem.js
+++ b/app/src/components/ListLabwareCard/LabwareItem.js
@@ -36,7 +36,7 @@ export type LabwareItemProps = {|
 
 export function LabwareItem(props: LabwareItemProps): React.Node {
   const { file } = props
-  const { type, filename, created, definition = null } = file
+  const { type, filename, modified, definition = null } = file
   const apiName = definition?.parameters.loadName || NA
   const displayName = definition?.metadata.displayName || NA
   const displayCategory = definition
@@ -75,7 +75,7 @@ export function LabwareItem(props: LabwareItemProps): React.Node {
         )}
       </div>
       <p className={styles.item_date_column}>
-        {format(new Date(created), 'yyyy-MM-dd')}
+        {format(new Date(modified), 'yyyy-MM-dd')}
       </p>
     </li>
   )

--- a/app/src/components/ListLabwareCard/__tests__/LabwareItem.test.js
+++ b/app/src/components/ListLabwareCard/__tests__/LabwareItem.test.js
@@ -17,14 +17,14 @@ describe('LabwareItem', () => {
     type: CustomLabware.INVALID_LABWARE_FILE,
     filename: 'some_file.json',
     // Oct 21, 2019, 20:00:00 UTC
-    created: 1571688000000,
+    modified: 1571688000000,
   }
 
   const validFile: ValidLabwareFile = {
     type: CustomLabware.VALID_LABWARE_FILE,
     filename: 'some_file.json',
     // Oct 21, 2019, 20:00:00 UTC
-    created: 1571688000000,
+    modified: 1571688000000,
     definition: {
       ...CustomLabwareFixtures.mockDefinition,
       parameters: {

--- a/app/src/components/ListLabwareCard/__tests__/__snapshots__/LabwareList.test.js.snap
+++ b/app/src/components/ListLabwareCard/__tests__/__snapshots__/LabwareList.test.js.snap
@@ -70,7 +70,6 @@ exports[`LabwareList component renders 3`] = `
     <LabwareItem
       file={
         Object {
-          "created": 1,
           "definition": Object {
             "brand": Object {
               "brand": "Opentrons",
@@ -104,6 +103,7 @@ exports[`LabwareList component renders 3`] = `
             "wells": Object {},
           },
           "filename": "a.json",
+          "modified": 1,
           "type": "VALID_LABWARE_FILE",
         }
       }
@@ -112,8 +112,8 @@ exports[`LabwareList component renders 3`] = `
     <LabwareItem
       file={
         Object {
-          "created": 2,
           "filename": "b.json",
+          "modified": 2,
           "type": "INVALID_LABWARE_FILE",
         }
       }
@@ -122,7 +122,6 @@ exports[`LabwareList component renders 3`] = `
     <LabwareItem
       file={
         Object {
-          "created": 3,
           "definition": Object {
             "brand": Object {
               "brand": "Opentrons",
@@ -156,6 +155,7 @@ exports[`LabwareList component renders 3`] = `
             "wells": Object {},
           },
           "filename": "c.json",
+          "modified": 3,
           "type": "OPENTRONS_LABWARE_FILE",
         }
       }
@@ -164,7 +164,6 @@ exports[`LabwareList component renders 3`] = `
     <LabwareItem
       file={
         Object {
-          "created": 4,
           "definition": Object {
             "brand": Object {
               "brand": "Opentrons",
@@ -198,6 +197,7 @@ exports[`LabwareList component renders 3`] = `
             "wells": Object {},
           },
           "filename": "d.json",
+          "modified": 4,
           "type": "DUPLICATE_LABWARE_FILE",
         }
       }

--- a/app/src/custom-labware/__fixtures__/index.js
+++ b/app/src/custom-labware/__fixtures__/index.js
@@ -29,7 +29,7 @@ export const mockDefinition: LabwareDefinition2 = {
 export const mockValidLabware: Types.ValidLabwareFile = {
   type: 'VALID_LABWARE_FILE',
   filename: 'a.json',
-  created: 1,
+  modified: 1,
   definition: {
     ...mockDefinition,
     metadata: {
@@ -43,13 +43,13 @@ export const mockValidLabware: Types.ValidLabwareFile = {
 export const mockInvalidLabware: Types.InvalidLabwareFile = {
   type: 'INVALID_LABWARE_FILE',
   filename: 'b.json',
-  created: 2,
+  modified: 2,
 }
 
 export const mockOpentronsLabware: Types.OpentronsLabwareFile = {
   type: 'OPENTRONS_LABWARE_FILE',
   filename: 'c.json',
-  created: 3,
+  modified: 3,
   definition: {
     ...mockDefinition,
     namespace: 'opentrons',
@@ -64,7 +64,7 @@ export const mockOpentronsLabware: Types.OpentronsLabwareFile = {
 export const mockDuplicateLabware: Types.DuplicateLabwareFile = {
   type: 'DUPLICATE_LABWARE_FILE',
   filename: 'd.json',
-  created: 4,
+  modified: 4,
   definition: {
     ...mockDefinition,
     metadata: {

--- a/app/src/custom-labware/__tests__/actions.test.js
+++ b/app/src/custom-labware/__tests__/actions.test.js
@@ -23,15 +23,15 @@ describe('custom labware actions', () => {
       creator: actions.customLabwareList,
       args: [
         [
-          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 },
-          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 1 },
+          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', modified: 0 },
+          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', modified: 1 },
         ],
       ],
       expected: {
         type: 'labware:CUSTOM_LABWARE_LIST',
         payload: [
-          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 },
-          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', created: 1 },
+          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', modified: 0 },
+          { type: 'INVALID_LABWARE_FILE', filename: 'b.json', modified: 1 },
         ],
         meta: { source: 'poll' },
       },
@@ -40,13 +40,13 @@ describe('custom labware actions', () => {
       name: 'customLabwareList from source',
       creator: actions.customLabwareList,
       args: [
-        [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 }],
+        [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', modified: 0 }],
         'changeDirectory',
       ],
       expected: {
         type: 'labware:CUSTOM_LABWARE_LIST',
         payload: [
-          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 },
+          { type: 'INVALID_LABWARE_FILE', filename: 'a.json', modified: 0 },
         ],
         meta: { source: 'changeDirectory' },
       },
@@ -103,7 +103,7 @@ describe('custom labware actions', () => {
     {
       name: 'addCustomLabwareFailure with failed labware',
       creator: actions.addCustomLabwareFailure,
-      args: [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', created: 0 }],
+      args: [{ type: 'INVALID_LABWARE_FILE', filename: 'a.json', modified: 0 }],
       expected: {
         type: 'labware:ADD_CUSTOM_LABWARE_FAILURE',
         payload: {
@@ -111,7 +111,7 @@ describe('custom labware actions', () => {
           labware: {
             type: 'INVALID_LABWARE_FILE',
             filename: 'a.json',
-            created: 0,
+            modified: 0,
           },
         },
       },

--- a/app/src/custom-labware/types.js
+++ b/app/src/custom-labware/types.js
@@ -6,7 +6,7 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 type LabwareFileProps = {|
   filename: string,
-  created: number,
+  modified: number,
 |}
 
 type ValidatedLabwareProps = {|


### PR DESCRIPTION
The custom labware screen in the more tab currently displays the create
time of each custom labware file, using node fs.birthtimeMs. This has a
couple problems, like
- it may use the date the file was created originally (e.g. passing it
around in a zip file may save the original file metadata, on some
filesystems)
- since we update labware by overwriting the file, on some operating
systems or filesystems this may actually overwrite the contents of the
file rather than deleting and creating a new file, which would leave the
creation time unchanged.

The second is particularly pernicious, since the time displayed in the
labware card is the only way the user can tell the file has changed.

We can solve this by using the file modification time.

Closes #6381

## Testing
On Windows and OSX (I developed and tested this on fedora),
- Either have some custom labware already added, or set your clock to the past, add it, and set the clock back to the present
- Note that the time displayed by the labware is now in the past
- Update that labware, by adding a file with the same name
- Note that the time is now today
- Add a new piece of labware, just to doublecheck, and note that the time is now today