### PR TITLE
style(api): enable docstring, type linting in protocol_engine

### DIFF
--- a/api/.flake8
+++ b/api/.flake8
@@ -39,7 +39,6 @@ per-file-ignores =
     src/opentrons/helpers/*:ANN,D
     src/opentrons/legacy_api/*:ANN,D
     src/opentrons/protocol_api/*:ANN,D
-    src/opentrons/protocol_engine/*:ANN,D
     src/opentrons/protocols/*:ANN,D
     src/opentrons/resources/*:ANN,D
     src/opentrons/system/*:ANN,D
@@ -70,7 +69,6 @@ per-file-ignores =
     tests/opentrons/labware/*:ANN,D
     tests/opentrons/performance/*:ANN,D
     tests/opentrons/protocol_api/*:ANN,D
-    tests/opentrons/protocol_engine/*:ANN,D
     tests/opentrons/protocols/*:ANN,D
     tests/opentrons/robot/*:ANN,D
     tests/opentrons/system/*:ANN,D

--- a/api/src/opentrons/protocol_engine/command_models/command.py
+++ b/api/src/opentrons/protocol_engine/command_models/command.py
@@ -14,6 +14,7 @@ ResT = TypeVar("ResT", bound=BaseModel)
 @dataclass(frozen=True)
 class CompletedCommand(Generic[ReqT, ResT]):
     """A command that has been successfully executed."""
+
     created_at: datetime
     started_at: datetime
     completed_at: datetime
@@ -24,6 +25,7 @@ class CompletedCommand(Generic[ReqT, ResT]):
 @dataclass(frozen=True)
 class FailedCommand(Generic[ReqT]):
     """A command that was executed but failed."""
+
     created_at: datetime
     started_at: datetime
     failed_at: datetime
@@ -34,6 +36,7 @@ class FailedCommand(Generic[ReqT]):
 @dataclass(frozen=True)
 class RunningCommand(Generic[ReqT, ResT]):
     """A command that is currently being executed."""
+
     created_at: datetime
     started_at: datetime
     request: ReqT
@@ -43,6 +46,7 @@ class RunningCommand(Generic[ReqT, ResT]):
         result: ResT,
         completed_at: datetime,
     ) -> CompletedCommand[ReqT, ResT]:
+        """Create a CompletedCommand from a RunningCommand."""
         return CompletedCommand(
             created_at=self.created_at,
             started_at=self.started_at,
@@ -56,6 +60,7 @@ class RunningCommand(Generic[ReqT, ResT]):
         error: ProtocolEngineError,
         failed_at: datetime,
     ) -> FailedCommand[ReqT]:
+        """Create a FailedCommand from a RunningCommand."""
         return FailedCommand(
             created_at=self.created_at,
             started_at=self.started_at,
@@ -68,10 +73,12 @@ class RunningCommand(Generic[ReqT, ResT]):
 @dataclass(frozen=True)
 class PendingCommand(Generic[ReqT, ResT]):
     """A command that has not yet been started."""
+
     created_at: datetime
     request: ReqT
 
     def to_running(self, started_at: datetime) -> RunningCommand[ReqT, ResT]:
+        """Create a RunningCommand from a PendingCommand."""
         return RunningCommand(
             created_at=self.created_at,
             request=self.request,

--- a/api/src/opentrons/protocol_engine/command_models/pipetting.py
+++ b/api/src/opentrons/protocol_engine/command_models/pipetting.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 
 
 class BasePipettingRequest(BaseModel):
+    """Base class for pipetting requests that interact with wells."""
+
     pipetteId: str = Field(
         ...,
         description="Identifier of pipette to use for liquid handling."
@@ -18,6 +20,8 @@ class BasePipettingRequest(BaseModel):
 
 
 class BaseLiquidHandlingRequest(BasePipettingRequest):
+    """Base class for liquid handling requests."""
+
     volume: float = Field(
         ...,
         description="Amount of liquid in uL. Must be greater than 0 and less "
@@ -34,40 +38,60 @@ class BaseLiquidHandlingRequest(BasePipettingRequest):
 
 
 class MoveToWellRequest(BasePipettingRequest):
+    """A request to move a pipette to a specific well."""
+
     pass
 
 
 class MoveToWellResult(BaseModel):
+    """The result of a MoveToWellRequest."""
+
     pass
 
 
 class PickUpTipRequest(BasePipettingRequest):
+    """A request to pick up a tip."""
+
     pass
 
 
 class PickUpTipResult(BaseModel):
+    """The result of a PickUpTipRequest."""
+
     pass
 
 
 class DropTipRequest(BasePipettingRequest):
+    """A request to drop a tip."""
+
     pass
 
 
 class DropTipResult(BaseModel):
+    """The result of a DropTipRequest."""
+
     pass
 
 
 class AspirateRequest(BaseLiquidHandlingRequest):
+    """A request to aspirate liquid from a well."""
+
     pass
 
 
 class AspirateResult(BaseModel):
+    """The result of a AspirateRequest."""
+
     pass
 
 
 class DispenseRequest(BaseLiquidHandlingRequest):
+    """A request to dispense liquid into a well."""
+
     pass
 
 
 class DispenseResult(BaseModel):
+    """The result of a DispenseRequest."""
+
     pass

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -3,6 +3,7 @@
 
 class ProtocolEngineError(RuntimeError):
     """Base Protocol Engine error class."""
+
     pass
 
 
@@ -15,7 +16,8 @@ class UnexpectedProtocolError(ProtocolEngineError):
     and wrapped.
     """
 
-    def __init__(self, original_error: Exception):
+    def __init__(self, original_error: Exception) -> None:
+        """Initialize an UnexpectedProtocolError with an original error."""
         super().__init__(str(original_error))
         self.original_error: Exception = original_error
 
@@ -28,27 +30,32 @@ class FailedToLoadPipetteError(ProtocolEngineError):
     - An incorrect pipette already attached to the mount
     - A missing pipette on the requested mount
     """
+
     # TODO(mc, 2020-10-18): differentiate between pipette missing vs incorrect
     pass
 
 
 class LabwareDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a labware that does not exist."""
+
     pass
 
 
 class WellDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a well that does not exist."""
+
     pass
 
 
 class PipetteDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a pipette that does not exist."""
+
     pass
 
 
 class SlotDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a deck slot that does not exist."""
+
     pass
 
 
@@ -56,4 +63,5 @@ class SlotDoesNotExistError(ProtocolEngineError):
 # existing LabwareHeightError
 class FailedToPlanMoveError(ProtocolEngineError):
     """An error raised when a requested movement could not be planned."""
+
     pass

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -72,7 +72,7 @@ class CommandExecutor:
         self,
         command: cmd.RunningCommandType,
     ) -> cmd.CompletedCommandType:
-        """Execute commands by routing to a specific handlers."""
+        """Execute commands by routing to specific handlers."""
         # call to correct implementation based on command request type
         # load labware
         if isinstance(command.request, cmd.LoadLabwareRequest):

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -72,10 +72,7 @@ class CommandExecutor:
         self,
         command: cmd.RunningCommandType,
     ) -> cmd.CompletedCommandType:
-        """
-        Private method to execute commands by routing to a specific command
-        implementation class.
-        """
+        """Execute commands by routing to a specific handlers."""
         # call to correct implementation based on command request type
         # load labware
         if isinstance(command.request, cmd.LoadLabwareRequest):

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -44,7 +44,7 @@ class ProtocolEngine:
         self,
         state_store: StateStore,
         executor: CommandExecutor,
-    ):
+    ) -> None:
         """
         Initialize a ProtocolEngine instance.
 

--- a/api/src/opentrons/protocol_engine/state/state_store.py
+++ b/api/src/opentrons/protocol_engine/state/state_store.py
@@ -14,7 +14,7 @@ from .motion import MotionStore, MotionState
 
 
 class StateView:
-    """A read-only view of a collection of a StateStore."""
+    """A read-only view of a StateStore."""
 
     _command_store: CommandStore
     _labware_store: LabwareStore

--- a/api/src/opentrons/protocol_engine/state/state_store.py
+++ b/api/src/opentrons/protocol_engine/state/state_store.py
@@ -14,6 +14,14 @@ from .motion import MotionStore, MotionState
 
 
 class StateView:
+    """A read-only view of a collection of a StateStore."""
+
+    _command_store: CommandStore
+    _labware_store: LabwareStore
+    _pipette_store: PipetteStore
+    _geometry_store: GeometryStore
+    _motion_store: MotionStore
+
     def __init__(
         self,
         command_store: CommandStore,
@@ -22,7 +30,7 @@ class StateView:
         geometry_store: GeometryStore,
         motion_store: MotionStore,
     ) -> None:
-        """A StateView class provides a read-only interface to a StateStore."""
+        """Initialize a StateView."""
         self._command_store = command_store
         self._labware_store = labware_store
         self._pipette_store = pipette_store
@@ -75,7 +83,7 @@ class StateStore(StateView):
     be allowed to modify State classes.
     """
 
-    def __init__(self, deck_definition: DeckDefinitionV2):
+    def __init__(self, deck_definition: DeckDefinitionV2) -> None:
         """Initialize a StateStore."""
         command_store = CommandStore()
         labware_store = LabwareStore()

--- a/api/src/opentrons/protocol_engine/state/substore.py
+++ b/api/src/opentrons/protocol_engine/state/substore.py
@@ -9,6 +9,7 @@ SubstateT = TypeVar("SubstateT")
 
 class Substore(ABC, Generic[SubstateT]):
     """Abstract base class for a sub-store."""
+
     _state: SubstateT
 
     @property
@@ -18,7 +19,7 @@ class Substore(ABC, Generic[SubstateT]):
 
 
 class CommandReactive(ABC):
-    """Abstract base class for a class that reacts to commands."""
+    """Abstract base class for an interface that reacts to commands."""
 
     def handle_completed_command(self, command: CompletedCommandType) -> None:
         """React to a CompletedCommand."""

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -10,6 +10,7 @@ from opentrons.types import DeckSlotName
 @dataclass(frozen=True)
 class DeckSlotLocation:
     """Location for labware placed in a single slot."""
+
     slot: DeckSlotName
 
 

--- a/api/tests/opentrons/protocol_engine/__init__.py
+++ b/api/tests/opentrons/protocol_engine/__init__.py
@@ -1,0 +1,1 @@
+"""ProtocolEngine tests module."""

--- a/api/tests/opentrons/protocol_engine/command_models/__init__.py
+++ b/api/tests/opentrons/protocol_engine/command_models/__init__.py
@@ -1,1 +1,1 @@
-"""ProtocolEngine command models tests."""
+"""ProtocolEngine command model tests."""

--- a/api/tests/opentrons/protocol_engine/command_models/__init__.py
+++ b/api/tests/opentrons/protocol_engine/command_models/__init__.py
@@ -1,0 +1,1 @@
+"""ProtocolEngine command models tests."""

--- a/api/tests/opentrons/protocol_engine/command_models/test_equipment_commands.py
+++ b/api/tests/opentrons/protocol_engine/command_models/test_equipment_commands.py
@@ -1,10 +1,10 @@
-"""Text creating equipment commands."""
+"""Test creating equipment commands."""
 from opentrons.protocol_engine import command_models as commands
 from opentrons.types import MountType, DeckSlotName
 from opentrons.protocol_engine.types import DeckSlotLocation
 
 
-def test_load_labware_request():
+def test_load_labware_request() -> None:
     """It should have a LoadLabwareRequest model."""
     payload = commands.LoadLabwareRequest(
         location=DeckSlotLocation(DeckSlotName.SLOT_3),
@@ -19,7 +19,7 @@ def test_load_labware_request():
     assert payload.version == 1
 
 
-def test_load_pipette_command():
+def test_load_pipette_command() -> None:
     """It should have a LoadPipetteRequest model."""
     payload = commands.LoadPipetteRequest(
         pipetteName="p300_single",

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -1,3 +1,4 @@
+"""ProtocolEngine shared test fixtures."""
 import pytest
 from datetime import datetime
 from mock import AsyncMock, MagicMock  # type: ignore[attr-defined]
@@ -20,46 +21,55 @@ from opentrons.protocol_engine import (
 
 @pytest.fixture
 def now() -> datetime:
+    """Get the current UTC time."""
     return utc_now()
 
 
 @pytest.fixture
 def mock_state_store() -> MagicMock:
+    """Get a mock in the shape of a StateStore."""
     return MagicMock(spec=StateStore)
 
 
 @pytest.fixture
 def mock_state_view() -> MagicMock:
+    """Get a mock in the shape of a StateView."""
     return MagicMock(spec=StateView)
 
 
 @pytest.fixture
 def mock_hardware() -> AsyncMock:
+    """Get an asynchronous mock in the shape of a HardwareController."""
     return AsyncMock(spec=HardwareController)
 
 
 @pytest.fixture
 def mock_executor() -> AsyncMock:
+    """Get an asynchronous mock in the shape of a CommandExecutor."""
     return AsyncMock(spec=CommandExecutor)
 
 
 @pytest.fixture(scope="session")
 def standard_deck_def() -> DeckDefinitionV2:
+    """Get the OT-2 standard deck definition."""
     return load_deck(STANDARD_DECK, 2)
 
 
 @pytest.fixture(scope="session")
 def well_plate_def() -> LabwareDefinition:
+    """Get the definition of a 96 well plate."""
     return load_definition("corning_96_wellplate_360ul_flat", 1)
 
 
 @pytest.fixture(scope="session")
 def reservoir_def() -> LabwareDefinition:
+    """Get the definition of single-row reservoir."""
     return load_definition("nest_12_reservoir_15ml", 1)
 
 
 @pytest.fixture
-def store(standard_deck_def) -> StateStore:
+def store(standard_deck_def: DeckDefinitionV2) -> StateStore:
+    """Get an actual StateStore."""
     return StateStore(deck_definition=standard_deck_def)
 
 
@@ -68,6 +78,7 @@ def engine(
     mock_state_store: MagicMock,
     mock_executor: AsyncMock
 ) -> ProtocolEngine:
+    """Get a ProtocolEngine with its dependencies mocked out."""
     return ProtocolEngine(
         state_store=mock_state_store,
         executor=mock_executor,

--- a/api/tests/opentrons/protocol_engine/execution/__init__.py
+++ b/api/tests/opentrons/protocol_engine/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Tests module for ProtocolEngine's command execution."""

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -15,11 +15,13 @@ from opentrons.protocol_engine.execution.pipetting import PipettingHandler
 
 @pytest.fixture
 def mock_equipment_handler() -> AsyncMock:
+    """Get an asynchronous mock in the shape of an EquipmentHandler."""
     return AsyncMock(spec=EquipmentHandler)
 
 
 @pytest.fixture
 def mock_pipetting_handler() -> AsyncMock:
+    """Get an asynchronous mock in the shape of an PipettingHandler."""
     return AsyncMock(spec=PipettingHandler)
 
 
@@ -28,6 +30,7 @@ def executor(
     mock_equipment_handler: AsyncMock,
     mock_pipetting_handler: AsyncMock,
 ) -> CommandExecutor:
+    """Get a CommandExecutor with its dependencies mocked out."""
     return CommandExecutor(
         equipment_handler=mock_equipment_handler,
         pipetting_handler=mock_pipetting_handler
@@ -36,6 +39,8 @@ def executor(
 
 @dataclass(frozen=True)
 class ExecutorRoutingSpec:
+    """Data for a test of the CommandExector's routing logic."""
+
     name: str
     request: cmd.CommandRequestType
     expected_handler: str
@@ -114,6 +119,7 @@ async def test_command_executor_routing(
     now: datetime,
     spec: ExecutorRoutingSpec,
 ) -> None:
+    """The CommandExecutor should route commands to handlers properly."""
     HANDLER_NAME_MAP = {
         "equipment_handler": mock_equipment_handler,
         "pipetting_handler": mock_pipetting_handler,
@@ -158,7 +164,7 @@ async def test_executor_handles_unexpected_error(
     mock_equipment_handler: AsyncMock,
     now: datetime,
 ) -> None:
-    """CommandExecutor should handle unexpected errors."""
+    """The CommandExecutor should handle unexpected errors."""
     error = RuntimeError('I did not see this coming')
     mock_equipment_handler.handle_load_labware.side_effect = error
 

--- a/api/tests/opentrons/protocol_engine/resources/__init__.py
+++ b/api/tests/opentrons/protocol_engine/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Tests module for ProtocolEngine resources."""

--- a/api/tests/opentrons/protocol_engine/resources/test_id_generator.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_id_generator.py
@@ -8,14 +8,14 @@ RE_UUID = re.compile(
 )
 
 
-def test_id_generator_generates_uuid():
+def test_id_generator_generates_uuid() -> None:
     """It should generate a string matching a UUID."""
     result = IdGenerator().generate_id()
 
     assert RE_UUID.match(result)
 
 
-def test_id_generator_generates_unique():
+def test_id_generator_generates_unique() -> None:
     """It should generate unique IDs."""
     results = [IdGenerator().generate_id() for i in range(1000)]
     unique_results = set(results)

--- a/api/tests/opentrons/protocol_engine/state/__init__.py
+++ b/api/tests/opentrons/protocol_engine/state/__init__.py
@@ -1,0 +1,1 @@
+"""Tests module for ProtocolEngine state."""

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_state.py
@@ -15,6 +15,7 @@ from opentrons.protocol_engine.state.geometry import GeometryStore
 
 @pytest.fixture
 def mock_labware_store() -> MagicMock:
+    """Get a mock in the shape of a LabwareStore."""
     return MagicMock(spec=LabwareStore)
 
 
@@ -23,6 +24,7 @@ def geometry_store(
     mock_labware_store: MagicMock,
     standard_deck_def: DeckDefinitionV2,
 ) -> GeometryStore:
+    """Get a GeometryStore with its store dependencies mocked out."""
     return GeometryStore(
         labware_store=mock_labware_store,
         deck_definition=standard_deck_def,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -16,6 +16,7 @@ def load_labware(
     definition: LabwareDefinition,
     calibration: Tuple[float, float, float],
 ) -> cmd.CompletedCommand[cmd.LoadLabwareRequest, cmd.LoadLabwareResult]:
+    """Load a labware into state using a LoadLabwareRequest."""
     request = cmd.LoadLabwareRequest(
         loadName="load-name",
         namespace="opentrons-test",
@@ -39,14 +40,17 @@ def load_labware(
     return command
 
 
-def test_get_labware_data_bad_id(store):
+def test_get_labware_data_bad_id(store: StateStore) -> None:
     """get_labware_data_by_id should raise if labware ID doesn't exist."""
     with pytest.raises(errors.LabwareDoesNotExistError):
         store.labware.get_labware_data_by_id("asdfghjkl")
 
 
-def test_handles_load_labware(store, well_plate_def):
-    """It should add the labware data to the state"""
+def test_handles_load_labware(
+    store: StateStore,
+    well_plate_def: LabwareDefinition
+) -> None:
+    """It should add the labware data to the state."""
     command = load_labware(
         store=store,
         labware_id="plate-id",

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -19,7 +19,7 @@ def test_initial_pipette_data_by_mount(store: StateStore) -> None:
 
 
 def test_handles_load_pipette(store: StateStore, now: datetime) -> None:
-    """It should add the pipette data to the state"""
+    """It should add the pipette data to the state."""
     command = cmd.CompletedCommand(
         request=cmd.LoadPipetteRequest(
             pipetteName="p300_single",

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -15,16 +15,21 @@ from opentrons.protocol_engine.command_models import (
 
 
 class CloseToNow:
-    def __init__(self):
+    """Matcher for any datetime that is close to now."""
+
+    def __init__(self) -> None:
+        """Initialize a CloseToNow matcher."""
         self._now = datetime.now(tz=timezone.utc)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        """Check if a target object is a datetime that is close to now."""
         return (
             isinstance(other, datetime) and
             isclose(self._now.timestamp(), other.timestamp(), rel_tol=5)
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Represent the matcher as a string."""
         return f"<datetime close to {self._now}>"
 
 


### PR DESCRIPTION
## Overview

In advance of continuing ProtocolEngine work, this PR enable our fancy new flake8-annotations and flake8-docstrings lints in the protocol_engine module and its tests module.

## Changelog

- style(api): enable docstring, type linting in protocol_engine

## Review requests

There's not much to do here except check new docstrings for typos and that the type annotations look correct.

## Risk assessment

N/A, type annotation and docstring changes only. Additionally, this code isn't used yet.
