### PR TITLE
feat(protocol-designer): strip no-op mixes from robot state generation

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/removePairs.test.js
+++ b/protocol-designer/src/step-generation/__tests__/removePairs.test.js
@@ -18,16 +18,16 @@ describe('removePairs', () => {
   })
 
   const cases = [
-    // { input: [2], expected: [2] },
-    // { input: [2, 3], expected: [] },
-    // { input: [2, 3, 2, 3], expected: [] },
-    // { input: [2, 3, 2, 3, 2, 3], expected: [] },
-    // { input: [1, 2, 3], expected: [1] },
+    { input: [2], expected: [2] },
+    { input: [2, 3], expected: [] },
+    { input: [2, 3, 2, 3], expected: [] },
+    { input: [2, 3, 2, 3, 2, 3], expected: [] },
+    { input: [1, 2, 3], expected: [1] },
     { input: [2, 3, 4], expected: [4] },
-    // { input: [1, 2, 3, 4], expected: [1, 4] },
-    // { input: [1, 2, 3, 4, 2, 3], expected: [1, 4] },
-    // { input: [2, 3, 1, 2, 3, 4], expected: [1, 4] },
-    // { input: [2, 2, 2, 2], expected: [2, 2, 2, 2] },
+    { input: [1, 2, 3, 4], expected: [1, 4] },
+    { input: [1, 2, 3, 4, 2, 3], expected: [1, 4] },
+    { input: [2, 3, 1, 2, 3, 4], expected: [1, 4] },
+    { input: [2, 2, 2, 2], expected: [2, 2, 2, 2] },
   ]
   cases.forEach(({ input, expected }) =>
     it(`should do ${JSON.stringify(input)} => ${JSON.stringify(

--- a/protocol-designer/src/step-generation/__tests__/removePairs.test.js
+++ b/protocol-designer/src/step-generation/__tests__/removePairs.test.js
@@ -1,0 +1,40 @@
+// @flow
+import { removePairs } from '../utils/removePairs'
+
+const twoThenThree = (a, b) => {
+  if (a === undefined) {
+    throw new Error('a is undefined')
+  }
+  if (b === undefined) {
+    throw new Error('b is undefined')
+  }
+  return a === 2 && b === 3
+}
+
+describe('removePairs', () => {
+  it('should work with empty array', () => {
+    expect(removePairs([], () => true)).toEqual([])
+    expect(removePairs([], () => false)).toEqual([])
+  })
+
+  const cases = [
+    // { input: [2], expected: [2] },
+    // { input: [2, 3], expected: [] },
+    // { input: [2, 3, 2, 3], expected: [] },
+    // { input: [2, 3, 2, 3, 2, 3], expected: [] },
+    // { input: [1, 2, 3], expected: [1] },
+    { input: [2, 3, 4], expected: [4] },
+    // { input: [1, 2, 3, 4], expected: [1, 4] },
+    // { input: [1, 2, 3, 4, 2, 3], expected: [1, 4] },
+    // { input: [2, 3, 1, 2, 3, 4], expected: [1, 4] },
+    // { input: [2, 2, 2, 2], expected: [2, 2, 2, 2] },
+  ]
+  cases.forEach(({ input, expected }) =>
+    it(`should do ${JSON.stringify(input)} => ${JSON.stringify(
+      expected
+    )}`, () => {
+      const result = removePairs(input, twoThenThree)
+      expect(result).toEqual(expected)
+    })
+  )
+})

--- a/protocol-designer/src/step-generation/__tests__/stripNoOpMixCommands.test.js
+++ b/protocol-designer/src/step-generation/__tests__/stripNoOpMixCommands.test.js
@@ -1,0 +1,64 @@
+// @flow
+import { _stripNoOpMixCommands } from '../utils/stripNoOpCommands'
+
+describe('_stripNoOpMixCommands', () => {
+  it('should remove pairs of aspirate+dispense commands when they result in no liquid changes', () => {
+    const commands = [
+      {
+        command: 'aspirate',
+        params: {
+          pipette: 'pipetteId',
+          volume: 3,
+          labware: 'labwareId',
+          well: 'A1',
+          offsetFromBottomMm: 1,
+          flowRate: 3.75,
+        },
+      },
+      {
+        command: 'dispense',
+        params: {
+          pipette: 'pipetteId',
+          volume: 3,
+          labware: 'labwareId',
+          well: 'A1',
+          //   NOTE: offsetFromBottomMm and flowRate can differ
+          offsetFromBottomMm: 1.5,
+          flowRate: 2.5,
+        },
+      },
+    ]
+    const result = _stripNoOpMixCommands(commands)
+    expect(result).toEqual([])
+  })
+
+  it('should NOT remove pairs of aspirate+dispense commands when they result in liquid changes', () => {
+    const commands = [
+      {
+        command: 'aspirate',
+        params: {
+          pipette: 'pipetteId',
+          volume: 3,
+          labware: 'labwareId',
+          well: 'A1',
+          offsetFromBottomMm: 1,
+          flowRate: 3.75,
+        },
+      },
+      {
+        command: 'dispense',
+        params: {
+          pipette: 'pipetteId',
+          // dispense different volume than aspirate
+          volume: 4,
+          labware: 'labwareId',
+          well: 'A1',
+          offsetFromBottomMm: 1,
+          flowRate: 3.75,
+        },
+      },
+    ]
+    const result = _stripNoOpMixCommands(commands)
+    expect(result).toEqual(commands)
+  })
+})

--- a/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
+++ b/protocol-designer/src/step-generation/getNextRobotStateAndWarnings/index.js
@@ -1,6 +1,7 @@
 // @flow
 import assert from 'assert'
 import produce from 'immer'
+import { stripNoOpCommands } from '../utils/stripNoOpCommands'
 import { forAspirate } from './forAspirate'
 import { forDispense } from './forDispense'
 import { forBlowout } from './forBlowout'
@@ -193,8 +194,9 @@ export function getNextRobotStateAndWarnings(
     warnings: [],
     robotState: initialRobotState,
   }
+  const strippedCommands = stripNoOpCommands(commands)
   return produce(prevState, draft => {
-    commands.forEach(command => {
+    strippedCommands.forEach(command => {
       _getNextRobotStateAndWarningsSingleCommand(
         command,
         invariantContext,

--- a/protocol-designer/src/step-generation/utils/commandCreatorsTimeline.js
+++ b/protocol-designer/src/step-generation/utils/commandCreatorsTimeline.js
@@ -1,6 +1,7 @@
 // @flow
 import last from 'lodash/last'
 import { getNextRobotStateAndWarningsSingleCommand } from '../getNextRobotStateAndWarnings'
+import { stripNoOpCommands } from './stripNoOpCommands'
 import type {
   InvariantContext,
   RobotState,
@@ -8,6 +9,7 @@ import type {
   CurriedCommandCreator,
   RobotStateAndWarnings,
 } from '../types'
+
 export const commandCreatorsTimeline = (
   commandCreators: Array<CurriedCommandCreator>,
   invariantContext: InvariantContext,
@@ -37,8 +39,8 @@ export const commandCreatorsTimeline = (
         }
       }
 
-      const commands = commandCreatorResult.commands
-      const nextRobotStateAndWarnings = commands.reduce(
+      const strippedCommands = stripNoOpCommands(commandCreatorResult.commands)
+      const nextRobotStateAndWarnings = strippedCommands.reduce(
         (acc: RobotStateAndWarnings, command) =>
           getNextRobotStateAndWarningsSingleCommand(
             command,

--- a/protocol-designer/src/step-generation/utils/removePairs.js
+++ b/protocol-designer/src/step-generation/utils/removePairs.js
@@ -1,0 +1,31 @@
+// @flow
+
+// Skip all pairs for which `excludeWhen` returns true
+export function removePairs<T>(
+  input: Array<T>,
+  excludeWhen: (T, T) => boolean
+): Array<T> {
+  const WIDTH = 2
+  let currentPos = 0
+  const res: Array<T> = []
+  while (currentPos + 1 < input.length) {
+    console.log({ currentPos })
+    const firstVal = input[currentPos]
+    const secondVal = input[currentPos + 1]
+    if (excludeWhen(firstVal, secondVal)) {
+      // we do not want to include these values, skip ahead by 2
+      currentPos += WIDTH
+      console.log({ res })
+      continue
+    } else {
+      res.push(firstVal)
+      currentPos += 1
+      console.log({ res })
+    }
+  }
+
+  if (currentPos + 1 === input.length) {
+    res.push(input[currentPos])
+  }
+  return res
+}

--- a/protocol-designer/src/step-generation/utils/removePairs.js
+++ b/protocol-designer/src/step-generation/utils/removePairs.js
@@ -9,21 +9,20 @@ export function removePairs<T>(
   let currentPos = 0
   const res: Array<T> = []
   while (currentPos + 1 < input.length) {
-    console.log({ currentPos })
     const firstVal = input[currentPos]
     const secondVal = input[currentPos + 1]
     if (excludeWhen(firstVal, secondVal)) {
       // we do not want to include these values, skip ahead by 2
       currentPos += WIDTH
-      console.log({ res })
       continue
     } else {
       res.push(firstVal)
       currentPos += 1
-      console.log({ res })
     }
   }
 
+  // make sure we account for the last item if we exited the while loop
+  // before we got to it
   if (currentPos + 1 === input.length) {
     res.push(input[currentPos])
   }

--- a/protocol-designer/src/step-generation/utils/stripNoOpCommands.js
+++ b/protocol-designer/src/step-generation/utils/stripNoOpCommands.js
@@ -1,0 +1,47 @@
+// @flow
+import type { _AspDispAirgapParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV6'
+
+// TODO IMMEDIATELY: clean up flow types here
+type AspOrDisp = {|
+  command: 'aspirate' | 'dispense' | 'airGap',
+  params: _AspDispAirgapParams,
+|}
+
+const _isEqualMix = (a: AspOrDisp, b: AspOrDisp): boolean => {
+  const compareParams = ['pipette', 'volume', 'labware', 'well']
+  return compareParams.every(param => a.params[param] === b.params[param])
+}
+
+export const _stripNoOpMixCommands = (
+  commands: Array<Command>
+): Array<Command> => {
+  const result: Array<Command> = []
+  commands.forEach((command, index) => {
+    if (command.command === 'aspirate') {
+      const nextCommand = commands[index + 1]
+      if (
+        nextCommand?.command === 'dispense' &&
+        _isEqualMix(command, nextCommand)
+      ) {
+        return
+      }
+    }
+    if (command.command === 'dispense' && index > 0) {
+      const prevCommand = commands[index - 1]
+      if (
+        prevCommand.command === 'aspirate' &&
+        _isEqualMix(command, prevCommand)
+      ) {
+        return
+      }
+    }
+    result.push(command)
+  })
+  return result
+}
+
+// This is an optimization to avoid unneeded computation during timeline generation.
+// Remove groups of commands from the array if together they will have no effect on the state
+export const stripNoOpCommands = (commands: Array<Command>): Array<Command> =>
+  _stripNoOpMixCommands(commands)

--- a/protocol-designer/src/step-generation/utils/stripNoOpCommands.js
+++ b/protocol-designer/src/step-generation/utils/stripNoOpCommands.js
@@ -1,4 +1,5 @@
 // @flow
+import { removePairs } from './removePairs'
 import type { AspDispAirgapParams } from '@opentrons/shared-data/protocol/flowTypes/schemaV3'
 import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV6'
 
@@ -12,35 +13,18 @@ const _isEqualMix = (
 
 export const _stripNoOpMixCommands = (
   commands: Array<Command>
-): Array<Command> => {
-  const result: Array<Command> = []
-  commands.forEach((command, index) => {
-    // aspirate followed by dispense
-    if (command.command === 'aspirate') {
-      const nextCommand: ?Command = commands[index + 1]
-      if (
-        nextCommand?.command === 'dispense' &&
-        _isEqualMix(command.params, nextCommand.params)
-      ) {
-        return
-      }
-    }
-    // dispense preceded by aspirate
-    if (command.command === 'dispense' && index > 0) {
-      const prevCommand: ?Command = commands[index - 1]
-      if (
-        prevCommand?.command === 'aspirate' &&
-        _isEqualMix(command.params, prevCommand.params)
-      ) {
-        return
-      }
-    }
-    result.push(command)
-  })
-  return result
-}
+): Array<Command> =>
+  removePairs<Command>(
+    commands,
+    (a, b) =>
+      a.command === 'aspirate' &&
+      b.command === 'dispense' &&
+      _isEqualMix(a.params, b.params)
+  )
 
 // This is an optimization to avoid unneeded computation during timeline generation.
 // Remove groups of commands from the array if together they will have no effect on the state
+// (NOTE: the only one here right now is strip mix commands, but we may add
+// additional transformations besides mix commands to stripNoOpCommands later on)
 export const stripNoOpCommands = (commands: Array<Command>): Array<Command> =>
   _stripNoOpMixCommands(commands)

--- a/shared-data/protocol/flowTypes/schemaV3.js
+++ b/shared-data/protocol/flowTypes/schemaV3.js
@@ -28,16 +28,16 @@ type VolumeParams = {| volume: number |}
 
 type OffsetParams = {| offsetFromBottomMm: number |}
 
-export type _AspDispAirgapParams = {|
+export type AspDispAirgapParams = {|
   ...FlowRateParams,
   ...PipetteAccessParams,
   ...VolumeParams,
   ...OffsetParams,
 |}
 
-export type AspirateParams = _AspDispAirgapParams
-export type DispenseParams = _AspDispAirgapParams
-export type AirGapParams = _AspDispAirgapParams
+export type AspirateParams = AspDispAirgapParams
+export type DispenseParams = AspDispAirgapParams
+export type AirGapParams = AspDispAirgapParams
 
 export type BlowoutParams = {|
   ...FlowRateParams,
@@ -73,7 +73,7 @@ export type DelayParams = {|
 export type Command =
   | {|
       command: 'aspirate' | 'dispense' | 'airGap',
-      params: _AspDispAirgapParams,
+      params: AspDispAirgapParams,
     |}
   | {|
       command: 'blowout',

--- a/shared-data/protocol/flowTypes/schemaV4.js
+++ b/shared-data/protocol/flowTypes/schemaV4.js
@@ -2,7 +2,7 @@
 import type { DeckSlotId, ModuleModel } from '@opentrons/shared-data'
 import type {
   ProtocolFile as V3ProtocolFile,
-  _AspDispAirgapParams,
+  AspDispAirgapParams,
   BlowoutParams,
   TouchTipParams,
   PipetteAccessParams,
@@ -41,7 +41,7 @@ export type ThermocyclerSetTargetBlockTemperatureArgs = {|
 export type Command =
   | {|
       command: 'aspirate' | 'dispense' | 'airGap',
-      params: _AspDispAirgapParams,
+      params: AspDispAirgapParams,
     |}
   | {|
       command: 'blowout',


### PR DESCRIPTION
# Overview

Closes #6176 (?!?)

Locally, made the "mix 200 times" benchmark go from 4.2 secs to 0.13 secs!

# Changelog

- Skip asp/disp commands in robot state update when together they don't to anything to liquid state (eg repeated mixes)

# Review requests

The tests are passing and I'm not sure what could go wrong since it is generating the proper commands it needs to generate both in unit and e2e.

A hole in our test coverage is the mouseover liquid tracking stuff (both deck and substep versions which are kinda independent) so I guess we could manually check that and feel pretty good about it??

Aside from "does it break anything?" I'm curious if this seems hacky or clean, IDK it's been in my head a long while so I can't get much objectivity on it myself

# Risk assessment

Could mess up PD and its protocols in weird ways if anything is wrong. PD only though.