### PR TITLE
refactor(api, robot-server): change tip length data model to include uri

### DIFF
--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -2,6 +2,8 @@ import typing
 from typing_extensions import TypedDict
 from datetime import datetime
 
+from opentrons_shared_data.pipette.dev_types import LabwareUri
+
 from .types import AttitudeMatrix, PipetteOffset, SourceType
 
 
@@ -16,6 +18,7 @@ class TipLengthCalibration(TypedDict):
     lastModified: datetime
     source: SourceType
     status: CalibrationStatusDict
+    uri: typing.Union[LabwareUri, str]
 
 
 class ModuleDict(TypedDict):

--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -1,5 +1,5 @@
 import typing
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Literal
 from datetime import datetime
 
 from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -18,7 +18,7 @@ class TipLengthCalibration(TypedDict):
     lastModified: datetime
     source: SourceType
     status: CalibrationStatusDict
-    uri: typing.Union[LabwareUri, str]
+    uri: typing.Union[LabwareUri, Literal['']]
 
 
 class ModuleDict(TypedDict):

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -5,6 +5,8 @@ labware calibration from its designated file location.
 """
 import itertools
 import typing
+from typing_extensions import Literal
+
 from opentrons import config
 from opentrons.types import Point, Mount
 
@@ -199,7 +201,7 @@ def _get_calibration_status(
         return local_types.CalibrationStatus(**data['status'])
 
 
-def _get_tip_rack_uri(data: typing.Dict) -> typing.Union['LabwareUri', str]:
+def _get_tip_rack_uri(data: typing.Dict) -> typing.Union['LabwareUri', Literal['']]:
     if 'uri' not in data.keys():
         # We cannot reverse look-up a labware definition using a hash
         # so we must return an empty string if no uri is found.

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -13,6 +13,7 @@ from . import (
     file_operators as io, helpers, migration, modify)
 if typing.TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.pipette.dev_types import LabwareUri
     from .dev_types import CalibrationIndexDict, CalibrationDict
 
 
@@ -75,7 +76,8 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
 
 
 def _get_tip_length_data(
-        pip_id: str, labware_hash: str, labware_load_name: str
+        pip_id: str, labware_hash: str,
+        labware_load_name: str, labware_uri: 'LabwareUri'
 ) -> local_types.TipLengthCalibration:
     try:
         pip_tip_length_path = config.get_tip_length_cal_path()/f'{pip_id}.json'
@@ -88,7 +90,8 @@ def _get_tip_length_data(
             tiprack=labware_hash,
             last_modified=tip_length_info['lastModified'],
             source=_get_calibration_source(tip_length_info),
-            status=_get_calibration_status(tip_length_info))
+            status=_get_calibration_status(tip_length_info),
+            uri=labware_uri)
     except (FileNotFoundError, KeyError):
         raise local_types.TipLengthCalNotFound(
             f'Tip length of {labware_load_name} has not been '
@@ -139,11 +142,13 @@ def load_tip_length_calibration(
     # assert labware._is_tiprack, \
     #     'cannot save tip length for non-tiprack labware'
     labware_hash = helpers.hash_labware_def(definition)
+    labware_uri = helpers.uri_from_definition(definition)
     load_name = definition['parameters']['loadName']
     return _get_tip_length_data(
         pip_id=pip_id,
         labware_hash=labware_hash + parent,
-        labware_load_name=load_name)
+        labware_load_name=load_name,
+        labware_uri=labware_uri)
 
 
 def get_all_tip_length_calibrations() \
@@ -174,7 +179,8 @@ def get_all_tip_length_calibrations() \
                         tiprack=tiprack,
                         last_modified=info['lastModified'],
                         source=_get_calibration_source(info),
-                        status=_get_calibration_status(info)))
+                        status=_get_calibration_status(info),
+                        uri=_get_tip_rack_uri(info)))
     return all_calibrations
 
 
@@ -191,6 +197,15 @@ def _get_calibration_status(
         return local_types.CalibrationStatus()
     else:
         return local_types.CalibrationStatus(**data['status'])
+
+
+def _get_tip_rack_uri(data: typing.Dict) -> typing.Union['LabwareUri', str]:
+    if 'uri' not in data.keys():
+        # We cannot reverse look-up a labware definition using a hash
+        # so we must return an empty string if no uri is found.
+        return ''
+    else:
+        return typing.cast('LabwareUri', data['uri'])
 
 
 def get_robot_deck_attitude() \

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -5,7 +5,7 @@ This module has functions that you can import to save robot or
 labware calibration to its designated file location.
 """
 import json
-from typing import Union, List, Dict, TYPE_CHECKING
+from typing import Union, List, Dict, TYPE_CHECKING, cast
 from dataclasses import is_dataclass, asdict
 
 
@@ -15,6 +15,7 @@ from . import types as local_types
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 
 DictionaryFactoryType = Union[List, Dict]
@@ -72,17 +73,20 @@ def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
 
 def uri_from_details(namespace: str, load_name: str,
                      version: Union[str, int],
-                     delimiter='/') -> str:
+                     delimiter='/') -> 'LabwareUri':
     """ Build a labware URI from its details.
 
     A labware URI is a string that uniquely specifies a labware definition.
 
     :returns str: The URI.
     """
-    return f'{namespace}{delimiter}{load_name}{delimiter}{version}'
+    return cast(
+        'LabwareUri',
+        f'{namespace}{delimiter}{load_name}{delimiter}{version}')
 
 
-def uri_from_definition(definition: 'LabwareDefinition', delimiter='/') -> str:
+def uri_from_definition(
+        definition: 'LabwareDefinition', delimiter='/') -> 'LabwareUri':
     """ Build a labware URI from its definition.
 
     A labware URI is a string that uniquely specifies a labware definition.

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -24,6 +24,7 @@ if typing.TYPE_CHECKING:
         TipLengthCalibration, PipTipLengthCalibration,
         DeckCalibrationData, PipetteCalibrationData, CalibrationStatusDict)
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 
 def _add_to_index_offset_file(parent: str, slot: str, uri: str, lw_hash: str):
@@ -124,6 +125,7 @@ def create_tip_length_data(
     # assert labware._is_tiprack, \
     #     'cannot save tip length for non-tiprack labware'
     labware_hash = helpers.hash_labware_def(definition)
+    labware_uri = helpers.uri_from_definition(definition)
     if cal_status:
         status = cal_status
     else:
@@ -135,7 +137,8 @@ def create_tip_length_data(
         'tipLength': length,
         'lastModified': utc_now(),
         'source': local_types.SourceType.user,
-        'status': status_dict
+        'status': status_dict,
+        'uri': typing.cast('LabwareUri', labware_uri)
     }
 
     data = {labware_hash + parent: tip_length_data}

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -24,7 +24,6 @@ if typing.TYPE_CHECKING:
         TipLengthCalibration, PipTipLengthCalibration,
         DeckCalibrationData, PipetteCalibrationData, CalibrationStatusDict)
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
-    from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 
 def _add_to_index_offset_file(parent: str, slot: str, uri: str, lw_hash: str):
@@ -138,7 +137,7 @@ def create_tip_length_data(
         'lastModified': utc_now(),
         'source': local_types.SourceType.user,
         'status': status_dict,
-        'uri': typing.cast('LabwareUri', labware_uri)
+        'uri': labware_uri
     }
 
     data = {labware_hash + parent: tip_length_data}

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from enum import Enum
 from os import PathLike
 
+from typing_extensions import Literal
 from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 CalibrationID = typing.NewType('CalibrationID', str)
@@ -105,7 +106,7 @@ class TipLengthCalibration:
     pipette: str
     tiprack: str
     last_modified: datetime
-    uri: typing.Union[LabwareUri, str]
+    uri: typing.Union[LabwareUri, Literal['']]
 
 
 @dataclass

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from enum import Enum
 from os import PathLike
 
+from opentrons_shared_data.pipette.dev_types import LabwareUri
 
 CalibrationID = typing.NewType('CalibrationID', str)
 StrPath = typing.Union[str, PathLike]
@@ -104,6 +105,7 @@ class TipLengthCalibration:
     pipette: str
     tiprack: str
     last_modified: datetime
+    uri: typing.Union[LabwareUri, str]
 
 
 @dataclass

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -849,7 +849,8 @@ def test_tip_length_for_caldata(ctx, monkeypatch, use_new_calibration):
             tiprack='fake_hash',
             last_modified='some time',
             source=cs_types.SourceType.user,
-            status=cs_types.CalibrationStatus(markedBad=False))
+            status=cs_types.CalibrationStatus(markedBad=False),
+            uri='opentrons/geb_96_tiprack_10ul/1')
     monkeypatch.setattr(get, 'load_tip_length_calibration', mock_tip_length)
     instr._tip_length_for.cache_clear()
     assert instr._tip_length_for(tiprack) == 2

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -157,6 +157,7 @@ def test_create_tip_length_calibration_data(monkeypatch):
             'lastModified': fake_time,
             'source': cs_types.SourceType.user,
             'status': {'markedBad': False},
+            'uri': 'opentrons/minimal_labware_def/1'
         }
     }
     result = modify.create_tip_length_data(
@@ -238,6 +239,7 @@ def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
         source=cs_types.SourceType.user,
         status=cs_types.CalibrationStatus(markedBad=False),
         tiprack=MOCK_HASH,
+        uri='opentrons/minimal_labware_def/1',
         last_modified=test_data[MOCK_HASH]['lastModified']
     )
     assert result == expected

--- a/robot-server/robot_server/service/tip_length/models.py
+++ b/robot-server/robot_server/service/tip_length/models.py
@@ -24,6 +24,8 @@ class TipLengthCalibration(ResponseDataModel):
         Field(..., description="The calibration source")
     status: cal_model.CalibrationStatus = \
         Field(..., description="The status of this calibration")
+    uri: str = \
+        Field(..., description="The uri of the tiprack")
 
 
 MultipleCalibrationsResponse = MultiResponseModel[

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -41,7 +41,8 @@ def _format_calibration(
     response_model=tl_models.MultipleCalibrationsResponse)
 async def get_all_tip_length_calibrations(
     tiprack_hash: str = None,
-    pipette_id: str = None
+    pipette_id: str = None,
+    tiprack_uri: str = None
 ) -> tl_models.MultipleCalibrationsResponse:
     all_calibrations = get_cal.get_all_tip_length_calibrations()
 
@@ -56,6 +57,9 @@ async def get_all_tip_length_calibrations(
     if pipette_id:
         all_calibrations = list(filter(
             lambda cal: cal.pipette == pipette_id, all_calibrations))
+    if tiprack_uri:
+        all_calibrations = list(filter(
+            lambda cal: cal.uri == tiprack_uri, all_calibrations))
 
     calibrations = [_format_calibration(cal) for cal in all_calibrations]
     return tl_models.MultipleCalibrationsResponse(data=calibrations)

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -28,7 +28,8 @@ def _format_calibration(
         pipette=calibration.pipette,
         lastModified=calibration.last_modified,
         source=calibration.source,
-        status=status)
+        status=status,
+        uri=calibration.uri)
 
     return formatted_cal
 

--- a/robot-server/tests/integration/test_tip_length_access.tavern.yaml
+++ b/robot-server/tests/integration/test_tip_length_access.tavern.yaml
@@ -32,6 +32,7 @@ stages:
             tiprack: !anystr
             tipLength: !anyfloat
             lastModified: !anystr
+            uri: !anystr
             source: 'unknown'
             status:
               markedAt: null
@@ -43,6 +44,7 @@ stages:
             tipLength: !anyfloat
             lastModified: !anystr
             source: 'unknown'
+            uri: !anystr
             status:
               markedAt: null
               markedBad: false
@@ -65,6 +67,7 @@ stages:
             tipLength: 30.5
             lastModified: !anystr
             source: 'unknown'
+            uri: !anystr
             status:
               markedAt: null
               markedBad: false
@@ -88,6 +91,7 @@ stages:
             tipLength: !anyfloat
             lastModified: !anystr
             source: 'unknown'
+            uri: !anystr
             status:
               markedAt: null
               markedBad: false
@@ -98,6 +102,7 @@ stages:
             tipLength: !anyfloat
             lastModified: !anystr
             source: 'unknown'
+            uri: !anystr
             status:
               markedAt: null
               markedBad: false
@@ -121,6 +126,7 @@ stages:
             tipLength: 30.5
             lastModified: !anystr
             source: 'unknown'
+            uri: !anystr
             status:
               markedAt: null
               markedBad: false

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -152,7 +152,8 @@ def build_mock_stored_tip_length(kind='normal'):
             tiprack='fake_hash',
             last_modified='some time',
             source=CSTypes.SourceType.user,
-            status=CSTypes.CalibrationStatus(markedBad=False))
+            status=CSTypes.CalibrationStatus(markedBad=False),
+            uri='path/to_my_labware/1')
         return MagicMock(return_value=tip_length)
     else:
         return MagicMock(return_value=None)

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -14,7 +14,8 @@ def test_access_tip_length_calibration(
         'lastModified': None,
         'source': 'unknown',
         'status': {
-            'markedAt': None, 'markedBad': False, 'source': None}
+            'markedAt': None, 'markedBad': False, 'source': None},
+        'uri': ''
     }
 
     resp = api_client.get(


### PR DESCRIPTION
# Overview

Add the uri for a tiprack in the tip length calibration data model and in the endpoint that returns tip length calibration. Since there is no way to reverse a hash into a uri, we can only update the uri key once a tip length has been saved again.

# Changelog

- Modify the data model in calibration storage
- Modify the data model in robot server that sends tip length info over
- Fix tests related to this.

# Review requests
Push to a robot, make sure nothing breaks. I tested both tip length calibration and uploading a protocol to make sure the tip length still shows up in the calibration panel.

# Risk assessment

Low because we are only adding the key in when saving next, and otherwise, loading an empty string.