### PR TITLE
chore(build): add github workflow for LL e2e tests

### DIFF
--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -34,7 +34,7 @@ jobs:
     name: 'LL e2e tests'
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -33,7 +33,7 @@ jobs:
     name: 'LL e2e tests'
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -1,0 +1,58 @@
+# This workflow runs end to end tests in Labware Library
+
+name: 'Labware Library E2E Tests'
+
+on:
+  pull_request:
+    paths:
+      - 'labware-library/**'
+      - 'shared-data/**'
+      - 'components/**'
+      - 'webpack-config/**'
+      - 'package.json'
+  push:
+    paths:
+      - 'labware-library/**'
+      - 'shared-data/**'
+      - 'components/**'
+      - 'webpack-config/**'
+      - 'package.json'
+      - '.github/workflows/labware-library-e2e-test.yaml'
+    tags:
+      - 'labware-library*'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CI: true
+
+jobs:
+  checks:
+    name: 'LL e2e tests'
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest']
+    runs-on: '${{ matrix.os }}'
+    steps:
+      - uses: 'actions/checkout@v2'
+      - uses: 'actions/setup-node@v1'
+        with:
+          node-version: '12'
+      - name: 'cache yarn cache'
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ github.workspace }}/.yarn-cache
+            ${{ github.workspace }}/.npm-cache
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
+      - name: 'setup-js'
+        run: |
+          npm config set cache ./.npm-cache
+          yarn config set cache-folder ./.yarn-cache
+          make setup-js
+      - name: 'test-e2e'
+        run: make -C labware-library test-e2e

--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -10,6 +10,7 @@ on:
       - 'components/**'
       - 'webpack-config/**'
       - 'package.json'
+      - '.github/workflows/labware-library-e2e-test.yaml'
   push:
     paths:
       - 'labware-library/**'


### PR DESCRIPTION
# Overview

This PR adds a github workflow for running LL end to end tests. Most of this was copied from the github action for pd e2e tests.

Closes #6997 

# Changelog

- Add github workflow for LL e2e tests

# Risk assessment

Low
