### PR TITLE
refactor(app): add continue button in tip length calibration control card

### DIFF
--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -1,14 +1,14 @@
 // @flow
-import { createSelector } from 'reselect'
 import { head } from 'lodash'
-import { PIPETTE_MOUNTS } from '../../pipettes/constants'
-import { getProtocolPipettesInfo } from '../../pipettes/'
+import { createSelector } from 'reselect'
+
+import { getProtocolPipettesInfo } from '../../pipettes/selectors'
 import { getTipracksByMount } from '../../robot/selectors'
+import { PIPETTE_MOUNTS } from  '../../robot/constants'
 
 import type { State } from '../../types'
-import type { ProtocolPipetteInfoByMount } from '../../pipettes/types'
 import type { TipLengthCalibration } from '../api-types'
-import type { TipracksByMountMap, Labware } from '../../robot/types'
+import type { TipracksByMountMap } from '../../robot/types'
 
 export const getTipLengthCalibrations: (
   state: State,
@@ -56,7 +56,7 @@ export const tipLengthExistsForPipetteAndTiprack: (
   return !!calibration
 }
 
-export const getUncalibratedTipracks: (
+export const getUncalibratedTipracksByMount: (
   state: State,
   robotName: string
 ) => TipracksByMountMap = createSelector(

--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -1,9 +1,14 @@
 // @flow
-
+import { createSelector } from 'reselect'
 import { head } from 'lodash'
+import { PIPETTE_MOUNTS } from '../../pipettes/constants'
+import { getProtocolPipettesInfo } from '../../pipettes/'
+import { getTipracksByMount } from '../../robot/selectors'
 
 import type { State } from '../../types'
+import type { ProtocolPipetteInfoByMount } from '../../pipettes/types'
 import type { TipLengthCalibration } from '../api-types'
+import type { TipracksByMountMap, Labware } from '../../robot/types'
 
 export const getTipLengthCalibrations: (
   state: State,
@@ -37,3 +42,48 @@ export const getTipLengthForPipetteAndTiprack: (
     ) || null
   )
 }
+
+export const tipLengthExistsForPipetteAndTiprack: (
+  calibrations: Array<TipLengthCalibration>,
+  pipetteSerial: string,
+  tiprackHash: string
+) => boolean = (calibrations, pipetteSerial, tiprackHash) => {
+  const calibration = head(
+    calibrations.filter(
+      cal => cal.pipette === pipetteSerial && cal.tiprack === tiprackHash
+    )
+  )
+  return !!calibration
+}
+
+export const getUncalibratedTipracks: (
+  state: State,
+  robotName: string
+) => TipracksByMountMap = createSelector(
+  getProtocolPipettesInfo,
+  getTipLengthCalibrations,
+  getTipracksByMount,
+  (infoByMount, calibrations, tipracksByMount) => {
+    return PIPETTE_MOUNTS.reduce<TipracksByMountMap>(
+      (result, mount) => {
+        const pip = infoByMount?.[mount]
+        const pipetteSerial = pip?.actual?.id
+        const tipracks = tipracksByMount?.[mount]
+        result[mount] =
+          Array.isArray(tipracks) && tipracks?.length && pipetteSerial
+            ? tipracks.filter(
+                tr =>
+                  tr.definitionHash &&
+                  !tipLengthExistsForPipetteAndTiprack(
+                    calibrations,
+                    pipetteSerial,
+                    tr.definitionHash
+                  )
+              )
+            : []
+        return result
+      },
+      { left: [], right: [] }
+    )
+  }
+)

--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect'
 
 import { getProtocolPipettesInfo } from '../../pipettes/selectors'
 import { getTipracksByMount } from '../../robot/selectors'
-import { PIPETTE_MOUNTS } from  '../../robot/constants'
+import { PIPETTE_MOUNTS } from '../../robot/constants'
 
 import type { State } from '../../types'
 import type { TipLengthCalibration } from '../api-types'

--- a/app/src/components/CalibratePanel/PipetteList.js
+++ b/app/src/components/CalibratePanel/PipetteList.js
@@ -56,14 +56,11 @@ export function PipetteListComponent(
     robotName && dispatch(fetchTipLengthCalibrations(robotName))
   }, [dispatch, robotName])
 
+  const titleListTitle = !ff.enableCalibrationOverhaul
+    ? PIPETTE_CALIBRATION
+    : TIP_LENGTH_CALIBRATION
   return (
-    <TitledList
-      title={
-        !ff.enableCalibrationOverhaul
-          ? PIPETTE_CALIBRATION
-          : TIP_LENGTH_CALIBRATION
-      }
-    >
+    <TitledList key={titleListTitle} title={titleListTitle}>
       {PIPETTE_MOUNTS.map(mount => {
         const protocolPipette =
           protocolPipettes.find(i => i.mount === mount) || null

--- a/app/src/components/CalibrateTipLength/TipLengthCalibrationInfoBox.js
+++ b/app/src/components/CalibrateTipLength/TipLengthCalibrationInfoBox.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+import {
+  Box,
+  Text,
+  BORDER_SOLID_LIGHT,
+  FONT_WEIGHT_SEMIBOLD,
+  SPACING_2,
+  SPACING_3,
+} from '@opentrons/components'
+
+export type TipLengthCalibrationInfoBoxProps = {|
+  title: string,
+  children: React.Node,
+|}
+
+export function TipLengthCalibrationInfoBox(
+  props: TipLengthCalibrationInfoBoxProps
+): React.Node {
+  const { title, children } = props
+
+  return (
+    <Box border={BORDER_SOLID_LIGHT} margin={SPACING_3} paddingY={SPACING_3}>
+      <Text
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        paddingLeft={SPACING_3}
+        paddingBottom={SPACING_2}
+      >
+        {title}
+      </Text>
+      {children}
+    </Box>
+  )
+}

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -19,12 +19,15 @@ import {
   ConfirmRecalibrationModal,
 } from '../../components/CalibrateTipLength'
 
-import { CalibrationInfoBox } from '../../components/CalibrationInfoBox'
+import { TipLengthCalibrationInfoBox } from '../../components/CalibrateTipLength/TipLengthCalibrationInfoBox'
 import { CalibrationInfoContent } from '../../components/CalibrationInfoContent'
 import { Portal } from '../../components/portal'
 import { CalibratePipetteOffset } from '../../components/CalibratePipetteOffset'
+import {
+  getLabwareDisplayName,
+  type LabwareDefinition2,
+} from '@opentrons/shared-data'
 
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { State, Dispatch } from '../../types'
 import type {
   SessionCommandString,
@@ -46,8 +49,8 @@ const spinnerCommandBlockList: Array<SessionCommandString> = [
   Sessions.sharedCalCommands.JOG,
 ]
 
-const IS_CALIBRATED = 'Pipette tip height is calibrated'
-const IS_NOT_CALIBRATED = 'Pipette tip height is not calibrated'
+const IS_CALIBRATED = 'Pipette tip length has been calibrated'
+const IS_NOT_CALIBRATED = 'Pipette tip length is not calibrated'
 const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
 const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
 
@@ -216,25 +219,24 @@ export function CalibrateTipLengthControl({
 
   return (
     <>
-      <CalibrationInfoBox
-        confirmed={hasCalibrated}
-        title={`${mount} pipette tip length calibration`}
+      <TipLengthCalibrationInfoBox
+        title={getLabwareDisplayName(tipRackDefinition)}
       >
         <UncalibratedInfo
           showSpinner={showSpinner}
           hasCalibrated={hasCalibrated}
           handleStart={confirm}
         />
-      </CalibrationInfoBox>
-      {showConfirmation && (
-        <Portal>
-          <ConfirmRecalibrationModal
-            confirm={confirm}
-            cancel={cancel}
-            tiprackDisplayName={tipRackDefinition.metadata.displayName}
-          />
-        </Portal>
-      )}
+        {showConfirmation && (
+          <Portal>
+            <ConfirmRecalibrationModal
+              confirm={confirm}
+              cancel={cancel}
+              tiprackDisplayName={tipRackDefinition.metadata.displayName}
+            />
+          </Portal>
+        )}
+      </TipLengthCalibrationInfoBox>
       {showCalBlockPrompt && (
         <Portal>
           <AskForCalibrationBlockModal setHasBlock={setHasBlock} />

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -11,7 +11,10 @@ import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
 
 import { getUseTrashSurfaceForTipCal } from '../../config'
-import { setUseTrashSurfaceForTipCal } from '../../calibration'
+import {
+  setUseTrashSurfaceForTipCal,
+  getUncalibratedTipracks,
+} from '../../calibration'
 
 import {
   CalibrateTipLength,
@@ -19,8 +22,8 @@ import {
   ConfirmRecalibrationModal,
 } from '../../components/CalibrateTipLength'
 
+import { UncalibratedInfo } from './UncalibratedInfo'
 import { TipLengthCalibrationInfoBox } from '../../components/CalibrateTipLength/TipLengthCalibrationInfoBox'
-import { CalibrationInfoContent } from '../../components/CalibrationInfoContent'
 import { Portal } from '../../components/portal'
 import { CalibratePipetteOffset } from '../../components/CalibratePipetteOffset'
 import {
@@ -48,11 +51,6 @@ export type CalibrateTipLengthControlProps = {|
 const spinnerCommandBlockList: Array<SessionCommandString> = [
   Sessions.sharedCalCommands.JOG,
 ]
-
-const IS_CALIBRATED = 'Pipette tip length has been calibrated'
-const IS_NOT_CALIBRATED = 'Pipette tip length is not calibrated'
-const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
-const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
 
 export function CalibrateTipLengthControl({
   robotName,
@@ -216,6 +214,9 @@ export function CalibrateTipLengthControl({
     handleStart,
     hasCalibrated
   )
+  const uncalibratedTipracksByMount = useSelector(state => {
+    return robotName && getUncalibratedTipracks(state, robotName)
+  })
 
   return (
     <>
@@ -223,6 +224,8 @@ export function CalibrateTipLengthControl({
         title={getLabwareDisplayName(tipRackDefinition)}
       >
         <UncalibratedInfo
+          uncalibratedTipracks={uncalibratedTipracksByMount}
+          mount={mount}
           showSpinner={showSpinner}
           hasCalibrated={hasCalibrated}
           handleStart={confirm}
@@ -267,31 +270,4 @@ export function CalibrateTipLengthControl({
       )}
     </>
   )
-}
-
-type UncalibratedInfoProps = {|
-  hasCalibrated: boolean,
-  handleStart: () => mixed,
-  showSpinner: boolean,
-|}
-function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
-  const { hasCalibrated, handleStart, showSpinner } = props
-
-  const buttonText = !hasCalibrated
-    ? CALIBRATE_TIP_LENGTH
-    : RECALIBRATE_TIP_LENGTH
-  const leftChildren = (
-    <div>
-      <p>{!hasCalibrated ? IS_NOT_CALIBRATED : IS_CALIBRATED}</p>
-      <PrimaryButton onClick={handleStart}>
-        {showSpinner ? (
-          <Icon name="ot-spinner" height="1em" spin />
-        ) : (
-          buttonText
-        )}
-      </PrimaryButton>
-    </div>
-  )
-
-  return <CalibrationInfoContent leftChildren={leftChildren} />
 }

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -1,12 +1,7 @@
 // @flow
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import {
-  Icon,
-  PrimaryButton,
-  type Mount,
-  useConditionalConfirm,
-} from '@opentrons/components'
+import { type Mount, useConditionalConfirm } from '@opentrons/components'
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
 

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -13,7 +13,7 @@ import * as Sessions from '../../sessions'
 import { getUseTrashSurfaceForTipCal } from '../../config'
 import {
   setUseTrashSurfaceForTipCal,
-  getUncalibratedTipracks,
+  getUncalibratedTipracksByMount,
 } from '../../calibration'
 
 import {
@@ -38,6 +38,7 @@ import type {
   TipLengthCalibrationSession,
 } from '../../sessions/types'
 import type { RequestState } from '../../robot-api/types'
+import type { TipracksByMountMap } from '../../robot'
 
 export type CalibrateTipLengthControlProps = {|
   robotName: string,
@@ -214,8 +215,9 @@ export function CalibrateTipLengthControl({
     handleStart,
     hasCalibrated
   )
-  const uncalibratedTipracksByMount = useSelector(state => {
-    return robotName && getUncalibratedTipracks(state, robotName)
+
+  const uncalibratedTipracksByMount: TipracksByMountMap = useSelector(state => {
+    return getUncalibratedTipracksByMount(state, robotName)
   })
 
   return (
@@ -224,7 +226,7 @@ export function CalibrateTipLengthControl({
         title={getLabwareDisplayName(tipRackDefinition)}
       >
         <UncalibratedInfo
-          uncalibratedTipracks={uncalibratedTipracksByMount}
+          uncalibratedTipracksByMount={uncalibratedTipracksByMount}
           mount={mount}
           showSpinner={showSpinner}
           hasCalibrated={hasCalibrated}

--- a/app/src/pages/Calibrate/UncalibratedInfo.js
+++ b/app/src/pages/Calibrate/UncalibratedInfo.js
@@ -47,7 +47,7 @@ type UncalibratedInfoProps = {|
   uncalibratedTipracksByMount: TipracksByMountMap,
   mount: Mount,
   hasCalibrated: boolean,
-  handleStart: () => void,
+  handleStart: () => mixed,
   showSpinner: boolean,
 |}
 

--- a/app/src/pages/Calibrate/UncalibratedInfo.js
+++ b/app/src/pages/Calibrate/UncalibratedInfo.js
@@ -7,6 +7,7 @@ import {
   Icon,
   PrimaryBtn,
   SecondaryBtn,
+  Text,
   SPACING_2,
   type Mount,
 } from '@opentrons/components'
@@ -68,7 +69,7 @@ export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
   ) : (
     buttonText
   )
-  console.log(`mount: ${mount}`)
+
   const otherMount: Mount | null = PIPETTE_MOUNTS.find(m => m !== mount) || null
   const nextLabware = useSelector(robotSelectors.getUnconfirmedLabware)[0]
 
@@ -91,8 +92,9 @@ export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
   }
   const leftChildren = (
     <div>
-      <p>{!hasCalibrated ? IS_NOT_CALIBRATED : IS_CALIBRATED}</p>
+      <Text>{!hasCalibrated ? IS_NOT_CALIBRATED : IS_CALIBRATED}</Text>
       <CalibrateButton
+        title={buttonText}
         hasCalibrated={hasCalibrated}
         marginBottom={SPACING_2}
         width={BTN_WIDTH}

--- a/app/src/pages/Calibrate/UncalibratedInfo.js
+++ b/app/src/pages/Calibrate/UncalibratedInfo.js
@@ -1,0 +1,114 @@
+// @flow
+import * as React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { push } from 'connected-react-router'
+
+import {
+  Icon,
+  PrimaryBtn,
+  SecondaryBtn,
+  SPACING_2,
+  type Mount,
+} from '@opentrons/components'
+
+import { CalibrationInfoContent } from '../../components/CalibrationInfoContent'
+import { PIPETTE_MOUNTS } from '../../pipettes'
+import { selectors as robotSelectors } from '../../robot'
+
+import type { TipracksByMountMap } from '../../robot'
+import type { Dispatch } from '../../types'
+
+const IS_CALIBRATED = 'Pipette tip length is calibrated.'
+const IS_NOT_CALIBRATED = 'Pipette tip length is not calibrated.'
+const CALIBRATE_TIP_LENGTH = 'Calibrate tip length'
+const RECALIBRATE_TIP_LENGTH = 'Re-Calibrate tip length'
+const CONTINUE_TO_NEXT_TIP_TYPE = 'Continue to next tip type'
+const CONTINUE_TO_NEXT_PIPETTE = 'Continue to next pipette'
+const CONTINUE_TO_LABWARE_CALIBRATION = 'Continue to labware calibration'
+
+const BTN_WIDTH = '23rem'
+
+type CalibrateButtonProps = {
+  hasCalibrated: boolean,
+  ...
+}
+
+function CalibrateButton(props: CalibrateButtonProps) {
+  const { hasCalibrated, ...otherProps } = props
+  if (hasCalibrated) {
+    return <SecondaryBtn {...otherProps} />
+  } else {
+    return <PrimaryBtn {...otherProps} />
+  }
+}
+
+type UncalibratedInfoProps = {|
+  uncalibratedTipracks: TipracksByMountMap,
+  mount: Mount,
+  hasCalibrated: boolean,
+  handleStart: () => void,
+  showSpinner: boolean,
+|}
+
+export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
+  const {
+    uncalibratedTipracks,
+    mount,
+    hasCalibrated,
+    handleStart,
+    showSpinner,
+  } = props
+  const dispatch = useDispatch<Dispatch>()
+
+  const buttonText = !hasCalibrated
+    ? CALIBRATE_TIP_LENGTH
+    : RECALIBRATE_TIP_LENGTH
+  const spinnerOrText = showSpinner ? (
+    <Icon name="ot-spinner" height="1em" spin />
+  ) : (
+    buttonText
+  )
+  const otherMount: Mount = PIPETTE_MOUNTS.find(m => m !== mount)
+  const nextLabware = useSelector(robotSelectors.getUnconfirmedLabware)[0]
+  console.log(nextLabware)
+  let continueText
+  let defHash
+  let continueButtonOnClick
+  if (uncalibratedTipracks[mount].length) {
+    continueText = CONTINUE_TO_NEXT_TIP_TYPE
+    defHash = uncalibratedTipracks[mount][0].definitionHash || ''
+    continueButtonOnClick = `/calibrate/pipettes/${mount}/${defHash}`
+  } else {
+    if (uncalibratedTipracks[otherMount].length) {
+      continueText = CONTINUE_TO_NEXT_PIPETTE
+      defHash = uncalibratedTipracks[otherMount][0].definitionHash || ''
+      continueButtonOnClick = `/calibrate/pipettes/${otherMount}/${defHash}`
+    } else {
+      continueText = CONTINUE_TO_LABWARE_CALIBRATION
+      continueButtonOnClick = `/calibrate/labware/${nextLabware.slot}`
+    }
+  }
+  const leftChildren = (
+    <div>
+      <p>{!hasCalibrated ? IS_NOT_CALIBRATED : IS_CALIBRATED}</p>
+      <CalibrateButton
+        hasCalibrated={hasCalibrated}
+        marginBottom={SPACING_2}
+        width={BTN_WIDTH}
+        onClick={handleStart}
+      >
+        {spinnerOrText}
+      </CalibrateButton>
+      {hasCalibrated ? (
+        <PrimaryBtn
+          width={BTN_WIDTH}
+          onClick={() => dispatch(push(continueButtonOnClick))}
+        >
+          {continueText}
+        </PrimaryBtn>
+      ) : null}
+    </div>
+  )
+
+  return <CalibrationInfoContent leftChildren={leftChildren} />
+}

--- a/app/src/pages/Calibrate/UncalibratedInfo.js
+++ b/app/src/pages/Calibrate/UncalibratedInfo.js
@@ -43,7 +43,7 @@ function CalibrateButton(props: CalibrateButtonProps) {
 }
 
 type UncalibratedInfoProps = {|
-  uncalibratedTipracks: TipracksByMountMap,
+  uncalibratedTipracksByMount: TipracksByMountMap,
   mount: Mount,
   hasCalibrated: boolean,
   handleStart: () => void,
@@ -52,7 +52,7 @@ type UncalibratedInfoProps = {|
 
 export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
   const {
-    uncalibratedTipracks,
+    uncalibratedTipracksByMount,
     mount,
     hasCalibrated,
     handleStart,
@@ -68,20 +68,21 @@ export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
   ) : (
     buttonText
   )
-  const otherMount: Mount = PIPETTE_MOUNTS.find(m => m !== mount)
+  console.log(`mount: ${mount}`)
+  const otherMount: Mount | null = PIPETTE_MOUNTS.find(m => m !== mount) || null
   const nextLabware = useSelector(robotSelectors.getUnconfirmedLabware)[0]
-  console.log(nextLabware)
+
   let continueText
   let defHash
   let continueButtonOnClick
-  if (uncalibratedTipracks[mount].length) {
+  if (uncalibratedTipracksByMount[mount].length) {
     continueText = CONTINUE_TO_NEXT_TIP_TYPE
-    defHash = uncalibratedTipracks[mount][0].definitionHash || ''
+    defHash = uncalibratedTipracksByMount[mount][0].definitionHash || ''
     continueButtonOnClick = `/calibrate/pipettes/${mount}/${defHash}`
   } else {
-    if (uncalibratedTipracks[otherMount].length) {
+    if (otherMount && uncalibratedTipracksByMount[otherMount].length) {
       continueText = CONTINUE_TO_NEXT_PIPETTE
-      defHash = uncalibratedTipracks[otherMount][0].definitionHash || ''
+      defHash = uncalibratedTipracksByMount[otherMount][0].definitionHash || ''
       continueButtonOnClick = `/calibrate/pipettes/${otherMount}/${defHash}`
     } else {
       continueText = CONTINUE_TO_LABWARE_CALIBRATION

--- a/app/src/pages/Calibrate/UncalibratedInfo.js
+++ b/app/src/pages/Calibrate/UncalibratedInfo.js
@@ -71,23 +71,27 @@ export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
   )
 
   const otherMount: Mount | null = PIPETTE_MOUNTS.find(m => m !== mount) || null
-  const nextLabware = useSelector(robotSelectors.getUnconfirmedLabware)[0]
+  const nextUnconfirmedLabware = useSelector(
+    robotSelectors.getUnconfirmedLabware
+  )
+  const nextLabware = useSelector(robotSelectors.getNotTipracks)
 
   let continueText
   let defHash
   let continueButtonOnClick
-  if (uncalibratedTipracksByMount[mount].length) {
+  if (uncalibratedTipracksByMount?.[mount].length) {
     continueText = CONTINUE_TO_NEXT_TIP_TYPE
     defHash = uncalibratedTipracksByMount[mount][0].definitionHash || ''
     continueButtonOnClick = `/calibrate/pipettes/${mount}/${defHash}`
   } else {
-    if (otherMount && uncalibratedTipracksByMount[otherMount].length) {
+    if (otherMount && uncalibratedTipracksByMount?.[otherMount].length) {
       continueText = CONTINUE_TO_NEXT_PIPETTE
       defHash = uncalibratedTipracksByMount[otherMount][0].definitionHash || ''
       continueButtonOnClick = `/calibrate/pipettes/${otherMount}/${defHash}`
     } else {
       continueText = CONTINUE_TO_LABWARE_CALIBRATION
-      continueButtonOnClick = `/calibrate/labware/${nextLabware.slot}`
+      const slot = nextUnconfirmedLabware?.[0].slot || nextLabware?.[0].slot
+      continueButtonOnClick = `/calibrate/labware/${slot}`
     }
   }
   const leftChildren = (
@@ -105,7 +109,9 @@ export function UncalibratedInfo(props: UncalibratedInfoProps): React.Node {
       {hasCalibrated ? (
         <PrimaryBtn
           width={BTN_WIDTH}
-          onClick={() => dispatch(push(continueButtonOnClick))}
+          onClick={() => {
+            dispatch(push(continueButtonOnClick))
+          }}
         >
           {continueText}
         </PrimaryBtn>

--- a/app/src/pages/Calibrate/__tests__/CalibrateTipLengthControl.test.js
+++ b/app/src/pages/Calibrate/__tests__/CalibrateTipLengthControl.test.js
@@ -13,10 +13,14 @@ import type { State } from '../../../types'
 
 jest.mock('../../../robot-api')
 jest.mock('../../../sessions/selectors')
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-  useDispatch: jest.fn(),
-}))
+jest.mock('react-redux', () => {
+  const actualModule = jest.requireActual('react-redux')
+  return {
+    ...actualModule,
+    useSelector: jest.fn(),
+    useDispatch: jest.fn(),
+  }
+})
 
 const mockUseDispatchApiRequests: JestMockFn<
   [() => void],
@@ -64,10 +68,16 @@ describe('Testing calibrate tip length control', () => {
 
   it('check dispatch is called with a tip length session', () => {
     const { wrapper } = render()
-    const beginButton = wrapper.find('UncalibratedInfo').find('button')
+    const beginButton = wrapper
+      .find('UncalibratedInfo')
+      .find('button')
+      .at(0)
     beginButton.invoke('onClick')()
     wrapper.update()
-    const continueButton = wrapper.find('UncalibratedInfo').find('button')
+    const continueButton = wrapper
+      .find('ConfirmRecalibrationModal')
+      .find('button')
+      .at(0)
     continueButton.invoke('onClick')()
     wrapper.update()
     expect(dispatchApiRequests).toHaveBeenCalledWith(
@@ -85,10 +95,16 @@ describe('Testing calibrate tip length control', () => {
 
   it('check dispatch is called with a pipette offset session', () => {
     const { wrapper } = render({ isExtendedPipOffset: true })
-    const beginButton = wrapper.find('UncalibratedInfo').find('button')
+    const beginButton = wrapper
+      .find('UncalibratedInfo')
+      .find('button')
+      .at(0)
     beginButton.invoke('onClick')()
     wrapper.update()
-    const continueButton = wrapper.find('UncalibratedInfo').find('button')
+    const continueButton = wrapper
+      .find('ConfirmRecalibrationModal')
+      .find('button')
+      .at(0)
     continueButton.invoke('onClick')()
     wrapper.update()
     expect(dispatchApiRequests).toHaveBeenCalledWith(

--- a/app/src/pages/Calibrate/__tests__/UncalibratedInfo.test.js
+++ b/app/src/pages/Calibrate/__tests__/UncalibratedInfo.test.js
@@ -1,0 +1,2 @@
+// @flow
+import React from 'react'

--- a/app/src/pages/Calibrate/__tests__/UncalibratedInfo.test.js
+++ b/app/src/pages/Calibrate/__tests__/UncalibratedInfo.test.js
@@ -1,2 +1,146 @@
 // @flow
 import React from 'react'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import { PrimaryBtn } from '@opentrons/components'
+import type { State } from '../../../types'
+
+import wellPlate96Def from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import tiprack300Def from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
+import { UncalibratedInfo } from '../UncalibratedInfo'
+import { selectors as robotSelectors } from '../../../robot'
+
+import type { TipracksByMountMap, Labware } from '../../../robot/types'
+
+jest.mock('../../../robot/selectors')
+
+const mockGetUnconfirmedLabware: JestMockFn<
+  [State],
+  $Call<typeof robotSelectors.getUnconfirmedLabware, State>
+> = robotSelectors.getUnconfirmedLabware
+
+const leftTiprack = ({
+  type: 'some_tiprack',
+  definition: tiprack300Def,
+  slot: '3',
+  name: 'some tiprack',
+  calibratorMount: 'left',
+  isTiprack: true,
+  confirmed: true,
+}: $Shape<Labware>)
+
+const rightTiprack = ({
+  type: 'some_tiprack',
+  definition: tiprack300Def,
+  slot: '3',
+  name: 'some tiprack',
+  calibratorMount: 'right',
+  isTiprack: true,
+  confirmed: true,
+}: $Shape<Labware>)
+
+const stubUnconfirmedLabware = [
+  ({
+    _id: 123,
+    type: 'some_wellplate',
+    slot: '4',
+    position: null,
+    name: 'some wellplate',
+    calibratorMount: 'left',
+    isTiprack: false,
+    confirmed: false,
+    isLegacy: false,
+    definitionHash: 'some_hash',
+    calibration: 'unconfirmed',
+    isMoving: false,
+    definition: wellPlate96Def,
+  }: $Shape<Labware>),
+]
+
+describe('UncalibratedInfo', () => {
+  let render
+  let mockStore
+  let dispatch
+  let mockUncalibratedInfo: TipracksByMountMap = { left: [], right: [] }
+
+  beforeEach(() => {
+    dispatch = jest.fn()
+    mockStore = {
+      subscribe: () => {},
+      getState: () => ({
+        robotApi: {},
+      }),
+      dispatch,
+    }
+    mockGetUnconfirmedLabware.mockReturnValue(stubUnconfirmedLabware)
+
+    render = (props = {}) => {
+      const {
+        currentMount = 'left',
+        hasCalibrated = true,
+        showSpinner = false,
+        handleStart = () => {},
+      } = props
+      return mount(
+        <UncalibratedInfo
+          uncalibratedTipracksByMount={mockUncalibratedInfo}
+          mount={currentMount}
+          showSpinner={showSpinner}
+          hasCalibrated={hasCalibrated}
+          handleStart={handleStart}
+        />,
+        {
+          wrappingComponent: Provider,
+          wrappingComponentProps: { store: mockStore },
+        }
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('renders calibrate tip length button if hasCalibrated is truthy', () => {
+    const wrapper = render({ hasCalibrated: false })
+    const component = wrapper.find(`CalibrationInfoContent`)
+    expect(
+      component.find(`CalibrateButton[title='Calibrate tip length']`).exists()
+    ).toBe(true)
+  })
+
+  it('renders re-calibrate tip length button if hasCalibrated is truthy', () => {
+    const wrapper = render()
+    const component = wrapper.find(`CalibrationInfoContent`)
+    expect(
+      component
+        .find(`CalibrateButton[title='Re-Calibrate tip length']`)
+        .exists()
+    ).toBe(true)
+  })
+
+  it('renders move to next labware button if hasCalibrated is truthy and no unconfirmed tipracks', () => {
+    const wrapper = render()
+    const component = wrapper.find(`CalibrationInfoContent`)
+    expect(component.find(PrimaryBtn).prop('children')).toEqual(
+      'Continue to labware calibration'
+    )
+  })
+
+  it('renders move to next labware button if hasCalibrated is truthy and there is a unconfirmed tipracks in the same mount', () => {
+    mockUncalibratedInfo = { left: [leftTiprack], right: [] }
+    const wrapper = render()
+    const component = wrapper.find(`CalibrationInfoContent`)
+    expect(component.find(PrimaryBtn).prop('children')).toEqual(
+      'Continue to next tip type'
+    )
+  })
+
+  it('renders move to next labware button if hasCalibrated is truthy and there is a unconfirmed tipracks in the other mount', () => {
+    mockUncalibratedInfo = { left: [], right: [rightTiprack] }
+    const wrapper = render()
+    const component = wrapper.find(`CalibrationInfoContent`)
+    expect(component.find(PrimaryBtn).prop('children')).toEqual(
+      'Continue to next pipette'
+    )
+  })
+})

--- a/app/src/pipettes/types.js
+++ b/app/src/pipettes/types.js
@@ -3,7 +3,10 @@
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { Pipette as ProtocolPipette } from '../robot/types'
 import type { RobotApiRequestMeta } from '../robot-api/types'
-import type { PipetteOffsetCalibration } from '../calibration/types'
+import type {
+  PipetteOffsetCalibration,
+  TipLengthCalibration,
+} from '../calibration/types'
 
 // common types
 

--- a/app/src/pipettes/types.js
+++ b/app/src/pipettes/types.js
@@ -3,10 +3,7 @@
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { Pipette as ProtocolPipette } from '../robot/types'
 import type { RobotApiRequestMeta } from '../robot-api/types'
-import type {
-  PipetteOffsetCalibration,
-  TipLengthCalibration,
-} from '../calibration/types'
+import type { PipetteOffsetCalibration } from '../calibration/types'
 
 // common types
 

--- a/app/src/robot/selectors.js
+++ b/app/src/robot/selectors.js
@@ -1,5 +1,6 @@
 // @flow
 // robot selectors
+import { head } from 'lodash'
 import padStart from 'lodash/padStart'
 import some from 'lodash/some'
 import uniqBy from 'lodash/uniqBy'
@@ -27,6 +28,7 @@ import type {
   SessionStatusInfo,
   SessionModule,
   TipracksByMountMap,
+  NextTiprackPipetteInfo,
   CommandNode,
 } from './types'
 
@@ -502,3 +504,21 @@ export const getTipracksByMount: (
     )
   }
 )
+
+export const getNextTiprackPipette: (
+  uncalibratedTipracksByMount: TipracksByMountMap
+) => NextTiprackPipetteInfo | null = uncalibratedTipracksByMount => {
+  const targetMount = head(
+    Constants.PIPETTE_MOUNTS.filter(
+      mount => uncalibratedTipracksByMount[mount].length > 0
+    )
+  )
+  if (targetMount) {
+    return {
+      mount: targetMount,
+      tiprack: uncalibratedTipracksByMount[targetMount][0],
+    }
+  } else {
+    return null
+  }
+}

--- a/app/src/robot/types.js
+++ b/app/src/robot/types.js
@@ -199,3 +199,8 @@ export type TipracksByMountMap = {|
   left: Array<Labware>,
   right: Array<Labware>,
 |}
+
+export type NextTiprackPipetteInfo = {|
+  mount: Mount,
+  tiprack: Labware,
+|}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
# Overview
This PR updates the tip length calibration control page by:
1. changing the style of the calibrate/re-calibrate tip length button
2. add a continue button for 
  a. **next tip type** if there is an uncalibrated tiprack for the active pipette mount
  b. **next pipette** if all tipracks for the active pipette have been calibrated, but not for the other mount
  c. **labware calibration** if all tip-lengths for each tiprack for both mounts have been calibrated

See [design](https://www.figma.com/file/SHavJVuFOvV6Cq1kPgY47W/Calibration-Overhaul---Tip-Length-Calibration?node-id=1160%3A0)

closes #6694
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- added selectors for tip length calibration based on the protocol tipracks by mount
- added `TipLengthCalibrationInfoBox` to replace the legacy `CalibrationInfoBox` when the feature flag is flipped on
- separated `UncalibratedInfo` from `CalibrateTipLengthControl` and added logic to handle the continue button
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test by uploading a protocol that requires both pipettes, each with 2 or more different tip types and make sure the continue button shows up and routes appropriately.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, changes are behind the calibration overhaul feature flag
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
