### PR TITLE
feat(notify-server): add models package and Event model

### DIFF
--- a/notify-server/README.rst
+++ b/notify-server/README.rst
@@ -2,16 +2,31 @@
 Notification Server
 =====================
 
-
 Introduction
 ------------
 The notification server is a pub/sub service for the OT2.
 
 
-Development Set up
-------------------
+Development Environment
+-----------------------------------
 - `poetry <https://python-poetry.org>`_ is used as the package manager. Follow these `installation instructions <https://python-poetry.org/docs/#installation>`_.
+- ``make setup`` will setup the project.
+- ``make test`` will run the unit tests.
+- ``make lint`` will run type checking and linting.
+- ``make dev`` will run the server application locally in dev mode.
 
 Project
 -------
-More to come.
+``notify_server`` is the root package and contains the following subpackages.
+
+server
+===============
+The ``server`` package contains the server application.
+
+clients
+=======
+The ``clients`` package has two clients: a subscriber and a publisher.
+
+models
+=======
+The ``models`` package defines event models.

--- a/notify-server/notify_server/models/__init__.py
+++ b/notify-server/notify_server/models/__init__.py
@@ -1,0 +1,1 @@
+"""The notify server model package."""

--- a/notify-server/notify_server/models/event.py
+++ b/notify-server/notify_server/models/event.py
@@ -1,0 +1,18 @@
+"""The Event model."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from notify_server.models.payload_type import PayloadType
+
+
+class Event(BaseModel):
+    """The type of published events."""
+
+    createdOn: datetime = \
+        Field(..., description="When this event was created")
+    publisher: str = \
+        Field(..., description="Creator of this event")
+    data: PayloadType = \
+        Field(..., description="Payload of the event")

--- a/notify-server/notify_server/models/payload_type.py
+++ b/notify-server/notify_server/models/payload_type.py
@@ -1,0 +1,10 @@
+"""The definition of payload types."""
+from typing import Union
+
+from notify_server.models.sample_events import SampleTwo, SampleOne
+
+
+PayloadType = Union[
+    SampleOne,
+    SampleTwo,
+]

--- a/notify-server/notify_server/models/sample_events.py
+++ b/notify-server/notify_server/models/sample_events.py
@@ -1,0 +1,25 @@
+"""Sample event models."""
+from pydantic import BaseModel
+from typing_extensions import Literal
+
+
+class SampleOneData(BaseModel):
+    """Sample data field of SampleOne payload."""
+
+    val1: int
+    val2: str
+
+
+class SampleOne(BaseModel):
+    """An example of a payload with a type and data member."""
+
+    type: Literal["SampleOne"] = "SampleOne"
+    data: SampleOneData
+
+
+class SampleTwo(BaseModel):
+    """An example of a payload with type and other attributes."""
+
+    type: Literal["SampleTwo"] = "SampleTwo"
+    val1: int
+    val2: str

--- a/notify-server/tests/models/__init__.py
+++ b/notify-server/tests/models/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for models package."""

--- a/notify-server/tests/models/test_event.py
+++ b/notify-server/tests/models/test_event.py
@@ -1,0 +1,64 @@
+"""Unit tests for Event module."""
+from datetime import datetime
+from typing import Dict, Any
+
+import pytest
+
+from notify_server.models.event import Event
+from notify_server.models.sample_events import (
+    SampleOne, SampleOneData, SampleTwo
+)
+
+
+@pytest.mark.parametrize(argnames=["data"],
+                         argvalues=[
+                             # Empty
+                             [{}],
+                             # Unknown type
+                             [{"type": "SampleThree"}],
+                             # Missing Data
+                             [{"type": "SampleOne"}],
+                             # Wrong Types
+                             [{"type": "SampleOne",
+                               "data": {"val1": "egg", "val2": 123}}],
+                             # Missing Attributes
+                             [{"type": "SampleTwo"}],
+                             # Wrong types
+                             [{"type": "SampleTwo",
+                               "val1": "egg", "val2": 123}],
+                             # Use SampleTwo schema on sample one type
+                             [{"type": "SampleOne", "val1": 123,
+                               "val2": "egg"}],
+                             # Use SampleOne schema on sample two type
+                             [{"type": "SampleTwo",
+                               "data": {"val1": 123, "val2": "egg"}}],
+                         ])
+def test_bad_data_attribute(data: Dict[str, Any]) -> None:
+    """Test that invalid data attribute will cause a validation error."""
+    event = {
+        'createdOn': datetime.now().isoformat(),
+        'publisher': 'pub',
+        'data': data
+    }
+    with pytest.raises(ValueError):
+        Event(**event)
+
+
+@pytest.mark.parametrize(
+    argnames=["data", "expected"],
+    argvalues=[
+        [{"type": "SampleOne", "data": {"val1": 123, "val2": "egg"}},
+         SampleOne(data=SampleOneData(val1=123, val2="egg"))
+         ],
+        [{"type": "SampleTwo", "val1": 123, "val2": "egg"},
+         SampleTwo(val1=123, val2="egg")
+         ],
+    ])
+def test_good_data(data: Dict[str, Any], expected: Event) -> None:
+    """Test that the data member is validated correctly."""
+    event = {
+        'createdOn': datetime.now().isoformat(),
+        'publisher': 'pub',
+        'data': data
+    }
+    assert expected == Event(**event).data


### PR DESCRIPTION
# Overview

This adds a package for pydantic model of `Event` object. Each `Event` will have some common metadata about the event plus a proprietary data field defined by the `PayloadType` `Union`. 

Two sample `PayloadType` objects were created to illustrate freedom of the `PayloadType`. We are taking advantage of the `Literal` type to empower better type coercion from Pydantic. 

closes #6705 

# Changelog

- add new package and tests.

# Review requests

- Should there be more fields in metadata?

# Risk assessment

None