### PR TITLE
refactor(app): checks pip offset cal data before showing clear deck cal warning

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -123,6 +123,9 @@ export function CalibrationCard(props: Props): React.Node {
     Calibration.DECK_CAL_STATUS_IDENTITY,
   ].includes(deckCalStatus)
 
+  const pipOffsetDataPresent = pipetteOffsetCalibrations
+    ? pipetteOffsetCalibrations.length > 0
+    : false
   return (
     <Card>
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_BASELINE}>
@@ -160,6 +163,7 @@ export function CalibrationCard(props: Props): React.Node {
         disabledReason={buttonDisabledReason}
         deckCalStatus={deckCalStatus}
         deckCalData={deckCalData}
+        pipOffsetDataPresent={pipOffsetDataPresent}
       />
       <PipetteOffsets pipettesPageUrl={pipettesPageUrl} robot={robot} />
     </Card>

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -182,7 +182,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
     cancel: cancelStart,
   } = useConditionalConfirm(() => {
     handleStartDeckCalSession()
-  }, true)
+  }, !!pipOffsetDataPresent)
 
   let warningType = null
   if (deckCalStatus && deckCalStatus !== Calibration.DECK_CAL_STATUS_OK) {

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -79,10 +79,17 @@ export type Props = {|
   disabledReason: string | null,
   deckCalStatus: DeckCalibrationStatus | null,
   deckCalData: DeckCalibrationData | null,
+  pipOffsetDataPresent: boolean,
 |}
 
 export function DeckCalibrationControl(props: Props): React.Node {
-  const { robotName, disabledReason, deckCalStatus, deckCalData } = props
+  const {
+    robotName,
+    disabledReason,
+    deckCalStatus,
+    deckCalData,
+    pipOffsetDataPresent,
+  } = props
 
   const [showWizard, setShowWizard] = React.useState(false)
   const [targetProps, tooltipProps] = useHoverTooltip()
@@ -220,7 +227,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
           </Text>
         )}
       </TitledControl>
-      {showConfirmStart && (
+      {showConfirmStart && pipOffsetDataPresent && (
         <Portal level="top">
           <ConfirmStartDeckCalModal
             confirm={confirmStart}

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -80,6 +80,7 @@ describe('DeckCalibrationControl', () => {
           disabledReason={disabledReason}
           deckCalStatus={deckCalStatus}
           deckCalData={deckCalData}
+          pipOffsetDataPresent={true}
         />,
         {
           wrappingComponent: Provider,

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -73,6 +73,7 @@ describe('DeckCalibrationControl', () => {
             markedAt: '',
           },
         },
+        pipOffsetDataPresent = true,
       } = props
       return mount(
         <DeckCalibrationControl
@@ -80,7 +81,7 @@ describe('DeckCalibrationControl', () => {
           disabledReason={disabledReason}
           deckCalStatus={deckCalStatus}
           deckCalData={deckCalData}
-          pipOffsetDataPresent={true}
+          pipOffsetDataPresent={pipOffsetDataPresent}
         />,
         {
           wrappingComponent: Provider,
@@ -142,6 +143,21 @@ describe('DeckCalibrationControl', () => {
     expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(true)
 
     getConfirmDeckCalButton(wrapper).invoke('onClick')()
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith({
+      ...Sessions.ensureSession(
+        'robot-name',
+        Sessions.SESSION_TYPE_DECK_CALIBRATION
+      ),
+      meta: expect.objectContaining({ requestId: expect.any(String) }),
+    })
+  })
+
+  it('button launches new deck calibration immediately without rendering ConfirmStartDeckCalModal', () => {
+    const wrapper = render({ pipOffsetDataPresent: false })
+    getDeckCalButton(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmStartDeckCalModal').exists()).toBe(false)
 
     expect(mockStore.dispatch).toHaveBeenCalledWith({
       ...Sessions.ensureSession(


### PR DESCRIPTION
Currently, even if you don't have any pipette offset data stored on the robot, a warning would show up telling you that starting deck cal will wipe all pipette offset and tip length data. 

This PR updates this so that the warning modal only shows up if pip offset data are detected.