### PR TITLE
fix(app): prettyprint cal check results

### DIFF
--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -66,7 +66,7 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
       instruments,
       savedAt: now.toISOString(),
     }
-    const data = new Blob([JSON.stringify(report)], {
+    const data = new Blob([JSON.stringify(report, null, 4)], {
       type: 'application/json',
     })
     saveAs(data, 'OT-2 Robot Calibration Check Report.json')


### PR DESCRIPTION
Now that we're not showing the results data in the cal check summary
screen anymore, it's more likely that users will want to look at the
check report, so let's pretty print it so they can read it without
putting it into an externnal formatter or something.


```json
{
    "comparisonsByPipette": {
        "first": {
            "tipLength": {
                "status": "IN_THRESHOLD",
                "comparingTip": {
                    "differenceVector": [
                        0,
                        0,
                        0
                    ],
                    "thresholdVector": [
                        0,
                        0,
                        0.27
                    ],
                    "exceedsThreshold": false
                }
            },
            "pipetteOffset": {
                "status": "IN_THRESHOLD",
                "comparingHeight": {
                    "differenceVector": [
                        0,
                        10,
                        0
                    ],
                    "thresholdVector": [
                        0,
                        0,
                        1
                    ],
                    "exceedsThreshold": false
                },
                "comparingPointOne": {
                    "differenceVector": [
                        -1,
                        0,
                        0
                    ],
                    "thresholdVector": [
                        2.7,
                        2.7,
                        0
                    ],
                    "exceedsThreshold": false
                }
            },
            "deck": {
                "status": "IN_THRESHOLD",
                "comparingPointOne": {
                    "differenceVector": [
                        -1,
                        0,
                        0
                    ],
                    "thresholdVector": [
                        2.7,
                        2.7,
                        0
                    ],
                    "exceedsThreshold": false
                },
                "comparingPointTwo": {
                    "differenceVector": [
                        -2,
                        0,
                        0
                    ],
                    "thresholdVector": [
                        2.7,
                        2.7,
                        0
                    ],
                    "exceedsThreshold": false
                },
                "comparingPointThree": {
                    "differenceVector": [
                        -2,
                        0,
                        0
                    ],
                    "thresholdVector": [
                        2.7,
                        2.7,
                        0
                    ],
                    "exceedsThreshold": false
                }
            }
        },
        "second": {
            "tipLength": null,
            "pipetteOffset": null,
            "deck": null
        }
    },
    "instruments": [
        {
            "model": "p1000_single_v2.0",
            "name": "p1000_single_gen2",
            "tipLength": 78.3,
            "mount": "LEFT",
            "serial": "P1KSV202019072443",
            "rank": "first",
            "tipRackLoadName": "opentrons_96_tiprack_1000ul",
            "tipRackDisplay": "Opentrons 96 Tip Rack 1000 µL",
            "tipRackUri": "opentrons/opentrons_96_tiprack_1000ul/1"
        }
    ],
    "savedAt": "2020-11-10T22:45:23.743Z"
}
```
