### PR TITLE
feat(chore): remove e2e tests from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,6 @@ jobs:
           bucket: opentrons-components
           upload-dir: $TRAVIS_BRANCH
 
-    # typecheck JavaScript projects
-    - stage: test
-      name: 'JS type checks'
-      language: node_js
-      install:
-        - make setup-js
-      script:
-        - make check-js
-
 env:
   global:
     # include $HOME/.local/bin for `aws`

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,6 @@ jobs:
           bucket: opentrons-components
           upload-dir: $TRAVIS_BRANCH
 
-    # E2E tests for FE JavaScript projects
-    - stage: test
-      name: 'JS E2E tests'
-      language: node_js
-      install:
-        - make setup-js
-      script:
-        - make test-e2e
-
     # typecheck JavaScript projects
     - stage: test
       name: 'JS type checks'


### PR DESCRIPTION
# Overview
Cypress e2e tests are now all in github actions so we don't need them to run in travis anymore (woooo!)

Closes #7032

# Changelog

Example changelog:
- Remove e2e tests from travis


# Risk assessment

Low