### PR TITLE
refactor(api): move some private methods out of InstrumentContext class.

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -804,6 +804,20 @@ def filter_tipracks_to_start(
         lambda tr: starting_point.parent != tr, tipracks))
 
 
+def next_available_tip(
+        starting_tip: Optional[Well],
+        tip_racks: List[Labware],
+        channels: int) -> Tuple[Labware, Well]:
+    start = starting_tip
+    if start is None:
+        return select_tiprack_from_list(
+            tip_racks, channels)
+    else:
+        return select_tiprack_from_list(
+            filter_tipracks_to_start(start, tip_racks),
+            channels, start)
+
+
 def get_labware_hash(labware: 'Labware') -> str:
     return labware_module.get_labware_hash(
         labware._implementation

--- a/api/src/opentrons/protocols/advanced_control/mix.py
+++ b/api/src/opentrons/protocols/advanced_control/mix.py
@@ -1,0 +1,54 @@
+import typing
+
+from opentrons.protocols.advanced_control.transfers import MixStrategy, Mix
+
+
+def mix_from_kwargs(
+        top_kwargs: typing.Dict[str, typing.Any])\
+        -> typing.Tuple[MixStrategy, Mix]:
+    """A utility function to determine mix strategy from key word arguments
+    to InstrumentContext.mix"""
+
+    def _mix_requested(kwargs, opt):
+        """
+        Helper for determining mix options from :py:meth:`transfer` kwargs
+        Mixes can be ignored in kwargs by either
+        - Not specifying the kwarg
+        - Specifying it as None
+        - Specifying it as (0, 0)
+
+        This handles all these cases.
+        """
+        val = kwargs.get(opt)
+        if None is val:
+            return False
+        if val == (0, 0):
+            return False
+        return True
+
+    mix_opts = Mix()
+    if _mix_requested(top_kwargs, 'mix_before')\
+       and _mix_requested(top_kwargs, 'mix_after'):
+        mix_strategy = MixStrategy.BOTH
+        before_opts = top_kwargs['mix_before']
+        after_opts = top_kwargs['mix_after']
+        mix_opts = mix_opts._replace(
+            mix_after=mix_opts.mix_after._replace(
+                repetitions=after_opts[0], volume=after_opts[1]),
+            mix_before=mix_opts.mix_before._replace(
+                repetitions=before_opts[0], volume=before_opts[1]))
+    elif _mix_requested(top_kwargs, 'mix_before'):
+        mix_strategy = MixStrategy.BEFORE
+        before_opts = top_kwargs['mix_before']
+        mix_opts = mix_opts._replace(
+            mix_before=mix_opts.mix_before._replace(
+                repetitions=before_opts[0], volume=before_opts[1]))
+    elif _mix_requested(top_kwargs, 'mix_after'):
+        mix_strategy = MixStrategy.AFTER
+        after_opts = top_kwargs['mix_after']
+        mix_opts = mix_opts._replace(
+            mix_after=mix_opts.mix_after._replace(
+                repetitions=after_opts[0], volume=after_opts[1]))
+    else:
+        mix_strategy = MixStrategy.NEVER
+    return mix_strategy, mix_opts

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Optional, Any
+
+from opentrons import types
+from opentrons.calibration_storage import get
+from opentrons.calibration_storage.types import TipLengthCalNotFound
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.protocol_api.labware import Labware, Well
+from opentrons.protocols.api_support.labware_like import LabwareLike
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons_shared_data.protocol.dev_types import LiquidHandlingCommand, \
+    BlowoutLocation
+
+
+def validate_blowout_location(
+        api_version: APIVersion,
+        liquid_handling_command: LiquidHandlingCommand,
+        blowout_location: Optional[Any]) -> None:
+    """Validate the blowout location."""
+    if blowout_location and api_version < APIVersion(2, 8):
+        raise ValueError(
+            'Cannot specify blowout location when using api' +
+            ' version below 2.8, current version is {api_version}'
+            .format(api_version=api_version))
+
+    elif liquid_handling_command == 'consolidate' \
+            and blowout_location == 'source well':
+        raise ValueError(
+            "blowout location for consolidate cannot be source well")
+    elif liquid_handling_command == 'distribute' \
+            and blowout_location == 'destination well':
+        raise ValueError(
+            "blowout location for distribute cannot be destination well")
+    elif liquid_handling_command == 'transfer' and \
+            blowout_location and \
+            blowout_location not in \
+            [location.value for location in BlowoutLocation]:
+        raise ValueError(
+            "blowout location should be either 'source well', " +
+            " 'destination well', or 'trash'" +
+            f" but it is {blowout_location}")
+
+
+def tip_length_for(pipette: PipetteDict, tiprack: Labware) -> float:
+    """ Get the tip length, including overlap, for a tip from this rack """
+
+    def _build_length_from_overlap() -> float:
+        tip_overlap = pipette['tip_overlap'].get(
+            tiprack.uri,
+            pipette['tip_overlap']['default'])
+        tip_length = tiprack.tip_length
+        return tip_length - tip_overlap
+
+    try:
+        parent = LabwareLike(tiprack).first_parent() or ''
+        return get.load_tip_length_calibration(
+            pipette['pipette_id'],
+            tiprack._implementation.get_definition(),
+            parent).tip_length
+    except TipLengthCalNotFound:
+        return _build_length_from_overlap()
+
+
+VALID_PIP_TIPRACK_VOL = {
+    'p10': [10, 20],
+    'p20': [10, 20],
+    'p50': [200, 300],
+    'p300': [200, 300],
+    'p1000': [1000]
+}
+
+
+def validate_tiprack(
+        instrument_name: str,
+        tiprack: Labware,
+        log: logging.Logger) -> None:
+    """Validate a tiprack logging a warning message."""
+    # TODO AA 2020-06-24 - we should instead add the acceptable Opentrons
+    #  tipracks to the pipette as a refactor
+    if tiprack._implementation.get_definition()['namespace'] \
+            == 'opentrons':
+        tiprack_vol = tiprack.wells()[0].max_volume
+        valid_vols = VALID_PIP_TIPRACK_VOL[instrument_name.split('_')[0]]
+        if tiprack_vol not in valid_vols:
+            log.warning(
+                f'The pipette {instrument_name} and its tiprack '
+                f'{tiprack.load_name} in slot {tiprack.parent} appear to '
+                'be mismatched. Please check your protocol before running '
+                'on the robot.')
+
+
+def determine_drop_target(
+        api_version: APIVersion,
+        location: Well,
+        return_height: float,
+        version_breakpoint: APIVersion = None) -> types.Location:
+    """Determine the drop target based on well and api version."""
+    version_breakpoint = version_breakpoint or APIVersion(2, 2)
+    if api_version < version_breakpoint:
+        bot = location.bottom()
+        return types.Location(
+            point=bot.point._replace(z=bot.point.z + 10),
+            labware=location)
+    else:
+        tr = location.parent
+        assert tr.is_tiprack
+        z_height = return_height * tr.tip_length
+        return location.top(-z_height)

--- a/api/tests/opentrons/protocol_api/test_instrument.py
+++ b/api/tests/opentrons/protocol_api/test_instrument.py
@@ -2,11 +2,8 @@
 import pytest
 from unittest import mock
 import opentrons.protocol_api as papi
-from opentrons.protocol_api.labware import Well
 from opentrons.protocols.advanced_control import transfers
-from opentrons.protocols.implementations.well import WellImplementation
-from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.types import Mount, Point
+from opentrons.types import Mount
 from opentrons.protocols.api_support.types import APIVersion
 
 
@@ -121,46 +118,3 @@ def test_valid_blowout_location(
             .blow_out_strategy
 
         assert blowout_strat == expected_strat
-
-
-@pytest.mark.parametrize(argnames=["api_version", "expected_point"],
-                         argvalues=[
-                             # Above version_breakpoint:
-                             #  subtract return_height (0.5) * tip_length (1)
-                             #  from z (15)
-                             [APIVersion(2, 3), Point(10, 10, 14.5)],
-                             # Below version_breakpoint:
-                             #  add 10 to bottom (10)
-                             [APIVersion(2, 0), Point(10, 10, 20)],
-                         ])
-def test_determine_drop_target(
-        make_context_and_labware,
-        api_version,
-        expected_point):
-    fixture = make_context_and_labware(api_version)
-    lw_mock = fixture['lw1']
-    lw_mock._implementation.is_tiprack = mock.MagicMock(return_value=True)
-    lw_mock._implementation.get_tip_length = mock.MagicMock(return_value=1)
-    well = Well(
-        well_implementation=WellImplementation(
-            well_geometry=WellGeometry(
-                well_props={
-                    'shape': 'circular',
-                    'depth': 5,
-                    'totalLiquidVolume': 0,
-                    'x': 10,
-                    'y': 10,
-                    'z': 10,
-                    'diameter': 5,
-                },
-                parent_point=Point(0, 0, 0),
-                parent_object=lw_mock._implementation),
-            display_name="",
-            has_tip=False,
-            name="A1",
-        ),
-        api_level=api_version
-    )
-    r = fixture['instr']._determine_drop_target(well)
-    assert r.labware.object == well
-    assert r.point == expected_point

--- a/api/tests/opentrons/protocols/api_support/test_instrument.py
+++ b/api/tests/opentrons/protocols/api_support/test_instrument.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+from opentrons.protocol_api.labware import Well
+from opentrons.protocols.api_support.instrument import determine_drop_target
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocols.implementations.well import WellImplementation
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.types import Point
+
+
+@pytest.mark.parametrize(argnames=["api_version", "expected_point"],
+                         argvalues=[
+                             # Above version_breakpoint:
+                             #  subtract return_height (0.5) * tip_length (1)
+                             #  from z (15)
+                             [APIVersion(2, 3), Point(10, 10, 14.5)],
+                             # Below version_breakpoint:
+                             #  add 10 to bottom (10)
+                             [APIVersion(2, 0), Point(10, 10, 20)],
+                         ])
+def test_determine_drop_target(
+        api_version,
+        expected_point):
+    lw_mock = mock.MagicMock()
+    lw_mock.is_tiprack = mock.MagicMock(return_value=True)
+    lw_mock.get_tip_length = mock.MagicMock(return_value=1)
+    well = Well(
+        well_implementation=WellImplementation(
+            well_geometry=WellGeometry(
+                well_props={
+                    'shape': 'circular',
+                    'depth': 5,
+                    'totalLiquidVolume': 0,
+                    'x': 10,
+                    'y': 10,
+                    'z': 10,
+                    'diameter': 5,
+                },
+                parent_point=Point(0, 0, 0),
+                parent_object=lw_mock),
+            display_name="",
+            has_tip=False,
+            name="A1",
+        ),
+        api_level=api_version
+    )
+    r = determine_drop_target(api_version, well, 0.5)
+    assert r.labware.object == well
+    assert r.point == expected_point


### PR DESCRIPTION
# Overview

This is a modest effort to chip away at InstrumentContext's size. (-130 lines)

# Changelog

Move private utility functions out of the InstrumentContext class. Put them in `protocols` package. 

# Review requests

Not much. This is a cut and paste job.

**This should not be merged until 4.0 is in edge. Let's limit the merge issues.**

# Risk assessment

None