### PR TITLE
refactor(app): clarify cal check tip rack switching, skip when tip racks are same

### DIFF
--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -15,9 +15,7 @@ import {
   FONT_WEIGHT_SEMIBOLD,
   C_WHITE,
   C_NEAR_WHITE,
-  C_SELECTED_DARK,
   COLOR_WARNING,
-  COLOR_WARNING_LIGHT,
   SPACING_2,
   SPACING_3,
 } from '@opentrons/components'
@@ -25,8 +23,6 @@ import { getDeckDefinitions } from '@opentrons/components/src/deck/getDeckDefini
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import * as Sessions from '../../sessions'
-import type { Mount } from '../../pipettes/types'
-import type { RobotCalibrationCheckPipetteRank } from '../../sessions/calibration-check/types'
 import type {
   SessionType,
   SessionCommandString,

--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -88,7 +88,7 @@ function HealthCheckText({
     : DECK_SETUP_NO_BLOCK_PROMPT
   const secondCalBlockPortion = calBlock
     ? SECOND_RANK_WITH_BLOCK_PROMPT
-    : SECOND_RANK_WITH_BLOCK_PROMPT
+    : SECOND_RANK_NO_BLOCK_PROMPT
   return (
     <>
       {`${toCheck} ${mount.toLowerCase()} ${PIPETTE}, `}

--- a/app/src/components/CalibrationPanels/DeckSetup.js
+++ b/app/src/components/CalibrationPanels/DeckSetup.js
@@ -12,8 +12,12 @@ import {
   ALIGN_STRETCH,
   TEXT_ALIGN_CENTER,
   FONT_SIZE_HEADER,
+  FONT_WEIGHT_SEMIBOLD,
   C_WHITE,
   C_NEAR_WHITE,
+  C_SELECTED_DARK,
+  COLOR_WARNING,
+  COLOR_WARNING_LIGHT,
   SPACING_2,
   SPACING_3,
 } from '@opentrons/components'
@@ -23,21 +27,30 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 import * as Sessions from '../../sessions'
 import type { Mount } from '../../pipettes/types'
 import type { RobotCalibrationCheckPipetteRank } from '../../sessions/calibration-check/types'
-import type { SessionType, SessionCommandString } from '../../sessions/types'
+import type {
+  SessionType,
+  SessionCommandString,
+  CalibrationCheckInstrument,
+  CalibrationLabware,
+} from '../../sessions/types'
 import type { CalibrationPanelProps } from './types'
 import { CalibrationLabwareRender } from './CalibrationLabwareRender'
 import styles from './styles.css'
 
 const FIRST_RANK_TO_CHECK = 'To check'
-const SECOND_RANK_TO_CHECK = 'In order to check'
-const FIRST_RANK_PLACE_FULL = 'pipette, clear the deck and place a full'
-const SECOND_RANK_PLACE_FULL = 'pipette, switch out the tiprack for a full'
+const SECOND_RANK_TO_CHECK = 'Before we proceed to check the'
+const PIPETTE = 'pipette'
+const FIRST_RANK_PLACE_FULL = 'clear the deck and place a full'
+const SECOND_RANK_PLACE_FULL = 'switch out the tiprack for a full'
 const CLEAR_AND_PLACE_A_FULL = 'Clear the deck and place a full'
 const TIPRACK = 'tip rack'
 const DECK_SETUP_WITH_BLOCK_PROMPT =
-  'and Calibration Block on the deck within their designated slots as illustrated below.'
+  'and Calibration Block on the deck within their designated slots as illustrated below'
 const DECK_SETUP_NO_BLOCK_PROMPT =
   'on the deck within the designated slot as illustrated below'
+const SECOND_RANK_WITH_BLOCK_PROMPT =
+  "and ensure Calibration Block is within it's designated slot as illustrated below"
+const SECOND_RANK_NO_BLOCK_PROMPT = 'as illustrated below'
 const DECK_SETUP_BUTTON_TEXT = 'Confirm placement and continue'
 const contentsBySessionType: {
   [SessionType]: {
@@ -58,17 +71,35 @@ const contentsBySessionType: {
   },
 }
 
-function getHealthCheckText(
-  mount?: Mount | null,
-  rank?: RobotCalibrationCheckPipetteRank | null
-): string {
-  if (!mount || !rank) {
-    return ''
-  }
+function HealthCheckText({
+  activePipette,
+  calBlock,
+}: {
+  activePipette?: CalibrationCheckInstrument | null,
+  calBlock?: CalibrationLabware | null,
+}): React.Node {
+  if (!activePipette) return null
+  const { mount, rank, tipRackDisplay } = activePipette
   const toCheck = rank === 'first' ? FIRST_RANK_TO_CHECK : SECOND_RANK_TO_CHECK
   const placeFull =
     rank === 'first' ? FIRST_RANK_PLACE_FULL : SECOND_RANK_PLACE_FULL
-  return `${toCheck} ${mount.toLowerCase()} ${placeFull}`
+  const firstCalBlockPortion = calBlock
+    ? DECK_SETUP_WITH_BLOCK_PROMPT
+    : DECK_SETUP_NO_BLOCK_PROMPT
+  const secondCalBlockPortion = calBlock
+    ? SECOND_RANK_WITH_BLOCK_PROMPT
+    : SECOND_RANK_WITH_BLOCK_PROMPT
+  return (
+    <>
+      {`${toCheck} ${mount.toLowerCase()} ${PIPETTE}, `}
+      <Text
+        as="span"
+        fontWeight={FONT_WEIGHT_SEMIBOLD}
+        color={rank === 'second' ? COLOR_WARNING : C_WHITE}
+      >{`${placeFull} ${tipRackDisplay} `}</Text>
+      {rank === 'first' ? firstCalBlockPortion : secondCalBlockPortion}.
+    </>
+  )
 }
 
 export function DeckSetup(props: CalibrationPanelProps): React.Node {
@@ -113,12 +144,15 @@ export function DeckSetup(props: CalibrationPanelProps): React.Node {
           marginY={SPACING_2}
           textAlign={TEXT_ALIGN_CENTER}
         >
-          {isHealthCheck
-            ? getHealthCheckText(activePipette?.mount, activePipette?.rank)
-            : CLEAR_AND_PLACE_A_FULL}
-          <b>{` ${tipRackDisplayName} `}</b>
-          {calBlock ? DECK_SETUP_WITH_BLOCK_PROMPT : DECK_SETUP_NO_BLOCK_PROMPT}
-          .
+          {isHealthCheck ? (
+            <HealthCheckText {...{ activePipette, calBlock }} />
+          ) : (
+            `${CLEAR_AND_PLACE_A_FULL} ${tipRackDisplayName} ${
+              calBlock
+                ? DECK_SETUP_WITH_BLOCK_PROMPT
+                : DECK_SETUP_NO_BLOCK_PROMPT
+            }.`
+          )}
         </Text>
         <LightSecondaryBtn
           onClick={proceed}

--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -41,7 +41,7 @@ const GOOD_CALIBRATION = 'Good calibration'
 const BAD_CALIBRATION = 'Bad calibration'
 
 const ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER = 'health check results:'
-const DECK_CALIBRATION_HEADER = 'Robot Deck Calibration'
+const DECK_CALIBRATION_HEADER = 'Robot Deck'
 const PIPETTE = 'pipette'
 const HOME_AND_EXIT = 'Home robot and exit'
 const LOOKING_FOR_DATA = 'Looking for your detailed calibration data?'

--- a/app/src/components/CheckCalibration/ResultsSummary.js
+++ b/app/src/components/CheckCalibration/ResultsSummary.js
@@ -41,7 +41,7 @@ const GOOD_CALIBRATION = 'Good calibration'
 const BAD_CALIBRATION = 'Bad calibration'
 
 const ROBOT_CALIBRATION_CHECK_SUMMARY_HEADER = 'health check results:'
-const DECK_CALIBRATION_HEADER = 'Robot Deck'
+const DECK_CALIBRATION_HEADER = 'Robot Deck Calibration'
 const PIPETTE = 'pipette'
 const HOME_AND_EXIT = 'Home robot and exit'
 const LOOKING_FOR_DATA = 'Looking for your detailed calibration data?'

--- a/app/src/components/CheckCalibration/__tests__/ReturnTip.test.js
+++ b/app/src/components/CheckCalibration/__tests__/ReturnTip.test.js
@@ -1,15 +1,9 @@
 // @flow
 import * as React from 'react'
-import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
-import { act } from 'react-dom/test-utils'
-import * as Calibration from '../../../calibration'
-import { mockCalibrationStatus } from '../../../calibration/__fixtures__'
 import * as Fixtures from '../../../sessions/__fixtures__'
 import * as Sessions from '../../../sessions'
-import type { State } from '../../../types'
 import { ReturnTip } from '../ReturnTip'
-import { Box, Flex, PrimaryBtn } from '@opentrons/components'
 
 const mockSessionDetails = Fixtures.mockRobotCalibrationCheckSessionDetails
 

--- a/app/src/components/CheckCalibration/__tests__/ReturnTip.test.js
+++ b/app/src/components/CheckCalibration/__tests__/ReturnTip.test.js
@@ -1,0 +1,103 @@
+// @flow
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import * as Calibration from '../../../calibration'
+import { mockCalibrationStatus } from '../../../calibration/__fixtures__'
+import * as Fixtures from '../../../sessions/__fixtures__'
+import * as Sessions from '../../../sessions'
+import type { State } from '../../../types'
+import { ReturnTip } from '../ReturnTip'
+import { Box, Flex, PrimaryBtn } from '@opentrons/components'
+
+const mockSessionDetails = Fixtures.mockRobotCalibrationCheckSessionDetails
+
+describe('ReturnTip', () => {
+  let render
+  let mockSendCommands
+
+  const getContinueButton = wrapper =>
+    wrapper.find('button[title="confirmReturnTip"]')
+
+  beforeEach(() => {
+    mockSendCommands = jest.fn()
+
+    render = (props: $Shape<React.ElementProps<typeof ReturnTip>> = {}) => {
+      const {
+        pipMount = 'left',
+        isMulti = false,
+        tipRack = Fixtures.mockDeckCalTipRack,
+        calBlock = null,
+        sendCommands = mockSendCommands,
+        cleanUpAndExit = jest.fn(),
+        currentStep = Sessions.CHECK_STEP_RESULTS_SUMMARY,
+        sessionType = Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK,
+        comparisonsByPipette = mockSessionDetails.comparisonsByPipette,
+        instruments = mockSessionDetails.instruments,
+        activePipette = mockSessionDetails.activePipette,
+      } = props
+      return mount(
+        <ReturnTip
+          isMulti={isMulti}
+          mount={pipMount}
+          tipRack={tipRack}
+          calBlock={calBlock}
+          sendCommands={sendCommands}
+          cleanUpAndExit={cleanUpAndExit}
+          currentStep={currentStep}
+          sessionType={sessionType}
+          comparisonsByPipette={comparisonsByPipette}
+          instruments={instruments}
+          activePipette={activePipette}
+          checkBothPipettes
+        />
+      )
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('on continue, if final pipette, return tip and transition ', () => {
+    const wrapper = render({
+      activePipette: {
+        ...mockSessionDetails.activePipette,
+        rank: Sessions.CHECK_PIPETTE_RANK_SECOND,
+      },
+    })
+    getContinueButton(wrapper).invoke('onClick')()
+
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      { command: Sessions.checkCommands.RETURN_TIP },
+      { command: Sessions.checkCommands.TRANSITION }
+    )
+  })
+
+  it('on continue, if first pipette with diff tip racks, return tip and switch', () => {
+    const wrapper = render()
+    getContinueButton(wrapper).invoke('onClick')()
+
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      { command: Sessions.checkCommands.RETURN_TIP },
+      { command: Sessions.checkCommands.CHECK_SWITCH_PIPETTE }
+    )
+  })
+
+  it('on continue, if first pipette with same tip racks, return tip and switch, then move to ref point', () => {
+    const wrapper = render({
+      instruments: mockSessionDetails.instruments.map(i => ({
+        ...i,
+        tipRackLoadName: 'same-tip-rack-name',
+      })),
+    })
+    getContinueButton(wrapper).invoke('onClick')()
+
+    expect(mockSendCommands).toHaveBeenCalledWith(
+      { command: Sessions.checkCommands.RETURN_TIP },
+      { command: Sessions.checkCommands.CHECK_SWITCH_PIPETTE },
+      { command: Sessions.checkCommands.MOVE_TO_REFERENCE_POINT }
+    )
+  })
+})


### PR DESCRIPTION
# Overview

Emphasize the tip rack switch in the deck setup panel when on second pipette and the new tip rack is
in the same location as the old one. Also, don't show the deck setup panel on the second pipette if
the tip rack is the same as the first, as nothing needs to change


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

- dispatch the move to reference point command immediately from the return tip screen if the user is continuing to the second pipette and both pipettes share a tip rack
- add emphasizing treatment and copy change to the tip rack that needs to be swapped out, if the user is continuing to the second pipette and it uses a different tip rack than the first.

# Review requests

- run calibration check with two pipettes that share a tip rack, you shouldn't be prompted to change the deck at all when starting the second pipette
- run calibration check with two pipettes that use different tip racks, you should be prompted to change the deck and the DeckSetup panel should have special orange text calling out the switch

# Risk assessment

low
