### PR TITLE
refactor(api, shared-data): use pipette offset in hardware control

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -187,7 +187,8 @@ def load(
         dispense_flow_rate=cfg['defaultDispenseFlowRate']['value'],
         channels=ensure_value(cfg, 'channels', MUTABLE_CONFIGS),
         model_offset=ensure_value(cfg, 'modelOffset', MUTABLE_CONFIGS),
-        nozzle_offset=cfg.get('nozzleOffset', NOZZLE_OFFSET_DEFAULT),
+        nozzle_offset=cfg.get(  # type: ignore
+            'nozzleOffset', NOZZLE_OFFSET_DEFAULT),
         plunger_current=ensure_value(cfg, 'plungerCurrent', MUTABLE_CONFIGS),
         drop_tip_current=ensure_value(cfg, 'dropTipCurrent', MUTABLE_CONFIGS),
         drop_tip_speed=ensure_value(cfg, 'dropTipSpeed', MUTABLE_CONFIGS),

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -35,6 +35,7 @@ class PipetteConfig:
     dispense_flow_rate: float
     channels: float
     model_offset: Tuple[float, float, float]
+    nozzle_offset: Tuple[float, float, float]
     plunger_current: float
     drop_tip_current: float
     drop_tip_speed: float
@@ -80,6 +81,8 @@ Z_OFFSET_P10 = -13  # longest single-channel pipette
 Z_OFFSET_P50 = 0
 Z_OFFSET_P300 = 0
 Z_OFFSET_P1000 = 20  # shortest single-channel pipette
+
+NOZZLE_OFFSET_DEFAULT = [0.0, 0.0, 0.0]
 
 LOW_CURRENT_DEFAULT = 0.05
 
@@ -184,6 +187,7 @@ def load(
         dispense_flow_rate=cfg['defaultDispenseFlowRate']['value'],
         channels=ensure_value(cfg, 'channels', MUTABLE_CONFIGS),
         model_offset=ensure_value(cfg, 'modelOffset', MUTABLE_CONFIGS),
+        nozzle_offset=cfg.get('nozzleOffset', NOZZLE_OFFSET_DEFAULT),
         plunger_current=ensure_value(cfg, 'plungerCurrent', MUTABLE_CONFIGS),
         drop_tip_current=ensure_value(cfg, 'dropTipCurrent', MUTABLE_CONFIGS),
         drop_tip_speed=ensure_value(cfg, 'dropTipSpeed', MUTABLE_CONFIGS),

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -313,7 +313,8 @@ def build_config(deck_cal: List[List[float]],
             'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS),
         z_retract_distance=robot_settings.get(
             'z_retract_distance', Z_RETRACT_DISTANCE),
-        left_mount_offset=DEFAULT_MOUNT_OFFSET,
+        left_mount_offset=robot_settings.get(
+            'left_mount_offset', DEFAULT_MOUNT_OFFSET),
     )
     return cfg
 

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -196,7 +196,8 @@ robot_config = namedtuple(
         'log_level',
         'tip_probe',
         'default_pipette_configs',
-        'z_retract_distance'
+        'z_retract_distance',
+        'left_mount_offset'
     ]
 )
 
@@ -312,6 +313,7 @@ def build_config(deck_cal: List[List[float]],
             'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS),
         z_retract_distance=robot_settings.get(
             'z_retract_distance', Z_RETRACT_DISTANCE),
+        left_mount_offset=DEFAULT_MOUNT_OFFSET,
     )
     return cfg
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -906,10 +906,7 @@ class API(HardwareAPILike):
                  (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
                  (primary_z, abs_position.z - primary_offset.z - primary_cp.z)
                  ))
-        mod_log.info(f"########## =========> Target position: {target_position}")
-        mod_log.info(f"########## =========> Absolute position: {abs_position}")
-        mod_log.info(f"########## =========> Primary offset position: {primary_offset}")
-        mod_log.info(f"########## =========> Primary cp position: {primary_cp}")
+
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position, speed=speed,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -780,7 +780,10 @@ class API(HardwareAPILike):
             if mount == top_types.Mount.RIGHT:
                 offset = top_types.Point(0, 0, 0)
             else:
-                offset = top_types.Point(*self._config.mount_offset)
+                if ff.enable_calibration_overhaul():
+                    offset = top_types.Point(*self._config.left_mount_offset)
+                else:
+                    offset = top_types.Point(*self._config.mount_offset)
             z_ax = Axis.by_mount(mount)
             plunger_ax = Axis.of_plunger(mount)
             cp = self._critical_point_for(mount, critical_point)
@@ -880,12 +883,16 @@ class API(HardwareAPILike):
         if len(mounts) > 1:
             secondary_mount = mounts[1]  # type: ignore
 
+        if ff.enable_calibration_overhaul():
+            mount_offset = self._config.left_mount_offset
+        else:
+            mount_offset = self._config.mount_offset
         if primary_mount == top_types.Mount.LEFT:
-            primary_offset = top_types.Point(*self._config.mount_offset)
+            primary_offset = top_types.Point(*mount_offset)
             s_offset = top_types.Point(0, 0, 0)
         else:
             primary_offset = top_types.Point(0, 0, 0)
-            s_offset = top_types.Point(*self._config.mount_offset)
+            s_offset = top_types.Point(*mount_offset)
 
         if secondary_mount:
             primary_z = Axis.by_mount(primary_mount)

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -906,7 +906,10 @@ class API(HardwareAPILike):
                  (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
                  (primary_z, abs_position.z - primary_offset.z - primary_cp.z)
                  ))
-
+        mod_log.info(f"########## =========> Target position: {target_position}")
+        mod_log.info(f"########## =========> Absolute position: {abs_position}")
+        mod_log.info(f"########## =========> Primary offset position: {primary_offset}")
+        mod_log.info(f"########## =========> Primary cp position: {primary_cp}")
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position, speed=speed,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -910,10 +910,7 @@ class API(HardwareAPILike):
                  (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
                  (primary_z, abs_position.z - primary_offset.z - primary_cp.z)
                  ))
-        mod_log.info(f"********** => target position: {target_position}")
-        mod_log.info(f"********** => absolute position: {abs_position}")
-        mod_log.info(f"********** => primary offset: {primary_offset}")
-        mod_log.info(f"********** => primary cp: {primary_cp}")
+
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
             target_position, speed=speed,

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -107,11 +107,11 @@ class Pipette:
         return self._config
 
     @property
-    def model_offset(self):
+    def model_offset(self) -> Tuple[float, float, float]:
         return self._model_offset
 
     @property
-    def nozzle_offset(self):
+    def nozzle_offset(self) -> Tuple[float, float, float]:
         return self._nozzle_offset
 
     def update_config_item(self, elem_name: str, elem_val: Any):
@@ -163,7 +163,7 @@ class Pipette:
                 0, -offsets[1], offsets[2]]
             cp_type = CriticalPoint.FRONT_NOZZLE
         else:
-            mod_offset_xy = offsets
+            mod_offset_xy = list(offsets)
         mod_and_tip = Point(mod_offset_xy[0],
                             mod_offset_xy[1],
                             mod_offset_xy[2] - tip_length)

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -140,8 +140,7 @@ class Pipette:
         """
         if enable_calibration_overhaul():
             instr = self._instrument_offset
-            # offsets = self.model_offset
-            offsets = [self.model_offset[0], self.model_offset[1], self.nozzle_offset[2]]
+            offsets = self.nozzle_offset
         else:
             instr = self._instrument_offset._replace(z=0)
             offsets = self.model_offset
@@ -166,7 +165,6 @@ class Pipette:
                             mod_offset_xy[2] - tip_length)
 
         cp = mod_and_tip + instr
-        mod_log.info(f"************ ===> Critical point: {cp}")
 
         if self._log.isEnabledFor(logging.DEBUG):
             info_str = 'cp: {}{}: {} (from: '\

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """
 from dataclasses import asdict, replace
 import logging
-import operator
 from typing import Any, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 from opentrons.types import Point
@@ -144,16 +143,11 @@ class Pipette:
         critical point will be used.
         """
         if enable_calibration_overhaul():
-            instr = self._instrument_offset
-            offsets = list(map(
-                operator.add,
-                self.nozzle_offset, self._pipette_offset.offset))
-            mod_log.info(f'#####========> Nozzle offset: {self.nozzle_offset}')
-            mod_log.info(f'#####========> Pipette offset: {self._pipette_offset.offset}')
+            instr = Point(*self._pipette_offset.offset)
+            offsets = self.nozzle_offset
         else:
             instr = self._instrument_offset._replace(z=0)
             offsets = self.model_offset
-            mod_log.info(f'#####========> Model offset: {self.model_offset}')
 
         if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -38,6 +38,7 @@ dummy_settings = {
     'z_retract_distance': 2,
     'tip_length': 999,
     'mount_offset': [-3, -2, -1],
+    'left_mount_offset': [-34, 0, 0],
     'serial_speed': 888,
     'default_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
     'low_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -47,6 +47,29 @@ def test_critical_points(model):
 
 
 @pytest.mark.parametrize('model', pipette_config.config_models)
+def test_critical_points_cal_overhaul(model, use_new_calibration):
+    loaded = pipette_config.load(model)
+    pip = pipette.Pipette(loaded,
+                          {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          'testID')
+    nozzle_offset = Point(*loaded.nozzle_offset)
+    assert pip.critical_point() == nozzle_offset
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == nozzle_offset
+    assert pip.critical_point(types.CriticalPoint.TIP) == nozzle_offset
+    tip_length = 25.0
+    pip.add_tip(tip_length)
+    new = nozzle_offset._replace(
+        z=nozzle_offset.z - tip_length)
+    assert pip.critical_point() == new
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == nozzle_offset
+    assert pip.critical_point(types.CriticalPoint.TIP) == new
+    pip.remove_tip()
+    assert pip.critical_point() == nozzle_offset
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == nozzle_offset
+    assert pip.critical_point(types.CriticalPoint.TIP) == nozzle_offset
+
+
+@pytest.mark.parametrize('model', pipette_config.config_models)
 def test_critical_point_tiplength(use_new_calibration, model):
     loaded = pipette_config.load(model)
     instr_z = 25
@@ -70,6 +93,32 @@ def test_critical_point_tiplength(use_new_calibration, model):
     assert pip.critical_point() == mod_plus_instr
     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
     assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
+
+
+# @pytest.mark.parametrize('model', pipette_config.config_models)
+# def test_critical_point_tiplength_cal_overhaul(use_new_calibration, model):
+#     loaded = pipette_config.load(model)
+#     instr_z = 25
+#     pip = pipette.Pipette(
+#         loaded,
+#         {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+#         'testID')
+#     mod_plus_instr = Point(*loaded.model_offset) + Point(0, 0, instr_z)
+#     assert pip.critical_point() == mod_plus_instr
+#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
+#     assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
+#     tip_length = 25.0
+#     pip.add_tip(tip_length)
+#     # unlike the above case, mod offset should not change
+#     assert pip.critical_point() == mod_plus_instr - Point(0, 0, tip_length)
+#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
+#     # if there is a tip, we should see it here added
+#     assert pip.critical_point(types.CriticalPoint.TIP)\
+#         == mod_plus_instr - Point(0, 0, tip_length)
+#     pip.remove_tip()
+#     assert pip.critical_point() == mod_plus_instr
+#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
+#     assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
 
 
 @pytest.mark.parametrize('config_model', pipette_config.config_models)

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -1,7 +1,11 @@
 import pytest
 from opentrons.types import Point
-from opentrons.hardware_control import pipette, types
+from opentrons.hardware_control import \
+    pipette, types, robot_calibration as rb_cal
 from opentrons.config import pipette_config
+
+PIP_CAL = rb_cal.PipetteCalibration(
+    offset=[0, 0, 0])
 
 
 def test_tip_tracking():
@@ -28,6 +32,7 @@ def test_critical_points(model):
     loaded = pipette_config.load(model)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testID')
     mod_offset = Point(*loaded.model_offset)
     assert pip.critical_point() == mod_offset
@@ -47,11 +52,14 @@ def test_critical_points(model):
 
 
 @pytest.mark.parametrize('model', pipette_config.config_models)
-def test_critical_points_cal_overhaul(model, use_new_calibration):
+def test_critical_points_nozzle_offset(model, use_new_calibration):
     loaded = pipette_config.load(model)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testID')
+    # default pipette offset is[0, 0, 0], only nozzle offset would be used
+    # to determine critical point
     nozzle_offset = Point(*loaded.nozzle_offset)
     assert pip.critical_point() == nozzle_offset
     assert pip.critical_point(types.CriticalPoint.NOZZLE) == nozzle_offset
@@ -70,55 +78,30 @@ def test_critical_points_cal_overhaul(model, use_new_calibration):
 
 
 @pytest.mark.parametrize('model', pipette_config.config_models)
-def test_critical_point_tiplength(use_new_calibration, model):
+def test_critical_points_pipette_offset(model, use_new_calibration):
     loaded = pipette_config.load(model)
-    instr_z = 25
-    pip = pipette.Pipette(
-        loaded,
-        {'single': [0, 0, instr_z], 'multi': [0, 0, instr_z]},
-        'testID')
-    mod_plus_instr = Point(*loaded.model_offset) + Point(0, 0, instr_z)
-    assert pip.critical_point() == mod_plus_instr
-    assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-    assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
+    # set pipette offset calibration
+    pip_cal = rb_cal.PipetteCalibration(offset=[10, 10, 10])
+    pip = pipette.Pipette(loaded,
+                          {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          pip_cal,
+                          'testID')
+    # pipette offset + nozzle offset to determine critical point
+    offsets = Point(*pip_cal.offset) + Point(*pip.nozzle_offset)
+    assert pip.critical_point() == offsets
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == offsets
+    assert pip.critical_point(types.CriticalPoint.TIP) == offsets
     tip_length = 25.0
     pip.add_tip(tip_length)
-    # unlike the above case, mod offset should not change
-    assert pip.critical_point() == mod_plus_instr - Point(0, 0, tip_length)
-    assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-    # if there is a tip, we should see it here added
-    assert pip.critical_point(types.CriticalPoint.TIP)\
-        == mod_plus_instr - Point(0, 0, tip_length)
+    new = offsets._replace(
+        z=offsets.z - tip_length)
+    assert pip.critical_point() == new
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == offsets
+    assert pip.critical_point(types.CriticalPoint.TIP) == new
     pip.remove_tip()
-    assert pip.critical_point() == mod_plus_instr
-    assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-    assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
-
-
-# @pytest.mark.parametrize('model', pipette_config.config_models)
-# def test_critical_point_tiplength_cal_overhaul(use_new_calibration, model):
-#     loaded = pipette_config.load(model)
-#     instr_z = 25
-#     pip = pipette.Pipette(
-#         loaded,
-#         {'single': [0, 0, 0], 'multi': [0, 0, 0]},
-#         'testID')
-#     mod_plus_instr = Point(*loaded.model_offset) + Point(0, 0, instr_z)
-#     assert pip.critical_point() == mod_plus_instr
-#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-#     assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
-#     tip_length = 25.0
-#     pip.add_tip(tip_length)
-#     # unlike the above case, mod offset should not change
-#     assert pip.critical_point() == mod_plus_instr - Point(0, 0, tip_length)
-#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-#     # if there is a tip, we should see it here added
-#     assert pip.critical_point(types.CriticalPoint.TIP)\
-#         == mod_plus_instr - Point(0, 0, tip_length)
-#     pip.remove_tip()
-#     assert pip.critical_point() == mod_plus_instr
-#     assert pip.critical_point(types.CriticalPoint.NOZZLE) == mod_plus_instr
-#     assert pip.critical_point(types.CriticalPoint.TIP) == mod_plus_instr
+    assert pip.critical_point() == offsets
+    assert pip.critical_point(types.CriticalPoint.NOZZLE) == offsets
+    assert pip.critical_point(types.CriticalPoint.TIP) == offsets
 
 
 @pytest.mark.parametrize('config_model', pipette_config.config_models)
@@ -126,6 +109,7 @@ def test_volume_tracking(config_model):
     loaded = pipette_config.load(config_model)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testID')
     assert pip.current_volume == 0.0
     assert pip.available_volume == loaded.max_volume
@@ -152,6 +136,7 @@ def test_config_update(config_model):
     loaded = pipette_config.load(config_model)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testID')
     sample_plunger_pos = {'top': 19.5}
     pip.update_config_item('top', sample_plunger_pos.get('top'))
@@ -168,6 +153,7 @@ def test_tip_overlap(config_model):
     loaded = pipette_config.load(config_model)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testId')
     assert pip.config.tip_overlap\
         == pipette_config.configs[config_model]['tipOverlap']
@@ -176,6 +162,7 @@ def test_tip_overlap(config_model):
 def test_flow_rate_setting():
     pip = pipette.Pipette(pipette_config.load('p300_single_v2.0'),
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_CAL,
                           'testId')
     # pipettes should load settings from config at init time
     assert pip.aspirate_flow_rate\

--- a/api/tests/opentrons/util/test_tip_probe.py
+++ b/api/tests/opentrons/util/test_tip_probe.py
@@ -135,3 +135,4 @@ def test_update_instrument_config(fixture):
     # pprint(actual)
     # print()
     assert actual == expected
+    filename.unlink()

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -199,6 +199,8 @@ class PipetteOffsetCalibrationUserFlow:
                 pip_id=self._hw_pipette.pipette_id,
                 tiprack_hash=tiprack_hash,
                 tiprack_uri=self._tip_rack.uri)
+            # reload new pipette offset data by resetting instrument
+            self._hardware.reset_instrument(self._mount)
 
     async def pick_up_tip(self):
         await uf.pick_up_tip(self, tip_length=self._get_tip_length())

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -199,8 +199,6 @@ class PipetteOffsetCalibrationUserFlow:
                 pip_id=self._hw_pipette.pipette_id,
                 tiprack_hash=tiprack_hash,
                 tiprack_uri=self._tip_rack.uri)
-            # reload new pipette offset data by resetting instrument
-            self._hardware.reset_instrument(self._mount)
 
     async def pick_up_tip(self):
         await uf.pick_up_tip(self, tip_length=self._get_tip_length())
@@ -217,3 +215,5 @@ class PipetteOffsetCalibrationUserFlow:
     async def exit_session(self):
         await self.move_to_tip_rack()
         await self._return_tip()
+        # reload new pipette offset data by resetting instrument
+        self._hardware.reset_instrument(self._mount)

--- a/robot-server/tests/integration/test_settings_robot.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_robot.tavern.yaml
@@ -96,6 +96,10 @@ stages:
         - !anyint
         - !anyint
         - !anyint
+        left_mount_offset:
+        - -34
+        - 0
+        - 0
         log_level: !re_match "DEBUG|INFO|WARNING|ERROR"
         tip_probe: !anylist
         default_pipette_configs:

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -108,6 +108,7 @@ async def test_save_default_pick_up_current(mock_hw):
     # modified during tip pick up
     pip = pipette.Pipette(load("p20_multi_v2.1", 'testId'),
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                          PIP_OFFSET,
                           'testid')
     mock_hw._attached_instruments[Mount.LEFT] = pip
     uf = DeckCalibrationUserFlow(hardware=mock_hw)

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -2,12 +2,18 @@ import pytest
 from unittest.mock import MagicMock, call
 from typing import List, Tuple
 from opentrons.types import Mount, Point
-from opentrons.hardware_control import pipette
+from opentrons.hardware_control import \
+    pipette, robot_calibration as rb_cal
+from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
 from robot_server.robot.calibration.deck.user_flow import \
     DeckCalibrationUserFlow, tuplefy_cal_point_dicts
 from robot_server.robot.calibration.deck.constants import \
     POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID, DeckCalibrationState
+
+
+PIP_OFFSET = rb_cal.PipetteCalibration(
+        offset=robot_configs.DEFAULT_PIPETTE_OFFSET)
 
 
 @pytest.fixture
@@ -17,6 +23,7 @@ def mock_hw(hardware):
                               'single': [0, 0, 0],
                               'multi': [0, 0, 0]
                           },
+                          PIP_OFFSET,
                           'testId')
     hardware._attached_instruments = {Mount.RIGHT: pip, Mount.LEFT: pip}
     hardware._current_pos = Point(0, 0, 0)
@@ -60,10 +67,12 @@ def test_user_flow_select_pipette(pipettes, target_mount, hardware):
     if pipettes[0]:
         pip = pipette.Pipette(load(pipettes[0], 'testId'),
                               {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                              PIP_OFFSET,
                               'testId')
     if pipettes[1]:
         pip2 = pipette.Pipette(load(pipettes[1], 'testId'),
                                {'single': [0, 0, 0], 'multi': [0, 0, 0]},
+                               PIP_OFFSET,
                                'testId2')
     hardware._attached_instruments = {Mount.LEFT: pip, Mount.RIGHT: pip2}
 

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -73,6 +73,11 @@ Object {
     -25.8,
   ],
   "name": "p10_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -289,6 +294,11 @@ Object {
     -25.8,
   ],
   "name": "p10_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -505,6 +515,11 @@ Object {
     -25.8,
   ],
   "name": "p10_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -721,6 +736,11 @@ Object {
     -25.8,
   ],
   "name": "p10_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -907,6 +927,11 @@ Object {
     -13,
   ],
   "name": "p10_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    12,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -1128,6 +1153,11 @@ Object {
     -13,
   ],
   "name": "p10_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    12,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -1349,6 +1379,11 @@ Object {
     -13,
   ],
   "name": "p10_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    12,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -1570,6 +1605,11 @@ Object {
     -13,
   ],
   "name": "p10_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    12,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -1755,6 +1795,11 @@ Object {
     -25.8,
   ],
   "name": "p50_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -1960,6 +2005,11 @@ Object {
     -25.8,
   ],
   "name": "p50_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -2165,6 +2215,11 @@ Object {
     -25.8,
   ],
   "name": "p50_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -2370,6 +2425,11 @@ Object {
     -25.8,
   ],
   "name": "p50_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -2555,6 +2615,11 @@ Object {
     0,
   ],
   "name": "p50_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -2760,6 +2825,11 @@ Object {
     0,
   ],
   "name": "p50_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -2965,6 +3035,11 @@ Object {
     0,
   ],
   "name": "p50_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -3170,6 +3245,11 @@ Object {
     -25.8,
   ],
   "name": "p300_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -3339,6 +3419,11 @@ Object {
     -25.8,
   ],
   "name": "p300_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -3508,6 +3593,11 @@ Object {
     -25.8,
   ],
   "name": "p300_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -3677,6 +3767,11 @@ Object {
     -25.8,
   ],
   "name": "p300_multi",
+  "nozzleOffset": Array [
+    0,
+    31.5,
+    0.8,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -3847,6 +3942,11 @@ Object {
     0,
   ],
   "name": "p300_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -4072,6 +4172,11 @@ Object {
     0,
   ],
   "name": "p300_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -4297,6 +4402,11 @@ Object {
     0,
   ],
   "name": "p300_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -4522,6 +4632,11 @@ Object {
     0,
   ],
   "name": "p300_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    25,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -4711,6 +4826,11 @@ Object {
     20,
   ],
   "name": "p1000_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    45,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -4902,6 +5022,11 @@ Object {
     20,
   ],
   "name": "p1000_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    45,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -5093,6 +5218,11 @@ Object {
     20,
   ],
   "name": "p1000_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    45,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,
@@ -5284,6 +5414,11 @@ Object {
     20,
   ],
   "name": "p1000_single",
+  "nozzleOffset": Array [
+    0,
+    0,
+    45,
+  ],
   "pickUpCurrent": Object {
     "max": 2,
     "min": 0.05,

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -66,6 +66,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
+      "nozzleOffset": [0.0, 0.0, 12],
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
@@ -191,6 +192,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
+      "nozzleOffset": [0.0, 0.0, 12],
       "ulPerMm": [
         {
           "aspirate": [
@@ -316,6 +318,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
+      "nozzleOffset": [0.0, 0.0, 12],
       "ulPerMm": [
         {
           "aspirate": [
@@ -441,6 +444,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -13],
+      "nozzleOffset": [0.0, 0.0, 12],
       "ulPerMm": [
         {
           "aspirate": [
@@ -556,6 +560,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -680,6 +685,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -804,6 +810,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -928,6 +935,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -1043,6 +1051,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -1167,6 +1176,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -14.55],
+      "nozzleOffset": [0.0, 0.0, 10.45],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -1337,6 +1347,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, -14.55],
+      "nozzleOffset": [0.0, 0.0, 10.45],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -1507,6 +1518,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -5.6],
+      "nozzleOffset": [0.0, 0.0, 19.4],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -1678,6 +1690,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -5.6],
+      "nozzleOffset": [0.0, 0.0, 19.4],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -1848,6 +1861,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -1969,6 +1983,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "plungerCurrent": {
         "value": 0.3,
         "min": 0.1,
@@ -2090,6 +2105,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2211,6 +2227,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2326,6 +2343,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2447,6 +2465,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2568,6 +2587,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2689,6 +2709,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2803,6 +2824,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2928,6 +2950,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3054,6 +3077,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3180,6 +3204,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 0.0],
+      "nozzleOffset": [0.0, 0.0, 25.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3297,6 +3322,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 4.45],
+      "nozzleOffset": [0.0, 0.0, 29.45],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3465,6 +3491,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 4.45],
+      "nozzleOffset": [0.0, 0.0, 29.45],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3633,6 +3660,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3745,6 +3773,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3856,6 +3885,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3967,6 +3997,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
+      "nozzleOffset": [0.0, 0.0, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4079,6 +4110,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, 10.52],
+      "nozzleOffset": [0.0, 0.0, 35.52],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4249,6 +4281,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, 10.52],
+      "nozzleOffset": [0.0, 0.0, 35.52],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4418,6 +4451,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
+      "nozzleOffset": [0.0, 0.0, 45.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4534,6 +4568,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
+      "nozzleOffset": [0.0, 0.0, 45.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4650,6 +4685,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
+      "nozzleOffset": [0.0, 0.0, 45.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4766,6 +4802,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 20.0],
+      "nozzleOffset": [0.0, 0.0, 45.0],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4883,6 +4920,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 25.14],
+      "nozzleOffset": [0.0, 0.0, 50.14],
       "ulPerMm": [
         {
           "aspirate": [
@@ -5053,6 +5091,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 0.0, 25.14],
+      "nozzleOffset": [0.0, 0.0, 50.14],
       "ulPerMm": [
         {
           "aspirate": [

--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -560,7 +560,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -685,7 +685,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -810,7 +810,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -935,7 +935,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -1051,7 +1051,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -1518,7 +1518,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -5.6],
-      "nozzleOffset": [0.0, 0.0, 19.4],
+      "nozzleOffset": [0.0, 31.5, 19.4],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -1690,7 +1690,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -5.6],
-      "nozzleOffset": [0.0, 0.0, 19.4],
+      "nozzleOffset": [0.0, 31.5, 19.4],
       "plungerCurrent": {
         "value": 1.0,
         "min": 0.01,
@@ -2343,7 +2343,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2465,7 +2465,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2587,7 +2587,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -2709,7 +2709,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3660,7 +3660,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3773,7 +3773,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3885,7 +3885,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -3997,7 +3997,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, -25.8],
-      "nozzleOffset": [0.0, 0.0, 0.8],
+      "nozzleOffset": [0.0, 31.5, 0.8],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4110,7 +4110,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, 10.52],
-      "nozzleOffset": [0.0, 0.0, 35.52],
+      "nozzleOffset": [0.0, 31.5, 35.52],
       "ulPerMm": [
         {
           "aspirate": [
@@ -4281,7 +4281,7 @@
         "type": "float"
       },
       "modelOffset": [0.0, 31.5, 10.52],
-      "nozzleOffset": [0.0, 0.0, 35.52],
+      "nozzleOffset": [0.0, 31.5, 35.52],
       "ulPerMm": [
         {
           "aspirate": [

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -84,7 +84,8 @@
             "dropTipCurrent",
             "dropTipSpeed",
             "ulPerMm",
-            "tipLength"
+            "tipLength",
+            "nozzleOffset"
           ],
           "additionalProperties": false,
           "properties": {
@@ -106,6 +107,7 @@
             "pickUpIncrement": { "$ref": "#/definitions/editConfigurations" },
             "pickUpSpeed": { "$ref": "#/definitions/editConfigurations" },
             "modelOffset": { "$ref": "#/definitions/xyzArray" },
+            "nozzleOffset": { "$ref": "#/definitions/xyzArray" },
             "plungerCurrent": { "$ref": "#/definitions/editConfigurations" },
             "dropTipCurrent": { "$ref": "#/definitions/editConfigurations" },
             "dropTipSpeed": { "$ref": "#/definitions/editConfigurations" },

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -104,6 +104,7 @@ class PipetteModelSpec(TypedDict, total=False):
     dropTipCurrent: PipetteCustomizableConfigElementFloat
     dropTipSpeed: PipetteCustomizableConfigElementFloat
     modelOffset: List[float]
+    nozzleOffset: List[float]
     ulPerMm: List[UlPerMm]
     tipOverlap: Dict[str, float]
     tipLength: PipetteCustomizableConfigElementFloat


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR incorporates pipette offset calibration data in hardware motion by updating the pipette's critical point.

closes #6427, closes #6534

# Changelog
- add new property `nozzleOffset` to pipetteModelSpecs to represent the true distance from the mount to the pipette nozzle
- load `nozzle_offset` to pipette config
- load pipette offset calibration during `cache_instruments` and pass to `Pipette`
   - default offset is `[0, 0, 0]` if data do not exist
- use pipette offset and nozzle offset to determine critical point, instead of using the instrument and model offset
- update to tests to reflect the above changes
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
To test this PR, make sure your robot has the changes in #6586 and to remove all old pipette offset data.

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium, new features are behind a feature flag but they affect robot motion. Any old deck/pipette offset calibration should be cleared and recalibrated before testing these changes.
