### PR TITLE
fix(robot-server): tip length cal -  use nozzle height for tip length calculation

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -195,8 +195,10 @@ class DeckCalibrationUserFlow:
         return (CriticalPoint.FRONT_NOZZLE if
                 self._hw_pipette.config.channels == 8 else None)
 
-    async def _get_current_point(self) -> Point:
-        return await self._hardware.gantry_position(self._mount)
+    async def _get_current_point(
+            self,
+            critical_point: CriticalPoint = None) -> Point:
+        return await uf.get_current_point(self, critical_point)
 
     async def load_labware(self):
         pass
@@ -237,7 +239,7 @@ class DeckCalibrationUserFlow:
         await self._move(self._get_move_to_point_loc_by_state())
 
     async def save_offset(self):
-        cur_pt = await self._get_current_point()
+        cur_pt = await self._get_current_point(critical_point=None)
         if self.current_state == State.joggingToDeck:
             self._z_height_reference = cur_pt.z
         else:

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -198,7 +198,8 @@ class DeckCalibrationUserFlow:
     async def _get_current_point(
             self,
             critical_point: CriticalPoint = None) -> Point:
-        return await uf.get_current_point(self, critical_point)
+        return await self._hardware.gantry_position(self._mount,
+                                                    critical_point)
 
     async def load_labware(self):
         pass

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -127,8 +127,10 @@ class PipetteOffsetCalibrationUserFlow:
         return (CriticalPoint.FRONT_NOZZLE if
                 self._hw_pipette.config.channels == 8 else None)
 
-    async def _get_current_point(self) -> Point:
-        return await self._hardware.gantry_position(self._mount)
+    async def _get_current_point(
+            self,
+            critical_point: CriticalPoint = None) -> Point:
+        return await uf.get_current_point(self, critical_point)
 
     async def load_labware(self):
         pass
@@ -173,7 +175,7 @@ class PipetteOffsetCalibrationUserFlow:
             point_loc.move(point=Point(0, 0, self._z_height_reference)))
 
     async def save_offset(self):
-        cur_pt = await self._get_current_point()
+        cur_pt = await self._get_current_point(critical_point=None)
         if self.current_state == State.joggingToDeck:
             self._z_height_reference = cur_pt.z
         elif self._current_state == State.savingPointOne:

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -129,8 +129,9 @@ class PipetteOffsetCalibrationUserFlow:
 
     async def _get_current_point(
             self,
-            critical_point: CriticalPoint = None) -> Point:
-        return await uf.get_current_point(self, critical_point)
+            critical_point: Optional[CriticalPoint]) -> Point:
+        return await self._hardware.gantry_position(self._mount,
+                                                    critical_point)
 
     async def load_labware(self):
         pass

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -204,7 +204,8 @@ class TipCalibrationUserFlow:
     async def _get_current_point(
             self,
             critical_point: CriticalPoint = None) -> Point:
-        return await uf.get_current_point(self, critical_point)
+        return await self._hardware.gantry_position(self._mount,
+                                                    critical_point)
 
     async def jog(self, vector):
         await self._hardware.move_rel(mount=self._mount,

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -1,7 +1,7 @@
 import contextlib
-from typing import Set, Dict, Any, Union, TYPE_CHECKING
+from typing import Set, Dict, Any, Optional, Union, TYPE_CHECKING
 
-from opentrons.hardware_control import Pipette
+from opentrons.hardware_control import Pipette, CriticalPoint
 from opentrons.hardware_control.util import plan_arc
 from opentrons.protocols.geometry import planning
 from opentrons.types import Point, Location
@@ -79,6 +79,13 @@ CalibrationUserFlow = Union[
     'PipetteOffsetCalibrationUserFlow']
 
 
+async def get_current_point(
+        user_flow: CalibrationUserFlow,
+        critical_point: Optional[CriticalPoint]) -> Point:
+    return await user_flow._hardware.gantry_position(
+        user_flow._mount, critical_point)
+
+
 async def invalidate_tip(user_flow: CalibrationUserFlow):
     await user_flow._return_tip()
     await user_flow.move_to_tip_rack()
@@ -130,7 +137,7 @@ async def return_tip(user_flow: CalibrationUserFlow, tip_length: float):
 
 
 async def move(user_flow: CalibrationUserFlow, to_loc: Location):
-    from_pt = await user_flow._get_current_point()
+    from_pt = await user_flow._get_current_point(None)
     from_loc = Location(from_pt, None)
     cp = user_flow._get_critical_point_override()
 

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -1,7 +1,7 @@
 import contextlib
-from typing import Set, Dict, Any, Optional, Union, TYPE_CHECKING
+from typing import Set, Dict, Any, Union, TYPE_CHECKING
 
-from opentrons.hardware_control import Pipette, CriticalPoint
+from opentrons.hardware_control import Pipette
 from opentrons.hardware_control.util import plan_arc
 from opentrons.protocols.geometry import planning
 from opentrons.types import Point, Location
@@ -77,13 +77,6 @@ CalibrationUserFlow = Union[
     'DeckCalibrationUserFlow',
     'TipCalibrationUserFlow',
     'PipetteOffsetCalibrationUserFlow']
-
-
-async def get_current_point(
-        user_flow: CalibrationUserFlow,
-        critical_point: Optional[CriticalPoint]) -> Point:
-    return await user_flow._hardware.gantry_position(
-        user_flow._mount, critical_point)
 
 
 async def invalidate_tip(user_flow: CalibrationUserFlow):

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -80,7 +80,7 @@ def mock_user_flow(mock_hw):
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point()
+    cur_pt = await uf._get_current_point(None)
     assert cur_pt == uf._tip_rack.wells()[0].top().point + Point(0, 0, 10)
 
 
@@ -88,7 +88,7 @@ async def test_pick_up_tip(mock_user_flow):
     uf = mock_user_flow
     assert uf._tip_origin_pt is None
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point()
+    cur_pt = await uf._get_current_point(None)
     await uf.pick_up_tip()
     assert uf._tip_origin_pt == cur_pt
 
@@ -137,9 +137,9 @@ async def test_return_tip(mock_user_flow):
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point() == Point(0, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point() == Point(1, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -123,16 +123,16 @@ hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point()
+    cur_pt = await uf._get_current_point(None)
     assert cur_pt == uf._deck['8'].wells()[0].top().point + Point(0, 0, 10)
 
 
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point() == Point(0, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point() == Point(1, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
 
 
 async def test_pick_up_tip(mock_user_flow):

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -154,7 +154,7 @@ hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point()
+    cur_pt = await uf._get_current_point(None)
     assert cur_pt == uf._deck['8'].wells()[0].top().point + Point(0, 0, 10)
 
 
@@ -163,7 +163,7 @@ async def test_move_to_reference_point(mock_user_flow_all_combos):
     await uf.move_to_reference_point()
     buff = Point(0, 0, 5)
     trash_offset = Point(-57.84, -55, 0)  # offset from center of trash
-    cur_pt = await uf._get_current_point()
+    cur_pt = await uf._get_current_point(None)
     if uf._has_calibration_block:
         if uf._mount == Mount.LEFT:
             assert cur_pt == \
@@ -180,9 +180,9 @@ async def test_move_to_reference_point(mock_user_flow_all_combos):
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point() == Point(0, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point() == Point(1, 0, 0.1)
+    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
 
 
 async def test_pick_up_tip(mock_user_flow):


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In a previous refactor, the height of the pipette tip is incorrectly used in calculating the tip length during tip length calibration. This PR fixes the issue by passing the correct critical point to get the robot's gantry position.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- pull `get_current_point()` from all calibration flows to util.py
- add optional critical point arg to `get_current_point()`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
1. Run tip length calibration to make sure the tip length data look correct (10 uL/20 uL tip length should be around 30 mm)
2. Make sure pipettes are moving to the correct locations in all calibration flows 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium, a refactor that touches all three cal flows but the change itself is pretty small
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
