### PR TITLE
fix(api): correct Deck.get_slot_center z value

### DIFF
--- a/api/src/opentrons/protocol_api/geometry.py
+++ b/api/src/opentrons/protocol_api/geometry.py
@@ -420,7 +420,7 @@ class Deck(UserDict):
         return types.Point(
             defn['position'][0] + defn['boundingBox']['xDimension']/2,
             defn['position'][1] + defn['boundingBox']['yDimension']/2,
-            defn['position'][2] + defn['boundingBox']['yDimension']/2)
+            defn['position'][2] + defn['boundingBox']['zDimension']/2)
 
     def resolve_module_location(
             self, module_type: ModuleType,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes the z value for `Deck.get_slot_center()` by using the z-Dimension of the bounding box of the slot.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->


# Risk assessment
Low. All of the z values returned by this method in our code base are not really being used in any way.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
