### PR TITLE
test(protocol-designer): add tests with all advanced settings enabled

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -890,6 +890,7 @@ describe('consolidate single-channel', () => {
       )
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // Pre-wet
         {
           command: 'aspirate',
           params: {
@@ -924,6 +925,7 @@ describe('consolidate single-channel', () => {
             wait: 12,
           },
         },
+        // First aspirate: source well A1
         {
           command: 'aspirate',
           params: {
@@ -963,6 +965,7 @@ describe('consolidate single-channel', () => {
             offsetFromBottomMm: 14.5,
           },
         },
+        // Air Gap: after aspirating from A1
         {
           command: 'airGap',
           params: {
@@ -980,6 +983,7 @@ describe('consolidate single-channel', () => {
             wait: 11,
           },
         },
+        // Second aspirate: source well A2
         {
           command: 'aspirate',
           params: {
@@ -1019,6 +1023,7 @@ describe('consolidate single-channel', () => {
             offsetFromBottomMm: 14.5,
           },
         },
+        // Air Gap: after aspirating from A2
         {
           command: 'airGap',
           params: {
@@ -1036,6 +1041,7 @@ describe('consolidate single-channel', () => {
             wait: 11,
           },
         },
+        // Dispense full air + liquid volume all together to dest well (45+31+45+31 = 152uL)
         {
           command: 'dispense',
           params: {
@@ -1066,6 +1072,7 @@ describe('consolidate single-channel', () => {
             wait: 12,
           },
         },
+        // Mix (disp)
         {
           command: 'aspirate',
           params: {
@@ -1100,6 +1107,7 @@ describe('consolidate single-channel', () => {
             wait: 12,
           },
         },
+        // Touch tip (disp)
         {
           command: 'touchTip',
           params: {
@@ -1109,6 +1117,7 @@ describe('consolidate single-channel', () => {
             offsetFromBottomMm: 3.4,
           },
         },
+        // Blowout to trash
         {
           command: 'blowout',
           params: {

--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -863,10 +863,6 @@ describe('consolidate single-channel', () => {
         volume: 45,
         // aspirate column
         preWetTip: true,
-        mixBeforeAspirate: {
-          volume: 35,
-          times: 1,
-        },
         aspirateDelay: { seconds: 11, mmFromBottom: 15 },
         touchTipAfterAspirate: true,
         touchTipAfterAspirateOffsetMmFromBottom: 14.5,

--- a/protocol-designer/src/step-generation/__tests__/consolidate.test.js
+++ b/protocol-designer/src/step-generation/__tests__/consolidate.test.js
@@ -852,6 +852,276 @@ describe('consolidate single-channel', () => {
       dispenseHelper('B1', 155),
     ])
   })
+
+  describe('all advanced settings enabled', () => {
+    it('should create commands in the expected order with expected params', () => {
+      const args = {
+        ...mixinArgs,
+        sourceWells: ['A1', 'A2'],
+        destWell: 'B1',
+        changeTip: 'never',
+        volume: 45,
+        // aspirate column
+        preWetTip: true,
+        mixBeforeAspirate: {
+          volume: 35,
+          times: 1,
+        },
+        aspirateDelay: { seconds: 11, mmFromBottom: 15 },
+        touchTipAfterAspirate: true,
+        touchTipAfterAspirateOffsetMmFromBottom: 14.5,
+        aspirateAirGapVolume: 31,
+        // dispense column
+        dispenseDelay: { seconds: 12, mmFromBottom: 14 },
+        mixInDestination: {
+          volume: 36,
+          times: 1,
+        },
+        touchTipAfterDispense: true,
+        blowoutLocation: 'trashId',
+        blowoutFlowRateUlSec: 2.3,
+        blowoutOffsetFromTopMm: 3.3,
+      }
+
+      const result = consolidate(
+        args,
+        invariantContext,
+        robotStatePickedUpOneTip
+      )
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'sourcePlateId',
+            well: 'A2',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A2',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A2',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A2',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 152,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 80.3,
+          },
+        },
+      ])
+    })
+  })
 })
 
 describe('consolidate multi-channel', () => {

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -755,7 +755,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
 
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
-      console.log(JSON.stringify(res.commands, null, 4))
       expect(res.commands).toEqual([
         {
           command: 'aspirate',

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -722,6 +722,239 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       ...delayWithOffset('A5', DEST_LABWARE),
     ])
   })
+
+  describe('all advanced settings enabled', () => {
+    it('should create commands in the expected order with expected params', () => {
+      const args = {
+        ...mixinArgs,
+        sourceWell: 'A1',
+        destWells: ['B1', 'B2'],
+        changeTip: 'never',
+        volume: 45,
+        // aspirate column
+        preWetTip: true,
+        mixBeforeAspirate: {
+          volume: 35,
+          times: 1,
+        },
+        aspirateDelay: { seconds: 11, mmFromBottom: 15 },
+        touchTipAfterAspirate: true,
+        touchTipAfterAspirateOffsetMmFromBottom: 14.5,
+        aspirateAirGapVolume: 31,
+        // dispense column
+        dispenseDelay: { seconds: 12, mmFromBottom: 14 },
+        mixInDestination: {
+          volume: 36,
+          times: 1,
+        },
+        touchTipAfterDispense: true,
+        blowoutLocation: 'trashId',
+        blowoutFlowRateUlSec: 2.3,
+        blowoutOffsetFromTopMm: 3.3,
+      }
+
+      const result = distribute(args, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      console.log(JSON.stringify(res.commands, null, 4))
+      expect(res.commands).toEqual([
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 150,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 45,
+            labware: 'destPlateId',
+            well: 'B2',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B2',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B2',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 80.3,
+          },
+        },
+      ])
+    })
+  })
 })
 
 describe('invalid input + state errors', () => {

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -752,6 +752,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // mix (asp)
         {
           command: 'aspirate',
           params: {
@@ -786,6 +787,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             wait: 12,
           },
         },
+        // aspirate
         {
           command: 'aspirate',
           params: {
@@ -816,6 +818,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             wait: 11,
           },
         },
+        // touch tip (asp)
         {
           command: 'touchTip',
           params: {
@@ -825,6 +828,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             offsetFromBottomMm: 14.5,
           },
         },
+        // air gap
         {
           command: 'airGap',
           params: {
@@ -842,6 +846,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             wait: 11,
           },
         },
+        // dispense #1
         {
           command: 'dispenseAirGap',
           params: {
@@ -889,6 +894,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             wait: 12,
           },
         },
+        // touch tip (disp #1)
         {
           command: 'touchTip',
           params: {
@@ -898,6 +904,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             offsetFromBottomMm: 3.4,
           },
         },
+        // dispense #2
         {
           command: 'dispense',
           params: {
@@ -928,6 +935,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             wait: 12,
           },
         },
+        // touch tip (disp #2)
         {
           command: 'touchTip',
           params: {
@@ -937,6 +945,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
             offsetFromBottomMm: 3.4,
           },
         },
+        // blowout
         {
           command: 'blowout',
           params: {

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -743,10 +743,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         aspirateAirGapVolume: 31,
         // dispense column
         dispenseDelay: { seconds: 12, mmFromBottom: 14 },
-        mixInDestination: {
-          volume: 36,
-          times: 1,
-        },
         touchTipAfterDispense: true,
         blowoutLocation: 'trashId',
         blowoutFlowRateUlSec: 2.3,

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -857,4 +857,455 @@ describe('advanced options', () => {
       ])
     })
   })
+
+  describe('all advanced settings enabled', () => {
+    it('should create commands in the expected order with expected params', () => {
+      const args = {
+        ...mixinArgs,
+        sourceWells: ['A1'],
+        destWells: ['B1'],
+        changeTip: 'never',
+        volume: 350,
+        // aspirate column
+        preWetTip: true,
+        mixBeforeAspirate: {
+          volume: 35,
+          times: 1,
+        },
+        aspirateDelay: { seconds: 11, mmFromBottom: 15 },
+        touchTipAfterAspirate: true,
+        touchTipAfterAspirateOffsetMmFromBottom: 14.5,
+        aspirateAirGapVolume: 31,
+        // dispense column
+        dispenseDelay: { seconds: 12, mmFromBottom: 14 },
+        mixInDestination: {
+          volume: 36,
+          times: 1,
+        },
+        touchTipAfterDispense: true,
+        blowoutLocation: 'trashId',
+        blowoutFlowRateUlSec: 2.3,
+        blowoutOffsetFromTopMm: 3.3,
+      }
+
+      const result = transfer(args, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 80.3,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 80.3,
+          },
+        },
+      ])
+    })
+  })
 })

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -891,6 +891,7 @@ describe('advanced options', () => {
       const result = transfer(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // Pre-wet
         {
           command: 'aspirate',
           params: {
@@ -925,6 +926,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // mix (asp)
         {
           command: 'aspirate',
           params: {
@@ -959,6 +961,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // aspirate
         {
           command: 'aspirate',
           params: {
@@ -989,6 +992,7 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
+        // touch tip (asp)
         {
           command: 'touchTip',
           params: {
@@ -998,6 +1002,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 14.5,
           },
         },
+        // air gap
         {
           command: 'airGap',
           params: {
@@ -1015,6 +1020,7 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
+        // dispense
         {
           command: 'dispenseAirGap',
           params: {
@@ -1062,6 +1068,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // mix (disp)
         {
           command: 'aspirate',
           params: {
@@ -1096,6 +1103,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // touch tip (disp)
         {
           command: 'touchTip',
           params: {
@@ -1105,6 +1113,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 3.4,
           },
         },
+        // blowout
         {
           command: 'blowout',
           params: {
@@ -1115,6 +1124,9 @@ describe('advanced options', () => {
             offsetFromBottomMm: 80.3,
           },
         },
+        // next chunk from A1: remaining volume
+        // do not pre-wet
+        // mix (asp)
         {
           command: 'aspirate',
           params: {
@@ -1149,6 +1161,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // aspirate 81 (= total vol 350 - prev transfer's 269)
         {
           command: 'aspirate',
           params: {
@@ -1179,6 +1192,7 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
+        // touch tip (asp)
         {
           command: 'touchTip',
           params: {
@@ -1188,6 +1202,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 14.5,
           },
         },
+        // air gap
         {
           command: 'airGap',
           params: {
@@ -1205,6 +1220,7 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
+        // dispense air gap then liquid
         {
           command: 'dispenseAirGap',
           params: {
@@ -1252,6 +1268,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // mix (disp)
         {
           command: 'aspirate',
           params: {
@@ -1286,6 +1303,7 @@ describe('advanced options', () => {
             wait: 12,
           },
         },
+        // touch tip (disp)
         {
           command: 'touchTip',
           params: {
@@ -1295,6 +1313,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 3.4,
           },
         },
+        // blowout
         {
           command: 'blowout',
           params: {

--- a/protocol-designer/src/step-generation/commandCreators/atomic/moveToWell.js
+++ b/protocol-designer/src/step-generation/commandCreators/atomic/moveToWell.js
@@ -55,17 +55,24 @@ export const moveToWell: CommandCreator<MoveToWellParams> = (
     return { errors }
   }
 
+  const params: MoveToWellParams = {
+    pipette,
+    labware,
+    well,
+    offset,
+  }
+  // add optional fields only if specified
+  if (forceDirect != null) {
+    params.forceDirect = forceDirect
+  }
+  if (minimumZHeight != null) {
+    params.minimumZHeight = minimumZHeight
+  }
+
   const commands = [
     {
       command: 'moveToWell',
-      params: {
-        pipette,
-        labware,
-        well,
-        offset,
-        forceDirect,
-        minimumZHeight,
-      },
+      params,
     },
   ]
 


### PR DESCRIPTION
# Overview

Closes #6412

# Changelog

- add tests for all advanced settings enabled
- refactor moveToWell to not add keys with undefined values

# Review requests

These tests were generated as a manual snapshot, so them passing doesn't mean anything until we comb over them and make sure that all the commands are exactly what we want

- [ ] Transfer
- [ ] Consolidate
- [ ] Distribute

Also, incidental change: I made `moveToWell` not put out `optionalKey: undefined` keys because it makes the test errors more confusing to read

# Risk assessment

Low, just adding tests