### PR TITLE
refactor(robot-server): Only attempt to return tip when there is a tip attached to the pipette

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -322,8 +322,9 @@ class DeckCalibrationUserFlow:
         await uf.move(self, to_loc)
 
     async def exit_session(self):
-        await self.move_to_tip_rack()
-        await self.return_tip()
+        if self.hw_pipette.has_tip:
+            await self.move_to_tip_rack()
+            await self.return_tip()
         # reload new deck calibration
         self._hardware.reset_robot_calibration()
         await self._hardware.home()

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -441,8 +441,9 @@ class PipetteOffsetCalibrationUserFlow:
         await util.move(self, to_loc)
 
     async def exit_session(self):
-        await self.move_to_tip_rack()
-        await self.return_tip()
+        if self.hw_pipette.has_tip:
+            await self.move_to_tip_rack()
+            await self.return_tip()
         # reload new pipette offset data by resetting instrument
         self._hardware.reset_instrument(self._mount)
         await self._hardware.home()

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -219,8 +219,9 @@ class TipCalibrationUserFlow:
         await util.invalidate_tip(self)
 
     async def exit_session(self):
-        await self.move_to_tip_rack()
-        await self.return_tip()
+        if self.hw_pipette.has_tip:
+            await self.move_to_tip_rack()
+            await self.return_tip()
         await self._hardware.home()
 
     def _get_tip_rack_lw(self,


### PR DESCRIPTION

# Overview

Rather than always trying to return tip in the calibration flows, we should only do it if there is a tip currently attached to the pipette.

# Risk assessment

Very low. Only modifying exit behavior slightly.
