### PR TITLE
perf(api): simulation optimizations

### DIFF
--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -38,10 +38,11 @@ def do_publish(
         broker.logger.info("{}: {}".format(
             f.__qualname__,
             {k: v for k, v in call_args.items() if str(k) != 'self'}))
+    getfullargspec = inspect.getfullargspec(cmd)
     command_args = dict(
         zip(
-            reversed(inspect.getfullargspec(cmd).args),
-            reversed(inspect.getfullargspec(cmd).defaults
+            reversed(getfullargspec.args),
+            reversed(getfullargspec.defaults
                      or [])))
 
     # TODO (artyom, 20170927): we are doing this to be able to use
@@ -49,7 +50,7 @@ def do_publish(
     # self is effectively an instrument.
     # To narrow the scope of this hack, we are checking if the
     # command is expecting instrument first.
-    if 'instrument' in inspect.getfullargspec(cmd).args:
+    if 'instrument' in getfullargspec.args:
         # We are also checking if call arguments have 'self' and
         # don't have instruments specified, in which case
         # instruments should take precedence.
@@ -59,7 +60,7 @@ def do_publish(
     command_args.update({
         key: call_args[key]
         for key in
-        (set(inspect.getfullargspec(cmd).args)
+        (set(getfullargspec.args)
          & call_args.keys())
     })
 

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -139,8 +139,8 @@ class publish:
 
 
 class SignatureCache:
-    def __init__(self):
-        self._cache = {}
+    def __init__(self) -> None:
+        self._cache: Dict[Callable, inspect.Signature] = {}
 
     def get(self, f: Callable) -> inspect.Signature:
         sig = self._cache.get(f)

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class PipetteConfig:
     top: float
     bottom: float

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -67,6 +67,7 @@ class Pipette:
             = self._config.default_dispense_flow_rates['2.0']
         self._blow_out_flow_rate\
             = self._config.default_blow_out_flow_rates['2.0']
+        self._config_as_dict = asdict(config)
 
     def act_as(self, name: PipetteName):
         """ Reconfigure to act as ``name``. ``name`` must be either the
@@ -105,6 +106,8 @@ class Pipette:
         self._log.info("updated config: {}={}".format(elem_name, elem_val))
         self._config = replace(self._config,
                                **{elem_name: elem_val})
+        # Update the cached dict representation
+        self._config_as_dict = asdict(self._config)
 
     @property
     def name(self) -> PipetteName:
@@ -295,18 +298,19 @@ class Pipette:
                                     id(self))
 
     def as_dict(self) -> 'Pipette.DictType':
-        config_dict = asdict(self.config)
-        config_dict.update({'current_volume': self.current_volume,
-                            'available_volume': self.available_volume,
-                            'name': self.name,
-                            'model': self.model,
-                            'pipette_id': self.pipette_id,
-                            'has_tip': self.has_tip,
-                            'working_volume': self.working_volume,
-                            'aspirate_flow_rate':  self.aspirate_flow_rate,
-                            'dispense_flow_rate': self.dispense_flow_rate,
-                            'blow_out_flow_rate': self.blow_out_flow_rate})
-        return config_dict
+        self._config_as_dict.update({
+            'current_volume': self.current_volume,
+            'available_volume': self.available_volume,
+            'name': self.name,
+            'model': self.model,
+            'pipette_id': self.pipette_id,
+            'has_tip': self.has_tip,
+            'working_volume': self.working_volume,
+            'aspirate_flow_rate':  self.aspirate_flow_rate,
+            'dispense_flow_rate': self.dispense_flow_rate,
+            'blow_out_flow_rate': self.blow_out_flow_rate
+        })
+        return self._config_as_dict
 
 
 def _reload_and_check_skip(

--- a/api/src/opentrons/hardware_control/pipette.py
+++ b/api/src/opentrons/hardware_control/pipette.py
@@ -67,6 +67,8 @@ class Pipette:
             = self._config.default_dispense_flow_rates['2.0']
         self._blow_out_flow_rate\
             = self._config.default_blow_out_flow_rates['2.0']
+        # cache a dict representation of config for improved performance of
+        # as_dict.
         self._config_as_dict = asdict(config)
 
     def act_as(self, name: PipetteName):

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -377,11 +377,12 @@ def requires_version(
             added_in = decorated_obj.__opentrons_version_added  # type: ignore
             current_version = slf._api_version
 
-            # __qualname__ is *probably* set on every kind of object we care
-            # about, but the docs leave it ambiguous, so fall back to str().
-            name = getattr(decorated_obj, "__qualname__", str(decorated_obj))
-
             if APIVersion(2, 0) <= current_version < added_in:
+                # __qualname__ is *probably* set on every kind of object we care
+                # about, but the docs leave it ambiguous, so fall back to str().
+                name = getattr(decorated_obj, "__qualname__",
+                               str(decorated_obj))
+
                 raise APIVersionError(
                     f'{name} was added in {added_in}, but your '
                     f'protocol requested version {current_version}. You '

--- a/api/src/opentrons/protocols/implementations/instrument_context.py
+++ b/api/src/opentrons/protocols/implementations/instrument_context.py
@@ -231,7 +231,7 @@ class InstrumentContextImplementation(InstrumentContextInterface):
     def get_pipette(self) -> PipetteDict:
         """Get the hardware pipette dictionary."""
         hw_manager = self._protocol_interface.get_hardware()
-        pipette = hw_manager.hardware.attached_instruments[self._mount]
+        pipette = hw_manager.hardware.get_attached_instrument(self._mount)
         if pipette is None:
             raise types.PipetteNotAttachedError()
         return pipette


### PR DESCRIPTION
# Overview

This is a series of optimizations to improve the run time of simulations. 

In thinking about the value of simulation I decided to look at low hanging optimization fruit using `cProfiler`. Here are the top offenders as reported by profiler. 

Before:
```
        65592123 function calls (57143719 primitive calls) in 27.429 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
4311964/14767    5.540    0.000   14.864    0.001 dataclasses.py:1047(_asdict_inner)
    30500    3.918    0.000    3.918    0.000 {method 'acquire' of '_thread.lock' objects}
3325278/3278278    2.736    0.000    3.988    0.000 copy.py:132(deepcopy)
17196305/17195585    2.029    0.000    2.094    0.000 {built-in method builtins.isinstance}
  4326731    1.551    0.000    2.518    0.000 dataclasses.py:1012(_is_dataclass_instance)
4474401/1048457    1.175    0.000   11.462    0.000 dataclasses.py:1079(<genexpr>)
  6959146    0.655    0.000    0.655    0.000 {method 'get' of 'dict' objects}
4513678/4513669    0.562    0.000    0.562    0.000 {built-in method builtins.hasattr}
    55894    0.420    0.000    1.166    0.000 inspect.py:2117(_signature_from_function)
    88602    0.411    0.000    0.712    0.000 pipette_config.py:226(piecewise_volume_conversion)
    14768    0.391    0.000   16.699    0.001 api.py:427(get_attached_instruments)
    44704    0.324    0.000    1.445    0.000 inspect.py:1089(getfullargspec)
  3317674    0.316    0.000    0.316    0.000 copy.py:190(_deepcopy_atomic)
```
After
```
         9355602 function calls (9185625 primitive calls) in 9.150 seconds                                    
                                                                                                              
   Ordered by: internal time                                                                                  
                                                                                                              
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)                                       
    30500    3.312    0.000    3.312    0.000 {method 'acquire' of '_thread.lock' objects}                    
    88602    0.391    0.000    0.679    0.000 pipette_config.py:226(piecewise_volume_conversion)              
  2569458    0.288    0.000    0.288    0.000 pipette_config.py:242(<lambda>)                                 
    14769    0.188    0.000    1.248    0.000 api.py:448(get_attached_instrument)                             
    55182    0.162    0.000    0.374    0.000 labware_like.py:30(__init__)                                    
    11176    0.144    0.000    1.974    0.000 publisher.py:24(do_publish)                                     
    34563    0.139    0.000    0.334    0.000 adapters.py:58(__getattribute__)                                
102943/3605    0.135    0.000    8.513    0.002 util.py:374(_check_version_wrapper)                           
605743/605023    0.117    0.000    0.175    0.000 {built-in method builtins.isinstance}                       
    11176    0.116    0.000    0.169    0.000 inspect.py:2879(_bind)                                          
153475/153466    0.113    0.000    0.113    0.000 {built-in method builtins.hasattr}                          
     4207    0.103    0.000    3.887    0.001 instrument_context.py:155(move_to)                              
    11206    0.100    0.000    0.263    0.000 inspect.py:2117(_signature_from_function)                       
    11176    0.094    0.000    0.450    0.000 inspect.py:1089(getfullargspec)                                 
```

# Changelog

- Publisher makes a needless number of calls to `inspect.getfullargspec`. Reduce to 1 vs 4.

Before
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
44704    0.324    0.000    1.445    0.000 inspect.py:1089(getfullargspec)
```
After
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
11176    0.094    0.000    0.450    0.000 inspect.py:1089(getfullargspec)
```

- Memoize the results of `inspect.signature`.

Before
``` 
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
55894    0.420    0.000    1.166    0.000 inspect.py:2117(_signature_from_function)
```
After
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
11206    0.100    0.000    0.263    0.000 inspect.py:2117(_signature_from_function)
```
- add `API. get_attached_instrument` to get only the one `PipetteDict` that is needed from `InstrumentContext`.
- This is by far the most significant change. `Pipette.as_dict` can be called 1000s of times. Use some caching to avoid constant use of [`dataclass.asdict`]. 

Before (look at `cumtime` )
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
14767    0.078    0.000   15.040    0.001 pipette.py:297(as_dict)
```
After
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
14767    0.059    0.000    0.110    0.000 pipette.py:300(as_dict)
```
# Review requests

All tests were running on a mac. Protocol is Zymo_extraction.py.

```
def get_values(*names):
    import json
    _all_values = json.loads("""{"num_samples":96,"starting_vol":200,"binding_buffer_vol":400,"wash1_vol":500,"wash2_vol":500,"wash3_vol":500,"elution_vol":50,"mix_reps":10,"settling_time":5,"park_tips":true,"tip_track":false,"flash":true}""")
    return [_all_values[n] for n in names]


from opentrons.types import Point
import json
import os
import math
import threading
from time import sleep

metadata = {
    'protocolName': 'Zymo Extraction',
    'author': 'Opentrons <protocols@opentrons.com>',
    'apiLevel': '2.4'
}


"""
Here is where you can modify the magnetic module engage height:
"""
MAG_HEIGHT = 13.7


# Definitions for deck light flashing
class CancellationToken:
    def __init__(self):
        self.is_continued = False

    def set_true(self):
        self.is_continued = True

    def set_false(self):
        self.is_continued = False


def turn_on_blinking_notification(ccctx, pause):
    while pause.is_continued:
        ccctx.set_rail_lights(True)
        sleep(1)
        hardware.set_rail_lights(False)
        sleep(1)


def create_thread(ctx, cancel_token):
    t1 = threading.Thread(target=turn_on_blinking_notification,
                          args=(ctx, cancel_token))
    t1.start()
    return t1


# Start protocol
def run(ctx):
    # Setup for flashing lights notification to empty trash
    cancellationToken = CancellationToken()

    [num_samples, starting_vol, binding_buffer_vol, wash1_vol, wash2_vol,
     wash3_vol, elution_vol, mix_reps, settling_time,
     park_tips, tip_track, flash] = get_values(  # noqa: F821
        'num_samples', 'starting_vol', 'binding_buffer_vol', 'wash1_vol',
        'wash2_vol', 'wash3_vol', 'elution_vol', 'mix_reps', 'settling_time',
        'park_tips', 'tip_track', 'flash')

    """
    Here is where you can change the locations of your labware and modules
    (note that this is the recommended configuration)
    """
    magdeck = ctx.load_module('magnetic module gen2', '6')
    magdeck.disengage()
    magplate = magdeck.load_labware('nest_96_wellplate_2ml_deep',
                                    'deepwell plate')
    tempdeck = ctx.load_module('Temperature Module Gen2', '1')
    elutionplate = tempdeck.load_labware(
                'opentrons_96_aluminumblock_nest_wellplate_100ul',
                'elution plate')
    waste = ctx.load_labware('nest_1_reservoir_195ml', '9',
                             'Liquid Waste').wells()[0].top()
    res2 = ctx.load_labware(
        'nest_12_reservoir_15ml', '3', 'reagent reservoir 2')
    res1 = ctx.load_labware(
        'nest_12_reservoir_15ml', '2', 'reagent reservoir 1')
    num_cols = math.ceil(num_samples/8)
    tips300 = [ctx.load_labware('opentrons_96_tiprack_300ul', slot,
                                '200µl filtertiprack')
               for slot in ['4', '7', '8', '10', '11']]
    if park_tips:
        parkingrack = ctx.load_labware(
            'opentrons_96_tiprack_300ul', '5', 'tiprack for parking')
        parking_spots = parkingrack.rows()[0][:num_cols]
    else:
        tips300.insert(0, ctx.load_labware('opentrons_96_tiprack_300ul', '5',
                                           '200µl filtertiprack'))
        parking_spots = [None for none in range(12)]

    # load P300M pipette
    m300 = ctx.load_instrument(
        'p300_multi_gen2', 'left', tip_racks=tips300)

    """
    Here is where you can define the locations of your reagents.
    """
    binding_buffer = res1.wells()[:4]
    wash1 = res1.wells()[4:8]
    wash2 = res1.wells()[8:]
    wash3 = res2.wells()[:4]
    wash4 = res2.wells()[4:8]
    elution_solution = res2.wells()[-1]

    mag_samples_m = magplate.rows()[0][:num_cols]
    elution_samples_m = elutionplate.rows()[0][:num_cols]

    magdeck.disengage()  # just in case
#    tempdeck.set_temperature(4)

    m300.flow_rate.aspirate = 50
    m300.flow_rate.dispense = 150
    m300.flow_rate.blow_out = 300

    folder_path = '/data/B'
    tip_file_path = folder_path + '/tip_log.json'
    tip_log = {'count': {}}
    if tip_track and not ctx.is_simulating():
        if os.path.isfile(tip_file_path):
            with open(tip_file_path) as json_file:
                data = json.load(json_file)
                if 'tips300' in data:
                    tip_log['count'][m300] = data['tips300']
                else:
                    tip_log['count'][m300] = 0
        else:
            tip_log['count'][m300] = 0
    else:
        tip_log['count'] = {m300: 0}

    tip_log['tips'] = {
        m300: [tip for rack in tips300 for tip in rack.rows()[0]]}
    tip_log['max'] = {m300: len(tip_log['tips'][m300])}

    def _pick_up(pip, loc=None):
        nonlocal tip_log
        if tip_log['count'][pip] == tip_log['max'][pip] and not loc:
            ctx.pause('Replace ' + str(pip.max_volume) + 'µl tipracks before \
resuming.')
            pip.reset_tipracks()
            tip_log['count'][pip] = 0
        if loc:
            pip.pick_up_tip(loc)
        else:
            pip.pick_up_tip(tip_log['tips'][pip][tip_log['count'][pip]])
            tip_log['count'][pip] += 1

    switch = True
    drop_count = 0
    # number of tips trash will accommodate before prompting user to empty
    drop_threshold = 120

    def _drop(pip):
        nonlocal switch
        nonlocal drop_count
        side = 30 if switch else -18
        drop_loc = ctx.loaded_labwares[12].wells()[0].top().move(
            Point(x=side))
        pip.drop_tip(drop_loc)
        switch = not switch
        drop_count += 8
        if drop_count == drop_threshold:
            # Setup for flashing lights notification to empty trash
            if flash:
                if not ctx.is_simulating():
                    cancellationToken.set_true()
                thread = create_thread(ctx, cancellationToken)
            m300.home()
            ctx.pause('Please empty tips from waste before resuming.')

            ctx.home()  # home before continuing with protocol
            if flash:
                cancellationToken.set_false()  # stop light flashing after home
                thread.join()

            drop_count = 0

    waste_vol = 0
    waste_threshold = 185000

    def remove_supernatant(vol, park=False):
        """
        `remove_supernatant` will transfer supernatant from the deepwell
        extraction plate to the liquid waste reservoir.
        :param vol (float): The amount of volume to aspirate from all deepwell
                            sample wells and dispense in the liquid waste.
        :param park (boolean): Whether to pick up sample-corresponding tips
                               in the 'parking rack' or to pick up new tips.
        """

        def _waste_track(vol):
            nonlocal waste_vol
            if waste_vol + vol >= waste_threshold:
                # Setup for flashing lights notification to empty liquid waste
                if flash:
                    if not ctx.is_simulating():
                        cancellationToken.set_true()
                    thread = create_thread(ctx, cancellationToken)
                m300.home()
                ctx.pause('Please empty liquid waste (slot 11) before \
resuming.')

                ctx.home()  # home before continuing with protocol
                if flash:
                    # stop light flashing after home
                    cancellationToken.set_false()
                    thread.join()

                waste_vol = 0
            waste_vol += vol

        m300.flow_rate.aspirate = 30
        num_trans = math.ceil(vol/200)
        vol_per_trans = vol/num_trans
        for i, (m, spot) in enumerate(zip(mag_samples_m, parking_spots)):
            if park:
                _pick_up(m300, spot)
            else:
                _pick_up(m300)
            side = -1 if i % 2 == 0 else 1
            loc = m.bottom(0.5).move(Point(x=side*2))
            for _ in range(num_trans):
                _waste_track(vol_per_trans)
                if m300.current_volume > 0:
                    # void air gap if necessary
                    m300.dispense(m300.current_volume, m.top())
                m300.move_to(m.center())
                m300.transfer(vol_per_trans, loc, waste, new_tip='never',
                              air_gap=20)
                m300.blow_out(waste)
                m300.air_gap(20)
            _drop(m300)
        m300.flow_rate.aspirate = 150

    def bind(vol, park=True):
        """
        `bind` will perform magnetic bead binding on each sample in the
        deepwell plate. Each channel of binding beads will be mixed before
        transfer, and the samples will be mixed with the binding beads after
        the transfer. The magnetic deck activates after the addition to all
        samples, and the supernatant is removed after bead bining.
        :param vol (float): The amount of volume to aspirate from the elution
                            buffer source and dispense to each well containing
                            beads.
        :param park (boolean): Whether to save sample-corresponding tips
                               between adding elution buffer and transferring
                               supernatant to the final clean elutions PCR
                               plate.
        """
        latest_chan = -1
        for i, (well, spot) in enumerate(zip(mag_samples_m, parking_spots)):
            if park:
                _pick_up(m300, spot)
            else:
                _pick_up(m300)
            num_trans = math.ceil(vol/200)
            vol_per_trans = vol/num_trans
            asp_per_chan = 14000//(vol_per_trans*8)
            for t in range(num_trans):
                chan_ind = int((i*num_trans + t)//asp_per_chan)
                source = binding_buffer[chan_ind]
                if m300.current_volume > 0:
                    # void air gap if necessary
                    m300.dispense(m300.current_volume, source.top())
                if chan_ind > latest_chan:  # mix if accessing new channel
                    for _ in range(5):
                        m300.aspirate(180, source.bottom(0.5))
                        m300.dispense(180, source.bottom(5))
                    latest_chan = chan_ind
                m300.transfer(vol_per_trans, source, well.top(), air_gap=20,
                              new_tip='never')
                if t < num_trans - 1:
                    m300.air_gap(20)
            m300.mix(5, 200, well)
            m300.blow_out(well.top(-2))
            m300.air_gap(20)
            if park:
                m300.drop_tip(spot)
            else:
                _drop(m300)

        magdeck.engage(height=MAG_HEIGHT)
        ctx.delay(minutes=settling_time, msg='Incubating on MagDeck for \
' + str(settling_time) + ' minutes.')

        # remove initial supernatant
        remove_supernatant(vol+starting_vol, park=park)

    def wash(vol, source, mix_reps=15, park=True, resuspend=True):
        """
        `wash` will perform bead washing for the extraction protocol.
        :param vol (float): The amount of volume to aspirate from each
                            source and dispense to each well containing beads.
        :param source (List[Well]): A list of wells from where liquid will be
                                    aspirated. If the length of the source list
                                    > 1, `wash` automatically calculates
                                    the index of the source that should be
                                    accessed.
        :param mix_reps (int): The number of repititions to mix the beads with
                               specified wash buffer (ignored if resuspend is
                               False).
        :param park (boolean): Whether to save sample-corresponding tips
                               between adding wash buffer and removing
                               supernatant.
        :param resuspend (boolean): Whether to resuspend beads in wash buffer.
        """

        if resuspend and magdeck.status == 'engaged':
            magdeck.disengage()

        num_trans = math.ceil(vol/200)
        vol_per_trans = vol/num_trans
        for i, (m, spot) in enumerate(zip(mag_samples_m, parking_spots)):
            _pick_up(m300)
            side = 1 if i % 2 == 0 else -1
            loc = m.bottom(0.5).move(Point(x=side*2))
            src = source[i//(12//len(source))]
            for n in range(num_trans):
                if m300.current_volume > 0:
                    m300.dispense(m300.current_volume, src.top())
                m300.transfer(vol_per_trans, src, m.top(), air_gap=20,
                              new_tip='never')
                if n < num_trans - 1:  # only air_gap if going back to source
                    m300.air_gap(20)
            if resuspend:
                m300.mix(mix_reps, 150, loc)
            m300.blow_out(m.top())
            m300.air_gap(20)
            if park:
                m300.drop_tip(spot)
            else:
                _drop(m300)

        if magdeck.status == 'disengaged':
            magdeck.engage(height=MAG_HEIGHT)

        ctx.delay(minutes=settling_time, msg='Incubating on MagDeck for \
' + str(settling_time) + ' minutes.')

        remove_supernatant(vol, park=park)

    def elute(vol, park=True):
        """
        `elute` will perform elution from the deepwell extraciton plate to the
        final clean elutions PCR plate to complete the extraction protocol.
        :param vol (float): The amount of volume to aspirate from the elution
                            buffer source and dispense to each well containing
                            beads.
        :param park (boolean): Whether to save sample-corresponding tips
                               between adding elution buffer and transferring
                               supernatant to the final clean elutions PCR
                               plate.
        """

        # resuspend beads in elution
        if magdeck.status == 'enagaged':
            magdeck.disengage()
        for i, (m, spot) in enumerate(zip(mag_samples_m, parking_spots)):
            _pick_up(m300)
            side = 1 if i % 2 == 0 else -1
            loc = m.bottom(0.5).move(Point(x=side*2))
            m300.aspirate(vol, elution_solution)
            m300.move_to(m.center())
            m300.dispense(vol, loc)
            m300.mix(mix_reps, 0.8*vol, loc)
            m300.blow_out(m.bottom(5))
            m300.air_gap(20)
            if park:
                m300.drop_tip(spot)
            else:
                _drop(m300)

        # agitate after resuspension
        for i, (m, spot) in enumerate(zip(mag_samples_m, parking_spots)):
            if park:
                _pick_up(m300, spot)
            else:
                _pick_up(m300)
            side = 1 if i % 2 == 0 else -1
            loc = m.bottom(0.5).move(Point(x=side*2))
            m300.mix(10, 0.8*vol, loc)
            m300.blow_out(m.bottom(5))
            m300.air_gap(20)
            if park:
                m300.drop_tip(spot)
            else:
                _drop(m300)

        magdeck.engage(height=MAG_HEIGHT)
        ctx.delay(minutes=settling_time, msg='Incubating on MagDeck for \
' + str(settling_time) + ' minutes.')

        for i, (m, e, spot) in enumerate(
                zip(mag_samples_m, elution_samples_m, parking_spots)):
            if park:
                _pick_up(m300, spot)
            else:
                _pick_up(m300)
            side = -1 if i % 2 == 0 else 1
            loc = m.bottom(0.5).move(Point(x=side*2))
            m300.transfer(vol, loc, e.bottom(5), air_gap=20, new_tip='never')
            m300.blow_out(e.top(-2))
            m300.air_gap(20)
            m300.drop_tip()

    """
    Here is where you can call the methods defined above to fit your specific
    protocol. The normal sequence is:
    """
    bind(binding_buffer_vol, park=park_tips)
    wash(wash1_vol, wash1, park=park_tips)
    wash(wash2_vol, wash2, park=park_tips)
    wash(wash3_vol, wash3, park=park_tips)
    wash(wash3_vol, wash4, park=park_tips)
    elute(elution_vol, park=park_tips)

    # track final used tip
    if tip_track and not ctx.is_simulating():
        if not os.path.isdir(folder_path):
            os.mkdir(folder_path)
        data = {'tips300': tip_log['count'][m300]}
        with open(tip_file_path, 'w') as outfile:
            json.dump(data, outfile)
```


# Risk assessment

Moderate. This is relatively simple refactoring.