### PR TITLE
fix(robot-server): calcheck: fix invalidation, pickup, retract

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/check/state_machine.py
@@ -24,7 +24,7 @@ CALIBRATION_CHECK_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
     State.preparingPipette: {
         CalibrationCommand.jog: State.preparingPipette,
         CalibrationCommand.pick_up_tip: State.inspectingTip,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.inspectingTip: {
         CalibrationCommand.invalidate_tip: State.preparingPipette,
@@ -34,32 +34,32 @@ CALIBRATION_CHECK_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
         CheckCalibrationCommand.compare_point: State.comparingTip,
         CalibrationCommand.jog: State.comparingTip,
         CalibrationCommand.move_to_deck: State.comparingHeight,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.comparingHeight: {
         CalibrationCommand.jog: State.comparingHeight,
         CheckCalibrationCommand.compare_point: State.comparingHeight,
         CalibrationCommand.move_to_point_one: State.comparingPointOne,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.comparingPointOne: {
         CalibrationCommand.jog: State.comparingPointOne,
         CheckCalibrationCommand.compare_point: State.comparingPointOne,
         DeckCalibrationCommand.move_to_point_two: State.comparingPointTwo,
         CalibrationCommand.move_to_tip_rack: State.returningTip,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.comparingPointTwo: {
         CalibrationCommand.jog: State.comparingPointTwo,
         CheckCalibrationCommand.compare_point: State.comparingPointTwo,
         DeckCalibrationCommand.move_to_point_three: State.comparingPointThree,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.comparingPointThree: {
         CalibrationCommand.jog: State.comparingPointThree,
         CheckCalibrationCommand.compare_point: State.comparingPointThree,
         CalibrationCommand.move_to_tip_rack: State.returningTip,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.preparingPipette
     },
     State.returningTip: {
         CheckCalibrationCommand.return_tip: State.returningTip,

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -58,6 +58,7 @@ def mock_hw(hardware):
     hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
     hardware.move_to = MagicMock(side_effect=async_mock_move_to)
     hardware.get_instrument_max_height.return_value = 180
+    hardware.retract = MagicMock(side_effect=async_mock)
     return hardware
 
 


### PR DESCRIPTION
Fix three bugs in calibration check:
- Invalidation moving to the wrong place and getting out of sync with
the app
- Retract the pipette after dropping the first tip, so the user has
space to switch tipracks
- Reset the tip origin when you switch pipettes, so the second pipette
moves to the right default location for its tiprack rather than the
saved point from the first tiprack

## Testing
- invalidate from various places and make sure it all lines up
- Check that the pipette retracts when you switch after returning the tip
- Check that the second pipette moves to the appropriate default place relative to the tiprack