### PR TITLE
fix(api,robot-server): reload robot calibration on deck calibration exit

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -95,6 +95,10 @@ class API(HardwareAPILike):
     def robot_calibration(self) -> rb_cal.RobotCalibration:
         return self._robot_calibration
 
+    def reset_robot_calibration(self):
+        self._calculate_valid_attitude.cache_clear()
+        self._robot_calibration = rb_cal.load()
+
     def set_robot_calibration(
             self, robot_calibration: rb_cal.RobotCalibration):
         self._calculate_valid_attitude.cache_clear()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -320,7 +320,7 @@ class DeckCalibrationUserFlow:
 
     async def exit_session(self):
         await self.move_to_tip_rack()
-        await self._return_tip()
+        await self.return_tip()
         # reload new deck calibration
         self._hardware.reset_robot_calibration()
         await self._hardware.home()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -320,5 +320,7 @@ class DeckCalibrationUserFlow:
 
     async def exit_session(self):
         await self.move_to_tip_rack()
-        await self.return_tip()
+        await self._return_tip()
+        # reload new deck calibration
+        self._hardware.reset_robot_calibration()
         await self._hardware.home()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Currently, new calibration data acquired after deck calibration is not being used in hardware motion until the robot has been restarted manually. The last calibrated datetime for deck calibration also doesn't reflect the actual last calibrated time because of that.

This PR reloads robot calibration when exiting deck calibration to make sure new data will be used right away.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->


# Review requests
After deck calibration, you should see that the last calibration datetime to be updated right away when deck calibration ends. You should also notice the new deck calibration data is being used in hardware motion without having to first restart the robot.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
