### PR TITLE
refactor(api): hc: reconfigure pipettes only when they change

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -552,7 +552,7 @@ class Session(RobotBusy):
                 self.resume()
                 self._pre_run_hooks()
                 self._hardware.cache_instruments()
-                self._hardware.reset_instruments()
+                self._hardware.reset_instrument()
                 ctx = ProtocolContext.build_using(
                     self._protocol,
                     loop=self._loop,

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -552,6 +552,7 @@ class Session(RobotBusy):
                 self.resume()
                 self._pre_run_hooks()
                 self._hardware.cache_instruments()
+                self._hardware.reset_instruments()
                 ctx = ProtocolContext.build_using(
                     self._protocol,
                     loop=self._loop,

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import json
@@ -39,14 +40,14 @@ class PipetteConfig:
     drop_tip_speed: float
     min_volume: float
     max_volume: float
-    ul_per_mm: 'UlPerMm'
-    quirks: List['Quirk']
+    ul_per_mm: UlPerMm
+    quirks: List[Quirk]
     tip_length: float  # TODO(seth): remove
     # TODO: Replace entirely with tip length calibration
     tip_overlap: Dict[str, float]
     display_name: str
-    name: 'PipetteName'
-    back_compat_names: List['PipetteName']
+    name: PipetteName
+    back_compat_names: List[PipetteName]
     return_tip_height: float
     blow_out_flow_rate: float
     max_travel: float
@@ -56,6 +57,7 @@ class PipetteConfig:
     default_blow_out_flow_rates: Dict[str, float]
     default_aspirate_flow_rates: Dict[str, float]
     default_dispense_flow_rates: Dict[str, float]
+    model: PipetteModel
 
 
 # Notes:
@@ -92,7 +94,7 @@ VALID_QUIRKS = model_config()['validQuirks']
 
 
 def load(
-        pipette_model: 'PipetteModel',
+        pipette_model: PipetteModel,
         pipette_id: str = None) -> PipetteConfig:
     """
     Load pipette config data
@@ -209,6 +211,7 @@ def load(
         default_aspirate_flow_rates=cfg['defaultAspirateFlowRate'].get(
             'valuesByApiLevel',
             {'2.0': cfg['defaultAspirateFlowRate']['value']}),
+        model=pipette_model,
     )
 
     return res
@@ -281,7 +284,7 @@ def override(pipette_id: str, fields: TypeOverrides):
 
 def save_overrides(pipette_id: str,
                    overrides: TypeOverrides,
-                   model: 'PipetteModel'):
+                   model: PipetteModel):
     """
     Save overrides for the pipette.
 
@@ -362,7 +365,7 @@ def validate_quirks(quirks: List[str]):
 
 
 def ensure_value(
-        config: 'PipetteFusedSpec',
+        config: PipetteFusedSpec,
         name: Union[str, Tuple[str, ...]],
         mutable_config_list: List[str]):
     """

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -381,6 +381,7 @@ class API(HardwareAPILike):
                       reset both
         """
         def _reset(m: top_types.Mount):
+            self._log.info(f"Resetting configuration for {m}")
             p = self._attached_instruments[m]
             if not p:
                 return
@@ -438,8 +439,12 @@ class API(HardwareAPILike):
                     self._attached_instruments[mount],
                     req_instr,
                     instrument_data.get('id')):
+                self._log.info(
+                    f"Skipping configuration on {mount.name}")
                 continue
 
+            self._log.info(
+                f"Doing full configuration on {mount.name}")
             mount_axis = Axis.by_mount(mount)
             plunger_axis = Axis.of_plunger(mount)
             splits: Dict[str, MoveSplit] = {}
@@ -650,6 +655,8 @@ class API(HardwareAPILike):
         information about their presence or state.
         """
         await self._execution_manager.reset()
+        self._attached_instruments = {
+            k: None for k in self._attached_instruments.keys()}
         await self.cache_instruments()
 
     # Gantry/frame (i.e. not pipette) action API

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -377,17 +377,19 @@ class API(HardwareAPILike):
         any lower level reconfiguration. This is useful to make sure that no
         settings changes from a protocol persist.
 
-        :param mount: If specified, reset that mount. If not specified, reset both
+        :param mount: If specified, reset that mount. If not specified,
+                      reset both
         """
         def _reset(m: top_types.Mount):
             p = self._attached_instruments[m]
             if not p:
                 return
-            self._attached_instruments[m] = Pipette(
+            new_p = Pipette(
                 p._config,
                 self._config.instrument_offset[m.name.lower()],
                 p.pipette_id)
-            self._attached_instruments[m].act_as(p.acting_as)
+            new_p.act_as(p.acting_as)
+            self._attached_instruments[m] = new_p
 
         if not mount:
             for m in top_types.Mount:
@@ -415,9 +417,9 @@ class API(HardwareAPILike):
             This function will only change the things that need to be changed.
             If the same pipette (by serial) or the same lack of pipette is
             observed on a mount before and after the scan, no action will be
-            taken. That makes this function appropriate for setting up the robot
-            for operation, but not for making sure that any previous settings
-            changes have been reset. For the latter use case, use
+            taken. That makes this function appropriate for setting up the
+            robot for operation, but not for making sure that any previous
+            settings changes have been reset. For the latter use case, use
             :py:meth:`reset_instrument`.
 
         """

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from contextlib import contextmanager, ExitStack
 import logging
@@ -11,7 +12,7 @@ except OSError:
 from opentrons.drivers.smoothie_drivers import driver_3_0
 from opentrons.drivers.rpi_drivers import build_gpio_chardev
 import opentrons.config
-from opentrons.config.pipette_config import config_models
+from opentrons.config import pipette_config
 from opentrons.types import Mount
 
 from . import modules
@@ -22,7 +23,8 @@ if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
         PipetteModel, PipetteName
     )
-    from .dev_types import RegisterModules, AttachedInstrument  # noqa (F501)
+    from .dev_types import (
+        RegisterModules, AttachedInstrument, AttachedInstruments)  # noqa (F501)
     from opentrons.drivers.rpi_drivers.dev_types\
         import GPIODriverLike # noqa(F501)
 
@@ -71,7 +73,7 @@ class Controller:
                 'or door, likely because not running on linux')
 
     @property
-    def gpio_chardev(self) -> 'GPIODriverLike':
+    def gpio_chardev(self) -> GPIODriverLike:
         return self._gpio_chardev
 
     @property
@@ -115,9 +117,43 @@ class Controller:
         converted_axes = ''.join(axes)
         return self._smoothie_driver.fast_home(converted_axes, margin)
 
+    def _query_mount(
+            self,
+            mount: Mount,
+            expected: Union[PipetteModel, PipetteName, None]
+    ) -> AttachedInstrument:
+        found_model: Optional[PipetteModel]\
+                = self._smoothie_driver.read_pipette_model(  # type: ignore
+                    mount.name.lower())
+        if found_model and found_model not in pipette_config.config_models:
+            # TODO: Consider how to handle this error - it bubbles up now
+            # and will cause problems at higher levels
+            MODULE_LOG.error(
+                f'Bad model on {mount.name}: {found_model}')
+            found_model = None
+        found_id = self._smoothie_driver.read_pipette_id(
+            mount.name.lower())
+
+        if found_model:
+            config = pipette_config.load(found_model, found_id)
+            if expected:
+                acceptable = [config.name] + config.back_compat_names
+                if expected not in acceptable:
+                    raise RuntimeError(f'mount {mount}: instrument'
+                                       f' {expected} was requested'
+                                       f' but {config.model} is present')
+            return {'config': config,
+                    'id': found_id}
+        else:
+            if expected:
+                raise RuntimeError(
+                        f'mount {mount}: instrument {expected} was'
+                        f' requested, but no instrument is present')
+            return {'config': None, 'id': None}
+
     def get_attached_instruments(
-            self, expected: Dict[Mount, Union['PipetteModel', 'PipetteName']])\
-            -> Dict[Mount, 'AttachedInstrument']:
+            self, expected: Dict[Mount, PipetteName])\
+            -> AttachedInstruments:
         """ Find the instruments attached to our mounts.
         :param expected: is ignored, it is just meant to enforce
                           the same interface as the simulator, where
@@ -126,24 +162,11 @@ class Controller:
         :returns: A dict with mounts as the top-level keys. Each mount value is
             a dict with keys 'model' (containing an instrument model name or
             `None`) and 'id' (containing the serial number of the pipette
-            attached to that mount, or `None`).
+            attached to that mount, or `None`). Both mounts will always be
+            specified.
         """
-        to_return: Dict[Mount, 'AttachedInstrument'] = {}
-        for mount in Mount:
-            found_model: 'PipetteModel'\
-                = self._smoothie_driver.read_pipette_model(  # type: ignore
-                    mount.name.lower())
-            if found_model and found_model not in config_models:
-                # TODO: Consider how to handle this error - it bubbles up now
-                # and will cause problems at higher levels
-                MODULE_LOG.error(
-                    f'Bad model on {mount.name}: {found_model}')
-            found_id = self._smoothie_driver.read_pipette_id(
-                mount.name.lower())
-            to_return[mount] = {
-                'model': found_model,
-                'id': found_id}
-        return to_return
+        return {mount: self._query_mount(mount, expected.get(mount))
+                for mount in Mount}
 
     def set_active_current(self, axis_currents: Dict[Axis, float]):
         """
@@ -162,7 +185,7 @@ class Controller:
         finally:
             self._smoothie_driver.pop_active_current()
 
-    async def _handle_watch_event(self, register_modules: 'RegisterModules'):
+    async def _handle_watch_event(self, register_modules: RegisterModules):
         try:
             event = await self._module_watcher.get_event()
         except asyncio.IncompleteReadError:
@@ -192,7 +215,7 @@ class Controller:
                         'Exception in Module registration')
 
     async def watch_modules(self, loop: asyncio.AbstractEventLoop,
-                            register_modules: 'RegisterModules'):
+                            register_modules: RegisterModules):
         can_watch = aionotify is not None
         if can_watch:
             await self._module_watcher.setup(loop)

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import asyncio
 from typing import List, Optional, Dict, Union
 
+from typing_extensions import Protocol, TypedDict, Literal
+
 from opentrons_shared_data.pipette.dev_types import (
     PipetteModel, PipetteName, ChannelCount
 )
 
+from opentrons.drivers.types import MoveSplit
 from .modules import ModuleAtPort
 from .types import HardwareEventType
-from typing_extensions import Protocol, TypedDict, Literal
+
 from opentrons.types import Mount
 from opentrons.config.pipette_config import PipetteConfig
 
@@ -78,3 +81,11 @@ class PipetteDict(TypedDict):
     default_blow_out_speeds: Dict[str, float]
     ready_to_aspirate: bool
     has_tip: bool
+
+
+class InstrumentHardwareConfigs(TypedDict):
+    steps_per_mm: float
+    home_pos: float
+    max_travel: float
+    idle_current: float
+    splits: Optional[MoveSplit]

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 # this file defines types that require dev dependencies
 # and are only relevant for static typechecking. this file should only
 # be imported if typing.TYPE_CHECKING is True
 import asyncio
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Union
 
 from opentrons_shared_data.pipette.dev_types import (
     PipetteModel, PipetteName, ChannelCount
@@ -11,6 +12,8 @@ from opentrons_shared_data.pipette.dev_types import (
 from .modules import ModuleAtPort
 from .types import HardwareEventType
 from typing_extensions import Protocol, TypedDict, Literal
+from opentrons.types import Mount
+from opentrons.config.pipette_config import PipetteConfig
 
 
 class RegisterModules(Protocol):
@@ -30,9 +33,17 @@ class HasLoop(Protocol):
 DoorStateNotificationType = Literal[HardwareEventType.DOOR_SWITCH_CHANGE]
 
 
-class AttachedInstrument(TypedDict):
-    model: Optional[PipetteModel]
+class InstrumentSpec(TypedDict):
+    model: Union[PipetteModel, None]
     id: Optional[str]
+
+
+class AttachedInstrument(TypedDict):
+    config: Optional[PipetteConfig]
+    id: Optional[str]
+
+
+AttachedInstruments = Dict[Mount, AttachedInstrument]
 
 
 EIGHT_CHANNELS = Literal[8]

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """ Classes and functions for pipette state tracking
 """
 from dataclasses import asdict, replace
@@ -8,11 +9,10 @@ from opentrons.types import Point
 from opentrons.config import pipette_config
 from opentrons.config.feature_flags import enable_calibration_overhaul
 from .types import CriticalPoint
-from opentrons_shared_data.pipette import name_for_model
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
-        PipetteModel, UlPerMmAction
+        UlPerMmAction, PipetteName, PipetteModel
     )
 
 mod_log = logging.getLogger(__name__)
@@ -29,12 +29,13 @@ class Pipette:
     #: The type of this data class as a dict
 
     def __init__(self,
-                 model: 'PipetteModel',
+                 config: pipette_config.PipetteConfig,
                  inst_offset_config: Dict[str, Tuple[float, float, float]],
                  pipette_id: str = None) -> None:
-        self._config = pipette_config.load(model, pipette_id)
-        self._name = name_for_model(model)
-        self._model = model
+        self._config = config
+        self._acting_as = self._config.name
+        self._name = self._config.name
+        self._model = self._config.model
         self._model_offset = self._config.model_offset
         self._current_volume = 0.0
         self._working_volume = self._config.max_volume
@@ -49,7 +50,7 @@ class Pipette:
         self._log = mod_log.getChild(self._pipette_id
                                      if self._pipette_id else '<unknown>')
         self._log.info("loaded: {}, instr offset {}"
-                       .format(model, self._instrument_offset))
+                       .format(config.model, self._instrument_offset))
         self.ready_to_aspirate = False
         #: True if ready to aspirate
         self._aspirate_flow_rate\
@@ -58,6 +59,26 @@ class Pipette:
             = self._config.default_dispense_flow_rates['2.0']
         self._blow_out_flow_rate\
             = self._config.default_blow_out_flow_rates['2.0']
+
+    def act_as(self, name: PipetteName):
+        """ Reconfigure to act as ``name``. ``name`` must be either the
+        actual name of the pipette, or a name in its back-compatibility
+        config.
+        """
+        if name == self._acting_as:
+            return
+
+        assert name in self._config.back_compat_names + [self.name],\
+            f'{self._name} is not back-compatible with {name}'
+        name_conf = pipette_config.name_config()
+        bc_conf = name_conf[name]
+        self.working_volume = bc_conf['maxVolume']
+        self.update_config_item('min_volume', bc_conf['minVolume'])
+        self.update_config_item('max_volume', bc_conf['maxVolume'])
+
+    @property
+    def acting_as(self) -> PipetteName:
+        return self._acting_as
 
     def update_instrument_offset(self, new_offset: Point):
         self._log.info("updated instrument offset to {}".format(new_offset))
@@ -77,11 +98,11 @@ class Pipette:
                                **{elem_name: elem_val})
 
     @property
-    def name(self) -> str:
+    def name(self) -> PipetteName:
         return self._name
 
     @property
-    def model(self) -> str:
+    def model(self) -> PipetteModel:
         return self._model
 
     @property
@@ -250,7 +271,7 @@ class Pipette:
     def has_tip(self) -> bool:
         return self._has_tip
 
-    def ul_per_mm(self, ul: float, action: 'UlPerMmAction') -> float:
+    def ul_per_mm(self, ul: float, action: UlPerMmAction) -> float:
         sequence = self._config.ul_per_mm[action]
         return pipette_config.piecewise_volume_conversion(ul, sequence)
 

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -4,7 +4,7 @@ import copy
 import logging
 from threading import Event
 from typing import (Dict, Optional, List, Tuple,
-                    TYPE_CHECKING, Sequence, cast)
+                    TYPE_CHECKING, Sequence)
 from contextlib import contextmanager
 
 from opentrons_shared_data.pipette import dummy_model_for_name
@@ -23,9 +23,7 @@ from .types import BoardRevision, Axis
 
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import (
-        PipetteName, PipetteModel
-    )
+    from opentrons_shared_data.pipette.dev_types import PipetteName
     from .dev_types import (
         RegisterModules, AttachedInstrument,
         AttachedInstruments, InstrumentSpec)
@@ -97,8 +95,10 @@ class Simulator:
             if passed_ai['model'] in config_models:
                 return passed_ai  # type: ignore
             if passed_ai['model'] in config_names:
-                return {'model': dummy_model_for_name(passed_ai['model']),   # type: ignore
-                        'id': passed_ai.get('id')}
+                return {
+                    'model':
+                    dummy_model_for_name(passed_ai['model']),  # type: ignore
+                    'id': passed_ai.get('id')}
             raise KeyError(
                 'If you specify attached_instruments, the model '
                 'should be pipette names or pipette models, but '

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -553,9 +553,10 @@ class ProtocolContext(CommandPublisher):
             raise RuntimeError("Instrument already present in {} mount: {}"
                                .format(checked_mount.name.lower(),
                                        instr.name))
-        attached = {att_mount: instr.get('model', None)
+        attached = {att_mount: instr.get('name', None)
                     for att_mount, instr
-                    in self._hw_manager.hardware.attached_instruments.items()}
+                    in self._hw_manager.hardware.attached_instruments.items()
+                    if instr}
         attached[checked_mount] = instrument_name
         self._log.debug("cache instruments expectation: {}"
                         .format(attached))

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -8,7 +8,8 @@ except OSError:
     aionotify = None  # type: ignore
 from opentrons.config import (CONFIG,
                               robot_configs,
-                              advanced_settings as advs)
+                              advanced_settings as advs,
+                              pipette_config as pc)
 from opentrons.types import Mount
 from opentrons.deck_calibration import dc_main
 from opentrons.deck_calibration.dc_main import get_calibration_points
@@ -31,10 +32,10 @@ def hw_with_pipettes(monkeypatch, sync_hardware, model1, model2):
         def fake_gai(expected):
             return {
                 Mount.LEFT: {
-                    'model': model1[0],
+                    'config': pc.load(model1[0]),
                     'id': 'fakeid'},
                 Mount.RIGHT: {
-                    'model': model1[0],
+                    'config': pc.load(model1[0]),
                     'id': 'fakeid2'}}
         monkeypatch.setattr(
             sync_hardware._obj_to_adapt._backend,
@@ -44,8 +45,8 @@ def hw_with_pipettes(monkeypatch, sync_hardware, model1, model2):
 
         def fake_gai(expected):
             return {
-                Mount.LEFT: {'model': model2[0], 'id': 'fakeid'},
-                Mount.RIGHT: {'model': model2[0], 'id': 'fakeid2'}}
+                Mount.LEFT: {'config': pc.load(model2[0]), 'id': 'fakeid'},
+                Mount.RIGHT: {'config': pc.load(model2[0]), 'id': 'fakeid2'}}
 
         monkeypatch.setattr(
             sync_hardware._obj_to_adapt._backend,

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -238,8 +238,7 @@ async def dc_session(request, hardware, monkeypatch, loop):
     Mock session manager for deck calibation
     """
     await hardware.cache_instruments({
-        types.Mount.LEFT: None,
-        types.Mount.RIGHT: 'p300_multi_v1'})
+        types.Mount.RIGHT: 'p300_multi'})
     ses = endpoints.SessionManager(hardware)
     endpoints.session_wrapper.session = ses
     yield ses

--- a/api/tests/opentrons/deck_calibration/calibration_integration_test.py
+++ b/api/tests/opentrons/deck_calibration/calibration_integration_test.py
@@ -19,17 +19,16 @@ from opentrons.hardware_control.types import CriticalPoint
 
 async def test_transform_from_moves_v2(
         hardware, monkeypatch):
-    test_mount, test_model = (types.Mount.LEFT, 'p300_multi_v1')
+    test_mount, test_model = (types.Mount.LEFT, 'p300_multi')
 
     await hardware.reset()
     await hardware.cache_instruments({
-        test_mount: test_model,
-        types.Mount.RIGHT: None})
+        test_mount: test_model})
     await hardware.home()
     resp = await dc.endpoints.create_session(False, hardware=hardware)
     token = resp.token
     assert resp.pipette.get('mount') == 'left'
-    assert resp.pipette.get('model') == test_model
+    assert resp.pipette.get('model') == test_model + '_v1'
 
     await dc.endpoints.attach_tip({'tipLength': 51.7})
 

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -141,7 +141,8 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
         return mount, value
 
     sim = await hc.API.build_hardware_simulator(loop=loop)
-    # With nothing specified at init or expected, we should have nothing
+    # With nothing specified at init or expected, we should have nothing afterwards
+    # and nothing should have been reconfigured
     sim._backend._smoothie_driver.update_steps_per_mm = mock.Mock(fake_func1)
     sim._backend._smoothie_driver.update_pipette_config = mock.Mock(fake_func2)
     sim._backend._smoothie_driver.set_dwelling_current = mock.Mock(fake_func1)
@@ -150,30 +151,20 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     attached = sim.attached_instruments
     assert attached == {
         types.Mount.LEFT: {}, types.Mount.RIGHT: {}}
-    steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 768})]
-    pip_config_calls = [
-        mock.call('Z', {'home': 220}),
-        mock.call('A', {'home': 220}),
-        mock.call('B', {'max_travel': 30}),
-        mock.call('C', {'max_travel': 30})]
-    current_calls = [mock.call({'B': 0.05}), mock.call({'C': 0.05})]
-    sim._backend._smoothie_driver.update_steps_per_mm.assert_has_calls(
-        steps_mm_calls, any_order=True)
-    sim._backend._smoothie_driver.update_pipette_config.assert_has_calls(
-        pip_config_calls, any_order=True)
-    sim._backend._smoothie_driver.set_dwelling_current.assert_has_calls(
-        current_calls, any_order=True)
+    sim._backend._smoothie_driver.update_steps_per_mm.assert_not_called()
+    sim._backend._smoothie_driver.update_pipette_config.assert_not_called()
+    sim._backend._smoothie_driver.set_dwelling_current.assert_not_called()
 
     sim._backend._smoothie_driver.update_steps_per_mm.reset_mock()
     sim._backend._smoothie_driver.update_pipette_config.reset_mock()
     # When we expect instruments, we should get what we expect since nothing
     # was specified at init time
     await sim.cache_instruments(
-        {types.Mount.LEFT: 'p10_single_v1.3',
-         types.Mount.RIGHT: 'p300_single_v2.0'})
+        {types.Mount.LEFT: 'p10_single',
+         types.Mount.RIGHT: 'p300_single_gen2'})
     attached = sim.attached_instruments
     assert attached[types.Mount.LEFT]['model']\
-        == 'p10_single_v1.3'
+        == 'p10_single_v1'
     assert attached[types.Mount.LEFT]['name']\
         == 'p10_single'
 
@@ -190,8 +181,8 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
         pip_config_calls, any_order=True)
 
     await sim.cache_instruments(
-        {types.Mount.LEFT: 'p10_single_v1.3',
-         types.Mount.RIGHT: 'p300_multi_v2.0'})
+        {types.Mount.LEFT: 'p10_single',
+         types.Mount.RIGHT: 'p300_multi_gen2'})
     current_calls = [mock.call({'B': 0.05}), mock.call({'C': 0.3})]
     sim._backend._smoothie_driver.set_dwelling_current.assert_has_calls(
         current_calls, any_order=True)
@@ -226,10 +217,8 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
 
     with pytest.raises(RuntimeError):
-        # When we say prefixes we really mean names or models should
-        # equally work with some special casing for gen2; if you do
-        # just some arbitrary stuff that happens to be a prefix, that
-        # absolutely should not work
+        # If you pass something that isn't a pipette name it absolutely
+        # should not work
         await sim.cache_instruments({types.Mount.LEFT: 'p10_sing'})
 
 

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -141,8 +141,8 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
         return mount, value
 
     sim = await hc.API.build_hardware_simulator(loop=loop)
-    # With nothing specified at init or expected, we should have nothing afterwards
-    # and nothing should have been reconfigured
+    # With nothing specified at init or expected, we should have nothing
+    # afterwards and nothing should have been reconfigured
     sim._backend._smoothie_driver.update_steps_per_mm = mock.Mock(fake_func1)
     sim._backend._smoothie_driver.update_pipette_config = mock.Mock(fake_func2)
     sim._backend._smoothie_driver.set_dwelling_current = mock.Mock(fake_func1)

--- a/api/tests/opentrons/hardware_control/test_paired_pipettes.py
+++ b/api/tests/opentrons/hardware_control/test_paired_pipettes.py
@@ -4,6 +4,7 @@ from unittest import mock
 from opentrons import hardware_control as hc
 from opentrons.hardware_control.types import PipettePair, Axis
 from opentrons import types
+from opentrons.config import pipette_config as pc
 
 
 @pytest.fixture
@@ -241,7 +242,9 @@ async def test_tip_action_currents(
         mock_active_current)
 
     def fake_attached(stuff):
-        return dummy_instruments
+        return {mount: {'config': pc.load(value['model']),
+                        'id': value['id']}
+                for mount, value in dummy_instruments.items()}
     monkeypatch.setattr(
         hardware_api._backend, 'get_attached_instruments', fake_attached)
 

--- a/api/tests/opentrons/hardware_control/test_tip_probe.py
+++ b/api/tests/opentrons/hardware_control/test_tip_probe.py
@@ -1,4 +1,5 @@
 import pytest
+from opentrons_shared_data.pipette import name_for_model
 from opentrons.types import Mount, Point
 from opentrons.config import robot_configs, pipette_config
 
@@ -62,7 +63,7 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
     monkeypatch.setattr(hardware_api, 'move_rel', fake_move_rel)
     monkeypatch.setattr(hardware_api._backend, 'probe', fake_probe)
 
-    await hardware_api.cache_instruments({mount: pipette_model})
+    await hardware_api.cache_instruments({mount: name_for_model(pipette_model)})
     await hardware_api.home()
 
     center = await hardware_api.locate_tip_probe_center(mount, 30)
@@ -105,7 +106,7 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
 @pytest.mark.parametrize('mount', [Mount.RIGHT, Mount.LEFT])
 @pytest.mark.parametrize('pipette_model', pipette_config.config_models)
 async def test_update_instrument_offset(hardware_api, mount, pipette_model):
-    await hardware_api.cache_instruments({mount: pipette_model})
+    await hardware_api.cache_instruments({mount: name_for_model(pipette_model)})
     p = Point(1, 2, 3)
     with pytest.raises(ValueError):
         await hardware_api.update_instrument_offset(mount)

--- a/api/tests/opentrons/hardware_control/test_tip_probe.py
+++ b/api/tests/opentrons/hardware_control/test_tip_probe.py
@@ -63,7 +63,8 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
     monkeypatch.setattr(hardware_api, 'move_rel', fake_move_rel)
     monkeypatch.setattr(hardware_api._backend, 'probe', fake_probe)
 
-    await hardware_api.cache_instruments({mount: name_for_model(pipette_model)})
+    await hardware_api.cache_instruments(
+        {mount: name_for_model(pipette_model)})
     await hardware_api.home()
 
     center = await hardware_api.locate_tip_probe_center(mount, 30)
@@ -106,7 +107,8 @@ async def test_moves_to_hotspot(hardware_api, monkeypatch,
 @pytest.mark.parametrize('mount', [Mount.RIGHT, Mount.LEFT])
 @pytest.mark.parametrize('pipette_model', pipette_config.config_models)
 async def test_update_instrument_offset(hardware_api, mount, pipette_model):
-    await hardware_api.cache_instruments({mount: name_for_model(pipette_model)})
+    await hardware_api.cache_instruments(
+        {mount: name_for_model(pipette_model)})
     p = Point(1, 2, 3)
     with pytest.raises(ValueError):
         await hardware_api.update_instrument_offset(mount)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -7,14 +7,13 @@ import opentrons.protocol_api as papi
 import opentrons.protocols.api_support as papi_support
 import opentrons.protocols.geometry as papi_geometry
 from opentrons_shared_data import load_shared_data
-from opentrons_shared_data.pipette import name_for_model
 from opentrons.types import Mount, Point, Location, TransferTipPolicy
 from opentrons.hardware_control import API, NoTipAttachedError
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
-from opentrons.config.pipette_config import config_models
 from opentrons.protocol_api import paired_instrument_context as paired
 from opentrons.protocols.advanced_control import transfers as tf
+from opentrons.config.pipette_config import config_names
 from opentrons.protocols.types import APIVersion
 from opentrons.calibration_storage import get, types as cs_types
 
@@ -53,18 +52,16 @@ def get_labware_def(monkeypatch):
     monkeypatch.setattr(papi.labware, 'get_labware_definition', dummy_load)
 
 
-def test_load_instrument(loop):
+@pytest.mark.parametrize('name', config_names)
+def test_load_instrument(loop, name):
     ctx = papi.ProtocolContext(loop=loop)
     assert ctx.loaded_instruments == {}
-    for model in config_models:
-        loaded = ctx.load_instrument(model, Mount.LEFT, replace=True)
-        assert ctx.loaded_instruments[Mount.LEFT.name.lower()] == loaded
-        assert loaded.model == model
-        instr_name = name_for_model(model)
-        loaded = ctx.load_instrument(instr_name, Mount.RIGHT, replace=True)
-        assert loaded.name == instr_name
-        assert ctx.loaded_instruments[Mount.RIGHT.name.lower()] == loaded
-
+    loaded = ctx.load_instrument(name, Mount.LEFT, replace=True)
+    assert ctx.loaded_instruments[Mount.LEFT.name.lower()] == loaded
+    assert loaded.name == name
+    loaded = ctx.load_instrument(name, Mount.RIGHT, replace=True)
+    assert ctx.loaded_instruments[Mount.RIGHT.name.lower()] == loaded
+    assert loaded.name == name
 
 async def test_motion(loop, hardware):
     ctx = papi.ProtocolContext(loop)

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -63,6 +63,7 @@ def test_load_instrument(loop, name):
     assert ctx.loaded_instruments[Mount.RIGHT.name.lower()] == loaded
     assert loaded.name == name
 
+
 async def test_motion(loop, hardware):
     ctx = papi.ProtocolContext(loop)
     ctx.connect(hardware)

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -9,6 +9,7 @@ import pytest
 from opentrons import execute, types
 from opentrons.hardware_control import controller, api
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
+from opentrons.config.pipette_config import load
 
 HERE = Path(__file__).parent
 
@@ -37,9 +38,9 @@ def test_execute_function_apiv2(protocol,
                                 mock_get_attached_instr):
 
     mock_get_attached_instr.return_value[types.Mount.LEFT]\
-        = {'model': 'p10_single_v1.5', 'id': 'testid'}
+        = {'config': load('p10_single_v1.5'), 'id': 'testid'}
     mock_get_attached_instr.return_value[types.Mount.RIGHT]\
-        = {'model': 'p300_single_v1.5', 'id': 'testid2'}
+        = {'config': load('p300_single_v1.5'), 'id': 'testid2'}
     entries = []
 
     def emit_runlog(entry):
@@ -69,7 +70,7 @@ def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'model': 'p10_single_v1.5', 'id': 'testid'}
+        'config': load('p10_single_v1.5'), 'id': 'testid'}
     execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
@@ -95,7 +96,7 @@ def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'model': 'p10_single_v1.5', 'id': 'testid'}
+        'config': load('p10_single_v1.5'), 'id': 'testid'}
     execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
@@ -121,7 +122,7 @@ def test_execute_function_json_v5_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'model': 'p10_single_v1.5', 'id': 'testid'}
+        'config': load('p10_single_v1.5'), 'id': 'testid'}
     execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
@@ -146,7 +147,7 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'model': 'p10_single_v1.5', 'id': 'testid'}
+        'config': load('p10_single_v1.5'), 'id': 'testid'}
     execute.execute(
         bundle['filelike'], 'simple_bundle.zip', emit_runlog=emit_runlog)
     assert [item['payload']['text']
@@ -184,7 +185,7 @@ def test_execute_function_v1(protocol, protocol_file,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        'model': 'p300_single_v1.5', 'id': 'testid'}
+        'config': load('p300_single_v1.5'), 'id': 'testid'}
     execute.execute(protocol.filelike, 'testosaur.py', emit_runlog=emit_runlog)
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
@@ -209,7 +210,7 @@ def test_execute_extra_labware(protocol, protocol_file, monkeypatch,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        'model': 'p300_single_v2.0', 'id': 'testid'}
+        'config': load('p300_single_v2.0'), 'id': 'testid'}
     # make sure we can load labware explicitly
     # make sure we don't have an exception from not finding the labware
     execute.execute(protocol.filelike, 'custom_labware.py',

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, call
 from typing import List, Tuple
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
+from opentrons.config.pipette_config import load
 from robot_server.robot.calibration.deck.user_flow import \
     DeckCalibrationUserFlow, tuplefy_cal_point_dicts
 from robot_server.robot.calibration.deck.constants import \
@@ -11,7 +12,7 @@ from robot_server.robot.calibration.deck.constants import \
 
 @pytest.fixture
 def mock_hw(hardware):
-    pip = pipette.Pipette("p300_single_v2.1",
+    pip = pipette.Pipette(load("p300_single_v2.1", 'testiId'),
                           {
                               'single': [0, 0, 0],
                               'multi': [0, 0, 0]
@@ -57,11 +58,11 @@ pipette_combos: List[Tuple[List[str], Mount]] = [
 def test_user_flow_select_pipette(pipettes, target_mount, hardware):
     pip, pip2 = None, None
     if pipettes[0]:
-        pip = pipette.Pipette(pipettes[0],
+        pip = pipette.Pipette(load(pipettes[0], 'testId'),
                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                               'testId')
     if pipettes[1]:
-        pip2 = pipette.Pipette(pipettes[1],
+        pip2 = pipette.Pipette(load(pipettes[1], 'testId'),
                                {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                                'testId2')
     hardware._attached_instruments = {Mount.LEFT: pip, Mount.RIGHT: pip2}
@@ -96,7 +97,7 @@ async def test_pick_up_tip(mock_user_flow):
 async def test_save_default_pick_up_current(mock_hw):
     # make sure pick up current for multi-channels is
     # modified during tip pick up
-    pip = pipette.Pipette("p20_multi_v2.1",
+    pip = pipette.Pipette(load("p20_multi_v2.1", 'testId'),
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                           'testid')
     mock_hw._attached_instruments[Mount.LEFT] = pip

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, call
 from typing import List, Tuple, Dict, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
+from opentrons.config.pipette_config import load
 
 from robot_server.service.errors import RobotServerError
 from robot_server.service.session.models import CalibrationCommand
@@ -30,7 +31,7 @@ pipette_map = {
 @pytest.fixture(params=pipette_map.keys())
 def mock_hw_pipette_all_combos(request):
     model = request.param
-    return pipette.Pipette(model,
+    return pipette.Pipette(load(model, 'testId'),
                            {
                                'single': [0, 0, 0],
                                'multi': [0, 0, 0]
@@ -69,7 +70,7 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
 
 @pytest.fixture
 def mock_hw(hardware):
-    pip = pipette.Pipette("p300_single_v2.1",
+    pip = pipette.Pipette(load("p300_single_v2.1", 'testId'),
                           {
                               'single': [0, 0, 0],
                               'multi': [0, 0, 0]

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -4,6 +4,7 @@ from typing import List, Tuple, Dict, Any
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 from opentrons.protocol_api.labware import get_labware_definition
+from opentrons.config.pipette_config import load
 
 from robot_server.service.errors import RobotServerError
 from robot_server.service.session.models import (
@@ -32,7 +33,7 @@ pipette_map = {
 @pytest.fixture(params=pipette_map.keys())
 def mock_hw_pipette_all_combos(request):
     model = request.param
-    return pipette.Pipette(model,
+    return pipette.Pipette(load(model, 'testId'),
                            {
                                'single': [0, 0, 0],
                                'multi': [0, 0, 0]
@@ -71,7 +72,7 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
 
 @pytest.fixture
 def mock_hw(hardware):
-    pip = pipette.Pipette("p300_single_v2.1",
+    pip = pipette.Pipette(load("p300_single_v2.1", 'testId'),
                           {
                               'single': [0, 0, 0],
                               'multi': [0, 0, 0]

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -62,6 +62,6 @@ def fuse_specs(
 
 def dummy_model_for_name(pipette_name: PipetteName) -> PipetteModel:
     if 'gen2' in pipette_name:
-        return '_'.join(pipette_name.split('_')[:-1]) + '_v2.0'
+        return '_'.join(pipette_name.split('_')[:-1]) + '_v2.0'  # type: ignore
     else:
-        return pipette_name + '_v1'
+        return pipette_name + '_v1'  # type: ignore

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 opentrons_shared_data.pipette: functions and types for pipette config
 """
@@ -12,28 +13,28 @@ if TYPE_CHECKING:
                             PipetteName, PipetteModel, PipetteFusedSpec)
 
 
-def model_config() -> 'PipetteModelSpecs':
+def model_config() -> PipetteModelSpecs:
     """ Load the per-pipette-model config file from within the wheel """
     return json.loads(
         load_shared_data('pipette/definitions/pipetteModelSpecs.json')
         or '{}')
 
 
-def name_config() -> 'PipetteNameSpecs':
+def name_config() -> PipetteNameSpecs:
     """ Load the per-pipette-name config file from within the wheel """
     return json.loads(
         load_shared_data('pipette/definitions/pipetteNameSpecs.json')
         or '{}')
 
 
-def name_for_model(pipette_model: 'PipetteModel') -> 'PipetteName':
+def name_for_model(pipette_model: PipetteModel) -> PipetteName:
     """ Quickly look up the name for this model """
     return model_config()['config'][pipette_model]['name']
 
 
 def fuse_specs(
-        pipette_model: 'PipetteModel',
-        pipette_name: 'PipetteName' = None) -> 'PipetteFusedSpec':
+        pipette_model: PipetteModel,
+        pipette_name: PipetteName = None) -> PipetteFusedSpec:
     """ Combine the model and name spec for a given model.
 
     if pipette_name is not given, the name field of the pipette config
@@ -57,3 +58,10 @@ def fuse_specs(
     new_model = copy.deepcopy(model_data)
     new_name = copy.deepcopy(name_data)
     return {**new_model, **new_name}  # type: ignore
+
+
+def dummy_model_for_name(pipette_name: PipetteName) -> PipetteModel:
+    if 'gen2' in pipette_name:
+        return '_'.join(pipette_name.split('_')[:-1]) + '_v2.0'
+    else:
+        return pipette_name + '_v1'

--- a/shared-data/python/tests/pipette/test_typechecks.py
+++ b/shared-data/python/tests/pipette/test_typechecks.py
@@ -3,7 +3,8 @@ from itertools import chain
 import pytest
 import typeguard
 
-from opentrons_shared_data.pipette import model_config, name_config, fuse_specs
+from opentrons_shared_data.pipette import (
+    model_config, name_config, fuse_specs, dummy_model_for_name)
 from opentrons_shared_data.pipette.dev_types import (
     PipetteModelSpecs, PipetteNameSpecs, PipetteFusedSpec)
 
@@ -29,3 +30,11 @@ def build_model_name_pairs():
 def test_fuse(model, name):
     defdict = fuse_specs(model, name)
     typeguard.check_type('defdict', defdict, PipetteFusedSpec)
+
+
+@pytest.mark.parametrize(
+    'name', list(name_config().keys())
+)
+def test_model_for_name(name):
+    model = dummy_model_for_name(name)
+    assert model in model_config()['config']


### PR DESCRIPTION
This PR changes the semantics of hardware_control.cache_instruments from "reset all internal pipette state" to "update any pipette state that is no longer valid based on the instrument scan", and adds and uses a new method that resets internal state.

`cache_instruments` would previously scan mounts for attached pipettes and then recreate the internal pipette state from scratch and do smoothie configurations regardless of whether or not the attached pipettes had actually changed since this was last done. This is inefficient and gives rise to bugs like #6454 and other bad behaviors like much-too-frequent unsticks (since every time the system reconfigures the smoothie in `cache_instruments`, it will reset the unstick counters).

Instead, we now scan for instruments and then only do these reconfigurations and state updates for instruments that are different, after the scan, from what is cached. This should reduce the frequency of unsticks and fix #6454 .

Sometimes, however, we do want to reset the internal state for pipettes regardless of whether or not they have changed. For instance, things like aspirate flow rates are currently configured in the  Pipette objects themselves. That means that if a protocol changes a flow rate, the change could persist now that the next `cache_instruments` does not remove it. To fix this, we use the new method `reset_instruments`, which creates new `Pipette` objects based on their default configurations. This is called from the protocol orchestration components only.

Closes #6454, closes #6455

## Risk Assessment
High. This is a change to a very important and low level function that could have affects both in and out of protocol execution.

## Test Plan
The important thing to test with this PR is the effects of running multiple protocols and changing pipettes.

### Basics:
- #6454 should be fixed.
- Pipettes should be detected appropriately at boot and after change pipette

### Cross-protocol behaviors:
- If you run a protocol that uses a gen2 multi and then immediately reset it and run it again, the pipette should not do an unstick behavior
- If you run a protocol that changes flow rates half way through and then reset it and run it again, the flow rate should only change after the protocol actually tells it to

### Pipette settings changes
- If you alter a pipette setting, it should work, including altering the behavior of a subsequent protocol

