### PR TITLE
refactor(robot-server): Increase tolerance on tip length check

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/constants.py
+++ b/robot-server/robot_server/robot/calibration/check/constants.py
@@ -37,9 +37,9 @@ PIPETTE_TOLERANCES = {
     'p300_crosses': Point(1.8, 1.8, 0.0),
     'p20_crosses': Point(1.4, 1.4, 0.0),
     'other_height': Point(0.0, 0.0, 0.8),
-    'p20_tip': Point(0.0, 0.0, 0.20),
-    'p300_tip': Point(0.0, 0.0, 0.39),
-    'p1000_tip': Point(0.0, 0.0, 0.27)
+    'p20_tip': Point(0.0, 0.0, 0.50),
+    'p300_tip': Point(0.0, 0.0, 1.0),
+    'p1000_tip': Point(0.0, 0.0, 1.0)
 }
 
 TIPRACK_SLOT = '8'

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -343,7 +343,7 @@ async def test_compare_z_height(mock_user_flow):
     # difference and so it should exceed the threshold
     expected_status = ComparisonStatus(
         differenceVector=(0.0, 0.0, 0.0),
-        thresholdVector=(0.0, 0.0, 0.39),
+        thresholdVector=(0.0, 0.0, 1.0),
         exceedsThreshold=False)
     expected_tip_length = TipComparisonMap(
         status='IN_THRESHOLD', comparingTip=expected_status)


### PR DESCRIPTION
# Overview

This PR bumps up the tolerances for all of the pipette models from:

p20 -> 0.2 -> **0.5**
p300 -> 0.39 -> **1.0**
p1000 -> 0.27 -> **1.0**
