### PR TITLE
chore(build): workaround set-env deprecation

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -57,6 +57,10 @@ jobs:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -85,6 +89,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     if: github.event_name == 'push'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -31,6 +31,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 jobs:
   lint:
     name: 'opentrons package linting'
@@ -59,8 +62,7 @@ jobs:
     steps:
       - name: 'set insecure variable to work around actions/github-script not being updated'
         run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
+          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -89,10 +91,6 @@ jobs:
     runs-on: 'ubuntu-latest'
     if: github.event_name == 'push'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -50,6 +50,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: 'opentrons app frontend unit tests'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -88,6 +92,10 @@ jobs:
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -42,6 +42,7 @@ env:
   CI: true
   OT_APP_DEPLOY_BUCKET: opentrons-app
   OT_APP_DEPLOY_FOLDER: builds
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   js-unit-test:
@@ -52,8 +53,7 @@ jobs:
     steps:
       - name: 'set insecure variable to work around actions/github-script not being updated'
         run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
+          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -92,10 +92,6 @@ jobs:
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -29,6 +29,10 @@ jobs:
     name: opentrons documentation build
     runs-on: 'ubuntu-latest'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -20,6 +20,10 @@ on:
       - '*'
   workflow_dispatch:
 
+
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 defaults:
   run:
     shell: bash
@@ -31,8 +35,7 @@ jobs:
     steps:
       - name: 'set insecure variable to work around actions/github-script not being updated'
         run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
+          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -33,6 +33,10 @@ jobs:
     name: 'js checks'
     runs-on: 'ubuntu-latest'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -51,6 +51,10 @@ jobs:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
+      - name: 'set insecure variable to work around actions/github-script not being updated'
+        run: |
+          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
+          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -21,6 +21,9 @@ on:
       - 'shared-data/*/**'
   workflow_dispatch:
 
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 defaults:
   run:
     shell: bash
@@ -53,8 +56,7 @@ jobs:
     steps:
       - name: 'set insecure variable to work around actions/github-script not being updated'
         run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
+          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:


### PR DESCRIPTION
Github recently disabled the ::set-env command in their protocol runners because it was insecure (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). The fix for this was to use environment file piping instead. Unfortunately, even if you're interacting with it through e.g. a node wrapper like in https://github.com/actions/core, this is what you're always doing, so core needed a bump to v1.2.6 in all its dependencies. This didn't happen in https://github.com/actions/github-script as of this writing (open pr: https://github.com/actions/github-script/pull/91) and therefore our builds started breaking.

The workaround is to enable the old behavior and have a message that yells at you about it.