### PR TITLE
feat(protocol-designer): add validation to dispense > air gap volume

### DIFF
--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -15,6 +15,13 @@ import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
 } from '../utils/createPresavedStepForm'
+import { getPrereleaseFeatureFlag } from '../../persist'
+jest.mock('../../persist')
+
+const getPrereleaseFeatureFlagMock: JestMockFn<
+  any,
+  boolean
+> = getPrereleaseFeatureFlag
 
 const stepId = 'stepId123'
 const EXAMPLE_ENGAGE_HEIGHT = '18'
@@ -122,7 +129,11 @@ describe('createPresavedStepForm', () => {
     })
   })
 
-  it(`should call handleFormChange with a default pipette for "moveLiquid" step`, () => {
+  it(`should call handleFormChange with a default pipette for "moveLiquid" step (DISPENSE AIRGAP DISABLED)`, () => {
+    getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+      expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+      return false
+    })
     const args = {
       ...defaultArgs,
       stepType: 'moveLiquid',
@@ -155,6 +166,65 @@ describe('createPresavedStepForm', () => {
       blowout_checkbox: false,
       blowout_location: 'trashId',
       changeTip: 'always',
+      dispense_flowRate: null,
+      dispense_labware: null,
+      dispense_mix_checkbox: false,
+      dispense_mix_times: null,
+      dispense_mix_volume: null,
+      dispense_mmFromBottom: '0.5',
+      dispense_touchTip_checkbox: false,
+      dispense_wellOrder_first: 't2b',
+      dispense_wellOrder_second: 'l2r',
+      dispense_wells: [],
+      disposalVolume_checkbox: true,
+      disposalVolume_volume: '1',
+      path: 'single',
+      preWetTip: false,
+      stepDetails: '',
+      stepName: 'transfer',
+      volume: null,
+    })
+  })
+
+  it(`should call handleFormChange with a default pipette for "moveLiquid" step (DISPENSE AIRGAP ENABLED)`, () => {
+    getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+      expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+      return true
+    })
+    const args = {
+      ...defaultArgs,
+      stepType: 'moveLiquid',
+    }
+
+    expect(createPresavedStepForm(args)).toEqual({
+      id: stepId,
+      pipette: 'leftPipetteId',
+      stepType: 'moveLiquid',
+      // default fields
+      aspirate_airGap_checkbox: false,
+      aspirate_airGap_volume: '1',
+      aspirate_delay_checkbox: false,
+      aspirate_delay_mmFromBottom: '1',
+      aspirate_delay_seconds: '1',
+      dispense_delay_checkbox: false,
+      dispense_delay_seconds: '1',
+      dispense_delay_mmFromBottom: '0.5',
+      aspirate_flowRate: null,
+      aspirate_labware: null,
+      aspirate_mix_checkbox: false,
+      aspirate_mix_times: null,
+      aspirate_mix_volume: null,
+      aspirate_mmFromBottom: '1',
+      aspirate_touchTip_checkbox: false,
+      aspirate_wellOrder_first: 't2b',
+      aspirate_wellOrder_second: 'l2r',
+      aspirate_wells: [],
+      aspirate_wells_grouped: false,
+      blowout_checkbox: false,
+      blowout_location: 'trashId',
+      changeTip: 'always',
+      dispense_airGap_checkbox: false,
+      dispense_airGap_volume: '1',
       dispense_flowRate: null,
       dispense_labware: null,
       dispense_mix_checkbox: false,

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -11,11 +11,11 @@ import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul'
 import { getStateAndContextTempTCModules } from '../../step-generation/__fixtures__'
 import { DEFAULT_DELAY_SECONDS } from '../../constants'
+import { getPrereleaseFeatureFlag } from '../../persist'
 import {
   createPresavedStepForm,
   type CreatePresavedStepFormArgs,
 } from '../utils/createPresavedStepForm'
-import { getPrereleaseFeatureFlag } from '../../persist'
 jest.mock('../../persist')
 
 const getPrereleaseFeatureFlagMock: JestMockFn<

--- a/protocol-designer/src/steplist/fieldLevel/index.js
+++ b/protocol-designer/src/steplist/fieldLevel/index.js
@@ -88,6 +88,14 @@ const stepFieldHelperMap: { [StepFieldName]: StepFieldHelpers } = {
     getErrors: composeErrors(requiredField, minimumWellCount(1)),
     maskValue: defaultTo([]),
   },
+  dispense_airGap_volume: {
+    maskValue: composeMaskers(
+      maskToFloat,
+      onlyPositiveNumbers,
+      trimDecimals(1)
+    ),
+    castValue: Number,
+  },
   dispense_labware: {
     getErrors: composeErrors(requiredField),
     hydrate: getLabwareEntity,

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -8,12 +8,15 @@ import {
   DEFAULT_DELAY_SECONDS,
   FIXED_TRASH_ID,
 } from '../../constants'
-
+import { getPrereleaseFeatureFlag } from '../../persist'
 import type { StepType, StepFieldName } from '../../form-types'
 
 export function getDefaultsForStepType(
   stepType: StepType
 ): { [StepFieldName]: any } {
+  const dispenseAirGapEnabled = getPrereleaseFeatureFlag(
+    'OT_PD_ENABLE_AIR_GAP_DISPENSE'
+  )
   switch (stepType) {
     case 'mix':
       return {
@@ -74,6 +77,9 @@ export function getDefaultsForStepType(
         aspirate_delay_checkbox: false,
         aspirate_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_ASPIRATE}`,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        ...(dispenseAirGapEnabled
+          ? { dispense_airGap_checkbox: false, dispense_airGap_volume: null }
+          : {}),
         dispense_delay_checkbox: false,
         dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/moveLiquid.test.js
@@ -13,6 +13,13 @@ import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
   DEST_WELL_BLOWOUT_DESTINATION,
 } from '../../../../step-generation'
+import { getPrereleaseFeatureFlag } from '../../../../persist'
+jest.mock('../../../../persist')
+
+const getPrereleaseFeatureFlagMock: JestMockFn<
+  any,
+  boolean
+> = getPrereleaseFeatureFlag
 
 let pipetteEntities
 let labwareEntities
@@ -79,7 +86,7 @@ describe('path should update...', () => {
       const testCases = [
         {
           description:
-            'should not reset path when air gap checkbox is unchecked',
+            'should not reset path when aspirate > air gap checkbox is unchecked',
           volume: '3',
           aspirate_airGap_checkbox: false,
           aspirate_airGap_volume: '8',
@@ -88,7 +95,7 @@ describe('path should update...', () => {
         },
         {
           description:
-            'should not reset path when air gap volume is not a number',
+            'should not reset path when aspirate > air gap volume is not a number',
           volume: '3',
           aspirate_airGap_checkbox: true,
           aspirate_airGap_volume: '',
@@ -96,7 +103,8 @@ describe('path should update...', () => {
           expectedPath: path,
         },
         {
-          description: 'should not reset path when air gap volume is small',
+          description:
+            'should not reset path when aspirate > air gap volume is small',
           volume: '3',
           aspirate_airGap_checkbox: true,
           aspirate_airGap_volume: '1',
@@ -104,7 +112,8 @@ describe('path should update...', () => {
           expectedPath: path,
         },
         {
-          description: 'should reset path when air gap volume is large',
+          description:
+            'should reset path when aspirate > air gap volume is large',
           volume: '3',
           aspirate_airGap_checkbox: true,
           aspirate_airGap_volume: '5',
@@ -112,7 +121,8 @@ describe('path should update...', () => {
           expectedPath: 'single',
         },
         {
-          description: 'should reset path when volume is large',
+          description:
+            'should reset path when aspirate > air gap volume is large',
           volume: '6',
           aspirate_airGap_checkbox: false,
           aspirate_airGap_volume: '5',
@@ -232,7 +242,7 @@ describe('disposal volume should update...', () => {
     expect(result).toEqual(patch)
   })
 
-  it('when the air gap volume is large', () => {
+  it('when the aspirate > air gap volume is large', () => {
     const patch = { disposalVolume_volume: '6' }
     const result = handleFormHelper(patch, {
       ...form,
@@ -242,7 +252,7 @@ describe('disposal volume should update...', () => {
     })
     expect(result).toEqual({ disposalVolume_volume: '5' })
   })
-  it('when the air gap volume is increased', () => {
+  it('when the aspirate > air gap volume is increased', () => {
     const patch = { aspirate_airGap_volume: '3' }
     const result = handleFormHelper(patch, {
       ...form,
@@ -256,7 +266,7 @@ describe('disposal volume should update...', () => {
       disposalVolume_volume: '5',
     })
   })
-  it('skipped when the air gap checkbox not checked', () => {
+  it('skipped when the aspirate > air gap checkbox not checked', () => {
     const patch = { disposalVolume_volume: '6' }
     const result = handleFormHelper(patch, {
       ...form,
@@ -377,7 +387,7 @@ describe('disposal volume should update...', () => {
   })
 })
 
-describe('air gap volume', () => {
+describe('aspirate > air gap volume', () => {
   describe('when the path is single', () => {
     let form
     beforeEach(() => {
@@ -392,22 +402,22 @@ describe('air gap volume', () => {
       }
     })
 
-    it('should update the air gap volume to 0 when the patch volume is less than 0', () => {
+    it('should update the aspirate > air gap volume to 0 when the patch volume is less than 0', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '-1' }, form)
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
-    it('should update the air gap volume to 0 when the raw form volume is less than 0', () => {
+    it('should update the aspirate > air gap volume to 0 when the raw form volume is less than 0', () => {
       const result = handleFormHelper(
         {},
         { ...form, aspirate_airGap_volume: '-1' }
       )
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
-    it('should update the air gap volume to the pipette capacity - min pipette volume when the patch air gap volume is too big', () => {
+    it('should update the aspirate > air gap volume to the pipette capacity - min pipette volume when the patch air gap volume is too big', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '100' }, form)
       expect(result.aspirate_airGap_volume).toEqual('9')
     })
-    it('should update the air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
+    it('should update the aspirate > air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
       const result = handleFormHelper(
         {},
         { ...form, aspirate_airGap_volume: '10' }
@@ -452,22 +462,22 @@ describe('air gap volume', () => {
       }
     })
 
-    it('should update the air gap volume to 0 when the patch volume is less than 0', () => {
+    it('should update the aspirate > air gap volume to 0 when the patch volume is less than 0', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '-1' }, form)
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
-    it('should update the air gap volume to 0 when the raw form volume is less than 0', () => {
+    it('should update the aspirate > air gap volume to 0 when the raw form volume is less than 0', () => {
       const result = handleFormHelper(
         {},
         { ...form, aspirate_airGap_volume: '-1' }
       )
       expect(result.aspirate_airGap_volume).toEqual('0')
     })
-    it('should update the air gap volume to the pipette capacity - min pipette volume when the air gap volume is too big', () => {
+    it('should update the aspirate > air gap volume to the pipette capacity - min pipette volume when the air gap volume is too big', () => {
       const result = handleFormHelper({ aspirate_airGap_volume: '100' }, form)
       expect(result.aspirate_airGap_volume).toEqual('9')
     })
-    it('should update the air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
+    it('should update the aspirate > air gap volume to the pipette capacity - min pipette volume when the raw form air gap volume is too big', () => {
       const result = handleFormHelper(
         {},
         { ...form, aspirate_airGap_volume: '10' }
@@ -512,6 +522,158 @@ describe('air gap volume', () => {
     it('should reset to pipette min when pipette is changed', () => {
       const result = handleFormHelper({ pipette: 'otherPipetteId' }, form)
       expect(result).toMatchObject({ aspirate_airGap_volume: '30' })
+    })
+  })
+})
+
+describe('air gap > dispense volume', () => {
+  getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+    expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+    return true
+  })
+
+  const paths = ['single', 'multiAspirate']
+  paths.forEach(path => {
+    // max should equal pipette/tip capacity for single and for multi-dispense
+
+    it(`should clamp max dispense > air gap when pipette field is changed, for ${path} path`, () => {
+      // for otherPipetteId, P300, capacity is 300 so 150 is below air gap max
+      const form = {
+        path,
+        aspirate_wells: ['A1'],
+        dispense_wells: ['B2', 'B3'],
+        volume: '2',
+        pipette: 'otherPipetteId',
+        disposalVolume_checkbox: true,
+        disposalVolume_volume: '1.1',
+        dispense_airGap_checkbox: true,
+        dispense_airGap_volume: '150',
+      }
+      const result = handleFormHelper({ pipette: 'pipetteId' }, form)
+      // new max should be 10 for the P10
+      expect(result).toMatchObject({ dispense_airGap_volume: '10' })
+    })
+
+    it(`should clamp max dispense > air gap when dispense_airGap_volume field is changed, for ${path} path`, () => {
+      const form = {
+        path,
+        aspirate_wells: ['A1', 'A2'],
+        dispense_wells: ['B2'],
+        volume: '2',
+        pipette: 'pipetteId',
+        disposalVolume_checkbox: true,
+        disposalVolume_volume: '1.1',
+        dispense_airGap_checkbox: true,
+        dispense_airGap_volume: '2',
+      }
+      const result = handleFormHelper({ dispense_airGap_volume: '29' }, form)
+      // clamp to max, which should be 10 for the P10
+      expect(result).toMatchObject({ dispense_airGap_volume: '10' })
+    })
+  })
+
+  it('should clamp max dispense > air gap when going from single path to multiDispense', () => {
+    // NOTE: multiDispense is potentially lower max than single, so changing the path can cause this clamp
+    const form = {
+      path: 'single',
+      aspirate_wells: ['A1'],
+      dispense_wells: ['B2', 'B3'],
+      volume: '5',
+      pipette: 'pipetteId',
+      // NOTE: disposal volume is cleared out when changing the path to multiDispense,
+      // so should not affect the clamp
+      disposalVolume_checkbox: true,
+      disposalVolume_volume: '4',
+      dispense_airGap_checkbox: true,
+      dispense_airGap_volume: '9',
+    }
+    const result = handleFormHelper({ path: 'multiDispense' }, form)
+    expect(result).toMatchObject({
+      dispense_airGap_volume: String(10 - 0 - 5),
+
+      // this isn't specific to dispense > air gap
+      path: 'multiDispense',
+      disposalVolume_checkbox: false,
+      disposalVolume_volume: null,
+    })
+  })
+
+  const multiDispenseCases = [
+    {
+      update: { dispense_airGap_volume: '300' },
+      expected: {
+        dispense_airGap_volume: String(300 - 1.1 - 2),
+      },
+    },
+    {
+      // NOTE: in this case, disposal volume gets rounded due to pipette change,
+      // which affects dispense > airgap clamping
+      update: { pipette: 'pipetteId' },
+      expected: {
+        pipette: 'pipetteId',
+        dispense_airGap_volume: String(10 - Math.round(1.1) - 2),
+      },
+    },
+    {
+      update: { disposalVolume_volume: '50' },
+      expected: {
+        dispense_airGap_volume: String(300 - 50 - 2),
+      },
+    },
+    {
+      update: { volume: '55' },
+      expected: {
+        dispense_airGap_volume: String(300 - 1.1 - 55),
+      },
+    },
+  ]
+  // Multi-dispense max is different: max = pipette/tip capacity - disposal volume - transfer volume
+  // Ensure updating ANY one of the fields will cause the clamp (selected pipette, disposal volume, transfer volume, air gap)
+  multiDispenseCases.forEach(({ update, expected }) => {
+    it(`should clamp max air gap > dispense volume, if path is multi-dispense, when field '${Object.keys(
+      update
+    ).join(', ')}' updated`, () => {
+      const form = {
+        path: 'multiDispense',
+        aspirate_wells: ['A1'],
+        dispense_wells: ['B2', 'B3'],
+        volume: '2',
+        pipette: 'otherPipetteId',
+        disposalVolume_checkbox: true,
+        disposalVolume_volume: '1.1',
+        dispense_airGap_checkbox: true,
+        dispense_airGap_volume: '295',
+      }
+      const result = handleFormHelper(update, form)
+      expect(result).toMatchObject(expected)
+    })
+  })
+
+  // FF OFF cases: remove when removing FF
+  getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+    expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+    return false
+  })
+  const noFlagCases = [
+    { pipette: 'pipetteId' },
+    { volume: '55' },
+    { disposalVolume_volume: '12.3' },
+    { path: 'multiAspirate' },
+  ]
+  noFlagCases.forEach(update => {
+    it('with FF off, dispense > air gap fields should not be added in', () => {
+      const form = {
+        path: 'transfer',
+        aspirate_wells: ['A1', 'A2'],
+        dispense_wells: ['B2'],
+        volume: '2',
+        pipette: 'otherPipetteId',
+        disposalVolume_checkbox: true,
+        disposalVolume_volume: '1.1',
+      }
+      const result = handleFormHelper(update, form)
+      expect(result.dispense_airGap_checkbox).toBeUndefined()
+      expect(result.dispense_airGap_volume).toBeUndefined()
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/index.js
+++ b/protocol-designer/src/steplist/formLevel/index.js
@@ -26,7 +26,8 @@ import {
   minDisposalVolume,
   type FormWarning,
   type FormWarningType,
-  minAirGapVolume,
+  minAspirateAirGapVolume,
+  minDispenseAirGapVolume,
 } from './warnings'
 import type { StepType } from '../../form-types'
 
@@ -67,7 +68,8 @@ const stepFormHelperMap: { [StepType]: FormHelpers } = {
       belowPipetteMinimumVolume,
       maxDispenseWellVolume,
       minDisposalVolume,
-      minAirGapVolume
+      minAspirateAirGapVolume,
+      minDispenseAirGapVolume
     ),
   },
   magnet: {

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
@@ -9,13 +9,24 @@ import {
   DEFAULT_DELAY_SECONDS,
 } from '../../../constants'
 import { getDefaultsForStepType } from '..'
+import { getPrereleaseFeatureFlag } from '../../../persist'
+jest.mock('../../../persist')
+
+const getPrereleaseFeatureFlagMock: JestMockFn<
+  any,
+  boolean
+> = getPrereleaseFeatureFlag
 
 describe('getDefaultsForStepType', () => {
   afterEach(() => {
     jest.resetAllMocks()
   })
   describe('moveLiquid step', () => {
-    it('should get the correct defaults', () => {
+    it('should get the correct defaults (DISPENSE AIR GAP DISABLED)', () => {
+      getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+        expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+        return false
+      })
       expect(getDefaultsForStepType('moveLiquid')).toEqual({
         pipette: null,
         volume: null,
@@ -57,6 +68,61 @@ describe('getDefaultsForStepType', () => {
         aspirate_delay_checkbox: false,
         aspirate_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_ASPIRATE}`,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        dispense_delay_checkbox: false,
+        dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+        dispense_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`,
+      })
+    })
+
+    it('should get the correct defaults (DISPENSE AIR GAP ENABLED)', () => {
+      getPrereleaseFeatureFlagMock.mockImplementation(flag => {
+        expect(flag).toEqual('OT_PD_ENABLE_AIR_GAP_DISPENSE')
+        return true
+      })
+      expect(getDefaultsForStepType('moveLiquid')).toEqual({
+        pipette: null,
+        volume: null,
+        changeTip: DEFAULT_CHANGE_TIP_OPTION,
+        path: 'single',
+        aspirate_wells_grouped: false,
+
+        aspirate_flowRate: null,
+        aspirate_labware: null,
+        aspirate_wells: [],
+        aspirate_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        aspirate_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        aspirate_mix_checkbox: false,
+        aspirate_mix_times: null,
+        aspirate_mix_volume: null,
+        aspirate_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_ASPIRATE}`,
+        aspirate_touchTip_checkbox: false,
+
+        dispense_flowRate: null,
+        dispense_labware: null,
+        dispense_wells: [],
+        dispense_wellOrder_first: DEFAULT_WELL_ORDER_FIRST_OPTION,
+        dispense_wellOrder_second: DEFAULT_WELL_ORDER_SECOND_OPTION,
+        dispense_mix_checkbox: false,
+        dispense_mix_times: null,
+        dispense_mix_volume: null,
+        dispense_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`,
+        dispense_touchTip_checkbox: false,
+
+        disposalVolume_checkbox: false,
+        disposalVolume_volume: null,
+
+        blowout_checkbox: false,
+        blowout_location: FIXED_TRASH_ID,
+        preWetTip: false,
+
+        aspirate_airGap_checkbox: false,
+        aspirate_airGap_volume: null,
+        aspirate_delay_checkbox: false,
+        aspirate_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_ASPIRATE}`,
+        aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
+
+        dispense_airGap_checkbox: false,
+        dispense_airGap_volume: null,
         dispense_delay_checkbox: false,
         dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_mmFromBottom: `${DEFAULT_MM_FROM_BOTTOM_DISPENSE}`,

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.js
@@ -1,56 +1,65 @@
 // @flow
-import { minAirGapVolume } from '../warnings'
+import { _minAirGapVolume } from '../warnings'
 
-describe('warnings', () => {
-  let pipette
-  beforeEach(() => {
-    pipette = {
-      spec: {
-        minVolume: 100,
-      },
-    }
-  })
-  describe('min air gap volume', () => {
-    it('should NOT return a warning when the air gap checkbox is not selected', () => {
-      const fields = {
-        aspirate_airGap_checkbox: false,
-        aspirate_airGap_volume: null,
-        ...{ pipette },
+const aspDisp = ['aspirate', 'dispense']
+aspDisp.forEach(aspOrDisp => {
+  const checkboxField = `${aspDisp}_airGap_checkbox`
+  const volumeField = `${aspDisp}_airGap_volume`
+
+  describe(`${aspOrDisp} -> air gap`, () => {
+    let pipette
+    beforeEach(() => {
+      pipette = {
+        spec: {
+          minVolume: 100,
+        },
       }
-      expect(minAirGapVolume({ ...fields })).toBe(null)
-    })
-    it('should NOT return a warning when there is no air gap volume specified', () => {
-      const fields = {
-        aspirate_airGap_checkbox: true,
-        aspirate_airGap_volume: null,
-        ...{ pipette },
-      }
-      expect(minAirGapVolume({ ...fields })).toBe(null)
-    })
-    it('should NOT return a warning when the air gap volume is greater than the pipette min volume', () => {
-      const fields = {
-        aspirate_airGap_checkbox: true,
-        aspirate_airGap_volume: '150',
-        ...{ pipette },
-      }
-      expect(minAirGapVolume(fields)).toBe(null)
     })
 
-    it('should NOT return a warning when the air gap volume is equal to the the pipette min volume', () => {
-      const fields = {
-        aspirate_airGap_checkbox: true,
-        aspirate_airGap_volume: '100',
-        ...{ pipette },
-      }
-      expect(minAirGapVolume(fields)).toBe(null)
-    })
-    it('should return a warning when the air gap volume is less than the pipette min volume', () => {
-      const fields = {
-        aspirate_airGap_checkbox: true,
-        aspirate_airGap_volume: '0',
-        ...{ pipette },
-      }
-      expect(minAirGapVolume(fields).type).toBe('BELOW_MIN_AIR_GAP_VOLUME')
+    const minAirGapVolume = _minAirGapVolume(checkboxField, volumeField)
+
+    describe('min air gap volume', () => {
+      it('should NOT return a warning when the air gap checkbox is not selected', () => {
+        const fields = {
+          [checkboxField]: false,
+          [volumeField]: null,
+          ...{ pipette },
+        }
+        expect(minAirGapVolume({ ...fields })).toBe(null)
+      })
+      it('should NOT return a warning when there is no air gap volume specified', () => {
+        const fields = {
+          [checkboxField]: true,
+          [volumeField]: null,
+          ...{ pipette },
+        }
+        expect(minAirGapVolume({ ...fields })).toBe(null)
+      })
+      it('should NOT return a warning when the air gap volume is greater than the pipette min volume', () => {
+        const fields = {
+          [checkboxField]: true,
+          [volumeField]: '150',
+          ...{ pipette },
+        }
+        expect(minAirGapVolume(fields)).toBe(null)
+      })
+
+      it('should NOT return a warning when the air gap volume is equal to the the pipette min volume', () => {
+        const fields = {
+          [checkboxField]: true,
+          [volumeField]: '100',
+          ...{ pipette },
+        }
+        expect(minAirGapVolume(fields)).toBe(null)
+      })
+      it('should return a warning when the air gap volume is less than the pipette min volume', () => {
+        const fields = {
+          [checkboxField]: true,
+          [volumeField]: '0',
+          ...{ pipette },
+        }
+        expect(minAirGapVolume(fields).type).toBe('BELOW_MIN_AIR_GAP_VOLUME')
+      })
     })
   })
 })

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -99,19 +99,36 @@ export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
 }
 
-export const minAirGapVolume = (fields: HydratedFormData): ?FormWarning => {
-  const { aspirate_airGap_checkbox, aspirate_airGap_volume, pipette } = fields
-  if (
-    !aspirate_airGap_checkbox ||
-    !aspirate_airGap_volume ||
-    !pipette ||
-    !pipette.spec
-  )
-    return null
+// both aspirate and dispense air gap volumes have the same minimums
+export const _minAirGapVolume: (
+  checkboxField: 'aspirate_airGap_checkbox' | 'dispense_airGap_checkbox',
+  volumeField: 'aspirate_airGap_volume' | 'dispense_airGap_volume'
+) => HydratedFormData => ?FormWarning = (
+  checkboxField,
+  volumeField
+) => fields => {
+  const checkboxValue = fields[checkboxField]
+  const volumeValue = fields[volumeField]
+  const { pipette } = fields
+  if (!checkboxValue || !volumeValue || !pipette || !pipette.spec) return null
 
-  const isBelowMin = Number(aspirate_airGap_volume) < pipette.spec.minVolume
+  const isBelowMin = Number(volumeValue) < pipette.spec.minVolume
   return isBelowMin ? FORM_WARNINGS.BELOW_MIN_AIR_GAP_VOLUME : null
 }
+
+export const minAspirateAirGapVolume: (
+  fields: HydratedFormData
+) => ?FormWarning = _minAirGapVolume(
+  'aspirate_airGap_checkbox',
+  'aspirate_airGap_volume'
+)
+
+export const minDispenseAirGapVolume: (
+  fields: HydratedFormData
+) => ?FormWarning = _minAirGapVolume(
+  'dispense_airGap_checkbox',
+  'dispense_airGap_volume'
+)
 
 /*******************
  **     Helpers    **


### PR DESCRIPTION
# Overview

Closes #6500, closes #6513, closes #6652

Also unticketed but implied in those tickets: default value of `dispense > air gap > volume` should be pipette min volume.

# Review requests

Plz both code review (inc tests) and smoke test

FF ON
- Default "dispense > air gap" value for volume when you open a Transfer form
- Air gap volume field is masked: positive numbers only
- If your dispense air gap vol value is below suggested min, show air gap form-level warning. Suggested min = pipette min (same for all paths)
- Single transfer and multi-dispense paths: Max vol is clamped pipette/tip capacity
- Multi-aspirate path: Max vol is clamped at `pipette/tip capacity - disposal volume - transfer volume`.
- Ensure updating ANY one of the fields will cause the clamp (selected pipette, disposal volume, transfer volume, air gap, path)

FF OFF
- Field not shown
- Default value not initially set (need to check via redux devtools bc fields are hidden with FF off)
- `dispense_airGap_*` fields not added to form when you change pipette/path/disposal vol fields (need to check via redux devtools)

# Risk assessment

Medium, should be covered by FF and be tested