### PR TITLE
refactor(app): Update pipette display in CalibrationCard

### DIFF
--- a/app/src/components/InlineCalibrationWarning.js
+++ b/app/src/components/InlineCalibrationWarning.js
@@ -21,7 +21,7 @@ export const RECOMMENDED: 'recommended' = 'recommended'
 export type WarningType = typeof REQUIRED | typeof RECOMMENDED
 
 const CALIBRATION_REQUIRED = 'Calibration required'
-const CALIBRATION_RECOMMENDED = 'Calibration recommended'
+const CALIBRATION_RECOMMENDED = 'Recalibration recommended'
 
 const CONTENT_MAP = {
   [REQUIRED]: {

--- a/app/src/components/RobotSettings/PipetteOffsetItem.js
+++ b/app/src/components/RobotSettings/PipetteOffsetItem.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import { format } from 'date-fns'
+import { format, getTime } from 'date-fns'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
@@ -9,20 +9,30 @@ import { findLabwareDefWithCustom } from '../../findLabware'
 
 import {
   Box,
+  Flex,
   Text,
-  DISPLAY_INLINE_BLOCK,
+  ALIGN_CENTER,
+  JUSTIFY_CENTER,
+  DIRECTION_COLUMN,
+  DISPLAY_BLOCK,
   FONT_STYLE_ITALIC,
   FONT_WEIGHT_SEMIBOLD,
   SPACING_1,
   SPACING_2,
+  SPACING_3,
+  OVERLAY_LIGHT_GRAY_50,
   TEXT_TRANSFORM_UPPERCASE,
+  TEXT_TRANSFORM_CAPITALIZE,
+  JUSTIFY_SPACE_BETWEEN,
 } from '@opentrons/components'
 
 import {
   InlineCalibrationWarning,
   RECOMMENDED,
+  REQUIRED,
 } from '../InlineCalibrationWarning'
 import type { AttachedPipette, PipetteCalibrations } from '../../pipettes/types'
+import type {PipetteOffsetCalibration, TipLengthCalibration} from '../../calibration/types'
 
 type Props = {|
   mount: 'left' | 'right',
@@ -31,11 +41,15 @@ type Props = {|
   customLabware: Array<LabwareDefinition2>,
 |}
 
-const NO_PIPETTE = 'n/a'
+const NO_PIPETTE = 'No pipette attached'
 const NO_CALIBRATION = "You haven't calibrated this pipette yet"
 const LAST_CALIBRATED = 'Last calibrated'
 const WITH = 'with'
 const UNKNOWN_CUSTOM_LABWARE = 'unknown custom tiprack'
+const PIPETTE_OFFSET_CALIBRATION = 'pipette offset calibration'
+const TIP_LENGTH_CALIBRATION = 'tip length calibration'
+const SERIAL_NUMBER = 'Serial number'
+const TIP_LENGTH_NOT_DISPLAYED = 'Calibrate your pipette to see saved tip length'
 
 function getDisplayNameForTiprack(
   tiprackUri: string,
@@ -53,58 +67,123 @@ function getDisplayNameForTiprack(
     : `${UNKNOWN_CUSTOM_LABWARE}`
 }
 
-function buildCalibrationText(
-  calibration: PipetteCalibrations | null,
-  customLabware: Array<LabwareDefinition2>
+function getCalibrationDate(
+  calibration: PipetteOffsetCalibration | TipLengthCalibration,
 ): React.Node {
-  return calibration && calibration.offset ? (
-    <>
-      <Text fontStyle={FONT_STYLE_ITALIC}>
-        {`${LAST_CALIBRATED}: ${format(
-          new Date(calibration?.offset?.lastModified ?? ''),
+  return <Text key={"calibrationDate"} fontStyle={FONT_STYLE_ITALIC} marginTop={SPACING_1}>
+    {`${LAST_CALIBRATED}: ${format(
+          new Date(calibration.lastModified),
           'MMMM d y HH:mm'
         )}`}
-      </Text>
-      <Text fontStyle={FONT_STYLE_ITALIC}>
-        {`${WITH} ${getDisplayNameForTiprack(
-          calibration?.offset?.tiprackUri ?? '',
-          customLabware
-        )}`}
-      </Text>
-    </>
-  ) : (
-    <Text fontStyle={FONT_STYLE_ITALIC}>{NO_CALIBRATION}</Text>
-  )
+  </Text>
+}
+
+type PipetteOffsetSectionProps = {|
+   pipette: AttachedPipette,
+   calibration: PipetteOffsetCalibration | null
+|}
+
+function PipetteOffsetSection(props: PipetteOffsetSectionProps): React.Node {
+  const {pipette, calibration} = props
+  return <Box
+           key={"pipetteOffset"}
+           marginTop={SPACING_2}>
+           <Text
+             textTransform={TEXT_TRANSFORM_CAPITALIZE}
+             fontWeight={FONT_WEIGHT_SEMIBOLD}
+             marginBottom={SPACING_2}
+           >
+             {PIPETTE_OFFSET_CALIBRATION}
+           </Text>
+           {( calibration
+              ? <Flex flexDirection={DIRECTION_COLUMN}>
+                  <Text key={"displayName"}>{pipette.modelSpecs.displayName}</Text>
+                  <Text key={"serialNumber"}>{`${SERIAL_NUMBER}: ${pipette.id}`}</Text>
+                  {getCalibrationDate(calibration)}
+                </Flex>
+              : <InlineCalibrationWarning warningType={REQUIRED}/>
+            )}
+         </Box>
+}
+
+type TipLengthSectionProps = {|
+  pipette: AttachedPipette,
+  calibration: PipetteCalibrations | null,
+  customLabware: Array<LabwareDefinition2>
+|}
+
+export function TipLengthSection(props: TipLengthSectionProps): React.Node {
+  const {pipette, calibration, customLabware} = props
+  return <Box key={"tipLength"}
+              marginTop={SPACING_3}>
+           <Text
+             textTransform={TEXT_TRANSFORM_CAPITALIZE}
+             fontWeight={FONT_WEIGHT_SEMIBOLD}
+             marginBottom={SPACING_2}>
+             {TIP_LENGTH_CALIBRATION}
+           </Text>
+           {( (calibration?.offset && calibration?.tipLength)
+               ? <Flex flexDirection={DIRECTION_COLUMN}>
+                 <Text key={"tiprackDisplayName"}>
+                   {getDisplayNameForTiprack(calibration.offset.tiprackUri, customLabware)}
+                 </Text>
+                   {(calibration?.tipLength && getCalibrationDate(calibration.tipLength))}
+               </Flex>
+              : <Text fontStyle={FONT_STYLE_ITALIC}>
+                  {TIP_LENGTH_NOT_DISPLAYED}
+                </Text>
+           )}
+
+         </Box>
 }
 
 export function PipetteOffsetItem(props: Props): React.Node {
   const { mount, pipette, calibration, customLabware } = props
   return (
-    <Box width={'50%'} display={DISPLAY_INLINE_BLOCK}>
+    <Box width={'50%'} display={DISPLAY_BLOCK}>
       <Text
         as={'h4'}
         textTransform={TEXT_TRANSFORM_UPPERCASE}
         fontWeight={FONT_WEIGHT_SEMIBOLD}
         marginBottom={SPACING_1}
       >
-        {mount}
+        {`${mount} mount`}
       </Text>
-      {pipette &&
-        (calibration?.offset?.status.markedBad ||
-          calibration?.tipLength?.status.markedBad) && (
-          <InlineCalibrationWarning warningType={RECOMMENDED} />
-        )}
-      <Text
-        textTransform={TEXT_TRANSFORM_UPPERCASE}
-        fontWeight={FONT_WEIGHT_SEMIBOLD}
-        marginTop={SPACING_1}
+      <Box
+        marginTop={SPACING_2}
+        backgroundColor={OVERLAY_LIGHT_GRAY_50}
+        width={'95%'}
+        height={'90%'}
+        padding={SPACING_2}
         marginBottom={SPACING_2}
       >
-        {pipette && pipette.modelSpecs
-          ? pipette.modelSpecs.displayName
-          : NO_PIPETTE}
-      </Text>
-      {pipette && buildCalibrationText(calibration, customLabware)}
+        {pipette &&
+         (calibration?.offset?.status.markedBad ||
+          calibration?.tipLength?.status.markedBad) && (
+            <InlineCalibrationWarning
+              marginTop={'0'}
+              warningType={RECOMMENDED} />
+          )}
+
+        {( (pipette && pipette.modelSpecs)
+           ? <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+               <PipetteOffsetSection
+                 pipette={pipette}
+                 calibration={calibration?.offset ?? null}/>
+               <TipLengthSection
+                 pipette={pipette}
+                 calibration={calibration}
+                 customLabware={customLabware}/>
+             </Flex>
+           :
+           <Flex size={"100%"} alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_CENTER}>
+             <Text fontStyle={FONT_STYLE_ITALIC}>
+               {NO_PIPETTE}
+             </Text>
+           </Flex>
+         )}
+
+      </Box>
     </Box>
   )
 }

--- a/app/src/components/RobotSettings/PipetteOffsetItem.js
+++ b/app/src/components/RobotSettings/PipetteOffsetItem.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import { format, getTime } from 'date-fns'
+import { format } from 'date-fns'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
@@ -32,7 +32,10 @@ import {
   REQUIRED,
 } from '../InlineCalibrationWarning'
 import type { AttachedPipette, PipetteCalibrations } from '../../pipettes/types'
-import type {PipetteOffsetCalibration, TipLengthCalibration} from '../../calibration/types'
+import type {
+  PipetteOffsetCalibration,
+  TipLengthCalibration,
+} from '../../calibration/types'
 
 type Props = {|
   mount: 'left' | 'right',
@@ -42,14 +45,13 @@ type Props = {|
 |}
 
 const NO_PIPETTE = 'No pipette attached'
-const NO_CALIBRATION = "You haven't calibrated this pipette yet"
 const LAST_CALIBRATED = 'Last calibrated'
-const WITH = 'with'
 const UNKNOWN_CUSTOM_LABWARE = 'unknown custom tiprack'
 const PIPETTE_OFFSET_CALIBRATION = 'pipette offset calibration'
 const TIP_LENGTH_CALIBRATION = 'tip length calibration'
 const SERIAL_NUMBER = 'Serial number'
-const TIP_LENGTH_NOT_DISPLAYED = 'Calibrate your pipette to see saved tip length'
+const TIP_LENGTH_NOT_DISPLAYED =
+  'Calibrate your pipette to see saved tip length'
 
 function getDisplayNameForTiprack(
   tiprackUri: string,
@@ -68,73 +70,82 @@ function getDisplayNameForTiprack(
 }
 
 function getCalibrationDate(
-  calibration: PipetteOffsetCalibration | TipLengthCalibration,
+  calibration: PipetteOffsetCalibration | TipLengthCalibration
 ): React.Node {
-  return <Text key={"calibrationDate"} fontStyle={FONT_STYLE_ITALIC} marginTop={SPACING_1}>
-    {`${LAST_CALIBRATED}: ${format(
-          new Date(calibration.lastModified),
-          'MMMM d y HH:mm'
-        )}`}
-  </Text>
+  return (
+    <Text
+      key={'calibrationDate'}
+      fontStyle={FONT_STYLE_ITALIC}
+      marginTop={SPACING_1}
+    >
+      {`${LAST_CALIBRATED}: ${format(
+        new Date(calibration.lastModified),
+        'MMMM d y HH:mm'
+      )}`}
+    </Text>
+  )
 }
 
 type PipetteOffsetSectionProps = {|
-   pipette: AttachedPipette,
-   calibration: PipetteOffsetCalibration | null
+  pipette: AttachedPipette,
+  calibration: PipetteOffsetCalibration | null,
 |}
 
 function PipetteOffsetSection(props: PipetteOffsetSectionProps): React.Node {
-  const {pipette, calibration} = props
-  return <Box
-           key={"pipetteOffset"}
-           marginTop={SPACING_2}>
-           <Text
-             textTransform={TEXT_TRANSFORM_CAPITALIZE}
-             fontWeight={FONT_WEIGHT_SEMIBOLD}
-             marginBottom={SPACING_2}
-           >
-             {PIPETTE_OFFSET_CALIBRATION}
-           </Text>
-           {( calibration
-              ? <Flex flexDirection={DIRECTION_COLUMN}>
-                  <Text key={"displayName"}>{pipette.modelSpecs.displayName}</Text>
-                  <Text key={"serialNumber"}>{`${SERIAL_NUMBER}: ${pipette.id}`}</Text>
-                  {getCalibrationDate(calibration)}
-                </Flex>
-              : <InlineCalibrationWarning warningType={REQUIRED}/>
-            )}
-         </Box>
+  const { pipette, calibration } = props
+  return (
+    <Box key={'pipetteOffset'} marginTop={SPACING_2}>
+      <Text
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        marginBottom={SPACING_2}
+      >
+        {PIPETTE_OFFSET_CALIBRATION}
+      </Text>
+      {calibration ? (
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Text key={'displayName'}>{pipette.modelSpecs.displayName}</Text>
+          <Text key={'serialNumber'}>{`${SERIAL_NUMBER}: ${pipette.id}`}</Text>
+          {getCalibrationDate(calibration)}
+        </Flex>
+      ) : (
+        <InlineCalibrationWarning warningType={REQUIRED} />
+      )}
+    </Box>
+  )
 }
 
 type TipLengthSectionProps = {|
-  pipette: AttachedPipette,
   calibration: PipetteCalibrations | null,
-  customLabware: Array<LabwareDefinition2>
+  customLabware: Array<LabwareDefinition2>,
 |}
 
 export function TipLengthSection(props: TipLengthSectionProps): React.Node {
-  const {pipette, calibration, customLabware} = props
-  return <Box key={"tipLength"}
-              marginTop={SPACING_3}>
-           <Text
-             textTransform={TEXT_TRANSFORM_CAPITALIZE}
-             fontWeight={FONT_WEIGHT_SEMIBOLD}
-             marginBottom={SPACING_2}>
-             {TIP_LENGTH_CALIBRATION}
-           </Text>
-           {( (calibration?.offset && calibration?.tipLength)
-               ? <Flex flexDirection={DIRECTION_COLUMN}>
-                 <Text key={"tiprackDisplayName"}>
-                   {getDisplayNameForTiprack(calibration.offset.tiprackUri, customLabware)}
-                 </Text>
-                   {(calibration?.tipLength && getCalibrationDate(calibration.tipLength))}
-               </Flex>
-              : <Text fontStyle={FONT_STYLE_ITALIC}>
-                  {TIP_LENGTH_NOT_DISPLAYED}
-                </Text>
-           )}
-
-         </Box>
+  const { calibration, customLabware } = props
+  return (
+    <Box key={'tipLength'} marginTop={SPACING_3}>
+      <Text
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        marginBottom={SPACING_2}
+      >
+        {TIP_LENGTH_CALIBRATION}
+      </Text>
+      {calibration?.offset && calibration?.tipLength ? (
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Text key={'tiprackDisplayName'}>
+            {getDisplayNameForTiprack(
+              calibration.offset.tiprackUri,
+              customLabware
+            )}
+          </Text>
+          {calibration?.tipLength && getCalibrationDate(calibration.tipLength)}
+        </Flex>
+      ) : (
+        <Text fontStyle={FONT_STYLE_ITALIC}>{TIP_LENGTH_NOT_DISPLAYED}</Text>
+      )}
+    </Box>
+  )
 }
 
 export function PipetteOffsetItem(props: Props): React.Node {
@@ -158,31 +169,37 @@ export function PipetteOffsetItem(props: Props): React.Node {
         marginBottom={SPACING_2}
       >
         {pipette &&
-         (calibration?.offset?.status.markedBad ||
-          calibration?.tipLength?.status.markedBad) && (
+          (calibration?.offset?.status.markedBad ||
+            calibration?.tipLength?.status.markedBad) && (
             <InlineCalibrationWarning
               marginTop={'0'}
-              warningType={RECOMMENDED} />
+              warningType={RECOMMENDED}
+            />
           )}
 
-        {( (pipette && pipette.modelSpecs)
-           ? <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-               <PipetteOffsetSection
-                 pipette={pipette}
-                 calibration={calibration?.offset ?? null}/>
-               <TipLengthSection
-                 pipette={pipette}
-                 calibration={calibration}
-                 customLabware={customLabware}/>
-             </Flex>
-           :
-           <Flex size={"100%"} alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_CENTER}>
-             <Text fontStyle={FONT_STYLE_ITALIC}>
-               {NO_PIPETTE}
-             </Text>
-           </Flex>
-         )}
-
+        {pipette && pipette.modelSpecs ? (
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_SPACE_BETWEEN}
+          >
+            <PipetteOffsetSection
+              pipette={pipette}
+              calibration={calibration?.offset ?? null}
+            />
+            <TipLengthSection
+              calibration={calibration}
+              customLabware={customLabware}
+            />
+          </Flex>
+        ) : (
+          <Flex
+            size={'100%'}
+            alignItems={ALIGN_CENTER}
+            justifyContent={JUSTIFY_CENTER}
+          >
+            <Text fontStyle={FONT_STYLE_ITALIC}>{NO_PIPETTE}</Text>
+          </Flex>
+        )}
       </Box>
     </Box>
   )

--- a/app/src/components/RobotSettings/PipetteOffsets.js
+++ b/app/src/components/RobotSettings/PipetteOffsets.js
@@ -63,9 +63,11 @@ export function PipetteOffsets(props: Props): React.Node {
         </SecondaryBtn>
       }
     >
-      <Flex alignItems={ALIGN_START}
-            flexDirection={DIRECTION_COLUMN}
-            marginBottom={SPACING_3}>
+      <Flex
+        alignItems={ALIGN_START}
+        flexDirection={DIRECTION_COLUMN}
+        marginBottom={SPACING_3}
+      >
         <Flex width={'100%'} paddingTop={SPACING_4}>
           <PipetteOffsetItem
             mount={'left'}

--- a/app/src/components/RobotSettings/PipetteOffsets.js
+++ b/app/src/components/RobotSettings/PipetteOffsets.js
@@ -63,7 +63,9 @@ export function PipetteOffsets(props: Props): React.Node {
         </SecondaryBtn>
       }
     >
-      <Flex alignItems={ALIGN_START} flexDirection={DIRECTION_COLUMN}>
+      <Flex alignItems={ALIGN_START}
+            flexDirection={DIRECTION_COLUMN}
+            marginBottom={SPACING_3}>
         <Flex width={'100%'} paddingTop={SPACING_4}>
           <PipetteOffsetItem
             mount={'left'}

--- a/app/src/components/RobotSettings/PipetteOffsets.js
+++ b/app/src/components/RobotSettings/PipetteOffsets.js
@@ -8,32 +8,27 @@ import type { State } from '../../types'
 import * as Pipettes from '../../pipettes'
 import * as CustomLabware from '../../custom-labware'
 
+import { TitledControl } from '../TitledControl'
+
 import {
-  Box,
   Flex,
-  Link,
-  Text,
   ALIGN_START,
   BORDER_SOLID_LIGHT,
   DIRECTION_COLUMN,
-  FONT_SIZE_BODY_1,
-  FONT_WEIGHT_SEMIBOLD,
-  SPACING_2,
   SPACING_3,
   SPACING_4,
-  SPACING_AUTO,
-  TEXT_TRANSFORM_CAPITALIZE,
+  SecondaryBtn,
 } from '@opentrons/components'
 
 import type { ViewableRobot } from '../../discovery/types'
 
 import { PipetteOffsetItem } from './PipetteOffsetItem'
 
-const TITLE = 'pipette offset calibration'
+const TITLE = 'Attached Pipette Calibrations'
 const DESCRIPTION =
-  'Calibration for the position of each pipette. See information about all pipettes and calibrate under'
+  'Calibrate the position for the the default tip and pipette combination.'
 
-const LINK_TEXT = 'Robot > Pipettes and Modules'
+const BUTTON_TEXT = 'Manage Pipettes'
 
 type Props = {|
   pipettesPageUrl: string,
@@ -57,28 +52,18 @@ export function PipetteOffsets(props: Props): React.Node {
   })
 
   return (
-    <Box
+    <TitledControl
       padding={SPACING_3}
       borderBottom={BORDER_SOLID_LIGHT}
-      fontSize={FONT_SIZE_BODY_1}
+      title={TITLE}
+      description={DESCRIPTION}
+      control={
+        <SecondaryBtn as={RRDLink} to={pipettesPageUrl}>
+          {BUTTON_TEXT}
+        </SecondaryBtn>
+      }
     >
       <Flex alignItems={ALIGN_START} flexDirection={DIRECTION_COLUMN}>
-        <Box paddingRight={SPACING_3} marginRight={SPACING_AUTO}>
-          <Text
-            as="h4"
-            fontWeight={FONT_WEIGHT_SEMIBOLD}
-            marginBottom={SPACING_2}
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
-          >
-            {TITLE}
-          </Text>
-          <Text>
-            {`${DESCRIPTION} `}
-            <Link as={RRDLink} to={pipettesPageUrl}>
-              {LINK_TEXT}
-            </Link>
-          </Text>
-        </Box>
         <Flex width={'100%'} paddingTop={SPACING_4}>
           <PipetteOffsetItem
             mount={'left'}
@@ -94,6 +79,6 @@ export function PipetteOffsets(props: Props): React.Node {
           />
         </Flex>
       </Flex>
-    </Box>
+    </TitledControl>
   )
 }

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -36,11 +36,11 @@ const mockGetLabwareDisplayName: JestMockFn<
 
 const getMountLabel = wrapper => wrapper.find('h4')
 
-const getPipetteName = wrapper => wrapper.find('p').at(0)
+const getPipetteName = wrapper => wrapper.find('p').at(1)
 const getNotCalibrated = wrapper => wrapper.find('p').at(1)
 const getCalibrationText = wrapper => wrapper.find('p')
-const getCalibrationTime = wrapper => wrapper.find('p').at(1)
-const getCalibrationTiprack = wrapper => wrapper.find('p').at(2)
+const getCalibrationTime = wrapper => wrapper.find('p').at(3)
+const getCalibrationTiprack = wrapper => wrapper.find('p').at(5)
 const getCalibrationWarning = wrapper => wrapper.find(InlineCalibrationWarning)
 
 describe('PipetteOffsetItem', () => {
@@ -103,18 +103,16 @@ describe('PipetteOffsetItem', () => {
 
   it('shows null when no pipette present', () => {
     const wrapper = render({ pipette: null })
-    expect(getMountLabel(wrapper).text()).toEqual('left')
-    expect(getCalibrationText(wrapper).text()).toEqual('n/a')
+    expect(getMountLabel(wrapper).text()).toEqual('left mount')
+    expect(getCalibrationText(wrapper).text()).toMatch(/no pipette attached/i)
     expect(getCalibrationWarning(wrapper).exists()).toBe(false)
   })
 
   it('says when you havent calibrated', () => {
     const wrapper = render({ calibration: null })
-    expect(getMountLabel(wrapper).text()).toEqual('left')
-    expect(getPipetteName(wrapper).text()).toEqual('P300 Single GEN2')
-    expect(getNotCalibrated(wrapper).text()).toMatch(/haven't calibrated/)
-    expect(getCalibrationText(wrapper)).toHaveLength(2)
-    expect(getCalibrationWarning(wrapper).exists()).toBe(false)
+    expect(getMountLabel(wrapper).text()).toEqual('left mount')
+    expect(getNotCalibrated(wrapper).text()).toMatch(/calibration required/i)
+    expect(getCalibrationWarning(wrapper).exists()).toBe(true)
   })
 
   it('displays date and tiprack display name from def', () => {
@@ -133,7 +131,7 @@ describe('PipetteOffsetItem', () => {
     expect(mockGetLabwareDisplayName).toHaveBeenCalledWith({
       parameters: { loadName: 'opentrons_96_tiprack_300ul' },
     })
-    expect(getMountLabel(wrapper).text()).toEqual('left')
+    expect(getMountLabel(wrapper).text()).toEqual('left mount')
     expect(getPipetteName(wrapper).text()).toEqual('P300 Single GEN2')
     expect(getCalibrationTime(wrapper).text()).toMatch(/September 10/)
     expect(getCalibrationTiprack(wrapper).text()).toMatch(

--- a/components/src/styles/colors.js
+++ b/components/src/styles/colors.js
@@ -27,6 +27,10 @@ export const C_SELECTED_DARK = '#00c3e6'
 export const OVERLAY_WHITE_10 = 'rgba(255, 255, 255, 0.1)'
 export const OVERLAY_WHITE_20 = 'rgba(255, 255, 255, 0.2)'
 
+// used to set aside further subsections of cards beyond
+// what can be distinguished with a border
+export const OVERLAY_LIGHT_GRAY_50 = 'rgba(230, 230, 230, 0.4)'
+
 // used as default BaseModal overlay color
 export const OVERLAY_GRAY_90 = 'rgba(127, 127, 127, 0.9)'
 


### PR DESCRIPTION
Match [the new designs](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=124%3A0) (plus some offline conversations) in the calibration card. Specifically,
- The pipette information is set apart in a tinted-background block per pipette. This is a new building block in our designs and is necessary because of the depth of the information hierarchy in this panel
- Have titled subsections for pipette offset and tip length calibration, which drives home the concept that they are two separate things
- Make the control more like the others in the card, in that it now has a button to manage pipettes instead of a link.