### PR TITLE
feat(protocol-designer): implement dispense > air gap for Transfer command creator

### DIFF
--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -1122,25 +1122,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 3.4,
           },
         },
-        // blowout is not in destination well (it's in trash)
-        // so we use the dispense > air gap here before moving to trash
-        {
-          command: 'airGap',
-          params: {
-            pipette: 'p300SingleId',
-            volume: 3,
-            labware: 'destPlateId',
-            well: 'B1',
-            offsetFromBottomMm: 11.54,
-            flowRate: 2.1,
-          },
-        },
-        {
-          command: 'delay',
-          params: {
-            wait: 11,
-          },
-        },
+        // no dispense > air gap, because tip will be reused
         // blowout
         {
           command: 'blowout',
@@ -1150,42 +1132,6 @@ describe('advanced options', () => {
             well: 'A1',
             flowRate: 2.3,
             offsetFromBottomMm: 80.3,
-          },
-        },
-        // another dispense > air gap while moving from trash to source well
-        {
-          command: 'airGap',
-          params: {
-            pipette: 'p300SingleId',
-            volume: 3,
-            labware: 'destPlateId',
-            well: 'B1',
-            offsetFromBottomMm: 11.54,
-            flowRate: 2.1,
-          },
-        },
-        {
-          command: 'delay',
-          params: {
-            wait: 11,
-          },
-        },
-        // then get rid of the dispense > air gap in the previous source well
-        {
-          command: 'dispenseAirGap',
-          params: {
-            pipette: 'p300SingleId',
-            volume: 3,
-            labware: 'sourcePlateId',
-            well: 'A1',
-            offsetFromBottomMm: 11.54,
-            flowRate: 2.2,
-          },
-        },
-        {
-          command: 'delay',
-          params: {
-            wait: 12,
           },
         },
         // next chunk from A1: remaining volume
@@ -1395,18 +1341,8 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
-        // blowout
-        {
-          command: 'blowout',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'trashId',
-            well: 'A1',
-            flowRate: 2.3,
-            offsetFromBottomMm: 80.3,
-          },
-        },
         // since we used dispense > air gap, drop the tip
+        // skip blowout into trash b/c we're about to drop tip anyway
         {
           command: 'dropTip',
           params: {
@@ -1661,43 +1597,8 @@ describe('advanced options', () => {
             offsetFromBottomMm: 13.84,
           },
         },
-        // dispense > air gap
-        {
-          command: 'airGap',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'destPlateId',
-            well: 'B1',
-            volume: 3,
-            flowRate: 2.1,
-            offsetFromBottomMm: 11.54,
-          },
-        },
-        {
-          command: 'delay',
-          params: {
-            wait: 11,
-          },
-        },
-        // we're re-using the tip, so instead of disposing the tip
-        // we will dispense the dispense > air gap in the source well
-        {
-          command: 'dispenseAirGap',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'sourcePlateId',
-            well: 'A1',
-            volume: 3,
-            flowRate: 2.2,
-            offsetFromBottomMm: 11.54,
-          },
-        },
-        {
-          command: 'delay',
-          params: {
-            wait: 12,
-          },
-        },
+        // don't dispense > air gap bc we're re-using the tip
+        //
         // next chunk from A1: remaining volume
         // do not pre-wet
         // mix (asp)
@@ -1780,12 +1681,12 @@ describe('advanced options', () => {
         {
           command: 'airGap',
           params: {
+            flowRate: 2.1,
+            labware: 'sourcePlateId',
+            offsetFromBottomMm: 11.54,
             pipette: 'p300SingleId',
             volume: 31,
-            labware: 'sourcePlateId',
             well: 'A1',
-            offsetFromBottomMm: 11.54,
-            flowRate: 2.1,
           },
         },
         {
@@ -1794,16 +1695,15 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
-        // dispense "aspirate > air gap" then dispense liquid
         {
           command: 'dispenseAirGap',
           params: {
+            flowRate: 2.2,
+            labware: 'destPlateId',
+            offsetFromBottomMm: 11.54,
             pipette: 'p300SingleId',
             volume: 31,
-            labware: 'destPlateId',
             well: 'B1',
-            offsetFromBottomMm: 11.54,
-            flowRate: 2.2,
           },
         },
         {
@@ -1887,7 +1787,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 3.4,
           },
         },
-        // blowout
+        // blowout to dest well
         {
           command: 'blowout',
           params: {
@@ -1898,7 +1798,7 @@ describe('advanced options', () => {
             offsetFromBottomMm: 13.84,
           },
         },
-        // dispense > air gap
+        // dispense > air gap on the way to trash
         {
           command: 'airGap',
           params: {
@@ -2440,8 +2340,7 @@ describe('advanced options', () => {
             wait: 11,
           },
         },
-        // this step is over, and we used dispense > air gap, so
-        // we will dispose of the tip
+        // we used dispense > air gap, so we will dispose of the tip
         {
           command: 'dropTip',
           params: {

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -20,6 +20,7 @@ import {
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
 } from '../__fixtures__'
+import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils/misc'
 import { transfer } from '../commandCreators/compound/transfer'
 import type { TransferArgs } from '../types'
 
@@ -860,8 +861,9 @@ describe('advanced options', () => {
   })
 
   describe('all advanced settings enabled', () => {
-    it('should create commands in the expected order with expected params', () => {
-      const args = {
+    let allArgs
+    beforeEach(() => {
+      allArgs = {
         ...mixinArgs,
         sourceWells: ['A1'],
         destWells: ['B1'],
@@ -884,11 +886,14 @@ describe('advanced options', () => {
           times: 1,
         },
         touchTipAfterDispense: true,
-        blowoutLocation: 'trashId',
         blowoutFlowRateUlSec: 2.3,
         blowoutOffsetFromTopMm: 3.3,
+        dispenseAirGapVolume: 3,
       }
+    })
 
+    it('should create commands in the expected order with expected params (blowout in trash)', () => {
+      const args = { ...allArgs, blowoutLocation: 'trashId' }
       const result = transfer(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1323,6 +1328,484 @@ describe('advanced options', () => {
             well: 'A1',
             flowRate: 2.3,
             offsetFromBottomMm: 80.3,
+          },
+        },
+      ])
+    })
+
+    it('should create commands in the expected order with expected params (blowout in dest well)', () => {
+      const args = {
+        ...allArgs,
+        blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
+      }
+
+      const result = transfer(args, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        // Pre-wet
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (asp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // aspirate
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // touch tip (asp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        // air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // dispense
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (disp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // touch tip (disp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        // blowout
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 13.84,
+          },
+        },
+        // dispense air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            flowRate: 2.1,
+            offsetFromBottomMm: 11.54,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // next chunk from A1: remaining volume
+        // do not pre-wet
+        // mix (asp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // aspirate 81 (= total vol 350 - prev transfer's 269)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // touch tip (asp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        // air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // dispense air gap then liquid
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (disp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // touch tip (disp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        // blowout
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 13.84,
+          },
+        },
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            flowRate: 2.1,
+            offsetFromBottomMm: 11.54,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
           },
         },
       ])

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -20,7 +20,10 @@ import {
   SOURCE_LABWARE,
   makeDispenseAirGapHelper,
 } from '../__fixtures__'
-import { DEST_WELL_BLOWOUT_DESTINATION } from '../utils/misc'
+import {
+  DEST_WELL_BLOWOUT_DESTINATION,
+  SOURCE_WELL_BLOWOUT_DESTINATION,
+} from '../utils/misc'
 import { transfer } from '../commandCreators/compound/transfer'
 import type { TransferArgs } from '../types'
 
@@ -2089,39 +2092,8 @@ describe('advanced options', () => {
             offsetFromBottomMm: 13.84,
           },
         },
-        // dispense > air gap
-        {
-          command: 'airGap',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'destPlateId',
-            well: 'B1',
-            flowRate: 2.1,
-            offsetFromBottomMm: 11.54,
-            volume: 3,
-          },
-        },
-        {
-          command: 'delay',
-          params: { wait: 11 },
-        },
-        // we're not re-using the tip, so instead of dispenseAirGap we'll change the tip
-        {
-          command: 'dropTip',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'trashId',
-            well: 'A1',
-          },
-        },
-        {
-          command: 'pickUpTip',
-          params: {
-            pipette: 'p300SingleId',
-            labware: 'tiprack1Id',
-            well: 'B1',
-          },
-        },
+        // we're re-using the tip, so we'll skip the dispense > air gap
+        //
         // next chunk from A1: remaining volume
         // do not pre-wet
         // mix (asp)
@@ -2351,9 +2323,528 @@ describe('advanced options', () => {
         },
       ])
     })
-    // TODO IMMEDIATELY also, we still have to add a test case for blowout in SOURCE)
+
     it('should create commands in the expected order with expected params (blowout in source well, change tip each aspirate)', () => {
-      expect('not implemented').toEqual('TODO!')
+      const args = {
+        ...allArgs,
+        changeTip: 'always',
+        blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
+      }
+
+      const result = transfer(args, invariantContext, robotStateWithTip)
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        // get fresh tip b/c it's per source
+        {
+          command: 'dropTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+          },
+        },
+        {
+          command: 'pickUpTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'tiprack1Id',
+            well: 'A1',
+          },
+        },
+        // Pre-wet
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (asp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // aspirate
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // touch tip (asp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        // aspirate > air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // dispense
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 269,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (disp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // touch tip (disp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        // blowout
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 13.84,
+          },
+        },
+        // dispense > air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            flowRate: 2.1,
+            offsetFromBottomMm: 11.54,
+            volume: 3,
+          },
+        },
+        {
+          command: 'delay',
+          params: { wait: 11 },
+        },
+        // we're not re-using the tip, so instead of dispenseAirGap we'll change the tip
+        {
+          command: 'dropTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+          },
+        },
+        {
+          command: 'pickUpTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'tiprack1Id',
+            well: 'B1',
+          },
+        },
+        // next chunk from A1: remaining volume
+        // do not pre-wet
+        // mix (asp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 35,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // aspirate 81 (= total vol 350 - prev transfer's 269)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 3.1,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 15,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // touch tip (asp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 14.5,
+          },
+        },
+        // aspirate > air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'sourcePlateId',
+            well: 'A1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // dispense "aspirate > air gap" then dispense liquid
+        {
+          command: 'dispenseAirGap',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 31,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 11.54,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 81,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'moveToWell',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offset: {
+              x: 0,
+              y: 0,
+              z: 14,
+            },
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // mix (disp)
+        {
+          command: 'aspirate',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.1,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        {
+          command: 'dispense',
+          params: {
+            pipette: 'p300SingleId',
+            volume: 36,
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.2,
+            flowRate: 2.2,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 12,
+          },
+        },
+        // touch tip (disp)
+        {
+          command: 'touchTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            offsetFromBottomMm: 3.4,
+          },
+        },
+        // blowout
+        {
+          command: 'blowout',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'sourcePlateId',
+            well: 'A1',
+            flowRate: 2.3,
+            offsetFromBottomMm: 13.84,
+          },
+        },
+        // dispense > air gap
+        {
+          command: 'airGap',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'destPlateId',
+            well: 'B1',
+            volume: 3,
+            flowRate: 2.1,
+            offsetFromBottomMm: 11.54,
+          },
+        },
+        {
+          command: 'delay',
+          params: {
+            wait: 11,
+          },
+        },
+        // we used dispense > air gap, so we will dispose of the tip
+        {
+          command: 'dropTip',
+          params: {
+            pipette: 'p300SingleId',
+            labware: 'trashId',
+            well: 'A1',
+          },
+        },
+      ])
     })
   })
 })

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -107,6 +107,7 @@ export const transfer: CommandCreator<TransferArgs> = (
 
   const aspirateAirGapVolume = args.aspirateAirGapVolume || 0
   const dispenseAirGapVolume = args.dispenseAirGapVolume || 0
+  console.log({ dispenseAirGapVolume, args })
 
   const effectiveTransferVol =
     getPipetteWithTipMaxVol(args.pipette, invariantContext) -

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -107,7 +107,6 @@ export const transfer: CommandCreator<TransferArgs> = (
 
   const aspirateAirGapVolume = args.aspirateAirGapVolume || 0
   const dispenseAirGapVolume = args.dispenseAirGapVolume || 0
-  console.log({ dispenseAirGapVolume, args })
 
   const effectiveTransferVol =
     getPipetteWithTipMaxVol(args.pipette, invariantContext) -
@@ -383,13 +382,13 @@ export const transfer: CommandCreator<TransferArgs> = (
               : []
 
           // if using dispense > air gap, drop or change the tip at the end
-          const dropTipIfDispenseAirGapWasUsed =
+          const dropTipAfterDispenseAirGap =
             airGapAfterDispenseCommands.length > 0 && isLastChunk && isLastPair
               ? [curryCommandCreator(dropTip, { pipette: args.pipette })]
               : []
 
           const blowoutCommand =
-            dropTipIfDispenseAirGapWasUsed.length > 0 &&
+            dropTipAfterDispenseAirGap.length > 0 &&
             args.blowoutLocation === FIXED_TRASH_ID
               ? [] // skip blowout it's in the trash we're replacing the tip due to dispense > air gap
               : blowoutUtil({
@@ -432,7 +431,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             ...touchTipAfterDispenseCommands,
             ...blowoutCommand,
             ...airGapAfterDispenseCommands,
-            ...dropTipIfDispenseAirGapWasUsed,
+            ...dropTipAfterDispenseAirGap,
           ]
 
           // NOTE: side-effecting

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -88,6 +88,14 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     maskValue: defaultTo([]),
   },
+  dispense_airGap_volume: {
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
+    castValue: Number,
+  },
   dispense_labware: {
     getErrors: composeErrors(requiredField),
     hydrate: getLabwareEntity,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -187,7 +187,6 @@ export const moveLiquidFormToArgs = (
     'dispense_airGap_checkbox',
     'dispense_airGap_volume'
   )
-  console.log('moveLiquid', { dispenseAirGapVolume, fields })
 
   const commonFields = {
     pipette: pipetteId,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -187,6 +187,7 @@ export const moveLiquidFormToArgs = (
     'dispense_airGap_checkbox',
     'dispense_airGap_volume'
   )
+  console.log('moveLiquid', { dispenseAirGapVolume, fields })
 
   const commonFields = {
     pipette: pipetteId,


### PR DESCRIPTION
# Overview

Closes #6508 

# Changelog

-Also fixes casting `dispense_airGap_volume` to number (which we missed)

# Review requests

- Big test & code review
- You can observe the `commands` array of the saved JSON

# Risk assessment

PD-only. Medium, though under a FF.