### PR TITLE
fix(build): proper prod pypi deploys

### DIFF
--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -18,18 +18,19 @@ runs:
         if [[ ${{ inputs.repository_url }} =~ "test" ]]; then
           echo "Uploading to test pypi"
         else if [[ ${{ inputs.repository_url }} =~ "upload.pypi.org" ]]; then
-                 echo "Uploading to prod pypi"
-                 # this needs to be cleared otherwise the makefiles append a dev tag
-                 OT_BUILD=
-             else
-                 echo "::error ::Invalid repository url ${{ inputs.repository_url }}"
-                 exit 1
-             fi
+          echo "Uploading to prod pypi"
+          # this needs to be cleared otherwise the makefiles append a dev tag
+          OT_BUILD=
+                 
+          else
+            echo "::error ::Invalid repository url ${{ inputs.repository_url }}"
+            exit 1
+          fi
         fi
         status=0
         QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=opentrons pypi_password=${{ inputs.password }} || status=$?
         if [[ ${status} != 0 ]] && [[ ${{ inputs.repository_url }} =~ "test.pypi.org" ]]; then
-           echo "upload failures allowed to test pypi"
-           exit 0
+          echo "upload failures allowed to test pypi"
+          exit 0
         fi
         exit ${status}

--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -20,16 +20,12 @@ runs:
         else if [[ ${{ inputs.repository_url }} =~ "upload.pypi.org" ]]; then
                  echo "Uploading to prod pypi"
                  # this needs to be cleared otherwise the makefiles append a dev tag
-                 echo 'OT_BUILD=' >> $GITHUB_ENV
+                 OT_BUILD=
              else
                  echo "::error ::Invalid repository url ${{ inputs.repository_url }}"
                  exit 1
              fi
         fi
-
-
-    - shell: bash
-      run: |
         status=0
         QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=opentrons pypi_password=${{ inputs.password }} || status=$?
         if [[ ${status} != 0 ]] && [[ ${{ inputs.repository_url }} =~ "test.pypi.org" ]]; then


### PR DESCRIPTION
This should now correctly clear the OT_BUILD environ variable for the
pypi upload by collapsing the two steps into one and using a local
change to the env var rather than writing the env file
