### PR TITLE
fix(api): bump y max bounds to match robot geometry

### DIFF
--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -1,3 +1,17 @@
+from typing_extensions import Final
+
+
+HOMED_POSITION: Final = {
+    'X': 418.0,
+    'Y': 353.0,
+    'Z': 218.0,
+    'A': 218.0,
+    'B': 19.0,
+    'C': 19.0
+}
+Y_BOUND_OVERRIDE: Final = 370
+
+
 class SmoothieDriver(object):
 
     def __init__(self):
@@ -13,7 +27,6 @@ class VirtualSmoothie(object):
 class SimulatingDriver:
     def __init__(self):
         self._steps_per_mm = {}
-        self.homed_position = {}
 
     def home(self, axis):
         pass
@@ -81,3 +94,13 @@ class SimulatingDriver:
 
     def set_acceleration(self, settings):
         pass
+
+    @property
+    def homed_position(self):
+        return HOMED_POSITION.copy()
+
+    @property
+    def axis_bounds(self):
+        position = HOMED_POSITION.copy()
+        position['Y'] = Y_BOUND_OVERRIDE
+        return position

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -5,6 +5,9 @@ import logging
 from time import sleep, time
 from threading import Event, RLock
 from typing import Any, Dict, Optional, Union, List, Tuple, cast
+from typing import Any, Dict, Optional, Union, List, Tuple, cast
+from typing_extensions import Final
+
 from math import isclose
 from serial.serialutil import SerialException  # type: ignore
 
@@ -33,14 +36,15 @@ ALARM_KEYWORD = 'alarm'
 
 
 # TODO (artyom, ben 20171026): move to config
-HOMED_POSITION: Dict[str, float] = {
-    'X': 418,
-    'Y': 353,
-    'Z': 218,
-    'A': 218,
-    'B': 19,
-    'C': 19
+HOMED_POSITION: Final = {
+    'X': 418.0,
+    'Y': 353.0,
+    'Z': 218.0,
+    'A': 218.0,
+    'B': 19.0,
+    'C': 19.0
 }
+Y_BOUND_OVERRIDE: Final = 370
 
 
 PLUNGER_BACKLASH_MM = 0.3
@@ -415,8 +419,14 @@ class SmoothieDriver_3_0_0:
         self._gpio_chardev = gpio_chardev
 
     @property
-    def homed_position(self):
+    def homed_position(self) -> Dict[str, float]:
         return self._homed_position.copy()
+
+    @property
+    def axis_bounds(self) -> Dict[str, float]:
+        bounds = {k: v for k, v in self._homed_position.items()}
+        bounds['Y'] = Y_BOUND_OVERRIDE
+        return bounds
 
     def _update_position(self, target):
         self._position.update({

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -5,8 +5,6 @@ import logging
 from time import sleep, time
 from threading import Event, RLock
 from typing import Any, Dict, Optional, Union, List, Tuple, cast
-from typing import Any, Dict, Optional, Union, List, Tuple, cast
-from typing_extensions import Final
 
 from math import isclose
 from serial.serialutil import SerialException  # type: ignore
@@ -20,6 +18,9 @@ from opentrons.drivers.utils import (
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 from opentrons.system import smoothie_update
+from . import HOMED_POSITION, Y_BOUND_OVERRIDE
+
+
 """
 - Driver is responsible for providing an interface for motion control
 - Driver is the only system component that knows about GCODES or how smoothie
@@ -33,19 +34,6 @@ log = logging.getLogger(__name__)
 
 ERROR_KEYWORD = 'error'
 ALARM_KEYWORD = 'alarm'
-
-
-# TODO (artyom, ben 20171026): move to config
-HOMED_POSITION: Final = {
-    'X': 418.0,
-    'Y': 353.0,
-    'Z': 218.0,
-    'A': 218.0,
-    'B': 19.0,
-    'C': 19.0
-}
-Y_BOUND_OVERRIDE: Final = 370
-
 
 PLUNGER_BACKLASH_MM = 0.3
 LOW_CURRENT_Z_SPEED = 30

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -263,7 +263,7 @@ class Controller:
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
         return {Axis[ax]: (0, pos) for ax, pos
-                in self._smoothie_driver.homed_position.items()
+                in self._smoothie_driver.axis_bounds.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -36,7 +36,10 @@ if TYPE_CHECKING:
 MODULE_LOG = logging.getLogger(__name__)
 
 
-_HOME_POSITION = {'X': 418.0, 'Y': 353.0, 'Z': 218.0,
+_HOME_POSITION: Final = {'X': 418.0, 'Y': 353.0, 'Z': 218.0,
+                         'A': 218.0, 'B': 19.0, 'C': 19.0}
+
+_BOUNDS: Final = {'X': 418.0, 'Y': 370.0, 'Z': 218.0,
                   'A': 218.0, 'B': 19.0, 'C': 19.0}
 
 
@@ -288,7 +291,7 @@ class Simulator:
     @property
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {Axis[ax]: (0, pos) for ax, pos in _HOME_POSITION.items()
+        return {Axis[ax]: (0, pos) for ax, pos in _BOUNDS.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -5,7 +5,6 @@ import logging
 from threading import Event
 from typing import (Dict, Optional, List, Tuple,
                     TYPE_CHECKING, Sequence)
-from typing_extensions import Final
 from contextlib import contextmanager
 
 from opentrons_shared_data.pipette import dummy_model_for_name
@@ -17,6 +16,7 @@ from opentrons.config.pipette_config import (config_models,
                                              load)
 from opentrons.config.types import RobotConfig
 from opentrons.drivers.smoothie_drivers import SimulatingDriver
+
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 
 from . import modules
@@ -34,13 +34,6 @@ if TYPE_CHECKING:
 
 
 MODULE_LOG = logging.getLogger(__name__)
-
-
-_HOME_POSITION: Final = {'X': 418.0, 'Y': 353.0, 'Z': 218.0,
-                         'A': 218.0, 'B': 19.0, 'C': 19.0}
-
-_BOUNDS: Final = {'X': 418.0, 'Y': 370.0, 'Z': 218.0,
-                  'A': 218.0, 'B': 19.0, 'C': 19.0}
 
 
 class Simulator:
@@ -119,7 +112,8 @@ class Simulator:
         """
         self.config = config
         self._loop = loop
-        self._gpio_chardev: Final = gpio_chardev
+        self._smoothie_driver = SimulatingDriver()
+        self._gpio_chardev = gpio_chardev
 
         def _sanitize_attached_instrument(
                 passed_ai: Dict[str, Optional[str]] = None)\
@@ -142,13 +136,13 @@ class Simulator:
             m: _sanitize_attached_instrument(attached_instruments.get(m))
             for m in types.Mount}
         self._stubbed_attached_modules = attached_modules
-        self._position = copy.copy(_HOME_POSITION)
+        self._position = copy.copy(self._smoothie_driver.homed_position)
         # Engaged axes start all true in smoothie for some reason so we
         # imitate that here
         # TODO(LC2642019) Create a simulating driver for smoothie instead of
         # using a flag
-        self._smoothie_driver = SimulatingDriver()
-        self._engaged_axes = {ax: True for ax in _HOME_POSITION}
+
+        self._engaged_axes = {ax: True for ax in self._smoothie_driver.homed_position}
         self._lights = {'button': False, 'rails': False}
         self._run_flag = Event()
         self._run_flag.set()
@@ -172,7 +166,7 @@ class Simulator:
     def home(self, axes: List[str] = None) -> Dict[str, float]:
         # driver_3_0-> HOMED_POSITION
         checked_axes = axes or 'XYZABC'
-        self._position.update({ax: _HOME_POSITION[ax]
+        self._position.update({ax: self._smoothie_driver.homed_position[ax]
                                for ax in checked_axes})
         self._engaged_axes.update({ax: True
                                    for ax in checked_axes})
@@ -181,7 +175,7 @@ class Simulator:
     def fast_home(
             self, axis: Sequence[str], margin: float) -> Dict[str, float]:
         for ax in axis:
-            self._position[ax] = _HOME_POSITION[ax]
+            self._position[ax] = self._smoothie_driver.homed_position[ax]
             self._engaged_axes[ax] = True
         return self._position
 
@@ -291,7 +285,8 @@ class Simulator:
     @property
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
         """ The (minimum, maximum) bounds for each axis. """
-        return {Axis[ax]: (0, pos) for ax, pos in _BOUNDS.items()
+        return {Axis[ax]: (0, pos) for ax, pos
+                in self._smoothie_driver.axis_bounds.items()
                 if ax not in 'BC'}
 
     @property

--- a/api/src/opentrons/tools/overnight_test.py
+++ b/api/src/opentrons/tools/overnight_test.py
@@ -29,8 +29,8 @@ start_time_minutes = int(time.time() / 60)
 attempts_to_home = 1
 too_many_attempts_to_home = 3
 
-XY_TOLERANCE = 30
-ZA_TOLERANCE = 10
+XY_TOLERANCE = 30.0
+ZA_TOLERANCE = 10.0
 
 AXIS_TEST_SKIPPING_TOLERANCE = 0.5
 


### PR DESCRIPTION
We now helpfully check that jogs don't overlap the maximum motion range
of each axis, at least in the positive direction, using the home
positions. This works pretty well for Z and X since it straightforwardly
prevents hard limit errors from unintentional endstop triggers, which
happen at the home position as one might expect.

Unfortunately, the robot geometry makes this approach completely invalid
for Y. When homing, the Y endstop (which is located on the back of the
head) actually interacts with a post projecting from the back of the
robot, which is located on the right side of the robot. This is the
reason we must always home X before homing Y: to make sure the head is
in the correct position for the Y endstop to interact with the post.

If the head is _not_ all the way to the right, it can actually go much
farther back - past the home location, past where the switch would
interact with the post. And the deck layout is designed to take
advantage of this; the position that A1 of most labware lives in is
farther back than the post, and thus customers would get spurious jog
failures when calibrating labwares in slots 10 and 11 using single
channel pipettes (because multi channels are wider in Y, the gantry
doesn't go far enough back to trigger the issue).

The fix is to create a different bound in the Y.

Closes #6886

## Risk
Low, only happens during jog during labware calibration and widens the bound

## Testing
Put a labware in slot 10 or 11 and try to calibrate it using a single channel. You should be able to jog freely.