### PR TITLE
fix(notify-server): fix errors in readme.

### DIFF
--- a/notify-server/Pipfile
+++ b/notify-server/Pipfile
@@ -10,6 +10,7 @@ python_version = "3.7"
 pyzmq = "==19.*,>=19.0.2"
 pydantic = "==1.4"
 opentrons = {editable = true, path = "./../api"}
+opentrons-shared-data = {editable = true, path = "./../shared-data/python"}
 
 [dev-packages]
 flake8 = "==3.*,>=3.8.4"

--- a/notify-server/Pipfile.lock
+++ b/notify-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3d0bec4df82ac37e64314a71110a5df214213548d4083159f729a29c7dcc7ea8"
+            "sha256": "2bbe0011067a6ca7af45fe3b92abfdbfed3fd4b423beba695384144045bc5a09"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -91,11 +91,8 @@
             "path": "./../api"
         },
         "opentrons-shared-data": {
-            "hashes": [
-                "sha256:47a34843aa11e0e1e9211de62309dd9668045427135bf3d962cc5e61e18c793e"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.21.2"
+            "editable": true,
+            "path": "./../shared-data/python"
         },
         "pydantic": {
             "hashes": [

--- a/notify-server/README.rst
+++ b/notify-server/README.rst
@@ -9,7 +9,7 @@ The notification server is a pub/sub service for the OT2.
 
 Development Environment
 -----------------------------------
-- `poetry <https://python-poetry.org>`_ is used as the package manager. Follow these `installation instructions <https://python-poetry.org/docs/#installation>`_.
+- `pipenv <https://github.com/pypa/pipenv>`_ is the package manager.
 - ``make setup`` will setup the project.
 - ``make test`` will run the unit tests.
 - ``make lint`` will run type checking and linting.
@@ -67,7 +67,7 @@ To start from the command line:
 
 .. code-block:: bash
 
-   python -m notify_server.subscriber -s tcp://localhost:5555 topic1 topic2
+   python -m notify_server.app_sub -s tcp://localhost:5555 topic1 topic2
 
 models
 =======


### PR DESCRIPTION
# Overview

Fix errors in readme

# Changelog

notify-server does not use poetry. 
also, correct the example of using the command line subscriber

# Review requests


# Risk assessment

None