### PR TITLE
feat(api): Allow pipette pairing for aspirate and dispense functions

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1487,6 +1487,44 @@ class API(HardwareAPILike):
                 assert instr1.has_tip, 'Cannot drop tip without a tip attached'
         return instr1, primary_mount, instr2, secondary_mount
 
+    @typing.overload
+    def _instruments_for(
+            self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]: ...
+
+    @typing.overload
+    def _instruments_for(
+            self, mount: PipettePair) -> Tuple[PipetteHandlingData, PipetteHandlingData]: ...
+        
+    @typing.overload
+    def _instruments_for(self, mount):
+        if isinstance(mount, PipettePair):
+            primary_mount = mount.primary
+            secondary_mount = mount.secondary
+            instr1 = self._attached_instruments[primary_mount]
+            instr2 = self._attached_instruments[secondary_mount]
+            return tuple((instr1, primary_mount), (instr2, secondary_mount))
+        else:
+            primary_mount = mount
+            instr1 = self._attached_instruments[primary_mount]
+            return tuple((instr1, primary_mount))
+
+    def _ready_for_pick_up_tip(self, targets: Sequence[PipetteHandlingData]):
+        for pipettes in targets:
+            if not pipettes[0]:
+                raise top_types.PipetteNotAttachedError(
+                    f'No pipette attached to {pipettes[1].name} mount')
+            assert not pipettes[0].has_tip,\
+                'Cannot pick up tip with a tip attached'
+
+    def _ready_for_tip_action(
+            self, targets: Sequence[PipetteHandlingData], action: str):
+        for pipettes in targets:
+            if not pipettes[0]:
+                raise top_types.NoPipetteAttachedError(
+                    f'No pipette attached to {pipettes[1].name} mount')
+            assert pipettes[0].has_tip,\
+                f'Cannot perform {action} without a tip attached'
+
     async def pick_up_tip(self,
                           mount: Union[top_types.Mount, PipettePair],
                           tip_length: float,
@@ -1532,7 +1570,7 @@ class API(HardwareAPILike):
                     "Number of pipette pickups must match")
             checked_presses = all_presses[0]
         else:
-            checked_presses = presses
+            checked_presses = tuple(presses)
 
         if not increment or increment < 0:
             checked_increment = tuple(

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1467,41 +1467,6 @@ class API(HardwareAPILike):
             secondary_mount = mount.secondary
             instr1 = self._attached_instruments[primary_mount]
             instr2 = self._attached_instruments[secondary_mount]
-            assert instr1 and instr2, \
-                (f'No instrument on {primary_mount.name}'
-                 ' or {secondary_mount.name}')
-            if action == 'pickup':
-                assert not instr1.has_tip and not instr2.has_tip, \
-                    'Tip already attached'
-            else:
-                assert instr1.has_tip and instr2.has_tip, \
-                    'Cannot drop tip without a tip attached'
-        else:
-            primary_mount = mount
-            instr1 = self._attached_instruments[primary_mount]
-            instr2 = None
-            assert instr1, f'No instrument on {primary_mount.name}'
-            if action == 'pickup':
-                assert not instr1.has_tip, 'Tip already attached'
-            else:
-                assert instr1.has_tip, 'Cannot drop tip without a tip attached'
-        return instr1, primary_mount, instr2, secondary_mount
-
-    @overload
-    def _instruments_for(
-        self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]: ...
-
-    @overload
-    def _instruments_for(
-        self, mount: PipettePair) ->\
-        Tuple[PipetteHandlingData, PipetteHandlingData]: ...
-
-    def _instruments_for(self, mount):
-        if isinstance(mount, PipettePair):
-            primary_mount = mount.primary
-            secondary_mount = mount.secondary
-            instr1 = self._attached_instruments[primary_mount]
-            instr2 = self._attached_instruments[secondary_mount]
             return ((instr1, primary_mount), (instr2, secondary_mount))
         else:
             primary_mount = mount
@@ -1513,19 +1478,22 @@ class API(HardwareAPILike):
             if not pipettes[0]:
                 raise top_types.PipetteNotAttachedError(
                     f'No pipette attached to {pipettes[1].name} mount')
-            assert not pipettes[0].has_tip,\
-                'Cannot pick up tip with a tip attached'
-            self._log.info(f'Picking up tip on {pipettes[0].name}')
+            if pipettes[0].has_tip:
+                raise TipAttachedError(
+                    'Cannot pick up tip with a tip attached')
+            self._log.debug(f'Picking up tip on {pipettes[0].name}')
 
     def _ready_for_tip_action(
-            self, targets: Sequence[PipetteHandlingData], action: str):
+            self, targets: Sequence[PipetteHandlingData],
+            action: HardwareAction):
         for pipettes in targets:
             if not pipettes[0]:
                 raise top_types.PipetteNotAttachedError(
                     f'No pipette attached to {pipettes[1].name} mount')
-            assert pipettes[0].has_tip,\
-                f'Cannot perform {action} without a tip attached'
-            self._log.info(f'{action} on {pipettes[0].name}')
+            if not pipettes[0].has_tip:
+                raise NoTipAttachedError(
+                    f'Cannot perform {action} without a tip attached')
+            self._log.debug(f'{action} on {pipettes[0].name}')
 
     async def pick_up_tip(self,
                           mount: Union[top_types.Mount, PipettePair],
@@ -1536,7 +1504,7 @@ class API(HardwareAPILike):
         Pick up tip from current location.
 
         This is achieved by attempting to move the instrument down by its
-        `pick_up_distance`, in a series of presses. This distance is largerr
+        `pick_up_distance`, in a series of presses. This distance is larger
         than the space available in the tip, so the stepper motor will
         eventually skip steps, which is resolved by homing afterwards. The
         pick up operation is done at a current specified in the pipette config,

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -193,6 +193,10 @@ class PipettePair(enum.Enum):
 
 class HardwareAction(enum.Enum):
     DROPTIP = enum.auto()
+    ASPIRATE = enum.auto()
+    DISPENSE = enum.auto()
+    BLOWOUT = enum.auto()
+    PREPARE_ASPIRATE = enum.auto()
 
     def __str__(self):
         return self.name

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -356,13 +356,16 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
     ctx = papi.ProtocolContext(loop)
     ctx.home()
     lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
-    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+    tiprack = ctx.load_labware('opentrons_96_tiprack_10ul', 2)
+    instr = ctx.load_instrument(
+        'p10_single', Mount.RIGHT, tip_racks=[tiprack])
 
     fake_hw_aspirate = mock.Mock()
     fake_move = mock.Mock()
     monkeypatch.setattr(API, 'aspirate', fake_hw_aspirate)
     monkeypatch.setattr(API, 'move_to', fake_move)
 
+    instr.pick_up_tip()
     instr.aspirate(2.0, lw.wells()[0].bottom())
     assert 'aspirating' in ','.join([cmd.lower() for cmd in ctx.commands()])
 


### PR DESCRIPTION
# Overview

closes #6273 and closes #6274. This PR adds in functionality for pipette pairing in the aspirate/dispense functions for hardware control.

# Changelog
- Modify aspirate/dispense/blow out/prepare for aspirate functions to accommodate for pipette pairing
- Add tests to ensure the plungers move to the correct positions for these functions

# Review requests
I am currently taking the minimum speed for aspirate/dispense, but the maximum speed in blow out. Do we think this assumption is correct/good?

Any other tests we might need?

# Risk assessment

Low/Medium. There shouldn't be any changes for single pipette moves, but we should run a protocol now that all hardware control stuff is done to make sure nothing is broken.