### PR TITLE
feat(protocol-designer): export airgap protocols as v5

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -91,13 +91,15 @@ export const getIsV4Protocol: Selector<boolean> = createSelector(
   }
 )
 
-const requiresV5 = (command: Command): boolean =>
-  command.command === 'moveToWell'
+// Note: though airGap is supported in the v4 executor, we want to simplify things
+// for users in terms of managing robot stack upgrades, so we will force v5
+const _requiresV5 = (command: Command): boolean =>
+  command.command === 'moveToWell' || command.command === 'airGap'
 export const getRequiresV5: Selector<boolean> = createSelector(
   getRobotStateTimelineWithoutAirGapDispenseCommand,
   robotStateTimeline => {
     return robotStateTimeline.timeline.some(timelineFrame =>
-      timelineFrame.commands.some(command => requiresV5(command))
+      timelineFrame.commands.some(command => _requiresV5(command))
     )
   }
 )


### PR DESCRIPTION
# Overview

Closes #6400

# Changelog


# Review requests

Should be covered in tests but might want to check:
- exporting protocol with no modules, no delay advanced setting, no air gap: schema v3
- modules (still no delay/airGap): schema v4
- delay and/or airGap: schema v5

# Risk assessment

Low, should have coverage, PD only