### PR TITLE
chore(protocol-designer): bump PD version to 5.0.1

### DIFF
--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '5.0.0'
+const OT_PD_VERSION = '5.0.1'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION
## overview

Bump PD version to 5.0.1 after failed QA in 5.0.0

## changelog
```
897e71172a3d1246529c2922de28eff6eef1cf3b: feat(protocol-designer): account for two air gaps when bumping down multi aspirate
```

## risk assessment

Low