### PR TITLE
feat(app,robot-server): Retry cal actions

### DIFF
--- a/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
+++ b/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
@@ -1,7 +1,13 @@
 // @flow
 import * as React from 'react'
 
-import { AlertModal, FONT_WEIGHT_BOLD, Text } from '@opentrons/components'
+import {
+  AlertModal,
+  FONT_WEIGHT_SEMIBOLD,
+  Text,
+  SecondaryBtn,
+} from '@opentrons/components'
+import styles from './styles.css'
 
 export type ConfirmCrashRecoveryModalProps = {|
   back: () => mixed,
@@ -15,9 +21,9 @@ const HEADING = 'Start Over?'
 const MAIN_BODY = 'Starting over will cancel your calibration progress.'
 const CANCEL = 'cancel'
 const START_OVER = 'yes, start over'
-const CONFIRM_AND_START_OVER = 'confirm tip placement in a1 and start over'
+const CONFIRM_AND_START_OVER = 'tip placed in a1, start over'
 const buildTiprackRequest: (string, string) => string = (displayName, slot) =>
-  `Please put another tip in position A1 of the ${displayName} in slot ${slot}`
+  `Please put another tip in position A1 of the ${displayName} in slot ${slot}.`
 
 export function ConfirmCrashRecoveryModal(
   props: ConfirmCrashRecoveryModalProps
@@ -33,11 +39,14 @@ export function ConfirmCrashRecoveryModal(
   return (
     <AlertModal
       heading={HEADING}
+      className={styles.confirm_crash_modal}
       buttons={[
-        { children: CANCEL, onClick: back },
+        { Component: SecondaryBtn, children: CANCEL, onClick: back },
         {
+          Component: SecondaryBtn,
           children: requiresNewTip ? CONFIRM_AND_START_OVER : START_OVER,
           onClick: confirm,
+          width: '20rem',
         },
       ]}
       alertOverlay
@@ -45,7 +54,7 @@ export function ConfirmCrashRecoveryModal(
     >
       <Text>{MAIN_BODY}</Text>
       {requiresNewTip && (
-        <Text fontWeight={FONT_WEIGHT_BOLD}>
+        <Text fontWeight={FONT_WEIGHT_SEMIBOLD}>
           {buildTiprackRequest(tipRackDisplayName, tipRackSlot)}
         </Text>
       )}

--- a/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
+++ b/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
@@ -1,0 +1,54 @@
+// @flow
+import * as React from 'react'
+
+import { AlertModal, FONT_WEIGHT_BOLD, Text } from '@opentrons/components'
+
+export type ConfirmCrashRecoveryModalProps = {|
+  back: () => mixed,
+  confirm: () => mixed,
+  tipRackDisplayName: string,
+  tipRackSlot: string,
+  requiresNewTip: boolean,
+|}
+
+const HEADING = 'Start Over?'
+const MAIN_BODY = 'Starting over will cancel your calibration progress.'
+const CANCEL = 'cancel'
+const START_OVER = 'yes, start over'
+const CONFIRM_AND_START_OVER = 'confirm tip placement in a1 and start over'
+const buildTiprackRequest: (string, string) => string = (displayName, slot) =>
+  `Please put another tip in position A1 of the ${displayName} in slot ${slot}`
+
+export function ConfirmCrashRecoveryModal(
+  props: ConfirmCrashRecoveryModalProps
+): React.Node {
+  const {
+    back,
+    confirm,
+    tipRackDisplayName,
+    tipRackSlot,
+    requiresNewTip,
+  } = props
+
+  return (
+    <AlertModal
+      heading={HEADING}
+      buttons={[
+        { children: CANCEL, onClick: back },
+        {
+          children: requiresNewTip ? CONFIRM_AND_START_OVER : START_OVER,
+          onClick: confirm,
+        },
+      ]}
+      alertOverlay
+      iconName={null}
+    >
+      <Text>{MAIN_BODY}</Text>
+      {requiresNewTip && (
+        <Text fontWeight={FONT_WEIGHT_BOLD}>
+          {buildTiprackRequest(tipRackDisplayName, tipRackSlot)}
+        </Text>
+      )}
+    </AlertModal>
+  )
+}

--- a/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
+++ b/app/src/components/CalibrationPanels/ConfirmCrashRecoveryModal.js
@@ -46,7 +46,7 @@ export function ConfirmCrashRecoveryModal(
           Component: SecondaryBtn,
           children: requiresNewTip ? CONFIRM_AND_START_OVER : START_OVER,
           onClick: confirm,
-          width: '20rem',
+          width: '17rem',
         },
       ]}
       alertOverlay

--- a/app/src/components/CalibrationPanels/MeasureNozzle.js
+++ b/app/src/components/CalibrationPanels/MeasureNozzle.js
@@ -27,6 +27,7 @@ import * as Sessions from '../../sessions'
 import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
 import type { CalibrationPanelProps } from './types'
 
+import { useConfirmCrashRecovery } from './useConfirmCrashRecovery'
 import { formatJogVector } from './utils'
 import leftMultiBlockAsset from '../../assets/videos/tip-length-cal/Left_Multi_CalBlock_NO_TIP_(330x260)REV1.webm'
 import leftMultiTrashAsset from '../../assets/videos/tip-length-cal/Left_Multi_Trash_NO_TIP_(330x260)REV1.webm'
@@ -109,6 +110,11 @@ export function MeasureNozzle(props: CalibrationPanelProps): React.Node {
     )
   }
 
+  const [confirmLink, confirmModal] = useConfirmCrashRecovery({
+    requiresNewTip: false,
+    ...props,
+  })
+
   return (
     <>
       <Flex
@@ -166,6 +172,8 @@ export function MeasureNozzle(props: CalibrationPanelProps): React.Node {
           </PrimaryBtn>
         </Flex>
       </Flex>
+      {confirmLink}
+      {confirmModal}
     </>
   )
 }

--- a/app/src/components/CalibrationPanels/MeasureTip.js
+++ b/app/src/components/CalibrationPanels/MeasureTip.js
@@ -25,6 +25,7 @@ import * as Sessions from '../../sessions'
 import { JogControls } from '../JogControls'
 import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
 import type { CalibrationPanelProps } from '../CalibrationPanels/types'
+import { useConfirmCrashRecovery } from './useConfirmCrashRecovery'
 import { formatJogVector } from '../CalibrationPanels/utils'
 import leftMultiBlockAsset from '../../assets/videos/tip-length-cal/Left_Multi_CalBlock_WITH_TIP_(330x260)REV1.webm'
 import leftMultiTrashAsset from '../../assets/videos/tip-length-cal/Left_Multi_Trash_WITH_TIP_(330x260)REV1.webm'
@@ -123,6 +124,10 @@ export function MeasureTip(props: CalibrationPanelProps): React.Node {
   }
 
   const proceed = isExtendedPipOffset ? proceedPipetteOffset : proceedTipLength
+  const [confirmLink, confirmModal] = useConfirmCrashRecovery({
+    requiresNewTip: true,
+    ...props,
+  })
 
   return (
     <>
@@ -181,6 +186,8 @@ export function MeasureTip(props: CalibrationPanelProps): React.Node {
           </PrimaryBtn>
         </Flex>
       </Flex>
+      {confirmLink}
+      {confirmModal}
     </>
   )
 }

--- a/app/src/components/CalibrationPanels/MeasureTip.js
+++ b/app/src/components/CalibrationPanels/MeasureTip.js
@@ -186,7 +186,7 @@ export function MeasureTip(props: CalibrationPanelProps): React.Node {
           </PrimaryBtn>
         </Flex>
       </Flex>
-      {confirmLink}
+      <Box width="100%">{confirmLink}</Box>
       {confirmModal}
     </>
   )

--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -26,6 +26,7 @@ import type {
 } from '../../sessions/types'
 import { JogControls } from '../JogControls'
 import { formatJogVector } from './utils'
+import { useConfirmCrashRecovery } from './useConfirmCrashRecovery'
 
 import slot1LeftMultiDemoAsset from '../../assets/videos/cal-movement/SLOT_1_LEFT_MULTI_X-Y.webm'
 import slot1LeftSingleDemoAsset from '../../assets/videos/cal-movement/SLOT_1_LEFT_SINGLE_X-Y.webm'
@@ -153,6 +154,11 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
     sendCommands(...commands)
   }
 
+  const [confirmLink, confirmModal] = useConfirmCrashRecovery({
+    requiresNewTip: true,
+    ...props,
+  })
+
   return (
     <>
       <Text
@@ -208,6 +214,8 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
           {buttonText}
         </PrimaryBtn>
       </Flex>
+      {confirmLink}
+      {confirmModal}
     </>
   )
 }

--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 import {
+  Box,
   PrimaryBtn,
   Flex,
   Text,
@@ -214,7 +215,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
           {buttonText}
         </PrimaryBtn>
       </Flex>
-      {confirmLink}
+      <Box width="100%">{confirmLink}</Box>
       {confirmModal}
     </>
   )

--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { css } from 'styled-components'
 import {
   PrimaryBtn,
+  Box,
   Flex,
   Text,
   FONT_WEIGHT_SEMIBOLD,
@@ -154,7 +155,7 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
           {buttonText}
         </PrimaryBtn>
       </Flex>
-      {confirmLink}
+      <Box width="100%">{confirmLink}</Box>
       {confirmModal}
     </>
   )

--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -23,6 +23,7 @@ import type { JogAxis, JogDirection, JogStep } from '../../http-api-client'
 import type { CalibrationPanelProps } from './types'
 import { JogControls } from '../JogControls'
 import { formatJogVector } from './utils'
+import { useConfirmCrashRecovery } from './useConfirmCrashRecovery'
 
 import slot5LeftMultiDemoAsset from '../../assets/videos/cal-movement/SLOT_5_LEFT_MULTI_Z.webm'
 import slot5LeftSingleDemoAsset from '../../assets/videos/cal-movement/SLOT_5_LEFT_SINGLE_Z.webm'
@@ -94,6 +95,11 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
     )
   }
 
+  const [confirmLink, confirmModal] = useConfirmCrashRecovery({
+    requiresNewTip: true,
+    ...props,
+  })
+
   return (
     <>
       <Text
@@ -148,6 +154,8 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
           {buttonText}
         </PrimaryBtn>
       </Flex>
+      {confirmLink}
+      {confirmModal}
     </>
   )
 }

--- a/app/src/components/CalibrationPanels/TipPickUp.js
+++ b/app/src/components/CalibrationPanels/TipPickUp.js
@@ -13,6 +13,7 @@ import {
   FONT_SIZE_BODY_2,
   JUSTIFY_CENTER,
   POSITION_RELATIVE,
+  SPACING_1,
   SPACING_2,
   SPACING_3,
   TEXT_ALIGN_CENTER,
@@ -90,11 +91,12 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
 
   return (
     <Flex
-      marginY={SPACING_2}
+      marginTop={SPACING_2}
       flexDirection={DIRECTION_COLUMN}
       alignItems={ALIGN_FLEX_START}
       position={POSITION_RELATIVE}
       width="100%"
+      marginBottom="0"
     >
       <Text
         css={FONT_HEADER_DARK}
@@ -153,7 +155,9 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
           {TIP_PICK_UP_BUTTON_TEXT}
         </PrimaryBtn>
       </Flex>
-      {confirmLink}
+      <Box marginTop={SPACING_1} marginBottom="0" width="100%">
+        {confirmLink}
+      </Box>
       {confirmModal}
     </Flex>
   )

--- a/app/src/components/CalibrationPanels/TipPickUp.js
+++ b/app/src/components/CalibrationPanels/TipPickUp.js
@@ -29,6 +29,8 @@ import { JogControls } from '../JogControls'
 import type { CalibrationPanelProps } from './types'
 import { formatJogVector } from './utils'
 
+import { useConfirmCrashRecovery } from './useConfirmCrashRecovery'
+
 import multiDemoAsset from '../../assets/videos/tip-pick-up/A1_Multi_Channel_REV1.webm'
 import singleDemoAsset from '../../assets/videos/tip-pick-up/A1_Single_Channel_REV1.webm'
 
@@ -81,6 +83,10 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
       },
     })
   }
+  const [confirmLink, confirmModal] = useConfirmCrashRecovery({
+    requiresNewTip: false,
+    ...props,
+  })
 
   return (
     <Flex
@@ -147,6 +153,8 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
           {TIP_PICK_UP_BUTTON_TEXT}
         </PrimaryBtn>
       </Flex>
+      {confirmLink}
+      {confirmModal}
     </Flex>
   )
 }

--- a/app/src/components/CalibrationPanels/TipPickUp.js
+++ b/app/src/components/CalibrationPanels/TipPickUp.js
@@ -90,75 +90,77 @@ export function TipPickUp(props: CalibrationPanelProps): React.Node {
   })
 
   return (
-    <Flex
-      marginTop={SPACING_2}
-      flexDirection={DIRECTION_COLUMN}
-      alignItems={ALIGN_FLEX_START}
-      position={POSITION_RELATIVE}
-      width="100%"
-      marginBottom="0"
-    >
-      <Text
-        css={FONT_HEADER_DARK}
-        marginBottom={SPACING_3}
-        textTransform={TEXT_TRANSFORM_UPPERCASE}
-      >
-        {TIP_PICK_UP_HEADER}
-        {tipRackDef
-          ? getLabwareDisplayName(tipRackDef).replace('µL', 'uL')
-          : null}
-      </Text>
-      <Box
-        padding={SPACING_3}
-        border={BORDER_SOLID_LIGHT}
-        borderWidth="2px"
+    <>
+      <Flex
+        marginTop={SPACING_2}
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_FLEX_START}
+        position={POSITION_RELATIVE}
         width="100%"
+        marginBottom="0"
       >
-        <Flex
-          justifyContent={JUSTIFY_CENTER}
-          flexDirection={DIRECTION_COLUMN}
-          alignItems={ALIGN_CENTER}
-          textAlign={TEXT_ALIGN_CENTER}
+        <Text
+          css={FONT_HEADER_DARK}
+          marginBottom={SPACING_3}
+          textTransform={TEXT_TRANSFORM_UPPERCASE}
         >
-          <Text fontSize={FONT_SIZE_BODY_2} paddingX={SPACING_2}>
-            {jogUntilAbove}
-          </Text>
-          <Text
-            fontSize={FONT_SIZE_BODY_2}
-            marginBottom={SPACING_3}
-            paddingX={SPACING_2}
+          {TIP_PICK_UP_HEADER}
+          {tipRackDef
+            ? getLabwareDisplayName(tipRackDef).replace('µL', 'uL')
+            : null}
+        </Text>
+        <Box
+          padding={SPACING_3}
+          border={BORDER_SOLID_LIGHT}
+          borderWidth="2px"
+          width="100%"
+        >
+          <Flex
+            justifyContent={JUSTIFY_CENTER}
+            flexDirection={DIRECTION_COLUMN}
+            alignItems={ALIGN_CENTER}
+            textAlign={TEXT_ALIGN_CENTER}
           >
-            <Text as="strong">{` ${TIP_WELL_NAME} `}</Text>
-            {`${POSITION} ${AND}`}
-            <Text as="strong">{` ${FLUSH} `}</Text>
-            {WITH_TOP_OF_TIP}
-          </Text>
-          <Box marginLeft={SPACING_3}>
-            <video
-              key={demoAsset}
-              css={css`
-                max-width: 100%;
-                max-height: 15rem;
-              `}
-              autoPlay={true}
-              loop={true}
-              controls={false}
+            <Text fontSize={FONT_SIZE_BODY_2} paddingX={SPACING_2}>
+              {jogUntilAbove}
+            </Text>
+            <Text
+              fontSize={FONT_SIZE_BODY_2}
+              marginBottom={SPACING_3}
+              paddingX={SPACING_2}
             >
-              <source src={demoAsset} />
-            </video>
-          </Box>
+              <Text as="strong">{` ${TIP_WELL_NAME} `}</Text>
+              {`${POSITION} ${AND}`}
+              <Text as="strong">{` ${FLUSH} `}</Text>
+              {WITH_TOP_OF_TIP}
+            </Text>
+            <Box marginLeft={SPACING_3}>
+              <video
+                key={demoAsset}
+                css={css`
+                  max-width: 100%;
+                  max-height: 15rem;
+                `}
+                autoPlay={true}
+                loop={true}
+                controls={false}
+              >
+                <source src={demoAsset} />
+              </video>
+            </Box>
+          </Flex>
+        </Box>
+        <JogControls jog={jog} />
+        <Flex width="100%" justifyContent={JUSTIFY_CENTER}>
+          <PrimaryBtn onClick={pickUpTip} flex="1" marginX={SPACING_5}>
+            {TIP_PICK_UP_BUTTON_TEXT}
+          </PrimaryBtn>
         </Flex>
-      </Box>
-      <JogControls jog={jog} />
-      <Flex width="100%" justifyContent={JUSTIFY_CENTER}>
-        <PrimaryBtn onClick={pickUpTip} flex="1" marginX={SPACING_5}>
-          {TIP_PICK_UP_BUTTON_TEXT}
-        </PrimaryBtn>
+        <Box marginTop={SPACING_1} marginBottom="0" width="100%">
+          {confirmLink}
+        </Box>
       </Flex>
-      <Box marginTop={SPACING_1} marginBottom="0" width="100%">
-        {confirmLink}
-      </Box>
       {confirmModal}
-    </Flex>
+    </>
   )
 }

--- a/app/src/components/CalibrationPanels/__tests__/ConfirmCrashRecoveryModal.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/ConfirmCrashRecoveryModal.test.js
@@ -14,9 +14,7 @@ describe('ConfirmCrashRecoveryModal', () => {
   const getNoTipRestartButton = wrapper =>
     wrapper.find('OutlineButton[children="yes, start over"]')
   const getReplaceTipRestartButton = wrapper =>
-    wrapper.find(
-      'OutlineButton[children="confirm tip placement in a1 and start over"]'
-    )
+    wrapper.find('OutlineButton[children="tip placed in a1, start over"]')
 
   beforeEach(() => {
     render = (

--- a/app/src/components/CalibrationPanels/__tests__/ConfirmCrashRecoveryModal.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/ConfirmCrashRecoveryModal.test.js
@@ -1,0 +1,95 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { ConfirmCrashRecoveryModal } from '../ConfirmCrashRecoveryModal'
+
+describe('ConfirmCrashRecoveryModal', () => {
+  let render
+  const mockBack = jest.fn()
+  const mockConfirm = jest.fn()
+
+  const getExitButton = wrapper =>
+    wrapper.find('OutlineButton[children="cancel"]')
+  const getNoTipRestartButton = wrapper =>
+    wrapper.find('OutlineButton[children="yes, start over"]')
+  const getReplaceTipRestartButton = wrapper =>
+    wrapper.find(
+      'OutlineButton[children="confirm tip placement in a1 and start over"]'
+    )
+
+  beforeEach(() => {
+    render = (
+      props: $Shape<React.ElementProps<typeof ConfirmCrashRecoveryModal>> = {}
+    ) => {
+      const {
+        back = mockBack,
+        confirm = mockConfirm,
+        tipRackDisplayName = 'tipRackName',
+        tipRackSlot = '8',
+        requiresNewTip = true,
+      } = props
+      return mount(
+        <ConfirmCrashRecoveryModal
+          back={back}
+          confirm={confirm}
+          tipRackDisplayName={tipRackDisplayName}
+          tipRackSlot={tipRackSlot}
+          requiresNewTip={requiresNewTip}
+        />
+      )
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('clicking cancel cancels', () => {
+    const wrapper = render()
+    expect(getExitButton(wrapper).exists()).toBe(true)
+    getExitButton(wrapper).invoke('onClick')()
+    wrapper.update()
+
+    expect(mockBack).toHaveBeenCalled()
+  })
+
+  it('has a working button with the right text when no tip placement needed', () => {
+    const wrapper = render({ requiresNewTip: false })
+
+    expect(getNoTipRestartButton(wrapper).exists()).toBe(true)
+    getNoTipRestartButton(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(mockConfirm).toHaveBeenCalled()
+  })
+
+  it('has a working button with the right text when tip placement needed', () => {
+    const wrapper = render({ requiresNewTip: true })
+    expect(getReplaceTipRestartButton(wrapper).exists()).toBe(true)
+    getReplaceTipRestartButton(wrapper).invoke('onClick')()
+    wrapper.update()
+
+    expect(mockConfirm).toHaveBeenCalled()
+  })
+
+  it('renders no request to replace tip when not needed', () => {
+    const wrapper = render({ requiresNewTip: false })
+    expect(wrapper.html()).toMatch(
+      /starting over will cancel your calibration progress/i
+    )
+    expect(wrapper.html()).not.toMatch(/please put another tip in position a1/i)
+  })
+
+  it('renders a request to replace tip with specified name if needed', () => {
+    const wrapper = render({
+      requiresNewTip: true,
+      tipRackSlot: '4',
+      tipRackDisplayName: 'my tip rack',
+    })
+    expect(wrapper.html()).toMatch(
+      /starting over will cancel your calibration progress/i
+    )
+    expect(wrapper.html()).toMatch(/please put another tip in position a1/i)
+    expect(wrapper.html()).toMatch(/my tip rack/i)
+    expect(wrapper.html()).toMatch(/slot 4/i)
+  })
+})

--- a/app/src/components/CalibrationPanels/__tests__/MeasureNozzle.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/MeasureNozzle.test.js
@@ -53,6 +53,18 @@ describe('MeasureNozzle', () => {
     jest.resetAllMocks()
   })
 
+  it('renders the confirm crash link', () => {
+    const wrapper = render()
+    expect(wrapper.find('a[children="Start over"]').exists()).toBe(true)
+  })
+
+  it('renders the confirm crash modal when invoked', () => {
+    const wrapper = render()
+    wrapper.find('a[children="Start over"]').invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmCrashRecoveryModal').exists()).toBe(true)
+  })
+
   it('allows jogging in z axis', () => {
     const wrapper = render()
 

--- a/app/src/components/CalibrationPanels/__tests__/MeasureTip.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/MeasureTip.test.js
@@ -53,6 +53,18 @@ describe('MeasureTip', () => {
     jest.resetAllMocks()
   })
 
+  it('renders the confirm crash link', () => {
+    const wrapper = render()
+    expect(wrapper.find('a[children="Start over"]').exists()).toBe(true)
+  })
+
+  it('renders the confirm crash modal when invoked', () => {
+    const wrapper = render()
+    wrapper.find('a[children="Start over"]').invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmCrashRecoveryModal').exists()).toBe(true)
+  })
+
   it('allows jogging in z axis', () => {
     const wrapper = render()
 

--- a/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveXYPoint.test.js
@@ -221,4 +221,16 @@ describe('SaveXYPoint', () => {
       command: Sessions.sharedCalCommands.SAVE_OFFSET,
     })
   })
+
+  it('renders the confirm crash link', () => {
+    const wrapper = render()
+    expect(wrapper.find('a[children="Start over"]').exists()).toBe(true)
+  })
+
+  it('renders the confirm crash modal when invoked', () => {
+    const wrapper = render()
+    wrapper.find('a[children="Start over"]').invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmCrashRecoveryModal').exists()).toBe(true)
+  })
 })

--- a/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
@@ -131,4 +131,16 @@ describe('SaveZPoint', () => {
     expect(allText).toContain('remember z-axis and move to slot 1')
     expect(allText).toContain('z-axis in slot 5')
   })
+
+  it('renders the confirm crash link', () => {
+    const wrapper = render()
+    expect(wrapper.find('a[children="Start over"]').exists()).toBe(true)
+  })
+
+  it('renders the confirm crash modal when invoked', () => {
+    const wrapper = render()
+    wrapper.find('a[children="Start over"]').invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmCrashRecoveryModal').exists()).toBe(true)
+  })
 })

--- a/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/TipPickUp.test.js
@@ -78,4 +78,16 @@ describe('TipPickUp', () => {
       command: Sessions.sharedCalCommands.PICK_UP_TIP,
     })
   })
+
+  it('renders the confirm crash link', () => {
+    const wrapper = render()
+    expect(wrapper.find('a[children="Start over"]').exists()).toBe(true)
+  })
+
+  it('renders the confirm crash modal when invoked', () => {
+    const wrapper = render()
+    wrapper.find('a[children="Start over"]').invoke('onClick')()
+    wrapper.update()
+    expect(wrapper.find('ConfirmCrashRecoveryModal').exists()).toBe(true)
+  })
 })

--- a/app/src/components/CalibrationPanels/__tests__/useConfirmCrashRecovery.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/useConfirmCrashRecovery.test.js
@@ -1,0 +1,95 @@
+// @flow
+
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { useConfirmCrashRecovery } from '../useConfirmCrashRecovery'
+import type { Props } from '../useConfirmCrashRecovery'
+import type { CalibrationLabware } from '../../../sessions/types'
+import type {
+  LabwareDefinition2,
+  LabwareMetadata,
+} from '@opentrons/shared-data'
+
+describe('useConfirmCrashRecovery', () => {
+  let render
+  const mockSendCommands = jest.fn()
+  const mockTipRack: $Shape<CalibrationLabware> = {
+    slot: '4',
+    definition: ({
+      metadata: ({
+        displayName: 'my tiprack',
+      }: $Shape<LabwareMetadata>),
+    }: $Shape<LabwareDefinition2>),
+  }
+
+  const getStarterLink = wrapper => wrapper.find('a')
+  const getModal = wrapper => wrapper.find('ConfirmCrashRecoveryModal')
+  const getExitButton = wrapper =>
+    wrapper.find('OutlineButton[children="cancel"]')
+  const getRestartButton = wrapper => wrapper.find('OutlineButton').at(1)
+
+  const TestUseConfirmCrashRecovery = (props: $Shape<Props>) => {
+    const {
+      requiresNewTip = false,
+      sendCommands = mockSendCommands,
+      tipRack = mockTipRack,
+    } = props
+    const [starterText, maybeModal] = useConfirmCrashRecovery({
+      ...props,
+      requiresNewTip: requiresNewTip,
+      sendCommands: sendCommands,
+      tipRack: tipRack,
+    })
+    return (
+      <>
+        {starterText}
+        {maybeModal}
+      </>
+    )
+  }
+  beforeEach(() => {
+    render = (props: $Shape<Props> = {}) => {
+      return mount(<TestUseConfirmCrashRecovery {...props} />)
+    }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders the starter link text', () => {
+    const wrapper = render()
+    expect(getStarterLink(wrapper).exists()).toBe(true)
+  })
+
+  it('renders the modal with the right props when you click the link', () => {
+    const wrapper = render()
+    getStarterLink(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(getModal(wrapper).exists()).toBe(true)
+    expect(getModal(wrapper).prop('requiresNewTip')).toBe(false)
+    expect(getModal(wrapper).prop('tipRackSlot')).toEqual('4')
+    expect(getModal(wrapper).prop('tipRackDisplayName')).toEqual('my tiprack')
+  })
+
+  it('invokes invalidate_last_action when you click confirm', () => {
+    const wrapper = render()
+    getStarterLink(wrapper).invoke('onClick')()
+    wrapper.update()
+    getRestartButton(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(mockSendCommands).toHaveBeenCalledWith({
+      command: 'calibration.invalidateLastAction',
+    })
+  })
+
+  it('stops rendering the modal when you click cancel', () => {
+    const wrapper = render()
+    getStarterLink(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(getModal(wrapper).exists()).toBe(true)
+    getExitButton(wrapper).invoke('onClick')()
+    wrapper.update()
+    expect(getModal(wrapper).exists()).toBe(false)
+  })
+})

--- a/app/src/components/CalibrationPanels/styles.css
+++ b/app/src/components/CalibrationPanels/styles.css
@@ -9,3 +9,8 @@
   flex-direction: column;
   justify-content: flex-end;
 }
+
+.confirm_crash_modal {
+  padding: 1rem;
+  max-width: 64rem;
+}

--- a/app/src/components/CalibrationPanels/useConfirmCrashRecovery.js
+++ b/app/src/components/CalibrationPanels/useConfirmCrashRecovery.js
@@ -1,0 +1,67 @@
+// @flow
+
+import * as React from 'react'
+import { css } from 'styled-components'
+
+import { getLabwareDisplayName } from '@opentrons/shared-data'
+
+import * as Sessions from '../../sessions'
+import {
+  Flex,
+  Text,
+  JUSTIFY_CENTER,
+  FONT_SIZE_BODY_1,
+  C_BLUE,
+} from '@opentrons/components'
+
+import { ConfirmCrashRecoveryModal } from './ConfirmCrashRecoveryModal'
+
+import type { CalibrationPanelProps } from './types'
+
+const CONDITION = 'Jog too far or bend a tip?'
+const START_OVER = 'Start over'
+
+export type Props = {|
+  requiresNewTip: boolean,
+  ...CalibrationPanelProps,
+|}
+
+export function useConfirmCrashRecovery(
+  props: Props
+): [React.Node, React.Node] {
+  const { sendCommands, tipRack, requiresNewTip } = props
+  const [showModal, setShowModal] = React.useState(false)
+
+  const doStartOver = () => {
+    sendCommands({ command: Sessions.sharedCalCommands.INVALIDATE_LAST_ACTION })
+  }
+  return [
+    <Flex key="crash-recovery-link" justifyContent={JUSTIFY_CENTER}>
+      <Text fontSize={FONT_SIZE_BODY_1}>{CONDITION}</Text>
+      &nbsp;
+      <Text
+        fontSize={FONT_SIZE_BODY_1}
+        color={C_BLUE}
+        as="a"
+        onClick={() => setShowModal(true)}
+        css={css`
+          cursor: pointer;
+        `}
+      >
+        {START_OVER}
+      </Text>
+    </Flex>,
+    showModal ? (
+      <ConfirmCrashRecoveryModal
+        key="crash-recovery-modal"
+        confirm={doStartOver}
+        back={() => {
+          setShowModal(false)
+        }}
+        tipRackDisplayName={getLabwareDisplayName(tipRack.definition)}
+        tipRackSlot={tipRack.slot}
+        requiresNewTip={requiresNewTip}
+      />
+    ) : null,
+  ]
+}

--- a/app/src/sessions/common-calibration/constants.js
+++ b/app/src/sessions/common-calibration/constants.js
@@ -16,6 +16,8 @@ const SAVE_OFFSET: 'calibration.saveOffset' = 'calibration.saveOffset'
 const SET_CALIBRATION_BLOCK: 'calibration.setHasCalibrationBlock' =
   'calibration.setHasCalibrationBlock'
 const EXIT: 'calibration.exitSession' = 'calibration.exitSession'
+const INVALIDATE_LAST_ACTION: 'calibration.invalidateLastAction' =
+  'calibration.invalidateLastAction'
 
 export const sharedCalCommands = {
   LOAD_LABWARE,
@@ -29,5 +31,6 @@ export const sharedCalCommands = {
   MOVE_TO_REFERENCE_POINT,
   SAVE_OFFSET,
   SET_CALIBRATION_BLOCK,
+  INVALIDATE_LAST_ACTION,
   EXIT,
 }

--- a/robot-server/robot_server/robot/calibration/deck/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/deck/state_machine.py
@@ -19,6 +19,7 @@ DECK_CALIBRATION_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
         CalibrationCommand.jog: State.preparingPipette,
         CalibrationCommand.pick_up_tip: State.inspectingTip,
         CalibrationCommand.move_to_tip_rack: State.preparingPipette,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.inspectingTip: {
         CalibrationCommand.invalidate_tip: State.preparingPipette,
@@ -28,21 +29,25 @@ DECK_CALIBRATION_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
         CalibrationCommand.jog: State.joggingToDeck,
         CalibrationCommand.save_offset: State.joggingToDeck,
         CalibrationCommand.move_to_point_one: State.savingPointOne,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.savingPointOne: {
         CalibrationCommand.jog: State.savingPointOne,
         CalibrationCommand.save_offset: State.savingPointOne,
-        DeckCalCommand.move_to_point_two: State.savingPointTwo
+        DeckCalCommand.move_to_point_two: State.savingPointTwo,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.savingPointTwo: {
         CalibrationCommand.jog: State.savingPointTwo,
         CalibrationCommand.save_offset: State.savingPointTwo,
-        DeckCalCommand.move_to_point_three: State.savingPointThree
+        DeckCalCommand.move_to_point_three: State.savingPointThree,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.savingPointThree: {
         CalibrationCommand.jog: State.savingPointThree,
         CalibrationCommand.save_offset: State.savingPointThree,
-        CalibrationCommand.move_to_tip_rack: State.calibrationComplete
+        CalibrationCommand.move_to_tip_rack: State.calibrationComplete,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.WILDCARD: {
         CalibrationCommand.exit: State.sessionExited

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -334,6 +334,6 @@ class DeckCalibrationUserFlow:
         if self._current_state != State.preparingPipette:
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'
-            await self._move(trash['A1'].top())
+            await uf.move(self, trash['A1'].top(), CriticalPoint.XY_CENTER)
             await self.hardware.drop_tip(self.mount)
         await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -99,6 +99,7 @@ class DeckCalibrationUserFlow:
             DeckCalibrationCommand.move_to_point_two: self.move_to_point_two,
             DeckCalibrationCommand.move_to_point_three: self.move_to_point_three,  # noqa: E501
             CalibrationCommand.exit: self.exit_session,
+            CalibrationCommand.invalidate_last_action: self.invalidate_last_action,  # noqa: E501
         }
 
     @property
@@ -212,7 +213,6 @@ class DeckCalibrationUserFlow:
         """
         next_state = self._state_machine.get_next_state(self._current_state,
                                                         name)
-
         handler = self._command_map.get(name)
         if handler is not None:
             await handler(**data)
@@ -327,3 +327,9 @@ class DeckCalibrationUserFlow:
         # reload new deck calibration
         self._hardware.reset_robot_calibration()
         await self._hardware.home()
+
+    async def invalidate_last_action(self):
+        await self.hardware.home()
+        if self._current_state != State.preparingPipette:
+            await self.hardware.drop_tip(self.mount)
+        await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -331,5 +331,8 @@ class DeckCalibrationUserFlow:
     async def invalidate_last_action(self):
         await self.hardware.home()
         if self._current_state != State.preparingPipette:
+            trash = self._deck.get_fixed_trash()
+            assert trash, 'Bad deck setup'
+            await self._move(trash['A1'].top())
             await self.hardware.drop_tip(self.mount)
         await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -330,6 +330,7 @@ class DeckCalibrationUserFlow:
 
     async def invalidate_last_action(self):
         await self.hardware.home()
+        await self._hardware.gantry_position(self.mount, refresh=True)
         if self._current_state != State.preparingPipette:
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -22,6 +22,7 @@ PIP_OFFSET_CAL_TRANSITIONS: PipetteOffsetTransitions = {
     POCState.preparingPipette: {
         CalibrationCommand.jog: POCState.preparingPipette,
         CalibrationCommand.pick_up_tip: POCState.inspectingTip,
+        CalibrationCommand.invalidate_last_action: POCState.preparingPipette,
     },
     POCState.inspectingTip: {
         CalibrationCommand.invalidate_tip: POCState.preparingPipette,
@@ -31,10 +32,12 @@ PIP_OFFSET_CAL_TRANSITIONS: PipetteOffsetTransitions = {
         CalibrationCommand.jog: POCState.joggingToDeck,
         CalibrationCommand.save_offset: POCState.joggingToDeck,
         CalibrationCommand.move_to_point_one: POCState.savingPointOne,
+        CalibrationCommand.invalidate_last_action: POCState.preparingPipette,
     },
     POCState.savingPointOne: {
         CalibrationCommand.jog: POCState.savingPointOne,
         CalibrationCommand.save_offset: POCState.calibrationComplete,
+        CalibrationCommand.invalidate_last_action: POCState.preparingPipette,
     },
     POCState.calibrationComplete: {
         CalibrationCommand.move_to_tip_rack: POCState.calibrationComplete,
@@ -55,11 +58,14 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
     POWTState.measuringNozzleOffset: {
         CalibrationCommand.save_offset: POWTState.measuringNozzleOffset,
         CalibrationCommand.jog: POWTState.measuringNozzleOffset,
-        CalibrationCommand.move_to_tip_rack: POWTState.preparingPipette
+        CalibrationCommand.move_to_tip_rack: POWTState.preparingPipette,
+        CalibrationCommand.invalidate_last_action:
+            POWTState.measuringNozzleOffset,
     },
     POWTState.preparingPipette: {
         CalibrationCommand.jog: POWTState.preparingPipette,
         CalibrationCommand.pick_up_tip: POWTState.inspectingTip,
+        CalibrationCommand.invalidate_last_action: POWTState.preparingPipette,
     },
     POWTState.inspectingTip: {
         CalibrationCommand.invalidate_tip: POWTState.preparingPipette,
@@ -68,7 +74,8 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
     },
     POWTState.measuringTipOffset: {
         CalibrationCommand.jog: POWTState.measuringTipOffset,
-        CalibrationCommand.save_offset: POWTState.tipLengthComplete
+        CalibrationCommand.save_offset: POWTState.tipLengthComplete,
+        CalibrationCommand.invalidate_last_action: POWTState.preparingPipette,
     },
     POWTState.tipLengthComplete: {
         CalibrationCommand.set_has_calibration_block:
@@ -79,10 +86,12 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
         CalibrationCommand.jog: POWTState.joggingToDeck,
         CalibrationCommand.save_offset: POWTState.joggingToDeck,
         CalibrationCommand.move_to_point_one: POWTState.savingPointOne,
+        CalibrationCommand.invalidate_last_action: POWTState.preparingPipette,
     },
     POWTState.savingPointOne: {
         CalibrationCommand.jog: POWTState.savingPointOne,
         CalibrationCommand.save_offset: POWTState.calibrationComplete,
+        CalibrationCommand.invalidate_last_action: POWTState.preparingPipette,
     },
     POWTState.calibrationComplete: {
         CalibrationCommand.move_to_tip_rack: POWTState.calibrationComplete,

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -445,7 +445,7 @@ class PipetteOffsetCalibrationUserFlow:
             await self._hardware.gantry_position(self.mount, refresh=True)
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'
-            await self._move(trash['A1'].top())
+            await util.move(self, trash['A1'].top(), CriticalPoint.XY_CENTER)
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -130,7 +130,7 @@ class PipetteOffsetCalibrationUserFlow:
                 self.set_has_calibration_block,
             CalibrationCommand.exit: self.exit_session,
             CalibrationCommand.invalidate_last_action:
-               self.invalidate_last_action,
+                self.invalidate_last_action,
         }
 
     @property

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -433,9 +433,16 @@ class PipetteOffsetCalibrationUserFlow:
     async def invalidate_last_action(self):
         if self._current_state == POWTState.measuringNozzleOffset:
             await self._hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
             await self.move_to_reference_point()
+        elif self._current_state == self._state.preparingPipette:
+            self.reset_tip_origin()
+            await self._hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
+            await self.move_to_tip_rack()
         else:
             await self.hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'
             await self._move(trash['A1'].top())

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -129,6 +129,8 @@ class PipetteOffsetCalibrationUserFlow:
             CalibrationCommand.set_has_calibration_block:
                 self.set_has_calibration_block,
             CalibrationCommand.exit: self.exit_session,
+            CalibrationCommand.invalidate_last_action:
+               self.invalidate_last_action,
         }
 
     @property
@@ -427,6 +429,15 @@ class PipetteOffsetCalibrationUserFlow:
             deck=self._deck,
             has_calibration_block=self._has_calibration_block)
         await self._move(ref_loc)
+
+    async def invalidate_last_action(self):
+        if self._current_state == POWTState.measuringNozzleOffset:
+            await self._hardware.home()
+            await self.move_to_reference_point()
+        else:
+            await self.hardware.home()
+            await self.hardware.drop_tip(self.mount)
+            await self.move_to_tip_rack()
 
     async def pick_up_tip(self):
         await util.pick_up_tip(self, tip_length=self._get_tip_length())

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -436,6 +436,9 @@ class PipetteOffsetCalibrationUserFlow:
             await self.move_to_reference_point()
         else:
             await self.hardware.home()
+            trash = self._deck.get_fixed_trash()
+            assert trash, 'Bad deck setup'
+            await self._move(trash['A1'].top())
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()
 

--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -20,11 +20,13 @@ TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
     State.measuringNozzleOffset: {
         CalibrationCommand.save_offset: State.measuringNozzleOffset,
         CalibrationCommand.jog: State.measuringNozzleOffset,
-        CalibrationCommand.move_to_tip_rack: State.preparingPipette
+        CalibrationCommand.move_to_tip_rack: State.preparingPipette,
+        CalibrationCommand.invalidate_last_action: State.measuringNozzleOffset,
     },
     State.preparingPipette: {
         CalibrationCommand.jog: State.preparingPipette,
         CalibrationCommand.pick_up_tip: State.inspectingTip,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.inspectingTip: {
         CalibrationCommand.invalidate_tip: State.preparingPipette,
@@ -33,7 +35,8 @@ TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
     State.measuringTipOffset: {
         CalibrationCommand.save_offset: State.measuringTipOffset,
         CalibrationCommand.jog: State.measuringTipOffset,
-        CalibrationCommand.move_to_tip_rack: State.calibrationComplete
+        CalibrationCommand.move_to_tip_rack: State.calibrationComplete,
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.WILDCARD: {
         CalibrationCommand.exit: State.sessionExited

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -255,12 +255,15 @@ class TipCalibrationUserFlow:
     async def invalidate_last_action(self):
         if self._current_state == State.measuringNozzleOffset:
             await self.hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
             await self.move_to_reference_point()
         elif self._current_state == State.preparingPipette:
             await self.hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
             await self.move_to_tip_rack()
         else:
             await self.hardware.home()
+            await self._hardware.gantry_position(self.mount, refresh=True)
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'
             await self._move(trash['A1'].top())

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -266,6 +266,6 @@ class TipCalibrationUserFlow:
             await self._hardware.gantry_position(self.mount, refresh=True)
             trash = self._deck.get_fixed_trash()
             assert trash, 'Bad deck setup'
-            await self._move(trash['A1'].top())
+            await util.move(self, trash['A1'].top(), CriticalPoint.XY_CENTER)
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -261,5 +261,8 @@ class TipCalibrationUserFlow:
             await self.move_to_tip_rack()
         else:
             await self.hardware.home()
+            trash = self._deck.get_fixed_trash()
+            assert trash, 'Bad deck setup'
+            await self._move(trash['A1'].top())
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -76,6 +76,7 @@ class TipCalibrationUserFlow:
             CalibrationCommand.save_offset: self.save_offset,
             CalibrationCommand.move_to_reference_point: self.move_to_reference_point,  # noqa: E501
             CalibrationCommand.move_to_tip_rack: self.move_to_tip_rack,  # noqa: E501
+            CalibrationCommand.invalidate_last_action: self.invalidate_last_action,  # noqa: E501
             CalibrationCommand.exit: self.exit_session,
         }
 
@@ -250,3 +251,15 @@ class TipCalibrationUserFlow:
 
     async def _move(self, to_loc: Location):
         await util.move(self, to_loc)
+
+    async def invalidate_last_action(self):
+        if self._current_state == State.measuringNozzleOffset:
+            await self.hardware.home()
+            await self.move_to_reference_point()
+        elif self._current_state == State.preparingPipette:
+            await self.hardware.home()
+            await self.move_to_tip_rack()
+        else:
+            await self.hardware.home()
+            await self.hardware.drop_tip(self.mount)
+            await self.move_to_tip_rack()

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -3,6 +3,7 @@ from typing import Set, Dict, Any, Union, TYPE_CHECKING
 
 from opentrons.hardware_control import Pipette
 from opentrons.hardware_control.util import plan_arc
+from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.geometry.deck import Deck
@@ -136,10 +137,12 @@ async def return_tip(user_flow: CalibrationUserFlow, tip_length: float):
         await user_flow.hardware.drop_tip(user_flow.mount)
 
 
-async def move(user_flow: CalibrationUserFlow, to_loc: Location):
+async def move(user_flow: CalibrationUserFlow,
+               to_loc: Location,
+               this_move_cp: CriticalPoint = None):
     from_pt = await user_flow.get_current_point(None)
     from_loc = Location(from_pt, None)
-    cp = user_flow.critical_point_override
+    cp = this_move_cp or user_flow.critical_point_override
 
     max_height = user_flow.hardware.get_instrument_max_height(
         user_flow.mount)

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -185,6 +185,7 @@ class CalibrationCommand(CommandDefinition):
     invalidate_tip = "invalidateTip"
     save_offset = "saveOffset"
     exit = "exitSession"
+    invalidate_last_action = "invalidateLastAction"
 
     @staticmethod
     def namespace():

--- a/robot-server/tests/robot/calibration/deck/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/deck/test_state_machine.py
@@ -34,6 +34,11 @@ valid_commands: List[Tuple[str, str, str]] = [
     (CalCommand.exit, 'savingPointOne', 'sessionExited'),
     (CalCommand.exit, 'savingPointTwo', 'sessionExited'),
     (CalCommand.exit, 'savingPointThree', 'sessionExited'),
+    (CalCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
+    (CalCommand.invalidate_last_action, 'joggingToDeck', 'preparingPipette'),
+    (CalCommand.invalidate_last_action, 'savingPointOne', 'preparingPipette'),
+    (CalCommand.invalidate_last_action, 'savingPointTwo', 'preparingPipette'),
+    (CalCommand.invalidate_last_action, 'savingPointThree', 'preparingPipette'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/deck/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/deck/test_state_machine.py
@@ -34,11 +34,13 @@ valid_commands: List[Tuple[str, str, str]] = [
     (CalCommand.exit, 'savingPointOne', 'sessionExited'),
     (CalCommand.exit, 'savingPointTwo', 'sessionExited'),
     (CalCommand.exit, 'savingPointThree', 'sessionExited'),
-    (CalCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
+    (CalCommand.invalidate_last_action,
+     'preparingPipette', 'preparingPipette'),
     (CalCommand.invalidate_last_action, 'joggingToDeck', 'preparingPipette'),
     (CalCommand.invalidate_last_action, 'savingPointOne', 'preparingPipette'),
     (CalCommand.invalidate_last_action, 'savingPointTwo', 'preparingPipette'),
-    (CalCommand.invalidate_last_action, 'savingPointThree', 'preparingPipette'),
+    (CalCommand.invalidate_last_action,
+     'savingPointThree', 'preparingPipette'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
@@ -3,37 +3,107 @@ from typing import List, Tuple
 
 from robot_server.service.session.models.command import\
   CalibrationCommand
-from robot_server.robot.calibration.pipette_offset.state_machine import \
-    PipetteOffsetCalibrationStateMachine
+from robot_server.robot.calibration.pipette_offset.state_machine import (
+    PipetteOffsetCalibrationStateMachine,
+    PipetteOffsetWithTipLengthStateMachine)
 
-valid_commands: List[Tuple[str, str, str]] = [
-  (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-  (CalibrationCommand.move_to_tip_rack, 'labwareLoaded', 'preparingPipette'),
-  (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-  (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-  (CalibrationCommand.move_to_deck, 'inspectingTip', 'joggingToDeck'),
-  (CalibrationCommand.jog, 'joggingToDeck', 'joggingToDeck'),
-  (CalibrationCommand.save_offset, 'joggingToDeck', 'joggingToDeck'),
-  (CalibrationCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
-  (CalibrationCommand.jog, 'savingPointOne', 'savingPointOne'),
-  (CalibrationCommand.save_offset, 'savingPointOne', 'calibrationComplete'),
-  (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
-  (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
-  (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
-  (CalibrationCommand.exit, 'joggingToDeck', 'sessionExited'),
-  (CalibrationCommand.exit, 'savingPointOne', 'sessionExited'),
-  (CalibrationCommand.exit, 'inspectingTip', 'sessionExited'),
-  (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
+offset_valid_commands: List[Tuple[str, str, str]] = [
+    (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
+    (CalibrationCommand.move_to_tip_rack, 'labwareLoaded', 'preparingPipette'),
+    (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
+    (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
+    (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
+    (CalibrationCommand.move_to_deck, 'inspectingTip', 'joggingToDeck'),
+    (CalibrationCommand.jog, 'joggingToDeck', 'joggingToDeck'),
+    (CalibrationCommand.save_offset, 'joggingToDeck', 'joggingToDeck'),
+    (CalibrationCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
+    (CalibrationCommand.jog, 'savingPointOne', 'savingPointOne'),
+    (CalibrationCommand.save_offset, 'savingPointOne', 'calibrationComplete'),
+    (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
+    (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
+    (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
+    (CalibrationCommand.exit, 'joggingToDeck', 'sessionExited'),
+    (CalibrationCommand.exit, 'savingPointOne', 'sessionExited'),
+    (CalibrationCommand.exit, 'inspectingTip', 'sessionExited'),
+    (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
+    (CalibrationCommand.invalidate_last_action,
+     'preparingPipette', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'joggingToDeck', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'savingPointOne', 'preparingPipette')
 ]
 
 
 @pytest.fixture
-def state_machine():
+def offset_state_machine():
     return PipetteOffsetCalibrationStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', valid_commands)
-async def test_valid_commands(command, from_state, to_state, state_machine):
-    next_state = state_machine.get_next_state(from_state, command)
+@pytest.mark.parametrize('command,from_state,to_state', offset_valid_commands)
+async def test_valid_offset_commands(
+        command, from_state, to_state, offset_state_machine):
+    next_state = offset_state_machine.get_next_state(from_state, command)
+    assert next_state == to_state
+
+
+fused_valid_commands: List[Tuple[str, str, str]] = [
+    (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
+    (CalibrationCommand.move_to_reference_point,
+     'labwareLoaded', 'measuringNozzleOffset'),
+    (CalibrationCommand.move_to_reference_point,
+     'inspectingTip', 'measuringTipOffset'),
+    (CalibrationCommand.save_offset,
+     'measuringNozzleOffset', 'measuringNozzleOffset'),
+    (CalibrationCommand.save_offset,
+     'measuringTipOffset', 'tipLengthComplete'),
+    (CalibrationCommand.save_offset,
+     'joggingToDeck', 'joggingToDeck'),
+    (CalibrationCommand.save_offset,
+     'savingPointOne', 'calibrationComplete'),
+    (CalibrationCommand.jog, 'measuringNozzleOffset', 'measuringNozzleOffset'),
+    (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
+    (CalibrationCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
+    (CalibrationCommand.jog, 'joggingToDeck', 'joggingToDeck'),
+    (CalibrationCommand.jog, 'savingPointOne', 'savingPointOne'),
+    (CalibrationCommand.move_to_tip_rack,
+     'measuringNozzleOffset', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringNozzleOffset', 'measuringNozzleOffset'),
+    (CalibrationCommand.invalidate_last_action,
+     'preparingPipette', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringTipOffset', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'joggingToDeck', 'preparingPipette'),
+    (CalibrationCommand.invalidate_last_action,
+     'savingPointOne', 'preparingPipette'),
+    (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
+    (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
+    (CalibrationCommand.set_has_calibration_block,
+     'tipLengthComplete', 'tipLengthComplete'),
+    (CalibrationCommand.move_to_deck, 'tipLengthComplete', 'joggingToDeck'),
+    (CalibrationCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
+    (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
+    (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
+    (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
+    (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
+    (CalibrationCommand.exit, 'inspectingTip', 'sessionExited'),
+    (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
+    (CalibrationCommand.exit, 'tipLengthComplete', 'sessionExited'),
+    (CalibrationCommand.exit, 'joggingToDeck', 'sessionExited'),
+    (CalibrationCommand.exit, 'savingPointOne', 'sessionExited'),
+    (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
+]
+
+
+@pytest.fixture
+def fused_state_machine():
+    return PipetteOffsetWithTipLengthStateMachine()
+
+
+@pytest.mark.parametrize('command,from_state,to_state', fused_valid_commands)
+async def test_valid_fused_commands(
+        command, from_state, to_state, fused_state_machine):
+    next_state = fused_state_machine.get_next_state(from_state, command)
     assert next_state == to_state

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -373,7 +373,8 @@ async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
     getattr(mock_user_flow._hardware, hw_meth).assert_called()
 
 
-@pytest.mark.parametrize('command,current_state,data,hw_meth', hw_commands_fused)
+@pytest.mark.parametrize(
+    'command,current_state,data,hw_meth', hw_commands_fused)
 async def test_hw_calls_fused(
         command, current_state, data, hw_meth, mock_user_flow_fused):
     mock_user_flow_fused._current_state = current_state

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -31,10 +31,14 @@ valid_commands: List[Tuple[str, str, str]] = [
   (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
   (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
   (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
-  (CalibrationCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.invalidate_last_action, 'measuringNozzleOffset', 'measuringNozzleOffset'),
-  (CalibrationCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.invalidate_last_action, 'measuringTipOffset', 'preparingPipette'),
+  (CalibrationCommand.invalidate_last_action,
+   'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.invalidate_last_action,
+   'measuringNozzleOffset', 'measuringNozzleOffset'),
+  (CalibrationCommand.invalidate_last_action,
+   'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.invalidate_last_action,
+   'measuringTipOffset', 'preparingPipette'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -31,6 +31,10 @@ valid_commands: List[Tuple[str, str, str]] = [
   (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
   (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
   (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
+  (CalibrationCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.invalidate_last_action, 'measuringNozzleOffset', 'measuringNozzleOffset'),
+  (CalibrationCommand.invalidate_last_action, 'preparingPipette', 'preparingPipette'),
+  (CalibrationCommand.invalidate_last_action, 'measuringTipOffset', 'preparingPipette'),
 ]
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -106,6 +106,8 @@ def mock_hw(hardware):
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
     hardware.home_plunger = MagicMock(side_effect=async_mock_home_plunger)
+    hardware.drop_tip = MagicMock(side_effect=async_mock)
+    hardware.home = MagicMock(side_effect=async_mock)
     return hardware
 
 
@@ -154,6 +156,20 @@ hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
      {}, 'move_to'),
     (CalibrationCommand.move_to_tip_rack, 'measuringTipOffset',
      {}, 'move_to'),
+    (CalibrationCommand.invalidate_last_action,
+     'preparingPipette', {}, 'home'),
+    (CalibrationCommand.invalidate_last_action,
+     'preparingPipette', {}, 'move_to'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringTipOffset', {}, 'home'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringTipOffset', {}, 'drop_tip'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringTipOffset', {}, 'move_to'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringNozzleOffset', {}, 'home'),
+    (CalibrationCommand.invalidate_last_action,
+     'measuringNozzleOffset', {}, 'move_to'),
 ]
 
 


### PR DESCRIPTION
When users are jogging pipettes around during calibration, sometimes they jog too far. This PR adds machinery on both the server and client side to add nice little links in calibration screens where you jog that invalidate your last action and cause the robot to home; drop the tip, if there is one; and go back to the most recent useful place to restart the flow from (usually picking up a tip).

This is based on designs [here](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=280%3A113).

## Reviews and Testing
- Look at the state machine changes; are those transitions right?
- Is this in all the places we want?