### PR TITLE
refactor(app): add more information on xy jog

### DIFF
--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -64,8 +64,9 @@ const TO_USE_Z =
   'button to use this z position for the rest of deck calibration'
 const CALIBRATION_HEALTH_TO_DETERMINE =
   'button to determine how this position compares to the previously saved z-axis calibration coordinate'
-const ALLOW_HORIZONTAL_TEXT =
-  'Need to jog across the deck to align the pipette in slot 5?'
+const ALLOW_HORIZONTAL_TEXT = 'Reveal XY jog controls to move across deck'
+const ALLOW_XY_JOG_INSTRUCTIONS =
+  'If the pipette is over the embossed 5, on the ridge of the slot, or hard to see, reveal the jog controls to move the pipette across the deck.'
 
 const contentsBySessionType: {
   [SessionType]: {
@@ -180,6 +181,9 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
           {THEN}
           <b>{` '${buttonText}' `}</b>
           {isHealthCheck ? CALIBRATION_HEALTH_TO_DETERMINE : TO_USE_Z}.
+          <br />
+          <br />
+          {ALLOW_XY_JOG_INSTRUCTIONS}
         </Text>
         <video
           key={demoAsset}

--- a/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
@@ -113,9 +113,7 @@ describe('SaveZPoint', () => {
       expect(getJogButton(wrapper, dir).exists()).toBe(false)
     })
     wrapper
-      .find(
-        'button[children="Reveal XY jog controls to move across deck"]'
-      )
+      .find('button[children="Reveal XY jog controls to move across deck"]')
       .invoke('onClick')({ preventDefault: () => {} })
     jogDirections.forEach(direction => {
       getJogButton(wrapper, direction).invoke('onClick')()

--- a/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
+++ b/app/src/components/CalibrationPanels/__tests__/SaveZPoint.test.js
@@ -114,7 +114,7 @@ describe('SaveZPoint', () => {
     })
     wrapper
       .find(
-        'button[children="Need to jog across the deck to align the pipette in slot 5?"]'
+        'button[children="Reveal XY jog controls to move across deck"]'
       )
       .invoke('onClick')({ preventDefault: () => {} })
     jogDirections.forEach(direction => {


### PR DESCRIPTION
In user testing, it's not entirely clear why you would want to enable xy
jog when jogging to the deck, or where you would want to jog to. This
adds more information.

