### PR TITLE
fix(api): tolerate delete of nonexistent pip offset

### DIFF
--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -135,8 +135,11 @@ def delete_pipette_offset_file(pipette: str, mount: Mount):
     offset_dir = config.get_opentrons_path('pipette_calibration_dir')
     offset_path = offset_dir / mount.name.lower() / f'{pipette}.json'
 
-    _remove_pipette_offset_from_index(pipette, mount)
-    offset_path.unlink()
+    try:
+        _remove_pipette_offset_from_index(pipette, mount)
+        offset_path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def clear_pipette_offset_calibrations():

--- a/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
+++ b/robot-server/tests/integration/test_pipette_offset_access.tavern.yaml
@@ -142,4 +142,4 @@ stages:
         pipette_id: '321'
         mount: 'right'
     response:
-        status_code: 404
+        status_code: 200

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -44,14 +44,6 @@ def test_delete_pipette_offset_calibration(
         f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'
         f'mount={WRONG_MOUNT}')
     assert resp.status_code == 200
-    body = resp.json()
-    assert body == {
-        'errors': [{
-            'status': '404',
-            'title': 'Resource Not Found',
-            'detail': "Resource type 'PipetteOffsetCalibration' with id "
-                      "'123&right' was not found"
-        }]}
 
     resp = api_client.delete(
         f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -43,7 +43,7 @@ def test_delete_pipette_offset_calibration(
     resp = api_client.delete(
         f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'
         f'mount={WRONG_MOUNT}')
-    assert resp.status_code == 404
+    assert resp.status_code == 200
     body = resp.json()
     assert body == {
         'errors': [{


### PR DESCRIPTION
If you delete a pipette offset that doesn't exist, it really shouldn't
throw an exception and break a bunch of stuff.

## Testing

The reason this came up was doing a fused tip length + pipette offset calibration flow for the first time, when neither a tip length nor (crucially) pipette offset calibration exists for this pipette. This is therefore what we should test.

- Either attach a pipette that hasn't been calibrated before (tip length or pipette offset, so you get the fused flow) or delete the tip length and pipette offset calibrations for the pipette (remove the appropriate file in `/data/tip_length` and `/data/robot/pipettes/{mount}`
- Do the calibration and make sure it doesn't grind to a halt after you save the tip length