### PR TITLE
feat(app, robot-server): Report both the minimum and maximum supported protocol api versions

### DIFF
--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,7 +4,7 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION  # noqa(F401)
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION  # noqa(F401)
 from . import labware  # noqa(E402)
 from .contexts import (ProtocolContext,  # noqa(E402)
                        InstrumentContext,

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,7 +4,7 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION  # noqa(F401)
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION  # noqa(F401)
 from . import labware  # noqa(E402)
 from .contexts import (ProtocolContext,  # noqa(E402)
                        InstrumentContext,

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -6,5 +6,5 @@ MAX_SUPPORTED_VERSION = APIVersion(2, 8)
 V2_MODULE_DEF_VERSION = APIVersion(2, 3)
 #: The first API version in which we prefer the v2 module defs
 
-MINIMUM_SUPPORTED_VERSION = APIVersion(2, 0)
+MIN_SUPPORTED_VERSION = APIVersion(2, 0)
 #: The minimum supported protocol API version in this release

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, NamedTuple, Optional, Union, TYPE_CHECKING
-from .api_support.definitions import MINIMUM_SUPPORTED_VERSION
+from .api_support.definitions import MIN_SUPPORTED_VERSION
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
@@ -91,7 +91,7 @@ class ApiDeprecationError(Exception):
 
     def __str__(self):
         return PYTHON_API_VERSION_DEPRECATED.format(
-            self.version, MINIMUM_SUPPORTED_VERSION)
+            self.version, MIN_SUPPORTED_VERSION)
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.version)

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -40,12 +40,8 @@ const TITLE = 'Information'
 const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
-const MAX_PROTOCOL_API_VERSION_LABEL = 'Max Protocol API Version'
 const BOTH_PROTOCOL_API_VERSIONS_LABEL = 'Supported Protocol API Versions'
 const UNKNOWN = 'Unknown'
-
-const DEFAULT_MAX_API_VERSION = '1.0'
-const DEFAULT_MINIMUM_API_VERSION = '2.0'
 
 const UPDATE_RECHECK_DELAY_MS = 60000
 
@@ -66,11 +62,8 @@ export function InformationCard(props: InformationCardProps): React.Node {
   const { displayName } = robot
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
-  const protocolApiVersions = getRobotProtocolApiVersion(robot).filter(
-    version => version
-  )
+  const protocolApiVersions = getRobotProtocolApiVersion(robot)
 
-  const oldHealthCheck = protocolApiVersions.length === 1
   const updateDisabled = autoUpdateDisabledReason !== null
 
   // check for available updates on an interval
@@ -95,19 +88,10 @@ export function InformationCard(props: InformationCardProps): React.Node {
               value={version || UNKNOWN}
             />
           </Box>
-          {oldHealthCheck ? (
-            <LabeledValue
-              label={MAX_PROTOCOL_API_VERSION_LABEL}
-              value={protocolApiVersions[0] || DEFAULT_MAX_API_VERSION}
-            />
-          ) : (
-            <LabeledValue
-              label={BOTH_PROTOCOL_API_VERSIONS_LABEL}
-              value={`Minimum: ${protocolApiVersions[0] ||
-                DEFAULT_MINIMUM_API_VERSION} Maximum: ${protocolApiVersions[1] ||
-                DEFAULT_MINIMUM_API_VERSION}`}
-            />
-          )}
+          <LabeledValue
+            label={BOTH_PROTOCOL_API_VERSIONS_LABEL}
+            value={`Minimum: ${protocolApiVersions.min} Maximum: ${protocolApiVersions.max}`}
+          />
         </Box>
         <SecondaryBtn
           {...updateBtnProps}

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -41,9 +41,11 @@ const NAME_LABEL = 'Robot name'
 const SERVER_VERSION_LABEL = 'Server version'
 const FIRMWARE_VERSION_LABEL = 'Firmware version'
 const MAX_PROTOCOL_API_VERSION_LABEL = 'Max Protocol API Version'
+const BOTH_PROTOCOL_API_VERSIONS_LABEL = 'Supported Protocol API Versions'
 const UNKNOWN = 'Unknown'
 
 const DEFAULT_MAX_API_VERSION = '1.0'
+const DEFAULT_MINIMUM_API_VERSION = '2.0'
 
 const UPDATE_RECHECK_DELAY_MS = 60000
 
@@ -64,7 +66,11 @@ export function InformationCard(props: InformationCardProps): React.Node {
   const { displayName } = robot
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
-  const maxApiVersion = getRobotProtocolApiVersion(robot)
+  const protocolApiVersions = getRobotProtocolApiVersion(robot).filter(
+    version => version
+  )
+
+  const oldHealthCheck = protocolApiVersions.length === 1
   const updateDisabled = autoUpdateDisabledReason !== null
 
   // check for available updates on an interval
@@ -89,10 +95,19 @@ export function InformationCard(props: InformationCardProps): React.Node {
               value={version || UNKNOWN}
             />
           </Box>
-          <LabeledValue
-            label={MAX_PROTOCOL_API_VERSION_LABEL}
-            value={maxApiVersion || DEFAULT_MAX_API_VERSION}
-          />
+          {oldHealthCheck ? (
+            <LabeledValue
+              label={MAX_PROTOCOL_API_VERSION_LABEL}
+              value={protocolApiVersions[0] || DEFAULT_MAX_API_VERSION}
+            />
+          ) : (
+            <LabeledValue
+              label={BOTH_PROTOCOL_API_VERSIONS_LABEL}
+              value={`Minimum: ${protocolApiVersions[0] ||
+                DEFAULT_MINIMUM_API_VERSION} Maximum: ${protocolApiVersions[1] ||
+                DEFAULT_MINIMUM_API_VERSION}`}
+            />
+          )}
         </Box>
         <SecondaryBtn
           {...updateBtnProps}

--- a/app/src/components/RobotSettings/InformationCard.js
+++ b/app/src/components/RobotSettings/InformationCard.js
@@ -63,6 +63,9 @@ export function InformationCard(props: InformationCardProps): React.Node {
   const version = getRobotApiVersion(robot)
   const firmwareVersion = getRobotFirmwareVersion(robot)
   const protocolApiVersions = getRobotProtocolApiVersion(robot)
+  const minProtocolApiVersion = protocolApiVersions?.min ?? UNKNOWN
+  const maxProtocolApiVersion = protocolApiVersions?.max ?? UNKNOWN
+  const API_VERSION_DISPLAY = `Min: ${minProtocolApiVersion},  Max: ${maxProtocolApiVersion}`
 
   const updateDisabled = autoUpdateDisabledReason !== null
 
@@ -90,7 +93,7 @@ export function InformationCard(props: InformationCardProps): React.Node {
           </Box>
           <LabeledValue
             label={BOTH_PROTOCOL_API_VERSIONS_LABEL}
-            value={`Minimum: ${protocolApiVersions.min} Maximum: ${protocolApiVersions.max}`}
+            value={API_VERSION_DISPLAY}
           />
         </Box>
         <SecondaryBtn

--- a/app/src/discovery/__fixtures__/index.js
+++ b/app/src/discovery/__fixtures__/index.js
@@ -9,13 +9,23 @@ import {
 
 import type { BaseRobot, Robot, ReachableRobot } from '../types'
 
-export const mockHealthResponse = {
+export const mockOldHealthResponse = {
   name: 'robot-name',
   api_version: '0.0.0-mock',
   fw_version: '0.0.0-mock',
   system_version: '0.0.0-mock',
   logs: ([]: Array<string>),
   protocol_api_version: ([2, 0]: [number, number]),
+}
+
+export const mockNewHealthResponse = {
+  name: 'robot-name',
+  api_version: '0.0.0-mock',
+  fw_version: '0.0.0-mock',
+  system_version: '0.0.0-mock',
+  logs: ([]: Array<string>),
+  minimum_protocol_api_version: ([2, 0]: [number, number]),
+  maximum_protocol_api_version: ([2, 0]: [number, number]),
 }
 
 export const mockUpdateServerHealthResponse = {
@@ -29,7 +39,7 @@ export const mockUpdateServerHealthResponse = {
 
 export const mockDiscoveryClientRobot = {
   name: 'robot-name',
-  health: mockHealthResponse,
+  health: mockOldHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   addresses: [
     {
@@ -57,7 +67,7 @@ export const mockBaseRobot: BaseRobot = {
 export const mockConnectableRobot: Robot = {
   ...mockBaseRobot,
   status: CONNECTABLE,
-  health: mockHealthResponse,
+  health: mockOldHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   healthStatus: HEALTH_STATUS_OK,
   serverHealthStatus: HEALTH_STATUS_OK,
@@ -74,7 +84,7 @@ export const mockConnectedRobot: Robot = {
 export const mockReachableRobot: ReachableRobot = {
   ...mockBaseRobot,
   status: REACHABLE,
-  health: mockHealthResponse,
+  health: mockOldHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   healthStatus: HEALTH_STATUS_NOT_OK,
   serverHealthStatus: HEALTH_STATUS_OK,

--- a/app/src/discovery/__fixtures__/index.js
+++ b/app/src/discovery/__fixtures__/index.js
@@ -9,23 +9,13 @@ import {
 
 import type { BaseRobot, Robot, ReachableRobot } from '../types'
 
-export const mockOldHealthResponse = {
+export const mockHealthResponse = {
   name: 'robot-name',
   api_version: '0.0.0-mock',
   fw_version: '0.0.0-mock',
   system_version: '0.0.0-mock',
   logs: ([]: Array<string>),
   protocol_api_version: ([2, 0]: [number, number]),
-}
-
-export const mockNewHealthResponse = {
-  name: 'robot-name',
-  api_version: '0.0.0-mock',
-  fw_version: '0.0.0-mock',
-  system_version: '0.0.0-mock',
-  logs: ([]: Array<string>),
-  minimum_protocol_api_version: ([2, 0]: [number, number]),
-  maximum_protocol_api_version: ([2, 0]: [number, number]),
 }
 
 export const mockUpdateServerHealthResponse = {
@@ -39,7 +29,7 @@ export const mockUpdateServerHealthResponse = {
 
 export const mockDiscoveryClientRobot = {
   name: 'robot-name',
-  health: mockOldHealthResponse,
+  health: mockHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   addresses: [
     {
@@ -67,7 +57,7 @@ export const mockBaseRobot: BaseRobot = {
 export const mockConnectableRobot: Robot = {
   ...mockBaseRobot,
   status: CONNECTABLE,
-  health: mockOldHealthResponse,
+  health: mockHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   healthStatus: HEALTH_STATUS_OK,
   serverHealthStatus: HEALTH_STATUS_OK,
@@ -84,7 +74,7 @@ export const mockConnectedRobot: Robot = {
 export const mockReachableRobot: ReachableRobot = {
   ...mockBaseRobot,
   status: REACHABLE,
-  health: mockOldHealthResponse,
+  health: mockHealthResponse,
   serverHealth: mockUpdateServerHealthResponse,
   healthStatus: HEALTH_STATUS_NOT_OK,
   serverHealthStatus: HEALTH_STATUS_OK,

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -412,14 +412,28 @@ describe('discovery selectors', () => {
         health: { protocol_api_version: [2, 0] },
       },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: '2.0',
+      expected: [null, '2.0'],
+    },
+    {
+      name:
+        'getRobotProtocolApiVersion returns minimum and maximum protocol versions',
+      // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
+      state: {
+        serverHealth: {},
+        health: {
+          minimum_protocol_api_version: [2, 0],
+          maximum_protocol_api_version: [2, 8],
+        },
+      },
+      selector: discovery.getRobotProtocolApiVersion,
+      expected: ['2.0', '2.8'],
     },
     {
       name: 'getRobotProtocolApiVersion returns null if no healths',
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: { serverHealth: null, health: null },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: null,
+      expected: [null, null],
     },
     {
       name: 'getRobotByName returns connectable robot by name',

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -409,10 +409,10 @@ describe('discovery selectors', () => {
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: {
         serverHealth: {},
-        health: { protocol_api_version: [2, 0] },
+        health: { protocol_api_version: [2, 1] },
       },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: [null, '2.0'],
+      expected: { min: '1.0', max: '2.1' },
     },
     {
       name:
@@ -426,14 +426,14 @@ describe('discovery selectors', () => {
         },
       },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: ['2.0', '2.8'],
+      expected: { min: '2.0', max: '2.8' },
     },
     {
       name: 'getRobotProtocolApiVersion returns null if no healths',
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: { serverHealth: null, health: null },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: [null, null],
+      expected: { min: '1.0', max: '2.0' },
     },
     {
       name: 'getRobotByName returns connectable robot by name',

--- a/app/src/discovery/__tests__/selectors.test.js
+++ b/app/src/discovery/__tests__/selectors.test.js
@@ -429,11 +429,22 @@ describe('discovery selectors', () => {
       expected: { min: '2.0', max: '2.8' },
     },
     {
-      name: 'getRobotProtocolApiVersion returns null if no healths',
+      name:
+        'getRobotProtocolApiVersion returns default protocol versions when none exists',
+      // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
+      state: {
+        serverHealth: {},
+        health: {},
+      },
+      selector: discovery.getRobotProtocolApiVersion,
+      expected: { min: '1.0', max: '1.0' },
+    },
+    {
+      name: 'getRobotProtocolApiVersion returns null if no health exists',
       // TODO(mc, 2018-10-11): state is a misnomer here, maybe rename it "input"
       state: { serverHealth: null, health: null },
       selector: discovery.getRobotProtocolApiVersion,
-      expected: { min: '1.0', max: '2.0' },
+      expected: null,
     },
     {
       name: 'getRobotByName returns connectable robot by name',

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -167,16 +167,19 @@ export const getRobotFirmwareVersion = (
 
 export const getRobotProtocolApiVersion = (
   robot: DiscoveredRobot
-): Array<string | null> => {
+): {| min: string, max: string |} => {
   const healthField = robot.health
+  const DEFAULT_MAX_API_VERSION = '2.0'
+  const DEFAULT_MINIMUM_API_VERSION = '1.0'
+
   const maxApiVersion =
-    healthField?.protocol_api_version ||
-    healthField?.maximum_protocol_api_version ||
-    null
-  const minApiVersion = healthField?.minimum_protocol_api_version || null
-  return [minApiVersion, maxApiVersion].map(version =>
-    Array.isArray(version) ? version.join('.') : null
-  )
+    healthField?.protocol_api_version ??
+    healthField?.maximum_protocol_api_version
+  const minApiVersion = healthField?.minimum_protocol_api_version
+  return {
+    min: minApiVersion ? minApiVersion.join('.') : DEFAULT_MINIMUM_API_VERSION,
+    max: maxApiVersion ? maxApiVersion.join('.') : DEFAULT_MAX_API_VERSION,
+  }
 }
 
 export const getRobotApiVersionByName = (

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -167,9 +167,16 @@ export const getRobotFirmwareVersion = (
 
 export const getRobotProtocolApiVersion = (
   robot: DiscoveredRobot
-): string | null => {
-  const maxApiVersion = robot.health?.protocol_api_version
-  return maxApiVersion ? maxApiVersion.join('.') : null
+): Array<string | null> => {
+  const healthField = robot.health
+  const maxApiVersion =
+    healthField?.protocol_api_version ||
+    healthField?.maximum_protocol_api_version ||
+    null
+  const minApiVersion = healthField?.minimum_protocol_api_version || null
+  return [minApiVersion, maxApiVersion].map(version =>
+    Array.isArray(version) ? version.join('.') : null
+  )
 }
 
 export const getRobotApiVersionByName = (

--- a/app/src/discovery/selectors.js
+++ b/app/src/discovery/selectors.js
@@ -167,18 +167,19 @@ export const getRobotFirmwareVersion = (
 
 export const getRobotProtocolApiVersion = (
   robot: DiscoveredRobot
-): {| min: string, max: string |} => {
+): {| min: string, max: string |} | null => {
   const healthField = robot.health
-  const DEFAULT_MAX_API_VERSION = '2.0'
-  const DEFAULT_MINIMUM_API_VERSION = '1.0'
+  const DEFAULT_API_VERSION = '1.0'
+  if (!healthField) {
+    return null
+  }
 
   const maxApiVersion =
-    healthField?.protocol_api_version ??
-    healthField?.maximum_protocol_api_version
-  const minApiVersion = healthField?.minimum_protocol_api_version
+    healthField.protocol_api_version ?? healthField.maximum_protocol_api_version
+  const minApiVersion = healthField.minimum_protocol_api_version
   return {
-    min: minApiVersion ? minApiVersion.join('.') : DEFAULT_MINIMUM_API_VERSION,
-    max: maxApiVersion ? maxApiVersion.join('.') : DEFAULT_MAX_API_VERSION,
+    min: minApiVersion ? minApiVersion.join('.') : DEFAULT_API_VERSION,
+    max: maxApiVersion ? maxApiVersion.join('.') : DEFAULT_API_VERSION,
   }
 }
 

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -10,7 +10,7 @@ import type {
 export type { RobotState, HostState, HealthStatus }
 
 // TODO(mc, 2018-10-03): figure out what to do with duplicate type in app
-export type HealthResponse = {
+export type DeprecatedHealthResponse = {
   name: string,
   api_version: string,
   fw_version: string,
@@ -19,6 +19,19 @@ export type HealthResponse = {
   protocol_api_version?: [number, number],
   ...
 }
+
+export type NewHealthResponse = {
+  name: string,
+  api_version: string,
+  fw_version: string,
+  system_version?: string,
+  logs?: Array<string>,
+  minimum_protocol_api_version: [number, number],
+  maximum_protocol_api_version: [number, number],
+  ...
+}
+
+export type HealthResponse = NewHealthResponse | DeprecatedHealthResponse
 
 export type Capability =
   | 'bootstrap'

--- a/discovery-client/src/types.js
+++ b/discovery-client/src/types.js
@@ -10,28 +10,17 @@ import type {
 export type { RobotState, HostState, HealthStatus }
 
 // TODO(mc, 2018-10-03): figure out what to do with duplicate type in app
-export type DeprecatedHealthResponse = {
+export type HealthResponse = {
   name: string,
   api_version: string,
   fw_version: string,
   system_version?: string,
   logs?: Array<string>,
   protocol_api_version?: [number, number],
+  minimum_protocol_api_version?: [number, number],
+  maximum_protocol_api_version?: [number, number],
   ...
 }
-
-export type NewHealthResponse = {
-  name: string,
-  api_version: string,
-  fw_version: string,
-  system_version?: string,
-  logs?: Array<string>,
-  minimum_protocol_api_version: [number, number],
-  maximum_protocol_api_version: [number, number],
-  ...
-}
-
-export type HealthResponse = NewHealthResponse | DeprecatedHealthResponse
 
 export type Capability =
   | 'bootstrap'

--- a/robot-server/robot_server/service/legacy/models/health.py
+++ b/robot-server/robot_server/service/legacy/models/health.py
@@ -44,9 +44,14 @@ class Health(BaseModel):
     system_version: str = \
         Field(...,
               description="The SemVer dotted-int version of the robot OS")
-    protocol_api_version: typing.List[int] = \
+    maximum_protocol_api_version: typing.List[int] = \
         Field(...,
-              description="A major.minor Protocol API version",
+              description="A major.minor maximum Protocol API version",
+              min_items=2,
+              max_items=2)
+    minimum_protocol_api_version: typing.List[int] = \
+        Field(...,
+              description="A major.minor minimum Protocol API version",
               min_items=2,
               max_items=2)
     links: Links
@@ -60,7 +65,8 @@ class Health(BaseModel):
                   "board_revision": "2.1",
                   "logs": ["/logs/serial.log", "/logs/api.log"],
                   "system_version": "1.2.1",
-                  "protocol_api_version": [2, 0],
+                  "maximum_protocol_api_version": [2, 8],
+                  "minimum_protocol_api_version": [2, 0],
                   "links": {
                     "apiLog": "/logs/api.log",
                     "serialLog": "/logs/serial.log",

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -3,9 +3,7 @@ import inspect
 from fastapi import APIRouter, Depends
 from opentrons import config, protocol_api
 from opentrons.hardware_control import ThreadManager
-from opentrons.protocols.api_support.types import APIVersion
 from opentrons import __version__
-from opentrons.config import feature_flags
 from robot_server.service.legacy.models.health import Health, Links
 from robot_server.service.dependencies import get_hardware
 

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -32,10 +32,8 @@ async def get_health(
     if inspect.isawaitable(fw_version):
         fw_version = await fw_version
 
-    if feature_flags.use_protocol_api_v2():
-        max_supported = protocol_api.MAX_SUPPORTED_VERSION
-    else:
-        max_supported = APIVersion(1, 0)
+    max_supported = protocol_api.MAX_SUPPORTED_VERSION
+    min_supported = protocol_api.MINIMUM_SUPPORTED_VERSION
 
     return Health(name=config.name(),
                   api_version=__version__,
@@ -43,7 +41,8 @@ async def get_health(
                   board_revision=hardware.board_revision,
                   logs=static_paths,
                   system_version=config.OT_SYSTEM_VERSION,
-                  protocol_api_version=list(max_supported),
+                  maximum_protocol_api_version=list(max_supported),
+                  minimum_protocol_api_version=list(min_supported),
                   links=Links(
                       apiLog='/logs/api.log',
                       serialLog='/logs/serial.log',

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -31,7 +31,7 @@ async def get_health(
         fw_version = await fw_version
 
     max_supported = protocol_api.MAX_SUPPORTED_VERSION
-    min_supported = protocol_api.MINIMUM_SUPPORTED_VERSION
+    min_supported = protocol_api.MIN_SUPPORTED_VERSION
 
     return Health(name=config.name(),
                   api_version=__version__,

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -1,0 +1,27 @@
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION)
+from opentrons import __version__, config
+
+minimum_version = list(MINIMUM_SUPPORTED_VERSION)
+maximum_version = list(MAX_SUPPORTED_VERSION)
+
+
+def check_health_response(response):
+    expected = {
+      'name': 'opentrons-dev',
+      'api_version': __version__,
+      'fw_version': 'Virtual Smoothie',
+      'board_revision': response.json().get('board_revision'),
+      'logs': ['/logs/serial.log', '/logs/api.log'],
+      'system_version': config.OT_SYSTEM_VERSION,
+      'minimum_protocol_api_version': minimum_version,
+      'maximum_protocol_api_version': maximum_version,
+      'links': {
+          'apiLog': '/logs/api.log',
+          'serialLog': '/logs/serial.log',
+          'apiSpec': '/openapi.json',
+          'systemTime': '/system/time'
+      }
+    }
+
+    return response.json() == expected

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -1,8 +1,8 @@
 from opentrons.protocol_api import (
-    MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION)
+    MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION)
 from opentrons import __version__, config
 
-minimum_version = list(MINIMUM_SUPPORTED_VERSION)
+minimum_version = list(MIN_SUPPORTED_VERSION)
 maximum_version = list(MAX_SUPPORTED_VERSION)
 
 

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -12,21 +12,3 @@ stages:
       status_code: 200
       verify_response_with:
         function: 'tests.integration.fixtures:check_health_response'
-      # json:
-      #   name: opentrons-dev
-      #   # starts with semantic version
-      #   api_version: !re_match "\\d+\\.\\d+\\.\\d+"
-      #   fw_version: Virtual Smoothie
-      #   board_revision: !re_match "\\d+\\.\\d+"
-      #   logs:
-      #   - /logs/serial.log
-      #   - /logs/api.log
-      #   system_version: 0.0.0
-      #   minimum_protocol_api_version: !include "fixtures:minimum_version"
-      #   maximum_protocol_api_version: !include "fixtures:maximum_version"
-      #   links:
-      #     apiLog: /logs/api.log
-      #     serialLog: /logs/serial.log
-      #     # Specific link can change.
-      #     apiSpec: !re_match "/openapi.*"
-      #     systemTime: /system/time

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -20,7 +20,10 @@ stages:
         - /logs/serial.log
         - /logs/api.log
         system_version: 0.0.0
-        protocol_api_version:
+        minimum_protocol_api_version:
+          - 2
+          - 0
+        maximum_protocol_api_version:
           - 2
           - 8
         links:

--- a/robot-server/tests/integration/test_health_check.tavern.yaml
+++ b/robot-server/tests/integration/test_health_check.tavern.yaml
@@ -10,25 +10,23 @@ stages:
       method: GET
     response:
       status_code: 200
-      json:
-        name: opentrons-dev
-        # starts with semantic version
-        api_version: !re_match "\\d+\\.\\d+\\.\\d+"
-        fw_version: Virtual Smoothie
-        board_revision: !re_match "\\d+\\.\\d+"
-        logs:
-        - /logs/serial.log
-        - /logs/api.log
-        system_version: 0.0.0
-        minimum_protocol_api_version:
-          - 2
-          - 0
-        maximum_protocol_api_version:
-          - 2
-          - 8
-        links:
-          apiLog: /logs/api.log
-          serialLog: /logs/serial.log
-          # Specific link can change.
-          apiSpec: !re_match "/openapi.*"
-          systemTime: /system/time
+      verify_response_with:
+        function: 'tests.integration.fixtures:check_health_response'
+      # json:
+      #   name: opentrons-dev
+      #   # starts with semantic version
+      #   api_version: !re_match "\\d+\\.\\d+\\.\\d+"
+      #   fw_version: Virtual Smoothie
+      #   board_revision: !re_match "\\d+\\.\\d+"
+      #   logs:
+      #   - /logs/serial.log
+      #   - /logs/api.log
+      #   system_version: 0.0.0
+      #   minimum_protocol_api_version: !include "fixtures:minimum_version"
+      #   maximum_protocol_api_version: !include "fixtures:maximum_version"
+      #   links:
+      #     apiLog: /logs/api.log
+      #     serialLog: /logs/serial.log
+      #     # Specific link can change.
+      #     apiSpec: !re_match "/openapi.*"
+      #     systemTime: /system/time

--- a/robot-server/tests/service/legacy/routers/test_health.py
+++ b/robot-server/tests/service/legacy/routers/test_health.py
@@ -1,6 +1,6 @@
 from opentrons import __version__
 from opentrons.protocol_api import (
-    MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION)
+    MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION)
 
 
 def test_health(api_client, hardware):
@@ -14,7 +14,7 @@ def test_health(api_client, hardware):
         'board_revision': 'BR2.1',
         'logs': ['/logs/serial.log', '/logs/api.log'],
         'system_version': '0.0.0',
-        'minimum_protocol_api_version': list(MINIMUM_SUPPORTED_VERSION),
+        'minimum_protocol_api_version': list(MIN_SUPPORTED_VERSION),
         'maximum_protocol_api_version': list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",

--- a/robot-server/tests/service/legacy/routers/test_health.py
+++ b/robot-server/tests/service/legacy/routers/test_health.py
@@ -1,5 +1,6 @@
 from opentrons import __version__
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION
+from opentrons.protocol_api import (
+    MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION)
 
 
 def test_health(api_client, hardware):

--- a/robot-server/tests/service/legacy/routers/test_health.py
+++ b/robot-server/tests/service/legacy/routers/test_health.py
@@ -1,5 +1,5 @@
 from opentrons import __version__
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MINIMUM_SUPPORTED_VERSION
 
 
 def test_health(api_client, hardware):
@@ -13,7 +13,8 @@ def test_health(api_client, hardware):
         'board_revision': 'BR2.1',
         'logs': ['/logs/serial.log', '/logs/api.log'],
         'system_version': '0.0.0',
-        'protocol_api_version': list(MAX_SUPPORTED_VERSION),
+        'minimum_protocol_api_version': list(MINIMUM_SUPPORTED_VERSION),
+        'maximum_protocol_api_version': list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",


### PR DESCRIPTION
# Overview

closes #6894. This PR surfaces both the minimum and maximum supported API version in the app in preparation for 4.0.0 since API V1 will be deprecated.

# Changelog

- Add in two new keys to the health request that represent the minimum/maximum protocol api version
- Modify the protocol api selector, add in a check for the old health request vs new health request and generate the label accordingly

# Review requests

Test two use-cases:
1. A robot with this branch pushed to it
2. A separate robot that has the older method 

# Risk assessment

Low, it's a small change in the app. However, since the keys are changing in the health response, we should thoroughly test on different server versions to make sure the app can still support both.
