### PR TITLE
fix(protocol-designer): skip 10000s of redundant state updates

### DIFF
--- a/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
+++ b/protocol-designer/src/step-generation/utils/reduceCommandCreators.js
@@ -40,9 +40,9 @@ export const reduceCommandCreators = (
 
       const allCommands = [...prev.commands, ...next.commands]
       const updates = getNextRobotStateAndWarnings(
-        allCommands,
+        next.commands,
         invariantContext,
-        initialRobotState
+        prev.robotState
       )
       return {
         ...prev,


### PR DESCRIPTION
Related to #6675 but instead of making cloning faster (which is good regardless) it just skips a lot of redundant cloning. This PR serves as its own ticket!

# Overview

Long story short -- a vast majority of the compute time is spent in `getNextRobotStateAndWarnings`. This expensive function was being called hundreds of thousands of times in a protocol that only needed to call it a few hundred times. 

This function is called by `reduceCommandCreators`, which is a somewhat recursive function because curried commands can be nested indefinitely. So `reduceCommandCreators` may execute thousands of times during protocol generation. The way it was written (my fault!) was re-calculating the state FROM SCRATCH many many times. This PR simply makes it so `reduceCommandCreators` instead builds up the state from where it left off, instead of starting from scratch over and over.

Test cases:
- this protocol [so many subtransfers.json.zip](https://github.com/Opentrons/opentrons/files/5598683/so.many.subtransfers.json.zip) takes me 3-4 sec to upload on this PR branch. On the edge sandbox build, the same upload takes me 1m37s.
- The new benchmark that does multiple transfers isn't committed into the repo yet (see Shlok's PR), but it looks like it goes from ~1.5s to ~360ms, roughly!

## Details

From lots of logging, I found that `getNextRobotStateAndWarnings` was responsible for most of the protocol load time upon importing a protocol. The `getNextRobotStateAndWarnings` fn was being called with a sort of stuttering repetition of the same commands, which can look like:

1. Pick up tip A1
2. Pick up tip A1
3. Pick up tip A1; aspirate
4. Pick up tip A1; aspirate; dispense
5. Drop tip
6. Drop tip; pick up tip B1
7. Pick up tip A1; aspirate; dispense, drop tip; pick up tip B1
8. Pick up tip A1; aspirate; dispense, drop tip; pick up tip B1; aspirate
9. Pick up tip A1; aspirate; dispense, drop tip; pick up tip B1; aspirate; dispense
10. Drop tip
11. Drop tip; pick up tip C1
12. everything from pick up tip A1 to pick up tip C1
... and so on.

This repetition keeps building up and up and the curried command creators are reduced and the state is re-built from different points.

# Changelog

# Review requests

- Thoroughly check that state updates are doing the same exact thing, nothing weird happens over the course of a protocol with tips or liquids etc. Should be able to compare this branch's sandbox build to edge, flicking back between 2 tabs. (Migration tests should cover this, and so should unit tests in step-generation, but just to make sure...)

# Risk assessment

PD-only. High, though all tests pass, let's make sure that state updates are still robust and correct