### PR TITLE
fix(app): change pipette exit button text

### DIFF
--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -204,7 +204,8 @@ function ExitButton(props: Props) {
   const { exit, attachedWrong, actualPipetteOffset, wantedPipette } = props
   let buttonText = EXIT_BUTTON_MESSAGE
   if (attachedWrong) buttonText = EXIT_BUTTON_MESSAGE_WRONG
-  else if (Boolean(wantedPipette) && !actualPipetteOffset) buttonText = EXIT_WITHOUT_CAL
+  else if (Boolean(wantedPipette) && !actualPipetteOffset)
+    buttonText = EXIT_WITHOUT_CAL
 
   return (
     <PrimaryBtn marginBottom={SPACING_2} width="100%" onClick={exit}>

--- a/app/src/components/ChangePipette/ConfirmPipette.js
+++ b/app/src/components/ChangePipette/ConfirmPipette.js
@@ -201,10 +201,10 @@ function TryAgainButton(props: Props) {
 }
 
 function ExitButton(props: Props) {
-  const { exit, attachedWrong, actualPipetteOffset } = props
+  const { exit, attachedWrong, actualPipetteOffset, wantedPipette } = props
   let buttonText = EXIT_BUTTON_MESSAGE
   if (attachedWrong) buttonText = EXIT_BUTTON_MESSAGE_WRONG
-  else if (!actualPipetteOffset) buttonText = EXIT_WITHOUT_CAL
+  else if (Boolean(wantedPipette) && !actualPipetteOffset) buttonText = EXIT_WITHOUT_CAL
 
   return (
     <PrimaryBtn marginBottom={SPACING_2} width="100%" onClick={exit}>


### PR DESCRIPTION
If you don't detach a pipette during the detach step, you shouldn't be
prompted to "skip calibration".
