### PR TITLE
fix(app): Display if DC was migrated

### DIFF
--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -196,7 +196,8 @@ def save_tip_length_calibration(
 def save_robot_deck_attitude(
         transform: local_types.AttitudeMatrix,
         pip_id: typing.Optional[str],
-        lw_hash: typing.Optional[str]):
+        lw_hash: typing.Optional[str],
+        source: local_types.SourceType = None):
     robot_dir = config.get_opentrons_path('robot_calibration_dir')
     robot_dir.mkdir(parents=True, exist_ok=True)
     gantry_path = robot_dir/'deck_calibration.json'
@@ -208,7 +209,7 @@ def save_robot_deck_attitude(
         'pipette_calibrated_with': pip_id,
         'last_modified': utc_now(),
         'tiprack': lw_hash,
-        'source': local_types.SourceType.user,
+        'source': source or local_types.SourceType.user,
         'status': status
     }
     io.save_to_file(gantry_path, gantry_dict)

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -18,6 +18,7 @@ class SourceType(str, Enum):
     factory = "factory"
     user = "user"
     calibration_check = "calibration_check"
+    legacy = 'legacy'
     unknown = "unknown"
 
 

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -104,7 +104,8 @@ def load_attitude_matrix() -> types.DeckCalibration:
             attitude = migrate_affine_xy_to_attitude(gantry_cal)
             modify.save_robot_deck_attitude(transform=attitude,
                                             pip_id=None,
-                                            lw_hash=None)
+                                            lw_hash=None,
+                                            source=types.SourceType.legacy)
             calibration_data = get.get_robot_deck_attitude()
 
     if calibration_data:

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -10,6 +10,7 @@ import typeof {
   CALIBRATION_SOURCE_USER,
   CALIBRATION_SOURCE_CALIBRATION_CHECK,
   CALIBRATION_SOURCE_UNKNOWN,
+  CALIBRATION_SOURCE_LEGACY,
 } from './constants'
 
 import type { Mount } from '@opentrons/components'
@@ -39,6 +40,7 @@ export type CalibrationSource =
   | CALIBRATION_SOURCE_USER
   | CALIBRATION_SOURCE_CALIBRATION_CHECK
   | CALIBRATION_SOURCE_UNKNOWN
+  | CALIBRATION_SOURCE_LEGACY
 
 export type IndividualCalibrationStatus = {|
   markedBad: boolean,

--- a/app/src/calibration/constants.js
+++ b/app/src/calibration/constants.js
@@ -6,6 +6,7 @@ export const CALIBRATION_SOURCE_USER: 'user' = 'user'
 export const CALIBRATION_SOURCE_CALIBRATION_CHECK: 'calibration_check' =
   'calibration_check'
 export const CALIBRATION_SOURCE_UNKNOWN: 'unknown' = 'unknown'
+export const CALIBRATION_SOURCE_LEGACY: 'legacy' = 'legacy'
 
 export const CALIBRATION_SOURCES = [
   CALIBRATION_SOURCE_DEFAULT,
@@ -13,6 +14,7 @@ export const CALIBRATION_SOURCES = [
   CALIBRATION_SOURCE_USER,
   CALIBRATION_SOURCE_CALIBRATION_CHECK,
   CALIBRATION_SOURCE_UNKNOWN,
+  CALIBRATION_SOURCE_LEGACY,
 ]
 
 export const DECK_CAL_STATUS_OK: 'OK' = 'OK'

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -42,6 +42,7 @@ import type { RequestState } from '../../robot-api/types'
 
 const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
 const LAST_CALIBRATED = 'Last calibrated: '
+const MIGRATED = 'Migrated from legacy data: '
 const CALIBRATE_DECK_DESCRIPTION =
   "Calibrate the position of the robot's deck. Recommended for all new robots and after moving robots."
 const CALIBRATE_BUTTON_TEXT = 'Calibrate'
@@ -58,7 +59,14 @@ const buildDeckLastCalibrated: (
     typeof data.lastModified === 'string'
       ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
       : 'unknown'
-  return `${LAST_CALIBRATED} ${datestring}`
+  const prefix = calData =>
+        typeof data?.source === 'string'
+        ? (calData.source === Calibration.CALIBRATION_SOURCE_LEGACY
+           ? MIGRATED
+           : LAST_CALIBRATED)
+        : LAST_CALIBRATED
+
+  return `${prefix(data)} ${datestring}`
 }
 
 // deck calibration commands for which the full page spinner should not appear

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -60,11 +60,11 @@ const buildDeckLastCalibrated: (
       ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
       : 'unknown'
   const prefix = calData =>
-        typeof data?.source === 'string'
-        ? (calData.source === Calibration.CALIBRATION_SOURCE_LEGACY
-           ? MIGRATED
-           : LAST_CALIBRATED)
+    typeof data?.source === 'string'
+      ? calData.source === Calibration.CALIBRATION_SOURCE_LEGACY
+        ? MIGRATED
         : LAST_CALIBRATED
+      : LAST_CALIBRATED
 
   return `${prefix(data)} ${datestring}`
 }

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -10,6 +10,10 @@ import {
   DECK_CAL_STATUS_IDENTITY,
   DECK_CAL_STATUS_BAD_CALIBRATION,
   DECK_CAL_STATUS_SINGULARITY,
+  CALIBRATION_SOURCE_USER,
+  CALIBRATION_SOURCE_FACTORY,
+  CALIBRATION_SOURCE_LEGACY,
+  CALIBRATION_SOURCE_UNKNOWN,
 } from '../../../calibration'
 import { DeckCalibrationControl } from '../DeckCalibrationControl'
 import { InlineCalibrationWarning } from '../../InlineCalibrationWarning'
@@ -87,6 +91,46 @@ describe('DeckCalibrationControl', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
+  })
+  const SOURCE_SPECS = [
+    {
+      it: 'displays migrated if source is legacy',
+      source: CALIBRATION_SOURCE_LEGACY,
+      shouldMatch: /migrated/i,
+    },
+    {
+      it: 'displays calibrated if source is user',
+      source: CALIBRATION_SOURCE_USER,
+      shouldMatch: /calibrated/i,
+    },
+    {
+      it: 'displays calibrated if source is factory',
+      source: CALIBRATION_SOURCE_FACTORY,
+      shouldMatch: /calibrated/i,
+    },
+    {
+      it: 'displays calibrated if source is unknown',
+      source: CALIBRATION_SOURCE_UNKNOWN,
+      shouldMatch: /calibrated/i,
+    }
+  ]
+  SOURCE_SPECS.forEach(spec => {
+    it(spec.it, () => {
+      const wrapper = render({
+        deckCalData: {
+          type: 'affine',
+          matrix: [[1, 2, 3], [5, 6, 7], [8, 9, 10]],
+          lastModified: '2020-10-19T00:01:02+00:00',
+          pipetteCalibratedWith: null,
+          tiprack: null,
+          source: spec.source,
+          status: { markedBad: false, source: 'unknown', markedAt: '' },
+        },
+      })
+      expect(
+        wrapper.findWhere(elem => elem.prop('fontStyle') === 'italic').html()
+      ).toMatch(spec.shouldMatch)
+    })
   })
 
   it('button launches new deck calibration after confirm', () => {

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -112,7 +112,7 @@ describe('DeckCalibrationControl', () => {
       it: 'displays calibrated if source is unknown',
       source: CALIBRATION_SOURCE_UNKNOWN,
       shouldMatch: /calibrated/i,
-    }
+    },
   ]
   SOURCE_SPECS.forEach(spec => {
     it(spec.it, () => {

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -25,7 +25,7 @@ stages:
             lastModified: !re_search "T"
             pipetteCalibratedWith: null
             tiprack: null
-            source: "user"
+            source: "legacy"
             status:
               markedBad: False
               source: null


### PR DESCRIPTION
If we migrated deck calibration data from a legacy format, we should
display that instead of saying that deck calibration was run at the time
that it was migrated.

## Testing
- Force a deck cal migration by removing `/data/robot/deck_calibration.json` and having valid data in `/data/deck_calibration.json`
- Restart the robot server with this pr on it
- In a `make dev` app on this branch, make sure the deck calibration control indicates that the data was migrated