### PR TITLE
refactor(api): Add a has_tip property on instrument context

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -183,6 +183,20 @@ To reset the tip tracking, you can call :py:meth:`.InstrumentContext.reset_tipra
 
 .. versionadded:: 2.0
 
+To check whether you should pick up a tip or not, you can utilize :py:meth:`.InstrumentContext.has_tip`:
+
+.. code-block:: python
+
+    for block in range(3):
+        if block == 0 and not pipette.has_tip:
+            pipette.pick_up_tip()
+        else:
+            m300.mix(mix_repetitions, 250, d)
+            m300.blow_out(s.bottom(10))
+            m300.return_tip()
+
+.. versionadded:: 2.7
+
 **********************
 
 ****************

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -178,3 +178,6 @@ Version 2.7
   .. note::
 
   This feature is still under development.
+
+- Calling :py:meth:`.InstrumentContext.has_tip` will return whether a particular instrument
+  has a tip attached or not.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -329,7 +329,7 @@ class InstrumentContext(CommandPublisher):
                 "aspirate) must previously have been called so the robot "
                 "knows where it is.")
 
-        c_vol = self.hw_pipette['current_volume'] if not volume else volume
+        c_vol = self.current_volume if not volume else volume
 
         cmds.do_publish(self.broker, cmds.dispense, self.dispense,
                         'before', None, None, self, c_vol, loc, rate)
@@ -380,7 +380,7 @@ class InstrumentContext(CommandPublisher):
             'mixing {}uL with {} repetitions in {} at rate={}'.format(
                 volume, repetitions,
                 location if location else 'current position', rate))
-        if not self.hw_pipette['has_tip']:
+        if not self.has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip. Aborting mix()')
 
         c_vol = self.hw_pipette['available_volume'] if not volume else volume
@@ -499,7 +499,7 @@ class InstrumentContext(CommandPublisher):
             :py:class:`.Placeable` as the ``location`` parameter)
 
         """
-        if not self.hw_pipette['has_tip']:
+        if not self.has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip to touch_tip()')
 
         checked_speed = self._determine_speed(speed)
@@ -574,7 +574,7 @@ class InstrumentContext(CommandPublisher):
 
 
         """
-        if not self.hw_pipette['has_tip']:
+        if not self.has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip. Aborting air_gap')
 
         if height is None:
@@ -598,7 +598,7 @@ class InstrumentContext(CommandPublisher):
 
         :returns: This instance
         """
-        if not self.hw_pipette['has_tip']:
+        if not self.has_tip:
             self._log.warning('Pipette has no tip to return')
         loc = self._last_tip_picked_up_from
         if not isinstance(loc, Well):
@@ -1291,6 +1291,15 @@ class InstrumentContext(CommandPublisher):
         The current amount of liquid, in microliters, held in the pipette.
         """
         return self.hw_pipette['current_volume']
+
+    @property  # type: ignore
+    @requires_version(2, 0)
+    def has_tip(self) -> bool:
+        """
+        :returns: Whether this instrument has a tip attached or not.
+        :type: bool
+        """
+        return self.hw_pipette['has_tip']
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -380,7 +380,7 @@ class InstrumentContext(CommandPublisher):
             'mixing {}uL with {} repetitions in {} at rate={}'.format(
                 volume, repetitions,
                 location if location else 'current position', rate))
-        if not self.has_tip:
+        if not self._has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip. Aborting mix()')
 
         c_vol = self.hw_pipette['available_volume'] if not volume else volume
@@ -499,7 +499,7 @@ class InstrumentContext(CommandPublisher):
             :py:class:`.Placeable` as the ``location`` parameter)
 
         """
-        if not self.has_tip:
+        if not self._has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip to touch_tip()')
 
         checked_speed = self._determine_speed(speed)
@@ -574,7 +574,7 @@ class InstrumentContext(CommandPublisher):
 
 
         """
-        if not self.has_tip:
+        if not self._has_tip:
             raise hc.NoTipAttachedError('Pipette has no tip. Aborting air_gap')
 
         if height is None:
@@ -598,7 +598,7 @@ class InstrumentContext(CommandPublisher):
 
         :returns: This instance
         """
-        if not self.has_tip:
+        if not self._has_tip:
             self._log.warning('Pipette has no tip to return')
         loc = self._last_tip_picked_up_from
         if not isinstance(loc, Well):
@@ -1293,11 +1293,19 @@ class InstrumentContext(CommandPublisher):
         return self.hw_pipette['current_volume']
 
     @property  # type: ignore
-    @requires_version(2, 0)
+    @requires_version(2, 7)
     def has_tip(self) -> bool:
         """
         :returns: Whether this instrument has a tip attached or not.
         :type: bool
+        """
+        return self.hw_pipette['has_tip']
+
+    @property  # type: ignore
+    def _has_tip(self) -> bool:
+        """
+        Internal function used to check whether this instrument has a
+        tip attached or not.
         """
         return self.hw_pipette['has_tip']
 


### PR DESCRIPTION
# Overview

Closes #6516.

# Changelog

- Add a `has_tip` property method to `InstrumentContext`.

# Review requests

Should I bump up the api version to 2.7 on the property? I wanted to be able to use it in the code base for the tip check which is why I kept it at 2.0.

# Risk assessment
Medium, if someone read through the docs and were not on 3.21+ they would get an error.
