### PR TITLE
docs(api): explain when to use home_after

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -788,7 +788,7 @@ class InstrumentContext(CommandPublisher):
         .. warning:: Setting ``home_after=False`` can severely reduce the
            volumetric accuracy of the pipette as well as cause unxexpected
            hard limit errors. Only use this setting with extensive testing
-           to make sure the pipette motor does not skip steps when droping
+           to make sure the pipette motor does not skip steps when dropping
            tips.
         """
         if location and isinstance(location, types.Location):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -777,13 +777,19 @@ class InstrumentContext(CommandPublisher):
         :type location: :py:class:`.types.Location` or :py:class:`.Well` or
                         None
         :param home_after: Whether to home the plunger after dropping the tip
-                           (defaults to ``True``). The plungeer must home after
+                           (defaults to ``True``). The plunger must home after
                            dropping tips because the ejector shroud that pops
                            the tip off the end of the pipette is driven by the
                            plunger motor, and may skip steps when dropping the
                            tip.
 
         :returns: This instance
+        
+        .. warning:: Setting ``home_after=False`` can severely reduce the
+           volumetric accuracy of the pipette as well as cause unxexpected
+           hard limit errors. Only use this setting with extensive testing
+           to make sure the pipette motor does not skip steps when droping
+           tips.
         """
         if location and isinstance(location, types.Location):
             if isinstance(location.labware, Well):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -786,7 +786,7 @@ class InstrumentContext(CommandPublisher):
         :returns: This instance
 
         .. warning:: Setting ``home_after=False`` can severely reduce the
-           volumetric accuracy of the pipette as well as cause unxexpected
+           volumetric accuracy of the pipette as well as cause unexpected
            hard limit errors. Only use this setting with extensive testing
            to make sure the pipette motor does not skip steps when dropping
            tips.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -784,7 +784,7 @@ class InstrumentContext(CommandPublisher):
                            tip.
 
         :returns: This instance
-        
+
         .. warning:: Setting ``home_after=False`` can severely reduce the
            volumetric accuracy of the pipette as well as cause unxexpected
            hard limit errors. Only use this setting with extensive testing


### PR DESCRIPTION
# Overview

while using `drop_tip()` with `home_after=False` can speed up protocols, it can also severely impact the volumetric accuracy of the pipette. It's crucial that users understand this before deciding to use `home_after=False` in their protocols

# Changelog

![image](https://user-images.githubusercontent.com/64100326/97485563-e9ac5d00-191f-11eb-94d1-0f156696e827.png)

# Review requests

- I think this deserves a warning admonition, do you?
- do folks know what a hard limit it? or should I explain that?

# Risk assessment

none: docs only
