### PR TITLE
refactor(app): results screen shows calibration and recommendations

### DIFF
--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -1,10 +1,9 @@
 // @flow
 import * as React from 'react'
-import reduce from 'lodash/reduce'
-import { css } from 'styled-components'
 import {
   Icon,
   Box,
+  Btn,
   Flex,
   PrimaryBtn,
   Text,
@@ -30,7 +29,7 @@ import {
   SPACING_5,
   SPACING_4,
   SPACING_1,
-  SPACING_7,
+  SIZE_5,
   DIRECTION_COLUMN,
   DISPLAY_INLINE_BLOCK,
 } from '@opentrons/components'
@@ -155,7 +154,11 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
         >
           {ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER}
         </Text>
-        <Box minHeight={SPACING_2} marginBottom={SPACING_3}>
+        <Box
+          minHeight={SPACING_2}
+          marginBottom={SPACING_3}
+          title="results-note-container"
+        >
           <WarningText
             deckCalibrationBad={
               deckCalibrationResult
@@ -169,22 +172,24 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
           />
         </Box>
       </Flex>
-      <Flex marginBottom={SPACING_4}>
-        <Box>
-          <Text
-            marginBottom={SPACING_2}
-            textTransform={TEXT_TRANSFORM_CAPITALIZE}
-            fontWeight={FONT_WEIGHT_SEMIBOLD}
-            fontSize={FONT_SIZE_BODY_2}
-          >
-            {DECK_CALIBRATION_HEADER}
-          </Text>
-          <RenderResult status={deckCalibrationResult} />
-        </Box>
+      <Flex
+        marginBottom={SPACING_4}
+        title="deck-calibration-container"
+        flexDirection={DIRECTION_COLUMN}
+      >
+        <Text
+          marginBottom={SPACING_2}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
+          fontWeight={FONT_WEIGHT_SEMIBOLD}
+          fontSize={FONT_SIZE_BODY_2}
+        >
+          {DECK_CALIBRATION_HEADER}
+        </Text>
+        <RenderResult status={deckCalibrationResult} />
       </Flex>
       <Flex marginBottom={SPACING_2} justifyContent={JUSTIFY_SPACE_BETWEEN}>
         {PIPETTE_MOUNTS.map(m => (
-          <Box key={m} width="48%">
+          <Box key={m} width="48%" title={`${m}-mount-container`}>
             <Text
               textTransform={TEXT_TRANSFORM_UPPERCASE}
               fontSize={FONT_SIZE_BODY_2}
@@ -195,7 +200,8 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
             <Box
               backgroundColor={OVERLAY_LIGHT_GRAY_50}
               paddingX="5%"
-              height={SPACING_7}
+              height={SIZE_5}
+              title={`${m}-mount-results`}
             >
               {calibrationsByMount[m].pipette &&
               calibrationsByMount[m].calibration &&
@@ -221,18 +227,15 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
         ))}
       </Flex>
       <Box>
-        <Text
-          as="a"
+        <Btn
           color={C_BLUE}
           onClick={handleDownloadButtonClick}
-          css={css`
-            cursor: pointer;
-          `}
           marginBottom={SPACING_5}
           fontSize={FONT_SIZE_BODY_2}
+          title="download-results-button"
         >
           {DOWNLOAD_SUMMARY}
-        </Text>
+        </Btn>
 
         <Flex
           marginTop={SPACING_4}
@@ -332,18 +335,14 @@ function WarningText(props: {|
     left: {| offsetBad: boolean, tipLengthBad: boolean |},
     right: {| offsetBad: boolean, tipLengthBad: boolean |},
   |},
-|}): React.Node {
-  const badCount = reduce(
-    [
-      props.deckCalibrationBad,
-      props.pipettes.left.offsetBad,
-      props.pipettes.left.tipLengthBad,
-      props.pipettes.right.offsetBad,
-      props.pipettes.right.tipLengthBad,
-    ],
-    (sum, item) => sum + (item === true ? 1 : 0),
-    0
-  )
+|}): React.Node | null {
+  const badCount = [
+    props.deckCalibrationBad,
+    props.pipettes.left.offsetBad,
+    props.pipettes.left.tipLengthBad,
+    props.pipettes.right.offsetBad,
+    props.pipettes.right.tipLengthBad,
+  ].reduce((sum, item) => sum + (item === true ? 1 : 0), 0)
   return badCount > 0 ? (
     <>
       <Box marginTop={SPACING_3} fontSize={FONT_SIZE_BODY_2}>
@@ -375,11 +374,7 @@ function WarningText(props: {|
         >{`${NOTE}: ${
           badCount > 1 ? DO_DECK_FIRST : ''
         } ${DECK_INVALIDATES}`}</Text>
-      ) : (
-        <React.Fragment />
-      )}
+      ) : null}
     </>
-  ) : (
-    <React.Fragment />
-  )
+  ) : null
 }

--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import reduce from 'lodash/reduce'
 import { css } from 'styled-components'
 import {
   Icon,
@@ -7,45 +8,75 @@ import {
   Flex,
   PrimaryBtn,
   Text,
+  Link,
   SPACING_2,
   SPACING_3,
   ALIGN_CENTER,
   C_BLUE,
   COLOR_SUCCESS,
   COLOR_WARNING,
+  OVERLAY_LIGHT_GRAY_50,
   FONT_HEADER_DARK,
   FONT_SIZE_BODY_2,
-  FONT_WEIGHT_LIGHT,
+  FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_SPACE_AROUND,
+  JUSTIFY_START,
   TEXT_TRANSFORM_CAPITALIZE,
+  TEXT_TRANSFORM_UPPERCASE,
+  FONT_STYLE_ITALIC,
   SPACING_5,
   SPACING_4,
+  SPACING_1,
+  SPACING_7,
   DIRECTION_COLUMN,
+  DISPLAY_INLINE_BLOCK,
 } from '@opentrons/components'
+
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 
 import find from 'lodash/find'
 import { PIPETTE_MOUNTS, LEFT, RIGHT } from '../../pipettes'
 import { saveAs } from 'file-saver'
-import { NeedHelpLink } from '../CalibrationPanels/NeedHelpLink'
 
 import type { CalibrationPanelProps } from '../CalibrationPanels/types'
+import {
+  CHECK_STATUS_OUTSIDE_THRESHOLD,
+  CHECK_STATUS_IN_THRESHOLD,
+} from '../../sessions'
 import type {
   CalibrationCheckInstrument,
   CalibrationCheckComparisonsPerCalibration,
 } from '../../sessions/types'
 
 const GOOD_CALIBRATION = 'Good calibration'
-const BAD_CALIBRATION = 'Bad calibration'
+const BAD_CALIBRATION = 'Recalibration recommended'
 
-const ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER = 'health check results:'
-const DECK_CALIBRATION_HEADER = 'Robot Deck'
-const PIPETTE = 'pipette'
+const ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER =
+  'calibration health check results'
+const DECK_CALIBRATION_HEADER = 'robot deck calibration'
+const MOUNT = 'mount'
 const HOME_AND_EXIT = 'Home robot and exit'
-const LOOKING_FOR_DATA = 'Looking for your detailed calibration data?'
-const DOWNLOAD_SUMMARY = 'Download JSON summary'
+const DOWNLOAD_SUMMARY = 'Download detailed JSON Calibration Check summary'
+const PIPETTE_OFFSET_CALIBRATION_HEADER = 'pipette offset calibration'
+const TIP_LENGTH_CALIBRATION_HEADER = 'tip length calibration'
+const NEED_HELP = 'If problems persist,'
+const CONTACT_SUPPORT = 'contact Opentrons support'
+const FOR_HELP = 'for help'
+const SUPPORT_URL = 'https://support.opentrons.com'
+
+const FOUND = 'Health check found'
+const ONE_ISSUE = 'an issue'
+const PLURAL_ISSUES = 'issues'
+const RECALIBRATE_AS_INDICATED =
+  'Redo the calibrations indicated below to troubleshoot'
+const NOTE = 'Note'
+const DO_DECK_FIRST = 'Recalibrate your deck before redoing other calibrations.'
+const DECK_INVALIDATES =
+  'Recalibrating your deck will invalidate Pipette Offsets, and you will need to recalibrate Pipette Offsets after redoing Deck Calibration.'
+const NO_PIPETTE = 'No pipette attached'
 
 export function ResultsSummary(props: CalibrationPanelProps): React.Node {
   const {
@@ -83,17 +114,15 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
 
   const calibrationsByMount = {
     left: {
-      headerText: `${LEFT} ${PIPETTE}`,
       pipette: leftPipette,
       calibration: leftPipette
-        ? comparisonsByPipette?.[leftPipette.rank]
+        ? comparisonsByPipette?.[leftPipette.rank] ?? null
         : null,
     },
     right: {
-      headerText: `${RIGHT} ${PIPETTE}`,
       pipette: rightPipette,
       calibration: rightPipette
-        ? comparisonsByPipette?.[rightPipette.rank]
+        ? comparisonsByPipette?.[rightPipette.rank] ?? null
         : null,
     },
   }
@@ -103,73 +132,114 @@ export function ResultsSummary(props: CalibrationPanelProps): React.Node {
     : comparisonsByPipette.first.deck?.status
   const deckCalibrationResult = getDeckCalibration ?? null
 
+  const pipetteResultsBad = perPipette => ({
+    offsetBad: perPipette?.pipetteOffset?.status
+      ? perPipette.pipetteOffset.status === CHECK_STATUS_OUTSIDE_THRESHOLD
+      : false,
+    tipLengthBad: perPipette?.tipLength?.status
+      ? perPipette.tipLength.status === CHECK_STATUS_OUTSIDE_THRESHOLD
+      : false,
+  })
+
   return (
     <>
-      <Flex width="100%" justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Flex
+        width="100%"
+        justifyContent={JUSTIFY_START}
+        flexDirection={DIRECTION_COLUMN}
+      >
         <Text
           css={FONT_HEADER_DARK}
           marginTop={SPACING_2}
-          marginBottom={SPACING_5}
           textTransform={TEXT_TRANSFORM_CAPITALIZE}
         >
           {ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER}
         </Text>
-        <NeedHelpLink maxHeight="1rem" />
-      </Flex>
-      <Box paddingX="5%">
-        <Flex marginBottom={SPACING_4}>
-          <Box>
-            <Text marginBottom={SPACING_2}>{DECK_CALIBRATION_HEADER}</Text>
-            <RenderResult status={deckCalibrationResult} />
-          </Box>
-        </Flex>
-        <Flex marginBottom={SPACING_5} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          {PIPETTE_MOUNTS.map(m => {
-            if (
-              calibrationsByMount[m].pipette &&
-              calibrationsByMount[m].calibration
-            ) {
-              return (
-                <Box key={m} width="48%">
-                  <Text
-                    textTransform={TEXT_TRANSFORM_CAPITALIZE}
-                    marginBottom={SPACING_3}
-                  >
-                    {calibrationsByMount[m].headerText}
-                  </Text>
-                  <PipetteResult
-                    pipetteInfo={calibrationsByMount[m].pipette}
-                    pipetteCalibration={calibrationsByMount[m].calibration}
-                  />
-                </Box>
-              )
+        <Box minHeight={SPACING_2} marginBottom={SPACING_3}>
+          <WarningText
+            deckCalibrationBad={
+              deckCalibrationResult
+                ? deckCalibrationResult === CHECK_STATUS_OUTSIDE_THRESHOLD
+                : false
             }
-          })}
-        </Flex>
-      </Box>
+            pipettes={{
+              left: pipetteResultsBad(calibrationsByMount.left.calibration),
+              right: pipetteResultsBad(calibrationsByMount.right.calibration),
+            }}
+          />
+        </Box>
+      </Flex>
+      <Flex marginBottom={SPACING_4}>
+        <Box>
+          <Text
+            marginBottom={SPACING_2}
+            textTransform={TEXT_TRANSFORM_CAPITALIZE}
+            fontWeight={FONT_WEIGHT_SEMIBOLD}
+            fontSize={FONT_SIZE_BODY_2}
+          >
+            {DECK_CALIBRATION_HEADER}
+          </Text>
+          <RenderResult status={deckCalibrationResult} />
+        </Box>
+      </Flex>
+      <Flex marginBottom={SPACING_2} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+        {PIPETTE_MOUNTS.map(m => (
+          <Box key={m} width="48%">
+            <Text
+              textTransform={TEXT_TRANSFORM_UPPERCASE}
+              fontSize={FONT_SIZE_BODY_2}
+              marginBottom={SPACING_3}
+            >
+              {`${m} ${MOUNT}`}
+            </Text>
+            <Box
+              backgroundColor={OVERLAY_LIGHT_GRAY_50}
+              paddingX="5%"
+              height={SPACING_7}
+            >
+              {calibrationsByMount[m].pipette &&
+              calibrationsByMount[m].calibration &&
+              Object.entries(calibrationsByMount[m].calibration).length ? (
+                <PipetteResult
+                  pipetteInfo={calibrationsByMount[m].pipette}
+                  pipetteCalibration={calibrationsByMount[m].calibration}
+                />
+              ) : (
+                <Flex
+                  alignItems={ALIGN_CENTER}
+                  justifyContent={JUSTIFY_CENTER}
+                  fontStyle={FONT_STYLE_ITALIC}
+                  fontSize={FONT_SIZE_BODY_1}
+                  flexDirection={DIRECTION_COLUMN}
+                  height="100%"
+                >
+                  {NO_PIPETTE}
+                </Flex>
+              )}
+            </Box>
+          </Box>
+        ))}
+      </Flex>
       <Box>
-        <Flex
-          alignItems={ALIGN_CENTER}
-          justifyContent={JUSTIFY_CENTER}
+        <Text
+          as="a"
+          color={C_BLUE}
+          onClick={handleDownloadButtonClick}
+          css={css`
+            cursor: pointer;
+          `}
           marginBottom={SPACING_5}
-          flexDirection={DIRECTION_COLUMN}
-          fontWeight={FONT_WEIGHT_LIGHT}
           fontSize={FONT_SIZE_BODY_2}
         >
-          <Text>{LOOKING_FOR_DATA}</Text>
-          <Text
-            as="a"
-            color={C_BLUE}
-            onClick={handleDownloadButtonClick}
-            css={css`
-              cursor: pointer;
-            `}
-          >
-            {DOWNLOAD_SUMMARY}
-          </Text>
-        </Flex>
-        <Flex margin={SPACING_4}>
-          <PrimaryBtn width="100%" onClick={cleanUpAndExit}>
+          {DOWNLOAD_SUMMARY}
+        </Text>
+
+        <Flex
+          marginTop={SPACING_4}
+          marginBottom={SPACING_2}
+          justifyContent={JUSTIFY_CENTER}
+        >
+          <PrimaryBtn width="95%" onClick={cleanUpAndExit}>
             {HOME_AND_EXIT}
           </PrimaryBtn>
         </Flex>
@@ -187,7 +257,7 @@ function RenderResult(props: RenderResultProps): React.Node {
   if (!status) {
     return null
   } else {
-    const isGoodCal = status === 'IN_THRESHOLD'
+    const isGoodCal = status === CHECK_STATUS_IN_THRESHOLD
     return (
       <Flex>
         <Icon
@@ -212,19 +282,26 @@ type PipetteResultProps = {|
 
 function PipetteResult(props: PipetteResultProps): React.Node {
   const { pipetteInfo, pipetteCalibration } = props
-
   const displayName =
     getPipetteModelSpecs(pipetteInfo.model)?.displayName || pipetteInfo.model
-
-  const tipRackdisplayName = pipetteInfo.tipRackDisplay
+  const tipRackDisplayName = pipetteInfo.tipRackDisplay
   return (
-    <>
-      <Box marginBottom={SPACING_4}>
+    <Flex
+      paddingY={SPACING_2}
+      flexDirection={DIRECTION_COLUMN}
+      justifyContent={JUSTIFY_SPACE_AROUND}
+      height="100%"
+    >
+      <Box>
         <Text
           fontSize={FONT_SIZE_BODY_2}
           fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginBottom={SPACING_2}
+          marginBottom={SPACING_1}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
         >
+          {PIPETTE_OFFSET_CALIBRATION_HEADER}
+        </Text>
+        <Text fontSize={FONT_SIZE_BODY_1} marginBottom={SPACING_2}>
           {displayName}
         </Text>
         <RenderResult
@@ -235,12 +312,74 @@ function PipetteResult(props: PipetteResultProps): React.Node {
         <Text
           fontSize={FONT_SIZE_BODY_2}
           fontWeight={FONT_WEIGHT_SEMIBOLD}
-          marginBottom={SPACING_2}
+          marginBottom={SPACING_1}
+          textTransform={TEXT_TRANSFORM_CAPITALIZE}
         >
-          {tipRackdisplayName}
+          {TIP_LENGTH_CALIBRATION_HEADER}
+        </Text>
+        <Text fontSize={FONT_SIZE_BODY_1} marginBottom={SPACING_2}>
+          {tipRackDisplayName}
         </Text>
         <RenderResult status={pipetteCalibration.tipLength?.status ?? null} />
       </Box>
+    </Flex>
+  )
+}
+
+function WarningText(props: {|
+  deckCalibrationBad: boolean,
+  pipettes: {|
+    left: {| offsetBad: boolean, tipLengthBad: boolean |},
+    right: {| offsetBad: boolean, tipLengthBad: boolean |},
+  |},
+|}): React.Node {
+  const badCount = reduce(
+    [
+      props.deckCalibrationBad,
+      props.pipettes.left.offsetBad,
+      props.pipettes.left.tipLengthBad,
+      props.pipettes.right.offsetBad,
+      props.pipettes.right.tipLengthBad,
+    ],
+    (sum, item) => sum + (item === true ? 1 : 0),
+    0
+  )
+  return badCount > 0 ? (
+    <>
+      <Box marginTop={SPACING_3} fontSize={FONT_SIZE_BODY_2}>
+        <Text display={DISPLAY_INLINE_BLOCK}>
+          {`${FOUND}`}
+          &nbsp;
+          {badCount === 1 ? ONE_ISSUE : PLURAL_ISSUES}. &nbsp;
+          {`${RECALIBRATE_AS_INDICATED}.`}
+        </Text>
+        &nbsp;
+        <Text display={DISPLAY_INLINE_BLOCK}>{NEED_HELP}</Text>
+        &nbsp;
+        <Link
+          display={DISPLAY_INLINE_BLOCK}
+          color={C_BLUE}
+          external={true}
+          href={SUPPORT_URL}
+        >
+          {CONTACT_SUPPORT}
+        </Link>
+        &nbsp;
+        <Text display={DISPLAY_INLINE_BLOCK}>{`${FOR_HELP}.`}</Text>
+      </Box>
+      {props.deckCalibrationBad ? (
+        <Text
+          fontSize={FONT_SIZE_BODY_1}
+          marginTop={SPACING_2}
+          fontStyle={FONT_STYLE_ITALIC}
+        >{`${NOTE}: ${
+          badCount > 1 ? DO_DECK_FIRST : ''
+        } ${DECK_INVALIDATES}`}</Text>
+      ) : (
+        <React.Fragment />
+      )}
     </>
+  ) : (
+    <React.Fragment />
   )
 }

--- a/app/src/components/CheckCalibration/__tests__/ResultsSummary.test.js
+++ b/app/src/components/CheckCalibration/__tests__/ResultsSummary.test.js
@@ -218,7 +218,6 @@ describe('ResultsSummary', () => {
 
   it('saves the calibration report when the button is clicked', () => {
     const wrapper = render()
-    console.log(getSaveLink(wrapper).debug())
     act(() => getSaveLink(wrapper).invoke('onClick')())
     wrapper.update()
     expect(mockSaveAs).toHaveBeenCalled()

--- a/app/src/components/CheckCalibration/__tests__/ResultsSummary.test.js
+++ b/app/src/components/CheckCalibration/__tests__/ResultsSummary.test.js
@@ -10,7 +10,7 @@ import * as Sessions from '../../../sessions'
 import type { State } from '../../../types'
 import { ResultsSummary } from '../ResultsSummary'
 import { saveAs } from 'file-saver'
-import { Box, PrimaryBtn, Flex, Text } from '@opentrons/components'
+import { PrimaryBtn, Flex, Text } from '@opentrons/components'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
@@ -52,36 +52,17 @@ describe('ResultsSummary', () => {
   const getExitButton = wrapper => wrapper.find(PrimaryBtn)
 
   const getSaveLink = wrapper =>
-    wrapper
-      .find('[children="Download detailed JSON Calibration Check summary"]')
-      .find('a')
+    wrapper.find('button[title="download-results-button"]')
+
   const getDeckParent = wrapper => wrapper.children(Flex).at(1)
-  const getPipParent = wrapper =>
-    wrapper
-      .children(Flex)
-      .at(2)
-      .children()
-      .at(0)
   const getLeftPipParent = wrapper =>
-    getPipParent(wrapper)
-      .children(Box)
-      .at(0)
-      .children()
-      .at(0)
+    wrapper.find('div[title="left-mount-container"]')
   const getLeftPipResultsParent = wrapper =>
-    getLeftPipParent(wrapper)
-      .children(Box)
-      .at(0)
+    wrapper.find('div[title="left-mount-results"]')
   const getRightPipParent = wrapper =>
-    getPipParent(wrapper)
-      .children(Box)
-      .at(1)
-      .children()
-      .at(0)
+    wrapper.find('div[title="right-mount-container"]')
   const getRightPipResultsParent = wrapper =>
-    getRightPipParent(wrapper)
-      .children(Box)
-      .at(0)
+    wrapper.find('div[title="right-mount-results"]')
   beforeEach(() => {
     mockDeleteSession = jest.fn()
     const mockSendCommands = jest.fn()
@@ -237,6 +218,7 @@ describe('ResultsSummary', () => {
 
   it('saves the calibration report when the button is clicked', () => {
     const wrapper = render()
+    console.log(getSaveLink(wrapper).debug())
     act(() => getSaveLink(wrapper).invoke('onClick')())
     wrapper.update()
     expect(mockSaveAs).toHaveBeenCalled()


### PR DESCRIPTION
In testing, users couldn't really figure out good next steps from
problems in the cal check recommendations; this way, we not only say
exactly what calibrations we're talking about but also explicitly tell
people to recalibrate rather than just saying a calibration is bad.
![Screenshot from 2020-11-12 16-41-46](https://user-images.githubusercontent.com/3091648/98999544-fb882580-2505-11eb-9e69-d7cb4881709c.png)

