### PR TITLE
refactor(app): robot settings calibration card

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -1,0 +1,92 @@
+// @flow
+// calibration panel with various calibration-related controls and info
+
+import * as React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import type { Dispatch, State } from '../../types'
+import * as Calibration from '../../calibration'
+import { CONNECTABLE } from '../../discovery'
+import type { ViewableRobot } from '../../discovery/types'
+import { selectors as robotSelectors } from '../../robot'
+
+import { useInterval, Card } from '@opentrons/components'
+
+import {
+  DECK_CAL_STATUS_POLL_INTERVAL,
+  DISABLED_CANNOT_CONNECT,
+  DISABLED_CONNECT_TO_ROBOT,
+  DISABLED_PROTOCOL_IS_RUNNING,
+} from './constants'
+import { DeckCalibrationControl } from './DeckCalibrationControl'
+import { CheckCalibrationControl } from './CheckCalibrationControl'
+
+type Props = {|
+  robot: ViewableRobot,
+|}
+
+const TITLE = 'Robot Calibration'
+
+// TODO: Change these two
+const BAD_DECK_CALIBRATION =
+  'Bad deck calibration detected. Please perform a full deck calibration.'
+const NO_DECK_CALIBRATION = 'Please perform a full deck calibration.'
+
+export function CalibrationCard(props: Props): React.Node {
+  const { robot } = props
+  const { name: robotName, status } = robot
+  const notConnectable = status !== CONNECTABLE
+
+  const dispatch = useDispatch<Dispatch>()
+  useInterval(
+    () => dispatch(Calibration.fetchCalibrationStatus(robotName)),
+    DECK_CAL_STATUS_POLL_INTERVAL,
+    true
+  )
+
+  const isRunning = useSelector(robotSelectors.getIsRunning)
+  const deckCalStatus = useSelector((state: State) => {
+    return Calibration.getDeckCalibrationStatus(state, robotName)
+  })
+  const deckCalData = useSelector((state: State) => {
+    return Calibration.getDeckCalibrationData(state, robotName)
+  })
+
+  let buttonDisabledReason = null
+  if (notConnectable) {
+    buttonDisabledReason = DISABLED_CANNOT_CONNECT
+  } else if (!robot.connected) {
+    buttonDisabledReason = DISABLED_CONNECT_TO_ROBOT
+  } else if (isRunning) {
+    buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
+  }
+
+  let calCheckDisabledReason = buttonDisabledReason
+  if (
+    deckCalStatus === Calibration.DECK_CAL_STATUS_BAD_CALIBRATION ||
+    deckCalStatus === Calibration.DECK_CAL_STATUS_SINGULARITY
+  ) {
+    calCheckDisabledReason = BAD_DECK_CALIBRATION
+  } else if (deckCalStatus === Calibration.DECK_CAL_STATUS_IDENTITY) {
+    calCheckDisabledReason = NO_DECK_CALIBRATION
+  }
+
+  const buttonDisabled = Boolean(buttonDisabledReason)
+  return (
+    <Card title={TITLE}>
+      <DeckCalibrationControl
+        robotName={robotName}
+        buttonDisabled={buttonDisabled}
+        deckCalStatus={deckCalStatus}
+        deckCalData={deckCalData}
+        startLegacyDeckCalibration={() => {}}
+      />
+      {deckCalStatus !== null && (
+        <CheckCalibrationControl
+          robotName={robotName}
+          disabledReason={calCheckDisabledReason}
+        />
+      )}
+    </Card>
+  )
+}

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -23,6 +23,7 @@ import * as Calibration from '../../calibration'
 import { restartRobot } from '../../robot-admin'
 import { selectors as robotSelectors } from '../../robot'
 import { CONNECTABLE } from '../../discovery'
+import { getFeatureFlags } from '../../config'
 
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
@@ -65,6 +66,7 @@ export function ControlsCard(props: Props): React.Node {
       dispatch(push(calibrateDeckUrl))
     )
   }
+  const ff = useSelector(getFeatureFlags)
 
   React.useEffect(() => {
     dispatch(fetchLights(robotName))
@@ -99,13 +101,15 @@ export function ControlsCard(props: Props): React.Node {
 
   return (
     <Card title={TITLE}>
-      <DeckCalibrationControl
-        robotName={robotName}
-        buttonDisabled={buttonDisabled}
-        deckCalStatus={deckCalStatus}
-        deckCalData={deckCalData}
-        startLegacyDeckCalibration={startLegacyDeckCalibration}
-      />
+      {!ff.enableCalibrationOverhaul && (
+        <DeckCalibrationControl
+          robotName={robotName}
+          buttonDisabled={buttonDisabled}
+          deckCalStatus={deckCalStatus}
+          deckCalData={deckCalData}
+          startLegacyDeckCalibration={startLegacyDeckCalibration}
+        />
+      )}
       <LabeledButton
         label="Home all axes"
         buttonProps={{
@@ -135,7 +139,7 @@ export function ControlsCard(props: Props): React.Node {
         <p>Control lights on deck.</p>
       </LabeledToggle>
 
-      {deckCalStatus !== null && (
+      {!ff.enableCalibrationOverhaul && deckCalStatus !== null && (
         <CheckCalibrationControl
           robotName={robotName}
           disabledReason={calCheckDisabledReason}

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -24,6 +24,12 @@ import { restartRobot } from '../../robot-admin'
 import { selectors as robotSelectors } from '../../robot'
 import { CONNECTABLE } from '../../discovery'
 import { getFeatureFlags } from '../../config'
+import {
+  DECK_CAL_STATUS_POLL_INTERVAL,
+  DISABLED_CANNOT_CONNECT,
+  DISABLED_CONNECT_TO_ROBOT,
+  DISABLED_PROTOCOL_IS_RUNNING,
+} from './constants'
 
 import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
@@ -38,14 +44,9 @@ type Props = {|
 
 const TITLE = 'Robot Controls'
 
-const CANNOT_CONNECT = 'Cannot connect to robot'
-const CONNECT_TO_ROBOT = 'Connect to robot to control'
-const PROTOCOL_IS_RUNNING = 'Protocol is running'
 const BAD_DECK_CALIBRATION =
   'Bad deck calibration detected. Please perform a full deck calibration.'
 const NO_DECK_CALIBRATION = 'Please perform a full deck calibration.'
-
-const DECK_CAL_STATUS_POLL_INTERVAL = 10000
 
 export function ControlsCard(props: Props): React.Node {
   const dispatch = useDispatch<Dispatch>()
@@ -73,18 +74,20 @@ export function ControlsCard(props: Props): React.Node {
   }, [dispatch, robotName])
 
   useInterval(
-    () => dispatch(Calibration.fetchCalibrationStatus(robotName)),
+    () =>
+      !ff.enableCalibrationOverhaul &&
+      dispatch(Calibration.fetchCalibrationStatus(robotName)),
     DECK_CAL_STATUS_POLL_INTERVAL,
     true
   )
 
   let buttonDisabledReason = null
   if (notConnectable) {
-    buttonDisabledReason = CANNOT_CONNECT
+    buttonDisabledReason = DISABLED_CANNOT_CONNECT
   } else if (!robot.connected) {
-    buttonDisabledReason = CONNECT_TO_ROBOT
+    buttonDisabledReason = DISABLED_CONNECT_TO_ROBOT
   } else if (isRunning) {
-    buttonDisabledReason = PROTOCOL_IS_RUNNING
+    buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
   }
 
   let calCheckDisabledReason = buttonDisabledReason

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -1,17 +1,21 @@
 // @flow
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import { format } from 'date-fns'
 import {
   Text,
   SecondaryBtn,
   BORDER_SOLID_LIGHT,
   SPACING_2,
+  SPACING_4,
   useConditionalConfirm,
+  FONT_STYLE_ITALIC,
 } from '@opentrons/components'
 
 import { getFeatureFlags } from '../../config'
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
+import { DECK_CAL_STATUS_IDENTITY } from '../../calibration'
 
 import type { State } from '../../types'
 import type {
@@ -35,6 +39,23 @@ type Props = {|
   deckCalData: DeckCalibrationData | null,
   startLegacyDeckCalibration: () => void,
 |}
+
+const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
+const LAST_CALIBRATED = 'Last calibrated: '
+
+const buildDeckLastCalibrated: (
+  data: DeckCalibrationData,
+  status: DeckCalibrationStatus
+) => string = (data, status) => {
+  if (status === DECK_CAL_STATUS_IDENTITY) {
+    return DECK_NEVER_CALIBRATED
+  }
+  const datestring =
+    typeof data.lastModified === 'string'
+      ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
+      : 'unknown'
+  return `${LAST_CALIBRATED} ${datestring}`
+}
 
 // deck calibration commands for which the full page spinner should not appear
 const spinnerCommandBlockList: Array<SessionCommandString> = [
@@ -168,7 +189,14 @@ export function DeckCalibrationControl(props: Props): React.Node {
           deckCalibrationStatus={deckCalStatus}
           marginTop={SPACING_2}
         />
-        {!ff.enableCalibrationOverhaul && (
+        {ff.enableCalibrationOverhaul ? (
+          deckCalData &&
+          deckCalStatus && (
+            <Text marginTop={SPACING_4} fontStyle={FONT_STYLE_ITALIC}>
+              {buildDeckLastCalibrated(deckCalData, deckCalStatus)}
+            </Text>
+          )
+        ) : (
           <DeckCalibrationDownload
             deckCalibrationStatus={deckCalStatus}
             deckCalibrationData={deckCalData}

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -168,12 +168,14 @@ export function DeckCalibrationControl(props: Props): React.Node {
           deckCalibrationStatus={deckCalStatus}
           marginTop={SPACING_2}
         />
-        <DeckCalibrationDownload
-          deckCalibrationStatus={deckCalStatus}
-          deckCalibrationData={deckCalData}
-          robotName={robotName}
-          marginTop={SPACING_2}
-        />
+        {!ff.enableCalibrationOverhaul && (
+          <DeckCalibrationDownload
+            deckCalibrationStatus={deckCalStatus}
+            deckCalibrationData={deckCalData}
+            robotName={robotName}
+            marginTop={SPACING_2}
+          />
+        )}
       </TitledControl>
       {showConfirmStart && (
         <Portal>

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -1,0 +1,202 @@
+// @flow
+
+import * as React from 'react'
+import { mountWithStore } from '@opentrons/components/__utils__'
+
+import * as Calibration from '../../../calibration'
+import * as Config from '../../../config'
+import * as RobotSelectors from '../../../robot/selectors'
+
+import { CalibrationCard } from '../CalibrationCard'
+import { CheckCalibrationControl } from '../CheckCalibrationControl'
+import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
+
+import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
+
+import type { State, Action } from '../../../types'
+import type { ViewableRobot } from '../../../discovery/types'
+
+jest.mock('../../../robot/selectors')
+jest.mock('../../../config/selectors')
+jest.mock('../../../calibration/selectors')
+jest.mock('../../../sessions/selectors')
+
+jest.mock('../CheckCalibrationControl', () => ({
+  CheckCalibrationControl: () => <></>,
+}))
+
+const MOCK_STATE: State = ({ mockState: true }: any)
+
+const mockGetIsRunning: JestMockFn<
+  [State],
+  $Call<typeof RobotSelectors.getIsRunning, State>
+> = RobotSelectors.getIsRunning
+
+const mockUnconnectableRobot: ViewableRobot = ({
+  name: 'robot-name',
+  connected: true,
+  status: UNREACHABLE,
+}: any)
+
+const mockRobot: ViewableRobot = ({
+  name: 'robot-name',
+  connected: true,
+  status: CONNECTABLE,
+}: any)
+
+const getFeatureFlags: JestMockFn<
+  [State],
+  $Call<typeof Config.getFeatureFlags, State>
+> = Config.getFeatureFlags
+
+const getDeckCalibrationStatus: JestMockFn<
+  [State, string],
+  $Call<typeof Calibration.getDeckCalibrationStatus, State, string>
+> = Calibration.getDeckCalibrationStatus
+const getDeckCalButton = wrapper =>
+  wrapper
+    .find('TitledControl[title="Calibrate deck"]')
+    .find('button')
+    .filter({ children: 'Calibrate' })
+
+const getCheckCalibrationControl = wrapper =>
+  wrapper.find(CheckCalibrationControl)
+
+describe('CalibrationCard', () => {
+  const render = (robot: ViewableRobot = mockRobot) => {
+    return mountWithStore<_, State, Action>(<CalibrationCard robot={robot} />, {
+      initialState: MOCK_STATE,
+    })
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    getDeckCalibrationStatus.mockReturnValue(Calibration.DECK_CAL_STATUS_OK)
+    getFeatureFlags.mockReturnValue({
+      enableCalibrationOverhaul: true,
+      allPipetteConfig: false,
+      enableBundleUpload: false,
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.resetAllMocks()
+    jest.useRealTimers()
+  })
+
+  it('calls fetchCalibrationStatus on mount and on a 10s interval', () => {
+    const { store } = render()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Calibration.fetchCalibrationStatus(mockRobot.name)
+    )
+    store.dispatch.mockReset()
+    jest.advanceTimersByTime(20000)
+    expect(store.dispatch).toHaveBeenCalledTimes(2)
+    expect(store.dispatch).toHaveBeenNthCalledWith(
+      1,
+      Calibration.fetchCalibrationStatus(mockRobot.name)
+    )
+    expect(store.dispatch).toHaveBeenNthCalledWith(
+      2,
+      Calibration.fetchCalibrationStatus(mockRobot.name)
+    )
+  })
+
+  it('DC and check cal buttons enabled if connected and not running', () => {
+    mockGetIsRunning.mockReturnValue(false)
+
+    const { wrapper } = render()
+
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(false)
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      null
+    )
+  })
+
+  it('DC and check cal buttons disabled if not connectable', () => {
+    const { wrapper } = render(mockUnconnectableRobot)
+
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Cannot connect to robot'
+    )
+  })
+
+  it('DC and check cal buttons disabled if not connected', () => {
+    const mockRobotNotConnected: ViewableRobot = ({
+      name: 'robot-name',
+      connected: false,
+      status: CONNECTABLE,
+    }: any)
+
+    const { wrapper } = render(mockRobotNotConnected)
+
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Connect to robot to control'
+    )
+  })
+
+  it('DC and check cal buttons disabled if protocol running', () => {
+    mockGetIsRunning.mockReturnValue(true)
+
+    const { wrapper } = render()
+
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Protocol is running'
+    )
+  })
+
+  it('does not render check cal button if GET /calibration/status has not responded', () => {
+    getDeckCalibrationStatus.mockReturnValue(null)
+
+    const { wrapper } = render()
+    expect(wrapper.exists(CheckCalibrationControl)).toBe(false)
+  })
+
+  it('disables check cal button if deck calibration is bad', () => {
+    getDeckCalibrationStatus.mockImplementation((state, rName) => {
+      expect(state).toEqual(MOCK_STATE)
+      expect(rName).toEqual(mockRobot.name)
+      return Calibration.DECK_CAL_STATUS_BAD_CALIBRATION
+    })
+
+    const { wrapper } = render()
+
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Bad deck calibration detected. Please perform a full deck calibration.'
+    )
+
+    getDeckCalibrationStatus.mockReturnValue(
+      Calibration.DECK_CAL_STATUS_SINGULARITY
+    )
+    wrapper.setProps({})
+    wrapper.update()
+
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Bad deck calibration detected. Please perform a full deck calibration.'
+    )
+
+    getDeckCalibrationStatus.mockReturnValue(
+      Calibration.DECK_CAL_STATUS_IDENTITY
+    )
+    wrapper.setProps({})
+    wrapper.update()
+
+    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
+      'Please perform a full deck calibration.'
+    )
+  })
+
+  it('DeckCalibrationWarning component renders if deck calibration is bad', () => {
+    const { wrapper } = render()
+
+    // check that the deck calibration warning component is not null
+    // TODO(lc, 2020-06-18): Mock out the new transform status such that
+    // this should evaluate to true.
+    expect(wrapper.exists(DeckCalibrationWarning)).toBe(true)
+  })
+})

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -96,7 +96,11 @@ describe('ControlsCard', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     getDeckCalibrationStatus.mockReturnValue(Calibration.DECK_CAL_STATUS_OK)
-    getFeatureFlags.mockReturnValue({})
+    getFeatureFlags.mockReturnValue({
+      enableCalibrationOverhaul: false,
+      allPipetteConfig: false,
+      enableBundleUpload: false,
+    })
   })
 
   afterEach(() => {

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -10,6 +10,7 @@ import * as RobotSelectors from '../../../robot/selectors'
 
 import { ControlsCard } from '../ControlsCard'
 import { CheckCalibrationControl } from '../CheckCalibrationControl'
+import { DeckCalibrationControl } from '../DeckCalibrationControl'
 import { LabeledToggle, LabeledButton } from '@opentrons/components'
 import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
 import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
@@ -134,6 +135,18 @@ describe('ControlsCard', () => {
       2,
       Calibration.fetchCalibrationStatus(mockRobot.name)
     )
+  })
+
+  it('does not call fetchCalibrationStatus if enableCalOverhaul is on', () => {
+    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    const { store } = render()
+
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      Calibration.fetchCalibrationStatus(mockRobot.name)
+    )
+    store.dispatch.mockReset()
+    jest.advanceTimersByTime(20000)
+    expect(store.dispatch).not.toHaveBeenCalled()
   })
 
   it('calls updateLights with toggle on button click', () => {
@@ -270,5 +283,26 @@ describe('ControlsCard', () => {
     // TODO(lc, 2020-06-18): Mock out the new transform status such that
     // this should evaluate to true.
     expect(wrapper.exists(DeckCalibrationWarning)).toBe(true)
+  })
+
+  it('DeckCalibrationWarning component does not render if cal is bad but ff is on', () => {
+    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    const { wrapper } = render()
+
+    expect(wrapper.exists(DeckCalibrationWarning)).toBe(false)
+  })
+
+  it('DeckCalibrationControl does not render if ff is on', () => {
+    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    const { wrapper } = render()
+
+    expect(wrapper.exists(DeckCalibrationControl)).toBe(false)
+  })
+
+  it('CheckCalibrationControl does not render if ff is on', () => {
+    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+    const { wrapper } = render()
+
+    expect(wrapper.exists(CheckCalibrationControl)).toBe(false)
   })
 })

--- a/app/src/components/RobotSettings/constants.js
+++ b/app/src/components/RobotSettings/constants.js
@@ -1,0 +1,7 @@
+// @flow
+
+export const DECK_CAL_STATUS_POLL_INTERVAL = 10000
+
+export const DISABLED_CANNOT_CONNECT = 'Cannot connect to robot'
+export const DISABLED_CONNECT_TO_ROBOT = 'Connect to robot to control'
+export const DISABLED_PROTOCOL_IS_RUNNING = 'Protocol is running'

--- a/app/src/components/RobotSettings/index.js
+++ b/app/src/components/RobotSettings/index.js
@@ -1,6 +1,7 @@
 // @flow
 // robot status panel with connect button
 import * as React from 'react'
+import { useSelector } from 'react-redux'
 
 import { CardContainer, CardRow } from '../layout'
 import { StatusCard } from './StatusCard'
@@ -8,7 +9,9 @@ import { InformationCard } from './InformationCard'
 import { ControlsCard } from './ControlsCard'
 import { ConnectionCard } from './ConnectionCard'
 import { AdvancedSettingsCard } from './AdvancedSettingsCard'
+import { CalibrationCard } from './CalibrationCard'
 import type { ViewableRobot } from '../../discovery/types'
+import { getFeatureFlags } from '../../config'
 
 export { ConnectAlertModal } from './ConnectAlertModal'
 
@@ -24,7 +27,7 @@ export type RobotSettingsProps = {|
 // on the buttons, this is currently limited by the existing LabeledButton component.
 export function RobotSettings(props: RobotSettingsProps): React.Node {
   const { robot, updateUrl, calibrateDeckUrl, resetUrl } = props
-
+  const ff = useSelector(getFeatureFlags)
   return (
     <CardContainer key={robot.name}>
       <CardRow>
@@ -33,6 +36,11 @@ export function RobotSettings(props: RobotSettingsProps): React.Node {
       <CardRow>
         <InformationCard robot={robot} updateUrl={updateUrl} />
       </CardRow>
+      {ff.enableCalibrationOverhaul && (
+        <CardRow>
+          <CalibrationCard robot={robot} />
+        </CardRow>
+      )}
       <CardRow>
         <ControlsCard robot={robot} calibrateDeckUrl={calibrateDeckUrl} />
       </CardRow>


### PR DESCRIPTION
When the calibration overhaul feature flag is selected, display a new Robot Calibration subpage in the robot settings page, which (for now) contains deck calibration and calibration check. Remove these buttons from the RobotControls subpage in this case, and hand the responsibility for things like polling deck calibration status over to the new subpage.

## Risk
Low, since this is under a feature flag

## Testing
- Make sure the buttons work when the ff is on
- Doublecheck that the network requests are still going out (though it's nice and tested and all)

Closes #6611 