### PR TITLE
chore(shared-data): Actually set password for pypi

### DIFF
--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -111,3 +111,4 @@ jobs:
         with:
           project: 'shared-data/python'
           repository_url: 'https://upload.pypi.org/legacy/'
+          password: '${{ secrets.OT_PYPI_PASSWORD }}'


### PR DESCRIPTION
Need to do this to actually deploy stuff, I had left this out because I didn't want to accidentally deploy stuff.