### PR TITLE
fix(robot-server): home plungers in cal flows

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -240,6 +240,9 @@ class DeckCalibrationUserFlow:
                                       delta=Point(*vector))
 
     async def move_to_tip_rack(self):
+        if self._current_state == State.labwareLoaded:
+            MODULE_LOG.info("homing plunger")
+            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     async def move_to_deck(self):

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -257,6 +257,9 @@ class PipetteOffsetCalibrationUserFlow:
             self._flag_unmet_transition_req(
                 command_handler="move_to_tip_rack",
                 unmet_condition="not performing tip length calibration")
+        if self._current_state != self._state.calibrationComplete:
+            MODULE_LOG.info("Homing plunger")
+            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     def _get_stored_tip_length_cal(self) -> Optional[float]:

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -158,6 +158,9 @@ class TipCalibrationUserFlow:
         pass
 
     async def move_to_tip_rack(self):
+        if self._current_state == State.measuringNozzleOffset:
+            MODULE_LOG.info("homing plunger")
+            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     async def save_offset(self):

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -50,6 +50,7 @@ def mock_hw(hardware):
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
+    hardware.home_plunger = MagicMock(side_effect=async_mock)
     return hardware
 
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -138,6 +138,7 @@ def mock_hw(hardware):
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
+    hardware.home_plunger = MagicMock(side_effect=async_mock)
 
     return hardware
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -66,6 +66,7 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     hardware.drop_tip = MagicMock(side_effect=async_mock)
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.home_plunger = MagicMock(side_effect=async_mock)
     hardware.get_instrument_max_height.return_value = 180
     return hardware
 
@@ -95,12 +96,16 @@ def mock_hw(hardware):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
+    async def async_mock_home_plunger(*args, **kwargs):
+        pass
+
     hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
     hardware.pick_up_tip = MagicMock(side_effect=async_mock)
     hardware.drop_tip = MagicMock(side_effect=async_mock)
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
+    hardware.home_plunger = MagicMock(side_effect=async_mock_home_plunger)
     return hardware
 
 


### PR DESCRIPTION
Cal flows in general don't home before hand. This is a reasonably
defensible position since we home when we boot and in general we home a
lot. But what we don't home when we boot is plungers, and so we now home
the active plunger in each cal flow. This fixes an issue where the first
time you ran a cal flow, when going to pick up the tip the tip ejector
shroud might interfere with the pickup.
