### PR TITLE
fix(app): full-width jog controls

### DIFF
--- a/app/src/components/CalibrationPanels/MeasureNozzle.js
+++ b/app/src/components/CalibrationPanels/MeasureNozzle.js
@@ -194,13 +194,12 @@ export function MeasureNozzle(props: CalibrationPanelProps): React.Node {
             </Box>
           </Flex>
         </Box>
-        <div>
-          <JogControls
-            jog={jog}
-            stepSizes={[0.1, 1]}
-            planes={[VERTICAL_PLANE]}
-          />
-        </div>
+        <JogControls
+          jog={jog}
+          stepSizes={[0.1, 1]}
+          planes={[VERTICAL_PLANE]}
+          width="100%"
+        />
         <Flex width="100%" justifyContent={JUSTIFY_CENTER} marginY={SPACING_3}>
           <PrimaryBtn onClick={proceed} flex="1">
             {isHealthCheck ? CHECK_NOZZLE_Z_AXIS : SAVE_NOZZLE_Z_AXIS}

--- a/app/src/components/CalibrationPanels/MeasureTip.js
+++ b/app/src/components/CalibrationPanels/MeasureTip.js
@@ -208,13 +208,12 @@ export function MeasureTip(props: CalibrationPanelProps): React.Node {
             </Box>
           </Flex>
         </Box>
-        <div>
-          <JogControls
-            jog={jog}
-            stepSizes={[0.1, 1]}
-            planes={[VERTICAL_PLANE]}
-          />
-        </div>
+        <JogControls
+          jog={jog}
+          stepSizes={[0.1, 1]}
+          planes={[VERTICAL_PLANE]}
+          width="100%"
+        />
         <Flex width="100%" justifyContent={JUSTIFY_CENTER} marginY={SPACING_3}>
           <PrimaryBtn title="saveTipLengthButton" onClick={proceed} flex="1">
             {isHealthCheck ? CHECK_NOZZLE_Z_AXIS : SAVE_NOZZLE_Z_AXIS}


### PR DESCRIPTION
The jog controls were in MeasureTip and MeasureNozzle weren't expanding to their parent properly; give them a width=100%.

## Testing

Check the MeasureTip and MeasureNozzle screens (doesn't matter if in cal check or tip length, they're invariant in this regard) and make sure the jog controls look right.