### PR TITLE
fix(app): make tip length calibration use generic calibration command

### DIFF
--- a/app/src/sessions/tip-length-calibration/constants.js
+++ b/app/src/sessions/tip-length-calibration/constants.js
@@ -17,11 +17,8 @@ export const TIP_LENGTH_STEP_CALIBRATION_COMPLETE: 'calibrationComplete' =
 
 const MOVE_TO_REFERENCE_POINT: 'calibration.tipLength.moveToReferencePoint' =
   'calibration.tipLength.moveToReferencePoint'
-const MOVE_TO_TIP_RACK: 'calibration.tipLength.moveToTipRack' =
-  'calibration.tipLength.moveToTipRack'
 
 export const tipCalCommands = {
   ...sharedCalCommands,
   MOVE_TO_REFERENCE_POINT,
-  MOVE_TO_TIP_RACK,
 }


### PR DESCRIPTION
# Overview

The moveToTipRack command was moved up into the generic calibration session command scope, but this instance was not updated, which caused the tip calibration flow to stop before grabbing the tip. 

# Changelog

Switch out the command string for the moveToTipRack command for the generically scoped calibration session command.

# Review requests

Ensure you can run through tip length calibration

# Risk assessment
 
Low, very small change
