### PR TITLE
feat(robot-server): increment HTTP API version

### DIFF
--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -1,10 +1,18 @@
-# This is the version of the API supported by the server. The
-# application version is in package.json.
-API_VERSION = 1
+# This is the version of the HTTP API used by the server.  This value should
+# be incremented anytime the schema of a request or response is changed. This
+# value is different and separaate from the application version.
+API_VERSION = 2
+
+# Minimum API version supported by the server. Increasing this value should
+# be considered a **breaking change** in the application.
+MIN_API_VERSION = 2
+
+# Keyword header value for a client to ask to use the latest HTTP API version.
+API_VERSION_LATEST = "*"
 
 # Header identifying maximum acceptable version in request and actual version
-# used to create response. Optional in requests. Mandatory in responses.
-API_VERSION_HEADER = 'Opentrons-Version'
+# used to create response. Mandatory in requests and responses.
+API_VERSION_HEADER = "Opentrons-Version"
 
 # Tag applied to legacy api endpoints
 V1_TAG = "v1"

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -14,6 +14,9 @@ API_VERSION_LATEST = "*"
 # used to create response. Mandatory in requests and responses.
 API_VERSION_HEADER = "Opentrons-Version"
 
+# Response header specifing minimum acceptable API version
+MIN_API_VERSION_HEADER = "Opentrons-Min-Version"
+
 # Allow-list for routes that are not subject to versioning requirements
 # TODO(mc, 2020-11-05): allow routes to opt-in to versionsing and request +
 # response migrations via decorator. Puting an allow-list in place for now

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -1,6 +1,6 @@
 # This is the version of the HTTP API used by the server.  This value should
 # be incremented anytime the schema of a request or response is changed. This
-# value is different and separaate from the application version.
+# value is different and separate from the application version.
 API_VERSION = 2
 
 # Minimum API version supported by the server. Increasing this value should

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -14,5 +14,20 @@ API_VERSION_LATEST = "*"
 # used to create response. Mandatory in requests and responses.
 API_VERSION_HEADER = "Opentrons-Version"
 
+# Allow-list for routes that are not subject to versioning requirements
+# TODO(mc, 2020-11-05): allow routes to opt-in to versionsing and request +
+# response migrations via decorator. Puting an allow-list in place for now
+# because allowing an endpoint to bypass versioning requirements in the future
+# is not a breaking change
+NON_VERSIONED_ROUTES = [
+    # keep the root RPC WebSocket path unversioned because browsers cannot
+    # specify headers for WebSocket client requests
+    "/",
+    # keep documentation endpoints unversioned
+    "/openapi.json",
+    "/docs",
+    "/redoc",
+]
+
 # Tag applied to legacy api endpoints
 V1_TAG = "v1"

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -22,7 +22,7 @@ MIN_API_VERSION_HEADER = "Opentrons-Min-Version"
 # response migrations via decorator. Puting an allow-list in place for now
 # because allowing an endpoint to bypass versioning requirements in the future
 # is not a breaking change
-NON_VERSIONED_ROUTES = [
+NON_VERSIONED_ROUTES = {
     # keep the root RPC WebSocket path unversioned because browsers cannot
     # specify headers for WebSocket client requests
     "/",
@@ -30,7 +30,7 @@ NON_VERSIONED_ROUTES = [
     "/openapi.json",
     "/docs",
     "/redoc",
-]
+}
 
 # Tag applied to legacy api endpoints
 V1_TAG = "v1"

--- a/robot-server/robot_server/service/app.py
+++ b/robot-server/robot_server/service/app.py
@@ -154,6 +154,9 @@ async def api_version_check(request: Request, call_next) -> Response:
 
     # Put the api version in the response header
     response.headers[constants.API_VERSION_HEADER] = str(api_version)
+    response.headers[constants.MIN_API_VERSION_HEADER] = str(
+        constants.MIN_API_VERSION
+    )
     return response
 
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 from opentrons.protocols.implementations.labware import LabwareImplementation
 from starlette.testclient import TestClient
+from robot_server.constants import API_VERSION_HEADER, API_VERSION_LATEST
 from robot_server.service.app import app
 from robot_server.service.dependencies import get_hardware, verify_hardware
 from opentrons.hardware_control import API, HardwareAPILike, ThreadedAsyncLock
@@ -59,14 +60,25 @@ def override_hardware(hardware):
 
 @pytest.fixture
 def api_client(override_hardware) -> TestClient:
-    return TestClient(app)
+    client = TestClient(app)
+    client.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    return client
 
 
 @pytest.fixture
 def api_client_no_errors(override_hardware) -> TestClient:
     """ An API client that won't raise server exceptions.
     Use only to test 500 pages; never use this for other tests. """
-    return TestClient(app, raise_server_exceptions=False)
+    client = TestClient(app, raise_server_exceptions=False)
+    client.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    return client
+
+
+@pytest.fixture(scope="session")
+def request_session():
+    session = requests.Session()
+    session.headers.update({API_VERSION_HEADER: API_VERSION_LATEST})
+    return session
 
 
 @pytest.fixture(scope="session")
@@ -82,7 +94,7 @@ def server_temp_directory():
 
 
 @pytest.fixture(scope="session")
-def run_server(server_temp_directory):
+def run_server(request_session, server_temp_directory):
     with subprocess.Popen([sys.executable, "-m", "robot_server.main"],
                           env={'OT_ROBOT_SERVER_DOT_ENV_PATH': "test.env",
                                'OT_API_CONFIG_DIR': server_temp_directory},
@@ -92,18 +104,17 @@ def run_server(server_temp_directory):
         # TODO (lc, 23-06-2020) We should investigate
         # using symlinks for the file copy to avoid
         # having such a long delay
-        import requests
         from requests.exceptions import ConnectionError
         while True:
             try:
-                requests.get("http://localhost:31950/health")
+                request_session.get("http://localhost:31950/health")
             except ConnectionError:
                 pass
             else:
                 break
             time.sleep(0.5)
-        requests.post("http://localhost:31950/robot/home",
-                      json={"target": "robot"})
+        request_session.post("http://localhost:31950/robot/home",
+                             json={"target": "robot"})
         yield proc
         proc.kill()
 
@@ -137,7 +148,7 @@ def set_up_index_file_temporary_directory(server_temp_directory):
         'nest_12_reservoir_15ml',
         'opentrons_96_tiprack_10ul']
     for idx, name in enumerate(labware_list):
-        parent = deck.position_for(idx+1)
+        parent = deck.position_for(idx + 1)
         definition = labware.get_labware_definition(name)
         lw = labware.Labware(
             implementation=LabwareImplementation(definition, parent)
@@ -170,8 +181,8 @@ def set_up_tip_length_temp_directory(server_temp_directory):
     def_hash = helpers.hash_labware_def(definition)
     for pip, tip_len in zip(attached_pip_list, tip_length_list):
         cal = {def_hash: {
-                'tipLength': tip_len,
-                'lastModified': datetime.now()}}
+            'tipLength': tip_len,
+            'lastModified': datetime.now()}}
         modify.save_tip_length_calibration(pip, cal)
 
 
@@ -192,7 +203,7 @@ def session_manager(hardware) -> SessionManager:
 
 
 @pytest.fixture
-def set_enable_http_protocol_sessions():
+def set_enable_http_protocol_sessions(request_session):
     """For integration tests that need to set then clear the
     enableHttpProtocolSessions feature flag"""
     url = "http://localhost:31950/settings"
@@ -200,17 +211,17 @@ def set_enable_http_protocol_sessions():
         "id": "enableHttpProtocolSessions",
         "value": True
     }
-    requests.post(url, json=data)
+    request_session.post(url, json=data)
     yield None
     data['value'] = None
-    requests.post(url, json=data)
+    request_session.post(url, json=data)
 
 
 @pytest.fixture
 def get_labware_fixture():
     def _get_labware_fixture(fixture_name):
-        with open((pathlib.Path(__file__).parent/'..'/'..'/'shared-data' /
-                   'labware' / 'fixtures'/'2'/f'{fixture_name}.json'), 'rb'
+        with open((pathlib.Path(__file__).parent / '..' / '..' / 'shared-data' /
+                   'labware' / 'fixtures' / '2' / f'{fixture_name}.json'), 'rb'
                   ) as f:
             return json.loads(f.read().decode('utf-8'))
 

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -220,9 +220,11 @@ def set_enable_http_protocol_sessions(request_session):
 @pytest.fixture
 def get_labware_fixture():
     def _get_labware_fixture(fixture_name):
-        with open((pathlib.Path(__file__).parent / '..' / '..' / 'shared-data' /
-                   'labware' / 'fixtures' / '2' / f'{fixture_name}.json'), 'rb'
-                  ) as f:
+        with open(
+            (pathlib.Path(__file__).parent / '..' / '..' / 'shared-data' /
+             'labware' / 'fixtures' / '2' / f'{fixture_name}.json'),
+            'rb'
+        ) as f:
             return json.loads(f.read().decode('utf-8'))
 
     return _get_labware_fixture

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -1,0 +1,6 @@
+def pytest_tavern_beta_before_every_test_run(test_dict, variables):
+    """Add Opentrons-Version header to requests that don't specify it."""
+    for stage in test_dict["stages"]:
+        headers = stage["request"].get("headers", {})
+        headers.setdefault("Opentrons-Version", "*")
+        stage["request"].update({"headers": headers})

--- a/robot-server/tests/service/test_app.py
+++ b/robot-server/tests/service/test_app.py
@@ -3,8 +3,10 @@ from http import HTTPStatus
 
 from robot_server.constants import (
     API_VERSION_HEADER,
+    MIN_API_VERSION_HEADER,
     API_VERSION,
     API_VERSION_LATEST,
+    MIN_API_VERSION,
 )
 
 
@@ -65,6 +67,7 @@ def test_custom_request_validation_exception_handler(api_client):
 def test_api_versioning(api_client, headers, expected_version):
     resp = api_client.get('/settings', headers=headers)
     assert resp.headers.get(API_VERSION_HEADER) == str(expected_version)
+    assert resp.headers.get(MIN_API_VERSION_HEADER) == str(MIN_API_VERSION)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview

This PR increments the robot-server's HTTP API version to account for the breaking response format changes included in v4.0.0 of the robot stack.

BREAKING CHANGE: Requests without Opentrons-Version or with a value lower than 2 will be rejected

Closes #6851

## Changelog

- Increment HTTP API version
- Require clients to specify an `Opentrons-Version` header that is at least `2`
- Add `*` as accepted value for `Opentrons-Version` that means "use latest available version"

## Review requests

We should carefully consider the implications of this change:

- Once a robot has been upgraded to v4, all requests, including health checks, to the robot-server from prior versions of the app will reject
    - In the app, this will manifest as a robot that "is not responding correctly to requests."
- The **update-server** is unaffected by these changes, and older versions of the app _should_ remain able to downgrade a 4.0 robot

Again, this is a **BREAKING CHANGE**.

# Risk assessment

In terms of pure functionality: low. Unit and integration tests have been updated to test for our desired behavior.

In terms of user experience: high. Old apps connecting to new robots is going to be a hopefully rare occurrence, but will be relatively confusing due to lack of messaging around this on the (old) app-side. That being said, I think this is probably less confusing than whatever random errors might bubble up to the user due to breaking changes in the response formats. themselves
