### PR TITLE
refactor(app): tip length calibration data card cleanup

### DIFF
--- a/app/src/components/CalibratePanel/PipetteTiprackListItem.js
+++ b/app/src/components/CalibratePanel/PipetteTiprackListItem.js
@@ -72,8 +72,6 @@ export function PipetteTiprackListItem(
             <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>{displayName}</Text>
             <TipLengthCalibrationData
               calibrationData={tipLengthCalibration}
-              // TODO: determine whether or not data were updated
-              calibratedThisSession={false}
               // the definitionHash will only be absent if old labware
               // or robot version <= 3.19
               calDataAvailable={definitionHash != null}

--- a/app/src/components/CalibratePanel/PipetteTiprackListItem.js
+++ b/app/src/components/CalibratePanel/PipetteTiprackListItem.js
@@ -2,13 +2,20 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 
-import { ListItem, HoverTooltip, Box, Text } from '@opentrons/components'
+import {
+  ListItem,
+  HoverTooltip,
+  Box,
+  Text,
+  FONT_WEIGHT_SEMIBOLD,
+} from '@opentrons/components'
 import styles from './styles.css'
 
 import type { AttachedPipette } from '../../pipettes/types'
 import type { BaseProtocolLabware } from '../../calibration/types'
 import type { State } from '../../types'
 
+import { TipLengthCalibrationData } from './TipLengthCalibrationData'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { getTipLengthForPipetteAndTiprack } from '../../calibration'
 
@@ -62,11 +69,14 @@ export function PipetteTiprackListItem(
           activeClassName={styles.active}
         >
           <Box marginLeft={MARGIN_LEFT_SIZE}>
-            <Text>{displayName}</Text>
-            {/* TODO: correctly render tip length calibraiton data */}
-            {tipLengthCalibration
-              ? tipLengthCalibration.tipLength
-              : 'not yet calibrated'}
+            <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>{displayName}</Text>
+            <TipLengthCalibrationData
+              calibrationData={tipLengthCalibration}
+              calibratedThisSession={false}
+              // the definitionHash will only be absent if old labware
+              // or robot version <= 3.19
+              calDataAvailable={definitionHash != null}
+            />
           </Box>
         </ListItem>
       )}

--- a/app/src/components/CalibratePanel/PipetteTiprackListItem.js
+++ b/app/src/components/CalibratePanel/PipetteTiprackListItem.js
@@ -72,6 +72,7 @@ export function PipetteTiprackListItem(
             <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>{displayName}</Text>
             <TipLengthCalibrationData
               calibrationData={tipLengthCalibration}
+              // TODO: determine whether or not data were updated
               calibratedThisSession={false}
               // the definitionHash will only be absent if old labware
               // or robot version <= 3.19

--- a/app/src/components/CalibratePanel/TipLengthCalibrationData.js
+++ b/app/src/components/CalibratePanel/TipLengthCalibrationData.js
@@ -7,24 +7,22 @@ import {
   DIRECTION_COLUMN,
   SPACING_2,
 } from '@opentrons/components'
-import type { TipLengthCalibration } from '../../calibration/tip-length/types'
+import type { TipLengthCalibration } from '../../calibration/api-types'
 
 // TODO(bc, 2020-08-03): i18n
 const NOT_CALIBRATED = 'Not yet calibrated'
-const UPDATED_DATA = 'Updated data'
 const EXISTING_DATA = 'Existing data'
 const LEGACY_DEFINITION = 'Calibration Data N/A'
 
 export type TipLengthCalibrationDataProps = {|
   calibrationData: TipLengthCalibration | null,
-  calibratedThisSession: boolean,
   calDataAvailable: boolean,
 |}
 
 export function TipLengthCalibrationData(
   props: TipLengthCalibrationDataProps
 ): React.Node {
-  const { calibrationData, calibratedThisSession, calDataAvailable } = props
+  const { calibrationData, calDataAvailable } = props
   if (!calDataAvailable) {
     return (
       <Text as="i" marginTop={SPACING_2}>
@@ -40,7 +38,7 @@ export function TipLengthCalibrationData(
   } else {
     return (
       <Flex flexDirection={DIRECTION_COLUMN} marginTop={SPACING_2}>
-        {calibratedThisSession ? UPDATED_DATA : EXISTING_DATA}:
+        {EXISTING_DATA}:
         <Box>{`${calibrationData.tipLength.toFixed(2)} mm`}</Box>
       </Flex>
     )

--- a/app/src/components/CalibratePanel/TipLengthCalibrationData.js
+++ b/app/src/components/CalibratePanel/TipLengthCalibrationData.js
@@ -1,0 +1,48 @@
+// @flow
+import * as React from 'react'
+import {
+  Box,
+  Flex,
+  Text,
+  DIRECTION_COLUMN,
+  SPACING_2,
+} from '@opentrons/components'
+import type { TipLengthCalibration } from '../../calibration/tip-length/types'
+
+// TODO(bc, 2020-08-03): i18n
+const NOT_CALIBRATED = 'Not yet calibrated'
+const UPDATED_DATA = 'Updated data'
+const EXISTING_DATA = 'Existing data'
+const LEGACY_DEFINITION = 'Calibration Data N/A'
+
+export type TipLengthCalibrationDataProps = {|
+  calibrationData: TipLengthCalibration | null,
+  calibratedThisSession: boolean,
+  calDataAvailable: boolean,
+|}
+
+export function TipLengthCalibrationData(
+  props: TipLengthCalibrationDataProps
+): React.Node {
+  const { calibrationData, calibratedThisSession, calDataAvailable } = props
+  if (!calDataAvailable) {
+    return (
+      <Text as="i" marginTop={SPACING_2}>
+        {LEGACY_DEFINITION}
+      </Text>
+    )
+  } else if (calibrationData === null) {
+    return (
+      <Text as="i" marginTop={SPACING_2}>
+        {NOT_CALIBRATED}
+      </Text>
+    )
+  } else {
+    return (
+      <Flex flexDirection={DIRECTION_COLUMN} marginTop={SPACING_2}>
+        {calibratedThisSession ? UPDATED_DATA : EXISTING_DATA}:
+        <Box>{`${calibrationData.tipLength.toFixed(2)} mm`}</Box>
+      </Flex>
+    )
+  }
+}

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -1,0 +1,77 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { TipLengthCalibrationData } from '../TipLengthCalibrationData'
+
+describe('TipLengthCalibrationData', () => {
+  let render
+
+  beforeEach(() => {
+    render = (props = {}) => {
+      const {
+        calibrationData = null,
+        calibratedThisSession = false,
+        calDataAvailable = true,
+      } = props
+      return mount(
+        <TipLengthCalibrationData
+          calibrationData={calibrationData}
+          calibratedThisSession={calibratedThisSession}
+          calDataAvailable={calDataAvailable}
+        />
+      )
+    }
+  })
+
+  it('displays not calibrated if no existing data and not calibrated in this session', () => {
+    const wrapper = render()
+    expect(wrapper.text().includes('Not yet calibrated')).toBe(true)
+  })
+
+  it('displays existing data if present and not calibrated in this session', () => {
+    const wrapper = render({
+      calibrationData: {
+        tipLength: 30,
+        tiprack: 'tiprack',
+        pipette: 'pip',
+        lastModified: 'time',
+      },
+      calibratedThisSession: false,
+    })
+    expect(wrapper.text().includes('Existing data')).toBe(true)
+  })
+
+  it('displays updated data if calibrated in this session', () => {
+    const wrapper = render({
+      calibrationData: {
+        tipLength: 30,
+        tiprack: 'tiprack',
+        pipette: 'pip',
+        lastModified: 'time',
+      },
+      calibratedThisSession: true,
+    })
+    expect(wrapper.text().includes('Updated data')).toBe(true)
+  })
+
+  it('displays updated data if calibrated in this session with same data', () => {
+    const wrapper = render({
+      calibrationData: {
+        tipLength: 30,
+        tiprack: 'tiprack',
+        pipette: 'pip',
+        lastModified: 'time',
+      },
+      calibratedThisSession: true,
+    })
+    expect(wrapper.text().includes('Updated data')).toBe(true)
+  })
+
+  it('displays calibration data n/a when labware is calDataAvailable', () => {
+    const wrapper = render({
+      calDataAvailable: false,
+    })
+    expect(wrapper.text().includes('Calibration Data N/A')).toBe(true)
+  })
+})

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -9,15 +9,10 @@ describe('TipLengthCalibrationData', () => {
 
   beforeEach(() => {
     render = (props = {}) => {
-      const {
-        calibrationData = null,
-        calibratedThisSession = false,
-        calDataAvailable = true,
-      } = props
+      const { calibrationData = null, calDataAvailable = true } = props
       return mount(
         <TipLengthCalibrationData
           calibrationData={calibrationData}
-          calibratedThisSession={calibratedThisSession}
           calDataAvailable={calDataAvailable}
         />
       )
@@ -37,35 +32,8 @@ describe('TipLengthCalibrationData', () => {
         pipette: 'pip',
         lastModified: 'time',
       },
-      calibratedThisSession: false,
     })
     expect(wrapper.text().includes('Existing data')).toBe(true)
-  })
-
-  it('displays updated data if calibrated in this session', () => {
-    const wrapper = render({
-      calibrationData: {
-        tipLength: 30,
-        tiprack: 'tiprack',
-        pipette: 'pip',
-        lastModified: 'time',
-      },
-      calibratedThisSession: true,
-    })
-    expect(wrapper.text().includes('Updated data')).toBe(true)
-  })
-
-  it('displays updated data if calibrated in this session with same data', () => {
-    const wrapper = render({
-      calibrationData: {
-        tipLength: 30,
-        tiprack: 'tiprack',
-        pipette: 'pip',
-        lastModified: 'time',
-      },
-      calibratedThisSession: true,
-    })
-    expect(wrapper.text().includes('Updated data')).toBe(true)
   })
 
   it('displays calibration data n/a when labware is calDataAvailable', () => {


### PR DESCRIPTION
closes #6593

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR properly displays the tip length data on the tiprack cards in the tip length calibration panel. (See [design](https://www.figma.com/file/SHavJVuFOvV6Cq1kPgY47W/Calibration-Overhaul---Tip-Length-Calibration?node-id=1160%3A0))
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- created `TipLengthCalibrationData` component
- added tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Does everything look ok?
How do we want to track if the tip length data have been updated in a tip length cal session?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low, changes are behind the calibration overhaul feature flag
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
