### PR TITLE
refactor(robot-server): Refactor command models to use literals

### DIFF
--- a/robot-server/robot_server/robot/calibration/check/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/check/state_machine.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
-from robot_server.service.session.models.command import (
-    CommandDefinition, CalibrationCommand,
-    CheckCalibrationCommand, DeckCalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CommandDefinition, CalibrationCommand, DeckCalibrationCommand, \
+    CheckCalibrationCommand
 from robot_server.robot.calibration.util import (
     SimpleStateMachine, StateTransitionError)
 

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -24,8 +24,8 @@ from robot_server.robot.calibration.helper_classes import (
     RobotHealthCheck, PipetteRank, PipetteInfo,
     RequiredLabware)
 
-from robot_server.service.session.models.command import (
-    CalibrationCommand, CheckCalibrationCommand, DeckCalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand, DeckCalibrationCommand, CheckCalibrationCommand
 from robot_server.service.errors import RobotServerError
 
 from .util import (

--- a/robot-server/robot_server/robot/calibration/deck/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/deck/state_machine.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
-from robot_server.service.session.models.command import (
-    CommandDefinition, DeckCalibrationCommand as DeckCalCommand,
-    CalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CommandDefinition, CalibrationCommand, \
+    DeckCalibrationCommand as DeckCalCommand
 from robot_server.robot.calibration.util import (
     SimpleStateMachine, StateTransitionError)
 from .constants import DeckCalibrationState as State

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -21,8 +21,8 @@ from robot_server.robot.calibration.constants import \
     TIP_RACK_LOOKUP_BY_MAX_VOL
 from robot_server.service.errors import RobotServerError
 
-from robot_server.service.session.models.command import (
-    CalibrationCommand, DeckCalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand, DeckCalibrationCommand
 from robot_server.robot.calibration.constants import (
     SHORT_TRASH_DECK, STANDARD_DECK, MOVE_TO_DECK_SAFETY_BUFFER,
     MOVE_TO_TIP_RACK_SAFETY_BUFFER, POINT_ONE_ID, POINT_TWO_ID,

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from robot_server.service.session.models.command import (
-    CommandDefinition, CalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CommandDefinition, CalibrationCommand
 from robot_server.robot.calibration.util import (
     SimpleStateMachine, StateTransitionError)
 from .constants import (

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -13,7 +13,7 @@ from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command import \
+from robot_server.service.session.models.command_definitions import \
     CalibrationCommand
 from robot_server.robot.calibration import util
 from robot_server.robot.calibration.constants import (

--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -1,6 +1,6 @@
 from typing import Dict
-from robot_server.service.session.models.command import (
-    CommandDefinition, CalibrationCommand)
+from robot_server.service.session.models.command_definitions import \
+    CommandDefinition, CalibrationCommand
 from robot_server.robot.calibration.util import (
     SimpleStateMachine,
     StateTransitionError

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -11,7 +11,8 @@ from opentrons.protocols.geometry.deck import Deck
 from robot_server.robot.calibration import util
 from robot_server.service.errors import RobotServerError
 
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from ..errors import CalibrationError
 from ..helper_classes import RequiredLabware, AttachedPipette
 from ..constants import (

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -12,8 +12,7 @@ from opentrons.calibration_storage import modify
 from opentrons.types import Point, Location
 
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command import (
-    CommandDefinition)
+from ...service.session.models.command_definitions import CommandDefinition
 from .constants import (
     STATE_WILDCARD, MOVE_TO_REF_POINT_SAFETY_BUFFER,
     TRASH_WELL, TRASH_REF_POINT_OFFSET)

--- a/robot-server/robot_server/service/session/command_execution/callable_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/callable_executor.py
@@ -24,7 +24,7 @@ class CallableExecutor(CommandExecutor):
     async def execute(self, command: Command) -> CompletedCommand:
         """Execute command"""
         with duration() as time_it:
-            name_arg = command.content.name.value
+            name_arg = command.content.name
             data = command.content.data
             data_arg = data.dict() if data else {}
 

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from robot_server.service.session.models.command import (
-    CommandDefinitionType, CommandDataType, CommandStatus, CommandResultType)
+    CommandDataType, CommandStatus, CommandResultType)
+from robot_server.service.session.models.command_definitions import \
+    CommandDefinitionType
 from robot_server.service.session.models.common import (
     IdentifierType, create_identifier)
 from opentrons.util.helpers import utc_now

--- a/robot-server/robot_server/service/session/command_execution/hardware_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/hardware_executor.py
@@ -5,7 +5,8 @@ from . import Command, CompletedCommand, CommandResult
 from . base_executor import CommandExecutor
 from ..errors import UnsupportedCommandException
 from ..models.command import (
-    CommandDataType, RobotCommand, CommandDefinition)
+    CommandDataType)
+from ..models.command_definitions import CommandDefinition, RobotCommand
 from robot_server.util import duration
 
 

--- a/robot-server/robot_server/service/session/models/command_definitions.py
+++ b/robot-server/robot_server/service/session/models/command_definitions.py
@@ -1,0 +1,128 @@
+import typing
+from enum import Enum
+
+
+class CommandDefinition(str, Enum):
+    def __new__(cls, value):
+        """Create a string enum."""
+        namespace = cls.namespace()
+        full_name = f"{namespace}.{value}" if namespace else value
+        # Ignoring type errors because this is exactly as described here
+        # https://docs.python.org/3/library/enum.html#when-to-use-new-vs-init
+        obj = str.__new__(cls, full_name)  # type: ignore
+        obj._value_ = full_name
+        obj._localname = value
+        return obj
+
+    @staticmethod
+    def namespace():
+        """
+        This is primarily for allowing  definitions to define a
+        namespace. The name space will be used to make the value of the
+        enum. It will be "{namespace}.{value}"
+        """
+        return None
+
+    @property
+    def localname(self):
+        """Get the name of the command without the namespace"""
+        return self._localname  # type: ignore
+
+
+class RobotCommand(CommandDefinition):
+    """Robot commands"""
+    home_all_motors = "homeAllMotors"
+    home_pipette = "homePipette"
+    toggle_lights = "toggleLights"
+
+    @staticmethod
+    def namespace():
+        return "robot"
+
+
+class ProtocolCommand(CommandDefinition):
+    """Protocol commands"""
+    start_run = "startRun"
+    start_simulate = "startSimulate"
+    cancel = "cancel"
+    pause = "pause"
+    resume = "resume"
+
+    @staticmethod
+    def namespace():
+        return "protocol"
+
+
+class EquipmentCommand(CommandDefinition):
+    load_labware = "loadLabware"
+    load_instrument = "loadInstrument"
+
+    @staticmethod
+    def namespace():
+        return "equipment"
+
+
+class PipetteCommand(CommandDefinition):
+    aspirate = "aspirate"
+    dispense = "dispense"
+    drop_tip = "dropTip"
+    pick_up_tip = "pickUpTip"
+
+    @staticmethod
+    def namespace():
+        return "pipette"
+
+
+class CalibrationCommand(CommandDefinition):
+    """Shared Between Calibration Flows"""
+    load_labware = "loadLabware"
+    jog = "jog"
+    set_has_calibration_block = "setHasCalibrationBlock"
+    move_to_tip_rack = "moveToTipRack"
+    move_to_point_one = "moveToPointOne"
+    move_to_deck = "moveToDeck"
+    move_to_reference_point = "moveToReferencePoint"
+    pick_up_tip = "pickUpTip"
+    confirm_tip_attached = "confirmTip"
+    invalidate_tip = "invalidateTip"
+    save_offset = "saveOffset"
+    exit = "exitSession"
+    invalidate_last_action = "invalidateLastAction"
+
+    @staticmethod
+    def namespace():
+        return "calibration"
+
+
+class DeckCalibrationCommand(CommandDefinition):
+    """Deck Calibration Specific"""
+    move_to_point_two = "moveToPointTwo"
+    move_to_point_three = "moveToPointThree"
+
+    @staticmethod
+    def namespace():
+        return "calibration.deck"
+
+
+class CheckCalibrationCommand(CommandDefinition):
+    """Check Calibration Health Specific"""
+    compare_point = "comparePoint"
+    switch_pipette = "switchPipette"
+    return_tip = "returnTip"
+    transition = "transition"
+
+    @staticmethod
+    def namespace():
+        return "calibration.check"
+
+
+CommandDefinitionType = typing.Union[
+    RobotCommand,
+    CalibrationCommand,
+    CheckCalibrationCommand,
+    DeckCalibrationCommand,
+    ProtocolCommand,
+    PipetteCommand,
+    EquipmentCommand,
+]
+"""A Union of all CommandDefinition enumerations accepted"""

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -136,23 +136,12 @@ async def session_command_execute_handler(
             reason=f"Session '{sessionId}' is not active. "
                    "Only the active session can execute commands")
 
-    command = create_command(command_request.data.command,
-                             command_request.data.data)
-    command_result = await session_obj.command_executor.execute(command)
+    command_result = await session_obj.execute_command(command_request.data)
 
     log.debug(f"Command result: {command_result}")
 
     return CommandResponse(
-        data=SessionCommand(
-            id=command_result.meta.identifier,
-            data=command_result.content.data,
-            command=command_result.content.name,
-            status=command_result.result.status,
-            createdAt=command_result.meta.created_at,
-            startedAt=command_result.result.started_at,
-            completedAt=command_result.result.completed_at,
-            result=command_result.result.data,
-        ),
+        data=command_result,
         links=get_valid_session_links(sessionId, router)
     )
 

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -9,11 +9,10 @@ from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ResourceLink
 from robot_server.service.json_api.resource_links import ResourceLinkKey, \
     ResourceLinks
-from robot_server.service.session.command_execution import create_command
 from robot_server.service.session.errors import CommandExecutionException
 from robot_server.service.session.manager import SessionManager, BaseSession
-from robot_server.service.session.models.command import SessionCommand, \
-    CommandResponse, CommandRequest
+from robot_server.service.session.models.command import CommandResponse,\
+    CommandRequest
 from robot_server.service.session.models.session import SessionResponse, \
     SessionCreateRequest, MultiSessionResponse, SessionType
 from robot_server.service.session.session_types import SessionMetaData

--- a/robot-server/robot_server/service/session/session_types/live_protocol/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/command_executor.py
@@ -6,7 +6,7 @@ from robot_server.service.session.command_execution import (
 from robot_server.service.session.errors import UnsupportedCommandException
 from robot_server.service.session.session_types.live_protocol.command_interface import CommandInterface  # noqa: E501
 from robot_server.service.session.session_types.live_protocol.state_store import StateStore  # noqa: E501
-from robot_server.service.session.models import command as models
+from robot_server.service.session.models import command_definitions as models
 from robot_server.util import duration
 
 log = logging.getLogger(__name__)

--- a/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/state_store.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from opentrons.types import Mount
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
+from robot_server.service.session.models import command_definitions
 from robot_server.service.session.models.common import OffsetVector
 from robot_server.service.session.models import command as models
 from robot_server.service.session.command_execution import (
@@ -28,12 +29,12 @@ class StateStore:
         self._commands: List[Command] = []
         self._command_results_map: Dict[str, CommandResult] = dict()
         self._handler_map: Dict[
-            models.CommandDefinition,
+            command_definitions.CommandDefinition,
             Callable[[Command, CommandResult], None]
         ] = {
-            models.EquipmentCommand.load_labware:
+            command_definitions.EquipmentCommand.load_labware:
                 self.handle_load_labware,
-            models.EquipmentCommand.load_instrument:
+            command_definitions.EquipmentCommand.load_instrument:
                 self.handle_load_instrument,
         }
         self._labware: Dict[models.IdentifierType, LabwareEntry] = {}

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
@@ -14,8 +14,8 @@ from robot_server.service.session.command_execution import CommandExecutor, \
     Command, CompletedCommand, CommandResult
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session.errors import UnsupportedCommandException
-from robot_server.service.session.models.command import (
-    ProtocolCommand, CommandDefinitionType)
+from robot_server.service.session.models.command_definitions import \
+    ProtocolCommand, CommandDefinitionType
 from robot_server.service.session.session_types.protocol.execution.\
     protocol_runner import ProtocolRunner
 from robot_server.service.session.session_types.protocol.execution.worker \

--- a/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
+++ b/robot-server/tests/integration/sessions/test_calibration_check.tavern.yaml
@@ -531,9 +531,9 @@ stages:
       json:
         data:
           id: "{session_id}"
-          command: calibration.moveToTipRack
+          command: calibration.jog
           data:
-            vector: [1, 2, 3]
+            vector: [1, 2]
     response:
       status_code: 422
 

--- a/robot-server/tests/robot/calibration/check/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/check/test_state_machine.py
@@ -1,10 +1,9 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command import (
-    CalibrationCommand as CalCommand,
-    DeckCalibrationCommand as DeckCommand,
-    CheckCalibrationCommand as CheckCommand)
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand as CalCommand, DeckCalibrationCommand as DeckCommand, \
+    CheckCalibrationCommand as CheckCommand
 from robot_server.robot.calibration.check.state_machine import \
     CalibrationCheckStateMachine
 

--- a/robot-server/tests/robot/calibration/deck/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/deck/test_state_machine.py
@@ -1,9 +1,8 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command import (
-    CalibrationCommand as CalCommand,
-    DeckCalibrationCommand as DeckCommand)
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand as CalCommand, DeckCalibrationCommand as DeckCommand
 from robot_server.robot.calibration.deck.state_machine import \
     DeckCalibrationStateMachine
 

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -8,7 +8,8 @@ from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
 from robot_server.robot.calibration.deck.user_flow import \
     DeckCalibrationUserFlow, tuplefy_cal_point_dicts
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.robot.calibration.deck.constants import \
     POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID, DeckCalibrationState
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
@@ -1,8 +1,8 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command import\
-  CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.robot.calibration.pipette_offset.state_machine import (
     PipetteOffsetCalibrationStateMachine,
     PipetteOffsetWithTipLengthStateMachine)

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -11,7 +11,8 @@ from opentrons.config.pipette_config import load
 from opentrons_shared_data.labware import load_definition
 
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.robot.calibration.pipette_offset.user_flow import \
     PipetteOffsetCalibrationUserFlow
 from robot_server.robot.calibration.pipette_offset.constants import (

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -1,7 +1,8 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.robot.calibration.tip_length.state_machine import \
     TipCalibrationStateMachine
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -8,7 +8,8 @@ from opentrons.config.pipette_config import load
 from opentrons.calibration_storage import types as cal_types
 
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.robot.calibration.tip_length.user_flow import \
     TipCalibrationUserFlow
 

--- a/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 import pytest
 
+from robot_server.service.session.models import command_definitions
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.session.command_execution.command import \
     CommandContent, CommandResult
@@ -63,7 +64,7 @@ async def test_load_labware(command_executor, mock_command_interface):
                                         namespace="test")
     result = await command_executor.execute(
         Command(content=CommandContent(
-            name=models.EquipmentCommand.load_labware,
+            name=command_definitions.EquipmentCommand.load_labware,
             data=command))
     )
 
@@ -71,7 +72,7 @@ async def test_load_labware(command_executor, mock_command_interface):
 
     assert result.result.data == expected_response
     assert result.content == CommandContent(
-            name=models.EquipmentCommand.load_labware,
+            name=command_definitions.EquipmentCommand.load_labware,
             data=command)
 
 
@@ -88,7 +89,7 @@ async def test_load_instrument(command_executor, mock_command_interface):
                                            mount=Mount.left)
     result = await command_executor.execute(
         Command(content=CommandContent(
-            name=models.EquipmentCommand.load_instrument,
+            name=command_definitions.EquipmentCommand.load_instrument,
             data=command))
     )
 
@@ -97,15 +98,15 @@ async def test_load_instrument(command_executor, mock_command_interface):
 
     assert result.result.data == expected_response
     assert result.content == CommandContent(
-            name=models.EquipmentCommand.load_instrument,
+            name=command_definitions.EquipmentCommand.load_instrument,
             data=command)
 
 
 @pytest.mark.parametrize(
     argnames=['handler_name', 'command_type'],
     argvalues=[
-        ['handle_aspirate', models.PipetteCommand.aspirate],
-        ['handle_dispense', models.PipetteCommand.dispense]
+        ['handle_aspirate', command_definitions.PipetteCommand.aspirate],
+        ['handle_dispense', command_definitions.PipetteCommand.dispense]
     ])
 async def test_liquid_commands(command_executor, mock_command_interface,
                                handler_name, command_type):
@@ -137,8 +138,8 @@ async def test_liquid_commands(command_executor, mock_command_interface,
 @pytest.mark.parametrize(
     argnames=['handler_name', 'command_type'],
     argvalues=[
-        ['handle_pick_up_tip', models.PipetteCommand.pick_up_tip],
-        ['handle_drop_tip', models.PipetteCommand.drop_tip]
+        ['handle_pick_up_tip', command_definitions.PipetteCommand.pick_up_tip],
+        ['handle_drop_tip', command_definitions.PipetteCommand.drop_tip]
     ])
 async def test_tip_commands(command_executor, mock_command_interface,
                             handler_name, command_type):

--- a/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
@@ -56,10 +56,10 @@ def test_store_has_handle_command_response_method():
 @pytest.mark.parametrize(
     argnames="command_name, handler",
     argvalues=[[
-                   command_definitions.EquipmentCommand.load_labware,
+                command_definitions.EquipmentCommand.load_labware,
                 "handle_load_labware"],
                [
-                   command_definitions.EquipmentCommand.load_instrument,
+                command_definitions.EquipmentCommand.load_instrument,
                 "handle_load_instrument"]]
 )
 def test_command_result_state_handler(command_name, handler):
@@ -77,7 +77,8 @@ def test_command_result_state_handler(command_name, handler):
 
 def test_load_labware_update():
     store = StateStore()
-    command = create_command(name=command_definitions.EquipmentCommand.load_labware,
+    labware = command_definitions.EquipmentCommand.load_labware
+    command = create_command(name=labware,
                              data=models.LoadLabwareRequest(
                                     location=1,
                                     loadName="labware-load-name",
@@ -101,7 +102,8 @@ def test_load_labware_update():
 
 def test_load_instrument_update():
     store = StateStore()
-    command = create_command(name=command_definitions.EquipmentCommand.load_instrument,
+    instrument = command_definitions.EquipmentCommand.load_instrument
+    command = create_command(name=instrument,
                              data=models.LoadInstrumentRequest(
                                  instrumentName='p10_single',
                                  mount=Mount.left)

--- a/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_state_store.py
@@ -2,6 +2,8 @@ import pytest
 from unittest.mock import patch
 
 from opentrons import types
+
+from robot_server.service.session.models import command_definitions
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.session.models import command as models
 from robot_server.service.session.command_execution \
@@ -13,7 +15,7 @@ from robot_server.service.session.session_types.live_protocol.state_store \
 def test_handle_command_request():
     store = StateStore()
     command = create_command(
-        name=models.EquipmentCommand.load_labware,
+        name=command_definitions.EquipmentCommand.load_labware,
         data=models.LoadLabwareRequest(
             location=1,
             loadName="labware-load-name",
@@ -31,7 +33,7 @@ def test_store_has_handle_command_response_method():
     with patch.object(StateStore, "handle_load_labware"):
         store = StateStore()
         command = create_command(
-            name=models.EquipmentCommand.load_labware,
+            name=command_definitions.EquipmentCommand.load_labware,
             data=models.LoadLabwareRequest(
                 location=1,
                 loadName="labware-load-name",
@@ -53,9 +55,11 @@ def test_store_has_handle_command_response_method():
 
 @pytest.mark.parametrize(
     argnames="command_name, handler",
-    argvalues=[[models.EquipmentCommand.load_labware,
+    argvalues=[[
+                   command_definitions.EquipmentCommand.load_labware,
                 "handle_load_labware"],
-               [models.EquipmentCommand.load_instrument,
+               [
+                   command_definitions.EquipmentCommand.load_instrument,
                 "handle_load_instrument"]]
 )
 def test_command_result_state_handler(command_name, handler):
@@ -73,7 +77,7 @@ def test_command_result_state_handler(command_name, handler):
 
 def test_load_labware_update():
     store = StateStore()
-    command = create_command(name=models.EquipmentCommand.load_labware,
+    command = create_command(name=command_definitions.EquipmentCommand.load_labware,
                              data=models.LoadLabwareRequest(
                                     location=1,
                                     loadName="labware-load-name",
@@ -97,7 +101,7 @@ def test_load_labware_update():
 
 def test_load_instrument_update():
     store = StateStore()
-    command = create_command(name=models.EquipmentCommand.load_instrument,
+    command = create_command(name=command_definitions.EquipmentCommand.load_instrument,
                              data=models.LoadInstrumentRequest(
                                  instrumentName='p10_single',
                                  mount=Mount.left)

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -4,7 +4,8 @@ import pytest
 
 from robot_server.service.session.command_execution.command import Command, CommandContent  # noqa: E501
 from robot_server.service.session.errors import UnsupportedCommandException
-from robot_server.service.session.models.command import ProtocolCommand
+from robot_server.service.session.models.command_definitions import \
+    ProtocolCommand
 from robot_server.service.session.models.common import EmptyModel
 from robot_server.service.session.session_types.protocol.execution import \
     command_executor

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -51,7 +51,8 @@ def command_created_at():
 
 @pytest.fixture
 def patch_create_command(command_id, command_created_at):
-    with patch("robot_server.service.session.session_types.base_session.create_command") as p:
+    session_path = "robot_server.service.session.session_types"
+    with patch(f"{session_path}.base_session.create_command") as p:
         p.side_effect = lambda c, n: Command(
             content=CommandContent(c, n),
             meta=CommandMeta(command_id, command_created_at))

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -14,7 +14,8 @@ from robot_server.service.session.command_execution.command import \
 from robot_server.service.session.errors import SessionCreationException, \
     UnsupportedCommandException, CommandExecutionException
 from robot_server.service.session.models.common import EmptyModel, JogPosition
-from robot_server.service.session.models.command import CalibrationCommand
+from robot_server.service.session.models.command_definitions import \
+    CalibrationCommand
 from robot_server.service.session.models.session import SessionType
 from robot_server.service.session.session_types import (
     LiveProtocolSession, SessionMetaData)
@@ -50,7 +51,7 @@ def command_created_at():
 
 @pytest.fixture
 def patch_create_command(command_id, command_created_at):
-    with patch("robot_server.service.session.router.create_command") as p:
+    with patch("robot_server.service.session.session_types.base_session.create_command") as p:
         p.side_effect = lambda c, n: Command(
             content=CommandContent(c, n),
             meta=CommandMeta(command_id, command_created_at))


### PR DESCRIPTION
# Overview

A mostly @amitlissack driven PR. This is a refactor to avoid pydantic unions confusing which request model to use again if you do not pass in a value. We need this to support #7131 and avoid making the `load_labware` command a breaking change.

# Changelog

- Separate out commands further by creating separate definitions for commands that have different request models (like jog for instance, and subsequently the load labware command)
- Modify the base session class to create and execute a command
- Modify tests based on the above

# Review requests

I've tested on a robot already, but feel free to run through cal overhaul flows to make sure nothing gets broken.
