### PR TITLE
refactor(app): clear all sessions for robot when disconnected, disable cal buttons

### DIFF
--- a/app/src/components/CalibrationPanels/SaveZPoint.js
+++ b/app/src/components/CalibrationPanels/SaveZPoint.js
@@ -207,6 +207,7 @@ export function SaveZPoint(props: CalibrationPanelProps): React.Node {
             : [VERTICAL_PLANE]
         }
         auxiliaryControl={allowHorizontal ? null : <AllowHorizontalPrompt />}
+        width="100%"
       />
       <Flex
         width="100%"

--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -242,21 +242,23 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
         </Flex>
 
         <SecondaryBtn
-          {...changePipTargetProps}
+          {...(buttonDisabledReason ? changePipTargetProps : {})}
           as={buttonDisabledReason ? 'button' : Link}
           to={changeUrl}
           disabled={buttonDisabledReason}
+          title="changePipetteButton"
         >
           {direction}
         </SecondaryBtn>
       </Flex>
       {settingsUrl !== null && (
         <SecondaryBtn
-          {...settingsTargetProps}
+          {...(buttonDisabledReason ? settingsTargetProps : {})}
           {...PER_PIPETTE_BTN_STYLE}
           as={buttonDisabledReason ? 'button' : Link}
           to={settingsUrl}
           disabled={buttonDisabledReason}
+          title="pipetteSettingsButton"
         >
           settings
         </SecondaryBtn>

--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { css } from 'styled-components'
 import { Link } from 'react-router-dom'
 
 import { getLabwareDisplayName } from '@opentrons/shared-data'
@@ -15,6 +14,8 @@ import {
   Flex,
   Text,
   SecondaryBtn,
+  useHoverTooltip,
+  Tooltip,
   DIRECTION_COLUMN,
   FONT_WEIGHT_SEMIBOLD,
   SPACING_1,
@@ -41,19 +42,23 @@ import {
   INTENT_PIPETTE_OFFSET,
   INTENT_TIP_LENGTH_OUTSIDE_PROTOCOL,
 } from '../CalibrationPanels'
-import type { State } from '../../types'
-
 import {
   getCalibrationForPipette,
   getTipLengthForPipetteAndTiprack,
 } from '../../calibration'
-
-import { InlineCalibrationWarning } from '../InlineCalibrationWarning'
-
-import type { Mount, AttachedPipette } from '../../pipettes/types'
+import { getRobotByName } from '../../discovery'
+import { getIsRunning } from '../../robot/selectors'
 import { findLabwareDefWithCustom } from '../../findLabware'
 import * as CustomLabware from '../../custom-labware'
 import { Portal } from '../portal'
+import { InlineCalibrationWarning } from '../InlineCalibrationWarning'
+import {
+  DISABLED_CONNECT_TO_ROBOT,
+  DISABLED_PROTOCOL_IS_RUNNING,
+} from '../RobotSettings/constants'
+
+import type { State } from '../../types'
+import type { Mount, AttachedPipette } from '../../pipettes/types'
 
 export type PipetteInfoProps = {|
   robotName: string,
@@ -134,6 +139,23 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
         )
       : null
   )
+
+  const isRunning = useSelector(getIsRunning)
+  const isConnected = useSelector(
+    (state: State) => getRobotByName(state, robotName)?.connected
+  )
+
+  const [tlcTargetProps, tlcTooltipProps] = useHoverTooltip()
+  const [pocTargetProps, pocTooltipProps] = useHoverTooltip()
+  const [settingsTargetProps, settingsTooltipProps] = useHoverTooltip()
+  const [changePipTargetProps, changePipTooltipProps] = useHoverTooltip()
+
+  let buttonDisabledReason = null
+  if (!isConnected) {
+    buttonDisabledReason = DISABLED_CONNECT_TO_ROBOT
+  } else if (isRunning) {
+    buttonDisabledReason = DISABLED_PROTOCOL_IS_RUNNING
+  }
 
   const [
     startPipetteOffsetCalibration,
@@ -222,18 +244,30 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
           <LabeledValue label={SERIAL_NUMBER} value={serialNumber || 'None'} />
         </Flex>
 
-        <OutlineButton Component={Link} to={changeUrl}>
+        <SecondaryBtn
+          {...changePipTargetProps}
+          as={buttonDisabledReason ? 'button' : Link}
+          to={changeUrl}
+          disabled={buttonDisabledReason}
+        >
           {direction}
-        </OutlineButton>
+        </SecondaryBtn>
       </Flex>
       {settingsUrl !== null && (
-        <SecondaryBtn {...PER_PIPETTE_BTN_STYLE} as={Link} to={settingsUrl}>
+        <SecondaryBtn
+          {...settingsTargetProps}
+          {...PER_PIPETTE_BTN_STYLE}
+          as={buttonDisabledReason ? 'button' : Link}
+          to={settingsUrl}
+          disabled={buttonDisabledReason}
+        >
           settings
         </SecondaryBtn>
       )}
       {serialNumber && (
         <>
           <SecondaryBtn
+            {...pocTargetProps}
             {...PER_PIPETTE_BTN_STYLE}
             title="pipetteOffsetCalButton"
             onClick={
@@ -241,6 +275,7 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
                 ? startPipetteOffsetCalibrationDirectly
                 : () => startPipetteOffsetWizard({ keepTipLength: true })
             }
+            disabled={buttonDisabledReason}
           >
             {CALIBRATE_OFFSET}
           </SecondaryBtn>
@@ -302,11 +337,13 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
                   )}
                 </Text>
                 <SecondaryBtn
+                  {...tlcTargetProps}
                   {...PER_PIPETTE_BTN_STYLE}
                   title="recalibrateTipButton"
                   onClick={() =>
                     startPipetteOffsetWizard({ keepTipLength: false })
                   }
+                  disabled={buttonDisabledReason}
                 >
                   {RECALIBRATE_TIP}
                 </SecondaryBtn>
@@ -324,6 +361,14 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
               </Text>
             )}
           </Box>
+        </>
+      )}
+      {buttonDisabledReason !== null && (
+        <>
+          <Tooltip {...settingsTooltipProps}>{buttonDisabledReason}</Tooltip>
+          <Tooltip {...pocTooltipProps}>{buttonDisabledReason}</Tooltip>
+          <Tooltip {...tlcTooltipProps}>{buttonDisabledReason}</Tooltip>
+          <Tooltip {...changePipTooltipProps}>{buttonDisabledReason}</Tooltip>
         </>
       )}
     </Flex>

--- a/app/src/components/InstrumentSettings/PipetteInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteInfo.js
@@ -8,7 +8,6 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 import {
   LabeledValue,
-  OutlineButton,
   InstrumentDiagram,
   Box,
   Flex,
@@ -228,9 +227,7 @@ export function PipetteInfo(props: PipetteInfoProps): React.Node {
       <Flex
         alignItems={ALIGN_FLEX_START}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
-        css={css`
-          max-width: 14rem;
-        `}
+        maxWidth="14rem"
       >
         <Flex
           flexDirection={DIRECTION_COLUMN}

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -13,15 +13,20 @@ import type { State } from '../../../types'
 
 import { PipetteInfo } from '../PipetteInfo'
 import { mockAttachedPipette } from '../__fixtures__'
+import { mockConnectedRobot } from '../../../discovery/__fixtures__'
 import { mockPipetteOffsetCalibration1 } from '../../../calibration/pipette-offset/__fixtures__'
 import { mockTipLengthCalibration1 } from '../../../calibration/tip-length/__fixtures__'
 import { getCustomLabwareDefinitions } from '../../../custom-labware'
+import { getRobotByName } from '../../../discovery'
+import { getIsRunning } from '../../../robot/selectors'
 
 jest.mock('../../../calibration')
 jest.mock('../../../config')
 jest.mock('../../../custom-labware')
 jest.mock('../../CalibratePipetteOffset/useCalibratePipetteOffset')
 jest.mock('react-router-dom', () => ({ Link: () => <></> }))
+jest.mock('../../../discovery')
+jest.mock('../../../robot/selectors')
 
 const mockGetCustomLabwareDefinitions: JestMockFn<
   [State],
@@ -48,6 +53,16 @@ const mockGetHasCalibrationBlock: JestMockFn<
   $Call<typeof Config.getHasCalibrationBlock, State>
 > = Config.getHasCalibrationBlock
 
+const mockGetRobotByName: JestMockFn<
+  [State, string],
+  $Call<typeof getRobotByName, State, string>
+> = getRobotByName
+
+const mockGetIsRunning: JestMockFn<
+  [State],
+  $Call<typeof getIsRunning, State>
+> = getIsRunning
+
 describe('PipetteInfo', () => {
   const robotName = 'robot-name'
   let render
@@ -60,6 +75,8 @@ describe('PipetteInfo', () => {
     mockGetTipLengthForPipetteAndTiprack.mockReturnValue(null)
     mockGetCustomLabwareDefinitions.mockReturnValue([])
     mockGetHasCalibrationBlock.mockReturnValue(null)
+    mockGetIsRunning.mockReturnValue(false)
+    mockGetRobotByName.mockReturnValue(mockConnectedRobot)
 
     render = (props: $Shape<React.ElementProps<typeof PipetteInfo>> = {}) => {
       const { pipette = mockAttachedPipette } = props

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -234,4 +234,23 @@ describe('PipetteInfo', () => {
       withIntent: 'tip-length-no-protocol',
     })
   })
+
+  it('buttons are disabled if robot is running', () => {
+    mockGetHasCalibrationBlock.mockReturnValue(true)
+
+    mockGetCalibrationForPipette.mockReturnValue(mockPipetteOffsetCalibration1)
+    mockGetTipLengthForPipetteAndTiprack.mockReturnValue(
+      mockTipLengthCalibration1
+    )
+    mockGetIsRunning.mockReturnValue(true)
+    const { wrapper } = render()
+    expect(
+      wrapper.find('button[title="recalibrateTipButton"]').props()?.disabled
+    ).toEqual(expect.any(String))
+    // expect(
+    //   wrapper.find('button[title="pipetteOffsetCalButton"]')
+    // ).toBeDisabled()
+    // expect(wrapper.find('button[title="pipetteSettingsButton"]')).toBeDisabled()
+    // expect(wrapper.find('button[title="changePipetteButton"]')).toBeDisabled()
+  })
 })

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -247,10 +247,14 @@ describe('PipetteInfo', () => {
     expect(
       wrapper.find('button[title="recalibrateTipButton"]').props()?.disabled
     ).toEqual(expect.any(String))
-    // expect(
-    //   wrapper.find('button[title="pipetteOffsetCalButton"]')
-    // ).toBeDisabled()
-    // expect(wrapper.find('button[title="pipetteSettingsButton"]')).toBeDisabled()
-    // expect(wrapper.find('button[title="changePipetteButton"]')).toBeDisabled()
+    expect(
+      wrapper.find('button[title="pipetteOffsetCalButton"]').props()?.disabled
+    ).toEqual(expect.any(String))
+    expect(
+      wrapper.find('button[title="pipetteSettingsButton"]').props()?.disabled
+    ).toEqual(expect.any(String))
+    expect(
+      wrapper.find('button[title="changePipetteButton"]').props()?.disabled
+    ).toEqual(expect.any(String))
   })
 })

--- a/app/src/components/JogControls/index.js
+++ b/app/src/components/JogControls/index.js
@@ -18,6 +18,7 @@ import {
 } from './constants'
 
 import type { Jog, Plane, StepSize } from './types'
+import type { StyleProps } from '@opentrons/components'
 
 export type { Jog }
 export type JogControlsProps = {|
@@ -25,6 +26,7 @@ export type JogControlsProps = {|
   planes?: Array<Plane>,
   stepSizes?: Array<StepSize>,
   auxiliaryControl?: React.Node | null,
+  ...StyleProps,
 |}
 
 export { HORIZONTAL_PLANE, VERTICAL_PLANE }
@@ -35,6 +37,7 @@ export function JogControls(props: JogControlsProps): React.Node {
     planes = [HORIZONTAL_PLANE, VERTICAL_PLANE],
     jog,
     auxiliaryControl = null,
+    ...styleProps
   } = props
   const [currentStepSize, setCurrentStepSize] = React.useState<number>(
     stepSizes[0]
@@ -46,6 +49,7 @@ export function JogControls(props: JogControlsProps): React.Node {
       paddingTop={SPACING_4}
       paddingBottom="2.5rem"
       alignSelf={ALIGN_STRETCH}
+      {...styleProps}
     >
       <StepSizeControl
         {...{ currentStepSize, setCurrentStepSize, stepSizes }}

--- a/app/src/sessions/__tests__/actions.test.js
+++ b/app/src/sessions/__tests__/actions.test.js
@@ -188,6 +188,17 @@ describe('robot session check actions', () => {
         meta: {},
       },
     },
+    {
+      name: 'sessions:CLEAR_ALL_SESSIONS',
+      creator: Actions.clearAllSessions,
+      args: ['robot-name'],
+      expected: {
+        type: 'sessions:CLEAR_ALL_SESSIONS',
+        payload: {
+          robotName: 'robot-name',
+        },
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/sessions/__tests__/reducer.test.js
+++ b/app/src/sessions/__tests__/reducer.test.js
@@ -343,6 +343,34 @@ const SPECS: Array<ReducerSpec> = [
       },
     },
   },
+  {
+    name: 'handles sessions:CLEAR_ALL_SESSIONS',
+    action: {
+      type: 'sessions:CLEAR_ALL_SESSIONS',
+      payload: {
+        robotName: 'blithering-idiot',
+      },
+    },
+    state: {
+      'blithering-idiot': {
+        robotSessions: {
+          existing_fake_session_id: {
+            ...Fixtures.mockTipLengthCalibrationSessionAttributes,
+            id: 'existing_fake_session_id',
+          },
+          [Fixtures.mockSessionId]: {
+            ...Fixtures.mockTipLengthCalibrationSessionAttributes,
+            id: Fixtures.mockSessionId,
+          },
+        },
+      },
+    },
+    expected: {
+      'blithering-idiot': {
+        robotSessions: null,
+      },
+    },
+  },
 ]
 
 describe('robotSessionReducer', () => {

--- a/app/src/sessions/actions.js
+++ b/app/src/sessions/actions.js
@@ -166,3 +166,10 @@ export const ensureSession = (
   payload: { robotName, sessionType, params },
   meta: {},
 })
+
+export const clearAllSessions = (
+  robotName: string
+): Types.ClearAllSessionsAction => ({
+  type: Constants.CLEAR_ALL_SESSIONS,
+  payload: { robotName },
+})

--- a/app/src/sessions/constants.js
+++ b/app/src/sessions/constants.js
@@ -68,3 +68,6 @@ export const SESSION_TYPE_DECK_CALIBRATION: 'deckCalibration' =
   'deckCalibration'
 export const SESSION_TYPE_PIPETTE_OFFSET_CALIBRATION: 'pipetteOffsetCalibration' =
   'pipetteOffsetCalibration'
+
+export const CLEAR_ALL_SESSIONS: 'sessions:CLEAR_ALL_SESSIONS' =
+  'sessions:CLEAR_ALL_SESSIONS'

--- a/app/src/sessions/epic/__tests__/clearAllSessionsOnDisconnectEpic.js
+++ b/app/src/sessions/epic/__tests__/clearAllSessionsOnDisconnectEpic.js
@@ -1,0 +1,71 @@
+// @flow
+import { TestScheduler } from 'rxjs/testing'
+
+import * as DiscoverySelectors from '../../../discovery/selectors'
+import * as RobotSelectors from '../../../robot/selectors'
+import { mockRobot } from '../../../robot-api/__fixtures__'
+
+import * as Actions from '../../actions'
+import { sessionsEpic } from '../../epic'
+
+jest.mock('../../../discovery/selectors')
+jest.mock('../../../robot/selectors')
+
+const mockState = { state: true }
+
+const mockGetRobotByName: JestMockFn<[any, string], mixed> =
+  DiscoverySelectors.getRobotByName
+
+const mockGetConnectedRobotName: JestMockFn<[any], ?string> =
+  RobotSelectors.getConnectedRobotName
+
+describe('clearAllSessionsOnDisconnectEpic', () => {
+  let testScheduler
+
+  beforeEach(() => {
+    mockGetRobotByName.mockReturnValue(mockRobot)
+    mockGetConnectedRobotName.mockReturnValue(mockRobot.name)
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('dispatches CLEAR_ALL_SESSIONS on robot:DISCONNECT_RESPONSE', () => {
+    const action = {
+      type: 'robot:DISCONNECT_RESPONSE',
+      payload: {},
+    }
+
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a--', { a: mockState })
+      const output$ = sessionsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.clearAllSessions(mockRobot.name),
+      })
+    })
+  })
+
+  it('dispatches CLEAR_ALL_SESSIONS on robot:UNEXPECTED_DISCONNECT', () => {
+    const action = {
+      type: 'robot:UNEXPECTED_DISCONNECT',
+      payload: {},
+    }
+
+    testScheduler.run(({ hot, cold, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: action })
+      const state$ = hot('a--', { a: mockState })
+      const output$ = sessionsEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.clearAllSessions(mockRobot.name),
+      })
+    })
+  })
+})

--- a/app/src/sessions/epic/__tests__/clearAllSessionsOnDisconnectEpic.test.js
+++ b/app/src/sessions/epic/__tests__/clearAllSessionsOnDisconnectEpic.test.js
@@ -35,9 +35,9 @@ describe('clearAllSessionsOnDisconnectEpic', () => {
     jest.resetAllMocks()
   })
 
-  it('dispatches CLEAR_ALL_SESSIONS on robot:DISCONNECT_RESPONSE', () => {
+  it('dispatches CLEAR_ALL_SESSIONS on robot:DISCONNECT', () => {
     const action = {
-      type: 'robot:DISCONNECT_RESPONSE',
+      type: 'robot:DISCONNECT',
       payload: {},
     }
 

--- a/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
+++ b/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
@@ -17,7 +17,7 @@ import type { Epic } from '../../types'
 
 export const clearAllSessionsOnDisconnectEpic: Epic = (action$, state$) => {
   return action$.pipe(
-    ofType('robot:DISCONNECT_RESPONSE', 'robot:UNEXPECTED_DISCONNECT'),
+    ofType('robot:DISCONNECT', 'robot:UNEXPECTED_DISCONNECT'),
     withLatestFrom(state$, (_a, s) => getConnectedRobotName(s)),
     filter(robotName => {
       console.log(robotName)

--- a/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
+++ b/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
@@ -1,0 +1,24 @@
+// @flow
+import { of } from 'rxjs'
+import { filter, switchMap, withLatestFrom, pairwise } from 'rxjs/operators'
+import { ofType } from 'redux-observable'
+
+import { getConnectedRobotName } from '../../robot/selectors'
+import * as Actions from '../actions'
+
+import type { Epic } from '../../types'
+
+export const clearAllSessionsOnDisconnectEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType('robot:DISCONNECT_RESPONSE', 'robot:UNEXPECTED_DISCONNECT'),
+    withLatestFrom(state$, (_a, s) => getConnectedRobotName(s)),
+    pairwise(),
+    filter(
+      ([prevConnectedRobotName, nextConnectedRobotName]) =>
+        prevConnectedRobotName != null && nextConnectedRobotName == null
+    ),
+    switchMap(([prevConnectedRobotName, nextConnectedRobotName]) =>
+      of(Actions.clearAllSessions(prevConnectedRobotName))
+    )
+  )
+}

--- a/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
+++ b/app/src/sessions/epic/clearAllSessionsOnDisconnectEpic.js
@@ -1,6 +1,6 @@
 // @flow
 import { of } from 'rxjs'
-import { filter, switchMap, withLatestFrom, pairwise } from 'rxjs/operators'
+import { filter, switchMap, withLatestFrom } from 'rxjs/operators'
 import { ofType } from 'redux-observable'
 
 import { getConnectedRobotName } from '../../robot/selectors'
@@ -8,17 +8,21 @@ import * as Actions from '../actions'
 
 import type { Epic } from '../../types'
 
+// NOTE: this epic is responsible for clearing out the (only) redux state of the sessions
+// that belong to the connected robot as soon as it is disconnected. This is doing the
+// job of what a reducer would more traditionally do, though sessions and "connected"
+// state live in different branches of the redux store. This provides a bridge between
+// the two branches, that should be removed in favor of reducer logic when the concept of
+// "connecting" to a robot is rethought and collocated with session logic.
+
 export const clearAllSessionsOnDisconnectEpic: Epic = (action$, state$) => {
   return action$.pipe(
     ofType('robot:DISCONNECT_RESPONSE', 'robot:UNEXPECTED_DISCONNECT'),
     withLatestFrom(state$, (_a, s) => getConnectedRobotName(s)),
-    pairwise(),
-    filter(
-      ([prevConnectedRobotName, nextConnectedRobotName]) =>
-        prevConnectedRobotName != null && nextConnectedRobotName == null
-    ),
-    switchMap(([prevConnectedRobotName, nextConnectedRobotName]) =>
-      of(Actions.clearAllSessions(prevConnectedRobotName))
-    )
+    filter(robotName => {
+      console.log(robotName)
+      return robotName != null
+    }),
+    switchMap(robotName => of(Actions.clearAllSessions(robotName)))
   )
 }

--- a/app/src/sessions/epic/index.js
+++ b/app/src/sessions/epic/index.js
@@ -7,6 +7,7 @@ import { fetchAllSessionsEpic } from './fetchAllSessionsEpic'
 import { fetchAllSessionsOnConnectEpic } from './fetchAllSessionsOnConnectEpic'
 import { createSessionCommandEpic } from './createSessionCommandEpic'
 import { deleteSessionEpic } from './deleteSessionEpic'
+import { clearAllSessionsOnDisconnectEpic } from './clearAllSessionsOnDisconnectEpic'
 
 import type { Epic } from '../../types'
 
@@ -17,5 +18,6 @@ export const sessionsEpic: Epic = combineEpics(
   fetchAllSessionsEpic,
   fetchAllSessionsOnConnectEpic,
   createSessionCommandEpic,
-  deleteSessionEpic
+  deleteSessionEpic,
+  clearAllSessionsOnDisconnectEpic
 )

--- a/app/src/sessions/reducer.js
+++ b/app/src/sessions/reducer.js
@@ -82,6 +82,15 @@ export function sessionReducer(
         return state
       }
     }
+
+    case Constants.CLEAR_ALL_SESSIONS: {
+      const { robotName } = action.payload
+
+      return {
+        ...state,
+        [robotName]: INITIAL_PER_ROBOT_STATE,
+      }
+    }
   }
 
   return state

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -16,6 +16,7 @@ import typeof {
   FETCH_ALL_SESSIONS_SUCCESS,
   FETCH_ALL_SESSIONS_FAILURE,
   ENSURE_SESSION,
+  CLEAR_ALL_SESSIONS,
   CREATE_SESSION_COMMAND,
   CREATE_SESSION_COMMAND_SUCCESS,
   CREATE_SESSION_COMMAND_FAILURE,
@@ -285,6 +286,11 @@ export type CreateSessionCommandFailureAction = {|
   meta: RobotApiRequestMeta,
 |}
 
+export type ClearAllSessionsAction = {|
+  type: CLEAR_ALL_SESSIONS,
+  payload: {| robotName: string |},
+|}
+
 export type SessionsAction =
   | CreateSessionAction
   | CreateSessionSuccessAction
@@ -302,6 +308,7 @@ export type SessionsAction =
   | CreateSessionCommandSuccessAction
   | CreateSessionCommandFailureAction
   | EnsureSessionAction
+  | ClearAllSessionsAction
 
 export type SessionsById = $Shape<{|
   [id: string]: Session,


### PR DESCRIPTION
# Overview

In order to prevent sessions from sticking around in redux state after a robot has disconnected,
purge all sessions that belong to the disconnected robot from redux state. All buttons on the
pipette info tab should be disabled with a tooltip if not connected to the robot, just as the
buttons on the robot page are.

# Changelog

- add new client only `sessions:CLEAR_ALL_SESSIONS` action that purges the redux store of the sessions associated with the given robot
- new epic listens for `robot:DISCONNECT_RESPONSE` or `robot:UNEXPECTED_DISCONNECT` and dispatches new `sessions:CLEAR_ALL_SESSIONS` with the connected robot
- fix small unrelated jog controls layout inconsistency (1 liner) on the SaveZ component,  the two controls should be justified center in the cal check

# Review requests

- start a cal check session and the disconnect from wifi/usb, you should see the disconnect modal appear behind the session modal, and then the session modal should disappear.  Upon reconnecting to the robot, the session modal should reappear where you left off.
- run cal check and make sure that the jog controls in the z checks are properly center justified

# Risk assessment

low, this mostly shore's up edge cases, but is worth thoroughly testing
