### PR TITLE
feat(api): fast instrument simulation

### DIFF
--- a/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
@@ -2,7 +2,6 @@ import typing
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, \
     Clearances
 from opentrons.protocols.implementations.interfaces.instrument_context import \
@@ -10,24 +9,23 @@ from opentrons.protocols.implementations.interfaces.instrument_context import \
 from opentrons.protocols.implementations.interfaces.protocol_context import \
     ProtocolContextInterface
 from opentrons.protocols.implementations.well import WellImplementation
-from opentrons.protocols.types import APIVersion
 
 
 class SimInstrumentContext(InstrumentContextInterface):
+    """A simulation of an instrument context."""
 
     def __init__(self,
                  protocol_interface: ProtocolContextInterface,
                  pipette_dict: PipetteDict,
                  mount: types.Mount,
                  instrument_name: str,
-                 default_speed: float = 400.0,
-                 api_version: APIVersion = None):
+                 default_speed: float = 400.0):
+        """Constructor."""
         self._protocol_interface = protocol_interface
         self._mount = mount
         self._pipette_dict = pipette_dict
         self._instrument_name = instrument_name
         self._default_speed = default_speed
-        self._api_version = api_version or MAX_SUPPORTED_VERSION
         self._flow_rate = FlowRates(self)
         self._plunger_speeds = PlungerSpeeds(self)
 

--- a/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
@@ -1,0 +1,126 @@
+import typing
+
+from opentrons import types
+from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, \
+    Clearances
+from opentrons.protocols.implementations.interfaces.instrument_context import \
+    InstrumentContextInterface
+from opentrons.protocols.implementations.interfaces.protocol_context import \
+    ProtocolContextInterface
+from opentrons.protocols.implementations.well import WellImplementation
+
+
+class SimInstrumentContext(InstrumentContextInterface):
+
+    def __init__(self,
+                 protocol_interface: ProtocolContextInterface,
+                 pipette_dict: PipetteDict,
+                 mount: types.Mount,
+                 instrument_name: str):
+        self._protocol_interface = protocol_interface
+        self._mount = mount
+        self._pipette_dict = pipette_dict
+        self._instrument_name = instrument_name
+
+    def get_default_speed(self) -> float:
+        return 40
+
+    def set_default_speed(self, speed: float) -> None:
+        pass
+
+    def aspirate(self, volume: float, rate: float = 1.0) -> None:
+        pass
+
+    def dispense(self, volume: float, rate: float = 1.0) -> None:
+        pass
+
+    def blow_out(self) -> None:
+        pass
+
+    def touch_tip(self, location: WellImplementation, radius: float = 1.0,
+                  v_offset: float = -1.0, speed: float = 60.0) -> None:
+        pass
+
+    def pick_up_tip(self, well: WellImplementation, tip_length: float,
+                    presses: typing.Optional[int] = None,
+                    increment: typing.Optional[float] = None) -> None:
+        pass
+
+    def drop_tip(self, home_after: bool = True) -> None:
+        pass
+
+    def home(self) -> None:
+        pass
+
+    def home_plunger(self) -> None:
+        pass
+
+    def delay(self) -> None:
+        pass
+
+    def move_to(self, location: types.Location, force_direct: bool = False,
+                minimum_z_height: typing.Optional[float] = None,
+                speed: typing.Optional[float] = None) -> None:
+        pass
+
+    def get_mount(self) -> types.Mount:
+        return self._mount
+
+    def get_instrument_name(self) -> str:
+        return self._instrument_name
+
+    def get_pipette_name(self) -> str:
+        return self._pipette_dict['name']
+
+    def get_model(self) -> str:
+        return self._pipette_dict['model']
+
+    def get_min_volume(self) -> float:
+        return self._pipette_dict['min_volume']
+
+    def get_max_volume(self) -> float:
+        return self._pipette_dict['max_volume']
+
+    def get_current_volume(self) -> float:
+        return self._pipette_dict['current_volume']
+
+    def get_available_volume(self) -> float:
+        return self._pipette_dict['available_volume']
+
+    def get_pipette(self) -> PipetteDict:
+        return self._pipette_dict
+
+    def get_channels(self) -> int:
+        return self._pipette_dict['channels']
+
+    def has_tip(self) -> bool:
+        return self._pipette_dict['has_tip']
+
+    def is_ready_to_aspirate(self) -> bool:
+        return self._pipette_dict['ready_to_aspirate']
+
+    def prepare_for_aspirate(self) -> None:
+        pass
+
+    def get_return_height(self) -> float:
+        return self._pipette_dict['return_tip_height']
+
+    def get_well_bottom_clearance(self) -> Clearances:
+        return Clearances(default_aspirate=1, default_dispense=1)
+
+    def get_speed(self) -> PlungerSpeeds:
+        return PlungerSpeeds(self)
+
+    def get_flow_rate(self) -> FlowRates:
+        return FlowRates(self)
+
+    def set_flow_rate(self, aspirate: typing.Optional[float] = None,
+                      dispense: typing.Optional[float] = None,
+                      blow_out: typing.Optional[float] = None) -> None:
+        pass
+
+    def set_pipette_speed(self, aspirate: typing.Optional[float] = None,
+                          dispense: typing.Optional[float] = None,
+                          blow_out: typing.Optional[float] = None) -> None:
+        pass

--- a/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
@@ -1,0 +1,36 @@
+from opentrons import types
+from opentrons.protocols.implementations.interfaces.instrument_context import \
+    InstrumentContextInterface
+from opentrons.protocols.implementations.protocol_context import \
+    ProtocolContextImplementation
+from opentrons.protocols.implementations.simulators.instrument_context import \
+    SimInstrumentContext
+
+
+class SimProtocolContext(ProtocolContextImplementation):
+    def load_instrument(self,
+                        instrument_name: str,
+                        mount: types.Mount,
+                        replace: bool = False) -> InstrumentContextInterface:
+        instr = self._instruments[mount]
+        if instr and not replace:
+            raise RuntimeError(
+                f"Instrument already present in {mount.name.lower()} "
+                f"mount: {instr.get_instrument_name()}")
+
+        attached = {att_mount: instr.get('name', None)
+                    for att_mount, instr
+                    in self._hw_manager.hardware.attached_instruments.items()
+                    if instr}
+        attached[mount] = instrument_name
+        self._hw_manager.hardware.cache_instruments(attached)
+        # If the cache call didn’t raise, the instrument is attached
+        new_instr = SimInstrumentContext(
+            protocol_interface=self,
+            pipette_dict=self._hw_manager.hardware.get_attached_instruments()[mount],
+            mount=mount,
+            instrument_name=instrument_name,
+        )
+        self._instruments[mount] = new_instr
+        self._log.info("Instrument {} loaded".format(new_instr))
+        return new_instr

--- a/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
@@ -12,6 +12,7 @@ class SimProtocolContext(ProtocolContextImplementation):
                         instrument_name: str,
                         mount: types.Mount,
                         replace: bool = False) -> InstrumentContextInterface:
+        """Create a simulating instrument context."""
         instr = self._instruments[mount]
         if instr and not replace:
             raise RuntimeError(
@@ -24,13 +25,15 @@ class SimProtocolContext(ProtocolContextImplementation):
                     if instr}
         attached[mount] = instrument_name
         self._hw_manager.hardware.cache_instruments(attached)
-        # If the cache call didn’t raise, the instrument is attached
+
         new_instr = SimInstrumentContext(
             protocol_interface=self,
-            pipette_dict=self._hw_manager.hardware.get_attached_instruments()[mount],
+            pipette_dict=self._hw_manager.hardware.get_attached_instruments()[
+                mount
+            ],
             mount=mount,
             instrument_name=instrument_name,
         )
         self._instruments[mount] = new_instr
-        self._log.info("Instrument {} loaded".format(new_instr))
+        self._log.info(f"Instrument {new_instr} loaded")
         return new_instr


### PR DESCRIPTION
# Overview

This PR adds a lightweight simulation of an `InstrumentContextInterface`. The benefit is a simulation time improvement of roughly 10x in my and @jerader 's testing. 

The speed improvement is achieved by not using a `SynchronousAdapter`. 

# Changelog

- Create `SimInstrumentContext` that modifies a cached `PipetteDict` as hardware controller does
- Create `SimProtocolContext` that creates a `SimInstrumentContext` in `load_instrument` instead of `InstrumentContextImplementation`.

# Review requests

This simulator has been tested against a few complex protocols provided by @jerader . The run log was validated as being identical to full simulation result.

Is there more that this instrument context simulation should do?

I am slightly conflicted about the approach of this PR. Part of me believes that we should address the root cause of simulation performance: hardware controller's mishmash of asyncio and multithreading requiring complex adapters.  

# Risk assessment

None. This is not used yet.