### PR TITLE
fix(robot-server): ProtocolManager expects a ThreadManager and not a SynchronousAdapter.

### DIFF
--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -4,7 +4,7 @@ import threading
 import logging
 import asyncio
 import functools
-from typing import Generic, TypeVar, Any
+from typing import Generic, TypeVar, Any, Optional
 from .adapters import SynchronousAdapter
 from .modules.mod_abc import AbstractModule
 
@@ -105,7 +105,7 @@ class ThreadManager:
         self._loop = None
         self.managed_obj = None
         self.bridged_obj = None
-        self._sync_managed_obj = None
+        self._sync_managed_obj: Optional[SynchronousAdapter] = None
         is_running = threading.Event()
         self._is_running = is_running
 
@@ -159,8 +159,12 @@ class ThreadManager:
             loop.close()
 
     @property
-    def sync(self):
-        return self._sync_managed_obj
+    def sync(self) -> SynchronousAdapter:
+        # Why the ignore?
+        # While self._sync_managed_obj is initialized None, a failure to build
+        # the managed_obj and _sync_managed_obj is a catastrophic failure.
+        # All callers of this property assume it to be valid.
+        return self._sync_managed_obj  # type: ignore
 
     def __repr__(self):
         return '<ThreadManager>'

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/command_executor.py
@@ -89,7 +89,7 @@ class ProtocolCommandExecutor(CommandExecutor, WorkerListener):
         protocol_runner = ProtocolRunner(
             protocol=protocol,
             loop=loop,
-            hardware=configuration.hardware.sync,
+            hardware=configuration.hardware,
             motion_lock=configuration.motion_lock)
         # The async worker to which all commands are delegated.
         return _Worker(


### PR DESCRIPTION
# Overview

There was a mixup in the type of adapter sent to `ProtocolRunner`. It expects a `ThreadManager` but got a `SynchronousAdapter`.

# Changelog

- Add typing to `ThreadManager.sync`. 
- Fix mismatch.

# Review requests

None

# Risk assessment

None. This is in a feature behind a feature flag. 