### PR TITLE
refactor(app): don't display offset warning if no pipette

### DIFF
--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -122,7 +122,7 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
       {serialNumber && (
         <PipetteOffsetCalibrationControl robotName={robotName} mount={mount} />
       )}
-      {!pipetteOffsetCalibration && (
+      {serialNumber && !pipetteOffsetCalibration && (
         <Flex
           marginTop={SPACING_2}
           alignItems={ALIGN_FLEX_START}


### PR DESCRIPTION
If there's no pipette attached we shouldn't display a warning that it's
not calibrated.

## Testing
- Check that you don't get the warning when the feature flag is on and no pipette is attached