### PR TITLE
fix(robot-server): Fix return tip moves in cal flows

### DIFF
--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -92,7 +92,7 @@ def mock_user_flow(mock_hw):
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point(None)
+    cur_pt = await uf.get_current_point(None)
     assert cur_pt == uf._tip_rack.wells()[0].top().point + Point(0, 0, 10)
 
 
@@ -100,7 +100,7 @@ async def test_pick_up_tip(mock_user_flow):
     uf = mock_user_flow
     assert uf._tip_origin_pt is None
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point(None)
+    cur_pt = await uf.get_current_point(None)
     await uf.pick_up_tip()
     assert uf._tip_origin_pt == cur_pt
 
@@ -134,14 +134,13 @@ async def test_return_tip(mock_user_flow):
     uf._hw_pipette._has_tip = True
     z_offset = uf._hw_pipette.config.return_tip_height * \
         uf._get_tip_length()
-    await uf._return_tip()
+    await uf.return_tip()
     # should move to return tip
     move_calls = [
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._get_critical_point_override()
-        ),
+            critical_point=uf.critical_point_override)
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
@@ -150,9 +149,9 @@ async def test_return_tip(mock_user_flow):
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(1, 0, 0.1)
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -257,21 +257,20 @@ def test_create_params(mock_hw,
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point(None)
+    cur_pt = await uf.get_current_point(None)
     assert cur_pt == uf._deck['8'].wells()[0].top().point + Point(0, 0, 10)
 
 
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(1, 0, 0.1)
 
 
 async def test_pick_up_tip(mock_user_flow):
     uf = mock_user_flow
-    assert uf._tip_origin_pt is None
     await uf.pick_up_tip()
     # check that it saves the tip pick up location locally
     assert uf._tip_origin_pt == Point(0, 0, 0)
@@ -283,14 +282,13 @@ async def test_return_tip(mock_user_flow):
     uf._hw_pipette._has_tip = True
     z_offset = uf._hw_pipette.config.return_tip_height * \
         uf._get_tip_length()
-    await uf._return_tip()
+    await uf.return_tip()
     # should move to return tip
     move_calls = [
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._get_critical_point_override()
-        ),
+            critical_point=uf.critical_point_override)
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
@@ -337,8 +335,7 @@ async def test_save_pipette_calibration(mock_user_flow, mock_save_pipette):
     await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=40),
-            critical_point=uf._get_critical_point_override()
-        )
+            critical_point=uf.critical_point_override)
 
     await uf.save_offset()
     tiprack_hash = helpers.hash_labware_def(

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -155,7 +155,7 @@ hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
 async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
-    cur_pt = await uf._get_current_point(None)
+    cur_pt = await uf.get_current_point(None)
     assert cur_pt == uf._deck['8'].wells()[0].top().point + Point(0, 0, 10)
 
 
@@ -164,7 +164,7 @@ async def test_move_to_reference_point(mock_user_flow_all_combos):
     await uf.move_to_reference_point()
     buff = Point(0, 0, 5)
     trash_offset = Point(-57.84, -55, 0)  # offset from center of trash
-    cur_pt = await uf._get_current_point(None)
+    cur_pt = await uf.get_current_point(None)
     if uf._has_calibration_block:
         if uf._mount == Mount.LEFT:
             assert cur_pt == \
@@ -181,9 +181,9 @@ async def test_move_to_reference_point(mock_user_flow_all_combos):
 async def test_jog(mock_user_flow):
     uf = mock_user_flow
     await uf.jog(vector=(0, 0, 0.1))
-    assert await uf._get_current_point(None) == Point(0, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(0, 0, 0.1)
     await uf.jog(vector=(1, 0, 0))
-    assert await uf._get_current_point(None) == Point(1, 0, 0.1)
+    assert await uf.get_current_point(None) == Point(1, 0, 0.1)
 
 
 async def test_pick_up_tip(mock_user_flow):
@@ -206,8 +206,7 @@ async def test_invalidate_tip(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._get_critical_point_override()
-        ),
+            critical_point=uf.critical_point_override,)
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
@@ -225,8 +224,7 @@ async def test_exit(mock_user_flow):
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf._get_critical_point_override()
-        ),
+            critical_point=uf.critical_point_override)
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
@@ -294,8 +292,7 @@ async def test_save_offsets(mock_user_flow):
         await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=10),
-            critical_point=uf._get_critical_point_override()
-        )
+            critical_point=uf.critical_point_override)
         await uf.save_offset()
         assert uf._nozzle_height_at_reference == 10
 
@@ -304,8 +301,7 @@ async def test_save_offsets(mock_user_flow):
         await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=40),
-            critical_point=uf._get_critical_point_override()
-        )
+            critical_point=uf.critical_point_override)
         await uf.save_offset()
         create_tip_length_data_patch.assert_called_with(ANY, '', 30)
 


### PR DESCRIPTION
While we do save the point at which the user indicated a tip was picked
up, and move to that point when we return the tip, _before_ we move to
that point we always were moving to the original tip rack well 0 top +
offset. Then, we'd do a single move to the point indicated by the
user (with the return tip height multiplier applied, so maybe inside the
well). If the user jogged at all, this would be the kind of diagonal XYZ
move that we like to avoid, because particularly if the destination
point is inside the well - because of return tip height - the tip can
hit the rack geometry on the way to its destination.

Instead, refactor the logic a bit to simplify it; make the user flow
utils only interact with public functions; and change the
move-to-tiprack command to move to the saved point if available. This
should mean that the move into the rack to return the tip is always a
pure-vertical move.

## Testing
- Run the cal flows and drop tips. It should work even if you jogged a bunch.