### PR TITLE
fix(api): session._dedupe needs to use equality checking

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -640,12 +640,11 @@ def _accumulate(iterable):
 
 
 def _dedupe(iterable):
-    acc = set()  # type: ignore
-
-    for item in iterable:
-        if item not in acc:
-            acc.add(item)
-            yield item
+    def _dupecheck(accumulator, item):
+        if not any([item == accumulated for accumulated in accumulator]):
+            accumulator.append(item)
+        return accumulator
+    return reduce(_dupecheck, iterable, [])
 
 
 def now():

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -56,7 +56,6 @@ def run_python(
         _runfunc_ok(new_globs.get('run'))
     except SyntaxError as se:
         raise MalformedProtocolError(str(se))
-
     new_globs['__context'] = context
     try:
         exec('run(__context)', new_globs)

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -111,7 +111,13 @@ def test_dedupe():
                   Location(point=Point(1, 2, 3), labware='2'))
     third = load('opentrons_96_tiprack_20ul',
                  Location(point=Point(4, 5, 6), labware='3'))
-    iterable = [first]*10 + [second]*10 + [third]*10
+
+    iterable = (
+        [first]*10
+        + [second]*10
+        # This is the key part of this test. Well.parent now builds a new
+        # Labware item that therefore breaks identity checking.
+        + [third['A1'].parent for elem in range(10)])
     assert sorted(_dedupe(iterable), key=lambda lw: lw.name)\
         == sorted([first, second, third], key=lambda lw: lw.name)
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -14,6 +14,8 @@ from functools import partial
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
+from opentrons.protocol_api.labware import load
+from opentrons.types import Location, Point
 
 state = partial(state, 'session')
 
@@ -103,7 +105,15 @@ def test_accumulate():
 
 
 def test_dedupe():
-    assert ''.join(_dedupe('aaaaabbbbcbbbbcccaa')) == 'abc'
+    first = load('opentrons_96_tiprack_300ul',
+                 Location(point=Point(0, 0, 0), labware='1'))
+    second = load('opentrons_96_tiprack_300ul',
+                  Location(point=Point(1, 2, 3), labware='2'))
+    third = load('opentrons_96_tiprack_20ul',
+                 Location(point=Point(4, 5, 6), labware='3'))
+    iterable = [first]*10 + [second]*10 + [third]*10
+    assert sorted(_dedupe(iterable), key=lambda lw: lw.name)\
+        == sorted([first, second, third], key=lambda lw: lw.name)
 
 
 @pytest.mark.parametrize('protocol_file', ['testosaur-gen2-v2.py'])


### PR DESCRIPTION
Recent refactors made Labware objects no longer comparable by
identity ("is", or, crucially, set inclusion checking) and therefore
broke dupe in that it wouldn't dupe stuff. What this leads to is
cripplingly bad performance when computing required labware after a
protocol simulation, to the extent that you may see the protocol
essentially "simulating" forever since followon algorithms after _dedupe
really really really need to operate on 11 or fewer labware objects
since, well, I cannot possibly think about this for one more second.

Anyway, using equality checking instead of identity checking "fixes" this.

## Testing
- Test a non-trivial protocol, which I don't really have a good example of because you can't paste custom labware defs and all mine have them. Anything with a lot of interactions should do it. This should now simulate in a reasonable amount of time.