### PR TITLE
refactor: Fix upload file modal styles

### DIFF
--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -19,7 +19,7 @@ export function FileUploadMessageModal(props: Props): React.Node {
   if (!message) return null
 
   const { title, body, okButtonText } = getModalContents(message)
-  const buttons = [
+  let buttons = [
     {
       children: okButtonText || 'ok',
       onClick: dismissModal,
@@ -31,6 +31,16 @@ export function FileUploadMessageModal(props: Props): React.Node {
       className: modalStyles.bottom_button,
     },
   ]
+  if (title === 'Incorrect file type' || title === 'Invalid JSON file') {
+    buttons = [
+      {
+        children: okButtonText || 'ok',
+        onClick: dismissModal,
+        className: modalStyles.button_medium,
+      },
+    ]
+  }
+
   return (
     <AlertModal
       heading={title}

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -1,6 +1,7 @@
 // @flow
 import { i18n } from '../../../localization'
 import * as React from 'react'
+import cx from 'classnames'
 import { AlertModal, OutlineButton } from '@opentrons/components'
 import modalStyles from '../modal.css'
 import { getModalContents } from './modalContents'
@@ -22,11 +23,12 @@ export function FileUploadMessageModal(props: Props): React.Node {
     {
       children: okButtonText || 'ok',
       onClick: dismissModal,
-      className: modalStyles.ok_button,
+      className: modalStyles.button_medium,
     },
     {
       children: i18n.t('button.cancel'),
       onClick: cancelProtocolMigration,
+      className: modalStyles.bottom_button,
     },
   ]
   return (
@@ -38,12 +40,15 @@ export function FileUploadMessageModal(props: Props): React.Node {
     >
       <div className={modalStyles.scrollable_modal_wrapper}>
         <div className={modalStyles.scrollable_modal_scroll}>{body}</div>
-        <div>
+        <div className={modalStyles.button_row}>
           {buttons.map((button, index) => (
             <OutlineButton
               {...button}
               key={index}
-              className={modalStyles.bottom_button}
+              className={cx(
+                modalStyles.bottom_button,
+                modalStyles.button_medium
+              )}
             />
           ))}
         </div>

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.js
@@ -21,14 +21,14 @@ export function FileUploadMessageModal(props: Props): React.Node {
   const { title, body, okButtonText } = getModalContents(message)
   let buttons = [
     {
-      children: okButtonText || 'ok',
-      onClick: dismissModal,
-      className: modalStyles.button_medium,
-    },
-    {
       children: i18n.t('button.cancel'),
       onClick: cancelProtocolMigration,
       className: modalStyles.bottom_button,
+    },
+    {
+      children: okButtonText || 'ok',
+      onClick: dismissModal,
+      className: modalStyles.button_medium,
     },
   ]
   if (title === 'Incorrect file type' || title === 'Invalid JSON file') {

--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.js
@@ -120,13 +120,15 @@ export const LabwareUploadMessageModal = (props: Props): React.Node => {
       alertOverlay
     >
       <MessageBody message={message} />
-      {buttons.map((button, index) => (
-        <OutlineButton
-          {...button}
-          key={index}
-          className={cx(modalStyles.bottom_button, button.className)}
-        />
-      ))}
+      <div className={modalStyles.button_row}>
+        {buttons.map((button, index) => (
+          <OutlineButton
+            {...button}
+            key={index}
+            className={cx(modalStyles.button_medium, button.className)}
+          />
+        ))}
+      </div>
     </AlertModal>
   )
 }

--- a/protocol-designer/src/components/modals/modal.css
+++ b/protocol-designer/src/components/modals/modal.css
@@ -71,6 +71,11 @@
 .scrollable_modal_contents {
   display: flex;
   width: 100%;
+
+  & p {
+    line-height: var(--lh-copy);
+    margin-top: 0.5rem;
+  }
 }
 
 .scrollable_modal_scroll {


### PR DESCRIPTION
# Overview

closes #4387 by updating the button sizing and adding a line height and spacing to the `<p>` tags in content

# Changelog

- refactor: Fix upload file modal styles

# Review requests

_note: I was on a modal roll and branched off of my last PR instead of edge, so I need to rebase once it's merged, so the changelog is not deja vu. Please review the second commit only here!_ 

Upload a .py file to PD
- [ ] invalid file modal has proper paragraph spacing and buttons

Upload a custom tiprack (new file modal)
- [ ] invalid file modal has proper paragraph spacing and buttons

Upload an invalid custom labware (deck setup)
- [ ] invalid file modal has proper paragraph spacing and buttons

# Risk assessment

low, CSS
