### PR TITLE
feat(protocol-designer): add labware to modules allowlists

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -74,6 +74,16 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleRealType]: Array<string> } = {
   [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
 }
 
+export const getLabwareIsRecommended = (
+  def: LabwareDefinition2,
+  moduleType: ?ModuleRealType
+): boolean =>
+  moduleType
+    ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
+        def.parameters.loadName
+      )
+    : false
+
 export const LabwareSelectionModal = (props: Props): React.Node => {
   const {
     customLabwareDefs,
@@ -135,18 +145,6 @@ export const LabwareSelectionModal = (props: Props): React.Node => {
     setFilterRecommended(moduleType != null)
   }, [moduleType])
 
-  const getLabwareRecommended = React.useCallback(
-    (def: LabwareDefinition2) => {
-      return (
-        moduleType &&
-        RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
-          def.parameters.loadName
-        )
-      )
-    },
-    [moduleType]
-  )
-
   const getLabwareCompatible = React.useCallback(
     (def: LabwareDefinition2) => {
       // assume that custom (non-standard) labware is (potentially) compatible
@@ -160,9 +158,9 @@ export const LabwareSelectionModal = (props: Props): React.Node => {
 
   const getLabwareDisabled = React.useCallback(
     (labwareDef: LabwareDefinition2) =>
-      (filterRecommended && !getLabwareRecommended(labwareDef)) ||
+      (filterRecommended && !getLabwareIsRecommended(labwareDef, moduleType)) ||
       !getLabwareCompatible(labwareDef),
-    [filterRecommended, getLabwareCompatible, getLabwareRecommended]
+    [filterRecommended, getLabwareCompatible, moduleType]
   )
 
   const customLabwareURIs: Array<string> = React.useMemo(
@@ -255,7 +253,7 @@ export const LabwareSelectionModal = (props: Props): React.Node => {
     'moduleCompatibility'
   > = null
   if (previewedLabware && moduleType) {
-    if (getLabwareRecommended(previewedLabware)) {
+    if (getLabwareIsRecommended(previewedLabware, moduleType)) {
       moduleCompatibility = 'recommended'
     } else if (getLabwareCompatible(previewedLabware)) {
       moduleCompatibility = 'potentiallyCompatible'
@@ -323,7 +321,7 @@ export const LabwareSelectionModal = (props: Props): React.Node => {
                           <LabwareItem
                             key={index}
                             icon={
-                              getLabwareRecommended(labwareDef)
+                              getLabwareIsRecommended(labwareDef, moduleType)
                                 ? 'check-decagram'
                                 : null
                             }

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.js
@@ -68,6 +68,7 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [ModuleRealType]: Array<string> } = {
     'opentrons_24_aluminumblock_nest_2ml_screwcap',
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
+    'opentrons_96_aluminumblock_nest_wellplate_100ul',
   ],
   [MAGNETIC_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
   [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],

--- a/protocol-designer/src/utils/labwareModuleCompatibility.js
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.js
@@ -38,11 +38,13 @@ const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: {
     'opentrons_24_aluminumblock_nest_2ml_screwcap',
     'opentrons_24_aluminumblock_nest_2ml_snapcap',
     'opentrons_24_aluminumblock_nest_0.5ml_screwcap',
+    'opentrons_96_aluminumblock_nest_wellplate_100ul',
   ],
   [MAGNETIC_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
     'usascientific_96_wellplate_2.4ml_deep',
     'nest_96_wellplate_100ul_pcr_full_skirt',
+    'nest_96_wellplate_2ml_deep',
   ],
   [THERMOCYCLER_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',


### PR DESCRIPTION
# Overview

Closes #6876 and closes #6860


# Changelog

# Review requests

- NEST 96 Deepwell Plate 2mL should now be available as compatible labware with Magnetic Module (NOT recommended, you should need to uncheck the "only show recommended" box before you can see it)
- Opentrons 96 Well Aluminum Block with NEST Well Plate 100 µL should be recommended labware to Temp Deck

# Risk assessment

PD-only, low