### PR TITLE
fix(api): handle missing intermediate keys in poc index

### DIFF
--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -121,10 +121,9 @@ def _remove_pipette_offset_from_index(pipette: str, mount: Mount):
     blob = io.read_cal_file(str(index_path))
 
     try:
-        if pipette in blob[mount.name.lower()]:
-            blob[mount.name.lower()].remove(pipette)
-            io.save_to_file(index_path, blob)
-    except KeyError:
+        blob[mount.name.lower()].remove(pipette)
+        io.save_to_file(index_path, blob)
+    except (KeyError, ValueError):
         # If the index file does not have a mount entry, you get
         # an error here
         pass

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -120,9 +120,14 @@ def _remove_pipette_offset_from_index(pipette: str, mount: Mount):
     index_path = offset_dir / 'index.json'
     blob = io.read_cal_file(str(index_path))
 
-    if pipette in blob[mount.name.lower()]:
-        blob[mount.name.lower()].remove(pipette)
-        io.save_to_file(index_path, blob)
+    try:
+        if pipette in blob[mount.name.lower()]:
+            blob[mount.name.lower()].remove(pipette)
+            io.save_to_file(index_path, blob)
+    except KeyError:
+        # If the index file does not have a mount entry, you get
+        # an error here
+        pass
 
 
 def delete_pipette_offset_file(pipette: str, mount: Mount):


### PR DESCRIPTION
Sometimes, if you reset or mess with the index file, it will be valid enough to pass precondition checks but be missing the `left` or `right` intermediate keys and cause errors.