### PR TITLE
refactor(robot-server): implement the load labware function to accept tipracks from the client

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/models.py
+++ b/robot-server/robot_server/robot/calibration/check/models.py
@@ -101,6 +101,8 @@ class CalibrationCheckSessionStatus(BaseModel):
     comparisonsByPipette: ComparisonStatePerPipette
     labware: List[RequiredLabware]
     activeTipRack: RequiredLabware
+    supportedCommands: List[Optional[str]] = Field(
+        ..., description="A list of supported commands for this user flow")
 
     class Config:
         arbitrary_types_allowed = True

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -163,7 +163,7 @@ class CheckCalibrationUserFlow:
     def hw_pipette(self) -> Pipette:
         return self._get_hw_pipettes()[0]
 
-    async def transition(self):
+    async def transition(self, tiprackDefinition: dict):
         pass
 
     async def change_active_pipette(self):

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -251,7 +251,9 @@ class CheckCalibrationUserFlow:
                     max_volume=pip.config.max_volume,
                     mount=mount,
                     tip_rack=self._get_tiprack_by_pipette_volume(
-                        pip.config.max_volume, pip_calibration))
+                        pip.config.max_volume, pip_calibration),
+                    default_tipracks=uf.get_default_tipracks(
+                        pip.config.default_tipracks))
                 return info, [info]
 
         right_pip = pips[Mount.RIGHT]
@@ -266,14 +268,18 @@ class CheckCalibrationUserFlow:
             rank=PipetteRank.first,
             mount=Mount.RIGHT,
             tip_rack=self._get_tiprack_by_pipette_volume(
-                right_pip.config.max_volume, r_calibration))
+                right_pip.config.max_volume, r_calibration),
+            default_tipracks=uf.get_default_tipracks(
+                right_pip.config.default_tipracks))
         l_info = PipetteInfo(
             channels=left_pip.config.channels,
             max_volume=left_pip.config.max_volume,
             rank=PipetteRank.first,
             mount=Mount.LEFT,
             tip_rack=self._get_tiprack_by_pipette_volume(
-                left_pip.config.max_volume, l_calibration))
+                left_pip.config.max_volume, l_calibration),
+            default_tipracks=uf.get_default_tipracks(
+                left_pip.config.default_tipracks))
         if left_pip.config.max_volume > right_pip.config.max_volume or \
                 right_pip.config.channels > left_pip.config.channels:
             r_info.rank = PipetteRank.second
@@ -479,7 +485,8 @@ class CheckCalibrationUserFlow:
                 tipRackUri=info_pip.tip_rack.uri,
                 rank=info_pip.rank.value,
                 mount=str(info_pip.mount),
-                serial=hw_pip.pipette_id)  # type: ignore[arg-type]
+                serial=hw_pip.pipette_id,  # type: ignore[arg-type]
+                defaultTipracks=info_pip.default_tipracks)
             for hw_pip, info_pip in zip(hw_pips, info_pips)]
 
     def get_active_pipette(self) -> CheckAttachedPipette:

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -167,7 +167,7 @@ class CheckCalibrationUserFlow:
     def get_supported_commands() -> List:
         return []
 
-    async def transition(self, tiprackDefinition: dict):
+    async def transition(self, tiprackDefinition: Optional[dict]):
         pass
 
     async def change_active_pipette(self):

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -167,7 +167,7 @@ class CheckCalibrationUserFlow:
     def get_supported_commands() -> List:
         return []
 
-    async def transition(self, tiprackDefinition: Optional[dict]):
+    async def transition(self, tiprackDefinition: Optional[dict] = None):
         pass
 
     async def change_active_pipette(self):
@@ -486,7 +486,7 @@ class CheckCalibrationUserFlow:
                 rank=info_pip.rank.value,
                 mount=str(info_pip.mount),
                 serial=hw_pip.pipette_id,  # type: ignore[arg-type]
-                defaultTipracks=info_pip.default_tipracks)
+                defaultTipracks=info_pip.default_tipracks)  # type: ignore[arg-type]  # noqa: E501
             for hw_pip, info_pip in zip(hw_pips, info_pips)]
 
     def get_active_pipette(self) -> CheckAttachedPipette:
@@ -505,7 +505,8 @@ class CheckCalibrationUserFlow:
             tipRackUri=self.active_pipette.tip_rack.uri,
             rank=self.active_pipette.rank.value,
             mount=str(self.mount),
-            serial=self.hw_pipette.pipette_id)  # type: ignore[arg-type]
+            serial=self.hw_pipette.pipette_id,  # type: ignore[arg-type]
+            defaultTipracks=self.active_pipette.default_tipracks)  # type: ignore[arg-type]  # noqa: E501
 
     def _determine_threshold(self) -> Point:
         """

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -163,6 +163,10 @@ class CheckCalibrationUserFlow:
     def hw_pipette(self) -> Pipette:
         return self._get_hw_pipettes()[0]
 
+    @staticmethod
+    def get_supported_commands() -> List:
+        return []
+
     async def transition(self, tiprackDefinition: dict):
         pass
 

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -22,7 +22,7 @@ from robot_server.robot.calibration.constants import (
 import robot_server.robot.calibration.util as uf
 from robot_server.robot.calibration.helper_classes import (
     RobotHealthCheck, PipetteRank, PipetteInfo,
-    RequiredLabware)
+    RequiredLabware, SupportedCommands)
 
 from robot_server.service.session.models.command_definitions import \
     CalibrationCommand, DeckCalibrationCommand, CheckCalibrationCommand
@@ -115,6 +115,7 @@ class CheckCalibrationUserFlow:
             CalibrationCommand.invalidate_last_action: self.invalidate_last_action,  # noqa: E501
             CalibrationCommand.exit: self.exit_session,
         }
+        self._supported_commands = SupportedCommands(namespace='calibration')
 
     @property
     def deck(self) -> Deck:
@@ -163,9 +164,9 @@ class CheckCalibrationUserFlow:
     def hw_pipette(self) -> Pipette:
         return self._get_hw_pipettes()[0]
 
-    @staticmethod
-    def get_supported_commands() -> List:
-        return []
+    @property
+    def supported_commands(self) -> List:
+        return self._supported_commands.supported()
 
     async def transition(self, tiprackDefinition: Optional[dict] = None):
         pass

--- a/robot-server/robot_server/robot/calibration/deck/models.py
+++ b/robot-server/robot_server/robot/calibration/deck/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 
 from ..helper_classes import AttachedPipette, RequiredLabware
 
@@ -11,6 +11,8 @@ class DeckCalibrationSessionStatus(BaseModel):
         ...,
         description="Current step of deck calibration user flow")
     labware: List[RequiredLabware]
+    supportedCommands: List[Optional[str]] = Field(
+        ..., description="A list of supported commands for this user flow")
 
     class Config:
         schema_extra = {

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -253,7 +253,7 @@ class DeckCalibrationUserFlow:
         return await self._hardware.gantry_position(self._mount,
                                                     critical_point)
 
-    async def load_labware(self, tiprackDefinition: Optional[dict]):
+    async def load_labware(self, tiprackDefinition: Optional[dict] = None):
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)
             self._tip_rack = self._get_tip_rack_lw(

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -248,7 +248,7 @@ class DeckCalibrationUserFlow:
         return await self._hardware.gantry_position(self._mount,
                                                     critical_point)
 
-    async def load_labware(self, tiprackDefinition: dict):
+    async def load_labware(self, tiprackDefinition: Optional[dict]):
         verified_definition = labware.verify_definition(tiprackDefinition)
         self._tip_rack = self._get_tip_rack_lw(
             verified_definition)

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -137,6 +137,10 @@ class DeckCalibrationUserFlow:
     def reset_tip_origin(self):
         self._tip_origin_pt = None
 
+    @staticmethod
+    def get_supported_commands() -> List:
+        return ['loadLabware']
+
     @property
     def current_state(self) -> State:
         return self._current_state
@@ -245,8 +249,9 @@ class DeckCalibrationUserFlow:
                                                     critical_point)
 
     async def load_labware(self, tiprackDefinition: dict):
+        verified_definition = labware.verify_definition(tiprackDefinition)
         self._tip_rack = self._get_tip_rack_lw(
-            cast(Optional['LabwareDefinition'], tiprackDefinition))
+            verified_definition)
         if self._deck[TIP_RACK_SLOT]:
             del self._deck[TIP_RACK_SLOT]
         self._deck[TIP_RACK_SLOT] = self._tip_rack

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -10,6 +10,7 @@ from opentrons.types import DeckLocation
 
 if typing.TYPE_CHECKING:
     from opentrons.protocol_api.labware import Labware
+    from opentrons_shared_data.labware import LabwareDefinition
 
 
 class RobotHealthCheck(Enum):
@@ -64,7 +65,7 @@ class PipetteInfo:
     max_volume: int
     channels: int
     tip_rack: 'Labware'
-    default_tipracks: typing.List[dict]
+    default_tipracks: typing.List['LabwareDefinition']
 
 
 # TODO: BC: the mount field here is typed as a string

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -64,6 +64,7 @@ class PipetteInfo:
     max_volume: int
     channels: int
     tip_rack: 'Labware'
+    default_tipracks: typing.List[dict]
 
 
 # TODO: BC: the mount field here is typed as a string
@@ -87,6 +88,8 @@ class AttachedPipette(BaseModel):
         Field(None, description="The mount this pipette attached to")
     serial: str =\
         Field(None, description="The serial number of the attached pipette")
+    defaultTipracks: typing.List[dict] =\
+        Field(None, description="A list of default tipracks for this pipette")
 
 
 class RequiredLabware(BaseModel):

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -2,7 +2,7 @@ import typing
 
 from opentrons.types import Mount
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pydantic import BaseModel, Field
 from opentrons.protocol_api import labware
 from opentrons.types import DeckLocation
@@ -66,6 +66,26 @@ class PipetteInfo:
     channels: int
     tip_rack: 'Labware'
     default_tipracks: typing.List['LabwareDefinition']
+
+
+@dataclass
+class SupportedCommands:
+    """
+    A class that allows you to set currently supported
+    commands depending on the current state.
+    """
+    loadLabware: bool = False
+
+    def __init__(self, namespace: str):
+        self._namespace = namespace
+
+    def supported(self):
+        commands = []
+        for field in fields(self):
+            result = getattr(self, field.name)
+            if result:
+                commands.append(f"{self._namespace}.{field.name}")
+        return commands
 
 
 # TODO: BC: the mount field here is typed as a string

--- a/robot-server/robot_server/robot/calibration/pipette_offset/constants.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/constants.py
@@ -8,16 +8,7 @@ if TYPE_CHECKING:
     from typing_extensions import Final
 
 
-class GenericState(str, Enum):
-    def __getattr__(self, name: str):
-        # We need to define this method
-        # to ensure that mypy will
-        # understand the defined attributes
-        # on the subclasses.
-        return getattr(self.__class__, name)
-
-
-class PipetteOffsetCalibrationState(GenericState):
+class PipetteOffsetCalibrationState(str, Enum):
     sessionStarted = "sessionStarted"
     labwareLoaded = "labwareLoaded"
     preparingPipette = "preparingPipette"
@@ -29,7 +20,7 @@ class PipetteOffsetCalibrationState(GenericState):
     WILDCARD = STATE_WILDCARD
 
 
-class PipetteOffsetWithTipLengthCalibrationState(GenericState):
+class PipetteOffsetWithTipLengthCalibrationState(str, Enum):
     sessionStarted = "sessionStarted"
     labwareLoaded = "labwareLoaded"
     measuringNozzleOffset = "measuringNozzleOffset"

--- a/robot-server/robot_server/robot/calibration/pipette_offset/models.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/models.py
@@ -14,6 +14,8 @@ class PipetteOffsetCalibrationSessionStatus(BaseModel):
     shouldPerformTipLength: bool =\
         Field(None, description="Does tip length calibration data exist for "
                                 "this pipette and tip rack combination")
+    supportedCommands: List[Optional[str]] = Field(
+        ..., description="A list of supported commands for this user flow")
     nextSteps: Optional[NextSteps] =\
         Field(None, description="Next Available Steps in Session")
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Type
 
 from robot_server.service.session.models.command_definitions import \
     CommandDefinition, CalibrationCommand
@@ -108,6 +108,11 @@ class PipetteOffsetCalibrationStateMachine:
             states=set(s for s in POCState),
             transitions=PIP_OFFSET_CAL_TRANSITIONS
         )
+        self._state = POCState
+
+    @property
+    def state(self) -> Type[POCState]:
+        return self._state
 
     def get_next_state(self, from_state: POCState, command: CommandDefinition):
         next_state = self._state_machine.get_next_state(from_state, command)
@@ -123,6 +128,11 @@ class PipetteOffsetWithTipLengthStateMachine:
             states=set(s for s in POWTState),
             transitions=PIP_OFFSET_WITH_TL_TRANSITIONS,
         )
+        self._state = POWTState
+
+    @property
+    def state(self) -> Type[POWTState]:
+        return self._state
 
     def get_next_state(
             self, from_state: POWTState, command: CommandDefinition):

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -109,10 +109,18 @@ class PipetteOffsetCalibrationStateMachine:
             transitions=PIP_OFFSET_CAL_TRANSITIONS
         )
         self._state = POCState
+        self._current_state = POCState.sessionStarted
 
     @property
     def state(self) -> Type[POCState]:
         return self._state
+
+    @property
+    def current_state(self) -> POCState:
+        return self._current_state
+
+    def set_state(self, state: POCState):
+        self._current_state = state
 
     def get_next_state(self, from_state: POCState, command: CommandDefinition):
         next_state = self._state_machine.get_next_state(from_state, command)
@@ -129,10 +137,18 @@ class PipetteOffsetWithTipLengthStateMachine:
             transitions=PIP_OFFSET_WITH_TL_TRANSITIONS,
         )
         self._state = POWTState
+        self._current_state = POWTState.sessionStarted
 
     @property
     def state(self) -> Type[POWTState]:
         return self._state
+
+    @property
+    def current_state(self) -> POWTState:
+        return self._current_state
+
+    def set_state(self, state: POWTState):
+        self._current_state = state
 
     def get_next_state(
             self, from_state: POWTState, command: CommandDefinition):

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -235,7 +235,7 @@ class PipetteOffsetCalibrationUserFlow:
         return await self._hardware.gantry_position(self._mount,
                                                     critical_point)
 
-    async def load_labware(self, tiprackDefinition: dict):
+    async def load_labware(self, tiprackDefinition: Optional[dict]):
         verified_definition = labware.verify_definition(tiprackDefinition)
         existing_offset_calibration = self._get_stored_pipette_offset_cal()
         self._load_tip_rack(

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -433,11 +433,11 @@ class PipetteOffsetCalibrationUserFlow:
                 tiprack_hash=tiprack_hash,
                 tiprack_uri=self._tip_rack.uri)
             self._saved_offset_this_session = True
-        elif isinstance(self._sm.state, POWTState)\
-                and current_state == self._sm.state.measuringNozzleOffset:
+        elif isinstance(current_state, POWTState)\
+                and current_state == POWTState.measuringNozzleOffset:
             self._nozzle_height_at_reference = cur_pt.z
-        elif isinstance(self._sm.state, POWTState)\
-                and current_state == self._sm.state.measuringTipOffset:
+        elif isinstance(current_state, POWTState)\
+                and current_state == POWTState.measuringTipOffset:
             assert self._hw_pipette.has_tip
             assert self._nozzle_height_at_reference is not None
             # set critical point explicitly to nozzle

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -184,7 +184,8 @@ class PipetteOffsetCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks)
+            defaultTipracks=self._default_tipracks  # type: ignore[arg-type]
+            )
 
     def get_required_labware(self) -> List[RequiredLabware]:
         slots = self._deck.get_non_fixture_slots()

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -181,10 +181,10 @@ class PipetteOffsetCalibrationUserFlow:
         return AttachedPipette(  # type: ignore[call-arg]
             model=self._hw_pipette.model,
             name=self._hw_pipette.name,
-            tip_length=self._hw_pipette.config.tip_length,
+            tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            default_tipracks=self._default_tipracks)
+            defaultTipracks=self._default_tipracks)
 
     def get_required_labware(self) -> List[RequiredLabware]:
         slots = self._deck.get_non_fixture_slots()

--- a/robot-server/robot_server/robot/calibration/tip_length/models.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/models.py
@@ -13,6 +13,8 @@ class TipCalibrationSessionStatus(BaseModel):
     nextSteps: Optional[NextSteps] =\
         Field(None, description="Next Available Steps in Session")
     labware: List[RequiredLabware]
+    supportedCommands: List[Optional[str]] = Field(
+        ..., description="A list of supported commands for this user flow")
 
     class Config:
         schema_extra = {

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -156,7 +156,7 @@ class TipCalibrationUserFlow:
         MODULE_LOG.debug(f'TipCalUserFlow handled command {name}, transitioned'
                          f'from {self._current_state} to {next_state}')
 
-    async def load_labware(self):
+    async def load_labware(self, tiprackDefinition: dict):
         pass
 
     async def move_to_tip_rack(self):

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -80,6 +80,8 @@ class TipCalibrationUserFlow:
             CalibrationCommand.invalidate_last_action: self.invalidate_last_action,  # noqa: E501
             CalibrationCommand.exit: self.exit_session,
         }
+        self._default_tipracks =\
+            util.get_default_tipracks(self.hw_pipette.config.default_tipracks)
 
     def _set_current_state(self, to_state: State):
         self._current_state = to_state
@@ -125,12 +127,13 @@ class TipCalibrationUserFlow:
 
     def get_pipette(self) -> AttachedPipette:
         # TODO(mc, 2020-09-17): s/tip_length/tipLength
-        return AttachedPipette(  # type: ignore[call-arg]
+        return AttachedPipette(
             model=self._hw_pipette.model,
             name=self._hw_pipette.name,
-            tip_length=self._hw_pipette.config.tip_length,
+            tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
-            serial=self._hw_pipette.pipette_id
+            serial=self._hw_pipette.pipette_id,
+            defaultTipracks=self._default_tipracks
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -160,7 +160,7 @@ class TipCalibrationUserFlow:
         MODULE_LOG.debug(f'TipCalUserFlow handled command {name}, transitioned'
                          f'from {self._current_state} to {next_state}')
 
-    async def load_labware(self, tiprackDefinition: dict):
+    async def load_labware(self, tiprackDefinition: Optional[dict]):
         pass
 
     async def move_to_tip_rack(self):

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -133,7 +133,7 @@ class TipCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks
+            defaultTipracks=self._default_tipracks  # type: ignore[arg-type]
         )
 
     def get_required_labware(self) -> List[RequiredLabware]:
@@ -163,7 +163,7 @@ class TipCalibrationUserFlow:
         MODULE_LOG.debug(f'TipCalUserFlow handled command {name}, transitioned'
                          f'from {self._current_state} to {next_state}')
 
-    async def load_labware(self, tiprackDefinition: Optional[dict]):
+    async def load_labware(self, tiprackDefinition: Optional[dict] = None):
         pass
 
     async def move_to_tip_rack(self):

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -115,6 +115,10 @@ class TipCalibrationUserFlow:
     def reset_tip_origin(self):
         self._tip_origin_pt = None
 
+    @staticmethod
+    def get_supported_commands() -> List:
+        return []
+
     @property
     def current_state(self) -> State:
         return self._current_state

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -14,7 +14,8 @@ from robot_server.service.errors import RobotServerError
 from robot_server.service.session.models.command_definitions import \
     CalibrationCommand
 from ..errors import CalibrationError
-from ..helper_classes import RequiredLabware, AttachedPipette
+from ..helper_classes import (
+    RequiredLabware, AttachedPipette, SupportedCommands)
 from ..constants import (
     TIP_RACK_LOOKUP_BY_MAX_VOL,
     SHORT_TRASH_DECK,
@@ -82,6 +83,7 @@ class TipCalibrationUserFlow:
         }
         self._default_tipracks =\
             util.get_default_tipracks(self.hw_pipette.config.default_tipracks)
+        self._supported_commands = SupportedCommands(namespace='calibration')
 
     def _set_current_state(self, to_state: State):
         self._current_state = to_state
@@ -117,9 +119,9 @@ class TipCalibrationUserFlow:
     def reset_tip_origin(self):
         self._tip_origin_pt = None
 
-    @staticmethod
-    def get_supported_commands() -> List:
-        return []
+    @property
+    def supported_commands(self) -> List:
+        return self._supported_commands.supported()
 
     @property
     def current_state(self) -> State:

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -1,6 +1,6 @@
 import logging
 import contextlib
-from typing import Set, Dict, Any, Union, TYPE_CHECKING
+from typing import Set, Dict, Any, Union, List, TYPE_CHECKING
 
 from opentrons.hardware_control import Pipette
 from opentrons.hardware_control.util import plan_arc
@@ -8,7 +8,7 @@ from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.geometry.deck import Deck
-from opentrons.calibration_storage import modify
+from opentrons.calibration_storage import modify, helpers
 from opentrons.types import Point, Location
 
 from robot_server.service.errors import RobotServerError
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from .tip_length.user_flow import TipCalibrationUserFlow
     from .pipette_offset.user_flow import PipetteOffsetCalibrationUserFlow
     from .check.user_flow import CheckCalibrationUserFlow
+    from opentrons_shared_data.pipette.dev_types import LabwareUri
+    from opentrons_shared_data.labware import LabwareDefinition
 
 ValidState = Union[TipCalibrationState, DeckCalibrationState,
                    PipetteOffsetCalibrationState, CalibrationCheckState,
@@ -195,3 +197,16 @@ def save_tip_length_calibration(pipette_id: str,
         tip_length_offset
     )
     modify.save_tip_length_calibration(pipette_id, tip_length_data)
+
+
+def get_default_tipracks(
+        default_uris: List['LabwareUri']) -> List['LabwareDefinition']:
+    definitions = []
+    for rack in default_uris:
+        details = helpers.details_from_uri(rack)
+        rack_def = labware.get_labware_definition(
+            details.load_name,
+            details.namespace,
+            details.version)
+        definitions.append(rack_def)
+    return definitions

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -119,6 +119,27 @@ class SetHasCalibrationBlockRequestData(BaseModel):
         description="whether or not there is a calibration block present")
 
 
+<<<<<<< HEAD
+=======
+CommandDataType = typing.Union[
+    SetHasCalibrationBlockRequest,
+    JogPosition,
+    LiquidRequest,
+    PipetteRequestBase,
+    LoadLabwareRequest,
+    LoadInstrumentRequest,
+    LoadTiprackRequest,
+    EmptyModel
+]
+
+# A Union of all command result types
+CommandResultType = typing.Union[
+    LoadLabwareResponse,
+    LoadInstrumentResponse,
+]
+
+
+>>>>>>> move LoadTiprackRequest down in the union CommandDataType list. It is very not specific.
 class CommandStatus(str, Enum):
     """The command status."""
     executed = "executed"

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -128,8 +128,8 @@ CommandDataType = typing.Union[
     PipetteRequestBase,
     LoadLabwareRequest,
     LoadInstrumentRequest,
-    LoadTiprackRequest,
-    EmptyModel
+    EmptyModel,
+    LoadTiprackRequest
 ]
 
 # A Union of all command result types

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -58,7 +58,7 @@ class LoadLabwareRequestData(BaseModel):
         description="The labware definition version")
 
 
-class LoadTiprackRequest(BaseModel):
+class LoadLabwareByDefinitionRequestData(BaseModel):
     tiprackDefinition: typing.Optional[dict] = Field(
         None,
         description="The tiprack definition to load into a user flow")
@@ -186,7 +186,6 @@ CommandsEmptyData = Literal[
     ProtocolCommand.cancel,
     ProtocolCommand.pause,
     ProtocolCommand.resume,
-    CalibrationCommand.load_labware,
     CalibrationCommand.move_to_tip_rack,
     CalibrationCommand.move_to_point_one,
     CalibrationCommand.move_to_deck,
@@ -289,16 +288,25 @@ JogRequest = SessionCommandRequest[
 ]
 
 
-class LoadTiprackRequestM(BasicSessionCommand):
-    command: Literal[CalibrationCommand.load_labware]
-    data: LoadTiprackRequest
+JogResponse = SessionCommandResponse[
+    Literal[CalibrationCommand.jog],
+    JogPosition,
+    EmptyModel
+]
 
 
-class DeckCalibrationCommandRequest(EmptySessionCommand):
-    command: Literal[
-        DeckCalibrationCommand.move_to_point_two,
-        DeckCalibrationCommand.move_to_point_three
-    ]
+LabwareByDefinitionRequest = SessionCommandRequest[
+    Literal[CalibrationCommand.load_labware],
+    LoadLabwareByDefinitionRequestData,
+    EmptyModel
+]
+
+
+LabwareByDefinitionResponse = SessionCommandResponse[
+    Literal[CalibrationCommand.load_labware],
+    LoadLabwareByDefinitionRequestData,
+    EmptyModel
+]
 
 
 SetHasCalibrationBlockRequest = SessionCommandRequest[
@@ -322,6 +330,7 @@ RequestTypes = typing.Union[
     TipRequest,
     JogRequest,
     SetHasCalibrationBlockRequest,
+    LabwareByDefinitionRequest
 ]
 """Union of all request types"""
 
@@ -333,6 +342,7 @@ ResponseTypes = typing.Union[
     TipResponse,
     JogResponse,
     SetHasCalibrationBlockResponse,
+    LabwareByDefinitionResponse
 ]
 """Union of all response types"""
 

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -58,9 +58,14 @@ class LoadLabwareRequestData(BaseModel):
         description="The labware definition version")
 
 
+class LoadTiprackRequest(BaseModel):
+    tiprackDefinition: typing.Optional[dict] = Field(
+        None,
+        description="The tiprack definition to load into a user flow")
+
+
 class LoadLabwareResponseData(BaseModel):
     """Result field in an equipment.loadLabware command response."""
-
     labwareId: IdentifierType
     definition: LabwareDefinition
     calibration: OffsetVector
@@ -284,11 +289,16 @@ JogRequest = SessionCommandRequest[
 ]
 
 
-JogResponse = SessionCommandResponse[
-    Literal[CalibrationCommand.jog],
-    JogPosition,
-    EmptyModel
-]
+class LoadTiprackRequestM(BasicSessionCommand):
+    command: Literal[CalibrationCommand.load_labware]
+    data: LoadTiprackRequest
+
+
+class DeckCalibrationCommandRequest(EmptySessionCommand):
+    command: Literal[
+        DeckCalibrationCommand.move_to_point_two,
+        DeckCalibrationCommand.move_to_point_three
+    ]
 
 
 SetHasCalibrationBlockRequest = SessionCommandRequest[

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -119,27 +119,6 @@ class SetHasCalibrationBlockRequestData(BaseModel):
         description="whether or not there is a calibration block present")
 
 
-<<<<<<< HEAD
-=======
-CommandDataType = typing.Union[
-    SetHasCalibrationBlockRequest,
-    JogPosition,
-    LiquidRequest,
-    PipetteRequestBase,
-    LoadLabwareRequest,
-    LoadInstrumentRequest,
-    EmptyModel,
-    LoadTiprackRequest
-]
-
-# A Union of all command result types
-CommandResultType = typing.Union[
-    LoadLabwareResponse,
-    LoadInstrumentResponse,
-]
-
-
->>>>>>> move LoadTiprackRequest down in the union CommandDataType list. It is very not specific.
 class CommandStatus(str, Enum):
     """The command status."""
     executed = "executed"

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -114,7 +114,8 @@ class CheckSession(BaseSession):
             comparisonsByPipette=comparison_map,
             labware=self._calibration_check.get_required_labware(),
             activePipette=self._calibration_check.get_active_pipette(),
-            activeTipRack=self._calibration_check.get_active_tiprack()
+            activeTipRack=self._calibration_check.get_active_tiprack(),
+            supportedCommands=self._calibration_check.get_supported_commands()
         )
 
     @property

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -115,7 +115,7 @@ class CheckSession(BaseSession):
             labware=self._calibration_check.get_required_labware(),
             activePipette=self._calibration_check.get_active_pipette(),
             activeTipRack=self._calibration_check.get_active_tiprack(),
-            supportedCommands=self._calibration_check.get_supported_commands()
+            supportedCommands=self._calibration_check.supported_commands
         )
 
     @property

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -90,7 +90,8 @@ class DeckCalibrationSession(BaseSession):
         return DeckCalibrationSessionStatus(
             instrument=self._deck_cal_user_flow.get_pipette(),  # type: ignore[arg-type] # noqa: e501
             currentStep=self._deck_cal_user_flow.current_state,
-            labware=self._deck_cal_user_flow.get_required_labware())
+            labware=self._deck_cal_user_flow.get_required_labware(),
+            supportedCommands=self._deck_cal_user_flow.get_supported_commands())
 
     async def clean_up(self):
         if self._shutdown_coroutine:

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -87,11 +87,12 @@ class DeckCalibrationSession(BaseSession):
     def _get_response_details(self) -> DeckCalibrationSessionStatus:
         # TODO(mc, 2020-09-17): get_pipette() returns an Optional value but
         # DeckCalibrationSessionStatus has an exact type for instrument
+        supported_commands = self._deck_cal_user_flow.get_supported_commands()
         return DeckCalibrationSessionStatus(
             instrument=self._deck_cal_user_flow.get_pipette(),  # type: ignore[arg-type] # noqa: e501
             currentStep=self._deck_cal_user_flow.current_state,
             labware=self._deck_cal_user_flow.get_required_labware(),
-            supportedCommands=self._deck_cal_user_flow.get_supported_commands())
+            supportedCommands=supported_commands)
 
     async def clean_up(self):
         if self._shutdown_coroutine:

--- a/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
+++ b/robot-server/robot_server/service/session/session_types/deck_calibration_session.py
@@ -87,7 +87,7 @@ class DeckCalibrationSession(BaseSession):
     def _get_response_details(self) -> DeckCalibrationSessionStatus:
         # TODO(mc, 2020-09-17): get_pipette() returns an Optional value but
         # DeckCalibrationSessionStatus has an exact type for instrument
-        supported_commands = self._deck_cal_user_flow.get_supported_commands()
+        supported_commands = self._deck_cal_user_flow.supported_commands
         return DeckCalibrationSessionStatus(
             instrument=self._deck_cal_user_flow.get_pipette(),  # type: ignore[arg-type] # noqa: e501
             currentStep=self._deck_cal_user_flow.current_state,

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -57,10 +57,9 @@ class PipetteOffsetCalibrationSession(BaseSession):
             = instance_meta.create_params.shouldRecalibrateTipLength
         has_cal_block = instance_meta.create_params.hasCalibrationBlock
         tip_rack_def = instance_meta.create_params.tipRackDefinition
+
         if tip_rack_def:
-            verified_definition = labware.verify_definition(tip_rack_def)
-        else:
-            verified_definition = tip_rack_def
+            labware.verify_definition(tip_rack_def)
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
@@ -74,7 +73,7 @@ class PipetteOffsetCalibrationSession(BaseSession):
                     mount=Mount[mount.upper()],
                     recalibrate_tip_length=recalibrate_tip_length,
                     has_calibration_block=has_cal_block,
-                    tip_rack_def=cast('LabwareDefinition', verified_definition))
+                    tip_rack_def=cast('LabwareDefinition', tip_rack_def))
         except AssertionError as e:
             raise SessionCreationException(str(e))
 

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -115,7 +115,7 @@ class PipetteOffsetCalibrationSession(BaseSession):
             currentStep=uf.current_state,
             labware=uf.get_required_labware(),
             shouldPerformTipLength=uf.should_perform_tip_length,
-            supportedCommands=uf.get_supported_commands()
+            supportedCommands=uf.supported_commands
         )
 
     async def clean_up(self):

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -104,7 +104,7 @@ class TipLengthCalibration(BaseSession):
             instrument=self._tip_cal_user_flow.get_pipette(),
             currentStep=self._tip_cal_user_flow.current_state,
             labware=self._tip_cal_user_flow.get_required_labware(),
-            supportedCommands=self._tip_cal_user_flow.get_supported_commands()
+            supportedCommands=self._tip_cal_user_flow.supported_commands
         )
 
     async def clean_up(self):

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -47,6 +47,8 @@ stages:
             activeTipRack: !anydict
             labware: !anylist
             comparisonsByPipette: !anydict
+            supportedCommands: !anylist
+
 
   - name: Load labware
     request: &post_command
@@ -55,8 +57,7 @@ stages:
       json:
         data:
           command: calibration.loadLabware
-          data:
-            tiprackDefinition: !include fixture_tiprack_300_ul.json
+          data: {}
     response:
       status_code: 200
   - name: Check the effect of command

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -55,7 +55,8 @@ stages:
       json:
         data:
           command: calibration.loadLabware
-          data: {}
+          data:
+            tiprackDefinition: !include fixture_tiprack_300_ul.json
     response:
       status_code: 200
   - name: Check the effect of command

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -44,7 +44,8 @@ stages:
       json:
         data:
           command: calibration.loadLabware
-          data: {}
+          data:
+            tiprackDefinition: !include fixture_tiprack_300_ul.json
     response:
       status_code: 200
   - name: Check the effect of command

--- a/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_deck_calibration.tavern.yaml
@@ -36,6 +36,7 @@ stages:
             currentStep: sessionStarted
             instrument: !anydict
             labware: !anylist
+            supportedCommands: !anylist
 
   - name: Load labware
     request: &post_command

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -39,6 +39,7 @@ stages:
             instrument: !anydict
             labware: !anylist
             nextSteps: null
+            supportedCommands: !anylist
           createParams:
             mount: left
             hasCalibrationBlock: true
@@ -52,8 +53,7 @@ stages:
       json:
         data:
           command: calibration.loadLabware
-          data:
-            tiprackDefinition: !include fixture_tiprack_300_ul.json
+          data: {}
     response:
       status_code: 200
       json:
@@ -66,8 +66,7 @@ stages:
             !re_match "\\d+-\\d+-\\d+T"
           startedAt: *dt
           completedAt: *dt
-          data:
-            tiprackDefinition: !include fixture_tiprack_300_ul.json
+          data: {}
           result: null
 
   - name: Attempt conflicting command

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -52,7 +52,8 @@ stages:
       json:
         data:
           command: calibration.loadLabware
-          data: {}
+          data:
+            tiprackDefinition: !include fixture_tiprack_300_ul.json
     response:
       status_code: 200
       json:
@@ -65,7 +66,8 @@ stages:
             !re_match "\\d+-\\d+-\\d+T"
           startedAt: *dt
           completedAt: *dt
-          data: {}
+          data:
+            tiprackDefinition: !include fixture_tiprack_300_ul.json
           result: null
 
   - name: Attempt conflicting command

--- a/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_tip_length_calibration.tavern.yaml
@@ -66,7 +66,8 @@ stages:
             !re_match "\\d+-\\d+-\\d+T"
           startedAt: *dt
           completedAt: *dt
-          data: {}
+          data:
+            tiprackDefinition: null
           result: null
 
   - name: Attempt conflicting command

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -6,6 +6,7 @@ from opentrons.types import Mount, Point
 from opentrons.hardware_control import pipette
 from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
+from opentrons.protocol_api import labware
 from robot_server.robot.calibration.deck.user_flow import \
     DeckCalibrationUserFlow, tuplefy_cal_point_dicts
 from robot_server.service.session.models.command_definitions import \
@@ -161,6 +162,17 @@ async def test_return_tip(mock_user_flow):
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
+
+
+async def test_load_labware(mock_user_flow):
+    old_tiprack = mock_user_flow._tip_rack
+    new_def = labware.get_labware_definition(
+        load_name='opentrons_96_filtertiprack_200ul',
+        namespace='opentrons', version=1)
+    await mock_user_flow.load_labware(new_def)
+    assert mock_user_flow._tip_rack.uri ==\
+        'opentrons/opentrons_96_filtertiprack_200ul/1'
+    assert mock_user_flow._tip_rack != old_tiprack
 
 
 async def test_jog(mock_user_flow):

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -367,7 +367,7 @@ async def test_return_tip(mock_user_flow):
 
 @pytest.mark.parametrize('command,current_state,data,hw_meth', hw_commands)
 async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
-    mock_user_flow._current_state = current_state
+    mock_user_flow._sm.set_state(current_state)
     # z height reference must be present for moving to point one
     if command == CalibrationCommand.move_to_point_one:
         mock_user_flow._z_height_reference = 0.1
@@ -380,7 +380,7 @@ async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
     'command,current_state,data,hw_meth', hw_commands_fused)
 async def test_hw_calls_fused(
         command, current_state, data, hw_meth, mock_user_flow_fused):
-    mock_user_flow_fused._current_state = current_state
+    mock_user_flow_fused._sm.set_state(current_state)
     # z height reference must be present for moving to point one
     if command == CalibrationCommand.move_to_point_one:
         mock_user_flow_fused._z_height_reference = 0.1
@@ -448,7 +448,7 @@ def mock_save_tip_length():
 async def test_save_tip_length(
         mock_user_flow_fused, mock_save_tip_length, mock_delete_pipette):
     uf = mock_user_flow_fused
-    uf._current_state = uf._state.measuringTipOffset
+    uf._sm.set_state(uf._sm.state.measuringTipOffset)
     uf._nozzle_height_at_reference = 10
     uf._hw_pipette.add_tip(50)
     await uf._hardware.move_to(mount=uf._mount,
@@ -467,7 +467,7 @@ async def test_save_tip_length(
 async def test_save_pipette_calibration(mock_user_flow, mock_save_pipette):
     uf = mock_user_flow
 
-    uf._current_state = 'savingPointOne'
+    uf._sm.set_state(uf._sm.state.savingPointOne)
     await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=40),

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -373,7 +373,7 @@ def test_execute_command_no_body(api_client,
     mock_command_executor.execute.assert_called_once_with(
         Command(
             request=SimpleCommandRequest(
-                command=CalibrationCommand.load_labware,
+                command=CalibrationCommand.move_to_tip_rack,
                 data=EmptyModel()),
             meta=CommandMeta(command_id, command_created_at)
         )

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -367,7 +367,7 @@ def test_execute_command_no_body(api_client,
     """Test that a command with empty body can be accepted"""
     response = api_client.post(
         f"/sessions/{mock_session_meta.identifier}/commands/execute",
-        json=command("calibration.loadLabware", None)
+        json=command("calibration.moveToTipRack", None)
     )
 
     mock_command_executor.execute.assert_called_once_with(
@@ -381,7 +381,7 @@ def test_execute_command_no_body(api_client,
 
     assert response.json() == {
         'data': {
-            'command': 'calibration.loadLabware',
+            'command': 'calibration.moveToTipRack',
             'data': {},
             'status': 'executed',
             'createdAt': '2000-01-01T00:00:00',


### PR DESCRIPTION
# Overview
This PR supports #7901 on the backend. 

# Changelog

- Add ability to pass a tiprack definition during a load labware command
- Implement load labware for deck calibration and pipette offset
- Add tests for that + modify older tests

# Review requests

Due to pydantic union issues (again) I had to make the tiprack definition required in load labware. Should we try to do a refactor of request models to avoid using unions again here, or is this fine for now?

# Risk assessment

Medium. We are changing how load labware works on the backend, and forcing the front end to pass in a tiprack definition for all of the user flows to this command.

We should test all of the user flows once #7901 is up.