### PR TITLE
feat(api): add drop tip command to engine

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -22,13 +22,14 @@ from .load_labware import LoadLabwareRequest, LoadLabwareResult
 from .load_pipette import LoadPipetteRequest, LoadPipetteResult
 from .move_to_well import MoveToWellRequest, MoveToWellResult
 from .pick_up_tip import PickUpTipRequest, PickUpTipResult
-
+from .drop_tip import DropTipRequest, DropTipResult
 
 CommandRequestType = Union[
     LoadLabwareRequest,
     LoadPipetteRequest,
     MoveToWellRequest,
     PickUpTipRequest,
+    DropTipRequest,
 ]
 
 CommandResultType = Union[
@@ -36,6 +37,7 @@ CommandResultType = Union[
     LoadPipetteResult,
     MoveToWellResult,
     PickUpTipResult,
+    DropTipResult,
 ]
 
 PendingCommandType = Union[
@@ -43,6 +45,7 @@ PendingCommandType = Union[
     PendingCommand[LoadPipetteRequest, LoadPipetteResult],
     PendingCommand[MoveToWellRequest, MoveToWellResult],
     PendingCommand[PickUpTipRequest, PickUpTipResult],
+    PendingCommand[DropTipRequest, DropTipResult],
 ]
 
 RunningCommandType = Union[
@@ -50,6 +53,7 @@ RunningCommandType = Union[
     RunningCommand[LoadPipetteRequest, LoadPipetteResult],
     RunningCommand[MoveToWellRequest, MoveToWellResult],
     RunningCommand[PickUpTipRequest, PickUpTipResult],
+    RunningCommand[DropTipRequest, DropTipResult],
 ]
 
 CompletedCommandType = Union[
@@ -57,6 +61,7 @@ CompletedCommandType = Union[
     CompletedCommand[LoadPipetteRequest, LoadPipetteResult],
     CompletedCommand[MoveToWellRequest, MoveToWellResult],
     CompletedCommand[PickUpTipRequest, PickUpTipResult],
+    CompletedCommand[DropTipRequest, DropTipResult],
 ]
 
 FailedCommandType = Union[
@@ -64,6 +69,7 @@ FailedCommandType = Union[
     FailedCommand[LoadPipetteRequest],
     FailedCommand[MoveToWellRequest],
     FailedCommand[PickUpTipRequest],
+    FailedCommand[DropTipRequest],
 ]
 
 CommandType = Union[
@@ -100,4 +106,6 @@ __all__ = [
     "MoveToWellResult",
     "PickUpTipRequest",
     "PickUpTipResult",
+    "DropTipRequest",
+    "DropTipResult",
 ]

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -1,0 +1,36 @@
+"""Drop tip command request, result, and implementation models."""
+from __future__ import annotations
+from pydantic import BaseModel
+
+from .command import CommandImplementation, CommandHandlers
+from .pipetting_common import BasePipettingRequest
+
+
+class DropTipRequest(BasePipettingRequest):
+    """A request to drop a tip in a specific well."""
+
+    def get_implementation(self) -> DropTipImplementation:
+        """Get the drop tip request's command implementation."""
+        return DropTipImplementation(self)
+
+
+class DropTipResult(BaseModel):
+    """Result data from the execution of a DropTipRequest."""
+
+    pass
+
+
+class DropTipImplementation(
+    CommandImplementation[DropTipRequest, DropTipResult]
+):
+    """Drop tip command implementation."""
+
+    async def execute(self, handlers: CommandHandlers) -> DropTipResult:
+        """Move to and drop a tip using the requested pipette."""
+        await handlers.pipetting.drop_tip(
+            pipette_id=self._request.pipetteId,
+            labware_id=self._request.labwareId,
+            well_name=self._request.wellName,
+        )
+
+        return DropTipResult()

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -1,5 +1,4 @@
 """Common pipetting command base models."""
-
 from pydantic import BaseModel, Field
 
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -1,6 +1,8 @@
 """Movement command handling."""
+from typing import Optional
 from opentrons.hardware_control.api import API as HardwareAPI
 
+from ..types import WellLocation
 from ..state import StateView
 
 
@@ -24,6 +26,7 @@ class MovementHandler:
         pipette_id: str,
         labware_id: str,
         well_name: str,
+        well_location: Optional[WellLocation] = None,
     ) -> None:
         """Move to a specific well."""
         # get the pipette's mount and current critical point, if applicable
@@ -43,6 +46,7 @@ class MovementHandler:
             pipette_id=pipette_id,
             labware_id=labware_id,
             well_name=well_name,
+            well_location=well_location,
             origin=origin,
             origin_cp=origin_cp,
             max_travel_z=max_travel_z,

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -12,6 +12,7 @@ from opentrons.motion_planning import (
 )
 
 from .. import commands, errors
+from ..types import WellLocation
 from .substore import Substore, CommandReactive
 from .labware import LabwareStore
 from .pipettes import PipetteStore
@@ -88,6 +89,7 @@ class MotionState:
         pipette_id: str,
         labware_id: str,
         well_name: str,
+        well_location: Optional[WellLocation],
         origin: Point,
         origin_cp: Optional[CriticalPoint],
         max_travel_z: float
@@ -101,7 +103,8 @@ class MotionState:
 
         dest = self._geometry_store.state.get_well_position(
             labware_id,
-            well_name
+            well_name,
+            well_location,
         )
         dest_cp = CriticalPoint.XY_CENTER if center_dest else None
 
@@ -163,7 +166,11 @@ class MotionStore(Substore[MotionState], CommandReactive):
         """Modify state in reaction to a CompletedCommand."""
         if isinstance(
             command.result,
-            (commands.MoveToWellResult, commands.PickUpTipResult),
+            (
+                commands.MoveToWellResult,
+                commands.PickUpTipResult,
+                commands.DropTipResult,
+            ),
         ):
             self._state._current_location = LocationData(
                 pipette_id=command.request.pipetteId,

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -1,6 +1,7 @@
 """Base protocol engine types and interfaces."""
+from enum import Enum
 from pydantic.dataclasses import dataclass
-from typing import Union
+from typing import Union, Tuple
 from typing_extensions import final
 
 from opentrons.types import DeckSlotName
@@ -16,3 +17,20 @@ class DeckSlotLocation:
 
 LabwareLocation = Union[DeckSlotLocation]
 """Union of all legal labware locations."""
+
+
+@final
+class WellOrigin(str, Enum):
+    """Origin of WellLocation offset."""
+
+    TOP = "top"
+    BOTTOM = "bottom"
+
+
+@final
+@dataclass(frozen=True)
+class WellLocation:
+    """A relative location in reference to a well's location."""
+
+    origin: WellOrigin = WellOrigin.TOP
+    offset: Tuple[float, float, float] = (0, 0, 0)

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -1,0 +1,49 @@
+"""Test pick up tip commands."""
+from mock import AsyncMock  # type: ignore[attr-defined]
+
+from opentrons.protocol_engine.commands import (
+    DropTipRequest,
+    DropTipResult,
+)
+
+
+def test_pick_up_tip_request() -> None:
+    """It should be able to create a DropTipRequest."""
+    request = DropTipRequest(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+    )
+
+    assert request.pipetteId == "abc"
+    assert request.labwareId == "123"
+    assert request.wellName == "A3"
+
+
+def test_pick_up_tip_result() -> None:
+    """It should be able to create a DropTipResult."""
+    # NOTE(mc, 2020-11-17): this model has no properties at this time
+    result = DropTipResult()
+
+    assert result
+
+
+async def test_pick_up_tip_implementation(mock_handlers: AsyncMock) -> None:
+    """A DropTipRequest should have an execution implementation."""
+    mock_handlers.pipetting.drop_tip.return_value = None
+
+    request = DropTipRequest(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+    )
+
+    impl = request.get_implementation()
+    result = await impl.execute(mock_handlers)
+
+    assert result == DropTipResult()
+    mock_handlers.pipetting.drop_tip.assert_called_with(
+        pipette_id="abc",
+        labware_id="123",
+        well_name="A3",
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_motion_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_state.py
@@ -27,6 +27,14 @@ def test_initial_location(store: StateStore) -> None:
         ),
         cmd.PickUpTipResult()
     ),
+    (
+        cmd.DropTipRequest(
+            pipetteId="pipette-id",
+            labwareId="labware-id",
+            wellName="B4"
+        ),
+        cmd.DropTipResult()
+    ),
 ])
 def test_handles_move_to_well_result(
     store: StateStore,

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -7,6 +7,7 @@ from typing import cast
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV2
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.types import DeckSlotName
+from opentrons.protocols.geometry.deck import FIXED_TRASH_ID
 
 from opentrons.protocol_engine import ProtocolEngine, errors
 from opentrons.protocol_engine.types import DeckSlotLocation
@@ -51,7 +52,7 @@ async def test_create_engine_initializes_state_with_deck_geometry(
     state = engine.state_store
 
     assert state.geometry.get_deck_definition() == standard_deck_def
-    assert state.labware.get_labware_data_by_id("fixedTrash") == LabwareData(
+    assert state.labware.get_labware_data_by_id(FIXED_TRASH_ID) == LabwareData(
         location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
         definition=fixed_trash_def,
         calibration=(0, 0, 0),


### PR DESCRIPTION
## Overview

This PR adds a `DropTip...` command to the protocol engine. Closes #6596.

## Changelog

- feat(api): add drop tip command to engine

### Models

- `commands.DropTipRequest`, `commands.DropTipResult`, and `commands.DropTipImplementation` added
    - Support for drop tip
- `types.WellLocation` dataclass and `types.WellOrigin` enum added
    - Origin + relative offset location-in-a-well specifier

### Selectors

- `motion.get_movement_waypoints` can now take a `WellLocation` relative offset
- `geometry.get_well_position` can now take a `WellLocation` relative offset
- `geometry.get_tip_drop_location` selector added, which returns a `WellLocation` for dropping a tip from a given pipette into a given labware

### Handlers

- `movement.move_to_well` can now take an optional `WellLocation`
- `pipetting.drop_tip` added, which threads together the `geometry.get_tip_drop_location` selector, `movement.move_to_well` handler, and `hardware.drop_tip` procedure

## Review requests

Smoke testing protocol below, which verifies:

- Tip can be dropped in the trash (at trash top)
- Tip can be dropped back into a tiprack (down into the tiprack)

Otherwise, please check out the tests and if this command addition is at all simpler after the #7026 refactor.

### Out of scope

- Tip rack tracking: the engine won't complain if you tell it to do something with tips that it shouldn't
    - The hardware controller will at least prevent trying to pick up a tip if the *pipette* already has one
- The PAPIv2.2/2.3 behavior where tips are always dropped 10 mm from the bottom of the tip rack well
    - Considering an engine option
    - But also considering adding an optional `WellLocation` param to the `DropTipRequest`, which would also allow a ProtocolContext to emulate the old bahavior

## Risk assessment

Low. Not hooked to anything, good test coverage, smoke test checks out for me

### Smoke test protocol (Jupyter Notebook)

1. Load a `p300_single_gen2` on the right
2. Load 300 uL tip racks in slots 5 and 8
3. Pick up a tip and drop it in the trash
4. Pick up a tip, move to another well in the tip rack, and then drop the tip back where it came from

```py
import asyncio
import opentrons.execute
from uuid import uuid4
from typing import Optional

from opentrons.types import DeckSlotName, MountType
from opentrons.protocol_api import ProtocolContext
from opentrons.protocol_engine import ProtocolEngine, commands
from opentrons.protocol_engine.types import DeckSlotLocation

opentrons.execute._clear_cached_hardware_controller()
protocol = opentrons.execute.get_protocol_api('2.7')
protocol.home()
engine = None
hw_api = None
async def run_protocol(ctx: ProtocolContext) -> None:
    global engine
    global hw_api
    # HACK(mc, 2020-11-06): don't ever do this in a real protocol
    hw_api = ctx._hw_manager.hardware._obj_to_adapt
    engine = await ProtocolEngine.create(hardware=hw_api)

    async def execute_command(
        request: commands.CommandRequestType
    ) -> Optional[commands.CommandResultType]:
        command_id = str(uuid4())
        command = await engine.execute_command(request, command_id=command_id)
        print(f"{type(command.request).__name__} - {command_id}")
        print(f"{command.request}")

        if isinstance(command, commands.FailedCommand):
            print(f"error: {command.error}")
            return None

        print(f"result: {command.result}")
        return command.result

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_5),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_5 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_8),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_8 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadPipetteRequest(
            pipetteName="p300_single_gen2",
            mount=MountType.RIGHT,
        ),
    )

    p300 = result.pipetteId  # type: ignore[union-attr]

    await execute_command(
        commands.PickUpTipRequest(pipetteId=p300, labwareId=rack_8, wellName="H12")
    )
    
    await execute_command(
        commands.DropTipRequest(pipetteId=p300, labwareId="fixedTrash", wellName="A1")
    )
    
    await execute_command(
        commands.PickUpTipRequest(pipetteId=p300, labwareId=rack_5, wellName="A1")
    )
    
    await execute_command(
        commands.MoveToWellRequest(pipetteId=p300, labwareId=rack_5, wellName="H12")
    )
    
    await execute_command(
        commands.DropTipRequest(pipetteId=p300, labwareId=rack_5, wellName="A1")
    )
    
loop = asyncio.get_event_loop()
loop.create_task(run_protocol(protocol))
```