### PR TITLE
refactor(api): Reset old deck cal

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -5,7 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple, Dict, Set
 
-from opentrons.config import IS_ROBOT
+from opentrons.config import IS_ROBOT, robot_configs
 from opentrons.data_storage import database as db
 from opentrons.calibration_storage import delete
 
@@ -102,6 +102,7 @@ def reset_boot_scripts():
 def reset_deck_calibration():
     delete.delete_robot_deck_attitude()
     delete.clear_pipette_offset_calibrations()
+    robot_configs.clear(calibration=True, robot=False)
 
 
 def reset_pipette_offset():

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -51,6 +51,12 @@ def mock_cal_storage_delete():
         yield m
 
 
+@pytest.fixture
+def mock_robot_config():
+    with patch('opentrons.config.reset.robot_configs', autospec=True) as m:
+        yield m
+
+
 def test_reset_empty_set(mock_reset_boot_scripts,
                          mock_reset_labware_calibration,
                          mock_reset_pipette_offset,
@@ -88,11 +94,13 @@ def test_labware_calibration_reset(mock_db, mock_labware):
     mock_labware.clear_calibrations.assert_called_once()
 
 
-def test_deck_calibration_reset(mock_cal_storage_delete):
+def test_deck_calibration_reset(mock_cal_storage_delete, mock_robot_config):
     reset.reset_deck_calibration()
     mock_cal_storage_delete.delete_robot_deck_attitude.assert_called_once()
     mock_cal_storage_delete.clear_pipette_offset_calibrations\
                            .assert_called_once()
+    mock_robot_config.clear.assert_called_once_with(
+        calibration=True, robot=False)
 
 
 def test_tip_length_calibrations_reset(mock_cal_storage_delete):


### PR DESCRIPTION
When you reset deck calibration it should reset _all_ the deck
calibrations, including the legacy one, so it doesn't get re-migrated.
