### PR TITLE
feat(protocol-designer): add mix delay commands

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/mix.test.js
+++ b/protocol-designer/src/step-generation/__tests__/mix.test.js
@@ -15,6 +15,7 @@ import {
   makeDispenseHelper,
   blowoutHelper,
   makeTouchTipHelper,
+  delayCommand,
 } from '../__fixtures__'
 import type { MixArgs } from '../types'
 
@@ -215,6 +216,92 @@ describe('mix: advanced options', () => {
         touchTipHelper(well),
       ])
     )
+  })
+  it('should delay after aspirating', () => {
+    const args: MixArgs = {
+      ...mixinArgs,
+      aspirateDelaySeconds: 12,
+      volume,
+      times,
+      changeTip: 'always',
+      wells: ['A1', 'B1', 'C1'],
+    }
+
+    const result = mix(args, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+
+    expect(res.commands).toEqual(
+      flatMap(args.wells, (well, idx) => [
+        ...replaceTipCommands(idx),
+        aspirateHelper(well, volume),
+        delayCommand(12),
+        dispenseHelper(well, volume),
+        aspirateHelper(well, volume),
+        delayCommand(12),
+        dispenseHelper(well, volume),
+      ])
+    )
+  })
+  it('should delay after dispensing', () => {
+    const args: MixArgs = {
+      ...mixinArgs,
+      dispenseDelaySeconds: 12,
+      volume,
+      times,
+      changeTip: 'always',
+      wells: ['A1', 'B1', 'C1'],
+    }
+
+    const result = mix(args, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+
+    expect(res.commands).toEqual(
+      flatMap(args.wells, (well, idx) => [
+        ...replaceTipCommands(idx),
+        aspirateHelper(well, volume),
+        dispenseHelper(well, volume),
+        delayCommand(12),
+        aspirateHelper(well, volume),
+        dispenseHelper(well, volume),
+        delayCommand(12),
+      ])
+    )
+  })
+  describe('all advanced settings enabled', () => {
+    it('should create commands in the expected order with expected params', () => {
+      const args: MixArgs = {
+        ...mixinArgs,
+        touchTip: true,
+        aspirateDelaySeconds: 10,
+        dispenseDelaySeconds: 12,
+        blowoutLocation: blowoutLabwareId,
+        volume,
+        times,
+        changeTip: 'always',
+        wells: ['A1', 'B1', 'C1'],
+      }
+
+      const result = mix(args, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+
+      expect(res.commands).toEqual(
+        flatMap(args.wells, (well, idx) => [
+          ...replaceTipCommands(idx),
+          aspirateHelper(well, volume),
+          delayCommand(10),
+          dispenseHelper(well, volume),
+          delayCommand(12),
+          aspirateHelper(well, volume),
+          delayCommand(10),
+          dispenseHelper(well, volume),
+          delayCommand(12),
+          blowoutHelper(blowoutLabwareId, {
+            offsetFromBottomMm: BLOWOUT_OFFSET_ANY,
+          }),
+          touchTipHelper(well),
+        ])
+      )
+    })
   })
 })
 

--- a/protocol-designer/src/step-generation/commandCreators/compound/mix.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/mix.js
@@ -25,8 +25,8 @@ export function mixUtil(args: {|
   dispenseOffsetFromBottomMm: number,
   aspirateFlowRateUlSec: number,
   dispenseFlowRateUlSec: number,
-  aspirateDelaySeconds?: number,
-  dispenseDelaySeconds?: number,
+  aspirateDelaySeconds?: ?number,
+  dispenseDelaySeconds?: ?number,
 |}): Array<CurriedCommandCreator> {
   const {
     pipette,
@@ -104,6 +104,8 @@ export const mix: CommandCreator<MixArgs> = (
     volume,
     times,
     changeTip,
+    aspirateDelaySeconds,
+    dispenseDelaySeconds,
     aspirateOffsetFromBottomMm,
     dispenseOffsetFromBottomMm,
     aspirateFlowRateUlSec,
@@ -172,6 +174,8 @@ export const mix: CommandCreator<MixArgs> = (
         dispenseOffsetFromBottomMm,
         aspirateFlowRateUlSec,
         dispenseFlowRateUlSec,
+        aspirateDelaySeconds,
+        dispenseDelaySeconds,
       })
 
       return [


### PR DESCRIPTION
# Overview
This PR adds mix delay commands (for both aspirate and dispense delays) to the mix command creator.

Closes #6498
# Changelog

- Add delay commands to mix command creator

# Review requests
- Code review (including tests)

You should now be able to enter values into the mix delay form field, save the mix form, and export the protocol!

Validate that when doing so, in the JSON you see the delay commands expected (both after aspirating and dispensing).
# Risk assessment
Low-Med, touches a compound command creator but it's well tested