### PR TITLE
feat(robot-server): expose uvicorn logs

### DIFF
--- a/robot-server/robot_server/service/legacy/models/health.py
+++ b/robot-server/robot_server/service/legacy/models/health.py
@@ -11,6 +11,9 @@ class Links(BaseModel):
     serialLog: str = \
         Field(...,
               description="The URI of the serial logs")
+    serverLog: str = \
+        Field(...,
+              description="The URI of the server logs")
     apiSpec: str = \
         Field(...,
               description="The URI to this API specification")

--- a/robot-server/robot_server/service/legacy/models/logs.py
+++ b/robot-server/robot_server/service/legacy/models/logs.py
@@ -5,6 +5,7 @@ class LogIdentifier(str, Enum):
     """Identifier of the log"""
     api = "api.log"
     serial = "serial.log"
+    server = "server.log"
 
 
 class LogFormat(str, Enum):

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -22,7 +22,7 @@ router = APIRouter()
             response_description="OT-2 /health response")
 async def get_health(
         hardware: ThreadManager = Depends(get_hardware)) -> Health:
-    static_paths = ['/logs/serial.log', '/logs/api.log']
+    static_paths = ['/logs/serial.log', '/logs/api.log', '/logs/server.log']
     # This conditional handles the case where we have just changed
     # the use protocol api v2 feature flag, so it does not match
     # the type of hardware we're actually using.
@@ -44,6 +44,7 @@ async def get_health(
                   links=Links(
                       apiLog='/logs/api.log',
                       serialLog='/logs/serial.log',
+                      serverLog='/logs/server.log',
                       apiSpec="/openapi.json",
                       systemTime="/system/time"
                   ))

--- a/robot-server/tests/service/legacy/routers/test_health.py
+++ b/robot-server/tests/service/legacy/routers/test_health.py
@@ -12,13 +12,14 @@ def test_health(api_client, hardware):
         'api_version': __version__,
         'fw_version': 'FW111',
         'board_revision': 'BR2.1',
-        'logs': ['/logs/serial.log', '/logs/api.log'],
+        'logs': ['/logs/serial.log', '/logs/api.log', '/logs/server.log'],
         'system_version': '0.0.0',
         'minimum_protocol_api_version': list(MIN_SUPPORTED_VERSION),
         'maximum_protocol_api_version': list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",
+            "serverLog": "/logs/server.log",
             "apiSpec": "/openapi.json",
             "systemTime": "/system/time"
         }


### PR DESCRIPTION
We currently expose nice ways to download logs from the opentrons api
package, and from the serial port handlers. What that leaves as a hole
is logging from the server, which encompasses both the built in response
logs (very useful for figuring out interaction patterns) and errors that
bubble up to the server logging handlers.

By adding a URI to the health response logs array, we can get the app to
download the server logs quite easily.

Closes #7097
