### PR TITLE
fix(api): Specify correct channels for a paired pipette during pick up tip

### DIFF
--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -211,8 +211,11 @@ class PairedInstrumentContext(CommandPublisher):
         """
         if location and isinstance(location, types.Location):
             if location.labware.is_labware:
-                tiprack = location.labware.as_labware()
-                target = tiprack.next_tip(self.channels)  # type: ignore
+                tiprack = location.labware
+                primary_channels =\
+                    self._instruments[self._pair_policy.primary].channels
+                target: Well =\
+                    tiprack.next_tip(primary_channels)  # type: ignore
                 if not target:
                     raise OutOfTipsError
             elif location.labware.is_well:

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -211,7 +211,7 @@ class PairedInstrumentContext(CommandPublisher):
         """
         if location and isinstance(location, types.Location):
             if location.labware.is_labware:
-                tiprack = location.labware
+                tiprack = location.labware.as_labware()
                 primary_channels =\
                     self._instruments[self._pair_policy.primary].channels
                 target: Well =\

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import opentrons.protocol_api as papi
 from opentrons.hardware_control import API
-from opentrons.types import Mount, Point
+from opentrons.types import Mount, Point, Location
 from opentrons.protocol_api import paired_instrument_context as pc
 from opentrons.hardware_control.pipette import Pipette
 
@@ -26,6 +26,10 @@ def set_up_paired_instrument(loop):
 def test_pick_up_and_drop_tip_with_tipracks(set_up_paired_instrument):
     paired, tipracks = set_up_paired_instrument
     assert paired.tip_racks == [tipracks[1]]
+
+    random_location = Location(Point(0, 0, 0), tipracks[0])
+    paired.pick_up_tip(random_location)
+    paired.drop_tip()
     for col in tipracks[1].columns()[0:4]:
         for well in col:
             second_well = paired._get_secondary_target(tipracks[1], well)

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -23,13 +23,18 @@ def set_up_paired_instrument(loop):
     return right.pair_with(left), [tiprack, tiprack2, tiprack3]
 
 
-def test_pick_up_and_drop_tip_with_tipracks(set_up_paired_instrument):
+def test_pick_up_and_drop_tip_in_specified_location(set_up_paired_instrument):
     paired, tipracks = set_up_paired_instrument
-    assert paired.tip_racks == [tipracks[1]]
 
     random_location = Location(Point(0, 0, 0), tipracks[0])
     paired.pick_up_tip(random_location)
     paired.drop_tip()
+
+
+def test_pick_up_and_drop_tip_with_tipracks(set_up_paired_instrument):
+    paired, tipracks = set_up_paired_instrument
+    assert paired.tip_racks == [tipracks[1]]
+
     for col in tipracks[1].columns()[0:4]:
         for well in col:
             second_well = paired._get_secondary_target(tipracks[1], well)


### PR DESCRIPTION
# Overview

There is no 'channels' attribute in a pipette pairing context, hence the use case in pick up tip would have failed. 

# Changelog

- Change `self.channels` to the primary_instrument channels

# Risk assessment

Low. Not a widely advertised feature and this is fixing a bug.