### PR TITLE
refactor(protocol-designer): Standardize alert modal styles

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.js
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.js
@@ -241,6 +241,7 @@ export function FileSidebar(props: Props): React.Node {
       {showExportWarningModal && (
         <Portal>
           <AlertModal
+            alertOverlay
             className={modalStyles.modal}
             heading={warning && warning.heading}
             onCloseClick={cancelModal}

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
@@ -144,6 +144,7 @@ export class FlowRateInput extends React.Component<Props, State> {
     const FlowRateModal = pipetteDisplayName && (
       <Portal>
         <AlertModal
+          alertOverlay
           className={modalStyles.modal}
           buttons={[
             {

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.js
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.js
@@ -13,6 +13,7 @@ type Props = {|
 
 export const AutoAddPauseUntilTempStepModal = (props: Props): React.Node => (
   <AlertModal
+    alertOverlay
     className={modalStyles.modal}
     contentsClassName={modalStyles.modal_contents}
   >

--- a/protocol-designer/src/components/modals/GateModal/index.js
+++ b/protocol-designer/src/components/modals/GateModal/index.js
@@ -65,7 +65,10 @@ class GateModalComponent extends React.Component<Props, State> {
     switch (this.state.gateStage) {
       case 'promptVerifyIdentity':
         return (
-          <AlertModal className={cx(modalStyles.modal, modalStyles.blocking)}>
+          <AlertModal
+            alertOverlay
+            className={cx(modalStyles.modal, modalStyles.blocking)}
+          >
             <h3>{i18n.t('modal.gate.sign_up_below')}</h3>
             <div className={settingsStyles.body_wrapper}>
               <SignUpForm />
@@ -84,6 +87,7 @@ class GateModalComponent extends React.Component<Props, State> {
       case 'promptOptForAnalytics':
         return (
           <AlertModal
+            alertOverlay
             className={cx(modalStyles.modal, modalStyles.blocking)}
             buttons={[
               { onClick: optOut, children: i18n.t('button.no') },
@@ -105,7 +109,10 @@ class GateModalComponent extends React.Component<Props, State> {
         )
       case 'failedIdentityVerification':
         return (
-          <AlertModal className={cx(modalStyles.modal, modalStyles.blocking)}>
+          <AlertModal
+            alertOverlay
+            className={cx(modalStyles.modal, modalStyles.blocking)}
+          >
             <h3>{i18n.t('modal.gate.failed_verification')}</h3>
             <div className={settingsStyles.body_wrapper}>
               <p className={settingsStyles.card_body}>
@@ -117,7 +124,10 @@ class GateModalComponent extends React.Component<Props, State> {
         )
       case 'promptCheckEmail':
         return (
-          <AlertModal className={cx(modalStyles.modal, modalStyles.blocking)}>
+          <AlertModal
+            alertOverlay
+            className={cx(modalStyles.modal, modalStyles.blocking)}
+          >
             <h3>{i18n.t('modal.gate.sign_up_success')}</h3>
             <div className={modalStyles.centered_icon_wrapper}>
               <img
@@ -137,7 +147,10 @@ class GateModalComponent extends React.Component<Props, State> {
       case 'loading':
       default:
         return (
-          <AlertModal className={cx(modalStyles.modal, modalStyles.blocking)}>
+          <AlertModal
+            alertOverlay
+            className={cx(modalStyles.modal, modalStyles.blocking)}
+          >
             <div className={settingsStyles.body_wrapper}>
               <div className={modalStyles.centered_icon_wrapper}>
                 <Icon


### PR DESCRIPTION
# Overview

closes #6972 by adding missing `alertOverlay` prop to all `AlertModal`s in PD.

# Changelog

- refactor(protocol-designer): Standardize alert modal styles

# Review requests

- [ ] export warning modal now has grey bg
- [ ] flow rate modal now has grey bg
- [ ] pause until temp modal now has grey bg
- [ ] gate modal (analytics) now has grey bg

# Risk assessment

low, CSS in PD only
