### PR TITLE
feat(protocol designer): remove mix tip position fields

### DIFF
--- a/protocol-designer/benchmarks/timelineGeneration.js
+++ b/protocol-designer/benchmarks/timelineGeneration.js
@@ -39,8 +39,8 @@ bench(`commandCreatorsTimeline: mix ${times} times`, b => {
       dispenseOffsetFromBottomMm: 2,
       aspirateFlowRateUlSec: 5,
       dispenseFlowRateUlSec: 6,
-      aspirateDelay: null,
-      dispenseDelay: null,
+      aspirateDelaySeconds: null,
+      dispenseDelaySeconds: null,
     }),
   ]
 

--- a/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
@@ -16,7 +16,7 @@ import type {
 type DelayFieldProps = {
   checkboxFieldName: DelayCheckboxFields,
   secondsFieldName: DelaySecondFields,
-  tipPositionFieldName: TipOffsetFields,
+  tipPositionFieldName?: TipOffsetFields,
   focusHandlers: FocusHandlers,
 }
 
@@ -42,7 +42,9 @@ export const DelayFields = (props: DelayFieldProps): React.Node => {
         className={styles.small_field}
         {...focusHandlers}
       />
-      <TipPositionField fieldName={tipPositionFieldName} />
+      {tipPositionFieldName && (
+        <TipPositionField fieldName={tipPositionFieldName} />
+      )}
     </CheckboxRowField>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -36,8 +36,6 @@ function getLabwareFieldForPositioningField(
     dispense_delay_mmFromBottom: 'dispense_labware',
     mix_mmFromBottom: 'labware',
     mix_touchTip_mmFromBottom: 'labware',
-    mix_aspirate_delay_mmFromBottom: 'labware',
-    mix_dispense_delay_mmFromBottom: 'labware',
   }
   return fieldMap[fieldName]
 }

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
@@ -16,7 +16,6 @@ describe('DelayFields', () => {
       props = {
         checkboxFieldName: 'aspirate_delay_checkbox',
         secondsFieldName: 'aspirate_delay_seconds',
-        tipPositionFieldName: 'aspirate_mmFromBottom',
         focusHandlers: {
           focusedField: '',
           dirtyFields: [],
@@ -26,9 +25,10 @@ describe('DelayFields', () => {
       }
     })
 
-    it('should render an aspirate delay field', () => {
-      const wrapper = render(props)
+    it('should render an aspirate delay field with a tip position field', () => {
+      props = { ...props, tipPositionFieldName: 'aspirate_mmFromBottom' }
 
+      const wrapper = render(props)
       const checkboxField = wrapper.find(CheckboxRowField)
       expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
       expect(checkboxField.prop('label')).toBe('delay')
@@ -44,6 +44,22 @@ describe('DelayFields', () => {
       expect(tipPosField.is(TipPositionField)).toBe(true)
       expect(tipPosField.prop('fieldName')).toBe(props.tipPositionFieldName)
     })
+    it('should render an aspirate delay field WITHOUT a tip position field', () => {
+      const wrapper = render(props)
+
+      const checkboxField = wrapper.find(CheckboxRowField)
+      expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
+      expect(checkboxField.prop('label')).toBe('delay')
+      expect(checkboxField.prop('tooltipComponent')).toBe(
+        FormTooltipText.step_fields.defaults.aspirate_delay_checkbox
+      )
+      const secondsField = checkboxField.childAt(0)
+      expect(secondsField.is(TextField)).toBe(true)
+      expect(secondsField.prop('name')).toBe(props.secondsFieldName)
+      expect(secondsField.prop('units')).toBe(ApplicationText.units.seconds)
+
+      expect(wrapper.find(TipPositionField).length).toBe(0)
+    })
   })
   describe('Dispense Delay', () => {
     let props
@@ -51,7 +67,6 @@ describe('DelayFields', () => {
       props = {
         checkboxFieldName: 'dispense_delay_checkbox',
         secondsFieldName: 'dispense_delay_seconds',
-        tipPositionFieldName: 'dispense_delay_mmFromBottom',
         focusHandlers: {
           focusedField: '',
           dirtyFields: [],
@@ -61,7 +76,9 @@ describe('DelayFields', () => {
       }
     })
 
-    it('should render an dispense delay field', () => {
+    it('should render an dispense delay field with a tip position field', () => {
+      props = { ...props, tipPositionFieldName: 'dispense_delay_mmFromBottom' }
+
       const wrapper = render(props)
 
       const checkboxField = wrapper.find(CheckboxRowField)
@@ -78,6 +95,23 @@ describe('DelayFields', () => {
       const tipPosField = checkboxField.childAt(1)
       expect(tipPosField.is(TipPositionField)).toBe(true)
       expect(tipPosField.prop('fieldName')).toBe(props.tipPositionFieldName)
+    })
+
+    it('should render an dispense delay field WITHOUT a tip position field', () => {
+      const wrapper = render(props)
+
+      const checkboxField = wrapper.find(CheckboxRowField)
+      expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
+      expect(checkboxField.prop('label')).toBe('delay')
+      expect(checkboxField.prop('tooltipComponent')).toBe(
+        FormTooltipText.step_fields.defaults.dispense_delay_checkbox
+      )
+      const secondsField = checkboxField.childAt(0)
+      expect(secondsField.is(TextField)).toBe(true)
+      expect(secondsField.prop('name')).toBe(props.secondsFieldName)
+      expect(secondsField.prop('units')).toBe(ApplicationText.units.seconds)
+
+      expect(wrapper.find(TipPositionField).length).toBe(0)
     })
   })
 })

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -117,7 +117,6 @@ export class MixForm extends React.Component<Props, State> {
               <DelayFields
                 checkboxFieldName={'aspirate_delay_checkbox'}
                 secondsFieldName={'aspirate_delay_seconds'}
-                tipPositionFieldName={'mix_aspirate_delay_mmFromBottom'}
                 focusHandlers={focusHandlers}
               />
             </div>
@@ -134,7 +133,6 @@ export class MixForm extends React.Component<Props, State> {
                 <DelayFields
                   checkboxFieldName={'dispense_delay_checkbox'}
                   secondsFieldName={'dispense_delay_seconds'}
-                  tipPositionFieldName={'mix_dispense_delay_mmFromBottom'}
                   focusHandlers={focusHandlers}
                 />
                 <CheckboxRowField

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -44,9 +44,8 @@ describe('MixForm', () => {
       expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
         'aspirate_delay_seconds'
       )
-      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(
-        'mix_aspirate_delay_mmFromBottom'
-      )
+      // no tip position field
+      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
     })
     it('should render the dispense delay fields', () => {
       const wrapper = render(props)
@@ -59,9 +58,8 @@ describe('MixForm', () => {
       expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
         'dispense_delay_seconds'
       )
-      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(
-        'mix_dispense_delay_mmFromBottom'
-      )
+      // no tip position field
+      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
     })
   })
 })

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -46,8 +46,6 @@ export type StepFieldName = any
 // | 'labwareLocationUpdate'
 // | 'mix_mmFromBottom'
 // | 'mix_touchTip_mmFromBottom'
-// | 'mix_aspirate_delay_mmFromBottom
-// | 'mix_dispense_delay_mmFromBottom
 // | 'path'
 // | 'pauseAction'
 // | 'pauseHour'
@@ -298,8 +296,6 @@ export type TipOffsetFields =
   | 'aspirate_delay_mmFromBottom'
   | 'dispense_delay_mmFromBottom'
   | 'mix_touchTip_mmFromBottom'
-  | 'mix_aspirate_delay_mmFromBottom'
-  | 'mix_dispense_delay_mmFromBottom'
 
 export type DelayCheckboxFields =
   | 'aspirate_delay_checkbox'
@@ -314,8 +310,6 @@ export function getIsTouchTipField(fieldName: string): boolean {
     'aspirate_touchTip_mmFromBottom',
     'dispense_touchTip_mmFromBottom',
     'mix_touchTip_mmFromBottom',
-    'mix_aspirate_delay_mmFromBottom',
-    'mix_dispense_delay_mmFromBottom',
   ]
   return touchTipFields.includes(fieldName)
 }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -27,8 +27,6 @@
       "mix_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
       "aspirate_delay_mmFromBottom": "Change from where in the well the robot delays after aspirating",
       "dispense_delay_mmFromBottom": "Change from where in the well the robot delays after dispensing",
-      "mix_aspirate_delay_mmFromBottom": "Change from where in the well the robot delays after aspirating",
-      "mix_dispense_delay_mmFromBottom": "Change from where in the well the robot delays after dispensing"
     },
     "field_label": "Distance from bottom of well"
   },

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -26,7 +26,7 @@
       "dispense_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
       "mix_touchTip_mmFromBottom": "Change from where in the well the robot performs touch tip",
       "aspirate_delay_mmFromBottom": "Change from where in the well the robot delays after aspirating",
-      "dispense_delay_mmFromBottom": "Change from where in the well the robot delays after dispensing",
+      "dispense_delay_mmFromBottom": "Change from where in the well the robot delays after dispensing"
     },
     "field_label": "Distance from bottom of well"
   },

--- a/protocol-designer/src/step-generation/__tests__/mix.test.js
+++ b/protocol-designer/src/step-generation/__tests__/mix.test.js
@@ -41,8 +41,8 @@ beforeEach(() => {
     blowoutLocation: null,
     touchTip: false,
 
-    aspirateDelay: null,
-    dispenseDelay: null,
+    aspirateDelaySeconds: null,
+    dispenseDelaySeconds: null,
   }
 
   invariantContext = makeContext()

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -167,8 +167,8 @@ export type MixArgs = {|
   aspirateFlowRateUlSec: number,
   dispenseFlowRateUlSec: number,
   /** delays */
-  aspirateDelay: ?InnerDelayArgs,
-  dispenseDelay: ?InnerDelayArgs,
+  aspirateDelay: ?{ seconds: number },
+  dispenseDelay: ?{ seconds: number },
 |}
 
 export type PauseArgs = {|

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -167,8 +167,8 @@ export type MixArgs = {|
   aspirateFlowRateUlSec: number,
   dispenseFlowRateUlSec: number,
   /** delays */
-  aspirateDelay: ?{ seconds: number },
-  dispenseDelay: ?{ seconds: number },
+  aspirateDelaySeconds: ?number,
+  dispenseDelaySeconds: ?number,
 |}
 
 export type PauseArgs = {|

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.js
@@ -5,7 +5,7 @@ import type {
   DelaySecondFields,
 } from '../../../form-types'
 
-export function getDelayData<F: any>(
+export function getMoveLiquidDelayData<F: any>(
   hydratedFormData: F,
   checkboxField: DelayCheckboxFields,
   secondsField: DelaySecondFields,
@@ -25,6 +25,20 @@ export function getDelayData<F: any>(
     (typeof mmFromBottom === 'number' && mmFromBottom > 0)
   ) {
     return { seconds, mmFromBottom }
+  }
+  return null
+}
+
+export function getMixDelayData<F: any>(
+  hydratedFormData: F,
+  checkboxField: DelayCheckboxFields,
+  secondsField: DelaySecondFields
+): {| seconds: number |} | null {
+  const checkbox = hydratedFormData[checkboxField]
+  const seconds = hydratedFormData[secondsField]
+
+  if (checkbox && (typeof seconds === 'number' && seconds > 0)) {
+    return { seconds }
   }
   return null
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.js
@@ -12,8 +12,6 @@ export function getMoveLiquidDelayData<F: any>(
   mmFromBottomField:
     | 'aspirate_delay_mmFromBottom'
     | 'dispense_delay_mmFromBottom'
-    | 'mix_aspirate_delay_mmFromBottom'
-    | 'mix_dispense_delay_mmFromBottom'
 ): InnerDelayArgs | null {
   const checkbox = hydratedFormData[checkboxField]
   const seconds = hydratedFormData[secondsField]
@@ -33,12 +31,12 @@ export function getMixDelayData<F: any>(
   hydratedFormData: F,
   checkboxField: DelayCheckboxFields,
   secondsField: DelaySecondFields
-): {| seconds: number |} | null {
+): number | null {
   const checkbox = hydratedFormData[checkboxField]
   const seconds = hydratedFormData[secondsField]
 
   if (checkbox && (typeof seconds === 'number' && seconds > 0)) {
-    return { seconds }
+    return seconds
   }
   return null
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -76,13 +76,13 @@ export const mixFormToArgs = (
   const aspirateDelay = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'aspirate_delay_checkbox',
-    'aspirate_delay_seconds',
+    'aspirate_delay_seconds'
   )
 
   const dispenseDelay = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'dispense_delay_checkbox',
-    'dispense_delay_seconds',
+    'dispense_delay_seconds'
   )
 
   return {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -9,7 +9,7 @@ import {
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP,
 } from '../../../constants'
 import { getOrderedWells } from '../../utils'
-import { getDelayData } from './getDelayData'
+import { getMixDelayData } from './getDelayData'
 import type { HydratedMixFormDataLegacy } from '../../../form-types'
 import type { MixArgs } from '../../../step-generation'
 
@@ -73,18 +73,16 @@ export const mixFormToArgs = (
     : 0
 
   // Delay settings
-  const aspirateDelay = getDelayData<HydratedMixFormDataLegacy>(
+  const aspirateDelay = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'aspirate_delay_checkbox',
     'aspirate_delay_seconds',
-    'mix_aspirate_delay_mmFromBottom'
   )
 
-  const dispenseDelay = getDelayData<HydratedMixFormDataLegacy>(
+  const dispenseDelay = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'dispense_delay_checkbox',
     'dispense_delay_seconds',
-    'mix_dispense_delay_mmFromBottom'
   )
 
   return {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.js
@@ -73,13 +73,13 @@ export const mixFormToArgs = (
     : 0
 
   // Delay settings
-  const aspirateDelay = getMixDelayData<HydratedMixFormDataLegacy>(
+  const aspirateDelaySeconds = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'aspirate_delay_checkbox',
     'aspirate_delay_seconds'
   )
 
-  const dispenseDelay = getMixDelayData<HydratedMixFormDataLegacy>(
+  const dispenseDelaySeconds = getMixDelayData<HydratedMixFormDataLegacy>(
     hydratedFormData,
     'dispense_delay_checkbox',
     'dispense_delay_seconds'
@@ -104,7 +104,7 @@ export const mixFormToArgs = (
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
     blowoutOffsetFromTopMm,
-    aspirateDelay,
-    dispenseDelay,
+    aspirateDelaySeconds,
+    dispenseDelaySeconds,
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -12,7 +12,7 @@ import {
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP,
 } from '../../../constants'
 import { getOrderedWells } from '../../utils'
-import { getDelayData } from './getDelayData'
+import { getMoveLiquidDelayData } from './getDelayData'
 
 import type { HydratedMoveLiquidFormData } from '../../../form-types'
 import type {
@@ -157,14 +157,14 @@ export const moveLiquidFormToArgs = (
     'dispense_mix_volume',
     'dispense_mix_times'
   )
-  const aspirateDelay = getDelayData<MoveLiquidFields>(
+  const aspirateDelay = getMoveLiquidDelayData<MoveLiquidFields>(
     fields,
     'aspirate_delay_checkbox',
     'aspirate_delay_seconds',
     'aspirate_delay_mmFromBottom'
   )
 
-  const dispenseDelay = getDelayData<MoveLiquidFields>(
+  const dispenseDelay = getMoveLiquidDelayData<MoveLiquidFields>(
     fields,
     'dispense_delay_checkbox',
     'dispense_delay_seconds',

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.js
@@ -1,10 +1,10 @@
 // @flow
-import { getDelayData } from '../getDelayData'
+import { getMoveLiquidDelayData, getMixDelayData } from '../getDelayData'
 
-describe('getDelayData', () => {
+describe('getMoveLiquidDelayData', () => {
   it('should return null if checkbox field is false', () => {
     expect(
-      getDelayData(
+      getMoveLiquidDelayData(
         { checkboxField: false, secondsField: 3, offsetField: 2 },
         'checkboxField',
         'secondsField',
@@ -19,7 +19,7 @@ describe('getDelayData', () => {
     cases.forEach(testCase => {
       const [secondsValue, offsetValue] = testCase
       expect(
-        getDelayData(
+        getMoveLiquidDelayData(
           {
             checkboxField: true,
             secondsField: secondsValue,
@@ -35,12 +35,51 @@ describe('getDelayData', () => {
 
   it('should return seconds & mmFromBottom if checkbox is checked', () => {
     expect(
-      getDelayData(
+      getMoveLiquidDelayData(
         { checkboxField: true, secondsField: 30, offsetField: 2 },
         'checkboxField',
         'secondsField',
         'offsetField'
       )
     ).toEqual({ seconds: 30, mmFromBottom: 2 })
+  })
+})
+
+describe('getMixDelayData', () => {
+  it('should return null if the checkbox field is false', () => {
+    expect(
+      getMixDelayData(
+        { checkboxField: false, secondsField: 3 },
+        'checkboxField',
+        'secondsField'
+      )
+    ).toBe(null)
+  })
+  it('should return null if the seconds field is 0', () => {
+    expect(
+      getMixDelayData(
+        { checkboxField: true, secondsField: 0 },
+        'checkboxField',
+        'secondsField'
+      )
+    ).toBe(null)
+  })
+  it('should return null if the seconds field is less than 0', () => {
+    expect(
+      getMixDelayData(
+        { checkboxField: true, secondsField: -1 },
+        'checkboxField',
+        'secondsField'
+      )
+    ).toBe(null)
+  })
+  it('should return the seconds field if checckbox is checked and the seconds field is > 0', () => {
+    expect(
+      getMixDelayData(
+        { checkboxField: true, secondsField: 10 },
+        'checkboxField',
+        'secondsField'
+      )
+    ).toEqual({ seconds: 10 })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.js
@@ -80,6 +80,6 @@ describe('getMixDelayData', () => {
         'checkboxField',
         'secondsField'
       )
-    ).toEqual({ seconds: 10 })
+    ).toEqual(10)
   })
 })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.js
@@ -44,10 +44,8 @@ beforeEach(() => {
     mix_touchTip_mmFromBottom: null,
     aspirate_delay_checkbox: false,
     aspirate_delay_seconds: null,
-    mix_aspirate_delay_mmFromBottom: null,
     dispense_delay_checkbox: false,
     dispense_delay_seconds: null,
-    mix_dispense_delay_mmFromBottom: null,
   }
 })
 
@@ -100,13 +98,12 @@ describe('mix step form -> command creator args', () => {
       checkboxField: 'aspirate_delay_checkbox',
       formFields: {
         aspirate_delay_seconds: 15,
-        mix_aspirate_delay_mmFromBottom: 11.2,
       },
       expectedArgsUnchecked: {
         aspirateDelay: null,
       },
       expectedArgsChecked: {
-        aspirateDelay: { seconds: 15, mmFromBottom: 11.2 },
+        aspirateDelay: { seconds: 15 },
       },
     },
     // Dispense delay
@@ -114,13 +111,12 @@ describe('mix step form -> command creator args', () => {
       checkboxField: 'dispense_delay_checkbox',
       formFields: {
         dispense_delay_seconds: 15,
-        mix_dispense_delay_mmFromBottom: 11.2,
       },
       expectedArgsUnchecked: {
         dispenseDelay: null,
       },
       expectedArgsChecked: {
-        dispenseDelay: { seconds: 15, mmFromBottom: 11.2 },
+        dispenseDelay: { seconds: 15 },
       },
     },
   ]

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/mixFormToArgs.test.js
@@ -100,10 +100,10 @@ describe('mix step form -> command creator args', () => {
         aspirate_delay_seconds: 15,
       },
       expectedArgsUnchecked: {
-        aspirateDelay: null,
+        aspirateDelaySeconds: null,
       },
       expectedArgsChecked: {
-        aspirateDelay: { seconds: 15 },
+        aspirateDelaySeconds: 15,
       },
     },
     // Dispense delay
@@ -113,10 +113,10 @@ describe('mix step form -> command creator args', () => {
         dispense_delay_seconds: 15,
       },
       expectedArgsUnchecked: {
-        dispenseDelay: null,
+        dispenseDelaySeconds: null,
       },
       expectedArgsChecked: {
-        dispenseDelay: { seconds: 15 },
+        dispenseDelaySeconds: 15,
       },
     },
   ]

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.js
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.js
@@ -98,8 +98,8 @@ describe('generateRobotStateTimeline', () => {
           aspirateOffsetFromBottomMm: 0.5,
           dispenseOffsetFromBottomMm: 0.5,
           blowoutOffsetFromTopMm: 0,
-          aspirateDelay: null,
-          dispenseDelay: null,
+          aspirateDelaySeconds: null,
+          dispenseDelaySeconds: null,
         },
       },
     }


### PR DESCRIPTION
# Overview

This PR remove mix tip position fields from UI, mixFormToArgs, types, and relevant utils.

closes #6589

# Review requests
- Tip position field in delay field should not show up in mix form
- References to `mix_aspirate_delay_mmFromBottom` and `mix_dispense_delay_mmFromBottom` should be gone

Make sure that the delay fields in the moveLiquid form still work, since I had to touch a util that the form relies on.

# Risk assessment

Low
