### PR TITLE
refactor(api): migrate legacy deck calibration to new format

### DIFF
--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -47,8 +47,8 @@ class CalibrationDict(TypedDict):
 class DeckCalibrationData(TypedDict):
     attitude: AttitudeMatrix
     last_modified: datetime
-    pipette_calibrated_with: str
-    tiprack: str
+    pipette_calibrated_with: typing.Optional[str]
+    tiprack: typing.Optional[str]
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -189,7 +189,8 @@ def save_tip_length_calibration(
 
 def save_robot_deck_attitude(
         transform: local_types.AttitudeMatrix,
-        pip_id: str, lw_hash: str):
+        pip_id: str = 'UNKNOWN',
+        lw_hash: str = 'UNKNOWN'):
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
     robot_dir.mkdir(parents=True, exist_ok=True)
     gantry_path = robot_dir/'deck_calibration.json'

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -189,8 +189,8 @@ def save_tip_length_calibration(
 
 def save_robot_deck_attitude(
         transform: local_types.AttitudeMatrix,
-        pip_id: str = 'UNKNOWN',
-        lw_hash: str = 'UNKNOWN'):
+        pip_id: typing.Optional[str],
+        lw_hash: typing.Optional[str]):
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
     robot_dir.mkdir(parents=True, exist_ok=True)
     gantry_path = robot_dir/'deck_calibration.json'

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -81,15 +81,15 @@ def validate_gantry_calibration(gantry_cal: List[List[float]]):
 def migrate_affine_xy_to_attitude(
         gantry_cal: List[List[float]]) -> types.AttitudeMatrix:
     masked_transform = np.array([
-        [False, False, False, True],
-        [False, False, False, True],
+        [True, True, True, False],
+        [True, True, True, False],
         [False, False, False, False],
         [False, False, False, False]])
     masked_array = np.ma.masked_array(gantry_cal, ~masked_transform)
     attitude_array = np.zeros((3, 3))
-    np.put(attitude_array, [0, 4, 8], 1)
-    np.put(attitude_array, [1], masked_array[0].compressed())
-    np.put(attitude_array, [3], masked_array[1].compressed())
+    np.put(attitude_array, [0, 1, 2], masked_array[0].compressed())
+    np.put(attitude_array, [3, 4, 5], masked_array[1].compressed())
+    np.put(attitude_array, 8, 1)
     return attitude_array.tolist()
 
 

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -106,13 +106,13 @@ def load_attitude_matrix() -> DeckCalibration:
         gantry_cal = robot_configs.load().gantry_calibration
         if validate_gantry_calibration(gantry_cal) == DeckTransformState.OK:
             log.debug(
-                "Attitude deck calibration matrix not found. Mirgating "
+                "Attitude deck calibration matrix not found. Migrating "
                 "existing affine deck calibration matrix to {}".format(
                     config.get_opentrons_path('robot_calibration_dir')))
             attitude = migrate_affine_xy_to_attitude(gantry_cal)
             modify.save_robot_deck_attitude(transform=attitude,
-                                            pip_id='UNKNOWN',
-                                            lw_hash='UNKNOWN')
+                                            pip_id=None,
+                                            lw_hash=None)
             calibration_data = get.get_robot_deck_attitude()
 
     if calibration_data:

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -1,10 +1,17 @@
+import logging
+import numpy as np  # type: ignore
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 
-from opentrons.config import robot_configs
+from opentrons import config
+from opentrons.config import robot_configs, feature_flags as ff
 from opentrons.calibration_storage import modify, types, get
 from opentrons.util import linal
+
+from .util import DeckTransformState
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -20,6 +27,72 @@ class RobotCalibration:
     deck_calibration: DeckCalibration
 
 
+def validate_attitude_deck_calibration(deck_cal: DeckCalibration):
+    """
+    This function determines whether the deck calibration is valid
+    or not based on the following use-cases:
+
+    TODO(lc, 8/10/2020): Expand on this method, or create
+    another method to diagnose bad instrument offset data
+    """
+    curr_cal = np.array(deck_cal.attitude)
+    row, _ = curr_cal.shape
+    rank = np.linalg.matrix_rank(curr_cal)
+    if row != rank:
+        # Check that the matrix is non-singular
+        return DeckTransformState.SINGULARITY
+    elif not deck_cal.last_modified:
+        # Check that the matrix is not an identity
+        return DeckTransformState.IDENTITY
+    else:
+        # Transform as it stands is sufficient.
+        return DeckTransformState.OK
+
+
+def validate_gantry_calibration(gantry_cal: List[List[float]]):
+    """
+    This function determines whether the gantry calibration is valid
+    or not based on the following use-cases:
+    """
+    curr_cal = np.array(gantry_cal)
+    row, _ = curr_cal.shape
+
+    rank = np.linalg.matrix_rank(curr_cal)
+
+    id_matrix = linal.identity_deck_transform()
+
+    z = abs(curr_cal[2][-1])
+
+    outofrange = z < 16 or z > 34
+    if row != rank:
+        # Check that the matrix is non-singular
+        return DeckTransformState.SINGULARITY
+    elif np.array_equal(curr_cal, id_matrix):
+        # Check that the matrix is not an identity
+        return DeckTransformState.IDENTITY
+    elif outofrange:
+        # Check that the matrix is not out of range.
+        return DeckTransformState.BAD_CALIBRATION
+    else:
+        # Transform as it stands is sufficient.
+        return DeckTransformState.OK
+
+
+def migrate_affine_xy_to_attitude(
+        gantry_cal: List[List[float]]) -> types.AttitudeMatrix:
+    masked_transform = np.array([
+        [False, False, False, True],
+        [False, False, False, True],
+        [False, False, False, False],
+        [False, False, False, False]])
+    masked_array = np.ma.masked_array(gantry_cal, ~masked_transform)
+    attitude_array = np.zeros((3, 3))
+    np.put(attitude_array, [0, 4, 8], 1)
+    np.put(attitude_array, [1], masked_array[0].compressed())
+    np.put(attitude_array, [3], masked_array[1].compressed())
+    return attitude_array.tolist()
+
+
 def save_attitude_matrix(
         expected: linal.SolvePoints, actual: linal.SolvePoints,
         pipette_id: str, tiprack_hash: str):
@@ -29,6 +102,19 @@ def save_attitude_matrix(
 
 def load_attitude_matrix() -> DeckCalibration:
     calibration_data = get.get_robot_deck_attitude()
+    if not calibration_data and ff.enable_calibration_overhaul():
+        gantry_cal = robot_configs.load().gantry_calibration
+        if validate_gantry_calibration(gantry_cal) == DeckTransformState.OK:
+            log.debug(
+                "Attitude deck calibration matrix not found. Mirgating "
+                "existing affine deck calibration matrix to {}".format(
+                    config.get_opentrons_path('robot_calibration_dir')))
+            attitude = migrate_affine_xy_to_attitude(gantry_cal)
+            modify.save_robot_deck_attitude(transform=attitude,
+                                            pip_id='UNKNOWN',
+                                            lw_hash='UNKNOWN')
+            calibration_data = get.get_robot_deck_attitude()
+
     if calibration_data:
         deck_cal_obj = DeckCalibration(**calibration_data)
     else:
@@ -38,4 +124,5 @@ def load_attitude_matrix() -> DeckCalibration:
 
 
 def load() -> RobotCalibration:
-    return RobotCalibration(deck_calibration=load_attitude_matrix())
+    return RobotCalibration(
+        deck_calibration=load_attitude_matrix())

--- a/api/tests/opentrons/hardware_control/test_api_helpers.py
+++ b/api/tests/opentrons/hardware_control/test_api_helpers.py
@@ -1,6 +1,6 @@
 from opentrons.hardware_control.util import DeckTransformState
 from opentrons.hardware_control.robot_calibration import (
-    DeckCalibration, RobotCalibration, load)
+    DeckCalibration, RobotCalibration)
 
 
 async def test_validating_calibration(hardware):
@@ -34,21 +34,22 @@ async def test_validating_calibration(hardware):
 
 async def test_validating_attitude(hardware, use_new_calibration):
 
-    singular_matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 1]]
-    deck_cal = DeckCalibration(
-        attitude=singular_matrix, last_modified='sometime')
-
-    hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
-
-    assert hardware.validate_calibration() == DeckTransformState.SINGULARITY
-
-    identity_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-    deck_cal.attitude = identity_matrix
-    hardware.set_robot_calibration(load())
-    assert hardware.validate_calibration() == DeckTransformState.IDENTITY
-
     inrange_matrix = [[1, 0, 1], [0, 1, 2], [0, 0, 1]]
-    deck_cal.attitude = inrange_matrix
+    deck_cal = DeckCalibration(
+        attitude=inrange_matrix, last_modified='sometime')
+
     hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
 
     assert hardware.validate_calibration() == DeckTransformState.OK
+
+    identity_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    deck_cal.attitude = identity_matrix
+    deck_cal.last_modified = None
+    hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
+    assert hardware.validate_calibration() == DeckTransformState.IDENTITY
+
+    singular_matrix = [[0, 0, 0], [0, 0, 0], [0, 0, 1]]
+    deck_cal.attitude = singular_matrix
+    hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
+
+    assert hardware.validate_calibration() == DeckTransformState.SINGULARITY

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -6,6 +6,20 @@ from opentrons.hardware_control import robot_calibration
 from opentrons.util.helpers import utc_now
 
 
+def test_migrate_affine_xy_to_attitude():
+    affine = [[1.0, 0.0, 0.0, 1.8],
+              [0.0, 1.0, 0.0, 3.9],
+              [0.0, 0.0, 1.0, -25.0],
+              [0.0, 0.0, 0.0, 1.0]]
+
+    expected = [[1.0, 1.8, 0.0],
+                [3.9, 1.0, 0.0],
+                [0.0, 0.0, 1.0]]
+
+    result = robot_calibration.migrate_affine_xy_to_attitude(affine)
+    assert result == expected
+
+
 def test_save_calibration(ot_config_tempdir):
     pathway = config.get_opentrons_path(
         'robot_calibration_dir') / 'deck_calibration.json'

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -7,13 +7,13 @@ from opentrons.util.helpers import utc_now
 
 
 def test_migrate_affine_xy_to_attitude():
-    affine = [[1.0, 0.0, 0.0, 1.8],
-              [0.0, 1.0, 0.0, 3.9],
-              [0.0, 0.0, 1.0, -25.0],
-              [0.0, 0.0, 0.0, 1.0]]
+    affine = [[1.0, 2.0, 3.0, 4.0],
+              [5.0, 6.0, 7.0, 8.0],
+              [9.0, 10.0, 11.0, 12.0],
+              [13.0, 14.0, 15.0, 16.0]]
 
-    expected = [[1.0, 1.8, 0.0],
-                [3.9, 1.0, 0.0],
+    expected = [[1.0, 2.0, 3.0],
+                [5.0, 6.0, 7.0],
                 [0.0, 0.0, 1.0]]
 
     result = robot_calibration.migrate_affine_xy_to_attitude(affine)


### PR DESCRIPTION
closes #6446

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When the enable calibration overhaul feature flag is switched on for the first time, valid legacy deck calibration data will be migrated to the new format if there is no current deck calibration. 

# Changelog
- during `load_attitude_matrix`, it will now try to load the affine deck calibration into the new format before loading the default calibration data

- the old calibration data do not contain info on the pipette or tiprack that were used in calibration, so they will be saved as `UNKNOWN`

- pull deck cal matrix validation methods out of hardware controller to be used in `load_attitude_matrix`

- add a new function `migrate_affine_xy_to_attitude`

- update some tests

# Review requests
Should `pipette_calibrated_with` and `tiprack` be `UNKNOWN` or an empty string? Does the code look sane?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium, as it migrates some data. However, it all happens behind a feature flag and the old data will not actually be removed; so it would not break anything when the feature flag is switched off again.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
