### PR TITLE
feat(app,app-shell): Show errors when labware definition invalid

### DIFF
--- a/app-shell/src/labware/validation.ts
+++ b/app-shell/src/labware/validation.ts
@@ -37,8 +37,8 @@ export function validateLabwareFiles(
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const definition = data && validateLabwareDefinition(data)
 
-    if (definition === null) {
-      return { filename, modified, type: INVALID_LABWARE_FILE }
+    if (errors) {
+      return { filename, modified, type: INVALID_LABWARE_FILE, errors }
     }
 
     const props = { filename, modified, definition }

--- a/app/src/pages/More/AddLabwareCard/AddLabwareFailureModal.tsx
+++ b/app/src/pages/More/AddLabwareCard/AddLabwareFailureModal.tsx
@@ -109,8 +109,12 @@ export function AddLabwareFailureModalTemplate(
         <p>
           {THE_FILE} {renderFilename(file)} {IS_NOT_A_VALID_LABWARE_DEFINITION}
         </p>
-        {file.errors && file.errors.map(({ dataPath, message }) =>
-          <p>{dataPath} {message}</p>)}
+        {file.errors &&
+          file.errors.map(({ dataPath, message }) => (
+            <p>
+              {dataPath} {message}
+            </p>
+          ))}
       </>
     )
   } else if (file.type === OPENTRONS_LABWARE_FILE) {

--- a/app/src/pages/More/AddLabwareCard/AddLabwareFailureModal.tsx
+++ b/app/src/pages/More/AddLabwareCard/AddLabwareFailureModal.tsx
@@ -105,9 +105,13 @@ export function AddLabwareFailureModalTemplate(
   } else if (file.type === INVALID_LABWARE_FILE) {
     heading = INVALID_LABWARE_DEFINITION
     children = (
-      <p>
-        {THE_FILE} {renderFilename(file)} {IS_NOT_A_VALID_LABWARE_DEFINITION}
-      </p>
+      <>
+        <p>
+          {THE_FILE} {renderFilename(file)} {IS_NOT_A_VALID_LABWARE_DEFINITION}
+        </p>
+        {file.errors && file.errors.map(({ dataPath, message }) =>
+          <p>{dataPath} {message}</p>)}
+      </>
     )
   } else if (file.type === OPENTRONS_LABWARE_FILE) {
     heading = CONFLICT_WITH_OPENTRONS_LABWARE

--- a/app/src/pages/More/ListLabwareCard/LabwareItem.tsx
+++ b/app/src/pages/More/ListLabwareCard/LabwareItem.tsx
@@ -70,6 +70,8 @@ export function LabwareItem(props: LabwareItemProps): JSX.Element {
           <div className={styles.item_warning_wrapper}>
             <Warning>
               <p>{warning}</p>
+                {errors && errors.map(({ dataPath, message }) =>
+                  <p>{dataPath} {message}</p>)}
             </Warning>
           </div>
         )}

--- a/app/src/pages/More/ListLabwareCard/LabwareItem.tsx
+++ b/app/src/pages/More/ListLabwareCard/LabwareItem.tsx
@@ -70,8 +70,12 @@ export function LabwareItem(props: LabwareItemProps): JSX.Element {
           <div className={styles.item_warning_wrapper}>
             <Warning>
               <p>{warning}</p>
-                {errors && errors.map(({ dataPath, message }) =>
-                  <p>{dataPath} {message}</p>)}
+              {errors &&
+                errors.map(({ dataPath, message }) => (
+                  <p>
+                    {dataPath} {message}
+                  </p>
+                ))}
             </Warning>
           </div>
         )}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

The purpose of this pull request is to show Ajv validation errors. I spent a good while today troubleshooting my labware definition, which I think is needless since Ajv points out exactly what went wrong.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Make [`validatelabwareDefinition`](https://github.com/MarcelRobitaille/opentrons/blob/4e889d470660c0ab20f0328bfaa140cac8aaad5f/app-shell/src/labware/validation.js#L28) return a list of validation errors
- Make [`validateLabwareFiles`](https://github.com/MarcelRobitaille/opentrons/blob/4e889d470660c0ab20f0328bfaa140cac8aaad5f/app-shell/src/labware/validation.js#L34) add `errors` key to each returned file object
- Make [`AddLabwareFailureModal`](https://github.com/MarcelRobitaille/opentrons/blob/4e889d470660c0ab20f0328bfaa140cac8aaad5f/app/src/components/AddLabwareCard/AddLabwareFailureModal.js#L111) and [`LabwareItem`](https://github.com/MarcelRobitaille/opentrons/blob/4e889d470660c0ab20f0328bfaa140cac8aaad5f/app/src/components/ListLabwareCard/LabwareItem.js#L73) show a list of validation errors

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Ack shows that `validateLabwareDefinition` is not used anywhere else, so there is no risk to change its signature.
Adding the `errors` key to the file object should not pose any risk either.

Adding elements to the UI could have an adverse affect on layout.

I admit that I have not run / added tests, but when I `make test-js`, I get `SyntaxError: Cannot use import statement outside a module` for each file, although I followed installation diligently.

I checked for open issues, and didn't find any.