### PR TITLE
docs(api): Elaborate on the home_after parameter

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -623,6 +623,9 @@ class InstrumentContext(CommandPublisher):
         It will not reset tip tracking so the well flag will remain False.
 
         :returns: This instance
+
+        :param home_after:
+            See the ``home_after`` parameter in :py:obj:`drop_tip`.
         """
         if not self._has_tip:
             self._log.warning('Pipette has no tip to return')

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -810,8 +810,9 @@ class InstrumentContext(CommandPublisher):
             * The pipette might aspirate or dispense the wrong volumes.
             * The pipette might not fully drop subsequent tips.
 
-            These problems are more likely with GEN1 pipettes than GEN2
-            pipettes.
+            GEN1 pipettes are especially likely to have these problems, so we
+            strongly discourage using ``home_after=False`` with them.  (There's
+            still a risk with GEN2 pipettes---it's just smaller.)
 
         :returns: This instance
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -773,15 +773,33 @@ class InstrumentContext(CommandPublisher):
               can be a :py:class:`.types.Location`; for instance, you can call
               `instr.drop_tip(tiprack.wells()[0].top())`.
 
-        :param location: The location to drop the tip
-        :type location: :py:class:`.types.Location` or :py:class:`.Well` or
-                        None
-        :param home_after: Whether to home the plunger after dropping the tip
-                           (defaults to ``True``). The plungeer must home after
-                           dropping tips because the ejector shroud that pops
-                           the tip off the end of the pipette is driven by the
-                           plunger motor, and may skip steps when dropping the
-                           tip.
+        :param location:
+            The location to drop the tip
+        :type location:
+            :py:class:`.types.Location` or :py:class:`.Well` or None
+        :param home_after:
+            Whether to home this pipette's plunger after dropping the tip.
+            Defaults to ``True``.
+
+            Setting this to ``False`` saves waiting a couple of seconds after
+            the tip drop, but risks causing other problems.
+
+            The ejector shroud that pops the tip off the end of the pipette is
+            driven by the plunger's stepper motor.  Sometimes, the strain of
+            ejecting the tip can make that motor *skip* and fall out of sync
+            with where the robot thinks it is.  Homing the plunger fixes this,
+            so, to be safe, we normally do it after every tip drop.
+
+            If you disable homing the plunger, and the motor happens to skip,
+            you might see problems like these until the next time the plunger
+            is homed:
+
+            * The run halting with a "hard limit" error message.
+            * The pipette aspirating or dispensing the wrong volumes.
+            * The pipette not fully dropping subsequent tips.
+
+            These problems are more likely with GEN1 pipettes than GEN2
+            pipettes.
 
         :returns: This instance
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -784,33 +784,36 @@ class InstrumentContext(CommandPublisher):
             Whether to home this pipette's plunger after dropping the tip.
             Defaults to ``True``.
 
-            Setting this to ``False`` saves waiting a couple of seconds after
-            the tip drop, but risks causing other problems.
+            Setting ``home_after=False`` saves waiting a couple of seconds
+            after the pipette drops the tip, but risks causing other problems.
+
+            .. warning::
+                Only set ``home_after=False`` if:
+
+                * You understand the risks described below.
+                * You've tested it extensively with your particular pipette and
+                  your particular tips.
 
             The ejector shroud that pops the tip off the end of the pipette is
             driven by the plunger's stepper motor.  Sometimes, the strain of
             ejecting the tip can make that motor *skip* and fall out of sync
-            with where the robot thinks it is.  Homing the plunger fixes this,
-            so, to be safe, we normally do it after every tip drop.
+            with where the robot thinks it is.
 
-            If you disable homing the plunger, and the motor happens to skip,
-            you might see problems like these until the next time the plunger
-            is homed:
+            Homing the plunger fixes this, so, to be safe, we normally do it
+            after every tip drop.
 
-            * The run halting with a "hard limit" error message.
-            * The pipette aspirating or dispensing the wrong volumes.
-            * The pipette not fully dropping subsequent tips.
+            If you set ``home_after=False`` to disable homing the plunger, and
+            the motor happens to skip, you might see problems like these until
+            the next time the plunger is homed:
+
+            * The run might halt with a "hard limit" error message.
+            * The pipette might aspirate or dispense the wrong volumes.
+            * The pipette might not fully drop subsequent tips.
 
             These problems are more likely with GEN1 pipettes than GEN2
             pipettes.
 
         :returns: This instance
-
-        .. warning:: Setting ``home_after=False`` can severely reduce the
-           volumetric accuracy of the pipette as well as cause unexpected
-           hard limit errors. Only use this setting with extensive testing
-           to make sure the pipette motor does not skip steps when dropping
-           tips.
         """
         if location and isinstance(location, types.Location):
             if isinstance(location.labware, Well):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -805,7 +805,7 @@ class InstrumentContext(CommandPublisher):
             pipettes.
 
         :returns: This instance
-        
+
         .. warning:: Setting ``home_after=False`` can severely reduce the
            volumetric accuracy of the pipette as well as cause unxexpected
            hard limit errors. Only use this setting with extensive testing

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -790,9 +790,10 @@ class InstrumentContext(CommandPublisher):
             .. warning::
                 Only set ``home_after=False`` if:
 
+                * You're using a GEN2 pipette, not a GEN1 pipette.
+                * You've tested ``home_after=False` extensively with your
+                  particular pipette and your particular tips.
                 * You understand the risks described below.
-                * You've tested it extensively with your particular pipette and
-                  your particular tips.
 
             The ejector shroud that pops the tip off the end of the pipette is
             driven by the plunger's stepper motor. Sometimes, the strain of

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -805,6 +805,12 @@ class InstrumentContext(CommandPublisher):
             pipettes.
 
         :returns: This instance
+        
+        .. warning:: Setting ``home_after=False`` can severely reduce the
+           volumetric accuracy of the pipette as well as cause unxexpected
+           hard limit errors. Only use this setting with extensive testing
+           to make sure the pipette motor does not skip steps when droping
+           tips.
         """
         if location and isinstance(location, types.Location):
             if isinstance(location.labware, Well):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -795,7 +795,7 @@ class InstrumentContext(CommandPublisher):
                   your particular tips.
 
             The ejector shroud that pops the tip off the end of the pipette is
-            driven by the plunger's stepper motor.  Sometimes, the strain of
+            driven by the plunger's stepper motor. Sometimes, the strain of
             ejecting the tip can make that motor *skip* and fall out of sync
             with where the robot thinks it is.
 
@@ -811,7 +811,7 @@ class InstrumentContext(CommandPublisher):
             * The pipette might not fully drop subsequent tips.
 
             GEN1 pipettes are especially likely to have these problems, so we
-            strongly discourage using ``home_after=False`` with them.  (There's
+            strongly discourage using ``home_after=False`` with them. (There's
             still a risk with GEN2 pipettes---it's just smaller.)
 
         :returns: This instance

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -811,10 +811,12 @@ class InstrumentContext(CommandPublisher):
             * The pipette might aspirate or dispense the wrong volumes.
             * The pipette might not fully drop subsequent tips.
 
-            GEN1 pipettes are much more vulnerable to this skipping. You should
-            never set this parameter to False on a GEN1 pipette. Even on GEN2
-            pipettes, the skip may still happen, so always test with your
-            particular pipette.
+            GEN1 pipettes are especially vulnerable to this skipping, so you
+            should never set ``home_after=False`` with a GEN1 pipette.
+
+            Even on GEN2 pipettes, the motor can still skip. So, always
+            extensively test ``home_after=False` with your particular pipette
+            and your particular tips before relying on it.
 
         :returns: This instance
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -810,9 +810,10 @@ class InstrumentContext(CommandPublisher):
             * The pipette might aspirate or dispense the wrong volumes.
             * The pipette might not fully drop subsequent tips.
 
-            GEN1 pipettes are especially likely to have these problems, so we
-            strongly discourage using ``home_after=False`` with them. (There's
-            still a risk with GEN2 pipettes---it's just smaller.)
+            GEN1 pipettes are much more vulnerable to this skipping. You should
+            never set this parameter to False on a GEN1 pipette. Even on GEN2
+            pipettes, the skip may still happen, so always test with your
+            particular pipette.
 
         :returns: This instance
         """

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -807,7 +807,7 @@ class InstrumentContext(CommandPublisher):
         :returns: This instance
 
         .. warning:: Setting ``home_after=False`` can severely reduce the
-           volumetric accuracy of the pipette as well as cause unxexpected
+           volumetric accuracy of the pipette as well as cause unexpected
            hard limit errors. Only use this setting with extensive testing
            to make sure the pipette motor does not skip steps when dropping
            tips.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -809,7 +809,7 @@ class InstrumentContext(CommandPublisher):
         .. warning:: Setting ``home_after=False`` can severely reduce the
            volumetric accuracy of the pipette as well as cause unxexpected
            hard limit errors. Only use this setting with extensive testing
-           to make sure the pipette motor does not skip steps when droping
+           to make sure the pipette motor does not skip steps when dropping
            tips.
         """
         if location and isinstance(location, types.Location):


### PR DESCRIPTION
# Overview

`InstrumentContext.drop_tip()` and `.return_tip()` have a `home_after` parameter. This PR synthesizes a few conversations in our internal Slack to clarify:

* What its intended purpose is.
* What the risks of using it are.
* Why those risks apply.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

* Is this list of problems correct? I based it on supposing what could happen, in general, when the pipette plunger is higher than the robot thinks it is.

  >  If you disable homing the plunger, and the motor happens to skip, you might see problems like these until the next time the plunger is homed:
  >  * The run halting with a "hard limit" error message.
  >  * The pipette aspirating or dispensing the wrong volumes.
  >  * The pipette not fully dropping subsequent tips.

* Does the wording feel concise and clear to an audience not necessarily familiar with robotics, nor the internal workings of our pipettes?

# Risk assessment

Low. Docs only.