### PR TITLE
feat(protocol-designer): add pipette min to warnings

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -7,7 +7,26 @@
   "field": {
     "required": "This field is required"
   },
-  "form": {},
+  "form": {
+    "warning": {
+      "OVER_MAX_WELL_VOLUME": {
+        "title": "Dispense volume will overflow a destination well"
+      },
+      "BELOW_PIPETTE_MINIMUM_VOLUME": {
+        "title": "Transfer volume is below pipette minimum ({{min}} uL)",
+        "body": "Pipettes cannot accurately handle volumes below their minimum. "
+      },
+      "BELOW_MIN_AIR_GAP_VOLUME": {
+        "title": "Air gap volume is below pipette minimum ({{min}} uL)",
+        "body": "Pipettes cannot accurately handle volumes below their minimum. "
+      },
+      "BELOW_MIN_DISPOSAL_VOLUME": {
+        "title": "Disposal volume is below recommended minimum ({{min}} uL)",
+        "body": "For accuracy in multi-dispense Transfers we recommend you use a disposal volume of at least the pipette's minimum. Read more ",
+        "link": "here"
+      }
+    }
+  },
   "hint": {
     "dont_show_again": "Don't show me again",
     "add_liquids_and_labware": {

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.js
@@ -1,24 +1,30 @@
 // @flow
-import { _minAirGapVolume } from '../warnings'
+import fixture_24_tuberack from '@opentrons/shared-data/labware/fixtures/2/fixture_24_tuberack.json'
+import {
+  _minAirGapVolume,
+  belowPipetteMinimumVolume,
+  minDisposalVolume,
+  maxDispenseWellVolume,
+} from '../warnings'
 
-const aspDisp = ['aspirate', 'dispense']
-aspDisp.forEach(aspOrDisp => {
-  const checkboxField = `${aspDisp}_airGap_checkbox`
-  const volumeField = `${aspDisp}_airGap_volume`
+describe('Min air gap volume', () => {
+  const aspDisp = ['aspirate', 'dispense']
+  aspDisp.forEach(aspOrDisp => {
+    const checkboxField = `${aspDisp}_airGap_checkbox`
+    const volumeField = `${aspDisp}_airGap_volume`
 
-  describe(`${aspOrDisp} -> air gap`, () => {
-    let pipette
-    beforeEach(() => {
-      pipette = {
-        spec: {
-          minVolume: 100,
-        },
-      }
-    })
+    describe(`${aspOrDisp} -> air gap`, () => {
+      let pipette
+      beforeEach(() => {
+        pipette = {
+          spec: {
+            minVolume: 100,
+          },
+        }
+      })
 
-    const minAirGapVolume = _minAirGapVolume(checkboxField, volumeField)
+      const minAirGapVolume = _minAirGapVolume(checkboxField, volumeField)
 
-    describe('min air gap volume', () => {
       it('should NOT return a warning when the air gap checkbox is not selected', () => {
         const fields = {
           [checkboxField]: false,
@@ -60,6 +66,168 @@ aspDisp.forEach(aspOrDisp => {
         }
         expect(minAirGapVolume(fields).type).toBe('BELOW_MIN_AIR_GAP_VOLUME')
       })
+      it('should return a warning when the transfer volume is less than the pipette min volume', () => {
+        const fields = {
+          [checkboxField]: true,
+          [volumeField]: '0',
+          ...{ pipette },
+        }
+        expect(minAirGapVolume(fields).type).toBe('BELOW_MIN_AIR_GAP_VOLUME')
+      })
     })
+  })
+})
+describe('Below pipette minimum volume', () => {
+  let fieldsWithPipette
+  beforeEach(() => {
+    fieldsWithPipette = {
+      pipette: {
+        spec: {
+          minVolume: 100,
+        },
+      },
+    }
+  })
+  it('should NOT return a warning when the volume equals the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      volume: 100,
+    }
+    expect(belowPipetteMinimumVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the volume is greater than the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      volume: 101,
+    }
+    expect(belowPipetteMinimumVolume(fields)).toBe(null)
+  })
+  it('should return a warning when the volume is less than the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      volume: 99,
+    }
+    expect(belowPipetteMinimumVolume(fields).type).toBe(
+      'BELOW_PIPETTE_MINIMUM_VOLUME'
+    )
+  })
+})
+describe('Below min disposal volume', () => {
+  let fieldsWithPipette
+  beforeEach(() => {
+    fieldsWithPipette = {
+      pipette: {
+        spec: {
+          minVolume: 100,
+        },
+      },
+      disposalVolume_checkbox: true,
+      disposalVolume_volume: 100,
+      path: 'multiDispense',
+    }
+  })
+  it('should NOT return a warning when there is no pipette', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      pipette: undefined,
+    }
+    expect(minDisposalVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when there is no pipette spec', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      pipette: { spec: undefined },
+    }
+    expect(minDisposalVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the path is NOT multi dispense', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      path: 'another_path',
+    }
+    expect(minDisposalVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the volume is equal to the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      disposalVolume_volume: 100,
+    }
+    expect(minDisposalVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the volume is greater than the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      disposalVolume_volume: 100,
+    }
+    expect(minDisposalVolume(fields)).toBe(null)
+  })
+
+  it('should return a warning when the volume is less than the min pipette volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      disposalVolume_volume: 99,
+    }
+    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
+  })
+  it('should return a warning when the path is multi dispense and the checkbox is unchecked', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      disposalVolume_checkbox: false,
+    }
+    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
+  })
+  it('should return a warning when the path is multi dispense and there is no disposal volume', () => {
+    const fields = {
+      ...fieldsWithPipette,
+      disposalVolume_volume: undefined,
+    }
+    expect(minDisposalVolume(fields).type).toBe('BELOW_MIN_DISPOSAL_VOLUME')
+  })
+})
+describe('Max dispense well volume', () => {
+  let fieldsWithDispenseLabware
+  beforeEach(() => {
+    fieldsWithDispenseLabware = {
+      dispense_labware: { def: { ...fixture_24_tuberack } },
+      dispense_wells: ['A1', 'A2'],
+    }
+  })
+  it('should NOT return a warning when there is no dispense labware', () => {
+    const fields = {
+      ...fieldsWithDispenseLabware,
+      dispense_labware: undefined,
+    }
+    expect(maxDispenseWellVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when there are no dispense wells', () => {
+    const fields = {
+      ...fieldsWithDispenseLabware,
+      dispense_wells: undefined,
+    }
+    expect(maxDispenseWellVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the volume is less than the well depth', () => {
+    const fields = {
+      ...fieldsWithDispenseLabware,
+      // well total liquid volume is 2000 (see fixture)
+      volume: 1999,
+    }
+    expect(maxDispenseWellVolume(fields)).toBe(null)
+  })
+  it('should NOT return a warning when the volume equals the well depth', () => {
+    const fields = {
+      ...fieldsWithDispenseLabware,
+      // well total liquid volume is also 2000 (see fixture)
+      volume: 2000,
+    }
+    expect(maxDispenseWellVolume(fields)).toBe(null)
+  })
+  it('should return a warning when the volume is greater than the well depth', () => {
+    const fields = {
+      ...fieldsWithDispenseLabware,
+      // well total liquid volume is 2000 (see fixture)
+      volume: 2001,
+    }
+    expect(maxDispenseWellVolume(fields).type).toBe('OVER_MAX_WELL_VOLUME')
   })
 })

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import { getWellTotalVolume } from '@opentrons/shared-data'
+import { i18n } from '../../localization'
 import { KnowledgeBaseLink } from '../../components/KnowledgeBaseLink'
 import type { FormError } from './errors'
 /*******************
@@ -17,41 +18,54 @@ export type FormWarning = {
   ...$Exact<FormError>,
   type: FormWarningType,
 }
+
 // TODO: Ian 2018-12-06 use i18n for title/body text
-const FORM_WARNINGS: { [FormWarningType]: FormWarning } = {
-  BELOW_MIN_AIR_GAP_VOLUME: {
+const FORM_WARNINGS: { [FormWarningType]: (?number) => FormWarning } = {
+  BELOW_MIN_AIR_GAP_VOLUME: min => ({
     type: 'BELOW_MIN_AIR_GAP_VOLUME',
-    title: 'Below recommended air gap',
+    title: i18n.t(`alert.form.warning.BELOW_MIN_AIR_GAP_VOLUME.title`, {
+      min,
+    }),
     body: (
       <React.Fragment>
-        For accuracy while using air gap we recommend you use a volume of at
-        least the pipette&apos;s minimum.
+        {i18n.t(`alert.form.warning.BELOW_MIN_AIR_GAP_VOLUME.body`)}
       </React.Fragment>
     ),
     dependentFields: ['disposalVolume_volume', 'pipette'],
-  },
-  BELOW_PIPETTE_MINIMUM_VOLUME: {
+  }),
+  BELOW_PIPETTE_MINIMUM_VOLUME: min => ({
     type: 'BELOW_PIPETTE_MINIMUM_VOLUME',
-    title: 'Specified volume is below pipette minimum',
-    dependentFields: ['pipette', 'volume'],
-  },
-  OVER_MAX_WELL_VOLUME: {
-    type: 'OVER_MAX_WELL_VOLUME',
-    title: 'Dispense volume will overflow a destination well',
-    dependentFields: ['dispense_labware', 'dispense_wells', 'volume'],
-  },
-  BELOW_MIN_DISPOSAL_VOLUME: {
-    type: 'BELOW_MIN_DISPOSAL_VOLUME',
-    title: 'Below Recommended disposal volume',
+    title: i18n.t(`alert.form.warning.BELOW_PIPETTE_MINIMUM_VOLUME.title`, {
+      min,
+    }),
     body: (
       <React.Fragment>
-        For accuracy in multi-dispense actions we recommend you use a disposal
-        volume of at least the pipette&apos;s minimum. Read more{' '}
-        <KnowledgeBaseLink to="multiDispense">here</KnowledgeBaseLink>.
+        {i18n.t(`alert.form.warning.BELOW_PIPETTE_MINIMUM_VOLUME.body`)}
+      </React.Fragment>
+    ),
+    dependentFields: ['pipette', 'volume'],
+  }),
+  OVER_MAX_WELL_VOLUME: () => ({
+    type: 'OVER_MAX_WELL_VOLUME',
+    title: i18n.t(`alert.form.warning.OVER_MAX_WELL_VOLUME.title`),
+    dependentFields: ['dispense_labware', 'dispense_wells', 'volume'],
+  }),
+  BELOW_MIN_DISPOSAL_VOLUME: min => ({
+    type: 'BELOW_MIN_DISPOSAL_VOLUME',
+    title: i18n.t(`alert.form.warning.BELOW_MIN_DISPOSAL_VOLUME.title`, {
+      min,
+    }),
+    body: (
+      <React.Fragment>
+        {i18n.t(`alert.form.warning.BELOW_MIN_DISPOSAL_VOLUME.body`)}
+        <KnowledgeBaseLink to="multiDispense">
+          {i18n.t(`alert.form.warning.BELOW_MIN_DISPOSAL_VOLUME.link`)}
+        </KnowledgeBaseLink>
+        .
       </React.Fragment>
     ),
     dependentFields: ['disposalVolume_volume', 'pipette'],
-  },
+  }),
 }
 
 export type WarningChecker = mixed => ?FormWarning
@@ -69,7 +83,7 @@ export const belowPipetteMinimumVolume = (
   const { pipette, volume } = fields
   if (!(pipette && pipette.spec)) return null
   return volume < pipette.spec.minVolume
-    ? FORM_WARNINGS.BELOW_PIPETTE_MINIMUM_VOLUME
+    ? FORM_WARNINGS.BELOW_PIPETTE_MINIMUM_VOLUME(pipette.spec.minVolume)
     : null
 }
 
@@ -82,7 +96,7 @@ export const maxDispenseWellVolume = (
     const maximum = getWellTotalVolume(dispense_labware.def, well)
     return maximum && volume > maximum
   })
-  return hasExceeded ? FORM_WARNINGS.OVER_MAX_WELL_VOLUME : null
+  return hasExceeded ? FORM_WARNINGS.OVER_MAX_WELL_VOLUME() : null
 }
 
 export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
@@ -94,9 +108,12 @@ export const minDisposalVolume = (fields: HydratedFormData): ?FormWarning => {
   } = fields
   if (!(pipette && pipette.spec) || path !== 'multiDispense') return null
   const isUnselected = !disposalVolume_checkbox || !disposalVolume_volume
-  if (isUnselected) return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME
+  if (isUnselected)
+    return FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME(pipette.spec.minVolume)
   const isBelowMin = disposalVolume_volume < pipette.spec.minVolume
-  return isBelowMin ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME : null
+  return isBelowMin
+    ? FORM_WARNINGS.BELOW_MIN_DISPOSAL_VOLUME(pipette.spec.minVolume)
+    : null
 }
 
 // both aspirate and dispense air gap volumes have the same minimums
@@ -113,7 +130,9 @@ export const _minAirGapVolume: (
   if (!checkboxValue || !volumeValue || !pipette || !pipette.spec) return null
 
   const isBelowMin = Number(volumeValue) < pipette.spec.minVolume
-  return isBelowMin ? FORM_WARNINGS.BELOW_MIN_AIR_GAP_VOLUME : null
+  return isBelowMin
+    ? FORM_WARNINGS.BELOW_MIN_AIR_GAP_VOLUME(pipette.spec.minVolume)
+    : null
 }
 
 export const minAspirateAirGapVolume: (

--- a/protocol-designer/src/steplist/formLevel/warnings.js
+++ b/protocol-designer/src/steplist/formLevel/warnings.js
@@ -19,7 +19,6 @@ export type FormWarning = {
   type: FormWarningType,
 }
 
-// TODO: Ian 2018-12-06 use i18n for title/body text
 const FORM_WARNINGS: { [FormWarningType]: (?number) => FormWarning } = {
   BELOW_MIN_AIR_GAP_VOLUME: min => ({
     type: 'BELOW_MIN_AIR_GAP_VOLUME',


### PR DESCRIPTION
# Overview

This PR adds the pipette minimum to "below recommended minimum" warnings. I also moved all form warning text into `i18n`.

closes #6493

# Changelog

- add pipette minimum to "below recommended minimum" warnings
- move all form warning text into i18n

# Review requests

- Code review
- Go through each of the warnings outlined in the [ticket](https://github.com/Opentrons/opentrons/issues/6493) and make sure the warning text matches, and that they include the correct pipette min.

I also moved the well overflow morning into `i18n` so make sure that guy still works too.

# Risk assessment

Low