### PR TITLE
fix(robot-server): calibraiton flows - fix assert statements

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -224,7 +224,8 @@ class DeckCalibrationUserFlow:
         await self._move(to_loc)
 
     def _get_move_to_point_loc_by_state(self) -> Location:
-        assert self._z_height_reference is not None
+        assert self._z_height_reference is not None, \
+            "saveOffset has not been called yet"
         pt_id = MOVE_POINT_STATE_MAP[self._current_state]
         coords = self._deck.get_calibration_position(pt_id).position
         loc = Location(Point(*coords), None)

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -224,7 +224,7 @@ class DeckCalibrationUserFlow:
         await self._move(to_loc)
 
     def _get_move_to_point_loc_by_state(self) -> Location:
-        assert self._z_height_reference
+        assert self._z_height_reference is not None
         pt_id = MOVE_POINT_STATE_MAP[self._current_state]
         coords = self._deck.get_calibration_position(pt_id).position
         loc = Location(Point(*coords), None)

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -169,7 +169,7 @@ class PipetteOffsetCalibrationUserFlow:
         await self._move(to_loc)
 
     async def move_to_point_one(self):
-        assert self._z_height_reference
+        assert self._z_height_reference is not None
         coords = self._deck.get_calibration_position(POINT_ONE_ID).position
         point_loc = Location(Point(*coords), None)
         await self._move(

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -169,7 +169,8 @@ class PipetteOffsetCalibrationUserFlow:
         await self._move(to_loc)
 
     async def move_to_point_one(self):
-        assert self._z_height_reference is not None
+        assert self._z_height_reference is not None, \
+            "saveOffset has not been called yet"
         coords = self._deck.get_calibration_position(POINT_ONE_ID).position
         point_loc = Location(Point(*coords), None)
         await self._move(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In deck calibration and pipette offset calibration flows, `assert z_reference_height` raises an error when z_reference_height is actually 0. This PR fixes that by evaluating against `None`: `assert z_reference_height is not None`.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
