### PR TITLE
feat(api): Add pipette pairing to the command log and support in rpc

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -762,6 +762,7 @@ def _get_labware(command):  # noqa(C901)
     modules.append(maybe_module)
 
     locations = command.get('locations')
+    multiple_instruments = command.get('instruments')
 
     if location:
         if isinstance(location, (Placeable)) or type(location) == tuple:
@@ -791,5 +792,10 @@ def _get_labware(command):  # noqa(C901)
         instruments.append(instrument)
         interactions.extend(
             [(instrument, container) for container in containers])
+    if multiple_instruments:
+        for instr in multiple_instruments:
+            instruments.append(instr)
+            interactions.extend(
+                [(instr, container) for container in containers])
 
     return instruments, containers, modules, interactions

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -4,7 +4,7 @@ from opentrons.broker import Broker
 
 import functools
 import inspect
-from typing import Union, Sequence, List, Any
+from typing import Union, Sequence, List, Any, Optional
 
 from opentrons.legacy_api.containers import (Well as OldWell,
                                              Container as OldContainer,
@@ -93,6 +93,18 @@ def _stringify_legacy_loc(loc: Union[OldWell, OldContainer,
         )
 
 
+def combine_locations(location: Sequence) -> str:
+    if len(location) > 1:
+        loc1 = stringify_location(location[0])
+        loc2 = stringify_location(location[1])
+        return f'{loc1} and {loc2}'
+    elif len(location) == 1:
+        loc1 = stringify_location(location[0])
+        return f'{loc1}'
+    else:
+        return ''
+
+
 def stringify_location(location: Union[Location, None,
                                        OldWell, OldContainer,
                                        OldSlot, Sequence]) -> str:
@@ -147,6 +159,38 @@ def aspirate(instrument, volume, location, rate):
     )
 
 
+def paired_aspirate(
+        instruments: Sequence, volume: float,
+        locations: Sequence, rate: float):
+    location_text = combine_locations(locations)
+    template = 'Aspirating {volume} uL from {location} at {flow} uL/sec'
+    try:
+        flow_rate = min(
+            rate * FlowRates(instr).aspirate for instr in instruments)
+        text = template.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+    except AttributeError:
+        flow_mms = min(instr.speeds['aspirate'] for instr in instruments)
+        flow_ulsec = min(
+            flow_mms * instr._ul_per_mm(instr.max_volume, 'aspirate')
+            for instr in instruments)
+        flow_rate = rate * flow_ulsec
+        flow_rate = round(flow_rate, 1)
+        text = template.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+
+    return make_command(
+        name=command_types.ASPIRATE,
+        payload={
+            'instruments': instruments,
+            'volume': volume,
+            'locations': locations,
+            'rate': rate,
+            'text': text
+        }
+    )
+
+
 def dispense(instrument, volume, location, rate):
     location_text = stringify_location(location)
     template = 'Dispensing {volume} uL into {location} at {flow} uL/sec'
@@ -169,6 +213,38 @@ def dispense(instrument, volume, location, rate):
             'instrument': instrument,
             'volume': volume,
             'location': location,
+            'rate': rate,
+            'text': text
+        }
+    )
+
+
+def paired_dispense(
+        instruments: Sequence, volume: float,
+        locations: Sequence, rate: float):
+    location_text = combine_locations(locations)
+    template = 'Dispensing {volume} uL into {location} at {flow} uL/sec'
+    try:
+        flow_rate = min(
+            rate * FlowRates(instr).dispense for instr in instruments)
+        text = template.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+    except AttributeError:
+        flow_mms = min(instr.speeds['dispense'] for instr in instruments)
+        flow_ulsec = min(
+            flow_mms * instr._ul_per_mm(instr.max_volume, 'dispense')
+            for instr in instruments)
+        flow_rate = rate * flow_ulsec
+        flow_rate = round(flow_rate, 1)
+        text = template.format(
+                volume=float(volume), location=location_text, flow=flow_rate)
+
+    return make_command(
+        name=command_types.ASPIRATE,
+        payload={
+            'instruments': instruments,
+            'volume': volume,
+            'locations': locations,
             'rate': rate,
             'text': text
         }
@@ -286,6 +362,22 @@ def mix(instrument, repetitions, volume, location):
     )
 
 
+def paired_mix(
+        instruments: Sequence, locations: Sequence,
+        repetitions: int, volume: float):
+    text = f'Mixing {repetitions} times with a volume of {volume} ul'
+    return make_command(
+        name=command_types.MIX,
+        payload={
+            'instruments': instruments,
+            'locations': locations,
+            'volume': volume,
+            'repetitions': repetitions,
+            'text': text
+        }
+    )
+
+
 def blow_out(instrument, location):
     location_text = stringify_location(location)
     text = 'Blowing out'
@@ -303,12 +395,46 @@ def blow_out(instrument, location):
     )
 
 
+def paired_blow_out(instruments: Sequence, locations: Optional[Sequence]):
+    text = 'Blowing out'
+
+    if locations is not None:
+        location_text = combine_locations(locations)
+        text += f' at {location_text}'
+
+    return make_command(
+        name=command_types.BLOW_OUT,
+        payload={
+            'instruments': instruments,
+            'locations': locations,
+            'text': text
+        }
+    )
+
+
 def touch_tip(instrument):
     text = 'Touching tip'
+
     return make_command(
         name=command_types.TOUCH_TIP,
         payload={
             'instrument': instrument,
+            'text': text
+        }
+    )
+
+
+def paired_touch_tip(instruments: Sequence, locations: Optional[Sequence]):
+    text = 'Touching tip'
+
+    if locations is not None:
+        location_text = combine_locations(locations)
+        text += f' at {location_text}'
+    return make_command(
+        name=command_types.TOUCH_TIP,
+        payload={
+            'instruments': instruments,
+            'locations': locations,
             'text': text
         }
     )
@@ -347,6 +473,19 @@ def pick_up_tip(instrument, location):
     )
 
 
+def paired_pick_up_tip(instruments: Sequence, locations: Sequence):
+    location_text = combine_locations(locations)
+    text = f'Picking up tip from {location_text}'
+    return make_command(
+        name=command_types.PICK_UP_TIP,
+        payload={
+            'instruments': instruments,
+            'locations': locations,
+            'text': text
+        }
+    )
+
+
 def drop_tip(instrument, location):
     location_text = stringify_location(location)
     text = 'Dropping tip into {location}'.format(location=location_text)
@@ -355,6 +494,19 @@ def drop_tip(instrument, location):
         payload={
             'instrument': instrument,
             'location': location,
+            'text': text
+        }
+    )
+
+
+def paired_drop_tip(instruments: Sequence, locations: Sequence):
+    location_text = combine_locations(locations)
+    text = f'Dropping tip into {location_text}'
+    return make_command(
+        name=command_types.DROP_TIP,
+        payload={
+            'instruments': instruments,
+            'locations': locations,
             'text': text
         }
     )
@@ -620,6 +772,23 @@ def do_publish(broker, cmd, f, when, res, meta, *args, **kwargs):
         message['return'] = res
     publish_command(
         message={**payload, '$': when})
+
+
+def publish_paired(broker, cmd, when, res, *args):
+    """ Implement a second publisher outside of the decorator that
+    relies on the method providing all of the arguments required
+    rather than binding defaults to the signature"""
+    publish_command = functools.partial(
+        broker.publish,
+        topic=command_types.COMMAND)
+
+    payload = cmd(*args)
+
+    message = {**payload, '$': when}
+    if when == 'after':
+        message['return'] = res
+
+    publish_command(message=message)
 
 
 def _publish_dec(before, after, command, meta=None):

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -413,7 +413,8 @@ class PairedInstrumentContext(CommandPublisher):
             c_vol = volume
 
         instruments = list(self._instruments.values())
-        primary_loc = self.paired_instrument_obj.aspirate(volume, loc, rate)
+        primary_loc, aspirate_func =\
+            self.paired_instrument_obj.aspirate(volume, loc, rate)
         if isinstance(primary_loc.labware, Well):
             labware = primary_loc.labware.parent
             well = primary_loc.labware
@@ -424,6 +425,7 @@ class PairedInstrumentContext(CommandPublisher):
             locations = [primary_loc]
         cmds.publish_paired(self.broker, cmds.paired_aspirate, 'before',
                             None, instruments, c_vol, locations, rate)
+        aspirate_func()
         cmds.publish_paired(self.broker, cmds.paired_aspirate, 'after',
                             self, instruments, c_vol, locations, rate)
         return self
@@ -505,7 +507,8 @@ class PairedInstrumentContext(CommandPublisher):
             c_vol = volume
 
         instruments = list(self._instruments.values())
-        primary_loc = self.paired_instrument_obj.dispense(volume, loc, rate)
+        primary_loc, dispense_func =\
+            self.paired_instrument_obj.dispense(volume, loc, rate)
 
         if isinstance(primary_loc.labware, Well):
             labware = primary_loc.labware.parent
@@ -517,6 +520,7 @@ class PairedInstrumentContext(CommandPublisher):
             locations = [primary_loc]
         cmds.publish_paired(self.broker, cmds.paired_dispense, 'before',
                             None, instruments, c_vol, locations, rate)
+        dispense_func()
         cmds.publish_paired(self.broker, cmds.paired_dispense, 'after',
                             self, instruments, c_vol, locations, rate)
         return self

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Union, Tuple, List, Optional
 
-from opentrons import types, hardware_control as hc
+from opentrons import types, commands as cmds, hardware_control as hc
 from opentrons.commands import CommandPublisher
 from opentrons.protocols.types import APIVersion
 from opentrons.protocols.implementations.paired_instrument import\
@@ -22,10 +22,9 @@ if TYPE_CHECKING:
     from opentrons.protocols.api_support.util import HardwareManager
 
 
-SECONDARY_WELL_SPACING = 4
-
-
-SECONDARY_WELL_SPACING = 4
+SBS_96_WELL_SPACING = 4
+SBS_384_WELL_SPACING = 7
+TUBERACK_24_WELL_SPACING = 2
 
 
 class UnsupportedInstrumentPairingError(Exception):
@@ -47,6 +46,7 @@ class PairedInstrumentContext(CommandPublisher):
                  hardware_manager: HardwareManager,
                  trash: Labware,
                  log_parent: logging.Logger) -> None:
+        super().__init__(ctx.broker)
         self._instruments = {
             pair_policy.primary: primary_instrument,
             pair_policy.secondary: secondary_instrument}
@@ -235,9 +235,16 @@ class PairedInstrumentContext(CommandPublisher):
         secondary_target = self._get_secondary_target(tiprack, target)
         primary_pipette = self._instruments[self._pair_policy.primary]
         tip_length = primary_pipette._tip_length_for(tiprack)
+
+        instruments = list(self._instruments.values())
+        targets = [target, secondary_target]
+        cmds.publish_paired(self.broker, cmds.paired_pick_up_tip,
+                            'before', None, instruments, targets)
         self.paired_instrument_obj.pick_up_tip(
             target, secondary_target, tiprack, presses, increment, tip_length)
         self._last_tip_picked_up_from = target
+        cmds.publish_paired(self.broker, cmds.paired_pick_up_tip,
+                            'after', self, instruments, targets)
         return self
 
     @requires_version(2, 7)
@@ -287,9 +294,12 @@ class PairedInstrumentContext(CommandPublisher):
 
         :raises TyepError: If a location is not relative to a well.
         """
+        is_trash = False
+        tiprack = None
         if location and isinstance(location, types.Location):
             if isinstance(location.labware, Well):
                 target = location
+                tiprack = location.labware.parent
             else:
                 raise TypeError(
                     "If a location is specified as a types.Location (for "
@@ -304,15 +314,29 @@ class PairedInstrumentContext(CommandPublisher):
             else:
                 primary_pipette = self._instruments[self._pair_policy.primary]
                 target = self._drop_tip_target(location, primary_pipette)
+                tiprack = location.parent
         elif not location:
             target = self.trash_container.wells()[0].top()
+            is_trash = True
         else:
             raise TypeError(
                 "If specified, location should be an instance of "
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
                 " However, it is a {}".format(location))
+
+        instruments = list(self._instruments.values())
+        if not is_trash and tiprack and isinstance(target.labware, Well):
+            targets = [
+                target,
+                self._get_secondary_target(tiprack, target.labware)]
+        else:
+            targets = [target]
+        cmds.publish_paired(self.broker, cmds.paired_drop_tip,
+                            'before', None, instruments, targets)
         self.paired_instrument_obj.drop_tip(target, home_after)
+        cmds.publish_paired(self.broker, cmds.paired_drop_tip,
+                            'after', self, instruments, targets)
         self._last_tip_picked_up_from = None
         return self
 
@@ -383,7 +407,25 @@ class PairedInstrumentContext(CommandPublisher):
         else:
             loc = location
 
-        self.paired_instrument_obj.aspirate(volume, loc, rate)
+        if not volume:
+            c_vol = self._get_minimum_available_volume(self._instruments)
+        else:
+            c_vol = volume
+
+        instruments = list(self._instruments.values())
+        primary_loc = self.paired_instrument_obj.aspirate(volume, loc, rate)
+        if isinstance(primary_loc.labware, Well):
+            labware = primary_loc.labware.parent
+            well = primary_loc.labware
+            locations = [
+                primary_loc,
+                self._get_secondary_target(labware, well)]
+        else:
+            locations = [primary_loc]
+        cmds.publish_paired(self.broker, cmds.paired_aspirate, 'before',
+                            None, instruments, c_vol, locations, rate)
+        cmds.publish_paired(self.broker, cmds.paired_aspirate, 'after',
+                            self, instruments, c_vol, locations, rate)
         return self
 
     @requires_version(2, 7)
@@ -456,9 +498,30 @@ class PairedInstrumentContext(CommandPublisher):
                 .format(location))
         else:
             loc = location
-        self.paired_instrument_obj.dispense(volume, loc, rate)
+
+        if not volume:
+            c_vol = self._get_minimum_current_volume(self._instruments)
+        else:
+            c_vol = volume
+
+        instruments = list(self._instruments.values())
+        primary_loc = self.paired_instrument_obj.dispense(volume, loc, rate)
+
+        if isinstance(primary_loc.labware, Well):
+            labware = primary_loc.labware.parent
+            well = primary_loc.labware
+            locations = [
+                primary_loc,
+                self._get_secondary_target(labware, well)]
+        else:
+            locations = [primary_loc]
+        cmds.publish_paired(self.broker, cmds.paired_dispense, 'before',
+                            None, instruments, c_vol, locations, rate)
+        cmds.publish_paired(self.broker, cmds.paired_dispense, 'after',
+                            self, instruments, c_vol, locations, rate)
         return self
 
+    @cmds.publish.both(command=cmds.air_gap)
     @requires_version(2, 7)
     def air_gap(self,
                 volume: float = None,
@@ -542,7 +605,16 @@ class PairedInstrumentContext(CommandPublisher):
         else:
             loc = location
 
+        locations: Optional[List] = None
+        if loc and isinstance(loc.labware, Well):
+            locations = self._get_locations(loc)
+
+        instruments = list(self._instruments.values())
+        cmds.publish_paired(self.broker, cmds.paired_blow_out,
+                            'before', None, instruments, locations)
         self.paired_instrument_obj.blow_out(loc)
+        cmds.publish_paired(self.broker, cmds.paired_blow_out,
+                            'after', self, instruments, locations)
         return self
 
     @requires_version(2, 7)
@@ -592,12 +664,25 @@ class PairedInstrumentContext(CommandPublisher):
                 raise hc.NoTipAttachedError(
                     'Pipette has no tip. Aborting mix()')
 
+        if not volume:
+            c_vol = self._get_minimum_available_volume(self._instruments)
+        else:
+            c_vol = volume
+
+        instruments = list(self._instruments.values())
+        locations: Optional[List] = None
+        if location:
+            locations = self._get_locations(location)
+        cmds.publish_paired(self.broker, cmds.paired_mix, 'before', None,
+                            instruments, locations, repetitions, c_vol)
         self.aspirate(volume, location, rate)
         while repetitions - 1 > 0:
             self.dispense(volume, rate=rate)
             self.aspirate(volume, rate=rate)
             repetitions -= 1
         self.dispense(volume, rate=rate)
+        cmds.publish_paired(self.broker, cmds.paired_mix, 'after', self,
+                            instruments, locations, repetitions, c_vol)
         return self
 
     @requires_version(2, 7)
@@ -648,10 +733,22 @@ class PairedInstrumentContext(CommandPublisher):
 
         checked_speed = clamp_value(speed, 80, 1, 'touch_tip:')
 
+        instruments = list(self._instruments.values())
+        locations: Optional[List] = None
+        if location:
+            locations = [
+                location,
+                self._get_secondary_target(location.parent, location)]
+
+        cmds.publish_paired(self.broker, cmds.paired_touch_tip,
+                            'before', None, instruments, locations)
         self.paired_instrument_obj.touch_tip(
             location, radius, v_offset, checked_speed)
+        cmds.publish_paired(self.broker, cmds.paired_touch_tip,
+                            'after', self, instruments, locations)
         return self
 
+    @cmds.publish.both(command=cmds.return_tip)
     @requires_version(2, 7)
     def return_tip(self,
                    home_after: bool = True) -> PairedInstrumentContext:
@@ -716,6 +813,17 @@ class PairedInstrumentContext(CommandPublisher):
                 filter_tipracks_to_start(start, self.tip_racks),
                 primary_channels, secondary_channels, starting_point=start)
 
+    def _get_locations(self, location) -> List:
+        if isinstance(location, Well):
+            labware = location.parent
+            well = location
+            return [location, self._get_secondary_target(labware, well)]
+        elif isinstance(location.labware, Well):
+            labware = location.labware.parent
+            well = location.labware
+            return [location, self._get_secondary_target(labware, well)]
+        return []
+
     @staticmethod
     def _drop_tip_target(
             location: Well,
@@ -726,10 +834,19 @@ class PairedInstrumentContext(CommandPublisher):
         return location.top(-z_height)
 
     @staticmethod
-    def _get_secondary_target(tiprack: Labware, primary_loc: Well) -> Well:
+    def _get_secondary_target(labware: Labware, primary_loc: Well) -> Well:
         try:
+            if len(labware.columns()) == 24:
+                spacing = SBS_384_WELL_SPACING
+                modulo_value = 16
+            elif len(labware.columns()) == 6:
+                spacing = TUBERACK_24_WELL_SPACING
+                modulo_value = 4
+            else:
+                spacing = SBS_96_WELL_SPACING
+                modulo_value = 8
             return labware_column_shift(
-                primary_loc, tiprack, SECONDARY_WELL_SPACING)
+                primary_loc, labware, spacing, modulo_value)
         except IndexError:
             raise PipettePairPickUpTipError(
                 f'The location you specified ({primary_loc}) is'
@@ -738,4 +855,11 @@ class PairedInstrumentContext(CommandPublisher):
     @staticmethod
     def _get_minimum_available_volume(instruments) -> float:
         return min(
-            instr.hw_pipette['available_volume'] for instr in instruments)
+            instr.hw_pipette['available_volume']
+            for instr in instruments.values())
+
+    @staticmethod
+    def _get_minimum_current_volume(instruments) -> float:
+        return min(
+            instr.hw_pipette['current_volume']
+            for instr in instruments.values())

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -2,7 +2,6 @@
 from collections import UserDict
 import functools
 import logging
-import math
 from dataclasses import dataclass, field, astuple
 from typing import (Any, Callable, Dict, Optional,
                     TYPE_CHECKING, Union, List, Set)
@@ -108,7 +107,7 @@ def labware_column_shift(
         well_spacing: int = 4,
         modulo_value: int = 8) -> 'Well':
     unshifted_index = tiprack.wells().index(initial_well)
-    unshifted_column = math.floor(unshifted_index/modulo_value)
+    unshifted_column = unshifted_index // modulo_value
     shifted_column = unshifted_column + well_spacing
     shifted_well = unshifted_index % modulo_value
     return tiprack.columns()[shifted_column][shifted_well]

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -105,11 +105,12 @@ def build_edges(
 
 def labware_column_shift(
         initial_well: 'Well', tiprack: 'Labware',
-        well_spacing: int = 4) -> 'Well':
+        well_spacing: int = 4,
+        modulo_value: int = 8) -> 'Well':
     unshifted_index = tiprack.wells().index(initial_well)
-    unshifted_column = math.floor(unshifted_index/8)
+    unshifted_column = math.floor(unshifted_index/modulo_value)
     shifted_column = unshifted_column + well_spacing
-    shifted_well = unshifted_index % 8
+    shifted_well = unshifted_index % modulo_value
     return tiprack.columns()[shifted_column][shifted_well]
 
 

--- a/api/src/opentrons/protocols/implementations/paired_instrument.py
+++ b/api/src/opentrons/protocols/implementations/paired_instrument.py
@@ -109,7 +109,7 @@ class PairedInstrument:
     def aspirate(
             self, volume: Optional[float],
             location: Optional[types.Location] = None,
-            rate: Optional[float] = 1.0):
+            rate: Optional[float] = 1.0) -> types.Location:
         if location:
             loc = location
         elif self._ctx.location_cache:
@@ -144,13 +144,17 @@ class PairedInstrument:
         elif loc != self._ctx.location_cache:
             self.move_to(loc)
         self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
+        return loc
 
     def dispense(
             self, volume: Optional[float],
-            location: Optional[types.Location], rate: float):
+            location: Optional[types.Location],
+            rate: float) -> types.Location:
         if location:
+            loc = location
             self.move_to(location)
         elif self._ctx.location_cache:
+            loc = self._ctx.location_cache
             pass
         else:
             raise RuntimeError(
@@ -159,6 +163,7 @@ class PairedInstrument:
                 "aspirate) must previously have been called so the robot "
                 "knows where it is.")
         self._hw_manager.hardware.dispense(self._pair_policy, volume, rate)
+        return loc
 
     def blow_out(self, location: types.Location):
         if location:

--- a/api/src/opentrons/protocols/implementations/paired_instrument.py
+++ b/api/src/opentrons/protocols/implementations/paired_instrument.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Union, Optional
+from functools import partial
+from typing import TYPE_CHECKING, Union, Optional, Callable, Tuple
 
 from opentrons import types
 from opentrons.hardware_control.types import CriticalPoint
@@ -109,7 +110,7 @@ class PairedInstrument:
     def aspirate(
             self, volume: Optional[float],
             location: Optional[types.Location] = None,
-            rate: Optional[float] = 1.0) -> types.Location:
+            rate: Optional[float] = 1.0) -> Tuple[types.Location, Callable]:
         if location:
             loc = location
         elif self._ctx.location_cache:
@@ -143,13 +144,14 @@ class PairedInstrument:
             self.move_to(loc)
         elif loc != self._ctx.location_cache:
             self.move_to(loc)
-        self._hw_manager.hardware.aspirate(self._pair_policy, volume, rate)
-        return loc
+
+        hw_aspirate = self._hw_manager.hardware.aspirate
+        return (loc, partial(hw_aspirate, self._pair_policy, volume, rate))
 
     def dispense(
             self, volume: Optional[float],
             location: Optional[types.Location],
-            rate: float) -> types.Location:
+            rate: float) -> Tuple[types.Location, Callable]:
         if location:
             loc = location
             self.move_to(location)
@@ -162,8 +164,8 @@ class PairedInstrument:
                 " method that moves to a location (such as move_to or "
                 "aspirate) must previously have been called so the robot "
                 "knows where it is.")
-        self._hw_manager.hardware.dispense(self._pair_policy, volume, rate)
-        return loc
+        hw_dispense = self._hw_manager.hardware.dispense
+        return (loc, partial(hw_dispense, self._pair_policy, volume, rate))
 
     def blow_out(self, location: types.Location):
         if location:
@@ -186,7 +188,10 @@ class PairedInstrument:
             raise RuntimeError('No previous Well cached to perform air gap')
         target = loc.labware.top(height)
         self.move_to(target)
-        self.aspirate(volume)
+        # Aspirate now returns a partial function for run log purposes
+        # but air gap only cares about executing an aspirate so here
+        # we automatically call the partial function
+        self.aspirate(volume)[1]()
 
     def touch_tip(
             self, location: Optional[Well], radius: float,


### PR DESCRIPTION
# Overview

Closes #6442. This PR adds support for pipette pairing in the app by adding all of the pipette pairing commands to the command log and rpc.

# Changelog

- Make a small change in `sessions.py` to support multiple instruments in a single command
- Add new command functions for all pipette pairing functions in `commands.py`
- Add a new publisher function that does not bind `commands.py` signatures to the `PairedInstrumentContext` signatures (especially since we don't need the defaults anyways)
- Add in a check in the tests to assert that context commands are getting populated
- Make shift labware more robust for the command logs so that it can show shifts for 96 well plates, 24 well tuberacks, 384 well plates & reservoirs.

# Review requests

Test on a robot if you can. Look over the code. Let me know if you want more tests somewhere.

# Risk assessment

Low, this is adding logs so that you can 1. calibrate in the app and 2. see these commands in the run log. After this PR is merged, we can start fully testing pipette pairing.
