### PR TITLE
refactor(api): remove legacy deck calibration

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -5,7 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple, Dict, Set
 
-from opentrons.config import IS_ROBOT, robot_configs
+from opentrons.config import IS_ROBOT
 from opentrons.calibration_storage import delete
 
 DATA_BOOT_D = Path('/data/boot.d')
@@ -101,7 +101,6 @@ def reset_boot_scripts():
 def reset_deck_calibration():
     delete.delete_robot_deck_attitude()
     delete.clear_pipette_offset_calibrations()
-    robot_configs.clear(calibration=True, robot=False)
 
 
 def reset_pipette_offset():

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 
-from typing import Any, Dict, List, NamedTuple, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 
 from opentrons.config import CONFIG
 

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -5,6 +5,7 @@ from typing import Optional, List
 
 from opentrons import config
 
+from opentrons.config.robot_configs import get_legacy_gantry_calibration
 from opentrons.calibration_storage import modify, types, get
 from opentrons.types import Mount
 from opentrons.util import linal
@@ -106,8 +107,8 @@ def save_attitude_matrix(
 
 def load_attitude_matrix() -> types.DeckCalibration:
     calibration_data = get.get_robot_deck_attitude()
-    if not calibration_data:
-        gantry_cal = config.robot_configs.load().gantry_calibration
+    gantry_cal = get_legacy_gantry_calibration()
+    if not calibration_data and gantry_cal:
         if validate_gantry_calibration(gantry_cal) == DeckTransformState.OK:
             log.debug(
                 "Attitude deck calibration matrix not found. Migrating "

--- a/api/src/opentrons/hardware_control/simulator_setup.py
+++ b/api/src/opentrons/hardware_control/simulator_setup.py
@@ -72,7 +72,7 @@ def _prepare_for_dict(key, value):
     if key == 'attached_instruments' and value:
         return {mount.name.lower(): data for (mount, data) in value.items()}
     if key == 'config' and value:
-        return robot_configs.config_to_save(value)[1]
+        return robot_configs.config_to_save(value)
     return value
 
 
@@ -81,7 +81,7 @@ def _prepare_for_simulator_setup(key, value):
     if key == 'attached_instruments' and value:
         return {Mount[mount.upper()]: data for (mount, data) in value.items()}
     if key == 'config' and value:
-        return robot_configs.build_config([], value)
+        return robot_configs.build_config(value)
     if key == 'attached_modules' and value:
         return {k: [ModuleCall(**data) for data in v] for (k, v)
                 in value.items()}

--- a/api/src/opentrons/hardware_control/socket_server.py
+++ b/api/src/opentrons/hardware_control/socket_server.py
@@ -66,8 +66,8 @@ _SERDES = {
         }
     ),
     robot_configs.robot_config: SerDes(
-        serializer=lambda config: list(robot_configs.config_to_save(config)),
-        deserializer=lambda clist: robot_configs.build_config(*clist)
+        serializer=lambda config: robot_configs.config_to_save(config),
+        deserializer=lambda clist: robot_configs.build_config(clist)
     ),
     List[types.Axis]: SerDes(
         serializer=lambda axlist: [ax.name for ax in axlist],

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -92,8 +92,6 @@ def test_deck_calibration_reset(mock_cal_storage_delete, mock_robot_config):
     mock_cal_storage_delete.delete_robot_deck_attitude.assert_called_once()
     mock_cal_storage_delete.clear_pipette_offset_calibrations\
                            .assert_called_once()
-    mock_robot_config.clear.assert_called_once_with(
-        calibration=True, robot=False)
 
 
 def test_tip_length_calibrations_reset(mock_cal_storage_delete):

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -45,12 +45,6 @@ def mock_cal_storage_delete():
         yield m
 
 
-@pytest.fixture
-def mock_robot_config():
-    with patch('opentrons.config.reset.robot_configs', autospec=True) as m:
-        yield m
-
-
 def test_reset_empty_set(mock_reset_boot_scripts,
                          mock_reset_labware_calibration,
                          mock_reset_pipette_offset,
@@ -87,7 +81,7 @@ def test_labware_calibration_reset(mock_labware):
     mock_labware.clear_calibrations.assert_called_once()
 
 
-def test_deck_calibration_reset(mock_cal_storage_delete, mock_robot_config):
+def test_deck_calibration_reset(mock_cal_storage_delete):
     reset.reset_deck_calibration()
     mock_cal_storage_delete.delete_robot_deck_attitude.assert_called_once()
     mock_cal_storage_delete.clear_pipette_offset_calibrations\

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import pytest
 import os
 
 from opentrons.config import CONFIG, robot_configs
@@ -38,7 +37,8 @@ def test_load_corrupt_json():
 
 def test_build_config():
     built_config = robot_configs.build_config(dummy_settings)
-    assert built_config == dummy_settings
+    new_config = robot_configs.config_to_save(built_config)
+    assert new_config == dummy_settings
 
 
 def test_dictify_roundtrip():

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -90,7 +90,7 @@ def test_persistance(tmpdir):
                                            kwargs={'celsius': 24})
             ]
         },
-        config=robot_configs.build_config([], {})
+        config=robot_configs.build_config({})
     )
     file = Path(tmpdir) / "sim_setup.json"
     simulator_setup.save_simulator_setup(sim, file)

--- a/api/tests/opentrons/hardware_control/test_socket_server.py
+++ b/api/tests/opentrons/hardware_control/test_socket_server.py
@@ -229,7 +229,7 @@ async def test_complex_method(hc_stream_server, loop, monkeypatch):
         (Dict[Axis, bool], {Axis.X: True}, {'X': True}),
         (robot_configs.robot_config,
          robot_configs.load(),
-         list(robot_configs.config_to_save(robot_configs.load()))),
+         robot_configs.config_to_save(robot_configs.load())),
         (Dict[Mount, Pipette.DictType],
          {Mount.LEFT: {'asdasd': 2, 'asda': False}},
          {'LEFT': {'asdasd': 2, 'asda': False}}),

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -110,12 +110,7 @@ async def test_max_speeds(ctx, monkeypatch, hardware):
 
 async def test_location_cache(ctx, monkeypatch, get_labware_def, hardware):
     ctx.connect(hardware)
-    # To avoid modifying the hardware fixture, we should change the
-    # gantry calibration inside this test.
-    ctx._implementation.get_hardware().hardware.update_config(
-        gantry_calibration=[
-            [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
+
     right = ctx.load_instrument('p10_single', Mount.RIGHT)
     lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
     ctx.home()

--- a/robot-server/tests/integration/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/test_deck_calibration.tavern.yaml
@@ -12,7 +12,7 @@ stages:
       status_code: 200
       json:
         deckCalibration:
-          status: OK
+          status: IDENTITY
           data:
             type: attitude
             matrix:
@@ -22,10 +22,10 @@ stages:
                 - !anyfloat
               - *matrix_row
               - *matrix_row
-            lastModified: !re_search "T"
+            lastModified: null
             pipetteCalibratedWith: null
             tiprack: null
-            source: "legacy"
+            source: "default"
             status:
               markedBad: False
               source: null

--- a/robot-server/tests/integration/test_settings_robot.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_robot.tavern.yaml
@@ -26,23 +26,6 @@ stages:
           X: !anyint
           Y: !anyint
           Z: !anyint
-        gantry_calibration:
-        - - 1.0
-          - 0.0
-          - 0.0
-          - 0.0
-        - - 0.0
-          - 1.0
-          - 0.0
-          - 0.0
-        - - 0.0
-          - 0.0
-          - 1.0
-          - -25.0
-        - - 0.0
-          - 0.0
-          - 0.0
-          - 1.0
         serial_speed: !anyint
         tip_length: !anydict
         default_current:
@@ -73,10 +56,6 @@ stages:
           X: 600
           Y: 400
           Z: 125
-        mount_offset:
-        - !anyint
-        - !anyint
-        - !anyint
         left_mount_offset:
         - -34
         - 0


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR removes the legacy mount offset (replaced by `left_mount_offset`) and gantry calibration from robot config.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- added a new func to load legacy gantry calibration if it exists
  - it is currently used only in `robot_calibration.load_attitude_matrix()` if the new deck cal doesn't exist yet
- update tests to reflect changes
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->



# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
