### PR TITLE
feat(protocol designer): put mix delay behind FF

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
+++ b/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
@@ -7,7 +7,7 @@ import styles from '../StepEditForm.css'
 type Props = {
   className?: ?string,
   collapsed?: ?boolean,
-  toggleCollapsed: () => mixed,
+  toggleCollapsed: () => void,
   prefix: 'aspirate' | 'dispense',
   children?: React.Node,
 }

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -1,11 +1,10 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
+import { useSelector } from 'react-redux'
 import { FormGroup } from '@opentrons/components'
-import { AspDispSection } from './AspDispSection'
-
+import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { i18n } from '../../../localization'
-
 import {
   TextField,
   CheckboxRowField,
@@ -20,159 +19,159 @@ import {
   WellOrderField,
   DelayFields,
 } from '../fields'
+import { AspDispSection } from './AspDispSection'
 
 import type { FocusHandlers } from '../types'
 import styles from '../StepEditForm.css'
 
 type Props = {| focusHandlers: FocusHandlers |}
-type State = {| collapsed?: boolean |}
 
-export class MixForm extends React.Component<Props, State> {
-  state: State = { collapsed: true }
+export const MixForm = (props: Props): React.Node => {
+  const { focusHandlers } = props
 
-  toggleCollapsed: () => void = () => {
-    this.setState({ collapsed: !this.state.collapsed })
-  }
+  const [collapsed, setCollapsed] = React.useState(true)
 
-  render(): React.Node {
-    const { focusHandlers } = this.props
-    const { collapsed } = this.state
-    return (
-      <div className={styles.form_wrapper}>
-        <div className={styles.section_header}>
-          <span className={styles.section_header_text}>
-            {i18n.t('application.stepType.mix')}
-          </span>
-        </div>
-        <div className={styles.form_row}>
-          <PipetteField name="pipette" {...focusHandlers} />
-          <VolumeField
-            label={i18n.t('form.step_edit_form.mixVolumeLabel')}
-            focusHandlers={focusHandlers}
-            stepType="mix"
-            className={styles.small_field}
-          />
-          <FormGroup
-            className={styles.small_field}
-            label={i18n.t('form.step_edit_form.mixRepetitions')}
-          >
-            <TextField
-              name="times"
-              units={i18n.t('application.units.times')}
-              {...focusHandlers}
-            />
-          </FormGroup>
-        </div>
-        <div className={styles.form_row}>
-          <FormGroup
-            label={i18n.t('form.step_edit_form.labwareLabel.mixLabware')}
-            className={styles.large_field}
-          >
-            <LabwareField name="labware" {...focusHandlers} />
-          </FormGroup>
-          <WellSelectionField
-            name="wells"
-            labwareFieldName="labware"
-            pipetteFieldName="pipette"
+  const mixDelayEnabled = useSelector(featureFlagSelectors.getEnabledMixDelay)
+
+  const toggleCollapsed = (): void =>
+    setCollapsed(prevCollapsed => !prevCollapsed)
+
+  return (
+    <div className={styles.form_wrapper}>
+      <div className={styles.section_header}>
+        <span className={styles.section_header_text}>
+          {i18n.t('application.stepType.mix')}
+        </span>
+      </div>
+      <div className={styles.form_row}>
+        <PipetteField name="pipette" {...focusHandlers} />
+        <VolumeField
+          label={i18n.t('form.step_edit_form.mixVolumeLabel')}
+          focusHandlers={focusHandlers}
+          stepType="mix"
+          className={styles.small_field}
+        />
+        <FormGroup
+          className={styles.small_field}
+          label={i18n.t('form.step_edit_form.mixRepetitions')}
+        >
+          <TextField
+            name="times"
+            units={i18n.t('application.units.times')}
             {...focusHandlers}
           />
-        </div>
-        <div className={styles.section_divider} />
+        </FormGroup>
+      </div>
+      <div className={styles.form_row}>
+        <FormGroup
+          label={i18n.t('form.step_edit_form.labwareLabel.mixLabware')}
+          className={styles.large_field}
+        >
+          <LabwareField name="labware" {...focusHandlers} />
+        </FormGroup>
+        <WellSelectionField
+          name="wells"
+          labwareFieldName="labware"
+          pipetteFieldName="pipette"
+          {...focusHandlers}
+        />
+      </div>
+      <div className={styles.section_divider} />
 
-        <div className={styles.section_wrapper}>
-          <AspDispSection
-            className={styles.section_column}
-            prefix="aspirate"
-            collapsed={collapsed}
-            toggleCollapsed={this.toggleCollapsed}
-          />
-          <AspDispSection
-            className={styles.section_column}
-            prefix="dispense"
-            collapsed={collapsed}
-            toggleCollapsed={this.toggleCollapsed}
-          />
-        </div>
+      <div className={styles.section_wrapper}>
+        <AspDispSection
+          className={styles.section_column}
+          prefix="aspirate"
+          collapsed={collapsed}
+          toggleCollapsed={toggleCollapsed}
+        />
+        <AspDispSection
+          className={styles.section_column}
+          prefix="dispense"
+          collapsed={collapsed}
+          toggleCollapsed={toggleCollapsed}
+        />
+      </div>
 
-        {!collapsed && (
-          <div
-            className={cx(
-              styles.section_wrapper,
-              styles.advanced_settings_panel
-            )}
-          >
-            <div className={styles.section_column}>
-              <div className={styles.form_row}>
-                <FlowRateField
-                  name="aspirate_flowRate"
-                  pipetteFieldName="pipette"
-                  flowRateType="aspirate"
-                />
-                <TipPositionField fieldName="mix_mmFromBottom" />
-                <WellOrderField
-                  prefix="mix"
-                  label={i18n.t('form.step_edit_form.field.well_order.label')}
-                />
-              </div>
+      {!collapsed && (
+        <div
+          className={cx(styles.section_wrapper, styles.advanced_settings_panel)}
+        >
+          <div className={styles.section_column}>
+            <div className={styles.form_row}>
+              <FlowRateField
+                name="aspirate_flowRate"
+                pipetteFieldName="pipette"
+                flowRateType="aspirate"
+              />
+              <TipPositionField fieldName="mix_mmFromBottom" />
+              <WellOrderField
+                prefix="mix"
+                label={i18n.t('form.step_edit_form.field.well_order.label')}
+              />
+            </div>
+            {mixDelayEnabled && (
               <DelayFields
                 checkboxFieldName={'aspirate_delay_checkbox'}
                 secondsFieldName={'aspirate_delay_seconds'}
                 focusHandlers={focusHandlers}
               />
-            </div>
+            )}
+          </div>
 
-            <div className={styles.section_column}>
-              <div className={styles.form_row}>
-                <FlowRateField
-                  name="dispense_flowRate"
-                  pipetteFieldName="pipette"
-                  flowRateType="dispense"
-                />
-              </div>
-              <div className={styles.checkbox_column}>
+          <div className={styles.section_column}>
+            <div className={styles.form_row}>
+              <FlowRateField
+                name="dispense_flowRate"
+                pipetteFieldName="pipette"
+                flowRateType="dispense"
+              />
+            </div>
+            <div className={styles.checkbox_column}>
+              {mixDelayEnabled && (
                 <DelayFields
                   checkboxFieldName={'dispense_delay_checkbox'}
                   secondsFieldName={'dispense_delay_seconds'}
                   focusHandlers={focusHandlers}
                 />
-                <CheckboxRowField
-                  className={styles.small_field}
-                  label={i18n.t('form.step_edit_form.field.touchTip.label')}
-                  tooltipComponent={i18n.t(
-                    'tooltip.step_fields.defaults.mix_touchTip_checkbox'
-                  )}
-                  name={'mix_touchTip_checkbox'}
-                >
-                  <TipPositionField fieldName={'mix_touchTip_mmFromBottom'} />
-                </CheckboxRowField>
+              )}
+              <CheckboxRowField
+                className={styles.small_field}
+                label={i18n.t('form.step_edit_form.field.touchTip.label')}
+                tooltipComponent={i18n.t(
+                  'tooltip.step_fields.defaults.mix_touchTip_checkbox'
+                )}
+                name={'mix_touchTip_checkbox'}
+              >
+                <TipPositionField fieldName={'mix_touchTip_mmFromBottom'} />
+              </CheckboxRowField>
 
-                <CheckboxRowField
-                  className={styles.small_field}
-                  label={i18n.t('form.step_edit_form.field.blowout.label')}
-                  name="blowout_checkbox"
-                >
-                  <BlowoutLocationField
-                    className={styles.full_width}
-                    name="blowout_location"
-                    {...focusHandlers}
-                  />
-                </CheckboxRowField>
-              </div>
+              <CheckboxRowField
+                className={styles.small_field}
+                label={i18n.t('form.step_edit_form.field.blowout.label')}
+                name="blowout_checkbox"
+              >
+                <BlowoutLocationField
+                  className={styles.full_width}
+                  name="blowout_location"
+                  {...focusHandlers}
+                />
+              </CheckboxRowField>
             </div>
           </div>
-        )}
-
-        <div className={styles.section_header}>
-          <span className={styles.section_header_text}>
-            {i18n.t('form.step_edit_form.section.sterility')}
-          </span>
         </div>
-        <div className={styles.section_wrapper}>
-          <div className={styles.form_row}>
-            <ChangeTipField name="changeTip" />
-          </div>
+      )}
+
+      <div className={styles.section_header}>
+        <span className={styles.section_header_text}>
+          {i18n.t('form.step_edit_form.section.sterility')}
+        </span>
+      </div>
+      <div className={styles.section_wrapper}>
+        <div className={styles.form_row}>
+          <ChangeTipField name="changeTip" />
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.js
@@ -13,7 +13,7 @@ import styles from '../../StepEditForm.css'
 type Props = {
   className?: ?string,
   collapsed?: ?boolean,
-  toggleCollapsed: () => mixed,
+  toggleCollapsed: () => void,
   focusHandlers: FocusHandlers,
   prefix: 'aspirate' | 'dispense',
 }

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -14,19 +14,19 @@ jest.mock('../../fields/', () => {
 
   return {
     ...actualFields,
-    LabwareField: () => <div>hello</div>,
-    PipetteField: () => <div>hello</div>,
-    FlowRateField: () => <div>hello</div>,
-    VolumeField: () => <div>hello</div>,
-    ChangeTipField: () => <div>hello</div>,
-    TipPositionField: () => <div>hello</div>,
-    WellOrderField: () => <div>hello</div>,
-    WellSelectionField: () => <div>hello</div>,
+    LabwareField: () => <div></div>,
+    PipetteField: () => <div></div>,
+    FlowRateField: () => <div></div>,
+    VolumeField: () => <div></div>,
+    ChangeTipField: () => <div></div>,
+    TipPositionField: () => <div></div>,
+    WellOrderField: () => <div></div>,
+    WellSelectionField: () => <div></div>,
   }
 })
 
 jest.mock('../../fields/FieldConnector', () => ({
-  FieldConnector: () => <div>hello</div>,
+  FieldConnector: () => <div></div>,
 }))
 
 const getEnabledMixDelayMock: JestMockFn<any, any> =

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -1,21 +1,61 @@
 // @flow
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import { selectors as featureSelectors } from '../../../../feature-flags'
 import { MixForm } from '../MixForm'
-import { DelayFields } from '../../fields'
 import { AspDispSection } from '../AspDispSection'
 
-describe('MixForm', () => {
-  const render = props => shallow(<MixForm {...props} />)
+const { DelayFields } = jest.requireActual('../../fields')
 
-  const showAdvancedSettings = wrapper =>
+jest.mock('../../../../feature-flags')
+jest.mock('../../fields/', () => {
+  const actualFields = jest.requireActual('../../fields')
+
+  return {
+    ...actualFields,
+    LabwareField: () => <div>hello</div>,
+    PipetteField: () => <div>hello</div>,
+    FlowRateField: () => <div>hello</div>,
+    VolumeField: () => <div>hello</div>,
+    ChangeTipField: () => <div>hello</div>,
+    TipPositionField: () => <div>hello</div>,
+    WellOrderField: () => <div>hello</div>,
+    WellSelectionField: () => <div>hello</div>,
+  }
+})
+
+jest.mock('../../fields/FieldConnector', () => ({
+  FieldConnector: () => <div>hello</div>,
+}))
+
+const getEnabledMixDelayMock: JestMockFn<any, any> =
+  featureSelectors.getEnabledMixDelay
+
+const mockStore = {
+  dispatch: jest.fn(),
+  subscribe: jest.fn(),
+  getState: () => ({}),
+}
+
+describe('MixForm', () => {
+  const render = props =>
+    mount(<MixForm {...props} />, {
+      wrappingComponent: Provider,
+      wrappingComponentProps: { store: mockStore },
+    })
+
+  const showAdvancedSettings = wrapper => {
     wrapper
       .find(AspDispSection)
       .first()
-      .prop('toggleCollapsed')()
+      .invoke('toggleCollapsed')()
+  }
 
   let props
+
   beforeEach(() => {
+    getEnabledMixDelayMock.mockReturnValue(false)
     props = {
       focusHandlers: {
         focusedField: '',
@@ -25,41 +65,72 @@ describe('MixForm', () => {
       },
     }
   })
-  it('should NOT render delay fields initially', () => {
-    const wrapper = render(props)
-
-    const delayFields = wrapper.find(DelayFields)
-    expect(delayFields).toHaveLength(0)
-  })
-
-  describe('when advanced settings are visible', () => {
-    it('should render the aspirate delay fields when advanced settings are visible', () => {
-      const wrapper = render(props)
-      showAdvancedSettings(wrapper)
-      const delayFields = wrapper.find(DelayFields)
-      const aspirateDelayFields = delayFields.at(0)
-      expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
-        'aspirate_delay_checkbox'
-      )
-      expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
-        'aspirate_delay_seconds'
-      )
-      // no tip position field
-      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
+  describe('when mix delay FF is disabled', () => {
+    beforeEach(() => {
+      getEnabledMixDelayMock.mockReturnValue(false)
     })
-    it('should render the dispense delay fields', () => {
+    it('should NOT render delay fields initially', () => {
       const wrapper = render(props)
-      showAdvancedSettings(wrapper)
       const delayFields = wrapper.find(DelayFields)
-      const aspirateDelayFields = delayFields.at(1)
-      expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
-        'dispense_delay_checkbox'
-      )
-      expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
-        'dispense_delay_seconds'
-      )
-      // no tip position field
-      expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
+      expect(delayFields).toHaveLength(0)
+    })
+
+    describe('when advanced settings are visible', () => {
+      it('should NOT render the aspirate delay fields when advanced settings are visible', () => {
+        const wrapper = render(props)
+
+        showAdvancedSettings(wrapper)
+        wrapper.update()
+
+        const delayFields = wrapper.find(DelayFields)
+        expect(delayFields).toHaveLength(0)
+      })
+    })
+  })
+  describe('when mix delay FF is enabled', () => {
+    beforeEach(() => {
+      getEnabledMixDelayMock.mockReturnValue(true)
+    })
+    it('should NOT render delay fields initially', () => {
+      const wrapper = render(props)
+
+      const delayFields = wrapper.find(DelayFields)
+      expect(delayFields).toHaveLength(0)
+    })
+
+    describe('when advanced settings are visible', () => {
+      it('should render the aspirate delay fields when advanced settings are visible', () => {
+        const wrapper = render(props)
+
+        showAdvancedSettings(wrapper)
+        wrapper.update()
+
+        const delayFields = wrapper.find(DelayFields)
+
+        const aspirateDelayFields = delayFields.at(0)
+        expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
+          'aspirate_delay_checkbox'
+        )
+        expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
+          'aspirate_delay_seconds'
+        )
+        // no tip position field
+        expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
+      })
+      it('should render the dispense delay fields', () => {
+        const wrapper = render(props)
+        showAdvancedSettings(wrapper)
+        const delayFields = wrapper.find(DelayFields)
+        const aspirateDelayFields = delayFields.at(1)
+        expect(aspirateDelayFields.prop('checkboxFieldName')).toBe(
+          'dispense_delay_checkbox'
+        )
+        expect(aspirateDelayFields.prop('secondsFieldName')).toBe(
+          'dispense_delay_seconds'
+        )
+        // no tip position field
+        expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview

Forgot to put the Mix Delay fields under a FF, so here it is!

# Review requests

- [ ] When FF is on, mix delay fields should be visible in mix form
- [ ] When FF is off, mix delay fields should NOT be visible in mix form

# Risk assessment

Low