### PR TITLE
refactor(api,robot-server): Make reset opts for cal

### DIFF
--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -156,3 +156,14 @@ def clear_pipette_offset_calibrations():
         _remove_json_files_in_directories(offset_dir)
     except FileNotFoundError:
         pass
+
+
+def delete_robot_deck_attitude():
+    """
+    Delete the robot deck attitude calibraiton.
+    """
+
+    robot_dir = config.get_opentrons_path('robot_calibration_dir')
+    gantry_path = robot_dir / 'deck_calibration.json'
+    if gantry_path.exists():
+        gantry_path.unlink()

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -160,7 +160,7 @@ def clear_pipette_offset_calibrations():
 
 def delete_robot_deck_attitude():
     """
-    Delete the robot deck attitude calibraiton.
+    Delete the robot deck attitude calibration.
     """
 
     robot_dir = config.get_opentrons_path('robot_calibration_dir')

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -144,7 +144,7 @@ def set_up_index_file_temporary_directory(server_temp_directory):
         labware.save_calibration(lw, Point(0, 0, 0))
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def set_up_pipette_offset_temp_directory(server_temp_directory):
     pip_list = ['pip_1', 'pip_2']
     mount_list = [Mount.LEFT, Mount.RIGHT]
@@ -157,7 +157,7 @@ def set_up_pipette_offset_temp_directory(server_temp_directory):
             tiprack_uri='uri')
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def set_up_tip_length_temp_directory(server_temp_directory):
     pip_list = ['pip_1', 'pip_2']
     tiprack_hash = 'fakehash'
@@ -200,3 +200,62 @@ def get_labware_fixture():
             return json.loads(f.read().decode('utf-8'))
 
     return _get_labware_fixture
+
+
+@pytest.fixture
+def tavern_enable_calibration_overhaul(run_server):
+    """For integration tests that need to set then clear the
+    enableTiplengthCalibration feature flag"""
+    url = "http://localhost:31950/settings"
+    data = {
+        "id": "enableTipLengthCalibration",
+        "value": True
+    }
+    requests.post(url, json=data)
+    yield None
+    data['value'] = None
+    requests.post(url, json=data)
+
+
+@pytest.fixture
+def tavern_disable_calibration_overhaul(run_server):
+    """For integration tests that need to set then clear the
+    enableTiplengthCalibration feature flag"""
+    url = "http://localhost:31950/settings"
+    data = {
+        "id": "enableTipLengthCalibration",
+        "value": False
+    }
+    requests.post(url, json=data)
+    yield None
+    data['value'] = None
+    requests.post(url, json=data)
+
+
+
+@pytest.fixture
+def apiclient_enable_calibration_overhaul(api_client):
+    """For integration tests that need to set then clear the
+    enableTiplengthCalibration feature flag"""
+    data = {
+        "id": "enableTipLengthCalibration",
+        "value": True
+    }
+    api_client.post(url='/settings', json=data)
+    yield None
+    data['value'] = None
+    api_client.post('/settings', json=data)
+
+
+@pytest.fixture
+def apiclient_disable_calibration_overhaul(api_client):
+    """For integration tests that need to set then clear the
+    enableTiplengthCalibration feature flag"""
+    data = {
+        "id": "enableTipLengthCalibration",
+        "value": False
+    }
+    api_client.post('/settings', json=data)
+    yield None
+    data['value'] = None
+    api_client.post('/settings', json=data)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -232,7 +232,6 @@ def tavern_disable_calibration_overhaul(run_server):
     requests.post(url, json=data)
 
 
-
 @pytest.fixture
 def apiclient_enable_calibration_overhaul(api_client):
     """For integration tests that need to set then clear the

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -1,8 +1,9 @@
 ---
-test_name: GET Settings Reset Options
+test_name: GET Settings Reset Options legacy
 marks:
   - usefixtures:
       - run_server
+      - tavern_disable_calibration_overhaul
 stages:
   - name: Reset Options GET request returns correct option
     request:
@@ -12,20 +13,52 @@ stages:
       status_code: 200
       json:
         options:
-        - id: tipProbe
-          name: Pipette Calibration
-          description: Clear pipette offset and tip length calibration
         - id: labwareCalibration
           name: Labware Calibration
           description: !re_search "Clear labware calibration and Protocol API v1 custom labware"
         - id: bootScripts
           name: Boot Scripts
           description: Clear custom boot scripts
+        - id: tipProbe
+          name: Pipette Calibration
+          description: Clear pipette offset and tip length calibration
+
+---
+test_name: GET Settings Reset Options cal overhaul
+marks:
+  - usefixtures:
+      - run_server
+      - tavern_enable_calibration_overhaul
+stages:
+  - name: Reset Options GET request returns correct option
+    request:
+      url: "{host:s}:{port:d}/settings/reset/options"
+      method: GET
+    response:
+      status_code: 200
+      json:
+        options:
+        - id: labwareCalibration
+          name: Labware Calibration
+          description: !re_search "Clear labware calibration and Protocol API v1 custom labware"
+        - id: bootScripts
+          name: Boot Scripts
+          description: Clear custom boot scripts
+        - id: deckCalibration
+          name: Deck Calibration
+          description: !re_search "Clear deck calibration"
+        - id: pipetteOffsetCalibrations
+          name: Pipette Offset Calibrations
+          description: !re_search "Clear pipette offset calibrations"
+        - id: tipLengthCalibrations
+          name: Tip Length Calibrations
+          description: !re_search "Clear tip length calibrations"
 ---
 test_name: POST Reset tipProbe option
 marks:
   - usefixtures:
       - run_server
+      - tavern_disable_calibration_overhaul
 stages:
   - name: POST Reset tipProbe true
     request:
@@ -100,12 +133,90 @@ stages:
       json:
         message: "Nothing to do"
 ---
+test_name: POST Reset deck calibration option
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: POST Reset deckCalibration true
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        deckCalibration: true
+    response:
+      status_code: 200
+      json:
+        message: "Options 'deck_calibration' were reset"
+  - name: POST Reset deckCalibration false
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        deckCalibration: false
+    response:
+      status_code: 200
+      json:
+        message: "Nothing to do"
+---
+test_name: POST Reset pipette offset calibrations option
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: POST Reset pipetteOffsetCalibrations true
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        pipetteOffsetCalibrations: true
+    response:
+      status_code: 200
+      json:
+        message: "Options 'pipette_offset' were reset"
+  - name: POST Reset pipetteOffsetCalibrations false
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        pipetteOffsetCalibrations: false
+    response:
+      status_code: 200
+      json:
+        message: "Nothing to do"
+---
+test_name: POST Reset tip length calibrations option
+marks:
+  - usefixtures:
+      - run_server
+stages:
+  - name: POST Reset tipLengthCalibrations true
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        tipLengthCalibrations: true
+    response:
+      status_code: 200
+      json:
+        message: "Options 'tip_length_calibrations' were reset"
+  - name: POST Reset tipLengthCalibrations false
+    request:
+      url: "{host:s}:{port:d}/settings/reset"
+      method: POST
+      json:
+        tipLengthCalibrations: false
+    response:
+      status_code: 200
+      json:
+        message: "Nothing to do"
+---
 test_name: POST Reset all options
 marks:
   - usefixtures:
       - run_server
 stages:
-  - name: POST Reset all options
+  - name: POST Reset all options (legacy)
     request:
       url: "{host:s}:{port:d}/settings/reset"
       method: POST

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -310,6 +310,7 @@ def test_reset_success(
     assert resp.status_code == 200
     mock_reset.assert_called_once_with(called_with)
 
+
 @pytest.mark.parametrize(argnames="body,called_with",
                          argvalues=[
                              # Empty body

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -249,12 +249,25 @@ def test_modify_pipette_settings_failure(api_client, mock_pipette_config):
     assert patch_body == {'message': "Failed!"}
 
 
-def test_available_resets(api_client):
+def test_available_resets(
+        api_client, apiclient_disable_calibration_overhaul):
     resp = api_client.get('/settings/reset/options')
     body = resp.json()
     options_list = body.get('options')
     assert resp.status_code == 200
     assert sorted(['tipProbe', 'labwareCalibration', 'bootScripts'])\
+        == sorted([item['id'] for item in options_list])
+
+
+def test_available_resets_overhaul(
+        api_client, apiclient_enable_calibration_overhaul):
+    resp = api_client.get('/settings/reset/options')
+    body = resp.json()
+    options_list = body.get('options')
+    assert resp.status_code == 200
+    assert sorted(
+        ['pipetteOffsetCalibrations', 'labwareCalibration', 'bootScripts',
+         'deckCalibration', 'tipLengthCalibrations'])\
         == sorted([item['id'] for item in options_list])
 
 
@@ -280,7 +293,9 @@ def mock_reset():
                                  'labwareCalibration': True,
                                  'tipProbe': True,
                                  'bootScripts': True
-                             }, set(v for v in ResetOptionId)],
+                             }, {ResetOptionId.labware_calibration,
+                                 ResetOptionId.tip_probe,
+                                 ResetOptionId.boot_scripts}],
                              [{'labwareCalibration': True},
                               {ResetOptionId.labware_calibration}],
                              [{'tipProbe': True},
@@ -288,7 +303,49 @@ def mock_reset():
                              [{'bootScripts': True},
                               {ResetOptionId.boot_scripts}],
                          ])
-def test_reset_success(api_client, mock_reset, body, called_with):
+def test_reset_success(
+        api_client, mock_reset, body, called_with,
+        apiclient_disable_calibration_overhaul):
+    resp = api_client.post('/settings/reset', json=body)
+    assert resp.status_code == 200
+    mock_reset.assert_called_once_with(called_with)
+
+@pytest.mark.parametrize(argnames="body,called_with",
+                         argvalues=[
+                             # Empty body
+                             [{}, set()],
+                             # None true
+                             [{
+                                 'labwareCalibration': False,
+                                 'deckCalibration': False,
+                                 'bootScripts': False,
+                                 'pipetteOffsetCalibrations': False,
+                                 'tipLengthCalibrations': False,
+                             }, set()],
+                             # All set
+                             [{
+                                 'labwareCalibration': True,
+                                 'bootScripts': True,
+                                 'pipetteOffsetCalibrations': True,
+                                 'tipLengthCalibrations': True,
+                                 'deckCalibration': True,
+                             }, {ResetOptionId.labware_calibration,
+                                 ResetOptionId.boot_scripts,
+                                 ResetOptionId.deck_calibration,
+                                 ResetOptionId.pipette_offset,
+                                 ResetOptionId.tip_length_calibrations}],
+                             [{'labwareCalibration': True},
+                              {ResetOptionId.labware_calibration}],
+                             [{'bootScripts': True},
+                              {ResetOptionId.boot_scripts}],
+                             [{'pipetteOffsetCalibrations': True},
+                              {ResetOptionId.pipette_offset}],
+                             [{'tipLengthCalibrations': True},
+                              {ResetOptionId.tip_length_calibrations}]
+                         ])
+def test_reset_success_overhaul(
+        api_client, mock_reset, body, called_with,
+        apiclient_enable_calibration_overhaul):
     resp = api_client.post('/settings/reset', json=body)
     assert resp.status_code == 200
     mock_reset.assert_called_once_with(called_with)

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -5,7 +5,8 @@ WRONG_MOUNT = 'right'
 
 
 def test_access_pipette_offset_calibration(
-        api_client, set_up_pipette_offset_temp_directory):
+        api_client, set_up_pipette_offset_temp_directory,
+        apiclient_enable_calibration_overhaul, server_temp_directory):
     expected = {
         'offset': [0, 0, 0],
         'pipette': 'pip_1',
@@ -37,7 +38,8 @@ def test_access_pipette_offset_calibration(
 
 
 def test_delete_pipette_offset_calibration(
-        api_client, set_up_pipette_offset_temp_directory):
+        api_client, set_up_pipette_offset_temp_directory,
+        apiclient_enable_calibration_overhaul):
     resp = api_client.delete(
         f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'
         f'mount={WRONG_MOUNT}')


### PR DESCRIPTION
While we may change this with an actual UX-design inspired approach, for
now let's just add some options to make the user actually able to reset
the calibrations, somehow.
