### PR TITLE
refactor(api): Refactor location class

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -754,7 +754,7 @@ def _get_labware(command):  # noqa(C901)
 
     placeable = location
     if isinstance(location, Location):
-        placeable = location.labware
+        placeable = location.labware.object
     elif isinstance(location, tuple):
         placeable = location[0]
 
@@ -770,8 +770,11 @@ def _get_labware(command):  # noqa(C901)
             # named tuple like location descends from tuple and therefore
             # passes the check
             containers.append(get_container(location))
-        elif isinstance(location, (Location, labware.Well, labware.Labware)):
-            containers.append(_get_new_labware(location))
+        elif isinstance(location, Location):
+            if location.labware.is_well:
+                containers.append(location.labware.parent.as_labware())
+            elif location.labware.is_labware:
+                containers.append(location.labware.as_labware())
         else:
             log.error(f'Cant handle location {location!r}')
 

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -55,12 +55,10 @@ class CommandPublisher:
 
 def _stringify_new_loc(loc: Union[Location, Well]) -> str:
     if isinstance(loc, Location):
-        if isinstance(loc.labware, str):
-            return loc.labware
-        elif isinstance(loc.labware, (Labware, Well, ModuleGeometry)):
-            return repr(loc.labware)
-        else:
+        if loc.labware.is_empty:
             return str(loc.point)
+        else:
+            return repr(loc.labware)
     elif isinstance(loc, Well):
         return str(loc)
     else:

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -10,8 +10,7 @@ from opentrons.legacy_api.containers import (Well as OldWell,
                                              Container as OldContainer,
                                              Slot as OldSlot,
                                              location_to_list)
-from opentrons.protocol_api.labware import Well, Labware
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+from opentrons.protocol_api.labware import Well
 from opentrons.protocols.api_support.util import FlowRates
 from opentrons.types import Location
 from opentrons.drivers import utils

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -736,7 +736,7 @@ class InstrumentContext(CommandPublisher):
         version_breakpoint = version_breakpoint or APIVersion(2, 2)
         if self.api_version < version_breakpoint:
             bot = location.bottom()
-            return bot._replace(point=bot.point._replace(z=bot.point.z + 10))
+            return bot.move(point=bot.point._replace(z=bot.point.z + 10))
         else:
             tr = location.parent
             assert tr.is_tiprack

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1187,7 +1187,8 @@ class InstrumentContext(CommandPublisher):
         if not speed:
             speed = self.default_speed
 
-        from_center = from_lw.center_multichannel_on_wells() if from_lw else False
+        from_center = from_lw.center_multichannel_on_wells() \
+            if from_lw else False
         cp_override = CriticalPoint.XY_CENTER if from_center else None
         from_loc = types.Location(
             self._hw_manager.hardware.gantry_position(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.util import (
     FlowRates, PlungerSpeeds, Clearances,
-    clamp_value, requires_version, build_edges, first_parent)
+    clamp_value, requires_version, build_edges)
 from opentrons.protocols.types import APIVersion
 from opentrons_shared_data.protocol.dev_types import (
     BlowoutLocation, LiquidHandlingCommand)
@@ -1534,7 +1534,7 @@ class InstrumentContext(CommandPublisher):
             return _build_length_from_overlap()
         else:
             try:
-                parent = first_parent(tiprack) or ''
+                parent = LabwareLike(tiprack).first_parent() or ''
                 return get.load_tip_length_calibration(
                     self.hw_pipette['pipette_id'],
                     tiprack._implementation.get_definition(),

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -735,11 +735,14 @@ class InstrumentContext(CommandPublisher):
         return self
 
     def _determine_drop_target(
-            self, location: Well, version_breakpoint: APIVersion = None):
+            self, location: Well,
+            version_breakpoint: APIVersion = None) -> types.Location:
         version_breakpoint = version_breakpoint or APIVersion(2, 2)
         if self.api_version < version_breakpoint:
             bot = location.bottom()
-            return bot.move(point=bot.point._replace(z=bot.point.z + 10))
+            return types.Location(
+                point=bot.point._replace(z=bot.point.z + 10),
+                labware=location)
         else:
             tr = location.parent
             assert tr.is_tiprack

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -536,7 +536,7 @@ class InstrumentContext(CommandPublisher):
             if not self._ctx.location_cache:
                 raise RuntimeError('No valid current location cache present')
             else:
-                well = self._ctx.location_cache.labware  # type: ignore
+                well = self._ctx.location_cache.labware
                 # type checked below
         else:
             well = LabwareLike(location)
@@ -554,7 +554,7 @@ class InstrumentContext(CommandPublisher):
             else:
                 move_with_z_offset =\
                     well.as_well().top().point + types.Point(0, 0, v_offset)
-                to_loc = types.Location(move_with_z_offset, location)
+                to_loc = types.Location(move_with_z_offset, well)
             self.move_to(to_loc)
         else:
             raise TypeError(

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -714,19 +714,6 @@ def get_all_labware_definitions() -> List[str]:
     return labware_module.get_all_labware_definitions()
 
 
-def quirks_from_any_parent(
-        loc: Union[Labware, Well, str, 'ModuleGeometry', None]) -> List[str]:
-    """ Walk the tree of wells and labwares and extract quirks """
-    def recursive_get_quirks(obj, found):
-        if isinstance(obj, Labware):
-            return found + obj.quirks
-        elif isinstance(obj, Well):
-            return recursive_get_quirks(obj.parent, found)
-        else:
-            return found
-    return recursive_get_quirks(loc, [])
-
-
 def split_tipracks(tip_racks: List[Labware]) -> Tuple[Labware, List[Labware]]:
     try:
         rest = tip_racks[1:]

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -262,7 +262,7 @@ class Labware(DeckItem):
     def parent(self) -> LocationLabware:
         """ The parent of this labware. Usually a slot name.
         """
-        return self._implementation.get_geometry().parent.labware
+        return self._implementation.get_geometry().parent.labware.object
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -436,8 +436,8 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def flag_unsafe_move(self,
                          to_loc: types.Location,
                          from_loc: types.Location):
-        to_lw, to_well = planning.split_loc_labware(to_loc)
-        from_lw, from_well = planning.split_loc_labware(from_loc)
+        to_lw, to_well = to_loc.labware.split_labware()
+        from_lw, from_well = from_loc.labware.split_labware()
         if self.labware is not None and \
                 (self.labware == to_lw or self.labware == from_lw) and \
                 self.lid_position != 'open':

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -435,8 +435,8 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     def flag_unsafe_move(self,
                          to_loc: types.Location,
                          from_loc: types.Location):
-        to_lw, to_well = to_loc.labware.split_labware()
-        from_lw, from_well = from_loc.labware.split_labware()
+        to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
+        from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
         if self.labware is not None and \
                 (self.labware == to_lw or self.labware == from_lw) and \
                 self.lid_position != 'open':

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -12,7 +12,6 @@ from .labware import (
     Labware, load, load_from_definition)
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry,\
     ThermocyclerGeometry
-from opentrons.protocols.geometry import planning
 from opentrons.protocols.api_support.util import requires_version
 
 if TYPE_CHECKING:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -498,7 +498,7 @@ class ProtocolContext(CommandPublisher):
         """
         def _modules() -> Iterator[Tuple[int, 'ModuleContext']]:
             for module in self._modules:
-                yield int(module.geometry.parent), module
+                yield int(str(module.geometry.parent)), module
 
         return dict(_modules())
 

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -854,7 +854,7 @@ class TransferPlan:
 
     def _is_valid_row(self, well: Union[Well, types.Location]):
         if isinstance(well, types.Location):
-            test_well: Well = well.labware  # type: ignore
+            test_well = well.labware.as_well()
         else:
             test_well = well
 

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -1,0 +1,75 @@
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Optional
+
+from opentrons.types import LocationLabware
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api.labware import Labware, Well
+    from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+
+class LabwareLikeType(int, Enum):
+    labware = auto()
+    name_only = auto()
+    well = auto()
+    module = auto()
+    none = auto()
+
+
+class LabwareLike:
+    def __init__(self, labware_like: LocationLabware):
+        """
+        Create a labware like object. Used by Location object's labware field.
+        """
+        # Import locally to avoid circular dependency
+        from opentrons.protocol_api.labware import Labware, Well
+        from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
+        self._labware_like = labware_like
+        self._type = LabwareLikeType.none
+
+        if isinstance(self._labware_like, Well):
+            self._type = LabwareLikeType.well
+            self._as_str = repr(self._labware_like)
+        elif isinstance(self._labware_like, Labware):
+            self._type = LabwareLikeType.labware
+            self._as_str = repr(self._labware_like)
+        elif isinstance(self._labware_like, str):
+            self._type = LabwareLikeType.name_only
+            self._as_str = self._labware_like
+        elif isinstance(self._labware_like, ModuleGeometry):
+            self._type = LabwareLikeType.module
+            self._as_str = repr(self._labware_like)
+        else:
+            self._as_str = ""
+
+    @property
+    def object(self) -> LocationLabware:
+        return self._labware_like
+
+    @property
+    def object_type(self) -> LabwareLikeType:
+        return self._type
+
+    @property
+    def has_parent(self) -> bool:
+        return self._type in {LabwareLikeType.labware,
+                              LabwareLikeType.well,
+                              LabwareLikeType.module}
+
+    @property
+    def parent(self) -> Optional['LabwareLike']:
+        if self.has_parent:
+            return LabwareLike(self.object.parent)
+        return None
+
+    def __str__(self) -> str:
+        return self._as_str
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __eq__(self, other):
+        return other is not None and \
+            isinstance(other, LabwareLike) and \
+            self.object == other.object

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -6,7 +6,14 @@ if TYPE_CHECKING:
     from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 
 
-LabwareLike = Union['Labware', 'Well', str, 'ModuleGeometry', None]
+LabwareLike = Union[
+    'Labware',
+    'Well',
+    str,
+    'ModuleGeometry',
+    'LabwareLikeWrapper',
+    None
+]
 
 
 class LabwareLikeType(int, Enum):
@@ -41,6 +48,9 @@ class LabwareLikeWrapper:
         elif isinstance(self._labware_like, ModuleGeometry):
             self._type = LabwareLikeType.module
             self._as_str = repr(self._labware_like)
+        elif isinstance(self._labware_like, LabwareLikeWrapper):
+            self._type = self._labware_like._type
+            self._labware_like = self._labware_like.object
         else:
             self._as_str = ""
 

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -17,11 +17,11 @@ LabwareLike = Union[
 
 
 class LabwareLikeType(int, Enum):
-    labware = auto()
-    slot_name = auto()
-    well = auto()
-    module = auto()
-    none = auto()
+    LABWARE = auto()
+    SLOT = auto()
+    WELL = auto()
+    MODULE = auto()
+    NONE = auto()
 
 
 class LabwareLikeWrapper:
@@ -34,19 +34,19 @@ class LabwareLikeWrapper:
         from opentrons.protocols.geometry.module_geometry import ModuleGeometry
 
         self._labware_like = labware_like
-        self._type = LabwareLikeType.none
+        self._type = LabwareLikeType.NONE
 
         if isinstance(self._labware_like, Well):
-            self._type = LabwareLikeType.well
+            self._type = LabwareLikeType.WELL
             self._as_str = repr(self._labware_like)
         elif isinstance(self._labware_like, Labware):
-            self._type = LabwareLikeType.labware
+            self._type = LabwareLikeType.LABWARE
             self._as_str = repr(self._labware_like)
         elif isinstance(self._labware_like, str):
-            self._type = LabwareLikeType.slot_name
+            self._type = LabwareLikeType.SLOT
             self._as_str = self._labware_like
         elif isinstance(self._labware_like, ModuleGeometry):
-            self._type = LabwareLikeType.module
+            self._type = LabwareLikeType.MODULE
             self._as_str = repr(self._labware_like)
         elif isinstance(self._labware_like, LabwareLikeWrapper):
             self._type = self._labware_like._type
@@ -64,9 +64,9 @@ class LabwareLikeWrapper:
 
     @property
     def has_parent(self) -> bool:
-        return self._type in {LabwareLikeType.labware,
-                              LabwareLikeType.well,
-                              LabwareLikeType.module}
+        return self._type in {LabwareLikeType.LABWARE,
+                              LabwareLikeType.WELL,
+                              LabwareLikeType.MODULE}
 
     @property
     def parent(self) -> Optional['LabwareLikeWrapper']:
@@ -76,15 +76,15 @@ class LabwareLikeWrapper:
 
     @property
     def is_well(self) -> bool:
-        return self.object_type == LabwareLikeType.well
+        return self.object_type == LabwareLikeType.WELL
 
     @property
     def is_labware(self) -> bool:
-        return self.object_type == LabwareLikeType.labware
+        return self.object_type == LabwareLikeType.LABWARE
 
     @property
     def is_slot(self) -> bool:
-        return self.object_type == LabwareLikeType.slot_name
+        return self.object_type == LabwareLikeType.SLOT
 
     def as_well(self) -> 'Well':
         # Import locally to avoid circular dependency

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -106,8 +106,8 @@ class LabwareLike:
         from opentrons.protocol_api.labware import Labware
         return cast(Labware, self.object)
 
-    def split_labware(self) -> Tuple[Optional['Labware'],
-                                     Optional['Well']]:
+    def get_parent_labware_and_well(self) -> Tuple[Optional['Labware'],
+                                                   Optional['Well']]:
         """Attempt to split into a labware and well."""
         if self.is_labware:
             return self.as_labware(), None

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -75,7 +75,9 @@ class LabwareLike:
     def parent(self) -> 'LabwareLike':
         # Type ignoring because type checker is not aware that has_parent
         # performs the validation.
-        parent = self.object.parent if self.has_parent else None  # type: ignore
+        parent = None
+        if self.has_parent:
+            parent = self.object.parent  # type: ignore
         return LabwareLike(parent)
 
     @property

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -73,7 +73,9 @@ class LabwareLike:
 
     @property
     def parent(self) -> 'LabwareLike':
-        parent = self.object.parent if self.has_parent else None
+        # Type ignoring because type checker is not aware that has_parent
+        # performs the validation.
+        parent = self.object.parent if self.has_parent else None  # type: ignore
         return LabwareLike(parent)
 
     @property

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -65,8 +65,8 @@ def determine_edge_path(
 
     r_mount = top_types.Mount.RIGHT
     l_mount = top_types.Mount.LEFT
-    l_col = labware.columns()[0]
-    r_col = labware.columns()[-1]
+    l_col = labware.as_labware().columns()[0]
+    r_col = labware.as_labware().columns()[-1]
     right_pip_criteria = mount is r_mount and where in l_col
     left_pip_criteria = mount is l_mount and where in r_col
 

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -7,7 +7,6 @@ from typing import (Any, Callable, Dict, Optional,
                     TYPE_CHECKING, Union, List)
 
 from opentrons import types as top_types
-from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.types import APIVersion
 from opentrons.hardware_control import (types, SynchronousAdapter, API,
                                         HardwareAPILike, ThreadManager)
@@ -112,14 +111,6 @@ def labware_column_shift(
     shifted_column = unshifted_column + well_spacing
     shifted_well = unshifted_index % modulo_value
     return tiprack.columns()[shifted_column][shifted_well]
-
-
-def first_parent(loc: top_types.LocationLabware) -> Optional[str]:
-    """ Return the topmost parent of this location. It should be
-    either a string naming a slot or a None if the location isn't
-    associated with a slot """
-
-    return LabwareLike(loc).first_parent()
 
 
 class FlowRates:

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -4,7 +4,7 @@ import functools
 import logging
 from dataclasses import dataclass, field, astuple
 from typing import (Any, Callable, Dict, Optional,
-                    TYPE_CHECKING, Union, List, Set)
+                    TYPE_CHECKING, Union, List)
 
 from opentrons import types as top_types
 from opentrons.protocols.api_support.labware_like import LabwareLike

--- a/api/src/opentrons/protocols/execution/execute_json_v3.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v3.py
@@ -3,6 +3,7 @@ from typing import Dict, TYPE_CHECKING
 
 from opentrons.protocol_api.contexts import ProtocolContext, InstrumentContext
 from opentrons.protocol_api import labware
+from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.types import Point, Location
 from opentrons_shared_data.protocol.constants import (
     JsonPipetteCommand, JsonRobotCommand)
@@ -83,7 +84,7 @@ def _get_location_with_offset(
     well = _get_well(loaded_labware, params)
 
     # Never move to the bottom of the fixed trash
-    if 'fixedTrash' in labware.quirks_from_any_parent(well):
+    if LabwareLike(well).is_fixed_trash():
         return well.top()
 
     offset_from_bottom = params['offsetFromBottomMm']

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -6,8 +6,8 @@ from typing import Optional, List, Dict, TYPE_CHECKING
 from opentrons import types
 from opentrons.protocol_api.labware import load as load_lw, Labware
 from opentrons.protocols.api_support.constants import STANDARD_DECK
+from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.api_support.util import first_parent
 from opentrons.protocols.geometry.module_geometry import ModuleGeometry, \
     ModuleType, ThermocyclerGeometry
 from opentrons_shared_data.deck import load as load_deck
@@ -130,7 +130,7 @@ class Deck(UserDict):
         depending on the mount you are using and the column you are moving
         to inside of the labware.
         """
-        slot = first_parent(target)
+        slot = LabwareLike(target).first_parent()
         if not slot:
             return False
         if mount is types.Mount.RIGHT:

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -415,13 +415,13 @@ def _load_from_v2(definition: 'ModuleDefinitionV2',
     pre_transform = np.array((definition['labwareOffset']['x'],
                               definition['labwareOffset']['y'],
                               1))
-    if not isinstance(parent.labware, str):
+    if not parent.labware.is_slot:
         par = ''
         log.warning(
             f'module location parent labware was {parent.labware} which is'
             'not a slot name; slot transforms will not be loaded')
     else:
-        par = parent.labware
+        par = str(parent.labware.object)
 
     # this needs to change to look up the current deck type if/when we add
     # that notion

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -212,7 +212,7 @@ class ModuleGeometry(DeckItem):
 
     @property
     def parent(self) -> LocationLabware:
-        return self._parent.labware
+        return self._parent.labware.object
 
     @property
     def labware(self) -> Optional[Labware]:

--- a/api/src/opentrons/protocols/geometry/planning.py
+++ b/api/src/opentrons/protocols/geometry/planning.py
@@ -25,16 +25,6 @@ def max_many(*args):
     return functools.reduce(max, args[1:], args[0])
 
 
-def split_loc_labware(
-        loc: types.Location) -> Tuple[Optional[Labware], Optional[Well]]:
-    if isinstance(loc.labware, Labware):
-        return loc.labware, None
-    elif isinstance(loc.labware, Well):
-        return loc.labware.parent, loc.labware
-    else:
-        return None, None
-
-
 BAD_PAIRS = [('1', '12'),
              ('12', '1'),
              ('4', '12'),
@@ -125,9 +115,9 @@ def _build_safe_height(from_loc: types.Location,
                        deck: Deck,
                        constraints: MoveConstraints) -> float:
     to_point = to_loc.point
-    to_lw, to_well = split_loc_labware(to_loc)
+    to_lw, to_well = to_loc.labware.split_labware()
     from_point = from_loc.point
-    from_lw, from_well = split_loc_labware(from_loc)
+    from_lw, from_well = from_loc.labware.split_labware()
 
     if to_lw and to_lw == from_lw:
         # If we know the labwares we’re moving from and to, we can calculate
@@ -219,9 +209,9 @@ def plan_moves(
     assert constraints.minimum_z_height >= 0.0
 
     to_point = to_loc.point
-    to_lw, to_well = split_loc_labware(to_loc)
+    to_lw, to_well = to_loc.labware.split_labware()
     from_point = from_loc.point
-    from_lw, from_well = split_loc_labware(from_loc)
+    from_lw, from_well = from_loc.labware.split_labware()
     dest_quirks = quirks_from_any_parent(to_lw)
     from_quirks = quirks_from_any_parent(from_lw)
     from_center = 'centerMultichannelOnWells' in from_quirks

--- a/api/src/opentrons/protocols/geometry/planning.py
+++ b/api/src/opentrons/protocols/geometry/planning.py
@@ -113,9 +113,9 @@ def _build_safe_height(from_loc: types.Location,
                        deck: Deck,
                        constraints: MoveConstraints) -> float:
     to_point = to_loc.point
-    to_lw, to_well = to_loc.labware.split_labware()
+    to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
     from_point = from_loc.point
-    from_lw, from_well = from_loc.labware.split_labware()
+    from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
 
     if to_lw and to_lw == from_lw:
         # If we know the labwares we’re moving from and to, we can calculate
@@ -207,9 +207,9 @@ def plan_moves(
     assert constraints.minimum_z_height >= 0.0
 
     to_point = to_loc.point
-    to_lw, to_well = to_loc.labware.split_labware()
+    to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
     from_point = from_loc.point
-    from_lw, from_well = from_loc.labware.split_labware()
+    from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
     from_center = LabwareLike(from_lw).center_multichannel_on_wells()
     to_center = LabwareLike(to_lw).center_multichannel_on_wells()
     dest_cp_override = CriticalPoint.XY_CENTER if to_center else None

--- a/api/src/opentrons/protocols/labware/definition.py
+++ b/api/src/opentrons/protocols/labware/definition.py
@@ -270,7 +270,7 @@ def _get_parent_identifier(labware: LabwareInterface) -> str:
     Helper function to return whether a labware is on top of a
     module or not.
     """
-    parent = labware.get_geometry().parent.labware
+    parent = labware.get_geometry().parent.labware.object
     # TODO (lc, 07-14-2020): Once we implement calibrations per slot,
     # this function should either return a slot using `first_parent` or
     # the module it is attached to.

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -66,7 +66,7 @@ class Point(NamedTuple):
 LocationLabware = Union['Labware', 'Well', str, 'ModuleGeometry', None]
 
 
-class Location(NamedTuple):
+class Location:
     """ A location to target as a motion.
 
     The location contains a :py:class:`.Point` (in
@@ -92,8 +92,26 @@ class Location(NamedTuple):
        If you only need to compare locations, compare the :py:attr:`point`
        of each item.
     """
-    point: Point
-    labware: LocationLabware
+    def __init__(self, point: Point, labware: LocationLabware):
+        self._point = point
+        self._labware = labware
+
+    @property
+    def point(self) -> Point:
+        return self._point
+
+    @property
+    def labware(self) -> LocationLabware:
+        return self._labware
+
+    def __iter__(self):
+        """Iterable interface to support unpacking. Like a tuple."""
+        return iter((self._point, self._labware,))
+
+    def __eq__(self, other):
+        return isinstance(other, Location) \
+               and other._point == self._point \
+               and other._labware == self._labware
 
     def move(self, point: Point) -> 'Location':
         """
@@ -110,7 +128,7 @@ class Location(NamedTuple):
             >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
-        return self._replace(point=self.point + point)
+        return Location(point=self.point + point, labware=self._labware)
 
 
 # TODO(mc, 2020-10-22): use MountType implementation for Mount

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -3,6 +3,8 @@ import enum
 from math import sqrt, isclose
 from typing import Any, NamedTuple, TYPE_CHECKING, Union
 
+from opentrons.protocols.api_support.labware_like import LabwareLikeWrapper
+
 if TYPE_CHECKING:
     from typing import (Optional,       # noqa(F401) Used for typechecking
                         Tuple)
@@ -94,14 +96,14 @@ class Location:
     """
     def __init__(self, point: Point, labware: LocationLabware):
         self._point = point
-        self._labware = labware
+        self._labware = LabwareLikeWrapper(labware)
 
     @property
     def point(self) -> Point:
         return self._point
 
     @property
-    def labware(self) -> LocationLabware:
+    def labware(self) -> LabwareLikeWrapper:
         return self._labware
 
     def __iter__(self):
@@ -128,7 +130,8 @@ class Location:
             >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
-        return Location(point=self.point + point, labware=self._labware)
+        return Location(point=self.point + point,
+                        labware=self._labware.object)
 
 
 # TODO(mc, 2020-10-22): use MountType implementation for Mount

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -3,7 +3,7 @@ import enum
 from math import sqrt, isclose
 from typing import Any, NamedTuple, TYPE_CHECKING, Union
 
-from opentrons.protocols.api_support.labware_like import LabwareLikeWrapper
+from opentrons.protocols.api_support.labware_like import LabwareLike
 
 if TYPE_CHECKING:
     from typing import (Optional,       # noqa(F401) Used for typechecking
@@ -65,7 +65,8 @@ class Point(NamedTuple):
         return sqrt(x_diff**2 + y_diff**2 + z_diff**2)
 
 
-LocationLabware = Union['Labware', 'Well', str, 'ModuleGeometry', None]
+LocationLabware = Union['Labware', 'Well', str,
+                        'ModuleGeometry', LabwareLike, None]
 
 
 class Location:
@@ -96,14 +97,14 @@ class Location:
     """
     def __init__(self, point: Point, labware: LocationLabware):
         self._point = point
-        self._labware = LabwareLikeWrapper(labware)
+        self._labware = LabwareLike(labware)
 
     @property
     def point(self) -> Point:
         return self._point
 
     @property
-    def labware(self) -> LabwareLikeWrapper:
+    def labware(self) -> LabwareLike:
         return self._labware
 
     def __iter__(self):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -144,7 +144,7 @@ async def test_location_cache(loop, monkeypatch, get_labware_def, hardware):
 
     # Once we have a location cache, that should be our from_loc
     right.move_to(lw.wells()[1].top())
-    assert test_args[0].labware == lw.wells()[0]
+    assert test_args[0].labware.as_well() == lw.wells()[0]
 
 
 async def test_move_uses_arc(loop, monkeypatch, get_labware_def, hardware):

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -140,7 +140,7 @@ async def test_location_cache(loop, monkeypatch, get_labware_def, hardware):
     # that the right pipette is a p10 single which is a different height than
     # the reference p300 single
     assert test_args[0].point == Point(418, 353, 205)
-    assert test_args[0].labware is None
+    assert test_args[0].labware.is_empty
 
     # Once we have a location cache, that should be our from_loc
     right.move_to(lw.wells()[1].top())
@@ -416,7 +416,7 @@ def test_aspirate(loop, get_labware_def, monkeypatch):
     # reset plunger at the top of the well after blowout
     assert fake_move.call_args_list[0] ==\
         mock.call(
-            Mount.RIGHT, dest_lw.top().point, critical_point=None,
+            Mount.RIGHT, dest_lw.as_well().top().point, critical_point=None,
             speed=400, max_speeds={})
     assert fake_move.call_args_list[1] ==\
         mock.call(

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -294,7 +294,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat):
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=parent.point,
-                parent_object=parent.labware._implementation
+                parent_object=parent.labware.as_labware()._implementation
             ),
             display_name=well_name,
             has_tip=has_tip,
@@ -302,12 +302,12 @@ def test_well_parent(corning_96_wellplate_360ul_flat):
         )
     )
     assert well.parent == lw
-    assert well.top().labware == well
-    assert well.top().labware.parent == lw
-    assert well.bottom().labware == well
-    assert well.bottom().labware.parent == lw
-    assert well.center().labware == well
-    assert well.center().labware.parent == lw
+    assert well.top().labware.object == well
+    assert well.top().labware.parent.object == lw
+    assert well.bottom().labware.object == well
+    assert well.bottom().labware.parent.object == lw
+    assert well.center().labware.object == well
+    assert well.center().labware.parent.object == lw
 
 
 def test_tip_tracking_init(corning_96_wellplate_360ul_flat,

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -138,7 +138,7 @@ def test_aspirate(set_up_paired_instrument, monkeypatch):
     # reset plunger at the top of the well after blowout
     assert fake_move.call_args_list[0] ==\
         mock.call(
-            paired._pair_policy, dest_lw.top().point,
+            paired._pair_policy, dest_lw.as_well().top().point,
             critical_point=None, speed=400, max_speeds={})
     assert fake_move.call_args_list[1] ==\
         mock.call(

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+import pytest
+from opentrons.protocol_api import labware
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
+from opentrons.protocols.api_support.labware_like import (
+    LabwareLike, LabwareLikeType)
+from opentrons.protocols.geometry import module_geometry
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.types import Location
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+
+@pytest.fixture(scope="session")
+def trough_definition() -> LabwareDefinition:
+    return labware.get_labware_definition('usascientific_12_reservoir_22ml')
+
+
+@pytest.fixture(scope="session")
+def trough(trough_definition):
+    deck = Deck()
+    return labware.load_from_definition(
+        trough_definition, deck.position_for(1))
+
+
+@pytest.fixture(scope="session")
+def module(trough):
+    deck = Deck()
+    mod = module_geometry.load_module(
+        module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
+        deck.position_for('6'),
+        MAX_SUPPORTED_VERSION)
+    return mod
+
+
+@pytest.fixture(scope="session")
+def mod_trough(trough_definition, module):
+    mod_trough = module.add_labware(
+        labware.load_from_definition(trough_definition, module.location)
+    )
+    return mod_trough
+
+
+def test_labware(trough):
+    ll = LabwareLike(trough)
+    assert ll.has_parent is True
+    assert ll.parent.object == trough.parent
+    assert ll.object == trough
+    assert ll.object_type == LabwareLikeType.LABWARE
+
+
+def test_well(trough):
+    well = trough['A1']
+    ll = LabwareLike(well)
+    assert ll.has_parent is True
+    assert ll.parent.object == trough
+    assert ll.object == well
+    assert ll.object_type == LabwareLikeType.WELL
+
+
+def test_module(module):
+    ll = LabwareLike(module)
+    assert ll.has_parent is True
+    assert ll.parent.object is module.parent
+    assert ll.object is module
+    assert ll.object_type == LabwareLikeType.MODULE
+
+
+def test_slot():
+    ll = LabwareLike('1')
+    assert ll.has_parent is False
+    assert ll.parent.object is None
+    assert ll.object == '1'
+    assert ll.object_type == LabwareLikeType.SLOT
+
+
+def test_empty():
+    ll = LabwareLike(None)
+    assert ll.has_parent is False
+    assert ll.parent.object is None
+    assert ll.object is None
+    assert ll.object_type == LabwareLikeType.NONE
+
+
+def test_first_parent(trough, module, mod_trough):
+    assert LabwareLike(trough).first_parent() == '1'
+    assert LabwareLike(trough['A2']).first_parent() == '1'
+    assert LabwareLike(None).first_parent() is None
+    assert LabwareLike('6').first_parent() == '6'
+
+    assert LabwareLike(mod_trough['A5']).first_parent() == '6'
+    assert LabwareLike(mod_trough).first_parent() == '6'
+    assert LabwareLike(module).first_parent() == '6'
+
+    # Set up recursion cycle test.
+    mock_labware_geometry = MagicMock()
+    mock_labware_geometry.parent = Location(point=None, labware=mod_trough)
+    mod_trough._implementation.get_geometry = MagicMock(
+        return_value=mock_labware_geometry)
+
+    with pytest.raises(RuntimeError):
+        # make sure we catch cycles
+        LabwareLike(mod_trough).first_parent()

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -4,7 +4,8 @@ import pytest
 
 from opentrons.types import Location, Point
 from opentrons.protocols.geometry.planning import (
-    plan_moves, safe_height, first_parent, should_dodge_thermocycler)
+    plan_moves, safe_height, should_dodge_thermocycler)
+from opentrons.protocols.api_support.util import first_parent
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import module_geometry

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -172,7 +172,7 @@ def test_no_labware_loc(labware_offset_tempdir):
     deck[1] = lw1
     deck[2] = lw2
     # Various flavors of locations without labware should work
-    no_lw = lw1.wells()[0].top()._replace(labware=None)
+    no_lw = Location(point=lw1.wells()[0].top().point, labware=None)
 
     no_from = plan_moves(no_lw, lw2.wells()[0].bottom(), deck,
                          P300M_GEN2_MAX_HEIGHT, 7.0, 15.0)
@@ -184,7 +184,7 @@ def test_no_labware_loc(labware_offset_tempdir):
     check_arc_basic(no_to, lw1.wells()[0].bottom(), no_lw)
     assert no_from[0][0].z == deck.highest_z + 15.0
 
-    no_well = lw1.wells()[0].top()._replace(labware=lw1)
+    no_well = Location(point=lw1.wells()[0].top(), labware=lw1)
 
     no_from_well = plan_moves(no_well, lw1.wells()[1].top(), deck,
                               P300M_GEN2_MAX_HEIGHT, 7.0, 15.0)

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -184,7 +184,7 @@ def test_no_labware_loc(labware_offset_tempdir):
     check_arc_basic(no_to, lw1.wells()[0].bottom(), no_lw)
     assert no_from[0][0].z == deck.highest_z + 15.0
 
-    no_well = Location(point=lw1.wells()[0].top(), labware=lw1)
+    no_well = Location(point=lw1.wells()[0].top().point, labware=lw1)
 
     no_from_well = plan_moves(no_well, lw1.wells()[1].top(), deck,
                               P300M_GEN2_MAX_HEIGHT, 7.0, 15.0)
@@ -207,7 +207,7 @@ def test_arc_tall_point():
     tall_z = 100
     old_top = lw1.wells()[0].top()
     tall_point = old_top.point._replace(z=tall_z)
-    tall_top = old_top._replace(point=tall_point)
+    tall_top = Location(point=tall_point, labware=old_top.labware)
     to_tall = plan_moves(lw1.wells()[2].top(), tall_top, deck, 7.0, 15.0)
     check_arc_basic(to_tall, lw1.wells()[2].top(), tall_top)
     assert to_tall[0][0].z == tall_z
@@ -216,7 +216,7 @@ def test_arc_tall_point():
     check_arc_basic(from_tall, tall_top, lw1.wells()[3].top())
     assert from_tall[0][0].z == tall_z
 
-    no_well = tall_top._replace(labware=lw1)
+    no_well = Location(point=tall_top.point, labware=lw1)
     from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
                               7.0, 15.0)
     check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom())
@@ -229,7 +229,7 @@ def test_arc_lower_minimum_z_height():
     minimum_z_height = 42
     old_top = lw1.wells()[0].top()
     tall_point = old_top.point._replace(z=tall_z)
-    tall_top = old_top._replace(point=tall_point)
+    tall_top = Location(point=tall_point, labware=old_top.labware)
     to_tall = plan_moves(
         lw1.wells()[2].top(), tall_top, deck,
         P300M_GEN2_MAX_HEIGHT, 7.0, 15.0, False,
@@ -244,7 +244,7 @@ def test_arc_lower_minimum_z_height():
     check_arc_basic(from_tall, tall_top, lw1.wells()[3].top())
     assert from_tall[0][0].z == tall_z
 
-    no_well = tall_top._replace(labware=lw1)
+    no_well = Location(point=tall_top.point, labware=lw1)
     from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
                               P300M_GEN2_MAX_HEIGHT, 7.0, 15.0)
     check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom())
@@ -424,7 +424,7 @@ def test_should_dodge():
     # with no parent
     assert not should_dodge_thermocycler(
         deck,
-        deck.position_for(1)._replace(labware=None),
+        Location(point=deck.position_for(1).point, labware=None),
         deck.position_for(12)
     )
 

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -1,11 +1,8 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from opentrons.types import Location, Point
 from opentrons.protocols.geometry.planning import (
     plan_moves, safe_height, should_dodge_thermocycler)
-from opentrons.protocols.api_support.util import first_parent
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import module_geometry
@@ -376,33 +373,6 @@ def test_instr_max_height():
             instr_max_height=round(instr_max_height, 2),
             well_z_margin=7.0,
             lw_z_margin=15.0)
-
-
-def test_first_parent():
-    deck = Deck()
-    trough = labware.load(trough_name, deck.position_for(1))
-    assert first_parent(trough) == '1'
-    assert first_parent(trough['A2']) == '1'
-    assert first_parent(None) is None
-    assert first_parent('6') == '6'
-    mod = module_geometry.load_module(
-        module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for('6'),
-        MAX_SUPPORTED_VERSION)
-    mod_trough = mod.add_labware(labware.load(trough_name, mod.location))
-    assert first_parent(mod_trough['A5']) == '6'
-    assert first_parent(mod_trough) == '6'
-    assert first_parent(mod) == '6'
-
-    # Set up recursion cycle test.
-    mock_labware_geometry = MagicMock()
-    mock_labware_geometry.parent = Location(point=None, labware=mod_trough)
-    mod_trough._implementation.get_geometry = MagicMock(
-        return_value=mock_labware_geometry)
-
-    with pytest.raises(RuntimeError):
-        # make sure we catch cycles
-        first_parent(mod_trough)
 
 
 def test_should_dodge():


### PR DESCRIPTION
# Overview

Background, we recently refactored `Labware` and `Well` to have internal protocol independent implementations. It would be nice to have `location.labware` support these implementations. Doing this is rather challenging because every use of `location.labware` performs a number of instance type checks. `location.labware` is very difficult to extend.

The idea is to make `location.labware` easier to interact with.  That means:
- removing instance checks. 
- having `Location` and `LabwareLike` have more utility functions that don't require knowledge of the type of wrapped labware.

closes #6690

# Changelog

- Change Location from a namedtuple to a class.
- Change type of `Location.labware` to the new `LabwareLike`.
- `LabwareLikeWrapper` is constructed given an object of type `WrappableLabwareLike` (this is nearly the same as  `LocationLabware'). `LabwareLike` will attempt to provide a friendly interface for a wrapped labware like item.

# Review requests

I don't know that this is necessarily the most beautiful approach, but at the very least changing the type of `location.labware` will cause all tests to fail. As we proceed we will find all the various ways in which `location.labware` is used and can consolidate those methods in `LabwareLike` or design something new.

# Risk assessment

High