### PR TITLE
refactor(app): cal check wizard shown if session in redux, rename cal check vars 

### DIFF
--- a/app/src/components/CalibrationPanels/Introduction.js
+++ b/app/src/components/CalibrationPanels/Introduction.js
@@ -60,7 +60,7 @@ const PIP_OFFSET_CAL_INTRO_FRAGMENT = 'Calibrating'
 const PIP_OFFSET_CAL_EXPLANATION_FRAGMENT =
   'enables the robot to accurately establish the location of the mounted pipette’s nozzle, relative to the deck.'
 const PIP_OFFSET_REQUIRES_TIP_LENGTH =
-  'You don’t have a tip length saved with this pipette yet. You will need to calibrate tip length before calibrating you pipette offset.'
+  'You don’t have a tip length saved with this pipette yet. You will need to calibrate tip length before calibrating your pipette offset.'
 
 const TIP_LENGTH_CAL_HEADER = 'tip length calibration'
 const TIP_LENGTH_CAL_NAME_FRAGMENT = 'Tip length'

--- a/app/src/components/CalibrationPanels/types.js
+++ b/app/src/components/CalibrationPanels/types.js
@@ -4,8 +4,8 @@ import type {
   SessionType,
   CalibrationSessionStep,
   CalibrationLabware,
-  CalibrationHealthCheckInstrument,
-  CalibrationHealthCheckComparisonByPipette,
+  CalibrationCheckInstrument,
+  CalibrationCheckComparisonByPipette,
 } from '../../sessions/types'
 
 import typeof {
@@ -61,8 +61,8 @@ export type CalibrationPanelProps = {|
   calBlock?: CalibrationLabware | null,
   shouldPerformTipLength?: boolean | null,
   checkBothPipettes?: boolean | null,
-  instruments?: Array<CalibrationHealthCheckInstrument> | null,
-  comparisonsByPipette?: CalibrationHealthCheckComparisonByPipette | null,
-  activePipette?: CalibrationHealthCheckInstrument,
+  instruments?: Array<CalibrationCheckInstrument> | null,
+  comparisonsByPipette?: CalibrationCheckComparisonByPipette | null,
+  activePipette?: CalibrationCheckInstrument,
   intent?: Intent,
 |}

--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -33,8 +33,8 @@ import { NeedHelpLink } from '../CalibrationPanels/NeedHelpLink'
 
 import type { CalibrationPanelProps } from '../CalibrationPanels/types'
 import type {
-  CalibrationHealthCheckInstrument,
-  CalibrationHealthCheckComparisonsPerCalibration,
+  CalibrationCheckInstrument,
+  CalibrationCheckComparisonsPerCalibration,
 } from '../../sessions/types'
 
 const GOOD_CALIBRATION = 'Good calibration'
@@ -69,11 +69,11 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
 
   const leftPipette = find(
     instruments,
-    (p: CalibrationHealthCheckInstrument) => p.mount.toLowerCase() === LEFT
+    (p: CalibrationCheckInstrument) => p.mount.toLowerCase() === LEFT
   )
   const rightPipette = find(
     instruments,
-    (p: CalibrationHealthCheckInstrument) => p.mount.toLowerCase() === RIGHT
+    (p: CalibrationCheckInstrument) => p.mount.toLowerCase() === RIGHT
   )
 
   const calibrationsByMount = {
@@ -198,8 +198,8 @@ function RenderResult(props: RenderResultProps): React.Node {
 }
 
 type PipetteResultProps = {|
-  pipetteInfo: CalibrationHealthCheckInstrument,
-  pipetteCalibration: CalibrationHealthCheckComparisonsPerCalibration,
+  pipetteInfo: CalibrationCheckInstrument,
+  pipetteCalibration: CalibrationCheckComparisonsPerCalibration,
 |}
 
 function PipetteResult(props: PipetteResultProps): React.Node {

--- a/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
+++ b/app/src/components/CheckCalibration/__tests__/CheckCalibration.test.js
@@ -7,7 +7,7 @@ import { act } from 'react-dom/test-utils'
 import * as Sessions from '../../../sessions'
 import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefinitions'
 
-import { CheckHealthCalibration } from '../index'
+import { CheckCalibration } from '../index'
 import { ResultsSummary } from '../ResultsSummary'
 import { ReturnTip } from '../ReturnTip'
 import {
@@ -93,7 +93,7 @@ describe('CheckCalibration', () => {
     render = (props = {}) => {
       const { showSpinner = false, isJogging = false } = props
       return mount(
-        <CheckHealthCalibration
+        <CheckCalibration
           robotName="robot-name"
           session={mockCalibrationCheckSession}
           dispatchRequests={dispatchRequests}

--- a/app/src/components/CheckCalibration/index.js
+++ b/app/src/components/CheckCalibration/index.js
@@ -38,7 +38,7 @@ import type {
 } from '../../sessions/types'
 
 import type { CalibrationPanelProps } from '../CalibrationPanels/types'
-import type { CalibrationHealthCheckParentProps } from './types'
+import type { CalibrationCheckParentProps } from './types'
 
 const ROBOT_CALIBRATION_CHECK_SUBTITLE = 'Calibration health check'
 const EXIT = 'exit'
@@ -98,8 +98,8 @@ const PANEL_STYLE_PROPS_BY_STEP: {
   [Sessions.CHECK_STEP_COMPARING_POINT_THREE]: terminalContentsStyleProps,
 }
 
-export function CheckHealthCalibration(
-  props: CalibrationHealthCheckParentProps
+export function CheckCalibration(
+  props: CalibrationCheckParentProps
 ): React.Node {
   const { session, robotName, dispatchRequests, showSpinner, isJogging } = props
   const {

--- a/app/src/components/CheckCalibration/types.js
+++ b/app/src/components/CheckCalibration/types.js
@@ -1,10 +1,6 @@
 // @flow
 import type { Action } from '../../types'
-import type {
-  SessionCommandParams,
-  CalibrationCheckSession,
-  CalibrationLabware,
-} from '../../sessions/types'
+import type { CalibrationCheckSession } from '../../sessions/types'
 
 export type CalibrationCheckParentProps = {|
   robotName: string,

--- a/app/src/components/CheckCalibration/types.js
+++ b/app/src/components/CheckCalibration/types.js
@@ -4,7 +4,6 @@ import type {
   SessionCommandParams,
   CalibrationCheckSession,
   CalibrationLabware,
-  RobotCalibrationCheckStep,
 } from '../../sessions/types'
 
 export type CalibrationCheckParentProps = {|

--- a/app/src/components/CheckCalibration/types.js
+++ b/app/src/components/CheckCalibration/types.js
@@ -7,7 +7,7 @@ import type {
   RobotCalibrationCheckStep,
 } from '../../sessions/types'
 
-export type CalibrationHealthCheckParentProps = {|
+export type CalibrationCheckParentProps = {|
   robotName: string,
   session: CalibrationCheckSession | null,
   dispatchRequests: (
@@ -16,13 +16,4 @@ export type CalibrationHealthCheckParentProps = {|
   isJogging: boolean,
   showSpinner: boolean,
   hasBlock?: boolean,
-|}
-
-export type CalibrateHealthCheckChildProps = {|
-  sendSessionCommands: (...Array<SessionCommandParams>) => void,
-  deleteSession: () => void,
-  tipRackList: Array<CalibrationLabware>,
-  isMulti: boolean,
-  mount: string,
-  currentStep: RobotCalibrationCheckStep,
 |}

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -15,9 +15,9 @@ import {
 } from '@opentrons/components'
 
 import { Portal } from '../portal'
-import { CheckHealthCalibration } from '../CheckCalibration'
+import { CheckCalibration } from '../CheckCalibration'
 import { TitledControl } from '../TitledControl'
-import { AskForCalibrationBlockModal } from '../../components/CalibrateTipLength/AskForCalibrationBlockModal'
+import { AskForCalibrationBlockModal } from '../CalibrateTipLength/AskForCalibrationBlockModal'
 
 import type { SessionCommandString } from '../../sessions/types'
 import type { RequestState } from '../../robot-api/types'
@@ -184,7 +184,7 @@ export function CheckCalibrationControl({
             }}
           />
         ) : null}
-        <CheckHealthCalibration
+        <CheckCalibration
           session={checkHealthSession}
           robotName={robotName}
           dispatchRequests={dispatchRequests}

--- a/app/src/components/RobotSettings/CheckCalibrationControl.js
+++ b/app/src/components/RobotSettings/CheckCalibrationControl.js
@@ -44,11 +44,9 @@ export function CheckCalibrationControl({
   robotName,
   disabledReason,
 }: CheckCalibrationControlProps): React.Node {
-  const [showWizard, setShowWizard] = React.useState(false)
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const trackedRequestId = React.useRef<string | null>(null)
-  const deleteRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
   const jogRequestId = React.useRef<string | null>(null)
 
@@ -56,11 +54,6 @@ export function CheckCalibrationControl({
     dispatchedAction => {
       if (dispatchedAction.type === Sessions.ENSURE_SESSION) {
         createRequestId.current = dispatchedAction.meta.requestId
-      } else if (
-        dispatchedAction.type === Sessions.DELETE_SESSION &&
-        checkHealthSession?.id === dispatchedAction.payload.sessionId
-      ) {
-        deleteRequestId.current = dispatchedAction.meta.requestId
       } else if (
         dispatchedAction.type === Sessions.CREATE_SESSION_COMMAND &&
         dispatchedAction.payload.command.command ===
@@ -78,12 +71,11 @@ export function CheckCalibrationControl({
     }
   )
 
-  const startingSession =
-    useSelector<State, RequestState | null>(state =>
-      createRequestId.current
-        ? RobotApi.getRequestById(state, createRequestId.current)
-        : null
-    )?.status === RobotApi.PENDING
+  const createStatus = useSelector<State, RequestState | null>(state =>
+    createRequestId.current
+      ? RobotApi.getRequestById(state, createRequestId.current)
+      : null
+  )?.status
 
   const showSpinner =
     useSelector<State, RequestState | null>(state =>
@@ -99,30 +91,11 @@ export function CheckCalibrationControl({
         : null
     )?.status === RobotApi.PENDING
 
-  const shouldClose =
-    useSelector<State, RequestState | null>(state =>
-      deleteRequestId.current
-        ? RobotApi.getRequestById(state, deleteRequestId.current)
-        : null
-    )?.status === RobotApi.SUCCESS
-
-  const shouldOpen =
-    useSelector((state: State) =>
-      createRequestId.current
-        ? RobotApi.getRequestById(state, createRequestId.current)
-        : null
-    )?.status === RobotApi.SUCCESS
-
   React.useEffect(() => {
-    if (shouldOpen) {
-      setShowWizard(true)
+    if (createStatus === RobotApi.SUCCESS) {
       createRequestId.current = null
     }
-    if (shouldClose) {
-      setShowWizard(false)
-      deleteRequestId.current = null
-    }
-  }, [shouldOpen, shouldClose])
+  }, [createStatus])
 
   const configHasCalibrationBlock = useSelector(Config.getHasCalibrationBlock)
   const [showCalBlockModal, setShowCalBlockModal] = React.useState(false)
@@ -199,7 +172,7 @@ export function CheckCalibrationControl({
             closePrompt={() => setShowCalBlockModal(false)}
           />
         ) : null}
-        {startingSession ? (
+        {createStatus === RobotApi.PENDING ? (
           <SpinnerModalPage
             titleBar={{
               title: CAL_HEALTH_CHECK,
@@ -211,15 +184,13 @@ export function CheckCalibrationControl({
             }}
           />
         ) : null}
-        {showWizard && (
-          <CheckHealthCalibration
-            session={checkHealthSession}
-            robotName={robotName}
-            dispatchRequests={dispatchRequests}
-            showSpinner={showSpinner}
-            isJogging={isJogging}
-          />
-        )}
+        <CheckHealthCalibration
+          session={checkHealthSession}
+          robotName={robotName}
+          dispatchRequests={dispatchRequests}
+          showSpinner={showSpinner}
+          isJogging={isJogging}
+        />
       </Portal>
     </>
   )

--- a/app/src/sessions/__fixtures__/calibration-check.js
+++ b/app/src/sessions/__fixtures__/calibration-check.js
@@ -1,10 +1,10 @@
 // @flow
 import type {
-  CheckCalibrationHealthSessionDetails,
-  CalibrationHealthCheckComparisonsPerCalibration,
-  CalibrationHealthCheckComparisonMap,
-  CalibrationHealthCheckComparison,
-  CheckCalibrationHealthSessionParams,
+  CheckCalibrationSessionDetails,
+  CalibrationCheckComparisonsPerCalibration,
+  CalibrationCheckComparisonMap,
+  CalibrationCheckComparison,
+  CheckCalibrationSessionParams,
   CalibrationLabware,
 } from '../types'
 
@@ -26,63 +26,63 @@ export const mockCalibrationCheckLabware: CalibrationLabware = {
   definition: tipRackFixture,
 }
 
-export const badZComparison: CalibrationHealthCheckComparison = {
+export const badZComparison: CalibrationCheckComparison = {
   differenceVector: [0, 0, 4],
   thresholdVector: [0, 0, 1],
   exceedsThreshold: true,
 }
-export const goodZComparison: CalibrationHealthCheckComparison = {
+export const goodZComparison: CalibrationCheckComparison = {
   differenceVector: [0, 0, 0.1],
   thresholdVector: [0, 0, 1],
   exceedsThreshold: false,
 }
-export const badXYComparison: CalibrationHealthCheckComparison = {
+export const badXYComparison: CalibrationCheckComparison = {
   differenceVector: [4, 4, 0],
   thresholdVector: [1, 1, 0],
   exceedsThreshold: true,
 }
-export const goodXYComparison: CalibrationHealthCheckComparison = {
+export const goodXYComparison: CalibrationCheckComparison = {
   differenceVector: [0.1, 0.1, 0],
   thresholdVector: [1, 1, 0],
   exceedsThreshold: false,
 }
 
-export const badTipLengthCalibration: CalibrationHealthCheckComparisonMap = {
+export const badTipLengthCalibration: CalibrationCheckComparisonMap = {
   status: 'OUTSIDE_THRESHOLD',
   [CHECK_STEP_COMPARING_TIP]: badZComparison,
 }
-export const badPipetteOffsetCalibration: CalibrationHealthCheckComparisonMap = {
+export const badPipetteOffsetCalibration: CalibrationCheckComparisonMap = {
   status: 'OUTSIDE_THRESHOLD',
   [CHECK_STEP_COMPARING_HEIGHT]: badZComparison,
   [CHECK_STEP_COMPARING_POINT_ONE]: badXYComparison,
 }
-export const goodTipLengthCalibration: CalibrationHealthCheckComparisonMap = {
+export const goodTipLengthCalibration: CalibrationCheckComparisonMap = {
   status: 'IN_THRESHOLD',
   [CHECK_STEP_COMPARING_TIP]: goodZComparison,
 }
-export const goodPipetteOffsetCalibration: CalibrationHealthCheckComparisonMap = {
+export const goodPipetteOffsetCalibration: CalibrationCheckComparisonMap = {
   status: 'IN_THRESHOLD',
   [CHECK_STEP_COMPARING_HEIGHT]: goodZComparison,
   [CHECK_STEP_COMPARING_POINT_ONE]: goodXYComparison,
 }
-export const goodDeckCalibration: CalibrationHealthCheckComparisonMap = {
+export const goodDeckCalibration: CalibrationCheckComparisonMap = {
   status: 'IN_THRESHOLD',
   [CHECK_STEP_COMPARING_POINT_ONE]: goodXYComparison,
   [CHECK_STEP_COMPARING_POINT_TWO]: goodXYComparison,
   [CHECK_STEP_COMPARING_POINT_THREE]: goodXYComparison,
 }
 
-export const mockSecondPipetteHealthCheckCalibration: CalibrationHealthCheckComparisonsPerCalibration = {
+export const mockSecondPipetteHealthCheckCalibration: CalibrationCheckComparisonsPerCalibration = {
   tipLength: badTipLengthCalibration,
   pipetteOffset: badPipetteOffsetCalibration,
 }
-export const mockFirstPipettteHealthCheckPerCalibration: CalibrationHealthCheckComparisonsPerCalibration = {
+export const mockFirstPipettteHealthCheckPerCalibration: CalibrationCheckComparisonsPerCalibration = {
   tipLength: goodTipLengthCalibration,
   pipetteOffset: goodPipetteOffsetCalibration,
   deck: goodDeckCalibration,
 }
 
-export const mockRobotCalibrationCheckSessionDetails: CheckCalibrationHealthSessionDetails = {
+export const mockRobotCalibrationCheckSessionDetails: CheckCalibrationSessionDetails = {
   instruments: [
     {
       model: 'fake_pipette_model',
@@ -127,7 +127,7 @@ export const mockRobotCalibrationCheckSessionDetails: CheckCalibrationHealthSess
   activeTipRack: mockCalibrationCheckLabware,
 }
 
-export const mockRobotCalibrationCheckSessionParams: CheckCalibrationHealthSessionParams = {
+export const mockRobotCalibrationCheckSessionParams: CheckCalibrationSessionParams = {
   hasCalibrationBlock: true,
   tipRacks: [],
 }

--- a/app/src/sessions/calibration-check/types.js
+++ b/app/src/sessions/calibration-check/types.js
@@ -51,7 +51,7 @@ export type RobotCalibrationCheckStatus =
   | CHECK_STATUS_IN_THRESHOLD
   | CHECK_STATUS_OUTSIDE_THRESHOLD
 
-export type CalibrationHealthCheckInstrument = {|
+export type CalibrationCheckInstrument = {|
   model: string,
   name: string,
   tip_length: number,
@@ -63,38 +63,38 @@ export type CalibrationHealthCheckInstrument = {|
   serial: string,
 |}
 
-export type CalibrationHealthCheckComparison = {|
+export type CalibrationCheckComparison = {|
   differenceVector: [number, number, number],
   thresholdVector: [number, number, number],
   exceedsThreshold: boolean,
 |}
 
-export type CalibrationHealthCheckComparisonMap = {
+export type CalibrationCheckComparisonMap = {
   status: RobotCalibrationCheckStatus,
-  [RobotCalibrationCheckStep]: CalibrationHealthCheckComparison,
+  [RobotCalibrationCheckStep]: CalibrationCheckComparison,
 }
 
-export type CalibrationHealthCheckComparisonsPerCalibration = {
-  tipLength?: CalibrationHealthCheckComparisonMap,
-  pipetteOffset?: CalibrationHealthCheckComparisonMap,
-  deck?: CalibrationHealthCheckComparisonMap,
+export type CalibrationCheckComparisonsPerCalibration = {
+  tipLength?: CalibrationCheckComparisonMap,
+  pipetteOffset?: CalibrationCheckComparisonMap,
+  deck?: CalibrationCheckComparisonMap,
 }
 
-export type CalibrationHealthCheckComparisonByPipette = {
-  first: CalibrationHealthCheckComparisonsPerCalibration,
-  second: CalibrationHealthCheckComparisonsPerCalibration,
+export type CalibrationCheckComparisonByPipette = {
+  first: CalibrationCheckComparisonsPerCalibration,
+  second: CalibrationCheckComparisonsPerCalibration,
 }
 
-export type CheckCalibrationHealthSessionDetails = {|
-  instruments: Array<CalibrationHealthCheckInstrument>,
+export type CheckCalibrationSessionDetails = {|
+  instruments: Array<CalibrationCheckInstrument>,
   currentStep: RobotCalibrationCheckStep,
-  comparisonsByPipette: CalibrationHealthCheckComparisonByPipette,
+  comparisonsByPipette: CalibrationCheckComparisonByPipette,
   labware: Array<CalibrationLabware>,
-  activePipette: CalibrationHealthCheckInstrument,
+  activePipette: CalibrationCheckInstrument,
   activeTipRack: CalibrationLabware,
 |}
 
-export type CheckCalibrationHealthSessionParams = {|
+export type CheckCalibrationSessionParams = {|
   hasCalibrationBlock: boolean,
   tipRacks: Array<CalibrationLabware>,
 |}

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -57,7 +57,7 @@ export type SessionParams =
   | {||}
   | TipLengthCalTypes.TipLengthCalibrationSessionParams
   | PipOffsetCalTypes.PipetteOffsetCalibrationSessionParams
-  | CalCheckTypes.CheckCalibrationHealthSessionParams
+  | CalCheckTypes.CheckCalibrationSessionParams
 
 export type SessionCommandString =
   | $Values<typeof CalCheckConstants.checkCommands>
@@ -85,8 +85,8 @@ export type SessionCommandParams = {
 
 export type CalibrationCheckSessionResponseAttributes = {|
   sessionType: SESSION_TYPE_CALIBRATION_HEALTH_CHECK,
-  details: CalCheckTypes.CheckCalibrationHealthSessionDetails,
-  createParams: CalCheckTypes.CheckCalibrationHealthSessionParams,
+  details: CalCheckTypes.CheckCalibrationSessionDetails,
+  createParams: CalCheckTypes.CheckCalibrationSessionParams,
 |}
 
 export type TipLengthCalibrationSessionResponseAttributes = {|


### PR DESCRIPTION
# Overview

Removes react state boolean flag that hides health check wizard according to the component lifecycle,
and instead show cal  check wizard if a session exists in redux.

The naming of components and types around this feature started to fracture. The combinations "CalibrationHealthCheck", "CalibrationCheckHealth" and even "CheckHealthCalibration" all existed. The addition of the word health into the user-facing string shouldn't need to be reflected in the variable name. In the interest of standardizing these to minimize confusion, as well as shortening the string in general, this branch renames relevant variables and types that refer to the feature 
 as "CalibrationCheck". The verb form of this feature is still "checkCalibration". 

# Changelog

- Show Cal Check wizard if session exists in redux remove react state gating
- standardize naming of variables relating to Calibration Check  

# Review requests

- perform a calibration check, everything should function as before  

# Risk assessment

low
