### PR TITLE
feat(api): add pick up tip handling to protocol_engine

### DIFF
--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -35,8 +35,21 @@ class FailedToLoadPipetteError(ProtocolEngineError):
     pass
 
 
+class PipetteNotAttachedError(ProtocolEngineError):
+    """An error raised when an operation's required pipette is not attached."""
+
+    # TODO(mc, 2020-10-18): differentiate between pipette missing vs incorrect
+    pass
+
+
 class LabwareDoesNotExistError(ProtocolEngineError):
     """An error raised when referencing a labware that does not exist."""
+
+    pass
+
+
+class LabwareIsNotTipRackError(ProtocolEngineError):
+    """An error raised when trying to use a regular labware as a tip rack."""
 
     pass
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -1,0 +1,62 @@
+"""Movement command handling."""
+from opentrons.hardware_control.api import API as HardwareAPI
+
+from ..state import StateView
+from ..command_models import BasePipettingRequest, MoveToWellResult
+
+
+class MovementHandler:
+    """Implementation logic for gantry movement."""
+
+    _state: StateView
+    _hardware: HardwareAPI
+
+    def __init__(
+        self,
+        state: StateView,
+        hardware: HardwareAPI,
+    ) -> None:
+        """Initialize a MovementHandler instance."""
+        self._state = state
+        self._hardware = hardware
+
+    async def handle_move_to_well(
+        self,
+        request: BasePipettingRequest,
+    ) -> MoveToWellResult:
+        """Move to a specific well."""
+        pipette_id = request.pipetteId
+        labware_id = request.labwareId
+        well_name = request.wellName
+
+        # get the pipette's mount and current critical point, if applicable
+        pipette_location = self._state.motion.get_pipette_location(pipette_id)
+        hw_mount = pipette_location.mount.to_hw_mount()
+        origin_cp = pipette_location.critical_point
+
+        # get the origin of the movement from the hardware controller
+        origin = await self._hardware.gantry_position(
+            mount=hw_mount,
+            critical_point=origin_cp,
+        )
+        max_travel_z = self._hardware.get_instrument_max_height(mount=hw_mount)
+
+        # calculate the movement's waypoints
+        waypoints = self._state.motion.get_movement_waypoints(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            origin=origin,
+            origin_cp=origin_cp,
+            max_travel_z=max_travel_z,
+        )
+
+        # move through the waypoints
+        for wp in waypoints:
+            await self._hardware.move_to(
+                mount=hw_mount,
+                abs_position=wp.position,
+                critical_point=wp.critical_point
+            )
+
+        return MoveToWellResult()

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -30,9 +30,6 @@ class PipettingHandler:
         labware_id = request.labwareId
         well_name = request.wellName
 
-        # move the pipette to the top of the tip
-        await self._movement_handler.handle_move_to_well(request)
-
         # get mount and config data from state and hardware controller
         hw_pipette = self._state.pipettes.get_hardware_pipette(
             pipette_id=pipette_id,
@@ -45,6 +42,9 @@ class PipettingHandler:
             well_name=well_name,
             pipette_config=hw_pipette.config,
         )
+
+        # move the pipette to the top of the tip
+        await self._movement_handler.handle_move_to_well(request)
 
         # perform the tip pickup routine
         await self._hardware.pick_up_tip(

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -2,60 +2,67 @@
 from opentrons.hardware_control.api import API as HardwareAPI
 
 from ..state import StateView
-
-from ..command_models import (
-    MoveToWellRequest,
-    MoveToWellResult
-)
+from ..command_models import PickUpTipRequest, PickUpTipResult
+from .movement import MovementHandler
 
 
 class PipettingHandler:
     """Implementation logic for liquid handling commands."""
 
+    _state: StateView
+    _hardware: HardwareAPI
+    _movement_handler: MovementHandler
+
     def __init__(
         self,
-        hardware: HardwareAPI,
         state: StateView,
+        hardware: HardwareAPI,
+        movement_handler: MovementHandler,
     ) -> None:
         """Initialize a PipettingHandler instance."""
         self._state = state
-        self._hardware: HardwareAPI = hardware
+        self._hardware = hardware
+        self._movement_handler = movement_handler
 
-    async def handle_move_to_well(
-        self,
-        request: MoveToWellRequest,
-    ) -> MoveToWellResult:
-        """Move to a specific well."""
-        # get the pipette's mount and current critical point, if applicable
-        pipette_location = self._state.motion.get_pipette_location(
-            pipette_id=request.pipetteId,
-        )
-        hw_mount = pipette_location.mount.to_hw_mount()
-        origin_cp = pipette_location.critical_point
+    async def handle_pick_up_tip(self, request: PickUpTipRequest) -> PickUpTipResult:
+        """Pick up a tip at the specified "well"."""
+        pipette_id = request.pipetteId
+        labware_id = request.labwareId
+        well_name = request.wellName
 
-        # get the origin of the movement from the hardware controller
-        origin = await self._hardware.gantry_position(
-            mount=hw_mount,
-            critical_point=origin_cp,
-        )
-        max_travel_z = self._hardware.get_instrument_max_height(mount=hw_mount)
+        # move the pipette to the top of the tip
+        await self._movement_handler.handle_move_to_well(request)
 
-        # calculate the movement's waypoints
-        waypoints = self._state.motion.get_movement_waypoints(
-            pipette_id=request.pipetteId,
-            labware_id=request.labwareId,
-            well_name=request.wellName,
-            origin=origin,
-            origin_cp=origin_cp,
-            max_travel_z=max_travel_z,
+        # get mount and config data from state and hardware controller
+        hw_pipette = self._state.pipettes.get_hardware_pipette(
+            pipette_id=pipette_id,
+            attached_pipettes=self._hardware.attached_instruments
         )
 
-        # move through the waypoints
-        for wp in waypoints:
-            await self._hardware.move_to(
-                mount=hw_mount,
-                abs_position=wp.position,
-                critical_point=wp.critical_point
-            )
+        # use config data to get tip geometry (length, diameter, volume)
+        tip_geometry = self._state.geometry.get_tip_geometry(
+            labware_id=labware_id,
+            well_name=well_name,
+            pipette_config=hw_pipette.config,
+        )
 
-        return MoveToWellResult()
+        # perform the tip pickup routine
+        await self._hardware.pick_up_tip(
+            mount=hw_pipette.mount,
+            tip_length=tip_geometry.effective_length,
+            # TODO(mc, 2020-11-12): include these parameters in the request
+            presses=None,
+            increment=None
+        )
+
+        # after a successful pickup, update the hardware controller state
+        self._hardware.set_current_tiprack_diameter(
+            mount=hw_pipette.mount,
+            tiprack_diameter=tip_geometry.diameter
+        )
+        self._hardware.set_working_volume(
+            mount=hw_pipette.mount,
+            tip_volume=tip_geometry.volume
+        )
+
+        return PickUpTipResult()

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -2,8 +2,8 @@
 
 from .state_store import CommandState, StateStore, StateView
 from .labware import LabwareState, LabwareData
-from .pipettes import PipetteState, PipetteData
-from .geometry import GeometryState
+from .pipettes import PipetteState, PipetteData, HardwarePipette
+from .geometry import GeometryState, TipGeometry
 from .motion import MotionState, LocationData, PipetteLocationData
 
 __all__ = [
@@ -16,6 +16,8 @@ __all__ = [
     "MotionState",
     "LabwareData",
     "PipetteData",
+    "HardwarePipette",
+    "TipGeometry",
     "LocationData",
     "PipetteLocationData",
 ]

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -101,7 +101,8 @@ class GeometryState:
 
         return z_dim + slot_pos[2] + lw_data.calibration[2]
 
-    # TODO(mc, 2020-11-12): reconcile with existing protocol logic
+    # TODO(mc, 2020-11-12): reconcile with existing protocol logic and include
+    # data from tip-length calibration once v4.0.0 is in `edge`
     def get_effective_tip_length(
         self,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1,10 +1,25 @@
 """Geometry state store and getters."""
+from dataclasses import dataclass
+from typing_extensions import final
+
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV2, SlotDefV2
 from opentrons.types import Point, DeckSlotName
+from opentrons.hardware_control.dev_types import PipetteDict
 
 from .. import errors
 from .substore import Substore, CommandReactive
 from .labware import LabwareStore, LabwareData
+
+
+# TODO(mc, 2020-11-12): reconcile this data structure with WellGeometry
+@final
+@dataclass(frozen=True)
+class TipGeometry:
+    """Tip geometry data."""
+
+    effective_length: float
+    diameter: float
+    volume: int
 
 
 class GeometryState:
@@ -85,6 +100,55 @@ class GeometryState:
         slot_pos = self.get_slot_position(lw_data.location.slot)
 
         return z_dim + slot_pos[2] + lw_data.calibration[2]
+
+    # TODO(mc, 2020-11-12): reconcile with existing protocol logic
+    def get_effective_tip_length(
+        self,
+        labware_id: str,
+        pipette_config: PipetteDict
+    ) -> float:
+        """
+        Given a labware and a pipette's config, get the effective tip length.
+
+        Effective tip length is the nominal tip length less the distance the
+        tip overlaps with the pipette nozzle.
+        """
+        labware_uri = self._labware_store.state.get_definition_uri(labware_id)
+        nominal_length = self._labware_store.state.get_tip_length(labware_id)
+        overlap_config = pipette_config["tip_overlap"]
+        default_overlap = overlap_config.get("default", 0)
+        overlap = overlap_config.get(labware_uri, default_overlap)
+
+        return nominal_length - overlap
+
+    # TODO(mc, 2020-11-12): reconcile with existing geometry logic
+    def get_tip_geometry(
+        self,
+        labware_id: str,
+        well_name: str,
+        pipette_config: PipetteDict
+    ) -> TipGeometry:
+        """
+        Given a labware, well, and hardware pipette config, get the tip geometry.
+
+        Tip geometry includes effective tip length, tip diamter, and tip volume,
+        which is all data required by the hardware controller for proper tip handling.
+        """
+        effective_length = self.get_effective_tip_length(labware_id, pipette_config)
+        well_def = self._labware_store.state.get_well_definition(labware_id, well_name)
+
+        if well_def["shape"] != "circular":
+            raise errors.LabwareIsNotTipRackError(
+                f"Well {well_name} in labware {labware_id} is not circular."
+            )
+
+        return TipGeometry(
+            effective_length=effective_length,
+            diameter=well_def["diameter"],
+            # TODO(mc, 2020-11-12): WellDefinition type says totalLiquidVolume
+            # is a float, but hardware controller expects an int
+            volume=int(well_def["totalLiquidVolume"]),
+        )
 
 
 class GeometryStore(Substore[GeometryState], CommandReactive):

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -131,7 +131,7 @@ class GeometryState:
         """
         Given a labware, well, and hardware pipette config, get the tip geometry.
 
-        Tip geometry includes effective tip length, tip diamter, and tip volume,
+        Tip geometry includes effective tip length, tip diameter, and tip volume,
         which is all data required by the hardware controller for proper tip handling.
         """
         effective_length = self.get_effective_tip_length(labware_id, pipette_config)

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1,17 +1,20 @@
 """Basic labware data state and store."""
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
+from typing_extensions import final
 
 from opentrons_shared_data.labware.dev_types import (
     LabwareDefinition,
     WellDefinition,
 )
+from opentrons.calibration_storage.helpers import uri_from_definition
 
 from .. import command_models as cmd, errors
 from ..types import LabwareLocation
 from .substore import Substore, CommandReactive
 
 
+@final
 @dataclass(frozen=True)
 class LabwareData:
     """Labware data entry."""
@@ -30,20 +33,20 @@ class LabwareState:
         """Initialize a LabwareState instance."""
         self._labware_by_id = {}
 
-    def get_labware_data_by_id(self, uid: str) -> LabwareData:
+    def get_labware_data_by_id(self, labware_id: str) -> LabwareData:
         """Get labware data by the labware's unique identifier."""
         try:
-            return self._labware_by_id[uid]
+            return self._labware_by_id[labware_id]
         except KeyError:
-            raise errors.LabwareDoesNotExistError(f"Labware {uid} not found.")
+            raise errors.LabwareDoesNotExistError(f"Labware {labware_id} not found.")
 
     def get_all_labware(self) -> List[Tuple[str, LabwareData]]:
         """Get a list of all labware entries in state."""
         return [entry for entry in self._labware_by_id.items()]
 
-    def get_labware_has_quirk(self, uid: str, quirk: str) -> bool:
+    def get_labware_has_quirk(self, labware_id: str, quirk: str) -> bool:
         """Get if a labware has a certain quirk."""
-        data = self.get_labware_data_by_id(uid)
+        data = self.get_labware_data_by_id(labware_id)
         return quirk in data.definition["parameters"].get("quirks", ())
 
     def get_well_definition(
@@ -60,6 +63,20 @@ class LabwareState:
             raise errors.WellDoesNotExistError(
                 f"{well_name} does not exist in {labware_id}."
             )
+
+    def get_tip_length(self, labware_id: str) -> float:
+        """Get the tip length of a tip rack."""
+        data = self.get_labware_data_by_id(labware_id)
+        try:
+            return data.definition["parameters"]["tipLength"]
+        except KeyError:
+            raise errors.LabwareIsNotTipRackError(
+                f"Labware {labware_id} has no tip length defined."
+            )
+
+    def get_definition_uri(self, labware_id: str) -> str:
+        """Get a labware's definition URI."""
+        return uri_from_definition(self.get_labware_data_by_id(labware_id).definition)
 
 
 class LabwareStore(Substore[LabwareState], CommandReactive):

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -1,20 +1,32 @@
 """Basic pipette data state and store."""
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
+from typing_extensions import final
 
 from opentrons_shared_data.pipette.dev_types import PipetteName
-from opentrons.types import MountType
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.types import MountType, Mount as HwMount
 
 from .. import command_models as cmd, errors
 from .substore import Substore, CommandReactive
 
 
+@final
 @dataclass(frozen=True)
 class PipetteData:
     """Pipette state data."""
 
     mount: MountType
     pipette_name: PipetteName
+
+
+@final
+@dataclass(frozen=True)
+class HardwarePipette:
+    """Hardware pipette data."""
+
+    mount: HwMount
+    config: PipetteDict
 
 
 class PipetteState:
@@ -48,6 +60,29 @@ class PipetteState:
             if pipette.mount == mount:
                 return pipette
         return None
+
+    def get_hardware_pipette(
+        self,
+        pipette_id: str,
+        attached_pipettes: Mapping[HwMount, Optional[PipetteDict]],
+    ) -> HardwarePipette:
+        """Get a pipette's hardware configuration and state by ID."""
+        pipette_data = self.get_pipette_data_by_id(pipette_id)
+        pipette_name = pipette_data.pipette_name
+        mount = pipette_data.mount
+
+        hw_mount = mount.to_hw_mount()
+        hw_config = attached_pipettes[hw_mount]
+
+        if hw_config is None:
+            raise errors.PipetteNotAttachedError(f"No pipetted attached on {mount}")
+        elif hw_config["name"] != pipette_name:
+            raise errors.PipetteNotAttachedError(
+                f"Found {hw_config['name']} on {mount}, "
+                f"but {pipette_id} is a {pipette_name}"
+            )
+
+        return HardwarePipette(mount=hw_mount, config=hw_config)
 
 
 class PipetteStore(Substore[PipetteState], CommandReactive):

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -76,6 +76,7 @@ class PipetteState:
 
         if hw_config is None:
             raise errors.PipetteNotAttachedError(f"No pipetted attached on {mount}")
+        # TODO(mc, 2020-11-12): support hw_pipette.act_as
         elif hw_config["name"] != pipette_name:
             raise errors.PipetteNotAttachedError(
                 f"Found {hw_config['name']} on {mount}, "

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -67,6 +67,12 @@ def reservoir_def() -> LabwareDefinition:
     return load_definition("nest_12_reservoir_15ml", 1)
 
 
+@pytest.fixture(scope="session")
+def tip_rack_def() -> LabwareDefinition:
+    """Get the definition of Opentrons 300 uL tip rack."""
+    return load_definition("opentrons_96_tiprack_300ul", 1)
+
+
 @pytest.fixture
 def store(standard_deck_def: DeckDefinitionV2) -> StateStore:
     """Get an actual StateStore."""

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -1,0 +1,148 @@
+"""Pipetting command handler."""
+import pytest
+from mock import AsyncMock, MagicMock, call  # type: ignore[attr-defined]
+from typing import List
+
+from opentrons.types import MountType, Mount, Point
+from opentrons.hardware_control.types import CriticalPoint
+from opentrons.motion_planning import Waypoint
+
+from opentrons.protocol_engine import command_models as cmd
+from opentrons.protocol_engine.state import PipetteLocationData
+from opentrons.protocol_engine.execution.movement import MovementHandler
+
+
+@pytest.fixture
+def pipette_location_data() -> PipetteLocationData:
+    """Get an example PipetteLocationData."""
+    return PipetteLocationData(
+        mount=MountType.LEFT,
+        critical_point=CriticalPoint.FRONT_NOZZLE,
+    )
+
+
+@pytest.fixture
+def waypoints() -> List[Waypoint]:
+    """Get a list of example Waypoints."""
+    return [
+        Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER),
+        Waypoint(Point(4, 5, 6))
+    ]
+
+
+@pytest.fixture
+def state_with_data(
+    mock_state_view: MagicMock,
+    pipette_location_data: PipetteLocationData,
+    waypoints: List[Waypoint],
+) -> MagicMock:
+    """Prime a mock StateView with example data."""
+    mock_state_view.motion.get_pipette_location.return_value = \
+        pipette_location_data
+    mock_state_view.motion.get_movement_waypoints.return_value = waypoints
+
+    return mock_state_view
+
+
+@pytest.fixture
+def hc_with_data(
+    mock_hardware: AsyncMock,
+) -> MagicMock:
+    """Prime a mock HardwareController with example data."""
+    mock_hardware.gantry_position.return_value = Point(1, 1, 1)
+    mock_hardware.get_instrument_max_height.return_value = 42.0
+    return mock_hardware
+
+
+@pytest.fixture
+def handler(
+    state_with_data: MagicMock,
+    hc_with_data: AsyncMock
+) -> MovementHandler:
+    """Create a PipettingHandler with its dependencies mocked out."""
+    return MovementHandler(
+        state=state_with_data,
+        hardware=hc_with_data
+    )
+
+
+MOVE_REQUESTS: List[cmd.BasePipettingRequest] = [
+    cmd.MoveToWellRequest(
+        pipetteId="pipette-id",
+        labwareId="labware-id",
+        wellName="B2"
+    ),
+    cmd.PickUpTipRequest(
+        pipetteId="pipette-id",
+        labwareId="labware-id",
+        wellName="B2"
+    ),
+]
+
+
+@pytest.mark.parametrize("move_request", MOVE_REQUESTS)
+async def test_move_requests_pass_waypoints_to_hc(
+    move_request: cmd.BasePipettingRequest,
+    hc_with_data: AsyncMock,
+    handler: MovementHandler
+) -> None:
+    """Move requests should call hardware controller with movement data."""
+    await handler.handle_move_to_well(move_request)
+
+    hc_with_data.gantry_position.assert_called_with(
+        mount=Mount.LEFT,
+        critical_point=CriticalPoint.FRONT_NOZZLE,
+    )
+
+    hc_with_data.get_instrument_max_height.assert_called_with(
+        mount=Mount.LEFT,
+    )
+
+    assert hc_with_data.move_to.call_count == 2
+    hc_with_data.move_to.assert_has_calls([
+        call(
+            mount=Mount.LEFT,
+            abs_position=Point(1, 2, 3),
+            critical_point=CriticalPoint.XY_CENTER
+        ),
+        call(
+            mount=Mount.LEFT,
+            abs_position=Point(4, 5, 6),
+            critical_point=None
+        ),
+    ])
+
+
+@pytest.mark.parametrize("move_request", MOVE_REQUESTS)
+async def test_move_requests_get_data_from_state(
+    move_request: cmd.BasePipettingRequest,
+    state_with_data: MagicMock,
+    handler: MovementHandler
+) -> None:
+    """Move requests should get move parameters from state."""
+    await handler.handle_move_to_well(move_request)
+
+    state_with_data.motion.get_pipette_location.assert_called_with(
+        move_request.pipetteId,
+    )
+
+    state_with_data.motion.get_movement_waypoints.assert_called_with(
+        origin=Point(1, 1, 1),
+        origin_cp=CriticalPoint.FRONT_NOZZLE,
+        max_travel_z=42.0,
+        pipette_id=move_request.pipetteId,
+        labware_id=move_request.labwareId,
+        well_name=move_request.wellName,
+    )
+
+
+async def test_handle_move_to_well_result(handler: MovementHandler) -> None:
+    """It should return a MoveToWellResult for a MoveToWellRequest."""
+    request = cmd.MoveToWellRequest(
+        pipetteId="pipette-id",
+        labwareId="labware-id",
+        wellName="B2",
+    )
+    result = await handler.handle_move_to_well(request)
+
+    assert result == cmd.MoveToWellResult()

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -1,131 +1,90 @@
 """Pipetting command handler."""
 import pytest
 from mock import AsyncMock, MagicMock, call  # type: ignore[attr-defined]
-from typing import List
+from typing import cast
 
-from opentrons.types import MountType, Mount, Point
-from opentrons.hardware_control.types import CriticalPoint
-from opentrons.motion_planning import Waypoint
+from opentrons.types import Mount
+from opentrons.hardware_control.dev_types import PipetteDict
 
-from opentrons.protocol_engine import StateStore
-from opentrons.protocol_engine.state import PipetteLocationData
-from opentrons.protocol_engine.command_models import MoveToWellRequest
+from opentrons.protocol_engine import command_models as cmd
+from opentrons.protocol_engine.state import TipGeometry, HardwarePipette
+from opentrons.protocol_engine.execution.movement import MovementHandler
 from opentrons.protocol_engine.execution.pipetting import PipettingHandler
 
 
 @pytest.fixture
-def move_to_well_request() -> MoveToWellRequest:
-    """Get an example MoveToWellRequest."""
-    return MoveToWellRequest(
-        pipetteId="pipette-id",
-        labwareId="labware-id",
-        wellName="B2"
-    )
-
-
-@pytest.fixture
-def pipette_location_data() -> PipetteLocationData:
-    """Get an example PipetteLocationData."""
-    return PipetteLocationData(
-        mount=MountType.LEFT,
-        critical_point=CriticalPoint.FRONT_NOZZLE,
-    )
-
-
-@pytest.fixture
-def waypoints() -> List[Waypoint]:
-    """Get a list of example Waypoints."""
-    return [
-        Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER),
-        Waypoint(Point(4, 5, 6))
-    ]
-
-
-@pytest.fixture
-def store_with_data(
-    mock_state_view: MagicMock,
-    pipette_location_data: PipetteLocationData,
-    waypoints: List[Waypoint],
-) -> MagicMock:
-    """Prime a mock StateView with example data."""
-    mock_state_view.motion.get_pipette_location.return_value = \
-        pipette_location_data
-    mock_state_view.motion.get_movement_waypoints.return_value = waypoints
-
-    return mock_state_view
-
-
-@pytest.fixture
-def hc_with_data(
-    mock_hardware: AsyncMock,
-) -> MagicMock:
-    """Prime a mock HardwareController with example data."""
-    mock_hardware.gantry_position.return_value = Point(1, 1, 1)
-    mock_hardware.get_instrument_max_height.return_value = 42.0
-    return mock_hardware
+def mock_movement_handler() -> AsyncMock:
+    """Get an asynchronous mock in the shape of an MovementHandler."""
+    return AsyncMock(spec=MovementHandler)
 
 
 @pytest.fixture
 def handler(
-    store_with_data: StateStore,
-    hc_with_data: AsyncMock
+    mock_state_view: MagicMock,
+    mock_hardware: AsyncMock,
+    mock_movement_handler: AsyncMock,
 ) -> PipettingHandler:
     """Create a PipettingHandler with its dependencies mocked out."""
     return PipettingHandler(
-        state=store_with_data,
-        hardware=hc_with_data
+        state=mock_state_view,
+        hardware=mock_hardware,
+        movement_handler=mock_movement_handler,
     )
 
 
-async def test_handle_move_to_passes_waypoint_to_hc(
-    move_to_well_request: MoveToWellRequest,
-    hc_with_data: AsyncMock,
-    handler: PipettingHandler
+async def test_handle_pick_up_tip_request(
+    mock_state_view: MagicMock,
+    mock_hardware: AsyncMock,
+    mock_movement_handler: AsyncMock,
+    handler: PipettingHandler,
 ) -> None:
-    """It should call hardware control with the movement data."""
-    await handler.handle_move_to_well(move_to_well_request)
-
-    hc_with_data.gantry_position.assert_called_with(
-        mount=Mount.LEFT,
-        critical_point=CriticalPoint.FRONT_NOZZLE,
+    """It should handle a PickUpTipRequest properly."""
+    request = cmd.PickUpTipRequest(
+        pipetteId="pipette-id",
+        labwareId="labware-id",
+        wellName="B2",
     )
 
-    hc_with_data.get_instrument_max_height.assert_called_with(
+    mock_config = cast(PipetteDict, {"name": "p300_single"})
+    mock_attached_pipettes = {Mount.LEFT: mock_config, Mount.RIGHT: None}
+
+    mock_hardware.attached_instruments = mock_attached_pipettes
+
+    mock_state_view.pipettes.get_hardware_pipette.return_value = HardwarePipette(
         mount=Mount.LEFT,
+        config=mock_config,
     )
 
-    assert hc_with_data.move_to.call_count == 2
-    hc_with_data.move_to.assert_has_calls([
-        call(
+    mock_state_view.geometry.get_tip_geometry.return_value = TipGeometry(
+        effective_length=50,
+        diameter=5,
+        volume=300,
+    )
+
+    result = await handler.handle_pick_up_tip(request)
+
+    assert result == cmd.PickUpTipResult()
+
+    mock_movement_handler.handle_move_to_well.assert_called_with(request)
+
+    mock_hardware.assert_has_calls([
+        call.pick_up_tip(
             mount=Mount.LEFT,
-            abs_position=Point(1, 2, 3),
-            critical_point=CriticalPoint.XY_CENTER
+            tip_length=50,
+            presses=None,
+            increment=None,
         ),
-        call(
-            mount=Mount.LEFT,
-            abs_position=Point(4, 5, 6),
-            critical_point=None
-        ),
+        call.set_current_tiprack_diameter(mount=Mount.LEFT, tiprack_diameter=5),
+        call.set_working_volume(mount=Mount.LEFT, tip_volume=300)
     ])
 
-
-async def test_handle_move_to_gets_movement_data_from_state(
-    move_to_well_request: MoveToWellRequest,
-    store_with_data: MagicMock,
-    handler: PipettingHandler
-) -> None:
-    """It should call state.get_movement_waypoints with request data."""
-    await handler.handle_move_to_well(move_to_well_request)
-
-    store_with_data.motion.get_pipette_location.assert_called_with(
-        pipette_id=move_to_well_request.pipetteId,
+    mock_state_view.pipettes.get_hardware_pipette.assert_called_with(
+        pipette_id="pipette-id",
+        attached_pipettes=mock_attached_pipettes,
     )
 
-    store_with_data.motion.get_movement_waypoints.assert_called_with(
-        origin=Point(1, 1, 1),
-        origin_cp=CriticalPoint.FRONT_NOZZLE,
-        max_travel_z=42.0,
-        pipette_id=move_to_well_request.pipetteId,
-        labware_id=move_to_well_request.labwareId,
-        well_name=move_to_well_request.wellName,
+    mock_state_view.geometry.get_tip_geometry.assert_called_with(
+        labware_id="labware-id",
+        well_name="B2",
+        pipette_config={"name": "p300_single"},
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -169,3 +169,54 @@ def test_get_well_definition(
     )
 
     assert result == expected_well_def
+
+
+def test_get_tip_length_raises_with_non_tip_rack(
+    well_plate_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should raise if you try to get the tip length of a regular labware."""
+    load_labware(
+        store=store,
+        labware_id="plate-id",
+        location=DeckSlotLocation(DeckSlotName.SLOT_1),
+        definition=well_plate_def,
+        calibration=(1, 2, 3),
+    )
+
+    with pytest.raises(errors.LabwareIsNotTipRackError):
+        store.labware.get_tip_length("plate-id")
+
+
+def test_get_tip_length_gets_length_from_definition(
+    tip_rack_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should return the tip length from the definition."""
+    load_labware(
+        store=store,
+        labware_id="tip-rack-id",
+        location=DeckSlotLocation(DeckSlotName.SLOT_1),
+        definition=tip_rack_def,
+        calibration=(1, 2, 3),
+    )
+
+    length = store.labware.get_tip_length("tip-rack-id")
+    assert length == tip_rack_def["parameters"]["tipLength"]
+
+
+def test_get_labware_uri_from_definition(
+    tip_rack_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should return the tip length from the definition."""
+    load_labware(
+        store=store,
+        labware_id="tip-rack-id",
+        location=DeckSlotLocation(DeckSlotName.SLOT_1),
+        definition=tip_rack_def,
+        calibration=(1, 2, 3),
+    )
+
+    uri = store.labware.get_definition_uri("tip-rack-id")
+    assert uri == "opentrons/opentrons_96_tiprack_300ul/1"

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -1,9 +1,32 @@
 """Tests for equipment state in the protocol_engine state store."""
 import pytest
 from datetime import datetime
+from typing import cast, Dict, Optional
 
-from opentrons.types import MountType
+from opentrons.types import MountType, Mount as HwMount
+from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_engine import command_models as cmd, errors, StateStore
+
+
+CompletedLoadLabware = cmd.CompletedCommand[
+    cmd.LoadPipetteRequest,
+    cmd.LoadPipetteResult
+]
+
+
+@pytest.fixture
+def load_pipette_command(now: datetime) -> CompletedLoadLabware:
+    """Get a completed load pipette command."""
+    return cmd.CompletedCommand(
+        request=cmd.LoadPipetteRequest(
+            pipetteName="p300_single",
+            mount=MountType.LEFT,
+        ),
+        result=cmd.LoadPipetteResult(pipetteId='pipette-id'),
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+    )
 
 
 def test_initial_pipette_data_by_id(store: StateStore) -> None:
@@ -18,27 +41,74 @@ def test_initial_pipette_data_by_mount(store: StateStore) -> None:
     assert store.pipettes.get_pipette_data_by_mount(MountType.RIGHT) is None
 
 
-def test_handles_load_pipette(store: StateStore, now: datetime) -> None:
+def test_handles_load_pipette(
+    load_pipette_command: CompletedLoadLabware,
+    store: StateStore,
+) -> None:
     """It should add the pipette data to the state."""
-    command = cmd.CompletedCommand(
-        request=cmd.LoadPipetteRequest(
-            pipetteName="p300_single",
-            mount=MountType.LEFT,
-        ),
-        result=cmd.LoadPipetteResult(pipetteId='unique-id'),
-        created_at=now,
-        started_at=now,
-        completed_at=now,
-    )
+    store.handle_command(load_pipette_command, command_id="unique-id")
 
-    store.handle_command(command, command_id="unique-id")
     data_by_id = store.pipettes.get_pipette_data_by_id(
-        command.result.pipetteId
+        load_pipette_command.result.pipetteId
     )
     data_by_mount = store.pipettes.get_pipette_data_by_mount(
-        command.request.mount
+        load_pipette_command.request.mount
     )
 
-    assert data_by_id.mount == command.request.mount
-    assert data_by_id.pipette_name == command.request.pipetteName
+    assert data_by_id.mount == load_pipette_command.request.mount
+    assert data_by_id.pipette_name == load_pipette_command.request.pipetteName
     assert data_by_id == data_by_mount
+
+
+def test_get_hardware_pipette(
+    load_pipette_command: CompletedLoadLabware,
+    store: StateStore,
+) -> None:
+    """It maps a pipette ID to a config given the HC's attached pipettes."""
+    pipette_config = cast(PipetteDict, {"name": "p300_single"})
+    attached_pipettes: Dict[HwMount, Optional[PipetteDict]] = {
+        HwMount.LEFT: pipette_config,
+        HwMount.RIGHT: None,
+    }
+
+    load_pipette_command.request.mount = MountType.LEFT
+    load_pipette_command.result.pipetteId = "left-id"
+    store.handle_command(load_pipette_command, command_id="load-left")
+
+    load_pipette_command.request.mount = MountType.RIGHT
+    load_pipette_command.result.pipetteId = "right-id"
+    store.handle_command(load_pipette_command, command_id="load-right")
+
+    hw_pipette = store.pipettes.get_hardware_pipette(
+        pipette_id="left-id",
+        attached_pipettes=attached_pipettes,
+    )
+
+    assert hw_pipette.mount == HwMount.LEFT
+    assert hw_pipette.config == {"name": "p300_single"}
+
+    with pytest.raises(errors.PipetteNotAttachedError):
+        store.pipettes.get_hardware_pipette(
+            pipette_id="right-id",
+            attached_pipettes=attached_pipettes,
+        )
+
+
+def test_get_hardware_pipette_raises_with_name_mismatch(
+    load_pipette_command: CompletedLoadLabware,
+    store: StateStore,
+) -> None:
+    """It maps a pipette ID to a config given the HC's attached pipettes."""
+    pipette_config = cast(PipetteDict, {"name": "p300_single_gen2"})
+    attached_pipettes: Dict[HwMount, Optional[PipetteDict]] = {
+        HwMount.LEFT: pipette_config,
+        HwMount.RIGHT: None,
+    }
+
+    store.handle_command(load_pipette_command, command_id="load-left")
+
+    with pytest.raises(errors.PipetteNotAttachedError):
+        store.pipettes.get_hardware_pipette(
+            pipette_id="pipette-id",
+            attached_pipettes=attached_pipettes,
+        )


### PR DESCRIPTION
## Overview

This PR adds support for the `PickUpTipRequest` model to the protocol engine's command execution.

Closes #6595

## Changelog

- Renamed the existing `execution.pipetting.PipettingHandler` to `execution.movement.MovementHandler`
    - The `MovementHandler` contains the common logic to "move a pipette to a well"
    - `PipettingHandler` depends on `MovementHandler`
- Added a `handle_pick_up_tip` method `PipettingHandler`
- Added state selectors to pull necessary data out of the state
    - `pipette.get_hardware_pipette` gets the pipette's hardware config based on the pipette ID and the hardware controller's `attached_instruments` map
    - `geometry.get_tip_geometry` gets effective tip length, tip diameter, and tip volume based on the labware, well, and pipette's hardware config
    - Added various selectors to support those two main ones
        - `labware.get_tip_length` gets a tiprack's nominal tip length
        - `labware.get_definition_uri` gets the labware definition's URI string
        - `geometry.get_effective_tip_length` does the tip length calculation of `get_tip_geometry`
- Added new errors thrown by the various selectors
    - `PipetteNotAttachedError` - mirrors existing logic in the Protocol API and raises if you try to get hardware pipette config that doesn't exist or properly match
    - `LabwareIsNotTipRackError` - raises when you try to get tip data out of a labware that isn't a tiprack
        - If there is no `parameters.tipLength`
        - If the well shape is not circular


## Review requests

### General questions

- Is this logic easy to follow?
    - Are the docstrings and comments detailed enough?
- Any TODOs missing or that don't make sense?

### Specific questions

- Existing `InstrumentContext` calls `hardware.set_current_tiprack_diameter` **before** running the pick up tip. I've switched it to **after** here, because:
    - `hardware.pick_up_tip` does not seem to depend on that state (it looks like it's only used in `drop_tip`
    - Setting that state and then having the `pick_up_tip` fail seems like it could get us into a weird state place
    - Is this ok?
- Does everyone agree that the `CommandExecutor` routing is not scaling well?

### Known issues (out of scope for this PR)

- ~I'm pretty sure the intended behavior of `LoadPipetteRequest` throwing an error if the pipette isn't attached is not working~
    - Never mind, this is working as intended
- Pretty sure `hw_pipette.act_as` will not work as of this PR
- This PR doesn't include any protocol-side tip tracking

## Risk assessment

Low. Not hooked to anything and well covered by unit tests. Other that one change listed above, pick up tip behavior (after the move to) is exactly the same as InstrumentContext.

## Smoke testing

I used the following smoke testing protocol. `make push` this branch to your robot and try it out! My setup is:

- `p300_single_gen2` on the right mount
- `opentrons_96_tiprack_300ul` in slots 5 and 8

```py
import asyncio
from uuid import uuid4
from typing import Optional

from opentrons.types import DeckSlotName, MountType
from opentrons.protocol_api import ProtocolContext
from opentrons.protocol_engine import ProtocolEngine, command_models as cmd
from opentrons.protocol_engine.types import DeckSlotLocation

# metadata
metadata = {
    'protocolName': 'ProtocolEngine smoke test',
    'author': 'Mike Cousins <mike@opentrons.com>',
    'description': 'Protocol to smoke-test the ProtocolEngine by HACKING',
    'apiLevel': '2.7'
}


def run(ctx: ProtocolContext) -> None:
    asyncio.run(run_protocol(ctx))


async def run_protocol(ctx: ProtocolContext) -> None:
    # HACK(mc, 2020-11-06): don't ever do this in a real protocol
    hw_api = ctx._hw_manager.hardware._obj_to_adapt
    engine = ProtocolEngine.create(hardware=hw_api)

    async def execute_command(
        request: cmd.CommandRequestType
    ) -> Optional[cmd.CommandResultType]:
        command_id = str(uuid4())
        command = await engine.execute_command(request, command_id=command_id)
        ctx.comment(f"{type(command.request).__name__} - {command_id}")
        ctx.comment(f"{command.request}")

        if isinstance(command, cmd.FailedCommand):
            ctx.comment(f"{command.error}")
            return None

        return command.result

    result = await execute_command(
        cmd.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_5),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_5 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        cmd.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_8),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_8 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        cmd.LoadPipetteRequest(
            pipetteName="p300_single_gen2",
            mount=MountType.RIGHT,
        ),
    )

    p300 = result.pipetteId  # type: ignore[union-attr]

    await execute_command(
        cmd.MoveToWellRequest(pipetteId=p300, labwareId=rack_5, wellName="A1")
    )

    await execute_command(
        cmd.PickUpTipRequest(pipetteId=p300, labwareId=rack_8, wellName="H12")
    )
```

