### PR TITLE
fix(app): Handle cal data without status

### DIFF
--- a/app/src/components/RobotSettings/PipetteOffsetItem.js
+++ b/app/src/components/RobotSettings/PipetteOffsetItem.js
@@ -169,8 +169,8 @@ export function PipetteOffsetItem(props: Props): React.Node {
         marginBottom={SPACING_2}
       >
         {pipette &&
-          (calibration?.offset?.status.markedBad ||
-            calibration?.tipLength?.status.markedBad) && (
+          (calibration?.offset?.status?.markedBad ||
+            calibration?.tipLength?.status?.markedBad) && (
             <InlineCalibrationWarning
               marginTop={'0'}
               warningType={RECOMMENDED}

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -10,7 +10,10 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { PipetteOffsetItem, TipLengthSection } from '../PipetteOffsetItem'
 import { InlineCalibrationWarning } from '../../InlineCalibrationWarning'
 import { findLabwareDefWithCustom } from '../../../findLabware'
-import type {PipetteOffsetCalibration, TipLengthCalibration} from '../../../calibration/types'
+import type {
+  PipetteOffsetCalibration,
+  TipLengthCalibration,
+} from '../../../calibration/types'
 
 jest.mock('../../../findLabware')
 
@@ -123,8 +126,8 @@ describe('PipetteOffsetItem', () => {
           pipette: 'pipette-id-11',
           lastModified: '2020-09-10T05:10Z',
           source: 'user',
-        }: $Shape<TipLengthCalibration>)
-      }
+        }: $Shape<TipLengthCalibration>),
+      },
     })
     expect(wrapper.find('PipetteOffsetItem')).not.toBeNull()
   })

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -7,10 +7,10 @@ import type {
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
-import { PipetteOffsetItem } from '../PipetteOffsetItem'
+import { PipetteOffsetItem, TipLengthSection } from '../PipetteOffsetItem'
 import { InlineCalibrationWarning } from '../../InlineCalibrationWarning'
-
 import { findLabwareDefWithCustom } from '../../../findLabware'
+import type {PipetteOffsetCalibration, TipLengthCalibration} from '../../../calibration/types'
 
 jest.mock('../../../findLabware')
 
@@ -101,6 +101,32 @@ describe('PipetteOffsetItem', () => {
         />
       )
     }
+  })
+
+  it('renders acceptably when talking to a robot with cal data but no status', () => {
+    const wrapper = render({
+      calibration: {
+        offset: ({
+          pipette: 'pipette-id-11',
+          mount: 'left',
+          offset: [1, 2, 3],
+          tiprack: 'asdagasdfasdsa',
+          tiprackUri: 'opentrons/opentrons_96_tiprack_300ul/1',
+          lastModified: '2020-09-10T05:13Z',
+          source: 'user',
+          id: 'a_pip_id',
+        }: $Shape<PipetteOffsetCalibration>),
+        tipLength: ({
+          id: '1',
+          tipLength: 30,
+          tiprack: 'asdagasdfasdsa',
+          pipette: 'pipette-id-11',
+          lastModified: '2020-09-10T05:10Z',
+          source: 'user',
+        }: $Shape<TipLengthCalibration>)
+      }
+    })
+    expect(wrapper.find('PipetteOffsetItem')).not.toBeNull()
   })
 
   it('shows null when no pipette present', () => {

--- a/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
+++ b/app/src/components/RobotSettings/__tests__/PipetteOffsetItem.test.js
@@ -7,7 +7,7 @@ import type {
   LabwareDefinition2,
 } from '@opentrons/shared-data'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
-import { PipetteOffsetItem, TipLengthSection } from '../PipetteOffsetItem'
+import { PipetteOffsetItem } from '../PipetteOffsetItem'
 import { InlineCalibrationWarning } from '../../InlineCalibrationWarning'
 import { findLabwareDefWithCustom } from '../../../findLabware'
 import type {


### PR DESCRIPTION
If a user was on 3.21.0, which doesn't express status but does express
calibration if they have the data (e.g. from being in a user text), the
robot pane wouldn't render so they couldn't even update their robot.
