### PR TITLE
fix(app): fix pipette info page flag for configuring or changing pipette

### DIFF
--- a/app/src/pages/Robots/InstrumentSettings.js
+++ b/app/src/pages/Robots/InstrumentSettings.js
@@ -28,7 +28,7 @@ export function InstrumentSettings(props: InstrumentSettingsProps): React.Node {
       <Page titleBarProps={titleBarProps}>
         <SettingsContent
           robotName={robotName}
-          isChangingOrConfiguringPipette={pathname !== path}
+          isChangingOrConfiguringPipette={pathname !== url}
           makeChangePipetteUrl={mnt => `${url}/change-pipette/${mnt}`}
           makeConfigurePipetteUrl={mnt => `${url}/configure-pipette/${mnt}`}
         />


### PR DESCRIPTION
# Overview

Compare the current location pathname with the url, not the templatized path string when determining whether or not a subflow route (configure pipette, change pipette) is being rendered on top of the `InstrumentSettings` page

# Review requests

- Confirm POC/POWT work whether launched from the attach pipette flow, or from the buttons on the pipette page

# Risk assessment
low