### PR TITLE
feat(protocol-designer): update no tip error copy

### DIFF
--- a/protocol-designer/src/components/KnowledgeBaseLink/index.js
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.js
@@ -5,6 +5,7 @@ export const KNOWLEDGEBASE_ROOT_URL =
   'https://support.opentrons.com/en/collections/493886-protocol-designer'
 
 export const links = {
+  airGap: `https://support.opentrons.com/en/articles/4398106-air-gap`,
   multiDispense: `https://support.opentrons.com/en/articles/4170341-paths`,
   protocolSteps: `https://support.opentrons.com/en/collections/493886-protocol-designer#building-a-protocol-steps`,
   customLabware: `https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions`,

--- a/protocol-designer/src/components/alerts/ErrorContents.js
+++ b/protocol-designer/src/components/alerts/ErrorContents.js
@@ -32,6 +32,16 @@ export const ErrorContents = (props: ErrorContentsProps): React.Node => {
             </KnowledgeBaseLink>
           </>
         )
+      case 'NO_TIP_ON_PIPETTE':
+        return (
+          <>
+            {i18n.t(`alert.timeline.error.${props.errorType}.body1`)}
+            <KnowledgeBaseLink to="airGap">
+              {i18n.t(`alert.timeline.error.${props.errorType}.link`)}
+            </KnowledgeBaseLink>
+            {i18n.t(`alert.timeline.error.${props.errorType}.body2`)}
+          </>
+        )
       default:
         return bodyText
     }

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -61,8 +61,10 @@
         "body": "Add another tip rack to an empty slot in "
       },
       "NO_TIP_ON_PIPETTE": {
-        "title": "No tip on pipette",
-        "body": "The setting \"Get new tip\" cannot be \"Never\" the first time a pipette is used in a protocol"
+        "title": "No tip on pipette at the start of step",
+        "body1": "Choose a different Change Tip setting. Change Tip cannot be \"Never\" the first time a pipette is used in a protocol, or following a step that used the ",
+        "link": "Air gap dispense setting",
+        "body2": ". Pipetting steps must begin with a tip on."
       },
       "MODULE_PIPETTE_COLLISION_DANGER": {
         "title": "Pipette cannot access labware",


### PR DESCRIPTION
# Do not merge

Is not under FF, I feel silly putting it under the FF bc it would make the i18n gross & hold 2 cases until/if we remember to remove it - so let's just wait until FF removal to merge this one?

# Overview

Closes #6712

# Changelog

Change copy (and add link) for the "no tips" error banner

# Review requests

- Copy & link should match ticket

# Risk assessment

Low, PD only. Not under FF