### PR TITLE
refactor(app): Title CalCheckControl as Health Check

### DIFF
--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -22,7 +22,6 @@ import {
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   Tooltip,
-  TEXT_TRANSFORM_CAPITALIZE,
   useHoverTooltip,
 } from '@opentrons/components'
 
@@ -44,7 +43,7 @@ const CHECK_ROBOT_CAL = 'Check robot calibration'
 const CHECK_ROBOT_CAL_DESCRIPTION =
   "Check the robot's calibration status and diagnose common pipette positioning problems."
 const CAL_HEALTH_CHECK_DESCRIPTION =
-      'Check the calibration settings for your robot.'
+  'Check the calibration settings for your robot.'
 const COULD_NOT_START = 'Could not start Robot Calibration Check'
 const PLEASE_TRY_AGAIN =
   'Please try again or contact support if you continue to experience issues'
@@ -72,30 +71,27 @@ export function CheckCalibrationControl({
   const buttonDisabled =
     Boolean(disabledReason) || requestStatus === RobotApi.PENDING
 
-
   const ff = useSelector(getFeatureFlags)
 
   React.useEffect(() => {
     if (requestStatus === RobotApi.SUCCESS) setShowWizard(true)
   }, [requestStatus])
 
-  const titleContent: (boolean) => string = (useNewContent) =>
-    useNewContent
-        ? CAL_HEALTH_CHECK
-        : CHECK_ROBOT_CAL
-  const descriptionContent: (boolean) => React.Node = (useNewContent) =>
-        useNewContent
-        ? (<Text>{CAL_HEALTH_CHECK_DESCRIPTION}</Text>)
-        : (<Text>{CHECK_ROBOT_CAL_DESCRIPTION}</Text>)
-  const buttonChildren: (boolean) => React.Node =
-    requestStatus !== RobotApi.PENDING ? (
-      (useNewContent) => useNewContent ? <Text>{CHECK_HEALTH}</Text> : <Text>{CHECK}</Text>
+  const titleContent: boolean => string = useNewContent =>
+    useNewContent ? CAL_HEALTH_CHECK : CHECK_ROBOT_CAL
+  const descriptionContent: boolean => React.Node = useNewContent =>
+    useNewContent ? (
+      <Text>{CAL_HEALTH_CHECK_DESCRIPTION}</Text>
     ) : (
-      (_) => <Icon name="ot-spinner" height="1em" spin />
+      <Text>{CHECK_ROBOT_CAL_DESCRIPTION}</Text>
     )
-  const buttonWidth: (boolean) => string =
-        useNewContent => useNewContent ? "12rem" : "9rem"
-
+  const buttonChildren: boolean => React.Node =
+    requestStatus !== RobotApi.PENDING
+      ? useNewContent =>
+          useNewContent ? <Text>{CHECK_HEALTH}</Text> : <Text>{CHECK}</Text>
+      : _ => <Icon name="ot-spinner" height="1em" spin />
+  const buttonWidth: boolean => string = useNewContent =>
+    useNewContent ? '12rem' : '9rem'
 
   // TODO(mc, 2020-06-17): extract alert presentational stuff
   return (

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import last from 'lodash/last'
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
+import { getFeatureFlags } from '../../config'
 
 import {
   Icon,
@@ -21,6 +22,7 @@ import {
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   Tooltip,
+  TEXT_TRANSFORM_CAPITALIZE,
   useHoverTooltip,
 } from '@opentrons/components'
 
@@ -35,10 +37,14 @@ export type CheckCalibrationControlProps = {|
   disabledReason: string | null,
 |}
 
-const CHECK = 'Check'
+const CAL_HEALTH_CHECK = 'Calibration Health Check'
+const CHECK_HEALTH = 'check health'
+const CHECK = 'check'
 const CHECK_ROBOT_CAL = 'Check robot calibration'
 const CHECK_ROBOT_CAL_DESCRIPTION =
   "Check the robot's calibration status and diagnose common pipette positioning problems."
+const CAL_HEALTH_CHECK_DESCRIPTION =
+      'Check the calibration settings for your robot.'
 const COULD_NOT_START = 'Could not start Robot Calibration Check'
 const PLEASE_TRY_AGAIN =
   'Please try again or contact support if you continue to experience issues'
@@ -66,32 +72,46 @@ export function CheckCalibrationControl({
   const buttonDisabled =
     Boolean(disabledReason) || requestStatus === RobotApi.PENDING
 
-  const buttonChildren =
-    requestStatus !== RobotApi.PENDING ? (
-      CHECK
-    ) : (
-      <Icon name="ot-spinner" height="1em" spin />
-    )
+
+  const ff = useSelector(getFeatureFlags)
 
   React.useEffect(() => {
     if (requestStatus === RobotApi.SUCCESS) setShowWizard(true)
   }, [requestStatus])
+
+  const titleContent: (boolean) => string = (useNewContent) =>
+    useNewContent
+        ? CAL_HEALTH_CHECK
+        : CHECK_ROBOT_CAL
+  const descriptionContent: (boolean) => React.Node = (useNewContent) =>
+        useNewContent
+        ? (<Text>{CAL_HEALTH_CHECK_DESCRIPTION}</Text>)
+        : (<Text>{CHECK_ROBOT_CAL_DESCRIPTION}</Text>)
+  const buttonChildren: (boolean) => React.Node =
+    requestStatus !== RobotApi.PENDING ? (
+      (useNewContent) => useNewContent ? <Text>{CHECK_HEALTH}</Text> : <Text>{CHECK}</Text>
+    ) : (
+      (_) => <Icon name="ot-spinner" height="1em" spin />
+    )
+  const buttonWidth: (boolean) => string =
+        useNewContent => useNewContent ? "12rem" : "9rem"
+
 
   // TODO(mc, 2020-06-17): extract alert presentational stuff
   return (
     <>
       <TitledControl
         borderBottom={BORDER_SOLID_LIGHT}
-        title={CHECK_ROBOT_CAL}
-        description={<Text>{CHECK_ROBOT_CAL_DESCRIPTION}</Text>}
+        title={titleContent(Boolean(ff.enableCalibrationOverhaul))}
+        description={descriptionContent(Boolean(ff.enableCalibrationOverhaul))}
         control={
           <SecondaryBtn
             {...targetProps}
-            width="9rem"
+            width={buttonWidth(Boolean(ff.enableCalibrationOverhaul))}
             onClick={ensureSession}
             disabled={buttonDisabled}
           >
-            {buttonChildren}
+            {buttonChildren(Boolean(ff.enableCalibrationOverhaul))}
           </SecondaryBtn>
         }
       >

--- a/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
@@ -24,7 +24,10 @@ jest.mock('../../CheckCalibration', () => ({
 }))
 jest.mock('../../../config')
 
-const mockGetFeatureFlags: JestMockFn<[State], $Call<typeof Config.getFeatureFlags, State>> = Config.getFeatureFlags
+const mockGetFeatureFlags: JestMockFn<
+  [State],
+  $Call<typeof Config.getFeatureFlags, State>
+> = Config.getFeatureFlags
 
 const { name: robotName } = mockRobot
 const MOCK_STATE: $Shape<State> = {}
@@ -47,7 +50,7 @@ describe('CheckCalibrationControl', () => {
   }
 
   beforeEach(() => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: false})
+    mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: false })
   })
 
   afterEach(() => {
@@ -65,105 +68,105 @@ describe('CheckCalibrationControl', () => {
     expect(button.html()).toMatch(/check/i)
   })
 
-    it('should render a TitledControl with new ff', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: true})
+  it('should render a TitledControl with new ff', () => {
+    mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: true })
     const wrapper = render({ disabledReason: null })
     const titledButton = wrapper.find(TitledControl)
-      const button = titledButton.find(SecondaryBtn)
+    const button = titledButton.find(SecondaryBtn)
 
-      expect(titledButton.prop('title')).toMatch(/Calibration Health Check/)
-      expect(titledButton.html()).toMatch(/check the calibration settings for your robot/i)
-      expect(button.prop('width')).toBe("12rem")
-      expect(button.html()).toMatch(/check health/i)
+    expect(titledButton.prop('title')).toMatch(/Calibration Health Check/)
+    expect(titledButton.html()).toMatch(
+      /check the calibration settings for your robot/i
+    )
+    expect(button.prop('width')).toBe('12rem')
+    expect(button.html()).toMatch(/check health/i)
   })
-
 
   const FF_VAL = [true, false, undefined]
 
-  FF_VAL.forEach((val) => {
+  FF_VAL.forEach(val => {
+    it('should be able to disable the button', () => {
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: val })
+      const wrapper = render({ disabledReason: 'oh no!' })
+      const button = wrapper.find('button')
+      const tooltip = wrapper.find(Tooltip)
 
-  it('should be able to disable the button', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: val})
-    const wrapper = render({ disabledReason: 'oh no!' })
-    const button = wrapper.find('button')
-    const tooltip = wrapper.find(Tooltip)
-
-    expect(button.prop('disabled')).toBe(true)
-    expect(tooltip.prop('children')).toBe('oh no!')
-  })
-
-  it('should ensure a calibration check session exists on click', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: val})
-    const wrapper = render({ disabledReason: null })
-
-    wrapper.find('button').invoke('onClick')()
-
-    expect(dispatch).toHaveBeenCalledWith({
-      ...Sessions.ensureSession(
-        robotName,
-        Sessions.SESSION_TYPE_CALIBRATION_CHECK
-      ),
-      meta: { requestId: expect.any(String) },
-    })
-  })
-
-  it('should show a spinner in the button while request is pending', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: val})
-    const wrapper = render({ disabledReason: null })
-    wrapper.find('button').invoke('onClick')()
-
-    const action = dispatch.mock.calls[0][0]
-    const requestId = action.meta.requestId
-
-    getRequestById.mockImplementation((state, reqId) => {
-      expect(state).toBe(MOCK_STATE)
-      expect(reqId).toBe(requestId)
-      return { status: RobotApi.PENDING }
+      expect(button.prop('disabled')).toBe(true)
+      expect(tooltip.prop('children')).toBe('oh no!')
     })
 
-    wrapper.setProps({})
+    it('should ensure a calibration check session exists on click', () => {
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: val })
+      const wrapper = render({ disabledReason: null })
 
-    const button = wrapper.find('button')
-    const spinner = button.find(Icon)
+      wrapper.find('button').invoke('onClick')()
 
-    expect(button.prop('disabled')).toBe(true)
-    expect(spinner.prop('name')).toBe('ot-spinner')
-    expect(spinner.prop('spin')).toBe(true)
-  })
-
-  it('should show a CheckCalbration wizard in a Portal when request succeeds', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: val})
-    const wrapper = render({ disabledReason: null })
-
-    wrapper.find('button').invoke('onClick')()
-    getRequestById.mockReturnValue(({ status: RobotApi.SUCCESS }: any))
-    wrapper.setProps({})
-    wrapper.update()
-
-    const wizard = wrapper.find(Portal).find(CheckCalibration)
-    expect(wizard.prop('robotName')).toBe(robotName)
-
-    wrapper.find(CheckCalibration).invoke('closeCalibrationCheck')()
-    expect(wrapper.exists(CheckCalibration)).toBe(false)
-  })
-
-  it('should show a warning message if the request fails', () => {
-    mockGetFeatureFlags.mockReturnValue({enableCalibrationOverhaul: val})
-    const wrapper = render({ disabledReason: null })
-
-    wrapper.find('button').invoke('onClick')()
-    getRequestById.mockReturnValue({
-      status: RobotApi.FAILURE,
-      response: { ok: false, method: 'GET', path: '/sessions', status: 500 },
-      error: { errors: [{ detail: 'oh no!' }] },
+      expect(dispatch).toHaveBeenCalledWith({
+        ...Sessions.ensureSession(
+          robotName,
+          Sessions.SESSION_TYPE_CALIBRATION_CHECK
+        ),
+        meta: { requestId: expect.any(String) },
+      })
     })
-    wrapper.setProps({})
-    wrapper.update()
 
-    expect(wrapper.exists(CheckCalibration)).toBe(false)
-    expect(wrapper.exists('Icon[name="alert-circle"]')).toBe(true)
-    expect(wrapper.html()).toMatch(/could not start robot calibration check/i)
-    expect(wrapper.html()).toContain('oh no!')
-  })
+    it('should show a spinner in the button while request is pending', () => {
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: val })
+      const wrapper = render({ disabledReason: null })
+      wrapper.find('button').invoke('onClick')()
+
+      const action = dispatch.mock.calls[0][0]
+      const requestId = action.meta.requestId
+
+      getRequestById.mockImplementation((state, reqId) => {
+        expect(state).toBe(MOCK_STATE)
+        expect(reqId).toBe(requestId)
+        return { status: RobotApi.PENDING }
+      })
+
+      wrapper.setProps({})
+
+      const button = wrapper.find('button')
+      const spinner = button.find(Icon)
+
+      expect(button.prop('disabled')).toBe(true)
+      expect(spinner.prop('name')).toBe('ot-spinner')
+      expect(spinner.prop('spin')).toBe(true)
     })
+
+    it('should show a CheckCalbration wizard in a Portal when request succeeds', () => {
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: val })
+      const wrapper = render({ disabledReason: null })
+
+      wrapper.find('button').invoke('onClick')()
+      getRequestById.mockReturnValue(({ status: RobotApi.SUCCESS }: any))
+      wrapper.setProps({})
+      wrapper.update()
+
+      const wizard = wrapper.find(Portal).find(CheckCalibration)
+      expect(wizard.prop('robotName')).toBe(robotName)
+
+      wrapper.find(CheckCalibration).invoke('closeCalibrationCheck')()
+      expect(wrapper.exists(CheckCalibration)).toBe(false)
+    })
+
+    it('should show a warning message if the request fails', () => {
+      mockGetFeatureFlags.mockReturnValue({ enableCalibrationOverhaul: val })
+      const wrapper = render({ disabledReason: null })
+
+      wrapper.find('button').invoke('onClick')()
+      getRequestById.mockReturnValue({
+        status: RobotApi.FAILURE,
+        response: { ok: false, method: 'GET', path: '/sessions', status: 500 },
+        error: { errors: [{ detail: 'oh no!' }] },
+      })
+      wrapper.setProps({})
+      wrapper.update()
+
+      expect(wrapper.exists(CheckCalibration)).toBe(false)
+      expect(wrapper.exists('Icon[name="alert-circle"]')).toBe(true)
+      expect(wrapper.html()).toMatch(/could not start robot calibration check/i)
+      expect(wrapper.html()).toContain('oh no!')
+    })
+  })
 })


### PR DESCRIPTION
The control itself needed some copy (and slight resulting layout)
changes to match the designs.

This does part of #6725 but doesn't yet retitle the title bars (since there are a lot of upcoming changes there and I don't want to cause conflicts).

## Review Requests/Testing
- Does it say health check