### PR TITLE
refactor(app): Add clear the deck to deck setup modal

### DIFF
--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -30,9 +30,9 @@ import styles from './styles.css'
 
 const FIRST_RANK_TO_CHECK = 'To check'
 const SECOND_RANK_TO_CHECK = 'In order to check'
-const FIRST_RANK_PLACE_FULL = 'pipette, place a full'
+const FIRST_RANK_PLACE_FULL = 'pipette, clear the deck and place a full'
 const SECOND_RANK_PLACE_FULL = 'pipette, switch out the tiprack for a full'
-const PLACE_A_FULL = 'Place a full'
+const CLEAR_AND_PLACE_A_FULL = 'Clear the deck and place a full'
 const TIPRACK = 'tip rack'
 const DECK_SETUP_WITH_BLOCK_PROMPT =
   'and Calibration Block on the deck within their designated slots as illustrated below.'
@@ -115,7 +115,7 @@ export function DeckSetup(props: CalibrationPanelProps): React.Node {
         >
           {isHealthCheck
             ? getHealthCheckText(activePipette?.mount, activePipette?.rank)
-            : PLACE_A_FULL}
+            : CLEAR_AND_PLACE_A_FULL}
           <b>{` ${tipRackDisplayName} `}</b>
           {calBlock ? DECK_SETUP_WITH_BLOCK_PROMPT : DECK_SETUP_NO_BLOCK_PROMPT}
           .

--- a/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/DeckSetup.test.js
@@ -77,7 +77,7 @@ describe('DeckSetup', () => {
       calBlock: mockTipLengthCalBlock,
     })
     expect(wrapper.text()).toContain(
-      'Place a full Opentrons GEB 300uL Tiprack and Calibration Block on'
+      'Clear the deck and place a full Opentrons GEB 300uL Tiprack and Calibration Block on'
     )
   })
 
@@ -87,7 +87,7 @@ describe('DeckSetup', () => {
       calBlock: null,
     })
     expect(wrapper.text()).toContain(
-      'Place a full Opentrons GEB 300uL Tiprack on'
+      'Clear the deck and place a full Opentrons GEB 300uL Tiprack on'
     )
   })
 })


### PR DESCRIPTION
Make it more clear that you have to clear the deck when you set it up,
whichi s more necessary now that we don't have a separate clear the deck screen.
