### PR TITLE
fix(api): Do not perform a transfer if a zero volume is passed in

### DIFF
--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -439,6 +439,8 @@ will have the steps...
 .. versionadded:: 2.0
 
 
+.. _distribute-consolidate-volume-list:
+
 List of Volumes
 ---------------
 
@@ -518,6 +520,9 @@ will have the steps...
     Blowing out in well A1 in "12"
     Dropping tip well A1 in "12"
 
+.. warning::
+
+    This functionality is only available in Python API Version 2.8 or later.
 
 
 .. versionadded:: 2.8

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -270,6 +270,29 @@ will have the steps...
     Dispensing 60.0 uL into well B3 in "1"
     Dropping tip well A1 in "12"
 
+Skipping Wells
+++++++++++++++
+If you only wish to transfer to certain wells from a column, you
+can use a list of volumes to skip over certain wells by setting the volume to zero.
+
+.. code-block:: python
+
+    pipette.transfer(
+        [20, 0, 60],
+        plate['A1'],
+        [plate.wells_by_name()[well_name] for well_name in ['B1', 'B2', 'B3']])
+
+will have the steps...
+
+.. code-block:: python
+
+    Transferring [20, 40, 60] from well A1 in "1" to wells B1...B3 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 20.0 uL from well A1 in "1" at 1 speed
+    Dispensing 20.0 uL into well B1 in "1"
+    Aspirating 60.0 uL from well A1 in "1" at 1 speed
+    Dispensing 60.0 uL into well B3 in "1"
+    Dropping tip well A1 in "12"
 
 
 .. versionadded:: 2.0
@@ -414,6 +437,90 @@ will have the steps...
     Dropping tip well A1 in "12"
 
 .. versionadded:: 2.0
+
+
+List of Volumes
+---------------
+
+Instead of applying a single volume amount to all source/destination wells, you can instead pass a list of volumes to either
+consolidate or distribute.
+
+For example, this distribute command
+
+.. code-block:: python
+
+    pipette.distribute(
+        [20, 40, 60],
+        plate['A1'],
+        [plate.wells_by_name()[well_name] for well_name in ['B1', 'B2', 'B3']])
+
+
+will have the steps...
+
+.. code-block:: python
+
+    Distributing [20, 40, 60] from well A1 in "1" to wells B1...B3 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 150.0 uL from well A1 in "1" at 1 speed
+    Dispensing 20.0 uL into well B1 in "1"
+    Dispensing 40.0 uL into well B2 in "1"
+    Dispensing 60.0 uL into well B3 in "1"
+    Blowing out in well A1 in "12"
+    Dropping tip well A1 in "12"
+
+and this consolidate command
+
+.. code-block:: python
+
+    pipette.consolidate(
+        [20, 40, 60],
+        [plate.wells_by_name()[well_name] for well_name in ['B1', 'B2', 'B3']],
+        plate['A1'])
+
+will have the steps...
+
+.. code-block:: python
+
+    Consolidating [20, 40, 60] from wells B1...B3 in "1" to well A1 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 20.0 uL from well B1 in "1"
+    Aspirating 40.0 uL into well B2 in "1"
+    Aspirating 60.0 uL into well B3 in "1"
+    Dispensing 120.0 uL into well A1 in "1"
+    Dropping tip well A1 in "12"
+
+
+Skipping Wells
+++++++++++++++
+
+If you only wish to distribute or consolidate certain wells from a column, you
+can use a list of volumes to skip over certain wells by setting the volume to zero.
+
+.. code-block:: python
+
+    pipette.distribute(
+        [20, 40, 60, 0, 0, 0, 50, 100],
+        plate['A1'],
+        plate.columns_by_name()['2'])
+
+will have the steps...
+
+.. code-block:: python
+
+    Distributing [20, 40, 60] from well A1 in "1" to column 2 in "1"
+    Picking up tip well A1 in "2"
+    Aspirating 300.0 uL from well A1 in "1" at 1 speed
+    Dispensing 20.0 uL into well A2 in "1"
+    Dispensing 40.0 uL into well B2 in "1"
+    Dispensing 60.0 uL into well C2 in "1"
+    Dispensing 50.0 uL into well G2 in "1"
+    Dispensing 100.0 uL into well H2 in "1"
+    Blowing out in well A1 in "12"
+    Dropping tip well A1 in "12"
+
+
+
+.. versionadded:: 2.8
 
 Order of Operations In Complex Commands
 =======================================

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -108,6 +108,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.7     |          3.21.0             |
 +-------------+-----------------------------+
+|     2.8     |          4.0.0              |
++-------------+-----------------------------+
 
 Changes in API Versions
 -----------------------
@@ -181,4 +183,9 @@ Version 2.7
 
 - Calling :py:meth:`.InstrumentContext.has_tip` will return whether a particular instrument
   has a tip attached or not.
-- Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense
+
+
+Version 2.8
++++++++++++
+- You can now pass in a list of volumes to distribute and consolidate. See 
+    - Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -181,3 +181,4 @@ Version 2.7
 
 - Calling :py:meth:`.InstrumentContext.has_tip` will return whether a particular instrument
   has a tip attached or not.
+- Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -187,5 +187,5 @@ Version 2.7
 
 Version 2.8
 +++++++++++
-- You can now pass in a list of volumes to distribute and consolidate. See 
+- You can now pass in a list of volumes to distribute and consolidate. See :ref:`distribute-consolidate-volume-list` for more information.
     - Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -832,7 +832,7 @@ class InstrumentContext(CommandPublisher):
     @cmds.publish.both(command=cmds.distribute)
     @requires_version(2, 0)
     def distribute(self,
-                   volume: float,
+                   volume: Union[float, Sequence[float]],
                    source: Well,
                    dest: List[Well],
                    *args, **kwargs) -> InstrumentContext:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -841,6 +841,7 @@ class InstrumentContext(CommandPublisher):
 
         :param volume: The amount of volume to distribute to each destination
                        well.
+        :type volume: float or sequence of floats
         :param source: A single well from where liquid will be aspirated.
         :param dest: List of Wells where liquid will be dispensed to.
         :param kwargs: See :py:meth:`transfer`. Some arguments are changed.
@@ -860,7 +861,7 @@ class InstrumentContext(CommandPublisher):
     @cmds.publish.both(command=cmds.consolidate)
     @requires_version(2, 0)
     def consolidate(self,
-                    volume: float,
+                    volume: Union[float, Sequence[float]],
                     source: List[Well],
                     dest: Well,
                     *args, **kwargs) -> InstrumentContext:
@@ -869,6 +870,7 @@ class InstrumentContext(CommandPublisher):
 
         :param volume: The amount of volume to consolidate from each source
                        well.
+        :type volume: float or sequence of floats
         :param source: List of wells from where liquid will be aspirated.
         :param dest: The single well into which liquid will be dispensed.
         :param kwargs: See :py:meth:`transfer`. Some arguments are changed.

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -565,7 +565,8 @@ class TransferPlan:
                        self._strategy.disposal_volume +
                        self._strategy.air_gap +
                        current_xfer[0]) <= self._max_volume:
-                    append_xfer = self._check_volume_not_zero(current_xfer[0])
+                    append_xfer = self._check_volume_not_zero(
+                        self._api_version, current_xfer[0])
                     if append_xfer:
                         asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
@@ -652,7 +653,8 @@ class TransferPlan:
                        self._strategy.disposal_volume +
                        self._strategy.air_gap * len(asp_grouped) +
                        current_xfer[0]) <= self._max_volume:
-                    append_xfer = self._check_volume_not_zero(current_xfer[0])
+                    append_xfer = self._check_volume_not_zero(
+                        self._api_version, current_xfer[0])
                     if append_xfer:
                         asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
@@ -792,10 +794,11 @@ class TransferPlan:
             raise RuntimeError(
                 f"Invalid {id} for multichannel transfer: {old_well_list}")
 
-    def _check_volume_not_zero(self, volume: float) -> bool:
+    @staticmethod
+    def _check_volume_not_zero(api_version: APIVersion, volume: float) -> bool:
         # We should only be adding volumes to transfer plans if it is
         # greater than zero to prevent extraneous robot movements.
-        if self._api_version < APIVersion(2, 7):
+        if api_version < APIVersion(2, 8):
             return True
         elif volume > 0:
             return True

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -565,10 +565,15 @@ class TransferPlan:
                        self._strategy.disposal_volume +
                        self._strategy.air_gap +
                        current_xfer[0]) <= self._max_volume:
-                    asp_grouped.append(current_xfer)
+                    append_xfer = self._check_volume_not_zero(current_xfer[0])
+                    if append_xfer:
+                        asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
             except StopIteration:
                 done = True
+            if not asp_grouped:
+                break
+
             yield from self._aspirate_actions(sum(a[0] for a in asp_grouped) +
                                               self._strategy.disposal_volume,
                                               self._sources[0])
@@ -647,7 +652,9 @@ class TransferPlan:
                        self._strategy.disposal_volume +
                        self._strategy.air_gap * len(asp_grouped) +
                        current_xfer[0]) <= self._max_volume:
-                    asp_grouped.append(current_xfer)
+                    append_xfer = self._check_volume_not_zero(current_xfer[0])
+                    if append_xfer:
+                        asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
             except StopIteration:
                 done = True
@@ -784,6 +791,15 @@ class TransferPlan:
         if self._api_version >= APIVersion(2, 2) and len(well_list) < 1:
             raise RuntimeError(
                 f"Invalid {id} for multichannel transfer: {old_well_list}")
+
+    def _check_volume_not_zero(self, volume: float) -> bool:
+        # We should only be adding volumes to transfer plans if it is
+        # greater than zero to prevent extraneous robot movements.
+        if self._api_version < APIVersion(2, 7):
+            return True
+        elif volume > 0:
+            return True
+        return False
 
     def _multichannel_transfer(self, s, d):
         # TODO: add a check for container being multi-channel compatible?

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from opentrons.protocols import types
 
-MAX_SUPPORTED_VERSION = types.APIVersion(2, 7)
+MAX_SUPPORTED_VERSION = types.APIVersion(2, 8)
 #: The maximum supported protocol API version in this release
 
 V2_MODULE_DEF_VERSION = types.APIVersion(2, 3)

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -22,6 +22,16 @@ def _instr_labware(loop):
             'tiprack': tiprack, 'instr_multi': instr_multi}
 
 
+# +++++++ Test Helper Functions ++++++++++
+def test_check_if_zero():
+    tclass = tx.TransferPlan
+    assert tclass._check_volume_not_zero(APIVersion(2, 6), 0)
+    assert tclass._check_volume_not_zero(APIVersion(2, 6), 15)
+    assert not tclass._check_volume_not_zero(APIVersion(2, 8), 0)
+    assert tclass._check_volume_not_zero(APIVersion(2, 8), 15)
+
+
+# +++++++ Test transfer types ++++++++++++
 def test_default_transfers(_instr_labware):
     # Transfer 100ml from row1 of labware1 to row1 of labware2: first with
     #  new_tip = ONCE, then with new_tip = NEVER

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -22,7 +22,7 @@ stages:
         system_version: 0.0.0
         protocol_api_version:
           - 2
-          - 7
+          - 8
         links:
           apiLog: /logs/api.log
           serialLog: /logs/serial.log


### PR DESCRIPTION
# Overview

Closes #6452. Support found a bug/differing behavior between transfer + distribute/consolidate where a transfer would skip over an action if a zero volume is given whereas distribute/consolidate would at least 1. move to the location and/or 2. aspirate a disposal volume if given.

# Changelog

- Check whether the API version is below 2.7
      - if it is, append every volume passed for distribute/consolidate
      - If it's not, check that the volume is larger than zero to append
- Add tests to check both new behavior and old (broken) behavior so we make sure not to "break" users current protocols
- Add a note about the updated behavior in `version.rst`

# Review requests

Can we possibly get this into 3.21.0? Otherwise I'll change the API version to be 2.8. Should I add more details in the advanced commands page of the docs?

# Risk assessment

Low, gating a bug fix behind an API version