### PR TITLE
feat(protocol-designer): add 3.20 export warning modal

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -210,8 +210,6 @@ export function FileSidebar(props: Props): React.Node {
       modulesWithoutStep,
     })
 
-  // type T = {| isV4: boolean |}
-
   const getExportHintContent = (): {|
     hintKey: HintKey,
     content: React.Node,

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -37,8 +37,7 @@ type Props = {|
   pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>,
   modulesOnDeck: $PropertyType<InitialDeckSetup, 'modules'>,
   savedStepForms: SavedStepFormState,
-  requiresAtLeastV4Protocol: boolean,
-  requiresAtLeastV5Protocol: boolean,
+  schemaVersion: number,
 |}
 
 const saveFile = (downloadData: $PropertyType<Props, 'downloadData'>) => {
@@ -175,8 +174,7 @@ export function FileSidebar(props: Props): React.Node {
     modulesOnDeck,
     pipettesOnDeck,
     savedStepForms,
-    requiresAtLeastV4Protocol,
-    requiresAtLeastV5Protocol,
+    schemaVersion,
   } = props
   const [
     showExportWarningModal,
@@ -215,10 +213,11 @@ export function FileSidebar(props: Props): React.Node {
     content: React.Node,
   |} => {
     return {
-      hintKey: requiresAtLeastV5Protocol
-        ? 'export_v5_protocol_3_20'
-        : 'export_v4_protocol_3_18',
-      content: requiresAtLeastV5Protocol ? v5WarningContent : v4WarningContent,
+      hintKey:
+        schemaVersion === 5
+          ? 'export_v5_protocol_3_20'
+          : 'export_v4_protocol_3_18',
+      content: schemaVersion === 5 ? v5WarningContent : v4WarningContent,
     }
   }
 
@@ -258,7 +257,7 @@ export function FileSidebar(props: Props): React.Node {
                 children: 'CONTINUE WITH EXPORT',
                 className: modalStyles.long_button,
                 onClick: () => {
-                  if (requiresAtLeastV4Protocol || requiresAtLeastV5Protocol) {
+                  if (schemaVersion > 3) {
                     setShowExportWarningModal(false)
                     setShowBlockingHint(true)
                   } else {
@@ -290,10 +289,7 @@ export function FileSidebar(props: Props): React.Node {
                 if (hasWarning) {
                   scrollToTop()
                   setShowExportWarningModal(true)
-                } else if (
-                  requiresAtLeastV4Protocol ||
-                  requiresAtLeastV5Protocol
-                ) {
+                } else if (schemaVersion > 3) {
                   scrollToTop()
                   setShowBlockingHint(true)
                 } else {

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.js
@@ -45,8 +45,7 @@ describe('FileSidebar', () => {
       pipettesOnDeck: {},
       modulesOnDeck: {},
       savedStepForms: {},
-      requiresAtLeastV4Protocol: false,
-      requiresAtLeastV5Protocol: false,
+      schemaVersion: 3,
     }
 
     commands = [
@@ -222,9 +221,7 @@ describe('FileSidebar', () => {
 
     mockUseBlockingHint.mockReturnValue(<MockHintComponent />)
 
-    const wrapper = mount(
-      <FileSidebar {...props} requiresAtLeastV4Protocol={true} />
-    )
+    const wrapper = mount(<FileSidebar {...props} schemaVersion={4} />)
 
     expect(wrapper.exists(MockHintComponent)).toEqual(true)
     // Before save button is clicked, enabled should be false
@@ -259,9 +256,7 @@ describe('FileSidebar', () => {
 
     mockUseBlockingHint.mockReturnValue(<MockHintComponent />)
 
-    const wrapper = mount(
-      <FileSidebar {...props} requiresAtLeastV5Protocol={true} />
-    )
+    const wrapper = mount(<FileSidebar {...props} schemaVersion={5} />)
 
     expect(wrapper.exists(MockHintComponent)).toEqual(true)
     // Before save button is clicked, enabled should be false

--- a/protocol-designer/src/components/FileSidebar/index.js
+++ b/protocol-designer/src/components/FileSidebar/index.js
@@ -23,8 +23,7 @@ type SP = {|
   pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>,
   modulesOnDeck: $PropertyType<InitialDeckSetup, 'modules'>,
   savedStepForms: SavedStepFormState,
-  requiresAtLeastV4Protocol: boolean,
-  requiresAtLeastV5Protocol: boolean,
+  schemaVersion: number,
 |}
 
 export const FileSidebar: React.AbstractComponent<{||}> = connect<
@@ -59,8 +58,7 @@ function mapStateToProps(state: BaseState): SP {
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
-    requiresAtLeastV4Protocol: fileDataSelectors.getRequiresAtLeastV4(state),
-    requiresAtLeastV5Protocol: fileDataSelectors.getRequiresAtLeastV5(state),
+    schemaVersion: fileDataSelectors.getExportedFileSchemaVersion(state),
   }
 }
 
@@ -76,8 +74,7 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    requiresAtLeastV4Protocol,
-    requiresAtLeastV5Protocol,
+    schemaVersion,
   } = stateProps
   const { dispatch } = dispatchProps
   return {
@@ -98,7 +95,6 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    requiresAtLeastV4Protocol,
-    requiresAtLeastV5Protocol,
+    schemaVersion,
   }
 }

--- a/protocol-designer/src/components/FileSidebar/index.js
+++ b/protocol-designer/src/components/FileSidebar/index.js
@@ -23,7 +23,8 @@ type SP = {|
   pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>,
   modulesOnDeck: $PropertyType<InitialDeckSetup, 'modules'>,
   savedStepForms: SavedStepFormState,
-  isV4Protocol: boolean,
+  requiresAtLeastV4Protocol: boolean,
+  requiresAtLeastV5Protocol: boolean,
 |}
 
 export const FileSidebar: React.AbstractComponent<{||}> = connect<
@@ -58,7 +59,8 @@ function mapStateToProps(state: BaseState): SP {
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
-    isV4Protocol: fileDataSelectors.getIsV4Protocol(state),
+    requiresAtLeastV4Protocol: fileDataSelectors.getRequiresAtLeastV4(state),
+    requiresAtLeastV5Protocol: fileDataSelectors.getRequiresAtLeastV5(state),
   }
 }
 
@@ -74,7 +76,8 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    isV4Protocol,
+    requiresAtLeastV4Protocol,
+    requiresAtLeastV5Protocol,
   } = stateProps
   const { dispatch } = dispatchProps
   return {
@@ -95,6 +98,7 @@ function mergeProps(
     pipettesOnDeck,
     modulesOnDeck,
     savedStepForms,
-    isV4Protocol,
+    requiresAtLeastV4Protocol,
+    requiresAtLeastV5Protocol,
   }
 }

--- a/protocol-designer/src/file-data/__tests__/createFile.test.js
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.js
@@ -5,7 +5,7 @@ import protocolV3Schema from '@opentrons/shared-data/protocol/schemas/3.json'
 import protocolV4Schema from '@opentrons/shared-data/protocol/schemas/4.json'
 import protocolV5Schema from '@opentrons/shared-data/protocol/schemas/5.json'
 import labwareV2Schema from '@opentrons/shared-data/labware/schemas/2.json'
-import { createFile, getRequiresV5 } from '../selectors'
+import { createFile, getRequiresAtLeastV5 } from '../selectors'
 import {
   fileMetadata,
   dismissedWarnings,
@@ -101,7 +101,7 @@ describe('createFile selector', () => {
     expect(!isEmpty(result.pipettes)).toBe(true)
   })
 
-  it('should return a schema-valid JSON V5 protocol, if getRequiresV5 returns true', () => {
+  it('should return a schema-valid JSON V5 protocol, if getRequiresAtLeastV5 returns true', () => {
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
     const result = createFile.resultFunc(
       fileMetadata,
@@ -130,7 +130,7 @@ describe('createFile selector', () => {
   })
 })
 
-describe('getRequiresV5', () => {
+describe('getRequiresAtLeastV5', () => {
   it('should return true if protocol has airGap', () => {
     const airGapTimeline = {
       timeline: [
@@ -152,7 +152,7 @@ describe('getRequiresV5', () => {
       ],
     }
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresV5.resultFunc(airGapTimeline)).toBe(true)
+    expect(getRequiresAtLeastV5.resultFunc(airGapTimeline)).toBe(true)
   })
 
   it('should return true if protocol has moveToWell', () => {
@@ -178,13 +178,13 @@ describe('getRequiresV5', () => {
       ],
     }
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresV5.resultFunc(moveToWellTimeline)).toBe(true)
+    expect(getRequiresAtLeastV5.resultFunc(moveToWellTimeline)).toBe(true)
   })
   it('should return false if protocol has no airGap and no moveToWell', () => {
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresV5.resultFunc(noModules.robotStateTimeline)).toBe(false)
+    expect(getRequiresAtLeastV5.resultFunc(noModules.robotStateTimeline)).toBe(false)
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresV5.resultFunc(engageMagnet.robotStateTimeline)).toBe(
+    expect(getRequiresAtLeastV5.resultFunc(engageMagnet.robotStateTimeline)).toBe(
       false
     )
   })

--- a/protocol-designer/src/file-data/__tests__/createFile.test.js
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.js
@@ -182,10 +182,12 @@ describe('getRequiresAtLeastV5', () => {
   })
   it('should return false if protocol has no airGap and no moveToWell', () => {
     // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresAtLeastV5.resultFunc(noModules.robotStateTimeline)).toBe(false)
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-    expect(getRequiresAtLeastV5.resultFunc(engageMagnet.robotStateTimeline)).toBe(
+    expect(getRequiresAtLeastV5.resultFunc(noModules.robotStateTimeline)).toBe(
       false
     )
+    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    expect(
+      getRequiresAtLeastV5.resultFunc(engageMagnet.robotStateTimeline)
+    ).toBe(false)
   })
 })

--- a/protocol-designer/src/file-data/__tests__/createFile.test.js
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.js
@@ -185,8 +185,8 @@ describe('getRequiresAtLeastV5', () => {
     expect(getRequiresAtLeastV5.resultFunc(noModules.robotStateTimeline)).toBe(
       false
     )
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
     expect(
+      // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
       getRequiresAtLeastV5.resultFunc(engageMagnet.robotStateTimeline)
     ).toBe(false)
   })

--- a/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.js
+++ b/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.js
@@ -9,9 +9,11 @@ describe('getExportedFileSchemaVersion selector', () => {
     expect(getExportedFileSchemaVersion.resultFunc(true, true)).toBe(5)
   })
   it('should return 4 when getRequiresAtLeastV4 is true and getRequiresAtLeastV5 is false', () => {
+    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
     expect(getExportedFileSchemaVersion.resultFunc(true, false)).toBe(4)
   })
   it('should return 3 when neither is true', () => {
+    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
     expect(getExportedFileSchemaVersion.resultFunc(false, false)).toBe(3)
   })
 })

--- a/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.js
+++ b/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.js
@@ -1,0 +1,17 @@
+// @flow
+import { getExportedFileSchemaVersion } from '../selectors/fileCreator'
+
+describe('getExportedFileSchemaVersion selector', () => {
+  it('should return 5 when getRequiresAtLeastV5 is true', () => {
+    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    expect(getExportedFileSchemaVersion.resultFunc(false, true)).toBe(5)
+    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    expect(getExportedFileSchemaVersion.resultFunc(true, true)).toBe(5)
+  })
+  it('should return 4 when getRequiresAtLeastV4 is true and getRequiresAtLeastV5 is false', () => {
+    expect(getExportedFileSchemaVersion.resultFunc(true, false)).toBe(4)
+  })
+  it('should return 3 when neither is true', () => {
+    expect(getExportedFileSchemaVersion.resultFunc(false, false)).toBe(3)
+  })
+})

--- a/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.js
+++ b/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.js
@@ -1,12 +1,12 @@
 // @flow
-import { getIsV4Protocol } from '../selectors/fileCreator'
+import { getRequiresAtLeastV4 } from '../selectors/fileCreator'
 import {
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
 } from '@opentrons/shared-data'
 import type { ModuleEntities } from '../../step-forms'
 
-describe('getIsV4Protocol selector', () => {
+describe('getRequiresAtLeastV4 selector', () => {
   const testCases: Array<{|
     testName: string,
     robotStateTimeline: {
@@ -48,7 +48,7 @@ describe('getIsV4Protocol selector', () => {
     ({ testName, robotStateTimeline, moduleEntities, expected }) => {
       it(testName, () => {
         // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
-        const result = getIsV4Protocol.resultFunc(
+        const result = getRequiresAtLeastV4.resultFunc(
           robotStateTimeline,
           moduleEntities
         )

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -78,7 +78,7 @@ export const getRobotStateTimelineWithoutAirGapDispenseCommand: Selector<Timelin
  ** without having module entities b/c this will produce "no module for this step"
  ** form/timeline errors. Checking for v4 commands should be redundant,
  ** we do it just in case non-V3 commands somehow sneak in despite having no modules. */
-export const getIsV4Protocol: Selector<boolean> = createSelector(
+export const getRequiresAtLeastV4: Selector<boolean> = createSelector(
   getRobotStateTimelineWithoutAirGapDispenseCommand,
   stepFormSelectors.getModuleEntities,
   (robotStateTimeline, moduleEntities) => {
@@ -95,7 +95,7 @@ export const getIsV4Protocol: Selector<boolean> = createSelector(
 // for users in terms of managing robot stack upgrades, so we will force v5
 const _requiresV5 = (command: Command): boolean =>
   command.command === 'moveToWell' || command.command === 'airGap'
-export const getRequiresV5: Selector<boolean> = createSelector(
+export const getRequiresAtLeastV5: Selector<boolean> = createSelector(
   getRobotStateTimelineWithoutAirGapDispenseCommand,
   robotStateTimeline => {
     return robotStateTimeline.timeline.some(timelineFrame =>
@@ -119,8 +119,8 @@ export const createFile: Selector<PDProtocolFile> = createSelector(
   stepFormSelectors.getPipetteEntities,
   uiLabwareSelectors.getLabwareNicknamesById,
   labwareDefSelectors.getLabwareDefsByURI,
-  getIsV4Protocol,
-  getRequiresV5,
+  getRequiresAtLeastV4,
+  getRequiresAtLeastV5,
   (
     fileMetadata,
     initialRobotState,
@@ -135,8 +135,8 @@ export const createFile: Selector<PDProtocolFile> = createSelector(
     pipetteEntities,
     labwareNicknamesById,
     labwareDefsByURI,
-    isV4Protocol,
-    requiresV5
+    requiresAtLeastV4Protocol,
+    requiresAtLeastV5Protocol
   ) => {
     const { author, description, created } = fileMetadata
     const name = fileMetadata.protocolName || 'untitled'
@@ -248,7 +248,7 @@ export const createFile: Selector<PDProtocolFile> = createSelector(
       labwareDefinitions,
     }
 
-    if (requiresV5) {
+    if (requiresAtLeastV5Protocol) {
       return {
         ...protocolFile,
         $otSharedSchema: '#/protocol/schemas/5',
@@ -256,7 +256,7 @@ export const createFile: Selector<PDProtocolFile> = createSelector(
         modules,
         commands,
       }
-    } else if (isV4Protocol) {
+    } else if (requiresAtLeastV4Protocol) {
       return {
         ...protocolFile,
         $otSharedSchema: '#/protocol/schemas/4',

--- a/protocol-designer/src/file-data/selectors/fileCreator.js
+++ b/protocol-designer/src/file-data/selectors/fileCreator.js
@@ -103,6 +103,19 @@ export const getRequiresAtLeastV5: Selector<boolean> = createSelector(
     )
   }
 )
+export const getExportedFileSchemaVersion: Selector<number> = createSelector(
+  getRequiresAtLeastV4,
+  getRequiresAtLeastV5,
+  (requiresV4, requiresV5) => {
+    if (requiresV5) {
+      return 5
+    } else if (requiresV4) {
+      return 4
+    } else {
+      return 3
+    }
+  }
+)
 
 // $FlowFixMe(IL, 2020-03-02): presence of non-v3 commands should make 'isV4Protocol' true
 export const createFile: Selector<PDProtocolFile> = createSelector(

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -38,7 +38,7 @@
     },
     "export_v5_protocol_3_20": {
       "title": "Robot and app update may be required",
-      "body1": "This protocol uses settings that can only run on app and robot server version 3.20 or higher. Please ensure your OT-2 is updated to the correct version",
+      "body1": "This protocol uses settings that can only run on app and robot server version",
       "body2": "3.20 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -36,6 +36,12 @@
       "body2": "3.18 or higher",
       "body3": ". Please ensure your OT-2 is updated to the correct version."
     },
+    "export_v5_protocol_3_20": {
+      "title": "Robot and app update may be required",
+      "body1": "This protocol uses settings that can only run on app and robot server version 3.20 or higher. Please ensure your OT-2 is updated to the correct version",
+      "body2": "3.20 or higher",
+      "body3": ". Please ensure your OT-2 is updated to the correct version."
+    },
     "change_magnet_module_model": {
       "title": "All existing engage heights will be cleared"
     },

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -12,6 +12,7 @@ type HintKey =
   // blocking hints
   | 'custom_labware_with_modules'
   | 'export_v4_protocol_3_18'
+  | 'export_v5_protocol_3_20'
   | 'change_magnet_module_model'
 
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)


### PR DESCRIPTION
# Overview

This PR closes #6278 by adding a 3.20 export warning modal if the user attempts to export a protocol with an air gap or a delay.

# Changelog

- Add 3.20 export warning modal 

# Review requests
- Export protocol with no modules, no air gap/delays, export modal should not show up
- Export protocol with modules, no air gap/delays, export 3.18 export modal should show up
- Export protocol with air gap/delays, export 3.20 export modal should show up

# Risk assessment
Low
