### PR TITLE
feat(protocol-designer): add OT_PD_ENABLE_MIX_DELAY feature flag

### DIFF
--- a/protocol-designer/src/feature-flags/reducers.js
+++ b/protocol-designer/src/feature-flags/reducers.js
@@ -18,11 +18,12 @@ import type { Action } from '../types'
 // in the browser session, then corresponding env vars can be used to set the
 // initial values. Eg `OT_PD_PRERELEASE_MODE=1 make -C protocol-designer dev`
 // will initialize PRERELEASE_MODE to true (but as per the note above, that
-// initial value is only relevant matters if there is no persisted value already)
+// initial value is only relevant if there is no persisted value already)
 const initialFlags: Flags = {
   PRERELEASE_MODE: process.env.OT_PD_PRERELEASE_MODE === '1' || false,
   OT_PD_DISABLE_MODULE_RESTRICTIONS:
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
+  OT_PD_ENABLE_MIX_DELAY: process.env.OT_PD_ENABLE_MIX_DELAY === '1' || false,
 }
 
 // NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed

--- a/protocol-designer/src/feature-flags/selectors.js
+++ b/protocol-designer/src/feature-flags/selectors.js
@@ -16,3 +16,8 @@ export const getDisableModuleRestrictions: Selector<?boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_DISABLE_MODULE_RESTRICTIONS
 )
+
+export const getEnabledMixDelay: Selector<?boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_MIX_DELAY
+)

--- a/protocol-designer/src/feature-flags/types.js
+++ b/protocol-designer/src/feature-flags/types.js
@@ -15,7 +15,10 @@ export const DEPRECATED_FLAGS = [
 ]
 
 // union of feature flag string constant IDs
-export type FlagTypes = 'PRERELEASE_MODE' | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+export type FlagTypes =
+  | 'PRERELEASE_MODE'
+  | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
+  | 'OT_PD_ENABLE_MIX_DELAY'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: Array<FlagTypes> = [

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -7,5 +7,9 @@
     "title": "Disable module placement restrictions",
     "description_1": "Turn off all restrictions on module placement and related pipette crash guidance.",
     "description_2": "NOT recommended! Switching from default positions may cause crashes and the Protocol Designer cannot yet give guidance on what to expect. Use at your own discretion. "
+  },
+  "OT_PD_ENABLE_MIX_DELAY": {
+    "title": "Enable Mix > Delay advanced settings for Mix step",
+    "description": "Enable Delay advanced settings for Mix step"
   }
 }


### PR DESCRIPTION
# Overview

Closes #6523

# Changelog

# Review requests

- FF should show item in experimental settings card, should not show up when prerelease mode is off, and should default to `false`
- code review

# Risk assessment

Low, just adding an as-yet-unused FF