### PR TITLE
fix(app, robot-server): add param to set has cal block command 

### DIFF
--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -123,7 +123,7 @@ export function CalibratePipetteOffset(
       const sessionCommandActions = commands.map(c =>
         Sessions.createSessionCommand(robotName, session.id, {
           command: c.command,
-          data: c.data || {},
+          data: c.data ?? {},
         })
       )
       dispatchRequests(...sessionCommandActions)

--- a/app/src/components/CalibrationPanels/CompleteConfirmation.js
+++ b/app/src/components/CalibrationPanels/CompleteConfirmation.js
@@ -69,7 +69,7 @@ export function CompleteConfirmation(props: CalibrationPanelProps): React.Node {
     sendCommands(
       {
         command: Sessions.sharedCalCommands.SET_CALIBRATION_BLOCK,
-        data: { has_block: false },
+        data: { hasBlock: false },
       },
       { command: Sessions.sharedCalCommands.MOVE_TO_DECK }
     )

--- a/app/src/components/CalibrationPanels/CompleteConfirmation.js
+++ b/app/src/components/CalibrationPanels/CompleteConfirmation.js
@@ -67,7 +67,10 @@ export function CompleteConfirmation(props: CalibrationPanelProps): React.Node {
 
   const proceed = () => {
     sendCommands(
-      { command: Sessions.sharedCalCommands.SET_CALIBRATION_BLOCK },
+      {
+        command: Sessions.sharedCalCommands.SET_CALIBRATION_BLOCK,
+        data: { has_block: false },
+      },
       { command: Sessions.sharedCalCommands.MOVE_TO_DECK }
     )
   }

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -73,7 +73,10 @@ export type CalibrationSessionStep =
 
 export type VectorTuple = [number, number, number]
 
-export type SessionCommandData = {| vector: VectorTuple |} | {||}
+export type SessionCommandData =
+  | {| vector: VectorTuple |}
+  | {| has_block: boolean |}
+  | {||}
 export type SessionCommandParams = {
   command: SessionCommandString,
   data?: SessionCommandData,

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -75,7 +75,7 @@ export type VectorTuple = [number, number, number]
 
 export type SessionCommandData =
   | {| vector: VectorTuple |}
-  | {| has_block: boolean |}
+  | {| hasBlock: boolean |}
   | {||}
 export type SessionCommandParams = {
   command: SessionCommandString,

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -162,13 +162,12 @@ class PipetteOffsetCalibrationUserFlow:
             RequiredLabware.from_lw(lw, s)  # type: ignore
             for s, lw in lw_by_slot.items()]
 
-    async def set_has_calibration_block(self):
-        if self._has_calibration_block:
-            self._has_calibration_block = False
+    async def set_has_calibration_block(self, has_block: bool):
+        if self._has_calibration_block and not has_block:
             self._remove_calibration_block()
-        else:
-            self._has_calibration_block = True
+        elif has_block and not self._has_calibration_block:
             self._load_calibration_block()
+        self._has_calibration_block = has_block
 
     def _set_current_state(self, to_state: GenericState):
         self._current_state = to_state

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -162,12 +162,12 @@ class PipetteOffsetCalibrationUserFlow:
             RequiredLabware.from_lw(lw, s)  # type: ignore
             for s, lw in lw_by_slot.items()]
 
-    async def set_has_calibration_block(self, has_block: bool):
-        if self._has_calibration_block and not has_block:
+    async def set_has_calibration_block(self, hasBlock: bool):
+        if self._has_calibration_block and not hasBlock:
             self._remove_calibration_block()
-        elif has_block and not self._has_calibration_block:
+        elif hasBlock and not self._has_calibration_block:
             self._load_calibration_block()
-        self._has_calibration_block = has_block
+        self._has_calibration_block = hasBlock
 
     def _set_current_state(self, to_state: GenericState):
         self._current_state = to_state

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -87,7 +87,9 @@ class PipetteOffsetCalibrationUserFlow:
         self._using_default_tiprack = False
 
         existing_offset_calibration = self._get_stored_pipette_offset_cal()
-        self._initialize_deck(tip_rack_def, existing_offset_calibration)
+        self._load_tip_rack(tip_rack_def, existing_offset_calibration)
+        if recalibrate_tip_length and has_calibration_block:
+            self._load_calibration_block()
 
         existing_tip_length_calibration = self._get_stored_tip_length_cal()
 
@@ -171,14 +173,6 @@ class PipetteOffsetCalibrationUserFlow:
 
     def _set_current_state(self, to_state: GenericState):
         self._current_state = to_state
-
-    def _initialize_deck(
-            self,
-            tiprack_def: Optional['LabwareDefinition'],
-            existing_calibration: Optional[PipetteOffsetByPipetteMount]):
-        self._load_tiprack(tiprack_def, existing_calibration)
-        if self._has_calibration_block:
-            self._load_calibration_block()
 
     def _get_tip_rack_lw(self) -> labware.Labware:
         pip_vol = self._hw_pipette.config.max_volume
@@ -299,7 +293,7 @@ class PipetteOffsetCalibrationUserFlow:
         tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(volume)].load_name
         return True, labware.load(tr_load_name, position)
 
-    def _load_tiprack(
+    def _load_tip_rack(
             self,
             tip_rack_def: Optional['LabwareDefinition'],
             existing_calibration: Optional[PipetteOffsetByPipetteMount]):

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -82,7 +82,6 @@ class LoadInstrumentResponse(BaseModel):
     instrumentId: IdentifierType
 
 
-
 class CommandStatus(str, Enum):
     """The command status"""
     executed = "executed"

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -66,6 +66,12 @@ class LiquidRequest(PipetteRequestBase):
     )
 
 
+class SetHasCalibrationBlockRequest(BaseModel):
+    has_block: bool = Field(
+        ...,
+        description="whether or not there is a calibration block present")
+
+
 class LoadLabwareResponse(BaseModel):
     labwareId: IdentifierType
     definition: LabwareDefinition
@@ -74,6 +80,7 @@ class LoadLabwareResponse(BaseModel):
 
 class LoadInstrumentResponse(BaseModel):
     instrumentId: IdentifierType
+
 
 
 class CommandStatus(str, Enum):
@@ -168,7 +175,8 @@ class CalibrationCommand(CommandDefinition):
     """Shared Between Calibration Flows"""
     load_labware = "loadLabware"
     jog = ("jog", JogPosition)
-    set_has_calibration_block = "setHasCalibrationBlock"
+    set_has_calibration_block = ("setHasCalibrationBlock",
+                                 SetHasCalibrationBlockRequest)
     move_to_tip_rack = "moveToTipRack"
     move_to_point_one = "moveToPointOne"
     move_to_deck = "moveToDeck"
@@ -213,6 +221,7 @@ IMPORTANT: See note for SessionCreateParamType
 Read more here: https://pydantic-docs.helpmanual.io/usage/types/#unions
 """
 CommandDataType = typing.Union[
+    SetHasCalibrationBlockRequest,
     JogPosition,
     LiquidRequest,
     PipetteRequestBase,

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -67,7 +67,7 @@ class LiquidRequest(PipetteRequestBase):
 
 
 class SetHasCalibrationBlockRequest(BaseModel):
-    has_block: bool = Field(
+    hasBlock: bool = Field(
         ...,
         description="whether or not there is a calibration block present")
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The set_has_calibration_block session command didn't take any parameters, which means that it was not idempotent and just toggled the boolean in the session after every call to the command. This lead to the one place that the run app uses this command within a POWT session adding a calibration block to the deck upon completing the TLC portion (with no block).

In addition to patching this explicit use case, this PR makes the command idempotent by adding a boolean `has_block` parameter.

Add boolean parameter to the set_has_calibration_block command that allows a client to add or remove
a loaded calibration block from the session based on the boolean value passed with the command.

# Changelog

- add `hasBlock` command data to the `setHasCalibrationBlock` command
- change the implementation of the pipette offset user flow `set_has_calibration_block` command handler such that it accepts this new boolean in place of toggling state.

# Review requests

- run POWT without a block, easiest way is from "Re-calibrate tip length" button on the pipettes tab, and make sure that at no point are you prompted to add or remove a block
- runt POWT with a block, you should be prompted to remove the block in the intermediate "Tip Length Complete" screen before proceeding to the pipette offset portion of the flow.

# Risk assessment

low