### PR TITLE
fix(robot-server): Opt logs out of version requirements

### DIFF
--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -22,6 +22,8 @@ MIN_API_VERSION_HEADER = "Opentrons-Min-Version"
 # response migrations via decorator. Puting an allow-list in place for now
 # because allowing an endpoint to bypass versioning requirements in the future
 # is not a breaking change
+# These will be compiled into a regex and checked with regex.match(), so you
+# can use regex syntax
 NON_VERSIONED_ROUTES = {
     # keep the root RPC WebSocket path unversioned because browsers cannot
     # specify headers for WebSocket client requests
@@ -30,7 +32,9 @@ NON_VERSIONED_ROUTES = {
     "/openapi.json",
     "/docs",
     "/redoc",
+    "/logs/.*"
 }
+
 
 # Tag applied to legacy api endpoints
 V1_TAG = "v1"

--- a/robot-server/robot_server/service/app.py
+++ b/robot-server/robot_server/service/app.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import traceback
 
 from opentrons import __version__
@@ -97,6 +98,9 @@ async def on_shutdown():
     get_protocol_manager().remove_all()
 
 
+NON_VERSIONED_RE = re.compile('|'.join(constants.NON_VERSIONED_ROUTES))
+
+
 @app.middleware("http")
 async def api_version_check(request: Request, call_next) -> Response:
     """Middleware to perform version check."""
@@ -107,7 +111,7 @@ async def api_version_check(request: Request, call_next) -> Response:
     # response migrations via decorator. Puting an allow-list in place for now
     # because allowing an endpoint to bypass versioning requirements in the
     # future is not a breaking change
-    if request.url.path not in constants.NON_VERSIONED_ROUTES:
+    if not NON_VERSIONED_RE.fullmatch(request.url.path):
         try:
             # Get the maximum version accepted by client
             header_value = request.headers.get(constants.API_VERSION_HEADER)

--- a/robot-server/tests/service/test_app.py
+++ b/robot-server/tests/service/test_app.py
@@ -76,6 +76,9 @@ def test_api_versioning(api_client, headers, expected_version):
         "/openapi.json",
         "/redoc",
         "/docs",
+        "/logs/serial.log",
+        "/logs/api.log",
+        "/logs/some-random-journald-thing",
         "/",
     ])
 def test_api_versioning_non_versions_endpoints(api_client, path):


### PR DESCRIPTION
Since the app-shell can't specify headers teh way it fetches logs. And
anyway it's a good idea.

This also requires a switch to regexes for version requirement checking
since the logs has url path params.
