### PR TITLE
fix(api): get correct instrument max height

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -725,9 +725,9 @@ class API(HardwareAPILike):
         gantry_calibration =\
             self.robot_calibration.deck_calibration.attitude
         right_deck = linal.apply_reverse(
-            gantry_calibration, right, with_offsets=False)
+            gantry_calibration, right)
         left_deck = linal.apply_reverse(
-            gantry_calibration, left, with_offsets=False)
+            gantry_calibration, left)
         deck_pos = {Axis.X: right_deck[0],
                     Axis.Y: right_deck[1],
                     Axis.by_mount(top_types.Mount.RIGHT): right_deck[2],
@@ -1008,12 +1008,10 @@ class API(HardwareAPILike):
         # above that makes this OK
         primary_transformed = linal.apply_transform(
             self.robot_calibration.deck_calibration.attitude,
-            to_transform_primary,  # type: ignore
-            with_offsets=False)
+            to_transform_primary)  # type: ignore
         secondary_transformed = linal.apply_transform(
             self.robot_calibration.deck_calibration.attitude,
-            to_transform_secondary,  # type: ignore
-            with_offsets=False)
+            to_transform_secondary)  # type: ignore
         return primary_transformed, secondary_transformed
 
     async def _move(self, target_position: 'OrderedDict[Axis, float]',
@@ -1901,7 +1899,7 @@ class API(HardwareAPILike):
             self._config.z_retract_distance + cp.z
 
         _, _, transformed_z = linal.apply_reverse(
-            self._config.gantry_calibration,
+            self.robot_calibration.deck_calibration.attitude,
             (0, 0, max_height))
         return transformed_z
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1898,10 +1898,7 @@ class API(HardwareAPILike):
         max_height = pip.config.home_position - \
             self._config.z_retract_distance + cp.z
 
-        _, _, transformed_z = linal.apply_reverse(
-            self.robot_calibration.deck_calibration.attitude,
-            (0, 0, max_height))
-        return transformed_z
+        return max_height
 
     def clean_up(self):
         """ Get the API ready to stop cleanly. """

--- a/api/src/opentrons/util/linal.py
+++ b/api/src/opentrons/util/linal.py
@@ -172,29 +172,21 @@ def add_matrices(
 
 def apply_transform(
         t: Union[List[List[float]], np.ndarray],
-        pos: AxisPosition,
-        with_offsets=True) -> Tuple[float, float, float]:
+        pos: AxisPosition) -> Tuple[float, float, float]:
     """
     Change of base using a transform matrix. Primarily used to render a point
     in space in a way that is more readable for the user.
 
     :param t: A transformation matrix from one 3D space [A] to another [B]
     :param pos: XYZ point in space A
-    :param with_offsets: Whether to apply the transform as an affine transform
-                         or as a standard transform. You might use
-                         with_offsets=False
     :return: corresponding XYZ point in space B
     """
-    if with_offsets:
-        return tuple(dot(t, list(pos) + [1])[:3])  # type: ignore
-    else:
-        return tuple(dot(t, list(pos))[:3])  # type: ignore
+    return tuple(dot(t, list(pos))[:3])  # type: ignore
 
 
 def apply_reverse(
         t: Union[List[List[float]], np.ndarray],
-        pos: AxisPosition,
-        with_offsets=True) -> Tuple[float, float, float]:
+        pos: AxisPosition) -> Tuple[float, float, float]:
     """ Like apply_transform but inverts the transform first
     """
-    return apply_transform(inv(t), pos, with_offsets)
+    return apply_transform(inv(t), pos)

--- a/api/tests/opentrons/util/test_linal.py
+++ b/api/tests/opentrons/util/test_linal.py
@@ -1,5 +1,5 @@
 from math import pi, sin, cos
-from opentrons.util.linal import solve, add_z, apply_transform
+from opentrons.util.linal import solve, add_z, apply_transform, solve_attitude
 from numpy.linalg import inv
 import numpy as np
 
@@ -51,20 +51,20 @@ def test_apply_transform():
     y = 2
     z = 3
 
-    x_delta = -0.1
-    y_delta = -0.2
-    z_delta = 0.3
+    x_delta = 0.1
+    y_delta = 0.2
 
-    transform = [
-        [1, 0, 0, x_delta],
-        [0, 1, 0, y_delta],
-        [0, 0, 1, z_delta],
-        [0, 0, 0, 1]]
+    e = ((1, 1, 3), (2, 2, 2), (1, 2, 1))
+    a = (
+        (1 + x_delta, 1 + y_delta, 1.1),
+        (2 + x_delta, 2 + y_delta, 2.2),
+        (1 + x_delta, 2 + y_delta, 1.1))
+    transform = solve_attitude(e, a)
 
     expected = (
         round(x - x_delta, 2),
         round(y - y_delta, 2),
-        round(z - z_delta, 2))
+        round(z))
 
-    result = apply_transform(inv(transform), (x, y, z))
-    assert result == expected
+    result = apply_transform(inv(transform), (1, 2, 3))
+    assert np.isclose(result, expected, atol=0.1).all()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We forgot to update the `get_instrument_max_height()` in hardware control to not use the legacy gantry calibration. If a robot is using the new calibration but still has the old deck cal file (/data/deck_calibration.json), the max height it thinks the pipette can reach will be off.


# Changelog
- update `get_instrument_max_height()` so it doesn't transform the max height anymore (max height is already calculated using the new critical point, which uses pipette offset & nozzle offset)
- also refactored some methods in linal.py
  - now that we don't use the affine matrix, we don't have to use the `with_offsets` param
  - update a linal test to reflect the new changes
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
