### PR TITLE
fix(build): Dont break make with weird deps in shared-data

### DIFF
--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -30,8 +30,16 @@ BUILD_DIR := dist
 
 wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,opentrons_shared_data,$(BUILD_NUMBER),../../scripts/python_build_utils.py)
 
-py_sources = $(filter %.py,$(shell $(SHX) find opentrons_shared_data))
-json_sources = $(filter %.json,$(shell $(SHX) find ..))
+py_sources = $(filter %.py,$(shell $(SHX) find opentrons_shared_data)) opentrons_shared_data/py.typed
+deck_sources = $(wildcard ../deck/definitions/*/*.json) $(wildcard ../deck/schemas/*.json)
+labware_sources = $(wildcard ../labware/definitions/*/*.json) $(wildcard ../labware/schemas/*.json)
+module_sources = $(wildcard ../module/definitions/*.json) $(wildcard ../module/definitions/*/*.json) $(wildcard ../module/schemas/*.json)
+pipette_sources = $(wildcard ../pipette/definitions/*.json) $(wildcard ../pipette/schemas/*.json)
+protocol_sources = $(wildcard ../protocol/schemas/*.json)
+
+json_sources = $(deck_sources) $(labware_sources) $(module_sources) $(pipette_sources) $(protocol_sources)
+
+
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
@@ -49,6 +57,7 @@ setup-py:
 
 .PHONY: clean
 clean:
+	@echo $(CURDIR)
 	$(clean_cmd)
 
 
@@ -56,7 +65,7 @@ clean:
 wheel: $(wheel_file)
 
 
-$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources) clean
+$(BUILD_DIR)/opentrons_shared_data-%-py2.py3-none-any.whl: setup.py $(py_sources) $(json_sources)
 	$(SHX) mkdir -p build
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) ls $(BUILD_DIR)

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -57,7 +57,6 @@ setup-py:
 
 .PHONY: clean
 clean:
-	@echo $(CURDIR)
 	$(clean_cmd)
 
 


### PR DESCRIPTION
Calling find to look for json dependencies in the shared-data python
makefile was picking up the ones in the build directory, and is a bit
gross anyway. By not doing that anymore (in favor of writing them in
with wildcards) we get the same behavior but more reliably, and now
building wheels and thus deploying to pypi should work a bit better.

## Testing
- The action for uploading the shared-data dep should actually succeed (look at the output; uploads to test pypi, which happen for non-tag builds like this one, are allowed to fail, but if it does fail it should be because of a duplicate name not because the wheel failed to build)
- Push to a robot and make sure the wheel built