### PR TITLE
refactor(robot-server,app): force recalibrate TLC if one is not available in POC

### DIFF
--- a/app/src/components/InstrumentSettings/PipetteOffsetCalibrationControl.js
+++ b/app/src/components/InstrumentSettings/PipetteOffsetCalibrationControl.js
@@ -91,7 +91,7 @@ export function PipetteOffsetCalibrationControl(props: Props): React.Node {
   }, [shouldOpen, shouldClose])
 
   const hasCalibrationBlock = false
-  const shouldPerformTipLength = false
+  const shouldRecalibrateTipLength = false
   const tipRackDefinition = null
   const handleStartPipOffsetCalSession = () => {
     dispatchRequests(
@@ -100,7 +100,7 @@ export function PipetteOffsetCalibrationControl(props: Props): React.Node {
         Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
         {
           mount,
-          shouldPerformTipLength,
+          shouldRecalibrateTipLength,
           hasCalibrationBlock,
           tipRackDefinition,
         }

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -141,7 +141,7 @@ export function CalibrateTipLengthControl({
           {
             mount,
             hasCalibrationBlock: !useTrashSurface.current,
-            shouldPerformTipLength: true,
+            shouldRecalibrateTipLength: true,
             tipRackDefinition,
           }
         )

--- a/app/src/pages/Calibrate/__tests__/CalibrateTipLengthControl.test.js
+++ b/app/src/pages/Calibrate/__tests__/CalibrateTipLengthControl.test.js
@@ -98,7 +98,7 @@ describe('Testing calibrate tip length control', () => {
         {
           mount: fakeMount,
           hasCalibrationBlock: true,
-          shouldPerformTipLength: true,
+          shouldRecalibrateTipLength: true,
           tipRackDefinition: threehundredtiprack,
         }
       )

--- a/app/src/sessions/__fixtures__/pipette-offset-calibration.js
+++ b/app/src/sessions/__fixtures__/pipette-offset-calibration.js
@@ -30,7 +30,7 @@ export const mockPipetteOffsetCalibrationSessionDetails: PipetteOffsetCalibratio
 
 export const mockPipetteOffsetCalibrationSessionParams: PipetteOffsetCalibrationSessionParams = {
   mount: 'left',
-  shouldPerformTipLength: true,
+  shouldRecalibrateTipLength: true,
   tipRackDefinition: null,
   hasCalibrationBlock: true,
 }

--- a/app/src/sessions/pipette-offset-calibration/types.js
+++ b/app/src/sessions/pipette-offset-calibration/types.js
@@ -35,7 +35,7 @@ export type PipetteOffsetCalibrationInstrument = {|
 
 export type PipetteOffsetCalibrationSessionParams = {|
   mount: string,
-  shouldPerformTipLength: boolean,
+  shouldRecalibrateTipLength: boolean,
   hasCalibrationBlock: boolean,
   tipRackDefinition: ?LabwareDefinition2,
 |}

--- a/robot-server/robot_server/robot/calibration/models.py
+++ b/robot-server/robot_server/robot/calibration/models.py
@@ -16,14 +16,24 @@ class SessionCreateParams(BaseModel):
     hasCalibrationBlock: bool = Field(
         False,
         description='Whether to use a calibration block in the'
-                    'instance of TLC + pipette offset flow'
+                    'instance of TLC + pipette offset flow. If no tip length '
+                    'is performed, this is ignored, but it should always be '
+                    'specified.'
     )
     tipRackDefinition: Optional[dict] = Field(
         None,
-        description='The full labware definition of the tip rack to calibrate.'
+        description='The full labware definition of the tip rack to '
+                    'calibrate. If not specified, then a default will be '
+                    'used - either the same tiprack as in the current '
+                    'calibration, or, if there is no calibration, the '
+                    'default Opentrons tiprack for this pipette.'
     )
-    shouldPerformTipLength: bool = Field(
+    shouldRecalibrateTipLength: bool = Field(
         True,
-        description='whether to perform TLC with the loaded tip rack,'
-                    'prior to calibrating the pipette offset'
+        description='whether to perform TLC with the loaded tip rack, '
+                    'prior to recalibrating the pipette offset. If the '
+                    'tiprack used (either the one specified by '
+                    'tipRackDefinition or the default if not specified) '
+                    'does not have a tip length calibration, this will be '
+                    'forced to be true.'
     )

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -289,13 +289,13 @@ class PipetteOffsetCalibrationUserFlow:
                 tip_rack_def, position)
         if existing_calibration and existing_calibration.uri:
             try:
-                namespace, loadname, version\
-                    = existing_calibration.uri.split('/')
-            except (IndexError, ValueError):
-                pass
-            try:
-                return True, labware.load(loadname, position)
-            except FileNotFoundError:
+                details \
+                     = helpers.details_from_uri(existing_calibration.uri)
+                return True, labware.load(load_name=details.load_name,
+                                          namespace=details.namespace,
+                                          version=details.version,
+                                          parent=position)
+            except (IndexError, ValueError, FileNotFoundError):
                 pass
         tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(volume)].load_name
         return True, labware.load(tr_load_name, position)

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -86,14 +86,14 @@ class PipetteOffsetCalibrationUserFlow:
 
         self._using_default_tiprack = False
 
-        self._has_calibrated_tip_length: bool =\
-            (self._get_stored_tip_length_cal() is not None
-             or self._using_default_tiprack)
-
         existing_offset_calibration = self._get_stored_pipette_offset_cal()
         self._initialize_deck(tip_rack_def, existing_offset_calibration)
 
         existing_tip_length_calibration = self._get_stored_tip_length_cal()
+
+        self._has_calibrated_tip_length: bool =\
+            (self._get_stored_tip_length_cal() is not None
+             or self._using_default_tiprack)
 
         perform_tip_length = recalibrate_tip_length \
             or not existing_tip_length_calibration
@@ -249,7 +249,7 @@ class PipetteOffsetCalibrationUserFlow:
     def _get_stored_pipette_offset_cal(
             self) -> Optional[PipetteOffsetByPipetteMount]:
         return get.get_pipette_offset(
-            self._hw_pipette['pipette_id'], self._mount
+            self._hw_pipette.pipette_id, self._mount
         )
 
     def _get_tip_length(self) -> float:

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -1,10 +1,11 @@
 import logging
 from typing import (
     Any, Awaitable, Callable, Dict,
-    List, Optional, Union, TYPE_CHECKING)
+    List, Optional, Union, TYPE_CHECKING, Tuple)
 
 from opentrons.calibration_storage import get, modify, helpers
-from opentrons.calibration_storage.types import TipLengthCalNotFound
+from opentrons.calibration_storage.types import (
+    TipLengthCalNotFound, PipetteOffsetByPipetteMount)
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import ThreadManager, CriticalPoint
 from opentrons.protocol_api import labware
@@ -57,7 +58,7 @@ class PipetteOffsetCalibrationUserFlow:
     def __init__(self,
                  hardware: ThreadManager,
                  mount: Mount = Mount.RIGHT,
-                 perform_tip_length: bool = False,
+                 recalibrate_tip_length: bool = False,
                  has_calibration_block: bool = False,
                  tip_rack_def: Optional['LabwareDefinition'] = None):
 
@@ -84,11 +85,18 @@ class PipetteOffsetCalibrationUserFlow:
         self._nozzle_height_at_reference: Optional[float] = None
 
         self._using_default_tiprack = False
-        self._initialize_deck(tip_rack_def)
+
         self._has_calibrated_tip_length: bool =\
             (self._get_stored_tip_length_cal() is not None
              or self._using_default_tiprack)
 
+        existing_offset_calibration = self._get_stored_pipette_offset_cal()
+        self._initialize_deck(tip_rack_def, existing_offset_calibration)
+
+        existing_tip_length_calibration = self._get_stored_tip_length_cal()
+
+        perform_tip_length = recalibrate_tip_length \
+            or not existing_tip_length_calibration
         if perform_tip_length:
             self._state_machine: PipetteOffsetStateMachine =\
                 PipetteOffsetWithTipLengthStateMachine()
@@ -97,6 +105,7 @@ class PipetteOffsetCalibrationUserFlow:
             self._state_machine =\
                 PipetteOffsetCalibrationStateMachine()
             self._state = POCState  # type: ignore
+
         self._current_state = self._state.sessionStarted
         self._should_perform_tip_length = perform_tip_length
 
@@ -164,8 +173,11 @@ class PipetteOffsetCalibrationUserFlow:
     def _set_current_state(self, to_state: GenericState):
         self._current_state = to_state
 
-    def _initialize_deck(self, tiprack_def):
-        self._load_tiprack(tiprack_def)
+    def _initialize_deck(
+            self,
+            tiprack_def: Optional['LabwareDefinition'],
+            existing_calibration: Optional[PipetteOffsetByPipetteMount]):
+        self._load_tiprack(tiprack_def, existing_calibration)
         if self._has_calibration_block:
             self._load_calibration_block()
 
@@ -234,6 +246,12 @@ class PipetteOffsetCalibrationUserFlow:
         except TipLengthCalNotFound:
             return None
 
+    def _get_stored_pipette_offset_cal(
+            self) -> Optional[PipetteOffsetByPipetteMount]:
+        return get.get_pipette_offset(
+            self._hw_pipette['pipette_id'], self._mount
+        )
+
     def _get_tip_length(self) -> float:
         stored_tip_length_cal = self._get_stored_tip_length_cal()
         if stored_tip_length_cal is None:
@@ -255,24 +273,46 @@ class PipetteOffsetCalibrationUserFlow:
         cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
         del self._deck[cb_setup.slot]
 
-    def _load_tiprack(self,
-                      tip_rack_def: Optional['LabwareDefinition'] = None):
+    @staticmethod
+    def _get_tr_lw(tip_rack_def: Optional['LabwareDefinition'],
+                   existing_calibration: Optional[PipetteOffsetByPipetteMount],
+                   volume: float,
+                   position: Location) -> Tuple[bool, labware.Labware]:
+        """ Find the right tiprack to use. Specifically,
+
+        - If it's specified from above, use that
+        - If it's not, and we have a calibration, use that
+        - If we don't, use the default
+        """
+        if tip_rack_def:
+            return False, labware.load_from_definition(
+                tip_rack_def, position)
+        if existing_calibration and existing_calibration.uri:
+            try:
+                namespace, loadname, version\
+                    = existing_calibration.uri.split('/')
+            except (IndexError, ValueError):
+                pass
+            try:
+                return True, labware.load(loadname, position)
+            except FileNotFoundError:
+                pass
+        tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(volume)].load_name
+        return True, labware.load(tr_load_name, position)
+
+    def _load_tiprack(
+            self,
+            tip_rack_def: Optional['LabwareDefinition'],
+            existing_calibration: Optional[PipetteOffsetByPipetteMount]):
         """
         load onto the deck the default opentrons tip rack labware for this
         pipette and return the tip rack labware. If tip_rack_def is supplied,
         load specific tip rack from def onto the deck and return the labware.
         """
-        if tip_rack_def:
-            tr_lw = labware.load_from_definition(
-                tip_rack_def,
-                self._deck.position_for(TIP_RACK_SLOT))
-        else:
-            pip_vol = self._hw_pipette.config.max_volume
-            tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
-            tr_lw = labware.load(tr_load_name,
-                                 self._deck.position_for(TIP_RACK_SLOT))
-            self._using_default_tiprack = True
-        self._tip_rack = tr_lw
+        self._using_default_tiprack, self._tip_rack = self._get_tr_lw(
+            tip_rack_def, existing_calibration,
+            self._hw_pipette.config.max_volume,
+            self._deck.position_for(TIP_RACK_SLOT))
         self._deck[TIP_RACK_SLOT] = self._tip_rack
 
     def _flag_unmet_transition_req(self, command_handler: str,

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -50,7 +50,8 @@ class PipetteOffsetCalibrationSession(BaseSession):
                      instance_meta: SessionMetaData) -> 'BaseSession':
         assert isinstance(instance_meta.create_params, SessionCreateParams)
         mount = instance_meta.create_params.mount
-        perform_tip_length = instance_meta.create_params.shouldPerformTipLength
+        recalibrate_tip_length\
+            = instance_meta.create_params.shouldRecalibrateTipLength
         has_cal_block = instance_meta.create_params.hasCalibrationBlock
         tiprack = instance_meta.create_params.tipRackDefinition
         # if lights are on already it's because the user clicked the button,
@@ -62,7 +63,7 @@ class PipetteOffsetCalibrationSession(BaseSession):
             pip_offset_cal_user_flow = PipetteOffsetCalibrationUserFlow(
                     hardware=configuration.hardware,
                     mount=Mount[mount.upper()],
-                    perform_tip_length=perform_tip_length,
+                    recalibrate_tip_length=recalibrate_tip_length,
                     has_calibration_block=has_cal_block,
                     tip_rack_def=cast('LabwareDefinition', tiprack))
         except AssertionError as e:


### PR DESCRIPTION
When the user attaches a pipette, we want to do pipette offset
calibration. To do pipette offset calibration, you may or may not want
to specify a tiprack. If there is no pipette offset calibration stored
for the mount/pipette combo the user just attached, then we need to
figure out which tiprack to use, and depending on which tiprack you use,
you may want to do tip length calibration for it.

You can't figure out from available data which tip rack to use for
pipette offset calibration unless either
1. you force the user to tell you
2. you have the same lookup table for default labware in the client as
in the server

To fix this hole, this commit changes the semantics of pipette offset
calibration's createParams. The tip rack definition is now evaluated
before tip length recalibration (which is a new name) and the value of
tip length recalibration is based in part on the tip rack.
Change some semantics of how pipette offset calibrations are started and whether or not they do tip length calibration as part of the flow.

Specifically,
- If you specify a tiprack definition, it will be used for this pipette
offset calibration. If that specified tiprack definition does not have a
tip length calibration, recalibrateTipLength is forced to true;
otherwise, it is respected (so you can force a recalibrate where one
otherwise would not happen, but you cannot force POC to go ahead without
a tip length calibration)
- If you do not specify a tiprack definition, then a default one will be
generated: either the same one in the current pipette offset calibration
will be used, or (if there isn't a pipette offset calibration) the
default Opentrons tiprack for the volume is used. recalibrateTipLength
is respected or forced-on in the exact same way based on the exact same
criteria as if you did specify a tiprack definition.

The upshot of this is that clients in an attach-pipette scenario can
simply
- determine if a pipette offset calibration exists for this
mount/pipette combo
- if it does not, start a pipette offset calibration session without
specifying a tiprack or whether there should be a recalibration

and it will do the right thing.

Also, update the app since this changes the create param name.

## Testing
- If you have no pipette offset calibration for a pipette, and you have no tip length calibration for that pipette's "default tiprack" (e.g. `opentrons_96_tiprack_300ul` for a p300) with that pipette's serial, then when you click calibrate pipette in the pipette info screen you should be in a pipette offset + tip length flow
- If you have a pipette offset calibration for a pipette and you click calibrate in the attach pipette screen, you should _not_ get a pipette offset + tip length flow, just offset
- If you have no pipette offset calibration for a specific pipette but you do have a tip length calibration for that pipette (maybe delete the offset calibration) and click attach in the pipette info screen, you should get just the offset flow
- In pre-protocol calibration, if you calibrate a tip rack that was used for a pipette offset, you should still get the offset + tip length flow
