### PR TITLE
refactor(robot-server): Robot server model refactor

### DIFF
--- a/robot-server/robot_server/service/access/models.py
+++ b/robot-server/robot_server/service/access/models.py
@@ -4,8 +4,8 @@ import typing
 
 from pydantic import BaseModel, Field
 
-from robot_server.service.json_api import \
-    ResponseDataModel, ResponseModel, RequestDataModel, RequestModel
+from robot_server.service.json_api import (
+    ResponseModel, RequestModel, ResponseDataModel, MultiResponseModel)
 
 TokenType = str
 
@@ -17,14 +17,18 @@ class AccessTokenInfo(BaseModel):
         Field(..., description="When this token was created")
 
 
+class AccessTokenInfoResponse(ResponseDataModel, AccessTokenInfo):
+    pass
+
+
 AccessTokenResponse = ResponseModel[
-    ResponseDataModel[AccessTokenInfo], dict
+    AccessTokenInfoResponse
 ]
-MultipleAccessTokenResponse = ResponseModel[
-    typing.List[ResponseDataModel[AccessTokenInfo]], dict
+MultipleAccessTokenResponse = MultiResponseModel[
+    AccessTokenInfoResponse
 ]
 AccessTokenRequest = RequestModel[
-    RequestDataModel[AccessTokenInfo]
+    AccessTokenInfo
 ]
 
 

--- a/robot-server/robot_server/service/access/router.py
+++ b/robot-server/robot_server/service/access/router.py
@@ -25,12 +25,10 @@ async def create_access_token() -> access.AccessTokenResponse:
     token = secrets.token_urlsafe(nbytes=8)
     # TODO Store the token
     return access.AccessTokenResponse(
-        data=access.ResponseDataModel.create(
-            attributes=access.AccessTokenInfo(
-                token=token,
-                createdAt=utc_now()),
-            resource_id=token,
-        ))
+        data=access.AccessTokenInfoResponse(
+            id=token,
+            token=token,
+            createdAt=utc_now()))
 
 
 @router.delete("/access/tokens/{access_token}",

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -1,4 +1,4 @@
-from .request import RequestModel, RequestDataModel  # noqa(W0611)
-from .response import ResponseModel, ResponseDataModel  # noqa(W0611)
+from .request import RequestModel  # noqa(W0611)
+from .response import ResponseModel, MultiResponseModel, ResponseDataModel  # noqa(W0611)
 from .errors import Error, ErrorSource, ErrorResponse  # noqa(W0611)
 from .resource_links import ResourceLink, ResourceLinks  # noqa(W0611)

--- a/robot-server/robot_server/service/json_api/request.py
+++ b/robot-server/robot_server/service/json_api/request.py
@@ -1,43 +1,14 @@
-from typing import Generic, TypeVar, Optional
+from typing import Generic, TypeVar
 from pydantic import Field
 from pydantic.generics import GenericModel
 
 
-AttributesT = TypeVar('AttributesT')
+RequestDataT = TypeVar('RequestDataT')
 
 
-class RequestDataModel(GenericModel, Generic[AttributesT]):
+class RequestModel(GenericModel, Generic[RequestDataT]):
     """
     """
-    id: Optional[str] = \
-        Field(None,
-              description="id member represents a resource object and is not"
-                          " required when the resource object originates at"
-                          " the client and represents a new resource to be"
-                          " created on the server.")
-    type: str = \
-        Field(...,
-              description="type member is used to describe resource objects"
-                          " that share common attributes.")
-    attributes: AttributesT = \
-        Field(...,
-              description="an attributes object representing some of the"
-                          " resource’s data.")
-
-    @classmethod
-    def create(cls, attributes: AttributesT, resource_id: str = None):
-        return RequestDataModel[AttributesT](
-            id=resource_id,
-            attributes=attributes,
-            type=attributes.__class__.__name__)
-
-
-class RequestModel(GenericModel, Generic[AttributesT]):
-    """
-    """
-    data: RequestDataModel[AttributesT] = \
+    data: RequestDataT = \
         Field(...,
               description="the document’s 'primary data'")
-
-    def attributes(self):
-        return self.data.attributes

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -1,39 +1,19 @@
 from typing import Generic, TypeVar, Optional, List
-from pydantic import Field
+from pydantic import Field, BaseModel
 from pydantic.generics import GenericModel
 
 from .resource_links import ResourceLinks
 
 
-AttributesT = TypeVar('AttributesT')
-
-
-class ResponseDataModel(GenericModel, Generic[AttributesT]):
+class ResponseDataModel(BaseModel):
     """
     """
-    id: Optional[str] = \
+    id: str = \
         Field(None,
               description="id member represents a resource object.")
-    type: Optional[str] = \
-        Field(None,
-              description="type member is used to describe resource objects"
-                          " that share common attributes.")
-    attributes: AttributesT = \
-        Field({},
-              description="an attributes object representing some of the"
-                          " resource’s data.")
 
-    # Note(isk: 3/13/20): Need this to validate attribute default
-    # see here: https://pydantic-docs.helpmanual.io/usage/model_config/
-    class Config:
-        validate_all = True
 
-    @classmethod
-    def create(cls, attributes: AttributesT, resource_id: str):
-        return ResponseDataModel[AttributesT](
-            id=resource_id,
-            attributes=attributes,
-            type=attributes.__class__.__name__)
+ResponseDataT = TypeVar('ResponseDataT', bound=ResponseDataModel)
 
 
 DESCRIPTION_DATA = "the document’s 'primary data'"
@@ -43,26 +23,22 @@ DESCRIPTION_LINKS = "a links object related to the primary data."
 DESCRIPTION_META = "a meta object that contains non-standard" \
                              " meta-information."
 
-MetaT = TypeVar('MetaT')
 
-
-class ResponseModel(GenericModel, Generic[AttributesT, MetaT]):
+class ResponseModel(GenericModel, Generic[ResponseDataT]):
     """A response that returns a single resource"""
 
-    meta: Optional[MetaT] = Field(None, description=DESCRIPTION_META)
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: ResponseDataModel[AttributesT] = Field(
+    data: ResponseDataT = Field(
         ...,
         description=DESCRIPTION_DATA
     )
 
 
-class MultiResponseModel(GenericModel, Generic[AttributesT, MetaT]):
+class MultiResponseModel(GenericModel, Generic[ResponseDataT]):
     """A response that returns multiple resources"""
 
-    meta: Optional[MetaT] = Field(None, description=DESCRIPTION_META)
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: List[ResponseDataModel[AttributesT]] = Field(
+    data: List[ResponseDataT] = Field(
         ...,
         description=DESCRIPTION_DATA
     )

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from functools import partial
 from pydantic import BaseModel, Field
 
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, ResponseDataModel, MultiResponseModel)
 
 OffsetVector = typing.Tuple[float, float, float]
 
@@ -39,7 +39,7 @@ class CalibrationData(BaseModel):
         Field(..., description="The tip length of a labware, if relevant.")
 
 
-class LabwareCalibration(BaseModel):
+class LabwareCalibration(ResponseDataModel):
     """
     A model describing labware calibrations (tiplength and offset)
     """
@@ -102,9 +102,9 @@ class LabwareCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    LabwareCalibration, dict
+    LabwareCalibration
 ]
 
 SingleCalibrationResponse = ResponseModel[
-    LabwareCalibration, dict
+    LabwareCalibration
 ]

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.labware import models as lw_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 
 router = APIRouter()
 
@@ -50,16 +50,14 @@ def _format_calibrations(
         cal_data = lw_models.CalibrationData(
             offset=offset, tipLength=tip_length)
         formatted_cal = lw_models.LabwareCalibration(
+            id=calInfo.labware_id,
             calibrationData=cal_data,
             loadName=details.load_name,
             namespace=details.namespace,
             version=details.version,
             parent=parent_info,
             definitionHash=calInfo.labware_id)
-        formatted_calibrations.append(
-                ResponseDataModel.create(
-                    attributes=formatted_cal,
-                    resource_id=calInfo.labware_id))
+        formatted_calibrations.append(formatted_cal)
     return formatted_calibrations
 
 

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -2,11 +2,11 @@ import typing
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, MultiResponseModel, ResponseDataModel)
 from robot_server.service.shared_models import calibration as cal_model
 
 OffsetVector = typing.Tuple[float, float, float]
@@ -18,7 +18,7 @@ class MountType(str, Enum):
     right = "right"
 
 
-class PipetteOffsetCalibration(BaseModel):
+class PipetteOffsetCalibration(ResponseDataModel):
     """
     A model describing pipette calibration based on the mount and
     the pipette's serial number
@@ -50,10 +50,10 @@ class PipetteOffsetCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    PipetteOffsetCalibration, dict
+    PipetteOffsetCalibration
 ]
 
 
 SingleCalibrationResponse = ResponseModel[
-    PipetteOffsetCalibration, dict
+    PipetteOffsetCalibration
 ]

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -10,7 +10,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.pipette_offset import models as pip_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 from robot_server.service.shared_models import calibration as cal_model
 
 router = APIRouter()
@@ -18,10 +18,11 @@ router = APIRouter()
 
 def _format_calibration(
     calibration: cal_types.PipetteOffsetCalibration
-) -> ResponseDataModel[pip_models.PipetteOffsetCalibration]:
+) -> pip_models.PipetteOffsetCalibration:
     status = cal_model.CalibrationStatus(
         **helpers.convert_to_dict(calibration.status))
     formatted_cal = pip_models.PipetteOffsetCalibration(
+        id=f'{calibration.pipette}&{calibration.mount}',
         pipette=calibration.pipette,
         mount=calibration.mount,
         offset=calibration.offset,
@@ -31,9 +32,7 @@ def _format_calibration(
         source=calibration.source,
         status=status)
 
-    return ResponseDataModel.create(
-        attributes=formatted_cal,
-        resource_id=f'{calibration.pipette}&{calibration.mount}')
+    return formatted_cal
 
 
 @router.get(

--- a/robot-server/robot_server/service/protocol/models.py
+++ b/robot-server/robot_server/service/protocol/models.py
@@ -3,23 +3,21 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from robot_server.service.json_api import ResponseModel, ResponseDataModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, ResponseDataModel, MultiResponseModel)
 
 
 class FileAttributes(BaseModel):
     basename: str
 
 
-class ProtocolResponseAttributes(BaseModel):
+class ProtocolResponseAttributes(ResponseDataModel):
     protocolFile: FileAttributes
     supportFiles: typing.List[FileAttributes]
     lastModifiedAt: datetime
     createdAt: datetime
 
 
-ProtocolResponseDataModel = ResponseDataModel[ProtocolResponseAttributes]
+ProtocolResponse = ResponseModel[ProtocolResponseAttributes]
 
-ProtocolResponse = ResponseModel[ProtocolResponseAttributes, dict]
-
-MultiProtocolResponse = MultiResponseModel[ProtocolResponseAttributes, dict]
+MultiProtocolResponse = MultiResponseModel[ProtocolResponseAttributes]

--- a/robot-server/robot_server/service/protocol/router.py
+++ b/robot-server/robot_server/service/protocol/router.py
@@ -99,21 +99,19 @@ async def create_protocol_file(
 
 
 def _to_response(uploaded_protocol: UploadedProtocol) \
-        -> route_models.ProtocolResponseDataModel:
+        -> route_models.ProtocolResponseAttributes:
     """Create ProtocolResponse from an UploadedProtocol"""
     meta = uploaded_protocol.meta
-    return route_models.ProtocolResponseDataModel.create(
-        attributes=route_models.ProtocolResponseAttributes(
-            protocolFile=route_models.FileAttributes(
-                basename=meta.protocol_file.path.name
-            ),
-            supportFiles=[route_models.FileAttributes(
-                basename=s.path.name
-            ) for s in meta.support_files],
-            lastModifiedAt=meta.last_modified_at,
-            createdAt=meta.created_at
+    return route_models.ProtocolResponseAttributes(
+        id=meta.identifier,
+        protocolFile=route_models.FileAttributes(
+            basename=meta.protocol_file.path.name
         ),
-        resource_id=meta.identifier
+        supportFiles=[route_models.FileAttributes(
+            basename=s.path.name
+        ) for s in meta.support_files],
+        lastModifiedAt=meta.last_modified_at,
+        createdAt=meta.created_at,
     )
 
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from enum import Enum
 import typing
-from functools import lru_cache
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteName
@@ -10,7 +9,7 @@ from robot_server.service.session.models.common import (
 from pydantic import BaseModel, Field, validator
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.json_api import (
-    ResponseModel, RequestModel)
+    ResponseModel, RequestModel, ResponseDataModel)
 from opentrons.util.helpers import utc_now
 
 
@@ -32,11 +31,21 @@ class LoadLabwareRequest(BaseModel):
         description="The labware definition version")
 
 
+class LoadLabwareResponse(BaseModel):
+    labwareId: IdentifierType
+    definition: LabwareDefinition
+    calibration: OffsetVector
+
+
 class LoadInstrumentRequest(BaseModel):
     instrumentName: PipetteName = Field(
         ...,
         description="The name of the instrument model")
     mount: Mount
+
+
+class LoadInstrumentResponse(BaseModel):
+    instrumentId: IdentifierType
 
 
 class PipetteRequestBase(BaseModel):
@@ -70,16 +79,6 @@ class SetHasCalibrationBlockRequest(BaseModel):
     hasBlock: bool = Field(
         ...,
         description="whether or not there is a calibration block present")
-
-
-class LoadLabwareResponse(BaseModel):
-    labwareId: IdentifierType
-    definition: LabwareDefinition
-    calibration: OffsetVector
-
-
-class LoadInstrumentResponse(BaseModel):
-    instrumentId: IdentifierType
 
 
 class CommandStatus(str, Enum):
@@ -265,26 +264,8 @@ class BasicSessionCommand(BaseModel):
                              f"Expecting {v.model}")
         return v
 
-    @validator('command', pre=True)
-    def pre_namespace_backwards_compatibility(cls, v):
-        """Support commands that were released before namespace."""
-        # TODO: AmitL 2020.7.9. Remove this backward compatibility once
-        #  clients reliably use fully namespaced command names
-        return BasicSessionCommand._pre_namespace_mapping().get(v, v)
 
-    @staticmethod
-    @lru_cache(maxsize=1)
-    def _pre_namespace_mapping() -> typing.Dict[str, CommandDefinition]:
-        """Create a dictionary of pre-namespace name to CommandDefinition"""
-        # A tuple of CommandDefinition enums which need to be identified by
-        # localname and full namespaced name
-        pre_namespace_ns = CalibrationCheckCommand, CalibrationCommand
-        # Flatten
-        t = tuple(v for k in pre_namespace_ns for v in k)
-        return {k.localname: k for k in t}
-
-
-class SessionCommand(BasicSessionCommand):
+class SessionCommand(ResponseDataModel, BasicSessionCommand):
     """A session command response"""
     status: CommandStatus
     createdAt: datetime = Field(..., default_factory=utc_now)
@@ -298,5 +279,5 @@ CommandRequest = RequestModel[
     BasicSessionCommand
 ]
 CommandResponse = ResponseModel[
-    SessionCommand, dict
+    SessionCommand
 ]

--- a/robot-server/robot_server/service/session/models/session.py
+++ b/robot-server/robot_server/service/session/models/session.py
@@ -15,8 +15,8 @@ from robot_server.robot.calibration.pipette_offset.models import\
     PipetteOffsetCalibrationSessionStatus
 from robot_server.robot.calibration.tip_length.models import\
     TipCalibrationSessionStatus
-from robot_server.service.json_api import RequestModel, ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    RequestModel, ResponseModel, ResponseDataModel, MultiResponseModel)
 from robot_server.service.session.models.common import EmptyModel
 from robot_server.service.session.session_types.protocol.models import \
     ProtocolCreateParams, ProtocolSessionDetails
@@ -116,7 +116,7 @@ class BasicSession(BaseModel):
         return v
 
 
-class Session(BasicSession):
+class Session(ResponseDataModel, BasicSession):
     """The attributes of a created session"""
     details: SessionDetails =\
         Field(...,
@@ -131,8 +131,8 @@ SessionCreateRequest = RequestModel[
     BasicSession
 ]
 SessionResponse = ResponseModel[
-    Session, dict
+    Session
 ]
 MultiSessionResponse = MultiResponseModel[
-    Session, dict
+    Session
 ]

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -55,7 +55,8 @@ class BaseSession(ABC):
 
     def get_response_model(self) -> models.Session:
         """Get the response model"""
-        return models.Session(sessionType=self.session_type,
+        return models.Session(id=self.meta.identifier,
+                              sessionType=self.session_type,
                               details=self._get_response_details(),
                               createdAt=self.meta.created_at,
                               createParams=self.meta.create_params)

--- a/robot-server/robot_server/service/system/models.py
+++ b/robot-server/robot_server/service/system/models.py
@@ -10,8 +10,10 @@ class SystemTimeAttributes(BaseModel):
     systemTime: datetime
 
 
-SystemTimeResponseDataModel = ResponseDataModel[SystemTimeAttributes]
+class SystemTimeAttributesResponse(ResponseDataModel, SystemTimeAttributes):
+    pass
 
-SystemTimeResponse = ResponseModel[SystemTimeAttributes, dict]
+
+SystemTimeResponse = ResponseModel[SystemTimeAttributesResponse]
 
 SystemTimeRequest = RequestModel[SystemTimeAttributes]

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -19,11 +19,9 @@ def _create_response(dt: datetime) \
         -> time_models.SystemTimeResponse:
     """Create a SystemTimeResponse with system datetime"""
     return time_models.SystemTimeResponse(
-        data=time_models.SystemTimeResponseDataModel.create(
-            attributes=time_models.SystemTimeAttributes(
-                systemTime=dt
-            ),
-            resource_id="time"
+        data=time_models.SystemTimeAttributesResponse(
+                systemTime=dt,
+                id="time"
         ),
         links={
             ResourceLinkKey.self: ResourceLink(href='/system/time')
@@ -49,5 +47,5 @@ async def get_time() -> time_models.SystemTimeResponse:
             response_model=time_models.SystemTimeResponse)
 async def set_time(new_time: time_models.SystemTimeRequest) \
         -> time_models.SystemTimeResponse:
-    sys_time = await time.set_system_time(new_time.data.attributes.systemTime)
+    sys_time = await time.set_system_time(new_time.data.systemTime)
     return _create_response(sys_time)

--- a/robot-server/robot_server/service/tip_length/models.py
+++ b/robot-server/robot_server/service/tip_length/models.py
@@ -1,14 +1,14 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, MultiResponseModel, ResponseDataModel)
 from robot_server.service.shared_models import calibration as cal_model
 
 
-class TipLengthCalibration(BaseModel):
+class TipLengthCalibration(ResponseDataModel):
     """
     A model describing tip length calibration
     """
@@ -27,9 +27,9 @@ class TipLengthCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    TipLengthCalibration, dict
+    TipLengthCalibration
 ]
 
 SingleCalibrationResponse = ResponseModel[
-    TipLengthCalibration, dict
+    TipLengthCalibration
 ]

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -9,7 +9,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.tip_length import models as tl_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 from robot_server.service.shared_models import calibration as cal_model
 
 
@@ -18,10 +18,11 @@ router = APIRouter()
 
 def _format_calibration(
     calibration: cal_types.TipLengthCalibration
-) -> ResponseDataModel[tl_models.TipLengthCalibration]:
+) -> tl_models.TipLengthCalibration:
     status = cal_model.CalibrationStatus(
         **helpers.convert_to_dict(calibration.status))
     formatted_cal = tl_models.TipLengthCalibration(
+        id=f'{calibration.tiprack}&{calibration.pipette}',
         tipLength=calibration.tip_length,
         tiprack=calibration.tiprack,
         pipette=calibration.pipette,
@@ -29,9 +30,7 @@ def _format_calibration(
         source=calibration.source,
         status=status)
 
-    return ResponseDataModel.create(
-        attributes=formatted_cal,
-        resource_id=f'{calibration.tiprack}&{calibration.pipette}')
+    return formatted_cal
 
 
 @router.get(

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -16,14 +16,12 @@ stages:
       json:
         data: &response_data
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-              - basename: data.csv
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+            - basename: data.csv
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -89,13 +87,11 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles: []
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles: []
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -112,13 +108,11 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles: []
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles: []
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -137,14 +131,12 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-            - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+          - basename: 'data.csv'
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -161,14 +153,12 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-            - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+          - basename: 'data.csv'
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols'

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -43,7 +43,7 @@ stages:
       method: POST
       json:
         data:
-          command: loadLabware
+          command: calibration.loadLabware
           data: {}
     response:
       status_code: 200
@@ -64,8 +64,7 @@ stages:
       <<: *post_command
       json:
         data:
-          id: "{session_id}"
-          command: preparePipette
+          command: calibration.check.preparePipette
           data: {}
     response:
       status_code: 200
@@ -86,7 +85,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: jog
+          command: calibration.jog
           data:
             vector: [0, 0, -10]
     response:
@@ -108,7 +107,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: pickUpTip
+          command: calibration.pickUpTip
           data: {}
     response:
       status_code: 200
@@ -129,7 +128,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: confirmTip
+          command: calibration.confirmTip
           data: {}
     response:
       status_code: 200
@@ -150,7 +149,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: jog
+          command: calibration.jog
           data:
             vector: [0, 0, -10]
     response:
@@ -172,7 +171,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -195,7 +194,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -218,7 +217,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -242,7 +241,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -266,7 +265,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -291,7 +290,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -316,7 +315,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -342,7 +341,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -368,7 +367,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: jog
+          command: calibration.jog
           data:
             vector: [0, 0, -10]
     response:
@@ -395,7 +394,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: pickUpTip
+          command: calibration.pickUpTip
           data: {}
     response:
       status_code: 200
@@ -421,7 +420,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: confirmTip
+          command: calibration.confirmTip
           data: {}
     response:
       status_code: 200
@@ -447,7 +446,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -474,7 +473,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -501,7 +500,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: comparePoint
+          command: calibration.check.comparePoint
           data: {}
     response:
       status_code: 200
@@ -529,7 +528,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: goToNextCheck
+          command: calibration.check.goToNextCheck
           data: {}
     response:
       status_code: 200
@@ -607,7 +606,7 @@ stages:
       json:
         data:
           id: "{session_id}"
-          command: preparePipette
+          command: calibration.preparePipette
           data:
             vector: [1, 2, 3]
     response:
@@ -618,7 +617,7 @@ stages:
       <<: *post_command
       json:
         data:
-          command: jog
+          command: calibration.jog
           data: {}
     response:
       status_code: 422

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -12,9 +12,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
+          sessionType: calibrationCheck
     response:
       status_code: 201
       save:
@@ -30,16 +28,14 @@ stages:
         links: !anydict
         data: &session_data
           id: "{session_id}"
-          type: Session
-          attributes: &session_data_attributes
-            sessionType: calibrationCheck
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createParams: null
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instruments: !anydict
-              labware: !anylist
-              comparisonsByStep: {}
+          sessionType: calibrationCheck
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createParams: null
+          details: &session_data_details
+            currentStep: sessionStarted
+            instruments: !anydict
+            labware: !anylist
+            comparisonsByStep: {}
 
   - name: Load labware
     request: &post_command
@@ -47,10 +43,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: loadLabware
-            data: {}
+          command: loadLabware
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -61,11 +55,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: labwareLoaded
+          details:
+            <<: *session_data_details
+            currentStep: labwareLoaded
 
   - name: Prepare first pipette
     request:
@@ -73,10 +65,8 @@ stages:
       json:
         data:
           id: "{session_id}"
-          type: SessionCommand
-          attributes:
-            command: preparePipette
-            data: {}
+          command: preparePipette
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -87,22 +77,18 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingFirstPipette
+          details:
+            <<: *session_data_details
+            currentStep: preparingFirstPipette
 
   - name: Jog first pipette
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: jog
-            data:
-              vector: [0, 0, -10]
+          command: jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -113,21 +99,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingFirstPipette
+          details:
+            <<: *session_data_details
+            currentStep: preparingFirstPipette
 
   - name: Pick up tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: pickUpTip
-            data: {}
+          command: pickUpTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -138,21 +120,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: inspectingFirstTip
+          details:
+            <<: *session_data_details
+            currentStep: inspectingFirstTip
 
   - name: Confirm tip attached
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: confirmTip
-            data: {}
+          command: confirmTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -163,22 +141,18 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingFirstPipetteToHeight
+          details:
+            <<: *session_data_details
+            currentStep: joggingFirstPipetteToHeight
 
   - name: Jog first pipette to height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: jog
-            data:
-              vector: [0, 0, -10]
+          command: jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -189,21 +163,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingFirstPipetteToHeight
+          details:
+            <<: *session_data_details
+            currentStep: joggingFirstPipetteToHeight
 
   - name: Compare first pipette height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -214,23 +184,19 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingFirstPipetteHeight
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingFirstPipetteHeight
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -241,23 +207,19 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingFirstPipetteToPointOne
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: joggingFirstPipetteToPointOne
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
 
   - name: Compare first pipette point one
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -268,24 +230,20 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingFirstPipettePointOne
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingFirstPipettePointOne
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -296,24 +254,20 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingFirstPipetteToPointTwo
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: joggingFirstPipetteToPointTwo
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
 
   - name: Compare first pipette point two
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -324,25 +278,21 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingFirstPipettePointTwo
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingFirstPipettePointTwo
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -353,25 +303,21 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingFirstPipetteToPointThree
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: joggingFirstPipetteToPointThree
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
 
   - name: Compare first pipette point three
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -382,26 +328,22 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingFirstPipettePointThree
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingFirstPipettePointThree
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -412,27 +354,23 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingSecondPipette
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: preparingSecondPipette
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
 
   - name: Jog Second Pipette
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: jog
-            data:
-              vector: [0, 0, -10]
+          command: jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -443,26 +381,22 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingSecondPipette
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: preparingSecondPipette
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
 
   - name: Pick up tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: pickUpTip
-            data: {}
+          command: pickUpTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -473,26 +407,22 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: inspectingSecondTip
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: inspectingSecondTip
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
 
   - name: Confirm tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: confirmTip
-            data: {}
+          command: confirmTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -503,26 +433,22 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingSecondPipetteToHeight
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: joggingSecondPipetteToHeight
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
 
   - name: Compare second pipette to height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -533,27 +459,23 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingSecondPipetteHeight
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
-                comparingSecondPipetteHeight: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingSecondPipetteHeight
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
+              comparingSecondPipetteHeight: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -564,27 +486,23 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingSecondPipetteToPointOne
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
-                comparingSecondPipetteHeight: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: joggingSecondPipetteToPointOne
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
+              comparingSecondPipetteHeight: !anydict
 
   - name: Compare second pipette to point one
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: comparePoint
-            data: {}
+          command: comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -595,28 +513,24 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingSecondPipettePointOne
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
-                comparingSecondPipetteHeight: !anydict
-                comparingSecondPipettePointOne: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: comparingSecondPipettePointOne
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
+              comparingSecondPipetteHeight: !anydict
+              comparingSecondPipettePointOne: !anydict
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: goToNextCheck
-            data: {}
+          command: goToNextCheck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -627,18 +541,16 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: checkComplete
-              comparisonsByStep:
-                comparingFirstPipetteHeight: !anydict
-                comparingFirstPipettePointOne: !anydict
-                comparingFirstPipettePointTwo: !anydict
-                comparingFirstPipettePointThree: !anydict
-                comparingSecondPipetteHeight: !anydict
-                comparingSecondPipettePointOne: !anydict
+          details:
+            <<: *session_data_details
+            currentStep: checkComplete
+            comparisonsByStep:
+              comparingFirstPipetteHeight: !anydict
+              comparingFirstPipettePointOne: !anydict
+              comparingFirstPipettePointTwo: !anydict
+              comparingFirstPipettePointThree: !anydict
+              comparingSecondPipetteHeight: !anydict
+              comparingSecondPipettePointOne: !anydict
 
   - name: Delete the session
     request:
@@ -656,12 +568,10 @@ stages:
       json:
         data:
           - id: "default"
-            type: Session
-            attributes:
-              sessionType: default
-              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-              details: {}
-              createParams: null
+            sessionType: default
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            details: {}
+            createParams: null
 ---
 test_name: Calibration check session errors
 strict:
@@ -676,9 +586,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
+          sessionType: calibrationCheck
     response:
       status_code: 201
       save:
@@ -689,10 +597,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: loadSomething
-            data: {}
+          command: loadSomething
+          data: {}
     response:
       status_code: 422
   - name: Send a command with invalid body
@@ -701,11 +607,9 @@ stages:
       json:
         data:
           id: "{session_id}"
-          type: SessionCommand
-          attributes:
-            command: preparePipette
-            data:
-              vector: [1, 2, 3]
+          command: preparePipette
+          data:
+            vector: [1, 2, 3]
     response:
       status_code: 422
 
@@ -714,10 +618,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: jog
-            data: {}
+          command: jog
+          data: {}
     response:
       status_code: 422
 

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -12,9 +12,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: deckCalibration
+          sessionType: deckCalibration
     response:
       status_code: 201
       save:
@@ -31,15 +29,13 @@ stages:
         links: !anydict
         data: &session_data
           id: "{session_id}"
-          type: Session
-          attributes: &session_data_attributes
-            sessionType: deckCalibration
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createParams: null
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instrument: !anydict
-              labware: !anylist
+          sessionType: deckCalibration
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createParams: null
+          details: &session_data_attribute_details
+            currentStep: sessionStarted
+            instrument: !anydict
+            labware: !anylist
 
   - name: Load labware
     request: &post_command
@@ -47,10 +43,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -61,21 +55,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: labwareLoaded
+          details:
+            <<: *session_data_attribute_details
+            currentStep: labwareLoaded
 
   - name: Move to tiprack
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToTipRack
-            data: {}
+          command: calibration.moveToTipRack
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -86,21 +76,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Pick up the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -111,21 +97,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: inspectingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: inspectingTip
 
   - name: Invalidate the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.invalidateTip
-            data: {}
+          command: calibration.invalidateTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -136,21 +118,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Pick up the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 200
 
@@ -159,10 +137,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToDeck
-            data: {}
+          command: calibration.moveToDeck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -173,22 +149,18 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Jog pipette to deck
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.jog
-            data:
-              vector: [0, 0, -10]
+          command: calibration.jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -199,21 +171,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Save deck height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.saveOffset
-            data: {}
+          command: calibration.saveOffset
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -224,11 +192,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Move to point one
     request:
@@ -236,10 +202,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToPointOne
-            data: {}
+          command: calibration.moveToPointOne
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -250,11 +214,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointOne
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointOne
 
   - name: Move to point two
     request:
@@ -262,10 +224,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointTwo
-            data: {}
+          command: calibration.deck.moveToPointTwo
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -276,11 +236,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointTwo
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointTwo
 
   - name: Move to point three
     request:
@@ -288,10 +246,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointThree
-            data: {}
+          command: calibration.deck.moveToPointThree
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -302,11 +258,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointThree
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointThree
 
   - name: Exit Session
     request:
@@ -314,10 +268,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.exitSession
-            data: {}
+          command: calibration.exitSession
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -328,11 +280,9 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: sessionExited
+          details:
+            <<: *session_data_attribute_details
+            currentStep: sessionExited
 
   - name: Delete the session
     request:
@@ -350,9 +300,7 @@ stages:
       json:
         data:
           - id: "default"
-            type: Session
-            attributes:
-              sessionType: default
-              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-              details: {}
-              createParams: null
+            sessionType: default
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            details: {}
+            createParams: null

--- a/robot-server/tests/integration/sessions/test_default.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_default.tavern.yaml
@@ -11,8 +11,7 @@ stages:
       json:
         data:
           type: Session
-          attributes:
-            sessionType: default
+          sessionType: default
     response:
       status_code: 403
       json:
@@ -53,12 +52,10 @@ stages:
         links: !anydict
         data:
           id: default
-          type: Session
-          attributes:
-            sessionType: default
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: {}
-            createParams: null
+          sessionType: default
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: {}
+          createParams: null
 ---
 test_name: Default Commands
 marks:
@@ -71,10 +68,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: robot.homeAllMotors
-            data: {}
+          command: robot.homeAllMotors
+          data: {}
     response:
       status_code: 200
   - name: Send a toggleLights command
@@ -83,10 +78,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: robot.toggleLights
-            data: {}
+          command: robot.toggleLights
+          data: {}
     response:
       status_code: 200
   - name: Rejects an unknown command
@@ -95,10 +88,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 403
 

--- a/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
@@ -12,9 +12,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: liveProtocol
+          sessionType: liveProtocol
     response:
       save:
         json:
@@ -26,94 +24,82 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadLabware
-            data: &labware_data
-              location: 2
-              loadName: corning_96_wellplate_360ul_flat
-              displayName: my well plate
-              namespace: Opentrons
-              version: 1
+          command: equipment.loadLabware
+          data: &labware_data
+            location: 2
+            loadName: corning_96_wellplate_360ul_flat
+            displayName: my well plate
+            namespace: Opentrons
+            version: 1
     response:
       status_code: 200
       json:
         links: !anydict
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *labware_data
-            command: equipment.loadLabware
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              labwareId: !anystr
-              definition: !anydict
-              calibration: !anylist
+          data: *labware_data
+          command: equipment.loadLabware
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            labwareId: !anystr
+            definition: !anydict
+            calibration: !anylist
   - name: Load tip rack command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadLabware
-            data: &tiprack_data
-              location: 1
-              loadName: opentrons_96_tiprack_300ul
-              displayName: my tip rack
-              namespace: Opentrons
-              version: 1
+          command: equipment.loadLabware
+          data: &tiprack_data
+            location: 1
+            loadName: opentrons_96_tiprack_300ul
+            displayName: my tip rack
+            namespace: Opentrons
+            version: 1
     response:
       status_code: 200
       json:
         links: !anydict
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *tiprack_data
-            command: equipment.loadLabware
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              labwareId: !anystr
-              definition: !anydict
-              calibration: !anylist
+          data: *tiprack_data
+          command: equipment.loadLabware
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            labwareId: !anystr
+            definition: !anydict
+            calibration: !anylist
   - name: Load instrument command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadInstrument
-            data: &create_instrument_data
-              instrumentName: p300_single
-              mount: left
+          command: equipment.loadInstrument
+          data: &create_instrument_data
+            instrumentName: p300_single
+            mount: left
     response:
       status_code: 200
       json:
         links: !anydict
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *create_instrument_data
-            command: equipment.loadInstrument
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              instrumentId: !anystr
+          data: *create_instrument_data
+          command: equipment.loadInstrument
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            instrumentId: !anystr
   - name: Delete the session
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}"

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -13,11 +13,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "my_protocol"
+          sessionType: protocol
+          createParams:
+            protocolId: "my_protocol"
     response:
       status_code: 404
 ---
@@ -45,11 +43,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
     response:
       status_code: 403
       json:
@@ -87,11 +83,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
     response:
       status_code: 201
       save:
@@ -100,16 +94,14 @@ stages:
       json: &proto_session
         data:
           id: !anystr
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
-            createdAt: !anystr
-            details:
-              protocolId: "{protocol_id}"
-              currentState: !anystr
-              events: !anylist
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
+          createdAt: !anystr
+          details:
+            protocolId: "{protocol_id}"
+            currentState: !anystr
+            events: !anylist
         links: !anydict
   - name: Get the session
     request:

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -12,13 +12,11 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: tipLengthCalibration
-            createParams:
-              mount: left
-              hasCalibrationBlock: true
-              tipRackDefinition: !include fixture_tiprack_300_ul.json
+          sessionType: tipLengthCalibration
+          createParams:
+            mount: left
+            hasCalibrationBlock: true
+            tipRackDefinition: !include fixture_tiprack_300_ul.json
     response:
       status_code: 201
       save:
@@ -34,19 +32,17 @@ stages:
         links: !anydict
         data:
           id: "{session_id}"
-          type: Session
-          attributes:
-            sessionType: tipLengthCalibration
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instrument: !anydict
-              labware: !anylist
-              nextSteps: null
-            createParams:
-              mount: left
-              hasCalibrationBlock: true
-              tipRackDefinition: !include fixture_tiprack_300_ul.json
+          sessionType: tipLengthCalibration
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: &session_data_attribute_details
+            currentStep: sessionStarted
+            instrument: !anydict
+            labware: !anylist
+            nextSteps: null
+          createParams:
+            mount: left
+            hasCalibrationBlock: true
+            tipRackDefinition: !include fixture_tiprack_300_ul.json
 
   - name: Load labware
     request:
@@ -54,25 +50,21 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 200
       json:
         links: !anydict
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            status: executed
-            command: calibration.loadLabware
-            createdAt: &dt
-              !re_match "\\d+-\\d+-\\d+T"
-            startedAt: *dt
-            completedAt: *dt
-            data: {}
+          status: executed
+          command: calibration.loadLabware
+          createdAt: &dt
+            !re_match "\\d+-\\d+-\\d+T"
+          startedAt: *dt
+          completedAt: *dt
+          data: {}
 
   - name: Attempt conflicting command
     request:
@@ -80,10 +72,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 409
 
@@ -103,10 +93,8 @@ stages:
       json:
         data:
           - id: "default"
-            type: Session
-            attributes:
-              sessionType: default
-              createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-              details: {}
-              createParams: null
+            sessionType: default
+            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+            details: {}
+            createParams: null
 

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -12,15 +12,12 @@ stages:
       status_code: 200
       json:
         data:
-          attributes:
-            systemTime: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          systemTime: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           id: 'time'
-          type: 'SystemTimeAttributes'
         links:
           self:
             href: '/system/time'
             meta: null
-        meta: null
 
 ---
 test_name: PUT Time
@@ -35,8 +32,6 @@ stages:
       json:
         data:
           id: "time"
-          type: "SystemTimeAttributes"
-          attributes: {}
     response:
       status_code: 422
       json:
@@ -45,7 +40,7 @@ stages:
             title: "value_error.missing"
             detail: "field required"
             source:
-              pointer: "/body/new_time/data/attributes/systemTime"
+              pointer: "/body/new_time/data/systemTime"
   - name: System Time PUT request on a dev server raises error
     request:
       url: "{host:s}:{port:d}/system/time"
@@ -53,9 +48,7 @@ stages:
       json:
         data:
           id: "time"
-          type: "SystemTimeAttributes"
-          attributes:
-            systemTime: "2020-09-10T21:00:15.741Z"
+          systemTime: "2020-09-10T21:00:15.741Z"
     response:
       status_code: 501
       json:

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 ---
@@ -28,55 +27,43 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-
 ---
 test_name: GET Labware Calibrations, Filter LoadName
 marks:
@@ -93,18 +80,15 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: 'nest_96_wellplate_2ml_deep'
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: 'nest_96_wellplate_2ml_deep'
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
 ---
 test_name: GET Labware Calibrations, Filter Version & namespace
 marks:
@@ -123,53 +107,42 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
 ---
 test_name: GET Labware Calibrations, Version Does Not Exist
 marks:
@@ -187,5 +160,4 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data: []

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response: &no_offset_response
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 
@@ -27,31 +26,26 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: 'pip_1'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
-          - attributes:
-              pipette: 'pip_2'
-              mount: 'right'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: 'pip_2'
+            mount: 'right'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with pipette id
     request:
@@ -62,20 +56,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: 'pip_1'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with mount
     request:
@@ -86,20 +77,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              tiprackUri: !anystr
-              lastModified: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: 'pip_1'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            tiprackUri: !anystr
+            lastModified: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with pipette AND mount
     request:
@@ -111,20 +99,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: 'pip_1'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with wrong pipette AND mount
     request:

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -10,9 +10,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
+          sessionType: calibrationCheck
     response:
       status_code: 201
       save:
@@ -52,9 +50,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: "null"
+          sessionType: "null"
     response:
       status_code: 201
       save:
@@ -67,9 +63,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
+          sessionType: calibrationCheck
     response:
       status_code: 201
       save:
@@ -85,26 +79,20 @@ stages:
       json:
         data:
         - id: "default"
-          type: Session
-          attributes:
-            sessionType: "default"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: {}
-            createParams: null
+          sessionType: "default"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: {}
+          createParams: null
         - id: "{session_id_1}"
-          type: Session
-          attributes:
-            sessionType: "null"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: {}
-            createParams: null
+          sessionType: "null"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: {}
+          createParams: null
         - id: "{session_id_2}"
-          type: Session
-          attributes:
-            sessionType: "calibrationCheck"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: !anydict
-            createParams: null
+          sessionType: "calibrationCheck"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: !anydict
+          createParams: null
 
   - name: Get just the calcheck sessions
     request:
@@ -115,12 +103,10 @@ stages:
       json:
         data:
         - id: "{session_id_2}"
-          type: Session
-          attributes:
-            sessionType: "calibrationCheck"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: !anydict
-            createParams: null
+          sessionType: "calibrationCheck"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: !anydict
+          createParams: null
 
   - name: Delete session 1
     request:
@@ -145,9 +131,7 @@ stages:
       json:
         data:
         - id: "default"
-          type: Session
-          attributes:
-            sessionType: "default"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: {}
-            createParams: null
+          sessionType: "default"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: {}
+          createParams: null

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response: &no_tip_length_response
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 
@@ -27,33 +26,28 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with pipette id
     request:
@@ -64,22 +58,18 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              tiprack: 'fakehash'
-              tipLength: 30.5
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
-
+          - pipette: 'pip_1'
+            tiprack: 'fakehash'
+            tipLength: 30.5
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: 'fakehash&pip_1'
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with tiprack hash
     request:
@@ -90,33 +80,28 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with pipette AND tiprack
     request:
@@ -128,21 +113,18 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: 'pip_1'
-              tiprack: 'fakehash'
-              tipLength: 30.5
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: 'pip_1'
+            tiprack: 'fakehash'
+            tipLength: 30.5
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: 'fakehash&pip_1'
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with wrong pipette AND tiprack
     request:

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 
+from robot_server.service.json_api import ResponseDataModel
 from robot_server.service.json_api.request import (
-    RequestModel, RequestDataModel)
+    RequestModel)
 
 
 class ItemModel(BaseModel):
@@ -10,4 +11,8 @@ class ItemModel(BaseModel):
     price: float
 
 
-ItemRequest = RequestModel[RequestDataModel[ItemModel]]
+class ItemResponseModel(ResponseDataModel, ItemModel):
+    pass
+
+
+ItemRequest = RequestModel[ItemModel]

--- a/robot-server/tests/service/json_api/test_request.py
+++ b/robot-server/tests/service/json_api/test_request.py
@@ -3,22 +3,18 @@ from pytest import raises
 from pydantic import ValidationError
 
 from robot_server.service.json_api.request import (
-    RequestModel, RequestDataModel)
+    RequestModel)
 from tests.service.helpers import ItemModel
 
 
 def test_attributes_as_dict():
     DictRequest = RequestModel[dict]
     obj_to_validate = {
-        'data': {'type': 'item', 'attributes': {}}
+        'data': {'some_data': 1}
     }
     my_request_obj = DictRequest(**obj_to_validate)
     assert my_request_obj.dict() == {
-        'data': {
-            'type': 'item',
-            'attributes': {},
-            'id': None,
-        }
+        'data': {'some_data': 1}
     }
 
 
@@ -26,25 +22,19 @@ def test_attributes_as_item_model():
     ItemRequest = RequestModel[ItemModel]
     obj_to_validate = {
         'data': {
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20
-            },
-            'id': None,
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20
         }
     }
     my_request_obj = ItemRequest(**obj_to_validate)
     assert my_request_obj.dict() == obj_to_validate
 
 
-def test_attributes_as_item_model__empty_dict():
+def test_attributes_as_item_model_empty_dict():
     ItemRequest = RequestModel[ItemModel]
     obj_to_validate = {
         'data': {
-            'type': 'item',
-            'attributes': {}
         }
     }
     with raises(ValidationError) as e:
@@ -52,15 +42,15 @@ def test_attributes_as_item_model__empty_dict():
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes', 'name'),
+            'loc': ('data', 'name'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'quantity'),
+            'loc': ('data', 'quantity'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'price'),
+            'loc': ('data', 'price'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }
@@ -68,16 +58,16 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_attributes_required():
-    MyRequest = RequestModel[RequestDataModel[dict]]
+    MyRequest = RequestModel[dict]
     obj_to_validate = {
-        'data': {'type': 'item', 'attributes': None}
+        'data': None
     }
     with raises(ValidationError) as e:
         MyRequest(**obj_to_validate)
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes'),
+            'loc': ('data',),
             'msg': 'none is not an allowed value',
             'type': 'type_error.none.not_allowed'
         },
@@ -85,7 +75,7 @@ def test_attributes_required():
 
 
 def test_data_required():
-    MyRequest = RequestModel[RequestDataModel[dict]]
+    MyRequest = RequestModel[dict]
     obj_to_validate = {
         'data': None
     }

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -1,174 +1,92 @@
 from pytest import raises
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from robot_server.service.json_api.response import (
     ResponseDataModel, ResponseModel, MultiResponseModel)
-from tests.service.helpers import ItemModel
+from tests.service.helpers import ItemResponseModel
 
 
 def test_attributes_as_dict():
-    MyResponse = ResponseModel[dict, dict]
+    MyResponse = ResponseModel[ResponseDataModel]
     obj_to_validate = {
-        'data': {'id': '123', 'type': 'item', 'attributes': {}},
+        'data': {'id': '123'},
     }
     my_response_object = MyResponse(**obj_to_validate)
     assert my_response_object.dict() == {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {},
         }
     }
-
-
-def test_missing_attributes_dict():
-    MyResponse = ResponseModel[dict, dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item'}
-    }
-    my_response_object = MyResponse(**obj_to_validate)
-    assert my_response_object.dict() == {
-        'meta': None,
-        'links': None,
-        'data': {
-            'id': '123',
-            'type': 'item',
-            'attributes': {},
-        }
-    }
-
-
-def test_missing_attributes_empty_model():
-    class EmptyModel(BaseModel):
-        pass
-
-    MyResponse = ResponseModel[EmptyModel, dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item'}
-    }
-    my_response_object = MyResponse(**obj_to_validate)
-    assert my_response_object.dict() == {
-        'meta': None,
-        'links': None,
-        'data': {
-            'id': '123',
-            'type': 'item',
-            'attributes': {},
-        }
-    }
-    assert isinstance(my_response_object.data.attributes, EmptyModel)
 
 
 def test_attributes_as_item_model():
-    ItemResponse = ResponseModel[ItemModel, dict]
+    ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20
-            }
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20
         }
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20,
-            }
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20,
         }
     }
 
 
 def test_list_item_model():
-    ItemResponse = MultiResponseModel[ItemModel, dict]
+    ItemResponse = MultiResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '123',
-                'type': 'item',
-                'attributes': {
-                    'name': 'apple',
-                    'quantity': 10,
-                    'price': 1.20
-                },
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20
             },
             {
                 'id': '321',
-                'type': 'item',
-                'attributes': {
-                    'name': 'banana',
-                    'quantity': 20,
-                    'price': 2.34
-                },
+                'name': 'banana',
+                'quantity': 20,
+                'price': 2.34
             },
         ],
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '123',
-                'type': 'item',
-                'attributes': {
-                    'name': 'apple',
-                    'quantity': 10,
-                    'price': 1.20,
-                },
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20,
             },
             {
                 'id': '321',
-                'type': 'item',
-                'attributes': {
-                    'name': 'banana',
-                    'quantity': 20,
-                    'price': 2.34,
-                },
+                'name': 'banana',
+                'quantity': 20,
+                'price': 2.34,
             },
         ],
     }
 
 
-def test_attributes_required():
-    ItemResponse = ResponseModel[ResponseDataModel[ItemModel], dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item', 'attributes': None}
-    }
-    with raises(ValidationError) as e:
-        ItemResponse(**obj_to_validate)
-
-    assert e.value.errors() == [
-        {
-            'loc': ('data', 'attributes'),
-            'msg': 'none is not an allowed value',
-            'type': 'type_error.none.not_allowed',
-        },
-    ]
-
-
-def test_attributes_as_item_model__empty_dict():
-    ItemResponse = ResponseModel[ItemModel, dict]
+def test_attributes_as_item_model_empty_dict():
+    ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {}
         }
     }
     with raises(ValidationError) as e:
@@ -176,32 +94,30 @@ def test_attributes_as_item_model__empty_dict():
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes', 'name'),
+            'loc': ('data', 'name'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'quantity'),
+            'loc': ('data', 'quantity'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'price'),
+            'loc': ('data', 'price'),
             'msg': 'field required',
             'type': 'value_error.missing'
         },
     ]
 
 
-def test_resource_data_model_create():
-    item = ItemModel(name='pear', price=1.2, quantity=10)
-    document = ResponseDataModel.create(
-        resource_id='abc123',
-        attributes=item
-    ).dict()
+def test_response_constructed_with_resource_object():
+    ItemResponse = ResponseModel[ItemResponseModel]
+    item = ItemResponseModel(id="abc123", name='pear', price=1.2, quantity=10)
+    data = item.dict()
 
-    assert document == {
-        'id': 'abc123',
-        'type': 'ItemModel',
-        'attributes': {
+    assert ItemResponse(data=data).dict() == {
+        'links': None,
+        "data": {
+            'id': 'abc123',
             'name': 'pear',
             'price': 1.2,
             'quantity': 10,
@@ -209,84 +125,36 @@ def test_resource_data_model_create():
     }
 
 
-def test_resource_data_model_create_no_attributes():
-    document = ResponseDataModel.create(
-        resource_id='abc123', attributes={}).dict()
-
-    assert document == {
-        'id': 'abc123',
-        'type': 'dict',
-        'attributes': {},
-    }
-
-
-def test_response_constructed_with_resource_object():
-    ItemResponse = ResponseModel[ItemModel, dict]
-    item = ItemModel(name='pear', price=1.2, quantity=10)
-    data = ResponseDataModel.create(
-            resource_id='abc123',
-            attributes=item
-    ).dict()
-
-    assert ItemResponse(data=data).dict() == {
-        'meta': None,
-        'links': None,
-        "data": {
-            'id': 'abc123',
-            "type": 'ItemModel',
-            "attributes": {
-                'name': 'pear',
-                'price': 1.2,
-                'quantity': 10,
-            },
-        }
-    }
-
-
 def test_response_constructed_with_resource_object_list():
-    ItemResponse = MultiResponseModel[ItemModel, dict]
-    items = (
-        (1, ItemModel(name='apple', price=1.5, quantity=3)),
-        (2, ItemModel(name='pear', price=1.2, quantity=10)),
-        (3, ItemModel(name='orange', price=2.2, quantity=5))
-    )
+    ItemResponse = MultiResponseModel[ItemResponseModel]
+    items = [
+        ItemResponseModel(id="1", name='apple', price=1.5, quantity=3),
+        ItemResponseModel(id="2", name='pear', price=1.2, quantity=10),
+        ItemResponseModel(id="3", name='orange', price=2.2, quantity=5)
+    ]
     response = ItemResponse(
-        data=[
-            ResponseDataModel.create(resource_id=str(item[0]),
-                                     attributes=item[1])
-            for item in items
-        ]
+        data=items
     )
     assert response.dict() == {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '1',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'apple',
-                    'price': 1.5,
-                    'quantity': 3,
-                },
+                'name': 'apple',
+                'price': 1.5,
+                'quantity': 3,
             },
             {
                 'id': '2',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'pear',
-                    'price': 1.2,
-                    'quantity': 10,
-                },
+                'name': 'pear',
+                'price': 1.2,
+                'quantity': 10,
             },
             {
                 'id': '3',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'orange',
-                    'price': 2.2,
-                    'quantity': 5,
-                },
+                'name': 'orange',
+                'price': 2.2,
+                'quantity': 5,
             },
         ]
     }

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -22,6 +22,7 @@ def grab_id(set_up_index_file_temporary_directory):
 def test_access_individual_labware(api_client, grab_id):
     calibration_id = grab_id
     expected = {
+        'id': calibration_id,
         'calibrationData': {
             'offset': {
                 'value': [0.0, 0.0, 0.0],
@@ -39,8 +40,6 @@ def test_access_individual_labware(api_client, grab_id):
     assert resp.status_code == 200
     body = resp.json()
     data = body['data']
-    assert data['type'] == 'LabwareCalibration'
-    assert data['id'] == calibration_id
     data['calibrationData']['offset']['lastModified'] = None
     data['calibrationData']['tipLength']['lastModified'] = None
     assert data == expected

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -41,9 +41,9 @@ def test_access_individual_labware(api_client, grab_id):
     data = body['data']
     assert data['type'] == 'LabwareCalibration'
     assert data['id'] == calibration_id
-    data['attributes']['calibrationData']['offset']['lastModified'] = None
-    data['attributes']['calibrationData']['tipLength']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['calibrationData']['offset']['lastModified'] = None
+    data['calibrationData']['tipLength']['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get('/labware/calibrations/funnyId')
     assert resp.status_code == 404

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -26,9 +26,8 @@ def test_access_pipette_offset_calibration(
         f'/calibration/pipette_offset?mount={MOUNT}&pipette_id={PIPETTE_ID}')
     assert resp.status_code == 200
     data = resp.json()['data'][0]
-    assert data['type'] == 'PipetteOffsetCalibration'
-    data['attributes']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get(
         f'/calibration/pipette_offset?mount={MOUNT}&'

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -8,6 +8,7 @@ def test_access_pipette_offset_calibration(
         api_client, set_up_pipette_offset_temp_directory,
         apiclient_enable_calibration_overhaul, server_temp_directory):
     expected = {
+        'id': 'pip_1&left',
         'offset': [0, 0, 0],
         'pipette': 'pip_1',
         'mount': 'left',

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -29,14 +29,11 @@ def mock_session_meta():
 @pytest.fixture
 def session_response(mock_session_meta):
     return {
-        'attributes': {
-            'details': {
-            },
-            'sessionType': 'null',
-            'createdAt': mock_session_meta.created_at.isoformat(),
-            'createParams': None,
+        'details': {
         },
-        'type': 'Session',
+        'sessionType': 'null',
+        'createdAt': mock_session_meta.created_at.isoformat(),
+        'createParams': None,
         'id': mock_session_meta.identifier
     }
 
@@ -123,10 +120,7 @@ def test_create_session_error(api_client,
 
     response = api_client.post("/sessions", json={
         "data": {
-            "type": "Session",
-            "attributes": {
-                "sessionType": "null"
-            }
+            "sessionType": "null"
         }
     })
     assert response.json() == {
@@ -144,10 +138,7 @@ def test_create_session(api_client,
                         session_response):
     response = api_client.post("/sessions", json={
         "data": {
-            "type": "Session",
-            "attributes": {
-                "sessionType": "null"
-            }
+            "sessionType": "null"
         }
     })
     assert response.json() == {
@@ -272,11 +263,8 @@ def command(command_type: str, body: typing.Optional[BaseModel]):
     """Helper to create command"""
     return {
         "data": {
-            "type": "SessionCommand",
-            "attributes": {
-                "command": command_type,
-                "data": body.dict(exclude_unset=True) if body else {}
-            }
+            "command": command_type,
+            "data": body.dict(exclude_unset=True) if body else {}
         }
     }
 
@@ -326,15 +314,12 @@ def test_execute_command(api_client,
 
     assert response.json() == {
         'data': {
-            'attributes': {
-                'command': 'calibration.jog',
-                'data': {'vector': [1.0, 2.0, 3.0]},
-                'status': 'executed',
-                'createdAt': '2000-01-01T00:00:00',
-                'startedAt': '2019-01-01T00:00:00',
-                'completedAt': '2020-01-01T00:00:00',
-            },
-            'type': 'SessionCommand',
+            'command': 'calibration.jog',
+            'data': {'vector': [1.0, 2.0, 3.0]},
+            'status': 'executed',
+            'createdAt': '2000-01-01T00:00:00',
+            'startedAt': '2019-01-01T00:00:00',
+            'completedAt': '2020-01-01T00:00:00',
             'id': command_id,
         },
         'links': {
@@ -379,14 +364,12 @@ def test_execute_command_no_body(api_client,
 
     assert response.json() == {
         'data': {
-            'attributes': {
-                'command': 'calibration.loadLabware',
-                'data': {},
-                'status': 'executed',
-                'createdAt': '2000-01-01T00:00:00',
-                'startedAt': '2019-01-01T00:00:00',
-                'completedAt': '2020-01-01T00:00:00',
-            },
+            'command': 'calibration.loadLabware',
+            'data': {},
+            'status': 'executed',
+            'createdAt': '2000-01-01T00:00:00',
+            'startedAt': '2019-01-01T00:00:00',
+            'completedAt': '2020-01-01T00:00:00',
             'type': 'SessionCommand',
             'id': command_id
         },

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -273,7 +273,7 @@ def test_execute_command_no_session(api_client, mock_session_meta):
     """Test that command is rejected if there's no session"""
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,))))
     assert response.json() == {
         'errors': [{
@@ -370,7 +370,6 @@ def test_execute_command_no_body(api_client,
             'createdAt': '2000-01-01T00:00:00',
             'startedAt': '2019-01-01T00:00:00',
             'completedAt': '2020-01-01T00:00:00',
-            'type': 'SessionCommand',
             'id': command_id
         },
         'links': {
@@ -410,7 +409,7 @@ def test_execute_command_error(api_client,
 
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,)))
     )
 
@@ -436,7 +435,7 @@ def test_execute_command_session_inactive(
 
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,)))
     )
 

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -19,7 +19,7 @@ def mock_set_system_time(mock_system_time):
 def response_links():
     return {
         'self': {
-            'href': '/system/time',
+            'href': '/system/time', 'meta': None,
         }
     }
 
@@ -82,7 +82,8 @@ def test_set_system_time(api_client, mock_system_time,
     assert response.json() == {
         'data': {
             'systemTime': mock_system_time.isoformat(),
-            'id': 'time',},
+            'id': 'time'
+        },
         'links': response_links,
     }
     assert response.status_code == 200

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -20,7 +20,6 @@ def response_links():
     return {
         'self': {
             'href': '/system/time',
-            'meta': None
         }
     }
 
@@ -34,8 +33,7 @@ def test_raise_system_synchronized_error(api_client,
     response = api_client.put("/system/time", json={
         "data": {
             "id": "time",
-            "type": "SystemTimeAttributes",
-            "attributes": {"systemTime": mock_system_time.isoformat()}
+            "systemTime": mock_system_time.isoformat()
         }
     })
     assert response.json() == {'errors': [{
@@ -55,8 +53,7 @@ def test_raise_system_exception(api_client,
     response = api_client.put("/system/time", json={
         "data": {
             "id": "time",
-            "type": "SystemTimeAttributes",
-            "attributes": {"systemTime": mock_system_time.isoformat()}
+            "systemTime": mock_system_time.isoformat()
         }
     })
     assert response.json() == {'errors': [{
@@ -77,18 +74,15 @@ def test_set_system_time(api_client, mock_system_time,
     response = api_client.put("/system/time",
                               json={
                                   'data': {
-                                      'attributes': {
-                                          'systemTime':
-                                              mock_system_time.isoformat()},
+                                      'systemTime':
+                                          mock_system_time.isoformat(),
                                       'id': 'time',
-                                      'type': 'SystemTimeAttributes'},
+                                  },
                               })
     assert response.json() == {
         'data': {
-            'attributes': {'systemTime': mock_system_time.isoformat()},
-            'id': 'time',
-            'type': 'SystemTimeAttributes'},
+            'systemTime': mock_system_time.isoformat(),
+            'id': 'time',},
         'links': response_links,
-        'meta': None
     }
     assert response.status_code == 200

--- a/robot-server/tests/service/test_errors.py
+++ b/robot-server/tests/service/test_errors.py
@@ -11,9 +11,7 @@ from tests.service.helpers import ItemRequest
 def test_transform_validation_error_to_json_api_errors():
     with pytest.raises(ValidationError) as e:
         ItemRequest(**{
-            'data': {
-                'type': 'type'
-            }
+            'data': {}
         })
     assert errors.transform_validation_error_to_json_api_errors(
         HTTP_422_UNPROCESSABLE_ENTITY,
@@ -24,7 +22,23 @@ def test_transform_validation_error_to_json_api_errors():
                 'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
                 'detail': 'field required',
                 'source': {
-                    'pointer': '/data/attributes'
+                    'pointer': '/data/name'
+                },
+                'title': 'value_error.missing'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/quantity'
+                },
+                'title': 'value_error.missing'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/price'
                 },
                 'title': 'value_error.missing'
             },

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -7,6 +7,7 @@ WRONG_LW_HASH = 'wronghash'
 def test_access_tip_length_calibration(
         api_client, set_up_tip_length_temp_directory):
     expected = {
+        'id': 'fakehash&pip_1',
         'tipLength': 30.5,
         'pipette': PIPETTE_ID,
         'tiprack': LW_HASH,
@@ -21,7 +22,6 @@ def test_access_tip_length_calibration(
         f'tiprack_hash={LW_HASH}')
     assert resp.status_code == 200
     data = resp.json()['data'][0]
-    assert data['type'] == 'TipLengthCalibration'
     data['lastModified'] = None
     assert data == expected
 

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -22,8 +22,8 @@ def test_access_tip_length_calibration(
     assert resp.status_code == 200
     data = resp.json()['data'][0]
     assert data['type'] == 'TipLengthCalibration'
-    data['attributes']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get(
         f'/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&'


### PR DESCRIPTION
# Overview

Simplify http v2 models for version 4.

See https://github.com/Opentrons/opentrons/issues/6847 for details.

closes #6849 

# Changelog

- Remove `type` and `meta` fields. 
- Eliminate `attributes` level in responses and requests.
- Delete backwards compatibility for calibration check commands that do not have a namespace.

# Review requests

Please look at the integration tests to review the new schema. 


# Risk assessment

High. This introduces breaking changes in the API. Only v4 will support.