### PR TITLE
refactor(app): display pipette offset calibration data in file info

### DIFF
--- a/app/src/components/FileInfo/InstrumentItem.js
+++ b/app/src/components/FileInfo/InstrumentItem.js
@@ -23,6 +23,7 @@ import type { PipetteCompatibility } from '../../pipettes/types'
 const NOT_CALIBRATED = 'Not yet calibrated'
 const NOT_CONNECTED = 'Not connected'
 const CALIBRATION_DATA = 'Calibration data:'
+const AXIS_NAMES = ['x', 'y', 'z']
 
 export type InstrumentItemProps = {|
   compatibility?: PipetteCompatibility,
@@ -103,7 +104,7 @@ function BuildOffsetText(props: {|
   return (
     <Flex>
       <Text marginRight={SPACING_2}>{CALIBRATION_DATA}</Text>
-      {['x', 'y', 'z'].map((key, index) => (
+      {AXIS_NAMES.map((key, index) => (
         <React.Fragment key={key}>
           <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>{key.toUpperCase()}</Text>
           <Text marginLeft={SPACING_1} marginRight={SPACING_3}>

--- a/app/src/components/FileInfo/InstrumentItem.js
+++ b/app/src/components/FileInfo/InstrumentItem.js
@@ -1,9 +1,28 @@
 // @flow
 import * as React from 'react'
-import { Icon } from '@opentrons/components'
+import {
+  Box,
+  Icon,
+  Flex,
+  Text,
+  ALIGN_CENTER,
+  C_DARK_GRAY,
+  COLOR_ERROR,
+  FONT_BODY_1_DARK,
+  FONT_SIZE_BODY_1,
+  FONT_STYLE_ITALIC,
+  FONT_WEIGHT_SEMIBOLD,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+} from '@opentrons/components'
 import styles from './styles.css'
 
 import type { PipetteCompatibility } from '../../pipettes/types'
+
+const NOT_CALIBRATED = 'Not yet calibrated'
+const NOT_CONNECTED = 'Not connected'
+const CALIBRATION_DATA = 'Calibration data:'
 
 export type InstrumentItemProps = {|
   compatibility?: PipetteCompatibility,
@@ -11,23 +30,61 @@ export type InstrumentItemProps = {|
   children: React.Node,
   hidden?: boolean,
   needsOffsetCalibration: boolean,
+  pipetteOffsetData?: [number, number, number] | null,
 |}
 
 export function InstrumentItem(props: InstrumentItemProps): React.Node {
-  if (props.hidden) return null
+  const {
+    compatibility,
+    mount,
+    children,
+    hidden,
+    needsOffsetCalibration,
+    pipetteOffsetData = null,
+  } = props
+  if (hidden) return null
+  const match = ['match', 'inexact_match'].includes(compatibility)
   return (
-    <div className={styles.instrument_item}>
-      <StatusIcon
-        match={
-          ['match', 'inexact_match'].includes(props.compatibility) &&
-          !props.needsOffsetCalibration
-        }
-      />
-      {props.mount && (
-        <span className={styles.mount_label}>{props.mount.toUpperCase()}</span>
-      )}
-      {props.children}
-    </div>
+    <>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        marginTop={SPACING_1}
+        marginBottom={SPACING_3}
+      >
+        <StatusIcon match={match && !needsOffsetCalibration} />
+        <Box>
+          <Flex marginBottom={SPACING_1}>
+            {mount && (
+              <Text
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
+                fontSize={FONT_SIZE_BODY_1}
+                minWidth={'3rem'}
+              >
+                {mount.toUpperCase()}
+              </Text>
+            )}
+            <Text css={FONT_BODY_1_DARK}>{children}</Text>
+          </Flex>
+          {!match ? (
+            <Text fontSize={FONT_SIZE_BODY_1} fontStyle={FONT_STYLE_ITALIC}>
+              {NOT_CONNECTED}
+            </Text>
+          ) : !!pipetteOffsetData ? (
+            <Text css={FONT_BODY_1_DARK}>
+              <BuildOffsetText offsetData={pipetteOffsetData} />
+            </Text>
+          ) : (
+            <Text
+              fontSize={FONT_SIZE_BODY_1}
+              fontStyle={FONT_STYLE_ITALIC}
+              color={match ? COLOR_ERROR : C_DARK_GRAY}
+            >
+              {match ? NOT_CALIBRATED : NOT_CONNECTED}
+            </Text>
+          )}
+        </Box>
+      </Flex>
+    </>
   )
 }
 
@@ -37,4 +94,23 @@ function StatusIcon(props: {| match: boolean |}) {
   const iconName = match ? 'check-circle' : 'checkbox-blank-circle-outline'
 
   return <Icon name={iconName} className={styles.status_icon} />
+}
+
+function BuildOffsetText(props: {|
+  offsetData: [number, number, number],
+|}): React.Node {
+  const { offsetData } = props
+  return (
+    <Flex>
+      <Text marginRight={SPACING_2}>{CALIBRATION_DATA}</Text>
+      {['x', 'y', 'z'].map((key, index) => (
+        <React.Fragment key={key}>
+          <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>{key.toUpperCase()}</Text>
+          <Text marginLeft={SPACING_1} marginRight={SPACING_3}>
+            {offsetData[index] != null ? offsetData[index].toFixed(2) : null}
+          </Text>
+        </React.Fragment>
+      ))}
+    </Flex>
+  )
 }

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -66,7 +66,7 @@ export function ProtocolPipettesCard(
           hidden: !info.protocol.name,
           displayName: info.protocol.displayName,
           needsOffsetCalibration: info.needsOffsetCalibration,
-          calibrationData: offsetData,
+          calibrationData: offsetData.offset,
         }
       : null
   }).filter(Boolean)

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -7,6 +7,7 @@ import { Icon } from '@opentrons/components'
 import {
   PIPETTE_MOUNTS,
   fetchPipettes,
+  getAttachedPipetteCalibrations,
   getProtocolPipettesInfo,
   getProtocolPipettesMatching,
   getProtocolPipettesCalibrated,
@@ -44,6 +45,9 @@ export function ProtocolPipettesCard(
   const someInexactMatches = useSelector((state: State) =>
     getSomeProtocolPipettesInexact(state, robotName)
   )
+  const pipetteOffsetCalibrations = useSelector((state: State) =>
+    getAttachedPipetteCalibrations(state, robotName)
+  )
 
   React.useEffect(() => {
     dispatch(fetchPipettes(robotName))
@@ -53,6 +57,7 @@ export function ProtocolPipettesCard(
 
   const pipetteItemProps = PIPETTE_MOUNTS.map(mount => {
     const info = infoByMount[mount]
+    const offsetData = pipetteOffsetCalibrations[mount]
 
     return info.protocol
       ? {
@@ -61,6 +66,7 @@ export function ProtocolPipettesCard(
           hidden: !info.protocol.name,
           displayName: info.protocol.displayName,
           needsOffsetCalibration: info.needsOffsetCalibration,
+          calibrationData: offsetData ? offsetData.offset : null,
         }
       : null
   }).filter(Boolean)
@@ -77,6 +83,7 @@ export function ProtocolPipettesCard(
             mount={itemProps.mount}
             hidden={itemProps.hidden}
             needsOffsetCalibration={itemProps.needsOffsetCalibration}
+            pipetteOffsetData={itemProps.calibrationData}
           >
             {itemProps.displayName}
           </InstrumentItem>

--- a/app/src/components/FileInfo/ProtocolPipettesCard.js
+++ b/app/src/components/FileInfo/ProtocolPipettesCard.js
@@ -66,7 +66,7 @@ export function ProtocolPipettesCard(
           hidden: !info.protocol.name,
           displayName: info.protocol.displayName,
           needsOffsetCalibration: info.needsOffsetCalibration,
-          calibrationData: offsetData ? offsetData.offset : null,
+          calibrationData: offsetData,
         }
       : null
   }).filter(Boolean)
@@ -83,7 +83,7 @@ export function ProtocolPipettesCard(
             mount={itemProps.mount}
             hidden={itemProps.hidden}
             needsOffsetCalibration={itemProps.needsOffsetCalibration}
-            pipetteOffsetData={itemProps.calibrationData}
+            pipetteOffsetData={itemProps.calibrationData?.offset}
           >
             {itemProps.displayName}
           </InstrumentItem>


### PR DESCRIPTION
closes #6767

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR surfaces the pipette offset calibration data in the File Info card to clarify what is blocking the pre-protocol calibrations and the protocol run.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
# Preview
Connected pipettes with one missing pipette offset calibration:
![Screen Shot 2020-10-15 at 4 31 00 PM](https://user-images.githubusercontent.com/20424172/96182718-db177c00-0f03-11eb-99db-ed92483d3938.png)

Missing required pipette:
![Screen Shot 2020-10-15 at 4 32 40 PM](https://user-images.githubusercontent.com/20424172/96182864-11ed9200-0f04-11eb-99e4-b27dbf0bb074.png)



# Review requests

- [ ] when a required pipette is not attached, there should be an italic string below the pipette name saying "Not connected"
- [ ] when a required pipette is connected but not calibrated, there should be an italic red string "Not yet calibrated"
- [ ] when a pipette is connected with pipette offset calibration, the calibration data should be displayed below the pipette name in this format: `Calibration data: X  Y Z`
<!--
Describe any requests for your reviewers here.
-->


<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
