### PR TITLE
fix(robot-server): prefer smaller pipette in deck cal

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -173,11 +173,18 @@ class DeckCalibrationUserFlow:
 
         right_pip = pips[Mount.RIGHT]
         left_pip = pips[Mount.LEFT]
-        if right_pip.config.max_volume > left_pip.config.max_volume or \
-                right_pip.config.channels > left_pip.config.channels:
-            return left_pip, Mount.LEFT
+        if right_pip.config.max_volume == left_pip.config.max_volume:
+            if right_pip.config.channels == left_pip.config.channels:
+                return right_pip, Mount.RIGHT
+            else:
+                return sorted(
+                    [(right_pip, Mount.RIGHT), (left_pip, Mount.LEFT)],
+                    key=lambda p_m: p_m[0].config.channels
+                )[0]
         else:
-            return right_pip, Mount.RIGHT
+            return sorted(
+                [(right_pip, Mount.RIGHT), (left_pip, Mount.LEFT)],
+                key=lambda p_m: p_m[0].config.max_volume)[0]
 
     def _get_tip_rack_lw(self) -> labware.Labware:
         pip_vol = self._hw_pipette.config.max_volume

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -59,6 +59,7 @@ def mock_hw(hardware):
 pipette_combos: List[Tuple[List[str], Mount]] = [
     (['p20_multi_v2.1', 'p20_multi_v2.1'], Mount.RIGHT),
     (['p20_single_v2.1', 'p20_multi_v2.1'], Mount.LEFT),
+    (['p1000_single_v2.1', 'p20_multi_v2.1'], Mount.RIGHT),
     (['p20_multi_v2.1', 'p300_single_v2.1'], Mount.LEFT),
     (['p300_multi_v2.1', 'p1000_single_v2.1'], Mount.LEFT),
     (['p1000_single_v2.1', ''], Mount.LEFT),


### PR DESCRIPTION
This logic was mostly correct, but if specifically the right pipette was
a multi that was smaller than the left pipette, it would use the left
pipette anyway. That's fixed now, with a nice added test case.


## Testing
- Put a smaller, multi pipette on the right and a larger, single pipette on the left
- Start deck cal
- Make sure it asks for the smaller tiprack