### PR TITLE
refactor(api): add deck and deck fixture loading to ProtocolEngine factory

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -9,10 +9,12 @@ protocol state and side-effects like robot movements.
 from .protocol_engine import ProtocolEngine
 from .state import StateStore, StateView
 from .execution import CommandHandlers
+from .resources import ResourceProviders
 
 __all__ = [
     "ProtocolEngine",
     "StateStore",
     "StateView",
     "CommandHandlers",
+    "ResourceProviders",
 ]

--- a/api/src/opentrons/protocol_engine/execution/command_handlers.py
+++ b/api/src/opentrons/protocol_engine/execution/command_handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from opentrons.hardware_control.api import API as HardwareAPI
 
-from .. import resources
+from ..resources import ResourceProviders
 from ..state import StateView
 from .equipment import EquipmentHandler
 from .movement import MovementHandler
@@ -26,17 +26,14 @@ class CommandHandlers:
     def create(
         cls,
         hardware: HardwareAPI,
-        state: StateView
+        state: StateView,
+        resources: ResourceProviders,
     ) -> CommandHandlers:
         """Create a CommandHandlers container and its child handlers."""
-        id_generator = resources.IdGenerator()
-        labware_data = resources.LabwareData()
-
         equipment = EquipmentHandler(
             state=state,
-            id_generator=id_generator,
-            labware_data=labware_data,
             hardware=hardware,
+            resources=resources,
         )
 
         movement = MovementHandler(

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -8,7 +8,7 @@ from opentrons.types import MountType
 from opentrons.hardware_control.api import API as HardwareAPI
 
 from ..errors import FailedToLoadPipetteError
-from ..resources import IdGenerator, LabwareData
+from ..resources import ResourceProviders
 from ..state import StateView
 from ..types import LabwareLocation
 
@@ -34,21 +34,18 @@ class EquipmentHandler:
 
     _hardware: HardwareAPI
     _state: StateView
-    _id_generator: IdGenerator
-    _labware_data: LabwareData
+    _resources: ResourceProviders
 
     def __init__(
         self,
         hardware: HardwareAPI,
         state: StateView,
-        id_generator: IdGenerator,
-        labware_data: LabwareData,
+        resources: ResourceProviders,
     ) -> None:
         """Initialize an EquipmentHandler instance."""
         self._hardware = hardware
         self._state = state
-        self._id_generator = id_generator
-        self._labware_data = labware_data
+        self._resources = resources
 
     async def load_labware(
         self,
@@ -58,15 +55,15 @@ class EquipmentHandler:
         location: LabwareLocation,
     ) -> LoadedLabware:
         """Load labware by assigning an identifier and pulling required data."""
-        labware_id = self._id_generator.generate_id()
+        labware_id = self._resources.id_generator.generate_id()
 
-        definition = await self._labware_data.get_labware_definition(
+        definition = await self._resources.labware_data.get_labware_definition(
             load_name=load_name,
             namespace=namespace,
             version=version,
         )
 
-        calibration = await self._labware_data.get_labware_calibration(
+        calibration = await self._resources.labware_data.get_labware_calibration(
             definition=definition,
             location=location,
         )
@@ -102,6 +99,6 @@ class EquipmentHandler:
         except RuntimeError as e:
             raise FailedToLoadPipetteError(str(e)) from e
 
-        pipette_id = self._id_generator.generate_id()
+        pipette_id = self._resources.id_generator.generate_id()
 
         return LoadedPipette(pipette_id=pipette_id)

--- a/api/src/opentrons/protocol_engine/resources/__init__.py
+++ b/api/src/opentrons/protocol_engine/resources/__init__.py
@@ -1,59 +1,14 @@
 """Resources used by command execution handlers."""
-# TODO(mc, 2020-10-21): break this module up when it becames > 100 lines
-
-from uuid import uuid4
-from typing import Tuple
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-
-from opentrons.protocol_api.labware import get_labware_definition
-from opentrons.calibration_storage.get import get_labware_calibration
-from opentrons.calibration_storage.helpers import hash_labware_def
-
-from ..types import LabwareLocation
+from .resource_providers import ResourceProviders
+from .id_generator import IdGenerator
+from .deck_data_provider import DeckDataProvider, DeckFixedLabware
+from .labware_data_provider import LabwareDataProvider
 
 
-class IdGenerator:
-    """Unique ID generation provider."""
-
-    def generate_id(self) -> str:
-        """
-        Generate a unique identifier.
-
-        Uses UUIDv4 for safety in a multiprocessing environment.
-        """
-        return str(uuid4())
-
-
-class LabwareData:
-    """Labware data provider."""
-
-    # NOTE(mc, 2020-10-18): async to allow file reading and parsing to be
-    # async on a worker thread in the future
-    async def get_labware_definition(
-        self,
-        load_name: str,
-        namespace: str,
-        version: int,
-    ) -> LabwareDefinition:
-        """Get a labware definition given the labware's identification."""
-        return get_labware_definition(load_name, namespace, version)
-
-    # NOTE(mc, 2020-10-18): async to allow file reading and parsing to be
-    # async on a worker thread in the future
-    async def get_labware_calibration(
-        self,
-        definition: LabwareDefinition,
-        location: LabwareLocation,
-    ) -> Tuple[float, float, float]:
-        """Get a labware's calibration data given its definition."""
-        # TODO(mc, 2020-10-18): Fetching labware calibration data is a little
-        # convoluted and could use some clean up
-        labware_path = f'{hash_labware_def(definition)}.json'
-        cal_point = get_labware_calibration(
-            labware_path,
-            definition,
-            # TODO(mc, 2020-10-18): Support labware on modules
-            parent='',
-        )
-
-        return (cal_point.x, cal_point.y, cal_point.z)
+__all__ = [
+    "ResourceProviders",
+    "IdGenerator",
+    "LabwareDataProvider",
+    "DeckDataProvider",
+    "DeckFixedLabware",
+]

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -1,0 +1,74 @@
+"""Deck data resource provider."""
+from dataclasses import dataclass
+from typing import List
+from typing_extensions import final
+
+from opentrons_shared_data.deck import load as load_deck
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV2
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons.types import DeckSlotName
+from opentrons.protocols.api_support.constants import STANDARD_DECK, SHORT_TRASH_DECK
+
+from ..types import DeckSlotLocation
+from .labware_data_provider import LabwareDataProvider
+
+
+@final
+@dataclass(frozen=True)
+class DeckFixedLabware:
+    """A labware fixture that is always present on a deck."""
+
+    labware_id: str
+    location: DeckSlotLocation
+    definition: LabwareDefinition
+
+
+class DeckDataProvider:
+    """Provider class to wrap deck definition and data retrieval."""
+
+    _labware_data: LabwareDataProvider
+
+    def __init__(self, labware_data: LabwareDataProvider) -> None:
+        """Initialize a DeckDataProvider."""
+        self._labware_data = labware_data
+
+    # NOTE(mc, 2020-11-18): async to allow file reading and parsing to be
+    # async on a worker thread in the future
+    async def get_deck_definition(
+        self,
+        *,
+        short_fixed_trash: bool = False,
+    ) -> DeckDefinitionV2:
+        """Get a labware definition given the labware's identification."""
+        deck_load_name = SHORT_TRASH_DECK if short_fixed_trash else STANDARD_DECK
+        return load_deck(deck_load_name, 2)
+
+    async def get_deck_fixed_labware(
+        self,
+        deck_definition: DeckDefinitionV2
+    ) -> List[DeckFixedLabware]:
+        """Get a list of all labware fixtures from a given deck definition."""
+        labware = []
+
+        for fixture in deck_definition["locations"]["fixtures"]:
+            labware_id = fixture["id"]
+            load_name = fixture.get("labware")  # type: ignore[misc]
+            slot = fixture.get("slot")  # type: ignore[misc]
+
+            if load_name is not None and slot is not None:
+                location = DeckSlotLocation(slot=DeckSlotName.from_string(slot))
+                definition = await self._labware_data.get_labware_definition(
+                    load_name=load_name,
+                    namespace="opentrons",
+                    version=1,
+                )
+
+                labware.append(
+                    DeckFixedLabware(
+                        labware_id=labware_id,
+                        definition=definition,
+                        location=location,
+                    )
+                )
+
+        return labware

--- a/api/src/opentrons/protocol_engine/resources/id_generator.py
+++ b/api/src/opentrons/protocol_engine/resources/id_generator.py
@@ -1,0 +1,15 @@
+"""Unique ID generation provider."""
+
+from uuid import uuid4
+
+
+class IdGenerator:
+    """Unique ID generation provider."""
+
+    def generate_id(self) -> str:
+        """
+        Generate a unique identifier.
+
+        Uses UUIDv4 for safety in a multiprocessing environment.
+        """
+        return str(uuid4())

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -1,0 +1,44 @@
+"""Labware data resource provider."""
+from typing import Tuple
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+from opentrons.protocol_api.labware import get_labware_definition
+from opentrons.calibration_storage.get import get_labware_calibration
+from opentrons.calibration_storage.helpers import hash_labware_def
+
+from ..types import LabwareLocation
+
+
+class LabwareDataProvider:
+    """Labware data provider."""
+
+    # NOTE(mc, 2020-10-18): async to allow file reading and parsing to be
+    # async on a worker thread in the future
+    async def get_labware_definition(
+        self,
+        load_name: str,
+        namespace: str,
+        version: int,
+    ) -> LabwareDefinition:
+        """Get a labware definition given the labware's identification."""
+        return get_labware_definition(load_name, namespace, version)
+
+    # NOTE(mc, 2020-10-18): async to allow file reading and parsing to be
+    # async on a worker thread in the future
+    async def get_labware_calibration(
+        self,
+        definition: LabwareDefinition,
+        location: LabwareLocation,
+    ) -> Tuple[float, float, float]:
+        """Get a labware's calibration data given its definition."""
+        # TODO(mc, 2020-10-18): Fetching labware calibration data is a little
+        # convoluted and could use some clean up
+        labware_path = f'{hash_labware_def(definition)}.json'
+        cal_point = get_labware_calibration(
+            labware_path,
+            definition,
+            # TODO(mc, 2020-10-18): Support labware on modules
+            parent='',
+        )
+
+        return (cal_point.x, cal_point.y, cal_point.z)

--- a/api/src/opentrons/protocol_engine/resources/resource_providers.py
+++ b/api/src/opentrons/protocol_engine/resources/resource_providers.py
@@ -1,0 +1,58 @@
+"""Resource providers."""
+from __future__ import annotations
+
+from .id_generator import IdGenerator
+from .deck_data_provider import DeckDataProvider
+from .labware_data_provider import LabwareDataProvider
+
+
+class ResourceProviders:
+    """
+    ResourceProviders container class.
+
+    Wraps various data providers that define procedures to pull and generate
+    data for engine setup and command execution.
+    """
+
+    _id_generator: IdGenerator
+    _labware_data: LabwareDataProvider
+    _deck_data: DeckDataProvider
+
+    @classmethod
+    def create(cls) -> ResourceProviders:
+        """Create a ResourceProviders container and its children."""
+        id_generator = IdGenerator()
+        labware_data = LabwareDataProvider()
+        deck_data = DeckDataProvider(labware_data=labware_data)
+
+        return cls(
+            id_generator=id_generator,
+            labware_data=labware_data,
+            deck_data=deck_data,
+        )
+
+    def __init__(
+        self,
+        id_generator: IdGenerator,
+        labware_data: LabwareDataProvider,
+        deck_data: DeckDataProvider,
+    ) -> None:
+        """Initialize a ResourceProviders container."""
+        self._id_generator = id_generator
+        self._labware_data = labware_data
+        self._deck_data = deck_data
+
+    @property
+    def id_generator(self) -> IdGenerator:
+        """Get the unique ID generator resource."""
+        return self._id_generator
+
+    @property
+    def labware_data(self) -> LabwareDataProvider:
+        """Get the labware data provider resource."""
+        return self._labware_data
+
+    @property
+    def deck_data(self) -> DeckDataProvider:
+        """Get the deck data provider resource."""
+        return self._deck_data

--- a/api/src/opentrons/protocol_engine/state/state_store.py
+++ b/api/src/opentrons/protocol_engine/state/state_store.py
@@ -1,10 +1,11 @@
 """Protocol engine state management."""
 from __future__ import annotations
-from typing import List
+from typing import List, Sequence
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV2
 
 from .. import commands as cmd
+from ..resources import DeckFixedLabware
 from .substore import CommandReactive
 from .commands import CommandStore, CommandState
 from .labware import LabwareStore, LabwareState
@@ -83,10 +84,16 @@ class StateStore(StateView):
     be allowed to modify State classes.
     """
 
-    def __init__(self, deck_definition: DeckDefinitionV2) -> None:
+    def __init__(
+        self,
+        deck_definition: DeckDefinitionV2,
+        deck_fixed_labware: Sequence[DeckFixedLabware],
+    ) -> None:
         """Initialize a StateStore."""
         command_store = CommandStore()
-        labware_store = LabwareStore()
+        labware_store = LabwareStore(
+            deck_fixed_labware=deck_fixed_labware
+        )
         pipette_store = PipetteStore()
         geometry_store = GeometryStore(
             deck_definition=deck_definition,

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -181,6 +181,11 @@ class DeckSlotName(int, enum.Enum):
     SLOT_11 = 11
     FIXED_TRASH = 12
 
+    @classmethod
+    def from_string(cls, value: str) -> DeckSlotName:
+        int_val = int(value)
+        return cls(int_val)
+
     def __str__(self):
         """Stringify to a simple integer string."""
         return str(self.value)

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -1,0 +1,94 @@
+"""Test deck data provider."""
+import pytest
+from mock import AsyncMock  # type: ignore[attr-defined]
+
+from opentrons_shared_data.deck.dev_types import DeckDefinitionV2
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons.types import DeckSlotName
+
+from opentrons.protocol_engine.types import DeckSlotLocation
+from opentrons.protocol_engine.resources import (
+    LabwareDataProvider,
+    DeckDataProvider,
+    DeckFixedLabware,
+)
+
+
+@pytest.fixture
+def mock_labware_data(minimal_labware_def: LabwareDefinition) -> AsyncMock:
+    """Get a mock in the shape of the LabwareDataProvider."""
+    return AsyncMock(spec=LabwareDataProvider)
+
+
+@pytest.fixture
+def deck_data(mock_labware_data: AsyncMock) -> DeckDataProvider:
+    """Create a DeckDataProvider with mocked out dependencies."""
+    return DeckDataProvider(labware_data=mock_labware_data)
+
+
+async def test_get_deck_definition(
+    standard_deck_def: DeckDefinitionV2,
+    deck_data: DeckDataProvider,
+) -> None:
+    """It should be able to load the deck definition."""
+    result = await deck_data.get_deck_definition()
+    assert result == standard_deck_def
+
+
+async def test_get_deck_definition_short_trash(
+    short_trash_deck_def: DeckDefinitionV2,
+    deck_data: DeckDataProvider,
+) -> None:
+    """It should be able to load the short-trash deck definition."""
+    result = await deck_data.get_deck_definition(short_fixed_trash=True)
+    assert result == short_trash_deck_def
+
+
+async def test_get_deck_labware_fixtures(
+    standard_deck_def: DeckDefinitionV2,
+    fixed_trash_def: LabwareDefinition,
+    mock_labware_data: AsyncMock,
+    deck_data: DeckDataProvider,
+) -> None:
+    """It should be able to get a list of prepopulated labware on the deck."""
+    mock_labware_data.get_labware_definition.return_value = fixed_trash_def
+
+    result = await deck_data.get_deck_fixed_labware(standard_deck_def)
+
+    assert result == [
+        DeckFixedLabware(
+            labware_id="fixedTrash",
+            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+            definition=fixed_trash_def
+        )
+    ]
+    mock_labware_data.get_labware_definition.assert_called_with(
+        load_name="opentrons_1_trash_1100ml_fixed",
+        namespace="opentrons",
+        version=1,
+    )
+
+
+async def test_get_deck_labware_fixtures_short_trash(
+    short_trash_deck_def: DeckDefinitionV2,
+    short_fixed_trash_def: LabwareDefinition,
+    mock_labware_data: AsyncMock,
+    deck_data: DeckDataProvider,
+) -> None:
+    """It should be able to get a list of prepopulated labware on the deck."""
+    mock_labware_data.get_labware_definition.return_value = short_fixed_trash_def
+
+    result = await deck_data.get_deck_fixed_labware(short_trash_deck_def)
+
+    assert result == [
+        DeckFixedLabware(
+            labware_id="fixedTrash",
+            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+            definition=short_fixed_trash_def
+        )
+    ]
+    mock_labware_data.get_labware_definition.assert_called_with(
+        load_name="opentrons_1_trash_850ml_fixed",
+        namespace="opentrons",
+        version=1,
+    )

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
@@ -6,7 +6,7 @@ from opentrons.protocol_api.labware import get_labware_definition
 from opentrons.calibration_storage.helpers import hash_labware_def
 
 from opentrons.protocol_engine.types import DeckSlotLocation
-from opentrons.protocol_engine.resources import LabwareData
+from opentrons.protocol_engine.resources import LabwareDataProvider
 
 
 async def test_labware_data_gets_standard_definition() -> None:
@@ -16,7 +16,7 @@ async def test_labware_data_gets_standard_definition() -> None:
         namespace="opentrons",
         version=1
     )
-    result = await LabwareData().get_labware_definition(
+    result = await LabwareDataProvider().get_labware_definition(
         load_name="opentrons_96_tiprack_300ul",
         namespace="opentrons",
         version=1
@@ -32,11 +32,11 @@ async def test_labware_data_gets_calibration(
     # TODO(mc, 2020-10-18): this mock is a kinda code-smelly. Fetching labware
     # calibration data is a little convoluted and could use some clean up
     with patch(
-        'opentrons.protocol_engine.resources.get_labware_calibration'
+        'opentrons.protocol_engine.resources.labware_data_provider.get_labware_calibration'  # noqa[E501]
     ) as mock_get_lw_calibration:
         mock_get_lw_calibration.return_value = Point(1, 2, 3)
 
-        result = await LabwareData().get_labware_calibration(
+        result = await LabwareDataProvider().get_labware_calibration(
             minimal_labware_def,
             DeckSlotLocation(DeckSlotName.SLOT_5),
         )


### PR DESCRIPTION
## Overview

This PR adds deck fixture (i.e. fixed trash) loading to the protocol engine, so that the labware store's initial state includes the fixed trash. This unblocks #6596, since that ticket spec's tip drops in the trash.

## Changelog

- refactor(api): add deck and deck fixture loading to ProtocolEngine factory

## Review requests

I ended up codifying the "data providers" system the same way #7026 did this for the "execution handlers." We now have the following data providers:

- `IdGenerator` - UUID generator, nothing really to see here
    - Already existed in `resources/__init__.py`
- `LabwareDataProvider` - Knows how to retrieve labware definitions and labware calibration data
    - Already existed in `resources/__init__.py`
- `DeckDataProvider` - Knows how to retrieve deck definitions
    - New class for this PR, but takes over for existing deck definition loading that was just sitting in the `ProtocolEngine.create` factory
    - Depends on `LabwareDataProvider` to load fixtures

To keep things simpler in the future, the data providers that read from files are defined as `async` to avoid too much churn when we're able to actually put the file reading and parsing onto worker threads.

This means that the `ProtocolEngine.create` factory is now async, as it needs to load information from the filesystem to create a ProtocolEngine with state set up properly.

## Risk assessment

Low. Not hooked to anything, good test coverage, no change in smoke test results since #7026

### Smoke test protocol

```py
import asyncio
import opentrons.execute
from uuid import uuid4
from typing import Optional

from opentrons.types import DeckSlotName, MountType
from opentrons.protocol_api import ProtocolContext
from opentrons.protocol_engine import ProtocolEngine, commands
from opentrons.protocol_engine.types import DeckSlotLocation

opentrons.execute._clear_cached_hardware_controller()
protocol = opentrons.execute.get_protocol_api('2.7')
protocol.home()

# for testing purposes when playing around in Jupyter
# e.g. examine the engine state after the run
hw_api = None
engine = None

async def run_protocol(ctx: ProtocolContext) -> None:
    global hw_api
    global engine

    # HACK(mc, 2020-11-06): don't ever do this in a real protocol
    hw_api = ctx._hw_manager.hardware._obj_to_adapt
    engine = await ProtocolEngine.create(hardware=hw_api)

    async def execute_command(
        request: commands.CommandRequestType
    ) -> Optional[commands.CommandResultType]:
        command_id = str(uuid4())
        command = await engine.execute_command(request, command_id=command_id)
        print(f"{type(command.request).__name__} - {command_id}")
        print(f"{command.request}")

        if isinstance(command, commands.FailedCommand):
            print(f"error: {command.error}")
            return None

        print(f"result: {command.result}")
        return command.result

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_5),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_5 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_8),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_8 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadPipetteRequest(
            pipetteName="p300_single_gen2",
            mount=MountType.RIGHT,
        ),
    )

    p300 = result.pipetteId  # type: ignore[union-attr]

    await execute_command(
        commands.MoveToWellRequest(pipetteId=p300, labwareId=rack_5, wellName="A1")
    )

    await execute_command(
        commands.PickUpTipRequest(pipetteId=p300, labwareId=rack_8, wellName="H12")
    )

loop = asyncio.get_event_loop()
loop.create_task(run_protocol(protocol))
```