### PR TITLE
fix(robot-server): load tip length data correctly in pipette offset cal

### DIFF
--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -194,6 +194,10 @@ class Pipette:
         """ The length of the current tip attached (0.0 if no tip) """
         return self._current_tip_length
 
+    @current_tip_length.setter
+    def current_tip_length(self, tip_length: float):
+        self._current_tip_length = tip_length
+
     @property
     def current_tiprack_diameter(self) -> float:
         """ The diameter of the current tip rack (0.0 if no tip) """


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Currently, previously saved tip length data are not cleared and are used when you re-calibrate the same tiprack, which could cause your pipette to crash if the saved tip length is too short. The newly calibrated tip length is also not loaded into hardware pipette after being saved. This means that the robot is not using the most up-to-date tip length to perform the subsequent pip offset calibration.

# Changelog
- add a setter for hw pipette `current_tip_length` so we can reset its value after a tip has already been picked up
- load default tip length when `should_perform_tip_length` is truthy
- reset current tip length in hw pipette after the new tip length is saved
- remove some redundant code that was using the wrong state
- fix a test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Re-run tip length + pipette offset calibration and run a protocol to make sure the data are correct
<!--
Describe any requests for your reviewers here.
-->



