### PR TITLE
fix(robot-server,api): reset cal during dc process

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -365,6 +365,23 @@ class API(HardwareAPILike):
         else:
             _reset(mount)
 
+    def set_instrument_offset(
+            self, mount: top_types.Mount, new_offset: top_types.Point):
+        """
+        Temporarily (i.e., without saving to disk) override the instrument
+        offset of the instrument attached to ``mount``. This should only be
+        used in calibration workflows where the device under calibration
+        should be using no calibration at all, to avoid altering the saved
+        calibration.
+
+        To reload the saved value, call :py:meth:`cache_instruments` again.
+        """
+        pip = self._attached_instruments[mount]
+        if not pip:
+            raise top_types.PipetteNotAttachedError(
+                f'No pipette attached to {mount.name} mount')
+        pip.update_instrument_offset(new_offset)
+
     async def cache_instruments(
             self,
             require: Dict[top_types.Mount, 'PipetteName'] = None):
@@ -1769,7 +1786,7 @@ class API(HardwareAPILike):
         :type mount: opentrons.types.Mount
         """
         # Clear the old offset during calibration
-        pip.update_instrument_offset(top_types.Point())
+        self.set_instrument_offset(mount, top_types.Point())
         # Hotspots based on our expectation of tip length and config
         hotspots = robot_configs.calculate_tip_probe_hotspots(
             pip.current_tip_length, self._config.tip_probe)
@@ -1898,6 +1915,9 @@ class API(HardwareAPILike):
         This will update both the stored value in the robot settings and
         the live value in the currently-loaded pipette.
 
+        If you just want to change the live value for the currently-attached
+        instrument without saving it, use :py:meth:`.set_instrument_offset`.
+
         This can be specified either directly by using the new_offset arg
         or using the result of a previous call to
         :py:meth:`locate_tip_probe_center` with the same mount.
@@ -1925,7 +1945,7 @@ class API(HardwareAPILike):
                                                    new_offset.y,
                                                    new_offset.z]
         await self.update_config(instrument_offset=inst_offs)
-        pip.update_instrument_offset(new_offset)
+        self.set_instrument_offset(mount, new_offset)
         robot_configs.save_robot_settings(self._config)
 
     def get_instrument_max_height(

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -325,7 +325,8 @@ def _reload_and_check_skip(
     # are similar enough that we might skip, see if the configs
     # match closely enough.
     # Returns a pipette object and True if we may skip hw reconfig
-    if new_config == attached_instr.config:
+    if new_config == attached_instr.config\
+       and pipette_offset == attached_instr._pipette_offset:
         # Same config, good enough
         return attached_instr, True
     else:

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -19,6 +19,17 @@ class RobotCalibration:
     deck_calibration: types.DeckCalibration
 
 
+def build_temporary_identity_calibration() -> RobotCalibration:
+    """
+    Get a temporary identity deck cal suitable for use during
+    calibration
+    """
+    return RobotCalibration(
+        deck_calibration=types.DeckCalibration(
+            attitude=linal.identity_deck_transform().tolist(),
+            source=types.SourceType.default,
+            status=types.CalibrationStatus()))
+
 def validate_attitude_deck_calibration(deck_cal: types.DeckCalibration):
     """
     This function determines whether the deck calibration is valid

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -30,6 +30,7 @@ def build_temporary_identity_calibration() -> RobotCalibration:
             source=types.SourceType.default,
             status=types.CalibrationStatus()))
 
+
 def validate_attitude_deck_calibration(deck_cal: types.DeckCalibration):
     """
     This function determines whether the deck calibration is valid

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -15,11 +15,11 @@ from opentrons.hardware_control.pipette import Pipette
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
+from opentrons.util import linal
 
 from robot_server.robot.calibration.constants import \
     TIP_RACK_LOOKUP_BY_MAX_VOL
 from robot_server.service.errors import RobotServerError
-from opentrons.util import linal
 
 from robot_server.service.session.models.command import (
     CalibrationCommand, DeckCalibrationCommand)
@@ -100,6 +100,8 @@ class DeckCalibrationUserFlow:
             CalibrationCommand.exit: self.exit_session,
             CalibrationCommand.invalidate_last_action: self.invalidate_last_action,  # noqa: E501
         }
+        self.hardware.set_robot_calibration(
+            robot_cal.build_temporary_identity_calibration())
 
     @property
     def deck(self) -> Deck:

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -248,6 +248,8 @@ class DeckCalibrationUserFlow:
                                       delta=Point(*vector))
 
     async def move_to_tip_rack(self):
+        if self._current_state == State.labwareLoaded:
+            await self.hardware.home()
         await self._move(Location(self.tip_origin, None))
 
     async def move_to_deck(self):

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -47,7 +47,6 @@ class DeckCalibrationSession(BaseSession):
         session_controls_lights =\
             not configuration.hardware.get_lights()['rails']
         await configuration.hardware.cache_instruments()
-        await configuration.hardware.home()
         try:
             deck_cal_user_flow = DeckCalibrationUserFlow(
                 hardware=configuration.hardware)


### PR DESCRIPTION
We shouldn't use the currently-set calibration data when we're executing
deck cal, since it's likely to be wrong in annoying ways. Instead, we
should temporarily set the deck calibration to identity, and also
temporarily reset the calibration for the instrument we're using.

## Testing
- Run deck calibration several times in a row. It should always go to the same place when it goes to points and tiprack.
- If you jog the same amount, it should always save the same data.