### PR TITLE
fix(app): place top portal at higher z index than page level portal

### DIFF
--- a/app/src/components/portal/index.js
+++ b/app/src/components/portal/index.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import ReactDom from 'react-dom'
+import { Box } from '@opentrons/components'
 
 type PortalLevel = 'page' | 'top'
 
@@ -18,20 +19,20 @@ type PortalLevelInfo = {|
   zIndex: number | string,
 |}
 
-const PORTAL_INFO_BY_LEVEL: { [PortalLevel]: PortalLevelInfo } = {
+const PORTAL_ROOT_PROPS_BY_LEVEL: { [PortalLevel]: PortalLevelInfo } = {
   page: { id: '__otAppModalPortalRoot', zIndex: 1 },
   top: { id: '__otAppTopPortalRoot', zIndex: 10 },
 }
 
 const getPortalRoot = level =>
-  global.document.getElementById(PORTAL_INFO_BY_LEVEL[level].id)
+  global.document.getElementById(PORTAL_ROOT_PROPS_BY_LEVEL[level].id)
 
 export function PortalRoot(): React.Node {
-  return <div id={PORTAL_INFO_BY_LEVEL.page.id} />
+  return <Box {...PORTAL_ROOT_PROPS_BY_LEVEL.page} />
 }
 
 export function TopPortalRoot(): React.Node {
-  return <div id={PORTAL_INFO_BY_LEVEL.top.id} />
+  return <Box {...PORTAL_ROOT_PROPS_BY_LEVEL.top} />
 }
 
 // the children of Portal are rendered into the PortalRoot if it exists in DOM

--- a/app/src/components/portal/index.js
+++ b/app/src/components/portal/index.js
@@ -13,20 +13,25 @@ type State = {|
   hasRoot: boolean,
 |}
 
-const PORTAL_ROOT_ID_BY_LEVEL: { [PortalLevel]: string } = {
-  page: '__otAppModalPortalRoot',
-  top: '__otAppTopPortalRoot',
+type PortalLevelInfo = {|
+  id: string,
+  zIndex: number | string,
+|}
+
+const PORTAL_INFO_BY_LEVEL: { [PortalLevel]: PortalLevelInfo } = {
+  page: { id: '__otAppModalPortalRoot', zIndex: 1 },
+  top: { id: '__otAppTopPortalRoot', zIndex: 10 },
 }
 
 const getPortalRoot = level =>
-  global.document.getElementById(PORTAL_ROOT_ID_BY_LEVEL[level])
+  global.document.getElementById(PORTAL_INFO_BY_LEVEL[level].id)
 
 export function PortalRoot(): React.Node {
-  return <div id={PORTAL_ROOT_ID_BY_LEVEL.page} />
+  return <div id={PORTAL_INFO_BY_LEVEL.page.id} />
 }
 
 export function TopPortalRoot(): React.Node {
-  return <div id={PORTAL_ROOT_ID_BY_LEVEL.top} />
+  return <div id={PORTAL_INFO_BY_LEVEL.top.id} />
 }
 
 // the children of Portal are rendered into the PortalRoot if it exists in DOM


### PR DESCRIPTION
# Overview

In order to ensure that top level modals render on top of any page level modals, this sets the z
index of the top level portal root's contents to 10 as opposed to 1 for the page level portal

# Changelog

- add zIndex of 10 to top level portals

# Review requests

- pretty hard to test, but you can start any one of the new calibration flows and then turn off wifi or unplug from usb, you should see the disconnect modal appear behind the session modal for an instant before the whole page unmounts. The edge case that this is really preventing is the app update modal appearing above the active calibration modal. 

# Risk assessment

low