### PR TITLE
perf(api): more (small) simulation improvements

### DIFF
--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -239,7 +239,12 @@ def piecewise_volume_conversion(
     """
     # pick the first item from the seq for which the target is less than
     # the bracketing element
-    i = list(filter(lambda x: ul <= x[0], sequence))[0]
+    i = None
+    for x in sequence:
+        if ul <= x[0]:
+            i = x
+            break
+    assert i
     # use that element to calculate the movement distance in mm
     return i[1]*ul + i[2]
 

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -239,14 +239,14 @@ def piecewise_volume_conversion(
     """
     # pick the first item from the seq for which the target is less than
     # the bracketing element
-    i = None
     for x in sequence:
         if ul <= x[0]:
-            i = x
-            break
-    assert i
-    # use that element to calculate the movement distance in mm
-    return i[1]*ul + i[2]
+            # use that element to calculate the movement distance in mm
+            return x[1] * ul + x[2]
+
+    # Compatibility with previous implementation of search.
+    #  list(filter(lambda x: ul <= x[0], sequence))[0]
+    raise IndexError()
 
 
 TypeOverrides = Dict[str, Union[float, bool, None]]


### PR DESCRIPTION
# Overview

Some small optimizations for simulation improvements. Roughly 5-10% improvement using same protocol as https://github.com/Opentrons/opentrons/pull/7124


# Changelog

- slight change to `piecewise_volume_conversion`. Use simple loop instead of `filter` and `list` construction.

Before:
```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     88602    0.391    0.000    0.679    0.000 pipette_config.py:226(piecewise_volum     e_conversion)
```
After:
```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    88602    0.192    0.000    0.192    0.000 pipette_config.py:226(piecewise_volume_conversion)
```
- memoize calls to `inpect.getfullargspec`:

Before:
```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    11176    0.094    0.000    0.450    0.000 inspect.py:1089(getfullargspec)
```

After:
```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       13    0.000    0.000    0.000    0.000 inspect.py:1089(getfullargspec)
```

# Review requests

Using same protocol for testing as https://github.com/Opentrons/opentrons/pull/7124


# Risk assessment

Low.