### PR TITLE
fix(api): recache position before plunger home

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -628,8 +628,7 @@ class API(HardwareAPILike):
             with self._backend.save_current():
                 self._backend.set_active_current(
                     {checked_axis: instr.config.plunger_current})
-                smoothie_pos = self._backend.home([checked_axis.name.upper()])
-                smoothie_pos.update(self._backend.update_position())
+                self._backend.home([checked_axis.name.upper()])
                 # either we were passed False for our acquire_lock and we
                 # should pass it on, or we acquired the lock above and
                 # shouldn't do it again
@@ -645,6 +644,7 @@ class API(HardwareAPILike):
         :param mount: the mount associated with the target plunger
         :type mount: :py:class:`.top_types.Mount`
         """
+        await self.current_position(mount=mount, refresh=True)
         await self._do_plunger_home(mount=mount,
                                     acquire_lock=True)
 


### PR DESCRIPTION
When you're homing the plunger through its top-level home attribute,
there are some particularities around the way the position cache is
updated that can leave you with a slightly-different position cache than
what you started with. A big part of the reason why is, well, floating
point math + inverting matrices.

If the difference is big enough, then a move right after a home plunger - for instance, the move of the plunger back to its bottom position -
will also imply a move in other axes like X and Y.

And finally, if you do that - have a normal move on a plunger axis, and
a really tiny move on X or Y or both - then the plunger stalls for some
reason.

This is not quite the root cause of #6879 - that lies deeper in
either something the smoothie is doing in acceleration planning, or
something the power supply is doing - and it isn't quite the right fix
for #6879 - that involves fixing the stupid reverse calculations and
making home_plunger not perturb axes other than the ones that it's
homing - but it is pretty close to both of them.

Closes #6879
