### PR TITLE
refactor(robot-server): pipette offset user flow - save pipette calibration

### DIFF
--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -205,7 +205,7 @@ def save_robot_deck_attitude(
 
 
 def save_pipette_calibration(
-        offset: local_types.PipetteOffset,
+        offset: 'Point',
         pip_id: str, mount: Mount,
         tiprack_hash: str, tiprack_uri: str):
     pip_dir = config.get_opentrons_path(
@@ -213,7 +213,7 @@ def save_pipette_calibration(
     pip_dir.mkdir(parents=True, exist_ok=True)
     offset_path = pip_dir/f'{pip_id}.json'
     offset_dict: 'PipetteCalibrationData' = {
-        'offset': offset,
+        'offset': [offset.x, offset.y, offset.z],
         'tiprack': tiprack_hash,
         'uri': tiprack_uri,
         'last_modified': utc_now(),

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -193,6 +193,7 @@ def save_robot_deck_attitude(
         pip_id: typing.Optional[str],
         lw_hash: typing.Optional[str]):
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
+    print(robot_dir)
     robot_dir.mkdir(parents=True, exist_ok=True)
     gantry_path = robot_dir/'deck_calibration.json'
     gantry_dict: 'DeckCalibrationData' = {

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -193,7 +193,6 @@ def save_robot_deck_attitude(
         pip_id: typing.Optional[str],
         lw_hash: typing.Optional[str]):
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
-    print(robot_dir)
     robot_dir.mkdir(parents=True, exist_ok=True)
     gantry_path = robot_dir/'deck_calibration.json'
     gantry_dict: 'DeckCalibrationData' = {

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -175,7 +175,7 @@ class PipetteOffsetCalibrationUserFlow:
             self._z_height_reference = cur_pt.z
         elif self._current_state == State.savingPointOne:
             tiprack_hash = helpers.hash_labware_def(
-                self._deck[TIP_RACK_SLOT]._definition) + ''
+                self._tip_rack._definition)
             modify.save_pipette_calibration(
                 offset=cur_pt,
                 pip_id=self._hw_pipette.pipette_id,

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
-from opentrons.calibration_storage import get
+from opentrons.calibration_storage import get, modify, helpers
 from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import ThreadManager, CriticalPoint
@@ -174,8 +174,13 @@ class PipetteOffsetCalibrationUserFlow:
         if self.current_state == State.joggingToDeck:
             self._z_height_reference = cur_pt.z
         elif self._current_state == State.savingPointOne:
-            # TODO: save pipette offset
-            pass
+            tiprack_hash = helpers.hash_labware_def(
+                self._deck[TIP_RACK_SLOT]._definition) + ''
+            modify.save_pipette_calibration(
+                offset=cur_pt,
+                pip_id=self._hw_pipette.pipette_id,
+                tiprack_hash=tiprack_hash,
+                tiprack_uri=self._tip_rack.uri)
 
     async def pick_up_tip(self):
         await uf.pick_up_tip(self, tip_length=self._get_tip_length())

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, call
 from typing import List, Tuple, Dict, Any
+from opentrons.calibration_storage import modify, helpers
 from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 
@@ -190,3 +191,31 @@ def test_no_pipette(hardware, mount):
                                          mount=mount)
 
     assert error.value.error.detail == f"No pipette present on {mount} mount"
+
+
+async def test_save_pipette_calibration(mock_user_flow):
+    uf = mock_user_flow
+
+    def mock_save_pipette_offset(*args, **kwargs):
+        pass
+
+    def mock_hash_labware_def(*args, **kwargs):
+        return 'fakeHash'
+
+    modify.save_pipette_calibration = \
+        MagicMock(side_effect=mock_save_pipette_offset)
+    helpers.hash_labware_def = MagicMock(side_effect=mock_hash_labware_def)
+
+    uf._current_state = 'savingPointOne'
+    await uf._hardware.move_to(
+            mount=uf._mount,
+            abs_position=Point(x=10, y=10, z=40),
+            critical_point=uf._get_critical_point_override()
+        )
+    await uf.save_offset()
+    modify.save_pipette_calibration.assert_called_with(
+        offset=Point(x=10, y=10, z=40),
+        pip_id=uf._hw_pipette.pipette_id,
+        tiprack_hash='fakeHash',
+        tiprack_uri=uf._tip_rack.uri
+    )

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -199,12 +199,8 @@ async def test_save_pipette_calibration(mock_user_flow):
     def mock_save_pipette_offset(*args, **kwargs):
         pass
 
-    def mock_hash_labware_def(*args, **kwargs):
-        return 'fakeHash'
-
     modify.save_pipette_calibration = \
         MagicMock(side_effect=mock_save_pipette_offset)
-    helpers.hash_labware_def = MagicMock(side_effect=mock_hash_labware_def)
 
     uf._current_state = 'savingPointOne'
     await uf._hardware.move_to(
@@ -212,10 +208,13 @@ async def test_save_pipette_calibration(mock_user_flow):
             abs_position=Point(x=10, y=10, z=40),
             critical_point=uf._get_critical_point_override()
         )
+
     await uf.save_offset()
+    tiprack_hash = helpers.hash_labware_def(uf._tip_rack._definition)
+
     modify.save_pipette_calibration.assert_called_with(
         offset=Point(x=10, y=10, z=40),
         pip_id=uf._hw_pipette.pipette_id,
-        tiprack_hash='fakeHash',
+        tiprack_hash=tiprack_hash,
         tiprack_uri=uf._tip_rack.uri
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR plugs the save calibration method created in #6502 in the pipette offset user flow.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- `offset` arg now expects a `Point` instead of a `list` to make sure we're only storing the correct data
- add appropriate test

# Review requests
Make sure the pipette offset data are being saved as you run through the offset calibration
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low, behind a feature flag
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
