### PR TITLE
feat(protocol-designer): setup Mixpanel and add initial events

### DIFF
--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -57,6 +57,10 @@ Used for analytics segmentation. In Travis CI, this is fed by `$TRAVIS_COMMIT`.
 
 Used for FullStory. Should be provided in the Travis build.
 
+### `OT_PD_MIXPANEL_ID`
+
+Used for Mixpanel. Should be provided in the Travis build.
+
 ### `OT_PD_SHOW_GATE`
 
 If truthy, uses the `GateModal` component in development. The `GateModal` component is always used in production.

--- a/protocol-designer/src/analytics/__tests__/flattenNestedProperties.test.js
+++ b/protocol-designer/src/analytics/__tests__/flattenNestedProperties.test.js
@@ -1,0 +1,58 @@
+// @flow
+import { flattenNestedProperties } from '../utils/flattenNestedProperties'
+
+describe('flattenNestedProperties', () => {
+  it('should flatten shallow nested properties', () => {
+    const result = flattenNestedProperties({ a: { b: 'blah' } })
+    expect(result).toEqual({ __a__b: 'blah' })
+  })
+
+  it('should flatten deep nested properties', () => {
+    const result = flattenNestedProperties({
+      outer: { inner: { innermost: { x: 123 } } },
+    })
+
+    expect(result).toEqual({ __outer__inner__innermost__x: 123 })
+  })
+
+  it('should handle arrays', () => {
+    const result = flattenNestedProperties({
+      arr: [1, 2, 3],
+      x: { y: 'foo', innerArr: [11, 22, 33] },
+    })
+    expect(result).toEqual({ __x__y: 'foo', __x__innerArr: [11, 22, 33] })
+  })
+
+  it('should exclude non-nested properties', () => {
+    const result = flattenNestedProperties({ a: 123, arr: [1, 2, 3] })
+    expect(result).toEqual({})
+  })
+
+  it('should handle getting empty object', () => {
+    const result = flattenNestedProperties({})
+    expect(result).toEqual({})
+  })
+
+  it('should work with several levels of nesting in the input', () => {
+    const result = flattenNestedProperties({
+      apple: {
+        seeds: true,
+        color: 'red',
+        alternatives: { color: 'green', seeds: false },
+      },
+      banana: {
+        seeds: false,
+        color: 'yellow',
+      },
+      foo: 'blah',
+    })
+    expect(result).toEqual({
+      __apple__seeds: true,
+      __apple__color: 'red',
+      __apple__alternatives__color: 'green',
+      __apple__alternatives__seeds: false,
+      __banana__seeds: false,
+      __banana__color: 'yellow',
+    })
+  })
+})

--- a/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
+++ b/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
@@ -1,0 +1,87 @@
+// @flow
+import { reduxActionToAnalyticsEvent } from '../middleware'
+import { getFileMetadata } from '../../file-data/selectors'
+import {
+  getArgsAndErrorsByStepId,
+  getPipetteEntities,
+} from '../../step-forms/selectors'
+import type { FileMetadataFields } from '../../file-data/types'
+
+jest.mock('../../file-data/selectors')
+jest.mock('../../step-forms/selectors')
+
+const getFileMetadataMock: JestMockFn<any, FileMetadataFields> = getFileMetadata
+const getArgsAndErrorsByStepIdMock: JestMockFn<
+  any,
+  any
+> = getArgsAndErrorsByStepId
+const getPipetteEntitiesMock: JestMockFn<any, any> = getPipetteEntities
+
+let fooState: any
+beforeEach(() => {
+  fooState = {}
+  getFileMetadataMock.mockReturnValue({
+    protocolName: 'protocol name here',
+    created: 1600000000000, // 2020-09-13T12:26:40.000Z
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('reduxActionToAnalyticsEvent', () => {
+  it('should return null for unhandled actions', () => {
+    expect(
+      reduxActionToAnalyticsEvent(fooState, { type: 'SOME_UNHANDLED_ACTION' })
+    ).toBe(null)
+  })
+
+  it('should return payload of ANALYTICS_EVENT action, as-is', () => {
+    // IRL the payload would be an AnalyticsEventAction
+    const action = { type: 'ANALYTICS_EVENT', payload: { foo: 123 } }
+    const result = reduxActionToAnalyticsEvent(fooState, action)
+    expect(result).toBe(action.payload)
+  })
+
+  it('should convert a SAVE_STEP_FORM action into a saveStep action with additional properties', () => {
+    getArgsAndErrorsByStepIdMock.mockReturnValue({
+      stepId: {
+        stepArgs: {
+          id: 'stepId',
+          pipette: 'pipetteId',
+          otherField: 123,
+          nested: { inner: true },
+        },
+      },
+    })
+    getPipetteEntitiesMock.mockReturnValue({
+      pipetteId: { name: 'some_pipette_spec_name' },
+    })
+
+    const action = {
+      type: 'SAVE_STEP_FORM',
+      payload: {
+        id:
+          'stepId' /* .. other fields don't matter, will be read from getArgsAndErrors */,
+      },
+    }
+    const result = reduxActionToAnalyticsEvent(fooState, action)
+    expect(result).toEqual({
+      name: 'saveStep',
+      properties: {
+        // existing fields
+        id: 'stepId',
+        pipette: 'pipetteId',
+        otherField: 123,
+        // de-nested fields
+        __nested__inner: true,
+        nested: { inner: true },
+        // additional special properties for analytics
+        __dateCreated: '2020-09-13T12:26:40.000Z',
+        __protocolName: 'protocol name here',
+        __pipetteName: 'some_pipette_spec_name',
+      },
+    })
+  })
+})

--- a/protocol-designer/src/analytics/actions.js
+++ b/protocol-designer/src/analytics/actions.js
@@ -1,5 +1,7 @@
 // @flow
 import { initializeFullstory, shutdownFullstory } from './fullstory'
+import { setMixpanelTracking } from './mixpanel'
+import type { AnalyticsEvent } from './mixpanel'
 
 export type SetOptIn = {|
   type: 'SET_OPT_IN',
@@ -10,8 +12,10 @@ const _setOptIn = (payload: $PropertyType<SetOptIn, 'payload'>): SetOptIn => {
   // side effects
   if (payload) {
     initializeFullstory()
+    setMixpanelTracking(true)
   } else {
     shutdownFullstory()
+    setMixpanelTracking(false)
   }
 
   return {
@@ -22,3 +26,22 @@ const _setOptIn = (payload: $PropertyType<SetOptIn, 'payload'>): SetOptIn => {
 
 export const optIn = (): SetOptIn => _setOptIn(true)
 export const optOut = (): SetOptIn => _setOptIn(false)
+
+export type AnalyticsEventAction = {|
+  type: 'ANALYTICS_EVENT',
+  payload: AnalyticsEvent,
+|}
+
+// NOTE: this action creator should only be used for special cases where you want to
+// report an analytics event but you do not have any Redux action that sensibly represents
+// that analytics event.
+//
+// When there *is* a Redux action associated with what you want to report to analytics,
+// use the analytics middleware (usually this means adding a case to
+// `reduxActionToAnalyticsEvent` fn) and don't dispatch ANALYTICS_EVENT.
+//
+// PS: ANALYTICS_EVENT action is effected by the analytics middleware anyway, because
+// we need to read opt-in status from the Redux state.
+export const analyticsEvent = (
+  payload: AnalyticsEvent
+): AnalyticsEventAction => ({ type: 'ANALYTICS_EVENT', payload })

--- a/protocol-designer/src/analytics/middleware.js
+++ b/protocol-designer/src/analytics/middleware.js
@@ -1,0 +1,54 @@
+// @flow
+import { trackEvent } from './mixpanel'
+import { getHasOptedIn } from './selectors'
+import { getArgsAndErrorsByStepId } from '../step-forms/selectors'
+import type { Middleware } from 'redux'
+import type { BaseState } from '../types'
+import type { SaveStepFormAction } from '../ui/steps/actions/thunks'
+import type { AnalyticsEventAction } from './actions'
+import type { AnalyticsEvent } from './mixpanel'
+
+// Converts Redux actions to analytics events (read: Mixpanel events).
+// Returns null if there is no analytics event associated with the action,
+// which happens for most actions.
+export const reduxActionToAnalyticsEvent = (
+  state: BaseState,
+  action: any
+): AnalyticsEvent | null => {
+  if (action.type === 'SAVE_STEP_FORM') {
+    // create the "saveStep" action, taking advantage of the formToArgs machinery
+    // to get nice cleaned-up data instead of the raw form data.
+    const a: SaveStepFormAction = action
+    const argsAndErrors = getArgsAndErrorsByStepId(state)[a.payload.id]
+    if (argsAndErrors.stepArgs !== null) {
+      return {
+        name: 'saveStep',
+        // TODO IMMEDIATELY: add human-readable pipette info instead of UUID?
+        properties: argsAndErrors.stepArgs,
+      }
+    }
+  }
+  if (action.type === 'ANALYTICS_EVENT') {
+    const a: AnalyticsEventAction = action
+    return a.payload
+  }
+  return null
+}
+
+export const trackEventMiddleware: Middleware<BaseState, any> = ({
+  getState,
+  dispatch,
+}) => next => action => {
+  const result = next(action)
+
+  // NOTE: this is the Redux state AFTER the action has been fully dispatched
+  const state = getState()
+
+  const optedIn = getHasOptedIn(state) || false
+  const event = reduxActionToAnalyticsEvent(state, action)
+  if (event) {
+    // actually report to analytics (trackEvent is responsible for using optedIn)
+    trackEvent(event, optedIn)
+  }
+  return result
+}

--- a/protocol-designer/src/analytics/mixpanel.js
+++ b/protocol-designer/src/analytics/mixpanel.js
@@ -1,0 +1,67 @@
+// @flow
+// TODO(IL, 2020-09-09): reconcile with app/src/analytics/mixpanel.js, which this is derived from
+import mixpanel from 'mixpanel-browser'
+import { getHasOptedIn } from './selectors'
+import type { BaseState } from '../types'
+
+// TODO(IL, 2020-09-09): AnalyticsEvent type copied from app/src/analytics/types.js, consider merging
+export type AnalyticsEvent =
+  | {|
+      name: string,
+      properties: { ... },
+      superProperties?: { ... },
+    |}
+  | {| superProperties: { ... } |}
+
+// pulled in from environment at build time
+const MIXPANEL_ID = process.env.OT_PD_MIXPANEL_ID
+
+const MIXPANEL_OPTS = {
+  // opt out by default
+  opt_out_tracking_by_default: true,
+}
+
+export function initializeMixpanel(state: BaseState) {
+  const optedIn = getHasOptedIn(state) || false
+  if (MIXPANEL_ID) {
+    console.debug('Initializing Mixpanel', { optedIn })
+
+    mixpanel.init(MIXPANEL_ID, MIXPANEL_OPTS)
+    setMixpanelTracking(optedIn)
+    trackEvent({ name: 'appOpen', properties: {} }, optedIn) // TODO IMMEDIATELY: do we want this?
+  } else {
+    console.warn('MIXPANEL_ID not found; this is a bug if build is production')
+  }
+}
+
+// NOTE: Do not use directly. Used in analytics Redux middleware: trackEventMiddleware.
+export function trackEvent(event: AnalyticsEvent, optedIn: boolean) {
+  console.debug('Trackable event', { event, optedIn })
+  if (MIXPANEL_ID && optedIn) {
+    if (event.superProperties) {
+      mixpanel.register(event.superProperties)
+    }
+    if (event.name) {
+      mixpanel.track(event.name, event.properties)
+    }
+  }
+}
+
+export function setMixpanelTracking(optedIn: boolean) {
+  if (MIXPANEL_ID) {
+    if (optedIn) {
+      console.debug('User has opted into analytics; tracking with Mixpanel')
+      mixpanel.opt_in_tracking()
+      // Register "super properties" which are included with all events
+      mixpanel.register({
+        appVersion: process.env.OT_PD_VERSION,
+      })
+    } else {
+      console.debug(
+        'User has opted out of analytics; stopping Mixpanel tracking'
+      )
+      mixpanel.opt_out_tracking()
+      mixpanel.reset()
+    }
+  }
+}

--- a/protocol-designer/src/analytics/mixpanel.js
+++ b/protocol-designer/src/analytics/mixpanel.js
@@ -55,6 +55,8 @@ export function setMixpanelTracking(optedIn: boolean) {
       // Register "super properties" which are included with all events
       mixpanel.register({
         appVersion: process.env.OT_PD_VERSION,
+        // NOTE(IL, 2020): Since PD may be in the same Mixpanel project as other OT web apps, this 'appName' property is intended to distinguish it
+        appName: 'protocolDesigner',
       })
     } else {
       console.debug(

--- a/protocol-designer/src/analytics/utils/flattenNestedProperties.js
+++ b/protocol-designer/src/analytics/utils/flattenNestedProperties.js
@@ -1,0 +1,37 @@
+// @flow
+import isPlainObject from 'lodash/isPlainObject'
+
+const SEPARATOR = '__'
+
+const _innerFnFlattenNested = (innerProperties: any, prefix: string) => {
+  return Object.keys(innerProperties).reduce((acc, key) => {
+    // if the key's value is an object, recurse into it
+    const nestedValue = innerProperties[key]
+    if (isPlainObject(nestedValue)) {
+      return {
+        ...acc,
+        ..._innerFnFlattenNested(nestedValue, `${prefix}${SEPARATOR}${key}`),
+      }
+    }
+
+    // ignore non-nested (aka top-level) keys: if no prefix, we're on the top level
+    // of the original object.
+    if (prefix === '') {
+      return acc
+    } else {
+      return {
+        ...acc,
+        [`${prefix}${SEPARATOR}${key}`]: nestedValue,
+      }
+    }
+  }, {})
+}
+
+// Mixpanel isn't as easy to query if you have nested properties.
+// Instead of hard-coding how to transform each nested field to flat ones,
+// this util does {a: {b: 1, c: 'ccc'}, d: 123, e: [1,2,3]} => {__a__b: 1, __a__c: 'ccc'}.
+// Note that non-nested properties are omitted from the result.
+// Also, the separator will not be escaped, so if you have a field already named '__foo__a'
+// and also have a {foo: {a: 123}}, they'll clash.
+export const flattenNestedProperties = (properties: any): any =>
+  _innerFnFlattenNested(properties, '')

--- a/protocol-designer/src/configureStore.js
+++ b/protocol-designer/src/configureStore.js
@@ -1,6 +1,7 @@
 // @flow
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
+import { trackEventMiddleware } from './analytics/middleware'
 import { makePersistSubscriber, rehydratePersistedAction } from './persist'
 import { fileUploadMessage } from './load-file/actions'
 import { makeTimelineMiddleware } from './timelineMiddleware/makeTimelineMiddleware'
@@ -74,7 +75,9 @@ export function configureStore(): Store<
   const store = createStore<BaseState, Action, ThunkDispatch<*>>(
     reducer,
     /* preloadedState, */
-    composeEnhancers(applyMiddleware(timelineMiddleware, thunk))
+    composeEnhancers(
+      applyMiddleware(trackEventMiddleware, timelineMiddleware, thunk)
+    )
   )
 
   // give reselect tools access to state if in dev env

--- a/protocol-designer/src/index.js
+++ b/protocol-designer/src/index.js
@@ -6,9 +6,14 @@ import { AppContainer } from 'react-hot-loader'
 import { configureStore } from './configureStore'
 import { App } from './components/App'
 import { initialize } from './initialize'
-const store = configureStore()
+import { initializeMixpanel } from './analytics/mixpanel'
 
+// initialize Redux
+const store = configureStore()
 initialize(store)
+
+// initialize analytics
+initializeMixpanel(store.getState())
 
 const render = Component => {
   ReactDOM.render(


### PR DESCRIPTION
# Overview

Closes #6057 

# Changelog

- Add Mixpanel to PD
- Add appVersion and appName super properties
- Add appOpen and saveStep analytics action

# Review requests

Should be fully functional in sandbox build -- I added the Mixpanel ID to Travis settings.

All analytics events are logged in JS console -- even when you've opted out, it should log the event in the JS console but will say `optedIn: false` in the log to indicate that it won't actually be sent.

Remember you can toggle opt in/out live in PD's gear-icon SETTINGS page

- [ ] `appOpen` event should be logged once, upon loading PD
- [ ] `saveStep` event should be logged upon saving any step form, including module steps. Should match the "saveStep proposed properties:" stuff in the spreadsheet.
- [ ] Confirm that no analytics events are sent to Mixpanel (eg via Network dev tools tab) when not opted in, even if you started PD opted in
- [ ] When opted in, confirm via Network that the events are actually sent and not just logged
- [ ] OPTIONAL: log into Mixpanel and see the events.
- [ ] Dev server should work but won't log the events unless you include the new env var: `make -C protocol-designer dev OT_PD_MIXPANEL_ID=123fooWhatever`

# Risk assessment

Low to med. Should be only analytics, but new Redux middleware could potentially mess stuff up. PD only.