### PR TITLE
refactor: Shrink edit pipettes modal height

### DIFF
--- a/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
+++ b/protocol-designer/src/components/modals/FilePipettesModal/FilePipettesModal.css
@@ -41,6 +41,10 @@
   justify-content: space-between;
 }
 
+.edit_pipettes_modal {
+  height: auto;
+}
+
 .new_file_modal_title {
   @apply --font-header-dark;
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.js
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.js
@@ -254,7 +254,8 @@ export class FilePipettesModal extends React.Component<Props, State> {
         <Modal
           contentsClassName={cx(
             styles.new_file_modal_contents,
-            modalStyles.scrollable_modal_wrapper
+            modalStyles.scrollable_modal_wrapper,
+            { [styles.edit_pipettes_modal]: !showProtocolFields }
           )}
           className={cx(modalStyles.modal, styles.new_file_modal)}
         >


### PR DESCRIPTION
# Overview

closes #6831 by shrinking the edit pipettes modal


# Changelog

- refactor: Shrink edit pipettes modal height

# Review requests

- [ ] New file modal still scrolls (select a crashable pipette and module to confirm
- [ ] Edit pipettes modal now fits content

# Risk assessment

low. CSS
