### PR TITLE
fix(app): Ensure cal check exit button on the title modal only displays if there is no primary exit

### DIFF
--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -248,6 +248,9 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
         hasTwoPipettes
       )
       const comparison = comparisonsByStep[currentStep]
+      if (comparison?.exceedsThreshold) {
+        shouldDisplayTitleBarExit = false
+      }
       stepContents = (
         <CheckXYPoint
           slotNumber={slotNumber}
@@ -280,6 +283,9 @@ export function CheckCalibration(props: CheckCalibrationProps): React.Node {
         hasTwoPipettes
       )
       const comparison = comparisonsByStep[currentStep]
+      if (comparison?.exceedsThreshold) {
+        shouldDisplayTitleBarExit = false
+      }
       stepContents = (
         <CheckHeight
           isMulti={isActiveInstrumentMultiChannel}


### PR DESCRIPTION
# Overview

Closes #5990. For the 'bad calibration' displays on the height and the XY check modals, there were two exit button options being displayed. We generate a results report when a user presses the primary exit button so we want to make sure they cannot exit the modal using the back exit button.

# Changelog

- Set `shouldDisplayTitleBarExit` to false if a value on a check exceeds the threshold 

# Review requests

Test on your robot.

1. Force calibration check to fail for both a height and an XY check.
     a. You should see that no exit button exists in the top left corner.
2. Force calibration check to pass for both a height and an XY check.
     a. You should see that the exit button in the top left corner is still there.

# Risk assessment

Low, just removing an extraneous exit button for cal check.
