### PR TITLE
refactor(app): Add download cal link

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -3,16 +3,32 @@
 
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { saveAs } from 'file-saver'
 
 import type { Dispatch, State } from '../../types'
 import * as Calibration from '../../calibration'
 import * as PipetteOffset from '../../calibration/pipette-offset'
 import * as Pipettes from '../../pipettes'
+import * as TipLength from '../../calibration/tip-length'
 import { CONNECTABLE } from '../../discovery'
 import type { ViewableRobot } from '../../discovery/types'
 import { selectors as robotSelectors } from '../../robot'
 
-import { useInterval, Card } from '@opentrons/components'
+import {
+  useInterval,
+  Card,
+  ALIGN_BASELINE,
+  FONT_SIZE_BODY_1,
+  Link,
+  Text,
+  Flex,
+  SPACING_3,
+  JUSTIFY_SPACE_BETWEEN,
+  TEXT_TRANSFORM_CAPITALIZE,
+  FONT_WEIGHT_REGULAR,
+  FONT_SIZE_HEADER,
+  C_DARK_GRAY,
+} from '@opentrons/components'
 
 import {
   DECK_CAL_STATUS_POLL_INTERVAL,
@@ -31,6 +47,8 @@ type Props = {|
 |}
 
 const TITLE = 'Robot Calibration'
+
+const DOWNLOAD_CALIBRATION = 'Download your calibration data'
 
 export function CalibrationCard(props: Props): React.Node {
   const { robot, pipettesPageUrl } = props
@@ -52,6 +70,7 @@ export function CalibrationCard(props: Props): React.Node {
     robotName && dispatch(Pipettes.fetchPipettes(robotName))
     robotName &&
       dispatch(PipetteOffset.fetchPipetteOffsetCalibrations(robotName))
+    robotName && dispatch(TipLength.fetchTipLengthCalibrations(robotName))
   }, [dispatch, robotName, status])
 
   const isRunning = useSelector(robotSelectors.getIsRunning)
@@ -60,6 +79,14 @@ export function CalibrationCard(props: Props): React.Node {
   })
   const deckCalData = useSelector((state: State) => {
     return Calibration.getDeckCalibrationData(state, robotName)
+  })
+
+  const pipetteOffsetCalibrations = useSelector((state: State) => {
+    return Calibration.getPipetteOffsetCalibrations(state, robotName)
+  })
+
+  const tipLengthCalibrations = useSelector((state: State) => {
+    return Calibration.getTipLengthCalibrations(state, robotName)
   })
 
   let buttonDisabledReason = null
@@ -71,6 +98,20 @@ export function CalibrationCard(props: Props): React.Node {
     buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
   }
 
+  const onClickSaveAs = e => {
+    e.preventDefault()
+    saveAs(
+      new Blob([
+        JSON.stringify({
+          deck: deckCalData,
+          pipetteOffset: pipetteOffsetCalibrations,
+          tipLength: tipLengthCalibrations,
+        }),
+      ]),
+      `opentrons-${robotName}-calibration.json`
+    )
+  }
+
   const warningInsteadOfCalcheck = [
     Calibration.DECK_CAL_STATUS_SINGULARITY,
     Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
@@ -78,7 +119,30 @@ export function CalibrationCard(props: Props): React.Node {
   ].includes(deckCalStatus)
 
   return (
-    <Card title={TITLE}>
+    <Card>
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_BASELINE}>
+        <Text
+          as="h3"
+          fontSize={FONT_SIZE_HEADER}
+          fontWeight={FONT_WEIGHT_REGULAR}
+          color={C_DARK_GRAY}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          paddingTop={SPACING_3}
+          paddingX={SPACING_3}
+        >
+          {TITLE}
+        </Text>
+        <Link
+          href="#"
+          paddingTop={SPACING_3}
+          paddingX={SPACING_3}
+          fontSize={FONT_SIZE_BODY_1}
+          onClick={onClickSaveAs}
+          textDecoration="underline"
+        >
+          {DOWNLOAD_CALIBRATION}
+        </Link>
+      </Flex>
       {warningInsteadOfCalcheck ? (
         <CalibrationCardWarning />
       ) : (
@@ -87,7 +151,6 @@ export function CalibrationCard(props: Props): React.Node {
           disabledReason={buttonDisabledReason}
         />
       )}
-
       <DeckCalibrationControl
         robotName={robotName}
         disabledReason={buttonDisabledReason}

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -143,7 +143,6 @@ export function CalibrationCard(props: Props): React.Node {
           paddingX={SPACING_3}
           fontSize={FONT_SIZE_BODY_1}
           onClick={onClickSaveAs}
-          textDecoration="underline"
         >
           {DOWNLOAD_CALIBRATION}
         </Link>

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -13,6 +13,7 @@ import * as TipLength from '../../calibration/tip-length'
 import { CONNECTABLE } from '../../discovery'
 import type { ViewableRobot } from '../../discovery/types'
 import { selectors as robotSelectors } from '../../robot'
+import { useTrackEvent } from '../../analytics'
 
 import {
   useInterval,
@@ -46,6 +47,7 @@ type Props = {|
   pipettesPageUrl: string,
 |}
 
+const EVENT_CALIBRATION_DOWNLOADED = 'calibrationDataDownloaded'
 const TITLE = 'Robot Calibration'
 
 const DOWNLOAD_CALIBRATION = 'Download your calibration data'
@@ -89,6 +91,8 @@ export function CalibrationCard(props: Props): React.Node {
     return Calibration.getTipLengthCalibrations(state, robotName)
   })
 
+  const doTrackEvent = useTrackEvent()
+
   let buttonDisabledReason = null
   if (notConnectable) {
     buttonDisabledReason = DISABLED_CANNOT_CONNECT
@@ -100,6 +104,7 @@ export function CalibrationCard(props: Props): React.Node {
 
   const onClickSaveAs = e => {
     e.preventDefault()
+    doTrackEvent({ name: EVENT_CALIBRATION_DOWNLOADED, properties: {} })
     saveAs(
       new Blob([
         JSON.stringify({

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -23,9 +23,6 @@ import type { State, Action } from '../../../types'
 import type { ViewableRobot } from '../../../discovery/types'
 import type { AnalyticsEvent } from '../../../analytics/types'
 
-global.Blob = function(content, options) {
-  return { content, options }
-}
 
 const mockCallTrackEvent: JestMockFn<[AnalyticsEvent], void> = jest.fn()
 
@@ -100,6 +97,18 @@ describe('CalibrationCard', () => {
       }
     )
   }
+
+  const realBlob = global.Blob
+  beforeAll(()=> {
+    global.Blob = function(content, options) {
+      return { content, options }
+    }
+
+  })
+
+  afterAll(() => {
+    global.Blob = realBlob
+  })
 
   beforeEach(() => {
     jest.useFakeTimers()
@@ -228,9 +237,7 @@ describe('CalibrationCard', () => {
   it('lets you click download to download', () => {
     const { wrapper } = render()
 
-    act(() =>
-      getDownloadButton(wrapper).invoke('onClick')({ preventDefault: () => {} })
-    )
+    getDownloadButton(wrapper).invoke('onClick')({ preventDefault: () => {} })
     expect(saveAs).toHaveBeenCalled()
     expect(mockCallTrackEvent).toHaveBeenCalledWith({
       name: 'calibrationDataDownloaded',

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { mountWithStore } from '@opentrons/components/__utils__'
 
 import * as PipetteOffset from '../../../calibration/pipette-offset'
+import * as TipLength from '../../../calibration/tip-length'
 import * as Calibration from '../../../calibration'
 import * as Pipettes from '../../../pipettes'
 import * as Config from '../../../config'
@@ -24,6 +25,8 @@ jest.mock('react-router-dom', () => ({ Link: 'a' }))
 jest.mock('../../../robot/selectors')
 jest.mock('../../../config/selectors')
 jest.mock('../../../calibration/selectors')
+jest.mock('../../../calibration/tip-length/selectors')
+jest.mock('../../../calibration/pipette-offset/selectors')
 jest.mock('../../../sessions/selectors')
 
 jest.mock('../CheckCalibrationControl', () => ({
@@ -111,6 +114,10 @@ describe('CalibrationCard', () => {
     expect(store.dispatch).toHaveBeenNthCalledWith(
       3,
       PipetteOffset.fetchPipetteOffsetCalibrations(mockRobot.name)
+    )
+    expect(store.dispatch).toHaveBeenNthCalledWith(
+      4,
+      TipLength.fetchTipLengthCalibrations(mockRobot.name)
     )
     store.dispatch.mockReset()
     jest.advanceTimersByTime(20000)

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { mountWithStore } from '@opentrons/components/__utils__'
-import { act } from 'react-dom/test-utils'
 import { saveAs } from 'file-saver'
 
 import * as PipetteOffset from '../../../calibration/pipette-offset'
@@ -22,7 +21,6 @@ import { CONNECTABLE, UNREACHABLE } from '../../../discovery'
 import type { State, Action } from '../../../types'
 import type { ViewableRobot } from '../../../discovery/types'
 import type { AnalyticsEvent } from '../../../analytics/types'
-
 
 const mockCallTrackEvent: JestMockFn<[AnalyticsEvent], void> = jest.fn()
 
@@ -99,11 +97,10 @@ describe('CalibrationCard', () => {
   }
 
   const realBlob = global.Blob
-  beforeAll(()=> {
+  beforeAll(() => {
     global.Blob = function(content, options) {
       return { content, options }
     }
-
   })
 
   afterAll(() => {


### PR DESCRIPTION
Implements the download your calibration data link in the [designs](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=124%3A410).

Couple implementation notes:
- The way the `Link` item works is mildly bizarre but is what is necessary to get the correct styling (the `href=#` part) and not screw up the app's navigation when you click it (the `e.preventDefault` part).
- This also adds the epic linking for the fetch tip length calibration; this may be fixed in another pr first and have to get removed here, so keep an eye on that
- You'll need to have a robot on recent edge to make the pipette offset and tip length calibration endpoints available

Also, adds analytics event `calibrationDataDownloaded` for when the user clicks the button

## Risk
Low

## Testing/Review Requests
- Clicking the link should in fact download stuff
- The stuff should in general match what the robot knows about

Closes #6615 
Closes #6624 