### PR TITLE
refactor(app): Show warning before recalibrating tip length

### DIFF
--- a/app/src/components/CalibrateTipLength/ConfirmRecalibrationModal.js
+++ b/app/src/components/CalibrateTipLength/ConfirmRecalibrationModal.js
@@ -31,7 +31,7 @@ const CONTINUE = 'continue to calibrate tip length'
 const CANCEL = 'cancel'
 
 // TODO: This link needs to be real(er)
-const CALIBRATION_URL = 'https://support.opentrons.com'
+const CALIBRATION_URL = 'https://support.opentrons.com/en/articles/4523313'
 
 type Props = {|
   confirm: () => mixed,

--- a/app/src/components/CalibrateTipLength/ConfirmRecalibrationModal.js
+++ b/app/src/components/CalibrateTipLength/ConfirmRecalibrationModal.js
@@ -1,0 +1,85 @@
+// @flow
+import * as React from 'react'
+
+import {
+  AlertModal,
+  Box,
+  Flex,
+  JUSTIFY_FLEX_END,
+  Link,
+  SecondaryBtn,
+  SPACING_3,
+  Text,
+} from '@opentrons/components'
+
+import { Portal } from '../portal'
+
+import styles from './styles.css'
+
+const TITLE = 'Are you sure you want to continue?'
+
+const TIP_LENGTH_DATA_EXISTS = 'Tip length data already exists for'
+
+const RECOMMEND_RECALIBRATING_IF =
+  'We recommend recalibrating only if you believe the tip length calibration for'
+const INACCURATE = 'is inaccurate.'
+const VIEW = 'View'
+const TO_LEARN_MORE = 'to learn more.'
+const THIS_LINK = 'this link'
+
+const CONTINUE = 'continue to calibrate tip length'
+const CANCEL = 'cancel'
+
+// TODO: This link needs to be real(er)
+const CALIBRATION_URL = 'https://support.opentrons.com'
+
+type Props = {|
+  confirm: () => mixed,
+  cancel: () => mixed,
+  tiprackDisplayName: string,
+|}
+
+export function ConfirmRecalibrationModal(props: Props): React.Node {
+  const { confirm, cancel, tiprackDisplayName } = props
+
+  return (
+    <Portal>
+      <AlertModal
+        className={styles.alert_modal_padding}
+        iconName={null}
+        heading={TITLE}
+        alertOverlay
+      >
+        <Box>
+          <Text>
+            {TIP_LENGTH_DATA_EXISTS}
+            &nbsp;
+            {`"${tiprackDisplayName}".`}
+            <br />
+            <br />
+            {RECOMMEND_RECALIBRATING_IF}
+            &nbsp;
+            {`"${tiprackDisplayName}"`}
+            &nbsp;
+            {INACCURATE}
+            &nbsp;
+            {VIEW}
+            &nbsp;
+            <Link href={CALIBRATION_URL} external>
+              {THIS_LINK}
+            </Link>
+            &nbsp;
+            {TO_LEARN_MORE}
+          </Text>
+        </Box>
+
+        <Flex marginY={SPACING_3} justifyContent={JUSTIFY_FLEX_END}>
+          <SecondaryBtn onClick={confirm} marginRight={SPACING_3}>
+            {CONTINUE}
+          </SecondaryBtn>
+          <SecondaryBtn onClick={cancel}>{CANCEL}</SecondaryBtn>
+        </Flex>
+      </AlertModal>
+    </Portal>
+  )
+}

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -39,6 +39,7 @@ import {
 import type { CalibrateTipLengthParentProps } from './types'
 
 export { AskForCalibrationBlockModal } from './AskForCalibrationBlockModal'
+export { ConfirmRecalibrationModal } from './ConfirmRecalibrationModal'
 
 const TIP_LENGTH_CALIBRATION_SUBTITLE = 'Tip length calibration'
 const EXIT = 'exit'

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -1,7 +1,12 @@
 // @flow
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { Icon, PrimaryButton, type Mount } from '@opentrons/components'
+import {
+  Icon,
+  PrimaryButton,
+  type Mount,
+  useConditionalConfirm,
+} from '@opentrons/components'
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
 import { getUseTrashSurfaceForTipCal } from '../../config'
@@ -10,6 +15,7 @@ import { setUseTrashSurfaceForTipCal } from '../../calibration'
 import {
   CalibrateTipLength,
   AskForCalibrationBlockModal,
+  ConfirmRecalibrationModal,
 } from '../../components/CalibrateTipLength'
 
 import { CalibrationInfoBox } from '../../components/CalibrationInfoBox'
@@ -158,6 +164,11 @@ export function CalibrateTipLengthControl({
     useTrashSurface.current = useTrashSurfaceForTipCalSetting
   }
 
+  const { confirm, showConfirmation, cancel } = useConditionalConfirm(
+    handleStart,
+    hasCalibrated
+  )
+
   return (
     <>
       <CalibrationInfoBox
@@ -167,9 +178,18 @@ export function CalibrateTipLengthControl({
         <UncalibratedInfo
           showSpinner={showSpinner}
           hasCalibrated={hasCalibrated}
-          handleStart={handleStart}
+          handleStart={confirm}
         />
       </CalibrationInfoBox>
+      {showConfirmation && (
+        <Portal>
+          <ConfirmRecalibrationModal
+            confirm={confirm}
+            cancel={cancel}
+            tiprackDisplayName={tipRackDefinition.metadata.displayName}
+          />
+        </Portal>
+      )}
       {showCalBlockPrompt && (
         <Portal>
           <AskForCalibrationBlockModal setHasBlock={setHasBlock} />
@@ -193,7 +213,7 @@ export function CalibrateTipLengthControl({
 
 type UncalibratedInfoProps = {|
   hasCalibrated: boolean,
-  handleStart: () => void,
+  handleStart: () => mixed,
   showSpinner: boolean,
 |}
 function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {


### PR DESCRIPTION
Now that we know if there's already a tip length calibration, we can pop
the warning modal from the design to get people to not do it unless
there's a problem.

Closes #6696

## Tests
- Should pop up on a button that says re-calibrate
- Shouldn't pop up on a button that says calibrate