### PR TITLE
feat(protocol-designer): expand Add Step items upwards

### DIFF
--- a/protocol-designer/src/components/listButtons.css
+++ b/protocol-designer/src/components/listButtons.css
@@ -10,6 +10,7 @@
   position: absolute;
   left: 2rem;
   right: 2rem;
+  bottom: 3.25rem;
 }
 
 .step_button_disabled {


### PR DESCRIPTION
# Overview

Closes #6056 ...maybe? The ticket doesn't specify what to do so I improvised by putting the steps above the ADD STEP button instead of below it.

One alternative would be scrolling down to the bottom once you click the button, but then your mouse might move off the menu so I'm not sure if that would be nice.

# Changelog


# Review requests

Design review
CSS review - cleaner way to do this? (Not that it's too bad.)

# Risk assessment

Low, PD only and small surface area. Should be safe as long as the button still works.