### PR TITLE
refactor(app): remove attributes, types & meta from http models

### DIFF
--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -99,16 +99,11 @@ export type LabwareCalibration = {|
   version: number,
   parent: string,
   definitionHash: string,
-|}
-
-export type LabwareCalibrationModel = {|
-  attributes: LabwareCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllLabwareCalibrations = {|
-  data: Array<LabwareCalibrationModel>,
+  data: Array<LabwareCalibration>,
   meta: { ... },
 |}
 
@@ -141,15 +136,9 @@ export type TipLengthCalibration = {|
   lastModified: string,
   source: CalibrationSource,
   status: IndividualCalibrationStatus,
-|}
-
-export type TipLengthCalibrationModel = {|
-  attributes: TipLengthCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllTipLengthCalibrations = {|
-  data: Array<TipLengthCalibrationModel>,
-  meta: { ... },
+  data: Array<TipLengthCalibration>,
 |}

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -116,17 +116,11 @@ export type PipetteOffsetCalibration = {|
   lastModified: string,
   source: CalibrationSource,
   status: IndividualCalibrationStatus,
-|}
-
-export type PipetteOffsetCalibrationModel = {|
-  attributes: PipetteOffsetCalibration,
-  type: string,
   id: string,
 |}
 
 export type AllPipetteOffsetCalibrations = {|
-  data: Array<PipetteOffsetCalibrationModel>,
-  meta: { ... },
+  data: Array<PipetteOffsetCalibration>,
 |}
 
 export type TipLengthCalibration = {|

--- a/app/src/calibration/api-types.js
+++ b/app/src/calibration/api-types.js
@@ -104,7 +104,6 @@ export type LabwareCalibration = {|
 
 export type AllLabwareCalibrations = {|
   data: Array<LabwareCalibration>,
-  meta: { ... },
 |}
 
 export type PipetteOffsetCalibration = {|

--- a/app/src/calibration/labware/__fixtures__/labware-calibration.js
+++ b/app/src/calibration/labware/__fixtures__/labware-calibration.js
@@ -52,7 +52,6 @@ export const mockLabwareCalibration2: LabwareCalibration = {
 
 export const mockAllLabwareCalibration: AllLabwareCalibrations = {
   data: [mockLabwareCalibration1, mockLabwareCalibration2],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/labware/__fixtures__/labware-calibration.js
+++ b/app/src/calibration/labware/__fixtures__/labware-calibration.js
@@ -8,52 +8,46 @@ import { LABWARE_CALIBRATION_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  LabwareCalibrationModel,
+  LabwareCalibration,
   AllLabwareCalibrations,
 } from '../../api-types'
 
-export const mockLabwareCalibration1: LabwareCalibrationModel = {
-  attributes: {
-    calibrationData: {
-      offset: {
-        value: [0.0, 0.0, 0.0],
-        lastModified: '2020-04-05T14:30',
-      },
-      tipLength: {
-        value: 30,
-        lastModified: '2007-05-05T0:30',
-      },
+export const mockLabwareCalibration1: LabwareCalibration = {
+  calibrationData: {
+    offset: {
+      value: [0.0, 0.0, 0.0],
+      lastModified: '2020-04-05T14:30',
     },
-    loadName: 'opentrons_96_tiprack_10ul',
-    namespace: 'opentrons',
-    version: 1,
-    parent: 'fake_id',
-    definitionHash: '123FakeDefinitionHash',
+    tipLength: {
+      value: 30,
+      lastModified: '2007-05-05T0:30',
+    },
   },
+  loadName: 'opentrons_96_tiprack_10ul',
+  namespace: 'opentrons',
+  version: 1,
+  parent: 'fake_id',
+  definitionHash: '123FakeDefinitionHash',
   id: 'some id',
-  type: 'Labware Calibration',
 }
 
-export const mockLabwareCalibration2: LabwareCalibrationModel = {
-  attributes: {
-    calibrationData: {
-      offset: {
-        value: [1.0, 1.0, 1.0],
-        lastModified: '2020-04-05T14:30',
-      },
-      tipLength: {
-        value: 30,
-        lastModified: '2007-05-05T0:30',
-      },
+export const mockLabwareCalibration2: LabwareCalibration = {
+  calibrationData: {
+    offset: {
+      value: [1.0, 1.0, 1.0],
+      lastModified: '2020-04-05T14:30',
     },
-    loadName: 'opentrons_96_tiprack_1000ul',
-    namespace: 'opentrons',
-    version: 1,
-    parent: '',
-    definitionHash: '456FakeDefinitionHash',
+    tipLength: {
+      value: 30,
+      lastModified: '2007-05-05T0:30',
+    },
   },
+  loadName: 'opentrons_96_tiprack_1000ul',
+  namespace: 'opentrons',
+  version: 1,
+  parent: '',
+  definitionHash: '456FakeDefinitionHash',
   id: 'some id',
-  type: 'Labware Calibration',
 }
 
 export const mockAllLabwareCalibration: AllLabwareCalibrations = {

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -65,6 +65,10 @@ describe('labware calibration selectors', () => {
   describe('getProtocolLabwareList', () => {
     let state: $Shape<State>
 
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
     beforeEach(() => {
       state = { calibration: {} }
 
@@ -77,7 +81,7 @@ describe('labware calibration selectors', () => {
             definition: wellPlate96Def,
             slot: '3',
             definitionHash:
-              Fixtures.mockLabwareCalibration1.attributes.definitionHash,
+              Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',
@@ -111,8 +115,7 @@ describe('labware calibration selectors', () => {
       getModulesBySlot.mockReturnValue({})
 
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       state = ({
         calibration: {
@@ -125,18 +128,15 @@ describe('labware calibration selectors', () => {
               data: [
                 {
                   ...lwCalibration,
-                  attributes: {
-                    ...attributes,
-                    loadName: wellPlate96Def.parameters.loadName,
-                    namespace: wellPlate96Def.namespace,
-                    version: wellPlate96Def.version,
-                    parent: '',
-                    calibrationData: {
-                      ...calibrationData,
-                      offset: {
-                        ...calibrationData.offset,
-                        value: [1.23, 4.56, 7.89],
-                      },
+                  loadName: wellPlate96Def.parameters.loadName,
+                  namespace: wellPlate96Def.namespace,
+                  version: wellPlate96Def.version,
+                  parent: '',
+                  calibrationData: {
+                    ...calibrationData,
+                    offset: {
+                      ...calibrationData.offset,
+                      value: [1.23, 4.56, 7.89],
                     },
                   },
                 },
@@ -168,31 +168,25 @@ describe('labware calibration selectors', () => {
 
     it('grabs calibration data for labware on module if present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const calNotOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [0, 0, 0],
-            },
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [0, 0, 0],
           },
         },
       }
 
       const calOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
           parent: 'magneticModuleV1',
           loadName: wellPlate96Def.parameters.loadName,
           namespace: wellPlate96Def.namespace,
@@ -204,7 +198,6 @@ describe('labware calibration selectors', () => {
               value: [1.23, 4.56, 7.89],
             },
           },
-        },
       }
 
       state = ({
@@ -231,7 +224,7 @@ describe('labware calibration selectors', () => {
           version: wellPlate96Def.version,
           parent: 'magneticModuleV1',
           calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
-          definitionHash: attributes.definitionHash,
+          definitionHash: lwCalibration.definitionHash,
         },
         {
           type: 'some_v1_labware',
@@ -248,41 +241,34 @@ describe('labware calibration selectors', () => {
 
     it('grabs calibration data for labware not on module if on-module cal data is present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const calNotOnModule = {
-        ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+      ...lwCalibration,
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
         },
       }
 
       const calOnModule = {
         ...lwCalibration,
-        attributes: {
-          ...attributes,
-          parent: 'magneticModuleV1',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [0, 0, 0],
-            },
+        parent: 'magneticModuleV1',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [0, 0, 0],
           },
         },
       }
@@ -312,7 +298,7 @@ describe('labware calibration selectors', () => {
           namespace: wellPlate96Def.namespace,
           version: wellPlate96Def.version,
           parent: null,
-          definitionHash: attributes.definitionHash,
+          definitionHash: lwCalibration.definitionHash,
           calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
         },
         {
@@ -330,23 +316,19 @@ describe('labware calibration selectors', () => {
 
     it('grabs no calibration data for labware if definitionHash not present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
-      const { attributes } = lwCalibration
-      const { calibrationData } = attributes
+      const { calibrationData } = lwCalibration
 
       const oldLwCal = {
         ...omit(lwCalibration, 'definitionHash'),
-        attributes: {
-          ...attributes,
-          parent: '',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+        parent: '',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
         },
       }
@@ -368,7 +350,7 @@ describe('labware calibration selectors', () => {
       }: $Shape<State>)
 
       expect(Selectors.getProtocolLabwareList(state, robotName)).toEqual([
-        {
+        { // No calibrationData
           type: wellPlate96Def.parameters.loadName,
           definition: wellPlate96Def,
           slot: '3',
@@ -376,10 +358,14 @@ describe('labware calibration selectors', () => {
           namespace: wellPlate96Def.namespace,
           version: wellPlate96Def.version,
           parent: null,
-          definitionHash: attributes.definitionHash,
-          calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
+          definitionHash: lwCalibration.definitionHash,
+          calibrationData: null,
         },
-        {
+        { // This calibrationData is grabbed unintentionally as a side-effect
+          // of the Selector logic. Both labware & calibration have hashes missing
+          // hence the matchesLabwareIdentityForCalibration logic gets satisfied 
+          // and we get a calibrationData in the definition. This case should never arise
+          // in reality
           type: 'some_v1_labware',
           definition: null,
           slot: '1',
@@ -387,7 +373,7 @@ describe('labware calibration selectors', () => {
           namespace: null,
           version: null,
           parent: null,
-          calibrationData: null,
+          calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
         },
       ])
     })
@@ -408,7 +394,7 @@ describe('labware calibration selectors', () => {
             definition: wellPlate96Def,
             slot: '3',
             definitionHash:
-              Fixtures.mockLabwareCalibration1.attributes.definitionHash,
+              Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -80,8 +80,7 @@ describe('labware calibration selectors', () => {
             type: wellPlate96Def.parameters.loadName,
             definition: wellPlate96Def,
             slot: '3',
-            definitionHash:
-              Fixtures.mockLabwareCalibration1.definitionHash,
+            definitionHash: Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',
@@ -186,17 +185,17 @@ describe('labware calibration selectors', () => {
 
       const calOnModule = {
         ...lwCalibration,
-          parent: 'magneticModuleV1',
-          loadName: wellPlate96Def.parameters.loadName,
-          namespace: wellPlate96Def.namespace,
-          version: wellPlate96Def.version,
-          calibrationData: {
-            ...calibrationData,
-            offset: {
-              ...calibrationData.offset,
-              value: [1.23, 4.56, 7.89],
-            },
+        parent: 'magneticModuleV1',
+        loadName: wellPlate96Def.parameters.loadName,
+        namespace: wellPlate96Def.namespace,
+        version: wellPlate96Def.version,
+        calibrationData: {
+          ...calibrationData,
+          offset: {
+            ...calibrationData.offset,
+            value: [1.23, 4.56, 7.89],
           },
+        },
       }
 
       state = ({
@@ -242,7 +241,7 @@ describe('labware calibration selectors', () => {
       const { calibrationData } = lwCalibration
 
       const calNotOnModule = {
-      ...lwCalibration,
+        ...lwCalibration,
         parent: '',
         loadName: wellPlate96Def.parameters.loadName,
         namespace: wellPlate96Def.namespace,
@@ -346,7 +345,8 @@ describe('labware calibration selectors', () => {
       }: $Shape<State>)
 
       expect(Selectors.getProtocolLabwareList(state, robotName)).toEqual([
-        { // No calibrationData
+        {
+          // No calibrationData
           type: wellPlate96Def.parameters.loadName,
           definition: wellPlate96Def,
           slot: '3',
@@ -357,9 +357,10 @@ describe('labware calibration selectors', () => {
           definitionHash: lwCalibration.definitionHash,
           calibrationData: null,
         },
-        { // This calibrationData is grabbed unintentionally as a side-effect
+        {
+          // This calibrationData is grabbed unintentionally as a side-effect
           // of the Selector logic. Both labware & calibration have hashes missing
-          // hence the matchesLabwareIdentityForCalibration logic gets satisfied 
+          // hence the matchesLabwareIdentityForCalibration logic gets satisfied
           // and we get a calibrationData in the definition. This case should never arise
           // in reality
           type: 'some_v1_labware',
@@ -389,8 +390,7 @@ describe('labware calibration selectors', () => {
             type: wellPlate96Def.parameters.loadName,
             definition: wellPlate96Def,
             slot: '3',
-            definitionHash:
-              Fixtures.mockLabwareCalibration1.definitionHash,
+            definitionHash: Fixtures.mockLabwareCalibration1.definitionHash,
           }: $Shape<ProtocolLabware>),
           ({
             type: 'some_v1_labware',

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -86,6 +86,7 @@ describe('labware calibration selectors', () => {
             type: 'some_v1_labware',
             definition: null,
             slot: '1',
+            definitionHash: null,
           }: $Shape<ProtocolLabware>),
         ]
       })
@@ -159,7 +160,7 @@ describe('labware calibration selectors', () => {
           parentDisplayName: null,
           quantity: 1,
           calibration: null,
-          calDataAvailable: true,
+          calDataAvailable: false,
         },
       ])
     })
@@ -232,11 +233,12 @@ describe('labware calibration selectors', () => {
           version: null,
           parent: null,
           calibrationData: null,
+          definitionHash: null,
         },
       ])
     })
 
-    it('grabs calibration data for labware not on module if on-module cal data is present', () => {
+    it('grabs calibration data for labware not on module even if on-module cal data is also present', () => {
       const lwCalibration = Fixtures.mockLabwareCalibration1
       const { calibrationData } = lwCalibration
 
@@ -305,6 +307,7 @@ describe('labware calibration selectors', () => {
           namespace: null,
           version: null,
           parent: null,
+          definitionHash: null,
           calibrationData: null,
         },
       ])
@@ -372,7 +375,8 @@ describe('labware calibration selectors', () => {
           namespace: null,
           version: null,
           parent: null,
-          calibrationData: { x: 1.2, y: 4.6, z: 7.9 },
+          definitionHash: null,
+          calibrationData: null,
         },
       ])
     })

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -361,13 +361,6 @@ describe('labware calibration selectors', () => {
           calibrationData: null,
         },
         {
-          // This calibrationData is grabbed unintentionally as a side-effect
-          // of the Selector logic. Both labware & calibration have hashes missing
-          // hence the matchesLabwareIdentityForCalibration logic gets satisfied
-          // and we get a calibrationData in the definition. This could happen
-          // in case of v1 labware. In such a case, the LabwareSummary object sets
-          // its calDataAvailable property to false and hides the calibrationData
-          // from view.
           type: 'some_v1_labware',
           definition: null,
           slot: '1',

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -124,7 +124,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [
                 {
                   ...lwCalibration,
@@ -207,7 +206,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [calNotOnModule, calOnModule],
             },
           },
@@ -282,7 +280,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [calOnModule, calNotOnModule],
             },
           },
@@ -342,7 +339,6 @@ describe('labware calibration selectors', () => {
             pipetteOffsetCalibrations: null,
             tipLengthCalibrations: null,
             labwareCalibrations: {
-              meta: {},
               data: [oldLwCal],
             },
           },

--- a/app/src/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/calibration/labware/__tests__/selectors.test.js
@@ -361,8 +361,10 @@ describe('labware calibration selectors', () => {
           // This calibrationData is grabbed unintentionally as a side-effect
           // of the Selector logic. Both labware & calibration have hashes missing
           // hence the matchesLabwareIdentityForCalibration logic gets satisfied
-          // and we get a calibrationData in the definition. This case should never arise
-          // in reality
+          // and we get a calibrationData in the definition. This could happen
+          // in case of v1 labware. In such a case, the LabwareSummary object sets
+          // its calDataAvailable property to false and hides the calibrationData
+          // from view.
           type: 'some_v1_labware',
           definition: null,
           slot: '1',

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -46,7 +46,7 @@ export const getProtocolLabwareList: (
         calibrationData: null,
       }
       const calData = calibrations
-        .filter((calibration) =>
+        .filter(calibration =>
           matchesLabwareIdentityForCalibration(calibration, baseLabware)
         )
         .map(formatCalibrationData)

--- a/app/src/calibration/labware/selectors.js
+++ b/app/src/calibration/labware/selectors.js
@@ -16,13 +16,13 @@ import {
 } from './utils'
 
 import type { State } from '../../types'
-import type { LabwareCalibrationModel } from '../types'
+import type { LabwareCalibration } from '../types'
 import type { LabwareSummary, BaseProtocolLabware } from './types'
 
 export const getLabwareCalibrations = (
   state: State,
   robotName: string
-): Array<LabwareCalibrationModel> => {
+): Array<LabwareCalibration> => {
   return state.calibration[robotName]?.labwareCalibrations?.data ?? []
 }
 
@@ -46,8 +46,8 @@ export const getProtocolLabwareList: (
         calibrationData: null,
       }
       const calData = calibrations
-        .filter(({ attributes }) =>
-          matchesLabwareIdentityForCalibration(attributes, baseLabware)
+        .filter((calibration) =>
+          matchesLabwareIdentityForCalibration(calibration, baseLabware)
         )
         .map(formatCalibrationData)
 
@@ -72,7 +72,7 @@ export const getUniqueProtocolLabwareSummaries: (
   getLabwareCalibrations,
   (
     baseLabwareList: Array<BaseProtocolLabware>,
-    calibrations: Array<LabwareCalibrationModel>
+    calibrations: Array<LabwareCalibration>
   ) => {
     const uniqueLabware = uniqWith<BaseProtocolLabware>(
       baseLabwareList,

--- a/app/src/calibration/labware/utils.js
+++ b/app/src/calibration/labware/utils.js
@@ -44,8 +44,6 @@ export const matchesLabwareIdentityForCalibration = (
 export function formatCalibrationData(
   model: LabwareCalibration
 ): LabwareCalibrationData {
-  const calVector = model.calibrationData.offset.value.map(n =>
-    round(n, 1)
-  )
+  const calVector = model.calibrationData.offset.value.map(n => round(n, 1))
   return { x: calVector[0], y: calVector[1], z: calVector[2] }
 }

--- a/app/src/calibration/labware/utils.js
+++ b/app/src/calibration/labware/utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import round from 'lodash/round'
-import type { LabwareCalibrationModel, LabwareCalibration } from '../types'
+import type { LabwareCalibration } from '../types'
 import type { LabwareCalibrationData, BaseProtocolLabware } from './types'
 
 const normalizeParent = parent =>
@@ -42,9 +42,9 @@ export const matchesLabwareIdentityForCalibration = (
 }
 
 export function formatCalibrationData(
-  model: LabwareCalibrationModel
+  model: LabwareCalibration
 ): LabwareCalibrationData {
-  const calVector = model.attributes.calibrationData.offset.value.map(n =>
+  const calVector = model.calibrationData.offset.value.map(n =>
     round(n, 1)
   )
   return { x: calVector[0], y: calVector[1], z: calVector[2] }

--- a/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
+++ b/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
@@ -29,34 +29,34 @@ export const mockPipetteOffsetCalibration1: PipetteOffsetCalibration = {
 }
 
 export const mockPipetteOffsetCalibration2: PipetteOffsetCalibration = {
-    pipette: 'P20MV2008052020A02',
-    mount: 'right',
-    offset: [2.0, 4.0, 6.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
-    tiprack: 'aasdhakfghakjsdhlaksjhdak',
-    lastModified: '2020-07-25T20:00',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+  pipette: 'P20MV2008052020A02',
+  mount: 'right',
+  offset: [2.0, 4.0, 6.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_20ul/1',
+  tiprack: 'aasdhakfghakjsdhlaksjhdak',
+  lastModified: '2020-07-25T20:00',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
+  },
   id: 'some id',
 }
 
 export const mockPipetteOffsetCalibration3: PipetteOffsetCalibration = {
-    pipette: 'P1KVS2108052020A02',
-    mount: 'right',
-    offset: [4.0, 6.0, 8.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
-    tiprack: 'asdakjsdhalksjdhlakjsdhalkhsd',
-    lastModified: '2020-09-10T05:13',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+  pipette: 'P1KVS2108052020A02',
+  mount: 'right',
+  offset: [4.0, 6.0, 8.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
+  tiprack: 'asdakjsdhalksjdhlakjsdhalkhsd',
+  lastModified: '2020-09-10T05:13',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
+  },
   id: 'some id',
 }
 

--- a/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
+++ b/app/src/calibration/pipette-offset/__fixtures__/pipette-offset-calibration.js
@@ -8,31 +8,27 @@ import { PIPETTE_OFFSET_CALIBRATIONS_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  PipetteOffsetCalibrationModel,
+  PipetteOffsetCalibration,
   AllPipetteOffsetCalibrations,
 } from '../../api-types'
 
-export const mockPipetteOffsetCalibration1: PipetteOffsetCalibrationModel = {
-  attributes: {
-    pipette: 'P3HSV2008052020A02',
-    mount: 'left',
-    offset: [1.0, 2.0, 3.0],
-    tiprackUri: 'opentrons/opentrons_96_tiprack_300ul/1',
-    tiprack: 'asdasfasdasdhasjhdasdasda',
-    lastModified: '2020-08-30T10:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockPipetteOffsetCalibration1: PipetteOffsetCalibration = {
+  pipette: 'P3HSV2008052020A02',
+  mount: 'left',
+  offset: [1.0, 2.0, 3.0],
+  tiprackUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+  tiprack: 'asdasfasdasdhasjhdasdasda',
+  lastModified: '2020-08-30T10:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
-export const mockPipetteOffsetCalibration2: PipetteOffsetCalibrationModel = {
-  attributes: {
+export const mockPipetteOffsetCalibration2: PipetteOffsetCalibration = {
     pipette: 'P20MV2008052020A02',
     mount: 'right',
     offset: [2.0, 4.0, 6.0],
@@ -45,19 +41,15 @@ export const mockPipetteOffsetCalibration2: PipetteOffsetCalibrationModel = {
       source: 'unknown',
       markedAt: '',
     },
-  },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
-export const mockPipetteOffsetCalibration3: PipetteOffsetCalibrationModel = {
-  attributes: {
+export const mockPipetteOffsetCalibration3: PipetteOffsetCalibration = {
     pipette: 'P1KVS2108052020A02',
     mount: 'right',
     offset: [4.0, 6.0, 8.0],
     tiprackUri: 'opentrons/opentrons_96_tiprack_1000ul/1',
     tiprack: 'asdakjsdhalksjdhlakjsdhalkhsd',
-
     lastModified: '2020-09-10T05:13',
     source: 'user',
     status: {
@@ -65,9 +57,7 @@ export const mockPipetteOffsetCalibration3: PipetteOffsetCalibrationModel = {
       source: 'unknown',
       markedAt: '',
     },
-  },
   id: 'some id',
-  type: 'Pipette Offset Calibration',
 }
 
 export const mockAllPipetteOffsetsCalibration: AllPipetteOffsetCalibrations = {
@@ -76,7 +66,6 @@ export const mockAllPipetteOffsetsCalibration: AllPipetteOffsetCalibrations = {
     mockPipetteOffsetCalibration2,
     mockPipetteOffsetCalibration3,
   ],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/pipette-offset/__tests__/selectors.test.js
+++ b/app/src/calibration/pipette-offset/__tests__/selectors.test.js
@@ -21,9 +21,9 @@ describe('getPipetteOffsetCalibrations', () => {
     expect(
       Selectors.getPipetteOffsetCalibrations(mockState, 'robot-name')
     ).toEqual([
-      Fixtures.mockPipetteOffsetCalibration1.attributes,
-      Fixtures.mockPipetteOffsetCalibration2.attributes,
-      Fixtures.mockPipetteOffsetCalibration3.attributes,
+      Fixtures.mockPipetteOffsetCalibration1,
+      Fixtures.mockPipetteOffsetCalibration2,
+      Fixtures.mockPipetteOffsetCalibration3,
     ])
   })
   it('should not find calibrations from other robots', () => {
@@ -41,7 +41,7 @@ describe('getCalibrationForPipette', () => {
         'robot-name',
         'P1KVS2108052020A02'
       )
-    ).toEqual(Fixtures.mockPipetteOffsetCalibration3.attributes)
+    ).toEqual(Fixtures.mockPipetteOffsetCalibration3)
   })
   it('should get no calibration when no matching calibration exists', () => {
     expect(

--- a/app/src/calibration/pipette-offset/selectors.js
+++ b/app/src/calibration/pipette-offset/selectors.js
@@ -14,7 +14,7 @@ export const getPipetteOffsetCalibrations: (
   }
   const calibrations =
     state.calibration[robotName]?.pipetteOffsetCalibrations?.data || []
-  return calibrations.map(calibration => calibration.attributes)
+  return calibrations
 }
 
 export const getCalibrationForPipette: (

--- a/app/src/calibration/tip-length/__fixtures__/tip-length-calibration.js
+++ b/app/src/calibration/tip-length/__fixtures__/tip-length-calibration.js
@@ -8,60 +8,50 @@ import { TIP_LENGTH_CALIBRATIONS_PATH } from '../constants'
 
 import type { ResponseFixtures } from '../../../robot-api/__fixtures__'
 import type {
-  TipLengthCalibrationModel,
+  TipLengthCalibration,
   AllTipLengthCalibrations,
 } from '../../api-types'
 
-export const mockTipLengthCalibration1: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P3HSV2008052020A02',
-    tiprack: 'asdasfasdasdhasjhdasdasda',
-    tipLength: 30.5,
-    lastModified: '2020-09-29T10:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration1: TipLengthCalibration = {
+  pipette: 'P3HSV2008052020A02',
+  tiprack: 'asdasfasdasdhasjhdasdasda',
+  tipLength: 30.5,
+  lastModified: '2020-09-29T10:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
-export const mockTipLengthCalibration2: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P20MV2008052020A02',
-    tiprack: 'aasdhakfghakjsdhlaksjhdak',
-    tipLength: 32.5,
-    lastModified: '2020-09-29T12:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration2: TipLengthCalibration = {
+  pipette: 'P20MV2008052020A02',
+  tiprack: 'aasdhakfghakjsdhlaksjhdak',
+  tipLength: 32.5,
+  lastModified: '2020-09-29T12:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
-export const mockTipLengthCalibration3: TipLengthCalibrationModel = {
-  attributes: {
-    pipette: 'P20MV2008052020A02',
-    tiprack: 'opentrons_96_tiprack_20ul_hash',
-    tipLength: 29.0,
-    lastModified: '2020-09-29T13:02',
-    source: 'user',
-    status: {
-      markedBad: false,
-      source: 'unknown',
-      markedAt: '',
-    },
+export const mockTipLengthCalibration3: TipLengthCalibration = {
+  pipette: 'P20MV2008052020A02',
+  tiprack: 'opentrons_96_tiprack_20ul_hash',
+  tipLength: 29.0,
+  lastModified: '2020-09-29T13:02',
+  source: 'user',
+  status: {
+    markedBad: false,
+    source: 'unknown',
+    markedAt: '',
   },
-
   id: 'someID',
-  type: 'TipLengthCalibration',
 }
 
 export const mockAllTipLengthCalibrations: AllTipLengthCalibrations = {
@@ -70,7 +60,6 @@ export const mockAllTipLengthCalibrations: AllTipLengthCalibrations = {
     mockTipLengthCalibration2,
     mockTipLengthCalibration3,
   ],
-  meta: {},
 }
 
 export const {

--- a/app/src/calibration/tip-length/__tests__/selectors.test.js
+++ b/app/src/calibration/tip-length/__tests__/selectors.test.js
@@ -20,9 +20,9 @@ describe('getTipLengthCalibrations', () => {
   it('should find all tip length calibrations when they exist', () => {
     expect(Selectors.getTipLengthCalibrations(mockState, 'robot-name')).toEqual(
       [
-        Fixtures.mockTipLengthCalibration1.attributes,
-        Fixtures.mockTipLengthCalibration2.attributes,
-        Fixtures.mockTipLengthCalibration3.attributes,
+        Fixtures.mockTipLengthCalibration1,
+        Fixtures.mockTipLengthCalibration2,
+        Fixtures.mockTipLengthCalibration3,
       ]
     )
   })
@@ -42,7 +42,7 @@ describe('getCalibrationForPipette', () => {
         'P20MV2008052020A02',
         'opentrons_96_tiprack_20ul_hash'
       )
-    ).toEqual(Fixtures.mockTipLengthCalibration3.attributes)
+    ).toEqual(Fixtures.mockTipLengthCalibration3)
   })
   it('should get no calibration when no matching calibration exists', () => {
     expect(

--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -13,7 +13,7 @@ export const getTipLengthCalibrations: (
   }
   const calibrations =
     state.calibration[robotName]?.tipLengthCalibrations?.data || []
-  return calibrations//.map(calibration => calibration)
+  return calibrations
 }
 
 export const filterTipLengthForPipetteAndTiprack: (

--- a/app/src/calibration/tip-length/selectors.js
+++ b/app/src/calibration/tip-length/selectors.js
@@ -13,7 +13,7 @@ export const getTipLengthCalibrations: (
   }
   const calibrations =
     state.calibration[robotName]?.tipLengthCalibrations?.data || []
-  return calibrations.map(calibration => calibration.attributes)
+  return calibrations//.map(calibration => calibration)
 }
 
 export const filterTipLengthForPipetteAndTiprack: (

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -27,6 +27,7 @@ describe('TipLengthCalibrationData', () => {
   it('displays existing data if present and not calibrated in this session', () => {
     const wrapper = render({
       calibrationData: {
+        id: '1',
         tipLength: 30,
         tiprack: 'tiprack',
         pipette: 'pip',

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -38,7 +38,6 @@ describe('TipLengthCalibrationData', () => {
           source: 'unknown',
           markedAt: '',
         },
-        id: 'fake_id'
       },
     })
     expect(wrapper.text().includes('Existing data')).toBe(true)

--- a/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
+++ b/app/src/components/CalibratePanel/__tests__/TipLengthCalibrationData.test.js
@@ -37,6 +37,7 @@ describe('TipLengthCalibrationData', () => {
           source: 'unknown',
           markedAt: '',
         },
+        id: 'fake_id'
       },
     })
     expect(wrapper.text().includes('Existing data')).toBe(true)

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -87,7 +87,7 @@ describe('PipetteInfo', () => {
 
   it('just launch POC w/o cal block modal if POC button clicked and data exists', () => {
     mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
+      mockPipetteOffsetCalibration1
     )
     const { wrapper } = render()
     wrapper.find('button[children="Calibrate offset"]').invoke('onClick')()
@@ -138,10 +138,10 @@ describe('PipetteInfo', () => {
 
   it('launch POWT w/ cal block modal denied if recal tip button clicked and no cal block pref saved', () => {
     mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
+      mockPipetteOffsetCalibration1
     )
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -162,10 +162,10 @@ describe('PipetteInfo', () => {
 
   it('launch POWT w/ cal block modal confirmed if recal tip button clicked and no cal block pref saved', () => {
     mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
+      mockPipetteOffsetCalibration1
     )
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -186,10 +186,10 @@ describe('PipetteInfo', () => {
     mockGetHasCalibrationBlock.mockReturnValue(true)
 
     mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
+      mockPipetteOffsetCalibration1
     )
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)
@@ -209,10 +209,10 @@ describe('PipetteInfo', () => {
     mockGetHasCalibrationBlock.mockReturnValue(false)
 
     mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1.attributes
+      mockPipetteOffsetCalibration1
     )
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
-      mockTipLengthCalibration1.attributes
+      mockTipLengthCalibration1
     )
     const { wrapper } = render()
     expect(wrapper.find('AskForCalibrationBlockModal').exists()).toBe(false)

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -86,9 +86,7 @@ describe('PipetteInfo', () => {
   })
 
   it('just launch POC w/o cal block modal if POC button clicked and data exists', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     const { wrapper } = render()
     wrapper.find('button[children="Calibrate offset"]').invoke('onClick')()
     wrapper.update()
@@ -137,9 +135,7 @@ describe('PipetteInfo', () => {
   })
 
   it('launch POWT w/ cal block modal denied if recal tip button clicked and no cal block pref saved', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
       mockTipLengthCalibration1
     )
@@ -161,9 +157,7 @@ describe('PipetteInfo', () => {
   })
 
   it('launch POWT w/ cal block modal confirmed if recal tip button clicked and no cal block pref saved', () => {
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
       mockTipLengthCalibration1
     )
@@ -185,9 +179,7 @@ describe('PipetteInfo', () => {
   it('launch POWT w/o cal block modal if recal tip button clicked and cal block pref saved as true', () => {
     mockGetHasCalibrationBlock.mockReturnValue(true)
 
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
       mockTipLengthCalibration1
     )
@@ -208,9 +200,7 @@ describe('PipetteInfo', () => {
   it('launch POWT w/o cal block modal if recal tip button clicked and cal block pref saved as false', () => {
     mockGetHasCalibrationBlock.mockReturnValue(false)
 
-    mockGetCalibrationForPipette.mockReturnValue(
-      mockPipetteOffsetCalibration1
-    )
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
       mockTipLengthCalibration1
     )

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -77,6 +77,7 @@ describe('PipetteOffsetItem', () => {
             id: 'a_pip_id',
           },
           tipLength: {
+            id: '1',
             tipLength: 30,
             tiprack: 'asdagasdfasdsa',
             pipette: 'pipette-id-11',
@@ -168,6 +169,7 @@ describe('PipetteOffsetItem', () => {
           id: 'a_pip_id',
         },
         tipLength: {
+          id: '1',
           tipLength: 30,
           tiprack: 'asdagasdfasdsa',
           pipette: 'pipette-id-11',
@@ -210,6 +212,7 @@ describe('PipetteOffsetItem', () => {
           id: 'a_pip_id',
         },
         tipLength: {
+          id: '1',
           tipLength: 30,
           tiprack: 'asdagasdfasdsa',
           pipette: 'pipette-id-11',

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -88,7 +88,6 @@ describe('PipetteOffsetItem', () => {
               source: 'unknown',
               markedAt: '',
             },
-            id: 'fake_id',
           },
         },
         customLabware = [],
@@ -180,7 +179,6 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '',
           },
-          id: 'fake_id',
         },
       },
     })
@@ -223,7 +221,6 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '',
           },
-          id: 'fake_id',
         },
       },
     })

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -74,6 +74,7 @@ describe('PipetteOffsetItem', () => {
               source: 'unknown',
               markedAt: '',
             },
+            id: 'a_pip_id',
           },
           tipLength: {
             tipLength: 30,
@@ -86,6 +87,7 @@ describe('PipetteOffsetItem', () => {
               source: 'unknown',
               markedAt: '',
             },
+            id: 'fake_id',
           },
         },
         customLabware = [],
@@ -163,6 +165,7 @@ describe('PipetteOffsetItem', () => {
             source: 'calibration_check',
             markedAt: '2020-10-09T13:30:00Z',
           },
+          id: 'a_pip_id',
         },
         tipLength: {
           tipLength: 30,
@@ -175,6 +178,7 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '',
           },
+          id: 'fake_id',
         },
       },
     })
@@ -203,6 +207,7 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '2020-10-09T13:30:00Z',
           },
+          id: 'a_pip_id',
         },
         tipLength: {
           tipLength: 30,
@@ -215,6 +220,7 @@ describe('PipetteOffsetItem', () => {
             source: 'unknown',
             markedAt: '',
           },
+          id: 'fake_id',
         },
       },
     })

--- a/app/src/pipettes/__tests__/selectors.test.js
+++ b/app/src/pipettes/__tests__/selectors.test.js
@@ -82,11 +82,11 @@ describe('getAttachedPipetteCalibrations', () => {
           attachedByMount: {
             left: {
               ...Fixtures.mockAttachedPipette,
-              id: POCFixtures.mockPipetteOffsetCalibration1.attributes.pipette,
+              id: POCFixtures.mockPipetteOffsetCalibration1.pipette,
             },
             right: {
               ...Fixtures.mockAttachedPipette,
-              id: POCFixtures.mockPipetteOffsetCalibration2.attributes.pipette,
+              id: POCFixtures.mockPipetteOffsetCalibration2.pipette,
             },
           },
           settingsById: null,
@@ -107,12 +107,12 @@ describe('getAttachedPipetteCalibrations', () => {
       Selectors.getAttachedPipetteCalibrations(mockPipetteState, 'robotName')
     ).toEqual({
       left: {
-        offset: POCFixtures.mockPipetteOffsetCalibration1.attributes,
-        tipLength: TLCFixtures.mockTipLengthCalibration1.attributes,
+        offset: POCFixtures.mockPipetteOffsetCalibration1,
+        tipLength: TLCFixtures.mockTipLengthCalibration1,
       },
       right: {
-        offset: POCFixtures.mockPipetteOffsetCalibration2.attributes,
-        tipLength: TLCFixtures.mockTipLengthCalibration2.attributes,
+        offset: POCFixtures.mockPipetteOffsetCalibration2,
+        tipLength: TLCFixtures.mockTipLengthCalibration2,
       },
     })
   })

--- a/app/src/robot-admin/__fixtures__/system-time.js
+++ b/app/src/robot-admin/__fixtures__/system-time.js
@@ -6,12 +6,10 @@ import {
   mockFailureBody,
 } from '../../robot-api/__fixtures__'
 
-import type { SystemTimeData, SystemTimeAttributes } from '../api-types'
+import type { SystemTimeData } from '../api-types'
 import type { ResponseFixtures } from '../../robot-api/__fixtures__'
 
-export const mockSystemTimeAttributes: SystemTimeAttributes = {
-  systemTime: '2020-09-08T18:02:01.318292+00:00',
-}
+export const mockSystemTime = '2020-09-08T18:02:01.318292+00:00'
 
 export const {
   successMeta: mockFetchSystemTimeSuccessMeta,
@@ -27,8 +25,7 @@ export const {
   successStatus: 200,
   successBody: {
     id: 'time',
-    type: 'SystemTimeAttributes',
-    attributes: mockSystemTimeAttributes,
+    systemTime: mockSystemTime,
   },
   failureStatus: 500,
   failureBody: mockFailureBody,

--- a/app/src/robot-admin/api-types.js
+++ b/app/src/robot-admin/api-types.js
@@ -1,13 +1,7 @@
 // @flow
 
-export type SystemTimeAttributes = {
-  systemTime: string,
-  ...
-}
-
 export type SystemTimeData = {
   id: 'time',
-  type: 'SystemTimeAttributes',
-  attributes: SystemTimeAttributes,
+  systemTime: string,
   ...
 }

--- a/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
+++ b/app/src/robot-admin/epic/__tests__/syncTimeOnConnectEpic.test.js
@@ -15,7 +15,7 @@ const createConnectAction = robotName => (RobotActions.connect(robotName): any)
 
 const createTimeSuccessResponse = (time: Date) => {
   const response = cloneDeep(mockFetchSystemTimeSuccess)
-  set(response, 'body.data.attributes.systemTime', time.toISOString())
+  set(response, 'body.data.systemTime', time.toISOString())
   return response
 }
 
@@ -78,15 +78,14 @@ describe('syncTimeOnConnectEpic', () => {
         path: '/system/time',
         body: {
           data: {
-            type: 'SystemTimeAttributes',
-            attributes: { systemTime: expect.any(String) },
+            systemTime: expect.any(String),
           },
         },
       })
 
       const updatedTime = get(
         mocks.fetchRobotApi.mock.calls[1][1],
-        'body.data.attributes.systemTime'
+        'body.data.systemTime'
       )
 
       expect(

--- a/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
+++ b/app/src/robot-admin/epic/syncTimeOnConnectEpic.js
@@ -25,8 +25,7 @@ const createUpdateRequest = (date: Date): RobotApiRequestOptions => {
     path: Constants.SYSTEM_TIME_PATH,
     body: {
       data: {
-        type: 'SystemTimeAttributes',
-        attributes: { systemTime: date.toISOString() },
+        systemTime: date.toISOString(),
       },
     },
   }
@@ -43,7 +42,7 @@ export const syncTimeOnConnectEpic: Epic = (action$, state$) => {
 
       return fetchRobotApi(robot, fetchSystemTimeReq).pipe(
         filter(response => response.ok),
-        map(response => response.body.data.attributes.systemTime),
+        map(response => response.body.data.systemTime),
         filter(systemTimeString => {
           const systemTime = parseISO(systemTimeString)
           const drift = differenceInSeconds(systemTime, new Date())

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -70,19 +70,13 @@ export type ResourceLinks = $Shape<{| [string]: ResourceLink | string | void |}>
 // generic response data supertype
 export type RobotApiV2ResponseData = {|
   id: string,
-  // the "+" means that these properties are covariant, so
-  // "extending" types may specify more strict subtypes
-  +type: string,
-  +attributes: { ... },
 |}
 
 export type RobotApiV2ResponseBody<
-  DataT: RobotApiV2ResponseData | $ReadOnlyArray<RobotApiV2ResponseData>,
-  MetaT = void
+  DataT: RobotApiV2ResponseData | $ReadOnlyArray<RobotApiV2ResponseData>
 > = {|
   data: DataT,
   links?: ResourceLinks,
-  meta?: MetaT,
 |}
 
 export type RobotApiV2Error = {|

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -70,6 +70,7 @@ export type ResourceLinks = $Shape<{| [string]: ResourceLink | string | void |}>
 // generic response data supertype
 export type RobotApiV2ResponseData = {
   id: string,
+  ...
 }
 
 export type RobotApiV2ResponseBody<

--- a/app/src/robot-api/types.js
+++ b/app/src/robot-api/types.js
@@ -68,9 +68,9 @@ export type ResourceLink = {|
 export type ResourceLinks = $Shape<{| [string]: ResourceLink | string | void |}>
 
 // generic response data supertype
-export type RobotApiV2ResponseData = {|
+export type RobotApiV2ResponseData = {
   id: string,
-|}
+}
 
 export type RobotApiV2ResponseBody<
   DataT: RobotApiV2ResponseData | $ReadOnlyArray<RobotApiV2ResponseData>

--- a/app/src/sessions/__fixtures__/index.js
+++ b/app/src/sessions/__fixtures__/index.js
@@ -65,62 +65,54 @@ export const mockSessionCommand: Types.SessionCommandAttributes = {
 
 export const mockSessionCommandAttributes: Types.SessionCommandAttributes = {
   command: 'calibration.check.comparePoint',
-  status: 'accepted',
   data: {},
 }
 
 export const mockSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockCalibrationCheckSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockCalibrationCheckSessionAttributes,
   },
 }
 
 export const mockTipLengthCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockTipLengthCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockTipLengthCalibrationSessionAttributes,
   },
 }
 
 export const mockPipetteOffsetCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockPipetteOffsetCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockPipetteOffsetCalibrationSessionAttributes,
   },
 }
 
 export const mockDeckCalibrationSessionResponse: Types.SessionResponse = {
   data: {
+    ...mockDeckCalibrationSessionAttributes,
     id: mockSessionId,
-    type: 'Session',
-    attributes: mockDeckCalibrationSessionAttributes,
   },
 }
 
 export const mockMultiSessionResponse: Types.MultiSessionResponse = {
   data: [
     {
+      ...mockCalibrationCheckSessionAttributes,
       id: mockSessionId,
-      type: 'Session',
-      attributes: mockCalibrationCheckSessionAttributes,
     },
     {
+      ...mockCalibrationCheckSessionAttributes,
       id: mockOtherSessionId,
-      type: 'Session',
-      attributes: mockCalibrationCheckSessionAttributes,
     },
   ],
 }
 
 export const mockSessionCommandResponse: Types.SessionCommandResponse = {
   data: {
+    ...mockSessionCommandAttributes,
     id: mockSessionId,
-    type: 'SessionCommand',
-    attributes: mockSessionCommandAttributes,
   },
 }
 

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -34,7 +34,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -55,7 +55,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -65,11 +65,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -93,7 +93,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
         },
@@ -114,7 +114,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -124,11 +124,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -147,7 +147,7 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -157,11 +157,11 @@ const SPECS: Array<ReducerSpec> = [
       'eggplant-parm': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: Fixtures.mockSessionId,
           },
           existing_fake_session_id: {
-            ...Fixtures.mockSessionResponse.data.attributes,
+            ...Fixtures.mockSessionResponse.data,
             id: 'existing_fake_session_id',
           },
         },
@@ -185,11 +185,11 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[0].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[0],
             id: Fixtures.mockSessionId,
           },
           [Fixtures.mockOtherSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[1].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[1],
             id: Fixtures.mockOtherSessionId,
           },
         },
@@ -221,11 +221,11 @@ const SPECS: Array<ReducerSpec> = [
       'rock-lobster': {
         robotSessions: {
           [Fixtures.mockSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[0].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[0],
             id: Fixtures.mockSessionId,
           },
           [Fixtures.mockOtherSessionId]: {
-            ...Fixtures.mockMultiSessionResponse.data[1].attributes,
+            ...Fixtures.mockMultiSessionResponse.data[1],
             id: Fixtures.mockOtherSessionId,
           },
         },

--- a/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionCommandEpic.test.js
@@ -31,12 +31,9 @@ describe('createSessionCommandEpic', () => {
     path: '/sessions/1234/commands/execute',
     body: {
       data: {
-        type: 'Command',
-        attributes: {
-          command: 'calibration.jog',
-          data: {
-            vector: [32, 0, 0],
-          },
+        command: 'calibration.jog',
+        data: {
+          vector: [32, 0, 0],
         },
       },
     },

--- a/app/src/sessions/epic/__tests__/createSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/createSessionEpic.test.js
@@ -18,11 +18,8 @@ describe('createSessionEpic', () => {
     path: '/sessions',
     body: {
       data: {
-        type: 'Session',
-        attributes: {
-          sessionType: 'calibrationCheck',
-          createParams: {},
-        },
+        sessionType: 'calibrationCheck',
+        createParams: {},
       },
     },
   }

--- a/app/src/sessions/epic/__tests__/ensureSessionEpic.test.js
+++ b/app/src/sessions/epic/__tests__/ensureSessionEpic.test.js
@@ -31,11 +31,8 @@ const expectedCreateRequest = {
   path: '/sessions',
   body: {
     data: {
-      type: 'Session',
-      attributes: {
-        sessionType: 'calibrationCheck',
-        createParams: {},
-      },
+      sessionType: 'calibrationCheck',
+      createParams: {},
     },
   },
 }

--- a/app/src/sessions/epic/createSessionCommandEpic.js
+++ b/app/src/sessions/epic/createSessionCommandEpic.js
@@ -25,11 +25,8 @@ const mapActionToRequest = (
   path: `${Constants.SESSIONS_PATH}/${action.payload.sessionId}${Constants.SESSIONS_COMMANDS_EXECUTE_PATH_EXTENSION}`,
   body: {
     data: {
-      type: 'Command',
-      attributes: {
-        command: action.payload.command.command,
-        data: action.payload.command.data,
-      },
+      command: action.payload.command.command,
+      data: action.payload.command.data,
     },
   },
 })

--- a/app/src/sessions/epic/createSessionEpic.js
+++ b/app/src/sessions/epic/createSessionEpic.js
@@ -22,11 +22,8 @@ export const mapActionToRequest = (
   path: Constants.SESSIONS_PATH,
   body: {
     data: {
-      type: 'Session',
-      attributes: {
-        sessionType: action.payload.sessionType,
-        createParams: action.payload.params,
-      },
+      sessionType: action.payload.sessionType,
+      createParams: action.payload.params,
     },
   },
 })

--- a/app/src/sessions/epic/ensureSessionEpic.js
+++ b/app/src/sessions/epic/ensureSessionEpic.js
@@ -47,8 +47,8 @@ export const ensureSessionEpic: Epic = (action$, state$) => {
               !ok ||
               body.data.some(
                 s =>
-                  s.attributes.sessionType === sessionType &&
-                  isEqual(s.attributes.createParams, params)
+                  s.sessionType === sessionType &&
+                  isEqual(s.createParams, params)
               )
             ) {
               return of(

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -29,10 +29,7 @@ export function sessionReducer(
           ...robotState,
           robotSessions: {
             ...robotState.robotSessions,
-            [sessionState.data.id]: {
-              ...sessionState.data.attributes,
-              id: sessionState.data.id,
-            },
+            [sessionState.data.id]: sessionState.data,
           },
         },
       }
@@ -42,7 +39,7 @@ export function sessionReducer(
       const { robotName, sessions } = action.payload
       const robotState = state[robotName] || INITIAL_PER_ROBOT_STATE
       const sessionsById = sessions.reduce(
-        (acc, s) => ({ ...acc, [s.id]: { ...s.attributes, id: s.id } }),
+        (acc, s) => ({ ...acc, [s.id]: { ...s, id: s.id } }),
         {}
       )
 

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -140,31 +140,22 @@ export type Session =
 export type SessionCommandAttributes = {|
   command: SessionCommandString,
   data: SessionCommandData,
+|}
+
+export type SessionResponseModel = Session
+
+export type SessionCommandResponseModel = {|
+  ...SessionCommandAttributes,
+  id: string,
   status?: string,
 |}
 
-export type SessionResponseModel = {|
-  id: string,
-  type: 'Session',
-  attributes: SessionResponseAttributes,
-|}
-
-export type SessionCommandResponseModel = {|
-  id: string,
-  type: 'SessionCommand',
-  attributes: SessionCommandAttributes,
-|}
-
-export type SessionResponse = RobotApiV2ResponseBody<SessionResponseModel, {||}>
+export type SessionResponse = RobotApiV2ResponseBody<SessionResponseModel>
 export type MultiSessionResponse = RobotApiV2ResponseBody<
-  $ReadOnlyArray<SessionResponseModel>,
-  {||}
+  $ReadOnlyArray<SessionResponseModel>
 >
 
-export type SessionCommandResponse = RobotApiV2ResponseBody<
-  SessionCommandResponseModel,
-  Session
->
+export type SessionCommandResponse = RobotApiV2ResponseBody<SessionCommandResponseModel>
 
 export type CreateSessionAction = {|
   type: CREATE_SESSION,


### PR DESCRIPTION
# Overview

This PR is part of the HTTP model flattening initiative to remove unused properties. See #6847 for more details.
Closes #6850 

# Changelog

Removed attributes, types & meta from client-side http request/response models from
- All calibration models
- All Sessions models
- robot-server/system models

# Review requests

- [ ] the changes are compatible with server-side
- [ ] the calibration selector logic changes are correct

# Risk assessment

High. Changes the structure of all http endpoints in use
