### PR TITLE
fix(app): make cal commands chain instead of race

### DIFF
--- a/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
+++ b/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
@@ -98,7 +98,9 @@ describe('CalibratePipetteOffset', () => {
         <CalibratePipetteOffset
           robotName="robot-name"
           session={mockPipOffsetCalSession}
-          closeWizard={() => {}}
+          closeWizard={jest.fn()}
+          dispatchRequests={jest.fn()}
+          showSpinner={false}
         />,
         {
           wrappingComponent: Provider,

--- a/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
+++ b/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
@@ -138,12 +138,12 @@ describe('CalibratePipetteOffset', () => {
     expect(wrapper.find('ConfirmExitModal').exists()).toBe(true)
   })
 
-  it('does not render spinner when not shown', () => {
+  it('does not render spinner when showSpinner is false', () => {
     const wrapper = render({ showSpinner: false })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(false)
   })
 
-  it('renders spinner when last tracked request is pending', () => {
+  it('renders spinner when showSpinner is true', () => {
     const wrapper = render({ showSpinner: true })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(true)
   })

--- a/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
+++ b/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
@@ -6,7 +6,6 @@ import { act } from 'react-dom/test-utils'
 
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 
-import { getRequestById } from '../../../robot-api'
 import * as Sessions from '../../../sessions'
 import { mockPipetteOffsetCalibrationSessionAttributes } from '../../../sessions/__fixtures__'
 
@@ -21,7 +20,6 @@ import {
   CompleteConfirmation,
 } from '../../CalibrationPanels'
 
-import type { State } from '../../../types'
 import type { PipetteOffsetCalibrationStep } from '../../../sessions/types'
 
 jest.mock('@opentrons/components/src/deck/getDeckDefinitions')
@@ -39,11 +37,6 @@ const mockGetDeckDefinitions: JestMockFn<
   [],
   $Call<typeof getDeckDefinitions, any>
 > = getDeckDefinitions
-
-const mockGetRequestById: JestMockFn<
-  [State, string],
-  $Call<typeof getRequestById, State, string>
-> = getRequestById
 
 describe('CalibratePipetteOffset', () => {
   let mockStore
@@ -93,14 +86,15 @@ describe('CalibratePipetteOffset', () => {
       ...mockPipetteOffsetCalibrationSessionAttributes,
     }
 
-    render = () => {
+    render = (props = {}) => {
+      const { showSpinner = false } = props
       return mount(
         <CalibratePipetteOffset
           robotName="robot-name"
           session={mockPipOffsetCalSession}
           closeWizard={jest.fn()}
           dispatchRequests={jest.fn()}
-          showSpinner={false}
+          showSpinner={showSpinner}
         />,
         {
           wrappingComponent: Provider,
@@ -144,12 +138,13 @@ describe('CalibratePipetteOffset', () => {
     expect(wrapper.find('ConfirmExitModal').exists()).toBe(true)
   })
 
-  it('renders spinner when last tracked request is pending, and not present otherwise', () => {
-    const wrapper = render()
+  it('does not render spinner when not shown', () => {
+    const wrapper = render({ showSpinner: false })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(false)
+  })
 
-    mockGetRequestById.mockReturnValue({ status: 'pending' })
-    wrapper.setProps({})
+  it('renders spinner when last tracked request is pending', () => {
+    const wrapper = render({ showSpinner: true })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(true)
   })
 })

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -1,7 +1,6 @@
 // @flow
 // Pipette Offset Calibration Orchestration Component
 import * as React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
 
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import {
@@ -10,20 +9,11 @@ import {
   useConditionalConfirm,
 } from '@opentrons/components'
 
-import type { State } from '../../types'
 import type {
-  SessionCommandString,
-  SessionCommandData,
   DeckCalibrationLabware,
   SessionCommandParams,
 } from '../../sessions/types'
 import * as Sessions from '../../sessions'
-import {
-  useDispatchApiRequests,
-  getRequestById,
-  PENDING,
-} from '../../robot-api'
-import type { RequestState } from '../../robot-api/types'
 import {
   Introduction,
   DeckSetup,
@@ -38,11 +28,6 @@ import styles from '../CalibrateDeck/styles.css'
 
 import type { CalibratePipetteOffsetParentProps } from './types'
 import type { CalibrationPanelProps } from '../CalibrationPanels/types'
-
-// session commands for which the full page spinner should not appear
-const spinnerCommandBlockList: Array<SessionCommandString> = [
-  Sessions.sharedCalCommands.JOG,
-]
 
 const PIPETTE_OFFSET_CALIBRATION_SUBTITLE = 'Pipette offset calibration'
 const EXIT = 'exit'

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -89,7 +89,7 @@ export function CalibratePipetteOffset(
 
   const showSpinner =
     useSelector<State, RequestState | null>(state =>
-      getRequestById(state, trackedRequestId)
+      getRequestById(state, trackedRequestId.current)
     )?.status === PENDING
 
   function sendCommands(...comms: Array<CommandToSend>) {
@@ -114,8 +114,14 @@ export function CalibratePipetteOffset(
     confirm: confirmExit,
     cancel: cancelExit,
   } = useConditionalConfirm(() => {
-    sendCommands(Sessions.deckCalCommands.EXIT)
-    deleteSession()
+    dispatchRequests(
+      Sessions.createSessionCommand(robotName, session.id, {
+        command: Sessions.deckCalCommands.EXIT,
+        data: {},
+      }),
+      Sessions.deleteSession(robotName, session.id)
+    )
+    closeWizard()
   }, true)
 
   const isMulti = React.useMemo(() => {

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -129,7 +129,7 @@ export function CalibratePipetteOffset(
         contentsClassName={PANEL_STYLE_BY_STEP[currentStep]}
       >
         <Panel
-          sendSessionCommand={sendCommands}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           tipRack={tipRack}
           isMulti={isMulti}

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Action } from '../../types'
 import type {
   SessionCommandString,
   SessionCommandData,
@@ -15,6 +16,10 @@ export type CalibratePipetteOffsetParentProps = {|
   robotName: string,
   session: PipetteOffsetCalibrationSession | null,
   closeWizard: () => void,
+  dispatchRequests: (
+    ...Array<{ ...Action, meta: { requestId: string } }>
+  ) => void,
+  showSpinner: boolean,
 |}
 
 export type CalibratePipetteOffsetChildProps = {|

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -1,8 +1,6 @@
 // @flow
 import type { Action } from '../../types'
 import type {
-  SessionCommandString,
-  SessionCommandData,
   SessionCommandParams,
   PipetteOffsetCalibrationSession,
 } from '../../sessions/types'

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -2,6 +2,7 @@
 import type {
   SessionCommandString,
   SessionCommandData,
+  SessionCommandParams,
   PipetteOffsetCalibrationSession,
 } from '../../sessions/types'
 
@@ -16,14 +17,8 @@ export type CalibratePipetteOffsetParentProps = {|
   closeWizard: () => void,
 |}
 
-export type CommandToSend = {
-  command: SessionCommandString,
-  data?: SessionCommandData,
-  loadingSpinner?: boolean,
-}
-
 export type CalibratePipetteOffsetChildProps = {|
-  sendSessionCommands: (Array<CommandToSend>) => void,
+  sendSessionCommands: (...Array<SessionCommandParams>) => void,
   deleteSession: () => void,
   tipRack: PipetteOffsetCalibrationLabware,
   isMulti: boolean,

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -16,12 +16,14 @@ export type CalibratePipetteOffsetParentProps = {|
   closeWizard: () => void,
 |}
 
+export type CommandToSend = {
+  command: SessionCommandString,
+  data?: SessionCommandData,
+  loadingSpinner?: boolean,
+}
+
 export type CalibratePipetteOffsetChildProps = {|
-  sendSessionCommand: (
-    command: SessionCommandString,
-    data?: SessionCommandData,
-    loadingSpinner?: boolean
-  ) => void,
+  sendSessionCommands: (Array<CommandToSend>) => void,
   deleteSession: () => void,
   tipRack: PipetteOffsetCalibrationLabware,
   isMulti: boolean,

--- a/app/src/components/CalibrationPanels/CompleteConfirmation.js
+++ b/app/src/components/CalibrationPanels/CompleteConfirmation.js
@@ -31,14 +31,8 @@ export function CompleteConfirmation(props: CalibrationPanelProps): React.Node {
   const { sessionType } = props
   const { headerText } = contentsBySessionType[sessionType]
 
-  // TODO: BC 2020-09-04 avoid potential race condition by having an epic send the delete
-  // session command upon a successful exit response
   const exitSession = () => {
-    props.sendSessionCommand(Sessions.sharedCalCommands.EXIT)
-    // TODO: IMMEDIATELY use actualy epic for managing chained dependent commands
-    setTimeout(() => {
-      props.deleteSession()
-    }, 300)
+    props.deleteSession()
   }
   return (
     <Flex

--- a/app/src/components/CalibrationPanels/CompleteConfirmation.js
+++ b/app/src/components/CalibrationPanels/CompleteConfirmation.js
@@ -32,7 +32,7 @@ export function CompleteConfirmation(props: CalibrationPanelProps): React.Node {
   const { headerText } = contentsBySessionType[sessionType]
 
   const exitSession = () => {
-    props.deleteSession()
+    props.cleanUpAndExit()
   }
   return (
     <Flex

--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -31,10 +31,10 @@ const DECK_SETUP_BUTTON_TEXT = 'Confirm placement and continue'
 export function DeckSetup(props: CalibrationPanelProps): React.Node {
   const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
 
-  const { tipRack, sendSessionCommand } = props
+  const { tipRack, sendCommands } = props
 
   const proceed = () => {
-    sendSessionCommand({ command: Sessions.sharedCalCommands.MOVE_TO_TIP_RACK })
+    sendCommands({ command: Sessions.sharedCalCommands.MOVE_TO_TIP_RACK })
   }
 
   return (

--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -34,7 +34,7 @@ export function DeckSetup(props: CalibrationPanelProps): React.Node {
   const { tipRack, sendSessionCommand } = props
 
   const proceed = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.MOVE_TO_TIP_RACK)
+    sendSessionCommand({ command: Sessions.sharedCalCommands.MOVE_TO_TIP_RACK })
   }
 
   return (

--- a/app/src/components/CalibrationPanels/Introduction.js
+++ b/app/src/components/CalibrationPanels/Introduction.js
@@ -82,7 +82,7 @@ export function Introduction(props: CalibrationPanelProps): React.Node {
 
   const { showConfirmation, confirm: proceed, cancel } = useConditionalConfirm(
     () => {
-      sendSessionCommand(Sessions.sharedCalCommands.LOAD_LABWARE)
+      sendSessionCommand({ command: Sessions.sharedCalCommands.LOAD_LABWARE })
     },
     true
   )

--- a/app/src/components/CalibrationPanels/Introduction.js
+++ b/app/src/components/CalibrationPanels/Introduction.js
@@ -78,11 +78,11 @@ const contentsBySessionType: {
 }
 
 export function Introduction(props: CalibrationPanelProps): React.Node {
-  const { tipRack, sendSessionCommand, sessionType } = props
+  const { tipRack, sendCommands, sessionType } = props
 
   const { showConfirmation, confirm: proceed, cancel } = useConditionalConfirm(
     () => {
-      sendSessionCommand({ command: Sessions.sharedCalCommands.LOAD_LABWARE })
+      sendCommands({ command: Sessions.sharedCalCommands.LOAD_LABWARE })
     },
     true
   )

--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -121,7 +121,7 @@ const contentsBySessionTypeByCurrentStep: {
 }
 
 export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
-  const { isMulti, mount, sendSessionCommand, currentStep, sessionType } = props
+  const { isMulti, mount, sendCommands, currentStep, sessionType } = props
 
   const {
     slotNumber,
@@ -136,7 +136,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand({
+    sendCommands({
       command: Sessions.sharedCalCommands.JOG,
       data: {
         vector: formatJogVector(axis, dir, step),
@@ -150,7 +150,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
     if (moveCommandString) {
       commands = [...commands, { command: moveCommandString }]
     }
-    sendSessionCommand(...commands)
+    sendCommands(...commands)
   }
 
   return (

--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -136,21 +136,21 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand(
-      Sessions.deckCalCommands.JOG,
-      {
+    sendSessionCommand({
+      command: Sessions.sharedCalCommands.JOG,
+      data: {
         vector: formatJogVector(axis, dir, step),
       },
-      false
-    )
+    })
   }
 
   const savePoint = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.SAVE_OFFSET)
-    // TODO: IMMEDIATELY use actualy epic for managing chained dependent commands
-    setTimeout(() => {
-      moveCommandString && sendSessionCommand(moveCommandString)
-    }, 300)
+    let commands = [{ command: Sessions.sharedCalCommands.SAVE_OFFSET }]
+
+    if (moveCommandString) {
+      commands = [...commands, { command: moveCommandString }]
+    }
+    sendSessionCommand(...commands)
   }
 
   return (

--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -69,7 +69,7 @@ const contentsBySessionType: {
 }
 
 export function SaveZPoint(props: CalibrationPanelProps): React.Node {
-  const { isMulti, mount, sendSessionCommand, sessionType } = props
+  const { isMulti, mount, sendCommands, sessionType } = props
 
   const { headerText, buttonText } = contentsBySessionType[sessionType]
 
@@ -79,7 +79,7 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand({
+    sendCommands({
       command: Sessions.sharedCalCommands.JOG,
       data: {
         vector: formatJogVector(axis, dir, step),
@@ -88,7 +88,7 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
   }
 
   const savePoint = () => {
-    sendSessionCommand(
+    sendCommands(
       { command: Sessions.sharedCalCommands.SAVE_OFFSET },
       { command: Sessions.sharedCalCommands.MOVE_TO_POINT_ONE }
     )

--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -80,7 +80,7 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
     sendSessionCommand({
-      command: Sessions.deckCalCommands.JOG,
+      command: Sessions.sharedCalCommands.JOG,
       data: {
         vector: formatJogVector(axis, dir, step),
       },

--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -79,21 +79,19 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
   )
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand(
-      Sessions.deckCalCommands.JOG,
-      {
+    sendSessionCommand({
+      command: Sessions.deckCalCommands.JOG,
+      data: {
         vector: formatJogVector(axis, dir, step),
       },
-      false
-    )
+    })
   }
 
   const savePoint = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.SAVE_OFFSET)
-    // TODO: IMMEDIATELY use actualy epic for managing chained dependent commands
-    setTimeout(() => {
-      sendSessionCommand(Sessions.sharedCalCommands.MOVE_TO_POINT_ONE)
-    }, 300)
+    sendSessionCommand(
+      { command: Sessions.sharedCalCommands.SAVE_OFFSET },
+      { command: Sessions.sharedCalCommands.MOVE_TO_POINT_ONE }
+    )
   }
 
   return (

--- a/app/src/components/CalibrationPanels/TipConfirmation.js
+++ b/app/src/components/CalibrationPanels/TipConfirmation.js
@@ -18,13 +18,13 @@ const CONFIRM_TIP_YES_BUTTON_TEXT = 'Yes, move to slot 5'
 const CONFIRM_TIP_NO_BUTTON_TEXT = 'No, try again'
 
 export function TipConfirmation(props: CalibrationPanelProps): React.Node {
-  const { sendSessionCommand } = props
+  const { sendCommands } = props
 
   const invalidateTip = () => {
-    sendSessionCommand({ command: Sessions.sharedCalCommands.INVALIDATE_TIP })
+    sendCommands({ command: Sessions.sharedCalCommands.INVALIDATE_TIP })
   }
   const confirmTip = () => {
-    sendSessionCommand({ command: Sessions.sharedCalCommands.MOVE_TO_DECK })
+    sendCommands({ command: Sessions.sharedCalCommands.MOVE_TO_DECK })
   }
 
   return (

--- a/app/src/components/CalibrationPanels/TipConfirmation.js
+++ b/app/src/components/CalibrationPanels/TipConfirmation.js
@@ -21,10 +21,10 @@ export function TipConfirmation(props: CalibrationPanelProps): React.Node {
   const { sendSessionCommand } = props
 
   const invalidateTip = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.INVALIDATE_TIP)
+    sendSessionCommand({ command: Sessions.sharedCalCommands.INVALIDATE_TIP })
   }
   const confirmTip = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.MOVE_TO_DECK)
+    sendSessionCommand({ command: Sessions.sharedCalCommands.MOVE_TO_DECK })
   }
 
   return (

--- a/app/src/components/CalibrationPanels/TipPickUp.js
+++ b/app/src/components/CalibrationPanels/TipPickUp.js
@@ -70,17 +70,16 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
   )
 
   const pickUpTip = () => {
-    sendSessionCommand(Sessions.sharedCalCommands.PICK_UP_TIP)
+    sendSessionCommand({ command: Sessions.sharedCalCommands.PICK_UP_TIP })
   }
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand(
-      Sessions.sharedCalCommands.JOG,
-      {
+    sendSessionCommand({
+      command: Sessions.sharedCalCommands.JOG,
+      data: {
         vector: formatJogVector(axis, dir, step),
       },
-      false
-    )
+    })
   }
 
   return (

--- a/app/src/components/CalibrationPanels/TipPickUp.js
+++ b/app/src/components/CalibrationPanels/TipPickUp.js
@@ -50,7 +50,7 @@ const ASSET_MAP = {
   single: singleDemoAsset,
 }
 export function TipPickUp(props: CalibrationPanelProps): React.Node {
-  const { sendSessionCommand, tipRack, isMulti } = props
+  const { sendCommands, tipRack, isMulti } = props
 
   const tipRackDef = React.useMemo(
     () => getLatestLabwareDef(tipRack?.loadName),
@@ -70,11 +70,11 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
   )
 
   const pickUpTip = () => {
-    sendSessionCommand({ command: Sessions.sharedCalCommands.PICK_UP_TIP })
+    sendCommands({ command: Sessions.sharedCalCommands.PICK_UP_TIP })
   }
 
   const jog = (axis: JogAxis, dir: JogDirection, step: JogStep) => {
-    sendSessionCommand({
+    sendCommands({
       command: Sessions.sharedCalCommands.JOG,
       data: {
         vector: formatJogVector(axis, dir, step),

--- a/app/src/components/CalibrationPanels/__tests__/CompleteConfirmation.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/CompleteConfirmation.test.js
@@ -25,7 +25,7 @@ describe('CompleteConfirmation', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_SESSION_STARTED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -35,7 +35,7 @@ describe('CompleteConfirmation', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/CompleteConfirmation.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/CompleteConfirmation.test.js
@@ -9,14 +9,13 @@ import { CompleteConfirmation } from '../CompleteConfirmation'
 describe('CompleteConfirmation', () => {
   let render
 
-  const mockSendCommand = jest.fn()
-  const mockDeleteSession = jest.fn()
+  const mockSendCommands = jest.fn()
+  const mockCleanUpAndExit = jest.fn()
 
   const getContinueButton = wrapper =>
     wrapper.find('button[title="Return tip to tip rack and exit"]')
 
   beforeEach(() => {
-    jest.useFakeTimers()
     render = (
       props: $Shape<React.ElementProps<typeof CompleteConfirmation>> = {}
     ) => {
@@ -24,8 +23,8 @@ describe('CompleteConfirmation', () => {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
-        cleanUpAndExit = mockDeleteSession,
+        sendCommands = mockSendCommands,
+        cleanUpAndExit = mockCleanUpAndExit,
         currentStep = Sessions.DECK_STEP_SESSION_STARTED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -34,7 +33,7 @@ describe('CompleteConfirmation', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -45,8 +44,6 @@ describe('CompleteConfirmation', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
-    jest.clearAllTimers()
-    jest.useRealTimers()
   })
 
   it('clicking continue sends exit command and deletes session', () => {
@@ -55,11 +52,8 @@ describe('CompleteConfirmation', () => {
     expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(false)
     getContinueButton(wrapper).invoke('onClick')()
     wrapper.update()
-    jest.runAllTimers()
-    expect(mockDeleteSession).toHaveBeenCalled()
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.EXIT
-    )
+
+    expect(mockCleanUpAndExit).toHaveBeenCalled()
   })
 
   it('pip offset cal session type shows correct text', () => {

--- a/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
@@ -26,7 +26,7 @@ describe('DeckSetup', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_LABWARE_LOADED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -36,7 +36,7 @@ describe('DeckSetup', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
@@ -16,7 +16,7 @@ jest.mock('@opentrons/components/src/deck/RobotWorkSpace', () => ({
 describe('DeckSetup', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   beforeEach(() => {
@@ -25,7 +25,7 @@ describe('DeckSetup', () => {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_LABWARE_LOADED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -35,7 +35,7 @@ describe('DeckSetup', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -54,8 +54,8 @@ describe('DeckSetup', () => {
     act(() => wrapper.find('button').invoke('onClick')())
     wrapper.update()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.MOVE_TO_TIP_RACK
-    )
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.sharedCalCommands.MOVE_TO_TIP_RACK,
+    })
   })
 })

--- a/app/src/components/CalibrationPanels/__tests__/Introduction.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/Introduction.test.js
@@ -28,7 +28,7 @@ describe('Introduction', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_SESSION_STARTED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -38,7 +38,7 @@ describe('Introduction', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/Introduction.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/Introduction.test.js
@@ -9,7 +9,7 @@ import { Introduction } from '../Introduction'
 describe('Introduction', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   const getContinueButton = wrapper =>
@@ -27,7 +27,7 @@ describe('Introduction', () => {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_SESSION_STARTED,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -37,7 +37,7 @@ describe('Introduction', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -60,9 +60,9 @@ describe('Introduction', () => {
 
     getConfirmDeckClearButton(wrapper).invoke('onClick')()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.deckCalCommands.LOAD_LABWARE
-    )
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.deckCalCommands.LOAD_LABWARE,
+    })
   })
 
   it('clicking continue launches clear deck warning then cancel closes modal', () => {
@@ -76,9 +76,9 @@ describe('Introduction', () => {
     getCancelDeckClearButton(wrapper).invoke('onClick')()
 
     expect(wrapper.find('ConfirmClearDeckModal').exists()).toBe(false)
-    expect(mockSendCommand).not.toHaveBeenCalledWith(
-      Sessions.deckCalCommands.LOAD_LABWARE
-    )
+    expect(mockSendCommands).not.toHaveBeenCalledWith({
+      command: Sessions.deckCalCommands.LOAD_LABWARE,
+    })
   })
 
   it('pip offset cal session type shows correct text', () => {

--- a/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
@@ -34,7 +34,7 @@ describe('SaveXYPoint', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_SAVING_POINT_ONE,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -44,7 +44,7 @@ describe('SaveXYPoint', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
@@ -15,7 +15,7 @@ const currentStepBySlot = {
 describe('SaveXYPoint', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   const getSaveButton = (wrapper, direction) =>
@@ -27,13 +27,12 @@ describe('SaveXYPoint', () => {
   const getVideo = wrapper => wrapper.find(`source`)
 
   beforeEach(() => {
-    jest.useFakeTimers()
     render = (props = {}) => {
       const {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_SAVING_POINT_ONE,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -43,7 +42,7 @@ describe('SaveXYPoint', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -53,8 +52,6 @@ describe('SaveXYPoint', () => {
   })
   afterEach(() => {
     jest.resetAllMocks()
-    jest.clearAllTimers()
-    jest.useRealTimers()
   })
 
   it('displays proper asset', () => {
@@ -133,13 +130,12 @@ describe('SaveXYPoint', () => {
       getJogButton(wrapper, direction).invoke('onClick')()
       wrapper.update()
 
-      expect(mockSendCommand).toHaveBeenCalledWith(
-        Sessions.sharedCalCommands.JOG,
-        {
+      expect(mockSendCommands).toHaveBeenCalledWith({
+        command: Sessions.sharedCalCommands.JOG,
+        data: {
           vector: jogVectorByDirection[direction],
         },
-        false
-      )
+      })
     })
 
     const unavailableJogDirections = ['up', 'down']
@@ -158,13 +154,14 @@ describe('SaveXYPoint', () => {
     getSaveButton(wrapper).invoke('onClick')()
 
     wrapper.update()
-    jest.runAllTimers()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.SAVE_OFFSET
-    )
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.deckCalCommands.MOVE_TO_POINT_TWO
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      {
+        command: Sessions.sharedCalCommands.SAVE_OFFSET,
+      },
+      {
+        command: Sessions.deckCalCommands.MOVE_TO_POINT_TWO,
+      }
     )
   })
 
@@ -177,13 +174,14 @@ describe('SaveXYPoint', () => {
     expect(wrapper.text()).toContain('slot 3')
     getSaveButton(wrapper).invoke('onClick')()
     wrapper.update()
-    jest.runAllTimers()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.SAVE_OFFSET
-    )
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.deckCalCommands.MOVE_TO_POINT_THREE
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      {
+        command: Sessions.sharedCalCommands.SAVE_OFFSET,
+      },
+      {
+        command: Sessions.deckCalCommands.MOVE_TO_POINT_THREE,
+      }
     )
   })
 
@@ -196,13 +194,14 @@ describe('SaveXYPoint', () => {
     expect(wrapper.text()).toContain('slot 7')
     getSaveButton(wrapper).invoke('onClick')()
     wrapper.update()
-    jest.runAllTimers()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.SAVE_OFFSET
-    )
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.MOVE_TO_TIP_RACK
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      {
+        command: Sessions.sharedCalCommands.SAVE_OFFSET,
+      },
+      {
+        command: Sessions.sharedCalCommands.MOVE_TO_TIP_RACK,
+      }
     )
   })
 
@@ -217,9 +216,9 @@ describe('SaveXYPoint', () => {
 
     getSaveButton(wrapper).invoke('onClick')()
     wrapper.update()
-    jest.runAllTimers()
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.SAVE_OFFSET
-    )
+
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.sharedCalCommands.SAVE_OFFSET,
+    })
   })
 })

--- a/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
@@ -9,7 +9,7 @@ import { SaveZPoint } from '../SaveZPoint'
 describe('SaveZPoint', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   const getSaveButton = wrapper => wrapper.find('button[title="save"]')
@@ -20,13 +20,12 @@ describe('SaveZPoint', () => {
   const getVideo = wrapper => wrapper.find(`source`)
 
   beforeEach(() => {
-    jest.useFakeTimers()
     render = (props = {}) => {
       const {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_JOGGING_TO_DECK,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -36,7 +35,7 @@ describe('SaveZPoint', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -46,8 +45,6 @@ describe('SaveZPoint', () => {
   })
   afterEach(() => {
     jest.resetAllMocks()
-    jest.clearAllTimers()
-    jest.useRealTimers()
   })
 
   it('displays proper asset', () => {
@@ -87,13 +84,12 @@ describe('SaveZPoint', () => {
       getJogButton(wrapper, direction).invoke('onClick')()
       wrapper.update()
 
-      expect(mockSendCommand).toHaveBeenCalledWith(
-        Sessions.deckCalCommands.JOG,
-        {
+      expect(mockSendCommands).toHaveBeenCalledWith({
+        command: Sessions.deckCalCommands.JOG,
+        data: {
           vector: jogVectorByDirection[direction],
         },
-        false
-      )
+      })
     })
 
     const unavailableJogDirections = ['left', 'right', 'back', 'forward']
@@ -107,13 +103,14 @@ describe('SaveZPoint', () => {
 
     getSaveButton(wrapper).invoke('onClick')()
     wrapper.update()
-    jest.runAllTimers()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.deckCalCommands.SAVE_OFFSET
-    )
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.deckCalCommands.MOVE_TO_POINT_ONE
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      {
+        command: Sessions.deckCalCommands.SAVE_OFFSET,
+      },
+      {
+        command: Sessions.deckCalCommands.MOVE_TO_POINT_ONE,
+      }
     )
   })
 

--- a/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
@@ -27,7 +27,7 @@ describe('SaveZPoint', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_JOGGING_TO_DECK,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -37,7 +37,7 @@ describe('SaveZPoint', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/TipConfirmation.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/TipConfirmation.test.js
@@ -27,7 +27,7 @@ describe('TipConfirmation', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_INSPECTING_TIP,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -37,7 +37,7 @@ describe('TipConfirmation', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/__tests__/TipConfirmation.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/TipConfirmation.test.js
@@ -9,7 +9,7 @@ import { TipConfirmation } from '../TipConfirmation'
 describe('TipConfirmation', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   const getConfirmTipButton = wrapper =>
@@ -26,7 +26,7 @@ describe('TipConfirmation', () => {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_INSPECTING_TIP,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -36,7 +36,7 @@ describe('TipConfirmation', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -55,17 +55,17 @@ describe('TipConfirmation', () => {
     getConfirmTipButton(wrapper).invoke('onClick')()
     wrapper.update()
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.MOVE_TO_DECK
-    )
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.sharedCalCommands.MOVE_TO_DECK,
+    })
   })
   it('clicking invalidate tip send invalidate tip command', () => {
     const wrapper = render()
 
     getInvalidateTipButton(wrapper).invoke('onClick')()
     wrapper.update()
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.INVALIDATE_TIP
-    )
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.sharedCalCommands.INVALIDATE_TIP,
+    })
   })
 })

--- a/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
@@ -9,7 +9,7 @@ import { TipPickUp } from '../TipPickUp'
 describe('TipPickUp', () => {
   let render
 
-  const mockSendCommand = jest.fn()
+  const mockSendCommands = jest.fn()
   const mockDeleteSession = jest.fn()
 
   const getPickUpTipButton = wrapper =>
@@ -24,7 +24,7 @@ describe('TipPickUp', () => {
         pipMount = 'left',
         isMulti = false,
         tipRack = mockDeckCalTipRack,
-        sendSessionCommand = mockSendCommand,
+        sendCommands = mockSendCommands,
         cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_PREPARING_PIPETTE,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
@@ -34,7 +34,7 @@ describe('TipPickUp', () => {
           isMulti={isMulti}
           mount={pipMount}
           tipRack={tipRack}
-          sendSessionCommand={sendSessionCommand}
+          sendCommands={sendCommands}
           cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
@@ -63,11 +63,10 @@ describe('TipPickUp', () => {
       getJogButton(wrapper, direction).invoke('onClick')()
       wrapper.update()
 
-      expect(mockSendCommand).toHaveBeenCalledWith(
-        Sessions.sharedCalCommands.JOG,
-        { vector: jogVectorsByDirection[direction] },
-        false
-      )
+      expect(mockSendCommands).toHaveBeenCalledWith({
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: jogVectorsByDirection[direction] },
+      })
     })
   })
   it('clicking pick up tip sends pick up tip command', () => {
@@ -75,8 +74,8 @@ describe('TipPickUp', () => {
 
     getPickUpTipButton(wrapper).invoke('onClick')()
     wrapper.update()
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      Sessions.sharedCalCommands.PICK_UP_TIP
-    )
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: Sessions.sharedCalCommands.PICK_UP_TIP,
+    })
   })
 })

--- a/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
@@ -25,7 +25,7 @@ describe('TipPickUp', () => {
         isMulti = false,
         tipRack = mockDeckCalTipRack,
         sendSessionCommand = mockSendCommand,
-        deleteSession = mockDeleteSession,
+        cleanUpAndExit = mockDeleteSession,
         currentStep = Sessions.DECK_STEP_PREPARING_PIPETTE,
         sessionType = Sessions.SESSION_TYPE_DECK_CALIBRATION,
       } = props
@@ -35,7 +35,7 @@ describe('TipPickUp', () => {
           mount={pipMount}
           tipRack={tipRack}
           sendSessionCommand={sendSessionCommand}
-          deleteSession={deleteSession}
+          cleanUpAndExit={cleanUpAndExit}
           currentStep={currentStep}
           sessionType={sessionType}
         />

--- a/app/src/components/CalibrationPanels/types.js
+++ b/app/src/components/CalibrationPanels/types.js
@@ -12,7 +12,7 @@ import type { TipLengthCalibrationLabware } from '../../sessions/tip-length-cali
 
 export type CalibrationPanelProps = {|
   sendSessionCommand: (...Array<SessionCommandParams>) => void,
-  deleteSession: () => void,
+  cleanUpAndExit: () => void,
   tipRack:
     | DeckCalibrationLabware
     | PipetteOffsetCalibrationLabware

--- a/app/src/components/CalibrationPanels/types.js
+++ b/app/src/components/CalibrationPanels/types.js
@@ -2,6 +2,7 @@
 import type {
   SessionCommandString,
   SessionCommandData,
+  SessionCommandParams,
   SessionType,
   CalibrationSessionStep,
 } from '../../sessions/types'
@@ -10,11 +11,7 @@ import type { PipetteOffsetCalibrationLabware } from '../../sessions/pipette-off
 import type { TipLengthCalibrationLabware } from '../../sessions/tip-length-calibration/types'
 
 export type CalibrationPanelProps = {|
-  sendSessionCommand: (
-    command: SessionCommandString,
-    data?: SessionCommandData,
-    loadingSpinner?: boolean
-  ) => void,
+  sendSessionCommand: (...Array<SessionCommandParams>) => void,
   deleteSession: () => void,
   tipRack:
     | DeckCalibrationLabware

--- a/app/src/components/CalibrationPanels/types.js
+++ b/app/src/components/CalibrationPanels/types.js
@@ -1,7 +1,5 @@
 // @flow
 import type {
-  SessionCommandString,
-  SessionCommandData,
   SessionCommandParams,
   SessionType,
   CalibrationSessionStep,
@@ -11,7 +9,7 @@ import type { PipetteOffsetCalibrationLabware } from '../../sessions/pipette-off
 import type { TipLengthCalibrationLabware } from '../../sessions/tip-length-calibration/types'
 
 export type CalibrationPanelProps = {|
-  sendSessionCommand: (...Array<SessionCommandParams>) => void,
+  sendCommands: (...Array<SessionCommandParams>) => void,
   cleanUpAndExit: () => void,
   tipRack:
     | DeckCalibrationLabware

--- a/app/src/components/CalibrationPanels/utils.js
+++ b/app/src/components/CalibrationPanels/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import type { JogAxis } from '../../http-api-client'
+import type { VectorTuple } from '../../sessions/types'
 
 const ORDERED_AXES: [JogAxis, JogAxis, JogAxis] = ['x', 'y', 'z']
 
@@ -8,7 +9,7 @@ export function formatJogVector(
   axis: string,
   direction: number,
   step: number
-): [number, number, number] {
+): VectorTuple {
   const vector = [0, 0, 0]
   const index = ORDERED_AXES.findIndex(a => a === axis)
   if (index >= 0) {

--- a/app/src/components/InstrumentSettings/PipetteOffsetCalibrationControl.js
+++ b/app/src/components/InstrumentSettings/PipetteOffsetCalibrationControl.js
@@ -47,7 +47,7 @@ export function PipetteOffsetCalibrationControl(props: Props): React.Node {
       }
       if (
         dispatchedAction.type === Sessions.DELETE_SESSION &&
-        pipOffsetCalSession?.id == dispatchedAction.payload.sessionId
+        pipOffsetCalSession?.id === dispatchedAction.payload.sessionId
       ) {
         deleteRequestId.current = dispatchedAction.meta.requestId
       }
@@ -81,7 +81,7 @@ export function PipetteOffsetCalibrationControl(props: Props): React.Node {
       setShowWizard(false)
       deleteRequestId.current = null
     }
-  }, [requestStatus])
+  }, [requestStatus, shouldClose])
 
   const handleStartPipOffsetCalSession = () => {
     dispatchRequests(

--- a/app/src/robot-api/__tests__/hooks.test.js
+++ b/app/src/robot-api/__tests__/hooks.test.js
@@ -1,13 +1,9 @@
 // @flow
 import * as React from 'react'
 import uniqueId from 'lodash/uniqueId'
-import { mount } from 'enzyme'
 import { mountWithStore } from '@opentrons/components/__utils__'
 import { PENDING, SUCCESS } from '../constants'
 import { useDispatchApiRequest, useDispatchApiRequests } from '../hooks'
-
-import type { State } from '../../types'
-import { initializeState } from '@opentrons/discovery-client/src/store'
 
 jest.mock('lodash/uniqueId')
 
@@ -52,7 +48,7 @@ describe('useDispatchApiRequest', () => {
   })
 
   it('adds requestId to requestIds list', () => {
-    const { wrapper, store } = render()
+    const { wrapper } = render()
     wrapper.find('button').invoke('onClick')()
     wrapper.update()
 
@@ -77,7 +73,7 @@ describe('useDispatchApiRequests', () => {
   const TestUseDispatchApiRequests = props => {
     const mockAction: any = { type: 'mockAction', meta: {} }
     const mockOtherAction: any = { type: 'mockOtherAction', meta: {} }
-    const [dispatchRequests, requestIds] = useDispatchApiRequests()
+    const [dispatchRequests] = useDispatchApiRequests()
 
     return (
       <button onClick={() => dispatchRequests(mockAction, mockOtherAction)}>

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -94,19 +94,23 @@ export function useDispatchApiRequests<
 
   const trackedRequestIsPending =
     useSelector<State, RequestState | null>(state =>
-      getRequestById(state, trackedRequestId)
+      getRequestById(state, trackedRequestId.current)
     )?.status === PENDING
 
-  if (!trackedRequestIsPending && unrequestedQueue.current.length > 0) {
+  const triggerNext = () => {
+    console.log('in trigger', unrequestedQueue.current)
     const action = dispatchRequest(unrequestedQueue.current[0])
     if (onDispatch) onDispatch(action)
     trackedRequestId.current = action.meta.requestId
     unrequestedQueue.current = unrequestedQueue.current.slice(1) // dequeue
   }
+  if (unrequestedQueue.current.length > 0 && !trackedRequestIsPending) {
+    triggerNext()
+  }
 
   const dispatchApiRequests = (...a: Array<A>) => {
-    console.log('called', a)
     unrequestedQueue.current = a
+    triggerNext()
   }
 
   return [dispatchApiRequests, requestIds]

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -1,9 +1,8 @@
 // @flow
 // hooks for components that depend on API state
-import { useReducer, useCallback, useEffect, useRef, useState } from 'react'
+import { useReducer, useCallback, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import uniqueId from 'lodash/uniqueId'
-import last from 'lodash/last'
 
 import type { State, Action } from '../types'
 import { PENDING } from './constants'
@@ -104,7 +103,6 @@ export function useDispatchApiRequests<
     )?.status === PENDING
 
   if (unrequestedQueue.length > 0 && !trackedRequestIsPending) {
-    console.log('in trigger', unrequestedQueue, trackedRequestId)
     const action = dispatchRequest(unrequestedQueue[0])
     if (onDispatchedRequest) onDispatchedRequest(action)
     trackedRequestId.current = action.meta.requestId
@@ -112,7 +110,6 @@ export function useDispatchApiRequests<
   }
 
   const dispatchApiRequests = (...a: Array<A>) => {
-    console.log('in dars', a)
     setUnrequestedQueue([...unrequestedQueue, ...a])
   }
 

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -79,7 +79,7 @@ export function useDispatchApiRequest<
  *   const [dispatchRequests, requestIds] = useDispatchApiRequest()
  *
  *   return (
- *     <button onClick={() => dispatchRequest([fetchPipettes(robotName), fetchModules(robotName)])}>
+ *     <button onClick={() => dispatchRequests([fetchPipettes(robotName), fetchModules(robotName)])}>
  *       Check Pipettes
  *     </button>
  *   )

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -88,7 +88,7 @@ export function useDispatchApiRequest<
 export function useDispatchApiRequests<
   A: { ...Action, meta: { requestId: string } }
 >(
-  onDispatchedRequest: (A => void) | null
+  onDispatchedRequest: (A => void) | null = null
 ): [(...Array<A>) => void, Array<string>] {
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
 
@@ -96,11 +96,11 @@ export function useDispatchApiRequests<
   const [unrequestedQueue, setUnrequestedQueue] = useState<Array<A>>([])
 
   const trackedRequestIsPending =
-    useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current
+    useSelector<State, RequestState | null>(state => {
+      return trackedRequestId.current
         ? getRequestById(state, trackedRequestId.current)
         : null
-    )?.status === PENDING
+    })?.status === PENDING
 
   if (unrequestedQueue.length > 0 && !trackedRequestIsPending) {
     const action = dispatchRequest(unrequestedQueue[0])

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -1,8 +1,11 @@
 // @flow
 // hooks for components that depend on API state
-import { useReducer, useCallback } from 'react'
-import { useDispatch } from 'react-redux'
+import { useReducer, useCallback, useEffect, useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { getRequestById } from './selectors'
 import uniqueId from 'lodash/uniqueId'
+import last from 'lodash/last'
+import { PENDING } from './constants'
 
 /**
  * React hook to attach a unique request ID to and dispatch an API action
@@ -40,15 +43,71 @@ export function useDispatchApiRequest<A: { meta: { requestId: string } }>(): [
   )
 
   const dispatchApiRequest = useCallback(
-    (a: A) => {
+    (a: A): A => {
       const requestId = uniqueId('robotApi_request_')
       const action = { ...a, meta: { ...a.meta, requestId } }
 
       addRequestId(requestId)
       dispatch(action)
+      return action
     },
     [dispatch]
   )
 
   return [dispatchApiRequest, requestIds]
+}
+
+/**
+ * React hook to attach a unique request ID to and sequentially
+ * dispatch multiple API actions upon completion of the last request.
+ * One optional parameter for function to be called with tracked action
+ * upon dispatch of said action.
+ * Note: dispatching will trigger a re-render of the component
+ *
+ * @returns {[action => mixed, Array<string>]} tuple of dispatch function and dispatched request IDs
+ *
+ * @example
+ * import { useDispatchApiRequests } from '../../robot-api'
+ * import { fetchPipettes } from '../../pipettes'
+ * import { fetchModules } from '../../modules'
+ *
+ * type Props = {| robotName: string |}
+ *
+ * export function FetchPipettesButton(props: Props) {
+ *   const { robotName } = props
+ *   const [dispatchRequests, requestIds] = useDispatchApiRequest()
+ *
+ *   return (
+ *     <button onClick={() => dispatchRequest([fetchPipettes(robotName), fetchModules(robotName)])}>
+ *       Check Pipettes
+ *     </button>
+ *   )
+ * }
+ */
+export function useDispatchApiRequests<
+  A: Array<{ meta: { requestId: string } }>
+>(onDispatch: A => void = null): [(A) => void, Array<string>] {
+  const [dispatchRequest, requestIds] = useDispatchApiRequest()
+
+  const trackedRequestId = useRef<string | null>(null)
+  const unrequestedQueue = useRef<Array<A>>([])
+
+  const trackedRequestIsPending =
+    useSelector<State, RequestState | null>(state =>
+      getRequestById(state, trackedRequestId)
+    )?.status === PENDING
+
+  if (!trackedRequestIsPending && unrequestedQueue.current.length > 0) {
+    const action = dispatchRequest(unrequestedQueue.current[0])
+    if (onDispatch) onDispatch(action)
+    trackedRequestId.current = action.meta.requestId
+    unrequestedQueue.current = unrequestedQueue.current.slice(1) // dequeue
+  }
+
+  const dispatchApiRequests = (...a: Array<A>) => {
+    console.log('called', a)
+    unrequestedQueue.current = a
+  }
+
+  return [dispatchApiRequests, requestIds]
 }

--- a/app/src/robot-api/hooks.js
+++ b/app/src/robot-api/hooks.js
@@ -76,7 +76,7 @@ export function useDispatchApiRequest<
  *
  * export function FetchPipettesButton(props: Props) {
  *   const { robotName } = props
- *   const [dispatchRequests, requestIds] = useDispatchApiRequest()
+ *   const [dispatchRequests, requestIds] = useDispatchApiRequests()
  *
  *   return (
  *     <button onClick={() => dispatchRequests([fetchPipettes(robotName), fetchModules(robotName)])}>

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -60,7 +60,7 @@ export const mockSession: Types.Session = {
 
 export const mockSessionCommand: Types.SessionCommandAttributes = {
   command: 'calibration.jog',
-  data: { someData: 32 },
+  data: { vector: [32, 0, 0] },
 }
 
 export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {

--- a/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
@@ -35,7 +35,7 @@ describe('createSessionCommandEpic', () => {
         attributes: {
           command: 'calibration.jog',
           data: {
-            someData: 32,
+            vector: [32, 0, 0],
           },
         },
       },

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -37,6 +37,7 @@ import * as CalCheckConstants from './calibration-check/constants'
 import * as TipCalConstants from './tip-length-calibration/constants'
 import * as DeckCalConstants from './deck-calibration/constants'
 import * as PipOffsetCalConstants from './pipette-offset-calibration/constants'
+import * as CommonCalConstants from './common-calibration/constants'
 
 export type * from './calibration-check/types'
 export type * from './tip-length-calibration/types'
@@ -60,6 +61,7 @@ export type SessionCommandString =
   | $Values<typeof TipCalConstants.tipCalCommands>
   | $Values<typeof DeckCalConstants.deckCalCommands>
   | $Values<typeof PipOffsetCalConstants.pipOffsetCalCommands>
+  | $Values<typeof CommonCalConstants.sharedCalCommands>
 
 export type CalibrationSessionStep =
   | CalCheckTypes.RobotCalibrationCheckStep
@@ -69,7 +71,11 @@ export type CalibrationSessionStep =
 
 // TODO(al, 2020-05-11): data should be properly typed with all
 // known command types
-export type SessionCommandData = { ... }
+export type SessionCommandData = { vector: VectorTuple } | {}
+export type SessionCommandParams = {
+  command: SessionCommandString,
+  data?: SessionCommandData,
+}
 
 export type CalibrationCheckSessionResponseAttributes = {|
   sessionType: SESSION_TYPE_CALIBRATION_CHECK,
@@ -341,7 +347,7 @@ export type CalibrationCheckIntercomData = {|
   succeeded: boolean,
 |}
 
-type VectorTuple = [number, number, number]
+export type VectorTuple = [number, number, number]
 export type CalibrationCheckAnalyticsData = {|
   ...CalibrationCheckCommonEventData,
   comparingFirstPipetteHeightDifferenceVector?: VectorTuple,

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -69,6 +69,8 @@ export type CalibrationSessionStep =
   | DeckCalTypes.DeckCalibrationStep
   | PipOffsetCalTypes.PipetteOffsetCalibrationStep
 
+export type VectorTuple = [number, number, number]
+
 // TODO(al, 2020-05-11): data should be properly typed with all
 // known command types
 export type SessionCommandData = {| vector: VectorTuple |} | {||}
@@ -347,7 +349,6 @@ export type CalibrationCheckIntercomData = {|
   succeeded: boolean,
 |}
 
-export type VectorTuple = [number, number, number]
 export type CalibrationCheckAnalyticsData = {|
   ...CalibrationCheckCommonEventData,
   comparingFirstPipetteHeightDifferenceVector?: VectorTuple,

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -71,8 +71,6 @@ export type CalibrationSessionStep =
 
 export type VectorTuple = [number, number, number]
 
-// TODO(al, 2020-05-11): data should be properly typed with all
-// known command types
 export type SessionCommandData = {| vector: VectorTuple |} | {||}
 export type SessionCommandParams = {
   command: SessionCommandString,

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -71,7 +71,7 @@ export type CalibrationSessionStep =
 
 // TODO(al, 2020-05-11): data should be properly typed with all
 // known command types
-export type SessionCommandData = { vector: VectorTuple } | {}
+export type SessionCommandData = {| vector: VectorTuple |} | {||}
 export type SessionCommandParams = {
   command: SessionCommandString,
   data?: SessionCommandData,


### PR DESCRIPTION
# Overview

In order to avoid various race conditions created by sequential commands being requested of the
robot during/before/after calibration sessions, create mechanism to ensure that they are dispatched
sequentially. Also ensure that wizard only closes on successful deletion, to avoid orphaned session.

Closes #6535

NOTE: these changes have been made within the generic `CalibrationPanels` component directory, which is only being used in the pipette offset calibration flow. The deck calibration and tip length calibration flows will be refactored to use the panels from this shared directory in a following PR.

TODO: ~unit tests for new `useDispatchApiRequests` hook~, ensure unit tests for `PipetteOffsetCalibrationControl` cover new additions 
 
# Changelog

- add a new utility hook called `useDispatchApiRequests` that is very similar to the existing `useDispatchApiRequest`, but accepts any number of api request actions and will only dispatch each sequential action once the request from the previous action has resolved (`status !== PENDING`).
- plug this new hook into the pipette offset calibration flow for all sequential calls
- remove temporary setTimeout fix for sequential calls
- while hoisting dispatch machinery up to the `PipetteOffsetCalibrationControl` component, let it manage closing the wizard so as to avoid orphaned (undeleted) sessions on the robot that can't be viewed or "redeleted" on the app.

# Review requests

- [ ] run through the existing pipette offset calibration flow and ensure that all transitions occur as expected.

# Risk assessment

low, this change is contained within the unreleased pipette offset calibration flow, though this functionality will be added to the other cal overhaul front-ends immediately following this PR merging.
