### PR TITLE
fix(app): debounce calibration jog requests while others are in flight

### DIFF
--- a/app/src/components/CalibrateDeck/__tests__/CalibrateDeck.test.js
+++ b/app/src/components/CalibrateDeck/__tests__/CalibrateDeck.test.js
@@ -42,6 +42,7 @@ describe('CalibrateDeck', () => {
   let mockStore
   let render
   let dispatch
+  let dispatchRequests
   let mockDeckCalSession: Sessions.DeckCalibrationSession = {
     id: 'fake_session_id',
     ...mockDeckCalibrationSessionAttributes,
@@ -74,6 +75,7 @@ describe('CalibrateDeck', () => {
 
   beforeEach(() => {
     dispatch = jest.fn()
+    dispatchRequests = jest.fn()
     mockStore = {
       subscribe: () => {},
       getState: () => ({
@@ -89,14 +91,19 @@ describe('CalibrateDeck', () => {
     }
 
     render = (props = {}) => {
-      const { showSpinner = false } = props
+      const {
+        showSpinner = false,
+        isJogging = false,
+        session = mockDeckCalSession,
+      } = props
       return mount(
         <CalibrateDeck
           robotName="robot-name"
-          session={mockDeckCalSession}
+          session={session}
           closeWizard={() => {}}
-          dispatchRequests={jest.fn()}
+          dispatchRequests={dispatchRequests}
           showSpinner={showSpinner}
+          isJogging={isJogging}
         />,
         {
           wrappingComponent: Provider,
@@ -148,5 +155,42 @@ describe('CalibrateDeck', () => {
   it('renders spinner when showSpinner is true', () => {
     const wrapper = render({ showSpinner: true })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(true)
+  })
+  it('does dispatch jog requests when not isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockDeckCalibrationSessionAttributes,
+      details: {
+        ...mockDeckCalibrationSessionAttributes.details,
+        currentStep: Sessions.DECK_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: false, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
+  })
+
+  it('does not dispatch jog requests when isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockDeckCalibrationSessionAttributes,
+      details: {
+        ...mockDeckCalibrationSessionAttributes.details,
+        currentStep: Sessions.DECK_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: true, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).not.toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
   })
 })

--- a/app/src/components/CalibrateDeck/index.js
+++ b/app/src/components/CalibrateDeck/index.js
@@ -98,6 +98,7 @@ export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
     closeWizard,
     dispatchRequests,
     showSpinner,
+    isJogging,
   } = props
   const { currentStep, instrument, labware } = session?.details || {}
 
@@ -115,7 +116,7 @@ export function CalibrateDeck(props: CalibrateDeckParentProps): React.Node {
   }, [instrument])
 
   function sendCommands(...commands: Array<SessionCommandParams>) {
-    if (session?.id) {
+    if (session?.id && !isJogging) {
       const sessionCommandActions = commands.map(c =>
         Sessions.createSessionCommand(robotName, session.id, {
           command: c.command,

--- a/app/src/components/CalibrateDeck/types.js
+++ b/app/src/components/CalibrateDeck/types.js
@@ -10,4 +10,5 @@ export type CalibrateDeckParentProps = {|
     ...Array<{ ...Action, meta: { requestId: string } }>
   ) => void,
   showSpinner: boolean,
+  isJogging: boolean,
 |}

--- a/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
+++ b/app/src/components/CalibratePipetteOffset/__tests__/CalibratePipetteOffset.test.js
@@ -42,10 +42,8 @@ describe('CalibratePipetteOffset', () => {
   let mockStore
   let render
   let dispatch
-  let mockPipOffsetCalSession: Sessions.PipetteOffsetCalibrationSession = {
-    id: 'fake_session_id',
-    ...mockPipetteOffsetCalibrationSessionAttributes,
-  }
+  let dispatchRequests
+  let mockPipOffsetCalSession: Sessions.PipetteOffsetCalibrationSession
 
   const getExitButton = wrapper =>
     wrapper.find({ title: 'exit' }).find('button')
@@ -72,6 +70,7 @@ describe('CalibratePipetteOffset', () => {
 
   beforeEach(() => {
     dispatch = jest.fn()
+    dispatchRequests = jest.fn()
     mockStore = {
       subscribe: () => {},
       getState: () => ({
@@ -87,14 +86,19 @@ describe('CalibratePipetteOffset', () => {
     }
 
     render = (props = {}) => {
-      const { showSpinner = false } = props
+      const {
+        showSpinner = false,
+        isJogging = false,
+        session = mockPipOffsetCalSession,
+      } = props
       return mount(
         <CalibratePipetteOffset
           robotName="robot-name"
-          session={mockPipOffsetCalSession}
+          session={session}
           closeWizard={jest.fn()}
-          dispatchRequests={jest.fn()}
+          dispatchRequests={dispatchRequests}
           showSpinner={showSpinner}
+          isJogging={isJogging}
         />,
         {
           wrappingComponent: Provider,
@@ -146,5 +150,43 @@ describe('CalibratePipetteOffset', () => {
   it('renders spinner when showSpinner is true', () => {
     const wrapper = render({ showSpinner: true })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(true)
+  })
+
+  it('does dispatch jog requests when not isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockPipetteOffsetCalibrationSessionAttributes,
+      details: {
+        ...mockPipetteOffsetCalibrationSessionAttributes.details,
+        currentStep: Sessions.PIP_OFFSET_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: false, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
+  })
+
+  it('does not dispatch jog requests when isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockPipetteOffsetCalibrationSessionAttributes,
+      details: {
+        ...mockPipetteOffsetCalibrationSessionAttributes.details,
+        currentStep: Sessions.PIP_OFFSET_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: true, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).not.toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
   })
 })

--- a/app/src/components/CalibratePipetteOffset/index.js
+++ b/app/src/components/CalibratePipetteOffset/index.js
@@ -97,7 +97,7 @@ const PANEL_STYLE_PROPS_BY_STEP: {
 export function CalibratePipetteOffset(
   props: CalibratePipetteOffsetParentProps
 ): React.Node {
-  const { session, robotName, dispatchRequests, showSpinner } = props
+  const { session, robotName, dispatchRequests, showSpinner, isJogging } = props
   const { currentStep, instrument, labware } = session?.details || {}
 
   const {
@@ -120,7 +120,7 @@ export function CalibratePipetteOffset(
   }, [instrument])
 
   function sendCommands(...commands: Array<SessionCommandParams>) {
-    if (session?.id) {
+    if (session?.id && !isJogging) {
       const sessionCommandActions = commands.map(c =>
         Sessions.createSessionCommand(robotName, session.id, {
           command: c.command,

--- a/app/src/components/CalibratePipetteOffset/types.js
+++ b/app/src/components/CalibratePipetteOffset/types.js
@@ -16,6 +16,7 @@ export type CalibratePipetteOffsetParentProps = {|
     ...Array<{ ...Action, meta: { requestId: string } }>
   ) => void,
   showSpinner: boolean,
+  isJogging: boolean,
 |}
 
 export type CalibratePipetteOffsetChildProps = {|

--- a/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
+++ b/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
@@ -46,7 +46,6 @@ export function useCalibratePipetteOffset(
 
   const [dispatchRequests] = RobotApi.useDispatchApiRequests(
     dispatchedAction => {
-      console.log('dispatched')
       if (dispatchedAction.type === Sessions.ENSURE_SESSION) {
         createRequestId.current = dispatchedAction.meta.requestId
       } else if (
@@ -124,7 +123,6 @@ export function useCalibratePipetteOffset(
   const handleStartPipOffsetCalSession: Invoker = (
     overrideParams: $Shape<PipetteOffsetCalibrationSessionParams> | void = {}
   ) => {
-    console.log(overrideParams)
     dispatchRequests(
       Sessions.ensureSession(
         robotName,

--- a/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
+++ b/app/src/components/CalibratePipetteOffset/useCalibratePipetteOffset.js
@@ -33,9 +33,10 @@ export function useCalibratePipetteOffset(
 ): [Invoker, React.Node | null] {
   const [showWizard, setShowWizard] = React.useState(false)
 
-  const trackedRequestId = React.useRef<string | null>(null)
   const deleteRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
+  const jogRequestId = React.useRef<string | null>(null)
+  const spinnerRequestId = React.useRef<string | null>(null)
 
   const pipOffsetCalSession: PipetteOffsetCalibrationSession | null = useSelector(
     (state: State) => {
@@ -45,6 +46,7 @@ export function useCalibratePipetteOffset(
 
   const [dispatchRequests] = RobotApi.useDispatchApiRequests(
     dispatchedAction => {
+      console.log('dispatched')
       if (dispatchedAction.type === Sessions.ENSURE_SESSION) {
         createRequestId.current = dispatchedAction.meta.requestId
       } else if (
@@ -53,20 +55,26 @@ export function useCalibratePipetteOffset(
       ) {
         deleteRequestId.current = dispatchedAction.meta.requestId
       } else if (
+        dispatchedAction.type === Sessions.CREATE_SESSION_COMMAND &&
+        dispatchedAction.payload.command.command ===
+          Sessions.sharedCalCommands.JOG
+      ) {
+        jogRequestId.current = dispatchedAction.meta.requestId
+      } else if (
         dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
         !spinnerCommandBlockList.includes(
           dispatchedAction.payload.command.command
         )
       ) {
-        trackedRequestId.current = dispatchedAction.meta.requestId
+        spinnerRequestId.current = dispatchedAction.meta.requestId
       }
     }
   )
 
   const showSpinner =
     useSelector<State, RequestState | null>(state =>
-      trackedRequestId.current
-        ? RobotApi.getRequestById(state, trackedRequestId.current)
+      spinnerRequestId.current
+        ? RobotApi.getRequestById(state, spinnerRequestId.current)
         : null
     )?.status === RobotApi.PENDING
 
@@ -83,6 +91,13 @@ export function useCalibratePipetteOffset(
         ? RobotApi.getRequestById(state, createRequestId.current)
         : null
     )?.status === RobotApi.SUCCESS
+
+  const isJogging =
+    useSelector((state: State) =>
+      jogRequestId.current
+        ? RobotApi.getRequestById(state, jogRequestId.current)
+        : null
+    )?.status === RobotApi.PENDING
 
   const closeWizard = React.useCallback(() => {
     onComplete && onComplete()
@@ -106,7 +121,10 @@ export function useCalibratePipetteOffset(
     hasCalibrationBlock = false,
     tipRackDefinition = null,
   } = sessionParams
-  const handleStartPipOffsetCalSession: Invoker = overrideParams => {
+  const handleStartPipOffsetCalSession: Invoker = (
+    overrideParams: $Shape<PipetteOffsetCalibrationSessionParams> | void = {}
+  ) => {
+    console.log(overrideParams)
     dispatchRequests(
       Sessions.ensureSession(
         robotName,
@@ -132,6 +150,7 @@ export function useCalibratePipetteOffset(
           closeWizard={closeWizard}
           showSpinner={showSpinner}
           dispatchRequests={dispatchRequests}
+          isJogging={isJogging}
         />
       </Portal>
     ) : null,

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
@@ -99,7 +99,7 @@ describe('CalibrateTipLength', () => {
           robotName="robot-name"
           session={session}
           closeWizard={() => {}}
-          dispatchRequests={jest.fn()}
+          dispatchRequests={dispatchRequests}
           showSpinner={showSpinner}
           isJogging={isJogging}
         />,

--- a/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
+++ b/app/src/components/CalibrateTipLength/__tests__/CalibrateTipLength.test.js
@@ -42,6 +42,7 @@ describe('CalibrateTipLength', () => {
   let mockStore
   let render
   let dispatch
+  let dispatchRequests
   let mockTipLengthSession: Sessions.TipLengthCalibrationSession = {
     id: 'fake_session_id',
     ...mockTipLengthCalibrationSessionAttributes,
@@ -72,6 +73,7 @@ describe('CalibrateTipLength', () => {
 
   beforeEach(() => {
     dispatch = jest.fn()
+    dispatchRequests = jest.fn()
     mockStore = {
       subscribe: () => {},
       getState: () => ({
@@ -87,14 +89,19 @@ describe('CalibrateTipLength', () => {
     }
 
     render = (props = {}) => {
-      const { showSpinner = false } = props
+      const {
+        showSpinner = false,
+        isJogging = false,
+        session = mockTipLengthSession,
+      } = props
       return mount(
         <CalibrateTipLength
           robotName="robot-name"
-          session={mockTipLengthSession}
+          session={session}
           closeWizard={() => {}}
           dispatchRequests={jest.fn()}
           showSpinner={showSpinner}
+          isJogging={isJogging}
         />,
         {
           wrappingComponent: Provider,
@@ -146,5 +153,43 @@ describe('CalibrateTipLength', () => {
   it('renders spinner when showSpinner is true', () => {
     const wrapper = render({ showSpinner: true })
     expect(wrapper.find('SpinnerModalPage').exists()).toBe(true)
+  })
+
+  it('does dispatch jog requests when not isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockTipLengthCalibrationSessionAttributes,
+      details: {
+        ...mockTipLengthCalibrationSessionAttributes.details,
+        currentStep: Sessions.TIP_LENGTH_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: false, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
+  })
+
+  it('does not dispatch jog requests when isJogging', () => {
+    const session = {
+      id: 'fake_session_id',
+      ...mockTipLengthCalibrationSessionAttributes,
+      details: {
+        ...mockTipLengthCalibrationSessionAttributes.details,
+        currentStep: Sessions.TIP_LENGTH_STEP_PREPARING_PIPETTE,
+      },
+    }
+    const wrapper = render({ isJogging: true, session })
+    wrapper.find('button[title="forward"]').invoke('onClick')()
+    expect(dispatchRequests).not.toHaveBeenCalledWith(
+      Sessions.createSessionCommand('robot-name', session.id, {
+        command: Sessions.sharedCalCommands.JOG,
+        data: { vector: [0, -0.1, 0] },
+      })
+    )
   })
 })

--- a/app/src/components/CalibrateTipLength/index.js
+++ b/app/src/components/CalibrateTipLength/index.js
@@ -99,6 +99,7 @@ export function CalibrateTipLength(
     closeWizard,
     showSpinner,
     dispatchRequests,
+    isJogging,
   } = props
   const { currentStep, instrument, labware } = session?.details || {}
 
@@ -114,7 +115,7 @@ export function CalibrateTipLength(
     : null
 
   function sendCommands(...commands: Array<SessionCommandParams>) {
-    if (session?.id) {
+    if (session?.id && !isJogging) {
       const sessionCommandActions = commands.map(c =>
         Sessions.createSessionCommand(robotName, session.id, {
           command: c.command,

--- a/app/src/components/CalibrateTipLength/types.js
+++ b/app/src/components/CalibrateTipLength/types.js
@@ -11,4 +11,5 @@ export type CalibrateTipLengthParentProps = {|
     ...Array<{ ...Action, meta: { requestId: string } }>
   ) => void,
   showSpinner: boolean,
+  isJogging: boolean,
 |}

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -82,6 +82,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
   const trackedRequestId = React.useRef<string | null>(null)
   const deleteRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
+  const jogRequestId = React.useRef<string | null>(null)
 
   const [dispatchRequests] = RobotApi.useDispatchApiRequests(
     dispatchedAction => {
@@ -92,6 +93,12 @@ export function DeckCalibrationControl(props: Props): React.Node {
         deckCalibrationSession?.id === dispatchedAction.payload.sessionId
       ) {
         deleteRequestId.current = dispatchedAction.meta.requestId
+      } else if (
+        dispatchedAction.type === Sessions.CREATE_SESSION_COMMAND &&
+        dispatchedAction.payload.command.command ===
+          Sessions.sharedCalCommands.JOG
+      ) {
+        jogRequestId.current = dispatchedAction.meta.requestId
       } else if (
         dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
         !spinnerCommandBlockList.includes(
@@ -123,6 +130,13 @@ export function DeckCalibrationControl(props: Props): React.Node {
         ? RobotApi.getRequestById(state, createRequestId.current)
         : null
     )?.status === RobotApi.SUCCESS
+
+  const isJogging =
+    useSelector((state: State) =>
+      jogRequestId.current
+        ? RobotApi.getRequestById(state, jogRequestId.current)
+        : null
+    )?.status === RobotApi.PENDING
 
   React.useEffect(() => {
     if (shouldOpen) {
@@ -214,6 +228,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
             closeWizard={() => setShowWizard(false)}
             dispatchRequests={dispatchRequests}
             showSpinner={showSpinner}
+            isJogging={isJogging}
           />
         </Portal>
       )}

--- a/app/src/pages/Calibrate/CalibrateTipLengthControl.js
+++ b/app/src/pages/Calibrate/CalibrateTipLengthControl.js
@@ -58,6 +58,7 @@ export function CalibrateTipLengthControl({
   const trackedRequestId = React.useRef<string | null>(null)
   const deleteRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
+  const jogRequestId = React.useRef<string | null>(null)
 
   const [dispatchRequests] = RobotApi.useDispatchApiRequests(
     dispatchedAction => {
@@ -68,6 +69,12 @@ export function CalibrateTipLengthControl({
         calibrationSession?.id === dispatchedAction.payload.sessionId
       ) {
         deleteRequestId.current = dispatchedAction.meta.requestId
+      } else if (
+        dispatchedAction.type === Sessions.CREATE_SESSION_COMMAND &&
+        dispatchedAction.payload.command.command ===
+          Sessions.sharedCalCommands.JOG
+      ) {
+        jogRequestId.current = dispatchedAction.meta.requestId
       } else if (
         dispatchedAction.type !== Sessions.CREATE_SESSION_COMMAND ||
         !spinnerCommandBlockList.includes(
@@ -142,6 +149,13 @@ export function CalibrateTipLengthControl({
         : null
     )?.status === RobotApi.SUCCESS
 
+  const isJogging =
+    useSelector((state: State) =>
+      jogRequestId.current
+        ? RobotApi.getRequestById(state, jogRequestId.current)
+        : null
+    )?.status === RobotApi.PENDING
+
   React.useEffect(() => {
     if (shouldOpen) {
       setShowWizard(true)
@@ -201,6 +215,7 @@ export function CalibrateTipLengthControl({
               closeWizard={handleCloseWizard}
               showSpinner={showSpinner}
               dispatchRequests={dispatchRequests}
+              isJogging={isJogging}
             />
           ) : (
             <CalibrateTipLength
@@ -209,6 +224,7 @@ export function CalibrateTipLengthControl({
               closeWizard={handleCloseWizard}
               showSpinner={showSpinner}
               dispatchRequests={dispatchRequests}
+              isJogging={isJogging}
             />
           )}
         </Portal>


### PR DESCRIPTION
# Overview

In order to prevent jog commands from queueing up, which can be sometimes considerable given network
latency, do not register jog commands that are fired while another is still bending on the robot.
Note: at the moment this is not attached to a visual change in the ui, as the requests generally
clear in under 2 seconds, and it is often considered bad UX to change the visual for any action that
takes less than two seconds.

# Changelog

- debounce jog requests in TLC, POC, and Deck Calibration such that any jog click/keypress will be ignored if there is already an unresolved (active) jog request in progress on the robot.

# Review requests

- Try out all panels that involve jogging in TLC, POC, and Deck Calibration. You shouldn't be able to queue up jog requests.  
- Does the jogging experience still work for you?

# Risk assessment

medium, effect the feeling of many calibration flows
