### PR TITLE
feat(shared-data): add default tipracks to each pipette name spec

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -14,7 +14,7 @@ from opentrons_shared_data.pipette import (
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
         PipetteName, PipetteModel, UlPerMm, Quirk,
-        PipetteFusedSpec, PipetteDefaultTiprack
+        PipetteFusedSpec, LabwareUri
     )
 
 
@@ -59,7 +59,7 @@ class PipetteConfig:
     default_aspirate_flow_rates: Dict[str, float]
     default_dispense_flow_rates: Dict[str, float]
     model: PipetteModel
-    default_tipracks: List[PipetteDefaultTiprack]
+    default_tipracks: List[LabwareUri]
 
 
 # Notes:

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -13,7 +13,8 @@ from opentrons_shared_data.pipette import (
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
-        PipetteName, PipetteModel, UlPerMm, Quirk, PipetteFusedSpec
+        PipetteName, PipetteModel, UlPerMm, Quirk,
+        PipetteFusedSpec, PipetteDefaultTiprack
     )
 
 
@@ -58,6 +59,7 @@ class PipetteConfig:
     default_aspirate_flow_rates: Dict[str, float]
     default_dispense_flow_rates: Dict[str, float]
     model: PipetteModel
+    default_tipracks: List[PipetteDefaultTiprack]
 
 
 # Notes:
@@ -215,6 +217,7 @@ def load(
             'valuesByApiLevel',
             {'2.0': cfg['defaultAspirateFlowRate']['value']}),
         model=pipette_model,
+        default_tipracks=cfg['defaultTipracks']
     )
 
     return res

--- a/app/src/components/InstrumentSettings/__fixtures__/index.js
+++ b/app/src/components/InstrumentSettings/__fixtures__/index.js
@@ -24,5 +24,6 @@ export const mockAttachedPipette = {
       homePosition: 0,
       travelDistance: 100,
     },
+    defaultTipracks: ['opentrons/my_fav_tiprack_200ul/1'],
   },
 }

--- a/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
+++ b/shared-data/js/__tests__/__snapshots__/pipettes.test.js.snap
@@ -41,6 +41,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
@@ -262,6 +267,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
@@ -483,6 +493,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
@@ -704,6 +719,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
   "dropTip": Object {
@@ -895,6 +915,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
@@ -1121,6 +1146,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
@@ -1347,6 +1377,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
@@ -1573,6 +1608,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
   "dropTip": Object {
@@ -1763,6 +1803,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
@@ -1973,6 +2017,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
@@ -2183,6 +2231,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
@@ -2393,6 +2445,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
   "dropTip": Object {
@@ -2583,6 +2639,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
@@ -2793,6 +2853,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
@@ -3003,6 +3067,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
   "dropTip": Object {
@@ -3213,6 +3281,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
@@ -3387,6 +3459,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
@@ -3561,6 +3637,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
@@ -3735,6 +3815,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
   "dropTip": Object {
@@ -3910,6 +3994,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
@@ -4140,6 +4228,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
@@ -4370,6 +4462,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
@@ -4600,6 +4696,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
   "dropTip": Object {
@@ -4794,6 +4894,11 @@ Object {
       "2.0": 1000,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_1000ul/1",
+    "opentrons/opentrons_96_filtertiprack_1000ul/1",
+    "opentrons/geb_96_tiprack_1000ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
@@ -4990,6 +5095,11 @@ Object {
       "2.0": 1000,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_1000ul/1",
+    "opentrons/opentrons_96_filtertiprack_1000ul/1",
+    "opentrons/geb_96_tiprack_1000ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
@@ -5186,6 +5296,11 @@ Object {
       "2.0": 1000,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_1000ul/1",
+    "opentrons/opentrons_96_filtertiprack_1000ul/1",
+    "opentrons/geb_96_tiprack_1000ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
@@ -5382,6 +5497,11 @@ Object {
       "2.0": 1000,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_1000ul/1",
+    "opentrons/opentrons_96_filtertiprack_1000ul/1",
+    "opentrons/geb_96_tiprack_1000ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
   "dropTip": Object {
@@ -5564,6 +5684,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 8-Channel GEN1",
   "maxVolume": 10,
@@ -5604,6 +5729,11 @@ Object {
       "2.0": 10,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_10ul/1",
+    "opentrons/opentrons_96_filtertiprack_10ul/1",
+    "opentrons/geb_96_tiprack_10ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P10 Single-Channel GEN1",
   "maxVolume": 10,
@@ -5644,6 +5774,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 8-Channel GEN1",
   "maxVolume": 50,
@@ -5684,6 +5818,10 @@ Object {
       "2.0": 50,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P50 Single-Channel GEN1",
   "maxVolume": 50,
@@ -5724,6 +5862,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 8-Channel GEN1",
   "maxVolume": 300,
@@ -5764,6 +5906,10 @@ Object {
       "2.0": 300,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_300ul/1",
+    "opentrons/opentrons_96_filtertiprack_200ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P300 Single-Channel GEN1",
   "maxVolume": 300,
@@ -5804,6 +5950,11 @@ Object {
       "2.0": 1000,
     },
   },
+  "defaultTipracks": Array [
+    "opentrons/opentrons_96_tiprack_1000ul/1",
+    "opentrons/opentrons_96_filtertiprack_1000ul/1",
+    "opentrons/geb_96_tiprack_1000ul/1",
+  ],
   "displayCategory": "GEN1",
   "displayName": "P1000 Single-Channel GEN1",
   "maxVolume": 1000,

--- a/shared-data/js/types.js
+++ b/shared-data/js/types.js
@@ -298,6 +298,7 @@ export type PipetteNameSpecs = {|
   defaultAspirateFlowRate: FlowRateSpec,
   defaultDispenseFlowRate: FlowRateSpec,
   defaultBlowOutFlowRate: FlowRateSpec,
+  defaultTipracks: Array<string>,
   smoothieConfigs?: {|
     stepsPerMM: number,
     homePosition: number,

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -31,7 +31,8 @@
     "defaultTipracks": [
       "opentrons/opentrons_96_tiprack_10ul/1",
       "opentrons/opentrons_96_filtertiprack_10ul/1",
-      "opentrons/geb_96_tiprack_10ul/1"]
+      "opentrons/geb_96_tiprack_10ul/1"
+    ]
   },
   "p10_multi": {
     "displayName": "P10 8-Channel GEN1",
@@ -65,7 +66,8 @@
     "defaultTipracks": [
       "opentrons/opentrons_96_tiprack_10ul/1",
       "opentrons/opentrons_96_filtertiprack_10ul/1",
-      "opentrons/geb_96_tiprack_10ul/1"]
+      "opentrons/geb_96_tiprack_10ul/1"
+    ]
   },
   "p20_single_gen2": {
     "displayName": "P20 Single-Channel GEN2",
@@ -110,7 +112,8 @@
       "opentrons/opentrons_96_filtertiprack_20ul/1",
       "opentrons/opentrons_96_tiprack_10ul/1",
       "opentrons/opentrons_96_filtertiprack_10ul/1",
-      "opentrons/geb_96_tiprack_10ul/1"]
+      "opentrons/geb_96_tiprack_10ul/1"
+    ]
   },
   "p20_multi_gen2": {
     "displayName": "P20 8-Channel GEN2",
@@ -152,7 +155,8 @@
       "opentrons/opentrons_96_filtertiprack_20ul/1",
       "opentrons/opentrons_96_tiprack_10ul/1",
       "opentrons/opentrons_96_filtertiprack_10ul/1",
-      "opentrons/geb_96_tiprack_10ul/1"]
+      "opentrons/geb_96_tiprack_10ul/1"
+    ]
   },
   "p50_single": {
     "displayName": "P50 Single-Channel GEN1",
@@ -405,7 +409,8 @@
     "defaultTipracks": [
       "opentrons/opentrons_96_tiprack_1000ul/1",
       "opentrons/opentrons_96_filtertiprack_1000ul/1",
-      "opentrons/geb_96_tiprack_1000ul/1"]
+      "opentrons/geb_96_tiprack_1000ul/1"
+    ]
   },
   "p1000_single_gen2": {
     "displayName": "P1000 Single-Channel GEN2",
@@ -448,6 +453,7 @@
     "defaultTipracks": [
       "opentrons/opentrons_96_tiprack_1000ul/1",
       "opentrons/opentrons_96_filtertiprack_1000ul/1",
-      "opentrons/geb_96_tiprack_1000ul/1"]
+      "opentrons/geb_96_tiprack_1000ul/1"
+    ]
   }
 }

--- a/shared-data/pipette/definitions/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/pipetteNameSpecs.json
@@ -27,7 +27,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_10ul/1",
+      "opentrons/opentrons_96_filtertiprack_10ul/1",
+      "opentrons/geb_96_tiprack_10ul/1"]
   },
   "p10_multi": {
     "displayName": "P10 8-Channel GEN1",
@@ -57,7 +61,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_10ul/1",
+      "opentrons/opentrons_96_filtertiprack_10ul/1",
+      "opentrons/geb_96_tiprack_10ul/1"]
   },
   "p20_single_gen2": {
     "displayName": "P20 Single-Channel GEN2",
@@ -96,7 +104,13 @@
       "stepsPerMM": 3200,
       "homePosition": 172.15,
       "travelDistance": 60
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_20ul/1",
+      "opentrons/opentrons_96_filtertiprack_20ul/1",
+      "opentrons/opentrons_96_tiprack_10ul/1",
+      "opentrons/opentrons_96_filtertiprack_10ul/1",
+      "opentrons/geb_96_tiprack_10ul/1"]
   },
   "p20_multi_gen2": {
     "displayName": "P20 8-Channel GEN2",
@@ -132,7 +146,13 @@
       "stepsPerMM": 3200,
       "homePosition": 155.75,
       "travelDistance": 60
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_20ul/1",
+      "opentrons/opentrons_96_filtertiprack_20ul/1",
+      "opentrons/opentrons_96_tiprack_10ul/1",
+      "opentrons/opentrons_96_filtertiprack_10ul/1",
+      "opentrons/geb_96_tiprack_10ul/1"]
   },
   "p50_single": {
     "displayName": "P50 Single-Channel GEN1",
@@ -162,7 +182,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p50_multi": {
     "displayName": "P50 8-Channel GEN1",
@@ -192,7 +216,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p300_single": {
     "displayName": "P300 Single-Channel GEN1",
@@ -222,7 +250,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p300_single_gen2": {
     "displayName": "P300 Single-Channel GEN2",
@@ -261,7 +293,11 @@
       "stepsPerMM": 3200,
       "homePosition": 172.15,
       "travelDistance": 60
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p300_multi_gen2": {
     "displayName": "P300 8-Channel GEN2",
@@ -297,7 +333,11 @@
       "stepsPerMM": 3200,
       "homePosition": 155.75,
       "travelDistance": 60
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p300_multi": {
     "displayName": "P300 8-Channel GEN1",
@@ -327,7 +367,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_300ul/1",
+      "opentrons/opentrons_96_filtertiprack_200ul/1"
+    ]
   },
   "p1000_single": {
     "displayName": "P1000 Single-Channel GEN1",
@@ -357,7 +401,11 @@
       "stepsPerMM": 768,
       "homePosition": 220,
       "travelDistance": 30
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_1000ul/1",
+      "opentrons/opentrons_96_filtertiprack_1000ul/1",
+      "opentrons/geb_96_tiprack_1000ul/1"]
   },
   "p1000_single_gen2": {
     "displayName": "P1000 Single-Channel GEN2",
@@ -396,6 +444,10 @@
       "stepsPerMM": 3200,
       "homePosition": 172.15,
       "travelDistance": 60
-    }
+    },
+    "defaultTipracks": [
+      "opentrons/opentrons_96_tiprack_1000ul/1",
+      "opentrons/opentrons_96_filtertiprack_1000ul/1",
+      "opentrons/geb_96_tiprack_1000ul/1"]
   }
 }

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -85,7 +85,8 @@
             "dropTipSpeed",
             "ulPerMm",
             "tipLength",
-            "nozzleOffset"
+            "nozzleOffset",
+            "defaultTipracks"
           ],
           "additionalProperties": false,
           "properties": {
@@ -136,6 +137,12 @@
                 "default": { "type": "number" }
               },
               "additionalProperties": { "type": "number" }
+            },
+            "defaultTipracks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteModelSpecsSchema.json
@@ -85,8 +85,7 @@
             "dropTipSpeed",
             "ulPerMm",
             "tipLength",
-            "nozzleOffset",
-            "defaultTipracks"
+            "nozzleOffset"
           ],
           "additionalProperties": false,
           "properties": {
@@ -137,12 +136,6 @@
                 "default": { "type": "number" }
               },
               "additionalProperties": { "type": "number" }
-            },
-            "defaultTipracks": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
             }
           }
         }

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -81,9 +81,9 @@
         },
         "defaultTipracks": {
           "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
+++ b/shared-data/pipette/schemas/pipetteNameSpecsSchema.json
@@ -51,7 +51,8 @@
         "defaultDispenseFlowRate",
         "defaultBlowOutFlowRate",
         "maxVolume",
-        "minVolume"
+        "minVolume",
+        "defaultTipracks"
       ],
       "additionalProperties": false,
       "properties": {
@@ -77,6 +78,12 @@
             "homePosition": { "type": "number" },
             "travelDistance": { "type": "number" }
           }
+        },
+        "defaultTipracks": {
+          "type": "array",
+            "items": {
+              "type": "string"
+            }
         }
       }
     }

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -18,11 +18,16 @@ PipetteName = Union[Literal['p10_single'], Literal['p10_multi'],
                     Literal['p1000_single'], Literal['p100_single_gen2']]
 
 PipetteDefaultTiprack =\
-    Union[Literal["opentrons/opentrons_96_tiprack_10ul/1"], Literal["opentrons/opentrons_96_filtertiprack_10ul/1"],
-          Literal["opentrons/geb_96_tiprack_10ul/1"], Literal["opentrons/opentrons_96_tiprack_20ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_20ul/1"], Literal["opentrons/opentrons_96_tiprack_300ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_200ul/1"], Literal["opentrons/opentrons_96_tiprack_1000ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_1000ul/1"], Literal["opentrons/geb_96_tiprack_1000ul/1"]]
+    Union[Literal["opentrons/opentrons_96_tiprack_10ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_10ul/1"],
+          Literal["opentrons/geb_96_tiprack_10ul/1"],
+          Literal["opentrons/opentrons_96_tiprack_20ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_20ul/1"],
+          Literal["opentrons/opentrons_96_tiprack_300ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_200ul/1"],
+          Literal["opentrons/opentrons_96_tiprack_1000ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_1000ul/1"],
+          Literal["opentrons/geb_96_tiprack_1000ul/1"]]
 
 # Generic NewType for models because we get new ones frequently and theres
 # a huge number of them

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -17,6 +17,13 @@ PipetteName = Union[Literal['p10_single'], Literal['p10_multi'],
                     Literal['p300_single_gen2'], Literal['p300_multi_gen2'],
                     Literal['p1000_single'], Literal['p100_single_gen2']]
 
+PipetteDefaultTiprack =\
+    Union[Literal["opentrons/opentrons_96_tiprack_10ul/1"], Literal["opentrons/opentrons_96_filtertiprack_10ul/1"],
+          Literal["opentrons/geb_96_tiprack_10ul/1"], Literal["opentrons/opentrons_96_tiprack_20ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_20ul/1"], Literal["opentrons/opentrons_96_tiprack_300ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_200ul/1"], Literal["opentrons/opentrons_96_tiprack_1000ul/1"],
+          Literal["opentrons/opentrons_96_filtertiprack_1000ul/1"], Literal["opentrons/geb_96_tiprack_1000ul/1"]]
+
 # Generic NewType for models because we get new ones frequently and theres
 # a huge number of them
 PipetteModel = NewType('PipetteModel', str)
@@ -82,6 +89,7 @@ class PipetteNameSpec(TypedDict):
     defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
     smoothieConfigs: SmoothieConfigs
+    defaultTipracks: List[PipetteDefaultTiprack]
 
 
 PipetteNameSpecs = Dict[PipetteName, PipetteNameSpec]

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -4,11 +4,12 @@ require typing_extensions.
 
 This module should only be imported if typing.TYPE_CHECKING is True.
 """
-
 from typing import Dict, List, NewType, Union
 
 from typing_extensions import Literal, TypedDict
 
+
+LabwareUri = NewType('LabwareUri', str)
 # Explicit listing of pipette names because we don't frequently get new ones
 PipetteName = Union[Literal['p10_single'], Literal['p10_multi'],
                     Literal['p20_single_gen2'], Literal['p20_multi_gen2'],
@@ -16,18 +17,6 @@ PipetteName = Union[Literal['p10_single'], Literal['p10_multi'],
                     Literal['p300_single'], Literal['p300_multi'],
                     Literal['p300_single_gen2'], Literal['p300_multi_gen2'],
                     Literal['p1000_single'], Literal['p100_single_gen2']]
-
-PipetteDefaultTiprack =\
-    Union[Literal["opentrons/opentrons_96_tiprack_10ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_10ul/1"],
-          Literal["opentrons/geb_96_tiprack_10ul/1"],
-          Literal["opentrons/opentrons_96_tiprack_20ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_20ul/1"],
-          Literal["opentrons/opentrons_96_tiprack_300ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_200ul/1"],
-          Literal["opentrons/opentrons_96_tiprack_1000ul/1"],
-          Literal["opentrons/opentrons_96_filtertiprack_1000ul/1"],
-          Literal["opentrons/geb_96_tiprack_1000ul/1"]]
 
 # Generic NewType for models because we get new ones frequently and theres
 # a huge number of them
@@ -94,7 +83,7 @@ class PipetteNameSpec(TypedDict):
     defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
     defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
     smoothieConfigs: SmoothieConfigs
-    defaultTipracks: List[PipetteDefaultTiprack]
+    defaultTipracks: List[LabwareUri]
 
 
 PipetteNameSpecs = Dict[PipetteName, PipetteNameSpec]


### PR DESCRIPTION
# Overview

Closes #7085. Add a key called `defaultTipracks` which holds a list of tiprack URIs that are compatible with that pipette type, and part of the opentrons labware library.

# Changelog

- Modify pipetteNameSpecs to accommodate the new key
- Load that key into pipette configs
- Update snapshots

# Review requests

Cool with the key name? Anything else you would like to change?

# Risk assessment

Low, adding another key to `pipetteNameSpecs`.
