### PR TITLE
fix(api): Labware.__hash__ fix

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -640,11 +640,12 @@ def _accumulate(iterable):
 
 
 def _dedupe(iterable):
-    def _dupecheck(accumulator, item):
-        if not any([item == accumulated for accumulated in accumulator]):
-            accumulator.append(item)
-        return accumulator
-    return reduce(_dupecheck, iterable, [])
+    acc = set()  # type: ignore
+
+    for item in iterable:
+        if item not in acc:
+            acc.add(item)
+            yield item
 
 
 def now():

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -666,7 +666,7 @@ def _get_parent_module(placeable):
 
 def _get_new_labware(loc):
     if isinstance(loc, Location):
-        return _get_new_labware(loc.labware)
+        return _get_new_labware(loc.labware.object)
     elif isinstance(loc, labware.Well):
         return loc.parent
     elif isinstance(loc, labware.Labware):

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -580,7 +580,7 @@ class Labware(DeckItem):
         return self._implementation == other._implementation
 
     def __hash__(self):
-        return id(self)
+        return hash((id(self._implementation), self._api_version))
 
     def previous_tip(self, num_tips: int = 1) -> Optional[Well]:
         """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -580,7 +580,7 @@ class Labware(DeckItem):
         return self._implementation == other._implementation
 
     def __hash__(self):
-        return hash((id(self._implementation), self._api_version))
+        return hash((self._implementation, self._api_version))
 
     def previous_tip(self, num_tips: int = 1) -> Optional[Well]:
         """

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -8,6 +8,8 @@ from opentrons.api import session
 from opentrons.api.session import (
     _accumulate, _dedupe)
 from opentrons.hardware_control import ThreadedAsyncForbidden
+from opentrons.protocol_api.labware import load
+from opentrons.types import Point, Location
 
 from tests.opentrons.conftest import state
 from functools import partial

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -8,8 +8,6 @@ from opentrons.api import session
 from opentrons.api.session import (
     _accumulate, _dedupe)
 from opentrons.hardware_control import ThreadedAsyncForbidden
-from opentrons.protocol_api.labware import load
-from opentrons.types import Point, Location
 
 from tests.opentrons.conftest import state
 from functools import partial

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -678,3 +678,45 @@ def test_get_parent_identifier():
     )
     assert _get_parent_identifier(lw._implementation)\
         == MagneticModuleModel.MAGNETIC_V1.value
+
+
+def test_labware_hash_func_same_implementation(minimal_labware_def):
+    """Test that multiple Labware objects with same implementation and version
+    have the same __hash__"""
+    impl = LabwareImplementation(minimal_labware_def,
+                                 Location(Point(0, 0, 0),
+                                          'Test Slot'))
+    s = set(labware.Labware(implementation=impl,
+                            api_level=APIVersion(2, 3)) for i in range(10))
+    assert len(s) == 1
+
+
+def test_labware_hash_func_same_implementation_different_version(
+        minimal_labware_def):
+    """Test that multiple Labware objects with same implementation yet
+    different version have different __hash__"""
+    impl = LabwareImplementation(minimal_labware_def,
+                                 Location(Point(0, 0, 0),
+                                          'Test Slot'))
+
+    l1 = labware.Labware(implementation=impl, api_level=APIVersion(2, 3))
+    l2 = labware.Labware(implementation=impl, api_level=APIVersion(2, 4))
+
+    assert len({l1, l2}) == 2
+
+
+def test_labware_hash_func_diff_implementation_same_version(
+        minimal_labware_def):
+    """Test that multiple Labware objects with different implementation yet
+    sane version have different __hash__"""
+    impl1 = LabwareImplementation(minimal_labware_def,
+                                  Location(Point(0, 0, 0),
+                                           'Test Slot'))
+    impl2 = LabwareImplementation(minimal_labware_def,
+                                  Location(Point(0, 0, 0),
+                                           'Test Slot2'))
+
+    l1 = labware.Labware(implementation=impl1, api_level=APIVersion(2, 3))
+    l2 = labware.Labware(implementation=impl2, api_level=APIVersion(2, 3))
+
+    assert len({l1, l2}) == 2

--- a/robot-server/tests/service/test_app.py
+++ b/robot-server/tests/service/test_app.py
@@ -1,3 +1,4 @@
+from mock import patch
 import pytest
 from http import HTTPStatus
 
@@ -70,6 +71,13 @@ def test_api_versioning(api_client, headers, expected_version):
     assert resp.headers.get(MIN_API_VERSION_HEADER) == str(MIN_API_VERSION)
 
 
+@pytest.fixture
+def mock_log_control():
+    with patch("opentrons.system.log_control.get_records_dumb") as p:
+        p.return_value = b""
+        yield p
+
+
 @pytest.mark.parametrize(
     argnames="path",
     argvalues=[
@@ -81,7 +89,8 @@ def test_api_versioning(api_client, headers, expected_version):
         "/logs/some-random-journald-thing",
         "/",
     ])
-def test_api_versioning_non_versions_endpoints(api_client, path):
+def test_api_versioning_non_versions_endpoints(
+        api_client, path, mock_log_control):
     del api_client.headers["Opentrons-Version"]
     resp = api_client.get(path)
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)


### PR DESCRIPTION
# Overview

Seth found a bug in the Labware deduping logic: See this PR  https://github.com/Opentrons/opentrons/pull/6988. The fix was merged into 4.0.

This fixes the root cause. 

It also fixes a bug introduced by the `LabwareLike` refactor.

closes #6992 

# Changelog

- `Labware.__hash__` is now a combination of the hash of `self._implementation` and `self._api_version`.
- Tests to prove that __hash__ is working correctly
- Bring @sfoster1 test from _dedupe fix into test_session yet retain the set inclusion deduping logic.
- Fix `session._get_labware` method to properly deal with `Labware` and `Well`. This was a regression from `LabwareLike` refactor.

# Review requests

This should not be merged until 4.0 is in edge. Let's limit the merge issues.

# Risk assessment

Low