### PR TITLE
refactor(protocol-designer): do not have presaved step hold uuid

### DIFF
--- a/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.js
@@ -1,5 +1,6 @@
 // @flow
 import { addAndSelectStepWithHints } from '../thunks'
+import { PRESAVED_STEP_ID } from '../../../../steplist/types'
 import { addHint } from '../../../../tutorial/actions'
 import * as uiModuleSelectors from '../../../../ui/modules/selectors'
 import { selectors as labwareIngredSelectors } from '../../../../labware-ingred/selectors'
@@ -55,7 +56,7 @@ describe('addAndSelectStepWithHints', () => {
       [
         {
           type: 'ADD_STEP',
-          payload: { id: stepId, stepType: 'pause' },
+          payload: { id: PRESAVED_STEP_ID, stepType: 'pause' },
           meta: { robotStateTimeline: 'mockGetRobotStateTimelineValue' },
         },
       ],
@@ -74,7 +75,7 @@ describe('addAndSelectStepWithHints', () => {
         {
           type: 'ADD_STEP',
           payload: {
-            id: stepId,
+            id: PRESAVED_STEP_ID,
             stepType: 'moveLiquid',
           },
           meta: { robotStateTimeline: 'mockGetRobotStateTimelineValue' },
@@ -144,7 +145,7 @@ describe('addAndSelectStepWithHints', () => {
           [
             {
               type: 'ADD_STEP',
-              payload: { id: stepId, stepType },
+              payload: { id: PRESAVED_STEP_ID, stepType },
               meta: { robotStateTimeline: 'mockGetRobotStateTimelineValue' },
             },
           ],

--- a/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.js
@@ -6,16 +6,12 @@ import * as uiModuleSelectors from '../../../../ui/modules/selectors'
 import { selectors as labwareIngredSelectors } from '../../../../labware-ingred/selectors'
 import * as fileDataSelectors from '../../../../file-data/selectors'
 
-import { uuid } from '../../../../utils'
 jest.mock('../../../../tutorial/actions')
 jest.mock('../../../../ui/modules/selectors')
 jest.mock('../../../../labware-ingred/selectors')
 jest.mock('../../../../file-data/selectors')
-jest.mock('../../../../utils')
 const dispatch = jest.fn()
 const getState = jest.fn()
-const stepId = 'stepId'
-const mockUuid: JestMockFn<[], string> = uuid
 const addHintMock: JestMockFn<[any, string], any> = addHint
 const mockGetDeckHasLiquid: JestMockFn<[Object], any> =
   labwareIngredSelectors.getDeckHasLiquid
@@ -36,7 +32,6 @@ beforeEach(() => {
 
   addHintMock.mockReturnValue('addHintReturnValue')
 
-  mockUuid.mockReturnValue(stepId)
   mockGetDeckHasLiquid.mockReturnValue(true)
   mockGetMagnetModuleHasLabware.mockReturnValue(false)
   mockGetTemperatureModuleHasLabware.mockReturnValue(false)

--- a/protocol-designer/src/ui/steps/actions/__tests__/addStep.test.js
+++ b/protocol-designer/src/ui/steps/actions/__tests__/addStep.test.js
@@ -1,24 +1,14 @@
 // @flow
 import { addStep } from '../actions'
-import { uuid } from '../../../../utils'
-jest.mock('../../../../utils')
-
-const uuidMock: JestMockFn<[], string> = uuid
-const id = 'someUUID'
-
-beforeEach(() => {
-  jest.clearAllMocks()
-
-  uuidMock.mockReturnValue(id)
-})
+import { PRESAVED_STEP_ID } from '../../../../steplist/types'
 
 describe('addStep', () => {
-  it('should dispatch an ADD_STEP action with given stepType and a UUID', () => {
+  it('should dispatch an ADD_STEP action with given stepType and id = PRESAVED_STEP_ID', () => {
     const stepType = 'transfer'
     expect(addStep({ stepType, robotStateTimeline: { timeline: [] } })).toEqual(
       {
         type: 'ADD_STEP',
-        payload: { stepType, id },
+        payload: { stepType, id: PRESAVED_STEP_ID },
         meta: { robotStateTimeline: { timeline: [] } },
       }
     )

--- a/protocol-designer/src/ui/steps/actions/actions.js
+++ b/protocol-designer/src/ui/steps/actions/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import forEach from 'lodash/forEach'
-import { uuid } from '../../../utils'
+import { PRESAVED_STEP_ID } from '../../../steplist/types'
 import { MAIN_CONTENT_FORCED_SCROLL_CLASSNAME } from '../constants'
 import { selectors as stepFormSelectors } from '../../../step-forms'
 import type { StepIdType, StepType } from '../../../form-types'
@@ -27,12 +27,11 @@ export const addStep = (args: {
   stepType: StepType,
   robotStateTimeline: Timeline,
 }): AddStepAction => {
-  const stepId = uuid()
   return {
     type: 'ADD_STEP',
     payload: {
       stepType: args.stepType,
-      id: stepId,
+      id: PRESAVED_STEP_ID,
     },
     meta: {
       robotStateTimeline: args.robotStateTimeline,

--- a/protocol-designer/src/ui/steps/actions/thunks/index.js
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.js
@@ -5,6 +5,7 @@ import {
   getUnsavedFormIsPristineSetTempForm,
 } from '../../../../step-forms/selectors'
 import { changeFormInput } from '../../../../steplist/actions/actions'
+import { PRESAVED_STEP_ID } from '../../../../steplist/types'
 
 import { PAUSE_UNTIL_TEMP } from '../../../../constants'
 import { uuid } from '../../../../utils'
@@ -135,7 +136,13 @@ export const saveStepForm: () => ThunkAction<any> = () => (
   }
 
   // save the form
-  dispatch(_saveStepForm(unsavedForm))
+  if (unsavedForm.id === PRESAVED_STEP_ID) {
+    // if presaved, transform pseudo ID to real UUID upon save
+    const id = uuid()
+    dispatch(_saveStepForm({ ...unsavedForm, id }))
+  } else {
+    dispatch(_saveStepForm(unsavedForm))
+  }
 }
 
 /** "power action", mimicking saving the never-saved "set temperature X" step,
@@ -158,6 +165,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
     )
     return
   }
+  // TODO IMMEDIATELY: this is broken!!
   const { id } = unsavedSetTemperatureForm
 
   if (!isPristineSetTempForm) {
@@ -175,7 +183,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
     `tried to auto-add a pause until temp, but targetTemperature is missing: ${temperature}`
   )
   // save the set temperature step form that is currently open
-  dispatch(_saveStepForm(unsavedSetTemperatureForm))
+  dispatch(_saveStepForm(unsavedSetTemperatureForm)) // TODO IMMEDIATELY this is broken
 
   // add a new pause step form
   dispatch(
@@ -201,7 +209,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
 
   // this conditional is for Flow, the unsaved form should always exist
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm))
+    dispatch(_saveStepForm(unsavedPauseForm)) // TODO IMMEDIATELY this is broken, ID
   } else {
     assert(false, 'could not auto-save pause form, getUnsavedForm returned')
   }

--- a/protocol-designer/src/ui/steps/actions/thunks/index.js
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.js
@@ -109,10 +109,14 @@ export type SaveStepFormAction = {|
   payload: FormData,
 |}
 
-export const _saveStepForm = (form: FormData): SaveStepFormAction => ({
-  type: SAVE_STEP_FORM,
-  payload: form,
-})
+export const _saveStepForm = (form: FormData): SaveStepFormAction => {
+  // if presaved, transform pseudo ID to real UUID upon save
+  const payload = form.id === PRESAVED_STEP_ID ? { ...form, id: uuid() } : form
+  return {
+    type: SAVE_STEP_FORM,
+    payload,
+  }
+}
 
 /** take unsavedForm state and put it into the payload */
 export const saveStepForm: () => ThunkAction<any> = () => (
@@ -136,13 +140,7 @@ export const saveStepForm: () => ThunkAction<any> = () => (
   }
 
   // save the form
-  if (unsavedForm.id === PRESAVED_STEP_ID) {
-    // if presaved, transform pseudo ID to real UUID upon save
-    const id = uuid()
-    dispatch(_saveStepForm({ ...unsavedForm, id }))
-  } else {
-    dispatch(_saveStepForm(unsavedForm))
-  }
+  dispatch(_saveStepForm(unsavedForm))
 }
 
 /** "power action", mimicking saving the never-saved "set temperature X" step,
@@ -165,7 +163,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
     )
     return
   }
-  // TODO IMMEDIATELY: this is broken!!
+
   const { id } = unsavedSetTemperatureForm
 
   if (!isPristineSetTempForm) {
@@ -183,7 +181,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
     `tried to auto-add a pause until temp, but targetTemperature is missing: ${temperature}`
   )
   // save the set temperature step form that is currently open
-  dispatch(_saveStepForm(unsavedSetTemperatureForm)) // TODO IMMEDIATELY this is broken
+  dispatch(_saveStepForm(unsavedSetTemperatureForm))
 
   // add a new pause step form
   dispatch(
@@ -209,7 +207,7 @@ export const saveSetTempFormWithAddedPauseUntilTemp: () => ThunkAction<any> = ()
 
   // this conditional is for Flow, the unsaved form should always exist
   if (unsavedPauseForm != null) {
-    dispatch(_saveStepForm(unsavedPauseForm)) // TODO IMMEDIATELY this is broken, ID
+    dispatch(_saveStepForm(unsavedPauseForm))
   } else {
     assert(false, 'could not auto-save pause form, getUnsavedForm returned')
   }


### PR DESCRIPTION
# Overview

Follow-up to #6503

# Changelog

Presaved step initial id now is `PRESAVED_STEP_ID` constant, marking it as "not a real saved step" while retaining the `FormData` type

# Review requests

- [ ] E2E tests should pass (the add pause after temperature form tests this pretty well)
- [ ] Code review: should never be able to save a presaved step with `id: PRESAVED_STEP_ID` but rather `id: uuid()` (`_saveStepForm` fn ensures this)
- [ ] I don't anticipate any problems with loaded saved files, because you should never be able to save the presaved step form part of the file, but worth a smoke test (eg: have a presaved form open, save the file without saving the form, reload PD, load the file, check the step list)

# Risk assessment

Medium, affects core PD functionality. PD only. But should just be a refactor