### PR TITLE
refactor(app): fixup: remove react redux mock in calibrate tip length control test

### DIFF
--- a/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
+++ b/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
+import { getPipetteOffsetCalibrationSession } from '../../sessions/pipette-offset-calibration/selectors'
 
 import type { State } from '../../types'
 import type {
@@ -32,20 +33,11 @@ export function useCalibratePipetteOffset(
   const deleteRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
 
-  const pipOffsetCalSession = useSelector<
-    State,
-    PipetteOffsetCalibrationSession | null
-  >((state: State) => {
-    const session: Sessions.Session | null = Sessions.getRobotSessionOfType(
-      state,
-      robotName,
-      Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-    )
-    return session &&
-      session.sessionType === Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-      ? session
-      : null
-  })
+  const pipOffsetCalSession: PipetteOffsetCalibrationSession | null = useSelector(
+    (state: State) => {
+      return getPipetteOffsetCalibrationSession(state, robotName)
+    }
+  )
 
   const [dispatchRequests] = RobotApi.useDispatchApiRequests(
     dispatchedAction => {

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -10,6 +10,7 @@ import { Portal } from '../portal'
 import { CalibrateDeck } from '../CalibrateDeck'
 import { TitledControl } from '../TitledControl'
 import { ConfirmStartDeckCalModal } from './ConfirmStartDeckCalModal'
+import { getDeckCalibrationSession } from '../../sessions/deck-calibration/selectors'
 import {
   InlineCalibrationWarning,
   REQUIRED,
@@ -33,7 +34,10 @@ import type {
   DeckCalibrationStatus,
   DeckCalibrationData,
 } from '../../calibration/types'
-import type { SessionCommandString } from '../../sessions/types'
+import type {
+  SessionCommandString,
+  DeckCalibrationSession,
+} from '../../sessions/types'
 import type { RequestState } from '../../robot-api/types'
 
 const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
@@ -137,20 +141,11 @@ export function DeckCalibrationControl(props: Props): React.Node {
     )
   }
 
-  const deckCalibrationSession = useSelector((state: State) => {
-    const session: Sessions.Session | null = Sessions.getRobotSessionOfType(
-      state,
-      robotName,
-      Sessions.SESSION_TYPE_DECK_CALIBRATION
-    )
-    if (
-      session &&
-      session.sessionType === Sessions.SESSION_TYPE_DECK_CALIBRATION
-    ) {
-      return session
+  const deckCalibrationSession: DeckCalibrationSession | null = useSelector(
+    (state: State) => {
+      return getDeckCalibrationSession(state, robotName)
     }
-    return null
-  })
+  )
 
   const {
     showConfirmation: showConfirmStart,

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -10,6 +10,8 @@ import {
   setUseTrashSurfaceForTipCal,
   getUncalibratedTipracksByMount,
 } from '../../calibration'
+import { getTipLengthCalibrationSession } from '../../sessions/tip-length-calibration/selectors'
+import { getPipetteOffsetCalibrationSession } from '../../sessions/pipette-offset-calibration/selectors'
 
 import {
   CalibrateTipLength,
@@ -92,37 +94,12 @@ export function CalibrateTipLengthControl({
 
   const tipLengthCalibrationSession: TipLengthCalibrationSession | null = useSelector(
     (state: State) => {
-      const tipLengthSession: Sessions.Session | null = Sessions.getRobotSessionOfType(
-        state,
-        robotName,
-        Sessions.SESSION_TYPE_TIP_LENGTH_CALIBRATION
-      )
-
-      if (
-        tipLengthSession &&
-        tipLengthSession.sessionType ===
-          Sessions.SESSION_TYPE_TIP_LENGTH_CALIBRATION
-      ) {
-        return tipLengthSession
-      }
-      return null
+      return getTipLengthCalibrationSession(state, robotName)
     }
   )
   const extendedPipetteCalibrationSession: PipetteOffsetCalibrationSession | null = useSelector(
     (state: State) => {
-      const extendedPipOffsetSession: Sessions.Session | null = Sessions.getRobotSessionOfType(
-        state,
-        robotName,
-        Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-      )
-      if (
-        extendedPipOffsetSession &&
-        extendedPipOffsetSession.sessionType ===
-          Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
-      ) {
-        return extendedPipOffsetSession
-      }
-      return null
+      return getPipetteOffsetCalibrationSession(state, robotName)
     }
   )
 
@@ -159,7 +136,6 @@ export function CalibrateTipLengthControl({
       setShowCalBlockPrompt(true)
     }
   }
-
   const showSpinner =
     useSelector<State, RequestState | null>(state =>
       trackedRequestId.current

--- a/app/src/sessions/calibration-check/selectors.js
+++ b/app/src/sessions/calibration-check/selectors.js
@@ -1,0 +1,23 @@
+// @flow
+import type { State } from '../../types'
+import { SESSION_TYPE_CALIBRATION_CHECK } from '../constants'
+import type { Session, CalibrationCheckSession } from '../types'
+import { getRobotSessionOfType } from '../selectors'
+
+export const getCalibrationCheckSession: (
+  state: State,
+  robotName: string
+) => CalibrationCheckSession | null = (state, robotName) => {
+  const calCheckSession: Session | null = getRobotSessionOfType(
+    state,
+    robotName,
+    SESSION_TYPE_CALIBRATION_CHECK
+  )
+  if (
+    calCheckSession &&
+    calCheckSession.sessionType === SESSION_TYPE_CALIBRATION_CHECK
+  ) {
+    return calCheckSession
+  }
+  return null
+}

--- a/app/src/sessions/deck-calibration/selectors.js
+++ b/app/src/sessions/deck-calibration/selectors.js
@@ -1,0 +1,23 @@
+// @flow
+import type { State } from '../../types'
+import { SESSION_TYPE_DECK_CALIBRATION } from '../constants'
+import type { Session, DeckCalibrationSession } from '../types'
+import { getRobotSessionOfType } from '../selectors'
+
+export const getDeckCalibrationSession: (
+  state: State,
+  robotName: string
+) => DeckCalibrationSession | null = (state, robotName) => {
+  const deckSession: Session | null = getRobotSessionOfType(
+    state,
+    robotName,
+    SESSION_TYPE_DECK_CALIBRATION
+  )
+  if (
+    deckSession &&
+    deckSession.sessionType === SESSION_TYPE_DECK_CALIBRATION
+  ) {
+    return deckSession
+  }
+  return null
+}

--- a/app/src/sessions/pipette-offset-calibration/selectors.js
+++ b/app/src/sessions/pipette-offset-calibration/selectors.js
@@ -1,0 +1,23 @@
+// @flow
+import type { State } from '../../types'
+import { SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION } from '../constants'
+import type { Session, PipetteOffsetCalibrationSession } from '../types'
+import { getRobotSessionOfType } from '../selectors'
+
+export const getPipetteOffsetCalibrationSession: (
+  state: State,
+  robotName: string
+) => PipetteOffsetCalibrationSession | null = (state, robotName) => {
+  const pipetteOffsetSession: Session | null = getRobotSessionOfType(
+    state,
+    robotName,
+    SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
+  )
+  if (
+    pipetteOffsetSession &&
+    pipetteOffsetSession.sessionType === SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION
+  ) {
+    return pipetteOffsetSession
+  }
+  return null
+}

--- a/app/src/sessions/tip-length-calibration/selectors.js
+++ b/app/src/sessions/tip-length-calibration/selectors.js
@@ -1,0 +1,23 @@
+// @flow
+import type { State } from '../../types'
+import { SESSION_TYPE_TIP_LENGTH_CALIBRATION } from '../constants'
+import type { Session, TipLengthCalibrationSession } from '../types'
+import { getRobotSessionOfType } from '../selectors'
+
+export const getTipLengthCalibrationSession: (
+  state: State,
+  robotName: string
+) => TipLengthCalibrationSession | null = (state, robotName) => {
+  const tipLengthSession: Session | null = getRobotSessionOfType(
+    state,
+    robotName,
+    SESSION_TYPE_TIP_LENGTH_CALIBRATION
+  )
+  if (
+    tipLengthSession &&
+    tipLengthSession.sessionType === SESSION_TYPE_TIP_LENGTH_CALIBRATION
+  ) {
+    return tipLengthSession
+  }
+  return null
+}


### PR DESCRIPTION
# Overview
This PR creates new selectors to get calibration sessions based on session type easily. The changes here also allow us to refactor `/pages/Calibrate/__tests__/CalibrateTipLengthControl.test.js` to get rid of that infamous `react-redux` mock we all hate to see.

# Review requests
Does everything look okay?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, the changes touch several files but it's mainly just moving codes around.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
