### PR TITLE
refactor(app): deck cal button says recalibrate

### DIFF
--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -42,11 +42,12 @@ import type {
 import type { RequestState } from '../../robot-api/types'
 
 const DECK_NEVER_CALIBRATED = "You haven't calibrated the deck yet"
-const LAST_CALIBRATED = 'Last calibrated: '
-const MIGRATED = 'Migrated from legacy data: '
+const LAST_CALIBRATED = 'Last calibrated:'
+const MIGRATED = 'Last known calibration migrated'
 const CALIBRATE_DECK_DESCRIPTION =
   "Calibrate the position of the robot's deck. Recommended for all new robots and after moving robots."
-const CALIBRATE_BUTTON_TEXT = 'Calibrate'
+const BUTTON_TEXT_CALIBRATE = 'calibrate deck'
+const BUTTON_TEXT_RECALIBRATE = 'recalibrate deck'
 const CALIBRATE_TITLE_TEXT = 'Calibrate deck'
 const STARTING = 'Deck calibration is starting'
 const ENDING = 'Deck calibration is ending'
@@ -209,8 +210,11 @@ export function DeckCalibrationControl(props: Props): React.Node {
 
   const buttonChildren = showSpinner ? (
     <Icon name="ot-spinner" height="1em" spin />
+  ) : deckCalStatus &&
+    deckCalStatus !== Calibration.DECK_CAL_STATUS_IDENTITY ? (
+    BUTTON_TEXT_RECALIBRATE
   ) : (
-    CALIBRATE_BUTTON_TEXT
+    BUTTON_TEXT_CALIBRATE
   )
 
   return (
@@ -227,7 +231,7 @@ export function DeckCalibrationControl(props: Props): React.Node {
         control={
           <SecondaryBtn
             {...targetProps}
-            width="9rem"
+            width="13rem"
             onClick={confirmStart}
             disabled={disabledIncludingSpinner}
           >

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -226,6 +226,11 @@ export function DeckCalibrationControl(props: Props): React.Node {
           <>
             <InlineCalibrationWarning warningType={warningType} />
             <Text>{CALIBRATE_DECK_DESCRIPTION}</Text>
+            {deckCalData && deckCalStatus && (
+              <Text marginTop={SPACING_4} fontStyle={FONT_STYLE_ITALIC}>
+                {buildDeckLastCalibrated(deckCalData, deckCalStatus)}
+              </Text>
+            )}
           </>
         }
         control={
@@ -241,12 +246,6 @@ export function DeckCalibrationControl(props: Props): React.Node {
       >
         {disabledIncludingSpinner !== null && (
           <Tooltip {...tooltipProps}>{disabledIncludingSpinner}</Tooltip>
-        )}
-
-        {deckCalData && deckCalStatus && (
-          <Text marginTop={SPACING_4} fontStyle={FONT_STYLE_ITALIC}>
-            {buildDeckLastCalibrated(deckCalData, deckCalStatus)}
-          </Text>
         )}
       </TitledControl>
       {showConfirmStart && pipOffsetDataPresent && (

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -76,9 +76,8 @@ const getDeckCalibrationStatus: JestMockFn<
 
 const getDeckCalButton = wrapper =>
   wrapper
-    .find('TitledControl[title="Calibrate deck"]')
+    .find('DeckCalibrationControl')
     .find('button')
-    .filter({ children: 'Calibrate' })
 
 const getCheckCalibrationControl = wrapper =>
   wrapper.find(CheckCalibrationControl)

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -75,9 +75,7 @@ const getDeckCalibrationStatus: JestMockFn<
 > = Calibration.getDeckCalibrationStatus
 
 const getDeckCalButton = wrapper =>
-  wrapper
-    .find('DeckCalibrationControl')
-    .find('button')
+  wrapper.find('DeckCalibrationControl').find('button')
 
 const getCheckCalibrationControl = wrapper =>
   wrapper.find(CheckCalibrationControl)

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -257,7 +257,7 @@ describe('DeckCalibrationControl', () => {
   ]
 
   CALIBRATE_STATUSES.forEach(status => {
-    it(`The button says calibrate when status is ${status}`, () => {
+    it(`The button says calibrate when status is ${String(status)}`, () => {
       const wrapper = render({ deckCalStatus: status })
       expect(getDeckCalButton(wrapper).prop('children')).toMatch(
         /calibrate deck/i

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -27,9 +27,8 @@ describe('DeckCalibrationControl', () => {
 
   const getDeckCalButton = wrapper =>
     wrapper
-      .find('TitledControl[title="Calibrate deck"]')
+      .find('DeckCalibrationControl')
       .find('button')
-      .filter({ children: 'Calibrate' })
 
   const getCancelDeckCalButton = wrapper =>
     wrapper.find('OutlineButton[children="cancel"]').find('button')
@@ -250,5 +249,29 @@ describe('DeckCalibrationControl', () => {
   it('InlineCalibrationWarning component not rendered if deck cal is good and marked ok', () => {
     const wrapper = render()
     expect(getCalibrationWarning(wrapper).children()).toHaveLength(0)
+  })
+
+  const CALIBRATE_STATUSES = [
+    DECK_CAL_STATUS_IDENTITY,
+    null
+  ]
+  const RECALIBRATE_STATUSES = [
+    DECK_CAL_STATUS_OK,
+    DECK_CAL_STATUS_BAD_CALIBRATION,
+    DECK_CAL_STATUS_SINGULARITY
+  ]
+
+  CALIBRATE_STATUSES.forEach(status => {
+    it(`The button says calibrate when status is ${status}`, () => {
+      const wrapper = render({ deckCalStatus: status })
+      expect(getDeckCalButton(wrapper).prop('children')).toMatch(/calibrate deck/i)
+    })
+  })
+
+  RECALIBRATE_STATUSES.forEach(status => {
+    it(`The button says recalibrate when status is ${status}`, () => {
+      const wrapper = render({ deckCalStatus: status })
+      expect(getDeckCalButton(wrapper).prop('children')).toMatch(/recalibrate deck/i)
+    })
   })
 })

--- a/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/DeckCalibrationControl.test.js
@@ -26,9 +26,7 @@ describe('DeckCalibrationControl', () => {
   let render
 
   const getDeckCalButton = wrapper =>
-    wrapper
-      .find('DeckCalibrationControl')
-      .find('button')
+    wrapper.find('DeckCalibrationControl').find('button')
 
   const getCancelDeckCalButton = wrapper =>
     wrapper.find('OutlineButton[children="cancel"]').find('button')
@@ -251,27 +249,28 @@ describe('DeckCalibrationControl', () => {
     expect(getCalibrationWarning(wrapper).children()).toHaveLength(0)
   })
 
-  const CALIBRATE_STATUSES = [
-    DECK_CAL_STATUS_IDENTITY,
-    null
-  ]
+  const CALIBRATE_STATUSES = [DECK_CAL_STATUS_IDENTITY, null]
   const RECALIBRATE_STATUSES = [
     DECK_CAL_STATUS_OK,
     DECK_CAL_STATUS_BAD_CALIBRATION,
-    DECK_CAL_STATUS_SINGULARITY
+    DECK_CAL_STATUS_SINGULARITY,
   ]
 
   CALIBRATE_STATUSES.forEach(status => {
     it(`The button says calibrate when status is ${status}`, () => {
       const wrapper = render({ deckCalStatus: status })
-      expect(getDeckCalButton(wrapper).prop('children')).toMatch(/calibrate deck/i)
+      expect(getDeckCalButton(wrapper).prop('children')).toMatch(
+        /calibrate deck/i
+      )
     })
   })
 
   RECALIBRATE_STATUSES.forEach(status => {
     it(`The button says recalibrate when status is ${status}`, () => {
       const wrapper = render({ deckCalStatus: status })
-      expect(getDeckCalButton(wrapper).prop('children')).toMatch(/recalibrate deck/i)
+      expect(getDeckCalButton(wrapper).prop('children')).toMatch(
+        /recalibrate deck/i
+      )
     })
   })
 })

--- a/app/src/components/TitledControl/index.js
+++ b/app/src/components/TitledControl/index.js
@@ -5,7 +5,7 @@ import {
   Flex,
   Text,
   FLEX_NONE,
-  ALIGN_START,
+  ALIGN_CENTER,
   SPACING_AUTO,
   SPACING_1,
   SPACING_2,
@@ -33,7 +33,7 @@ export function TitledControl({
 }: TitledControlProps): React.Node {
   return (
     <Box fontSize={FONT_SIZE_BODY_1} padding={SPACING_3} {...styleProps}>
-      <Flex alignItems={ALIGN_START}>
+      <Flex alignItems={ALIGN_CENTER}>
         <Box paddingRight={SPACING_3} marginRight={SPACING_AUTO}>
           <Text
             as="h4"


### PR DESCRIPTION
When we have a deck calibration already, the deck cal button should say
recalibrate rather than calibrate.

Also slightly change the migrated content note.
