### PR TITLE
feat(notify-server): Notify server publisher client

### DIFF
--- a/notify-server/.flake8
+++ b/notify-server/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = ANN101

--- a/notify-server/.flake8
+++ b/notify-server/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = ANN101
+ignore = ANN101, ANN102

--- a/notify-server/README.rst
+++ b/notify-server/README.rst
@@ -27,6 +27,20 @@ clients
 =======
 The ``clients`` package has two clients: a subscriber and a publisher.
 
+Publisher Client Example
+........................
+
+.. code-block:: python
+
+   from notify_server.clients.publisher import create
+
+   # Create the async publisher client
+   pub = create("tcp://123.123.123.123:1234")
+
+   # Publish an event
+   await pub.send(topic="topic", event=my_event)
+
+
 models
 =======
 The ``models`` package defines event models.

--- a/notify-server/notify_server/clients/__init__.py
+++ b/notify-server/notify_server/clients/__init__.py
@@ -1,0 +1,1 @@
+"""Clients package."""

--- a/notify-server/notify_server/clients/publisher.py
+++ b/notify-server/notify_server/clients/publisher.py
@@ -1,4 +1,6 @@
 """A publisher client."""
+from __future__ import annotations
+
 import asyncio
 import logging
 from asyncio import Task, Queue
@@ -13,7 +15,7 @@ from notify_server.models.event import Event
 log = logging.getLogger(__name__)
 
 
-def create(host_address: str) -> '_Publisher':
+def create(host_address: str) -> Publisher:
     """
     Construct a publisher.
 
@@ -21,7 +23,7 @@ def create(host_address: str) -> '_Publisher':
     """
     queue: Queue = Queue()
     task = asyncio.create_task(_send_task(address=host_address, queue=queue))
-    return _Publisher(task=task, queue=queue)
+    return Publisher(task=task, queue=queue)
 
 
 async def _send_task(address: str, queue: Queue) -> None:
@@ -52,7 +54,7 @@ class _Entry:
         ]
 
 
-class _Publisher:
+class Publisher:
     """Async publisher class."""
 
     def __init__(self, task: Task, queue: Queue) -> None:

--- a/notify-server/notify_server/clients/publisher.py
+++ b/notify-server/notify_server/clients/publisher.py
@@ -1,0 +1,64 @@
+"""A publisher client."""
+import asyncio
+from asyncio import Task, Queue
+from dataclasses import dataclass
+from typing import List
+
+import zmq  # type: ignore
+from zmq.asyncio import Context  # type: ignore
+
+from notify_server.models.event import Event
+
+
+def create(host_address: str) -> '_Publisher':
+    """
+    Construct a publisher.
+
+    :param host_address: uri to connect to.
+    """
+    queue: Queue = Queue()
+    task = asyncio.create_task(_send_task(address=host_address, queue=queue))
+    return _Publisher(task=task, queue=queue)
+
+
+async def _send_task(address: str, queue: Queue) -> None:
+    """Run asyncio task that reads from queue and publishes to server."""
+    ctx = Context()
+    sock = ctx.socket(zmq.PUSH)
+
+    sock.connect(address)
+
+    while True:
+        entry: _Entry = await queue.get()
+        await sock.send_multipart(entry.to_frames())
+
+
+@dataclass
+class _Entry:
+    """An entry in publisher send queue."""
+
+    topic: str
+    event: Event
+
+    def to_frames(self) -> List[bytes]:
+        """Create zmq frames from members."""
+        return [
+            bytes(v, 'utf-8') for v in (self.topic, self.event.json(),)
+        ]
+
+
+class _Publisher:
+    """Async publisher class."""
+
+    def __init__(self, task: Task, queue: Queue) -> None:
+        """Construct a _Publisher."""
+        self._task = task
+        self._queue = queue
+
+    async def send(self, topic: str, event: Event) -> None:
+        """Publish an event to a topic."""
+        await self._queue.put(_Entry(topic, event))
+
+    def stop(self) -> None:
+        """Stop the publisher task."""
+        self._task.cancel()

--- a/notify-server/notify_server/clients/publisher.py
+++ b/notify-server/notify_server/clients/publisher.py
@@ -1,5 +1,6 @@
 """A publisher client."""
 import asyncio
+import logging
 from asyncio import Task, Queue
 from dataclasses import dataclass
 from typing import List
@@ -8,6 +9,8 @@ import zmq  # type: ignore
 from zmq.asyncio import Context  # type: ignore
 
 from notify_server.models.event import Event
+
+log = logging.getLogger(__name__)
 
 
 def create(host_address: str) -> '_Publisher':
@@ -25,6 +28,8 @@ async def _send_task(address: str, queue: Queue) -> None:
     """Run asyncio task that reads from queue and publishes to server."""
     ctx = Context()
     sock = ctx.socket(zmq.PUSH)
+
+    log.info("Publisher connecting to %s", address)
 
     sock.connect(address)
 

--- a/notify-server/notify_server/server/server.py
+++ b/notify-server/notify_server/server/server.py
@@ -71,5 +71,4 @@ async def run(settings: Settings) -> None:
             settings.publisher_address.connection_string(), queue
         )
     )
-    await subtask
-    await pubtask
+    asyncio.gather([subtask, pubtask])

--- a/notify-server/notify_server/server/server.py
+++ b/notify-server/notify_server/server/server.py
@@ -71,4 +71,4 @@ async def run(settings: Settings) -> None:
             settings.publisher_address.connection_string(), queue
         )
     )
-    asyncio.gather([subtask, pubtask])
+    await asyncio.gather(subtask, pubtask)

--- a/notify-server/notify_server/settings.py
+++ b/notify-server/notify_server/settings.py
@@ -1,22 +1,31 @@
 """Settings class."""
 
+from typing_extensions import Literal
 from pydantic import BaseSettings, BaseModel, Field
 
 
 class ServerBindAddress(BaseModel):
     """A bind address for server zmq socket."""
 
-    scheme: str
-    port: int
+    scheme: Literal['ipc', 'tcp']
+    host: str = "*"
+    port: int = 5555
+    path: str = "/tmp/notify-server"
+
+    def connection_string(self) -> str:
+        """Create the connection string."""
+        if self.scheme == 'ipc':
+            remainder = self.path
+        else:
+            remainder = f"{self.host}:{self.port}"
+        return f"{self.scheme}://{remainder}"
 
 
 class Settings(BaseSettings):
     """Application Settings."""
 
-    publisher_address: ServerBindAddress = ServerBindAddress(scheme="tcp",
-                                                             port=5555)
-    subscriber_address: ServerBindAddress = ServerBindAddress(scheme="tcp",
-                                                              port=5556)
+    publisher_address: ServerBindAddress = ServerBindAddress(scheme="ipc")
+    subscriber_address: ServerBindAddress = ServerBindAddress(scheme="tcp")
 
     production: bool = Field(
         True,

--- a/notify-server/poetry.lock
+++ b/notify-server/poetry.lock
@@ -281,6 +281,20 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "dev"
+description = "Pytest support for asyncio."
+name = "pytest-asyncio"
+optional = false
+python-versions = ">= 3.5"
+version = "0.14.0"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+
+[[package]]
+category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
@@ -384,7 +398,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "e3538ec3034b92e6bd5a674328977b8fdd3078fee2e74505f701e67dac4e5b69"
+content-hash = "4cc06d9e121ddb5d3600141b74555775f225568512b33cede7a29067e4b490a4"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -536,6 +550,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.1.1-py3-none-any.whl", hash = "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9"},
     {file = "pytest-6.1.1.tar.gz", hash = "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
+    {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},

--- a/notify-server/pyproject.toml
+++ b/notify-server/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^3.8.4"
 flake8-docstrings = "^1.5.0"
 flake8-annotations = "^2.4.1"
 mock = "^4.0.2"
+pytest-asyncio = "^0.14.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/notify-server/tests/clients/__init__.py
+++ b/notify-server/tests/clients/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for clients package."""

--- a/notify-server/tests/clients/test_publisher.py
+++ b/notify-server/tests/clients/test_publisher.py
@@ -1,40 +1,12 @@
 """Unit tests for publisher module."""
 import asyncio
 from asyncio import AbstractEventLoop
-from datetime import datetime
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 from mock import AsyncMock
 import pytest
-from zmq.asyncio import Context  # type: ignore
 
 from notify_server.clients import publisher
 from notify_server.models.event import Event
-from notify_server.models.sample_events import SampleTwo
-
-
-@pytest.fixture
-def mock_zmq_socket() -> AsyncMock:
-    """Mock zmq socket."""
-    mock_sock = AsyncMock()
-    return mock_sock
-
-
-@pytest.fixture
-def zmq_context(mock_zmq_socket: AsyncMock) -> MagicMock:
-    """Mock zmq Context."""
-    with patch.object(Context, "socket") as p:
-        p.return_value = mock_zmq_socket
-        yield p
-
-
-@pytest.fixture
-def event() -> Event:
-    """Event fixture."""
-    return Event(
-        createdOn=datetime(2000, 1, 1),
-        publisher="pub",
-        data=SampleTwo(val1=1, val2="2")
-    )
 
 
 @pytest.mark.asyncio

--- a/notify-server/tests/clients/test_publisher.py
+++ b/notify-server/tests/clients/test_publisher.py
@@ -1,0 +1,63 @@
+"""Unit tests for publisher module."""
+import asyncio
+from asyncio import AbstractEventLoop
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+from mock import AsyncMock
+import pytest
+from zmq.asyncio import Context  # type: ignore
+
+from notify_server.clients import publisher
+from notify_server.models.event import Event
+from notify_server.models.sample_events import SampleTwo
+
+
+@pytest.fixture
+def mock_zmq_socket() -> AsyncMock:
+    """Mock zmq socket."""
+    mock_sock = AsyncMock()
+    return mock_sock
+
+
+@pytest.fixture
+def zmq_context(mock_zmq_socket: AsyncMock) -> MagicMock:
+    """Mock zmq Context."""
+    with patch.object(Context, "socket") as p:
+        p.return_value = mock_zmq_socket
+        yield p
+
+
+@pytest.fixture
+def event() -> Event:
+    """Event fixture."""
+    return Event(
+        createdOn=datetime(2000, 1, 1),
+        publisher="pub",
+        data=SampleTwo(val1=1, val2="2")
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_integration(event_loop: AbstractEventLoop,
+                                event: Event,
+                                zmq_context: MagicMock,
+                                mock_zmq_socket: AsyncMock) -> None:
+    """Integration test."""
+    pub = publisher.create("someaddress")
+    await pub.send(topic="topic", event=event)
+    await asyncio.sleep(0)
+    mock_zmq_socket.connect.assert_called_once_with("someaddress")
+    mock_zmq_socket.send_multipart.assert_called_once_with(
+        [b"topic",
+         event.json().encode('utf-8')]
+    )
+    pub.stop()
+
+
+def test_entry_to_frames(event: Event) -> None:
+    """Test that to frames method creates a list of byte frames."""
+    entry = publisher._Entry("topic",
+                             event)
+    assert entry.to_frames() == [
+        b'topic', event.json().encode('utf-8')
+    ]

--- a/notify-server/tests/conftest.py
+++ b/notify-server/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Pytest conf."""
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+from mock import AsyncMock
+
+from zmq.asyncio import Context
+
+from notify_server.models.event import Event
+from notify_server.models.sample_events import SampleTwo
+
+
+@pytest.fixture
+def mock_zmq_socket() -> AsyncMock:
+    """Mock zmq socket."""
+    mock_sock = AsyncMock()
+    return mock_sock
+
+
+@pytest.fixture
+def zmq_context(mock_zmq_socket: AsyncMock) -> MagicMock:
+    """Mock zmq Context."""
+    with patch.object(Context, "socket") as p:
+        p.return_value = mock_zmq_socket
+        yield p
+
+
+@pytest.fixture
+def event() -> Event:
+    """Event fixture."""
+    return Event(
+        createdOn=datetime(2000, 1, 1),
+        publisher="pub",
+        data=SampleTwo(val1=1, val2="2")
+    )

--- a/notify-server/tests/models/test_event.py
+++ b/notify-server/tests/models/test_event.py
@@ -31,8 +31,8 @@ from notify_server.models.sample_events import (
                                "val2": "egg"}],
                              # Use SampleOne schema on sample two type
                              [{"type": "SampleTwo",
-                               "data": {"val1": 123, "val2": "egg"}}],
-                         ])
+                               "data": {"val1": 123, "val2": "egg"}}]]
+                         )
 def test_bad_data_attribute(data: Dict[str, Any]) -> None:
     """Test that invalid data attribute will cause a validation error."""
     event = {

--- a/notify-server/tests/server/test_server.py
+++ b/notify-server/tests/server/test_server.py
@@ -1,17 +1,1 @@
 """Server module unit tests."""
-
-import pytest
-
-from notify_server.server import server
-from notify_server.settings import ServerBindAddress
-
-
-@pytest.mark.parametrize(argnames=["address", "expected"],
-                         argvalues=[
-                             [ServerBindAddress(scheme="tcp", port=1234),
-                              "tcp://*:1234"],
-                             [ServerBindAddress(scheme="ipc", port=4),
-                              "ipc://*:4"]])
-def test_to_zmq_address(address: ServerBindAddress, expected: str) -> None:
-    """Test creation of zmq host address from settings."""
-    assert server._to_zmq_address(address) == expected

--- a/notify-server/tests/server/test_server.py
+++ b/notify-server/tests/server/test_server.py
@@ -11,8 +11,7 @@ from notify_server.settings import ServerBindAddress
                              [ServerBindAddress(scheme="tcp", port=1234),
                               "tcp://*:1234"],
                              [ServerBindAddress(scheme="ipc", port=4),
-                              "ipc://*:4"],
-                         ])
+                              "ipc://*:4"]])
 def test_to_zmq_address(address: ServerBindAddress, expected: str) -> None:
     """Test creation of zmq host address from settings."""
     assert server._to_zmq_address(address) == expected

--- a/notify-server/tests/test_settings.py
+++ b/notify-server/tests/test_settings.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 from _pytest.fixtures import FixtureRequest
 
-from notify_server.settings import Settings
+from notify_server.settings import Settings, ServerBindAddress
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def port() -> int:
 @pytest.fixture
 def scheme() -> str:
     """Scheme fixture."""
-    return "ftp"
+    return "ipc"
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def server_address_override(request: FixtureRequest,
                             scheme: str) -> None:
     """Fixture that overrides a server address environment variable."""
     marker = request.node.get_closest_marker("env_var")
-    obj = {"scheme": "ftp", "port": 4444}
+    obj = {"scheme": scheme, "port": port}
     envvar_patch[marker.args[0]] = json.dumps(obj)
 
 
@@ -57,3 +57,14 @@ def test_override_subscriber_address(server_address_override: None,
     s = Settings()
     assert s.subscriber_address.port == port
     assert s.subscriber_address.scheme == scheme
+
+
+@pytest.mark.parametrize(argnames=["address", "expected"],
+                         argvalues=[
+                             [ServerBindAddress(scheme="tcp", port=1234),
+                              "tcp://*:1234"],
+                             [ServerBindAddress(scheme="ipc", path="/afile"),
+                              "ipc:///afile"]])
+def test_connection_string(address: ServerBindAddress, expected: str) -> None:
+    """Test creation of zmq host address from settings."""
+    assert address.connection_string() == expected


### PR DESCRIPTION
# Overview

Adding an async publisher client to wrap a zmq PUSH client. 

Assumption is that a client will want to stream many events in the background rather. If that proves to be off we can make some small changes to facilitate a different usage model.

closes #6706 

# Changelog

- added `clients` package and `publisher.py` module.
- api is a `create` method which takes the host address. A `_Publisher` is returned that manages a background asyncio task for sending events to server.
- unit tests

# Review requests


# Risk assessment

None