### PR TITLE
refactor(app): display missing calibration errors in robot calibration card

### DIFF
--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -29,6 +29,7 @@ import {
   FONT_WEIGHT_REGULAR,
   FONT_SIZE_HEADER,
   C_DARK_GRAY,
+  C_BLUE,
 } from '@opentrons/components'
 
 import {
@@ -36,6 +37,7 @@ import {
   DISABLED_CANNOT_CONNECT,
   DISABLED_CONNECT_TO_ROBOT,
   DISABLED_PROTOCOL_IS_RUNNING,
+  DISABLED_NO_PIPETTE_ATTACHED,
 } from './constants'
 import { DeckCalibrationControl } from './DeckCalibrationControl'
 import { CheckCalibrationControl } from './CheckCalibrationControl'
@@ -91,6 +93,10 @@ export function CalibrationCard(props: Props): React.Node {
     return Calibration.getTipLengthCalibrations(state, robotName)
   })
 
+  const attachedPipettes = useSelector((state: State) => {
+    return Pipettes.getAttachedPipettes(state, robotName)
+  })
+  const pipetteAttached = !!attachedPipettes.left && attachedPipettes.right
   const doTrackEvent = useTrackEvent()
 
   let buttonDisabledReason = null
@@ -100,6 +106,8 @@ export function CalibrationCard(props: Props): React.Node {
     buttonDisabledReason = DISABLED_CONNECT_TO_ROBOT
   } else if (isRunning) {
     buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
+  } else if (!pipetteAttached) {
+    buttonDisabledReason = DISABLED_NO_PIPETTE_ATTACHED
   }
 
   const onClickSaveAs = e => {
@@ -122,10 +130,10 @@ export function CalibrationCard(props: Props): React.Node {
     Calibration.DECK_CAL_STATUS_BAD_CALIBRATION,
     Calibration.DECK_CAL_STATUS_IDENTITY,
   ].includes(deckCalStatus)
-
   const pipOffsetDataPresent = pipetteOffsetCalibrations
     ? pipetteOffsetCalibrations.length > 0
     : false
+
   return (
     <Card>
       <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} alignItems={ALIGN_BASELINE}>
@@ -140,24 +148,20 @@ export function CalibrationCard(props: Props): React.Node {
         >
           {TITLE}
         </Text>
-        <Link
-          href="#"
-          paddingTop={SPACING_3}
-          paddingX={SPACING_3}
-          fontSize={FONT_SIZE_BODY_1}
-          onClick={onClickSaveAs}
-        >
-          {DOWNLOAD_CALIBRATION}
-        </Link>
+        {!warningInsteadOfCalcheck ? (
+          <Link
+            href="#"
+            color={C_BLUE}
+            paddingTop={SPACING_3}
+            paddingX={SPACING_3}
+            fontSize={FONT_SIZE_BODY_1}
+            onClick={onClickSaveAs}
+          >
+            {DOWNLOAD_CALIBRATION}
+          </Link>
+        ) : null}
       </Flex>
-      {warningInsteadOfCalcheck ? (
-        <CalibrationCardWarning />
-      ) : (
-        <CheckCalibrationControl
-          robotName={robotName}
-          disabledReason={buttonDisabledReason}
-        />
-      )}
+      {warningInsteadOfCalcheck ? <CalibrationCardWarning /> : null}
       <DeckCalibrationControl
         robotName={robotName}
         disabledReason={buttonDisabledReason}
@@ -166,6 +170,12 @@ export function CalibrationCard(props: Props): React.Node {
         pipOffsetDataPresent={pipOffsetDataPresent}
       />
       <PipetteOffsets pipettesPageUrl={pipettesPageUrl} robot={robot} />
+      {!warningInsteadOfCalcheck ? (
+        <CheckCalibrationControl
+          robotName={robotName}
+          disabledReason={buttonDisabledReason}
+        />
+      ) : null}
     </Card>
   )
 }

--- a/app/src/components/RobotSettings/CalibrationCard.js
+++ b/app/src/components/RobotSettings/CalibrationCard.js
@@ -199,7 +199,7 @@ export function CalibrationCard(props: Props): React.Node {
         pipOffsetDataPresent={pipOffsetDataPresent}
       />
       <PipetteOffsets pipettesPageUrl={pipettesPageUrl} robot={robot} />
-      {!warningInsteadOfCalcheck ? (
+      {!warningInsteadOfCalcheck && pipettePresent ? (
         <CheckCalibrationControl
           robotName={robotName}
           disabledReason={buttonDisabledReason}

--- a/app/src/components/RobotSettings/CalibrationCardWarning.js
+++ b/app/src/components/RobotSettings/CalibrationCardWarning.js
@@ -13,7 +13,6 @@ import {
   FONT_WEIGHT_SEMIBOLD,
   Icon,
   SIZE_2,
-  SPACING_3,
   SPACING_2,
   SPACING_1,
   Text,

--- a/app/src/components/RobotSettings/CalibrationCardWarning.js
+++ b/app/src/components/RobotSettings/CalibrationCardWarning.js
@@ -6,6 +6,7 @@ import {
   ALIGN_CENTER,
   Box,
   Flex,
+  BORDER_SOLID_LIGHT,
   COLOR_ERROR,
   DIRECTION_COLUMN,
   FONT_SIZE_BODY_1,
@@ -21,16 +22,20 @@ import {
 
 import type { StyleProps } from '@opentrons/components'
 
-const WARNING_HEADER = 'full robot calibration needed'
-const WARNING_TEXT =
-  'This OT-2 does not have a valid deck calibration. Deck calibration matches the motion of the OT-2 to its deck, and must be performed before you can run a protocol. To perform deck calibration, click the Calibrate button below.'
+const WARNING_HEADER = 'robot calibration required'
+const WARNING_TEXT = 'This OT-2 does not have a valid deck calibration.'
 
 type Props = {|
   ...StyleProps,
 |}
 export function CalibrationCardWarning({ ...styleProps }: Props): React.Node {
   return (
-    <Box padding={SPACING_3} color={COLOR_ERROR} {...styleProps}>
+    <Box
+      borderBottom={BORDER_SOLID_LIGHT}
+      padding="0.5rem 1rem 1rem"
+      color={COLOR_ERROR}
+      {...styleProps}
+    >
       <Flex flexDirection={DIRECTION_COLUMN} fontSize={FONT_SIZE_BODY_1}>
         <Flex alignItems={ALIGN_CENTER}>
           <Box paddingY={SPACING_1} paddingRight={SPACING_2} size={SIZE_2}>
@@ -45,7 +50,7 @@ export function CalibrationCardWarning({ ...styleProps }: Props): React.Node {
           </Text>
         </Flex>
         <Flex>
-          <Box size={SIZE_2} flex="1 1 auto" minWidth={SIZE_2} />
+          <Box minWidth={SIZE_2} />
           <Text>{WARNING_TEXT}</Text>
         </Flex>
       </Flex>

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -32,7 +32,7 @@ export type CheckCalibrationControlProps = {|
 const CAL_HEALTH_CHECK = 'Calibration Health Check'
 const CHECK_HEALTH = 'check health'
 const CAL_HEALTH_CHECK_DESCRIPTION =
-  'Check the calibration settings for your robot.'
+  'Check the health of the current calibration settings.'
 const EXIT = 'exit'
 
 // pipette calibration commands for which the full page spinner should not appear

--- a/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/components/RobotSettings/__tests__/CalibrationCard.test.js
@@ -200,16 +200,14 @@ describe('CalibrationCard', () => {
     )
   })
 
-  it('DC and check cal buttons disabled if no pipette attached', () => {
+  it('DC buttons disabled and check cal not renderedif no pipette attached', () => {
     getAttachedPipettes.mockReturnValue({ left: null, right: null })
     const { wrapper } = render()
 
     expect(getDeckCalButton(wrapper).prop('disabled')).toBe(
       'Attach a pipette to proceed'
     )
-    expect(getCheckCalibrationControl(wrapper).prop('disabledReason')).toBe(
-      'Attach a pipette to proceed'
-    )
+    expect(wrapper.exists(CheckCalibrationControl)).toBe(false)
   })
 
   it('DC and check cal buttons disabled if not connectable', () => {

--- a/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
+++ b/app/src/components/RobotSettings/__tests__/CheckCalibrationControl.test.js
@@ -68,7 +68,7 @@ describe('CheckCalibrationControl', () => {
 
     expect(titledButton.prop('title')).toMatch(/Calibration Health Check/)
     expect(titledButton.html()).toMatch(
-      /check the calibration settings for your robot/i
+      /check the health of the current calibration settings/i
     )
     expect(button.prop('width')).toBe('12rem')
     expect(button.html()).toMatch(/check health/i)

--- a/app/src/components/RobotSettings/constants.js
+++ b/app/src/components/RobotSettings/constants.js
@@ -5,3 +5,4 @@ export const DECK_CAL_STATUS_POLL_INTERVAL = 10000
 export const DISABLED_CANNOT_CONNECT = 'Cannot connect to robot'
 export const DISABLED_CONNECT_TO_ROBOT = 'Connect to robot to control'
 export const DISABLED_PROTOCOL_IS_RUNNING = 'Protocol is running'
+export const DISABLED_NO_PIPETTE_ATTACHED = 'Attach a pipette to proceed'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
closes #6874 
This PR updates the robot calibration card according to this [design](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=791%3A872):
1. changing the `Robot Calibration Required` warning text for when any of the robot cal is missing, or if deck cal is not valid
2. when the above warning is shown, do not display Calibration Health Check
3. when no pipettes are attached, disable Deck Calibration button and do not display cal check card
4. moving Calibration Health Check to the bottom of the calibration card
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Review requests
Am i missing anything?
<!--
Describe any requests for your reviewers here.
-->
