### PR TITLE
refactor(api): type harvested commands and dependents including RPC session machinery

### DIFF
--- a/api/.flake8
+++ b/api/.flake8
@@ -27,17 +27,17 @@ per-file-ignores =
     src/opentrons/execute.py:ANN,D
     src/opentrons/simulate.py:ANN,D
     src/opentrons/types.py:ANN,D
-    src/opentrons/api/*:ANN,D
+    src/opentrons/api/*:D
     src/opentrons/calibration_storage/*:ANN,D
     src/opentrons/cli/*:ANN,D
-    src/opentrons/commands/*:ANN,D
+    src/opentrons/commands/*:D
+    src/opentrons/commands/util.py:ANN,D
     src/opentrons/config/*:ANN,D
     src/opentrons/data_storage/*:ANN,D
     src/opentrons/deck_calibration/*:ANN,D
     src/opentrons/drivers/*:ANN,D
     src/opentrons/hardware_control/*:ANN,D
     src/opentrons/helpers/*:ANN,D
-    src/opentrons/legacy_api/*:ANN,D
     src/opentrons/protocol_api/*:ANN,D
     src/opentrons/protocols/*:ANN,D
     src/opentrons/resources/*:ANN,D
@@ -61,7 +61,6 @@ per-file-ignores =
     tests/opentrons/containers/*:ANN,D
     tests/opentrons/data/*:ANN,D
     tests/opentrons/database/*:ANN,D
-    tests/opentrons/deck_calibration/*:ANN,D
     tests/opentrons/drivers/*:ANN,D
     tests/opentrons/hardware_control/*:ANN,D
     tests/opentrons/helpers/*:ANN,D

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -4,9 +4,6 @@ ignore_missing_imports = False
 check_untyped_defs = True
 show_error_codes = True
 
-[mypy-opentrons.legacy_api.*]
-check_untyped_defs = False
-
 [mypy-opentrons.server.serialize]
 check_untyped_defs = False
 
@@ -16,13 +13,7 @@ check_untyped_defs = False
 [mypy-opentrons.tools.*]
 check_untyped_defs = False
 
-[mypy-opentrons.commands.*]
-check_untyped_defs = False
-
 [mypy-opentrons.helpers.*]
-check_untyped_defs = False
-
-[mypy-opentrons.deck_calibration.*]
 check_untyped_defs = False
 
 [pydantic-mypy]

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 import functools
 import logging
 from copy import copy
 from typing import Optional
+from typing_extensions import TypedDict, Literal, Final
 
 from opentrons.config import feature_flags as ff
 from opentrons.broker import Broker
@@ -43,12 +45,18 @@ def _home_if_first_call(func):
     return decorated
 
 
+class Message(TypedDict):
+    topic: Literal['calibration']
+    name: Literal['state']
+    payload: CalibrationManager
+
+
 class CalibrationManager(RobotBusy):
     """
     Serves endpoints that are primarily used in
     opentrons/app/ui/robot/api-client/client.js
     """
-    TOPIC = 'calibration'
+    TOPIC: Final = 'calibration'
 
     def __init__(self, hardware, loop=None, broker=None, lock=None):
         self._broker = broker or Broker()
@@ -235,7 +243,7 @@ class CalibrationManager(RobotBusy):
         delta = here - orig
         labware.save_calibration(container._container, delta)
 
-    def _snapshot(self):
+    def _snapshot(self) -> Message:
         return {
             'topic': CalibrationManager.TOPIC,
             'name': 'state',

--- a/api/src/opentrons/api/dev_types.py
+++ b/api/src/opentrons/api/dev_types.py
@@ -1,3 +1,4 @@
+from typing import Optional, List
 from typing_extensions import Literal, TypedDict
 
 State = Literal[
@@ -15,3 +16,28 @@ class StateInfo(TypedDict, total=False):
     userMessage: str
     #: If provided by the mechanism that changed the state, a message from the
     #: user
+
+
+class LastCommand(TypedDict):
+    id: int
+    handledAt: int
+
+
+class Error(TypedDict):
+    timestamp: int
+    error: Exception
+
+
+class SnapPayload(TypedDict):
+    state: State
+    stateInfo: StateInfo
+    startTime: Optional[float]
+    doorState: Optional[str]
+    blocked: Optional[bool]
+    errors: List[Error]
+    lastCommand: Optional[LastCommand]
+
+
+class Message(TypedDict):
+    topic: Literal['session']
+    payload: SnapPayload

--- a/api/src/opentrons/api/dev_types.py
+++ b/api/src/opentrons/api/dev_types.py
@@ -41,3 +41,9 @@ class SnapPayload(TypedDict):
 class Message(TypedDict):
     topic: Literal['session']
     payload: SnapPayload
+
+
+class CommandShortId(TypedDict):
+    level: int
+    description: str
+    id: int

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -16,9 +16,8 @@ class Container:
     def __init__(
             self,
             container: labware.Labware,
-            instruments: List[InstrumentContext] = None,
-            context: ProtocolContext = None):
-        instruments = instruments or []
+            instruments: List[InstrumentContext],
+            context: ProtocolContext):
         self._container = container
         self._context = context
         self.id = id(container)
@@ -36,7 +35,7 @@ class Container:
         self.definition_hash = labware.get_labware_hash_with_parent(
             container)
         self.instruments = [
-            Instrument(instrument)
+            Instrument(instrument, [], self._context)
             for instrument in instruments]
 
 
@@ -44,8 +43,8 @@ class Instrument:
     def __init__(
             self,
             instrument: InstrumentContext,
-            containers: List[labware.Labware] = None,
-            context: ProtocolContext = None):
+            containers: List[labware.Labware],
+            context: ProtocolContext):
         containers = containers or []
         self._instrument = instrument
         self._context = context
@@ -58,11 +57,11 @@ class Instrument:
         self.channels = instrument.channels
         self.mount = instrument.mount
         self.containers = [
-            Container(container)
+            Container(container, [], self._context)
             for container in containers
         ]
         self.tip_racks = [
-            Container(container)
+            Container(container, [], self._context)
             for container in instrument.tip_racks]
         if context:
             self.tip_racks.extend([
@@ -74,7 +73,7 @@ class Module:
     def __init__(
             self,
             module: module_geometry.ModuleGeometry,
-            context: ProtocolContext = None):
+            context: ProtocolContext):
         self.id = id(module)
         _type_lookup = {
             module_geometry.ModuleType.MAGNETIC: 'magdeck',

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,4 +1,7 @@
-from opentrons.protocol_api import labware
+from typing import List
+from opentrons.protocol_api import (
+    labware, InstrumentContext, ProtocolContext)
+
 from opentrons.protocols.geometry import module_geometry
 
 
@@ -10,7 +13,11 @@ def _get_parent_slot_and_position(labware_obj):
 
 
 class Container:
-    def __init__(self, container, instruments=None, context=None):
+    def __init__(
+            self,
+            container: labware.Labware,
+            instruments: List[InstrumentContext] = None,
+            context: ProtocolContext = None):
         instruments = instruments or []
         self._container = container
         self._context = context
@@ -34,7 +41,11 @@ class Container:
 
 
 class Instrument:
-    def __init__(self, instrument, containers=None, context=None):
+    def __init__(
+            self,
+            instrument: InstrumentContext,
+            containers: List[labware.Labware] = None,
+            context: ProtocolContext = None):
         containers = containers or []
         self._instrument = instrument
         self._context = context
@@ -60,7 +71,10 @@ class Instrument:
 
 
 class Module:
-    def __init__(self, module, context=None):
+    def __init__(
+            self,
+            module: module_geometry.ModuleGeometry,
+            context: ProtocolContext = None):
         self.id = id(module)
         _type_lookup = {
             module_geometry.ModuleType.MAGNETIC: 'magdeck',

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,15 +1,19 @@
-from typing import List
+from typing import cast, List, Optional, Tuple
+from opentrons.types import Point
 from opentrons.protocol_api import (
     labware, InstrumentContext, ProtocolContext)
 
 from opentrons.protocols.geometry import module_geometry
 
 
-def _get_parent_slot_and_position(labware_obj):
+def _get_parent_slot_and_position(
+        labware_obj: labware.Labware) -> Tuple[str, Optional[Point]]:
     if isinstance(labware_obj.parent, (module_geometry.ModuleGeometry)):
-        return (labware_obj.parent.parent, labware_obj.parent.labware_offset)
+        return (
+            cast(str, labware_obj.parent.parent),
+            labware_obj.parent.labware_offset)
     else:
-        return (labware_obj.parent, None)
+        return (cast(str, labware_obj.parent), None)
 
 
 class Container:
@@ -17,7 +21,7 @@ class Container:
             self,
             container: labware.Labware,
             instruments: List[InstrumentContext],
-            context: ProtocolContext):
+            context: ProtocolContext) -> None:
         self._container = container
         self._context = context
         self.id = id(container)
@@ -44,7 +48,7 @@ class Instrument:
             self,
             instrument: InstrumentContext,
             containers: List[labware.Labware],
-            context: ProtocolContext):
+            context: ProtocolContext) -> None:
         containers = containers or []
         self._instrument = instrument
         self._context = context
@@ -73,7 +77,7 @@ class Module:
     def __init__(
             self,
             module: module_geometry.ModuleGeometry,
-            context: ProtocolContext):
+            context: ProtocolContext) -> None:
         self.id = id(module)
         _type_lookup = {
             module_geometry.ModuleType.MAGNETIC: 'magdeck',

--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -12,7 +12,7 @@ class MainRouter:
             self,
             hardware: ThreadManager,
             loop: AbstractEventLoop = None,
-            lock: ThreadedAsyncLock = None):
+            lock: ThreadedAsyncLock = None) -> None:
         topics = [Session.TOPIC, CalibrationManager.TOPIC]
         self._broker = Broker()
         self._notifications: Notifications[
@@ -31,9 +31,10 @@ class MainRouter:
                                                       lock=lock)
 
     @property
-    def notifications(self):
+    def notifications(self) -> Notifications[
+            Union[SessionMessage, CalibrationMessage]]:
         return self._notifications
 
     @property
-    def broker(self):
+    def broker(self) -> Broker:
         return self._broker

--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -1,21 +1,25 @@
+from asyncio import AbstractEventLoop
 from typing import Union
 from opentrons.broker import Notifications, Broker
+from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 from .session import SessionManager, Session
 from .dev_types import Message as SessionMessage
 from .calibration import (CalibrationManager, Message as CalibrationMessage)
 
 
 class MainRouter:
-    def __init__(self, hardware=None, loop=None, lock=None):
+    def __init__(
+            self,
+            hardware: ThreadManager,
+            loop: AbstractEventLoop = None,
+            lock: ThreadedAsyncLock = None):
         topics = [Session.TOPIC, CalibrationManager.TOPIC]
         self._broker = Broker()
         self._notifications: Notifications[
             Union[SessionMessage, CalibrationMessage]] = Notifications(
                 topics, self._broker, loop=loop)
 
-        checked_hw = None
-        if hardware:
-            checked_hw = hardware.sync
+        checked_hw = hardware.sync
         self.session_manager = SessionManager(
             hardware=checked_hw,
             loop=loop,

--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -1,13 +1,17 @@
+from typing import Union
 from opentrons.broker import Notifications, Broker
 from .session import SessionManager, Session
-from .calibration import CalibrationManager
+from .dev_types import Message as SessionMessage
+from .calibration import (CalibrationManager, Message as CalibrationMessage)
 
 
 class MainRouter:
     def __init__(self, hardware=None, loop=None, lock=None):
         topics = [Session.TOPIC, CalibrationManager.TOPIC]
         self._broker = Broker()
-        self._notifications = Notifications(topics, self._broker, loop=loop)
+        self._notifications: Notifications[
+            Union[SessionMessage, CalibrationMessage]] = Notifications(
+                topics, self._broker, loop=loop)
 
         checked_hw = None
         if hardware:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -10,7 +10,7 @@ from typing import (
 from typing_extensions import Final
 from uuid import uuid4
 
-from opentrons_shared_data.labware import LabwareDefinition
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 from opentrons.api.util import (RobotBusy, robot_is_busy,
                                 requires_http_protocols_disabled)

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -5,7 +5,8 @@ from copy import copy
 from functools import reduce
 import logging
 from time import time, sleep
-from typing import cast, List, Dict, Any, Optional, Set, Sequence, Tuple, TypeVar
+from typing import (
+    cast, List, Dict, Any, Optional, Set, Sequence, Tuple, TypeVar, Iterator)
 from typing_extensions import Final
 from uuid import uuid4
 
@@ -668,7 +669,7 @@ def _accumulate(iterable: Sequence[CommandReferents]) -> CommandReferents:
 It = TypeVar('It')
 
 
-def _dedupe(iterable: Sequence[It]) -> Sequence[It]:
+def _dedupe(iterable: Sequence[It]) -> Iterator[It]:
     acc: Set[It] = set()
 
     for item in iterable:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -666,6 +666,8 @@ def _accumulate(iterable: Sequence[CommandReferents]) -> CommandReferents:
 
 
 It = TypeVar('It')
+
+
 def _dedupe(iterable: Sequence[It]) -> Sequence[It]:
     acc: Set[It] = set()
 

--- a/api/src/opentrons/api/util.py
+++ b/api/src/opentrons/api/util.py
@@ -1,5 +1,6 @@
 import functools
 from abc import ABC, abstractmethod
+from typing import Any, cast, Callable, TypeVar
 
 from opentrons.config.feature_flags import enable_http_protocol_sessions
 from opentrons.hardware_control import ThreadedAsyncLock
@@ -12,7 +13,10 @@ class RobotBusy(ABC):
         ...
 
 
-def robot_is_busy(func):
+Func = TypeVar('Func', bound=Callable[..., Any])
+
+
+def robot_is_busy(func: Func) -> Func:
     """ Decorator to mark a function as putting the robot in a busy
     state. Simultaneous attempts to call a busy function (from same or
     separate thread) will result in an exception.
@@ -21,28 +25,30 @@ def robot_is_busy(func):
      :raises ThreadedAsyncForbidden: on call during busy.
      """
     @functools.wraps(func)
-    def decorated(*args, **kwargs):
+    def decorated(*args: Any, **kwargs: Any) -> Any:
         self = args[0]
         if self.busy_lock:
             with self.busy_lock.forbid():
                 return func(*args, **kwargs)
         else:
             return func(*args, **kwargs)
-    return decorated
+
+    return cast(Func, decorated)
 
 
-def requires_http_protocols_disabled(func):
+def requires_http_protocols_disabled(func: Func) -> Func:
     """Decorator that makes sure the enableHttpProtocolSessions is disabled
     before proceeding.
 
     :raises RuntimeError: if enableHttpProtocolSessions is enabled
     """
     @functools.wraps(func)
-    def decorated(*args, **kwargs):
+    def decorated(*args: Any, **kwargs: Any) -> Any:
         if enable_http_protocol_sessions():
             raise RuntimeError(
                 "Please disable the 'Enable Experimental HTTP Protocol "
                 "Sessions' advanced setting for this robot if you'd like to "
                 "upload protocols from the Opentrons App")
         return func(*args, **kwargs)
-    return decorated
+
+    return cast(Func, decorated)

--- a/api/src/opentrons/broker.py
+++ b/api/src/opentrons/broker.py
@@ -1,16 +1,33 @@
+from __future__ import annotations
 import asyncio
-import logging
-
 from asyncio import Queue
 from contextlib import contextmanager
+import logging
+from typing import (
+    Any, Callable, Dict, Sequence, overload, Generic, TypeVar,
+    cast, TYPE_CHECKING)
+from typing_extensions import Literal
+
+from opentrons.commands import types
+
+if TYPE_CHECKING:
+    from opentrons.api.dev_types import Message as SessionStateMessage
+    from opentrons.api.calibration import Message as CalibrationStateMessage
+
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
-class Notifications(object):
-    def __init__(self, topics, broker, loop=None):
+UntypedMessage = Dict[str, Any]
+
+
+_HandledMessages = TypeVar('_HandledMessages')
+
+
+class Notifications(Generic[_HandledMessages]):
+    def __init__(self, topics: Sequence[str], broker: Broker, loop=None):
         self.loop = loop or asyncio.get_event_loop()
-        self.queue = Queue(loop=self.loop)  # type: ignore
+        self.queue: Queue[UntypedMessage] = Queue(loop=self.loop)
         self.snoozed = False
         self._unsubscribe = [
             broker.subscribe(topic, self.on_notify) for topic in topics]
@@ -23,23 +40,48 @@ class Notifications(object):
         finally:
             self.snoozed = False
 
-    def on_notify(self, message):
+    def on_notify(self, message: UntypedMessage):
         if self.snoozed:
             return
         self.queue.put_nowait(message)
 
-    async def __anext__(self):
-        return await self.queue.get()
+    async def __anext__(self) -> _HandledMessages:
+        msg = await self.queue.get()
+        return cast(_HandledMessages, msg)
 
     def __aiter__(self):
         return self
 
 
 class Broker:
-
     def __init__(self):
         self.subscriptions = {}
         self.logger = MODULE_LOG
+
+    @overload
+    def subscribe(
+            self,
+            topic: Literal['command'],
+            handler: Callable[[types.CommandMessage], None]) -> Callable[[], None]: ...
+
+    @overload
+    def subscribe(
+            self,
+            topic: Literal['calibration'],
+            handler: Callable[[CalibrationStateMessage], None])\
+        -> Callable[[], None]: ...
+
+    @overload
+    def subscribe(
+            self,
+            topic: Literal['session'],
+            handler: Callable[[SessionStateMessage], None]) -> Callable[[], None]: ...
+
+    @overload
+    def subscribe(
+            self,
+            topic: str,
+            handler: Callable[[UntypedMessage], None]) -> Callable[[], None]: ...
 
     def subscribe(self, topic, handler):
         if handler in self.subscriptions.setdefault(topic, []):
@@ -50,6 +92,23 @@ class Broker:
             self.subscriptions[topic].remove(handler)
 
         return unsubscribe
+
+    @overload
+    def publish(
+            self, topic: Literal['command'], message: types.CommandMessage) -> None: ...
+
+    @overload
+    def publish(
+            self,
+            topic: Literal['calibration'],
+            message: CalibrationStateMessage) -> None: ...
+
+    @overload
+    def publish(
+            self, topic: Literal['session'], message: SessionStateMessage) -> None: ...
+
+    @overload
+    def publish(self, topic: str, message: UntypedMessage) -> None: ...
 
     def publish(self, topic, message):
         [handler(message) for handler in self.subscriptions.get(topic, [])]

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Union, overload
 
 
 from .helpers import stringify_location, listify
@@ -140,6 +140,14 @@ def transfer(
             'text': text
         }
     }
+
+
+@overload
+def transform_volumes(volumes: Union[float, int]) -> float: ...
+
+
+@overload
+def transform_volumes(volumes: List[Union[float]]) -> List[float]: ...
 
 
 def transform_volumes(volumes):

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -4,10 +4,6 @@ from opentrons.protocol_api.labware import Well
 from opentrons.types import Location
 
 
-def make_command(name, payload):
-    return {'name': name, 'payload': payload}
-
-
 CommandLocation = Union[Location, None, Sequence, Well]
 
 

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -8,6 +8,9 @@ def make_command(name, payload):
     return {'name': name, 'payload': payload}
 
 
+CommandLocation = Union[Location, None, Sequence, Well]
+
+
 def listify(location: Any) -> List:
     if isinstance(location, list):
         try:
@@ -30,8 +33,7 @@ def _stringify_new_loc(loc: Union[Location, Well]) -> str:
         raise TypeError(loc)
 
 
-def stringify_location(location: Union[Location, None,
-                                       Sequence]) -> str:
+def stringify_location(location: CommandLocation) -> str:
     loc_str_list = [_stringify_new_loc(loc)
                     for loc in listify(location)]
     return ', '.join(loc_str_list)

--- a/api/src/opentrons/commands/introspection.py
+++ b/api/src/opentrons/commands/introspection.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import cast, Tuple, TYPE_CHECKING, List, Union, Optional
+from opentrons.types import Location
+from opentrons.protocols.api_support import labware_like
+
+import opentrons.commands.types as command_types
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api import InstrumentContext
+    from opentrons.protocol_api.labware import Labware, Well
+    from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+    ReferredObjects = Tuple[
+        List[InstrumentContext], List[Labware], List[ModuleGeometry]]
+
+
+def _labware_from_location(loc: Union[Location, Well]) -> Labware:
+    if isinstance(loc, Location):
+        if not loc.labware:
+            raise ValueError('Cannot handle location without labware')
+        labware, _ = loc.labware.get_parent_labware_and_well()
+        if not labware:
+            raise ValueError(f'Cannot handle location {loc}')
+        return labware
+    else:
+        return loc.parent
+
+# The casts and type: ignores in _get_locations and _get_instruments are necessary
+# until we either a) refactor this so payloads have tags that mypy can use to
+# discriminate the unions (or make commands dataclasses that can be checked with
+# isinstance) or b) mypy learns full disjoint union discrimination.
+
+
+def _get_locations(
+        command: command_types.HasLocationPayload) -> List[Optional[Labware]]:
+    if 'location' in command and command['location']:  # type: ignore
+        return [_labware_from_location(
+            cast(command_types.SingleLocationPayload, command)['location'])]
+    elif 'locations' in command and command['locations']:  # type: ignore
+        return [_labware_from_location(loc) for loc in
+                cast(command_types.MultiLocationPayload, command)['locations']]
+    else:
+        return []
+
+
+def _get_instruments(
+        command: command_types.HasInstrumentPayload) -> List[InstrumentContext]:
+    if 'instrument' in command:  # type: ignore
+        return [cast(command_types.SingleInstrumentPayload, command)['instrument']]
+    else:  # type: ignore
+        return [
+            inst for inst
+            in cast(command_types.MultiInstrumentPayload, command)['instruments']]
+
+
+def get_referred_objects(command: command_types.CommandPayload) -> ReferredObjects:
+    if 'location' in command or 'locations' in command:
+        locations = [lw for lw in _get_locations(
+            cast(command_types.HasLocationPayload, command)) if lw is not None]
+    else:
+        locations = []
+    if 'instrument' in command or 'instruments' in command:
+        instruments = _get_instruments(
+            cast(command_types.HasInstrumentPayload, command))
+    else:
+        instruments = []
+
+    maybe_modules = [
+        labware_like.LabwareLike(labware).module_parent() for labware in locations]
+    return instruments, locations, [mod for mod in maybe_modules if mod]

--- a/api/src/opentrons/commands/module_commands.py
+++ b/api/src/opentrons/commands/module_commands.py
@@ -1,80 +1,83 @@
-from opentrons.drivers import utils
+from typing import List
 
-from .helpers import make_command
+from opentrons.drivers import utils
+from opentrons.hardware_control.modules import ThermocyclerStep
+
 from . import types as command_types
 
 
-def magdeck_engage():
+def magdeck_engage() -> command_types.MagdeckEngageCommand:
     text = "Engaging Magnetic Module"
-    return make_command(
-        name=command_types.MAGDECK_ENGAGE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.MAGDECK_ENGAGE,
+        'payload': {'text': text}
+    }
 
 
-def magdeck_disengage():
+def magdeck_disengage() -> command_types.MagdeckDisengageCommand:
     text = "Disengaging Magnetic Module"
-    return make_command(
-        name=command_types.MAGDECK_DISENGAGE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.MAGDECK_DISENGAGE,
+        'payload': {'text': text}
+    }
 
 
-def magdeck_calibrate():
+def magdeck_calibrate() -> command_types.MagdeckCalibrateCommand:
     text = "Calibrating Magnetic Module"
-    return make_command(
-        name=command_types.MAGDECK_CALIBRATE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.MAGDECK_CALIBRATE,
+        'payload': {'text': text}
+    }
 
 
-def tempdeck_set_temp(celsius):
-    text = "Setting Temperature Module temperature " \
-           "to {temp} °C (rounded off to nearest integer)".format(
-            temp=round(float(celsius),
-                       utils.TEMPDECK_GCODE_ROUNDING_PRECISION))
-    return make_command(
-        name=command_types.TEMPDECK_SET_TEMP,
-        payload={
+def tempdeck_set_temp(celsius: float) -> command_types.TempdeckSetTempCommand:
+    temp = round(float(celsius),
+                 utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
+    text = f"Setting Temperature Module temperature " \
+           f"to {temp} °C (rounded off to nearest integer)"
+    return {
+        'name': command_types.TEMPDECK_SET_TEMP,
+        'payload': {
             'celsius': celsius,
             'text': text
         }
-    )
+    }
 
 
-def tempdeck_await_temp(celsius):
+def tempdeck_await_temp(celsius: float) -> command_types.TempdeckAwaitTempCommand:
     text = "Waiting for Temperature Module to reach temperature " \
            "{temp} °C (rounded off to nearest integer)".format(
             temp=round(float(celsius),
                        utils.TEMPDECK_GCODE_ROUNDING_PRECISION))
-    return make_command(
-        name=command_types.TEMPDECK_AWAIT_TEMP,
-        payload={
+    return {
+        'name': command_types.TEMPDECK_AWAIT_TEMP,
+        'payload': {
             'celsius': celsius,
             'text': text
         }
-    )
+    }
 
 
-def tempdeck_deactivate():
+def tempdeck_deactivate() -> command_types.TempdeckDeactivateCommand:
     text = "Deactivating Temperature Module"
-    return make_command(
-        name=command_types.TEMPDECK_DEACTIVATE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.TEMPDECK_DEACTIVATE,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_open():
+def thermocycler_open() -> command_types.ThermocyclerOpenCommand:
     text = "Opening Thermocycler lid"
-    return make_command(
-        name=command_types.THERMOCYCLER_OPEN,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_OPEN,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_set_block_temp(temperature,
-                                hold_time_seconds,
-                                hold_time_minutes):
+def thermocycler_set_block_temp(
+        temperature: float,
+        hold_time_seconds: float,
+        hold_time_minutes: float) -> command_types.ThermocyclerSetBlockTempCommand:
     temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
     text = f'Setting Thermocycler well block temperature to {temp} °C'
     total_seconds = None
@@ -93,88 +96,91 @@ def thermocycler_set_block_temp(temperature,
         if clean_minutes > 0:
             text += f'{clean_minutes} minutes and '
         text += f'{clean_seconds} seconds'
-    return make_command(
-        name=command_types.THERMOCYCLER_SET_BLOCK_TEMP,
-        payload={
+    return {
+        'name': command_types.THERMOCYCLER_SET_BLOCK_TEMP,
+        'payload': {
             'temperature': temperature,
             'hold_time': total_seconds,
             'text': text
         }
-    )
+    }
 
 
-def thermocycler_execute_profile(steps, repetitions):
+def thermocycler_execute_profile(
+        steps: List[ThermocyclerStep],
+        repetitions: int) -> command_types.ThermocyclerExecuteProfileCommand:
     text = f'Thermocycler starting {repetitions} repetitions' \
             ' of cycle composed of the following steps: {steps}'
-    return make_command(
-        name=command_types.THERMOCYCLER_EXECUTE_PROFILE,
-        payload={
+    return {
+        'name': command_types.THERMOCYCLER_EXECUTE_PROFILE,
+        'payload': {
             'text': text,
             'steps': steps
         }
-    )
+    }
 
 
-def thermocycler_wait_for_hold():
+def thermocycler_wait_for_hold() -> command_types.ThermocyclerWaitForHoldCommand:
     text = "Waiting for hold time duration"
-    return make_command(
-        name=command_types.THERMOCYCLER_WAIT_FOR_HOLD,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_WAIT_FOR_HOLD,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_wait_for_temp():
+def thermocycler_wait_for_temp() -> command_types.ThermocyclerWaitForTempCommand:
     text = "Waiting for Thermocycler to reach target"
-    return make_command(
-        name=command_types.THERMOCYCLER_WAIT_FOR_TEMP,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_WAIT_FOR_TEMP,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_set_lid_temperature(temperature):
+def thermocycler_set_lid_temperature(
+        temperature: float) -> command_types.ThermocyclerSetLidTempCommand:
     temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
     text = f'Setting Thermocycler lid temperature to {temp} °C'
-    return make_command(
-        name=command_types.THERMOCYCLER_SET_LID_TEMP,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_SET_LID_TEMP,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_deactivate_lid():
+def thermocycler_deactivate_lid() -> command_types.ThermocyclerDeactivateLidCommand:
     text = "Deactivating Thermocycler lid heating"
-    return make_command(
-        name=command_types.THERMOCYCLER_DEACTIVATE_LID,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_DEACTIVATE_LID,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_deactivate_block():
+def thermocycler_deactivate_block() -> command_types.ThermocyclerDeactivateBlockCommand:
     text = "Deactivating Thermocycler well block heating"
-    return make_command(
-        name=command_types.THERMOCYCLER_DEACTIVATE_BLOCK,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_DEACTIVATE_BLOCK,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_deactivate():
+def thermocycler_deactivate() -> command_types.ThermocyclerDeactivateCommand:
     text = "Deactivating Thermocycler"
-    return make_command(
-        name=command_types.THERMOCYCLER_DEACTIVATE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_DEACTIVATE,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_wait_for_lid_temp():
+def thermocycler_wait_for_lid_temp() -> command_types.ThermocyclerWaitForLidTempCommand:
     text = "Waiting for Thermocycler lid to reach target temperature"
-    return make_command(
-        name=command_types.THERMOCYCLER_WAIT_FOR_LID_TEMP,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_WAIT_FOR_LID_TEMP,
+        'payload': {'text': text}
+    }
 
 
-def thermocycler_close():
+def thermocycler_close() -> command_types.ThermocyclerCloseCommand:
     text = "Closing Thermocycler lid"
-    return make_command(
-        name=command_types.THERMOCYCLER_CLOSE,
-        payload={'text': text}
-    )
+    return {
+        'name': command_types.THERMOCYCLER_CLOSE,
+        'payload': {'text': text}
+    }

--- a/api/src/opentrons/commands/paired_commands.py
+++ b/api/src/opentrons/commands/paired_commands.py
@@ -1,4 +1,4 @@
-from .helpers import make_command, stringify_location
+from .helpers import stringify_location
 from . import types as command_types
 
 from typing import Union, Sequence, Optional, TYPE_CHECKING
@@ -30,149 +30,149 @@ def combine_locations(location: Sequence) -> str:
 def paired_aspirate(
         instruments: Apiv2Instruments, volume: float,
         locations: Apiv2Locations, rate: float,
-        pub_type: str):
+        pub_type: str) -> command_types.AspirateCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
         rate * FlowRates(instr).aspirate for instr in instruments)
     text_type = f'{pub_type}: Aspirating '
     text_content = f'{volume} uL from {loc_text} at {flow_rate} uL/sec'
     text = text_type + text_content
-    return make_command(
-        name=command_types.ASPIRATE,
-        payload={
+    return {
+        'name': command_types.ASPIRATE,
+        'payload': {
             'instruments': instruments,
             'volume': volume,
             'locations': locations,
             'rate': rate,
             'text': text
         }
-    )
+    }
 
 
 def paired_dispense(
         instruments: Apiv2Instruments, volume: float,
         locations: Apiv2Locations, rate: float,
-        pub_type: str):
+        pub_type: str) -> command_types.DispenseCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
         rate * FlowRates(instr).dispense for instr in instruments)
     text_type = f'{pub_type}: Dispensing '
     text_content = f'{volume} uL into {loc_text} at {flow_rate} uL/sec'
     text = text_type + text_content
-    return make_command(
-        name=command_types.ASPIRATE,
-        payload={
+    return {
+        'name': command_types.DISPENSE,
+        'payload': {
             'instruments': instruments,
             'volume': volume,
             'locations': locations,
             'rate': rate,
             'text': text
         }
-    )
+    }
 
 
 def paired_mix(
-        instruments: Apiv2Instruments, locations: Apiv2Locations,
-        repetitions: int, volume: float, pub_type: str):
+        instruments: Apiv2Instruments, locations: Optional[Apiv2Locations],
+        repetitions: int, volume: float, pub_type: str) -> command_types.MixCommand:
     text_type = f'{pub_type}: Mixing '
     text_content = '{repetitions} times with a volume of {volume} ul'
     text = text_type + text_content
-    return make_command(
-        name=command_types.MIX,
-        payload={
+    return {
+        'name': command_types.MIX,
+        'payload': {
             'instruments': instruments,
             'locations': locations,
             'volume': volume,
             'repetitions': repetitions,
             'text': text
         }
-    )
+    }
 
 
 def paired_blow_out(
         instruments: Apiv2Instruments,
         locations: Optional[Apiv2Locations],
-        pub_type: str):
+        pub_type: str) -> command_types.BlowOutCommand:
     text = f'{pub_type}: Blowing out'
 
     if locations is not None:
         location_text = combine_locations(locations)
         text += f' at {location_text}'
 
-    return make_command(
-        name=command_types.BLOW_OUT,
-        payload={
+    return {
+        'name': command_types.BLOW_OUT,
+        'payload': {
             'instruments': instruments,
             'locations': locations,
             'text': text
         }
-    )
+    }
 
 
 def paired_touch_tip(
         instruments: Apiv2Instruments,
         locations: Optional[Apiv2Locations],
-        pub_type: str):
+        pub_type: str) -> command_types.TouchTipCommand:
     text = f'{pub_type}: Touching tip'
 
     if locations is not None:
         location_text = combine_locations(locations)
         text += f' at {location_text}'
-    return make_command(
-        name=command_types.TOUCH_TIP,
-        payload={
+    return {
+        'name': command_types.TOUCH_TIP,
+        'payload': {
             'instruments': instruments,
             'locations': locations,
             'text': text
         }
-    )
+    }
 
 
-def air_gap():
+def air_gap() -> command_types.AirGapCommand:
     text = 'Air gap'
-    return make_command(
-        name=command_types.AIR_GAP,
-        payload={
+    return {
+        'name': command_types.AIR_GAP,
+        'payload': {
             'text': text
         }
-    )
+    }
 
 
-def return_tip():
+def return_tip() -> command_types.ReturnTipCommand:
     text = 'Returning tip'
-    return make_command(
-        name=command_types.RETURN_TIP,
-        payload={
+    return {
+        'name': command_types.RETURN_TIP,
+        'payload': {
             'text': text
         }
-    )
+    }
 
 
 def paired_pick_up_tip(
         instruments: Apiv2Instruments,
-        locations: Apiv2Locations, pub_type: str):
+        locations: Apiv2Locations, pub_type: str) -> command_types.PickUpTipCommand:
     location_text = combine_locations(locations)
     text = f'{pub_type}: Picking up tip from {location_text}'
-    return make_command(
-        name=command_types.PICK_UP_TIP,
-        payload={
+    return {
+        'name': command_types.PICK_UP_TIP,
+        'payload': {
             'instruments': instruments,
             'locations': locations,
             'text': text
         }
-    )
+    }
 
 
 def paired_drop_tip(
         instruments: Apiv2Instruments,
-        locations: Apiv2Locations, pub_type: str):
+        locations: Apiv2Locations, pub_type: str) -> command_types.DropTipCommand:
     location_text = combine_locations(locations)
     text = f'{pub_type}: Dropping tip into {location_text}'
-    return make_command(
-        name=command_types.DROP_TIP,
-        payload={
+    return {
+        'name': command_types.DROP_TIP,
+        'payload': {
             'instruments': instruments,
             'locations': locations,
             'text': text
         }
-    )
+    }

--- a/api/src/opentrons/commands/protocol_commands.py
+++ b/api/src/opentrons/commands/protocol_commands.py
@@ -1,53 +1,51 @@
 from datetime import timedelta
 
-from .helpers import make_command
 from . import types as command_types
 
 
-def comment(msg):
+def comment(msg: str) -> command_types.CommentCommand:
     text = msg
-    return make_command(
-        name=command_types.COMMENT,
-        payload={
-            'text': text
-        }
-    )
+    return {
+        'name': command_types.COMMENT,
+        'payload': {'text': text}
+    }
 
 
-def delay(seconds, minutes, msg=None):
+def delay(
+        seconds: float,
+        minutes: float,
+        msg: str = None) -> command_types.DelayCommand:
     td = timedelta(minutes=minutes, seconds=seconds)
     minutes, seconds = divmod(td.seconds, 60)
 
     text = f"Delaying for {minutes} minutes and {seconds} seconds"
     if msg:
         text = f"{text}. {msg}"
-    return make_command(
-        name=command_types.DELAY,
-        payload={
+    return {
+        'name': command_types.DELAY,
+        'payload': {
             'minutes': minutes,
             'seconds': seconds,
             'text': text
         }
-    )
+    }
 
 
-def pause(msg):
+def pause(msg: str = None) -> command_types.PauseCommand:
     text = 'Pausing robot operation'
     if msg:
         text = text + ': {}'.format(msg)
-    return make_command(
-        name=command_types.PAUSE,
-        payload={
+    return {
+        'name': command_types.PAUSE,
+        'payload': {
             'text': text,
             'userMessage': msg,
         }
-    )
+    }
 
 
-def resume():
-    return make_command(
-        name=command_types.RESUME,
-        payload={
-            'text': 'Resuming robot operation'
-        }
-    )
+def resume() -> command_types.ResumeCommand:
+    return {
+        'name': command_types.RESUME,
+        'payload': {'text': 'Resuming robot operation'}
+    }

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -1,20 +1,20 @@
 import functools
 import inspect
-from typing import Any, Callable, cast
+from typing import Any, Callable, cast, Dict, Tuple, Mapping
 from opentrons.broker import Broker
 from . import types as command_types
 
 
 class CommandPublisher:
-    def __init__(self, broker: Broker):
+    def __init__(self, broker: Broker) -> None:
         self._broker = broker or Broker()
 
     @property
-    def broker(self):
+    def broker(self) -> Broker:
         return self._broker
 
     @broker.setter
-    def broker(self, broker):
+    def broker(self, broker: Broker) -> None:
         self._broker = broker
 
 
@@ -28,7 +28,7 @@ def do_publish(
         when: command_types.MessageSequenceId,
         res: Any,
         meta: Any,
-        *args, **kwargs):
+        *args: Any, **kwargs: Any) -> None:
     """ Implement the publish so it can be called outside the decorator """
     publish_command = functools.partial(
         broker.publish,
@@ -77,8 +77,8 @@ def publish_paired(
         cmd: CmdFunction,
         when: command_types.MessageSequenceId,
         res: Any,
-        *args,
-        pub_type='Paired Pipettes'):
+        *args: Any,
+        pub_type: str = 'Paired Pipettes') -> None:
     """ Implement a second publisher outside of the decorator that
     relies on the method providing all of the arguments required
     rather than binding defaults to the signature"""
@@ -92,12 +92,15 @@ def publish_paired(
 
 
 def _publish_dec(
-        before: bool, after: bool, command: CmdFunction, meta: Any = None):
-    def decorator(f: Callable):
+        before: bool,
+        after: bool,
+        command: CmdFunction,
+        meta: Any = None):  # noqa: ANN202
+    def _decorator(f: Callable):  # noqa: ANN202,ANN003,ANN002
         @functools.wraps(
             f,
             updated=functools.WRAPPER_UPDATES+('__globals__',))  # type: ignore
-        def decorated(*args, **kwargs):
+        def _decorated(*args, **kwargs):  # noqa: ANN202,ANN003,ANN002
             try:
                 broker = cast(Broker, args[0].broker)
             except AttributeError:
@@ -111,9 +114,9 @@ def _publish_dec(
                 do_publish(
                     broker, command, f, 'after', res, meta, *args, **kwargs)
             return res
-        return decorated
+        return _decorated
 
-    return decorator
+    return _decorator
 
 
 class publish:
@@ -134,14 +137,17 @@ class publish:
     both = functools.partial(_publish_dec, before=True, after=True)
 
 
-def _get_args(f, args, kwargs):
+def _get_args(
+        f: Callable,
+        args: Tuple,
+        kwargs: Mapping[str, Any]) -> Dict[str, Any]:
     # Create the initial dictionary with args that have defaults
     res = {}
     sig = inspect.signature(f)
-    if inspect.ismethod(f) and args[0] is f.__self__:
+    if inspect.ismethod(f) and args[0] is f.__self__:  # type: ignore
         args = args[1:]
     if inspect.ismethod(f):
-        res['self'] = f.__self__
+        res['self'] = f.__self__  # type: ignore
 
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -1,58 +1,676 @@
-COMMAND = 'command'
+from __future__ import annotations
+
+from typing_extensions import Literal, Final, TypedDict
+from typing import Optional, List, Sequence, TYPE_CHECKING, Union, Any
+from opentrons.hardware_control.modules import ThermocyclerStep
+
+if TYPE_CHECKING:
+    from opentrons.protocol_api import InstrumentContext
+    from opentrons.protocol_api.labware import Well
+
+from opentrons.types import Location
 
 
-# helpers #
-
-def makeRobotCommandName(name):
-    return '{}.{}'.format(COMMAND, name)
-
+# type for subscriptions
+COMMAND: Final = 'command'
 
 # Robot #
 
-DELAY = makeRobotCommandName('DELAY')
-HOME = makeRobotCommandName('HOME')
-PAUSE = makeRobotCommandName('PAUSE')
-RESUME = makeRobotCommandName('RESUME')
-COMMENT = makeRobotCommandName('COMMENT')
+DELAY: Final = 'command.DELAY'
+HOME: Final = 'command.HOME'
+PAUSE: Final = 'command.PAUSE'
+RESUME: Final = 'command.RESUME'
+COMMENT: Final = 'command.COMMENT'
 
 # Pipette #
 
-ASPIRATE = makeRobotCommandName('ASPIRATE')
-DISPENSE = makeRobotCommandName('DISPENSE')
-MIX = makeRobotCommandName('MIX')
-CONSOLIDATE = makeRobotCommandName('CONSOLIDATE')
-DISTRIBUTE = makeRobotCommandName('DISTRIBUTE')
-TRANSFER = makeRobotCommandName('TRANSFER')
-PICK_UP_TIP = makeRobotCommandName('PICK_UP_TIP')
-DROP_TIP = makeRobotCommandName('DROP_TIP')
-BLOW_OUT = makeRobotCommandName('BLOW_OUT')
-AIR_GAP = makeRobotCommandName('AIR_GAP')
-TOUCH_TIP = makeRobotCommandName('TOUCH_TIP')
-RETURN_TIP = makeRobotCommandName('RETURN_TIP')
+ASPIRATE: Final = 'command.ASPIRATE'
+DISPENSE: Final = 'command.DISPENSE'
+MIX: Final = 'command.MIX'
+CONSOLIDATE: Final = 'command.CONSOLIDATE'
+DISTRIBUTE: Final = 'command.DISTRIBUTE'
+TRANSFER: Final = 'command.TRANSFER'
+PICK_UP_TIP: Final = 'command.PICK_UP_TIP'
+DROP_TIP: Final = 'command.DROP_TIP'
+BLOW_OUT: Final = 'command.BLOW_OUT'
+AIR_GAP: Final = 'command.AIR_GAP'
+TOUCH_TIP: Final = 'command.TOUCH_TIP'
+RETURN_TIP: Final = 'command.RETURN_TIP'
 
 # Modules #
 
-MAGDECK_CALIBRATE = makeRobotCommandName('MAGDECK_CALIBRATE')
-MAGDECK_DISENGAGE = makeRobotCommandName('MAGDECK_DISENGAGE')
-MAGDECK_ENGAGE = makeRobotCommandName('MAGDECK_ENGAGE')
+MAGDECK_CALIBRATE: Final = 'command.MAGDECK_CALIBRATE'
+MAGDECK_DISENGAGE: Final = 'command.MAGDECK_DISENGAGE'
+MAGDECK_ENGAGE: Final = 'command.MAGDECK_ENGAGE'
 
-TEMPDECK_DEACTIVATE = makeRobotCommandName('TEMPDECK_DEACTIVATE')
-TEMPDECK_SET_TEMP = makeRobotCommandName('TEMPDECK_SET_TEMP')
-TEMPDECK_AWAIT_TEMP = makeRobotCommandName('TEMPDECK_AWAIT_TEMP')
+TEMPDECK_DEACTIVATE: Final = 'command.TEMPDECK_DEACTIVATE'
+TEMPDECK_SET_TEMP: Final = 'command.TEMPDECK_SET_TEMP'
+TEMPDECK_AWAIT_TEMP: Final = 'command.TEMPDECK_AWAIT_TEMP'
 
-THERMOCYCLER_OPEN = makeRobotCommandName('THERMOCYCLER_OPEN')
-THERMOCYCLER_CLOSE = makeRobotCommandName('THERMOCYCLER_CLOSE')
-THERMOCYCLER_SET_BLOCK_TEMP = makeRobotCommandName(
-    'THERMOCYCLER_SET_BLOCK_TEMP')
-THERMOCYCLER_EXECUTE_PROFILE = makeRobotCommandName(
-    'THERMOCYCLER_EXECUTE_PROFILE')
-THERMOCYCLER_DEACTIVATE = makeRobotCommandName('THERMOCYCLER_DEACTIVATE')
-THERMOCYCLER_WAIT_FOR_HOLD = makeRobotCommandName('THERMOCYCLER_WAIT_FOR_HOLD')
-THERMOCYCLER_WAIT_FOR_TEMP = makeRobotCommandName('THERMOCYCLER_WAIT_FOR_TEMP')
-THERMOCYCLER_WAIT_FOR_LID_TEMP = makeRobotCommandName(
-    'THERMOCYCLER_WAIT_FOR_LID_TEMP')
-THERMOCYCLER_SET_LID_TEMP = makeRobotCommandName('THERMOCYCLER_SET_LID_TEMP')
-THERMOCYCLER_DEACTIVATE_LID = makeRobotCommandName(
-    'THERMOCYCLER_DEACTIVATE_LID')
-THERMOCYCLER_DEACTIVATE_BLOCK = makeRobotCommandName(
-    'THERMOCYCLER_DEACTIVATE_BLOCK')
+THERMOCYCLER_OPEN: Final = 'command.THERMOCYCLER_OPEN'
+THERMOCYCLER_CLOSE: Final = 'command.THERMOCYCLER_CLOSE'
+THERMOCYCLER_SET_BLOCK_TEMP: Final = 'command.THERMOCYCLER_SET_BLOCK_TEMP'
+THERMOCYCLER_EXECUTE_PROFILE: Final = 'command.THERMOCYCLER_EXECUTE_PROFILE'
+THERMOCYCLER_DEACTIVATE: Final = 'command.THERMOCYCLER_DEACTIVATE'
+THERMOCYCLER_WAIT_FOR_HOLD: Final = 'command.THERMOCYCLER_WAIT_FOR_HOLD'
+THERMOCYCLER_WAIT_FOR_TEMP: Final = 'command.THERMOCYCLER_WAIT_FOR_TEMP'
+THERMOCYCLER_WAIT_FOR_LID_TEMP: Final = 'command.THERMOCYCLER_WAIT_FOR_LID_TEMP'
+THERMOCYCLER_SET_LID_TEMP: Final = 'command.THERMOCYCLER_SET_LID_TEMP'
+THERMOCYCLER_DEACTIVATE_LID: Final = 'command.THERMOCYCLER_DEACTIVATE_LID'
+THERMOCYCLER_DEACTIVATE_BLOCK: Final = 'command.THERMOCYCLER_DEACTIVATE_BLOCK'
+
+
+class TextOnlyPayload(TypedDict):
+    text: str
+
+
+class SingleLocationPayload(TypedDict):
+    location: Union[Location, Well]
+
+
+class MultiLocationPayload(TypedDict):
+    locations: Sequence[Union[Location, Well]]
+
+
+class OptionalMultiLocationPayload(TypedDict):
+    locations: Optional[Sequence[Union[Location, Well]]]
+
+
+class OptionalSingleLocationPayload(TypedDict):
+    location: Union[Location, Well, None]
+
+
+HasLocationPayload = Union[
+    SingleLocationPayload, MultiLocationPayload,
+    OptionalSingleLocationPayload, OptionalMultiLocationPayload]
+
+
+class SingleInstrumentPayload(TypedDict):
+    instrument: InstrumentContext
+
+
+class MultiInstrumentPayload(TypedDict):
+    instruments: Sequence[InstrumentContext]
+
+
+HasInstrumentPayload = Union[SingleInstrumentPayload, MultiInstrumentPayload]
+
+
+class CommentCommandPayload(TextOnlyPayload):
+    pass
+
+
+class CommentCommand(TypedDict):
+    name: Literal['command.COMMENT']
+    payload: CommentCommandPayload
+
+
+class DelayCommandPayload(TextOnlyPayload):
+    minutes: float
+    seconds: float
+
+
+class DelayCommand(TypedDict):
+    name: Literal['command.DELAY']
+    payload: DelayCommandPayload
+
+
+class PauseCommandPayload(TextOnlyPayload):
+    userMessage: Optional[str]
+
+
+class PauseCommand(TypedDict):
+    name: Literal['command.PAUSE']
+    payload: PauseCommandPayload
+
+
+class ResumeCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ResumeCommand(TypedDict):
+    name: Literal['command.RESUME']
+    payload: ResumeCommandPayload
+
+
+class MagdeckEngageCommandPayload(TextOnlyPayload):
+    pass
+
+
+class MagdeckEngageCommand(TypedDict):
+    name: Literal['command.MAGDECK_ENGAGE']
+    payload: MagdeckEngageCommandPayload
+
+
+class MagdeckDisengageCommandPayload(TextOnlyPayload):
+    pass
+
+
+class MagdeckDisengageCommand(TypedDict):
+    name: Literal['command.MAGDECK_DISENGAGE']
+    payload: MagdeckDisengageCommandPayload
+
+
+class MagdeckCalibrateCommandPayload(TextOnlyPayload):
+    pass
+
+
+class MagdeckCalibrateCommand(TypedDict):
+    name: Literal['command.MAGDECK_CALIBRATE']
+    payload: MagdeckCalibrateCommandPayload
+
+
+class TempdeckSetTempCommandPayload(TextOnlyPayload):
+    celsius: float
+
+
+class TempdeckSetTempCommand(TypedDict):
+    name: Literal['command.TEMPDECK_SET_TEMP']
+    payload: TempdeckSetTempCommandPayload
+
+
+class TempdeckAwaitTempCommandPayload(TextOnlyPayload):
+    celsius: float
+
+
+class TempdeckAwaitTempCommand(TypedDict):
+    name: Literal['command.TEMPDECK_AWAIT_TEMP']
+    payload: TempdeckAwaitTempCommandPayload
+
+
+class TempdeckDeactivateCommandPayload(TextOnlyPayload):
+    pass
+
+
+class TempdeckDeactivateCommand(TypedDict):
+    name: Literal['command.TEMPDECK_DEACTIVATE']
+    payload: TempdeckDeactivateCommandPayload
+
+
+class ThermocyclerOpenCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerOpenCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_OPEN']
+    payload: ThermocyclerOpenCommandPayload
+
+
+class ThermocyclerSetBlockTempCommandPayload(TextOnlyPayload):
+    temperature: float
+    hold_time: Optional[float]
+
+
+class ThermocyclerSetBlockTempCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_SET_BLOCK_TEMP']
+    payload: ThermocyclerSetBlockTempCommandPayload
+
+
+class ThermocyclerExecuteProfileCommandPayload(TextOnlyPayload):
+    steps: List[ThermocyclerStep]
+
+
+class ThermocyclerExecuteProfileCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_EXECUTE_PROFILE']
+    payload: ThermocyclerExecuteProfileCommandPayload
+
+
+class ThermocyclerWaitForHoldCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerWaitForHoldCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_WAIT_FOR_HOLD']
+    payload: ThermocyclerWaitForHoldCommandPayload
+
+
+class ThermocyclerWaitForTempCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerWaitForTempCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_WAIT_FOR_TEMP']
+    payload: ThermocyclerWaitForTempCommandPayload
+
+
+class ThermocyclerSetLidTempCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerSetLidTempCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_SET_LID_TEMP']
+    payload: ThermocyclerSetLidTempCommandPayload
+
+
+class ThermocyclerDeactivateLidCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerDeactivateLidCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_DEACTIVATE_LID']
+    payload: ThermocyclerDeactivateLidCommandPayload
+
+
+class ThermocyclerDeactivateBlockCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerDeactivateBlockCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_DEACTIVATE_BLOCK']
+    payload: ThermocyclerDeactivateBlockCommandPayload
+
+
+class ThermocyclerDeactivateCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerDeactivateCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_DEACTIVATE']
+    payload: ThermocyclerDeactivateCommandPayload
+
+
+class ThermocyclerWaitForLidTempCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerWaitForLidTempCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_WAIT_FOR_LID_TEMP']
+    payload: ThermocyclerWaitForLidTempCommandPayload
+
+
+class ThermocyclerCloseCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ThermocyclerCloseCommand(TypedDict):
+    name: Literal['command.THERMOCYCLER_CLOSE']
+    payload: ThermocyclerCloseCommandPayload
+
+
+class HomeCommandPayload(TextOnlyPayload):
+    axis: str
+
+
+class HomeCommand(TypedDict):
+    name: Literal['command.HOME']
+    payload: HomeCommandPayload
+
+
+class SimpleLHCommandPayload(
+        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    volume: float
+    rate: float
+
+
+class SimplePairedLHCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    volume: float
+    rate: float
+
+
+class AspirateCommand(TypedDict):
+    name: Literal['command.ASPIRATE']
+    payload: Union[SimpleLHCommandPayload, SimplePairedLHCommandPayload]
+
+
+class DispenseCommand(TypedDict):
+    name: Literal['command.DISPENSE']
+    payload: Union[SimpleLHCommandPayload, SimplePairedLHCommandPayload]
+
+
+class ConsolidateCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    volume: Union[float, List[float]]
+    source: List[Union[Location, Well]]
+    dest: Union[Location, Well]
+
+
+class ConsolidateCommand(TypedDict):
+    name: Literal['command.CONSOLIDATE']
+    payload: ConsolidateCommandPayload
+
+
+class DistributeCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    volume: Union[float, List[float]]
+    source: Union[Location, Well]
+    dest: List[Union[Location, Well]]
+
+
+class DistributeCommand(TypedDict):
+    name: Literal['command.DISTRIBUTE']
+    payload: DistributeCommandPayload
+
+
+class TransferCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    volume: Union[float, List[float]]
+    source: List[Union[Location, Well]]
+    dest: List[Union[Location, Well]]
+
+
+class TransferCommand(TypedDict):
+    name: Literal['command.TRANSFER']
+    payload: TransferCommandPayload
+
+
+class MixCommandPayload(
+        TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload):
+    volume: float
+    repetitions: int
+
+
+class PairedMixCommandPayload(
+        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    volume: float
+    repetitions: int
+
+
+class MixCommand(TypedDict):
+    name: Literal['command.MIX']
+    payload: Union[MixCommandPayload, PairedMixCommandPayload]
+
+
+class BlowOutCommandPayload(
+        TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload):
+    pass
+
+
+class PairedBlowOutCommandPayload(
+        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    pass
+
+
+class BlowOutCommand(TypedDict):
+    name: Literal['command.BLOW_OUT']
+    payload: Union[BlowOutCommandPayload, PairedBlowOutCommandPayload]
+
+
+class TouchTipCommandPayload(
+        TextOnlyPayload, SingleInstrumentPayload):
+    pass
+
+
+class PairedTouchTipCommandPayload(
+        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    pass
+
+
+class TouchTipCommand(TypedDict):
+    name: Literal['command.TOUCH_TIP']
+    payload: Union[TouchTipCommandPayload, PairedTouchTipCommandPayload]
+
+
+class AirGapCommandPayload(TextOnlyPayload):
+    pass
+
+
+class AirGapCommand(TypedDict):
+    name: Literal['command.AIR_GAP']
+    payload: AirGapCommandPayload
+
+
+class ReturnTipCommandPayload(TextOnlyPayload):
+    pass
+
+
+class ReturnTipCommand(TypedDict):
+    name: Literal['command.RETURN_TIP']
+    payload: ReturnTipCommandPayload
+
+
+class PickUpTipCommandPayload(
+        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    pass
+
+
+class PairedPickUpTipCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    pass
+
+
+class PickUpTipCommand(TypedDict):
+    name: Literal['command.PICK_UP_TIP']
+    payload: Union[PickUpTipCommandPayload, PairedPickUpTipCommandPayload]
+    pass
+
+
+class DropTipCommandPayload(
+        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    pass
+
+
+class PairedDropTipCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    pass
+
+
+class DropTipCommand(TypedDict):
+    name: Literal['command.DROP_TIP']
+    payload: Union[DropTipCommandPayload, PairedDropTipCommandPayload]
+
+
+Command = Union[
+    DropTipCommand, PickUpTipCommand, ReturnTipCommand, AirGapCommand,
+    TouchTipCommand, BlowOutCommand, MixCommand, TransferCommand,
+    DistributeCommand, ConsolidateCommand, DispenseCommand, AspirateCommand,
+    HomeCommand, ThermocyclerCloseCommand, ThermocyclerWaitForLidTempCommand,
+    ThermocyclerDeactivateCommand, ThermocyclerDeactivateBlockCommand,
+    ThermocyclerDeactivateLidCommand, ThermocyclerSetLidTempCommand,
+    ThermocyclerWaitForTempCommand, ThermocyclerWaitForHoldCommand,
+    ThermocyclerExecuteProfileCommand, ThermocyclerSetBlockTempCommand,
+    ThermocyclerOpenCommand,
+    TempdeckDeactivateCommand, TempdeckAwaitTempCommand,
+    TempdeckSetTempCommand, MagdeckCalibrateCommand, MagdeckDisengageCommand,
+    MagdeckEngageCommand, ResumeCommand, PauseCommand, DelayCommand,
+    CommentCommand]
+
+
+CommandPayload = Union[
+    CommentCommandPayload, ResumeCommandPayload,
+    MagdeckEngageCommandPayload, MagdeckDisengageCommandPayload,
+    MagdeckCalibrateCommandPayload,
+    ThermocyclerOpenCommandPayload,
+    ThermocyclerWaitForHoldCommandPayload,
+    ThermocyclerWaitForTempCommandPayload,
+    ThermocyclerSetLidTempCommandPayload,
+    ThermocyclerDeactivateLidCommandPayload,
+    ThermocyclerDeactivateBlockCommandPayload,
+    ThermocyclerDeactivateCommandPayload,
+    ThermocyclerWaitForLidTempCommand,
+    ThermocyclerCloseCommandPayload,
+    AirGapCommandPayload, ReturnTipCommandPayload,
+    DropTipCommandPayload, PairedDropTipCommandPayload,
+    PickUpTipCommandPayload, PairedPickUpTipCommandPayload,
+    TouchTipCommandPayload, PairedTouchTipCommandPayload,
+    BlowOutCommandPayload, PairedBlowOutCommandPayload,
+    MixCommandPayload, PairedMixCommandPayload,
+    TransferCommandPayload, DistributeCommandPayload, ConsolidateCommandPayload,
+    SimpleLHCommandPayload, SimplePairedLHCommandPayload,
+    HomeCommandPayload,
+    ThermocyclerExecuteProfileCommandPayload,
+    ThermocyclerSetBlockTempCommandPayload,
+    TempdeckAwaitTempCommandPayload,
+    TempdeckSetTempCommandPayload,
+    PauseCommandPayload, DelayCommandPayload
+]
+
+
+MessageSequenceId = Union[Literal['before'], Literal['after']]
+
+
+CommandMessageSequence = TypedDict('CommandMessageSequence',
+
+                                   {'$': MessageSequenceId})
+CommandMessageMeta = TypedDict('CommandMessageMeta',
+                               {'meta': Any}, total=False)
+
+
+class CommandMessageFields(CommandMessageMeta, CommandMessageSequence):
+    pass
+
+
+class DropTipMessage(CommandMessageFields, DropTipCommand):
+    pass
+
+
+class PickUpTipMessage(CommandMessageFields, PickUpTipCommand):
+    pass
+
+
+class ReturnTipMessage(CommandMessageFields, ReturnTipCommand):
+    pass
+
+
+class AirGapMessage(CommandMessageFields, AirGapCommand):
+    pass
+
+
+class TouchTipMessage(CommandMessageFields, TouchTipCommand):
+    pass
+
+
+class BlowOutMessage(CommandMessageFields, BlowOutCommand):
+    pass
+
+
+class MixMessage(CommandMessageFields, MixCommand):
+    pass
+
+
+class TransferMessage(CommandMessageFields, TransferCommand):
+    pass
+
+
+class DistributeMessage(CommandMessageFields, DistributeCommand):
+    pass
+
+
+class ConsolidateMessage(CommandMessageFields, ConsolidateCommand):
+    pass
+
+
+class DispenseMessage(CommandMessageFields, DispenseCommand):
+    pass
+
+
+class AspirateMessage(CommandMessageFields, AspirateCommand):
+    pass
+
+
+class HomeMessage(CommandMessageFields, HomeCommand):
+    pass
+
+
+class ThermocyclerCloseMessage(
+        CommandMessageFields, ThermocyclerCloseCommand):
+    pass
+
+
+class ThermocyclerWaitForLidTempMessage(
+        CommandMessageFields, ThermocyclerWaitForLidTempCommand):
+    pass
+
+
+class ThermocyclerDeactivateMessage(
+        CommandMessageFields, ThermocyclerDeactivateCommand):
+    pass
+
+
+class ThermocyclerDeactivateBlockMessage(
+        CommandMessageFields, ThermocyclerDeactivateBlockCommand):
+    pass
+
+
+class ThermocyclerDeactivateLidMessage(
+        CommandMessageFields, ThermocyclerDeactivateLidCommand):
+    pass
+
+
+class ThermocyclerSetLidTempMessage(
+        CommandMessageFields, ThermocyclerSetLidTempCommand):
+    pass
+
+
+class ThermocyclerWaitForTempMessage(
+        CommandMessageFields, ThermocyclerWaitForTempCommand):
+    pass
+
+
+class ThermocyclerWaitForHoldMessage(
+        CommandMessageFields, ThermocyclerWaitForHoldCommand):
+    pass
+
+
+class ThermocyclerExecuteProfileMessage(
+        CommandMessageFields, ThermocyclerExecuteProfileCommand):
+    pass
+
+
+class ThermocyclerSetBlockTempMessage(
+        CommandMessageFields, ThermocyclerSetBlockTempCommand):
+    pass
+
+
+class ThermocyclerOpenMessage(
+        CommandMessageFields, ThermocyclerOpenCommand):
+    pass
+
+
+class TempdeckDeactivateMessage(
+        CommandMessageFields, TempdeckDeactivateCommand):
+    pass
+
+
+class TempdeckAwaitTempMessage(
+        CommandMessageFields, TempdeckAwaitTempCommand):
+    pass
+
+
+class TempdeckSetTempMessage(
+        CommandMessageFields, TempdeckSetTempCommand):
+    pass
+
+
+class MagdeckCalibrateMessage(
+        CommandMessageFields, MagdeckCalibrateCommand):
+    pass
+
+
+class MagdeckDisengageMessage(
+        CommandMessageFields, MagdeckDisengageCommand):
+    pass
+
+
+class MagdeckEngageMessage(CommandMessageFields, MagdeckEngageCommand):
+    pass
+
+
+class ResumeMessage(CommandMessageFields, ResumeCommand):
+    pass
+
+
+class PauseMessage(CommandMessageFields, PauseCommand):
+    pass
+
+
+class DelayMessage(CommandMessageFields, DelayCommand):
+    pass
+
+
+class CommentMessage(CommandMessageFields, CommentCommand):
+    pass
+
+
+CommandMessage = Union[
+    DropTipMessage, PickUpTipMessage, ReturnTipMessage, AirGapMessage,
+    TouchTipMessage, BlowOutMessage, MixMessage, TransferMessage,
+    DistributeMessage, ConsolidateMessage, DispenseMessage, AspirateMessage,
+    HomeMessage, ThermocyclerCloseMessage, ThermocyclerWaitForLidTempMessage,
+    ThermocyclerDeactivateMessage, ThermocyclerDeactivateBlockMessage,
+    ThermocyclerDeactivateLidMessage, ThermocyclerSetLidTempMessage,
+    ThermocyclerWaitForTempMessage, ThermocyclerWaitForHoldMessage,
+    ThermocyclerExecuteProfileMessage, ThermocyclerSetBlockTempMessage,
+    ThermocyclerOpenMessage, TempdeckSetTempMessage, TempdeckDeactivateMessage,
+    MagdeckEngageMessage, MagdeckDisengageMessage, MagdeckCalibrateMessage,
+    CommentMessage, DelayMessage, PauseMessage, ResumeMessage]

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -8,6 +8,7 @@ from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, M
 from . import labware  # noqa(E402)
 from .contexts import (ProtocolContext,  # noqa(E402)
                        InstrumentContext,
+                       PairedInstrumentContext,
                        TemperatureModuleContext,
                        MagneticModuleContext,
                        ThermocyclerContext)
@@ -17,4 +18,5 @@ __all__ = ['ProtocolContext',
            'TemperatureModuleContext',
            'MagneticModuleContext',
            'ThermocyclerContext',
+           'PairedInstrumentContext',
            'labware']

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -1,11 +1,12 @@
 from .protocol_context import ProtocolContext
 from .instrument_context import InstrumentContext
+from .paired_instrument_context import PairedInstrumentContext
 from .module_contexts import (
     ModuleContext, ThermocyclerContext, MagneticModuleContext,
     TemperatureModuleContext)
 
 
 __all__ = [
-    'ProtocolContext', 'InstrumentContext', 'ModuleContext',
+    'ProtocolContext', 'InstrumentContext', 'ModuleContext', 'PairedInstrumentContext',
     'ThermocyclerContext', 'MagneticModuleContext', 'TemperatureModuleContext'
 ]

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextlib
 import logging
-from typing import (Dict, Iterator, List,
+from typing import (Dict, Iterator, List, Callable,
                     Optional, Set, Tuple, Union, TYPE_CHECKING)
 
 from opentrons import types
@@ -115,7 +115,7 @@ class ProtocolContext(CommandPublisher):
         self._hw_manager = HardwareManager(hardware)
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
         self._commands: List[str] = []
-        self._unsubscribe_commands = None
+        self._unsubscribe_commands: Optional[Callable[[], None]] = None
         self.clear_commands()
 
         self._bundled_labware = bundled_labware

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -5,7 +5,8 @@ from typing import (Dict, Iterator, List,
                     Optional, Set, Tuple, Union, TYPE_CHECKING)
 
 from opentrons import types
-from opentrons.hardware_control import (SynchronousAdapter, modules,
+from opentrons.hardware_control import (SynchronousAdapter, ThreadManager,
+                                        modules,
                                         API, ExecutionManager)
 from opentrons.config import feature_flags as fflags
 from opentrons.commands import protocol_commands as cmds, types as cmd_types
@@ -228,7 +229,7 @@ class ProtocolContext(CommandPublisher):
             cmd_types.COMMAND, on_command)
 
     @contextlib.contextmanager
-    def temp_connect(self, hardware: API):
+    def temp_connect(self, hardware: Union[ThreadManager, SynchronousAdapter]):
         """ Connect temporarily to the specified hardware controller.
 
         This should be used as a context manager:

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -96,11 +96,11 @@ async def test_load_and_run_v2(
 def test_accumulate():
     res = \
         _accumulate([
-            (['a'], ['d'], ['g', 'h']),
-            (['b', 'c'], ['e', 'f'], ['i'])
+            (['a'], ['d'], ['g', 'h'], [('l', 'm')]),
+            (['b', 'c'], ['e', 'f'], ['i'], [('m', 'n')])
         ])
 
-    assert res == (['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i'])
+    assert res == (['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i'], [('l', 'm'), ('m', 'n')])
     assert _accumulate([]) == ([], [], [], [])
 
 

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -100,7 +100,8 @@ def test_accumulate():
             (['b', 'c'], ['e', 'f'], ['i'], [('m', 'n')])
         ])
 
-    assert res == (['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i'], [('l', 'm'), ('m', 'n')])
+    assert res == (['a', 'b', 'c'], ['d', 'e', 'f'],
+                   ['g', 'h', 'i'], [('l', 'm'), ('m', 'n')])
     assert _accumulate([]) == ([], [], [], [])
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -289,10 +289,10 @@ def build_v2_model(h, lw_name, loop):
         'opentrons_96_tiprack_300ul', '2')
     pip = ctx.load_instrument('p300_single', 'right',
                               tip_racks=[tiprack])
-    instrument = models.Instrument(pip, context=ctx)
+    instrument = models.Instrument(pip, [], ctx)
     plate = ctx.load_labware(
         lw_name or 'corning_96_wellplate_360ul_flat', 1)
-    container = models.Container(plate, context=ctx)
+    container = models.Container(plate, [], context=ctx)
     return namedtuple('model', 'robot instrument container')(
         robot=h,
         instrument=instrument,

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -41,7 +41,7 @@ def mod_trough(trough_definition, module):
     return mod_trough
 
 
-def test_labware(trough):
+def test_labware(trough, mod_trough, module):
     ll = LabwareLike(trough)
     assert ll.has_parent is True
     assert ll.parent.object == trough.parent
@@ -64,6 +64,8 @@ def test_module(module):
     assert ll.parent.object is module.parent
     assert ll.object is module
     assert ll.object_type == LabwareLikeType.MODULE
+    assert ll.is_module
+    assert ll.as_module() == module
 
 
 def test_slot():
@@ -80,6 +82,14 @@ def test_empty():
     assert ll.parent.object is None
     assert ll.object is None
     assert ll.object_type == LabwareLikeType.NONE
+
+
+def test_module_parent(trough, module, mod_trough):
+    assert LabwareLike(mod_trough).module_parent() == module
+    assert LabwareLike(mod_trough['A1']).module_parent() == module
+    assert LabwareLike(module).module_parent() == module
+    assert LabwareLike(trough).module_parent() is None
+    assert LabwareLike('1').module_parent() is None
 
 
 def test_first_parent(trough, module, mod_trough):

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
@@ -64,7 +64,7 @@ class ProtocolRunner:
             self._session = ApiProtocolSession.build_and_prep(
                 name=self._protocol.meta.protocol_file.path.name,
                 contents=self._protocol.get_contents(),
-                hardware=self._hardware,
+                hardware=self._hardware.sync,
                 loop=self._loop,
                 broker=self._broker,
                 motion_lock=self._motion_lock,

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
@@ -69,7 +69,7 @@ class ProtocolRunner:
                 broker=self._broker,
                 motion_lock=self._motion_lock,
                 # TODO Amit 8/3/2020 - need an answer for custom labware
-                extra_labware={})
+                extra_labware=[])
 
     def run(self):
         """Run the protocol"""

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
@@ -48,6 +48,7 @@ def mock_context():
 
 @pytest.fixture
 def protocol_runner(mock_protocol, loop, hardware):
+    setattr(hardware, 'sync', MagicMock())
     return ProtocolRunner(protocol=mock_protocol,
                           loop=loop,
                           hardware=hardware,
@@ -62,7 +63,7 @@ def test_load(protocol_runner, mock_context,
         mock.assert_called_once_with(
             name=uploaded_protocol_meta.protocol_file.path.name,
             contents=mock_protocol.get_contents(),
-            hardware=protocol_runner._hardware,
+            hardware=protocol_runner._hardware.sync,
             loop=protocol_runner._loop,
             broker=protocol_runner._broker,
             motion_lock=protocol_runner._motion_lock,

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
@@ -67,7 +67,7 @@ def test_load(protocol_runner, mock_context,
             loop=protocol_runner._loop,
             broker=protocol_runner._broker,
             motion_lock=protocol_runner._motion_lock,
-            extra_labware={})
+            extra_labware=[])
 
 
 @pytest.mark.parametrize(argnames="func",

--- a/robot-server/tests/service/test_dependencies.py
+++ b/robot-server/tests/service/test_dependencies.py
@@ -1,11 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from robot_server.service import dependencies
+from opentrons.hardware_control import ThreadManager
 
 
 @patch("robot_server.service.dependencies.get_hardware")
 def test_rpc_server_singleton(mock_get_hardware, loop):
     async def get_hardware():
-        return {}
+        return MagicMock(spec=ThreadManager)
 
     mock_get_hardware.side_effect = get_hardware
     x = loop.run_until_complete(dependencies.get_rpc_server())


### PR DESCRIPTION
Adds type annotations for all the commands generated by the publisher; the RPC session machinery (opentrons.api.session and opentrons.api.calibration) and their dependents, including fixing a bug in robot server protocol runner; and adds types for the broker so that everything that uses it can be fully typed.

## Risk
Medium. Very few actual code changes, but the ones that are there are in critical areas.

## Review Requests

There's a lot of noise in this pr; most of the LOC changes are the addition of the TypedDict definitions for all the commands, which are insanely messy because of how those commands are structured, particularly adding the $ key after the fact. I kept that structure the same because I wanted to minimize code changes.

The code changes to closely inspect are the ones in the session machinery. I pulled the code that gets objects from the commands out into a new module in the commands package; this should all be equivalent, and the tests still pass, but give it an eyeball - there's a bit less handling of Nones and the like because the typing now makes me confident they're unnecessary.

While a lot of this will probably go away eventually when we overhaul this session machinery, I think some things are really good cues for the future to take, especially the explicit types for the messages and the overloads based on topic for the broker.