### PR TITLE
fix(api): Increase the tolerance on this test for how long a function takes to execute

### DIFF
--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from unittest import mock
+from numpy import isclose
 from opentrons.hardware_control import modules, ExecutionManager
 
 
@@ -150,7 +151,7 @@ async def test_set_temperature(monkeypatch, loop):
     start = time.time()
     await hw_tc.set_temperature(40, hold_time_seconds=2)
     time_taken = time.time() - start
-    assert 1.9 < time_taken < 2.1
+    assert isclose(time_taken, 2, atol=0.5)
     set_temp_driver_mock.assert_called_once_with(temp=40,
                                                  hold_time=2,
                                                  volume=None,


### PR DESCRIPTION
# Overview

This test keeps failing for me in github actions. I am increasing the range we check for how long something takes to execute.

# Changelog
 - Changed `test_set_temperature` to check execution time based on a wider range of values

# Review requests

Is there a better way to mock out how long something takes to execute in terms of testing?

# Risk assessment

None/low it's just changing a test
