### PR TITLE
fix(api): fixed `axis` variable renaming in `driver_3_0.home`

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -30,7 +30,7 @@ ERROR_KEYWORD = 'error'
 ALARM_KEYWORD = 'alarm'
 
 # TODO (artyom, ben 20171026): move to config
-HOMED_POSITION = {
+HOMED_POSITION: Dict[str, float] = {
     'X': 418,
     'Y': 353,
     'Z': 218,
@@ -1600,23 +1600,24 @@ class SmoothieDriver_3_0_0:
                     self._set_saved_current()
 
         # Only update axes that have been selected for homing
+        homed_axes = "".join(home_sequence)
         homed = {
             ax: self.homed_position.get(ax)
-            for ax in ''.join(home_sequence)
+            for ax in homed_axes
         }
         self.update_position(default=homed)
-        for axis in ''.join(home_sequence):
-            self.engaged_axes[axis] = True
 
-        # coordinate after homing might not synce with default in API
+        for ax in homed_axes:
+            self.engaged_axes[ax] = True
+
+        # coordinate after homing might not sync with default in API
         # so update this driver's homed position using current coordinates
         new = {
             ax: self.position[ax]
-            for ax in self.homed_position.keys()
-            if ax in axis
+            for ax in homed_axes
         }
         self._homed_position.update(new)
-        self._axes_moved_at.mark_moved(axis)
+        self._axes_moved_at.mark_moved(homed_axes)
         return self.position
 
     def _build_fullstep_configurations(self, axes: str) -> Tuple[str, str]:


### PR DESCRIPTION
# Overview

Fixed updating of  `_axes_moved_at` in `driver_3_0.home` method. I encountered this error after the `needsUnstick` quirk was being executed after homes, even though a unstick was performed during the home.

# Changelog

`axis` was overwritten as a loop variable while updating `driver_3_0.engaged_axes` near the end of
the `home` method, which means `driver_3_0._axes_moved_at` was being updated only with the last loop variable that `axis` took. I rewrote `homed_axes` to only include axes that were homed for DRY reasons.

# Risk assessment

Low risk