### PR TITLE
fix(app): consistent date formatting for calibration last modified time

### DIFF
--- a/app/src/components/CalibrationPanels/utils.js
+++ b/app/src/components/CalibrationPanels/utils.js
@@ -1,4 +1,5 @@
 // @flow
+import { format } from 'date-fns'
 import type { JogAxis } from '../../http-api-client'
 import type { VectorTuple } from '../../sessions/types'
 
@@ -16,4 +17,10 @@ export function formatJogVector(
     vector[index] = step * direction
   }
   return vector
+}
+
+export function formatLastModified(lastModified: string | null): string {
+  return typeof lastModified === 'string'
+    ? format(new Date(lastModified), 'MMMM dd, yyyy HH:mm')
+    : 'unknown'
 }

--- a/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
@@ -40,8 +40,9 @@ import {
   INTENT_PIPETTE_OFFSET,
   INTENT_TIP_LENGTH_OUTSIDE_PROTOCOL,
 } from '../CalibrationPanels'
+import { formatLastModified } from '../CalibrationPanels/utils'
 import { Portal } from '../portal'
-import { getDisplayNameForTipRack, formatLastModified } from './utils'
+import { getDisplayNameForTipRack } from './utils'
 
 import type { Mount } from '../../pipettes/types'
 import type { State } from '../../types'

--- a/app/src/components/InstrumentSettings/utils.js
+++ b/app/src/components/InstrumentSettings/utils.js
@@ -1,5 +1,4 @@
 // @flow
-import { format } from 'date-fns'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
 import { findLabwareDefWithCustom } from '../../findLabware'
 
@@ -21,10 +20,4 @@ export function getDisplayNameForTipRack(
   return definition
     ? getLabwareDisplayName(definition)
     : `${UNKNOWN_CUSTOM_LABWARE}`
-}
-
-export function formatLastModified(lastModified: string | null): string {
-  return typeof lastModified === 'string'
-    ? format(new Date(lastModified), 'MMMM dd, yyyy HH:mm')
-    : 'unknown'
 }

--- a/app/src/components/RobotSettings/DeckCalibrationControl.js
+++ b/app/src/components/RobotSettings/DeckCalibrationControl.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { format } from 'date-fns'
 import {
   Icon,
   Text,
@@ -30,6 +29,7 @@ import {
   REQUIRED,
   RECOMMENDED,
 } from '../InlineCalibrationWarning'
+import { formatLastModified } from '../CalibrationPanels/utils'
 
 import type { State, Dispatch } from '../../types'
 import type {
@@ -66,7 +66,7 @@ const buildDeckLastCalibrated: (
   }
   const datestring =
     typeof data.lastModified === 'string'
-      ? format(new Date(data.lastModified), 'yyyy-MM-dd HH:mm')
+      ? formatLastModified(data.lastModified)
       : 'unknown'
   const prefix = calData =>
     typeof data?.source === 'string'

--- a/app/src/components/RobotSettings/PipetteOffsetItem.js
+++ b/app/src/components/RobotSettings/PipetteOffsetItem.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as React from 'react'
-import { format } from 'date-fns'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import { getLabwareDisplayName } from '@opentrons/shared-data'
@@ -31,6 +30,7 @@ import {
   RECOMMENDED,
   REQUIRED,
 } from '../InlineCalibrationWarning'
+import { formatLastModified } from '../CalibrationPanels/utils'
 import type { AttachedPipette, PipetteCalibrations } from '../../pipettes/types'
 import type {
   PipetteOffsetCalibration,
@@ -78,10 +78,7 @@ function getCalibrationDate(
       fontStyle={FONT_STYLE_ITALIC}
       marginTop={SPACING_1}
     >
-      {`${LAST_CALIBRATED}: ${format(
-        new Date(calibration.lastModified),
-        'MMMM d y HH:mm'
-      )}`}
+      {`${LAST_CALIBRATED}: ${formatLastModified(calibration.lastModified)}`}
     </Text>
   )
 }


### PR DESCRIPTION
# Overview

Format all dates associated with the last modified date of calibration data in the same manner for
consistency

Closes #7002

# Review requests

make sure last modified dates on the robot and pipettes calibration sections are in the format "November 15, 2020 21:32"

# Risk assessment

low