### PR TITLE
feat(protocol-designer): add mix delay default values

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -9,11 +9,19 @@ import {
 } from '@opentrons/shared-data'
 import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul'
+import { getPrereleaseFeatureFlag } from '../../persist'
 import { getStateAndContextTempTCModules } from '../../step-generation/__fixtures__'
 import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
 } from '../utils/createPresavedStepForm'
+
+jest.mock('../../persist')
+
+const getPrereleaseFeatureFlagMock: JestMockFn<
+  any,
+  any
+> = getPrereleaseFeatureFlag
 
 const stepId = 'stepId123'
 const EXAMPLE_ENGAGE_HEIGHT = '18'
@@ -174,30 +182,70 @@ describe('createPresavedStepForm', () => {
     })
   })
 
-  it('should call handleFormChange with a default pipette for mix step', () => {
-    const args = {
-      ...defaultArgs,
-      stepType: 'mix',
-    }
+  describe('mix step', () => {
+    describe('when mix delay FF is enabled', () => {
+      it('should call handleFormChange with a default pipette for mix step', () => {
+        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
+          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
+          return true
+        })
 
-    expect(createPresavedStepForm(args)).toEqual({
-      id: stepId,
-      pipette: 'leftPipetteId',
-      stepType: 'mix',
-      // default fields
-      labware: null,
-      wells: [],
-      aspirate_delay_checkbox: false,
-      aspirate_delay_seconds: '1',
-      mix_mmFromBottom: '0.5',
-      mix_wellOrder_first: 't2b',
-      mix_wellOrder_second: 'l2r',
-      blowout_checkbox: false,
-      blowout_location: 'trashId',
-      changeTip: 'always',
-      stepDetails: '',
-      stepName: 'mix',
-      // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
+        const args = {
+          ...defaultArgs,
+          stepType: 'mix',
+        }
+
+        expect(createPresavedStepForm(args)).toEqual({
+          id: stepId,
+          pipette: 'leftPipetteId',
+          stepType: 'mix',
+          // default fields
+          labware: null,
+          wells: [],
+          aspirate_delay_checkbox: false,
+          aspirate_delay_seconds: '1',
+          mix_mmFromBottom: '0.5',
+          mix_wellOrder_first: 't2b',
+          mix_wellOrder_second: 'l2r',
+          blowout_checkbox: false,
+          blowout_location: 'trashId',
+          changeTip: 'always',
+          stepDetails: '',
+          stepName: 'mix',
+          // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
+        })
+      })
+    })
+    describe('when mix delay FF is disabled', () => {
+      it('should call handleFormChange with a default pipette for mix step', () => {
+        getPrereleaseFeatureFlagMock.mockImplementation(FF => {
+          expect(FF).toBe('OT_PD_ENABLE_MIX_DELAY')
+          return false
+        })
+
+        const args = {
+          ...defaultArgs,
+          stepType: 'mix',
+        }
+
+        expect(createPresavedStepForm(args)).toEqual({
+          id: stepId,
+          pipette: 'leftPipetteId',
+          stepType: 'mix',
+          // default fields
+          labware: null,
+          wells: [],
+          mix_mmFromBottom: '0.5',
+          mix_wellOrder_first: 't2b',
+          mix_wellOrder_second: 'l2r',
+          blowout_checkbox: false,
+          blowout_location: 'trashId',
+          changeTip: 'always',
+          stepDetails: '',
+          stepName: 'mix',
+          // TODO(IL, 2020-04-27): mix defaults are missing volume, etc!!! Investigate in #3161
+        })
+      })
     })
   })
 

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -11,6 +11,7 @@ import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul'
 import { getPrereleaseFeatureFlag } from '../../persist'
 import { getStateAndContextTempTCModules } from '../../step-generation/__fixtures__'
+import { DEFAULT_DELAY_SECONDS } from '../../constants'
 import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
@@ -203,7 +204,9 @@ describe('createPresavedStepForm', () => {
           labware: null,
           wells: [],
           aspirate_delay_checkbox: false,
-          aspirate_delay_seconds: '1',
+          aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+          dispense_delay_checkbox: false,
+          dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
           mix_mmFromBottom: '0.5',
           mix_wellOrder_first: 't2b',
           mix_wellOrder_second: 'l2r',

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -187,6 +187,8 @@ describe('createPresavedStepForm', () => {
       // default fields
       labware: null,
       wells: [],
+      aspirate_delay_checkbox: false,
+      aspirate_delay_seconds: '1',
       mix_mmFromBottom: '0.5',
       mix_wellOrder_first: 't2b',
       mix_wellOrder_second: 'l2r',

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -35,6 +35,8 @@ export function getDefaultsForStepType(
           ? {
               aspirate_delay_checkbox: false,
               aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+              dispense_delay_checkbox: false,
+              dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
             }
           : {}),
       }

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -8,7 +8,12 @@ import {
   DEFAULT_DELAY_SECONDS,
   FIXED_TRASH_ID,
 } from '../../constants'
+import { getPrereleaseFeatureFlag } from '../../persist'
+
 import type { StepType, StepFieldName } from '../../form-types'
+
+const isMixDelayEnabled = () =>
+  getPrereleaseFeatureFlag('OT_PD_ENABLE_MIX_DELAY')
 
 export function getDefaultsForStepType(
   stepType: StepType
@@ -18,8 +23,6 @@ export function getDefaultsForStepType(
       return {
         changeTip: DEFAULT_CHANGE_TIP_OPTION,
         labware: null,
-        aspirate_delay_checkbox: false,
-        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
         mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
         blowout_checkbox: false,
@@ -28,6 +31,12 @@ export function getDefaultsForStepType(
         pipette: null,
         volume: undefined,
         wells: [],
+        ...(isMixDelayEnabled()
+          ? {
+              aspirate_delay_checkbox: false,
+              aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+            }
+          : {}),
       }
     case 'moveLiquid':
       return {

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
@@ -84,6 +84,8 @@ describe('getDefaultsForStepType', () => {
           labware: null,
           aspirate_delay_checkbox: false,
           aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+          dispense_delay_checkbox: false,
+          dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
           mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
           mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
           blowout_checkbox: false,

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
@@ -1,36 +1,20 @@
 // @flow
 import {
   DEFAULT_CHANGE_TIP_OPTION,
-  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
-  DEFAULT_MM_FROM_BOTTOM_DISPENSE,
   DEFAULT_WELL_ORDER_FIRST_OPTION,
   DEFAULT_WELL_ORDER_SECOND_OPTION,
-  DEFAULT_DELAY_SECONDS,
   FIXED_TRASH_ID,
-} from '../../constants'
-import type { StepType, StepFieldName } from '../../form-types'
+  DEFAULT_MM_FROM_BOTTOM_DISPENSE,
+  DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+  DEFAULT_DELAY_SECONDS,
+} from '../../../constants'
 
-export function getDefaultsForStepType(
-  stepType: StepType
-): { [StepFieldName]: any } {
-  switch (stepType) {
-    case 'mix':
-      return {
-        changeTip: DEFAULT_CHANGE_TIP_OPTION,
-        labware: null,
-        aspirate_delay_checkbox: false,
-        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
-        mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
-        mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
-        blowout_checkbox: false,
-        blowout_location: FIXED_TRASH_ID,
-        mix_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`, // NOTE: mix uses dispense for both asp + disp, for now
-        pipette: null,
-        volume: undefined,
-        wells: [],
-      }
-    case 'moveLiquid':
-      return {
+import { getDefaultsForStepType } from '..'
+
+describe('getDefaultsForStepType', () => {
+  describe('moveLiquid step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('moveLiquid')).toEqual({
         pipette: null,
         volume: null,
         changeTip: DEFAULT_CHANGE_TIP_OPTION,
@@ -74,9 +58,30 @@ export function getDefaultsForStepType(
         dispense_delay_checkbox: false,
         dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`,
-      }
-    case 'pause':
-      return {
+      })
+    })
+  })
+  describe('mix step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('mix')).toEqual({
+        changeTip: DEFAULT_CHANGE_TIP_OPTION,
+        labware: null,
+        aspirate_delay_checkbox: false,
+        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        mix_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        mix_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        blowout_checkbox: false,
+        blowout_location: FIXED_TRASH_ID,
+        mix_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`, // NOTE: mix uses dispense for both asp + disp, for now
+        pipette: null,
+        volume: undefined,
+        wells: [],
+      })
+    })
+  })
+  describe('pause step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('pause')).toEqual({
         pauseAction: null,
         pauseHour: null,
         pauseMinute: null,
@@ -84,27 +89,39 @@ export function getDefaultsForStepType(
         pauseMessage: '',
         moduleId: null,
         pauseTemperature: null,
-      }
-    case 'manualIntervention':
-      return {
+      })
+    })
+  })
+  describe('manual intervention step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('manualIntervention')).toEqual({
         labwareLocationUpdate: {},
         pipetteLocationUpdate: {},
         moduleLocationUpdate: {},
-      }
-    case 'magnet':
-      return {
+      })
+    })
+  })
+  describe('magnet step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('magnet')).toEqual({
         moduleId: null,
         magnetAction: null,
         engageHeight: null,
-      }
-    case 'temperature':
-      return {
+      })
+    })
+  })
+  describe('temperature step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('temperature')).toEqual({
         moduleId: null,
         setTemperature: null,
         targetTemperature: null,
-      }
-    case 'thermocycler':
-      return {
+      })
+    })
+  })
+  describe('thermocycler step', () => {
+    it('should get the correct defaults', () => {
+      expect(getDefaultsForStepType('thermocycler')).toEqual({
         thermocyclerFormType: null,
         moduleId: null,
         blockIsActive: false,
@@ -121,8 +138,10 @@ export function getDefaultsForStepType(
         lidIsActiveHold: false,
         lidTargetTempHold: null,
         lidOpenHold: null,
-      }
-    default:
-      return {}
-  }
-}
+      })
+    })
+    it('should default to an empty object', () => {
+      expect(getDefaultsForStepType('')).toEqual({})
+    })
+  })
+})


### PR DESCRIPTION
# Overview

This PR adds defaults to mix delay fields (checkbox and seconds). I also added tests for the other default step types.

closes #6579

# Changelog
- Add defaults to mix delay fields

# Review requests

- [ ] Turn mix delay FF on, make a mix step, check the delay field, 1 second should be the default value in the seconds field (both for aspirate and dispense)
- [ ] Turn mix delay FF ff, make a mix step, check the delay field, no defaults should appear (both for aspirate and dispense)

Note, because the FF is read through `localStorage`, you'll have to actually delete the the mix step and create a new one when toggling the FF on/off

# Risk assessment

Low
