### PR TITLE
feat(protocol-designer): memoize compound command creators

### DIFF
--- a/protocol-designer/benchmarks/timelineGeneration.js
+++ b/protocol-designer/benchmarks/timelineGeneration.js
@@ -4,6 +4,8 @@ import bench from 'nanobench'
 import {
   commandCreatorsTimeline,
   curryCommandCreator,
+  distribute,
+  transfer,
   mix,
 } from '../src/step-generation'
 import { getStateAndContextTempTCModules } from '../src/step-generation/__fixtures__'
@@ -43,6 +45,120 @@ bench(`commandCreatorsTimeline: mix ${times} times`, b => {
       dispenseDelaySeconds: null,
     }),
   ]
+
+  b.start()
+
+  const timeline = commandCreatorsTimeline(
+    curriedCommandCreators,
+    invariantContext,
+    initialRobotState
+  )
+
+  b.end()
+
+  if (timeline.errors !== null) {
+    assert(
+      false,
+      `Expected no timeline errors but got ${JSON.stringify(
+        timeline.errors,
+        null,
+        4
+      ) ?? 'undefined'}`
+    )
+  }
+})
+
+bench('command creation: transfer + distribute 40 times', b => {
+  const {
+    robotState: initialRobotState,
+    invariantContext,
+  } = getStateAndContextTempTCModules({
+    temperatureModuleId: 'someTemperatureModuleId',
+    thermocyclerId: 'someTCId',
+  })
+
+  const transferCommand = curryCommandCreator(transfer, {
+    commandCreatorFnName: 'transfer',
+    name: null,
+    description: null,
+    sourceLabware: 'sourcePlateId',
+    destLabware: 'destPlateId',
+    pipette: 'p300SingleId',
+    sourceWells: ['A1'],
+    destWells: ['A2'],
+    volume: 5,
+    touchTipAfterAspirate: false,
+    touchTipAfterAspirateOffsetMmFromBottom: 10,
+    touchTipAfterDispense: false,
+    touchTipAfterDispenseOffsetMmFromBottom: 10,
+    changeTip: 'once',
+    blowoutLocation: null,
+    blowoutFlowRateUlSec: 42,
+    blowoutOffsetFromTopMm: 1,
+    aspirateOffsetFromBottomMm: 1,
+    dispenseOffsetFromBottomMm: 2,
+    aspirateFlowRateUlSec: 5,
+    dispenseFlowRateUlSec: 6,
+    aspirateAirGapVolume: 0,
+    aspirateDelay: { seconds: 10, mmFromBottom: 10 },
+    dispenseDelay: { seconds: 10, mmFromBottom: 10 },
+    dispenseAirGapVolume: 10,
+    mixBeforeAspirate: { volume: 10, times: 5 },
+    mixInDestination: { volume: 10, times: 5 },
+    preWetTip: true,
+  })
+
+  const distributeCommand = curryCommandCreator(distribute, {
+    commandCreatorFnName: 'distribute',
+    name: null,
+    description: null,
+    sourceLabware: 'sourcePlateId',
+    destLabware: 'destPlateId',
+    pipette: 'p300SingleId',
+    sourceWell: 'A1',
+    destWells: [
+      'A2',
+      'A3',
+      'A4',
+      'A5',
+      'A6',
+      'A7',
+      'A8',
+      'A9',
+      'A10',
+      'B1',
+      'B2',
+      'B3',
+      'B4',
+    ],
+    volume: 5,
+    touchTipAfterAspirate: false,
+    touchTipAfterAspirateOffsetMmFromBottom: 10,
+    touchTipAfterDispense: false,
+    touchTipAfterDispenseOffsetMmFromBottom: 10,
+    changeTip: 'once',
+    blowoutLocation: null,
+    blowoutFlowRateUlSec: 42,
+    blowoutOffsetFromTopMm: 1,
+    aspirateOffsetFromBottomMm: 1,
+    dispenseOffsetFromBottomMm: 2,
+    aspirateFlowRateUlSec: 5,
+    dispenseFlowRateUlSec: 6,
+    aspirateAirGapVolume: 0,
+    aspirateDelay: { seconds: 10, mmFromBottom: 10 },
+    dispenseDelay: { seconds: 10, mmFromBottom: 10 },
+    dispenseAirGapVolume: 10,
+    mixBeforeAspirate: { volume: 10, times: 5 },
+    // mixInDestination: { volume: 10, times: 5 },
+    preWetTip: true,
+    disposalVolume: 20,
+  })
+
+  const curriedCommandCreators = []
+  for (let index = 0; index < 20; index++) {
+    curriedCommandCreators.push(transferCommand)
+    curriedCommandCreators.push(distributeCommand)
+  }
 
   b.start()
 

--- a/protocol-designer/src/step-generation/commandCreators/index.js
+++ b/protocol-designer/src/step-generation/commandCreators/index.js
@@ -1,12 +1,23 @@
 // @flow
-export {
-  transfer,
-  mix,
-  consolidate,
-  distribute,
-  thermocyclerProfileStep,
-  thermocyclerStateStep,
+import { memoize } from 'lodash'
+import {
+  transfer as _transfer,
+  mix as _mix,
+  consolidate as _consolidate,
+  distribute as _distribute,
+  thermocyclerProfileStep as _thermocyclerProfileStep,
+  thermocyclerStateStep as _thermocyclerStateStep,
 } from './compound'
+
+import type {
+  CommandCreator,
+  ConsolidateArgs,
+  DistributeArgs,
+  MixArgs,
+  ThermocyclerProfileStepArgs,
+  ThermocyclerStateStepArgs,
+  TransferArgs,
+} from '../types'
 
 export {
   aspirate,
@@ -23,3 +34,30 @@ export {
   setTemperature,
   touchTip,
 } from './atomic'
+
+const resolver = (args, invariantContext, prevRobotState) =>
+  `${JSON.stringify(args)}${JSON.stringify(invariantContext)}${JSON.stringify(
+    prevRobotState
+  )}`
+
+export const transfer: CommandCreator<TransferArgs> = memoize(
+  _transfer,
+  resolver
+)
+export const mix: CommandCreator<MixArgs> = memoize(_mix, resolver)
+export const consolidate: CommandCreator<ConsolidateArgs> = memoize(
+  _consolidate,
+  resolver
+)
+export const distribute: CommandCreator<DistributeArgs> = memoize(
+  _distribute,
+  resolver
+)
+export const thermocyclerProfileStep: CommandCreator<ThermocyclerProfileStepArgs> = memoize(
+  _thermocyclerProfileStep,
+  resolver
+)
+export const thermocyclerStateStep: CommandCreator<ThermocyclerStateStepArgs> = memoize(
+  _thermocyclerStateStep,
+  resolver
+)

--- a/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
+++ b/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
@@ -40,9 +40,9 @@ export const reduceCommandCreators = (
 
       const allCommands = [...prev.commands, ...next.commands]
       const updates = getNextRobotStateAndWarnings(
-        allCommands,
+        next.commands,
         invariantContext,
-        initialRobotState
+        prev.robotState
       )
       return {
         ...prev,


### PR DESCRIPTION
# Overview

This PR introduces memoization into the complex command creators. 

Command creation is a computationally intensive task, and it can get called over and over again with the same values. This PR caches calls to command creators so that needless computation can be avoided. 

closes #7021

# Changelog
- Memoize compound command creators

# Review requests

Upload the protocol attached into PD (it'll take a while to import)
Reorder steps/create a new step
You'll should see that the spinner time significantly decreases.

Try to do the same on production and you should see it taking way longer (except for the initial import)
[HG Vial Dispense 25ul non complete.json.zip](https://github.com/Opentrons/opentrons/files/5555844/HG.Vial.Dispense.25ul.non.complete.json.zip)


# Risk assessment
Low/med touches command creators but not changing any functionality 
