### PR TITLE
refactor(app): display alert-circle in robot tab if any calibration is marked bad

### DIFF
--- a/app/src/components/Navbar/NavbarLink.js
+++ b/app/src/components/Navbar/NavbarLink.js
@@ -88,7 +88,7 @@ export function NavbarLink(props: NavbarLinkProps): React.Node {
         <NotificationIcon
           name={iconName}
           childName={
-            hasNotification ? 'circle' : hasWarning ? 'alert-circle' : null
+            hasWarning ? 'alert-circle' : hasNotification ? 'circle' : null
           }
           width="100%"
           paddingX={SPACING_2}

--- a/app/src/components/Navbar/NavbarLink.js
+++ b/app/src/components/Navbar/NavbarLink.js
@@ -58,15 +58,18 @@ export function NavbarLink(props: NavbarLinkProps): React.Node {
     iconName,
     disabledReason,
     notificationReason,
+    warningReason,
     ...styleProps
   } = props
 
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_RIGHT,
   })
-  const tooltipContents = disabledReason ?? notificationReason ?? null
+  const tooltipContents =
+    disabledReason ?? notificationReason ?? warningReason ?? null
   const hasNotification = Boolean(notificationReason)
   const isDisabled = Boolean(disabledReason)
+  const hasWarning = Boolean(warningReason)
 
   const LinkComponent = isDisabled ? 'div' : NavLink
   const linkProps = isDisabled ? styleProps : { to: path, ...styleProps }
@@ -84,7 +87,9 @@ export function NavbarLink(props: NavbarLinkProps): React.Node {
       >
         <NotificationIcon
           name={iconName}
-          childName={hasNotification ? 'circle' : null}
+          childName={
+            hasNotification ? 'circle' : hasWarning ? 'alert-circle' : null
+          }
           width="100%"
           paddingX={SPACING_2}
         />

--- a/app/src/components/Navbar/__tests__/NavbarLink.test.js
+++ b/app/src/components/Navbar/__tests__/NavbarLink.test.js
@@ -122,6 +122,21 @@ describe('NavbarLink component', () => {
     expect(icon.prop('childName')).toBe('alert-circle')
   })
 
+  it('should render a warning icon if both notification and warning reasons exist', () => {
+    const wrapper = render({
+      id: 'foo',
+      path: '/foo',
+      title: 'Foo',
+      iconName: 'alert',
+      notificationReason: 'hi',
+      warningReason: 'hello',
+    })
+    const icon = wrapper.find(NotificationIcon)
+
+    expect(icon.prop('name')).toBe('alert')
+    expect(icon.prop('childName')).toBe('alert-circle')
+  })
+
   it('should render the link title', () => {
     const wrapper = render({
       id: 'foo',

--- a/app/src/components/Navbar/__tests__/NavbarLink.test.js
+++ b/app/src/components/Navbar/__tests__/NavbarLink.test.js
@@ -108,6 +108,20 @@ describe('NavbarLink component', () => {
     expect(icon.prop('childName')).toBe('circle')
   })
 
+  it('should render a warning if there is a reason to', () => {
+    const wrapper = render({
+      id: 'foo',
+      path: '/foo',
+      title: 'Foo',
+      iconName: 'alert',
+      warningReason: 'hello',
+    })
+    const icon = wrapper.find(NotificationIcon)
+
+    expect(icon.prop('name')).toBe('alert')
+    expect(icon.prop('childName')).toBe('alert-circle')
+  })
+
   it('should render the link title', () => {
     const wrapper = render({
       id: 'foo',

--- a/app/src/nav/__tests__/selectors.test.js
+++ b/app/src/nav/__tests__/selectors.test.js
@@ -97,6 +97,7 @@ const EXPECTED_ROBOTS = {
   title: 'Robot',
   iconName: 'ot-connect',
   notificationReason: null,
+  warningReason: null,
 }
 
 const EXPECTED_UPLOAD = {
@@ -295,7 +296,10 @@ describe('nav selectors', () => {
         mockGetDeckCalibrationStatus.mockReturnValue(DECK_CAL_STATUS_IDENTITY)
       },
       expected: [
-        EXPECTED_ROBOTS,
+        {
+          ...EXPECTED_ROBOTS,
+          warningReason: expect.stringMatching(/Robot calibration recommended/),
+        },
         {
           ...EXPECTED_UPLOAD,
           disabledReason: expect.stringMatching(/calibrate your deck/i),

--- a/app/src/nav/selectors.js
+++ b/app/src/nav/selectors.js
@@ -5,12 +5,19 @@ import { getConnectedRobot } from '../discovery'
 import {
   getProtocolPipettesMatching,
   getProtocolPipettesCalibrated,
+  getAttachedPipetteCalibrations,
+  PIPETTE_MOUNTS,
 } from '../pipettes'
 import { selectors as RobotSelectors } from '../robot'
 import { UPGRADE, getBuildrootUpdateAvailable } from '../buildroot'
 import { getAvailableShellUpdate } from '../shell'
 import { getU2EWindowsDriverStatus, OUTDATED } from '../system-info'
-import { getDeckCalibrationStatus, DECK_CAL_STATUS_OK } from '../calibration'
+import {
+  getDeckCalibrationStatus,
+  DECK_CAL_STATUS_OK,
+  getPipetteOffsetCalibrations,
+  getDeckCalibrationData,
+} from '../calibration'
 
 import type { State } from '../types'
 import type { NavLocation } from './types'
@@ -76,6 +83,25 @@ const getDeckCalibrationOk = (state: State): boolean => {
   return deckCalStatus === DECK_CAL_STATUS_OK
 }
 
+const getRobotCalibrationOk = (state: State): boolean => {
+  const connectedRobot = getConnectedRobot(state)
+  if (!connectedRobot) return false
+
+  const deckCalOk = getDeckCalibrationOk(state)
+  const pipCal = getAttachedPipetteCalibrations(state, connectedRobot.name)
+  for (const m of PIPETTE_MOUNTS) {
+    if (pipCal) {
+      if (
+        pipCal[m]?.offset?.status?.markedBad ||
+        pipCal[m]?.tipLength?.status?.markedBad
+      ) {
+        return false
+      }
+    }
+  }
+  return deckCalOk
+}
+
 const getRunDisabledReason: State => string | null = createSelector(
   getConnectedRobot,
   RobotSelectors.getSessionIsLoaded,
@@ -97,14 +123,14 @@ const getRunDisabledReason: State => string | null = createSelector(
 export const getRobotsLocation: State => NavLocation = createSelector(
   getConnectedRobot,
   getConnectedRobotUpdateAvailable,
-  getDeckCalibrationOk,
-  (robot, update, deckCalOk) => ({
+  getRobotCalibrationOk,
+  (robot, update, robotCalOk) => ({
     id: 'robots',
     path: '/robots',
     title: ROBOT,
     iconName: 'ot-connect',
     notificationReason: update ? ROBOT_UPDATE_AVAILABLE : null,
-    warningReason: robot && !deckCalOk ? ROBOT_CALIBRATION_RECOMMENDED : null,
+    warningReason: robot && !robotCalOk ? ROBOT_CALIBRATION_RECOMMENDED : null,
   })
 )
 

--- a/app/src/nav/selectors.js
+++ b/app/src/nav/selectors.js
@@ -41,6 +41,7 @@ const CALIBRATE_DECK_TO_PROCEED = 'Calibrate your deck to proceed'
 const APP_UPDATE_AVAILABLE = 'An app update is available'
 const DRIVER_UPDATE_AVAILABLE = 'A driver update is available'
 const ROBOT_UPDATE_AVAILABLE = 'A robot software update is available'
+const ROBOT_CALIBRATION_RECOMMENDED = 'Robot calibration recommended'
 
 const getConnectedRobotPipettesMatch = (state: State): boolean => {
   const connectedRobot = getConnectedRobot(state)
@@ -94,13 +95,16 @@ const getRunDisabledReason: State => string | null = createSelector(
 )
 
 export const getRobotsLocation: State => NavLocation = createSelector(
+  getConnectedRobot,
   getConnectedRobotUpdateAvailable,
-  update => ({
+  getDeckCalibrationOk,
+  (robot, update, deckCalOk) => ({
     id: 'robots',
     path: '/robots',
     title: ROBOT,
     iconName: 'ot-connect',
     notificationReason: update ? ROBOT_UPDATE_AVAILABLE : null,
+    warningReason: robot && !deckCalOk ? ROBOT_CALIBRATION_RECOMMENDED : null,
   })
 )
 

--- a/app/src/nav/selectors.js
+++ b/app/src/nav/selectors.js
@@ -12,12 +12,7 @@ import { selectors as RobotSelectors } from '../robot'
 import { UPGRADE, getBuildrootUpdateAvailable } from '../buildroot'
 import { getAvailableShellUpdate } from '../shell'
 import { getU2EWindowsDriverStatus, OUTDATED } from '../system-info'
-import {
-  getDeckCalibrationStatus,
-  DECK_CAL_STATUS_OK,
-  getPipetteOffsetCalibrations,
-  getDeckCalibrationData,
-} from '../calibration'
+import { getDeckCalibrationStatus, DECK_CAL_STATUS_OK } from '../calibration'
 
 import type { State } from '../types'
 import type { NavLocation } from './types'

--- a/app/src/nav/types.js
+++ b/app/src/nav/types.js
@@ -9,6 +9,7 @@ export type NavLocation = {|
   iconName: IconName,
   disabledReason?: string | null,
   notificationReason?: string | null,
+  warningReason?: string | null,
 |}
 
 export type SubnavLocation = {|


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guid

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
closes #6604 
This PR adds a warning icon on the robot tab if any calibration (deck cal, pip offset, tip length) is marked bad. See [design](https://www.figma.com/file/nbDHskbW5zaXwtrLvEIKVj/calibration-overhaul?node-id=0%3A1)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- add optional `warningReason` prop to NavBarLink to display the alert icon
- update tests to reflect new changes

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
This is what the new robot tab now looks like:
<img width="1019" alt="Screen Shot 2020-11-09 at 3 26 40 PM" src="https://user-images.githubusercontent.com/20424172/98593415-20c82a00-22a1-11eb-9dff-71a733a3aebe.png">

If there's an update available for the robot, the notification bubble will be shown instead of the warning icon. Is that ok? Or should we show both at the same time?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
