### PR TITLE
refactor(app): add calibrate deck warnings and gates

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -22,6 +22,7 @@ import {
 } from './constants'
 import { DeckCalibrationControl } from './DeckCalibrationControl'
 import { CheckCalibrationControl } from './CheckCalibrationControl'
+import { CalibrationCardWarning } from './CalibrationCardWarning'
 import { PipetteOffsets } from './PipetteOffsets'
 
 type Props = {|
@@ -30,11 +31,6 @@ type Props = {|
 |}
 
 const TITLE = 'Robot Calibration'
-
-// TODO: Change these two
-const BAD_DECK_CALIBRATION =
-  'Bad deck calibration detected. Please perform a full deck calibration.'
-const NO_DECK_CALIBRATION = 'Please perform a full deck calibration.'
 
 export function CalibrationCard(props: Props): React.Node {
   const { robot, pipettesPageUrl } = props
@@ -75,24 +71,23 @@ export function CalibrationCard(props: Props): React.Node {
     buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
   }
 
-  let calCheckDisabledReason = buttonDisabledReason
-  if (
-    deckCalStatus === Calibration.DECK_CAL_STATUS_BAD_CALIBRATION ||
-    deckCalStatus === Calibration.DECK_CAL_STATUS_SINGULARITY
-  ) {
-    calCheckDisabledReason = BAD_DECK_CALIBRATION
-  } else if (deckCalStatus === Calibration.DECK_CAL_STATUS_IDENTITY) {
-    calCheckDisabledReason = NO_DECK_CALIBRATION
-  }
+  const warningInsteadOfCalcheck = [
+    Calibration.DECK_CAL_STATUS_SINGULARITY,
+    Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
+    Calibration.DECK_CAL_STATUS_IDENTITY,
+  ].includes(deckCalStatus)
 
   return (
     <Card title={TITLE}>
-      {deckCalStatus !== null && (
+      {warningInsteadOfCalcheck ? (
+        <CalibrationCardWarning />
+      ) : (
         <CheckCalibrationControl
           robotName={robotName}
-          disabledReason={calCheckDisabledReason}
+          disabledReason={buttonDisabledReason}
         />
       )}
+
       <DeckCalibrationControl
         robotName={robotName}
         buttonDisabled={buttonDisabledReason}

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -90,7 +90,7 @@ export function CalibrationCard(props: Props): React.Node {
 
       <DeckCalibrationControl
         robotName={robotName}
-        buttonDisabled={buttonDisabledReason}
+        disabledReason={buttonDisabledReason}
         deckCalStatus={deckCalStatus}
         deckCalData={deckCalData}
       />

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -20,7 +20,7 @@ import {
   DISABLED_CONNECT_TO_ROBOT,
   DISABLED_PROTOCOL_IS_RUNNING,
 } from './constants'
-import { DeckCalibrationControl } from './DeckCalibrationControl'
+import { LegacyDeckCalibrationControl } from './LegacyDeckCalibrationControl'
 import { CheckCalibrationControl } from './CheckCalibrationControl'
 import { PipetteOffsets } from './PipetteOffsets'
 
@@ -88,19 +88,19 @@ export function CalibrationCard(props: Props): React.Node {
   const buttonDisabled = Boolean(buttonDisabledReason)
   return (
     <Card title={TITLE}>
-      <DeckCalibrationControl
-        robotName={robotName}
-        buttonDisabled={buttonDisabled}
-        deckCalStatus={deckCalStatus}
-        deckCalData={deckCalData}
-        startLegacyDeckCalibration={() => {}}
-      />
       {deckCalStatus !== null && (
         <CheckCalibrationControl
           robotName={robotName}
           disabledReason={calCheckDisabledReason}
         />
       )}
+      <LegacyDeckCalibrationControl
+        robotName={robotName}
+        buttonDisabled={buttonDisabled}
+        deckCalStatus={deckCalStatus}
+        deckCalData={deckCalData}
+        startLegacyDeckCalibration={() => {}}
+      />
       <PipetteOffsets pipettesPageUrl={pipettesPageUrl} robot={robot} />
     </Card>
   )

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -20,7 +20,7 @@ import {
   DISABLED_CONNECT_TO_ROBOT,
   DISABLED_PROTOCOL_IS_RUNNING,
 } from './constants'
-import { LegacyDeckCalibrationControl } from './LegacyDeckCalibrationControl'
+import { DeckCalibrationControl } from './DeckCalibrationControl'
 import { CheckCalibrationControl } from './CheckCalibrationControl'
 import { PipetteOffsets } from './PipetteOffsets'
 
@@ -85,7 +85,6 @@ export function CalibrationCard(props: Props): React.Node {
     calCheckDisabledReason = NO_DECK_CALIBRATION
   }
 
-  const buttonDisabled = Boolean(buttonDisabledReason)
   return (
     <Card title={TITLE}>
       {deckCalStatus !== null && (
@@ -94,12 +93,11 @@ export function CalibrationCard(props: Props): React.Node {
           disabledReason={calCheckDisabledReason}
         />
       )}
-      <LegacyDeckCalibrationControl
+      <DeckCalibrationControl
         robotName={robotName}
-        buttonDisabled={buttonDisabled}
+        buttonDisabled={buttonDisabledReason}
         deckCalStatus={deckCalStatus}
         deckCalData={deckCalData}
-        startLegacyDeckCalibration={() => {}}
       />
       <PipetteOffsets pipettesPageUrl={pipettesPageUrl} robot={robot} />
     </Card>

--- a/app/src/components/RobotSettings/CalibrationCardWarning.js
+++ b/app/src/components/RobotSettings/CalibrationCardWarning.js
@@ -1,0 +1,54 @@
+// @flow
+
+import * as React from 'react'
+
+import {
+  ALIGN_CENTER,
+  Box,
+  Flex,
+  COLOR_ERROR,
+  DIRECTION_COLUMN,
+  FONT_SIZE_BODY_1,
+  FONT_WEIGHT_SEMIBOLD,
+  Icon,
+  SIZE_2,
+  SPACING_3,
+  SPACING_2,
+  SPACING_1,
+  Text,
+  TEXT_TRANSFORM_CAPITALIZE,
+} from '@opentrons/components'
+
+import type { StyleProps } from '@opentrons/components'
+
+const WARNING_HEADER = 'full robot calibration needed'
+const WARNING_TEXT =
+  'This OT-2 does not have a valid deck calibration. Deck calibration matches the motion of the OT-2 to its deck, and must be performed before you can run a protocol. To perform deck calibration, click the Calibrate button below.'
+
+type Props = {|
+  ...StyleProps,
+|}
+export function CalibrationCardWarning({ ...styleProps }: Props): React.Node {
+  return (
+    <Box padding={SPACING_3} color={COLOR_ERROR} {...styleProps}>
+      <Flex flexDirection={DIRECTION_COLUMN} fontSize={FONT_SIZE_BODY_1}>
+        <Flex alignItems={ALIGN_CENTER}>
+          <Box paddingY={SPACING_1} paddingRight={SPACING_2} size={SIZE_2}>
+            <Icon name="alert-circle" />
+          </Box>
+          <Text
+            as="h4"
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
+            textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          >
+            {WARNING_HEADER}
+          </Text>
+        </Flex>
+        <Flex>
+          <Box size={SIZE_2} flex="1 1 auto" minWidth={SIZE_2} />
+          <Text>{WARNING_TEXT}</Text>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/app/src/components/RobotSettings/ControlsCard.js
+++ b/app/src/components/RobotSettings/ControlsCard.js
@@ -35,7 +35,7 @@ import type { State, Dispatch } from '../../types'
 import type { ViewableRobot } from '../../discovery/types'
 
 import { CheckCalibrationControl } from './CheckCalibrationControl'
-import { DeckCalibrationControl } from './DeckCalibrationControl'
+import { LegacyDeckCalibrationControl } from './LegacyDeckCalibrationControl'
 
 type Props = {|
   robot: ViewableRobot,
@@ -105,7 +105,7 @@ export function ControlsCard(props: Props): React.Node {
   return (
     <Card title={TITLE}>
       {!ff.enableCalibrationOverhaul && (
-        <DeckCalibrationControl
+        <LegacyDeckCalibrationControl
           robotName={robotName}
           buttonDisabled={buttonDisabled}
           deckCalStatus={deckCalStatus}

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -1,0 +1,216 @@
+// @flow
+
+import * as React from 'react'
+
+import * as RobotApi from '../../robot-api'
+import * as Sessions from '../../sessions'
+import * as Calibration from '../../calibration'
+
+import { Portal } from '../portal'
+import { CalibrateDeck } from '../CalibrateDeck'
+import { TitledControl } from '../TitledControl'
+import { ConfirmStartDeckCalModal } from './ConfirmStartDeckCalModal'
+import { DeckCalibrationWarning } from './DeckCalibrationWarning'
+import { useSelector } from 'react-redux'
+import { format } from 'date-fns'
+import {
+  Text,
+  SecondaryBtn,
+  BORDER_SOLID_LIGHT,
+  SPACING_2,
+  SPACING_4,
+  useConditionalConfirm,
+  FONT_STYLE_ITALIC,
+  Tooltip,
+  useHoverTooltip,
+} from '@opentrons/components'
+
+import type { State } from '../../types'
+import type {
+  DeckCalibrationStatus,
+  DeckCalibrationData,
+} from '../../calibration/types'
+import type { SessionCommandString } from '../../sessions/types'
+import type { RequestState } from '../../robot-api/types'
+
+const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
+const LAST_CALIBRATED = 'Last calibrated: '
+const CALIBRATE_DECK_DESCRIPTION =
+  "Calibrate the position of the robot's deck. Recommended for all new robots and after moving robots."
+const CALIBRATE_BUTTON_TEXT = 'Calibrate'
+const CALIBRATE_TITLE_TEXT = 'Calibrate deck'
+
+const buildDeckLastCalibrated: (
+  data: DeckCalibrationData,
+  status: DeckCalibrationStatus
+) => string = (data, status) => {
+  if (status === Calibration.DECK_CAL_STATUS_IDENTITY) {
+    return DECK_NEVER_CALIBRATED
+  }
+  const datestring =
+    typeof data.lastModified === 'string'
+      ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
+      : 'unknown'
+  return `${LAST_CALIBRATED} ${datestring}`
+}
+
+// deck calibration commands for which the full page spinner should not appear
+const spinnerCommandBlockList: Array<SessionCommandString> = [
+  Sessions.sharedCalCommands.JOG,
+]
+
+export type Props = {|
+  robotName: string,
+  buttonDisabled: string | null,
+  deckCalStatus: DeckCalibrationStatus | null,
+  deckCalData: DeckCalibrationData | null,
+|}
+
+export function DeckCalibrationControl(props: Props): React.Node {
+  const { robotName, buttonDisabled, deckCalStatus, deckCalData } = props
+
+  const [showWizard, setShowWizard] = React.useState(false)
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
+  const trackedRequestId = React.useRef<string | null>(null)
+  const deleteRequestId = React.useRef<string | null>(null)
+  const createRequestId = React.useRef<string | null>(null)
+
+  const [dispatchRequests] = RobotApi.useDispatchApiRequests(
+    dispatchedAction => {
+      if (dispatchedAction.type === Sessions.ENSURE_SESSION) {
+        createRequestId.current = dispatchedAction.meta.requestId
+      } else if (
+        dispatchedAction.type === Sessions.DELETE_SESSION &&
+        deckCalibrationSession?.id === dispatchedAction.payload.sessionId
+      ) {
+        deleteRequestId.current = dispatchedAction.meta.requestId
+      } else if (
+        dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
+        !spinnerCommandBlockList.includes(
+          dispatchedAction.payload.command.command
+        )
+      ) {
+        trackedRequestId.current = dispatchedAction.meta.requestId
+      }
+    }
+  )
+
+  const showSpinner =
+    useSelector<State, RequestState | null>(state =>
+      trackedRequestId.current
+        ? RobotApi.getRequestById(state, trackedRequestId.current)
+        : null
+    )?.status === RobotApi.PENDING
+
+  const shouldClose =
+    useSelector<State, RequestState | null>(state =>
+      deleteRequestId.current
+        ? RobotApi.getRequestById(state, deleteRequestId.current)
+        : null
+    )?.status === RobotApi.SUCCESS
+
+  const shouldOpen =
+    useSelector((state: State) =>
+      createRequestId.current
+        ? RobotApi.getRequestById(state, createRequestId.current)
+        : null
+    )?.status === RobotApi.SUCCESS
+
+  React.useEffect(() => {
+    if (shouldOpen) {
+      setShowWizard(true)
+      createRequestId.current = null
+    }
+    if (shouldClose) {
+      setShowWizard(false)
+      deleteRequestId.current = null
+    }
+  }, [shouldOpen, shouldClose])
+
+  const handleStartDeckCalSession = () => {
+    dispatchRequests(
+      Sessions.ensureSession(robotName, Sessions.SESSION_TYPE_DECK_CALIBRATION)
+    )
+  }
+
+  const deckCalibrationSession = useSelector((state: State) => {
+    const session: Sessions.Session | null = Sessions.getRobotSessionOfType(
+      state,
+      robotName,
+      Sessions.SESSION_TYPE_DECK_CALIBRATION
+    )
+    if (
+      session &&
+      session.sessionType === Sessions.SESSION_TYPE_DECK_CALIBRATION
+    ) {
+      return session
+    }
+    return null
+  })
+
+  const {
+    showConfirmation: showConfirmStart,
+    confirm: confirmStart,
+    cancel: cancelStart,
+  } = useConditionalConfirm(() => {
+    handleStartDeckCalSession()
+  }, true)
+
+  return (
+    <>
+      <TitledControl
+        borderBottom={BORDER_SOLID_LIGHT}
+        title={CALIBRATE_TITLE_TEXT}
+        description={
+          <>
+            <DeckCalibrationWarning
+              marginTop={SPACING_2}
+              deckCalibrationStatus={deckCalStatus}
+            />
+            <Text>{CALIBRATE_DECK_DESCRIPTION}</Text>
+          </>
+        }
+        control={
+          <SecondaryBtn
+            {...targetProps}
+            width="9rem"
+            onClick={confirmStart}
+            disabled={buttonDisabled}
+          >
+            {CALIBRATE_BUTTON_TEXT}
+          </SecondaryBtn>
+        }
+      >
+        {buttonDisabled !== null && (
+          <Tooltip {...tooltipProps}>{buttonDisabled}</Tooltip>
+        )}
+
+        {deckCalData && deckCalStatus && (
+          <Text marginTop={SPACING_4} fontStyle={FONT_STYLE_ITALIC}>
+            {buildDeckLastCalibrated(deckCalData, deckCalStatus)}
+          </Text>
+        )}
+      </TitledControl>
+      {showConfirmStart && (
+        <Portal>
+          <ConfirmStartDeckCalModal
+            confirm={confirmStart}
+            cancel={cancelStart}
+          />
+        </Portal>
+      )}
+      {showWizard && (
+        <Portal>
+          <CalibrateDeck
+            session={deckCalibrationSession}
+            robotName={robotName}
+            closeWizard={() => setShowWizard(false)}
+            dispatchRequests={dispatchRequests}
+            showSpinner={showSpinner}
+          />
+        </Portal>
+      )}
+    </>
+  )
+}

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -17,7 +17,6 @@ import {
   Text,
   SecondaryBtn,
   BORDER_SOLID_LIGHT,
-  SPACING_2,
   SPACING_4,
   useConditionalConfirm,
   FONT_STYLE_ITALIC,
@@ -61,13 +60,13 @@ const spinnerCommandBlockList: Array<SessionCommandString> = [
 
 export type Props = {|
   robotName: string,
-  buttonDisabled: string | null,
+  disabledReason: string | null,
   deckCalStatus: DeckCalibrationStatus | null,
   deckCalData: DeckCalibrationData | null,
 |}
 
 export function DeckCalibrationControl(props: Props): React.Node {
-  const { robotName, buttonDisabled, deckCalStatus, deckCalData } = props
+  const { robotName, disabledReason, deckCalStatus, deckCalData } = props
 
   const [showWizard, setShowWizard] = React.useState(false)
   const [targetProps, tooltipProps] = useHoverTooltip()
@@ -164,10 +163,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
         title={CALIBRATE_TITLE_TEXT}
         description={
           <>
-            <DeckCalibrationWarning
-              marginTop={SPACING_2}
-              deckCalibrationStatus={deckCalStatus}
-            />
+            <DeckCalibrationWarning deckCalibrationStatus={deckCalStatus} />
             <Text>{CALIBRATE_DECK_DESCRIPTION}</Text>
           </>
         }
@@ -176,14 +172,14 @@ export function DeckCalibrationControl(props: Props): React.Node {
             {...targetProps}
             width="9rem"
             onClick={confirmStart}
-            disabled={buttonDisabled}
+            disabled={disabledReason}
           >
             {CALIBRATE_BUTTON_TEXT}
           </SecondaryBtn>
         }
       >
-        {buttonDisabled !== null && (
-          <Tooltip {...tooltipProps}>{buttonDisabled}</Tooltip>
+        {disabledReason !== null && (
+          <Tooltip {...tooltipProps}>{disabledReason}</Tooltip>
         )}
 
         {deckCalData && deckCalStatus && (

--- a/app/src/components/RobotSettings/DeckCalibrationWarning.js
+++ b/app/src/components/RobotSettings/DeckCalibrationWarning.js
@@ -15,12 +15,10 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 
-import type { StyleProps } from '@opentrons/components'
 import { DECK_CAL_STATUS_OK } from '../../calibration'
 import type { DeckCalibrationStatus } from '../../calibration/types'
 
 export type DeckCalibrationWarningProps = {|
-  ...StyleProps,
   deckCalibrationStatus: DeckCalibrationStatus | null,
 |}
 
@@ -28,12 +26,15 @@ const CALIBRATION_REQUIRED = 'Calibration required'
 
 export function DeckCalibrationWarning({
   deckCalibrationStatus,
-  ...styleProps
 }: DeckCalibrationWarningProps): React.Node {
   return (
     <>
       {deckCalibrationStatus && deckCalibrationStatus !== DECK_CAL_STATUS_OK && (
-        <Flex alignItems={ALIGN_CENTER} color={COLOR_ERROR} {...styleProps}>
+        <Flex
+          alignItems={ALIGN_CENTER}
+          color={COLOR_ERROR}
+          marginTop={SPACING_2}
+        >
           <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
             <Icon name="alert-circle" />
           </Box>

--- a/app/src/components/RobotSettings/DeckCalibrationWarning.js
+++ b/app/src/components/RobotSettings/DeckCalibrationWarning.js
@@ -6,7 +6,6 @@ import {
   Flex,
   Text,
   FONT_SIZE_BODY_1,
-  COLOR_WARNING,
   COLOR_ERROR,
   SIZE_2,
   SPACING_AUTO,
@@ -15,47 +14,37 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 
-import * as Calibration from '../../calibration'
-
 import type { StyleProps } from '@opentrons/components'
+import { DECK_CAL_STATUS_OK } from '../../calibration'
 import type { DeckCalibrationStatus } from '../../calibration/types'
 
 export type DeckCalibrationWarningProps = {|
-  deckCalibrationStatus: DeckCalibrationStatus | null,
   ...StyleProps,
+  deckCalibrationStatus: DeckCalibrationStatus | null,
 |}
 
-const ROBOT_CAL_WARNING = "This robot's deck has not yet been calibrated."
-const ROBOT_CAL_ERROR =
-  'Bad deck calibration detected! This robot is likely to experience a crash.'
-const ROBOT_CAL_RESOLUTION =
-  'Please perform a deck calibration prior to uploading a protocol.'
+const CALIBRATION_REQUIRED = 'Calibration required'
 
 export function DeckCalibrationWarning({
-  deckCalibrationStatus: status,
+  deckCalibrationStatus,
   ...styleProps
 }: DeckCalibrationWarningProps): React.Node {
-  if (status === null || status === Calibration.DECK_CAL_STATUS_OK) {
-    return null
-  }
-
-  const isNoCalibration = status === Calibration.DECK_CAL_STATUS_IDENTITY
-  const message = isNoCalibration ? ROBOT_CAL_WARNING : ROBOT_CAL_ERROR
-  const color = isNoCalibration ? COLOR_WARNING : COLOR_ERROR
-
   return (
-    <Flex alignItems={ALIGN_CENTER} color={color} {...styleProps}>
-      <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
-        <Icon name="alert-circle" />
-      </Box>
-      <Box
-        fontSize={FONT_SIZE_BODY_1}
-        paddingRight={SPACING_1}
-        marginRight={SPACING_AUTO}
-      >
-        <Text>{message}</Text>
-        <Text>{ROBOT_CAL_RESOLUTION}</Text>
-      </Box>
-    </Flex>
+    <>
+      {deckCalibrationStatus && deckCalibrationStatus !== DECK_CAL_STATUS_OK && (
+        <Flex alignItems={ALIGN_CENTER} color={COLOR_ERROR} {...styleProps}>
+          <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
+            <Icon name="alert-circle" />
+          </Box>
+          <Box
+            fontSize={FONT_SIZE_BODY_1}
+            paddingRight={SPACING_1}
+            marginRight={SPACING_AUTO}
+          >
+            <Text>{CALIBRATION_REQUIRED}</Text>
+          </Box>
+        </Flex>
+      )}
+    </>
   )
 }

--- a/app/src/components/RobotSettings/DeckCalibrationWarning.js
+++ b/app/src/components/RobotSettings/DeckCalibrationWarning.js
@@ -5,6 +5,7 @@ import {
   Box,
   Flex,
   Text,
+  FONT_WEIGHT_SEMIBOLD,
   FONT_SIZE_BODY_1,
   COLOR_ERROR,
   SIZE_2,
@@ -40,6 +41,7 @@ export function DeckCalibrationWarning({
             fontSize={FONT_SIZE_BODY_1}
             paddingRight={SPACING_1}
             marginRight={SPACING_AUTO}
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
           >
             <Text>{CALIBRATION_REQUIRED}</Text>
           </Box>

--- a/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
@@ -39,32 +39,30 @@ export function LegacyDeckCalibrationControl(props: Props): React.Node {
   } = props
 
   return (
-    <>
-      <TitledControl
-        borderBottom={BORDER_SOLID_LIGHT}
-        title={CALIBRATE_TITLE_TEXT}
-        description={<Text>{CALIBRATE_DECK_DESCRIPTION}</Text>}
-        control={
-          <SecondaryBtn
-            width="9rem"
-            onClick={startLegacyDeckCalibration}
-            disabled={buttonDisabled}
-          >
-            {CALIBRATE_BUTTON_TEXT}
-          </SecondaryBtn>
-        }
-      >
-        <LegacyDeckCalibrationWarning
-          deckCalibrationStatus={deckCalStatus}
-          marginTop={SPACING_2}
-        />
-        <DeckCalibrationDownload
-          deckCalibrationStatus={deckCalStatus}
-          deckCalibrationData={deckCalData}
-          robotName={robotName}
-          marginTop={SPACING_2}
-        />
-      </TitledControl>
-    </>
+    <TitledControl
+      borderBottom={BORDER_SOLID_LIGHT}
+      title={CALIBRATE_TITLE_TEXT}
+      description={<Text>{CALIBRATE_DECK_DESCRIPTION}</Text>}
+      control={
+        <SecondaryBtn
+          width="9rem"
+          onClick={startLegacyDeckCalibration}
+          disabled={buttonDisabled}
+        >
+          {CALIBRATE_BUTTON_TEXT}
+        </SecondaryBtn>
+      }
+    >
+      <LegacyDeckCalibrationWarning
+        deckCalibrationStatus={deckCalStatus}
+        marginTop={SPACING_2}
+      />
+      <DeckCalibrationDownload
+        deckCalibrationStatus={deckCalStatus}
+        deckCalibrationData={deckCalData}
+        robotName={robotName}
+        marginTop={SPACING_2}
+      />
+    </TitledControl>
   )
 }

--- a/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
@@ -1,35 +1,19 @@
 // @flow
 import * as React from 'react'
-import { useSelector } from 'react-redux'
-import { format } from 'date-fns'
 import {
   Text,
   SecondaryBtn,
   BORDER_SOLID_LIGHT,
   SPACING_2,
-  SPACING_4,
-  useConditionalConfirm,
-  FONT_STYLE_ITALIC,
 } from '@opentrons/components'
 
-import { getFeatureFlags } from '../../config'
-import * as RobotApi from '../../robot-api'
-import * as Sessions from '../../sessions'
-import { DECK_CAL_STATUS_IDENTITY } from '../../calibration'
-
-import type { State } from '../../types'
 import type {
   DeckCalibrationStatus,
   DeckCalibrationData,
 } from '../../calibration/types'
-import type { SessionCommandString } from '../../sessions/types'
-import type { RequestState } from '../../robot-api/types'
 
-import { Portal } from '../portal'
 import { TitledControl } from '../TitledControl'
-import { CalibrateDeck } from '../CalibrateDeck'
-import { DeckCalibrationWarning } from './DeckCalibrationWarning'
-import { ConfirmStartDeckCalModal } from './ConfirmStartDeckCalModal'
+import { LegacyDeckCalibrationWarning } from './LegacyDeckCalibrationWarning'
 import { DeckCalibrationDownload } from './DeckCalibrationDownload'
 
 type Props = {|
@@ -39,28 +23,6 @@ type Props = {|
   deckCalData: DeckCalibrationData | null,
   startLegacyDeckCalibration: () => void,
 |}
-
-const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
-const LAST_CALIBRATED = 'Last calibrated: '
-
-const buildDeckLastCalibrated: (
-  data: DeckCalibrationData,
-  status: DeckCalibrationStatus
-) => string = (data, status) => {
-  if (status === DECK_CAL_STATUS_IDENTITY) {
-    return DECK_NEVER_CALIBRATED
-  }
-  const datestring =
-    typeof data.lastModified === 'string'
-      ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
-      : 'unknown'
-  return `${LAST_CALIBRATED} ${datestring}`
-}
-
-// deck calibration commands for which the full page spinner should not appear
-const spinnerCommandBlockList: Array<SessionCommandString> = [
-  Sessions.sharedCalCommands.JOG,
-]
 
 const CALIBRATE_DECK_DESCRIPTION =
   "Calibrate the position of the robot's deck. Recommended for all new robots and after moving robots."
@@ -76,99 +38,6 @@ export function LegacyDeckCalibrationControl(props: Props): React.Node {
     startLegacyDeckCalibration,
   } = props
 
-  const [showWizard, setShowWizard] = React.useState(false)
-
-  const trackedRequestId = React.useRef<string | null>(null)
-  const deleteRequestId = React.useRef<string | null>(null)
-  const createRequestId = React.useRef<string | null>(null)
-
-  const [dispatchRequests] = RobotApi.useDispatchApiRequests(
-    dispatchedAction => {
-      if (dispatchedAction.type === Sessions.ENSURE_SESSION) {
-        createRequestId.current = dispatchedAction.meta.requestId
-      } else if (
-        dispatchedAction.type === Sessions.DELETE_SESSION &&
-        deckCalibrationSession?.id === dispatchedAction.payload.sessionId
-      ) {
-        deleteRequestId.current = dispatchedAction.meta.requestId
-      } else if (
-        dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
-        !spinnerCommandBlockList.includes(
-          dispatchedAction.payload.command.command
-        )
-      ) {
-        trackedRequestId.current = dispatchedAction.meta.requestId
-      }
-    }
-  )
-
-  const showSpinner =
-    useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current
-        ? RobotApi.getRequestById(state, trackedRequestId.current)
-        : null
-    )?.status === RobotApi.PENDING
-
-  const shouldClose =
-    useSelector<State, RequestState | null>(state =>
-      deleteRequestId.current
-        ? RobotApi.getRequestById(state, deleteRequestId.current)
-        : null
-    )?.status === RobotApi.SUCCESS
-
-  const shouldOpen =
-    useSelector((state: State) =>
-      createRequestId.current
-        ? RobotApi.getRequestById(state, createRequestId.current)
-        : null
-    )?.status === RobotApi.SUCCESS
-
-  const ff = useSelector(getFeatureFlags)
-
-  React.useEffect(() => {
-    if (shouldOpen) {
-      setShowWizard(true)
-      createRequestId.current = null
-    }
-    if (shouldClose) {
-      setShowWizard(false)
-      deleteRequestId.current = null
-    }
-  }, [shouldOpen, shouldClose])
-
-  const handleStartDeckCalSession = () => {
-    dispatchRequests(
-      Sessions.ensureSession(robotName, Sessions.SESSION_TYPE_DECK_CALIBRATION)
-    )
-  }
-
-  const deckCalibrationSession = useSelector((state: State) => {
-    const session: Sessions.Session | null = Sessions.getRobotSessionOfType(
-      state,
-      robotName,
-      Sessions.SESSION_TYPE_DECK_CALIBRATION
-    )
-    if (
-      session &&
-      session.sessionType === Sessions.SESSION_TYPE_DECK_CALIBRATION
-    ) {
-      return session
-    }
-    return null
-  })
-
-  const {
-    showConfirmation: showConfirmStart,
-    confirm: confirmStart,
-    cancel: cancelStart,
-  } = useConditionalConfirm(() => {
-    handleStartDeckCalSession()
-  }, true)
-
-  const handleButtonClick = ff.enableCalibrationOverhaul
-    ? confirmStart
-    : startLegacyDeckCalibration
-
   return (
     <>
       <TitledControl
@@ -178,52 +47,24 @@ export function LegacyDeckCalibrationControl(props: Props): React.Node {
         control={
           <SecondaryBtn
             width="9rem"
-            onClick={handleButtonClick}
+            onClick={startLegacyDeckCalibration}
             disabled={buttonDisabled}
           >
             {CALIBRATE_BUTTON_TEXT}
           </SecondaryBtn>
         }
       >
-        <DeckCalibrationWarning
+        <LegacyDeckCalibrationWarning
           deckCalibrationStatus={deckCalStatus}
           marginTop={SPACING_2}
         />
-        {ff.enableCalibrationOverhaul ? (
-          deckCalData &&
-          deckCalStatus && (
-            <Text marginTop={SPACING_4} fontStyle={FONT_STYLE_ITALIC}>
-              {buildDeckLastCalibrated(deckCalData, deckCalStatus)}
-            </Text>
-          )
-        ) : (
-          <DeckCalibrationDownload
-            deckCalibrationStatus={deckCalStatus}
-            deckCalibrationData={deckCalData}
-            robotName={robotName}
-            marginTop={SPACING_2}
-          />
-        )}
+        <DeckCalibrationDownload
+          deckCalibrationStatus={deckCalStatus}
+          deckCalibrationData={deckCalData}
+          robotName={robotName}
+          marginTop={SPACING_2}
+        />
       </TitledControl>
-      {showConfirmStart && (
-        <Portal>
-          <ConfirmStartDeckCalModal
-            confirm={confirmStart}
-            cancel={cancelStart}
-          />
-        </Portal>
-      )}
-      {showWizard && (
-        <Portal>
-          <CalibrateDeck
-            session={deckCalibrationSession}
-            robotName={robotName}
-            closeWizard={() => setShowWizard(false)}
-            dispatchRequests={dispatchRequests}
-            showSpinner={showSpinner}
-          />
-        </Portal>
-      )}
     </>
   )
 }

--- a/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/LegacyDeckCalibrationControl.js
@@ -67,7 +67,7 @@ const CALIBRATE_DECK_DESCRIPTION =
 const CALIBRATE_BUTTON_TEXT = 'Calibrate'
 const CALIBRATE_TITLE_TEXT = 'Calibrate deck'
 
-export function DeckCalibrationControl(props: Props): React.Node {
+export function LegacyDeckCalibrationControl(props: Props): React.Node {
   const {
     robotName,
     buttonDisabled,

--- a/app/src/components/RobotSettings/LegacyDeckCalibrationWarning.js
+++ b/app/src/components/RobotSettings/LegacyDeckCalibrationWarning.js
@@ -1,0 +1,61 @@
+// @flow
+import * as React from 'react'
+import {
+  Icon,
+  Box,
+  Flex,
+  Text,
+  FONT_SIZE_BODY_1,
+  COLOR_WARNING,
+  COLOR_ERROR,
+  SIZE_2,
+  SPACING_AUTO,
+  SPACING_1,
+  SPACING_2,
+  ALIGN_CENTER,
+} from '@opentrons/components'
+
+import * as Calibration from '../../calibration'
+
+import type { StyleProps } from '@opentrons/components'
+import type { DeckCalibrationStatus } from '../../calibration/types'
+
+export type LegacyDeckCalibrationWarningProps = {|
+  deckCalibrationStatus: DeckCalibrationStatus | null,
+  ...StyleProps,
+|}
+
+const ROBOT_CAL_WARNING = "This robot's deck has not yet been calibrated."
+const ROBOT_CAL_ERROR =
+  'Bad deck calibration detected! This robot is likely to experience a crash.'
+const ROBOT_CAL_RESOLUTION =
+  'Please perform a deck calibration prior to uploading a protocol.'
+
+export function LegacyDeckCalibrationWarning({
+  deckCalibrationStatus: status,
+  ...styleProps
+}: LegacyDeckCalibrationWarningProps): React.Node {
+  if (status === null || status === Calibration.DECK_CAL_STATUS_OK) {
+    return null
+  }
+
+  const isNoCalibration = status === Calibration.DECK_CAL_STATUS_IDENTITY
+  const message = isNoCalibration ? ROBOT_CAL_WARNING : ROBOT_CAL_ERROR
+  const color = isNoCalibration ? COLOR_WARNING : COLOR_ERROR
+
+  return (
+    <Flex alignItems={ALIGN_CENTER} color={color} {...styleProps}>
+      <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
+        <Icon name="alert-circle" />
+      </Box>
+      <Box
+        fontSize={FONT_SIZE_BODY_1}
+        paddingRight={SPACING_1}
+        marginRight={SPACING_AUTO}
+      >
+        <Text>{message}</Text>
+        <Text>{ROBOT_CAL_RESOLUTION}</Text>
+      </Box>
+    </Flex>
+  )
+}

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -11,7 +11,7 @@ import * as RobotSelectors from '../../../robot/selectors'
 
 import { CalibrationCard } from '../CalibrationCard'
 import { CheckCalibrationControl } from '../CheckCalibrationControl'
-import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
+import { CalibrationCardWarning } from '../CalibrationCardWarning'
 import { PipetteOffsets } from '../PipetteOffsets'
 
 import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
@@ -177,55 +177,25 @@ describe('CalibrationCard', () => {
     )
   })
 
-  it('does not render check cal button if GET /calibration/status has not responded', () => {
-    getDeckCalibrationStatus.mockReturnValue(null)
+  const cals = [
+    Calibration.DECK_CAL_STATUS_SINGULARITY,
+    Calibration.DECK_CAL_STATUS_IDENTITY,
+    Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
+  ]
+  cals.forEach(status => {
+    it(`CalibrationCardWarning component renders instead of check calibration if deck calibration is ${status}`, () => {
+      getDeckCalibrationStatus.mockImplementation((state, rName) => {
+        expect(state).toEqual(MOCK_STATE)
+        expect(rName).toEqual(mockRobot.name)
+        return status
+      })
+      const { wrapper } = render()
 
-    const { wrapper } = render()
-    expect(wrapper.exists(CheckCalibrationControl)).toBe(false)
-  })
-
-  it('disables check cal button if deck calibration is bad', () => {
-    getDeckCalibrationStatus.mockImplementation((state, rName) => {
-      expect(state).toEqual(MOCK_STATE)
-      expect(rName).toEqual(mockRobot.name)
-      return Calibration.DECK_CAL_STATUS_BAD_CALIBRATION
+      expect(wrapper.exists(CalibrationCardWarning)).toBe(true)
+      expect(wrapper.exists(CheckCalibrationControl)).toBe(false)
     })
-
-    const { wrapper } = render()
-
-    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
-      'Bad deck calibration detected. Please perform a full deck calibration.'
-    )
-
-    getDeckCalibrationStatus.mockReturnValue(
-      Calibration.DECK_CAL_STATUS_SINGULARITY
-    )
-    wrapper.setProps({})
-    wrapper.update()
-
-    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
-      'Bad deck calibration detected. Please perform a full deck calibration.'
-    )
-
-    getDeckCalibrationStatus.mockReturnValue(
-      Calibration.DECK_CAL_STATUS_IDENTITY
-    )
-    wrapper.setProps({})
-    wrapper.update()
-
-    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
-      'Please perform a full deck calibration.'
-    )
   })
 
-  it('DeckCalibrationWarning component renders if deck calibration is bad', () => {
-    const { wrapper } = render()
-
-    // check that the deck calibration warning component is not null
-    // TODO(lc, 2020-06-18): Mock out the new transform status such that
-    // this should evaluate to true.
-    expect(wrapper.exists(DeckCalibrationWarning)).toBe(true)
-  })
   it('renders PipetteOffsets', () => {
     const { wrapper } = render()
     expect(wrapper.exists(PipetteOffsets)).toBe(true)

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -130,7 +130,7 @@ describe('CalibrationCard', () => {
 
     const { wrapper } = render()
 
-    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(false)
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(null)
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       null
     )
@@ -139,7 +139,9 @@ describe('CalibrationCard', () => {
   it('DC and check cal buttons disabled if not connectable', () => {
     const { wrapper } = render(mockUnconnectableRobot)
 
-    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(
+      'Cannot connect to robot'
+    )
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Cannot connect to robot'
     )
@@ -154,7 +156,9 @@ describe('CalibrationCard', () => {
 
     const { wrapper } = render(mockRobotNotConnected)
 
-    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(
+      'Connect to robot to control'
+    )
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Connect to robot to control'
     )
@@ -165,7 +169,9 @@ describe('CalibrationCard', () => {
 
     const { wrapper } = render()
 
-    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(true)
+    expect(getDeckCalButton(wrapper).prop('disabled')).toBe(
+      'Protocol is running'
+    )
     expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
       'Protocol is running'
     )

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -10,7 +10,7 @@ import * as RobotSelectors from '../../../robot/selectors'
 
 import { ControlsCard } from '../ControlsCard'
 import { CheckCalibrationControl } from '../CheckCalibrationControl'
-import { DeckCalibrationControl } from '../DeckCalibrationControl'
+import { LegacyDeckCalibrationControl } from '../LegacyDeckCalibrationControl'
 import { LabeledToggle, LabeledButton } from '@opentrons/components'
 import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
 import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
@@ -296,7 +296,7 @@ describe('ControlsCard', () => {
     getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     const { wrapper } = render()
 
-    expect(wrapper.exists(DeckCalibrationControl)).toBe(false)
+    expect(wrapper.exists(LegacyDeckCalibrationControl)).toBe(false)
   })
 
   it('CheckCalibrationControl does not render if ff is on', () => {

--- a/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/ControlsCard.test.js
@@ -14,6 +14,7 @@ import { LegacyDeckCalibrationControl } from '../LegacyDeckCalibrationControl'
 import { LabeledToggle, LabeledButton } from '@opentrons/components'
 import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
 import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
+import { LegacyDeckCalibrationWarning } from '../LegacyDeckCalibrationWarning'
 
 import type { State, Action } from '../../../types'
 import type { ViewableRobot } from '../../../discovery/types'
@@ -282,7 +283,7 @@ describe('ControlsCard', () => {
     // check that the deck calibration warning component is not null
     // TODO(lc, 2020-06-18): Mock out the new transform status such that
     // this should evaluate to true.
-    expect(wrapper.exists(DeckCalibrationWarning)).toBe(true)
+    expect(wrapper.exists(LegacyDeckCalibrationWarning)).toBe(true)
   })
 
   it('DeckCalibrationWarning component does not render if cal is bad but ff is on', () => {

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -4,22 +4,14 @@ import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 
 import * as Sessions from '../../../sessions'
-import * as Config from '../../../config'
 
-import { LegacyDeckCalibrationControl } from '../LegacyDeckCalibrationControl'
+import { DeckCalibrationControl } from '../DeckCalibrationControl'
 import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
-import type { State } from '../../../types'
 
 jest.mock('../../../robot-api/selectors')
-jest.mock('../../../config/selectors')
 jest.mock('../../../sessions/selectors')
 
-const getFeatureFlags: JestMockFn<
-  [State],
-  $Call<typeof Config.getFeatureFlags, State>
-> = Config.getFeatureFlags
-
-describe('ControlsCard', () => {
+describe('DeckCalibrationControl', () => {
   let mockStore
   let render
 
@@ -45,12 +37,10 @@ describe('ControlsCard', () => {
       dispatch: jest.fn(),
     }
 
-    getFeatureFlags.mockReturnValue({})
-
     render = (props = {}) => {
       const {
         robotName = 'robot-name',
-        buttonDisabled = false,
+        buttonDisabled = null,
         deckCalStatus = 'OK',
         deckCalData = {
           type: 'affine',
@@ -64,15 +54,13 @@ describe('ControlsCard', () => {
           pipetteCalibratedWith: null,
           tiprack: null,
         },
-        startLegacyDeckCalibration = () => {},
       } = props
       return mount(
-        <LegacyDeckCalibrationControl
+        <DeckCalibrationControl
           robotName={robotName}
           buttonDisabled={buttonDisabled}
           deckCalStatus={deckCalStatus}
           deckCalData={deckCalData}
-          startLegacyDeckCalibration={startLegacyDeckCalibration}
         />,
         {
           wrappingComponent: Provider,
@@ -86,20 +74,7 @@ describe('ControlsCard', () => {
     jest.resetAllMocks()
   })
 
-  it('button launches legacy deck calibration if feature flag for calibration overhaul is falsy', () => {
-    const wrapper = render()
-    getDeckCalButton(wrapper).invoke('onClick')()
-
-    expect(mockStore.dispatch).not.toHaveBeenCalledWith(
-      Sessions.ensureSession(
-        'robot-name',
-        Sessions.SESSION_TYPE_DECK_CALIBRATION
-      )
-    )
-  })
-
-  it('button launches new deck calibration after confirm if feature flag for calibration overhaul is truthy', () => {
-    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+  it('button launches new deck calibration after confirm', () => {
     const wrapper = render()
     expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
     getDeckCalButton(wrapper).invoke('onClick')()
@@ -117,8 +92,7 @@ describe('ControlsCard', () => {
     })
   })
 
-  it('button launches new deck calibration and cancel closes if feature flag for calibration overhaul is truthy', () => {
-    getFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
+  it('button launches new deck calibration and cancel closes', () => {
     const wrapper = render()
     expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
     getDeckCalButton(wrapper).invoke('onClick')()

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -40,7 +40,7 @@ describe('DeckCalibrationControl', () => {
     render = (props = {}) => {
       const {
         robotName = 'robot-name',
-        buttonDisabled = null,
+        disabledReason = null,
         deckCalStatus = 'OK',
         deckCalData = {
           type: 'affine',
@@ -58,7 +58,7 @@ describe('DeckCalibrationControl', () => {
       return mount(
         <DeckCalibrationControl
           robotName={robotName}
-          buttonDisabled={buttonDisabled}
+          disabledReason={disabledReason}
           deckCalStatus={deckCalStatus}
           deckCalData={deckCalData}
         />,

--- a/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationControl.js
@@ -6,7 +6,7 @@ import { mount } from 'enzyme'
 import * as Sessions from '../../../sessions'
 import * as Config from '../../../config'
 
-import { DeckCalibrationControl } from '../DeckCalibrationControl'
+import { LegacyDeckCalibrationControl } from '../LegacyDeckCalibrationControl'
 import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
 import type { State } from '../../../types'
 
@@ -67,7 +67,7 @@ describe('ControlsCard', () => {
         startLegacyDeckCalibration = () => {},
       } = props
       return mount(
-        <DeckCalibrationControl
+        <LegacyDeckCalibrationControl
           robotName={robotName}
           buttonDisabled={buttonDisabled}
           deckCalStatus={deckCalStatus}

--- a/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationControl.test.js
@@ -1,0 +1,97 @@
+// @flow
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+
+import * as Sessions from '../../../sessions'
+
+import { LegacyDeckCalibrationControl } from '../LegacyDeckCalibrationControl'
+import { LegacyDeckCalibrationWarning } from '../LegacyDeckCalibrationWarning'
+import { DeckCalibrationDownload } from '../DeckCalibrationDownload'
+
+describe('LegacyDeckCalibrationControl', () => {
+  let mockStore
+  let render
+
+  const getDeckCalButton = wrapper =>
+    wrapper
+      .find('TitledControl[title="Calibrate deck"]')
+      .find('button')
+      .filter({ children: 'Calibrate' })
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockStore = {
+      subscribe: () => {},
+      getState: () => ({
+        mockState: true,
+      }),
+      dispatch: jest.fn(),
+    }
+
+    render = (props = {}) => {
+      const {
+        robotName = 'robot-name',
+        buttonDisabled = false,
+        deckCalStatus = 'OK',
+        deckCalData = {
+          type: 'affine',
+          matrix: [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+          ],
+          lastModified: null,
+          pipetteCalibratedWith: null,
+          tiprack: null,
+        },
+        startLegacyDeckCalibration = () => {},
+      } = props
+      return mount(
+        <LegacyDeckCalibrationControl
+          robotName={robotName}
+          buttonDisabled={buttonDisabled}
+          deckCalStatus={deckCalStatus}
+          deckCalData={deckCalData}
+          startLegacyDeckCalibration={startLegacyDeckCalibration}
+        />,
+        {
+          wrappingComponent: Provider,
+          wrappingComponentProps: { store: mockStore },
+        }
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('button launches legacy deck calibration', () => {
+    const wrapper = render()
+    getDeckCalButton(wrapper).invoke('onClick')()
+
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith(
+      Sessions.ensureSession(
+        'robot-name',
+        Sessions.SESSION_TYPE_DECK_CALIBRATION
+      )
+    )
+  })
+
+  it('LegacyDeckCalibrationWarning component renders if deck calibration is bad', () => {
+    const wrapper = render({ deckCalStatus: 'BAD_CALIBRATION' })
+
+    // check that the deck calibration warning component is not null
+    // TODO(lc, 2020-06-18): Mock out the new transform status such that
+    // this should evaluate to true.
+    expect(wrapper.exists(LegacyDeckCalibrationWarning)).toBe(true)
+  })
+
+  it('DeckCalibrationDownload component renders', () => {
+    const wrapper = render()
+
+    expect(wrapper.exists(DeckCalibrationDownload)).toBe(true)
+  })
+})

--- a/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationWarning.test.js
+++ b/app/src/components/RobotSettings/__tests__/LegacyDeckCalibrationWarning.test.js
@@ -3,14 +3,16 @@ import * as React from 'react'
 import { mount } from 'enzyme'
 
 import * as Calibration from '../../../calibration'
-import { Flex, Icon, COLOR_ERROR } from '@opentrons/components'
-import { DeckCalibrationWarning } from '../DeckCalibrationWarning'
+import { Flex, Icon, COLOR_WARNING, COLOR_ERROR } from '@opentrons/components'
+import { LegacyDeckCalibrationWarning } from '../LegacyDeckCalibrationWarning'
 
 import type { DeckCalibrationStatus } from '../../../calibration/types'
 
 describe('Calibration Warning Component', () => {
   const render = (status: DeckCalibrationStatus | null) => {
-    return mount(<DeckCalibrationWarning deckCalibrationStatus={status} />)
+    return mount(
+      <LegacyDeckCalibrationWarning deckCalibrationStatus={status} />
+    )
   }
 
   it('renders nothing when calibration is unknown', () => {
@@ -23,14 +25,15 @@ describe('Calibration Warning Component', () => {
     expect(wrapper).toEqual({})
   })
 
-  it('should render an alert icon in COLOR_ERROR if status is IDENTITY', () => {
+  it('should render an alert icon in COLOR_WARNING if status is IDENTITY', () => {
     const wrapper = render(Calibration.DECK_CAL_STATUS_IDENTITY)
     const parent = wrapper.find(Flex).first()
     const icon = wrapper.find(Icon)
 
-    expect(parent.prop('color')).toBe(COLOR_ERROR)
+    expect(parent.prop('color')).toBe(COLOR_WARNING)
     expect(icon.prop('name')).toEqual('alert-circle')
-    expect(wrapper.html()).toMatch(/required/i)
+    expect(wrapper.html()).toMatch(/not yet been calibrated/i)
+    expect(wrapper.html()).toMatch(/please perform a deck calibration/i)
   })
 
   it('should render an alert icon in COLOR_ERROR if status is SINGULARITY', () => {
@@ -40,7 +43,8 @@ describe('Calibration Warning Component', () => {
 
     expect(parent.prop('color')).toBe(COLOR_ERROR)
     expect(icon.prop('name')).toEqual('alert-circle')
-    expect(wrapper.html()).toMatch(/required/i)
+    expect(wrapper.html()).toMatch(/bad deck calibration detected/i)
+    expect(wrapper.html()).toMatch(/please perform a deck calibration/i)
   })
 
   it('should render an alert icon in COLOR_ERROR if status is BAD_CALIBRATION', () => {
@@ -50,6 +54,7 @@ describe('Calibration Warning Component', () => {
 
     expect(parent.prop('color')).toBe(COLOR_ERROR)
     expect(icon.prop('name')).toEqual('alert-circle')
-    expect(wrapper.html()).toMatch(/required/i)
+    expect(wrapper.html()).toMatch(/bad deck calibration detected/i)
+    expect(wrapper.html()).toMatch(/please perform a deck calibration/i)
   })
 })


### PR DESCRIPTION
Implement the bad deck calibration gates from [the design](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=124%3A410).

When any of our static deck calibration quality checks fail (so, not-set, singularity, out-of-bounds, etc), then the app should
- Not allow protocol upload
- Display a warning instead of the calibration check button
- Display an individual warning in the deck calibration control

This also refactors the deck calibration control components to have a legacy deck calibration control used in the ControlsCard if the feature flag is off, and a new one in the calibration card otherwise.

## Testing
- Does legacy deck cal still work?
- In the new cal experience, if you make your deck cal bad (i.e. by deleting both the old and new one), 
  - You should not be able to upload a protocol 
  - There should be warnings rendered
- While you still have a good one, the check cal and deck cal buttons should render fine
- If you are viewing a non-connectable robot, there should be no warnings displayed but the check cal and deck cal buttons should be active

## Risk
Medium since this touched the old deck cal

Closes #6614 