### PR TITLE
feat(api): Add calibration status to all of the calibration data models

### DIFF
--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -2,12 +2,13 @@ import typing
 from typing_extensions import TypedDict
 from datetime import datetime
 
-from .types import AttitudeMatrix, PipetteOffset, SourceType
+from .types import AttitudeMatrix, PipetteOffset, SourceType, CalibrationStatus
 
 
 class TipLengthCalibration(TypedDict):
     tipLength: float
     lastModified: datetime
+    status: CalibrationStatus
 
 
 class ModuleDict(TypedDict):
@@ -50,6 +51,7 @@ class PipetteCalibrationData(TypedDict):
     uri: str
     last_modified: datetime
     source: SourceType
+    status: CalibrationStatus
 
 
 class DeckCalibrationData(TypedDict):
@@ -58,6 +60,7 @@ class DeckCalibrationData(TypedDict):
     source: SourceType
     pipette_calibrated_with: typing.Optional[str]
     tiprack: typing.Optional[str]
+    status: CalibrationStatus
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -2,13 +2,19 @@ import typing
 from typing_extensions import TypedDict
 from datetime import datetime
 
-from .types import AttitudeMatrix, PipetteOffset, SourceType, CalibrationStatus
+from .types import AttitudeMatrix, PipetteOffset, SourceType
+
+
+class CalibrationStatusDict(TypedDict):
+    markedBad: bool
+    source: typing.Optional[str]
+    markedAt: typing.Optional[datetime]
 
 
 class TipLengthCalibration(TypedDict):
     tipLength: float
     lastModified: datetime
-    status: CalibrationStatus
+    status: CalibrationStatusDict
 
 
 class ModuleDict(TypedDict):
@@ -51,7 +57,7 @@ class PipetteCalibrationData(TypedDict):
     uri: str
     last_modified: datetime
     source: SourceType
-    status: CalibrationStatus
+    status: CalibrationStatusDict
 
 
 class DeckCalibrationData(TypedDict):
@@ -60,7 +66,7 @@ class DeckCalibrationData(TypedDict):
     source: SourceType
     pipette_calibrated_with: typing.Optional[str]
     tiprack: typing.Optional[str]
-    status: CalibrationStatus
+    status: CalibrationStatusDict
 
 
 PipTipLengthCalibration = typing.Dict[str, TipLengthCalibration]

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -28,8 +28,7 @@ def _format_calibration_type(
     # based on the loaded pips + labware
     return local_types.CalibrationTypes(
             offset=offset,
-            tip_length=local_types.TipLengthData()
-        )
+            tip_length=local_types.TipLengthData())
 
 
 def _format_parent(
@@ -147,6 +146,14 @@ def _get_calibration_source(data: typing.Dict) -> local_types.SourceType:
         return local_types.SourceType[data['source']]
 
 
+def _get_calibration_status(
+        data: typing.Dict) -> local_types.CalibrationStatus:
+    if 'status' not in data.keys():
+        return local_types.CalibrationStatus()
+    else:
+        return local_types.CalibrationStatus(**data['status'])
+
+
 def get_robot_deck_attitude() \
             -> typing.Optional[local_types.DeckCalibration]:
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
@@ -159,7 +166,8 @@ def get_robot_deck_attitude() \
             source=_get_calibration_source(data),
             pipette_calibrated_with=data['pipette_calibrated_with'],
             tiprack=data['tiprack'],
-            last_modified=data['last_modified'])
+            last_modified=data['last_modified'],
+            status=_get_calibration_status(data))
     else:
         return None
 
@@ -178,7 +186,8 @@ def get_pipette_offset(
             source=_get_calibration_source(data),
             tiprack=data['tiprack'],
             uri=data['uri'],
-            last_modified=data['last_modified'])
+            last_modified=data['last_modified'],
+            status=_get_calibration_status(data))
     else:
         return None
 
@@ -212,5 +221,6 @@ def get_all_pipette_offset_calibrations() \
                         tiprack=data['tiprack'],
                         uri=data['uri'],
                         last_modified=data['last_modified'],
-                        source=_get_calibration_source(data)))
+                        source=_get_calibration_source(data),
+                        status=_get_calibration_status(data)))
     return all_calibrations

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -4,15 +4,37 @@ functions
 This module has functions that you can import to save robot or
 labware calibration to its designated file location.
 """
-import typing
 import json
+from typing import Union, List, Dict, TYPE_CHECKING
+from dataclasses import is_dataclass, asdict
+
 
 from hashlib import sha256
 
 from . import types as local_types
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+
+DictionaryFactoryType = Union[List, Dict]
+
+
+def dict_filter_none(data: DictionaryFactoryType) -> Dict:
+    """
+    Helper function to filter out None keys from a dataclass
+    before saving to file.
+    """
+    return dict(item for item in data if item[1] is not None)
+
+
+def convert_to_dict(obj) -> Dict:
+    # The correct way to type this is described here:
+    # https://github.com/python/mypy/issues/6568
+    # Unfortnately, since it's not currently supported I have an
+    # assert check instead.
+    assert is_dataclass(obj), 'This function is intended for dataclasses only'
+    return asdict(obj, dict_factory=dict_filter_none)
 
 
 def hash_labware_def(labware_def: 'LabwareDefinition') -> str:
@@ -49,7 +71,7 @@ def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
 
 
 def uri_from_details(namespace: str, load_name: str,
-                     version: typing.Union[str, int],
+                     version: Union[str, int],
                      delimiter='/') -> str:
     """ Build a labware URI from its details.
 

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -124,7 +124,8 @@ def create_tip_length_data(
 
     tip_length_data: 'TipLengthCalibration' = {
         'tipLength': length,
-        'lastModified': utc_now()
+        'lastModified': utc_now(),
+        'status': local_types.CalibrationStatus()
     }
 
     data = {labware_hash + parent: tip_length_data}
@@ -201,6 +202,7 @@ def save_robot_deck_attitude(
         'last_modified': utc_now(),
         'tiprack': lw_hash,
         'source': local_types.SourceType.user,
+        'status': local_types.CalibrationStatus()
     }
     io.save_to_file(gantry_path, gantry_dict)
 
@@ -236,6 +238,7 @@ def save_pipette_calibration(
         'uri': tiprack_uri,
         'last_modified': utc_now(),
         'source': local_types.SourceType.user,
+        'status': local_types.CalibrationStatus()
     }
     io.save_to_file(offset_path, offset_dict)
     _add_to_pipette_offset_index_file(pip_id, mount)

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -17,6 +17,7 @@ class SourceType(str, Enum):
     default = "default"
     factory = "factory"
     user = "user"
+    calibration_check = "calibration_check"
     unknown = "unknown"
 
 

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -25,6 +25,13 @@ class TipLengthCalNotFound(Exception):
 
 
 @dataclass
+class CalibrationStatus:
+    markedBad: bool = False
+    source: typing.Optional[SourceType] = None
+    markedAt: typing.Optional[datetime] = None
+
+
+@dataclass
 class UriDetails:
     namespace: str
     load_name: str
@@ -91,6 +98,7 @@ class CalibrationInformation:
 class DeckCalibration:
     attitude: AttitudeMatrix
     source: SourceType
+    status: CalibrationStatus
     last_modified: typing.Optional[datetime] = None
     pipette_calibrated_with: typing.Optional[str] = None
     tiprack: typing.Optional[str] = None
@@ -103,6 +111,7 @@ class PipetteOffsetByPipetteMount:
     """
     offset: PipetteOffset
     source: SourceType
+    status: CalibrationStatus
     tiprack: typing.Optional[str] = None
     uri: typing.Optional[str] = None
     last_modified: typing.Optional[datetime] = None
@@ -120,3 +129,4 @@ class PipetteOffsetCalibration:
     uri: str
     last_modified: datetime
     source: SourceType
+    status: CalibrationStatus

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -113,7 +113,8 @@ def load_attitude_matrix() -> types.DeckCalibration:
         # load default if deck calibration data do not exist
         return types.DeckCalibration(
             attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
-            source=types.SourceType.default)
+            source=types.SourceType.default,
+            status=types.CalibrationStatus())
 
 
 def load_pipette_offset(
@@ -122,7 +123,8 @@ def load_pipette_offset(
     # load default if pipette offset data do not exist
     pip_cal_obj = types.PipetteOffsetByPipetteMount(
         offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
-        source=types.SourceType.default)
+        source=types.SourceType.default,
+        status=types.CalibrationStatus())
     if pip_id:
         pip_offset_data = get.get_pipette_offset(pip_id, mount)
         if pip_offset_data:

--- a/api/tests/opentrons/hardware_control/test_api_helpers.py
+++ b/api/tests/opentrons/hardware_control/test_api_helpers.py
@@ -1,4 +1,5 @@
-from opentrons.calibration_storage.types import DeckCalibration, SourceType
+from opentrons.calibration_storage.types import (
+    DeckCalibration, SourceType, CalibrationStatus)
 from opentrons.hardware_control.util import DeckTransformState
 from opentrons.hardware_control.robot_calibration import RobotCalibration
 
@@ -38,7 +39,8 @@ async def test_validating_attitude(hardware, use_new_calibration):
     deck_cal = DeckCalibration(
         attitude=inrange_matrix,
         last_modified='sometime',
-        source=SourceType.user)
+        source=SourceType.user,
+        status=CalibrationStatus())
 
     hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
 

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -34,7 +34,8 @@ def test_save_calibration(ot_config_tempdir):
         'pipette_calibrated_with': pip_id,
         'last_modified': None,
         'tiprack': lw_hash,
-        'source': 'user'
+        'source': 'user',
+        'status': {'markedBad': False},
     }
     robot_calibration.save_attitude_matrix(e, a, pip_id, lw_hash)
     data = io.read_cal_file(pathway)

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -3,7 +3,8 @@ import pytest
 from opentrons import types
 from opentrons import hardware_control as hc
 from opentrons.config import robot_configs
-from opentrons.calibration_storage.types import DeckCalibration, SourceType
+from opentrons.calibration_storage.types import (
+    DeckCalibration, SourceType, CalibrationStatus)
 from opentrons.hardware_control.types import (
     Axis, CriticalPoint, OutOfBoundsMove, MotionChecks)
 from opentrons.hardware_control.robot_calibration import RobotCalibration
@@ -330,7 +331,9 @@ async def test_attitude_deck_cal_applied(
     monkeypatch.setattr(hardware_api._backend, 'move', mock_move)
     deck_cal = RobotCalibration(
         deck_calibration=DeckCalibration(
-            attitude=new_gantry_cal, source=SourceType.user))
+            attitude=new_gantry_cal,
+            source=SourceType.user,
+            status=CalibrationStatus()))
     hardware_api.set_robot_calibration(deck_cal)
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -6,7 +6,8 @@ from opentrons.config import pipette_config
 
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(
     offset=[0, 0, 0],
-    source=cal_types.SourceType.user)
+    source=cal_types.SourceType.user,
+    status=cal_types.CalibrationStatus())
 
 
 def test_tip_tracking():
@@ -84,7 +85,8 @@ def test_critical_points_pipette_offset(model, use_new_calibration):
     # set pipette offset calibration
     pip_cal = cal_types.PipetteOffsetByPipetteMount(
         offset=[10, 10, 10],
-        source=cal_types.SourceType.user)
+        source=cal_types.SourceType.user,
+        status=cal_types.CalibrationStatus())
     pip = pipette.Pipette(loaded,
                           {'single': [0, 0, 0], 'multi': [0, 0, 0]},
                           pip_cal,

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -157,7 +157,8 @@ def test_create_tip_length_calibration_data(monkeypatch):
     expected_data = {
         MOCK_HASH: {
             'tipLength': tip_length,
-            'lastModified': fake_time
+            'lastModified': fake_time,
+            'status': {'markedBad': False},
         }
     }
     result = modify.create_tip_length_data(

--- a/robot-server/robot_server/service/legacy/models/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/models/deck_calibration.py
@@ -201,6 +201,8 @@ class DeckCalibrationData(BaseModel):
     source: SourceType = \
         Field(None,
               description="The calibration source")
+    status: CalibrationStatus = \
+        Field(None, description="The status of this calibration")
 
 
 class DeckCalibrationStatus(BaseModel):

--- a/robot-server/robot_server/service/legacy/models/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/models/deck_calibration.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from opentrons.deck_calibration.endpoints import CalibrationCommand, \
     DeckCalibrationPoint
 from robot_server.service.legacy.models.control import Mount
+from robot_server.service.shared_models import calibration as cal_model
 
 
 class DeckStart(BaseModel):
@@ -201,8 +202,9 @@ class DeckCalibrationData(BaseModel):
     source: SourceType = \
         Field(None,
               description="The calibration source")
-    status: CalibrationStatus = \
-        Field(None, description="The status of this calibration")
+    status: cal_model.CalibrationStatus = \
+        Field(None, description="The status of this calibration as determined"
+                                "by a user performing calibration check.")
 
 
 class DeckCalibrationStatus(BaseModel):

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -4,9 +4,10 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from opentrons.calibration_storage.types import SourceType, CalibrationStatus
+from opentrons.calibration_storage.types import SourceType
 from robot_server.service.json_api import ResponseModel
 from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.shared_models import calibration as cal_model
 
 OffsetVector = typing.Tuple[float, float, float]
 
@@ -40,7 +41,7 @@ class PipetteOffsetCalibration(BaseModel):
               description="When this calibration was last modified")
     source: SourceType = \
         Field(..., description="The calibration source")
-    status: CalibrationStatus = \
+    status: cal_model.CalibrationStatus = \
         Field(..., description="The status of this calibration")
 
 

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from opentrons.calibration_storage.types import SourceType
+from opentrons.calibration_storage.types import SourceType, CalibrationStatus
 from robot_server.service.json_api import ResponseModel
 from robot_server.service.json_api.response import MultiResponseModel
 
@@ -40,6 +40,8 @@ class PipetteOffsetCalibration(BaseModel):
               description="When this calibration was last modified")
     source: SourceType = \
         Field(..., description="The calibration source")
+    status: CalibrationStatus = \
+        Field(..., description="The status of this calibration")
 
 
 MultipleCalibrationsResponse = MultiResponseModel[

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -5,11 +5,13 @@ from opentrons import types as ot_types
 from opentrons.calibration_storage import (
     types as cal_types,
     get as get_cal,
+    helpers,
     delete)
 
 from robot_server.service.pipette_offset import models as pip_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.shared_models import calibration as cal_model
 
 router = APIRouter()
 
@@ -17,6 +19,8 @@ router = APIRouter()
 def _format_calibration(
     calibration: cal_types.PipetteOffsetCalibration
 ) -> ResponseDataModel[pip_models.PipetteOffsetCalibration]:
+    status = cal_model.CalibrationStatus(
+        **helpers.convert_to_dict(calibration.status))
     formatted_cal = pip_models.PipetteOffsetCalibration(
         pipette=calibration.pipette,
         mount=calibration.mount,
@@ -24,7 +28,7 @@ def _format_calibration(
         tiprack=calibration.tiprack,
         lastModified=calibration.last_modified,
         source=calibration.source,
-        status=calibration.status)
+        status=status)
 
     return ResponseDataModel.create(
         attributes=formatted_cal,

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -23,7 +23,8 @@ def _format_calibration(
         offset=calibration.offset,
         tiprack=calibration.tiprack,
         lastModified=calibration.last_modified,
-        source=calibration.source)
+        source=calibration.source,
+        status=calibration.status)
 
     return ResponseDataModel.create(
         attributes=formatted_cal,

--- a/robot-server/robot_server/service/shared_models/calibration.py
+++ b/robot-server/robot_server/service/shared_models/calibration.py
@@ -1,0 +1,18 @@
+import typing
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+from opentrons.calibration_storage.types import SourceType
+
+
+class CalibrationStatus(BaseModel):
+    """
+    A model describing whether a calibration on the robot is valid
+    or not. This should be used for all calibration data models.
+    """
+    markedBad: bool = \
+        Field(..., description="Whether a calibration is invalid or not")
+    source: typing.Optional[SourceType] = \
+        Field(None, description="The source that marked the calibration bad.")
+    markedAt: typing.Optional[datetime] = \
+        Field(None, description="The time the calibration was marked bad.")

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -228,6 +228,7 @@ stages:
             pipetteCalibratedWith: null
             tiprack: null
             source: null
+            status: null
         instrumentCalibration:
           right: &inst
             single: &vector

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -14,7 +14,8 @@ from robot_server.robot.calibration.deck.constants import \
 
 PIP_OFFSET = cal_types.PipetteOffsetByPipetteMount(
         offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
-        source=cal_types.SourceType.user)
+        source=cal_types.SourceType.user,
+        status=cal_types.CalibrationStatus())
 
 
 @pytest.fixture

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -12,8 +12,13 @@ def test_access_pipette_offset_calibration(
         'mount': 'left',
         'tiprack': 'hash',
         'lastModified': None,
-        'source': 'user'
+        'source': 'user',
+        'status': {
+            'markedAt': None, 'markedBad': False, 'source': None}
     }
+    # Note, status should only have markedBad key, but according
+    # to this thread https://github.com/samuelcolvin/pydantic/issues/1223
+    # it's not easy to specify in the model itself
 
     resp = api_client.get(
         f'/calibration/pipette_offset?mount={MOUNT}&pipette_id={PIPETTE_ID}')


### PR DESCRIPTION
# Overview

Closes #6601. This PR adds a new status key to all calibration models which indicates whether this calibration is valid or not.

# Changelog
- Save all calibrations with a status key which automatically sets the value to `{markedBad: False}`
- Load calibrations, checking whether there is a status key, and loading accordingly
- Add a helper function to filter out unset values in dataclasses

# Review requests

Models OK? 

# Risk assessment

Low, adding a new key to the calibration models.
