### PR TITLE
fix(protocol-designer): fix 5.1.0 migration

### DIFF
--- a/protocol-designer/fixtures/protocol/5/doItAllV3.json
+++ b/protocol-designer/fixtures/protocol/5/doItAllV3.json
@@ -159,9 +159,9 @@
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": 11.8,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/fixtures/protocol/5/example_1_1_0MigratedFromV1_0_0.json
+++ b/protocol-designer/fixtures/protocol/5/example_1_1_0MigratedFromV1_0_0.json
@@ -142,9 +142,9 @@
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": 30.5,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "2e622080-92a6-11e9-ac62-1b173f839d9e": {
           "pauseAction": "untilTime",

--- a/protocol-designer/fixtures/protocol/5/mix_5_1_0.json
+++ b/protocol-designer/fixtures/protocol/5/mix_5_1_0.json
@@ -72,9 +72,9 @@
           "wells": ["A1"],
           "times": "2",
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/fixtures/protocol/5/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
+++ b/protocol-designer/fixtures/protocol/5/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
@@ -1226,9 +1226,9 @@
           "stepDetails": "",
           "times": 4,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "984e26c0-1811-11e9-9608-8bed9be8868f": {
           "pipette": "01217421-180a-11e9-9608-8bed9be8868f",
@@ -1479,9 +1479,9 @@
           "stepDetails": "Blow out, touch tip",
           "times": 4,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "07c41640-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "never",
@@ -1504,9 +1504,9 @@
           "aspirate_flowRate": 10,
           "dispense_flowRate": 5,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "63a2ea90-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "always",
@@ -1526,9 +1526,9 @@
           "stepDetails": "",
           "times": 2,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "7cd40b20-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "once",
@@ -1548,9 +1548,9 @@
           "stepDetails": "",
           "times": 2,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "9cafddc0-1812-11e9-9608-8bed9be8868f": {
           "pauseAction": "untilTime",
@@ -1597,9 +1597,9 @@
           "stepDetails": "Blow out, touch tip",
           "times": 4,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "b9afe0a0-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "never",
@@ -1622,9 +1622,9 @@
           "aspirate_flowRate": null,
           "dispense_flowRate": null,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "c495a450-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "always",
@@ -1644,9 +1644,9 @@
           "stepDetails": "",
           "times": 2,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         },
         "d7451ea0-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "once",
@@ -1666,9 +1666,9 @@
           "stepDetails": "",
           "times": 2,
           "aspirate_delay_checkbox": false,
-          "aspirate_delay_seconds": null,
+          "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": null
+          "dispense_delay_seconds": "1"
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/src/load-file/migration/5_1_0.js
+++ b/protocol-designer/src/load-file/migration/5_1_0.js
@@ -13,10 +13,10 @@ export const migrateSavedStepForms = (savedStepForms: {
       return {
         ...stepForm,
         aspirate_delay_checkbox: false,
-        aspirate_delay_seconds: null,
+        aspirate_delay_seconds: '1',
 
         dispense_delay_checkbox: false,
-        dispense_delay_seconds: null,
+        dispense_delay_seconds: '1',
       }
     }
     return stepForm


### PR DESCRIPTION
# Overview

Default delay seconds should be '`1'`, not `null`

# Changelog

# Review requests

- Loading a pre-v5.1.0 protocol with mixes should have the Mix > Delay > Seconds fields default to 1

# Risk assessment

Low should be a fix to an unreleased feature, PD only