### PR TITLE
refactor(robot-server): Home when initializing calibration sessions

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -716,10 +716,6 @@ class CheckCalibrationUserFlow:
             mount=self.mount,
             deck=self._deck,
             has_calibration_block=self._has_calibration_block)
-        if self.current_state == State.labwareLoaded:
-            MODULE_LOG.debug("homing plunger")
-            await self.hardware.home()
-            # await self.hardware.home_plunger(self.mount)
         await self._move(ref_loc)
 
     async def move_to_point_one(self):

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -239,9 +239,6 @@ class DeckCalibrationUserFlow:
                                       delta=Point(*vector))
 
     async def move_to_tip_rack(self):
-        if self._current_state == State.labwareLoaded:
-            MODULE_LOG.info("homing plunger")
-            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     async def move_to_deck(self):

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -260,9 +260,6 @@ class PipetteOffsetCalibrationUserFlow:
             self._flag_unmet_transition_req(
                 command_handler="move_to_tip_rack",
                 unmet_condition="not performing tip length calibration")
-        if self._current_state != self._state.calibrationComplete:
-            MODULE_LOG.info("Homing plunger")
-            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     def _get_stored_tip_length_cal(self) -> Optional[float]:

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -159,9 +159,6 @@ class TipCalibrationUserFlow:
         pass
 
     async def move_to_tip_rack(self):
-        if self._current_state == State.measuringNozzleOffset:
-            MODULE_LOG.info("homing plunger")
-            await self.hardware.home_plunger(self.mount)
         await self._move(Location(self.tip_origin, None))
 
     async def save_offset(self):

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -58,6 +58,7 @@ class CheckSession(BaseSession):
         session_controls_lights =\
             not configuration.hardware.get_lights()['rails']
         await configuration.hardware.cache_instruments()
+        await configuration.hardware.home()
         try:
             calibration_check = CheckCalibrationUserFlow(
                 configuration.hardware,

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -47,6 +47,7 @@ class DeckCalibrationSession(BaseSession):
         session_controls_lights =\
             not configuration.hardware.get_lights()['rails']
         await configuration.hardware.cache_instruments()
+        await configuration.hardware.home()
         try:
             deck_cal_user_flow = DeckCalibrationUserFlow(
                 hardware=configuration.hardware)

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -61,6 +61,7 @@ class PipetteOffsetCalibrationSession(BaseSession):
         session_controls_lights =\
             not configuration.hardware.get_lights()['rails']
         await configuration.hardware.cache_instruments()
+        await configuration.hardware.home()
         try:
             pip_offset_cal_user_flow = PipetteOffsetCalibrationUserFlow(
                     hardware=configuration.hardware,

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -56,6 +56,7 @@ class TipLengthCalibration(BaseSession):
         session_controls_lights =\
             not configuration.hardware.get_lights()['rails']
         await configuration.hardware.cache_instruments()
+        await configuration.hardware.home()
         try:
             tip_cal_user_flow = TipCalibrationUserFlow(
                     hardware=configuration.hardware,


### PR DESCRIPTION
Now that we display UI when a session is being established, it's
reasonable to do something that takes a while like homing before doing
calibration. This also handles a couple other issues:
- You don't have to home the plunger before picking up tip anymore;
since we home everything before hand, the problem is solved
- Since the home happens during session establish, by the time you get
toe the deck setup phase the head is out of the way.

## Testing
- Try the flows and make sure they start ok
- Cancel the flow after you pick up a tip (confirm the tip pickup first so we're in that state) and just double-check that the tip actually gets dropped still