### PR TITLE
refactor(app): Expose all tipracks to pipette calibration

### DIFF
--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -71,7 +71,13 @@ export function PipetteListComponent(
         const displayName = protocolPipette?.modelSpecs?.displayName || 'N/A'
         const { disabledReason = null } = urlsByMount[mount].default
         const pip_tipracks = uniqBy(
-          tipracks.filter(t => t.calibratorMount === mount),
+          tipracks.filter(
+            t =>
+              t.calibratorMount === mount ||
+              (protocolPipette
+                ? protocolPipette.tipRacks.includes(t._id)
+                : false)
+          ),
           t => t.definitionHash ?? t.name
         )
         const calibratePathFor = (

--- a/app/src/components/CalibratePanel/__tests__/PipetteList.test.js
+++ b/app/src/components/CalibratePanel/__tests__/PipetteList.test.js
@@ -81,12 +81,32 @@ const stubTipRacks = [
 
 const mockPipetteLocations = {
   left: {
-    path: '/path',
-    disabledReason: null,
+    default: {
+      path: '/path/left',
+      disabledReason: null,
+    },
+    'hash-1': {
+      path: '/path/left/hash-1',
+      disabledReason: null,
+    },
+    'hash-2': {
+      path: '/path/left/hash-2',
+      disabledReason: null,
+    },
   },
   right: {
-    path: '/path2',
-    disabledReason: null,
+    default: {
+      path: '/path/right',
+      disabledReason: null,
+    },
+    'hash-3': {
+      path: '/path/right/hash-3',
+      disabledReason: null,
+    },
+    'hash-2': {
+      path: '/path/right/hash-2',
+      disabledReason: null,
+    },
   },
 }
 

--- a/app/src/components/TipProbe/AttachTipPanel.js
+++ b/app/src/components/TipProbe/AttachTipPanel.js
@@ -23,7 +23,7 @@ export function AttachTipPanel(props: Props): React.Node {
   const { mount, channels } = props
   const dispatch = useDispatch<Dispatch>()
   const tipracksByMount = useSelector(robotSelectors.getTipracksByMount)
-  const tiprack = tipracksByMount[mount]
+  const tiprack = tipracksByMount[mount][0]
   const tiprackName =
     tiprack?.definition?.metadata.displayName || tiprack?.name || null
 

--- a/app/src/components/calibrate-pipettes/PipetteTabs.js
+++ b/app/src/components/calibrate-pipettes/PipetteTabs.js
@@ -18,7 +18,7 @@ export function PipetteTabs(props: PipetteTabsProps): React.Node {
 
   const pages = PIPETTE_MOUNTS.map(mount => ({
     title: mount,
-    href: pagesByMount[mount].path,
+    href: pagesByMount[mount].default.path,
     isActive: mount === currentMount,
     isDisabled: pagesByMount[mount].disabledReason !== null,
   }))

--- a/app/src/components/calibrate-pipettes/Pipettes.js
+++ b/app/src/components/calibrate-pipettes/Pipettes.js
@@ -7,18 +7,18 @@ import { InstrumentGroup } from '@opentrons/components'
 import styles from './styles.css'
 
 import type { InstrumentInfoProps } from '@opentrons/components'
-import type { Pipette, TiprackByMountMap } from '../../robot/types'
+import type { Pipette, Labware } from '../../robot/types'
 import type { Mount } from '../../pipettes/types'
 
 export type PipettesProps = {|
   currentMount: Mount | null,
   pipettes: Array<Pipette>,
-  tipracksByMount: TiprackByMountMap,
+  activeTipracks: {| left: Labware | null, right: Labware | null |},
   changePipetteUrl: string,
 |}
 
 export function Pipettes(props: PipettesProps): React.Node {
-  const { currentMount, pipettes, tipracksByMount } = props
+  const { currentMount, pipettes, activeTipracks } = props
 
   const infoByMount = PIPETTE_MOUNTS.reduce<
     $Shape<{|
@@ -27,7 +27,7 @@ export function Pipettes(props: PipettesProps): React.Node {
     |}>
   >((result, mount) => {
     const pipette = pipettes.find(p => p.mount === mount)
-    const tiprack = tipracksByMount[mount]
+    const tiprack = activeTipracks[mount]
     const pipetteConfig = pipette?.modelSpecs
     const isDisabled = !pipette || mount !== currentMount
 

--- a/app/src/pages/Calibrate/index.js
+++ b/app/src/pages/Calibrate/index.js
@@ -37,7 +37,10 @@ function CalibrateComponent(props: Props) {
   return (
     <Switch>
       <Redirect exact from={path} to={getRedirectUrl(props)} />
-      <Route path={`${path}/pipettes/:mount?`} component={CalibratePipettes} />
+      <Route
+        path={`${path}/pipettes/:mount?/:definitionHash?`}
+        component={CalibratePipettes}
+      />
       <Route path={`${path}/labware/:slot`} component={CalibrateLabware} />
     </Switch>
   )

--- a/app/src/robot/test/selectors.test.js
+++ b/app/src/robot/test/selectors.test.js
@@ -544,13 +544,29 @@ describe('robot selectors', () => {
               slot: '1',
               type: 's',
               isTiprack: true,
+              definitionHash: 'hash-1',
               calibratorMount: 'right',
             },
             2: {
               slot: '2',
               type: 'm',
               isTiprack: true,
+              definitionHash: 'hash-2',
               calibratorMount: 'left',
+            },
+            3: {
+              slot: '3',
+              type: 's',
+              isTiprack: true,
+              definitionHash: 'hash-1',
+              calibratorMount: 'left',
+            },
+            4: {
+              slot: '4',
+              type: 's',
+              isTiprack: true,
+              definitionHash: 'hash-1',
+              calibratorMount: 'right',
             },
             5: { slot: '5', type: 'a', isTiprack: false },
             7: { slot: '7', type: 'a', isTiprack: false },
@@ -601,8 +617,21 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'left',
           definition: null,
+          definitionHash: 'hash-2',
         },
         // then single channel tiprack
+        {
+          slot: '3',
+          type: 's',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left',
+          definition: null,
+          definitionHash: 'hash-1',
+        },
+
         {
           slot: '1',
           type: 's',
@@ -612,6 +641,19 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'right',
           definition: null,
+          definitionHash: 'hash-1',
+        },
+
+        {
+          calibration: 'unconfirmed',
+          calibratorMount: 'right',
+          confirmed: false,
+          definition: null,
+          definitionHash: 'hash-1',
+          isTiprack: true,
+          isMoving: false,
+          slot: '4',
+          type: 's',
         },
         // then other labware by slot
         {
@@ -657,7 +699,21 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'left',
           definition: null,
+          definitionHash: 'hash-2',
         },
+        // then single channel tiprack
+        {
+          slot: '3',
+          type: 's',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left',
+          definition: null,
+          definitionHash: 'hash-1',
+        },
+
         {
           slot: '1',
           type: 's',
@@ -667,6 +723,19 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'right',
           definition: null,
+          definitionHash: 'hash-1',
+        },
+
+        {
+          calibration: 'unconfirmed',
+          calibratorMount: 'right',
+          confirmed: false,
+          definition: null,
+          definitionHash: 'hash-1',
+          isTiprack: true,
+          isMoving: false,
+          slot: '4',
+          type: 's',
         },
       ])
     })
@@ -682,7 +751,21 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'left',
           definition: null,
+          definitionHash: 'hash-2',
         },
+        // then single channel tiprack
+        {
+          slot: '3',
+          type: 's',
+          isTiprack: true,
+          isMoving: false,
+          calibration: 'unconfirmed',
+          confirmed: false,
+          calibratorMount: 'left',
+          definition: null,
+          definitionHash: 'hash-1',
+        },
+
         {
           slot: '1',
           type: 's',
@@ -692,6 +775,19 @@ describe('robot selectors', () => {
           confirmed: false,
           calibratorMount: 'right',
           definition: null,
+          definitionHash: 'hash-1',
+        },
+
+        {
+          calibration: 'unconfirmed',
+          calibratorMount: 'right',
+          confirmed: false,
+          definition: null,
+          definitionHash: 'hash-1',
+          isTiprack: true,
+          isMoving: false,
+          slot: '4',
+          type: 's',
         },
         {
           slot: '9',
@@ -712,6 +808,7 @@ describe('robot selectors', () => {
         isTiprack: true,
         isMoving: false,
         calibration: 'unconfirmed',
+        definitionHash: 'hash-2',
         confirmed: false,
         calibratorMount: 'left',
         definition: null,
@@ -732,9 +829,11 @@ describe('robot selectors', () => {
       }
 
       expect(getNextLabware(nextState)).toEqual({
-        slot: '9',
-        type: 'b',
-        isTiprack: false,
+        slot: '3',
+        calibratorMount: 'left',
+        definitionHash: 'hash-1',
+        type: 's',
+        isTiprack: true,
         isMoving: false,
         calibration: 'unconfirmed',
         confirmed: false,
@@ -742,28 +841,45 @@ describe('robot selectors', () => {
       })
     })
 
-    it('returns tipracks by calibratorMount with getTipracksByMount', () => {
+    it('returns tipracks uniquely', () => {
       expect(getTipracksByMount(state)).toEqual({
-        left: {
-          slot: '2',
-          type: 'm',
-          isTiprack: true,
-          isMoving: false,
-          calibration: 'unconfirmed',
-          confirmed: false,
-          calibratorMount: 'left',
-          definition: null,
-        },
-        right: {
-          slot: '1',
-          type: 's',
-          isTiprack: true,
-          isMoving: true,
-          calibration: 'moving-to-slot',
-          confirmed: false,
-          calibratorMount: 'right',
-          definition: null,
-        },
+        left: [
+          {
+            slot: '2',
+            type: 'm',
+            isTiprack: true,
+            isMoving: false,
+            calibration: 'unconfirmed',
+            definitionHash: 'hash-2',
+            confirmed: false,
+            calibratorMount: 'left',
+            definition: null,
+          },
+          {
+            slot: '3',
+            type: 's',
+            isTiprack: true,
+            isMoving: false,
+            calibration: 'unconfirmed',
+            confirmed: false,
+            calibratorMount: 'left',
+            definitionHash: 'hash-1',
+            definition: null,
+          },
+        ],
+        right: [
+          {
+            slot: '1',
+            type: 's',
+            isTiprack: true,
+            isMoving: true,
+            calibration: 'moving-to-slot',
+            confirmed: false,
+            calibratorMount: 'right',
+            definition: null,
+            definitionHash: 'hash-1',
+          },
+        ],
       })
     })
 
@@ -775,6 +891,7 @@ describe('robot selectors', () => {
               _id: 1,
               slot: '1',
               type: 's',
+              definitionHash: 'hash-1',
               isTiprack: true,
               calibratorMount: 'right',
             },
@@ -783,6 +900,7 @@ describe('robot selectors', () => {
               slot: '2',
               type: 'm',
               isTiprack: true,
+              definitionHash: 'hash-2',
               calibratorMount: 'right',
             },
           },
@@ -801,28 +919,46 @@ describe('robot selectors', () => {
       })
 
       expect(getTipracksByMount(state)).toEqual({
-        left: {
-          _id: 2,
-          slot: '2',
-          type: 'm',
-          isTiprack: true,
-          isMoving: false,
-          calibration: 'unconfirmed',
-          confirmed: false,
-          calibratorMount: 'right',
-          definition: null,
-        },
-        right: {
-          _id: 1,
-          slot: '1',
-          type: 's',
-          isTiprack: true,
-          isMoving: false,
-          calibration: 'unconfirmed',
-          confirmed: false,
-          calibratorMount: 'right',
-          definition: null,
-        },
+        left: [
+          {
+            _id: 2,
+            slot: '2',
+            type: 'm',
+            isTiprack: true,
+            isMoving: false,
+            calibration: 'unconfirmed',
+            confirmed: false,
+            calibratorMount: 'right',
+            definition: null,
+            definitionHash: 'hash-2',
+          },
+        ],
+        right: [
+          {
+            _id: 1,
+            slot: '1',
+            type: 's',
+            isTiprack: true,
+            isMoving: false,
+            definitionHash: 'hash-1',
+            calibration: 'unconfirmed',
+            confirmed: false,
+            calibratorMount: 'right',
+            definition: null,
+          },
+          {
+            _id: 2,
+            slot: '2',
+            type: 'm',
+            isTiprack: true,
+            isMoving: false,
+            calibration: 'unconfirmed',
+            confirmed: false,
+            calibratorMount: 'right',
+            definition: null,
+            definitionHash: 'hash-2',
+          },
+        ],
       })
     })
   })

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -195,7 +195,7 @@ export type SessionUpdate = {|
   |},
 |}
 
-export type TiprackByMountMap = {|
-  left: Labware | null,
-  right: Labware | null,
+export type TipracksByMountMap = {|
+  left: Array<Labware>,
+  right: Array<Labware>,
 |}


### PR DESCRIPTION
Now that tip length calibration will back the pipette calibration phase
of the pre-protocol calibration, we need to make all the selectors there
actually work on every tiprack specified by the protocol. That means
things like

- The tiprack map selector needs to build a map of all tipracks used by
  a specific mount, uniq'd by the definition hash
 - The Pipette page needs to know about tiprack definition hashes in its
  react-router-dom route so it can look up the correct tiprack from the
  tiprack map
- Both of the above need to be routed around and have things fixed up
  for them; urls need to be fetched based on tiprack as well as mount;
  and we need to not break the situation when the feature flag is turned
  off.

This doesn't actually get around to hooking up the tip length
calibration session, but clicking different entries in the tiprack list
for pipette calibration will now both swap to the appropriate tab in the
pipette tab list, but also specialize that tab for the specific tiprack selected.


## Testing
- If the feature flag is off, clicking on the two pipettes still lets you tip probe them
- If the feature flag is on,
  - Uploading a protocol that has many tipracks should have each unique tiprack type appear on the left under each pipette where it is used
  - Clicking that element on the left should switch to the correct tab on the right, and the tab should display the display name of the tiprack
  - Each kind of tiprack should appear only once in the list per mount
  - Tipracks that are specified in the `load_instrument` of one instrument but explicitly picked up from the other should show up in both places

## Review Requests
Hopefully this is the right way to use rrd for this. Adding a second possibly-undefined route param isn't my favorite thing in the world, but there is never a situation where the tiprack def hash is specified but the mount isn't.

Closes #6700 