### PR TITLE
fix(shared-data): fix P300 GEN2 tip overlap values

### DIFF
--- a/shared-data/pipette/definitions/pipetteModelSpecs.json
+++ b/shared-data/pipette/definitions/pipetteModelSpecs.json
@@ -3582,9 +3582,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 10.3,
-        "opentrons/opentrons_96_tiprack_300ul/1": 10.3,
-        "opentrons/opentrons_96_filtertiprack_200ul/1": 10.3
+        "default": 8.2,
+        "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+        "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
       },
       "tipLength": {
         "value": 49,
@@ -3751,9 +3751,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 10.3,
-        "opentrons/opentrons_96_tiprack_300ul/1": 10.3,
-        "opentrons/opentrons_96_filtertiprack_200ul/1": 10.3
+        "default": 8.2,
+        "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+        "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
       },
       "tipLength": {
         "value": 49,
@@ -4370,9 +4370,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 10.3,
-        "opentrons/opentrons_96_tiprack_300ul/1": 10.3,
-        "opentrons/opentrons_96_filtertiprack_200ul/1": 10.3
+        "default": 8.2,
+        "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+        "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
       },
       "tipLength": {
         "value": 51,
@@ -4541,9 +4541,9 @@
         "type": "float"
       },
       "tipOverlap": {
-        "default": 10.3,
-        "opentrons/opentrons_96_tiprack_300ul/1": 10.3,
-        "opentrons/opentrons_96_filtertiprack_200ul/1": 10.3
+        "default": 8.2,
+        "opentrons/opentrons_96_tiprack_300ul/1": 8.2,
+        "opentrons/opentrons_96_filtertiprack_200ul/1": 8.2
       },
       "tipLength": {
         "value": 51,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Correcting the tip overlap values for P300 GEN2 pipettes to 8.2 mm.

# Review Request
Run tip length calibration, see that after the pipette picks up a tip and moves over the cal block, the distance between the tip and the cal block should be closer to 5 mm. (Without the new changes, the distance would only be ~2-3 mm)