### PR TITLE
refactor(app): Expand cal check analytics, and add calibration check info to intercom

### DIFF
--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -244,7 +244,7 @@ function getCalibrationCheckData(
       model: model,
     }
     return obj
-  }, ({}: $Shape<CalibrationCheckByMount>))
+  }, ({ left: null, right: null }: $Shape<CalibrationCheckByMount>))
 }
 
 export function getAnalyticsDeckCalibrationData(

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -6,6 +6,8 @@ import typeof {
   ANALYTICS_TIP_LENGTH_STARTED,
 } from './constants'
 import * as CalUITypes from '../components/CalibrationPanels/types'
+
+import type { CalibrationCheckComparisonsPerCalibration } from '../sessions/types'
 import type { DeckCalibrationStatus } from '../calibration/types'
 
 export type AnalyticsConfig = $PropertyType<Config, 'analytics'>
@@ -54,8 +56,8 @@ export type TipLengthCalibrationAnalyticsData = {|
 |}
 
 export type ModelsByMount = {|
-  left: { model: string },
-  right: { model: string },
+  left: { model: string } | null,
+  right: { model: string } | null,
 |}
 
 export type DeckCalibrationAnalyticsData = {|
@@ -64,8 +66,21 @@ export type DeckCalibrationAnalyticsData = {|
   pipettes: ModelsByMount,
 |}
 
+export type CalibrationCheckByMount = {|
+  left?: {
+    model: string,
+    comparisons: CalibrationCheckComparisonsPerCalibration,
+    succeeded: boolean,
+  },
+  right?: {
+    model: string,
+    comparisons: CalibrationCheckComparisonsPerCalibration,
+    succeeded: boolean,
+  },
+|}
+
 export type CalibrationHealthCheckAnalyticsData = {|
-  pipettes: ModelsByMount,
+  pipettes: CalibrationCheckByMount | null,
 |}
 
 export type AnalyticsSessionExitDetails = {|

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -67,16 +67,16 @@ export type DeckCalibrationAnalyticsData = {|
 |}
 
 export type CalibrationCheckByMount = {|
-  left?: {
+  left: {
     model: string,
     comparisons: CalibrationCheckComparisonsPerCalibration,
     succeeded: boolean,
-  },
-  right?: {
+  } | null,
+  right: {
     model: string,
     comparisons: CalibrationCheckComparisonsPerCalibration,
     succeeded: boolean,
-  },
+  } | null,
 |}
 
 export type CalibrationHealthCheckAnalyticsData = {|

--- a/app/src/sessions/types.js
+++ b/app/src/sessions/types.js
@@ -319,54 +319,6 @@ export type SessionState = $Shape<
   |}>
 >
 
-export type AnalyticsModelsByMount = {|
-  leftPipetteModel?: string,
-  rightPipetteModel?: string,
-|}
-
-export type CalibrationCheckCommonEventData = {|
-  comparingHeightExceedsThreshold?: boolean,
-  comparingPointOneExceedsThreshold?: boolean,
-  comparingPointTwoExceedsThreshold?: boolean,
-  comparingPointThreeExceedsThreshold?: boolean,
-|}
-
-export type CalibrationCheckIntercomData = {|
-  ...CalibrationCheckCommonEventData,
-  succeeded: boolean,
-|}
-
-export type CalibrationCheckAnalyticsData = {|
-  ...CalibrationCheckCommonEventData,
-  comparingHeightDifferenceVector?: VectorTuple,
-  comparingHeightThresholdVector?: VectorTuple,
-  comparingPointOneDifferenceVector?: VectorTuple,
-  comparingPointOneThresholdVector?: VectorTuple,
-  comparingPointTwoDifferenceVector?: VectorTuple,
-  comparingPointTwoThresholdVector?: VectorTuple,
-  comparingPointThreeDifferenceVector?: VectorTuple,
-  comparingPointThreeThresholdVector?: VectorTuple,
-|}
-
-export type SharedAnalyticsProps = {|
-  sessionType: SessionType,
-|}
-
-export type CalibrationCheckSessionAnalyticsProps = {|
-  ...SharedAnalyticsProps,
-  ...AnalyticsModelsByMount,
-  ...CalibrationCheckAnalyticsData,
-|}
-
-export type CalibrationCheckSessionIntercomProps = {|
-  ...SharedAnalyticsProps,
-  ...AnalyticsModelsByMount,
-  ...CalibrationCheckIntercomData,
-|}
-
-export type SessionAnalyticsProps = CalibrationCheckSessionAnalyticsProps
-export type SessionIntercomProps = CalibrationCheckSessionIntercomProps
-
 export type CalibrationLabware = {|
   slot: string,
   loadName: string,

--- a/app/src/support/__tests__/intercom-event.test.js
+++ b/app/src/support/__tests__/intercom-event.test.js
@@ -69,6 +69,7 @@ describe('support event tests', () => {
       const selectorValue = {
         pipettes: {
           left: { succeeded: false, comparisons: {}, model: 'some model' },
+          right: null,
         },
       }
       getAnalyticsHealthCheckData.mockReturnValue(selectorValue)

--- a/app/src/support/__tests__/intercom-event.test.js
+++ b/app/src/support/__tests__/intercom-event.test.js
@@ -5,11 +5,19 @@ import type { State } from '../../types'
 import * as Binding from '../intercom-binding'
 import * as Calibration from '../../calibration'
 import * as Config from '../../config'
+import * as Sessions from '../../sessions'
+import * as Analytics from '../../analytics'
+import * as AnalyticsTypes from '../../analytics/types'
 import { makeIntercomEvent, sendEvent } from '../intercom-event'
 import * as Constants from '../constants'
 
 jest.mock('../intercom-binding')
-jest.mock('../../sessions/selectors')
+jest.mock('../../analytics/selectors')
+
+const getAnalyticsHealthCheckData: JestMockFn<
+  [State, string, string],
+  AnalyticsTypes.CalibrationHealthCheckAnalyticsData | null
+> = Analytics.getAnalyticsHealthCheckData
 
 const sendIntercomEvent: JestMockFn<[string, IntercomPayload], void> =
   Binding.sendIntercomEvent
@@ -29,38 +37,95 @@ describe('support event tests', () => {
     expect(built).toBeNull()
   })
 
-  it('makeIntercomEvent should send an event for no cal block selected', () => {
-    expect(
-      makeIntercomEvent(
-        Calibration.setUseTrashSurfaceForTipCal(true),
+  describe('calibration check deleted sessions', () => {
+    it('makeIntercomEvent should ignore unhandled events', () => {
+      const built = makeIntercomEvent(
+        Sessions.createSession(
+          'whocares',
+          Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK,
+          {}
+        ),
         MOCK_STATE
       )
-    ).toEqual({
-      eventName: Constants.INTERCOM_EVENT_NO_CAL_BLOCK,
-      metadata: {},
+      expect(built).toBeNull()
+    })
+
+    it('makeIntercomEvent should send an event for calibration check complete', () => {
+      const selectorValue = {
+        pipettes: {
+          left: { succeeded: false, comparisons: {}, model: 'some model' },
+        },
+      }
+      getAnalyticsHealthCheckData.mockReturnValue(selectorValue)
+      const built = makeIntercomEvent(
+        Sessions.deleteSession('silly-robot', 'dummySessionID'),
+        MOCK_STATE
+      )
+      expect(built).toEqual({
+        eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+        metadata: selectorValue,
+      })
+    })
+
+    it('makeIntercomEvent should ignore events for which no data can be retrieved', () => {
+      getAnalyticsHealthCheckData.mockReturnValue(null)
+      const built = makeIntercomEvent(
+        Sessions.deleteSession('silly-robot', 'dummySessionID'),
+        MOCK_STATE
+      )
+      expect(built).toBeNull()
+    })
+
+    it('sendEvent should pass on its arguments', () => {
+      const props = {
+        eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+        metadata: {
+          someKey: true,
+          someOtherKey: 'hi',
+        },
+      }
+      sendEvent(props)
+      expect(sendIntercomEvent).toHaveBeenCalledWith(
+        props.eventName,
+        props.metadata
+      )
     })
   })
-  it('makeIntercomEvent should not send an event for cal block present', () => {
-    expect(
-      makeIntercomEvent(
-        Calibration.setUseTrashSurfaceForTipCal(false),
-        MOCK_STATE
-      )
-    ).toBe(null)
-  })
 
-  it('sendEvent should pass on its arguments', () => {
-    const props = {
-      eventName: Constants.INTERCOM_EVENT_NO_CAL_BLOCK,
-      metadata: {
-        someKey: true,
-        someOtherKey: 'hi',
-      },
-    }
-    sendEvent(props)
-    expect(sendIntercomEvent).toHaveBeenCalledWith(
-      props.eventName,
-      props.metadata
-    )
+  describe('calibration block event', () => {
+    it('makeIntercomEvent should send an event for no cal block selected', () => {
+      expect(
+        makeIntercomEvent(
+          Calibration.setUseTrashSurfaceForTipCal(true),
+          MOCK_STATE
+        )
+      ).toEqual({
+        eventName: Constants.INTERCOM_EVENT_NO_CAL_BLOCK,
+        metadata: {},
+      })
+    })
+    it('makeIntercomEvent should not send an event for cal block present', () => {
+      expect(
+        makeIntercomEvent(
+          Calibration.setUseTrashSurfaceForTipCal(false),
+          MOCK_STATE
+        )
+      ).toBe(null)
+    })
+
+    it('sendEvent should pass on its arguments', () => {
+      const props = {
+        eventName: Constants.INTERCOM_EVENT_NO_CAL_BLOCK,
+        metadata: {
+          someKey: true,
+          someOtherKey: 'hi',
+        },
+      }
+      sendEvent(props)
+      expect(sendIntercomEvent).toHaveBeenCalledWith(
+        props.eventName,
+        props.metadata
+      )
+    })
   })
 })

--- a/app/src/support/__tests__/intercom-event.test.js
+++ b/app/src/support/__tests__/intercom-event.test.js
@@ -37,6 +37,21 @@ describe('support event tests', () => {
     expect(built).toBeNull()
   })
 
+  it('sendEvent should pass on its arguments', () => {
+    const props = {
+      eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
+      metadata: {
+        someKey: true,
+        someOtherKey: 'hi',
+      },
+    }
+    sendEvent(props)
+    expect(sendIntercomEvent).toHaveBeenCalledWith(
+      props.eventName,
+      props.metadata
+    )
+  })
+
   describe('calibration check deleted sessions', () => {
     it('makeIntercomEvent should ignore unhandled events', () => {
       const built = makeIntercomEvent(
@@ -75,21 +90,6 @@ describe('support event tests', () => {
       )
       expect(built).toBeNull()
     })
-
-    it('sendEvent should pass on its arguments', () => {
-      const props = {
-        eventName: Constants.INTERCOM_EVENT_CALCHECK_COMPLETE,
-        metadata: {
-          someKey: true,
-          someOtherKey: 'hi',
-        },
-      }
-      sendEvent(props)
-      expect(sendIntercomEvent).toHaveBeenCalledWith(
-        props.eventName,
-        props.metadata
-      )
-    })
   })
 
   describe('calibration block event', () => {
@@ -111,21 +111,6 @@ describe('support event tests', () => {
           MOCK_STATE
         )
       ).toBe(null)
-    })
-
-    it('sendEvent should pass on its arguments', () => {
-      const props = {
-        eventName: Constants.INTERCOM_EVENT_NO_CAL_BLOCK,
-        metadata: {
-          someKey: true,
-          someOtherKey: 'hi',
-        },
-      }
-      sendEvent(props)
-      expect(sendIntercomEvent).toHaveBeenCalledWith(
-        props.eventName,
-        props.metadata
-      )
     })
   })
 })

--- a/app/src/support/intercom-event.js
+++ b/app/src/support/intercom-event.js
@@ -1,10 +1,17 @@
 // @flow
 // functions for sending events to intercom, both for enriching user profiles
 // and for triggering contextual support conversations
+import * as Sessions from '../sessions'
+import * as AnalyticsSelectors from '../analytics'
+
 import type { Action, State } from '../types'
+
 import { sendIntercomEvent } from './intercom-binding'
 import type { IntercomEvent } from './types'
-import { INTERCOM_EVENT_NO_CAL_BLOCK } from './constants'
+import {
+  INTERCOM_EVENT_NO_CAL_BLOCK,
+  INTERCOM_EVENT_CALCHECK_COMPLETE,
+} from './constants'
 import * as Config from '../config'
 
 export function makeIntercomEvent(
@@ -20,6 +27,16 @@ export function makeIntercomEvent(
       return {
         eventName: INTERCOM_EVENT_NO_CAL_BLOCK,
         metadata: {},
+      }
+    }
+    case Sessions.DELETE_SESSION: {
+      const eventProps = AnalyticsSelectors.getAnalyticsHealthCheckData(state)
+      if (eventProps === null) {
+        return null
+      }
+      return {
+        eventName: INTERCOM_EVENT_CALCHECK_COMPLETE,
+        metadata: eventProps,
       }
     }
   }

--- a/app/src/support/types.js
+++ b/app/src/support/types.js
@@ -7,6 +7,8 @@ import typeof {
   INTERCOM_EVENT_NO_CAL_BLOCK,
 } from './constants'
 
+import type { CalibrationHealthCheckAnalyticsData } from '../analytics/types'
+
 export type IntercomEventName =
   | INTERCOM_EVENT_CALCHECK_COMPLETE
   | INTERCOM_EVENT_NO_CAL_BLOCK
@@ -14,7 +16,12 @@ export type IntercomEventName =
 export type SupportConfig = $PropertyType<Config, 'support'>
 
 export type IntercomPayload = $Shape<{|
-  [propertyName: string]: string | number | boolean | null,
+  [propertyName: string]:
+    | string
+    | number
+    | boolean
+    | CalibrationHealthCheckAnalyticsData
+    | null,
 |}>
 
 export type SupportProfileUpdate = $Shape<{|

--- a/app/src/support/types.js
+++ b/app/src/support/types.js
@@ -15,14 +15,13 @@ export type IntercomEventName =
 
 export type SupportConfig = $PropertyType<Config, 'support'>
 
-export type IntercomPayload = $Shape<{|
-  [propertyName: string]:
-    | string
-    | number
-    | boolean
-    | CalibrationHealthCheckAnalyticsData
-    | null,
+export type BasicIntercomPayload = $Shape<{|
+  [propertyName: string]: string | number | boolean | null,
 |}>
+
+export type IntercomPayload =
+  | BasicIntercomPayload
+  | CalibrationHealthCheckAnalyticsData
 
 export type SupportProfileUpdate = $Shape<{|
   [propertyName: string]: string | number | boolean | null,


### PR DESCRIPTION
# Overview

Closes #6626. This PR adds in more specific analytics for calibration check and adds an intercom event upon session deletion.

# Changelog

- Edit the `getAnalyticsHealthCheckData` selector to return the pipette model + comparisons + whether it succeeded or not to the response.
- Modify the tests to match this new behavior
- Use the modified selector to get the same data for an intercom event upon deletion of a calibration session

# Review requests

Check out the structure, let me know if there are things you want to add and/or remove.

# Risk assessment

Low. Only adding analytics to the app.