### PR TITLE
perf(shared-data,api): speed up pipette settings

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -435,9 +435,9 @@ def list_mutable_configs(pipette_id: str) -> Dict[str, Any]:
     """
     cfg: Dict[str, Any] = {}
 
-    if pipette_id in known_pipettes():
+    try:
         config, model = load_config_dict(pipette_id)
-    else:
+    except FileNotFoundError:
         log.info(f'Pipette id {pipette_id} not found')
         return cfg
 


### PR DESCRIPTION
This improves (but does not fix the root cause of) full pipette settings
scans taking forever if you have a lot of pipettes. There are three
problems, of which two are fixed:

1. Accidental quadratic scanning of the pipette settings directory via
known_pipettes, which is fixed in the api by asking forgiveness rather
than permission
2. loading the big pipette model spec taking forever, which is fixed by
caching it. This is compromised somewhat by a lot of different places
modifying its return values which means a lot of stuff has to be
deepcopied, which I truly do not love.
3. general inefficiency and lots of layers of indirection in the pipette
config parsing code (not fixed)

So it's a step forward in that it improves perf by 75% but there's (much) more
to do.

Addresses some but not all of the problems in #6951 
