### PR TITLE
chore(scripts): add script to write version from git to package.json

### DIFF
--- a/api/src/opentrons/package.json
+++ b/api/src/opentrons/package.json
@@ -2,6 +2,9 @@
   "name": "@opentrons/api-server",
   "version": "3.21.0",
   "description": "Opentrons API server application",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -5,6 +5,9 @@
   "version": "3.21.0",
   "description": "Opentrons desktop application",
   "main": "lib/main.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "scripts": {
     "start": "make dev"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,9 @@
   "version": "3.21.0",
   "description": "Opentrons desktop application UI",
   "main": "src/index.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"

--- a/components/package.json
+++ b/components/package.json
@@ -4,6 +4,9 @@
   "description": "React components library for Opentrons' projects",
   "main": "src/index.js",
   "style": "src/index.css",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Opentrons/opentrons.git"

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -7,6 +7,9 @@
     "discovery": "bin/index.js",
     "discovery-ssh": "bin/discovery-ssh"
   },
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Opentrons/opentrons.git"

--- a/labware-designer/package.json
+++ b/labware-designer/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "labware-designer",
+  "productName": "Opentrons Labware Designer",
+  "private": true,
+  "version": "3.21.0",
+  "description": "Labware Designer",
+  "main": "src/index.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"
@@ -7,12 +16,6 @@
     "name": "Opentrons Labworks",
     "email": "engineering@opentrons.com"
   },
-  "name": "labware-designer",
-  "productName": "Opentrons Labware Designer",
-  "private": true,
-  "version": "3.21.0",
-  "description": "Labware Designer",
-  "main": "src/index.js",
   "bugs": {
     "url": "https://github.com/Opentrons/opentrons/issues"
   },

--- a/labware-library/package.json
+++ b/labware-library/package.json
@@ -4,6 +4,9 @@
   "version": "3.21.0",
   "description": "Opentrons standard labware library",
   "main": "src/index.js",
+  "config": {
+    "versionTagPrefix": "labware-library@"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git",

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "protocol-designer",
+  "productName": "Opentrons Protocol Designer BETA",
+  "private": true,
+  "version": "3.21.0",
+  "description": "Protocol designer app",
+  "main": "src/index.js",
+  "config": {
+    "versionTagPrefix": "protocol-designer@"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"
@@ -7,17 +16,11 @@
     "name": "Opentrons Labworks",
     "email": "engineering@opentrons.com"
   },
-  "name": "protocol-designer",
-  "productName": "Opentrons Protocol Designer BETA",
-  "private": true,
-  "version": "3.21.0",
-  "description": "Protocol designer app",
-  "main": "src/index.js",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons",
-  "license": "Apache-2.0",
   "dependencies": {
     "@hot-loader/react-dom": "16.8.6",
     "@opentrons/components": "3.21.0",

--- a/protocol-library-kludge/package.json
+++ b/protocol-library-kludge/package.json
@@ -1,4 +1,14 @@
 {
+
+  "name": "protocol-library-kludge",
+  "private": true,
+  "version": "3.21.0",
+  "productName": "Opentrons Protocol Library",
+  "description": "Protocol library stuff (WIP)",
+  "main": "src/index.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"
@@ -7,17 +17,11 @@
     "name": "Opentrons Labworks",
     "email": "engineering@opentrons.com"
   },
-  "name": "protocol-library-kludge",
-  "private": true,
-  "version": "3.21.0",
-  "productName": "Opentrons Protocol Library",
-  "description": "Protocol library stuff (WIP)",
-  "main": "src/index.js",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Opentrons/opentrons/issues"
   },
   "homepage": "https://github.com/Opentrons/opentrons",
-  "license": "Apache-2.0",
   "dependencies": {
     "@hot-loader/react-dom": "16.8.6",
     "@opentrons/components": "3.21.0",

--- a/robot-server/robot_server/package.json
+++ b/robot-server/robot_server/package.json
@@ -2,6 +2,9 @@
   "name": "@opentrons/robot-server",
   "version": "3.21.0",
   "description": "HTTP server for Opentrons robots",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"

--- a/scripts/write-versions-from-git.js
+++ b/scripts/write-versions-from-git.js
@@ -29,7 +29,7 @@ You may specify three options:
 If the commit matches a tag, then the version written will match the tag.
 Otherwise, the version will be:
 
-"{next_version}-snapshot.{commits_since_tag}-{commit_sha}"
+"{next_version}-dev.{commits_since_tag}+{commit_sha}"
 
 - {next_version} is the current version incremented by:
   - The minor version if the last tag was not a prerelease

--- a/scripts/write-versions-from-git.js
+++ b/scripts/write-versions-from-git.js
@@ -1,0 +1,263 @@
+// determine a project's version from git and write it to its package manifest
+// only depends on Node built-in libraries for easy use in GitHub actions
+// TODO(mc, 2020-10-02): add pyproject.toml support
+'use strict'
+
+const fs = require('fs').promises
+const path = require('path')
+const { promisify } = require('util')
+const exec = promisify(require('child_process').exec)
+
+const USAGE = `
+write-versions-from-git.js
+
+CLI usage:
+> node scripts/write-versions-from-git.js [--dryrun] [--reset] [--help]
+
+API usage:
+> require('./scripts/write-versions-from-git')(options)
+
+This script determines a project's version using git tags and writes
+that version to the project's manifest (package.json, pyproject.toml).
+
+You may specify three options:
+
+- dryrun: print changes to console but do not write them
+- reset: reset versions to the placeholder "0.0.0-dev"
+- help: print this usage text
+
+If the commit matches a tag, then the version written will match the tag.
+Otherwise, the version will be:
+
+"{next_version}-snapshot.{commits_since_tag}-{commit_sha}"
+
+- {next_version} is the current version incremented by:
+  - The minor version if the last tag was not a prerelease
+  - The prerelease version if the last tag was a prerelease
+- {commits_since_tag} and {commit_sha} are from git describe
+
+Examples:
+
+- 1.0.0         ->  1.1.0-dev.12+7942c0e08
+- 2.2.4         ->  2.3.0-dev.31+55daec2c6
+- 3.0.0-beta.3  ->  3.0.0-beta.4-dev.1+bc625168e
+`
+
+// TODO(mc, 2020-10-02): pull from filesystem somehow? this information
+// is redundant with other sources of truth in the repository
+const PROJECTS = [
+  {
+    name: '@opentrons/api-server',
+    manifestPath: 'api/src/opentrons/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/app',
+    manifestPath: 'app/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/app-shell',
+    manifestPath: 'app-shell/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/components',
+    manifestPath: 'components/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/discovery-client',
+    manifestPath: 'discovery-client/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: 'labware-designer',
+    manifestPath: 'labware-designer/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/labware-library',
+    manifestPath: 'labware-library/package.json',
+    tagPrefix: 'labware-library@',
+  },
+  {
+    name: 'protocol-designer',
+    manifestPath: 'protocol-designer/package.json',
+    tagPrefix: 'protocol-designer@',
+  },
+  {
+    name: 'protocol-library-kludge',
+    manifestPath: 'protocol-library-kludge/package.json',
+    tagPrefix: 'protocol-designer@',
+  },
+  {
+    name: '@opentrons/robot-server',
+    manifestPath: 'robot-server/robot_server/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/shared-data',
+    manifestPath: 'shared-data/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/update-server',
+    manifestPath: 'update-server/otupdate/package.json',
+    tagPrefix: null,
+  },
+  {
+    name: '@opentrons/webpack-config',
+    manifestPath: 'webpack-config/package.json',
+    tagPrefix: null,
+  },
+]
+
+const DEFAULT_PREFIX = 'v'
+const DEFAULT_VERSION = '0.0.0-dev'
+// TODO(mc, 2020-10-02): support toml
+const RE_CURRENT_VERSION = /"version": "([a-z0-9.-]+)"/
+const RE_DESCRIBE_VERSION = new RegExp(
+  [
+    // capture major (1), minor (2), and patch (3)
+    `(\\d+)\\.(\\d+)\\.(\\d+)`,
+    // capture optional prerelease identifier (4) and prerelease number (5)
+    `(?:-([a-z]+)\\.(\\d+))?`,
+    // capture optional count since last commit (6) and git sha (7)
+    `(?:-(\\d+)-g([a-z0-9]+))?`,
+  ].join('')
+)
+
+// TODO(mc, 2020-10-02): support toml
+const getDepVersionMatcher = depName => new RegExp(`"${depName}": ".+"`, 'g')
+
+const getFilename = ({ manifestPath }) =>
+  path.join(__dirname, '..', manifestPath)
+
+const Manifest = (
+  name,
+  manifestPath,
+  tagPrefix,
+  contents,
+  nextVersion = null,
+  nextContents = null
+) => ({
+  name,
+  manifestPath,
+  tagPrefix,
+  contents,
+  nextVersion,
+  nextContents,
+})
+
+function writeVersionsFromGit(options = {}) {
+  const { dryrun = false, reset = false, help = false } = options
+
+  if (help) {
+    console.log(USAGE)
+    return Promise.resolve(0)
+  }
+
+  const parseTasks = PROJECTS.map(readManifest)
+
+  return Promise.all(parseTasks)
+    .then(manifests => {
+      const versionTasks = manifests.map(addNextVersionFromGit)
+      return Promise.all(versionTasks)
+    })
+    .then(manifests => {
+      const writeTasks = manifests.map(m => {
+        const updatedManifest = updateManifestVersions(m, manifests)
+        return writeManifest(updatedManifest)
+      })
+
+      return Promise.all(writeTasks)
+    })
+    .then(() => {
+      console.log('All projects updated')
+      return 0
+    })
+    .catch(error => {
+      console.error(error)
+      return 1
+    })
+
+  function readManifest(project) {
+    const { name, manifestPath, tagPrefix } = project
+
+    return fs.readFile(getFilename(project), 'utf8').then(contents => {
+      return Manifest(name, manifestPath, tagPrefix, contents)
+    })
+  }
+
+  function addNextVersionFromGit(manifest) {
+    const { tagPrefix } = manifest
+    const prefix = tagPrefix === null ? DEFAULT_PREFIX : manifest.tagPrefix
+    const match = `${prefix}*`
+
+    if (reset) {
+      return { ...manifest, nextVersion: DEFAULT_VERSION }
+    }
+
+    return exec(`git describe --match ${match}`).then(({ stdout }) => {
+      const gitVersion = stdout.trim().slice(prefix.length)
+      const gitVersionParts = gitVersion.match(RE_DESCRIBE_VERSION)
+      const [, maj, min, patch, preId, preN, commitN, sha] = gitVersionParts
+      let nextVersion = gitVersion
+
+      if (sha) {
+        const nextVersionBase = preId
+          ? `${maj}.${min}.${patch}-${preId}.${Number(preN) + 1}`
+          : `${maj}.${Number(min) + 1}.0`
+
+        nextVersion = `${nextVersionBase}-dev.${commitN}+${sha}`
+      }
+
+      return { ...manifest, nextVersion }
+    })
+  }
+
+  function updateManifestVersions(manifest, allManifests) {
+    const { contents, nextVersion } = manifest
+    let nextContents = contents.replace(
+      RE_CURRENT_VERSION,
+      `"version": "${nextVersion}"`
+    )
+
+    allManifests.forEach(({ name: depName, nextVersion: depVersion }) => {
+      nextContents = nextContents.replace(
+        getDepVersionMatcher(depName),
+        `"${depName}": "${depVersion}"`
+      )
+    })
+
+    return { ...manifest, nextContents }
+  }
+
+  function writeManifest(manifest) {
+    const { name, manifestPath, nextVersion, nextContents } = manifest
+
+    console.log(`Updating ${name} with ${nextVersion}`)
+
+    if (!dryrun) {
+      return fs
+        .writeFile(getFilename(manifest), nextContents)
+        .then(() => console.log(`Wrote ${manifestPath}`))
+    }
+
+    console.log('DRYRUN:', manifestPath, nextContents)
+  }
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2)
+  const dryrun = argv.includes('--dryrun')
+  const reset = argv.includes('--reset')
+  const help = argv.includes('--help')
+
+  writeVersionsFromGit({ dryrun, reset, help }).then(
+    exitCode => (process.exitCode = exitCode)
+  )
+}
+
+module.exports = writeVersionsFromGit

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -2,13 +2,16 @@
   "name": "@opentrons/shared-data",
   "version": "3.21.0",
   "description": "Default labware definitions for Opentrons robots",
+  "main": "js/index.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"
   },
-  "author": "Opentrons Labworks",
+  "author": "Opentrons Labworks <engineering@opentrons.com",
   "license": "Apache-2.0",
-  "main": "js/index.js",
   "dependencies": {
     "ajv": "6.10.2",
     "lodash": "4.17.15"

--- a/update-server/otupdate/package.json
+++ b/update-server/otupdate/package.json
@@ -2,6 +2,9 @@
   "name": "@opentrons/update-server",
   "version": "3.21.0",
   "description": "Update server for Opentrons robots",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Opentrons/opentrons.git"

--- a/webpack-config/package.json
+++ b/webpack-config/package.json
@@ -3,6 +3,9 @@
   "version": "3.21.0",
   "description": "Shareable pieces of webpack configuration",
   "main": "index.js",
+  "config": {
+    "versionTagPrefix": "v"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Opentrons/opentrons.git"


### PR DESCRIPTION
## overview

This is a bit of an RFC for the [Release Automation Initiative](https://coda.io/d/Release-Automation-Initiative_dJclFpoTy5u), sepcifically focused on the "Move Versions to Git" step.

This PR adds a script to the repo (without using it) that reads `git describe` and uses it to construct the version string for every project in the repo.

- A project may specific a `versionTagPrefix`, e.g. `protocol-designer@` or `v` to filter `git describe`
- The version logic is:
    - If commit is exactly a tag, use the version from the tag
    - If last tag was a regular version, construct a pre-minor version with git describe metadata
        - e.g. `2.2.4 ->  2.3.0-dev.31+55daec2c6`
        - Went with minor rather than patch because that's our regular releases from `edge`
    - If last tag was a pre-release version, increment the pre-release with git describe metadata
        -e.g. `3.0.0-beta.3 -> 3.0.0-beta.4-dev.1+bc625168e`
- Version format was selected to be:
    - Compatible with semver
    - Normalizable according to [PEP 440 - Version Identification and Dependency Specification](https://www.python.org/dev/peps/pep-0440/)
- `pyproject.toml` support is not included, but could be if we thought it would help switch to poetry or anything like that

## changelog

chore(scripts): add script to write version from git to package.json

## review requests

So the sort of hypothetical workflow that this slots into looks like this:

0. Set all local versions to `0.0.0-dev` (using this script's `--reset` flag) and commit it
    - We do this once to declare "we now use git for versions"
1. In CI, we run this script before building any assets
    - The script will write definitive versions to the `package.json` files
    - The built assets will have those versions using the existing mechanisms of their build systems
        - This may mean we can remove custom version code in PD, but that would not be required
2. On a release tag, the logic of this script means that the assets being released will have a release version written to the assets
    - This script **doesn't care about the release itself**, it's just here to write versions

### play around with it

The usage instructions are in the script! If you clone this branch, run:

```shell
# print usage text
node scripts/write-versions-from-git.js --help

# see what would happen if you ran the --reset helper
node scripts/write-versions-from-git.js --dryrun --reset

# see what would happen if you ran the regular logic
node scripts/write-versions-from-git.js --dryrun
```

Try it out without `--dryrun` to watch it actually write files. Also, try jumping around your git history to see if you get the versions you expect.

## risk assessment

N/A; script is not used. Script will be a source of future risk if we decide to merge this PR and use it, though.