### PR TITLE
fix(app): fix fetch-on-session-end epics for POC, TLC

### DIFF
--- a/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { of } from 'rxjs'
 import { filter, withLatestFrom, map } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 
@@ -37,7 +36,7 @@ export const fetchPipetteOffsetCalibrationsOnCalibrationEndEpic: Epic = (
         sessionIncursRefetch(action.payload.data.attributes.sessionType) &&
         robotName != null
     ),
-    map((robotName) => {
+    map(robotName => {
       return Actions.fetchPipetteOffsetCalibrations(robotName)
     })
   )

--- a/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
@@ -5,18 +5,19 @@ import { ofType } from 'redux-observable'
 
 import { getConnectedRobotName } from '../../../robot/selectors'
 import * as Actions from '../actions'
-import type { Epic } from '../../../types'
+import type { Epic, State } from '../../../types'
 
 import type { SessionType } from '../../../sessions/types'
 import {
-  DELETE_SESSION_SUCCESS,
+  DELETE_SESSION,
   SESSION_TYPE_CALIBRATION_CHECK,
   SESSION_TYPE_TIP_LENGTH_CALIBRATION,
   SESSION_TYPE_DECK_CALIBRATION,
   SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
 } from '../../../sessions/constants'
+import { getRobotSessionById } from '../../../sessions/selectors'
 
-const sessionIncursRefetch: SessionType => boolean = sessionType =>
+const isTargetSessionType: SessionType => boolean = sessionType =>
   [
     SESSION_TYPE_CALIBRATION_CHECK,
     SESSION_TYPE_TIP_LENGTH_CALIBRATION,
@@ -24,17 +25,35 @@ const sessionIncursRefetch: SessionType => boolean = sessionType =>
     SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
   ].includes(sessionType)
 
+const sessionIncursRefetch: (
+  state: State,
+  robotName: string,
+  sessionId: string
+) => boolean = (state, robotName, sessionId) => {
+  const sessionType =
+    getRobotSessionById(state, robotName, sessionId)?.sessionType || null
+  if (sessionType) {
+    return isTargetSessionType(sessionType)
+  } else {
+    return false
+  }
+}
+
 export const fetchPipetteOffsetCalibrationsOnCalibrationEndEpic: Epic = (
   action$,
   state$
 ) => {
   return action$.pipe(
-    ofType(DELETE_SESSION_SUCCESS),
-    withLatestFrom(state$, (a, s) => [a, getConnectedRobotName(s)]),
+    ofType(DELETE_SESSION),
+    withLatestFrom(state$, (a, s) => [
+      a,
+      s,
+      getConnectedRobotName(s),
+      a.payload.sessionId,
+    ]),
     filter(
-      ([action, robotName]) =>
-        sessionIncursRefetch(action.payload.data.attributes.sessionType) &&
-        robotName != null
+      ([action, state, robotName, sessionId]) =>
+        robotName != null && sessionIncursRefetch(state, robotName, sessionId)
     ),
     map(robotName => {
       return Actions.fetchPipetteOffsetCalibrations(robotName)

--- a/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/pipette-offset/epic/fetchPipetteOffsetCalibrationsOnCalibrationEnd.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { of } from 'rxjs'
-import { filter, withLatestFrom, mergeMap } from 'rxjs/operators'
+import { filter, withLatestFrom, map } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 
 import { getConnectedRobotName } from '../../../robot/selectors'
@@ -37,8 +37,8 @@ export const fetchPipetteOffsetCalibrationsOnCalibrationEndEpic: Epic = (
         sessionIncursRefetch(action.payload.data.attributes.sessionType) &&
         robotName != null
     ),
-    mergeMap(robotName => {
-      return of(Actions.fetchPipetteOffsetCalibrations(robotName))
+    map((robotName) => {
+      return Actions.fetchPipetteOffsetCalibrations(robotName)
     })
   )
 }

--- a/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
@@ -5,34 +5,53 @@ import { ofType } from 'redux-observable'
 
 import { getConnectedRobotName } from '../../../robot/selectors'
 import * as Actions from '../actions'
-import type { Epic } from '../../../types'
+import type { Epic, State } from '../../../types'
 
 import type { SessionType } from '../../../sessions/types'
 import {
-  DELETE_SESSION_SUCCESS,
+  DELETE_SESSION,
   SESSION_TYPE_CALIBRATION_CHECK,
   SESSION_TYPE_TIP_LENGTH_CALIBRATION,
   SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
 } from '../../../sessions/constants'
+import { getRobotSessionById } from '../../../sessions/selectors'
 
-const sessionIncursRefetch: SessionType => boolean = sessionType =>
+const isTargetSessionType: SessionType => boolean = sessionType =>
   [
     SESSION_TYPE_CALIBRATION_CHECK,
     SESSION_TYPE_TIP_LENGTH_CALIBRATION,
     SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
   ].includes(sessionType)
 
+const sessionIncursRefetch: (
+  state: State,
+  robotName: string,
+  sessionId: string
+) => boolean = (state, robotName, sessionId) => {
+  const sessionType =
+    getRobotSessionById(state, robotName, sessionId)?.sessionType || null
+  if (sessionType) {
+    return isTargetSessionType(sessionType)
+  } else {
+    return false
+  }
+}
+
 export const fetchTipLengthCalibrationsOnCalibrationEndEpic: Epic = (
   action$,
   state$
 ) => {
   return action$.pipe(
-    ofType(DELETE_SESSION_SUCCESS),
-    withLatestFrom(state$, (a, s) => [a, getConnectedRobotName(s)]),
+    ofType(DELETE_SESSION),
+    withLatestFrom(state$, (a, s) => [
+      a,
+      s,
+      getConnectedRobotName(s),
+      a.payload.sessionId,
+    ]),
     filter(
-      ([action, robotName]) =>
-        sessionIncursRefetch(action.payload.data.attributes.sessionType) &&
-        robotName != null
+      ([action, state, robotName, sessionId]) =>
+        robotName != null && sessionIncursRefetch(state, robotName, sessionId)
     ),
     map(([_action, robotName]) => {
       return Actions.fetchTipLengthCalibrations(robotName)

--- a/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { of } from 'rxjs'
-import { filter, withLatestFrom, mergeMap } from 'rxjs/operators'
+import { filter, withLatestFrom, map } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 
 import { getConnectedRobotName } from '../../../robot/selectors'
@@ -35,8 +35,8 @@ export const fetchTipLengthCalibrationsOnCalibrationEndEpic: Epic = (
         sessionIncursRefetch(action.payload.data.attributes.sessionType) &&
         robotName != null
     ),
-    mergeMap(robotName => {
-      return of(Actions.fetchTipLengthCalibrations(robotName))
+    map(([_action, robotName]) => {
+      return Actions.fetchTipLengthCalibrations(robotName)
     })
   )
 }

--- a/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
+++ b/app/src/calibration/tip-length/epic/fetchTipLengthCalibrationsOnCalibrationEnd.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { of } from 'rxjs'
 import { filter, withLatestFrom, map } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 


### PR DESCRIPTION
The epics to fetch pipette offset calibration and tip length calibration
were using the wrong rxjs operators to emit their actions, and
consequently would fire at the right times but not actually incur a
fetch from the robot.

Closes #6747

## Testing
- You should be able to start and cancel tip lenght and pipette offset calibration sessions and see the actual fetches of the data going out

We may also want to change these to fire on the session delete requests instead of the delete success responses, since firing on the responses means a long period during the delete itself where data won't be available.