### PR TITLE
refactor(api, robot-server): add source field to robot calibrations

### DIFF
--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -55,9 +55,9 @@ class PipetteCalibrationData(TypedDict):
 class DeckCalibrationData(TypedDict):
     attitude: AttitudeMatrix
     last_modified: datetime
+    source: SourceType
     pipette_calibrated_with: typing.Optional[str]
     tiprack: typing.Optional[str]
-    source: typing.Optional[SourceType]
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -57,7 +57,7 @@ class DeckCalibrationData(TypedDict):
     last_modified: datetime
     pipette_calibrated_with: typing.Optional[str]
     tiprack: typing.Optional[str]
-    source: SourceType
+    source: typing.Optional[SourceType]
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -2,7 +2,7 @@ import typing
 from typing_extensions import TypedDict
 from datetime import datetime
 
-from .types import AttitudeMatrix, PipetteOffset
+from .types import AttitudeMatrix, PipetteOffset, SourceType
 
 
 class TipLengthCalibration(TypedDict):
@@ -49,6 +49,7 @@ class PipetteCalibrationData(TypedDict):
     tiprack: str
     uri: str
     last_modified: datetime
+    source: SourceType
 
 
 class DeckCalibrationData(TypedDict):
@@ -56,6 +57,7 @@ class DeckCalibrationData(TypedDict):
     last_modified: datetime
     pipette_calibrated_with: typing.Optional[str]
     tiprack: typing.Optional[str]
+    source: SourceType
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -193,5 +193,6 @@ def get_all_pipette_offset_calibrations() \
                         offset=data['offset'],
                         tiprack=data['tiprack'],
                         uri=data['uri'],
-                        last_modified=data['last_modified']))
+                        last_modified=data['last_modified'],
+                        source=local_types.SourceType[data['source']]))
     return all_calibrations

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -199,7 +199,8 @@ def save_robot_deck_attitude(
         'attitude': transform,
         'pipette_calibrated_with': pip_id,
         'last_modified': utc_now(),
-        'tiprack': lw_hash
+        'tiprack': lw_hash,
+        'source': local_types.SourceType.user,
     }
     io.save_to_file(gantry_path, gantry_dict)
 
@@ -234,6 +235,7 @@ def save_pipette_calibration(
         'tiprack': tiprack_hash,
         'uri': tiprack_uri,
         'last_modified': utc_now(),
+        'source': local_types.SourceType.user,
     }
     io.save_to_file(offset_path, offset_dict)
     _add_to_pipette_offset_index_file(pip_id, mount)

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -14,8 +14,10 @@ PipetteOffset = typing.List[float]
 
 class SourceType(str, Enum):
     """Calibration source type"""
+    default = "default"
     factory = "factory"
     user = "user"
+    unknown = "unknown"
 
 
 class TipLengthCalNotFound(Exception):
@@ -86,9 +88,30 @@ class CalibrationInformation:
 
 
 @dataclass
+class DeckCalibration:
+    attitude: AttitudeMatrix
+    source: SourceType
+    last_modified: typing.Optional[datetime] = None
+    pipette_calibrated_with: typing.Optional[str] = None
+    tiprack: typing.Optional[str] = None
+
+
+@dataclass
+class PipetteOffsetByPipetteMount:
+    """
+    Class to store pipette offset without pipette and monut info
+    """
+    offset: PipetteOffset
+    source: SourceType
+    tiprack: typing.Optional[str] = None
+    uri: typing.Optional[str] = None
+    last_modified: typing.Optional[datetime] = None
+
+
+@dataclass
 class PipetteOffsetCalibration:
     """
-    Class to store pipette offset calibration
+    Class to store pipette offset calibration with pipette and mount info
     """
     pipette: str
     mount: str

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -14,7 +14,6 @@ PipetteOffset = typing.List[float]
 
 class SourceType(str, Enum):
     """Calibration source type"""
-    default = "default"
     factory = "factory"
     user = "user"
 

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -2,6 +2,7 @@ import typing
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from os import PathLike
 
 
@@ -9,6 +10,13 @@ CalibrationID = typing.NewType('CalibrationID', str)
 StrPath = typing.Union[str, PathLike]
 AttitudeMatrix = typing.List[typing.List[float]]
 PipetteOffset = typing.List[float]
+
+
+class SourceType(str, Enum):
+    """Calibration source type"""
+    default = "default"
+    factory = "factory"
+    user = "user"
 
 
 class TipLengthCalNotFound(Exception):
@@ -89,3 +97,4 @@ class PipetteOffsetCalibration:
     tiprack: str
     uri: str
     last_modified: datetime
+    source: SourceType

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -6,11 +6,11 @@ import logging
 from typing import Any, Dict, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 from opentrons.types import Point
+from opentrons.calibration_storage.types import PipetteOffsetByPipetteMount
 from opentrons.config import pipette_config
 from opentrons.config.feature_flags import enable_calibration_overhaul
 from opentrons.drivers.types import MoveSplit
 from opentrons.config.robot_configs import robot_config
-from . import robot_calibration as rb_cal
 from .types import CriticalPoint
 
 
@@ -43,7 +43,7 @@ class Pipette:
             self,
             config: pipette_config.PipetteConfig,
             inst_offset_config: Union[InstrumentOffsetConfig, Point],
-            pipette_offset_cal: rb_cal.PipetteCalibration,
+            pipette_offset_cal: PipetteOffsetByPipetteMount,
             pipette_id: str = None) -> None:
         self._config = config
         self._pipette_offset = pipette_offset_cal
@@ -329,7 +329,7 @@ class Pipette:
 def _reload_and_check_skip(
         new_config: pipette_config.PipetteConfig,
         attached_instr: Pipette,
-        pipette_offset: rb_cal.PipetteCalibration) -> Tuple[Pipette, bool]:
+        pipette_offset: PipetteOffsetByPipetteMount) -> Tuple[Pipette, bool]:
     # Once we have determined that the new and attached pipettes
     # are similar enough that we might skip, see if the configs
     # match closely enough.
@@ -362,7 +362,7 @@ def load_from_config_and_check_skip(
         requested: Optional[PipetteName],
         serial: Optional[str],
         instrument_offset: InstrumentOffsetConfig,
-        pipette_offset: rb_cal.PipetteCalibration)\
+        pipette_offset: PipetteOffsetByPipetteMount)\
         -> Tuple[Optional[Pipette], bool]:
     """
     Given the pipette config for an attached pipette (if any) freshly read

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -18,19 +18,19 @@ log = logging.getLogger(__name__)
 @dataclass
 class DeckCalibration:
     attitude: types.AttitudeMatrix
-    source: types.SourceType
     last_modified: Optional[datetime] = None
     pipette_calibrated_with: Optional[str] = None
     tiprack: Optional[str] = None
+    source: Optional[types.SourceType] = None
 
 
 @dataclass
 class PipetteCalibration:
     offset: types.PipetteOffset
-    source: types.SourceType
     tiprack: Optional[str] = None
     uri: Optional[str] = None
     last_modified: Optional[datetime] = None
+    source: Optional[types.SourceType] = None
 
 
 @dataclass
@@ -129,18 +129,18 @@ def load_attitude_matrix() -> DeckCalibration:
     if calibration_data:
         deck_cal_obj = DeckCalibration(**calibration_data)
     else:
+        # load default if deck calibration data do not exist
         deck_cal_obj = DeckCalibration(
-            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
-            source=types.SourceType.default)
+            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2)
     return deck_cal_obj
 
 
 def load_pipette_offset(
         pip_id: Optional[str],
         mount: Mount) -> PipetteCalibration:
+    # load default if pipette offset data do not exist
     pip_cal_obj = PipetteCalibration(
-        offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
-        source=types.SourceType.default)
+        offset=robot_configs.DEFAULT_PIPETTE_OFFSET)
     if pip_id:
         pip_offset_data = get.get_pipette_offset(pip_id, mount)
         if pip_offset_data:

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -1,7 +1,6 @@
 import logging
 import numpy as np  # type: ignore
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional, List
 
 from opentrons import config
@@ -16,29 +15,11 @@ log = logging.getLogger(__name__)
 
 
 @dataclass
-class DeckCalibration:
-    attitude: types.AttitudeMatrix
-    last_modified: Optional[datetime] = None
-    pipette_calibrated_with: Optional[str] = None
-    tiprack: Optional[str] = None
-    source: Optional[types.SourceType] = None
-
-
-@dataclass
-class PipetteCalibration:
-    offset: types.PipetteOffset
-    tiprack: Optional[str] = None
-    uri: Optional[str] = None
-    last_modified: Optional[datetime] = None
-    source: Optional[types.SourceType] = None
-
-
-@dataclass
 class RobotCalibration:
-    deck_calibration: DeckCalibration
+    deck_calibration: types.DeckCalibration
 
 
-def validate_attitude_deck_calibration(deck_cal: DeckCalibration):
+def validate_attitude_deck_calibration(deck_cal: types.DeckCalibration):
     """
     This function determines whether the deck calibration is valid
     or not based on the following use-cases:
@@ -111,7 +92,7 @@ def save_attitude_matrix(
     modify.save_robot_deck_attitude(attitude, pipette_id, tiprack_hash)
 
 
-def load_attitude_matrix() -> DeckCalibration:
+def load_attitude_matrix() -> types.DeckCalibration:
     calibration_data = get.get_robot_deck_attitude()
     if not calibration_data and ff.enable_calibration_overhaul():
         gantry_cal = robot_configs.load().gantry_calibration
@@ -127,24 +108,25 @@ def load_attitude_matrix() -> DeckCalibration:
             calibration_data = get.get_robot_deck_attitude()
 
     if calibration_data:
-        deck_cal_obj = DeckCalibration(**calibration_data)
+        return calibration_data
     else:
         # load default if deck calibration data do not exist
-        deck_cal_obj = DeckCalibration(
-            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2)
-    return deck_cal_obj
+        return types.DeckCalibration(
+            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
+            source=types.SourceType.default)
 
 
 def load_pipette_offset(
         pip_id: Optional[str],
-        mount: Mount) -> PipetteCalibration:
+        mount: Mount) -> types.PipetteOffsetByPipetteMount:
     # load default if pipette offset data do not exist
-    pip_cal_obj = PipetteCalibration(
-        offset=robot_configs.DEFAULT_PIPETTE_OFFSET)
+    pip_cal_obj = types.PipetteOffsetByPipetteMount(
+        offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+        source=types.SourceType.default)
     if pip_id:
         pip_offset_data = get.get_pipette_offset(pip_id, mount)
         if pip_offset_data:
-            pip_cal_obj = PipetteCalibration(**pip_offset_data)
+            return pip_offset_data
     return pip_cal_obj
 
 

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 @dataclass
 class DeckCalibration:
     attitude: types.AttitudeMatrix
+    source: types.SourceType
     last_modified: Optional[datetime] = None
     pipette_calibrated_with: Optional[str] = None
     tiprack: Optional[str] = None
@@ -26,6 +27,7 @@ class DeckCalibration:
 @dataclass
 class PipetteCalibration:
     offset: types.PipetteOffset
+    source: types.SourceType
     tiprack: Optional[str] = None
     uri: Optional[str] = None
     last_modified: Optional[datetime] = None
@@ -128,7 +130,8 @@ def load_attitude_matrix() -> DeckCalibration:
         deck_cal_obj = DeckCalibration(**calibration_data)
     else:
         deck_cal_obj = DeckCalibration(
-            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2)
+            attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
+            source=types.SourceType.default)
     return deck_cal_obj
 
 
@@ -136,7 +139,8 @@ def load_pipette_offset(
         pip_id: Optional[str],
         mount: Mount) -> PipetteCalibration:
     pip_cal_obj = PipetteCalibration(
-        offset=robot_configs.DEFAULT_PIPETTE_OFFSET)
+        offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+        source=types.SourceType.default)
     if pip_id:
         pip_offset_data = get.get_pipette_offset(pip_id, mount)
         if pip_offset_data:

--- a/api/tests/opentrons/hardware_control/test_api_helpers.py
+++ b/api/tests/opentrons/hardware_control/test_api_helpers.py
@@ -1,6 +1,6 @@
+from opentrons.calibration_storage.types import DeckCalibration, SourceType
 from opentrons.hardware_control.util import DeckTransformState
-from opentrons.hardware_control.robot_calibration import (
-    DeckCalibration, RobotCalibration)
+from opentrons.hardware_control.robot_calibration import RobotCalibration
 
 
 async def test_validating_calibration(hardware):
@@ -36,7 +36,9 @@ async def test_validating_attitude(hardware, use_new_calibration):
 
     inrange_matrix = [[1, 0, 1], [0, 1, 2], [0, 0, 1]]
     deck_cal = DeckCalibration(
-        attitude=inrange_matrix, last_modified='sometime')
+        attitude=inrange_matrix,
+        last_modified='sometime',
+        source=SourceType.user)
 
     hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
 

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from opentrons import config
-from opentrons.calibration_storage import file_operators as io, types
+from opentrons.calibration_storage import file_operators as io
 from opentrons.hardware_control import robot_calibration
 from opentrons.util.helpers import utc_now
 from opentrons.types import Mount

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from opentrons import config
-from opentrons.calibration_storage import file_operators as io
+from opentrons.calibration_storage import file_operators as io, types
 from opentrons.hardware_control import robot_calibration
 from opentrons.util.helpers import utc_now
 from opentrons.types import Mount
@@ -33,7 +33,8 @@ def test_save_calibration(ot_config_tempdir):
         'attitude': transform,
         'pipette_calibrated_with': pip_id,
         'last_modified': None,
-        'tiprack': lw_hash
+        'tiprack': lw_hash,
+        'source': 'user'
     }
     robot_calibration.save_attitude_matrix(e, a, pip_id, lw_hash)
     data = io.read_cal_file(pathway)

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -3,10 +3,10 @@ import pytest
 from opentrons import types
 from opentrons import hardware_control as hc
 from opentrons.config import robot_configs
+from opentrons.calibration_storage.types import DeckCalibration, SourceType
 from opentrons.hardware_control.types import (
     Axis, CriticalPoint, OutOfBoundsMove, MotionChecks)
-from opentrons.hardware_control.robot_calibration import (
-    RobotCalibration, DeckCalibration)
+from opentrons.hardware_control.robot_calibration import RobotCalibration
 
 
 async def test_controller_home(loop, is_robot):
@@ -329,7 +329,8 @@ async def test_attitude_deck_cal_applied(
     hardware_api = await hc.API.build_hardware_simulator(loop=loop)
     monkeypatch.setattr(hardware_api._backend, 'move', mock_move)
     deck_cal = RobotCalibration(
-        deck_calibration=DeckCalibration(attitude=new_gantry_cal))
+        deck_calibration=DeckCalibration(
+            attitude=new_gantry_cal, source=SourceType.user))
     hardware_api.set_robot_calibration(deck_cal)
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -1,11 +1,12 @@
 import pytest
+from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Point
-from opentrons.hardware_control import \
-    pipette, types, robot_calibration as rb_cal
+from opentrons.hardware_control import pipette, types
 from opentrons.config import pipette_config
 
-PIP_CAL = rb_cal.PipetteCalibration(
-    offset=[0, 0, 0])
+PIP_CAL = cal_types.PipetteOffsetByPipetteMount(
+    offset=[0, 0, 0],
+    source=cal_types.SourceType.user)
 
 
 def test_tip_tracking():
@@ -81,7 +82,9 @@ def test_critical_points_nozzle_offset(model, use_new_calibration):
 def test_critical_points_pipette_offset(model, use_new_calibration):
     loaded = pipette_config.load(model)
     # set pipette offset calibration
-    pip_cal = rb_cal.PipetteCalibration(offset=[10, 10, 10])
+    pip_cal = cal_types.PipetteOffsetByPipetteMount(
+        offset=[10, 10, 10],
+        source=cal_types.SourceType.user)
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                           pip_cal,

--- a/robot-server/robot_server/service/legacy/models/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/models/deck_calibration.py
@@ -198,7 +198,7 @@ class DeckCalibrationData(BaseModel):
         Field(None,
               description="The sha256 hash of the tiprack used in this"
                           "calibration")
-    source: typing.Optional[SourceType] = \
+    source: SourceType = \
         Field(None,
               description="The calibration source")
 

--- a/robot-server/robot_server/service/legacy/models/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/models/deck_calibration.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import Enum
 from uuid import UUID
 
+from opentrons.calibration_storage.types import SourceType
 from opentrons.hardware_control.util import DeckTransformState
 from pydantic import BaseModel, Field
 from opentrons.deck_calibration.endpoints import CalibrationCommand, \
@@ -197,6 +198,9 @@ class DeckCalibrationData(BaseModel):
         Field(None,
               description="The sha256 hash of the tiprack used in this"
                           "calibration")
+    source: typing.Optional[SourceType] = \
+        Field(None,
+              description="The calibration source")
 
 
 class DeckCalibrationStatus(BaseModel):

--- a/robot-server/robot_server/service/legacy/routers/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/routers/deck_calibration.py
@@ -91,7 +91,8 @@ async def get_calibration_status(
             matrix=deck_cal.attitude,
             lastModified=deck_cal.last_modified,
             pipetteCalibratedWith=deck_cal.pipette_calibrated_with,
-            tiprack=deck_cal.tiprack)
+            tiprack=deck_cal.tiprack,
+            source=deck_cal.source)
     else:
         deck_cal_data = DeckCalibrationData(
             type=MatrixType.affine,

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -38,7 +38,7 @@ class PipetteOffsetCalibration(BaseModel):
     lastModified: datetime = \
         Field(...,
               description="When this calibration was last modified")
-    source: typing.Optional[SourceType] = \
+    source: SourceType = \
         Field(..., description="The calibration source")
 
 

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -37,6 +37,8 @@ class PipetteOffsetCalibration(BaseModel):
     lastModified: datetime = \
         Field(...,
               description="When this calibration was last modified")
+    source: typing.Optional[] = \
+        Field(..., description="The calibration source")
 
 
 MultipleCalibrationsResponse = MultiResponseModel[

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from opentrons.calibration_storage.types import SourceType
 from robot_server.service.json_api import ResponseModel
 from robot_server.service.json_api.response import MultiResponseModel
 
@@ -37,7 +38,7 @@ class PipetteOffsetCalibration(BaseModel):
     lastModified: datetime = \
         Field(...,
               description="When this calibration was last modified")
-    source: typing.Optional[] = \
+    source: typing.Optional[SourceType] = \
         Field(..., description="The calibration source")
 
 

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -22,7 +22,8 @@ def _format_calibration(
         mount=calibration.mount,
         offset=calibration.offset,
         tiprack=calibration.tiprack,
-        lastModified=calibration.last_modified)
+        lastModified=calibration.last_modified,
+        source=calibration.source)
 
     return ResponseDataModel.create(
         attributes=formatted_cal,

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -227,6 +227,7 @@ stages:
             lastModified: null
             pipetteCalibratedWith: null
             tiprack: null
+            source: null
         instrumentCalibration:
           right: &inst
             single: &vector

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -1,9 +1,9 @@
 import pytest
 from unittest.mock import MagicMock, call
 from typing import List, Tuple
+from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Mount, Point
-from opentrons.hardware_control import \
-    pipette, robot_calibration as rb_cal
+from opentrons.hardware_control import pipette
 from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
 from robot_server.robot.calibration.deck.user_flow import \
@@ -12,8 +12,9 @@ from robot_server.robot.calibration.deck.constants import \
     POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID, DeckCalibrationState
 
 
-PIP_OFFSET = rb_cal.PipetteCalibration(
-        offset=robot_configs.DEFAULT_PIPETTE_OFFSET)
+PIP_OFFSET = cal_types.PipetteOffsetByPipetteMount(
+        offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+        source=cal_types.SourceType.user)
 
 
 @pytest.fixture

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -11,7 +11,8 @@ def test_access_pipette_offset_calibration(
         'pipette': 'pip_1',
         'mount': 'left',
         'tiprack': 'hash',
-        'lastModified': None
+        'lastModified': None,
+        'source': 'user'
     }
 
     resp = api_client.get(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR saves a new metadata field "source" to deck and pipette offset calibration files.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
closes #6605 

# Changelog
- add a SourceType enum
- update deck and pipette off cal saving methods to include source and set the source to `SourceType.user`
- update deck and pipette offset calibration models

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported 

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Make sure to first add `"source": "user"` to the deck calibration and all pipette calibration offset files before pushing the changes to your robot.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, all changes are still behind a feature flag 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
