### PR TITLE
fix(app): pipette calibration info sections should be same height

### DIFF
--- a/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
@@ -164,6 +164,7 @@ export function PipetteCalibrationInfo(props: Props): React.Node {
       flexDirection={DIRECTION_COLUMN}
       backgroundColor={OVERLAY_LIGHT_GRAY_50}
       padding={SPACING_3}
+      flex="1 1 auto"
     >
       <Text
         fontWeight={FONT_WEIGHT_SEMIBOLD}


### PR DESCRIPTION
# Overview
@emilywools caught a visual inconsistency between the Pipette Info Calibration section and the Pipette Section of the Calibration Card on the Robot Page.

Regardless of the warnings or variable content inside of the two pipette calibration sections on the
pipette info page, they should grow to be the same height.

# Changelog

one line addition

# Review requests

make sure calibrations section of pipette page looks good given two pipettes with very different states (or just one pipette and one empty state)

# Risk assessment

very low, only visual