### PR TITLE
feat(protocol-designer): Add spacing to file details page

### DIFF
--- a/protocol-designer/src/components/FilePage.js
+++ b/protocol-designer/src/components/FilePage.js
@@ -105,7 +105,10 @@ export class FilePage extends React.Component<Props, State> {
             }: FormikProps<FileMetadataFields>) => (
               <form onSubmit={handleSubmit} className={styles.card_content}>
                 <div
-                  className={cx(formStyles.row_wrapper, formStyles.stacked_row)}
+                  className={cx(
+                    formStyles.row_wrapper,
+                    formStyles.stacked_row_large
+                  )}
                 >
                   <FormGroup
                     label="Date Created"

--- a/protocol-designer/src/components/forms/forms.css
+++ b/protocol-designer/src/components/forms/forms.css
@@ -19,6 +19,10 @@
   margin-bottom: 0.5rem;
 }
 
+.stacked_row_large {
+  margin-bottom: 1rem;
+}
+
 /* NOTE: explicit column classes should only be used for forms with a layout
  * that doesn't match the layout of transfer/distribute/consolidate/mix.
  * Eg the Pause form is an example of an exceptional layout.


### PR DESCRIPTION
# Overview

closes #6885 by adding a little more spacing between the file details text fields and editable fields

<img width="659" alt="Screen Shot 2020-11-10 at 5 09 55 PM" src="https://user-images.githubusercontent.com/3430313/98832913-699bf200-240b-11eb-8147-a748c1220110.png">

# Changelog

- feat(protocol-designer): Add spacing to file details page

# Review requests

upload or make a protocol and check file details page

- [ ] more space present between created and modified and editable forms below

# Risk assessment

low CSS only