### PR TITLE
feat(protocol-designer): Add mount designation for matching pipettes

### DIFF
--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -8,6 +8,10 @@
     },
     "default_protocol_name": "Untitled"
   },
+  "pipette_mount_label": {
+    "left": "(L)",
+    "right": "(R)"
+  },
   "liquid_edit": {
     "details": "Details",
     "description": "Description",

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -33,6 +33,7 @@ import {
   selectors as labwareDefSelectors,
   type LabwareDefByDefURI,
 } from '../../labware-defs'
+import { i18n } from '../../localization'
 
 import { typeof InstrumentGroup as InstrumentGroupProps } from '@opentrons/components'
 import type {
@@ -278,11 +279,6 @@ function _getPipettesSame(
   return pipettes[0]?.name === pipettes[1]?.name
 }
 
-const PIPETTE_MOUNT_LABEL = {
-  left: '(L)',
-  right: '(R)',
-}
-
 // TODO: Ian 2018-12-20 EVENTUALLY make this `getEquippedPipetteOptionsForStepId`, so it tells you
 // equipped pipettes per step id instead of always using initial deck setup
 // (for when we support multiple deck setup steps)
@@ -296,11 +292,10 @@ export const getEquippedPipetteOptions: Selector<
     return reduce(
       pipettes,
       (acc: Array<DropdownOption>, pipette: PipetteOnDeck, id: string) => {
+        const mountLabel = i18n.t(`form.pipette_mount_label.${pipette.mount}`)
         const nextOption = {
           name: pipettesSame
-            ? `${_getPipetteDisplayName(pipette.name)} ${
-                PIPETTE_MOUNT_LABEL[pipette.mount]
-              }`
+            ? `${_getPipetteDisplayName(pipette.name)} ${mountLabel}`
             : _getPipetteDisplayName(pipette.name),
           value: id,
         }

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -269,6 +269,20 @@ function _getPipetteDisplayName(name: string): string {
   return pipetteSpecs.displayName
 }
 
+function _getPipettesSame(
+  pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>
+) {
+  const pipettes = Object.keys(pipettesOnDeck).map(id => {
+    return pipettesOnDeck[id]
+  })
+  return pipettes[0]?.name === pipettes[1]?.name
+}
+
+const PIPETTE_MOUNT_LABEL = {
+  left: '(L)',
+  right: '(R)',
+}
+
 // TODO: Ian 2018-12-20 EVENTUALLY make this `getEquippedPipetteOptionsForStepId`, so it tells you
 // equipped pipettes per step id instead of always using initial deck setup
 // (for when we support multiple deck setup steps)
@@ -276,18 +290,25 @@ export const getEquippedPipetteOptions: Selector<
   Array<DropdownOption>
 > = createSelector(
   getInitialDeckSetup,
-  initialDeckSetup =>
-    reduce(
-      initialDeckSetup.pipettes,
+  initialDeckSetup => {
+    const pipettes = initialDeckSetup.pipettes
+    const pipettesSame = _getPipettesSame(pipettes)
+    return reduce(
+      pipettes,
       (acc: Array<DropdownOption>, pipette: PipetteOnDeck, id: string) => {
         const nextOption = {
-          name: _getPipetteDisplayName(pipette.name),
+          name: pipettesSame
+            ? `${_getPipetteDisplayName(pipette.name)} ${
+                PIPETTE_MOUNT_LABEL[pipette.mount]
+              }`
+            : _getPipetteDisplayName(pipette.name),
           value: id,
         }
         return [...acc, nextOption]
       },
       []
     )
+  }
 )
 
 // Formats pipette data specifically for file page InstrumentGroup component

--- a/protocol-designer/src/step-forms/test/selectors.test.js
+++ b/protocol-designer/src/step-forms/test/selectors.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { _hasFieldLevelErrors } from '../selectors'
+import { _hasFieldLevelErrors, getEquippedPipetteOptions } from '../selectors'
 import { getFieldErrors } from '../../steplist/fieldLevel'
 import { getProfileItemsHaveErrors } from '../utils/getProfileItemsHaveErrors'
 jest.mock('../../steplist/fieldLevel')
@@ -59,5 +59,66 @@ describe('_hasFieldLevelErrors', () => {
       const result = _hasFieldLevelErrors(formData)
       expect(result).toBe(expected)
     })
+  })
+})
+
+describe('getEquippedPipetteOptions', () => {
+  it('appends mount to pipette dropdown when pipettes are same model', () => {
+    const initialDeckState = {
+      pipettes: {
+        123: {
+          name: 'p20_single_gen2',
+          mount: 'left',
+        },
+        456: {
+          name: 'p20_single_gen2',
+          mount: 'right',
+        },
+      },
+    }
+    const expected = [
+      { name: 'P20 Single-Channel GEN2 (L)', value: '123' },
+      { name: 'P20 Single-Channel GEN2 (R)', value: '456' },
+    ]
+
+    const result = getEquippedPipetteOptions.resultFunc(initialDeckState)
+    expect(result).toEqual(expected)
+  })
+
+  it('does NOT append mount to pipette dropdown when pipettes are different models', () => {
+    const initialDeckState = {
+      pipettes: {
+        123: {
+          name: 'p300_single_gen2',
+          mount: 'left',
+        },
+        456: {
+          name: 'p20_single_gen2',
+          mount: 'right',
+        },
+      },
+    }
+    const expected = [
+      { name: 'P300 Single-Channel GEN2', value: '123' },
+      { name: 'P20 Single-Channel GEN2', value: '456' },
+    ]
+
+    const result = getEquippedPipetteOptions.resultFunc(initialDeckState)
+    expect(result).toEqual(expected)
+  })
+
+  it('does NOT append mount to pipette dropdown when only one pipette', () => {
+    const initialDeckState = {
+      pipettes: {
+        123: {
+          name: 'p300_single_gen2',
+          mount: 'left',
+        },
+      },
+    }
+    const expected = [{ name: 'P300 Single-Channel GEN2', value: '123' }]
+
+    const result = getEquippedPipetteOptions.resultFunc(initialDeckState)
+    expect(result).toEqual(expected)
   })
 })


### PR DESCRIPTION
# Overview

closes #6783 by adding `[L]` or `[R]` to the end of pipette names in pipette selection dropdowns when both pipettes are the same.

# Changelog

- feat (protocol-designer): Add L|R mount designation for same pipettes

# Review requests

- [ ] Left /Right designation appends to pipette name when both pipettes are the same
- [ ] Left /Right designation is not appended to pipette name when pipettes are different
- [ ] Pipette selection and step saving unaffected

# Risk assessment

Low, Isolated selector for pipette dropdown
