### PR TITLE
fix(app): Filter pipette offset calibrations by mount as well

### DIFF
--- a/app/src/calibration/pipette-offset/__tests__/selectors.test.js
+++ b/app/src/calibration/pipette-offset/__tests__/selectors.test.js
@@ -39,7 +39,8 @@ describe('getCalibrationForPipette', () => {
       Selectors.getCalibrationForPipette(
         mockState,
         'robot-name',
-        'P1KVS2108052020A02'
+        'P1KVS2108052020A02',
+        'right'
       )
     ).toEqual(Fixtures.mockPipetteOffsetCalibration3)
   })
@@ -48,7 +49,8 @@ describe('getCalibrationForPipette', () => {
       Selectors.getCalibrationForPipette(
         mockState,
         'robot-name',
-        'no such pipette'
+        'no such pipette',
+        'some mount'
       )
     ).toBeNull()
   })
@@ -57,7 +59,8 @@ describe('getCalibrationForPipette', () => {
       Selectors.getCalibrationForPipette(
         mockState,
         'some other robot',
-        'P20MV2008052020A02'
+        'P20MV2008052020A02',
+        'right'
       )
     ).toBeNull()
   })

--- a/app/src/calibration/pipette-offset/selectors.js
+++ b/app/src/calibration/pipette-offset/selectors.js
@@ -20,15 +20,28 @@ export const getPipetteOffsetCalibrations: (
 export const getCalibrationForPipette: (
   state: State,
   robotName: string,
-  pipetteSerial: string
-) => PipetteOffsetCalibration | null = (state, robotName, pipetteSerial) => {
+  pipetteSerial: string,
+  mount: string | null
+) => PipetteOffsetCalibration | null = (
+  state,
+  robotName,
+  pipetteSerial,
+  mount
+) => {
   const allCalibrations = getPipetteOffsetCalibrations(state, robotName)
-  return filterCalibrationForPipette(allCalibrations, pipetteSerial)
+  return filterCalibrationForPipette(allCalibrations, pipetteSerial, mount)
 }
 
 export const filterCalibrationForPipette: (
   calibrations: Array<PipetteOffsetCalibration>,
-  pipetteSerial: string
-) => PipetteOffsetCalibration | null = (calibrations, pipetteSerial) => {
-  return head(calibrations.filter(cal => cal.pipette === pipetteSerial)) || null
+  pipetteSerial: string,
+  mount: string | null
+) => PipetteOffsetCalibration | null = (calibrations, pipetteSerial, mount) => {
+  return (
+    head(
+      calibrations.filter(
+        cal => cal.pipette === pipetteSerial && cal.mount === mount
+      )
+    ) || null
+  )
 }

--- a/app/src/components/ChangePipette/index.js
+++ b/app/src/components/ChangePipette/index.js
@@ -83,7 +83,7 @@ export function ChangePipette(props: Props): React.Node {
   const actualPipette = attachedPipette?.modelSpecs || null
   const actualPipetteOffset = useSelector((state: State) =>
     attachedPipette?.id
-      ? getCalibrationForPipette(state, robotName, attachedPipette.id)
+      ? getCalibrationForPipette(state, robotName, attachedPipette.id, mount)
       : null
   )
 

--- a/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
+++ b/app/src/components/InstrumentSettings/PipetteCalibrationInfo.js
@@ -93,7 +93,7 @@ export function PipetteCalibrationInfo(props: Props): React.Node {
   const [pocTargetProps, pocTooltipProps] = useHoverTooltip()
   const pipetteOffsetCalibration = useSelector((state: State) =>
     serialNumber
-      ? getCalibrationForPipette(state, robotName, serialNumber)
+      ? getCalibrationForPipette(state, robotName, serialNumber, mount)
       : null
   )
   const tipLengthCalibration = useSelector((state: State) =>

--- a/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
+++ b/app/src/components/InstrumentSettings/__tests__/PipetteInfo.test.js
@@ -34,8 +34,8 @@ const mockGetCustomLabwareDefinitions: JestMockFn<
 > = getCustomLabwareDefinitions
 
 const mockGetCalibrationForPipette: JestMockFn<
-  [State, string, string],
-  $Call<typeof getCalibrationForPipette, State, string, string>
+  [State, string, string, string],
+  $Call<typeof getCalibrationForPipette, State, string, string, string>
 > = getCalibrationForPipette
 
 const mockGetTipLengthForPipetteAndTiprack: JestMockFn<

--- a/app/src/pages/Calibrate/Pipettes.js
+++ b/app/src/pages/Calibrate/Pipettes.js
@@ -105,7 +105,12 @@ export function Pipettes(props: Props): React.Node {
   const convertRobotNameToString = robotName || 'unknown'
   const pipetteOffsetCalibration = useSelector((state: State) =>
     serialNumber
-      ? getCalibrationForPipette(state, convertRobotNameToString, serialNumber)
+      ? getCalibrationForPipette(
+          state,
+          convertRobotNameToString,
+          serialNumber,
+          currentMount
+        )
       : null
   )
 

--- a/app/src/pipettes/selectors.js
+++ b/app/src/pipettes/selectors.js
@@ -90,10 +90,10 @@ export const getAttachedPipetteCalibrations: (
   (attached, calibrations, tipLengths) => {
     const offsets = {
       left: attached.left
-        ? filterCalibrationForPipette(calibrations, attached.left.id)
+        ? filterCalibrationForPipette(calibrations, attached.left.id, 'left')
         : null,
       right: attached.right
-        ? filterCalibrationForPipette(calibrations, attached.right.id)
+        ? filterCalibrationForPipette(calibrations, attached.right.id, 'right')
         : null,
     }
     return {


### PR DESCRIPTION
# Overview

Previously, the app only filtered pipette calibrations by the pipette serial number/robot. However, if you calibrated a pipette on the right mount and then switched it to the left mount the app would display calibration data for the right mount.

# Changelog

- Filter pipette calibrations based on serial number and mount
- Modify respective files and tests to match this new behavior

# Review requests

Calibrate a pipette on one mount, and then switch that same pipette to the other mount (where there is no calibration data). It should say you need to calibrate that pipette rather than showing data from the previously calibrated mount.

# Risk assessment

Low, bug fix to filter out pipette calibrations properly.
