### PR TITLE
fix(app): fix buildroot download modal title

### DIFF
--- a/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/DownloadUpdateModal.js
@@ -17,7 +17,7 @@ export function DownloadUpdateModal(
   props: DownloadUpdateModalProps
 ): React.Node {
   const { notNowButton, error, progress } = props
-  const heading = error !== null ? 'Downloading Update' : 'Download Error'
+  const heading = error !== null ? 'Download Error' : 'Downloading Update'
 
   return (
     <AlertModal

--- a/app/src/components/RobotSettings/UpdateBuildroot/__tests__/DownloadUpdateModal.test.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/__tests__/DownloadUpdateModal.test.js
@@ -1,0 +1,58 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { AlertModal } from '@opentrons/components'
+import { ProgressBar } from '../progress'
+import { DownloadUpdateModal } from '../DownloadUpdateModal'
+
+describe('DownloadUpdateModal', () => {
+  const handleClose = jest.fn()
+
+  const render = (error = null) => {
+    return mount(
+      <DownloadUpdateModal
+        notNowButton={{ onClick: handleClose, children: 'not now' }}
+        error={error}
+        progress={50}
+      />
+    )
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render an AlertModal with a heading', () => {
+    const wrapper = render()
+    const modal = wrapper.find(AlertModal)
+
+    expect(modal.prop('heading')).toBe('Downloading Update')
+  })
+
+  it('should render a close button', () => {
+    const wrapper = render()
+    const button = wrapper.find('button')
+
+    expect(button.text()).toMatch(/not now/)
+    expect(handleClose).not.toHaveBeenCalled()
+    button.invoke('onClick')()
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('should render a progress bar', () => {
+    const wrapper = render()
+    const progress = wrapper.find(ProgressBar)
+
+    expect(progress.prop('progress')).toBe(50)
+  })
+
+  it('should render a different heading, an error message, and no progress bar on error', () => {
+    const wrapper = render('oh no!')
+    const modal = wrapper.find(AlertModal)
+
+    expect(modal.prop('heading')).toBe('Download Error')
+    expect(modal.html()).toContain('oh no!')
+    expect(wrapper.exists(ProgressBar)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Overview

The "downloading update" view of the robot update modal has a flipped conditional, such that the title is "Download Error" when there is _not_ an error and "Downloading Update" when there _is_ an error. This PR flips the conditional so it's correct and adds tests to the component.

Fixes #5546

## Changelog

- fix(app): fix buildroot download modal title

## Review requests

This is really straightforward

## Risk assessment

Low. Very old, obvious bug that was easily fixed and tested for.
