### PR TITLE
fix(labware-library): Render custom labware footprint diagram correctly

### DIFF
--- a/labware-library/src/labware-creator/images/footprint.svg
+++ b/labware-library/src/labware-creator/images/footprint.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" 
+<svg xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink" width="361" height="254" viewBox="0 0 361 254">
     <defs>
         <clipPath id="a">
@@ -9,7 +9,7 @@
         </clipPath>
     </defs>
     <title>footprint</title>
-    <rect x="29.5" y="30" width="215" height="143" rx="1" fill="none" stroke="#000" stroke-width="2"/>
+    <rect x="29.5" y="30" width="215" height="143" rx="1" fill="none" stroke="black" stroke-width="3"/>
     <path d="M230.34,166.68H43.66A7.69,7.69,0,0,1,36,159V44.16a7.69,7.69,0,0,1,7.66-7.66H230.34A7.69,7.69,0,0,1,238,44.16V159a7.69,7.69,0,0,1-7.66,7.66Z" fill="none" stroke="#b3b3b3"/>
     <path d="M29,223V176.5m215,0V223m56-49.75H247.25m.63-143H300" fill="none" stroke="#3fb1ff" stroke-width="2"/>
     <line x1="233.46" y1="212.5" x2="37.54" y2="212.5" fill="none" stroke="#3fb1ff" stroke-dasharray="2 2"/>


### PR DESCRIPTION
# Overview

closes #6983. see ticket for before/after shots. basically, we want the big black outline to actually render.

# Changelog

- fix(labware-library): Render custom labware footprint diagram correctly

# Review requests

- [ ] labware footprint diagram now has the black outline for the slot

 _honestly, this was a lot of hunting and pecking, looks like upping the stroke for that `rect` was what it took_ 

# Risk assessment

low svg in LL LC only