### PR TITLE
chore: add release notes link to cal explainer

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -20,7 +20,6 @@ In Opentrons App and Robot Software 4.0.0, the calibration process for the OT-2 
 
 For more in-depth information on the changes, [click here](https://support.opentrons.com/en/articles/3499692-how-calibration-works-on-the-ot-2).
 
-
 ## Full Use of Python Protocol API Version 2
 
 We released Python Protocol API Version 2 almost a year ago, and have been continuously improving it since, with 8 new intermediate API levels, each containing bugfixes, improvements, or support for new hardware. It's ready to be the only way Python protocols are written for the OT-2. Accordingly, in 4.0.0 and subsequent releases, **the OT-2 will not accept Python Protocol API Version 1 protocols**.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -18,7 +18,8 @@ In addition, **after you install this update, Opentrons Apps on version 3.21.2 o
 
 In Opentrons App and Robot Software 4.0.0, the calibration process for the OT-2 is different and improved from major version 3. With these changes, you'll calibrate less often; the calibration processes are shorter, easier, and more reliable; and you can finally use different kinds of tips on the same pipette in the same protocol accurately.
 
-For more in-depth information on the changes, check out our LINKME blogpost LINKME.
+For more in-depth information on the changes, [click here](https://support.opentrons.com/en/articles/3499692-how-calibration-works-on-the-ot-2).
+
 
 ## Full Use of Python Protocol API Version 2
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -16,7 +16,7 @@ Opentrons App 4.0.0 is a major software release, bringing an entirely overhauled
 
 In Opentrons App and Robot Software 4.0.0, the calibration process for the OT-2 is different and improved from major version 3. With these changes, you'll calibrate less often; the calibration processes are shorter, easier, and more reliable; and you can finally use different kinds of tips on the same pipette in the same protocol accurately.
 
-For more in-depth information on the changes, check out our LINKME blogpost LINKME.
+For more in-depth information on the changes, [click here](https://support.opentrons.com/en/articles/3499692-how-calibration-works-on-the-ot-2).
 
 ## Full Use of Python Protocol API Version 2
 


### PR DESCRIPTION
Add actual links to the calibration info explainer to the release notes where we wanted them.