### PR TITLE
feat(protocol-designer): add dispense air gap to distribute command creator

### DIFF
--- a/protocol-designer/fixtures/protocol/5/doItAllV3.json
+++ b/protocol-designer/fixtures/protocol/5/doItAllV3.json
@@ -2683,16 +2683,6 @@
       }
     },
     {
-      "command": "blowout",
-      "params": {
-        "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-        "labware": "trashId",
-        "well": "A1",
-        "flowRate": 46.43,
-        "offsetFromBottomMm": 0
-      }
-    },
-    {
       "command": "dropTip",
       "params": {
         "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",

--- a/protocol-designer/fixtures/protocol/5/doItAllV3.json
+++ b/protocol-designer/fixtures/protocol/5/doItAllV3.json
@@ -2683,6 +2683,16 @@
       }
     },
     {
+      "command": "blowout",
+      "params": {
+        "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labware": "trashId",
+        "well": "A1",
+        "flowRate": 46.43,
+        "offsetFromBottomMm": 0
+      }
+    },
+    {
       "command": "dropTip",
       "params": {
         "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",

--- a/protocol-designer/src/step-generation/__fixtures__/commandFixtures.js
+++ b/protocol-designer/src/step-generation/__fixtures__/commandFixtures.js
@@ -234,7 +234,9 @@ export const delayCommand = (seconds: number): Command => ({
 
 export const delayWithOffset = (
   well: string,
-  labware: string
+  labware: string,
+  seconds?: number,
+  zOffset?: number
 ): Array<Command> => [
   {
     command: 'moveToWell',
@@ -245,13 +247,13 @@ export const delayWithOffset = (
       offset: {
         x: 0,
         y: 0,
-        z: 14,
+        z: zOffset || 14,
       },
     },
   },
   {
     command: 'delay',
-    params: { wait: 12 },
+    params: { wait: seconds || 12 },
   },
 ]
 

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -843,9 +843,9 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       }
 
       const result = distribute(args, invariantContext, robotStateWithTip)
-      // blowout location IS trash! but I am never changing the tip, so i still gotta blow out
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // no need to pickup tip/drop tip since change tip is never
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate
@@ -868,11 +868,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // after touch tip, this is the final dispense in the chunk
-        // does the chunk end in a tip change?
-        // changeTip: never => do not change tip => so NO
-        // this means we must blowout into trash, and then go back to aspirate
+        // blowout into trash since we are not changing tip
         blowoutSingleToTrash,
         // next chunk from A1: remaining volume
         // mix (asp)
@@ -885,12 +881,12 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // air gap
         airGapHelper('A1', 31),
         delayCommand(11),
-        // dispense #1
         dispenseAirGapHelper('A4', 31),
         delayCommand(12),
+        // dispense #3
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // use the dispense > air gap here before moving to trash
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
@@ -913,7 +909,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        // replace tip
+        // replace tip since change tip is always
         dropTipHelper('A1'),
         pickUpTipHelper('A1'),
         // mix (asp)
@@ -938,11 +934,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // after touch tip, this is the final dispense in the chunk
-        // does the chunk end in a tip change?
-        // changeTip: always => change tip => so YES
-        // chunk ending in a tip change so no need to blowout
+        // since we used dispense > air gap, drop the tip
+        // skip blowout into trash b/c we're about to drop tip anyway
         airGapHelper('A3', 3, { labware: DEST_LABWARE }), // need to air gap here
         delayCommand(11),
         // just drop the tip in the trash
@@ -959,12 +952,12 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // air gap
         airGapHelper('A1', 31),
         delayCommand(11),
-        // dispense #1
+        // dispense #3
         dispenseAirGapHelper('A4', 31),
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // use the dispense > air gap here before moving to trash
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
@@ -987,7 +980,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
-        // replace tip
+        // replace tip at the beginning of the step
         dropTipHelper('A1'),
         pickUpTipHelper('A1'),
         // mix (asp)
@@ -1012,14 +1005,9 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // after touch tip, this is the final dispense in the chunk
-        // does the chunk end in a tip change?
-        // changeTip: once => so NO
         // chunk NOT ending in a tip change, so we must blowout to trash
         blowoutSingleToTrash,
         // skip dispense => air gap since we are reusing the tip
-
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate 100 liquid + 60 for disposal vol
@@ -1035,10 +1023,9 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // use the dispense > air gap here before moving to trash
-        // since it is the final dispense in the step
         // skip blowout into trash b/c we're about to drop tip anyway
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
         delayCommand(11),
@@ -1059,6 +1046,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // no need to replace tip since change tip is never
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate
@@ -1081,8 +1069,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // blowout location is source so need to blowout
+        // blowout location is source so we gotta blowout
         blowoutSingleToSourceA1,
         // skip dispense => air gap since we are reusing the tip
         // mix (asp)
@@ -1100,11 +1087,12 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
+        // blowout location is source so we gotta blowout
+        blowoutSingleToSourceA1,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
-        blowoutSingleToSourceA1,
         // air gap from source since blowout location is source
         airGapHelper('A1', 3),
         delayCommand(11),
@@ -1150,7 +1138,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // air gap so no liquid drops off the tip as pipette moves from source well to trash
@@ -1176,9 +1163,9 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
-        // blowout to source
+        // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
         // air gap so no liquid drops off the tip as pipette moves from source well to trash
         airGapHelper('A1', 3),
@@ -1225,8 +1212,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // blowout location is source so need to blowout
+        // blowout location is source so we gotta blowout
         blowoutSingleToSourceA1,
         // skip dispense > air gap since tip is being reused
         // mix (asp)
@@ -1244,7 +1230,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
@@ -1268,6 +1254,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
+        // no need to replace tip since changeTip is never
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate
@@ -1290,8 +1277,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // blowout location is dest so need to blowout
+        // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
         // skip dispense => air gap since we are reusing the tip
         // mix (asp)
@@ -1311,7 +1297,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
-        // blowout location is dest so need to blowout
+        // blowout location is dest so we gotta blowout
         blowoutSingleToDestA4,
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
@@ -1359,8 +1345,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-
-        // blowout location is dest so need to blowout
+        // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
         // air gap so no liquid drops off the tip as pipette moves from destination well to trash
         airGapHelper('A3', 3, { labware: DEST_LABWARE }),
@@ -1385,7 +1370,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         delayCommand(12),
         dispenseHelper('A4', 100),
         ...delayWithOffset('A4', DEST_LABWARE),
-        // touch tip (disp #1)
+        // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // use the dispense > air gap here before moving to trash
         // since it is the final dispense in the step
@@ -1434,7 +1419,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-        // blowout location is dest so need to blowout
+        // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
         // skip dispense > air gap since tip is being reused
         // mix (asp)

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 // @flow
 import {
   ASPIRATE_OFFSET_FROM_BOTTOM_MM,

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -812,7 +812,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -852,7 +852,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -877,7 +877,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         dispenseAirGapHelper('A4', 31),
@@ -918,7 +918,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -934,7 +934,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         blowoutSingleToTrash,
-        // dispense => air gap since we are about to change the tip
+        // dispense > air gap since we are about to change the tip
         airGapHelper('A3', 3, { labware: DEST_LABWARE }), // need to air gap here
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
@@ -948,7 +948,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -990,7 +990,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1006,7 +1006,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         blowoutSingleToTrash,
-        // skip dispense => air gap since we are reusing the tip
+        // skip dispense > air gap since we are reusing the tip
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate 100 liquid + 60 for disposal vol
@@ -1014,7 +1014,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1053,7 +1053,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1070,7 +1070,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         // blowout location is source so we gotta blowout
         blowoutSingleToSourceA1,
-        // skip dispense => air gap since we are reusing the tip
+        // skip dispense > air gap since we are reusing the tip
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate 100 liquid + 60 for disposal vol
@@ -1078,7 +1078,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1090,9 +1090,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // blowout location is source so we gotta blowout
         blowoutSingleToSourceA1,
-        // use the dispense > air gap here before moving to trash
-        // since it is the final dispense in the step
-        // air gap from source since blowout location is source
+        // use the dispense > air gap here before moving to trash since it is the final dispense in the step
+        // dispense > air gap from source since blowout location is source
         airGapHelper('A1', 3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
@@ -1122,7 +1121,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1139,7 +1138,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
-        // air gap so no liquid drops off the tip as pipette moves from source well to trash
+        // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
         airGapHelper('A1', 3),
         // delay after aspirating air
         delayCommand(11),
@@ -1154,7 +1153,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1166,7 +1165,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A4', { labware: DEST_LABWARE }),
         // blowout location is source so need to blowout
         blowoutSingleToSourceA1,
-        // air gap so no liquid drops off the tip as pipette moves from source well to trash
+        // dispense > air gap so no liquid drops off the tip as pipette moves from source well to trash
         airGapHelper('A1', 3),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
@@ -1196,7 +1195,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1221,7 +1220,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1261,7 +1260,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1278,7 +1277,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
-        // skip dispense => air gap since we are reusing the tip
+        // skip dispense > air gap since we are reusing the tip
         // mix (asp)
         ...mixCommandsWithDelay,
         // aspirate 100 liquid + 60 for disposal vol
@@ -1286,7 +1285,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1329,7 +1328,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1346,7 +1345,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         touchTipHelper('A3', { labware: DEST_LABWARE }),
         // blowout location is dest so we gotta blowout
         blowoutSingleToDestA3,
-        // air gap so no liquid drops off the tip as pipette moves from destination well to trash
+        // dispense > air gap so no liquid drops off the tip as pipette moves from destination well to trash
         airGapHelper('A3', 3, { labware: DEST_LABWARE }),
         // dispense delay
         delayCommand(11),
@@ -1361,7 +1360,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3
@@ -1403,7 +1402,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #1
@@ -1428,7 +1427,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A1', SOURCE_LABWARE, 11, 15),
         // touch tip (asp)
         touchTipHelper('A1', { offsetFromBottomMm: 14.5 }),
-        // air gap
+        // aspirate > air gap
         airGapHelper('A1', 31),
         delayCommand(11),
         // dispense #3

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -24,6 +24,7 @@ import {
   SOURCE_LABWARE,
 } from '../__fixtures__'
 import { distribute } from '../commandCreators/compound/distribute'
+import type { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV6.js'
 import type { DistributeArgs } from '../types'
 import {
   SOURCE_WELL_BLOWOUT_DESTINATION,
@@ -237,6 +238,18 @@ describe('tip handling for multiple distribute chunks', () => {
 })
 
 describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position', () => {
+  let mixCommandsWithDelay: Array<Command>
+  beforeEach(() => {
+    mixCommandsWithDelay = [
+      aspirateHelper('A1', 35),
+      delayCommand(11),
+      dispenseHelper('A1', 35, {
+        labware: SOURCE_LABWARE,
+        offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
+      }),
+      delayCommand(12),
+    ]
+  })
   it('should mix before aspirate, then aspirate disposal volume', () => {
     // NOTE this also tests "uneven final chunk" eg A6 in [A2 A3 | A4 A5 | A6]
     // which is especially relevant to disposal volume
@@ -490,14 +503,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
       disposalVolume: 0,
     }
 
-    const result = distribute(
-      distributeArgs,
-      invariantContext,
-      robotStateWithTip
-    )
-    const res = getSuccessResult(result)
-
-    const mixCommandsWithDelay = [
+    mixCommandsWithDelay = [
       // mix 1
       aspirateHelper('A1', 50),
       delayCommand(12),
@@ -513,6 +519,13 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
       }),
     ]
+
+    const result = distribute(
+      distributeArgs,
+      invariantContext,
+      robotStateWithTip
+    )
+    const res = getSuccessResult(result)
 
     expect(res.commands).toEqual([
       ...mixCommandsWithDelay,
@@ -829,16 +842,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: 'trashId',
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
-
       const result = distribute(args, invariantContext, robotStateWithTip)
       // blowout location IS trash! but I am never changing the tip, so i still gotta blow out
       const res = getSuccessResult(result)
@@ -907,15 +910,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: 'trashId',
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -990,15 +984,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: 'trashId',
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1071,15 +1056,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1146,15 +1122,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1230,15 +1197,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1307,15 +1265,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1382,15 +1331,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([
@@ -1466,15 +1406,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         blowoutLocation: DEST_WELL_BLOWOUT_DESTINATION,
       }
 
-      const mixCommandsWithDelay = [
-        aspirateHelper('A1', 35),
-        delayCommand(11),
-        dispenseHelper('A1', 35, {
-          labware: SOURCE_LABWARE,
-          offsetFromBottomMm: ASPIRATE_OFFSET_FROM_BOTTOM_MM,
-        }),
-        delayCommand(12),
-      ]
       const result = distribute(args, invariantContext, robotStateWithTip)
       const res = getSuccessResult(result)
       expect(res.commands).toEqual([

--- a/protocol-designer/src/step-generation/__tests__/distribute.test.js
+++ b/protocol-designer/src/step-generation/__tests__/distribute.test.js
@@ -888,11 +888,11 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
+        blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip
-        // skip blowout into trash b/c we're about to drop tip anyway
         dropTipHelper('A1'),
       ])
     })
@@ -934,11 +934,11 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-        // since we used dispense > air gap, drop the tip
-        // skip blowout into trash b/c we're about to drop tip anyway
+        blowoutSingleToTrash,
+        // dispense => air gap since we are about to change the tip
         airGapHelper('A3', 3, { labware: DEST_LABWARE }), // need to air gap here
         delayCommand(11),
-        // just drop the tip in the trash
+        // since we used dispense > air gap, drop the tip
         dropTipHelper('A1'),
         // next chunk from A1: remaining volume
         pickUpTipHelper('B1'),
@@ -959,6 +959,7 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
+        blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
         delayCommand(11),
@@ -1005,7 +1006,6 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A3', DEST_LABWARE),
         // touch tip (disp #2)
         touchTipHelper('A3', { labware: DEST_LABWARE }),
-        // chunk NOT ending in a tip change, so we must blowout to trash
         blowoutSingleToTrash,
         // skip dispense => air gap since we are reusing the tip
         // mix (asp)
@@ -1025,8 +1025,8 @@ describe('advanced settings: volume, mix, pre-wet tip, tip touch, tip position',
         ...delayWithOffset('A4', DEST_LABWARE),
         // touch tip (disp #3)
         touchTipHelper('A4', { labware: DEST_LABWARE }),
+        blowoutSingleToTrash,
         // use the dispense > air gap here before moving to trash
-        // skip blowout into trash b/c we're about to drop tip anyway
         airGapHelper('A4', 3, { labware: DEST_LABWARE }),
         delayCommand(11),
         // since we used dispense > air gap, drop the tip

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -2589,8 +2589,8 @@ describe('advanced options', () => {
           command: 'airGap',
           params: {
             pipette: 'p300SingleId',
-            labware: 'destPlateId',
-            well: 'B1',
+            labware: 'sourcePlateId',
+            well: 'A1',
             flowRate: 2.1,
             offsetFromBottomMm: 11.54,
             volume: 3,
@@ -2822,8 +2822,8 @@ describe('advanced options', () => {
           command: 'airGap',
           params: {
             pipette: 'p300SingleId',
-            labware: 'destPlateId',
-            well: 'B1',
+            labware: 'sourcePlateId',
+            well: 'A1',
             volume: 3,
             flowRate: 2.1,
             offsetFromBottomMm: 11.54,

--- a/protocol-designer/src/step-generation/__tests__/transfer.test.js
+++ b/protocol-designer/src/step-generation/__tests__/transfer.test.js
@@ -1326,6 +1326,16 @@ describe('advanced options', () => {
             offsetFromBottomMm: 3.4,
           },
         },
+        {
+          command: 'blowout',
+          params: {
+            flowRate: 2.3,
+            labware: 'trashId',
+            offsetFromBottomMm: 80.3,
+            pipette: 'p300SingleId',
+            well: 'A1',
+          },
+        },
         // use the dispense > air gap here before moving to trash
         {
           command: 'airGap',
@@ -1345,7 +1355,6 @@ describe('advanced options', () => {
           },
         },
         // since we used dispense > air gap, drop the tip
-        // skip blowout into trash b/c we're about to drop tip anyway
         {
           command: 'dropTip',
           params: {

--- a/protocol-designer/src/step-generation/__tests__/utils.test.js
+++ b/protocol-designer/src/step-generation/__tests__/utils.test.js
@@ -21,6 +21,9 @@ import {
   AIR,
   repeatArray,
   makeInitialRobotState,
+  getDispenseAirGapLocation,
+  SOURCE_WELL_BLOWOUT_DESTINATION,
+  DEST_WELL_BLOWOUT_DESTINATION,
 } from '../utils/misc'
 import { thermocyclerStateDiff } from '../utils/thermocyclerStateDiff'
 import { FIXED_TRASH_ID } from '../__fixtures__'
@@ -663,6 +666,55 @@ describe('thermocyclerPipetteColision', () => {
       expect(thermocyclerPipetteCollision(modules, labware, labwareId)).toBe(
         expected
       )
+    })
+  })
+})
+
+describe('getDispenseAirGapLocation', () => {
+  let sourceLabware
+  let destLabware
+  let sourceWell
+  let destWell
+  beforeEach(() => {
+    sourceLabware = 'sourceLabware'
+    destLabware = 'destLabware'
+    sourceWell = 'sourceWell'
+    destWell = 'destWell'
+  })
+  it('should return destination when blowout location is NOT source', () => {
+    const locations = [
+      DEST_WELL_BLOWOUT_DESTINATION,
+      FIXED_TRASH_ID,
+      'some_rando_location',
+    ]
+    expect.assertions(locations.length)
+    locations.forEach(blowoutLocation => {
+      expect(
+        getDispenseAirGapLocation({
+          blowoutLocation,
+          sourceLabware,
+          destLabware,
+          sourceWell,
+          destWell,
+        })
+      ).toEqual({
+        dispenseAirGapLabware: destLabware,
+        dispenseAirGapWell: destWell,
+      })
+    })
+  })
+  it('should return source when blowout location is source', () => {
+    expect(
+      getDispenseAirGapLocation({
+        blowoutLocation: SOURCE_WELL_BLOWOUT_DESTINATION,
+        sourceLabware,
+        destLabware,
+        sourceWell,
+        destWell,
+      })
+    ).toEqual({
+      dispenseAirGapLabware: sourceLabware,
+      dispenseAirGapWell: sourceWell,
     })
   })
 })

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -22,7 +22,7 @@ import {
   curryCommandCreator,
   reduceCommandCreators,
   blowoutUtil,
-  SOURCE_WELL_BLOWOUT_DESTINATION,
+  getDispenseAirGapLocation,
 } from '../../utils'
 import type {
   DistributeArgs,
@@ -286,13 +286,16 @@ export const distribute: CommandCreator<DistributeArgs> = (
         moreWellsRemaining = true
       }
 
-      let dispenseAirGapLabware = args.destLabware
-      let dispenseAirGapWell = last(destWellChunk)
-
-      if (blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION) {
-        dispenseAirGapLabware = args.sourceLabware
-        dispenseAirGapWell = args.sourceWell
-      }
+      const {
+        dispenseAirGapLabware,
+        dispenseAirGapWell,
+      } = getDispenseAirGapLocation({
+        blowoutLocation,
+        sourceLabware: args.sourceLabware,
+        destLabware: args.destLabware,
+        sourceWell: args.sourceWell,
+        destWell: last(destWellChunk),
+      })
 
       const airGapAfterDispenseCommands =
         dispenseAirGapVolume &&

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -3,7 +3,7 @@ import chunk from 'lodash/chunk'
 import flatMap from 'lodash/flatMap'
 import last from 'lodash/last'
 import { getWellDepth } from '@opentrons/shared-data'
-import { AIR_GAP_OFFSET_FROM_TOP, FIXED_TRASH_ID } from '../../../constants'
+import { AIR_GAP_OFFSET_FROM_TOP } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -6,7 +6,6 @@ import { getWellDepth } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP, FIXED_TRASH_ID } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
-import { SOURCE_WELL_BLOWOUT_DESTINATION } from '../../utils/misc'
 import {
   airGap,
   aspirate,
@@ -23,6 +22,7 @@ import {
   curryCommandCreator,
   reduceCommandCreators,
   blowoutUtil,
+  SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
 import type {
   DistributeArgs,

--- a/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/distribute.js
@@ -311,7 +311,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             sourceWell: args.sourceWell,
             destLabwareId: args.destLabware,
             destWell: last(destWellChunk),
-            blowoutLocation: blowoutLocation,
+            blowoutLocation,
             flowRate: args.blowoutFlowRateUlSec,
             offsetFromTopMm: args.blowoutOffsetFromTopMm,
             invariantContext,

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -9,6 +9,7 @@ import {
   blowoutUtil,
   curryCommandCreator,
   reduceCommandCreators,
+  SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
 import {
   airGap,
@@ -356,14 +357,22 @@ export const transfer: CommandCreator<TransferArgs> = (
           }
           // TODO(IL, 2020-10-12): extract this ^ into a util to reuse in distribute/consolidate??
 
+          let dispenseAirGapLabware = args.destLabware
+          let dispenseAirGapWell = destWell
+
+          if (args.blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION) {
+            dispenseAirGapLabware = args.sourceLabware
+            dispenseAirGapWell = sourceWell
+          }
+
           const airGapAfterDispenseCommands =
             dispenseAirGapVolume && !willReuseTip
               ? [
                   curryCommandCreator(airGap, {
                     pipette: args.pipette,
                     volume: dispenseAirGapVolume,
-                    labware: args.destLabware,
-                    well: destWell,
+                    labware: dispenseAirGapLabware,
+                    well: dispenseAirGapWell,
                     flowRate: aspirateFlowRateUlSec,
                     offsetFromBottomMm: airGapOffsetDestWell,
                   }),

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -399,21 +399,17 @@ export const transfer: CommandCreator<TransferArgs> = (
               ? [curryCommandCreator(dropTip, { pipette: args.pipette })]
               : []
 
-          const blowoutCommand =
-            dropTipAfterDispenseAirGap.length > 0 &&
-            args.blowoutLocation === FIXED_TRASH_ID
-              ? [] // skip blowout it's in the trash we're replacing the tip due to dispense > air gap
-              : blowoutUtil({
-                  pipette: args.pipette,
-                  sourceLabwareId: args.sourceLabware,
-                  sourceWell: sourceWell,
-                  destLabwareId: args.destLabware,
-                  destWell: destWell,
-                  blowoutLocation: args.blowoutLocation,
-                  flowRate: blowoutFlowRateUlSec,
-                  offsetFromTopMm: blowoutOffsetFromTopMm,
-                  invariantContext,
-                })
+          const blowoutCommand = blowoutUtil({
+            pipette: args.pipette,
+            sourceLabwareId: args.sourceLabware,
+            sourceWell: sourceWell,
+            destLabwareId: args.destLabware,
+            destWell: destWell,
+            blowoutLocation: args.blowoutLocation,
+            flowRate: blowoutFlowRateUlSec,
+            offsetFromTopMm: blowoutOffsetFromTopMm,
+            invariantContext,
+          })
 
           const nextCommands = [
             ...tipCommands,

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -8,8 +8,8 @@ import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
   blowoutUtil,
   curryCommandCreator,
+  getDispenseAirGapLocation,
   reduceCommandCreators,
-  SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
 import {
   airGap,
@@ -357,13 +357,16 @@ export const transfer: CommandCreator<TransferArgs> = (
           }
           // TODO(IL, 2020-10-12): extract this ^ into a util to reuse in distribute/consolidate??
 
-          let dispenseAirGapLabware = args.destLabware
-          let dispenseAirGapWell = destWell
-
-          if (args.blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION) {
-            dispenseAirGapLabware = args.sourceLabware
-            dispenseAirGapWell = sourceWell
-          }
+          const {
+            dispenseAirGapLabware,
+            dispenseAirGapWell,
+          } = getDispenseAirGapLocation({
+            blowoutLocation: args.blowoutLocation,
+            sourceLabware: args.sourceLabware,
+            destLabware: args.destLabware,
+            sourceWell,
+            destWell,
+          })
 
           const airGapAfterDispenseCommands =
             dispenseAirGapVolume && !willReuseTip

--- a/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
+++ b/protocol-designer/src/step-generation/commandCreators/compound/transfer.js
@@ -2,7 +2,7 @@
 import assert from 'assert'
 import zip from 'lodash/zip'
 import { getWellDepth } from '@opentrons/shared-data'
-import { AIR_GAP_OFFSET_FROM_TOP, FIXED_TRASH_ID } from '../../../constants'
+import { AIR_GAP_OFFSET_FROM_TOP } from '../../../constants'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {

--- a/protocol-designer/src/step-generation/types.js
+++ b/protocol-designer/src/step-generation/types.js
@@ -129,11 +129,9 @@ export type DistributeArgs = {|
 
   /** Disposal volume is added to the volume of the first aspirate of each asp-asp-disp cycle */
   disposalVolume: ?number,
-  /** Disposal labware and well for final blowout destination of disposalVolume contents (e.g. trash, source well, etc.) */
-  disposalLabware: ?string,
-  disposalWell: ?string,
-
   /** pass to blowout **/
+  /** If given, blow out in the specified destination after dispense at the end of each asp-dispense cycle */
+  blowoutLocation: ?string,
   blowoutFlowRateUlSec: number,
   blowoutOffsetFromTopMm: number,
 

--- a/protocol-designer/src/step-generation/utils/misc.js
+++ b/protocol-designer/src/step-generation/utils/misc.js
@@ -277,6 +277,29 @@ export function createTipLiquidState<T>(
   )
 }
 
+// always return destination unless the blowout location is the source
+export const getDispenseAirGapLocation = (args: {|
+  blowoutLocation: ?string,
+  sourceLabware: string,
+  destLabware: string,
+  sourceWell: string,
+  destWell: string,
+|}): {|
+  dispenseAirGapLabware: string,
+  dispenseAirGapWell: string,
+|} => {
+  const {
+    blowoutLocation,
+    sourceLabware,
+    destLabware,
+    sourceWell,
+    destWell,
+  } = args
+  return blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION
+    ? { dispenseAirGapLabware: sourceLabware, dispenseAirGapWell: sourceWell }
+    : { dispenseAirGapLabware: destLabware, dispenseAirGapWell: destWell }
+}
+
 // NOTE: pipettes have no tips, tiprack are full
 export function makeInitialRobotState(args: {|
   invariantContext: InvariantContext,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -1,7 +1,7 @@
 // @flow
 import assert from 'assert'
 import { getWellsDepth } from '@opentrons/shared-data'
-import { SOURCE_WELL_BLOWOUT_DESTINATION } from '../../../step-generation/utils'
+import { DEST_WELL_BLOWOUT_DESTINATION } from '../../../step-generation/utils'
 import {
   DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
   DEFAULT_MM_FROM_BOTTOM_DISPENSE,
@@ -216,9 +216,9 @@ export const moveLiquidFormToArgs = (
   assert(
     !(
       path === 'multiDispense' &&
-      blowoutLocation === SOURCE_WELL_BLOWOUT_DESTINATION
+      blowoutLocation === DEST_WELL_BLOWOUT_DESTINATION
     ),
-    'blowout location for multiDispense cannot be source well'
+    'blowout location for multiDispense cannot be destination well'
   )
 
   switch (path) {

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.js
@@ -102,14 +102,9 @@ export const moveLiquidFormToArgs = (
     }
   }
 
-  let disposalVolume = null
-  if (fields.disposalVolume_checkbox || fields.blowout_checkbox) {
-    if (fields.disposalVolume_checkbox) {
-      // the disposal volume is only relevant when disposalVolume is checked,
-      // not when just blowout is checked.
-      disposalVolume = fields.disposalVolume_volume
-    }
-  }
+  const disposalVolume = fields.disposalVolume_checkbox
+    ? fields.disposalVolume_volume
+    : null
 
   const touchTipAfterAspirate = Boolean(fields.aspirate_touchTip_checkbox)
 
@@ -251,8 +246,8 @@ export const moveLiquidFormToArgs = (
         ...commonFields,
         commandCreatorFnName: 'distribute',
         disposalVolume,
-        // TODO: Ian 2019-01-15 these args have TODOs to get renamed, let's do it after deleting Distribute step
-        blowoutLocation,
+        // distribute needs blowout location field because disposal volume checkbox might be checked without blowout checkbox being checked
+        blowoutLocation: fields.blowout_location,
         mixBeforeAspirate,
         sourceWell: sourceWells[0],
         destWells,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
@@ -10,10 +10,7 @@ import {
   getMixData,
   type HydratedMoveLiquidFormData,
 } from '../moveLiquidFormToArgs'
-import {
-  DEST_WELL_BLOWOUT_DESTINATION,
-  SOURCE_WELL_BLOWOUT_DESTINATION,
-} from '../../../../step-generation/utils'
+import { DEST_WELL_BLOWOUT_DESTINATION } from '../../../../step-generation/utils'
 import { getOrderedWells } from '../../../utils'
 jest.mock('../../../utils')
 jest.mock('assert')

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.js
@@ -350,13 +350,13 @@ describe('move liquid step form -> command creator args', () => {
           ...hydratedForm.fields,
           ...disposalVolumeFields,
           blowout_checkbox: true,
-          blowout_location: SOURCE_WELL_BLOWOUT_DESTINATION,
+          blowout_location: DEST_WELL_BLOWOUT_DESTINATION,
         },
       })
 
       expect(assert).toHaveBeenCalledWith(
         false,
-        'blowout location for multiDispense cannot be source well'
+        'blowout location for multiDispense cannot be destination well'
       )
     })
 

--- a/protocol-designer/src/steplist/generateSubstepItem.js
+++ b/protocol-designer/src/steplist/generateSubstepItem.js
@@ -78,9 +78,7 @@ function getCommandCreatorForTransferlikeSubsteps(
       blowoutOffsetFromTopMm: stepArgs.blowoutOffsetFromTopMm,
       commandCreatorFnName: stepArgs.commandCreatorFnName,
       destWells: stepArgs.destWells,
-      disposalLabware: stepArgs.disposalLabware,
       disposalVolume: stepArgs.disposalVolume,
-      disposalWell: stepArgs.disposalWell,
       sourceWell: stepArgs.sourceWell,
       // set special values for substeps
       mixBeforeAspirate: null,


### PR DESCRIPTION
# Overview
This PR adds dispense air gap commands to the distribute compound command creator. 

closes #6510 

# Changelog
- Adds dispense air gap commands to the distribute compound command creator. 

# Review requests
- Code review
- Try to follow the tests, I'm pretty sure I covered every possibility but take your time reading through

# Risk assessment

Medium, noodles around with a compound command creator (responsible for actually generating commands to be fed into the robot)