### PR TITLE
chore(build): remove azure ubuntu package mirror because it's broken

### DIFF
--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -8,7 +8,8 @@ runs:
   using: 'composite'
   steps:
     - shell: bash
-      run: '[[ "${OSTYPE}" =~ "linux" ]] && sudo apt-get install -y --no-install-recommends libsystemd-dev || echo "do nothing and avoid pipefail"'
+      run: |
+        [[ "${OSTYPE}" =~ "linux" ]] && sudo sed -i 's/azure\.//' /etc/apt/sources.list && sudo apt-get update && sudo apt-get install -y --no-install-recommends libsystemd-dev || echo "do nothing and avoid pipefail"
     - shell: bash
       run: |
         npm install --global shx@0.2.2


### PR DESCRIPTION
Our api builds started failing on ubuntu because they couldn't install libsystemd. They appear to be hitting the package mirror http://azure.archive.ubuntu.com/ubuntu/ which as of 10 33am est today appears to have all content removed from the pool/ path.

This removes that mirror from the sources list and hopefully forces a fallback to another mirror that isn't broken in such a way.

Works around https://github.com/actions/virtual-environments/issues/2104