### PR TITLE
chore(build): bump actions/github-script to 3.1

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -31,8 +31,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   lint:
@@ -60,9 +58,6 @@ jobs:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -71,7 +66,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -99,7 +94,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -42,7 +42,7 @@ env:
   CI: true
   OT_APP_DEPLOY_BUCKET: opentrons-app
   OT_APP_DEPLOY_FOLDER: builds
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
 
 jobs:
   js-unit-test:
@@ -51,16 +51,13 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: 'opentrons app frontend unit tests'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
           node-version: '12'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -98,7 +95,7 @@ jobs:
           node-version: '12'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -21,9 +21,6 @@ on:
   workflow_dispatch:
 
 
-env:
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
 defaults:
   run:
     shell: bash
@@ -33,9 +30,6 @@ jobs:
     name: opentrons documentation build
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -47,7 +41,7 @@ jobs:
         with:
           project: 'api'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -33,17 +33,13 @@ jobs:
     name: 'js checks'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "ACTIONS_ALLOW_UNSECURE_COMMANDS=true" >> $GITHUB_ENV
-          echo "::warning Remove this as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
           node-version: '12'
       - name: 'set complex environment variables'
         id: 'set-vars'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -21,8 +21,6 @@ on:
       - 'shared-data/*/**'
   workflow_dispatch:
 
-env:
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 defaults:
   run:
@@ -54,9 +52,6 @@ jobs:
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
-      - name: 'set insecure variable to work around actions/github-script not being updated'
-        run: |
-          echo "::warning Remove the environment entry ACTIONS_ALLOW_UNSECURE_COMMANDS as soon as possible once https://github.com/actions/github-script/pull/91 gets merged, actions/github-script gets a release, and we rely on it later in this workflow"
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
         with:
@@ -68,7 +63,7 @@ jobs:
         with:
           project: 'shared-data/python'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
@@ -92,7 +87,7 @@ jobs:
         with:
           project: 'shared-data/python'
       - name: 'set complex environment variables'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v3.1
         with:
           script: |
             const { buildComplexEnvVars, } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)


### PR DESCRIPTION
This uses the version of actions/core to the one that uses the new
environment file implementation of setting environment commands, which
allows us to remove the allow-insecure flag from our builds.
