### PR TITLE
refactor(api):  more well and labware refactors

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -288,6 +288,21 @@ control of positions within the well for unusual or custom labware.
 
 .. versionadded:: 2.0
 
+
+From Center Cartesian
+---------------------
+
+The method :py:meth:`.Well.from_center_cartesian` specifies an arbitrary point
+in deck coordinates based on percentages of the radius in each axis.
+
+.. code-block:: python
+
+   plate['A1'].from_center_cartesian(1, 1, -0.5) # The back-right corner of a well at 1/4 of the well depth from the bottom
+
+.. versionadded:: 2.8
+
+
+
 Manipulating Positions
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -189,3 +189,4 @@ Version 2.8
 +++++++++++
 - You can now pass in a list of volumes to distribute and consolidate. See :ref:`distribute-consolidate-volume-list` for more information.
     - Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense
+- :py:meth:`.Well.from_center_cartesian` can be used to find a point within a well using normalized distance from the center in each axis.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -457,15 +457,12 @@ class Labware(DeckItem):
 
         :return: A list of row lists
         """
-        row_dict = self._well_name_grid.get_rows()
-        keys = self._well_name_grid.row_headers()
-
         if not args:
-            res = [row_dict[key] for key in keys]
+            res = self._well_name_grid.get_rows()
         elif isinstance(args[0], int):
-            res = [row_dict[keys[idx]] for idx in args]
+            res = [self._well_name_grid.get_rows()[idx] for idx in args]
         elif isinstance(args[0], str):
-            res = [row_dict[idx] for idx in args]
+            res = [self._well_name_grid.get_row(idx) for idx in args]
         else:
             raise TypeError
         return res
@@ -481,8 +478,7 @@ class Labware(DeckItem):
 
         :return: Dictionary of Well lists keyed by row name
         """
-        row_dict = self._well_name_grid.get_rows()
-        return row_dict
+        return self._well_name_grid.get_row_dict()
 
     @requires_version(2, 0)
     def rows_by_index(self) -> Dict[str, List[Well]]:
@@ -509,15 +505,12 @@ class Labware(DeckItem):
 
         :return: A list of column lists
         """
-        col_dict = self._well_name_grid.get_columns()
-        keys = sorted(col_dict, key=lambda x: int(x))
-
         if not args:
-            res = [col_dict[key] for key in keys]
+            res = self._well_name_grid.get_columns()
         elif isinstance(args[0], int):
-            res = [col_dict[keys[idx]] for idx in args]
+            res = [self._well_name_grid.get_columns()[idx] for idx in args]
         elif isinstance(args[0], str):
-            res = [col_dict[idx] for idx in args]
+            res = [self._well_name_grid.get_column(idx) for idx in args]
         else:
             raise TypeError
         return res
@@ -534,9 +527,7 @@ class Labware(DeckItem):
 
         :return: Dictionary of Well lists keyed by column name
         """
-        col_dict = self._well_name_grid.get_columns()
-        # Convert to wells from indexes
-        return col_dict
+        return self._well_name_grid.get_column_dict()
 
     @requires_version(2, 0)
     def columns_by_index(self) -> Dict[str, List[Well]]:

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -149,7 +149,7 @@ class Well:
         Specifies an arbitrary point in deck coordinates based
         on percentages of the radius in each axis. For example, to specify the
         back-right corner of a well at 1/4 of the well depth from the bottom,
-        the call would be `_from_center_cartesian(1, 1, -0.5)`.
+        the call would be `from_center_cartesian(1, 1, -0.5)`.
 
         No checks are performed to ensure that the resulting position will be
         inside of the well.

--- a/api/src/opentrons/protocols/api_support/well_grid.py
+++ b/api/src/opentrons/protocols/api_support/well_grid.py
@@ -1,0 +1,71 @@
+import re
+from collections import defaultdict
+from typing import List, Dict, NamedTuple
+
+
+HeaderToIndexes = Dict[str, List[int]]
+
+
+class Grid(NamedTuple):
+    rows: HeaderToIndexes
+    columns: HeaderToIndexes
+
+
+class WellGrid:
+    """A helper class to access extract row and column information from
+    well names"""
+
+    pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
+
+    def __init__(self, well_names: List[List[str]]):
+        """
+        Construct well grid from a list of lists of names as appear in
+        `ordering` field of Labware Defnition
+
+        :param well_names: a list of lists of well names ("A1, "B3", etc..)
+        """
+        # Flatten the list of lists
+        self._ordering = [well for col in well_names for well in col]
+        self._grid = self._create_row_column(self._ordering)
+        self._row_headers = sorted(self._grid.rows.keys())
+        self._column_headers = sorted(self._grid.columns.keys())
+
+    def ordered_names(self) -> List[str]:
+        """The flattened names of the wells in order"""
+        return self._ordering
+
+    def row_headers(self) -> List[str]:
+        """List of row header names"""
+        return self._row_headers
+
+    def column_headers(self) -> List[str]:
+        """List of column header names"""
+        return self._column_headers
+
+    def get_rows(self) -> HeaderToIndexes:
+        """A mapping of row header to a list of indexes"""
+        return self._grid.rows
+
+    def get_columns(self) -> HeaderToIndexes:
+        """A mapping of column header to a list of indexes"""
+        return self._grid.columns
+
+    @staticmethod
+    def _create_row_column(well_names: List[str]) -> Grid:
+        """
+        Creates a dict of lists of Wells. Which way the labware is segmented
+        determines whether this is a dict of rows or dict of columns. If group
+        is 1, then it will collect wells that have the same alphabetic prefix
+        and therefore are considered to be in the same row. If group is 2, it
+        will collect wells that have the same numeric postfix and therefore
+        are considered to be in the same column.
+        """
+        columns: Dict[str, List[int]] = defaultdict(list)
+        rows: Dict[str, List[int]] = defaultdict(list)
+        for index, well_name in enumerate(well_names):
+            match = WellGrid.pattern.match(well_name)
+            assert match, 'could not match well name pattern'
+            rows[match.group(1)].append(index)
+            columns[match.group(2)].append(index)
+        # copy to a non-default-dict
+        return Grid(columns=dict(columns), rows=dict(rows))

--- a/api/src/opentrons/protocols/implementations/well.py
+++ b/api/src/opentrons/protocols/implementations/well.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Labware
+
+
+class WellImplementation:
+
+    def __init__(self,
+                 well_geometry: WellGeometry,
+                 display_name: str,
+                 has_tip: bool,
+                 name: str = None) -> None:
+        """
+        Construct a well
+
+        :param well_geometry: The well's geometry
+        :param display_name: a string that identifies a well. Used primarily
+            for debug and test purposes. Should be unique and human-readable--
+            something like "Tip C3 of Opentrons 300ul Tiprack on Slot 5" or
+            "Well D1 of Biorad 96 PCR Plate on Magnetic Module in Slot 1".
+            This is created by the caller and passed in, so here it is just
+            saved and made available.
+        :param has_tip: whether a tip is present
+        :param name: The well name
+        """
+        self._display_name = display_name
+        self._geometry = well_geometry
+
+        self._has_tip = has_tip
+        if name:
+            self._name = name
+        else:
+            self._name = display_name
+
+    def get_parent(self) -> Labware:
+        return self._geometry.parent.labware   # type: ignore
+
+    def has_tip(self) -> bool:
+        return self._has_tip
+
+    def set_has_tip(self, value: bool) -> None:
+        self._has_tip = value
+
+    def get_display_name(self) -> str:
+        return self._display_name
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_geometry(self) -> WellGeometry:
+        return self._geometry

--- a/api/src/opentrons/protocols/implementations/well_grid.py
+++ b/api/src/opentrons/protocols/implementations/well_grid.py
@@ -1,9 +1,10 @@
 import re
 from collections import defaultdict
-from typing import List, Dict, NamedTuple
+from typing import List, Dict, NamedTuple, Generic, TypeVar, Sequence
 
+T = TypeVar('T')
 
-HeaderToIndexes = Dict[str, List[int]]
+HeaderToIndexes = Dict[str, List[T]]
 
 
 class Grid(NamedTuple):
@@ -11,28 +12,23 @@ class Grid(NamedTuple):
     columns: HeaderToIndexes
 
 
-class WellGrid:
+class WellGrid(Generic[T]):
     """A helper class to access extract row and column information from
     well names"""
 
     pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
 
-    def __init__(self, well_names: List[List[str]]):
+    def __init__(self, well_names: Sequence[str], well_objects: Sequence[T]):
         """
         Construct well grid from a list of lists of names as appear in
         `ordering` field of Labware Defnition
 
-        :param well_names: a list of lists of well names ("A1, "B3", etc..)
+        :param well_names: a list well names ("A1, "B3", etc..)
+        :param well_objects: a list of objects matching well_names
         """
-        # Flatten the list of lists
-        self._ordering = [well for col in well_names for well in col]
-        self._grid = self._create_row_column(self._ordering)
+        self._grid = self._create_row_column(well_names, well_objects)
         self._row_headers = sorted(self._grid.rows.keys())
         self._column_headers = sorted(self._grid.columns.keys())
-
-    def ordered_names(self) -> List[str]:
-        """The flattened names of the wells in order"""
-        return self._ordering
 
     def row_headers(self) -> List[str]:
         """List of row header names"""
@@ -51,7 +47,8 @@ class WellGrid:
         return self._grid.columns
 
     @staticmethod
-    def _create_row_column(well_names: List[str]) -> Grid:
+    def _create_row_column(well_names: Sequence[str],
+                           well_objects: Sequence[T]) -> Grid:
         """
         Creates a dict of lists of Wells. Which way the labware is segmented
         determines whether this is a dict of rows or dict of columns. If group
@@ -60,12 +57,14 @@ class WellGrid:
         will collect wells that have the same numeric postfix and therefore
         are considered to be in the same column.
         """
-        columns: Dict[str, List[int]] = defaultdict(list)
-        rows: Dict[str, List[int]] = defaultdict(list)
-        for index, well_name in enumerate(well_names):
+        wells = zip(well_names, well_objects)
+        columns: Dict[str, List[T]] = defaultdict(list)
+        rows: Dict[str, List[T]] = defaultdict(list)
+        for index, well in enumerate(wells):
+            well_name, well_object = well
             match = WellGrid.pattern.match(well_name)
             assert match, 'could not match well name pattern'
-            rows[match.group(1)].append(index)
-            columns[match.group(2)].append(index)
+            rows[match.group(1)].append(well_object)
+            columns[match.group(2)].append(well_object)
         # copy to a non-default-dict
         return Grid(columns=dict(columns), rows=dict(rows))

--- a/api/src/opentrons/protocols/implementations/well_grid.py
+++ b/api/src/opentrons/protocols/implementations/well_grid.py
@@ -1,13 +1,15 @@
 import re
 from collections import defaultdict
-from typing import List, Dict, NamedTuple, Generic, TypeVar, Sequence
+from dataclasses import dataclass
+from typing import List, Dict, Generic, TypeVar, Sequence
 
 T = TypeVar('T')
 
 HeaderToList = Dict[str, List[T]]
 
 
-class Grid(NamedTuple):
+@dataclass
+class Grid:
     rows: HeaderToList
     columns: HeaderToList
 
@@ -82,7 +84,8 @@ class WellGrid(Generic[T]):
         for index, well in enumerate(wells):
             well_name, well_object = well
             match = WellGrid.pattern.match(well_name)
-            assert match, 'could not match well name pattern'
+            assert match, f"could not match '{well_name}' using " \
+                          f"pattern '{WellGrid.pattern.pattern}'"
             rows[match.group(1)].append(well_object)
             columns[match.group(2)].append(well_object)
         # copy to a non-default-dict

--- a/api/src/opentrons/protocols/implementations/well_grid.py
+++ b/api/src/opentrons/protocols/implementations/well_grid.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Dict, Generic, TypeVar, Sequence
 
+from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
+
 T = TypeVar('T')
 
 HeaderToList = Dict[str, List[T]]
@@ -18,7 +20,7 @@ class WellGrid(Generic[T]):
     """A helper class to access extract row and column information from
     well names"""
 
-    pattern = re.compile(r'^([A-Z]+)([1-9][0-9]*)$', re.X)
+    pattern = re.compile(WELL_NAME_PATTERN, re.X)
 
     def __init__(self, well_names: Sequence[str], well_objects: Sequence[T]):
         """

--- a/api/src/opentrons/protocols/implementations/well_grid.py
+++ b/api/src/opentrons/protocols/implementations/well_grid.py
@@ -4,12 +4,12 @@ from typing import List, Dict, NamedTuple, Generic, TypeVar, Sequence
 
 T = TypeVar('T')
 
-HeaderToIndexes = Dict[str, List[T]]
+HeaderToList = Dict[str, List[T]]
 
 
 class Grid(NamedTuple):
-    rows: HeaderToIndexes
-    columns: HeaderToIndexes
+    rows: HeaderToList
+    columns: HeaderToList
 
 
 class WellGrid(Generic[T]):
@@ -28,7 +28,10 @@ class WellGrid(Generic[T]):
         """
         self._grid = self._create_row_column(well_names, well_objects)
         self._row_headers = sorted(self._grid.rows.keys())
-        self._column_headers = sorted(self._grid.columns.keys())
+        self._column_headers = sorted(self._grid.columns.keys(),
+                                      key=lambda k: int(k))
+        self._rows = [self._grid.rows[h] for h in self._row_headers]
+        self._columns = [self._grid.columns[h] for h in self._column_headers]
 
     def row_headers(self) -> List[str]:
         """List of row header names"""
@@ -38,13 +41,29 @@ class WellGrid(Generic[T]):
         """List of column header names"""
         return self._column_headers
 
-    def get_rows(self) -> HeaderToIndexes:
-        """A mapping of row header to a list of indexes"""
+    def get_row_dict(self) -> HeaderToList:
+        """A mapping of row header to a list"""
         return self._grid.rows
 
-    def get_columns(self) -> HeaderToIndexes:
-        """A mapping of column header to a list of indexes"""
+    def get_column_dict(self) -> HeaderToList:
+        """A mapping of column header to a list"""
         return self._grid.columns
+
+    def get_rows(self) -> List[List[T]]:
+        """Get all rows as list of lists"""
+        return self._rows
+
+    def get_columns(self) -> List[List[T]]:
+        """Get all columns as list of lists"""
+        return self._columns
+
+    def get_row(self, row: str) -> List[T]:
+        """Get an individual row"""
+        return self._grid.rows.get(row, [])
+
+    def get_column(self, column: str) -> List[T]:
+        """Get an individual column"""
+        return self._grid.columns.get(column, [])
 
     @staticmethod
     def _create_row_column(well_names: Sequence[str],
@@ -58,8 +77,8 @@ class WellGrid(Generic[T]):
         are considered to be in the same column.
         """
         wells = zip(well_names, well_objects)
-        columns: Dict[str, List[T]] = defaultdict(list)
-        rows: Dict[str, List[T]] = defaultdict(list)
+        columns: HeaderToList = defaultdict(list)
+        rows: HeaderToList = defaultdict(list)
         for index, well in enumerate(wells):
             well_name, well_object = well
             match = WellGrid.pattern.match(well_name)

--- a/api/src/opentrons/protocols/implementations/well_grid.py
+++ b/api/src/opentrons/protocols/implementations/well_grid.py
@@ -17,7 +17,7 @@ class Grid:
 
 
 class WellGrid(Generic[T]):
-    """A helper class to access extract row and column information from
+    """A helper class to extract row and column information from
     well names"""
 
     pattern = re.compile(WELL_NAME_PATTERN, re.X)

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -124,7 +124,7 @@ def test_labware_init():
     deck = Location(Point(0, 0, 0), 'deck')
     fake_labware = labware.Labware(minimalLabwareDef, deck)
     ordering = [well for col in minimalLabwareDef['ordering'] for well in col]
-    assert fake_labware._well_name_grid.ordered_names() == ordering
+    assert fake_labware._ordering == ordering
     assert fake_labware._well_definition == minimalLabwareDef['wells']
     assert fake_labware._offset == Point(x=10, y=10, z=5)
 

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -124,17 +124,9 @@ def test_labware_init():
     deck = Location(Point(0, 0, 0), 'deck')
     fake_labware = labware.Labware(minimalLabwareDef, deck)
     ordering = [well for col in minimalLabwareDef['ordering'] for well in col]
-    assert fake_labware._ordering == ordering
+    assert fake_labware._well_name_grid.ordered_names() == ordering
     assert fake_labware._well_definition == minimalLabwareDef['wells']
     assert fake_labware._offset == Point(x=10, y=10, z=5)
-
-
-def test_well_pattern():
-    deck = Location(Point(0, 0, 0), 'deck')
-    fake_labware = labware.Labware(minimalLabwareDef, deck)
-    assert fake_labware._pattern.match('A1')
-    assert fake_labware._pattern.match('A10')
-    assert not fake_labware._pattern.match('A0')
 
 
 def test_wells_accessor():

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -6,6 +6,7 @@ from opentrons.protocol_api import (
     labware, MAX_SUPPORTED_VERSION)
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocols.implementations.well import WellImplementation
 
 from opentrons_shared_data import load_shared_data
 from opentrons.calibration_storage import (
@@ -61,10 +62,12 @@ def test_well_init():
     well_name = 'circular_well_json'
     has_tip = False
     well1 = labware.Well(
-        WellGeometry(test_data[well_name], slot),
-        well_name,
-        has_tip,
-        MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well_name], slot),
+            display_name=well_name,
+            has_tip=has_tip
+        )
     )
     assert well1.geometry.diameter == test_data[well_name]['diameter']
     assert well1.geometry._length is None
@@ -72,10 +75,12 @@ def test_well_init():
 
     well2_name = 'rectangular_well_json'
     well2 = labware.Well(
-        WellGeometry(test_data[well2_name], slot),
-        well2_name,
-        has_tip,
-        MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well2_name], slot),
+            display_name=well2_name,
+            has_tip=has_tip
+        )
     )
     assert well2.geometry.diameter is None
     assert well2.geometry._length == test_data[well2_name]['xDimension']
@@ -87,10 +92,12 @@ def test_top():
     well_name = 'circular_well_json'
     has_tip = False
     well = labware.Well(
-        WellGeometry(test_data[well_name], slot),
-        well_name,
-        has_tip,
-        MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well_name], slot),
+            display_name=well_name,
+            has_tip=has_tip
+        )
     )
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
@@ -105,10 +112,12 @@ def test_bottom():
     well_name = 'rectangular_well_json'
     has_tip = False
     well = labware.Well(
-        WellGeometry(test_data[well_name], slot),
-        well_name,
-        has_tip,
-        MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well_name], slot),
+            display_name=well_name,
+            has_tip=has_tip
+        )
     )
     well_data = test_data[well_name]
     expected_x = well_data['x'] + slot.point.x
@@ -123,10 +132,12 @@ def test_from_center_cartesian():
     well_name = 'circular_well_json'
     has_tip = False
     well1 = labware.Well(
-        WellGeometry(test_data[well_name], slot1),
-        well_name,
-        has_tip,
-        MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well_name], slot1),
+            display_name=well_name,
+            has_tip=has_tip
+        )
     )
 
     percent1_x = 1
@@ -150,10 +161,14 @@ def test_from_center_cartesian():
     slot2 = Location(Point(13, 14, 15), 1)
     well2_name = 'rectangular_well_json'
     has_tip = False
-    well2 = labware.Well(WellGeometry(test_data[well2_name], slot2),
-                         well2_name,
-                         has_tip,
-                         MAX_SUPPORTED_VERSION)
+    well2 = labware.Well(
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well2_name], slot2),
+            display_name=well2_name,
+            has_tip=has_tip
+        )
+    )
     percent2_x = -0.25
     percent2_y = 0.1
     percent2_z = 0.9
@@ -225,12 +240,14 @@ def test_well_parent():
     parent = Location(Point(7, 8, 9), lw)
     well_name = 'circular_well_json'
     has_tip = True
-    well = labware.Well(WellGeometry(
-                            test_data[well_name],
-                            parent),
-                        well_name,
-                        has_tip,
-                        MAX_SUPPORTED_VERSION)
+    well = labware.Well(
+        api_level=MAX_SUPPORTED_VERSION,
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(test_data[well_name], parent),
+            display_name=well_name,
+            has_tip=has_tip
+        )
+    )
     assert well.parent is lw
     assert well.top().labware is well
     assert well.top().labware.parent is lw

--- a/api/tests/opentrons/protocols/api_support/test_well_grid.py
+++ b/api/tests/opentrons/protocols/api_support/test_well_grid.py
@@ -1,0 +1,102 @@
+import pytest
+from opentrons.protocols.api_support.well_grid import WellGrid
+
+NONE: list = [[]]
+ONE_VAL = [["A1"]]
+NORMAL = [
+    ["A1", "B1", "C1"],
+    ["A2", "B2", "C2"],
+    ["A3", "B3", "C3"],
+    ["A4", "B4", "C4"],
+  ]
+CRAZY_SHAPE = [
+    ["A1", "B1", "C1"],
+    ["B2", "C2"],
+    ["B3"],
+    ["A4", "C4", "D4"],
+  ]
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, []],
+        [ONE_VAL, ["A1"]],
+        [NORMAL, ["A1", "B1", "C1", "A2", "B2", "C2",
+                  "A3", "B3", "C3", "A4", "B4", "C4"]],
+        [CRAZY_SHAPE, ["A1", "B1", "C1", "B2", "C2", "B3", "A4", "C4", "D4"]]
+    ])
+def test_in_order(names, expected):
+    assert WellGrid(names).ordered_names() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, []],
+        [ONE_VAL, ['A']],
+        [NORMAL, ['A', 'B', 'C']],
+        [CRAZY_SHAPE, ['A', 'B', 'C', 'D']]
+    ])
+def test_row_headers(names, expected):
+    assert WellGrid(names).row_headers() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, {}],
+        [ONE_VAL, {'A': [0]}],
+        [NORMAL, {
+            "A": [0, 3, 6, 9],
+            "B": [1, 4, 7, 10],
+            "C": [2, 5, 8, 11],
+        }],
+        [CRAZY_SHAPE, {
+            "A": [0, 6],
+            "B": [1, 3, 5],
+            "C": [2, 4, 7],
+            "D": [8],
+        }]])
+def test_rows(names, expected):
+    assert WellGrid(names).get_rows() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, []],
+        [ONE_VAL, ['1']],
+        [NORMAL, ['1', '2', '3', '4']],
+        [CRAZY_SHAPE, ['1', '2', '3', '4']]
+    ])
+def test_column_headers(names, expected):
+    assert WellGrid(names).column_headers() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, {}],
+        [ONE_VAL, {'1': [0]}],
+        [NORMAL, {
+            '1': [0, 1, 2],
+            '2': [3, 4, 5],
+            '3': [6, 7, 8],
+            '4': [9, 10, 11],
+        }],
+        [CRAZY_SHAPE, {
+            '1': [0, 1, 2],
+            '2': [3, 4],
+            '3': [5],
+            '4': [6, 7, 8]
+        }]
+    ])
+def test_columns(names, expected):
+    assert WellGrid(names).get_columns() == expected
+
+
+def test_well_pattern():
+    assert WellGrid.pattern.match('A1')
+    assert WellGrid.pattern.match('A10')
+    assert not WellGrid.pattern.match('A0')

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -1,4 +1,5 @@
 from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocols.implementations.well import WellImplementation
 
 from tests.opentrons.protocol_api.test_accessor_fn import minimalLabwareDef2
 from unittest import mock
@@ -267,19 +268,22 @@ def test_dispense():
 def test_touch_tip():
     location = Location(Point(1, 2, 3), 'deck')
     well = labware.Well(
-        WellGeometry({
-            'shape': 'circular',
-            'depth': 40,
-            'totalLiquidVolume': 100,
-            'diameter': 30,
-            'x': 40,
-            'y': 50,
-            'z': 3},
-            parent=Location(Point(10, 20, 30), 1)
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry({
+                'shape': 'circular',
+                'depth': 40,
+                'totalLiquidVolume': 100,
+                'diameter': 30,
+                'x': 40,
+                'y': 50,
+                'z': 3},
+                parent=Location(Point(10, 20, 30), 1)
+            ),
+            has_tip=False,
+            display_name='some well'
         ),
-        has_tip=False,
-        display_name='some well',
-        api_level=MAX_SUPPORTED_VERSION)
+        api_level=MAX_SUPPORTED_VERSION
+    )
 
     pipette_mock = mock.create_autospec(InstrumentContext, name='pipette_mock')
     mock_get_location_with_offset = mock.MagicMock(

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocols.implementations.well import WellImplementation
 from opentrons.types import Location, Point
 from opentrons.protocol_api import InstrumentContext, \
     labware, MAX_SUPPORTED_VERSION
@@ -12,18 +13,20 @@ def test_move_to_well_with_optional_params():
     instruments = {'somePipetteId': pipette_mock}
 
     well = labware.Well(
-        WellGeometry({
-            'shape': 'circular',
-            'depth': 40,
-            'totalLiquidVolume': 100,
-            'diameter': 30,
-            'x': 40,
-            'y': 50,
-            'z': 3},
-            parent=Location(Point(10, 20, 30), 1)
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry({
+                'shape': 'circular',
+                'depth': 40,
+                'totalLiquidVolume': 100,
+                'diameter': 30,
+                'x': 40,
+                'y': 50,
+                'z': 3},
+                parent=Location(Point(10, 20, 30), 1)
+            ),
+            has_tip=False,
+            display_name='some well'
         ),
-        has_tip=False,
-        display_name='some well',
         api_level=MAX_SUPPORTED_VERSION)
 
     mock_get_well = mock.MagicMock(
@@ -58,18 +61,20 @@ def test_move_to_well_without_optional_params():
     instruments = {'somePipetteId': pipette_mock}
 
     well = labware.Well(
-        WellGeometry({
-            'shape': 'circular',
-            'depth': 40,
-            'totalLiquidVolume': 100,
-            'diameter': 30,
-            'x': 40,
-            'y': 50,
-            'z': 3},
-            parent=Location(Point(10, 20, 30), 1)
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry({
+                'shape': 'circular',
+                'depth': 40,
+                'totalLiquidVolume': 100,
+                'diameter': 30,
+                'x': 40,
+                'y': 50,
+                'z': 3},
+                parent=Location(Point(10, 20, 30), 1)
+            ),
+            has_tip=False,
+            display_name='some well'
         ),
-        has_tip=False,
-        display_name='some well',
         api_level=MAX_SUPPORTED_VERSION)
 
     mock_get_well = mock.MagicMock(

--- a/api/tests/opentrons/protocols/implementation/test_well_grid.py
+++ b/api/tests/opentrons/protocols/implementation/test_well_grid.py
@@ -14,7 +14,12 @@ CRAZY_SHAPE = [
     "B2", "C2",
     "B3",
     "A4", "C4", "D4",
-  ]
+]
+TWELVE_BY_TWELVE_GRID = [
+    [f'{c}{r}' for c in [chr(65 + i) for i in range(12)]] for r in range(1, 13)
+]
+# Flatten to a list of well names
+TWELVE_BY_TWELVE = [n for x in TWELVE_BY_TWELVE_GRID for n in x]
 
 
 @pytest.mark.parametrize(
@@ -23,7 +28,9 @@ CRAZY_SHAPE = [
         [NONE, []],
         [ONE_VAL, ['A']],
         [NORMAL, ['A', 'B', 'C']],
-        [CRAZY_SHAPE, ['A', 'B', 'C', 'D']]
+        [CRAZY_SHAPE, ['A', 'B', 'C', 'D']],
+        [TWELVE_BY_TWELVE, ['A', 'B', 'C', 'D', 'E', 'F',
+                            'G', 'H', 'I', 'J', 'K', 'L']]
     ])
 def test_row_headers(names, expected):
     assert WellGrid(names, list(range(len(names)))).row_headers() == expected
@@ -43,8 +50,29 @@ def test_row_headers(names, expected):
             "A": [0, 6],
             "B": [1, 3, 5],
             "C": [2, 4, 7],
-            "D": [8],
-        }]])
+            "D": [8]}],
+    ])
+def test_row_dict(names, expected):
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_row_dict() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, []],
+        [ONE_VAL, [[0]]],
+        [NORMAL, [
+            [0, 3, 6, 9],
+            [1, 4, 7, 10],
+            [2, 5, 8, 11],
+        ]],
+        [CRAZY_SHAPE, [
+            [0, 6],
+            [1, 3, 5],
+            [2, 4, 7],
+            [8],
+        ]]])
 def test_rows(names, expected):
     grid = WellGrid(names, list(range(len(names))))
     assert grid.get_rows() == expected
@@ -56,8 +84,10 @@ def test_rows(names, expected):
         [NONE, []],
         [ONE_VAL, ['1']],
         [NORMAL, ['1', '2', '3', '4']],
-        [CRAZY_SHAPE, ['1', '2', '3', '4']]
-    ])
+        [CRAZY_SHAPE, ['1', '2', '3', '4']],
+        [TWELVE_BY_TWELVE, ['1', '2', '3', '4', '5', '6',
+                            '7', '8', '9', '10', '11', '12']]
+        ])
 def test_column_headers(names, expected):
     grid = WellGrid(names, list(range(len(names))))
     assert grid.column_headers() == expected
@@ -81,9 +111,54 @@ def test_column_headers(names, expected):
             '4': [6, 7, 8]
         }]
     ])
+def test_column_dict(names, expected):
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_column_dict() == expected
+
+
+@pytest.mark.parametrize(
+    argnames=["names", "expected"],
+    argvalues=[
+        [NONE, []],
+        [ONE_VAL, [[0]]],
+        [NORMAL, [
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8],
+            [9, 10, 11],
+        ]],
+        [CRAZY_SHAPE, [
+            [0, 1, 2],
+            [3, 4],
+            [5],
+            [6, 7, 8]
+        ]]
+    ])
 def test_columns(names, expected):
     grid = WellGrid(names, list(range(len(names))))
     assert grid.get_columns() == expected
+
+
+@pytest.mark.parametrize(argnames=["column", "expected"],
+                         argvalues=[
+                             ["2", [3, 4, 5]],
+                             ["1000", []]
+                         ])
+def test_column(column, expected):
+    names = NORMAL
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_column(column) == expected
+
+
+@pytest.mark.parametrize(argnames=["row", "expected"],
+                         argvalues=[
+                             ["B", [1, 4, 7, 10]],
+                             ["X", []]
+                         ])
+def test_row(row, expected):
+    names = NORMAL
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_row(row) == expected
 
 
 def test_well_pattern():

--- a/api/tests/opentrons/protocols/implementation/test_well_grid.py
+++ b/api/tests/opentrons/protocols/implementation/test_well_grid.py
@@ -1,33 +1,20 @@
 import pytest
-from opentrons.protocols.api_support.well_grid import WellGrid
+from opentrons.protocols.implementations.well_grid import WellGrid
 
-NONE: list = [[]]
-ONE_VAL = [["A1"]]
+NONE: list = []
+ONE_VAL = ["A1"]
 NORMAL = [
-    ["A1", "B1", "C1"],
-    ["A2", "B2", "C2"],
-    ["A3", "B3", "C3"],
-    ["A4", "B4", "C4"],
+    "A1", "B1", "C1",
+    "A2", "B2", "C2",
+    "A3", "B3", "C3",
+    "A4", "B4", "C4",
   ]
 CRAZY_SHAPE = [
-    ["A1", "B1", "C1"],
-    ["B2", "C2"],
-    ["B3"],
-    ["A4", "C4", "D4"],
+    "A1", "B1", "C1",
+    "B2", "C2",
+    "B3",
+    "A4", "C4", "D4",
   ]
-
-
-@pytest.mark.parametrize(
-    argnames=["names", "expected"],
-    argvalues=[
-        [NONE, []],
-        [ONE_VAL, ["A1"]],
-        [NORMAL, ["A1", "B1", "C1", "A2", "B2", "C2",
-                  "A3", "B3", "C3", "A4", "B4", "C4"]],
-        [CRAZY_SHAPE, ["A1", "B1", "C1", "B2", "C2", "B3", "A4", "C4", "D4"]]
-    ])
-def test_in_order(names, expected):
-    assert WellGrid(names).ordered_names() == expected
 
 
 @pytest.mark.parametrize(
@@ -39,7 +26,7 @@ def test_in_order(names, expected):
         [CRAZY_SHAPE, ['A', 'B', 'C', 'D']]
     ])
 def test_row_headers(names, expected):
-    assert WellGrid(names).row_headers() == expected
+    assert WellGrid(names, list(range(len(names)))).row_headers() == expected
 
 
 @pytest.mark.parametrize(
@@ -59,7 +46,8 @@ def test_row_headers(names, expected):
             "D": [8],
         }]])
 def test_rows(names, expected):
-    assert WellGrid(names).get_rows() == expected
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_rows() == expected
 
 
 @pytest.mark.parametrize(
@@ -71,7 +59,8 @@ def test_rows(names, expected):
         [CRAZY_SHAPE, ['1', '2', '3', '4']]
     ])
 def test_column_headers(names, expected):
-    assert WellGrid(names).column_headers() == expected
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.column_headers() == expected
 
 
 @pytest.mark.parametrize(
@@ -93,7 +82,8 @@ def test_column_headers(names, expected):
         }]
     ])
 def test_columns(names, expected):
-    assert WellGrid(names).get_columns() == expected
+    grid = WellGrid(names, list(range(len(names))))
+    assert grid.get_columns() == expected
 
 
 def test_well_pattern():

--- a/shared-data/python/opentrons_shared_data/labware/constants.py
+++ b/shared-data/python/opentrons_shared_data/labware/constants.py
@@ -1,0 +1,6 @@
+from typing_extensions import Final
+
+
+# Regular expression to validate and extract row, column from well name
+# (ie A3, C1)
+WELL_NAME_PATTERN: Final[str] = r'^([A-Z]+)([1-9][0-9]*)$'


### PR DESCRIPTION
# Overview

Another step in Labware refactor. Goals are to reduce the amount of work done by Well and Labware.

This is part of the effort of making the public facing classes in `protocol_api` package be facades that delegate their work to inner classes.

# Changelog

- Created a `WellImplementation` class which `Well` will delegate all work to. `WellImplementation` can become our internal replacement for `Well`. A class that knows nothing of protocols. 
- Moved `Labware._create_indexed_dictionary` logic out of Labware and into its own class: `WellGrid`.
- **Next Step**: move tip tracking from Labware into a separate class. It's only dependency would be the `WellGrid`

# Review requests

- Does this approach make sense?  
- Naming and new module locations make sense?

# Risk assessment

Medium. This doesn't touch public interface of Labware or Well, but modifies the guts a lot.

closes #6679