### PR TITLE
feat(protocol-designer): add air gap dispense form fields to move liquid form

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react'
-
-import type { StepFieldName } from '../../../../steplist/fieldLevel'
+import { useSelector } from 'react-redux'
+import { selectors as featureFlagSelectors } from '../../../../feature-flags'
 import { i18n } from '../../../../localization'
 
+import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { FocusHandlers } from '../../types'
 
 import {
@@ -30,6 +31,9 @@ const makeAddFieldNamePrefix = (prefix: string) => (
 
 export const SourceDestFields = (props: Props): React.Node => {
   const { className, focusHandlers, prefix } = props
+  const dispenseAirGapEnabled = useSelector(
+    featureFlagSelectors.getEnabledAirGapDispense
+  )
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
 
   const getMixFields = () => (
@@ -123,8 +127,8 @@ export const SourceDestFields = (props: Props): React.Node => {
             />
           </CheckboxRowField>
         )}
-
-        {prefix === 'aspirate' && (
+        {/* (SA 2020/09/30): Remove both of these checks when dispenseAirGapEnabled FF is removed  */}
+        {(prefix === 'aspirate' || dispenseAirGapEnabled) && (
           <CheckboxRowField
             tooltipComponent={i18n.t(
               `tooltip.step_fields.defaults.${addFieldNamePrefix(

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
+import { selectors as featureFlagSelectors } from '../../../../feature-flags'
 import { SourceDestFields } from '../MoveLiquidForm/SourceDestFields'
 import { CheckboxRowField } from '../../fields'
 
@@ -14,6 +15,9 @@ jest.mock('../../utils')
 
 const getUnsavedFormMock: JestMockFn<[BaseState], any> =
   stepFormSelectors.getUnsavedForm
+
+const getEnabledAirGapDispenseMock: JestMockFn<any, any> =
+  featureFlagSelectors.getEnabledAirGapDispense
 
 describe('SourceDestFields', () => {
   let store
@@ -42,27 +46,61 @@ describe('SourceDestFields', () => {
         <SourceDestFields {...props} />
       </Provider>
     )
+  describe('When air gap dispense FF is disabled', () => {
+    beforeEach(() => {
+      getEnabledAirGapDispenseMock.mockReturnValue(false)
+    })
 
-  describe('Aspirate section', () => {
-    it('should render the correct checkboxes', () => {
-      const wrapper = render(props)
-      const checkboxes = wrapper.find(CheckboxRowField)
-      expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
-      expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
-      expect(checkboxes.at(2).prop('name')).toBe('aspirate_delay_checkbox')
-      expect(checkboxes.at(3).prop('name')).toBe('aspirate_touchTip_checkbox')
-      expect(checkboxes.at(4).prop('name')).toBe('aspirate_airGap_checkbox')
+    describe('Aspirate section', () => {
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
+        expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('aspirate_delay_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('aspirate_touchTip_checkbox')
+        expect(checkboxes.at(4).prop('name')).toBe('aspirate_airGap_checkbox')
+      })
+    })
+    describe('Dispense section', () => {
+      it('should render the correct checkboxes', () => {
+        props.prefix = 'dispense'
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('dispense_delay_checkbox')
+        expect(checkboxes.at(1).prop('name')).toBe('dispense_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('dispense_touchTip_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('blowout_checkbox')
+      })
     })
   })
-  describe('Dispense section', () => {
-    it('should render the correct checkboxes', () => {
-      props.prefix = 'dispense'
-      const wrapper = render(props)
-      const checkboxes = wrapper.find(CheckboxRowField)
-      expect(checkboxes.at(0).prop('name')).toBe('dispense_delay_checkbox')
-      expect(checkboxes.at(1).prop('name')).toBe('dispense_mix_checkbox')
-      expect(checkboxes.at(2).prop('name')).toBe('dispense_touchTip_checkbox')
-      expect(checkboxes.at(3).prop('name')).toBe('blowout_checkbox')
+  describe('When air gap dispense FF is enabled', () => {
+    beforeEach(() => {
+      getEnabledAirGapDispenseMock.mockReturnValue(true)
+    })
+
+    describe('Aspirate section', () => {
+      it('should render the correct checkboxes', () => {
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('preWetTip')
+        expect(checkboxes.at(1).prop('name')).toBe('aspirate_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('aspirate_delay_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('aspirate_touchTip_checkbox')
+        expect(checkboxes.at(4).prop('name')).toBe('aspirate_airGap_checkbox')
+      })
+    })
+    describe('Dispense section', () => {
+      it('should render the correct checkboxes', () => {
+        props.prefix = 'dispense'
+        const wrapper = render(props)
+        const checkboxes = wrapper.find(CheckboxRowField)
+        expect(checkboxes.at(0).prop('name')).toBe('dispense_delay_checkbox')
+        expect(checkboxes.at(1).prop('name')).toBe('dispense_mix_checkbox')
+        expect(checkboxes.at(2).prop('name')).toBe('dispense_touchTip_checkbox')
+        expect(checkboxes.at(3).prop('name')).toBe('blowout_checkbox')
+        expect(checkboxes.at(4).prop('name')).toBe('dispense_airGap_checkbox')
+      })
     })
   })
 })

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -16,6 +16,7 @@
   "step_fields": {
     "defaults": {
       "aspirate_airGap_checkbox": "Aspirate air before moving to next well",
+      "dispense_airGap_checkbox": "Aspirate air after dispense, before moving to next destination",
       "aspirate_flowRate": "The speed at which the pipette aspirates",
       "dispense_flowRate": "The speed at which the pipette dispenses",
       "aspirate_mix_checkbox": "Pipette up and down before aspirating",


### PR DESCRIPTION
# Overview

This PR adds air gap dispense form fields to move liquid form (under a FF).

closes #6499

# Changelog
- Add air gap dispense form fields to move liquid form

# Review requests

When dispense air gap FF enabled:
Check air gap checkbox in dispense advanced settings
When checked, air gap should generate a text field for uL
Air gap should have a tooltip matching [the design](https://www.figma.com/file/0dTEbGNsKYgNwKEW6LLfzJ/Airgap-Delay?node-id=104%3A0)

When dispense air gap FF disabled:
No air gap checkbox should appear in dispense advanced settings


# Risk assessment
Low