### PR TITLE
fix(app): prompt whether to replace pipette after detach

### DIFF
--- a/app/src/components/ChangePipette/Instructions.js
+++ b/app/src/components/ChangePipette/Instructions.js
@@ -68,19 +68,15 @@ export function Instructions(props: Props): React.Node {
       {!actualPipette && !wantedPipette && (
         <PipetteSelection onPipetteChange={setWantedName} />
       )}
-
-      {(actualPipette || wantedPipette) && (
-        <div>
-          <Steps {...props} />
-          <CheckPipettesButton
-            className={styles.check_pipette_button}
-            robotName={robotName}
-            onDone={confirm}
-          >
-            {actualPipette ? DETACH_CONFIRM : ATTACH_CONFIRM}
-          </CheckPipettesButton>
-        </div>
-      )}
+      {(actualPipette || wantedPipette) && <Steps {...props} />}
+      <CheckPipettesButton
+        className={styles.check_pipette_button}
+        robotName={robotName}
+        onDone={confirm}
+        hidden={!actualPipette && !wantedPipette}
+      >
+        {actualPipette ? DETACH_CONFIRM : ATTACH_CONFIRM}
+      </CheckPipettesButton>
     </ModalPage>
   )
 }


### PR DESCRIPTION
# Overview

**NOTE:** this is a QoL fix for a non-critical bug, and should not be merged until after 4.0.0 is released

Thanks to @Laura-Danielle for catching this sneaky regression from a while ago.

The addition of a loading button state, to the "confirm pipette is detached" button in the change
pipette flow, silently broke the wizard continuing onto the page that prompts the user to decide
whether or not they want to replace the pipette that they just detached. 

Because that request tracking logic lives in a hook on the `CheckPipettesButton` component, lets make sure that it doesn't unmount, before the onDone effect is triggered.

# Changelog

- add hidden optional prop to the `CheckPipettesButton` component
- update the request tracking logic to specifically track `fetchPipettes`actions

# Review requests

- Detach a pipette, you should receive a screen with a green check mark that looks like the screenshot below:
![Screen Shot 2020-11-17 at 4 54 00 PM](https://user-images.githubusercontent.com/4731953/99462784-679dcb80-2902-11eb-9a7c-b0ee6ef6e43f.png)


# Risk assessment

low
