### PR TITLE
refactor(robot-server): Robot server model refactor v4

### DIFF
--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -99,17 +99,11 @@ export type LabwareCalibration = {|
   version: number,
   parent: string,
   definitionHash: string,
-|}
-
-export type LabwareCalibrationModel = {|
-  attributes: LabwareCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllLabwareCalibrations = {|
-  data: Array<LabwareCalibrationModel>,
-  meta: { ... },
+  data: Array<LabwareCalibration>,
 |}
 
 export type PipetteOffsetCalibration = {|
@@ -121,17 +115,11 @@ export type PipetteOffsetCalibration = {|
   lastModified: string,
   source: CalibrationSource,
   status: IndividualCalibrationStatus,
-|}
-
-export type PipetteOffsetCalibrationModel = {|
-  attributes: PipetteOffsetCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllPipetteOffsetCalibrations = {|
-  data: Array<PipetteOffsetCalibrationModel>,
-  meta: { ... },
+  data: Array<PipetteOffsetCalibration>,
 |}
 
 export type TipLengthCalibration = {|
@@ -141,15 +129,9 @@ export type TipLengthCalibration = {|
   lastModified: string,
   source: CalibrationSource,
   status: IndividualCalibrationStatus,
-|}
-
-export type TipLengthCalibrationModel = {|
-  attributes: TipLengthCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllTipLengthCalibrations = {|
-  data: Array<TipLengthCalibrationModel>,
-  meta: { ... },
+  data: Array<TipLengthCalibration>,
 |}

--- a/app/src/calibration/labware/__fixtures__/labware-calibration.js
+++ b/app/src/calibration/labware/__fixtures__/labware-calibration.js
@@ -8,57 +8,50 @@ import { LABWARE_CALIBRATION_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  LabwareCalibrationModel,
+  LabwareCalibration,
   AllLabwareCalibrations,
 } from '../../api-types'
 
-export const mockLabwareCalibration1: LabwareCalibrationModel = {
-  attributes: {
-    calibrationData: {
-      offset: {
-        value: [0.0, 0.0, 0.0],
-        lastModified: '2020-04-05T14:30',
-      },
-      tipLength: {
-        value: 30,
-        lastModified: '2007-05-05T0:30',
-      },
+export const mockLabwareCalibration1: LabwareCalibration = {
+  calibrationData: {
+    offset: {
+      value: [0.0, 0.0, 0.0],
+      lastModified: '2020-04-05T14:30',
     },
-    loadName: 'opentrons_96_tiprack_10ul',
-    namespace: 'opentrons',
-    version: 1,
-    parent: 'fake_id',
-    definitionHash: '123FakeDefinitionHash',
+    tipLength: {
+      value: 30,
+      lastModified: '2007-05-05T0:30',
+    },
   },
+  loadName: 'opentrons_96_tiprack_10ul',
+  namespace: 'opentrons',
+  version: 1,
+  parent: 'fake_id',
+  definitionHash: '123FakeDefinitionHash',
   id: 'some id',
-  type: 'Labware Calibration',
 }
 
-export const mockLabwareCalibration2: LabwareCalibrationModel = {
-  attributes: {
-    calibrationData: {
-      offset: {
-        value: [1.0, 1.0, 1.0],
-        lastModified: '2020-04-05T14:30',
-      },
-      tipLength: {
-        value: 30,
-        lastModified: '2007-05-05T0:30',
-      },
+export const mockLabwareCalibration2: LabwareCalibration = {
+  calibrationData: {
+    offset: {
+      value: [1.0, 1.0, 1.0],
+      lastModified: '2020-04-05T14:30',
     },
-    loadName: 'opentrons_96_tiprack_1000ul',
-    namespace: 'opentrons',
-    version: 1,
-    parent: '',
-    definitionHash: '456FakeDefinitionHash',
+    tipLength: {
+      value: 30,
+      lastModified: '2007-05-05T0:30',
+    },
   },
+  loadName: 'opentrons_96_tiprack_1000ul',
+  namespace: 'opentrons',
+  version: 1,
+  parent: '',
+  definitionHash: '456FakeDefinitionHash',
   id: 'some id',
-  type: 'Labware Calibration',
 }
 
 export const mockAllLabwareCalibration: AllLabwareCalibrations = {
   data: [mockLabwareCalibration1, mockLabwareCalibration2],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -65,6 +65,10 @@ describe('labware calibration selectors', () => {
   describe('getProtocolLabwareList', () => {
     let state: $Shape<State>
 
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
     beforeEach(() => {
       state = { calibration: {} }
 
@@ -76,13 +80,13 @@ describe('labware calibration selectors', () => {
             type: wellPlate96Def.parameters.loadName,
             definition: wellPlate96Def,
             slot: '3',
-            definitionHash:
-              Fixtures.mockLabwareCalibration1.attributes.definitionHash,
+            definitionHash: Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',
             definition: null,
             slot: '1',
+            definitionHash: null,
           }: $Shape<ProtocolLabware>),
         ]
       })
@@ -111,8 +115,7 @@ describe('labware calibration selectors', () => {
       getModulesBySlot.mockReturnValue({})
 
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       state = ({
         calibration: {
@@ -121,22 +124,18 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [
                 {
                   ...lwCalibration,
-                  attributes: {
-                    ...attributes,
-                    loadName: wellPlate96Def.parameters.loadName,
-                    namespace: wellPlate96Def.namespace,
-                    version: wellPlate96Def.version,
-                    parent: '',
-                    calibrationData: {
-                      ...calibrationData,
-                      offset: {
-                        ...calibrationData.offset,
-                        value: [1.23, 4.56, 7.89],
-                      },
+                  loadName: wellPlate96Def.parameters.loadName,
+                  namespace: wellPlate96Def.namespace,
+                  version: wellPlate96Def.version,
+                  parent: '',
+                  calibrationData: {
+                    ...calibrationData,
+                    offset: {
+                      ...calibrationData.offset,
+                      value: [1.23, 4.56, 7.89],
                     },
                   },
                 },
@@ -161,48 +160,41 @@ describe('labware calibration selectors', () => {
           parentDisplayName: null,
           quantity: 1,
           calibration: null,
-          calDataAvailable: true,
+          calDataAvailable: false,
         },
       ])
     })
 
     it('grabs calibration data for labware on module if present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const calNotOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [0, 0, 0],
-            },
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [0, 0, 0],
           },
         },
       }
 
       const calOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: 'magneticModuleV1',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+        parent: 'magneticModuleV1',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
         },
       }
@@ -214,7 +206,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [calNotOnModule, calOnModule],
             },
           },
@@ -231,7 +222,7 @@ describe('labware calibration selectors', () => {
           version: wellPlate96Def.version,
           parent: 'magneticModuleV1',
           calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
-          definitionHash: attributes.definitionHash,
+          definitionHash: lwCalibration.definitionHash,
         },
         {
           type: 'some_v1_labware',
@@ -242,47 +233,41 @@ describe('labware calibration selectors', () => {
           version: null,
           parent: null,
           calibrationData: null,
+          definitionHash: null,
         },
       ])
     })
 
-    it('grabs calibration data for labware not on module if on-module cal data is present', () => {
+    it('grabs calibration data for labware not on module even if on-module cal data is also present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const calNotOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
         },
       }
 
       const calOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: 'magneticModuleV1',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [0, 0, 0],
-            },
+        parent: 'magneticModuleV1',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [0, 0, 0],
           },
         },
       }
@@ -296,7 +281,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [calOnModule, calNotOnModule],
             },
           },
@@ -312,7 +296,7 @@ describe('labware calibration selectors', () => {
           namespace: wellPlate96Def.namespace,
           version: wellPlate96Def.version,
           parent: null,
-          definitionHash: attributes.definitionHash,
+          definitionHash: lwCalibration.definitionHash,
           calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
         },
         {
@@ -323,6 +307,7 @@ describe('labware calibration selectors', () => {
           namespace: null,
           version: null,
           parent: null,
+          definitionHash: null,
           calibrationData: null,
         },
       ])
@@ -330,23 +315,19 @@ describe('labware calibration selectors', () => {
 
     it('grabs no calibration data for labware if definitionHash not present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const oldLwCal = {
         ...omit(lwCalibration, 'definitionHash'),
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
         },
       }
@@ -360,7 +341,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [oldLwCal],
             },
           },
@@ -369,6 +349,7 @@ describe('labware calibration selectors', () => {
 
       expect(Selectors.getProtocolLabwareList(state, robotName)).toEqual([
         {
+          // No calibrationData
           type: wellPlate96Def.parameters.loadName,
           definition: wellPlate96Def,
           slot: '3',
@@ -376,8 +357,8 @@ describe('labware calibration selectors', () => {
           namespace: wellPlate96Def.namespace,
           version: wellPlate96Def.version,
           parent: null,
-          definitionHash: attributes.definitionHash,
-          calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
+          definitionHash: lwCalibration.definitionHash,
+          calibrationData: null,
         },
         {
           type: 'some_v1_labware',
@@ -387,6 +368,7 @@ describe('labware calibration selectors', () => {
           namespace: null,
           version: null,
           parent: null,
+          definitionHash: null,
           calibrationData: null,
         },
       ])
@@ -407,8 +389,7 @@ describe('labware calibration selectors', () => {
             type: wellPlate96Def.parameters.loadName,
             definition: wellPlate96Def,
             slot: '3',
-            definitionHash:
-              Fixtures.mockLabwareCalibration1.attributes.definitionHash,
+            definitionHash: Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -16,13 +16,13 @@ import {
 } from './utils'
 
 import type { State } from '../../types'
-import type { LabwareCalibrationModel } from '../types'
+import type { LabwareCalibration } from '../types'
 import type { LabwareSummary, BaseProtocolLabware } from './types'
 
 export const getLabwareCalibrations = (
   state: State,
   robotName: string
-): Array<LabwareCalibrationModel> => {
+): Array<LabwareCalibration> => {
   return state.calibration[robotName]?.labwareCalibrations?.data ?? []
 }
 
@@ -46,8 +46,8 @@ export const getProtocolLabwareList: (
         calibrationData: null,
       }
       const calData = calibrations
-        .filter(({ attributes }) =>
-          matchesLabwareIdentityForCalibration(attributes, baseLabware)
+        .filter(calibration =>
+          matchesLabwareIdentityForCalibration(calibration, baseLabware)
         )
         .map(formatCalibrationData)
 
@@ -72,7 +72,7 @@ export const getUniqueProtocolLabwareSummaries: (
   getLabwareCalibrations,
   (
     baseLabwareList: Array<BaseProtocolLabware>,
-    calibrations: Array<LabwareCalibrationModel>
+    calibrations: Array<LabwareCalibration>
   ) => {
     const uniqueLabware = uniqWith<BaseProtocolLabware>(
       baseLabwareList,

--- a/app/src/calibration/labware/utils.js
+++ b/app/src/calibration/labware/utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import round from 'lodash/round'
-import type { LabwareCalibrationModel, LabwareCalibration } from '../types'
+import type { LabwareCalibration } from '../types'
 import type { LabwareCalibrationData, BaseProtocolLabware } from './types'
 
 const normalizeParent = parent =>
@@ -42,10 +42,8 @@ export const matchesLabwareIdentityForCalibration = (
 }
 
 export function formatCalibrationData(
-  model: LabwareCalibrationModel
+  model: LabwareCalibration
 ): LabwareCalibrationData {
-  const calVector = model.attributes.calibrationData.offset.value.map(n =>
-    round(n, 1)
-  )
+  const calVector = model.calibrationData.offset.value.map(n => round(n, 1))
   return { x: calVector[0], y: calVector[1], z: calVector[2] }
 }

--- a/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
+++ b/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
@@ -8,66 +8,56 @@ import { PIPETTE_OFFSET_CALIBRATIONS_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  PipetteOffsetCalibrationModel,
+  PipetteOffsetCalibration,
   AllPipetteOffsetCalibrations,
 } from '../../api-types'
 
-export const mockPipetteOffsetCalibration1: PipetteOffsetCalibrationModel = {
-  attributes: {
-    pipette: 'P3HSV2008052020A02',
-    mount: 'left',
-    offset: [1.0, 2.0, 3.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_300ul/1',
-    tiprack: 'asdasfasdasdhasjhdasdasda',
-    lastModified: '2020-08-30T10:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockPipetteOffsetCalibration1: PipetteOffsetCalibration = {
+  pipette: 'P3HSV2008052020A02',
+  mount: 'left',
+  offset: [1.0, 2.0, 3.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+  tiprack: 'asdasfasdasdhasjhdasdasda',
+  lastModified: '2020-08-30T10:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
-export const mockPipetteOffsetCalibration2: PipetteOffsetCalibrationModel = {
-  attributes: {
-    pipette: 'P20MV2008052020A02',
-    mount: 'right',
-    offset: [2.0, 4.0, 6.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
-    tiprack: 'aasdhakfghakjsdhlaksjhdak',
-    lastModified: '2020-07-25T20:00',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockPipetteOffsetCalibration2: PipetteOffsetCalibration = {
+  pipette: 'P20MV2008052020A02',
+  mount: 'right',
+  offset: [2.0, 4.0, 6.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+  tiprack: 'aasdhakfghakjsdhlaksjhdak',
+  lastModified: '2020-07-25T20:00',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
-export const mockPipetteOffsetCalibration3: PipetteOffsetCalibrationModel = {
-  attributes: {
-    pipette: 'P1KVS2108052020A02',
-    mount: 'right',
-    offset: [4.0, 6.0, 8.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
-    tiprack: 'asdakjsdhalksjdhlakjsdhalkhsd',
-
-    lastModified: '2020-09-10T05:13',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockPipetteOffsetCalibration3: PipetteOffsetCalibration = {
+  pipette: 'P1KVS2108052020A02',
+  mount: 'right',
+  offset: [4.0, 6.0, 8.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+  tiprack: 'asdakjsdhalksjdhlakjsdhalkhsd',
+  lastModified: '2020-09-10T05:13',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
 export const mockAllPipetteOffsetsCalibration: AllPipetteOffsetCalibrations = {
@@ -76,7 +66,6 @@ export const mockAllPipetteOffsetsCalibration: AllPipetteOffsetCalibrations = {
     mockPipetteOffsetCalibration2,
     mockPipetteOffsetCalibration3,
   ],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/pipette-offset/__tests__/selectors.test.js
+++ b/app/src/calibration/pipette-offset/__tests__/selectors.test.js
@@ -21,9 +21,9 @@ describe('getPipetteOffsetCalibrations', () => {
     expect(
       Selectors.getPipetteOffsetCalibrations(mockState, 'robot-name')
     ).toEqual([
-      Fixtures.mockPipetteOffsetCalibration1.attributes,
-      Fixtures.mockPipetteOffsetCalibration2.attributes,
-      Fixtures.mockPipetteOffsetCalibration3.attributes,
+      Fixtures.mockPipetteOffsetCalibration1,
+      Fixtures.mockPipetteOffsetCalibration2,
+      Fixtures.mockPipetteOffsetCalibration3,
     ])
   })
   it('should not find calibrations from other robots', () => {
@@ -41,7 +41,7 @@ describe('getCalibrationForPipette', () => {
         'robot-name',
         'P1KVS2108052020A02'
       )
-    ).toEqual(Fixtures.mockPipetteOffsetCalibration3.attributes)
+    ).toEqual(Fixtures.mockPipetteOffsetCalibration3)
   })
   it('should get no calibration when no matching calibration exists', () => {
     expect(

--- a/app/src/calibration/pipette-offset/selectors.js
+++ b/app/src/calibration/pipette-offset/selectors.js
@@ -14,7 +14,7 @@ export const getPipetteOffsetCalibrations: (
   }
   const calibrations =
     state.calibration[robotName]?.pipetteOffsetCalibrations?.data || []
-  return calibrations.map(calibration => calibration.attributes)
+  return calibrations
 }
 
 export const getCalibrationForPipette: (

--- a/app/src/calibration/tip-length/__fixtures__/tip-length-calibration.js
+++ b/app/src/calibration/tip-length/__fixtures__/tip-length-calibration.js
@@ -8,60 +8,50 @@ import { TIP_LENGTH_CALIBRATIONS_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  TipLengthCalibrationModel,
+  TipLengthCalibration,
   AllTipLengthCalibrations,
 } from '../../api-types'
 
-export const mockTipLengthCalibration1: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P3HSV2008052020A02',
-    tiprack: 'asdasfasdasdhasjhdasdasda',
-    tipLength: 30.5,
-    lastModified: '2020-09-29T10:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration1: TipLengthCalibration = {
+  pipette: 'P3HSV2008052020A02',
+  tiprack: 'asdasfasdasdhasjhdasdasda',
+  tipLength: 30.5,
+  lastModified: '2020-09-29T10:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
-export const mockTipLengthCalibration2: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P20MV2008052020A02',
-    tiprack: 'aasdhakfghakjsdhlaksjhdak',
-    tipLength: 32.5,
-    lastModified: '2020-09-29T12:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration2: TipLengthCalibration = {
+  pipette: 'P20MV2008052020A02',
+  tiprack: 'aasdhakfghakjsdhlaksjhdak',
+  tipLength: 32.5,
+  lastModified: '2020-09-29T12:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
-export const mockTipLengthCalibration3: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P20MV2008052020A02',
-    tiprack: 'opentrons_96_tiprack_20ul_hash',
-    tipLength: 29.0,
-    lastModified: '2020-09-29T13:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration3: TipLengthCalibration = {
+  pipette: 'P20MV2008052020A02',
+  tiprack: 'opentrons_96_tiprack_20ul_hash',
+  tipLength: 29.0,
+  lastModified: '2020-09-29T13:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
-
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
 export const mockAllTipLengthCalibrations: AllTipLengthCalibrations = {
@@ -70,7 +60,6 @@ export const mockAllTipLengthCalibrations: AllTipLengthCalibrations = {
     mockTipLengthCalibration2,
     mockTipLengthCalibration3,
   ],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/tip-length/__tests__/selectors.test.js
+++ b/app/src/calibration/tip-length/__tests__/selectors.test.js
@@ -20,9 +20,9 @@ describe('getTipLengthCalibrations', () => {
   it('should find all tip length calibrations when they exist', () => {
     expect(Selectors.getTipLengthCalibrations(mockState, 'robot-name')).toEqual(
       [
-        Fixtures.mockTipLengthCalibration1.attributes,
-        Fixtures.mockTipLengthCalibration2.attributes,
-        Fixtures.mockTipLengthCalibration3.attributes,
+        Fixtures.mockTipLengthCalibration1,
+        Fixtures.mockTipLengthCalibration2,
+        Fixtures.mockTipLengthCalibration3,
       ]
     )
   })
@@ -42,7 +42,7 @@ describe('getCalibrationForPipette', () => {
         'P20MV2008052020A02',
         'opentrons_96_tiprack_20ul_hash'
       )
-    ).toEqual(Fixtures.mockTipLengthCalibration3.attributes)
+    ).toEqual(Fixtures.mockTipLengthCalibration3)
   })
   it('should get no calibration when no matching calibration exists', () => {
     expect(

--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -13,7 +13,7 @@ export const getTipLengthCalibrations: (
   }
   const calibrations =
     state.calibration[robotName]?.tipLengthCalibrations?.data || []
-  return calibrations.map(calibration => calibration.attributes)
+  return calibrations
 }
 
 export const filterTipLengthForPipetteAndTiprack: (

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -27,6 +27,7 @@ describe('TipLengthCalibrationData', () => {
   it('displays existing data if present and not calibrated in this session', () => {
     const wrapper = render({
       calibrationData: {
+        id: '1',
         tipLength: 30,
         tiprack: 'tiprack',
         pipette: 'pip',

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -86,9 +86,7 @@ describe('PipetteInfo', () => {
   })
 
   it('just launch POC w/o cal block modal if POC button clicked and data exists', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     const { wrapper } = render()
     wrapper.find('button[children="Calibrate offset"]').invoke('onClick')()
     wrapper.update()
@@ -137,11 +135,9 @@ describe('PipetteInfo', () => {
   })
 
   it('launch POWT w/ cal block modal denied if recal tip button clicked and no cal block pref saved', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -161,11 +157,9 @@ describe('PipetteInfo', () => {
   })
 
   it('launch POWT w/ cal block modal confirmed if recal tip button clicked and no cal block pref saved', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -185,11 +179,9 @@ describe('PipetteInfo', () => {
   it('launch POWT w/o cal block modal if recal tip button clicked and cal block pref saved as true', () => {
     mockGetHasCalibrationBlock.mockReturnValue(true)
 
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -208,11 +200,9 @@ describe('PipetteInfo', () => {
   it('launch POWT w/o cal block modal if recal tip button clicked and cal block pref saved as false', () => {
     mockGetHasCalibrationBlock.mockReturnValue(false)
 
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -74,8 +74,10 @@ describe('PipetteOffsetItem', () => {
               source: 'unknown',
               markedAt: '',
             },
+            id: 'a_pip_id',
           },
           tipLength: {
+            id: '1',
             tipLength: 30,
             tiprack: 'asdagasdfasdsa',
             pipette: 'pipette-id-11',
@@ -163,8 +165,10 @@ describe('PipetteOffsetItem', () => {
             source: 'calibration_check',
             markedAt: '2020-10-09T13:30:00Z',
           },
+          id: 'a_pip_id',
         },
         tipLength: {
+          id: '1',
           tipLength: 30,
           tiprack: 'asdagasdfasdsa',
           pipette: 'pipette-id-11',
@@ -203,8 +207,10 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '2020-10-09T13:30:00Z',
           },
+          id: 'a_pip_id',
         },
         tipLength: {
+          id: '1',
           tipLength: 30,
           tiprack: 'asdagasdfasdsa',
           pipette: 'pipette-id-11',

--- a/app/src/pipettes/__tests__/selectors.test.js
+++ b/app/src/pipettes/__tests__/selectors.test.js
@@ -82,11 +82,11 @@ describe('getAttachedPipetteCalibrations', () => {
           attachedByMount: {
             left: {
               ...Fixtures.mockAttachedPipette,
-              id: POCFixtures.mockPipetteOffsetCalibration1.attributes.pipette,
+              id: POCFixtures.mockPipetteOffsetCalibration1.pipette,
             },
             right: {
               ...Fixtures.mockAttachedPipette,
-              id: POCFixtures.mockPipetteOffsetCalibration2.attributes.pipette,
+              id: POCFixtures.mockPipetteOffsetCalibration2.pipette,
             },
           },
           settingsById: null,
@@ -107,12 +107,12 @@ describe('getAttachedPipetteCalibrations', () => {
       Selectors.getAttachedPipetteCalibrations(mockPipetteState, 'robotName')
     ).toEqual({
       left: {
-        offset: POCFixtures.mockPipetteOffsetCalibration1.attributes,
-        tipLength: TLCFixtures.mockTipLengthCalibration1.attributes,
+        offset: POCFixtures.mockPipetteOffsetCalibration1,
+        tipLength: TLCFixtures.mockTipLengthCalibration1,
       },
       right: {
-        offset: POCFixtures.mockPipetteOffsetCalibration2.attributes,
-        tipLength: TLCFixtures.mockTipLengthCalibration2.attributes,
+        offset: POCFixtures.mockPipetteOffsetCalibration2,
+        tipLength: TLCFixtures.mockTipLengthCalibration2,
       },
     })
   })

--- a/app/src/robot-admin/__fixtures__/system-time.js
+++ b/app/src/robot-admin/__fixtures__/system-time.js
@@ -6,12 +6,10 @@ import {
   mockFailureBody,
 } from '../../robot-api/__fixtures__'
 
-import type { SystemTimeData, SystemTimeAttributes } from '../api-types'
+import type { SystemTimeData } from '../api-types'
 import type { ResponseFixtures } from '../../robot-api/__fixtures__'
 
-export const mockSystemTimeAttributes: SystemTimeAttributes = {
-  systemTime: '2020-09-08T18:02:01.318292+00:00',
-}
+export const mockSystemTime = '2020-09-08T18:02:01.318292+00:00'
 
 export const {
   successMeta: mockFetchSystemTimeSuccessMeta,
@@ -27,8 +25,7 @@ export const {
   successStatus: 200,
   successBody: {
     id: 'time',
-    type: 'SystemTimeAttributes',
-    attributes: mockSystemTimeAttributes,
+    systemTime: mockSystemTime,
   },
   failureStatus: 500,
   failureBody: mockFailureBody,

--- a/app/src/robot-admin/api-types.js
+++ b/app/src/robot-admin/api-types.js
@@ -1,13 +1,7 @@
 // @flow
 
-export type SystemTimeAttributes = {
-  systemTime: string,
-  ...
-}
-
 export type SystemTimeData = {
   id: 'time',
-  type: 'SystemTimeAttributes',
-  attributes: SystemTimeAttributes,
+  systemTime: string,
   ...
 }

--- a/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
+++ b/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
@@ -15,7 +15,7 @@ const createConnectAction = robotName => (RobotActions.connect(robotName): any)
 
 const createTimeSuccessResponse = (time: Date) => {
   const response = cloneDeep(mockFetchSystemTimeSuccess)
-  set(response, 'body.data.attributes.systemTime', time.toISOString())
+  set(response, 'body.data.systemTime', time.toISOString())
   return response
 }
 
@@ -78,15 +78,14 @@ describe('syncTimeOnConnectEpic', () => {
         path: '/system/time',
         body: {
           data: {
-            type: 'SystemTimeAttributes',
-            attributes: { systemTime: expect.any(String) },
+            systemTime: expect.any(String),
           },
         },
       })
 
       const updatedTime = get(
         mocks.fetchRobotApi.mock.calls[1][1],
-        'body.data.attributes.systemTime'
+        'body.data.systemTime'
       )
 
       expect(

--- a/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
+++ b/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
@@ -25,8 +25,7 @@ const createUpdateRequest = (date: Date): RobotApiRequestOptions => {
     path: Constants.SYSTEM_TIME_PATH,
     body: {
       data: {
-        type: 'SystemTimeAttributes',
-        attributes: { systemTime: date.toISOString() },
+        systemTime: date.toISOString(),
       },
     },
   }
@@ -43,7 +42,7 @@ export const syncTimeOnConnectEpic: Epic = (action$, state$) => {
 
       return fetchRobotApi(robot, fetchSystemTimeReq).pipe(
         filter(response => response.ok),
-        map(response => response.body.data.attributes.systemTime),
+        map(response => response.body.data.systemTime),
         filter(systemTimeString => {
           const systemTime = parseISO(systemTimeString)
           const drift = differenceInSeconds(systemTime, new Date())

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -68,21 +68,16 @@ export type ResourceLink = {|
 export type ResourceLinks = $Shape<{| [string]: ResourceLink | string | void |}>
 
 // generic response data supertype
-export type RobotApiV2ResponseData = {|
+export type RobotApiV2ResponseData = {
   id: string,
-  // the "+" means that these properties are covariant, so
-  // "extending" types may specify more strict subtypes
-  +type: string,
-  +attributes: { ... },
-|}
+  ...
+}
 
 export type RobotApiV2ResponseBody<
-  DataT: RobotApiV2ResponseData | $ReadOnlyArray<RobotApiV2ResponseData>,
-  MetaT = void
+  DataT: RobotApiV2ResponseData | $ReadOnlyArray<RobotApiV2ResponseData>
 > = {|
   data: DataT,
   links?: ResourceLinks,
-  meta?: MetaT,
 |}
 
 export type RobotApiV2Error = {|

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -68,62 +68,54 @@ export const mockSessionCommand: Types.SessionCommandAttributes = {
 
 export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {
   command: 'calibration.check.comparePoint',
-  status: 'accepted',
   data: {},
 }
 
 export const mockSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockCalibrationCheckSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockCalibrationCheckSessionAttributes,
   },
 }
 
 export const mockTipLengthCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockTipLengthCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockTipLengthCalibrationSessionAttributes,
   },
 }
 
 export const mockPipetteOffsetCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockPipetteOffsetCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockPipetteOffsetCalibrationSessionAttributes,
   },
 }
 
 export const mockDeckCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockDeckCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockDeckCalibrationSessionAttributes,
   },
 }
 
 export const mockMultiSessionResponse: Types.MultiSessionResponse = {
   data: [
     {
+      ...mockCalibrationCheckSessionAttributes,
       id: mockSessionId,
-      type: 'Session',
-      attributes: mockCalibrationCheckSessionAttributes,
     },
     {
+      ...mockCalibrationCheckSessionAttributes,
       id: mockOtherSessionId,
-      type: 'Session',
-      attributes: mockCalibrationCheckSessionAttributes,
     },
   ],
 }
 
 export const mockSessionCommandResponse: Types.SessionCommandResponse = {
   data: {
+    ...mockSessionCommandAttributes,
     id: mockSessionId,
-    type: 'SessionCommand',
-    attributes: mockSessionCommandAttributes,
   },
 }
 

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -34,7 +34,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -55,7 +55,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -65,11 +65,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -93,7 +93,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -114,7 +114,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -124,11 +124,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -147,7 +147,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -157,11 +157,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -185,11 +185,11 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[0].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[0],
             id: Fixtures.mockSessionId,
           },
           [Fixtures.mockOtherSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[1].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[1],
             id: Fixtures.mockOtherSessionId,
           },
         },
@@ -221,11 +221,11 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[0].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[0],
             id: Fixtures.mockSessionId,
           },
           [Fixtures.mockOtherSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[1].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[1],
             id: Fixtures.mockOtherSessionId,
           },
         },

--- a/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
@@ -31,12 +31,9 @@ describe('createSessionCommandEpic', () => {
     path: '/sessions/1234/commands/execute',
     body: {
       data: {
-        type: 'Command',
-        attributes: {
-          command: 'calibration.jog',
-          data: {
-            vector: [32, 0, 0],
-          },
+        command: 'calibration.jog',
+        data: {
+          vector: [32, 0, 0],
         },
       },
     },

--- a/app/src/sessions/epic/__tests__/createSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionEpic.test.js
@@ -18,11 +18,8 @@ describe('createSessionEpic', () => {
     path: '/sessions',
     body: {
       data: {
-        type: 'Session',
-        attributes: {
-          sessionType: 'calibrationCheck',
-          createParams: {},
-        },
+        sessionType: 'calibrationCheck',
+        createParams: {},
       },
     },
   }

--- a/app/src/sessions/epic/__tests__/ensureSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/ensureSessionEpic.test.js
@@ -34,13 +34,10 @@ const expectedCreateRequest = {
   path: '/sessions',
   body: {
     data: {
-      type: 'Session',
-      attributes: {
-        sessionType: 'calibrationCheck',
-        createParams: {
-          hasCalibrationBlock: true,
-          tipRacks: [],
-        },
+      sessionType: 'calibrationCheck',
+      createParams: {
+        hasCalibrationBlock: true,
+        tipRacks: [],
       },
     },
   },

--- a/app/src/sessions/epic/createSessionCommandEpic.js
+++ b/app/src/sessions/epic/createSessionCommandEpic.js
@@ -25,11 +25,8 @@ const mapActionToRequest = (
   path: `${Constants.SESSIONS_PATH}/${action.payload.sessionId}${Constants.SESSIONS_COMMANDS_EXECUTE_PATH_EXTENSION}`,
   body: {
     data: {
-      type: 'Command',
-      attributes: {
-        command: action.payload.command.command,
-        data: action.payload.command.data,
-      },
+      command: action.payload.command.command,
+      data: action.payload.command.data,
     },
   },
 })

--- a/app/src/sessions/epic/createSessionEpic.js
+++ b/app/src/sessions/epic/createSessionEpic.js
@@ -22,11 +22,8 @@ export const mapActionToRequest = (
   path: Constants.SESSIONS_PATH,
   body: {
     data: {
-      type: 'Session',
-      attributes: {
-        sessionType: action.payload.sessionType,
-        createParams: action.payload.params,
-      },
+      sessionType: action.payload.sessionType,
+      createParams: action.payload.params,
     },
   },
 })

--- a/app/src/sessions/epic/ensureSessionEpic.js
+++ b/app/src/sessions/epic/ensureSessionEpic.js
@@ -47,8 +47,8 @@ export const ensureSessionEpic: Epic = (action$, state$) => {
               !ok ||
               body.data.some(
                 s =>
-                  s.attributes.sessionType === sessionType &&
-                  isEqual(s.attributes.createParams, params)
+                  s.sessionType === sessionType &&
+                  isEqual(s.createParams, params)
               )
             ) {
               return of(

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -29,10 +29,7 @@ export function sessionReducer(
           ...robotState,
           robotSessions: {
             ...robotState.robotSessions,
-            [sessionState.data.id]: {
-              ...sessionState.data.attributes,
-              id: sessionState.data.id,
-            },
+            [sessionState.data.id]: sessionState.data,
           },
         },
       }
@@ -42,7 +39,7 @@ export function sessionReducer(
       const { robotName, sessions } = action.payload
       const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE
       const sessionsById = sessions.reduce(
-        (acc, s) => ({ ...acc, [s.id]: { ...s.attributes, id: s.id } }),
+        (acc, s) => ({ ...acc, [s.id]: { ...s, id: s.id } }),
         {}
       )
 

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -141,31 +141,22 @@ export type Session =
 export type SessionCommandAttributes = {|
   command: SessionCommandString,
   data: SessionCommandData,
+|}
+
+export type SessionResponseModel = Session
+
+export type SessionCommandResponseModel = {|
+  ...SessionCommandAttributes,
+  id: string,
   status?: string,
 |}
 
-export type SessionResponseModel = {|
-  id: string,
-  type: 'Session',
-  attributes: SessionResponseAttributes,
-|}
-
-export type SessionCommandResponseModel = {|
-  id: string,
-  type: 'SessionCommand',
-  attributes: SessionCommandAttributes,
-|}
-
-export type SessionResponse = RobotApiV2ResponseBody<SessionResponseModel, {||}>
+export type SessionResponse = RobotApiV2ResponseBody<SessionResponseModel>
 export type MultiSessionResponse = RobotApiV2ResponseBody<
-  $ReadOnlyArray<SessionResponseModel>,
-  {||}
+  $ReadOnlyArray<SessionResponseModel>
 >
 
-export type SessionCommandResponse = RobotApiV2ResponseBody<
-  SessionCommandResponseModel,
-  Session
->
+export type SessionCommandResponse = RobotApiV2ResponseBody<SessionCommandResponseModel>
 
 export type CreateSessionAction = {|
   type: CREATE_SESSION,

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -1,4 +1,4 @@
-from .request import RequestModel, RequestDataModel  # noqa(W0611)
-from .response import ResponseModel, ResponseDataModel  # noqa(W0611)
+from .request import RequestModel  # noqa(W0611)
+from .response import ResponseModel, MultiResponseModel, ResponseDataModel  # noqa(W0611)
 from .errors import Error, ErrorSource, ErrorResponse  # noqa(W0611)
 from .resource_links import ResourceLink, ResourceLinks  # noqa(W0611)

--- a/robot-server/robot_server/service/json_api/request.py
+++ b/robot-server/robot_server/service/json_api/request.py
@@ -1,43 +1,14 @@
-from typing import Generic, TypeVar, Optional
+from typing import Generic, TypeVar
 from pydantic import Field
 from pydantic.generics import GenericModel
 
 
-AttributesT = TypeVar('AttributesT')
+RequestDataT = TypeVar('RequestDataT')
 
 
-class RequestDataModel(GenericModel, Generic[AttributesT]):
+class RequestModel(GenericModel, Generic[RequestDataT]):
     """
     """
-    id: Optional[str] = \
-        Field(None,
-              description="id member represents a resource object and is not"
-                          " required when the resource object originates at"
-                          " the client and represents a new resource to be"
-                          " created on the server.")
-    type: str = \
-        Field(...,
-              description="type member is used to describe resource objects"
-                          " that share common attributes.")
-    attributes: AttributesT = \
-        Field(...,
-              description="an attributes object representing some of the"
-                          " resource’s data.")
-
-    @classmethod
-    def create(cls, attributes: AttributesT, resource_id: str = None):
-        return RequestDataModel[AttributesT](
-            id=resource_id,
-            attributes=attributes,
-            type=attributes.__class__.__name__)
-
-
-class RequestModel(GenericModel, Generic[AttributesT]):
-    """
-    """
-    data: RequestDataModel[AttributesT] = \
+    data: RequestDataT = \
         Field(...,
               description="the document’s 'primary data'")
-
-    def attributes(self):
-        return self.data.attributes

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -1,39 +1,19 @@
 from typing import Generic, TypeVar, Optional, List
-from pydantic import Field
+from pydantic import Field, BaseModel
 from pydantic.generics import GenericModel
 
 from .resource_links import ResourceLinks
 
 
-AttributesT = TypeVar('AttributesT')
-
-
-class ResponseDataModel(GenericModel, Generic[AttributesT]):
+class ResponseDataModel(BaseModel):
     """
     """
-    id: Optional[str] = \
+    id: str = \
         Field(None,
               description="id member represents a resource object.")
-    type: Optional[str] = \
-        Field(None,
-              description="type member is used to describe resource objects"
-                          " that share common attributes.")
-    attributes: AttributesT = \
-        Field({},
-              description="an attributes object representing some of the"
-                          " resource’s data.")
 
-    # Note(isk: 3/13/20): Need this to validate attribute default
-    # see here: https://pydantic-docs.helpmanual.io/usage/model_config/
-    class Config:
-        validate_all = True
 
-    @classmethod
-    def create(cls, attributes: AttributesT, resource_id: str):
-        return ResponseDataModel[AttributesT](
-            id=resource_id,
-            attributes=attributes,
-            type=attributes.__class__.__name__)
+ResponseDataT = TypeVar('ResponseDataT', bound=ResponseDataModel)
 
 
 DESCRIPTION_DATA = "the document’s 'primary data'"
@@ -43,26 +23,22 @@ DESCRIPTION_LINKS = "a links object related to the primary data."
 DESCRIPTION_META = "a meta object that contains non-standard" \
                              " meta-information."
 
-MetaT = TypeVar('MetaT')
 
-
-class ResponseModel(GenericModel, Generic[AttributesT, MetaT]):
+class ResponseModel(GenericModel, Generic[ResponseDataT]):
     """A response that returns a single resource"""
 
-    meta: Optional[MetaT] = Field(None, description=DESCRIPTION_META)
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: ResponseDataModel[AttributesT] = Field(
+    data: ResponseDataT = Field(
         ...,
         description=DESCRIPTION_DATA
     )
 
 
-class MultiResponseModel(GenericModel, Generic[AttributesT, MetaT]):
+class MultiResponseModel(GenericModel, Generic[ResponseDataT]):
     """A response that returns multiple resources"""
 
-    meta: Optional[MetaT] = Field(None, description=DESCRIPTION_META)
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: List[ResponseDataModel[AttributesT]] = Field(
+    data: List[ResponseDataT] = Field(
         ...,
         description=DESCRIPTION_DATA
     )

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from functools import partial
 from pydantic import BaseModel, Field
 
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, ResponseDataModel, MultiResponseModel)
 
 OffsetVector = typing.Tuple[float, float, float]
 
@@ -39,7 +39,7 @@ class CalibrationData(BaseModel):
         Field(..., description="The tip length of a labware, if relevant.")
 
 
-class LabwareCalibration(BaseModel):
+class LabwareCalibration(ResponseDataModel):
     """
     A model describing labware calibrations (tiplength and offset)
     """
@@ -102,9 +102,9 @@ class LabwareCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    LabwareCalibration, dict
+    LabwareCalibration
 ]
 
 SingleCalibrationResponse = ResponseModel[
-    LabwareCalibration, dict
+    LabwareCalibration
 ]

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.labware import models as lw_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 
 router = APIRouter()
 
@@ -50,16 +50,14 @@ def _format_calibrations(
         cal_data = lw_models.CalibrationData(
             offset=offset, tipLength=tip_length)
         formatted_cal = lw_models.LabwareCalibration(
+            id=calInfo.labware_id,
             calibrationData=cal_data,
             loadName=details.load_name,
             namespace=details.namespace,
             version=details.version,
             parent=parent_info,
             definitionHash=calInfo.labware_id)
-        formatted_calibrations.append(
-                ResponseDataModel.create(
-                    attributes=formatted_cal,
-                    resource_id=calInfo.labware_id))
+        formatted_calibrations.append(formatted_cal)
     return formatted_calibrations
 
 

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -2,11 +2,11 @@ import typing
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, MultiResponseModel, ResponseDataModel)
 from robot_server.service.shared_models import calibration as cal_model
 
 OffsetVector = typing.Tuple[float, float, float]
@@ -18,7 +18,7 @@ class MountType(str, Enum):
     right = "right"
 
 
-class PipetteOffsetCalibration(BaseModel):
+class PipetteOffsetCalibration(ResponseDataModel):
     """
     A model describing pipette calibration based on the mount and
     the pipette's serial number
@@ -50,10 +50,10 @@ class PipetteOffsetCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    PipetteOffsetCalibration, dict
+    PipetteOffsetCalibration
 ]
 
 
 SingleCalibrationResponse = ResponseModel[
-    PipetteOffsetCalibration, dict
+    PipetteOffsetCalibration
 ]

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -10,7 +10,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.pipette_offset import models as pip_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 from robot_server.service.shared_models import calibration as cal_model
 
 router = APIRouter()
@@ -18,10 +18,11 @@ router = APIRouter()
 
 def _format_calibration(
     calibration: cal_types.PipetteOffsetCalibration
-) -> ResponseDataModel[pip_models.PipetteOffsetCalibration]:
+) -> pip_models.PipetteOffsetCalibration:
     status = cal_model.CalibrationStatus(
         **helpers.convert_to_dict(calibration.status))
     formatted_cal = pip_models.PipetteOffsetCalibration(
+        id=f'{calibration.pipette}&{calibration.mount}',
         pipette=calibration.pipette,
         mount=calibration.mount,
         offset=calibration.offset,
@@ -31,9 +32,7 @@ def _format_calibration(
         source=calibration.source,
         status=status)
 
-    return ResponseDataModel.create(
-        attributes=formatted_cal,
-        resource_id=f'{calibration.pipette}&{calibration.mount}')
+    return formatted_cal
 
 
 @router.get(

--- a/robot-server/robot_server/service/protocol/models.py
+++ b/robot-server/robot_server/service/protocol/models.py
@@ -3,23 +3,21 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from robot_server.service.json_api import ResponseModel, ResponseDataModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, ResponseDataModel, MultiResponseModel)
 
 
 class FileAttributes(BaseModel):
     basename: str
 
 
-class ProtocolResponseAttributes(BaseModel):
+class ProtocolResponseAttributes(ResponseDataModel):
     protocolFile: FileAttributes
     supportFiles: typing.List[FileAttributes]
     lastModifiedAt: datetime
     createdAt: datetime
 
 
-ProtocolResponseDataModel = ResponseDataModel[ProtocolResponseAttributes]
+ProtocolResponse = ResponseModel[ProtocolResponseAttributes]
 
-ProtocolResponse = ResponseModel[ProtocolResponseAttributes, dict]
-
-MultiProtocolResponse = MultiResponseModel[ProtocolResponseAttributes, dict]
+MultiProtocolResponse = MultiResponseModel[ProtocolResponseAttributes]

--- a/robot-server/robot_server/service/protocol/router.py
+++ b/robot-server/robot_server/service/protocol/router.py
@@ -99,21 +99,19 @@ async def create_protocol_file(
 
 
 def _to_response(uploaded_protocol: UploadedProtocol) \
-        -> route_models.ProtocolResponseDataModel:
+        -> route_models.ProtocolResponseAttributes:
     """Create ProtocolResponse from an UploadedProtocol"""
     meta = uploaded_protocol.meta
-    return route_models.ProtocolResponseDataModel.create(
-        attributes=route_models.ProtocolResponseAttributes(
-            protocolFile=route_models.FileAttributes(
-                basename=meta.protocol_file.path.name
-            ),
-            supportFiles=[route_models.FileAttributes(
-                basename=s.path.name
-            ) for s in meta.support_files],
-            lastModifiedAt=meta.last_modified_at,
-            createdAt=meta.created_at
+    return route_models.ProtocolResponseAttributes(
+        id=meta.identifier,
+        protocolFile=route_models.FileAttributes(
+            basename=meta.protocol_file.path.name
         ),
-        resource_id=meta.identifier
+        supportFiles=[route_models.FileAttributes(
+            basename=s.path.name
+        ) for s in meta.support_files],
+        lastModifiedAt=meta.last_modified_at,
+        createdAt=meta.created_at,
     )
 
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from enum import Enum
 import typing
-from functools import lru_cache
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.pipette.dev_types import PipetteName
@@ -10,7 +9,7 @@ from robot_server.service.session.models.common import (
 from pydantic import BaseModel, Field, validator
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.json_api import (
-    ResponseModel, RequestModel)
+    ResponseModel, RequestModel, ResponseDataModel)
 from opentrons.util.helpers import utc_now
 
 
@@ -32,11 +31,21 @@ class LoadLabwareRequest(BaseModel):
         description="The labware definition version")
 
 
+class LoadLabwareResponse(BaseModel):
+    labwareId: IdentifierType
+    definition: LabwareDefinition
+    calibration: OffsetVector
+
+
 class LoadInstrumentRequest(BaseModel):
     instrumentName: PipetteName = Field(
         ...,
         description="The name of the instrument model")
     mount: Mount
+
+
+class LoadInstrumentResponse(BaseModel):
+    instrumentId: IdentifierType
 
 
 class PipetteRequestBase(BaseModel):
@@ -70,16 +79,6 @@ class SetHasCalibrationBlockRequest(BaseModel):
     hasBlock: bool = Field(
         ...,
         description="whether or not there is a calibration block present")
-
-
-class LoadLabwareResponse(BaseModel):
-    labwareId: IdentifierType
-    definition: LabwareDefinition
-    calibration: OffsetVector
-
-
-class LoadInstrumentResponse(BaseModel):
-    instrumentId: IdentifierType
 
 
 class CommandStatus(str, Enum):
@@ -265,26 +264,8 @@ class BasicSessionCommand(BaseModel):
                              f"Expecting {v.model}")
         return v
 
-    @validator('command', pre=True)
-    def pre_namespace_backwards_compatibility(cls, v):
-        """Support commands that were released before namespace."""
-        # TODO: AmitL 2020.7.9. Remove this backward compatibility once
-        #  clients reliably use fully namespaced command names
-        return BasicSessionCommand._pre_namespace_mapping().get(v, v)
 
-    @staticmethod
-    @lru_cache(maxsize=1)
-    def _pre_namespace_mapping() -> typing.Dict[str, CommandDefinition]:
-        """Create a dictionary of pre-namespace name to CommandDefinition"""
-        # A tuple of CommandDefinition enums which need to be identified by
-        # localname and full namespaced name
-        pre_namespace_ns = CheckCalibrationCommand, CalibrationCommand
-        # Flatten
-        t = tuple(v for k in pre_namespace_ns for v in k)
-        return {k.localname: k for k in t}
-
-
-class SessionCommand(BasicSessionCommand):
+class SessionCommand(ResponseDataModel, BasicSessionCommand):
     """A session command response"""
     status: CommandStatus
     createdAt: datetime = Field(..., default_factory=utc_now)
@@ -298,5 +279,5 @@ CommandRequest = RequestModel[
     BasicSessionCommand
 ]
 CommandResponse = ResponseModel[
-    SessionCommand, dict
+    SessionCommand
 ]

--- a/robot-server/robot_server/service/session/models/session.py
+++ b/robot-server/robot_server/service/session/models/session.py
@@ -16,8 +16,8 @@ from robot_server.robot.calibration.pipette_offset.models import\
     PipetteOffsetCalibrationSessionStatus
 from robot_server.robot.calibration.tip_length.models import\
     TipCalibrationSessionStatus
-from robot_server.service.json_api import RequestModel, ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    RequestModel, ResponseModel, ResponseDataModel, MultiResponseModel)
 from robot_server.service.session.models.common import EmptyModel
 from robot_server.service.session.session_types.protocol.models import \
     ProtocolCreateParams, ProtocolSessionDetails
@@ -108,7 +108,7 @@ class LiveProtocolCreateAttributes(SessionCreateAttributesNoParams):
         SessionType.live_protocol
 
 
-class SessionResponseAttributes(BaseModel):
+class SessionResponseAttributes(ResponseDataModel):
     """Common session response attributes."""
     createdAt: datetime = \
         Field(...,
@@ -185,8 +185,8 @@ SessionCreateRequest = RequestModel[
     RequestTypes
 ]
 SessionResponse = ResponseModel[
-    ResponseTypes, dict
+    ResponseTypes
 ]
 MultiSessionResponse = MultiResponseModel[
-    ResponseTypes, dict
+    ResponseTypes
 ]

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Query, Depends
 from robot_server.service.session.models.common import IdentifierType
 from robot_server.service.dependencies import get_session_manager
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ResourceLink, ResponseDataModel
+from robot_server.service.json_api import ResourceLink
 from robot_server.service.json_api.resource_links import ResourceLinkKey, \
     ResourceLinks
 from robot_server.service.session.command_execution import create_command
@@ -52,17 +52,15 @@ async def create_session_handler(
         session_manager: SessionManager = Depends(get_session_manager)) \
         -> SessionResponse:
     """Create a session"""
-    session_type = create_request.data.attributes.sessionType
-    create_params = create_request.data.attributes.createParams
+    session_type = create_request.data.sessionType
+    create_params = create_request.data.createParams
 
     new_session = await session_manager.add(
         session_type=session_type,
         session_meta_data=SessionMetaData(create_params=create_params))
 
     return SessionResponse(
-        data=ResponseDataModel.create(
-            attributes=new_session.get_response_model(),
-            resource_id=new_session.meta.identifier),
+        data=new_session.get_response_model(),
         links=get_valid_session_links(new_session.meta.identifier, router)
     )
 
@@ -81,9 +79,7 @@ async def delete_session_handler(
     await session_manager.remove(session_obj.meta.identifier)
 
     return SessionResponse(
-        data=ResponseDataModel.create(
-            attributes=session_obj.get_response_model(),
-            resource_id=sessionId),
+        data=session_obj.get_response_model(),
         links=get_sessions_links(router),
     )
 
@@ -100,9 +96,7 @@ async def get_session_handler(
                               api_router=router)
 
     return SessionResponse(
-        data=ResponseDataModel.create(
-            attributes=session_obj.get_response_model(),
-            resource_id=sessionId),
+        data=session_obj.get_response_model(),
         links=get_valid_session_links(sessionId, router)
     )
 
@@ -119,10 +113,7 @@ async def get_sessions_handler(
     """Get multiple sessions"""
     sessions = session_manager.get(session_type=session_type)
     return MultiSessionResponse(
-        data=[ResponseDataModel.create(
-            attributes=session.get_response_model(),
-            resource_id=session.meta.identifier) for session in sessions
-        ]
+        data=[session.get_response_model() for session in sessions]
     )
 
 
@@ -145,24 +136,22 @@ async def session_command_execute_handler(
             reason=f"Session '{sessionId}' is not active. "
                    "Only the active session can execute commands")
 
-    command = create_command(command_request.data.attributes.command,
-                             command_request.data.attributes.data)
+    command = create_command(command_request.data.command,
+                             command_request.data.data)
     command_result = await session_obj.command_executor.execute(command)
 
     log.debug(f"Command result: {command_result}")
 
     return CommandResponse(
-        data=ResponseDataModel.create(
-            attributes=SessionCommand(
-                data=command_result.content.data,
-                command=command_result.content.name,
-                status=command_result.result.status,
-                createdAt=command_result.meta.created_at,
-                startedAt=command_result.result.started_at,
-                completedAt=command_result.result.completed_at,
-                result=command_result.result.data,
-            ),
-            resource_id=command_result.meta.identifier
+        data=SessionCommand(
+            id=command_result.meta.identifier,
+            data=command_result.content.data,
+            command=command_result.content.name,
+            status=command_result.result.status,
+            createdAt=command_result.meta.created_at,
+            startedAt=command_result.result.started_at,
+            completedAt=command_result.result.completed_at,
+            result=command_result.result.data,
         ),
         links=get_valid_session_links(sessionId, router)
     )

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -98,7 +98,9 @@ class CheckSession(BaseSession):
 
     def get_response_model(self) -> CalibrationCheckResponseAttributes:
         return CalibrationCheckResponseAttributes(
-            createParams=cast(SessionCreateParams, self.meta.create_params),
+            id=self.meta.identifier,
+            createParams=cast(SessionCreateParams,
+                              self.meta.create_params),
             createdAt=self.meta.created_at,
             details=self._get_response_details()
         )

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -79,6 +79,7 @@ class DeckCalibrationSession(BaseSession):
 
     def get_response_model(self) -> DeckCalibrationResponseAttributes:
         return DeckCalibrationResponseAttributes(
+            id=self.meta.identifier,
             createParams=self.meta.create_params,
             details=self._get_response_details(),
             createdAt=self.meta.created_at

--- a/robot-server/robot_server/service/session/session_types/live_protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/session.py
@@ -42,6 +42,7 @@ class LiveProtocolSession(BaseSession):
 
     def get_response_model(self) -> models.LiveProtocolResponseAttributes:
         return models.LiveProtocolResponseAttributes(
+            id=self.meta.identifier,
             createdAt=self.meta.created_at,
             createParams=self.meta.create_params,
             details=EmptyModel()

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -97,6 +97,7 @@ class PipetteOffsetCalibrationSession(BaseSession):
 
     def get_response_model(self) -> PipetteOffsetCalibrationResponseAttributes:
         return PipetteOffsetCalibrationResponseAttributes(
+            id=self.meta.identifier,
             details=self._get_response_details(),
             createdAt=self.meta.created_at,
             createParams=cast(SessionCreateParams, self.meta.create_params)

--- a/robot-server/robot_server/service/session/session_types/protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/session.py
@@ -52,6 +52,7 @@ class ProtocolSession(BaseSession):
 
     def get_response_model(self) -> ProtocolResponseAttributes:
         return ProtocolResponseAttributes(
+            id=self.meta.identifier,
             createParams=cast(ProtocolCreateParams, self.meta.create_params),
             createdAt=self.meta.created_at,
             details=ProtocolSessionDetails(

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -91,6 +91,7 @@ class TipLengthCalibration(BaseSession):
 
     def get_response_model(self) -> TipLengthCalibrationResponseAttributes:
         return TipLengthCalibrationResponseAttributes(
+            id=self.meta.identifier,
             details=self._get_response_details(),
             createdAt=self.meta.created_at,
             createParams=cast(SessionCreateParams, self.meta.create_params)

--- a/robot-server/robot_server/service/system/models.py
+++ b/robot-server/robot_server/service/system/models.py
@@ -10,8 +10,10 @@ class SystemTimeAttributes(BaseModel):
     systemTime: datetime
 
 
-SystemTimeResponseDataModel = ResponseDataModel[SystemTimeAttributes]
+class SystemTimeAttributesResponse(ResponseDataModel, SystemTimeAttributes):
+    pass
 
-SystemTimeResponse = ResponseModel[SystemTimeAttributes, dict]
+
+SystemTimeResponse = ResponseModel[SystemTimeAttributesResponse]
 
 SystemTimeRequest = RequestModel[SystemTimeAttributes]

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -19,11 +19,9 @@ def _create_response(dt: datetime) \
         -> time_models.SystemTimeResponse:
     """Create a SystemTimeResponse with system datetime"""
     return time_models.SystemTimeResponse(
-        data=time_models.SystemTimeResponseDataModel.create(
-            attributes=time_models.SystemTimeAttributes(
-                systemTime=dt
-            ),
-            resource_id="time"
+        data=time_models.SystemTimeAttributesResponse(
+                systemTime=dt,
+                id="time"
         ),
         links={
             ResourceLinkKey.self: ResourceLink(href='/system/time')
@@ -49,5 +47,5 @@ async def get_time() -> time_models.SystemTimeResponse:
             response_model=time_models.SystemTimeResponse)
 async def set_time(new_time: time_models.SystemTimeRequest) \
         -> time_models.SystemTimeResponse:
-    sys_time = await time.set_system_time(new_time.data.attributes.systemTime)
+    sys_time = await time.set_system_time(new_time.data.systemTime)
     return _create_response(sys_time)

--- a/robot-server/robot_server/service/tip_length/models.py
+++ b/robot-server/robot_server/service/tip_length/models.py
@@ -1,14 +1,14 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
-from robot_server.service.json_api import ResponseModel
-from robot_server.service.json_api.response import MultiResponseModel
+from robot_server.service.json_api import (
+    ResponseModel, MultiResponseModel, ResponseDataModel)
 from robot_server.service.shared_models import calibration as cal_model
 
 
-class TipLengthCalibration(BaseModel):
+class TipLengthCalibration(ResponseDataModel):
     """
     A model describing tip length calibration
     """
@@ -27,9 +27,9 @@ class TipLengthCalibration(BaseModel):
 
 
 MultipleCalibrationsResponse = MultiResponseModel[
-    TipLengthCalibration, dict
+    TipLengthCalibration
 ]
 
 SingleCalibrationResponse = ResponseModel[
-    TipLengthCalibration, dict
+    TipLengthCalibration
 ]

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -9,7 +9,7 @@ from opentrons.calibration_storage import (
 
 from robot_server.service.tip_length import models as tl_models
 from robot_server.service.errors import RobotServerError, CommonErrorDef
-from robot_server.service.json_api import ErrorResponse, ResponseDataModel
+from robot_server.service.json_api import ErrorResponse
 from robot_server.service.shared_models import calibration as cal_model
 
 
@@ -18,10 +18,11 @@ router = APIRouter()
 
 def _format_calibration(
     calibration: cal_types.TipLengthCalibration
-) -> ResponseDataModel[tl_models.TipLengthCalibration]:
+) -> tl_models.TipLengthCalibration:
     status = cal_model.CalibrationStatus(
         **helpers.convert_to_dict(calibration.status))
     formatted_cal = tl_models.TipLengthCalibration(
+        id=f'{calibration.tiprack}&{calibration.pipette}',
         tipLength=calibration.tip_length,
         tiprack=calibration.tiprack,
         pipette=calibration.pipette,
@@ -29,9 +30,7 @@ def _format_calibration(
         source=calibration.source,
         status=status)
 
-    return ResponseDataModel.create(
-        attributes=formatted_cal,
-        resource_id=f'{calibration.tiprack}&{calibration.pipette}')
+    return formatted_cal
 
 
 @router.get(

--- a/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
+++ b/robot-server/tests/integration/protocols/test_protocol_upload.tavern.yaml
@@ -16,14 +16,12 @@ stages:
       json:
         data: &response_data
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-              - basename: data.csv
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+            - basename: data.csv
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -89,13 +87,11 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles: []
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles: []
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -112,13 +108,11 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles: []
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles: []
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -137,14 +131,12 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-            - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+          - basename: 'data.csv'
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols/phony_proto'
@@ -161,14 +153,12 @@ stages:
       json:
         data:
           id: phony_proto
-          type: ProtocolResponseAttributes
-          attributes:
-            protocolFile:
-              basename: phony_proto.py
-            supportFiles:
-            - basename: 'data.csv'
-            lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          protocolFile:
+            basename: phony_proto.py
+          supportFiles:
+          - basename: 'data.csv'
+          lastModifiedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
         links:
           self:
             href: '/protocols'

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -84,7 +84,6 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: !anydict
         data:
           <<: *session_data
@@ -171,7 +170,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -194,7 +192,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -15,12 +15,10 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
-            createParams:
-              tipRacks: []
-              hasCalibrationBlock: true
+          sessionType: calibrationCheck
+          createParams:
+            tipRacks: []
+            hasCalibrationBlock: true
     response:
       status_code: 201
       save:
@@ -35,23 +33,20 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data: &session_data
           id: "{session_id}"
-          type: !anystr
-          attributes: &session_data_attributes
-            sessionType: calibrationCheck
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createParams:
-              tipRacks: []
-              hasCalibrationBlock: true
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instruments: !anylist
-              activePipette: !anydict
-              activeTipRack: !anydict
-              labware: !anylist
-              comparisonsByPipette: !anydict
+          sessionType: calibrationCheck
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createParams:
+            tipRacks: []
+            hasCalibrationBlock: true
+          details: &session_data_attribute_details
+            currentStep: sessionStarted
+            instruments: !anylist
+            activePipette: !anydict
+            activeTipRack: !anydict
+            labware: !anylist
+            comparisonsByPipette: !anydict
 
   - name: Load labware
     request: &post_command
@@ -59,10 +54,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -71,24 +64,19 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: labwareLoaded
+          details:
+            <<: *session_data_attribute_details
+            currentStep: labwareLoaded
   
   - name: Move nozzle
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToReferencePoint
-            data: {}
+          command: calibration.moveToReferencePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -100,21 +88,17 @@ stages:
         links: !anydict
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingNozzle
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingNozzle
 
   - name: Prepare first pipette
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToTipRack
-            data: {}
+          command: calibration.moveToTipRack
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -123,25 +107,20 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Jog first pipette
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.jog
-            data:
-              vector: [0, 0, -10]
+          command: calibration.jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -150,24 +129,19 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Pick up tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -176,24 +150,19 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: inspectingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: inspectingTip
 
   - name: Confirm tip attached
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToReferencePoint
-            data: {}
+          command: calibration.moveToReferencePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -205,22 +174,18 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingTip
 
   - name: Jog pipette tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.jog
-            data:
-              vector: [0, 0, 0.1]
+          command: calibration.jog
+          data:
+            vector: [0, 0, 0.1]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -232,21 +197,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingTip
 
   - name: Compare Tip Length
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.check.comparePoint
-            data: {}
+          command: calibration.check.comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -255,14 +216,11 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingTip
 
   - name: Move to deck
     request:
@@ -270,9 +228,8 @@ stages:
       json:
         data:
           type: SessionCommand
-          attributes:
-            command: calibration.moveToDeck
-            data: {}
+          command: calibration.moveToDeck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -281,25 +238,20 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingHeight
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingHeight
 
   - name: Jog first pipette to height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.jog
-            data:
-              vector: [0, 0, -10]
+          command: calibration.jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -308,24 +260,19 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingHeight
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingHeight
 
   - name: Compare first pipette height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.check.comparePoint
-            data: {}
+          command: calibration.check.comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -334,33 +281,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingHeight
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: null
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingHeight
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: null
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToPointOne
-            data: {}
+          command: calibration.moveToPointOne
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -369,33 +311,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointOne
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: null
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointOne
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: null
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Compare first pipette point one
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.check.comparePoint
-            data: {}
+          command: calibration.check.comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -404,33 +341,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointOne
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: !anydict
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointOne
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: !anydict
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointTwo
-            data: {}
+          command: calibration.deck.moveToPointTwo
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -439,33 +371,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointTwo
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: !anydict
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointTwo
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: !anydict
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Compare first pipette point two
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.check.comparePoint
-            data: {}
+          command: calibration.check.comparePoint
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -474,33 +401,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointTwo
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: !anydict
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointTwo
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: !anydict
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Go to next check
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointThree
-            data: {}
+          command: calibration.deck.moveToPointThree
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -509,33 +431,28 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointThree
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: !anydict
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointThree
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: !anydict
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Compare first pipette point three
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.check.comparePoint
-            data: {}
+          command: calibration.check.comparePoint
+          data: {}
     response:
       status_code: 200
 
@@ -545,23 +462,20 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: comparingPointThree
-              comparisonsByPipette:
-                first:
-                  tipLength: !anydict
-                  pipetteOffset: !anydict
-                  deck: !anydict
-                second:
-                  tipLength: null
-                  pipetteOffset: null
-                  deck: null
+          details:
+            <<: *session_data_attribute_details
+            currentStep: comparingPointThree
+            comparisonsByPipette:
+              first:
+                tipLength: !anydict
+                pipetteOffset: !anydict
+                deck: !anydict
+              second:
+                tipLength: null
+                pipetteOffset: null
+                deck: null
 
   - name: Delete the session
     request:
@@ -578,7 +492,6 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data: []
 ---
 test_name: Calibration check session errors
@@ -597,12 +510,10 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: calibrationCheck
-            createParams:
-              tipRacks: []
-              hasCalibrationBlock: true
+          sessionType: calibrationCheck
+          createParams:
+            tipRacks: []
+            hasCalibrationBlock: true
     response:
       status_code: 201
       save:
@@ -613,10 +524,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: loadSomething
-            data: {}
+          command: loadSomething
+          data: {}
     response:
       status_code: 422
   - name: Send a command with invalid body
@@ -625,11 +534,9 @@ stages:
       json:
         data:
           id: "{session_id}"
-          type: SessionCommand
-          attributes:
-            command: preparePipette
-            data:
-              vector: [1, 2, 3]
+          command: calibration.moveToTipRack
+          data:
+            vector: [1, 2, 3]
     response:
       status_code: 422
 
@@ -638,10 +545,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: jog
-            data: {}
+          command: calibration.jog
+          data: {}
     response:
       status_code: 422
 

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -12,9 +12,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: deckCalibration
+          sessionType: deckCalibration
     response:
       status_code: 201
       save:
@@ -32,15 +30,13 @@ stages:
         meta: null
         data: &session_data
           id: "{session_id}"
-          type: !anystr
-          attributes: &session_data_attributes
-            sessionType: deckCalibration
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            createParams: null
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instrument: !anydict
-              labware: !anylist
+          sessionType: deckCalibration
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          createParams: null
+          details: &session_data_attribute_details
+            currentStep: sessionStarted
+            instrument: !anydict
+            labware: !anylist
 
   - name: Load labware
     request: &post_command
@@ -48,10 +44,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -63,21 +57,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: labwareLoaded
+          details:
+            <<: *session_data_attribute_details
+            currentStep: labwareLoaded
 
   - name: Move to tiprack
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToTipRack
-            data: {}
+          command: calibration.moveToTipRack
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -89,21 +79,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Pick up the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -115,21 +101,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: inspectingTip
+          details:
+            <<: *session_data_attribute_details
+            currentStep: inspectingTip
 
   - name: Invalidate the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.invalidateTip
-            data: {}
+          command: calibration.invalidateTip
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -141,21 +123,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: preparingPipette
+          details:
+            <<: *session_data_attribute_details
+            currentStep: preparingPipette
 
   - name: Pick up the tip
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 200
 
@@ -164,10 +142,8 @@ stages:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToDeck
-            data: {}
+          command: calibration.moveToDeck
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -179,22 +155,18 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Jog pipette to deck
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.jog
-            data:
-              vector: [0, 0, -10]
+          command: calibration.jog
+          data:
+            vector: [0, 0, -10]
     response:
       status_code: 200
   - name: Check the effect of command
@@ -206,21 +178,17 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Save deck height
     request:
       <<: *post_command
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.saveOffset
-            data: {}
+          command: calibration.saveOffset
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -232,11 +200,9 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: joggingToDeck
+          details:
+            <<: *session_data_attribute_details
+            currentStep: joggingToDeck
 
   - name: Move to point one
     request:
@@ -244,10 +210,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.moveToPointOne
-            data: {}
+          command: calibration.moveToPointOne
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -259,11 +223,9 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointOne
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointOne
 
   - name: Move to point two
     request:
@@ -271,10 +233,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointTwo
-            data: {}
+          command: calibration.deck.moveToPointTwo
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -286,11 +246,9 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointTwo
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointTwo
 
   - name: Move to point three
     request:
@@ -298,10 +256,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.deck.moveToPointThree
-            data: {}
+          command: calibration.deck.moveToPointThree
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -313,11 +269,9 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: savingPointThree
+          details:
+            <<: *session_data_attribute_details
+            currentStep: savingPointThree
 
   - name: Exit Session
     request:
@@ -325,10 +279,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.exitSession
-            data: {}
+          command: calibration.exitSession
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command
@@ -340,11 +292,9 @@ stages:
         meta: null
         data:
           <<: *session_data
-          attributes:
-            <<: *session_data_attributes
-            details:
-              <<: *session_data_attribute_details
-              currentStep: sessionExited
+          details:
+            <<: *session_data_attribute_details
+            currentStep: sessionExited
 
   - name: Delete the session
     request:

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -27,7 +27,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data: &session_data
           id: "{session_id}"
           sessionType: deckCalibration
@@ -54,7 +53,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -76,7 +74,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -98,7 +95,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -120,7 +116,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -152,7 +147,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -175,7 +169,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -197,7 +190,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -220,7 +212,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -243,7 +234,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -266,7 +256,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -289,7 +278,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           <<: *session_data
           details:
@@ -311,5 +299,4 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data: []

--- a/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
@@ -35,7 +35,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           id: !anystr
           data: *labware_data
@@ -65,7 +64,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           id: !anystr
           data: *tiprack_data
@@ -92,7 +90,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           id: !anystr
           data: *create_instrument_data

--- a/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_live_protocol.tavern.yaml
@@ -12,9 +12,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: liveProtocol
+          sessionType: liveProtocol
     response:
       save:
         json:
@@ -26,15 +24,13 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadLabware
-            data: &labware_data
-              location: 2
-              loadName: corning_96_wellplate_360ul_flat
-              displayName: my well plate
-              namespace: Opentrons
-              version: 1
+          command: equipment.loadLabware
+          data: &labware_data
+            location: 2
+            loadName: corning_96_wellplate_360ul_flat
+            displayName: my well plate
+            namespace: Opentrons
+            version: 1
     response:
       status_code: 200
       json:
@@ -42,33 +38,29 @@ stages:
         meta: null
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *labware_data
-            command: equipment.loadLabware
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              labwareId: !anystr
-              definition: !anydict
-              calibration: !anylist
+          data: *labware_data
+          command: equipment.loadLabware
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            labwareId: !anystr
+            definition: !anydict
+            calibration: !anylist
   - name: Load tip rack command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadLabware
-            data: &tiprack_data
-              location: 1
-              loadName: opentrons_96_tiprack_300ul
-              displayName: my tip rack
-              namespace: Opentrons
-              version: 1
+          command: equipment.loadLabware
+          data: &tiprack_data
+            location: 1
+            loadName: opentrons_96_tiprack_300ul
+            displayName: my tip rack
+            namespace: Opentrons
+            version: 1
     response:
       status_code: 200
       json:
@@ -76,30 +68,26 @@ stages:
         meta: null
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *tiprack_data
-            command: equipment.loadLabware
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              labwareId: !anystr
-              definition: !anydict
-              calibration: !anylist
+          data: *tiprack_data
+          command: equipment.loadLabware
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            labwareId: !anystr
+            definition: !anydict
+            calibration: !anylist
   - name: Load instrument command
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}/commands/execute"
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: equipment.loadInstrument
-            data: &create_instrument_data
-              instrumentName: p300_single
-              mount: left
+          command: equipment.loadInstrument
+          data: &create_instrument_data
+            instrumentName: p300_single
+            mount: left
     response:
       status_code: 200
       json:
@@ -107,16 +95,14 @@ stages:
         meta: null
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            data: *create_instrument_data
-            command: equipment.loadInstrument
-            status: executed
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            result:
-              instrumentId: !anystr
+          data: *create_instrument_data
+          command: equipment.loadInstrument
+          status: executed
+          createdAt: !anystr
+          startedAt: !anystr
+          completedAt: !anystr
+          result:
+            instrumentId: !anystr
   - name: Delete the session
     request:
       url: "{host:s}:{port:d}/sessions/{session_id}"

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -13,11 +13,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "my_protocol"
+          sessionType: protocol
+          createParams:
+            protocolId: "my_protocol"
     response:
       status_code: 404
 ---
@@ -45,11 +43,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
     response:
       status_code: 403
       json:
@@ -87,11 +83,9 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
     response:
       status_code: 201
       save:
@@ -101,16 +95,14 @@ stages:
         meta: null
         data:
           id: !anystr
-          type: !anystr
-          attributes:
-            sessionType: protocol
-            createParams:
-              protocolId: "{protocol_id}"
-            createdAt: !anystr
-            details:
-              protocolId: "{protocol_id}"
-              currentState: !anystr
-              events: !anylist
+          sessionType: protocol
+          createParams:
+            protocolId: "{protocol_id}"
+          createdAt: !anystr
+          details:
+            protocolId: "{protocol_id}"
+            currentState: !anystr
+            events: !anylist
         links: !anydict
   - name: Get the session
     request:

--- a/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_protocol.tavern.yaml
@@ -92,7 +92,6 @@ stages:
         json:
           session_id: data.id
       json: &proto_session
-        meta: null
         data:
           id: !anystr
           sessionType: protocol

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -30,7 +30,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           id: "{session_id}"
           sessionType: tipLengthCalibration
@@ -58,7 +57,6 @@ stages:
       status_code: 200
       json:
         links: !anydict
-        meta: null
         data:
           id: !anystr
           status: executed
@@ -68,6 +66,7 @@ stages:
           startedAt: *dt
           completedAt: *dt
           data: {}
+          result: null
 
   - name: Attempt conflicting command
     request:
@@ -95,5 +94,4 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data: []

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -12,13 +12,11 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: tipLengthCalibration
-            createParams:
-              mount: left
-              hasCalibrationBlock: true
-              tipRackDefinition: !include fixture_tiprack_300_ul.json
+          sessionType: tipLengthCalibration
+          createParams:
+            mount: left
+            hasCalibrationBlock: true
+            tipRackDefinition: !include fixture_tiprack_300_ul.json
     response:
       status_code: 201
       save:
@@ -35,20 +33,18 @@ stages:
         meta: null
         data:
           id: "{session_id}"
-          type: !anystr
-          attributes:
-            sessionType: tipLengthCalibration
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: &session_data_attribute_details
-              currentStep: sessionStarted
-              instrument: !anydict
-              labware: !anylist
-              nextSteps: null
-            createParams:
-              mount: left
-              hasCalibrationBlock: true
-              tipRackDefinition: !include fixture_tiprack_300_ul.json
-              shouldRecalibrateTipLength: true
+          sessionType: tipLengthCalibration
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: &session_data_attribute_details
+            currentStep: sessionStarted
+            instrument: !anydict
+            labware: !anylist
+            nextSteps: null
+          createParams:
+            mount: left
+            hasCalibrationBlock: true
+            tipRackDefinition: !include fixture_tiprack_300_ul.json
+            shouldRecalibrateTipLength: true
 
   - name: Load labware
     request:
@@ -56,10 +52,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.loadLabware
-            data: {}
+          command: calibration.loadLabware
+          data: {}
     response:
       status_code: 200
       json:
@@ -67,16 +61,13 @@ stages:
         meta: null
         data:
           id: !anystr
-          type: SessionCommand
-          attributes:
-            status: executed
-            command: calibration.loadLabware
-            createdAt: &dt
-              !re_match "\\d+-\\d+-\\d+T"
-            startedAt: *dt
-            completedAt: *dt
-            data: {}
-            result: null
+          status: executed
+          command: calibration.loadLabware
+          createdAt: &dt
+            !re_match "\\d+-\\d+-\\d+T"
+          startedAt: *dt
+          completedAt: *dt
+          data: {}
 
   - name: Attempt conflicting command
     request:
@@ -84,10 +75,8 @@ stages:
       method: POST
       json:
         data:
-          type: SessionCommand
-          attributes:
-            command: calibration.pickUpTip
-            data: {}
+          command: calibration.pickUpTip
+          data: {}
     response:
       status_code: 409
 
@@ -108,4 +97,3 @@ stages:
         links: null
         meta: null
         data: []
-

--- a/robot-server/tests/integration/system/test_system_time.tavern.yaml
+++ b/robot-server/tests/integration/system/test_system_time.tavern.yaml
@@ -12,15 +12,12 @@ stages:
       status_code: 200
       json:
         data:
-          attributes:
-            systemTime: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          systemTime: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           id: 'time'
-          type: 'SystemTimeAttributes'
         links:
           self:
             href: '/system/time'
             meta: null
-        meta: null
 
 ---
 test_name: PUT Time
@@ -35,8 +32,6 @@ stages:
       json:
         data:
           id: "time"
-          type: "SystemTimeAttributes"
-          attributes: {}
     response:
       status_code: 422
       json:
@@ -45,7 +40,7 @@ stages:
             title: "value_error.missing"
             detail: "field required"
             source:
-              pointer: "/body/new_time/data/attributes/systemTime"
+              pointer: "/body/new_time/data/systemTime"
   - name: System Time PUT request on a dev server raises error
     request:
       url: "{host:s}:{port:d}/system/time"
@@ -53,9 +48,7 @@ stages:
       json:
         data:
           id: "time"
-          type: "SystemTimeAttributes"
-          attributes:
-            systemTime: "2020-09-10T21:00:15.741Z"
+          systemTime: "2020-09-10T21:00:15.741Z"
     response:
       status_code: 501
       json:

--- a/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
+++ b/robot-server/tests/integration/test_labware_calibration_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 ---
@@ -28,55 +27,43 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-
 ---
 test_name: GET Labware Calibrations, Filter LoadName
 marks:
@@ -93,18 +80,15 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: 'nest_96_wellplate_2ml_deep'
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: 'nest_96_wellplate_2ml_deep'
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
 ---
 test_name: GET Labware Calibrations, Filter Version & namespace
 marks:
@@ -123,53 +107,42 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data:
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
-          - attributes:
-              calibrationData: !anydict
-              loadName: !anystr
-              parent: !anystr
-              namespace: 'opentrons'
-              version: 1
-              definitionHash: !anystr
+          - calibrationData: !anydict
+            loadName: !anystr
+            parent: !anystr
+            namespace: 'opentrons'
+            version: 1
+            definitionHash: !anystr
             id: !anystr
-            type: 'LabwareCalibration'
 ---
 test_name: GET Labware Calibrations, Version Does Not Exist
 marks:
@@ -187,5 +160,4 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data: []

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response: &no_offset_response
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 
@@ -27,31 +26,26 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: '123'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
-          - attributes:
-              pipette: '321'
-              mount: 'right'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: '321'
+            mount: 'right'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with pipette id
     request:
@@ -62,20 +56,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: '123'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with mount
     request:
@@ -86,20 +77,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              tiprackUri: !anystr
-              lastModified: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: '123'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            tiprackUri: !anystr
+            lastModified: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with pipette AND mount
     request:
@@ -111,20 +99,17 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              mount: 'left'
-              offset: [0.0, 0.0, 0.0]
-              tiprack: !anystr
-              lastModified: !anystr
-              tiprackUri: !anystr
-              source: 'user'
-              status: !anydict
+          - pipette: '123'
+            mount: 'left'
+            offset: [0.0, 0.0, 0.0]
+            tiprack: !anystr
+            lastModified: !anystr
+            tiprackUri: !anystr
+            source: 'user'
+            status: !anydict
             id: !anystr
-            type: 'PipetteOffsetCalibration'
 
   - name: GET request returns filter with wrong pipette AND mount
     request:

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -10,9 +10,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: deckCalibration
+          sessionType: deckCalibration
     response:
       status_code: 201
       save:
@@ -52,9 +50,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: "liveProtocol"
+          sessionType: "liveProtocol"
     response:
       status_code: 201
       save:
@@ -67,9 +63,7 @@ stages:
       method: POST
       json:
         data:
-          type: Session
-          attributes:
-            sessionType: deckCalibration
+          sessionType: deckCalibration
     response:
       status_code: 201
       save:
@@ -87,19 +81,15 @@ stages:
         meta: null
         data:
         - id: "{session_id_1}"
-          type: !anystr
-          attributes:
-            sessionType: "liveProtocol"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: {}
-            createParams: null
+          sessionType: "liveProtocol"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: {}
+          createParams: null
         - id: "{session_id_2}"
-          type: !anystr
-          attributes:
-            sessionType: "deckCalibration"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: !anydict
-            createParams: null
+          sessionType: "deckCalibration"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: !anydict
+          createParams: null
 
   - name: Get just the deck cal sessions
     request:
@@ -112,12 +102,10 @@ stages:
         meta: null
         data:
         - id: "{session_id_2}"
-          type: !anystr
-          attributes:
-            sessionType: "deckCalibration"
-            createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
-            details: !anydict
-            createParams: null
+          sessionType: "deckCalibration"
+          createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
+          details: !anydict
+          createParams: null
 
   - name: Delete session 1
     request:

--- a/robot-server/tests/integration/test_session.tavern.yaml
+++ b/robot-server/tests/integration/test_session.tavern.yaml
@@ -78,7 +78,6 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data:
         - id: "{session_id_1}"
           sessionType: "liveProtocol"
@@ -99,7 +98,6 @@ stages:
       status_code: 200
       json:
         links: null
-        meta: null
         data:
         - id: "{session_id_2}"
           sessionType: "deckCalibration"
@@ -129,5 +127,4 @@ stages:
       status_code: 200
       json:
         data: []
-        meta: null
         links: null

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -11,7 +11,6 @@ stages:
     response: &no_tip_length_response
       status_code: 200
       json:
-        meta: null
         links: null
         data: []
 
@@ -27,33 +26,28 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with pipette id
     request:
@@ -64,22 +58,19 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              tiprack: !anystr
-              tipLength: 30.5
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: '123'
+            tiprack: !anystr
+            tipLength: 30.5
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
 
             id: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824&123'
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with tiprack hash
     request:
@@ -90,33 +81,28 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
-          - attributes:
-              pipette: !anystr
-              tiprack: !anystr
-              tipLength: !anyfloat
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
+          - pipette: !anystr
+            tiprack: !anystr
+            tipLength: !anyfloat
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
             id: !anystr
-            type: 'TipLengthCalibration'
 
   - name: GET request returns filter with pipette AND tiprack
     request:
@@ -128,21 +114,18 @@ stages:
     response:
       status_code: 200
       json:
-        meta: null
         links: null
         data:
-          - attributes:
-              pipette: '123'
-              tiprack: !anystr
-              tipLength: 30.5
-              lastModified: !anystr
-              source: 'unknown'
-              status:
-                markedAt: null
-                markedBad: false
-                source: null
-            id: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824&123'
-            type: 'TipLengthCalibration'
+          - pipette: '123'
+            tiprack: !anystr
+            tipLength: 30.5
+            lastModified: !anystr
+            source: 'unknown'
+            status:
+              markedAt: null
+              markedBad: false
+              source: null
+          id: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824&123'
 
   - name: GET request returns filter with wrong pipette AND tiprack
     request:

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -125,7 +125,7 @@ stages:
               markedAt: null
               markedBad: false
               source: null
-          id: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824&123'
+            id: '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824&123'
 
   - name: GET request returns filter with wrong pipette AND tiprack
     request:

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 
+from robot_server.service.json_api import ResponseDataModel
 from robot_server.service.json_api.request import (
-    RequestModel, RequestDataModel)
+    RequestModel)
 
 
 class ItemModel(BaseModel):
@@ -10,4 +11,8 @@ class ItemModel(BaseModel):
     price: float
 
 
-ItemRequest = RequestModel[RequestDataModel[ItemModel]]
+class ItemResponseModel(ResponseDataModel, ItemModel):
+    pass
+
+
+ItemRequest = RequestModel[ItemModel]

--- a/robot-server/tests/service/json_api/test_request.py
+++ b/robot-server/tests/service/json_api/test_request.py
@@ -3,22 +3,18 @@ from pytest import raises
 from pydantic import ValidationError
 
 from robot_server.service.json_api.request import (
-    RequestModel, RequestDataModel)
+    RequestModel)
 from tests.service.helpers import ItemModel
 
 
 def test_attributes_as_dict():
     DictRequest = RequestModel[dict]
     obj_to_validate = {
-        'data': {'type': 'item', 'attributes': {}}
+        'data': {'some_data': 1}
     }
     my_request_obj = DictRequest(**obj_to_validate)
     assert my_request_obj.dict() == {
-        'data': {
-            'type': 'item',
-            'attributes': {},
-            'id': None,
-        }
+        'data': {'some_data': 1}
     }
 
 
@@ -26,25 +22,19 @@ def test_attributes_as_item_model():
     ItemRequest = RequestModel[ItemModel]
     obj_to_validate = {
         'data': {
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20
-            },
-            'id': None,
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20
         }
     }
     my_request_obj = ItemRequest(**obj_to_validate)
     assert my_request_obj.dict() == obj_to_validate
 
 
-def test_attributes_as_item_model__empty_dict():
+def test_attributes_as_item_model_empty_dict():
     ItemRequest = RequestModel[ItemModel]
     obj_to_validate = {
         'data': {
-            'type': 'item',
-            'attributes': {}
         }
     }
     with raises(ValidationError) as e:
@@ -52,15 +42,15 @@ def test_attributes_as_item_model__empty_dict():
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes', 'name'),
+            'loc': ('data', 'name'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'quantity'),
+            'loc': ('data', 'quantity'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'price'),
+            'loc': ('data', 'price'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }
@@ -68,16 +58,16 @@ def test_attributes_as_item_model__empty_dict():
 
 
 def test_attributes_required():
-    MyRequest = RequestModel[RequestDataModel[dict]]
+    MyRequest = RequestModel[dict]
     obj_to_validate = {
-        'data': {'type': 'item', 'attributes': None}
+        'data': None
     }
     with raises(ValidationError) as e:
         MyRequest(**obj_to_validate)
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes'),
+            'loc': ('data',),
             'msg': 'none is not an allowed value',
             'type': 'type_error.none.not_allowed'
         },
@@ -85,7 +75,7 @@ def test_attributes_required():
 
 
 def test_data_required():
-    MyRequest = RequestModel[RequestDataModel[dict]]
+    MyRequest = RequestModel[dict]
     obj_to_validate = {
         'data': None
     }

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -1,174 +1,92 @@
 from pytest import raises
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from robot_server.service.json_api.response import (
     ResponseDataModel, ResponseModel, MultiResponseModel)
-from tests.service.helpers import ItemModel
+from tests.service.helpers import ItemResponseModel
 
 
 def test_attributes_as_dict():
-    MyResponse = ResponseModel[dict, dict]
+    MyResponse = ResponseModel[ResponseDataModel]
     obj_to_validate = {
-        'data': {'id': '123', 'type': 'item', 'attributes': {}},
+        'data': {'id': '123'},
     }
     my_response_object = MyResponse(**obj_to_validate)
     assert my_response_object.dict() == {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {},
         }
     }
-
-
-def test_missing_attributes_dict():
-    MyResponse = ResponseModel[dict, dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item'}
-    }
-    my_response_object = MyResponse(**obj_to_validate)
-    assert my_response_object.dict() == {
-        'meta': None,
-        'links': None,
-        'data': {
-            'id': '123',
-            'type': 'item',
-            'attributes': {},
-        }
-    }
-
-
-def test_missing_attributes_empty_model():
-    class EmptyModel(BaseModel):
-        pass
-
-    MyResponse = ResponseModel[EmptyModel, dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item'}
-    }
-    my_response_object = MyResponse(**obj_to_validate)
-    assert my_response_object.dict() == {
-        'meta': None,
-        'links': None,
-        'data': {
-            'id': '123',
-            'type': 'item',
-            'attributes': {},
-        }
-    }
-    assert isinstance(my_response_object.data.attributes, EmptyModel)
 
 
 def test_attributes_as_item_model():
-    ItemResponse = ResponseModel[ItemModel, dict]
+    ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20
-            }
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20
         }
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'meta': None,
         'links': None,
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20,
-            }
+            'name': 'apple',
+            'quantity': 10,
+            'price': 1.20,
         }
     }
 
 
 def test_list_item_model():
-    ItemResponse = MultiResponseModel[ItemModel, dict]
+    ItemResponse = MultiResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '123',
-                'type': 'item',
-                'attributes': {
-                    'name': 'apple',
-                    'quantity': 10,
-                    'price': 1.20
-                },
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20
             },
             {
                 'id': '321',
-                'type': 'item',
-                'attributes': {
-                    'name': 'banana',
-                    'quantity': 20,
-                    'price': 2.34
-                },
+                'name': 'banana',
+                'quantity': 20,
+                'price': 2.34
             },
         ],
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '123',
-                'type': 'item',
-                'attributes': {
-                    'name': 'apple',
-                    'quantity': 10,
-                    'price': 1.20,
-                },
+                'name': 'apple',
+                'quantity': 10,
+                'price': 1.20,
             },
             {
                 'id': '321',
-                'type': 'item',
-                'attributes': {
-                    'name': 'banana',
-                    'quantity': 20,
-                    'price': 2.34,
-                },
+                'name': 'banana',
+                'quantity': 20,
+                'price': 2.34,
             },
         ],
     }
 
 
-def test_attributes_required():
-    ItemResponse = ResponseModel[ResponseDataModel[ItemModel], dict]
-    obj_to_validate = {
-        'data': {'id': '123', 'type': 'item', 'attributes': None}
-    }
-    with raises(ValidationError) as e:
-        ItemResponse(**obj_to_validate)
-
-    assert e.value.errors() == [
-        {
-            'loc': ('data', 'attributes'),
-            'msg': 'none is not an allowed value',
-            'type': 'type_error.none.not_allowed',
-        },
-    ]
-
-
-def test_attributes_as_item_model__empty_dict():
-    ItemResponse = ResponseModel[ItemModel, dict]
+def test_attributes_as_item_model_empty_dict():
+    ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
         'data': {
             'id': '123',
-            'type': 'item',
-            'attributes': {}
         }
     }
     with raises(ValidationError) as e:
@@ -176,32 +94,30 @@ def test_attributes_as_item_model__empty_dict():
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'attributes', 'name'),
+            'loc': ('data', 'name'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'quantity'),
+            'loc': ('data', 'quantity'),
             'msg': 'field required',
             'type': 'value_error.missing'
         }, {
-            'loc': ('data', 'attributes', 'price'),
+            'loc': ('data', 'price'),
             'msg': 'field required',
             'type': 'value_error.missing'
         },
     ]
 
 
-def test_resource_data_model_create():
-    item = ItemModel(name='pear', price=1.2, quantity=10)
-    document = ResponseDataModel.create(
-        resource_id='abc123',
-        attributes=item
-    ).dict()
+def test_response_constructed_with_resource_object():
+    ItemResponse = ResponseModel[ItemResponseModel]
+    item = ItemResponseModel(id="abc123", name='pear', price=1.2, quantity=10)
+    data = item.dict()
 
-    assert document == {
-        'id': 'abc123',
-        'type': 'ItemModel',
-        'attributes': {
+    assert ItemResponse(data=data).dict() == {
+        'links': None,
+        "data": {
+            'id': 'abc123',
             'name': 'pear',
             'price': 1.2,
             'quantity': 10,
@@ -209,84 +125,36 @@ def test_resource_data_model_create():
     }
 
 
-def test_resource_data_model_create_no_attributes():
-    document = ResponseDataModel.create(
-        resource_id='abc123', attributes={}).dict()
-
-    assert document == {
-        'id': 'abc123',
-        'type': 'dict',
-        'attributes': {},
-    }
-
-
-def test_response_constructed_with_resource_object():
-    ItemResponse = ResponseModel[ItemModel, dict]
-    item = ItemModel(name='pear', price=1.2, quantity=10)
-    data = ResponseDataModel.create(
-            resource_id='abc123',
-            attributes=item
-    ).dict()
-
-    assert ItemResponse(data=data).dict() == {
-        'meta': None,
-        'links': None,
-        "data": {
-            'id': 'abc123',
-            "type": 'ItemModel',
-            "attributes": {
-                'name': 'pear',
-                'price': 1.2,
-                'quantity': 10,
-            },
-        }
-    }
-
-
 def test_response_constructed_with_resource_object_list():
-    ItemResponse = MultiResponseModel[ItemModel, dict]
-    items = (
-        (1, ItemModel(name='apple', price=1.5, quantity=3)),
-        (2, ItemModel(name='pear', price=1.2, quantity=10)),
-        (3, ItemModel(name='orange', price=2.2, quantity=5))
-    )
+    ItemResponse = MultiResponseModel[ItemResponseModel]
+    items = [
+        ItemResponseModel(id="1", name='apple', price=1.5, quantity=3),
+        ItemResponseModel(id="2", name='pear', price=1.2, quantity=10),
+        ItemResponseModel(id="3", name='orange', price=2.2, quantity=5)
+    ]
     response = ItemResponse(
-        data=[
-            ResponseDataModel.create(resource_id=str(item[0]),
-                                     attributes=item[1])
-            for item in items
-        ]
+        data=items
     )
     assert response.dict() == {
-        'meta': None,
         'links': None,
         'data': [
             {
                 'id': '1',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'apple',
-                    'price': 1.5,
-                    'quantity': 3,
-                },
+                'name': 'apple',
+                'price': 1.5,
+                'quantity': 3,
             },
             {
                 'id': '2',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'pear',
-                    'price': 1.2,
-                    'quantity': 10,
-                },
+                'name': 'pear',
+                'price': 1.2,
+                'quantity': 10,
             },
             {
                 'id': '3',
-                'type': 'ItemModel',
-                'attributes': {
-                    'name': 'orange',
-                    'price': 2.2,
-                    'quantity': 5,
-                },
+                'name': 'orange',
+                'price': 2.2,
+                'quantity': 5,
             },
         ]
     }

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -22,6 +22,7 @@ def grab_id(set_up_index_file_temporary_directory):
 def test_access_individual_labware(api_client, grab_id):
     calibration_id = grab_id
     expected = {
+        'id': calibration_id,
         'calibrationData': {
             'offset': {
                 'value': [0.0, 0.0, 0.0],
@@ -39,8 +40,6 @@ def test_access_individual_labware(api_client, grab_id):
     assert resp.status_code == 200
     body = resp.json()
     data = body['data']
-    assert data['type'] == 'LabwareCalibration'
-    assert data['id'] == calibration_id
     data['calibrationData']['offset']['lastModified'] = None
     data['calibrationData']['tipLength']['lastModified'] = None
     assert data == expected

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -41,9 +41,9 @@ def test_access_individual_labware(api_client, grab_id):
     data = body['data']
     assert data['type'] == 'LabwareCalibration'
     assert data['id'] == calibration_id
-    data['attributes']['calibrationData']['offset']['lastModified'] = None
-    data['attributes']['calibrationData']['tipLength']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['calibrationData']['offset']['lastModified'] = None
+    data['calibrationData']['tipLength']['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get('/labware/calibrations/funnyId')
     assert resp.status_code == 404

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -26,9 +26,8 @@ def test_access_pipette_offset_calibration(
         f'/calibration/pipette_offset?mount={MOUNT}&pipette_id={PIPETTE_ID}')
     assert resp.status_code == 200
     data = resp.json()['data'][0]
-    assert data['type'] == 'PipetteOffsetCalibration'
-    data['attributes']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get(
         f'/calibration/pipette_offset?mount={MOUNT}&'

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -8,6 +8,7 @@ def test_access_pipette_offset_calibration(
         api_client, set_up_pipette_offset_temp_directory,
         server_temp_directory):
     expected = {
+        'id': 'pip_1&left',
         'offset': [0, 0, 0],
         'pipette': '123',
         'mount': 'left',

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -1,4 +1,5 @@
 PIPETTE_ID = '123'
+LW_HASH = '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824'
 MOUNT = 'left'
 FAKE_PIPETTE_ID = 'fake'
 WRONG_MOUNT = 'right'
@@ -8,11 +9,11 @@ def test_access_pipette_offset_calibration(
         api_client, set_up_pipette_offset_temp_directory,
         server_temp_directory):
     expected = {
-        'id': 'pip_1&left',
+        'id': f'{PIPETTE_ID}&{MOUNT}',
         'offset': [0, 0, 0],
         'pipette': '123',
-        'mount': 'left',
-        'tiprack': '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824',  # noqa: E501
+        'mount': MOUNT,
+        'tiprack': LW_HASH,
         'lastModified': None,
         'source': 'user',
         'tiprackUri': 'opentrons/opentrons_96_filtertiprack_200ul/1',

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -29,14 +29,11 @@ def mock_session_meta():
 @pytest.fixture
 def session_response(mock_session_meta):
     return {
-        'attributes': {
-            'details': {
-            },
-            'sessionType': 'liveProtocol',
-            'createdAt': mock_session_meta.created_at.isoformat(),
-            'createParams': None,
+        'details': {
         },
-        'type': 'LiveProtocolResponseAttributes',
+        'sessionType': 'liveProtocol',
+        'createdAt': mock_session_meta.created_at.isoformat(),
+        'createParams': None,
         'id': mock_session_meta.identifier,
     }
 
@@ -125,10 +122,7 @@ def test_create_session_error(api_client,
 
     response = api_client.post("/sessions", json={
         "data": {
-            "type": "Session",
-            "attributes": {
-                "sessionType": "liveProtocol"
-            }
+            "sessionType": "liveProtocol"
         }
     })
     assert response.json() == {
@@ -146,10 +140,7 @@ def test_create_session(api_client,
                         session_response):
     response = api_client.post("/sessions", json={
         "data": {
-            "type": "Session",
-            "attributes": {
-                "sessionType": "liveProtocol"
-            }
+            "sessionType": "liveProtocol"
         }
     })
     assert response.json() == {
@@ -283,11 +274,8 @@ def command(command_type: str, body: typing.Optional[BaseModel]):
     """Helper to create command"""
     return {
         "data": {
-            "type": "SessionCommand",
-            "attributes": {
-                "command": command_type,
-                "data": body.dict(exclude_unset=True) if body else {}
-            }
+            "command": command_type,
+            "data": body.dict(exclude_unset=True) if body else {}
         }
     }
 
@@ -337,16 +325,13 @@ def test_execute_command(api_client,
 
     assert response.json() == {
         'data': {
-            'attributes': {
-                'command': 'calibration.jog',
-                'data': {'vector': [1.0, 2.0, 3.0]},
-                'status': 'executed',
-                'createdAt': '2000-01-01T00:00:00',
-                'startedAt': '2019-01-01T00:00:00',
-                'completedAt': '2020-01-01T00:00:00',
-                'result': None,
-            },
-            'type': 'SessionCommand',
+            'command': 'calibration.jog',
+            'data': {'vector': [1.0, 2.0, 3.0]},
+            'status': 'executed',
+            'createdAt': '2000-01-01T00:00:00',
+            'startedAt': '2019-01-01T00:00:00',
+            'completedAt': '2020-01-01T00:00:00',
+            'result': None,
             'id': command_id,
         },
         'links': {
@@ -396,16 +381,13 @@ def test_execute_command_no_body(api_client,
 
     assert response.json() == {
         'data': {
-            'attributes': {
-                'command': 'calibration.loadLabware',
-                'data': {},
-                'status': 'executed',
-                'createdAt': '2000-01-01T00:00:00',
-                'startedAt': '2019-01-01T00:00:00',
-                'completedAt': '2020-01-01T00:00:00',
-                'result': None,
-            },
-            'type': 'SessionCommand',
+            'command': 'calibration.loadLabware',
+            'data': {},
+            'status': 'executed',
+            'createdAt': '2000-01-01T00:00:00',
+            'startedAt': '2019-01-01T00:00:00',
+            'completedAt': '2020-01-01T00:00:00',
+            'result': None,
             'id': command_id
         },
         'links': {

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -284,7 +284,7 @@ def test_execute_command_no_session(api_client, mock_session_meta):
     """Test that command is rejected if there's no session"""
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,))))
     assert response.json() == {
         'errors': [{
@@ -432,7 +432,7 @@ def test_execute_command_error(api_client,
 
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,)))
     )
 
@@ -458,7 +458,7 @@ def test_execute_command_session_inactive(
 
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("jog",
+        json=command("calibration.jog",
                      JogPosition(vector=(1, 2, 3,)))
     )
 

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -145,7 +145,6 @@ def test_create_session(api_client,
     })
     assert response.json() == {
         'data': session_response,
-        'meta': None,
         'links': {
             'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: E501
@@ -193,7 +192,6 @@ def test_delete_session(api_client,
     # mock_session.clean_up.assert_called_once()
     assert response.json() == {
         'data': session_response,
-        'meta': None,
         'links': {
             'self': {
                 'href': '/sessions', 'meta': None,
@@ -229,7 +227,6 @@ def test_get_session(api_client,
     response = api_client.get(f"/sessions/{mock_session_meta.identifier}")
     assert response.json() == {
         'data': session_response,
-        'meta': None,
         'links': {
             'commandExecute': {
                 'href': f'/sessions/{mock_session_meta.identifier}/commands/execute',  # noqa: e5011
@@ -255,7 +252,7 @@ def test_get_session(api_client,
 def test_get_sessions_no_sessions(api_client):
     response = api_client.get("/sessions")
     assert response.json() == {
-        'data': [], 'links': None, 'meta': None,
+        'data': [], 'links': None
     }
     assert response.status_code == 200
 
@@ -265,7 +262,7 @@ def test_get_sessions(api_client,
                       session_response):
     response = api_client.get("/sessions")
     assert response.json() == {
-        'data': [session_response], 'links': None, 'meta': None,
+        'data': [session_response], 'links': None
     }
     assert response.status_code == 200
 
@@ -352,7 +349,6 @@ def test_execute_command(api_client,
                 'meta': None,
             },
         },
-        'meta': None,
     }
     assert response.status_code == 200
 
@@ -408,7 +404,6 @@ def test_execute_command_no_body(api_client,
                 'meta': None,
             },
         },
-        'meta': None,
     }
     assert response.status_code == 200
 

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -19,7 +19,7 @@ def mock_set_system_time(mock_system_time):
 def response_links():
     return {
         'self': {
-            'href': '/system/time',
+            'href': '/system/time', 'meta': None,
         }
     }
 
@@ -82,7 +82,8 @@ def test_set_system_time(api_client, mock_system_time,
     assert response.json() == {
         'data': {
             'systemTime': mock_system_time.isoformat(),
-            'id': 'time',},
+            'id': 'time'
+        },
         'links': response_links,
     }
     assert response.status_code == 200

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -20,7 +20,6 @@ def response_links():
     return {
         'self': {
             'href': '/system/time',
-            'meta': None
         }
     }
 
@@ -34,8 +33,7 @@ def test_raise_system_synchronized_error(api_client,
     response = api_client.put("/system/time", json={
         "data": {
             "id": "time",
-            "type": "SystemTimeAttributes",
-            "attributes": {"systemTime": mock_system_time.isoformat()}
+            "systemTime": mock_system_time.isoformat()
         }
     })
     assert response.json() == {'errors': [{
@@ -55,8 +53,7 @@ def test_raise_system_exception(api_client,
     response = api_client.put("/system/time", json={
         "data": {
             "id": "time",
-            "type": "SystemTimeAttributes",
-            "attributes": {"systemTime": mock_system_time.isoformat()}
+            "systemTime": mock_system_time.isoformat()
         }
     })
     assert response.json() == {'errors': [{
@@ -77,18 +74,15 @@ def test_set_system_time(api_client, mock_system_time,
     response = api_client.put("/system/time",
                               json={
                                   'data': {
-                                      'attributes': {
-                                          'systemTime':
-                                              mock_system_time.isoformat()},
+                                      'systemTime':
+                                          mock_system_time.isoformat(),
                                       'id': 'time',
-                                      'type': 'SystemTimeAttributes'},
+                                  },
                               })
     assert response.json() == {
         'data': {
-            'attributes': {'systemTime': mock_system_time.isoformat()},
-            'id': 'time',
-            'type': 'SystemTimeAttributes'},
+            'systemTime': mock_system_time.isoformat(),
+            'id': 'time',},
         'links': response_links,
-        'meta': None
     }
     assert response.status_code == 200

--- a/robot-server/tests/service/test_errors.py
+++ b/robot-server/tests/service/test_errors.py
@@ -11,9 +11,7 @@ from tests.service.helpers import ItemRequest
 def test_transform_validation_error_to_json_api_errors():
     with pytest.raises(ValidationError) as e:
         ItemRequest(**{
-            'data': {
-                'type': 'type'
-            }
+            'data': {}
         })
     assert errors.transform_validation_error_to_json_api_errors(
         HTTP_422_UNPROCESSABLE_ENTITY,
@@ -24,7 +22,23 @@ def test_transform_validation_error_to_json_api_errors():
                 'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
                 'detail': 'field required',
                 'source': {
-                    'pointer': '/data/attributes'
+                    'pointer': '/data/name'
+                },
+                'title': 'value_error.missing'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/quantity'
+                },
+                'title': 'value_error.missing'
+            },
+            {
+                'status': str(HTTP_422_UNPROCESSABLE_ENTITY),
+                'detail': 'field required',
+                'source': {
+                    'pointer': '/data/price'
                 },
                 'title': 'value_error.missing'
             },

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -7,6 +7,7 @@ WRONG_LW_HASH = 'wronghash'
 def test_access_tip_length_calibration(
         api_client, set_up_tip_length_temp_directory):
     expected = {
+        'id': 'fakehash&pip_1',
         'tipLength': 30.5,
         'pipette': PIPETTE_ID,
         'tiprack': LW_HASH,
@@ -21,7 +22,6 @@ def test_access_tip_length_calibration(
         f'tiprack_hash={LW_HASH}')
     assert resp.status_code == 200
     data = resp.json()['data'][0]
-    assert data['type'] == 'TipLengthCalibration'
     data['lastModified'] = None
     assert data == expected
 

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -22,8 +22,8 @@ def test_access_tip_length_calibration(
     assert resp.status_code == 200
     data = resp.json()['data'][0]
     assert data['type'] == 'TipLengthCalibration'
-    data['attributes']['lastModified'] = None
-    assert data['attributes'] == expected
+    data['lastModified'] = None
+    assert data == expected
 
     resp = api_client.get(
         f'/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&'

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -7,7 +7,7 @@ WRONG_LW_HASH = 'wronghash'
 def test_access_tip_length_calibration(
         api_client, set_up_tip_length_temp_directory):
     expected = {
-        'id': 'fakehash&pip_1',
+        'id': f'{LW_HASH}&{PIPETTE_ID}',
         'tipLength': 30.5,
         'pipette': PIPETTE_ID,
         'tiprack': LW_HASH,


### PR DESCRIPTION
# Overview

Simplify http v2 models for version 4.

See https://github.com/Opentrons/opentrons/issues/6847 for details.

closes #6849 

# Changelog

- Remove `type` and `meta` fields. 
- Eliminate `attributes` level in responses and requests.
- Delete backwards compatibility for calibration check commands that do not have a namespace.

# Review requests

Please look at the integration tests to review the new schema. 

# Risk assessment

High. This introduces breaking changes in the API. Only v4 will support.

```
Affected endpoints:

1. GET /sessions
2. POST /sessions
3. GET /sessions/{session_id}
4. DELETE /sessions/{session_id}
5. POST /sessions/{sessionId}/commands/execute
6. GET /labware/calibrations
7. GET /labware/calibrations/{calibrationId}
8. DELETE /labware/calibrations/{calibrationId}
9. GET /protocols
10. POST /protocols
11. GET /protocols/{protocolId}
12. POST /protocols/{protocolId}
13. DELETE /protocols/{protocolId}
14. GET /calibration/pipette_offset
15. DELETE /calibration/pipette_offset
16. GET /calibration/tip_length
17. DELETE /calibration/tip_length
18. GET /system/time
19. PUT /system/time

```