### PR TITLE
feat(protocol-designer): account for two air gaps when bumping down multi aspirate to single path

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/PathField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/index.js
@@ -5,7 +5,11 @@ import { Path } from './Path'
 import { i18n } from '../../../../localization'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
 import { getWellRatio } from '../../../../steplist/utils'
-import { volumeInCapacityForMulti } from '../../../../steplist/formLevel/handleFormChange/utils'
+import { getPipetteCapacity } from '../../../../pipettes/pipetteData'
+import {
+  volumeInCapacityForMultiDispense,
+  volumeInCapacityForMultiAspirate,
+} from '../../../../steplist/formLevel/handleFormChange/utils'
 
 import type { PipetteEntities } from '../../../../step-forms'
 import type { FormData, PathOption } from '../../../../form-types'
@@ -21,14 +25,10 @@ function getDisabledPathMap(
 ): ?{ [PathOption]: string } {
   if (!rawForm || !rawForm.pipette) return null
 
-  const withinCapacityForMultiPath = volumeInCapacityForMulti(
-    rawForm,
-    pipetteEntities
-  )
   const wellRatio = getWellRatio(rawForm.aspirate_wells, rawForm.dispense_wells)
   const changeTip = rawForm.changeTip
 
-  let disabledPathMap = {}
+  let disabledPathMap: { multiAspirate: string, multiAspirate: string } = {}
 
   // changeTip is lowest priority disable reasoning
   if (changeTip === 'perDest') {
@@ -48,13 +48,40 @@ function getDisabledPathMap(
   }
 
   // transfer volume overwrites change tip disable reasoning
-  if (!withinCapacityForMultiPath) {
+  const pipetteEntity = pipetteEntities[rawForm.pipette]
+  const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
+
+  const volume = Number(rawForm.volume)
+  const airGapChecked = rawForm['aspirate_airGap_checkbox']
+  let airGapVolume = airGapChecked
+    ? Number(rawForm['aspirate_airGap_volume'])
+    : 0
+  airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
+
+  const withinCapacityForMultiDispense = volumeInCapacityForMultiDispense({
+    volume,
+    pipetteCapacity,
+    airGapVolume,
+  })
+
+  const withinCapacityForMultiAspirate = volumeInCapacityForMultiAspirate({
+    volume,
+    pipetteCapacity,
+    airGapVolume,
+  })
+
+  if (!withinCapacityForMultiDispense) {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiDispense: i18n.t(
+        'form.step_edit_form.field.path.subtitle.volume_too_high'
+      ),
+    }
+  }
+  if (!withinCapacityForMultiAspirate) {
     disabledPathMap = {
       ...disabledPathMap,
       multiAspirate: i18n.t(
-        'form.step_edit_form.field.path.subtitle.volume_too_high'
-      ),
-      multiDispense: i18n.t(
         'form.step_edit_form.field.path.subtitle.volume_too_high'
       ),
     }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/utils.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/utils.test.js
@@ -1,0 +1,250 @@
+// @flow
+import {
+  volumeInCapacityForMulti,
+  volumeInCapacityForMultiAspirate,
+  volumeInCapacityForMultiDispense,
+} from '../utils'
+import { fixtureP300Single } from '@opentrons/shared-data/pipette/fixtures/name'
+import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
+
+describe('utils', () => {
+  describe('volumeInCapacityForMulti', () => {
+    let sharedForm
+    let pipetteEntities
+    beforeEach(() => {
+      sharedForm = {
+        pipette: 'p300_single',
+      }
+      pipetteEntities = {
+        p300_single: {
+          spec: fixtureP300Single,
+          tiprackLabwareDef: fixture_tiprack_300_ul,
+        },
+      }
+    })
+    describe('multi dispense path', () => {
+      const testCases = [
+        {
+          msg: '2x volume + air gap vol <= max capacity',
+          form: {
+            path: 'multiDispense',
+            volume: '100',
+            aspirate_airGap_checkbox: true,
+            aspirate_airGap_volume: '100',
+          },
+          expected: true,
+        },
+        {
+          msg:
+            '2x volume + air gap vol >= max capacity, air gap checkbox NOT checked',
+          form: {
+            path: 'multiDispense',
+            volume: '150',
+            aspirate_airGap_checkbox: false,
+            aspirate_airGap_volume: '100',
+          },
+          expected: true,
+        },
+        {
+          msg: '2x volume + air gap vol >= max capacity',
+          form: {
+            path: 'multiDispense',
+            volume: '150',
+            aspirate_airGap_checkbox: true,
+            aspirate_airGap_volume: '100',
+          },
+          expected: false,
+        },
+        {
+          msg: 'volume too large, no air gap',
+          form: {
+            path: 'multiDispense',
+            volume: '200',
+            aspirate_airGap_checkbox: false,
+            aspirate_airGap_volume: '0',
+          },
+          expected: false,
+        },
+        {
+          msg: 'air gap too large',
+          form: {
+            path: 'multiDispense',
+            volume: '100',
+            aspirate_airGap_checkbox: true,
+            aspirate_airGap_volume: '101',
+          },
+          expected: false,
+        },
+      ]
+      describe('ensure that 2x volume + air gap volume can fit in pipette', () => {
+        testCases.forEach(({ msg, form, expected }) => {
+          it(msg, () => {
+            expect(
+              volumeInCapacityForMulti(
+                { ...sharedForm, ...form },
+                pipetteEntities
+              )
+            ).toBe(expected)
+          })
+        })
+      })
+    })
+    describe('multi aspirate path', () => {
+      const testCases = [
+        {
+          msg: '2x volume + 2x air gap vol >= max capacity',
+          form: {
+            path: 'multiAspirate',
+            volume: '100',
+            aspirate_airGap_checkbox: true,
+            aspirate_airGap_volume: '100',
+          },
+          expected: false,
+        },
+        {
+          msg:
+            '2x volume + 2x air gap vol >= max capacity, air gap checkbox NOT checked',
+          form: {
+            path: 'multiAspirate',
+            volume: '150',
+            aspirate_airGap_checkbox: false,
+            aspirate_airGap_volume: '100',
+          },
+          expected: true,
+        },
+        {
+          msg: 'volume too large, no air gap',
+          form: {
+            path: 'multiAspirate',
+            volume: '200',
+            aspirate_airGap_checkbox: false,
+            aspirate_airGap_volume: '0',
+          },
+          expected: false,
+        },
+        {
+          msg: 'air gap too large',
+          form: {
+            path: 'multiAspirate',
+            volume: '100',
+            aspirate_airGap_checkbox: true,
+            aspirate_airGap_volume: '51',
+          },
+          expected: false,
+        },
+      ]
+      describe('ensure that 2x volume + 2x air gap volume can fit in pipette', () => {
+        testCases.forEach(({ msg, form, expected }) => {
+          it(msg, () => {
+            expect(
+              volumeInCapacityForMulti(
+                { ...sharedForm, ...form },
+                pipetteEntities
+              )
+            ).toBe(expected)
+          })
+        })
+      })
+    })
+  })
+  describe('volumeInCapacityForMultiDispense', () => {
+    it('should return false when air gap is too large', () => {
+      const volume = 5
+      const pipetteCapacity = 300
+      const airGapVolume = 291
+      expect(
+        volumeInCapacityForMultiDispense({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(false)
+    })
+    it('should return false when volume is too large', () => {
+      const volume = 149
+      const pipetteCapacity = 300
+      const airGapVolume = 3
+      expect(
+        volumeInCapacityForMultiDispense({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(false)
+    })
+    it('should return true when air gap is small', () => {
+      const volume = 142
+      const pipetteCapacity = 300
+      const airGapVolume = 16
+      expect(
+        volumeInCapacityForMultiDispense({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(true)
+    })
+    it('should return true when volume is small', () => {
+      const volume = 1
+      const pipetteCapacity = 300
+      const airGapVolume = 298
+      expect(
+        volumeInCapacityForMultiDispense({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(true)
+    })
+  })
+  describe('volumeInCapacityForMultiAspirate', () => {
+    it('should return false when air gap is too large', () => {
+      const volume = 5
+      const pipetteCapacity = 300
+      const airGapVolume = 146
+      expect(
+        volumeInCapacityForMultiAspirate({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(false)
+    })
+    it('should return false when volume is too large', () => {
+      const volume = 149
+      const pipetteCapacity = 300
+      const airGapVolume = 2
+      expect(
+        volumeInCapacityForMultiAspirate({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(false)
+    })
+    it('should return true when air gap is small', () => {
+      const volume = 142
+      const pipetteCapacity = 300
+      const airGapVolume = 8
+      expect(
+        volumeInCapacityForMultiAspirate({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(true)
+    })
+    it('should return true when volume is small', () => {
+      const volume = 1
+      const pipetteCapacity = 300
+      const airGapVolume = 149
+      expect(
+        volumeInCapacityForMultiAspirate({
+          volume,
+          pipetteCapacity,
+          airGapVolume,
+        })
+      ).toBe(true)
+    })
+  })
+})

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -99,6 +99,38 @@ export function volumeInCapacityForMulti(
     : 0
   airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
 
+  return rawForm.path === 'multiAspirate'
+    ? volumeInCapacityForMultiAspirate({
+        volume,
+        pipetteCapacity,
+        airGapVolume,
+      })
+    : volumeInCapacityForMultiDispense({
+        volume,
+        pipetteCapacity,
+        airGapVolume,
+      })
+}
+
+export function volumeInCapacityForMultiAspirate(args: {
+  volume: number,
+  pipetteCapacity: number,
+  airGapVolume: number,
+}): boolean {
+  const { volume, pipetteCapacity, airGapVolume } = args
+  return (
+    volume > 0 &&
+    pipetteCapacity > 0 &&
+    volume * 2 + airGapVolume * 2 <= pipetteCapacity
+  )
+}
+
+export function volumeInCapacityForMultiDispense(args: {
+  volume: number,
+  pipetteCapacity: number,
+  airGapVolume: number,
+}): boolean {
+  const { volume, pipetteCapacity, airGapVolume } = args
   return (
     volume > 0 &&
     pipetteCapacity > 0 &&


### PR DESCRIPTION
# Overview

This PR closes #6469 by accounting for two air gaps when bumping down multi aspirate to single path. It also changes the path disable logic to explicitly check for whether a multi aspirate/multi dispense is possible. 

# Changelog
- Account for two air gaps when bumping down multi aspirate to single path

# Review requests
- Make a protocol with a `P20` single and a `20 ul tiprack`
- Add a tube rack with liquid
- Add a transfer step with 2 source wells, one dest well
- Change the transfer volume to 8
- Add an air gap of 2
- Select multi aspirate path

- [x] This should be fine as a multi aspirate, because (8 * 2) + (2 * 2) = 16 + 4 = 20, which does not exceed the max (20)

- Change air gap to be 3

- [x] This should bump the path down to single , because (8 * 2) + (2 * 3) = 22 > 20, which exceeds the max (20)

- Add another transfer step with 1 source wells, 2 dest wells
- Change the transfer volume to 8
- Add an air gap of 4
- Select multi dispense

- [x] This should be fine as a multi dispense, because (8 * 2) + 4 = 16 + 4 = 20, which does not exceed the max (20)

- Change air gap to be 5

- [x] This should bump the path down to single , because (8 * 2) + 5 = 21 > 20, which exceeds the max (20)


# Risk assessment
Low