### PR TITLE
docs(api): Correct protocol.load_labware() examples 

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -83,7 +83,7 @@ The ending well will be in the bottom right, see the diagram below for further e
 
     def run(protocol):
 
-        plate = protocol.load_labware('corning_24_wellplate_3.4ml_flat', slot='1')
+        plate = protocol.load_labware('corning_24_wellplate_3.4ml_flat', location='1')
 
 
 .. versionadded:: 2.0
@@ -328,7 +328,7 @@ For example:
 
     def run(protocol):
         plate = protocol.load_labware(
-        'corning_24_wellplate_3.4ml_flat', slot='1')
+        'corning_24_wellplate_3.4ml_flat', location='1')
 
         # Get the center of well A1.
         center_location = plate['A1'].center()


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When "slot" is used as a keyword argument as opposed to location, it causes a "TypeError: load_labware() got an unexpected keyword argument 'slot' "


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->



# Changelog
Changelog:
- Changing 'slot' key argument to 'location': Lines 86 and 333, this gets around the TypeError.
- This address errors found in **Well Ordering** and **Manipulating Positions**


<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->
n/a
# Risk assessment

The two examples this could possibly effect are: 
Low. 

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
