### PR TITLE
test(app): add tests for robot update wizard during upgrade, downgrade, and reinstall

### DIFF
--- a/app/src/components/RobotSettings/UpdateBuildroot/__tests__/UpdateBuildroot.test.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/__tests__/UpdateBuildroot.test.js
@@ -1,0 +1,182 @@
+// @flow
+import * as React from 'react'
+
+import { mountWithStore } from '@opentrons/components/__utils__'
+import { mockConnectableRobot as mockRobot } from '../../../../discovery/__fixtures__'
+import * as Buildroot from '../../../../buildroot'
+import { UpdateBuildroot } from '..'
+import { VersionInfoModal } from '../VersionInfoModal'
+import { ViewUpdateModal } from '../ViewUpdateModal'
+import { InstallModal } from '../InstallModal'
+
+import type { State } from '../../../../types'
+import type { ViewableRobot } from '../../../../discovery/types'
+
+// shallow render connected children
+jest.mock('../VersionInfoModal', () => ({
+  VersionInfoModal: () => <></>,
+}))
+
+jest.mock('../ViewUpdateModal', () => ({
+  ViewUpdateModal: () => <></>,
+}))
+
+jest.mock('../../../../buildroot/selectors')
+
+const getBuildrootUpdateAvailable: JestMockFn<
+  [State, ViewableRobot],
+  $Call<typeof Buildroot.getBuildrootUpdateAvailable, State, ViewableRobot>
+> = Buildroot.getBuildrootUpdateAvailable
+
+const getBuildrootSession: JestMockFn<
+  [State],
+  $Call<typeof Buildroot.getBuildrootSession, State>
+> = Buildroot.getBuildrootSession
+
+const getRobotSystemType: JestMockFn<
+  [ViewableRobot],
+  $Call<typeof Buildroot.getRobotSystemType, ViewableRobot>
+> = Buildroot.getRobotSystemType
+
+const MOCK_STATE: State = ({ mockState: true }: any)
+
+describe('UpdateBuildroot wizard', () => {
+  const closeModal = jest.fn()
+  const render = () => {
+    return mountWithStore(
+      <UpdateBuildroot robot={mockRobot} close={closeModal} />,
+      { initialState: MOCK_STATE }
+    )
+  }
+
+  beforeEach(() => {
+    getBuildrootUpdateAvailable.mockReturnValue(Buildroot.UPGRADE)
+    getRobotSystemType.mockReturnValue(Buildroot.BUILDROOT)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set the update as seen on mount', () => {
+    const { store } = render()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Buildroot.setBuildrootUpdateSeen(mockRobot.name)
+    )
+  })
+
+  it('should render a VersionInfoModal first', () => {
+    const { wrapper } = render()
+    const versionInfo = wrapper.find(VersionInfoModal)
+
+    expect(versionInfo.prop('robot')).toBe(mockRobot)
+    expect(versionInfo.prop('robotUpdateType')).toBe(Buildroot.UPGRADE)
+
+    expect(getBuildrootUpdateAvailable).toHaveBeenCalledWith(
+      MOCK_STATE,
+      mockRobot
+    )
+    expect(closeModal).not.toHaveBeenCalled()
+
+    versionInfo.invoke('close')()
+    expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('should proceed from the VersionInfoModal to a ViewUpdateModal', () => {
+    const { wrapper } = render()
+    const versionInfo = wrapper.find(VersionInfoModal)
+
+    expect(wrapper.exists(ViewUpdateModal)).toBe(false)
+    versionInfo.invoke('proceed')()
+
+    const viewUpdate = wrapper.find(ViewUpdateModal)
+    expect(viewUpdate.prop('robotName')).toBe(mockRobot.name)
+    expect(viewUpdate.prop('robotUpdateType')).toBe(Buildroot.UPGRADE)
+    expect(viewUpdate.prop('robotSystemType')).toBe(Buildroot.BUILDROOT)
+    expect(getRobotSystemType).toHaveBeenCalledWith(mockRobot)
+
+    viewUpdate.invoke('close')()
+    expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('should proceed from the ViewUpdateModal to an install', () => {
+    const { wrapper, store } = render()
+    wrapper.find(VersionInfoModal).invoke('proceed')()
+    wrapper.find(ViewUpdateModal).invoke('proceed')()
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Buildroot.startBuildrootUpdate(mockRobot.name)
+    )
+  })
+
+  it('should display an InstallModal if a session is in progress', () => {
+    const mockSession = {
+      robotName: mockRobot.name,
+      userFileInfo: null,
+      token: null,
+      pathPrefix: null,
+      step: null,
+      stage: null,
+      progress: null,
+      error: null,
+    }
+
+    getBuildrootSession.mockReturnValue(mockSession)
+
+    const { wrapper } = render()
+    const installModal = wrapper.find(InstallModal)
+
+    expect(installModal.prop('robot')).toBe(mockRobot)
+    expect(installModal.prop('robotSystemType')).toBe(Buildroot.BUILDROOT)
+    expect(installModal.prop('session')).toBe(mockSession)
+
+    expect(closeModal).not.toHaveBeenCalled()
+    installModal.invoke('close')()
+    expect(closeModal).toHaveBeenCalled()
+  })
+
+  it('should clear a finished session un unmount', () => {
+    const mockSession = {
+      robotName: mockRobot.name,
+      userFileInfo: null,
+      token: null,
+      pathPrefix: null,
+      step: Buildroot.FINISHED,
+      stage: null,
+      progress: null,
+      error: null,
+    }
+
+    getBuildrootSession.mockReturnValue(mockSession)
+
+    const { wrapper, store } = render()
+
+    wrapper.unmount()
+    expect(store.dispatch).toHaveBeenCalledWith(
+      Buildroot.clearBuildrootSession()
+    )
+  })
+
+  it('should not clear an unfinished session un unmount', () => {
+    const mockSession = {
+      robotName: mockRobot.name,
+      userFileInfo: null,
+      token: null,
+      pathPrefix: null,
+      step: Buildroot.RESTARTING,
+      stage: null,
+      progress: null,
+      error: null,
+    }
+
+    getBuildrootSession.mockReturnValue(mockSession)
+
+    const { wrapper, store } = render()
+
+    wrapper.unmount()
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      Buildroot.clearBuildrootSession()
+    )
+  })
+})

--- a/app/src/components/RobotSettings/UpdateBuildroot/__tests__/ViewUpdateModal.test.js
+++ b/app/src/components/RobotSettings/UpdateBuildroot/__tests__/ViewUpdateModal.test.js
@@ -1,0 +1,176 @@
+// @flow
+import * as React from 'react'
+
+import { mountWithStore } from '@opentrons/components/__utils__'
+import * as Buildroot from '../../../../buildroot'
+
+import { DownloadUpdateModal } from '../DownloadUpdateModal'
+import { ReleaseNotesModal } from '../ReleaseNotesModal'
+import { MigrationWarningModal } from '../MigrationWarningModal'
+import { ViewUpdateModal } from '../ViewUpdateModal'
+
+import type { State } from '../../../../types'
+
+jest.mock('../../../../buildroot')
+
+const getBuildrootUpdateInfo: JestMockFn<
+  [State],
+  $Call<typeof Buildroot.getBuildrootUpdateInfo, State>
+> = Buildroot.getBuildrootUpdateInfo
+
+const getBuildrootDownloadProgress: JestMockFn<
+  [State],
+  $Call<typeof Buildroot.getBuildrootDownloadProgress, State>
+> = Buildroot.getBuildrootDownloadProgress
+
+const getBuildrootDownloadError: JestMockFn<
+  [State],
+  $Call<typeof Buildroot.getBuildrootDownloadError, State>
+> = Buildroot.getBuildrootDownloadError
+
+const MOCK_STATE: State = ({ mockState: true }: any)
+const MOCK_ROBOT_NAME = 'robot-name'
+
+describe('ViewUpdateModal', () => {
+  const handleClose = jest.fn()
+  const handleProceed = jest.fn()
+
+  const render = (
+    robotUpdateType = Buildroot.UPGRADE,
+    robotSystemType = Buildroot.BUILDROOT
+  ) => {
+    return mountWithStore(
+      <ViewUpdateModal
+        robotName={MOCK_ROBOT_NAME}
+        robotUpdateType={robotUpdateType}
+        robotSystemType={robotSystemType}
+        close={handleClose}
+        proceed={handleProceed}
+      />,
+      { initialState: MOCK_STATE }
+    )
+  }
+
+  beforeEach(() => {
+    getBuildrootUpdateInfo.mockReturnValue(null)
+    getBuildrootDownloadProgress.mockReturnValue(50)
+    getBuildrootDownloadError.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should show a DownloadUpdateModal if the update has not been downloaded yet', () => {
+    const { wrapper } = render()
+    const downloadUpdateModal = wrapper.find(DownloadUpdateModal)
+
+    expect(downloadUpdateModal.prop('error')).toEqual(null)
+    expect(downloadUpdateModal.prop('progress')).toEqual(50)
+    expect(getBuildrootDownloadProgress).toHaveBeenCalledWith(MOCK_STATE)
+
+    const closeButtonProps = downloadUpdateModal.prop('notNowButton')
+
+    expect(closeButtonProps.children).toMatch(/not now/i)
+    expect(handleClose).not.toHaveBeenCalled()
+    closeButtonProps.onClick()
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('should show a DownloadUpdateModal if the update download errored out', () => {
+    getBuildrootDownloadError.mockReturnValue('oh no!')
+
+    const { wrapper } = render()
+    const downloadUpdateModal = wrapper.find(DownloadUpdateModal)
+
+    expect(downloadUpdateModal.prop('error')).toEqual('oh no!')
+    expect(getBuildrootDownloadError).toHaveBeenCalledWith(MOCK_STATE)
+
+    const closeButtonProps = downloadUpdateModal.prop('notNowButton')
+
+    expect(closeButtonProps.children).toMatch(/close/i)
+    expect(handleClose).not.toHaveBeenCalled()
+    closeButtonProps.onClick()
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('should show a ReleaseNotesModal if the update is an upgrade', () => {
+    getBuildrootUpdateInfo.mockReturnValue({
+      releaseNotes: 'hey look a release',
+    })
+
+    const { wrapper } = render()
+    const releaseNotesModal = wrapper.find(ReleaseNotesModal)
+
+    expect(releaseNotesModal.prop('robotName')).toBe(MOCK_ROBOT_NAME)
+    expect(releaseNotesModal.prop('releaseNotes')).toBe('hey look a release')
+    expect(releaseNotesModal.prop('systemType')).toBe(Buildroot.BUILDROOT)
+    expect(getBuildrootUpdateInfo).toHaveBeenCalledWith(MOCK_STATE)
+
+    const closeButtonProps = releaseNotesModal.prop('notNowButton')
+
+    expect(closeButtonProps.children).toMatch(/not now/i)
+    expect(handleClose).not.toHaveBeenCalled()
+    closeButtonProps.onClick()
+    expect(handleClose).toHaveBeenCalled()
+
+    expect(handleProceed).not.toHaveBeenCalled()
+    releaseNotesModal.invoke('proceed')()
+    expect(handleProceed).toHaveBeenCalled()
+  })
+
+  it('should proceed straight to update if downgrade', () => {
+    getBuildrootUpdateInfo.mockReturnValue({
+      releaseNotes: 'hey look a release',
+    })
+
+    render(Buildroot.DOWNGRADE)
+    expect(handleProceed).toHaveBeenCalled()
+  })
+
+  it('should proceed straight to update if reinstall', () => {
+    getBuildrootUpdateInfo.mockReturnValue({
+      releaseNotes: 'hey look a release',
+    })
+
+    render(Buildroot.REINSTALL)
+    expect(handleProceed).toHaveBeenCalled()
+  })
+
+  it('should show a MigrationWarningModal if the robot is on Balena', () => {
+    const { wrapper } = render(Buildroot.UPGRADE, Buildroot.BALENA)
+    const migrationWarning = wrapper.find(MigrationWarningModal)
+
+    expect(migrationWarning.prop('updateType')).toBe(Buildroot.UPGRADE)
+
+    const closeButtonProps = migrationWarning.prop('notNowButton')
+
+    expect(closeButtonProps.children).toMatch(/not now/i)
+    expect(handleClose).not.toHaveBeenCalled()
+    closeButtonProps.onClick()
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('should proceed from MigrationWarningModal to release notes if upgrade', () => {
+    getBuildrootUpdateInfo.mockReturnValue({
+      releaseNotes: 'hey look a release',
+    })
+
+    const { wrapper } = render(Buildroot.UPGRADE, Buildroot.BALENA)
+    const migrationWarning = wrapper.find(MigrationWarningModal)
+
+    migrationWarning.invoke('proceed')()
+
+    expect(wrapper.find(ReleaseNotesModal).prop('systemType')).toBe(
+      Buildroot.BALENA
+    )
+  })
+
+  it('should proceed from MigrationWarningModal to DownloadUpdateModal if still downloading', () => {
+    const { wrapper } = render(Buildroot.UPGRADE, Buildroot.BALENA)
+    const migrationWarning = wrapper.find(MigrationWarningModal)
+
+    migrationWarning.invoke('proceed')()
+    expect(wrapper.exists(DownloadUpdateModal)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Overview

Part of #5174. This PR adds tests to the robot update wizard UI to test that the correct behavior is followed when:

- There is an app update available
- There is a robot update available
- The robot is on a later version that the app
- The robot is on the same version as the app

Companion PR to #6957, #6963, and #6966

## Changelog

- test(app): add tests for robot update wizard during upgrade, downgrade, and reinstall

## Review requests

This PR replaces the manual test item `TS03-C007`, which instructs the tester to follow the test plan in #2401.

- Does this PR look like it covers all the cases in that matrix?

With this PR (along with the others listed above), the robot update UI should be considered sufficiently covered by unit tests such that manual QA should only be concerned with whether or not robot updates are able to be applied and not with if the correct messaging etc. is displayed at any given step in the upgrade

## Risk assessment

N/A, test only changes