### PR TITLE
refactor(app): Check for calibration block everywhere

### DIFF
--- a/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
+++ b/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
@@ -95,7 +95,6 @@ describe('CalibratePipetteOffset', () => {
           closeWizard={jest.fn()}
           dispatchRequests={jest.fn()}
           showSpinner={showSpinner}
-          hasBlock={false}
         />,
         {
           wrappingComponent: Provider,

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -110,8 +110,9 @@ export function CalibratePipetteOffset(
 
   const tipRack: CalibrationLabware | null =
     (labware && labware.find(l => l.isTiprack)) ?? null
-  const calBlock: CalibrationLabware | null =
-    labware ? labware.find(l => !l.isTiprack) ?? null : null
+  const calBlock: CalibrationLabware | null = labware
+    ? labware.find(l => !l.isTiprack) ?? null
+    : null
 
   const isMulti = React.useMemo(() => {
     const spec = instrument && getPipetteModelSpecs(instrument.model)

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -97,7 +97,7 @@ const PANEL_STYLE_PROPS_BY_STEP: {
 export function CalibratePipetteOffset(
   props: CalibratePipetteOffsetParentProps
 ): React.Node {
-  const { session, robotName, dispatchRequests, showSpinner, hasBlock } = props
+  const { session, robotName, dispatchRequests, showSpinner } = props
   const { currentStep, instrument, labware } = session?.details || {}
 
   const {
@@ -111,7 +111,7 @@ export function CalibratePipetteOffset(
   const tipRack: CalibrationLabware | null =
     (labware && labware.find(l => l.isTiprack)) ?? null
   const calBlock: CalibrationLabware | null =
-    hasBlock && labware ? labware.find(l => !l.isTiprack) ?? null : null
+    labware ? labware.find(l => !l.isTiprack) ?? null : null
 
   const isMulti = React.useMemo(() => {
     const spec = instrument && getPipetteModelSpecs(instrument.model)

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -16,7 +16,6 @@ export type CalibratePipetteOffsetParentProps = {|
     ...Array<{ ...Action, meta: { requestId: string } }>
   ) => void,
   showSpinner: boolean,
-  hasBlock?: boolean,
 |}
 
 export type CalibratePipetteOffsetChildProps = {|

--- a/app/src/components/CalibrateTipLength/AskForCalibrationBlockModal.js
+++ b/app/src/components/CalibrateTipLength/AskForCalibrationBlockModal.js
@@ -17,7 +17,6 @@ import {
 
 import styles from './styles.css'
 import { labwareImages } from '../CalibrationPanels/labwareImages'
-import { Portal } from '../portal'
 
 const ALERT_TIP_LENGTH_CAL_HEADER = 'Pipette calibration has been updated!'
 const ALERT_TIP_LENGTH_CAL_BODY =
@@ -52,60 +51,58 @@ export function AskForCalibrationBlockModal(props: Props): React.Node {
   }
 
   return (
-    <Portal>
-      <AlertModal
-        className={styles.alert_modal_padding}
-        iconName={null}
-        heading={ALERT_TIP_LENGTH_CAL_HEADER}
-        alertOverlay
-      >
-        <Box fontSize={FONT_SIZE_BODY_2}>
-          <Text marginBottom={SPACING_3}>{ALERT_TIP_LENGTH_CAL_BODY}</Text>
-          <Flex width="100%" flexDirection={DIRECTION_ROW}>
-            <div>
-              <Text marginBottom={SPACING_3}>
-                {PREREQS}
-                &nbsp;
-                <b>{CALIBRATION_BLOCK}</b>
-              </Text>
-              <Text marginBottom={SPACING_3}>
-                {IF_NO_BLOCK}
-                &nbsp;
-                <Link href={BLOCK_REQUEST_URL} external>
-                  {CONTACT_US}
-                </Link>
-                &nbsp;
-                {TO_RECEIVE}
-              </Text>
-              <Text marginBottom={SPACING_3}>{ALTERNATIVE}</Text>
-            </div>
-            <div>
-              <img
-                className={styles.block_image}
-                src={labwareImages[CAL_BLOCK_LOAD_NAME]}
-              />
-            </div>
-          </Flex>
-        </Box>
-        <Flex marginY={SPACING_3} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          <SecondaryBtn onClick={makeSetHasBlock(true)}>
-            {HAVE_BLOCK}
-          </SecondaryBtn>
-          <SecondaryBtn onClick={makeSetHasBlock(false)}>
-            {USE_TRASH}
-          </SecondaryBtn>
+    <AlertModal
+      className={styles.alert_modal_padding}
+      iconName={null}
+      heading={ALERT_TIP_LENGTH_CAL_HEADER}
+      alertOverlay
+    >
+      <Box fontSize={FONT_SIZE_BODY_2}>
+        <Text marginBottom={SPACING_3}>{ALERT_TIP_LENGTH_CAL_BODY}</Text>
+        <Flex width="100%" flexDirection={DIRECTION_ROW}>
+          <div>
+            <Text marginBottom={SPACING_3}>
+              {PREREQS}
+              &nbsp;
+              <b>{CALIBRATION_BLOCK}</b>
+            </Text>
+            <Text marginBottom={SPACING_3}>
+              {IF_NO_BLOCK}
+              &nbsp;
+              <Link href={BLOCK_REQUEST_URL} external>
+                {CONTACT_US}
+              </Link>
+              &nbsp;
+              {TO_RECEIVE}
+            </Text>
+            <Text marginBottom={SPACING_3}>{ALTERNATIVE}</Text>
+          </div>
+          <div>
+            <img
+              className={styles.block_image}
+              src={labwareImages[CAL_BLOCK_LOAD_NAME]}
+            />
+          </div>
         </Flex>
-        <div>
-          <CheckboxField
-            label={REMEMBER}
-            onChange={e => setRememberPreference(e.currentTarget.checked)}
-            value={rememberPreference}
-          />
-          <Text fontSize={FONT_SIZE_BODY_1} paddingX={NOTE_SPACING}>
-            {CAN_CHANGE}
-          </Text>
-        </div>
-      </AlertModal>
-    </Portal>
+      </Box>
+      <Flex marginY={SPACING_3} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        <SecondaryBtn onClick={makeSetHasBlock(true)}>
+          {HAVE_BLOCK}
+        </SecondaryBtn>
+        <SecondaryBtn onClick={makeSetHasBlock(false)}>
+          {USE_TRASH}
+        </SecondaryBtn>
+      </Flex>
+      <div>
+        <CheckboxField
+          label={REMEMBER}
+          onChange={e => setRememberPreference(e.currentTarget.checked)}
+          value={rememberPreference}
+        />
+        <Text fontSize={FONT_SIZE_BODY_1} paddingX={NOTE_SPACING}>
+          {CAN_CHANGE}
+        </Text>
+      </div>
+    </AlertModal>
   )
 }

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
@@ -93,7 +93,6 @@ describe('CalibrateTipLength', () => {
           robotName="robot-name"
           session={mockTipLengthSession}
           closeWizard={() => {}}
-          hasBlock={true}
           dispatchRequests={jest.fn()}
           showSpinner={showSpinner}
         />,

--- a/app/src/components/CalibrateTipLength/__tests__/useAskForCalibrationBlock.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/useAskForCalibrationBlock.test.js
@@ -1,0 +1,139 @@
+// @flow
+import * as React from 'react'
+import { mountWithStore } from '@opentrons/components/__utils__'
+import { act } from 'react-dom/test-utils'
+
+import { AskForCalibrationBlockModal } from '../AskForCalibrationBlockModal'
+import { useAskForCalibrationBlock } from '../useAskForCalibrationBlock'
+import { SecondaryBtn, CheckboxField } from '@opentrons/components'
+import { setUseTrashSurfaceForTipCal } from '../../../calibration'
+
+describe('useAskForCalibrationBlock', () => {
+  const onComplete = jest.fn()
+  let showCalBlock
+  const TestUseAskForCalibrationBlock = () => {
+    const [invoker, modal] = useAskForCalibrationBlock(onComplete)
+    React.useEffect(() => {
+      showCalBlock = invoker
+    })
+    return <>{modal}</>
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const mount = (initialValue: boolean | null) => {
+    return mountWithStore(<TestUseAskForCalibrationBlock />, {
+      initialState: {
+        config: { calibration: { useTrashSurfaceForTipCal: initialValue } },
+      },
+    })
+  }
+
+  const findCalBlockModal = wrapper => wrapper.find(AskForCalibrationBlockModal)
+  const findHaveBlock = wrapper =>
+    findCalBlockModal(wrapper)
+      .find(SecondaryBtn)
+      .at(0)
+  const findUseTrash = wrapper =>
+    findCalBlockModal(wrapper)
+      .find(SecondaryBtn)
+      .at(1)
+  const findRemember = wrapper =>
+    findCalBlockModal(wrapper)
+      .find(CheckboxField)
+      .first()
+
+  it('renders a modal when the stored setting is null', () => {
+    const { wrapper } = mount(null)
+    expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+    act(() => showCalBlock(null))
+    wrapper.update()
+    expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(true)
+  })
+  const BLOCK_NONNULLS = [true, false]
+  BLOCK_NONNULLS.forEach(val => {
+    it(`does not render a modal when the stored setting is ${String(
+      val
+    )}`, () => {
+      const { wrapper } = mount(val)
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      act(() => showCalBlock(null))
+      wrapper.update()
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+    })
+    it(`immediately calls the onComplete when the stored setting is ${String(
+      val
+    )}`, () => {
+      const { wrapper } = mount(val)
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      act(() => showCalBlock(null))
+      wrapper.update()
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      expect(onComplete).toHaveBeenCalledWith(!val)
+    })
+    it(`immediately calls an overridden onComplete when the stored setting is ${String(
+      val
+    )}`, () => {
+      const { wrapper } = mount(val)
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      const newOnComplete = jest.fn()
+      act(() => showCalBlock(newOnComplete))
+      wrapper.update()
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      expect(newOnComplete).toHaveBeenCalledWith(!val)
+      expect(onComplete).not.toHaveBeenCalled()
+    })
+  })
+
+  const SPECS = [
+    {
+      it: 'stops rendering the modal when block is picked but not saved',
+      which: findHaveBlock,
+      save: false,
+      savedVal: null,
+    },
+    {
+      it: 'stops rendering the modal when trash is picked but not saved',
+      which: findUseTrash,
+      save: false,
+      savedVal: null,
+    },
+    {
+      it: 'stops rendering the modal when block is picked and saved',
+      which: findHaveBlock,
+      save: true,
+      savedVal: true,
+    },
+    {
+      it: 'stops rendering the modal when trash is picked and saved',
+      which: findUseTrash,
+      save: true,
+      savedVal: false,
+    },
+  ]
+  SPECS.forEach(spec => {
+    it(spec.it, () => {
+      const { wrapper, store } = mount(null)
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+      act(() => showCalBlock(null))
+      wrapper.update()
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(true)
+      findRemember(wrapper).invoke('onChange')({
+        currentTarget: { checked: spec.save },
+      })
+
+      act(() => spec.which(wrapper).invoke('onClick')())
+      wrapper.update()
+      if (spec.save) {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          setUseTrashSurfaceForTipCal(!spec.savedVal)
+        )
+      } else {
+        expect(store.dispatch).not.toHaveBeenCalled()
+      }
+      expect(wrapper.exists(AskForCalibrationBlockModal)).toBe(false)
+    })
+  })
+})

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -109,8 +109,9 @@ export function CalibrateTipLength(
 
   const tipRack: CalibrationLabware | null =
     (labware && labware.find(l => l.isTiprack)) ?? null
-  const calBlock: CalibrationLabware | null =
-    labware ? labware.find(l => !l.isTiprack) ?? null : null
+  const calBlock: CalibrationLabware | null = labware
+    ? labware.find(l => !l.isTiprack) ?? null
+    : null
 
   function sendCommands(...commands: Array<SessionCommandParams>) {
     if (session?.id) {

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -96,7 +96,6 @@ export function CalibrateTipLength(
   const {
     session,
     robotName,
-    hasBlock,
     closeWizard,
     showSpinner,
     dispatchRequests,
@@ -111,7 +110,7 @@ export function CalibrateTipLength(
   const tipRack: CalibrationLabware | null =
     (labware && labware.find(l => l.isTiprack)) ?? null
   const calBlock: CalibrationLabware | null =
-    hasBlock && labware ? labware.find(l => !l.isTiprack) ?? null : null
+    labware ? labware.find(l => !l.isTiprack) ?? null : null
 
   function sendCommands(...commands: Array<SessionCommandParams>) {
     if (session?.id) {

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -7,7 +7,6 @@ export type CalibrateTipLengthParentProps = {|
   robotName: string,
   session: TipLengthCalibrationSession | null,
   closeWizard: () => void,
-  hasBlock: boolean,
   dispatchRequests: (
     ...Array<{ ...Action, meta: { requestId: string } }>
   ) => void,

--- a/app/src/components/CalibrateTipLength/useAskForCalibrationBlock.js
+++ b/app/src/components/CalibrateTipLength/useAskForCalibrationBlock.js
@@ -1,0 +1,58 @@
+// @flow
+import * as React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+
+import type { Dispatch } from '../../types'
+import { getUseTrashSurfaceForTipCal } from '../../config'
+import { setUseTrashSurfaceForTipCal } from '../../calibration'
+
+import { Portal } from '../portal'
+
+import { AskForCalibrationBlockModal } from './AskForCalibrationBlockModal'
+
+export type OnComplete = boolean => void
+export type Invoker = (OnComplete | null) => void
+
+export function useAskForCalibrationBlock(
+  onComplete: OnComplete | null = null
+): [Invoker, React.Node | null] {
+  const dispatch = useDispatch<Dispatch>()
+
+  const completer = React.useRef(onComplete)
+
+  const useTrashSurfaceForTipCalSetting = useSelector(
+    getUseTrashSurfaceForTipCal
+  )
+  const useTrashSurface = React.useRef<boolean | null>(
+    useTrashSurfaceForTipCalSetting
+  )
+
+  const [showCalBlockPrompt, setShowCalBlockPrompt] = React.useState(false)
+
+  const setHasBlock = (hasBlock: boolean, rememberPreference: boolean) => {
+    useTrashSurface.current = !hasBlock
+    if (rememberPreference) {
+      dispatch(setUseTrashSurfaceForTipCal(!hasBlock))
+    }
+    completer.current && completer.current(hasBlock)
+    setShowCalBlockPrompt(false)
+  }
+
+  const handleShowRequest = onCompleteOverride => {
+    completer.current = onCompleteOverride ?? completer.current
+    useTrashSurface.current === null
+      ? setShowCalBlockPrompt(true)
+      : (() => {
+          setShowCalBlockPrompt(false)
+          completer.current && completer.current(!useTrashSurface.current)
+        })()
+  }
+  return [
+    handleShowRequest,
+    showCalBlockPrompt ? (
+      <Portal>
+        <AskForCalibrationBlockModal setHasBlock={setHasBlock} />
+      </Portal>
+    ) : null,
+  ]
+}

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -24,6 +24,7 @@ import {
 } from '../../robot-controls'
 
 import { useCalibratePipetteOffset } from '../CalibratePipetteOffset/useCalibratePipetteOffset'
+import { useAskForCalibrationBlock } from '../CalibrateTipLength/useAskForCalibrationBlock'
 import { ClearDeckAlertModal } from '../ClearDeckAlertModal'
 import { ExitAlertModal } from './ExitAlertModal'
 import { Instructions } from './Instructions'
@@ -109,6 +110,13 @@ export function ChangePipette(props: Props): React.Node {
     PipetteOffsetCalibrationWizard,
   ] = useCalibratePipetteOffset(robotName, { mount }, closeModal)
 
+  const [
+    showAskForCalibrationBlock,
+    AskForCalibrationBlockModal,
+  ] = useAskForCalibrationBlock(calBlock => {
+    startPipetteOffsetCalibration({ hasCalibrationBlock: calBlock })
+  })
+
   const baseProps = {
     title: PIPETTE_SETUP,
     subtitle: `${mount} ${MOUNT}`,
@@ -189,7 +197,7 @@ export function ChangePipette(props: Props): React.Node {
       // home before cal flow to account for skips when attaching pipette
       setWizardStep(CALIBRATE_PIPETTE)
       dispatchApiRequests(home(robotName, ROBOT))
-      startPipetteOffsetCalibration({})
+      showAskForCalibrationBlock(null)
     }
 
     if (success && wantedPipette && shouldLevel(wantedPipette)) {
@@ -227,7 +235,7 @@ export function ChangePipette(props: Props): React.Node {
   }
 
   if (wizardStep === CALIBRATE_PIPETTE) {
-    return PipetteOffsetCalibrationWizard
+    return AskForCalibrationBlockModal || PipetteOffsetCalibrationWizard
   }
 
   // this will never be reached

--- a/app/src/components/InlineCalibrationWarning.js
+++ b/app/src/components/InlineCalibrationWarning.js
@@ -42,14 +42,14 @@ export type InlineCalibrationWarningProps = {|
 export function InlineCalibrationWarning(
   props: InlineCalibrationWarningProps
 ): React.Node {
-  const { warningType, marginTop = null } = props
+  const { warningType, marginTop = SPACING_2 } = props
   return (
     <>
       {warningType && (
         <Flex
           alignItems={ALIGN_CENTER}
           color={CONTENT_MAP[warningType].color}
-          marginTop={marginTop ?? SPACING_2}
+          marginTop={marginTop}
         >
           <Box size={SIZE_2} paddingY={SPACING_1} paddingRight={SPACING_2}>
             <Icon name="alert-circle" />

--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -35,6 +35,7 @@ import {
 } from '@opentrons/components'
 import styles from './styles.css'
 import { useCalibratePipetteOffset } from '../CalibratePipetteOffset/useCalibratePipetteOffset'
+import { useAskForCalibrationBlock } from '../CalibrateTipLength/useAskForCalibrationBlock'
 import type { State } from '../../types'
 
 import {
@@ -118,13 +119,28 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
     PipetteOffsetCalibrationWizard,
   ] = useCalibratePipetteOffset(robotName, { mount })
 
-  const startTipLengthAndPipetteOffsetCalibration = () => {
-    startPipetteOffsetCalibration({ shouldRecalibrateTipLength: true })
+  const startPipetteOffsetCalibrationOnly = useCalBlock => {
+    startPipetteOffsetCalibration({ hasCalibrationBlock: useCalBlock === true })
+  }
+  const startTipLengthAndPipetteOffsetCalibration = useCalBlock => {
+    startPipetteOffsetCalibration({
+      shouldRecalibrateTipLength: true,
+      hasCalibrationBlock: useCalBlock === true,
+    })
   }
 
   const customLabwareDefs = useSelector((state: State) => {
     return CustomLabware.getCustomLabwareDefinitions(state)
   })
+
+  const [showAskForBlock, AskForBlockModal] = useAskForCalibrationBlock(null)
+
+  const showBlockForPipetteOffset = () => {
+    showAskForBlock(startPipetteOffsetCalibrationOnly)
+  }
+  const showBlockForTipLength = () => {
+    showAskForBlock(startTipLengthAndPipetteOffsetCalibration)
+  }
 
   const pipImage = (
     <Box
@@ -179,11 +195,10 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
         <>
           <SecondaryBtn
             {...PER_PIPETTE_BTN_STYLE}
-            onClick={startPipetteOffsetCalibration}
+            onClick={showBlockForPipetteOffset}
           >
             {CALIBRATE_OFFSET}
           </SecondaryBtn>
-          {PipetteOffsetCalibrationWizard}
         </>
       )}
       {serialNumber && (
@@ -241,7 +256,7 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
           </Box>
           <SecondaryBtn
             {...PER_PIPETTE_BTN_STYLE}
-            onClick={startTipLengthAndPipetteOffsetCalibration}
+            onClick={showBlockForTipLength}
           >
             {RECALIBRATE_TIP}
           </SecondaryBtn>
@@ -254,11 +269,15 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
   )
 
   return (
-    <Flex width="50%" flexDirection={DIRECTION_COLUMN}>
-      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
-        {mount === 'right' ? [pipImage, pipInfo] : [pipInfo, pipImage]}
+    <>
+      {PipetteOffsetCalibrationWizard}
+      {AskForBlockModal}
+      <Flex width="50%" flexDirection={DIRECTION_COLUMN}>
+        <Flex justifyContent={JUSTIFY_SPACE_BETWEEN}>
+          {mount === 'right' ? [pipImage, pipInfo] : [pipInfo, pipImage]}
+        </Flex>
       </Flex>
-    </Flex>
+    </>
   )
 }
 

--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -135,6 +135,10 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
 
   const [showAskForBlock, AskForBlockModal] = useAskForCalibrationBlock(null)
 
+  const startPipetteOffsetCalibrationDirectly = () => {
+    startPipetteOffsetCalibration({})
+  }
+
   const showBlockForPipetteOffset = () => {
     showAskForBlock(startPipetteOffsetCalibrationOnly)
   }
@@ -195,7 +199,11 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
         <>
           <SecondaryBtn
             {...PER_PIPETTE_BTN_STYLE}
-            onClick={showBlockForPipetteOffset}
+            onClick={
+              pipetteOffsetCalibration
+                ? startPipetteOffsetCalibrationDirectly
+                : showBlockForPipetteOffset
+            }
           >
             {CALIBRATE_OFFSET}
           </SecondaryBtn>

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -1,21 +1,19 @@
 // @flow
 import * as React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { type Mount, useConditionalConfirm } from '@opentrons/components'
 import * as RobotApi from '../../robot-api'
 import * as Sessions from '../../sessions'
 
-import { getUseTrashSurfaceForTipCal } from '../../config'
-import { setUseTrashSurfaceForTipCal } from '../../calibration'
 import { getUncalibratedTipracksByMount } from '../../pipettes'
 import { getTipLengthCalibrationSession } from '../../sessions/tip-length-calibration/selectors'
 import { getPipetteOffsetCalibrationSession } from '../../sessions/pipette-offset-calibration/selectors'
 
 import {
   CalibrateTipLength,
-  AskForCalibrationBlockModal,
   ConfirmRecalibrationModal,
 } from '../../components/CalibrateTipLength'
+import { useAskForCalibrationBlock } from '../../components/CalibrateTipLength/useAskForCalibrationBlock'
 
 import { UncalibratedInfo } from './UncalibratedInfo'
 import { TipLengthCalibrationInfoBox } from '../../components/CalibrateTipLength/TipLengthCalibrationInfoBox'
@@ -26,7 +24,7 @@ import {
   type LabwareDefinition2,
 } from '@opentrons/shared-data'
 
-import type { State, Dispatch } from '../../types'
+import type { State } from '../../types'
 import type {
   SessionCommandString,
   PipetteOffsetCalibrationSession,
@@ -56,8 +54,6 @@ export function CalibrateTipLengthControl({
   isExtendedPipOffset,
 }: CalibrateTipLengthControlProps): React.Node {
   const [showWizard, setShowWizard] = React.useState(false)
-  const [showCalBlockPrompt, setShowCalBlockPrompt] = React.useState(false)
-  const dispatch = useDispatch<Dispatch>()
 
   const trackedRequestId = React.useRef<string | null>(null)
   const deleteRequestId = React.useRef<string | null>(null)
@@ -83,13 +79,6 @@ export function CalibrateTipLengthControl({
     }
   )
 
-  const useTrashSurfaceForTipCalSetting = useSelector(
-    getUseTrashSurfaceForTipCal
-  )
-  const useTrashSurface = React.useRef<boolean | null>(
-    useTrashSurfaceForTipCalSetting
-  )
-
   const tipLengthCalibrationSession: TipLengthCalibrationSession | null = useSelector(
     (state: State) => {
       return getTipLengthCalibrationSession(state, robotName)
@@ -104,34 +93,32 @@ export function CalibrateTipLengthControl({
   const calibrationSession = isExtendedPipOffset
     ? extendedPipetteCalibrationSession
     : tipLengthCalibrationSession
-  const handleStart = () => {
-    if (isExtendedPipOffset && useTrashSurface.current !== null) {
+  const handleStart = (useCalBlock: boolean) => {
+    if (isExtendedPipOffset) {
       dispatchRequests(
         Sessions.ensureSession(
           robotName,
           Sessions.SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION,
           {
             mount,
-            hasCalibrationBlock: !useTrashSurface.current,
+            hasCalibrationBlock: useCalBlock,
             shouldRecalibrateTipLength: true,
             tipRackDefinition,
           }
         )
       )
-    } else if (useTrashSurface.current !== null) {
+    } else {
       dispatchRequests(
         Sessions.ensureSession(
           robotName,
           Sessions.SESSION_TYPE_TIP_LENGTH_CALIBRATION,
           {
             mount,
-            hasCalibrationBlock: !useTrashSurface.current,
+            hasCalibrationBlock: useCalBlock,
             tipRackDefinition,
           }
         )
       )
-    } else {
-      setShowCalBlockPrompt(true)
     }
   }
   const showSpinner =
@@ -166,28 +153,21 @@ export function CalibrateTipLengthControl({
     }
   }, [shouldOpen, shouldClose])
 
-  const setHasBlock = (hasBlock: boolean, rememberPreference: boolean) => {
-    useTrashSurface.current = !hasBlock
-    if (rememberPreference) {
-      dispatch(setUseTrashSurfaceForTipCal(!hasBlock))
-    }
-    handleStart()
-    setShowCalBlockPrompt(false)
-  }
-
   const handleCloseWizard = () => {
     setShowWizard(false)
-    useTrashSurface.current = useTrashSurfaceForTipCalSetting
   }
-
-  const { confirm, showConfirmation, cancel } = useConditionalConfirm(
-    handleStart,
-    hasCalibrated
-  )
 
   const uncalibratedTipracksByMount: TipracksByMountMap = useSelector(state => {
     return getUncalibratedTipracksByMount(state, robotName)
   })
+
+  const [showCalBlockRequest, calBlockRequestModal] = useAskForCalibrationBlock(
+    handleStart
+  )
+
+  const { confirm, showConfirmation, cancel } = useConditionalConfirm(() => {
+    showCalBlockRequest(null)
+  }, hasCalibrated)
 
   return (
     <>
@@ -211,12 +191,8 @@ export function CalibrateTipLengthControl({
           </Portal>
         )}
       </TipLengthCalibrationInfoBox>
-      {showCalBlockPrompt && (
-        <Portal>
-          <AskForCalibrationBlockModal setHasBlock={setHasBlock} />
-        </Portal>
-      )}
-      {showWizard && useTrashSurface.current !== null && (
+      {calBlockRequestModal}
+      {showWizard && (
         <Portal>
           {isExtendedPipOffset ? (
             <CalibratePipetteOffset

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -222,7 +222,6 @@ export function CalibrateTipLengthControl({
             <CalibratePipetteOffset
               session={extendedPipetteCalibrationSession}
               robotName={robotName}
-              hasBlock={!useTrashSurface.current}
               closeWizard={handleCloseWizard}
               showSpinner={showSpinner}
               dispatchRequests={dispatchRequests}
@@ -232,7 +231,6 @@ export function CalibrateTipLengthControl({
               robotName={robotName}
               session={tipLengthCalibrationSession}
               closeWizard={handleCloseWizard}
-              hasBlock={!useTrashSurface.current}
               showSpinner={showSpinner}
               dispatchRequests={dispatchRequests}
             />


### PR DESCRIPTION
Everywhere we do a calibration flow that is tip length calibration; definitely fused pipette offset + tip length calibration; or maybe fused pipette offset + tip length calibration, we need to ask for a calibration block modal. This PR accomplishes this by
- Making a hooks interface to the `AskForCalibrationBlockModal` like the one for `CalibratePipetteOffset`
- Slightly fixing up some session interfaces to pull cal block labware independent of their client-side initialize params; the information is always the same shape, so we might as well pull it from the server labware response
- Using the new `askForCalibrationModal` hooks everywhere

## Testing
Check the following flows:
- Calibrate offset from pipette info
- Recalibrate tip from pipette info
- Calibrate after attach pipette
- Re/calibrate tip that wasn't used for pipette offset in pre-protocol
- Recalibrate tip that was used for pipette offset in pre-protocol

All of these flows should pop the modal if you haven't saved it (note: these do save the values in memory, so doing the same flow over and over won't ask every time). If you have saved it, the flow should always start with the value you saved.