### PR TITLE
fix(app): Ensure we are using the correct logic for screen transitions in cal check

### DIFF
--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -158,6 +158,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
     sessionType,
     activePipette,
     instruments,
+    checkBothPipettes,
   } = props
 
   const {
@@ -191,11 +192,7 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
     } else {
       commands = [{ command: Sessions.sharedCalCommands.SAVE_OFFSET }]
     }
-    if (
-      finalCommand &&
-      instruments?.length &&
-      activePipette?.rank === Sessions.CHECK_PIPETTE_RANK_FIRST
-    ) {
+    if (finalCommand && checkBothPipettes) {
       commands = [...commands, { command: finalCommand }]
     } else if (moveCommand) {
       commands = [...commands, { command: moveCommand }]

--- a/app/src/components/CalibrationPanels/SaveXYPoint.js
+++ b/app/src/components/CalibrationPanels/SaveXYPoint.js
@@ -192,7 +192,11 @@ export function SaveXYPoint(props: CalibrationPanelProps): React.Node {
     } else {
       commands = [{ command: Sessions.sharedCalCommands.SAVE_OFFSET }]
     }
-    if (finalCommand && checkBothPipettes) {
+    if (
+      finalCommand &&
+      checkBothPipettes &&
+      activePipette?.rank === Sessions.CHECK_PIPETTE_RANK_FIRST
+    ) {
       commands = [...commands, { command: finalCommand }]
     } else if (moveCommand) {
       commands = [...commands, { command: moveCommand }]


### PR DESCRIPTION
# Overview

Quick fix for some logic in the `SaveXY.js` screen. We should only move to the tiprack after point one if:
1. we are checking both pipettes and 2. the pipette has the 'first' rank.

# Changelog

- Check if you are using both pipettes rather than the length of the instruments

# Review requests

Test on a robot

# Risk assessment

Low, just fixing up some logic.
