### PR TITLE
refactor: Update step rename and notes modal styles

### DIFF
--- a/protocol-designer/src/components/modals/MoreOptionsModal.css
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.css
@@ -1,21 +1,19 @@
-.big_text_box {
-  height: 12rem;
+.modal_contents {
+  border-radius: 0;
 }
 
-.button_row {
-  /* TODO replicated in elsewhere -- does this pattern exist anywhere else? */
-  lost-utility: clearfix;
-  margin-top: 2rem;
+.form_group {
+  margin-bottom: 1rem;
+}
 
-  & > * {
-    lost-column: 1/6;
-  }
+.text_area_large {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  height: 12rem;
+  padding: 0.5rem;
+}
 
-  & > *:first-child {
-    lost-column: 2/6;
-  }
-
-  & > *:nth-child(2) {
-    lost-offset: 2/6;
-  }
+.cancel_button {
+  margin-right: 1rem;
 }

--- a/protocol-designer/src/components/modals/MoreOptionsModal.js
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.js
@@ -1,15 +1,20 @@
 // @flow
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { FlatButton, FormGroup, InputField, Modal } from '@opentrons/components'
+import {
+  FormGroup,
+  InputField,
+  Modal,
+  OutlineButton,
+} from '@opentrons/components'
 
 import { i18n } from '../../localization'
 import { actions as steplistActions } from '../../steplist'
 import type { StepFieldName } from '../../steplist/fieldLevel'
 import type { FormData } from '../../form-types'
 import type { ThunkDispatch } from '../../types'
-import styles from './MoreOptionsModal.css'
 import modalStyles from './modal.css'
+import styles from './MoreOptionsModal.css'
 
 type OP = {|
   close: (event: ?SyntheticEvent<>) => mixed,
@@ -44,38 +49,41 @@ class MoreOptionsModalComponent extends React.Component<Props, State> {
   render() {
     return (
       <Modal
-        onCloseClick={this.props.close}
+        heading={i18n.t('modal.step_notes.title')}
         className={modalStyles.modal}
-        contentsClassName={modalStyles.modal_contents}
+        contentsClassName={styles.modal_contents}
       >
         <div>
           <FormGroup
             label={i18n.t('form.step_edit_form.field.step_name.label')}
-            className={styles.column_1_2}
+            className={styles.form_group}
           >
             <InputField
               onChange={this.makeHandleChange('stepName')}
               value={String(this.state.stepName)}
             />
           </FormGroup>
+
           <FormGroup
             label={i18n.t('form.step_edit_form.field.step_notes.label')}
-            className={styles.column_1_2}
+            className={styles.form_group}
           >
-            {/* TODO: need textarea input in component library for big text boxes. */}
             <textarea
-              className={styles.big_text_box}
+              className={styles.text_area_large}
               onChange={this.makeHandleChange('stepDetails')}
               value={this.state.stepDetails}
             />
           </FormGroup>
-          <div className={styles.button_row}>
-            <FlatButton onClick={this.props.close}>
+          <div className={modalStyles.button_row}>
+            <OutlineButton
+              onClick={this.props.close}
+              className={styles.cancel_button}
+            >
               {i18n.t('button.cancel')}
-            </FlatButton>
-            <FlatButton onClick={this.handleSave}>
+            </OutlineButton>
+            <OutlineButton onClick={this.handleSave}>
               {i18n.t('button.save')}
-            </FlatButton>
+            </OutlineButton>
           </div>
         </div>
       </Modal>

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -145,5 +145,8 @@
     "body2": "Build a pause later if you want your protocol to proceed to the next steps while the temperature module ramps up to {{temperature}}°C.",
     "now_button": "Pause protocol now",
     "later_button": "I will build a pause later"
+  },
+  "step_notes": {
+    "title": "Step Notes"
   }
 }


### PR DESCRIPTION
# Overview


This PR closes #6833 by normalizing modal styles and form spacing for the rename/notes modal for any individual step

<img width="644" alt="Screen Shot 2020-11-05 at 3 46 06 PM" src="https://user-images.githubusercontent.com/3430313/98295120-0e877c80-1f7f-11eb-800a-07fc878cad48.png">
# Changelog

- refactor: Update step rename and notes modal styles

# Review requests

Make a step, click the notes button
- [ ] should look like screen shot (form field spacing, sizing, titles and border radius on modal)
- [ ] cancel doesn't edit, simply closes
- [ ] save does
- [ ] after saving the step, step is renamed, and motes are visible in sidebar when viewing step details in sidebar


# Risk assessment

Low. PD styling consistency snacklog