### PR TITLE
refactor(api): Extract geometry from Well into WellGeometry

### DIFF
--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -296,9 +296,9 @@ class CalibrationManager(RobotBusy):
             container._container.set_calibration(Point(0, 0, 0))
             if ff.calibrate_to_bottom() and not (
                     container._container.is_tiprack):
-                orig = _well0(container._container)._bottom().point
+                orig = _well0(container._container).geometry.bottom()
             else:
-                orig = _well0(container._container)._top().point
+                orig = _well0(container._container).geometry.top()
             delta = here - orig
             labware.save_calibration(container._container, delta)
         else:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -159,6 +159,7 @@ class Well:
         """
         return Location(self._geometry.center(), self)
 
+    @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
         Specifies an arbitrary point in deck coordinates based

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -159,6 +159,31 @@ class Well:
         """
         return Location(self._geometry.center(), self)
 
+    def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
+        """
+        Specifies an arbitrary point in deck coordinates based
+        on percentages of the radius in each axis. For example, to specify the
+        back-right corner of a well at 1/4 of the well depth from the bottom,
+        the call would be `_from_center_cartesian(1, 1, -0.5)`.
+
+        No checks are performed to ensure that the resulting position will be
+        inside of the well.
+
+        :param x: a float in the range [-1.0, 1.0] for a percentage of half of
+            the radius/length in the X axis
+        :param y: a float in the range [-1.0, 1.0] for a percentage of half of
+            the radius/width in the Y axis
+        :param z: a float in the range [-1.0, 1.0] for a percentage of half of
+            the height above/below the center
+
+        :return: a Point representing the specified location in absolute deck
+        coordinates
+        """
+        return self._from_center_cartesian(x, y, z)
+
+    def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
+        return self._geometry.from_center_cartesian(x, y, z)
+
     def __repr__(self):
         return self._display_name
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -180,9 +180,15 @@ class Well:
         :return: a Point representing the specified location in absolute deck
         coordinates
         """
-        return self._from_center_cartesian(x, y, z)
+        return self._geometry.from_center_cartesian(x, y, z)
 
     def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
+        """
+        Private version of from_center_cartesian. Present only for backward
+        compatibility.
+        """
+        MODULE_LOG.warning("This method is deprecated. Please use "
+                           "'from_center_cartesian' instead.")
         return self._geometry.from_center_cartesian(x, y, z)
 
     def __repr__(self):

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -189,7 +189,7 @@ class Well:
         """
         MODULE_LOG.warning("This method is deprecated. Please use "
                            "'from_center_cartesian' instead.")
-        return self._geometry.from_center_cartesian(x, y, z)
+        return self.from_center_cartesian(x, y, z)
 
     def __repr__(self):
         return self._display_name

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -87,11 +87,11 @@ def build_edges(
     # Determine the touch_tip edges/points
     offset_pt = top_types.Point(0, 0, offset)
     edge_list = EdgeList(
-        right=where.geometry.from_center_cartesian(x=radius, y=0, z=1) + offset_pt,  # noqa E501
-        left=where.geometry.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,  # noqa E501
-        center=where.geometry.from_center_cartesian(x=0, y=0, z=1) + offset_pt,  # noqa E501
-        up=where.geometry.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,  # noqa E501
-        down=where.geometry.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt  # noqa E501
+        right=where.from_center_cartesian(x=radius, y=0, z=1) + offset_pt,  # noqa E501
+        left=where.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,  # noqa E501
+        center=where.from_center_cartesian(x=0, y=0, z=1) + offset_pt,  # noqa E501
+        up=where.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,  # noqa E501
+        down=where.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt  # noqa E501
     )
 
     if version < APIVersion(2, 4):

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -87,11 +87,11 @@ def build_edges(
     # Determine the touch_tip edges/points
     offset_pt = top_types.Point(0, 0, offset)
     edge_list = EdgeList(
-        right=where._from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
-        left=where._from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
-        center=where._from_center_cartesian(x=0, y=0, z=1) + offset_pt,
-        up=where._from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-        down=where._from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
+        right=where.geometry.from_center_cartesian(x=radius, y=0, z=1) + offset_pt,  # noqa E501
+        left=where.geometry.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,  # noqa E501
+        center=where.geometry.from_center_cartesian(x=0, y=0, z=1) + offset_pt,  # noqa E501
+        up=where.geometry.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,  # noqa E501
+        down=where.geometry.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt  # noqa E501
     )
 
     if version < APIVersion(2, 4):

--- a/api/src/opentrons/protocols/execution/execute_json_v3.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v3.py
@@ -162,7 +162,7 @@ def _air_gap(instruments: Dict[str, InstrumentContext],
     volume = params['volume']
     _set_flow_rate(pipette, params)
     well = _get_well(loaded_labware, params)
-    offset_from_top = offset_from_bottom - well._depth
+    offset_from_top = offset_from_bottom - well.geometry._depth
 
     # NOTE(IL, 2020-06-25): air_gap API fn is stateful, uses location
     # cache. The JSON atomic command should be stateless. We'll

--- a/api/src/opentrons/protocols/geometry/well_geometry.py
+++ b/api/src/opentrons/protocols/geometry/well_geometry.py
@@ -1,0 +1,96 @@
+from typing import Optional
+
+from opentrons.types import Location, Point
+from opentrons_shared_data.labware.dev_types import WellDefinition
+
+
+class WellGeometry:
+
+    def __init__(self,
+                 well_props: WellDefinition,
+                 parent: Location):
+
+        self._position\
+            = Point(well_props['x'],
+                    well_props['y'],
+                    well_props['z'] + well_props['depth']) + parent.point
+
+        if not parent.labware:
+            raise ValueError("Wells must have a parent")
+        self._parent = parent
+
+        self._shape = well_props['shape']
+        if well_props['shape'] == 'rectangular':
+            self._length: Optional[float] = well_props['xDimension']
+            self._width: Optional[float] = well_props['yDimension']
+            self._diameter: Optional[float] = None
+        elif well_props['shape'] == 'circular':
+            self._length = None
+            self._width = None
+            self._diameter = well_props['diameter']
+        else:
+            raise ValueError(
+                'Shape "{}" is not a supported well shape'.format(
+                    well_props['shape']))
+        self._max_volume = well_props['totalLiquidVolume']
+        self._depth = well_props['depth']
+
+    @property
+    def parent(self) -> Location:
+        return self._parent
+
+    @property
+    def diameter(self) -> Optional[float]:
+        return self._diameter
+
+    def top(self, z: float = 0.0) -> Point:
+        return self._position + Point(0, 0, z)
+
+    def bottom(self, z: float = 0.0) -> Point:
+        top = self.top()
+        bottom_z = top.z - self._depth + z
+        return Point(x=top.x, y=top.y, z=bottom_z)
+
+    def center(self) -> Point:
+        top = self.top()
+        center_z = top.z - (self._depth / 2.0)
+        return Point(x=top.x, y=top.y, z=center_z)
+
+    @property
+    def max_volume(self) -> float:
+        return self._max_volume
+
+    def from_center_cartesian(
+            self, x: float, y: float, z: float) -> Point:
+        """
+        Specifies an arbitrary point in deck coordinates based
+        on percentages of the radius in each axis. For example, to specify the
+        back-right corner of a well at 1/4 of the well depth from the bottom,
+        the call would be `_from_center_cartesian(1, 1, -0.5)`.
+
+        No checks are performed to ensure that the resulting position will be
+        inside of the well.
+
+        :param x: a float in the range [-1.0, 1.0] for a percentage of half of
+            the radius/length in the X axis
+        :param y: a float in the range [-1.0, 1.0] for a percentage of half of
+            the radius/width in the Y axis
+        :param z: a float in the range [-1.0, 1.0] for a percentage of half of
+            the height above/below the center
+
+        :return: a Point representing the specified location in absolute deck
+        coordinates
+        """
+        center = self.center()
+        if self._shape == 'rectangular':
+            x_size: float = self._length  # type: ignore
+            y_size: float = self._width  # type: ignore
+        else:
+            x_size = self._diameter  # type: ignore
+            y_size = self._diameter  # type: ignore
+        z_size = self._depth
+
+        return Point(
+            x=center.x + (x * (x_size / 2.0)),
+            y=center.y + (y * (y_size / 2.0)),
+            z=center.z + (z * (z_size / 2.0)))

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -358,7 +358,7 @@ async def test_jog_calibrate_bottom_v2(
 
     # Check that the feature flag correctly implements calibrate to bottom
     container = model.container._container
-    height = container.wells()[0]._depth
+    height = container.wells()[0].geometry._depth
     old_bottom = container.wells()[0].bottom().point
 
     main_router.calibration_manager.home(model.instrument)

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -147,8 +147,8 @@ def test_wells_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.wells()[0]._position == a1
-    assert fake_labware.wells()[1]._position == a2
+    assert fake_labware.wells()[0].geometry._position == a1
+    assert fake_labware.wells()[1].geometry._position == a2
 
 
 def test_wells_name_accessor():
@@ -161,8 +161,8 @@ def test_wells_name_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.wells_by_name()['A1']._position == a1
-    assert fake_labware.wells_by_name()['A2']._position == a2
+    assert fake_labware.wells_by_name()['A1'].geometry._position == a1
+    assert fake_labware.wells_by_name()['A2'].geometry._position == a2
 
 
 def test_deprecated_index_accessors():
@@ -183,8 +183,8 @@ def test_dict_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware['A1']._position == a1
-    assert fake_labware['A2']._position == a2
+    assert fake_labware['A1'].geometry._position == a1
+    assert fake_labware['A2'].geometry._position == a2
 
 
 def test_rows_accessor():
@@ -199,8 +199,8 @@ def test_rows_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0] + x1, y=offset[1] + y1, z=offset[2] + depth1)
     b2 = Point(x=offset[0] + x2, y=offset[1] + y2, z=offset[2] + depth2)
-    assert fake_labware.rows()[0][0]._position == a1
-    assert fake_labware.rows()[1][1]._position == b2
+    assert fake_labware.rows()[0][0].geometry._position == a1
+    assert fake_labware.rows()[1][1].geometry._position == b2
 
 
 def test_row_name_accessor():
@@ -215,8 +215,8 @@ def test_row_name_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0] + x1, y=offset[1] + y1, z=offset[2] + depth1)
     b2 = Point(x=offset[0] + x2, y=offset[1] + y2, z=offset[2] + depth2)
-    assert fake_labware.rows_by_name()['A'][0]._position == a1
-    assert fake_labware.rows_by_name()['B'][1]._position == b2
+    assert fake_labware.rows_by_name()['A'][0].geometry._position == a1
+    assert fake_labware.rows_by_name()['B'][1].geometry._position == b2
 
 
 def test_cols_accessor():
@@ -229,8 +229,8 @@ def test_cols_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.columns()[0][0]._position == a1
-    assert fake_labware.columns()[1][0]._position == a2
+    assert fake_labware.columns()[0][0].geometry._position == a1
+    assert fake_labware.columns()[1][0].geometry._position == a2
 
 
 def test_col_name_accessor():
@@ -243,5 +243,5 @@ def test_col_name_accessor():
     offset = fake_labware._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert fake_labware.columns_by_name()['1'][0]._position == a1
-    assert fake_labware.columns_by_name()['2'][0]._position == a2
+    assert fake_labware.columns_by_name()['1'][0].geometry._position == a1
+    assert fake_labware.columns_by_name()['2'][0].geometry._position == a2

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -583,10 +583,10 @@ def test_touch_tip_default_args(loop, monkeypatch):
     instr.touch_tip()
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
     # Check that the old api version initial well move has the same z height
@@ -618,11 +618,11 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     instr.touch_tip()
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -583,10 +583,10 @@ def test_touch_tip_default_args(loop, monkeypatch):
     instr.touch_tip()
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
     # Check that the old api version initial well move has the same z height
@@ -618,11 +618,11 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     instr.touch_tip()
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -5,6 +5,7 @@ import pytest
 from opentrons.protocol_api import (
     labware, MAX_SUPPORTED_VERSION)
 from opentrons.protocols.geometry import module_geometry
+from opentrons.protocols.geometry.well_geometry import WellGeometry
 
 from opentrons_shared_data import load_shared_data
 from opentrons.calibration_storage import (
@@ -59,26 +60,38 @@ def test_well_init():
     slot = Location(Point(1, 2, 3), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well1 = labware.Well(test_data[well_name], slot, well_name, has_tip,
-                         MAX_SUPPORTED_VERSION)
-    assert well1._diameter == test_data[well_name]['diameter']
-    assert well1._length is None
-    assert well1._width is None
+    well1 = labware.Well(
+        WellGeometry(test_data[well_name], slot),
+        well_name,
+        has_tip,
+        MAX_SUPPORTED_VERSION
+    )
+    assert well1.geometry.diameter == test_data[well_name]['diameter']
+    assert well1.geometry._length is None
+    assert well1.geometry._width is None
 
     well2_name = 'rectangular_well_json'
-    well2 = labware.Well(test_data[well2_name], slot, well2_name, has_tip,
-                         MAX_SUPPORTED_VERSION)
-    assert well2._diameter is None
-    assert well2._length == test_data[well2_name]['xDimension']
-    assert well2._width == test_data[well2_name]['yDimension']
+    well2 = labware.Well(
+        WellGeometry(test_data[well2_name], slot),
+        well2_name,
+        has_tip,
+        MAX_SUPPORTED_VERSION
+    )
+    assert well2.geometry.diameter is None
+    assert well2.geometry._length == test_data[well2_name]['xDimension']
+    assert well2.geometry._width == test_data[well2_name]['yDimension']
 
 
 def test_top():
     slot = Location(Point(4, 5, 6), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well = labware.Well(test_data[well_name], slot, well_name, has_tip,
-                        MAX_SUPPORTED_VERSION)
+    well = labware.Well(
+        WellGeometry(test_data[well_name], slot),
+        well_name,
+        has_tip,
+        MAX_SUPPORTED_VERSION
+    )
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
     expected_y = well_data['y'] + slot.point.y
@@ -91,8 +104,12 @@ def test_bottom():
     slot = Location(Point(7, 8, 9), 1)
     well_name = 'rectangular_well_json'
     has_tip = False
-    well = labware.Well(test_data[well_name], slot, well_name, has_tip,
-                        MAX_SUPPORTED_VERSION)
+    well = labware.Well(
+        WellGeometry(test_data[well_name], slot),
+        well_name,
+        has_tip,
+        MAX_SUPPORTED_VERSION
+    )
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
     expected_y = well_data['y'] + slot.point.y
@@ -105,13 +122,19 @@ def test_from_center_cartesian():
     slot1 = Location(Point(10, 11, 12), 1)
     well_name = 'circular_well_json'
     has_tip = False
-    well1 = labware.Well(test_data[well_name], slot1, well_name, has_tip,
-                         MAX_SUPPORTED_VERSION)
+    well1 = labware.Well(
+        WellGeometry(test_data[well_name], slot1),
+        well_name,
+        has_tip,
+        MAX_SUPPORTED_VERSION
+    )
 
     percent1_x = 1
     percent1_y = 1
     percent1_z = -0.5
-    point1 = well1._from_center_cartesian(percent1_x, percent1_y, percent1_z)
+    point1 = well1.geometry.from_center_cartesian(percent1_x,
+                                                  percent1_y,
+                                                  percent1_z)
 
     # slot.x + well.x + 1 * well.diamter/2
     expected_x = 10 + 40 + 15
@@ -127,12 +150,16 @@ def test_from_center_cartesian():
     slot2 = Location(Point(13, 14, 15), 1)
     well2_name = 'rectangular_well_json'
     has_tip = False
-    well2 = labware.Well(test_data[well2_name], slot2, well2_name, has_tip,
+    well2 = labware.Well(WellGeometry(test_data[well2_name], slot2),
+                         well2_name,
+                         has_tip,
                          MAX_SUPPORTED_VERSION)
     percent2_x = -0.25
     percent2_y = 0.1
     percent2_z = 0.9
-    point2 = well2._from_center_cartesian(percent2_x, percent2_y, percent2_z)
+    point2 = well2.geometry.from_center_cartesian(percent2_x,
+                                                  percent2_y,
+                                                  percent2_z)
 
     # slot.x + well.x - 0.25 * well.length/2
     expected_x = 13 + 45 - 15
@@ -198,8 +225,9 @@ def test_well_parent():
     parent = Location(Point(7, 8, 9), lw)
     well_name = 'circular_well_json'
     has_tip = True
-    well = labware.Well(test_data[well_name],
-                        parent,
+    well = labware.Well(WellGeometry(
+                            test_data[well_name],
+                            parent),
                         well_name,
                         has_tip,
                         MAX_SUPPORTED_VERSION)

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -132,9 +132,9 @@ def test_from_center_cartesian():
     percent1_x = 1
     percent1_y = 1
     percent1_z = -0.5
-    point1 = well1.geometry.from_center_cartesian(percent1_x,
-                                                  percent1_y,
-                                                  percent1_z)
+    point1 = well1.from_center_cartesian(percent1_x,
+                                         percent1_y,
+                                         percent1_z)
 
     # slot.x + well.x + 1 * well.diamter/2
     expected_x = 10 + 40 + 15

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -327,11 +327,11 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     assert 'touching tip' in ','.join([cmd.lower() for cmd in ctx.commands()])
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -327,11 +327,11 @@ def test_touch_tip_new_default_args(loop, monkeypatch):
     assert 'touching tip' in ','.join([cmd.lower() for cmd in ctx.commands()])
     z_offset = Point(0, 0, 1)   # default z offset of 1mm
     speed = 60                  # default speed
-    edges = [lw.wells()[0]._from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0]._from_center_cartesian(0, -1, 1) - z_offset]
+    edges = [lw.wells()[0].geometry.from_center_cartesian(1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(-1, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, 0, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, 1, 1) - z_offset,
+             lw.wells()[0].geometry.from_center_cartesian(0, -1, 1) - z_offset]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -88,21 +88,21 @@ def test_build_edges():
     off = Point(0, 0, 1.0)
     deck = Deck()
     old_correct_edges = [
-        test_lw['A1']._from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     res = build_edges(
         test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 2))
     assert res == old_correct_edges
 
     new_correct_edges = [
-        test_lw['A1']._from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     res2 = build_edges(
         test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 4))
@@ -117,10 +117,10 @@ def test_build_edges_left_pipette(loop):
     mod.load_labware('corning_96_wellplate_360ul_flat')
     off = Point(0, 0, 1.0)
     left_pip_edges = [
-        test_lw['A12']._from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A12']._from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A12']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A12']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 3 results in modified edge list
     res = build_edges(
@@ -129,10 +129,10 @@ def test_build_edges_left_pipette(loop):
     assert res == left_pip_edges
 
     left_pip_edges = [
-        test_lw2['A12']._from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in modified edge list
     res2 = build_edges(
@@ -149,10 +149,10 @@ def test_build_edges_right_pipette(loop):
     mod.load_labware('corning_96_wellplate_360ul_flat')
     off = Point(0, 0, 1.0)
     right_pip_edges = [
-        test_lw['A1']._from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 1 results in modified edge list
     res = build_edges(
@@ -161,11 +161,11 @@ def test_build_edges_right_pipette(loop):
     assert res == right_pip_edges
 
     right_pip_edges = [
-        test_lw2['A12']._from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12']._from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in unmodified edge list
     res2 = build_edges(

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -88,21 +88,21 @@ def test_build_edges():
     off = Point(0, 0, 1.0)
     deck = Deck()
     old_correct_edges = [
-        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     res = build_edges(
         test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 2))
     assert res == old_correct_edges
 
     new_correct_edges = [
-        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     res2 = build_edges(
         test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 4))
@@ -117,10 +117,10 @@ def test_build_edges_left_pipette(loop):
     mod.load_labware('corning_96_wellplate_360ul_flat')
     off = Point(0, 0, 1.0)
     left_pip_edges = [
-        test_lw['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 3 results in modified edge list
     res = build_edges(
@@ -129,10 +129,10 @@ def test_build_edges_left_pipette(loop):
     assert res == left_pip_edges
 
     left_pip_edges = [
-        test_lw2['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in modified edge list
     res2 = build_edges(
@@ -149,10 +149,10 @@ def test_build_edges_right_pipette(loop):
     mod.load_labware('corning_96_wellplate_360ul_flat')
     off = Point(0, 0, 1.0)
     right_pip_edges = [
-        test_lw['A1'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 1 results in modified edge list
     res = build_edges(
@@ -161,11 +161,11 @@ def test_build_edges_right_pipette(loop):
     assert res == right_pip_edges
 
     right_pip_edges = [
-        test_lw2['A12'].geometry.from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12'].geometry.from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in unmodified edge list
     res2 = build_edges(

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -1,3 +1,5 @@
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+
 from tests.opentrons.protocol_api.test_accessor_fn import minimalLabwareDef2
 from unittest import mock
 from copy import deepcopy
@@ -264,15 +266,17 @@ def test_dispense():
 
 def test_touch_tip():
     location = Location(Point(1, 2, 3), 'deck')
-    well = labware.Well({
-        'shape': 'circular',
-        'depth': 40,
-        'totalLiquidVolume': 100,
-        'diameter': 30,
-        'x': 40,
-        'y': 50,
-        'z': 3},
-        parent=Location(Point(10, 20, 30), 1),
+    well = labware.Well(
+        WellGeometry({
+            'shape': 'circular',
+            'depth': 40,
+            'totalLiquidVolume': 100,
+            'diameter': 30,
+            'x': 40,
+            'y': 50,
+            'z': 3},
+            parent=Location(Point(10, 20, 30), 1)
+        ),
         has_tip=False,
         display_name='some well',
         api_level=MAX_SUPPORTED_VERSION)

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -1,4 +1,6 @@
 from unittest import mock
+
+from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Location, Point
 from opentrons.protocol_api import InstrumentContext, \
     labware, MAX_SUPPORTED_VERSION
@@ -9,15 +11,17 @@ def test_move_to_well_with_optional_params():
     pipette_mock = mock.create_autospec(InstrumentContext)
     instruments = {'somePipetteId': pipette_mock}
 
-    well = labware.Well({
-        'shape': 'circular',
-        'depth': 40,
-        'totalLiquidVolume': 100,
-        'diameter': 30,
-        'x': 40,
-        'y': 50,
-        'z': 3},
-        parent=Location(Point(10, 20, 30), 1),
+    well = labware.Well(
+        WellGeometry({
+            'shape': 'circular',
+            'depth': 40,
+            'totalLiquidVolume': 100,
+            'diameter': 30,
+            'x': 40,
+            'y': 50,
+            'z': 3},
+            parent=Location(Point(10, 20, 30), 1)
+        ),
         has_tip=False,
         display_name='some well',
         api_level=MAX_SUPPORTED_VERSION)
@@ -53,15 +57,17 @@ def test_move_to_well_without_optional_params():
     pipette_mock = mock.create_autospec(InstrumentContext)
     instruments = {'somePipetteId': pipette_mock}
 
-    well = labware.Well({
-        'shape': 'circular',
-        'depth': 40,
-        'totalLiquidVolume': 100,
-        'diameter': 30,
-        'x': 40,
-        'y': 50,
-        'z': 3},
-        parent=Location(Point(10, 20, 30), 1),
+    well = labware.Well(
+        WellGeometry({
+            'shape': 'circular',
+            'depth': 40,
+            'totalLiquidVolume': 100,
+            'diameter': 30,
+            'x': 40,
+            'y': 50,
+            'z': 3},
+            parent=Location(Point(10, 20, 30), 1)
+        ),
         has_tip=False,
         display_name='some well',
         api_level=MAX_SUPPORTED_VERSION)


### PR DESCRIPTION
# Overview

An attempt to separate `Well` class from its deck geometry. Tried to follow pattern that I saw in the modules. 

This is a step toward breaking apart the `labware.py` into smaller chunks. I'd like to do something similar for `Labware` class. 

# Changelog

- The well definition and parent only go to construct a `WellGeometry` object which is passed in to `Well` constructor.
- `WellGeometry` accessors returns `Point` objects. `Well` accessors return `Location` objects. I can see `location.labware` accepting a `WellGeometry` vs `Well`. But not now. 

# Review requests

- Is this correct approach? 
- `max_value` was a sneaky little public member of `Well`. I made into a property.

# Risk assessment

Tests pass, which took some effort.
