### PR TITLE
fix(api): Be fault-tolerant to bad deck cal data

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -146,7 +146,6 @@ def get_robot_deck_attitude() -> typing.Optional['DeckCalibrationData']:
     gantry_path = robot_dir / 'deck_calibration.json'
     if gantry_path.exists():
         data = io.read_cal_file(gantry_path)
-        assert 'attitude' in data.keys(), 'Not valid deck calibration data'
         return data  # type: ignore
     else:
         return None

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -124,9 +124,14 @@ def load_attitude_matrix() -> DeckCalibration:
                                             lw_hash=None)
             calibration_data = get.get_robot_deck_attitude()
 
+    deck_cal_obj = None
     if calibration_data:
-        deck_cal_obj = DeckCalibration(**calibration_data)
-    else:
+        try:
+            deck_cal_obj = DeckCalibration(**calibration_data)
+        except Exception as e:
+            log.warning(f"Bad deck calibration, falling back to identity: {e}")
+
+    if not deck_cal_obj:
         deck_cal_obj = DeckCalibration(
             attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2)
     return deck_cal_obj

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -56,6 +56,20 @@ def test_load_calibration(ot_config_tempdir):
     assert np.allclose(obj.attitude, transform)
 
 
+def test_load_malformed_calibration(ot_config_tempdir):
+    pathway = config.get_opentrons_path(
+        'robot_calibration_dir') / 'deck_calibration.json'
+    data = {
+        'atsadasitude': [[1, 0, 1], [0, 1, -.5], [0, 0, 1]],
+        'last_modified': utc_now(),
+        'tiprack': 'hash',
+        'statu': [1, 2, 3],
+    }
+    io.save_to_file(pathway, data)
+    obj = robot_calibration.load_attitude_matrix()
+    assert np.allclose(obj.attitude, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+
 def test_load_pipette_offset(ot_config_tempdir):
     pip_id = 'fakePip'
     mount = Mount.LEFT


### PR DESCRIPTION
Instead of raising an exception during server boot when we see bad deck
calibration data, replace it with an identity and quit our fussin'.

## Testing
- If you have a robot that has been used for recent cal overhaul testing, put this on it and make sure the server still boots
- Otherwise, touch a file called `/data/robot/deck_calibration.json`, then make it a valid json file containing basically whatever data you want, and restart the robot server. It should still come up.