### PR TITLE
refactor(api): remove URWID from the opentrons dependency list

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7e7ef69da7248742e869378f8421880cf8f0017f96d94d086813baa518a65489"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -38,6 +38,5 @@ jsonschema = "==3.0.2"
 numpy = "==1.15.1"
 pyserial = "==3.4"
 systemd-python = {version="==234", sys_platform="== 'linux'"}
-urwid = "==1.3.1"
 typing-extensions = "==3.7.4.3"
 pydantic = "==1.4"

--- a/api/setup.py
+++ b/api/setup.py
@@ -54,7 +54,6 @@ PACKAGES = find_packages(where='src')
 INSTALL_REQUIRES = [
     'pyserial==3.4',
     'numpy>=1.15.1',
-    'urwid==1.3.1',
     'jsonschema>=3.0.2,<4',
     'aionotify==0.2.0',
     f'opentrons_shared_data=={VERSION}',


### PR DESCRIPTION
# Overview
Closes #6802. Remove urwid dependency from the monorepo.

# Changelog
- remove urwid

# Review requests

I decided not to remove this from buildroot yet as we don't have a substitute library picked out. I'll do some research to see which substitutes would work without adding unwanted dependencies. 

# Risk assessment

Low. This is not used anywhere in our code anymore.
