### PR TITLE
fix(robot-server): pipette offset - uses z ref height to move to point one

### DIFF
--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -166,8 +166,11 @@ class PipetteOffsetCalibrationUserFlow:
         await self._move(to_loc)
 
     async def move_to_point_one(self):
+        assert self._z_height_reference
         coords = self._deck.get_calibration_position(POINT_ONE_ID).position
-        await self._move(Location(Point(*coords), None))
+        point_loc = Location(Point(*coords), None)
+        await self._move(
+            point_loc.move(point=Point(0, 0, self._z_height_reference)))
 
     async def save_offset(self):
         cur_pt = await self._get_current_point()

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -165,6 +165,9 @@ async def test_return_tip(mock_user_flow):
 @pytest.mark.parametrize('command,current_state,data,hw_meth', hw_commands)
 async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
     mock_user_flow._current_state = current_state
+    # z height reference must be present for moving to point one
+    if command == CalibrationCommand.move_to_point_one:
+        mock_user_flow._z_height_reference = 0.1
     await mock_user_flow.handle_command(command, data)
 
     getattr(mock_user_flow._hardware, hw_meth).assert_called()


### PR DESCRIPTION
closes #6424

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes the jog to point one z-location in pipette offset calibration by using the z height reference saved in the previous state.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# changelog
- change the move-to z height for the slot one cross in the pipette offset cal user flow 
- update test to reflect new changes


# Risk assessment
Low, very small change
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
