### PR TITLE
refactor(app): change trash surface setting name

### DIFF
--- a/app/src/components/app-settings/AppAdvancedSettingsCard.js
+++ b/app/src/components/app-settings/AppAdvancedSettingsCard.js
@@ -21,7 +21,7 @@ import type { Dispatch } from '../../types'
 const TITLE = 'Advanced Settings'
 
 const USE_TRASH_SURFACE_TIP_CAL_LABEL =
-  'Use Trash Bin surface for tip calibration'
+  'Tip Length Calibration Settings'
 const USE_TRASH_SURFACE_TIP_CAL_BODY =
   "An Opentrons Calibration Block makes tip length calibration easier. Contact us to request a calibration block. If you don't have one, use the Trash Bin."
 const ALWAYS_USE_BLOCK_LABEL = 'Always use Calibration Block to calibrate'

--- a/app/src/components/app-settings/AppAdvancedSettingsCard.js
+++ b/app/src/components/app-settings/AppAdvancedSettingsCard.js
@@ -20,8 +20,7 @@ import type { Dispatch } from '../../types'
 
 const TITLE = 'Advanced Settings'
 
-const USE_TRASH_SURFACE_TIP_CAL_LABEL =
-  'Tip Length Calibration Settings'
+const USE_TRASH_SURFACE_TIP_CAL_LABEL = 'Tip Length Calibration Settings'
 const USE_TRASH_SURFACE_TIP_CAL_BODY =
   "An Opentrons Calibration Block makes tip length calibration easier. Contact us to request a calibration block. If you don't have one, use the Trash Bin."
 const ALWAYS_USE_BLOCK_LABEL = 'Always use Calibration Block to calibrate'


### PR DESCRIPTION
Much better name is Tip Length Calibration Settings
![Screenshot from 2020-11-12 17-46-18](https://user-images.githubusercontent.com/3091648/99005614-1f039e00-250f-11eb-8915-6462d89b2013.png)

