### PR TITLE
fix(robot-server): cal check: fix comparingHeight y-value

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -748,7 +748,7 @@ class CheckCalibrationUserFlow:
                 current_point
         elif self.current_state == State.comparingHeight:
             self._reference_points.height.final_point = \
-                current_point + MOVE_TO_DECK_SAFETY_BUFFER
+                current_point + MOVE_TO_DECK_SAFETY_BUFFER._replace(y=0.0)
             self._z_height_reference = current_point.z
         elif self.current_state == State.comparingPointOne:
             self._reference_points.one.final_point = \


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The y-value for comparingHeight in cal check report is defaulted at 10 mm even if you didn't jog in the Y because the `MOVE_TO_DECK_SAFETY_BUFFER = Point(0, 10, 5)` was added when calculating the jog difference. We really only want to add the z-value of the buffer and not y.

# Review Request
Go through cal check, make sure the difference vectors for comparingHeight for your pipettes actually reflect the amount you've jogged.