### PR TITLE
refactor(app): gate protocol calibrate and run on pipette offset cal

### DIFF
--- a/app/src/calibration/pipette-offset/selectors.js
+++ b/app/src/calibration/pipette-offset/selectors.js
@@ -7,8 +7,11 @@ import type { PipetteOffsetCalibration } from '../api-types'
 
 export const getPipetteOffsetCalibrations: (
   state: State,
-  robotName: string
+  robotName: string | null
 ) => Array<PipetteOffsetCalibration> = (state, robotName) => {
+  if (!robotName) {
+    return []
+  }
   const calibrations =
     state.calibration[robotName]?.pipetteOffsetCalibrations?.data || []
   return calibrations.map(calibration => calibration.attributes)

--- a/app/src/components/FileInfo/Continue.js
+++ b/app/src/components/FileInfo/Continue.js
@@ -17,6 +17,7 @@ import {
   SIZE_5,
   TEXT_ALIGN_RIGHT,
   TOOLTIP_LEFT,
+  TOOLTIP_FIXED,
 } from '@opentrons/components'
 
 // TODO(mc, 2020-07-27): i18n
@@ -27,6 +28,7 @@ export function Continue(): React.Node {
   const { path, disabledReason } = useSelector(getCalibrateLocation)
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_LEFT,
+    strategy: TOOLTIP_FIXED,
   })
 
   return (

--- a/app/src/components/FileInfo/InstrumentItem.js
+++ b/app/src/components/FileInfo/InstrumentItem.js
@@ -10,7 +10,7 @@ export type InstrumentItemProps = {|
   mount?: string,
   children: React.Node,
   hidden?: boolean,
-  hasOffsetCalibration: boolean,
+  needsOffsetCalibration: boolean,
 |}
 
 export function InstrumentItem(props: InstrumentItemProps): React.Node {
@@ -20,7 +20,7 @@ export function InstrumentItem(props: InstrumentItemProps): React.Node {
       <StatusIcon
         match={
           ['match', 'inexact_match'].includes(props.compatibility) &&
-          props.hasOffsetCalibration
+          !props.needsOffsetCalibration
         }
       />
       {props.mount && (

--- a/app/src/components/FileInfo/InstrumentItem.js
+++ b/app/src/components/FileInfo/InstrumentItem.js
@@ -10,6 +10,7 @@ export type InstrumentItemProps = {|
   mount?: string,
   children: React.Node,
   hidden?: boolean,
+  hasOffsetCalibration: boolean,
 |}
 
 export function InstrumentItem(props: InstrumentItemProps): React.Node {
@@ -17,7 +18,10 @@ export function InstrumentItem(props: InstrumentItemProps): React.Node {
   return (
     <div className={styles.instrument_item}>
       <StatusIcon
-        match={['match', 'inexact_match'].includes(props.compatibility)}
+        match={
+          ['match', 'inexact_match'].includes(props.compatibility) &&
+          props.hasOffsetCalibration
+        }
       />
       {props.mount && (
         <span className={styles.mount_label}>{props.mount.toUpperCase()}</span>

--- a/app/src/components/FileInfo/MissingItemWarning.js
+++ b/app/src/components/FileInfo/MissingItemWarning.js
@@ -29,9 +29,9 @@ export function MissingItemWarning(props: MissingItemWarningProps): React.Node {
         texttransform={TEXT_TRANSFORM_UPPERCASE}
         Component={Link}
         to={url}
-         // this needs to be as a class because something about making a button
-         // pretending to be a Link means that stuff specified in the css that's
-         // passed to the link can't be overridden with props
+        // this needs to be as a class because something about making a button
+        // pretending to be a Link means that stuff specified in the css that's
+        // passed to the link can't be overridden with props
         className={styles.width_auto}
       >
         {urlLabel}

--- a/app/src/components/FileInfo/MissingItemWarning.js
+++ b/app/src/components/FileInfo/MissingItemWarning.js
@@ -2,9 +2,8 @@
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import {
-  OutlineButton,
+  SecondaryBtn,
   Text,
-  TEXT_TRANSFORM_UPPERCASE,
   SPACING_2,
   COLOR_WARNING,
   COLOR_ERROR,
@@ -25,17 +24,9 @@ export function MissingItemWarning(props: MissingItemWarningProps): React.Node {
   const { missingItem, urlLabel, url, isBlocking = false } = props
   return (
     <SectionContentHalf className={styles.align_center}>
-      <OutlineButton
-        texttransform={TEXT_TRANSFORM_UPPERCASE}
-        Component={Link}
-        to={url}
-        // this needs to be as a class because something about making a button
-        // pretending to be a Link means that stuff specified in the css that's
-        // passed to the link can't be overridden with props
-        className={styles.width_auto}
-      >
+      <SecondaryBtn as={Link} to={url}>
         {urlLabel}
-      </OutlineButton>
+      </SecondaryBtn>
       <Text
         marginTop={SPACING_2}
         fontSize={FONT_SIZE_CAPTION}

--- a/app/src/components/FileInfo/MissingItemWarning.js
+++ b/app/src/components/FileInfo/MissingItemWarning.js
@@ -1,36 +1,48 @@
 // @flow
 import * as React from 'react'
 import { Link } from 'react-router-dom'
-import cx from 'classnames'
-import { OutlineButton } from '@opentrons/components'
+import {
+  OutlineButton,
+  Text,
+  TEXT_TRANSFORM_UPPERCASE,
+  SPACING_2,
+  COLOR_WARNING,
+  COLOR_ERROR,
+  FONT_SIZE_CAPTION,
+} from '@opentrons/components'
 
 import styles from './styles.css'
 import { SectionContentHalf } from '../layout'
 
 export type MissingItemWarningProps = {|
-  instrumentType: string,
+  missingItem: string,
+  urlLabel: string,
   url: string,
   isBlocking?: boolean,
 |}
 
 export function MissingItemWarning(props: MissingItemWarningProps): React.Node {
-  const { instrumentType, url, isBlocking = false } = props
+  const { missingItem, urlLabel, url, isBlocking = false } = props
   return (
     <SectionContentHalf className={styles.align_center}>
       <OutlineButton
+        texttransform={TEXT_TRANSFORM_UPPERCASE}
         Component={Link}
         to={url}
-        className={styles.instrument_button}
+         // this needs to be as a class because something about making a button
+         // pretending to be a Link means that stuff specified in the css that's
+         // passed to the link can't be overridden with props
+        className={styles.width_auto}
       >
-        GO TO {instrumentType} SETUP
+        {urlLabel}
       </OutlineButton>
-      <p
-        className={cx(styles.instrument_warning, {
-          [styles.blocking]: isBlocking,
-        })}
+      <Text
+        marginTop={SPACING_2}
+        fontSize={FONT_SIZE_CAPTION}
+        color={isBlocking ? COLOR_ERROR : COLOR_WARNING}
       >
-        Required {instrumentType} is missing
-      </p>
+        {missingItem} is missing
+      </Text>
     </SectionContentHalf>
   )
 }

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -78,7 +78,7 @@ function ProtocolModulesCardComponent(props: Props) {
           <InstrumentItem
             key={m.slot}
             compatibility={m.modulesMatch}
-            hasOffsetCalibration={true}
+            needsOffsetCalibration={false}
           >
             {m.displayName}{' '}
           </InstrumentItem>

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -75,13 +75,21 @@ function ProtocolModulesCardComponent(props: Props) {
     <InfoSection title={TITLE}>
       <SectionContentHalf>
         {moduleInfo.map(m => (
-          <InstrumentItem key={m.slot} compatibility={m.modulesMatch}>
+          <InstrumentItem
+            key={m.slot}
+            compatibility={m.modulesMatch}
+            hasOffsetCalibration={true}
+          >
             {m.displayName}{' '}
           </InstrumentItem>
         ))}
       </SectionContentHalf>
       {!modulesMatch && (
-        <MissingItemWarning instrumentType="module" url={attachModulesUrl} />
+        <MissingItemWarning
+          missingItem="Required module"
+          urlLabel="go to module setup"
+          url={attachModulesUrl}
+        />
       )}
       {modulesMatch && someInexact && (
         <SectionContentHalf className={styles.soft_warning}>

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -60,7 +60,7 @@ export function ProtocolPipettesCard(
           mount: info.protocol.mount,
           hidden: !info.protocol.name,
           displayName: info.protocol.displayName,
-          hasOffsetCalibration: info.hasOffsetCalibration,
+          needsOffsetCalibration: info.needsOffsetCalibration,
         }
       : null
   }).filter(Boolean)
@@ -76,7 +76,7 @@ export function ProtocolPipettesCard(
             compatibility={itemProps.compatibility}
             mount={itemProps.mount}
             hidden={itemProps.hidden}
-            hasOffsetCalibration={itemProps.hasOffsetCalibration}
+            needsOffsetCalibration={itemProps.needsOffsetCalibration}
           >
             {itemProps.displayName}
           </InstrumentItem>

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -8,7 +8,7 @@ import {
   PIPETTE_MOUNTS,
   fetchPipettes,
   getProtocolPipettesInfo,
-  getProtocolPipettesMatch,
+  getProtocolPipettesMatching,
   getSomeProtocolPipettesInexact,
 } from '../../pipettes'
 import { InstrumentItem } from './InstrumentItem'
@@ -34,8 +34,8 @@ export function ProtocolPipettesCard(
   const infoByMount = useSelector((state: State) =>
     getProtocolPipettesInfo(state, robotName)
   )
-  const allPipettesMatch = useSelector((state: State) =>
-    getProtocolPipettesMatch(state, robotName)
+  const allPipettesMatching = useSelector((state: State) =>
+    getProtocolPipettesMatching(state, robotName)
   )
   const someInexactMatches = useSelector((state: State) =>
     getSomeProtocolPipettesInexact(state, robotName)
@@ -76,14 +76,14 @@ export function ProtocolPipettesCard(
           </InstrumentItem>
         ))}
       </SectionContentHalf>
-      {!allPipettesMatch && (
+      {!allPipettesMatching && (
         <MissingItemWarning
           isBlocking
           instrumentType="pipette"
           url={changePipetteUrl}
         />
       )}
-      {allPipettesMatch && someInexactMatches && (
+      {allPipettesMatching && someInexactMatches && (
         <SectionContentHalf className={styles.soft_warning}>
           <div className={styles.warning_info_wrapper}>
             <Icon name="information" className={styles.info_icon} />

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -9,6 +9,7 @@ import {
   fetchPipettes,
   getProtocolPipettesInfo,
   getProtocolPipettesMatching,
+  getProtocolPipettesCalibrated,
   getSomeProtocolPipettesInexact,
 } from '../../pipettes'
 import { InstrumentItem } from './InstrumentItem'
@@ -37,6 +38,9 @@ export function ProtocolPipettesCard(
   const allPipettesMatching = useSelector((state: State) =>
     getProtocolPipettesMatching(state, robotName)
   )
+  const allPipettesCalibrated = useSelector((state: State) =>
+    getProtocolPipettesCalibrated(state, robotName)
+  )
   const someInexactMatches = useSelector((state: State) =>
     getSomeProtocolPipettesInexact(state, robotName)
   )
@@ -56,6 +60,7 @@ export function ProtocolPipettesCard(
           mount: info.protocol.mount,
           hidden: !info.protocol.name,
           displayName: info.protocol.displayName,
+          hasOffsetCalibration: info.hasOffsetCalibration,
         }
       : null
   }).filter(Boolean)
@@ -71,6 +76,7 @@ export function ProtocolPipettesCard(
             compatibility={itemProps.compatibility}
             mount={itemProps.mount}
             hidden={itemProps.hidden}
+            hasOffsetCalibration={itemProps.hasOffsetCalibration}
           >
             {itemProps.displayName}
           </InstrumentItem>
@@ -79,7 +85,16 @@ export function ProtocolPipettesCard(
       {!allPipettesMatching && (
         <MissingItemWarning
           isBlocking
-          instrumentType="pipette"
+          missingItem="Required pipette"
+          urlLabel="go to pipette setup"
+          url={changePipetteUrl}
+        />
+      )}
+      {allPipettesMatching && !allPipettesCalibrated && (
+        <MissingItemWarning
+          isBlocking
+          urlLabel="go to pipette setup"
+          missingItem="Pipette offset calibration"
           url={changePipetteUrl}
         />
       )}

--- a/app/src/components/FileInfo/styles.css
+++ b/app/src/components/FileInfo/styles.css
@@ -46,10 +46,6 @@
   margin-right: 1rem;
 }
 
-.width_auto {
-  width: auto;
-}
-
 .labware_table {
   @apply --font-body-1-dark;
 

--- a/app/src/components/FileInfo/styles.css
+++ b/app/src/components/FileInfo/styles.css
@@ -41,22 +41,12 @@
   font-weight: var(--fw-semibold);
 }
 
-.instrument_warning {
-  margin-top: 0.5rem;
-  font-size: var(--fs-caption);
-  color: var(--c-warning);
-}
-
-.instrument_warning.blocking {
-  color: var(--c-error);
-}
-
 .status_icon {
   width: 1.5rem;
   margin-right: 1rem;
 }
 
-.instrument_button {
+.width_auto {
   width: auto;
 }
 

--- a/app/src/nav/__tests__/selectors.test.js
+++ b/app/src/nav/__tests__/selectors.test.js
@@ -35,10 +35,15 @@ const mockGetConnectedRobot: JestMockFn<
   $Call<typeof DiscoverySelectors.getConnectedRobot, State>
 > = DiscoverySelectors.getConnectedRobot
 
-const mockGetProtocolPipettesReady: JestMockFn<
+const mockGetProtocolPipettesMatching: JestMockFn<
   [State, string],
-  $Call<typeof PipetteSelectors.getProtocolPipettesReady, State, string>
-> = PipetteSelectors.getProtocolPipettesReady
+  $Call<typeof PipetteSelectors.getProtocolPipettesMatching, State, string>
+> = PipetteSelectors.getProtocolPipettesMatching
+
+const mockGetProtocolPipettesCalibrated: JestMockFn<
+  [State, string],
+  $Call<typeof PipetteSelectors.getProtocolPipettesCalibrated, State, string>
+> = PipetteSelectors.getProtocolPipettesCalibrated
 
 const mockGetAvailableShellUpdate: JestMockFn<
   [State],
@@ -125,7 +130,8 @@ describe('nav selectors', () => {
 
   beforeEach(() => {
     mockGetConnectedRobot.mockReturnValue(null)
-    mockGetProtocolPipettesReady.mockReturnValue(false)
+    mockGetProtocolPipettesMatching.mockReturnValue(false)
+    mockGetProtocolPipettesCalibrated.mockReturnValue(false)
     mockGetAvailableShellUpdate.mockReturnValue(null)
     mockGetBuildrootUpdateAvailable.mockReturnValue(null)
     mockGetIsRunning.mockReturnValue(false)
@@ -248,7 +254,8 @@ describe('nav selectors', () => {
       ],
     },
     {
-      name: 'getNavbarLocations with runnable protocol and pipettes compatible',
+      name:
+        'getNavbarLocations with runnable protocol and matching but uncalibrated pipettes',
       selector: Selectors.getNavbarLocations,
       before: () => {
         mockGetConnectedRobot.mockReturnValue(mockRobot)
@@ -256,10 +263,41 @@ describe('nav selectors', () => {
         mockGetCommands.mockReturnValue([
           { id: 0, description: 'Foo', handledAt: null, children: [] },
         ])
-        mockGetProtocolPipettesReady.mockReturnValue(true)
+        mockGetProtocolPipettesMatching.mockReturnValue(true)
+      },
+      expected: [
+        EXPECTED_ROBOTS,
+        { ...EXPECTED_UPLOAD, disabledReason: null },
+        {
+          ...EXPECTED_CALIBRATE,
+          disabledReason: expect.stringMatching(/calibrate all pipettes/),
+        },
+        {
+          ...EXPECTED_RUN,
+          disabledReason: expect.stringMatching(/calibrate all pipettes/),
+        },
+        EXPECTED_MORE,
+      ],
+    },
+    {
+      name:
+        'getNavbarLocations with runnable protocol and pipettes compatible and calibrated',
+      selector: Selectors.getNavbarLocations,
+      before: () => {
+        mockGetConnectedRobot.mockReturnValue(mockRobot)
+        mockGetSessionIsLoaded.mockReturnValue(true)
+        mockGetCommands.mockReturnValue([
+          { id: 0, description: 'Foo', handledAt: null, children: [] },
+        ])
+        mockGetProtocolPipettesMatching.mockReturnValue(true)
+        mockGetProtocolPipettesCalibrated.mockReturnValue(true)
       },
       after: () => {
-        expect(mockGetProtocolPipettesReady).toHaveBeenCalledWith(
+        expect(mockGetProtocolPipettesMatching).toHaveBeenCalledWith(
+          mockState,
+          mockRobot.name
+        )
+        expect(mockGetProtocolPipettesCalibrated).toHaveBeenCalledWith(
           mockState,
           mockRobot.name
         )

--- a/app/src/nav/__tests__/selectors.test.js
+++ b/app/src/nav/__tests__/selectors.test.js
@@ -35,10 +35,10 @@ const mockGetConnectedRobot: JestMockFn<
   $Call<typeof DiscoverySelectors.getConnectedRobot, State>
 > = DiscoverySelectors.getConnectedRobot
 
-const mockGetProtocolPipettesMatch: JestMockFn<
+const mockGetProtocolPipettesReady: JestMockFn<
   [State, string],
-  $Call<typeof PipetteSelectors.getProtocolPipettesMatch, State, string>
-> = PipetteSelectors.getProtocolPipettesMatch
+  $Call<typeof PipetteSelectors.getProtocolPipettesReady, State, string>
+> = PipetteSelectors.getProtocolPipettesReady
 
 const mockGetAvailableShellUpdate: JestMockFn<
   [State],
@@ -125,7 +125,7 @@ describe('nav selectors', () => {
 
   beforeEach(() => {
     mockGetConnectedRobot.mockReturnValue(null)
-    mockGetProtocolPipettesMatch.mockReturnValue(false)
+    mockGetProtocolPipettesReady.mockReturnValue(false)
     mockGetAvailableShellUpdate.mockReturnValue(null)
     mockGetBuildrootUpdateAvailable.mockReturnValue(null)
     mockGetIsRunning.mockReturnValue(false)
@@ -256,10 +256,10 @@ describe('nav selectors', () => {
         mockGetCommands.mockReturnValue([
           { id: 0, description: 'Foo', handledAt: null, children: [] },
         ])
-        mockGetProtocolPipettesMatch.mockReturnValue(true)
+        mockGetProtocolPipettesReady.mockReturnValue(true)
       },
       after: () => {
-        expect(mockGetProtocolPipettesMatch).toHaveBeenCalledWith(
+        expect(mockGetProtocolPipettesReady).toHaveBeenCalledWith(
           mockState,
           mockRobot.name
         )

--- a/app/src/nav/selectors.js
+++ b/app/src/nav/selectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect'
 
 import { getConnectedRobot } from '../discovery'
-import { getProtocolPipettesMatch } from '../pipettes'
+import { getProtocolPipettesReady } from '../pipettes'
 import { selectors as RobotSelectors } from '../robot'
 import { UPGRADE, getBuildrootUpdateAvailable } from '../buildroot'
 import { getAvailableShellUpdate } from '../shell'
@@ -40,7 +40,7 @@ const getConnectedRobotPipettesMatch = (state: State): boolean => {
   const connectedRobot = getConnectedRobot(state)
 
   return connectedRobot
-    ? getProtocolPipettesMatch(state, connectedRobot.name)
+    ? getProtocolPipettesReady(state, connectedRobot.name)
     : false
 }
 

--- a/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
+++ b/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
@@ -120,13 +120,13 @@ const SPECS: Array<SelectorSpec> = [
         compatibility: 'match',
         protocol: null,
         actual: null,
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
         protocol: null,
         actual: null,
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
     matching: true,
@@ -158,7 +158,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
@@ -168,7 +168,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockRightSpecs,
           displayName: 'Right Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
     matching: true,
@@ -217,7 +217,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
@@ -230,7 +230,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockRightSpecs,
           displayName: 'Right Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
     matching: true,
@@ -274,13 +274,13 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
         protocol: null,
         actual: null,
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
   },
@@ -322,13 +322,13 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
         protocol: null,
         actual: null,
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
   },
@@ -359,13 +359,13 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
         protocol: null,
         actual: null,
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
     before: () => {
@@ -402,7 +402,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
@@ -415,7 +415,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockRightSpecs,
           displayName: 'Right Pipette',
         },
-        hasOffsetCalibration: false,
+        needsOffsetCalibration: true,
       },
     },
     matching: true,
@@ -457,7 +457,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockLeftSpecs,
           displayName: 'Left Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
       right: {
         compatibility: 'match',
@@ -470,7 +470,7 @@ const SPECS: Array<SelectorSpec> = [
           modelSpecs: mockRightSpecs,
           displayName: 'Right Pipette',
         },
-        hasOffsetCalibration: true,
+        needsOffsetCalibration: false,
       },
     },
     matching: true,
@@ -483,6 +483,55 @@ const SPECS: Array<SelectorSpec> = [
       mockGetPipetteOffsetCalibrations.mockReturnValue([
         mockLeftPipetteCalibration,
         mockRightPipetteCalibration,
+      ])
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    },
+  },
+  {
+    name:
+      'allows pass if ff on and an unused but attached pipette is not calibrated',
+    state: {
+      pipettes: {
+        robotName: {
+          attachedByMount: {
+            left: mockLeftPipette,
+            right: mockRightPipette,
+          },
+          settingsById: null,
+        },
+      },
+    },
+    expected: {
+      left: {
+        compatibility: 'match',
+        protocol: {
+          ...mockLeftProtoPipette,
+          displayName: 'Left Pipette',
+        },
+        actual: {
+          ...mockLeftPipette,
+          modelSpecs: mockLeftSpecs,
+          displayName: 'Left Pipette',
+        },
+        needsOffsetCalibration: false,
+      },
+      right: {
+        compatibility: 'match',
+        protocol: null,
+        actual: {
+          ...mockRightPipette,
+          modelSpecs: mockRightSpecs,
+          displayName: 'Right Pipette',
+        },
+        needsOffsetCalibration: false,
+      },
+    },
+    matching: true,
+    calibrated: true,
+    before: () => {
+      mockGetProtocolPipettes.mockReturnValue([mockLeftProtoPipette])
+      mockGetPipetteOffsetCalibrations.mockReturnValue([
+        mockLeftPipetteCalibration,
       ])
       mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     },

--- a/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
+++ b/app/src/pipettes/__tests__/protocol-pipette-selectors.test.js
@@ -18,7 +18,6 @@ type SelectorSpec = {|
   name: string,
   state: $Shape<State>,
   expected: mixed,
-  ready: boolean,
   matching: boolean,
   calibrated: boolean,
   before?: () => mixed,
@@ -130,7 +129,6 @@ const SPECS: Array<SelectorSpec> = [
         hasOffsetCalibration: true,
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
     before: () => {
@@ -173,7 +171,6 @@ const SPECS: Array<SelectorSpec> = [
         hasOffsetCalibration: true,
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
     before: () => {
@@ -236,7 +233,6 @@ const SPECS: Array<SelectorSpec> = [
         hasOffsetCalibration: true,
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
   },
@@ -263,7 +259,6 @@ const SPECS: Array<SelectorSpec> = [
       ])
       mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: false })
     },
-    ready: true,
     matching: true,
     calibrated: true,
     expected: {
@@ -302,7 +297,6 @@ const SPECS: Array<SelectorSpec> = [
         },
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
     before: () => {
@@ -351,7 +345,6 @@ const SPECS: Array<SelectorSpec> = [
         },
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
     expected: {
@@ -425,7 +418,6 @@ const SPECS: Array<SelectorSpec> = [
         hasOffsetCalibration: false,
       },
     },
-    ready: false,
     matching: true,
     calibrated: false,
     before: () => {
@@ -440,7 +432,7 @@ const SPECS: Array<SelectorSpec> = [
     },
   },
   {
-    name: 'allows pass if ff on and all pipettes ready and calibrated',
+    name: 'allows pass if ff on and all pipettes matching and calibrated',
     state: {
       pipettes: {
         robotName: {
@@ -481,7 +473,6 @@ const SPECS: Array<SelectorSpec> = [
         hasOffsetCalibration: true,
       },
     },
-    ready: true,
     matching: true,
     calibrated: true,
     before: () => {
@@ -519,7 +510,6 @@ describe('protocol pipettes comparison selectors', () => {
       name,
       state,
       expected,
-      ready,
       matching,
       calibrated,
       before = noop,
@@ -537,9 +527,6 @@ describe('protocol pipettes comparison selectors', () => {
       expect(
         Selectors.getProtocolPipettesCalibrated(state, 'robotName')
       ).toEqual(calibrated)
-      expect(Selectors.getProtocolPipettesReady(state, 'robotName')).toEqual(
-        ready
-      )
       after()
     })
   })

--- a/app/src/pipettes/selectors.js
+++ b/app/src/pipettes/selectors.js
@@ -192,15 +192,6 @@ export const getProtocolPipettesCalibrated: (
   }
 )
 
-export const getProtocolPipettesReady: (
-  state: State,
-  robotName: string
-) => boolean = createSelector<State, string, boolean, _, _>(
-  getProtocolPipettesMatching,
-  getProtocolPipettesCalibrated,
-  (matching, calibrated) => matching && calibrated
-)
-
 export const getSomeProtocolPipettesInexact: (
   state: State,
   robotName: string

--- a/app/src/pipettes/selectors.js
+++ b/app/src/pipettes/selectors.js
@@ -70,7 +70,7 @@ const EMPTY_INFO = {
   actual: null,
   protocol: null,
   compatibility: Constants.MATCH,
-  hasOffsetCalibration: false,
+  needsOffsetCalibration: false,
 }
 
 const pipettesAreInexactMatch = (
@@ -149,12 +149,13 @@ export const getProtocolPipettesInfo: (
                   displayName: actualModelSpecs.displayName,
                 }
               : null,
-          hasOffsetCalibration: !featureFlags.enableCalibrationOverhaul
-            ? true
+          needsOffsetCalibration: !featureFlags.enableCalibrationOverhaul
+            ? false
             : actualPipette &&
+              protocolPipette &&
               actualModelSpecs &&
               compatibility !== Constants.INCOMPATIBLE
-            ? pipetteHasOffset(pipetteOffsetCalibrations, actualPipette.id)
+            ? !pipetteHasOffset(pipetteOffsetCalibrations, actualPipette.id)
             : false,
         }
 
@@ -187,7 +188,7 @@ export const getProtocolPipettesCalibrated: (
   infoByMount => {
     return every(
       infoByMount,
-      (info: Types.ProtocolPipetteInfo) => info.hasOffsetCalibration
+      (info: Types.ProtocolPipetteInfo) => !info.needsOffsetCalibration
     )
   }
 )

--- a/app/src/pipettes/types.js
+++ b/app/src/pipettes/types.js
@@ -70,7 +70,7 @@ export type ProtocolPipetteInfo = {|
     displayName: string,
   |},
   compatibility: PipetteCompatibility,
-  hasOffsetCalibration: boolean,
+  needsOffsetCalibration: boolean,
 |}
 
 export type ProtocolPipetteInfoByMount = {|

--- a/app/src/pipettes/types.js
+++ b/app/src/pipettes/types.js
@@ -70,6 +70,7 @@ export type ProtocolPipetteInfo = {|
     displayName: string,
   |},
   compatibility: PipetteCompatibility,
+  hasOffsetCalibration: boolean,
 |}
 
 export type ProtocolPipetteInfoByMount = {|


### PR DESCRIPTION
If the calibration overhaul is enabled, the user should not be able to start calibrating their labware or running their protocol until all pipettes used in the protocol have pipette offset calibrations. If they don't, disable those tabs and display the same kind of warning you get if a pipette isn't attached.

## Testing
- Make sure that if you don't have the cal overhaul enabled you never see this (a good way to test this is to enable cal overhaul, make sure you do see it, and then disable cal overhaul and make sure it goes away)
- Test that having a pipette that _isn't_ used in the protocol and doesn't have a calibration doesn't block you


Closes #6627 