### PR TITLE
feat(app): add analytics event to robot config reset

### DIFF
--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -225,5 +225,25 @@ describe('analytics events map', () => {
         },
       })
     })
+
+    it('robotAdmin:RESET_CONFIG -> resetRobotConfig event', () => {
+      const state = {}
+      const action = {
+        type: 'robotAdmin:RESET_CONFIG',
+        payload: {
+          robotName: 'robotName',
+          resets: {
+            foo: true,
+            bar: true,
+          },
+        },
+      }
+      return expect(makeEvent(action, state)).resolves.toEqual({
+        name: 'resetRobotConfig',
+        properties: {
+          ...action.payload.resets,
+        },
+      })
+    })
   })
 })

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -8,6 +8,7 @@ import * as SystemInfo from '../system-info'
 import * as brActions from '../buildroot/constants'
 import * as Sessions from '../sessions'
 import * as Alerts from '../alerts'
+import * as RobotAdmin from '../robot-admin'
 
 import {
   getProtocolAnalyticsData,
@@ -298,6 +299,14 @@ export function makeEvent(
       }
 
       return Promise.resolve(null)
+    }
+
+    case RobotAdmin.RESET_CONFIG: {
+      const { resets } = action.payload
+      return Promise.resolve({
+        name: 'resetRobotConfig',
+        properties: { ...resets },
+      })
     }
   }
 


### PR DESCRIPTION
closes #6625

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add an analytics event that fires when resetting robot config.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->


# Risk assessment
low, a small new feature
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
