### PR TITLE
refactor(robot-server): Version checking is changed from opt-out to opt-in

### DIFF
--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -17,24 +17,6 @@ API_VERSION_HEADER = "Opentrons-Version"
 # Response header specifing minimum acceptable API version
 MIN_API_VERSION_HEADER = "Opentrons-Min-Version"
 
-# Allow-list for routes that are not subject to versioning requirements
-# TODO(mc, 2020-11-05): allow routes to opt-in to versionsing and request +
-# response migrations via decorator. Puting an allow-list in place for now
-# because allowing an endpoint to bypass versioning requirements in the future
-# is not a breaking change
-# These will be compiled into a regex and checked with regex.match(), so you
-# can use regex syntax
-NON_VERSIONED_ROUTES = {
-    # keep the root RPC WebSocket path unversioned because browsers cannot
-    # specify headers for WebSocket client requests
-    "/",
-    # keep documentation endpoints unversioned
-    "/openapi.json",
-    "/docs",
-    "/redoc",
-    "/logs/.*"
-}
-
 
 # Tag applied to legacy api endpoints
 V1_TAG = "v1"

--- a/robot-server/robot_server/constants.py
+++ b/robot-server/robot_server/constants.py
@@ -1,21 +1,24 @@
 # This is the version of the HTTP API used by the server.  This value should
 # be incremented anytime the schema of a request or response is changed. This
 # value is different and separate from the application version.
-API_VERSION = 2
+from typing_extensions import Literal, Final
+
+API_VERSION: Final = 2
 
 # Minimum API version supported by the server. Increasing this value should
 # be considered a **breaking change** in the application.
-MIN_API_VERSION = 2
+MIN_API_VERSION: Final = 2
 
 # Keyword header value for a client to ask to use the latest HTTP API version.
-API_VERSION_LATEST = "*"
+API_VERSION_LATEST_TYPE = Literal["*"]
+API_VERSION_LATEST: API_VERSION_LATEST_TYPE = "*"
 
 # Header identifying maximum acceptable version in request and actual version
 # used to create response. Mandatory in requests and responses.
-API_VERSION_HEADER = "Opentrons-Version"
+API_VERSION_HEADER: Final = "Opentrons-Version"
 
 # Response header specifing minimum acceptable API version
-MIN_API_VERSION_HEADER = "Opentrons-Min-Version"
+MIN_API_VERSION_HEADER: Final = "Opentrons-Min-Version"
 
 
 # Tag applied to legacy api endpoints

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -1,10 +1,15 @@
 from functools import lru_cache
 
 from starlette import status
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Header
 from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
+from starlette.requests import Request
+from starlette.status import HTTP_400_BAD_REQUEST
 
+from robot_server import constants
 from robot_server.hardware_wrapper import HardwareWrapper
+from robot_server.service.errors import BaseRobotServerError
+from robot_server.service.json_api import Error
 from robot_server.service.session.manager import SessionManager
 from robot_server.service.protocol.manager import ProtocolManager
 from robot_server.service.legacy.rpc import RPCServer
@@ -86,3 +91,42 @@ def get_session_manager(
             motion_lock=motion_lock,
             protocol_manager=protocol_manager)
     return _session_manager_inst
+
+
+async def check_version_header(
+        request: Request,
+        opentrons_version: str = Header(
+            ...,
+            description=f"The requested HTTP API version which must be "
+                        f"'{constants.MIN_API_VERSION}' or higher. To use the "
+                        f"latest version specify "
+                        f"'{constants.API_VERSION_LATEST}'.")
+) -> None:
+    """Dependency that will check that Opentrons-Version header meets
+    requirements."""
+    # Get the maximum version accepted by client
+    header_value = opentrons_version
+    requested_version = (
+        int(opentrons_version)
+        if header_value != constants.API_VERSION_LATEST else
+        constants.API_VERSION
+    )
+
+    if requested_version < constants.MIN_API_VERSION:
+        error = Error(
+            id="OutdatedAPIVersion",
+            title="Requested HTTP API version no longer supported",
+            detail=(
+                f"HTTP API version {constants.MIN_API_VERSION - 1} is "
+                "no longer supported. Please upgrade your Opentrons "
+                "App or other HTTP API client."
+            ),
+        )
+        raise BaseRobotServerError(
+            status_code=HTTP_400_BAD_REQUEST,
+            error=error
+        )
+    else:
+        # Attach the api version to request's state dict
+        request.state.api_version = min(requested_version,
+                                        constants.API_VERSION)

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -1,10 +1,10 @@
+import typing
 from functools import lru_cache
 
 from starlette import status
 from fastapi import Depends, HTTPException, Header
-from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 from starlette.requests import Request
-from starlette.status import HTTP_400_BAD_REQUEST
+from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 
 from robot_server import constants
 from robot_server.hardware_wrapper import HardwareWrapper
@@ -95,11 +95,13 @@ def get_session_manager(
 
 async def check_version_header(
         request: Request,
-        opentrons_version: str = Header(
+        opentrons_version: typing.Union[
+            int, constants.API_VERSION_LATEST_TYPE
+        ] = Header(
             ...,
-            description=f"The requested HTTP API version which must be "
-                        f"'{constants.MIN_API_VERSION}' or higher. To use the "
-                        f"latest version specify "
+            description=f"The requested HTTP API version which must be at "
+                        f"least '{constants.MIN_API_VERSION}' or higher. To "
+                        f"use the latest version specify "
                         f"'{constants.API_VERSION_LATEST}'.")
 ) -> None:
     """Dependency that will check that Opentrons-Version header meets
@@ -122,7 +124,7 @@ async def check_version_header(
             ),
         )
         raise BaseRobotServerError(
-            status_code=HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_400_BAD_REQUEST,
             error=error
         )
     else:

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -105,10 +105,9 @@ async def check_version_header(
     """Dependency that will check that Opentrons-Version header meets
     requirements."""
     # Get the maximum version accepted by client
-    header_value = opentrons_version
     requested_version = (
         int(opentrons_version)
-        if header_value != constants.API_VERSION_LATEST else
+        if opentrons_version != constants.API_VERSION_LATEST else
         constants.API_VERSION
     )
 

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -12,8 +12,7 @@ legacy_routes.include_router(router=health.router,
                                            Depends(check_version_header)])
 legacy_routes.include_router(router=networking.router,
                              tags=["Networking"],
-                             dependencies=[Depends(check_version_header),
-                                           Depends(check_version_header)])
+                             dependencies=[Depends(check_version_header)])
 legacy_routes.include_router(router=control.router,
                              tags=["Control"],
                              dependencies=[Depends(verify_hardware),
@@ -40,8 +39,7 @@ legacy_routes.include_router(router=motors.router,
                                            Depends(check_version_header)])
 legacy_routes.include_router(router=camera.router,
                              tags=["Camera"],
-                             dependencies=[Depends(check_version_header),
-                                           Depends(check_version_header)])
+                             dependencies=[Depends(check_version_header)])
 legacy_routes.include_router(router=logs.router,
                              tags=["Logs"])
 legacy_routes.include_router(router=rpc.router,

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -2,35 +2,46 @@ from fastapi import APIRouter, Depends
 
 from . import health, networking, control, settings, deck_calibration, \
     modules, pipettes, motors, camera, logs, rpc
-from ...dependencies import verify_hardware
+from ...dependencies import verify_hardware, check_version_header
 
 legacy_routes = APIRouter()
 
 legacy_routes.include_router(router=health.router,
                              tags=["Health"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=networking.router,
-                             tags=["Networking"])
+                             tags=["Networking"],
+                             dependencies=[Depends(check_version_header),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=control.router,
                              tags=["Control"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=settings.router,
                              tags=["Settings"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=deck_calibration.router,
                              tags=["Deck Calibration"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=modules.router,
                              tags=["Modules"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=pipettes.router,
                              tags=["Pipettes"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=motors.router,
                              tags=["Motors"],
-                             dependencies=[Depends(verify_hardware)])
+                             dependencies=[Depends(verify_hardware),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=camera.router,
-                             tags=["Camera"])
+                             tags=["Camera"],
+                             dependencies=[Depends(check_version_header),
+                                           Depends(check_version_header)])
 legacy_routes.include_router(router=logs.router,
                              tags=["Logs"])
 legacy_routes.include_router(router=rpc.router,


### PR DESCRIPTION
# Overview

`Opentrons-Version` required header is not documented in the OpenAPI spec.  This causes the version checking middleware to make the /docs interactive GUI unusable. 

closes #7171

# Changelog

The middleware will no longer check the version but only populate response header. Header validation will happen in a dependency (fastapi Depends) check_version_header which is added to the routers that require version checking.

From the /api UI

![image](https://user-images.githubusercontent.com/6352830/103691525-4b162b00-4f64-11eb-88c7-ee9dac44a535.png)

From the /redoc UI
![image](https://user-images.githubusercontent.com/6352830/103691702-99c3c500-4f64-11eb-92e9-073bb76c2d42.png)


# Review requests

This is the cleanest way I could think of solving this issue.  Is it too cumbersome? While the `Depends(check_version_header)` is sprinkled throughout the legacy API, it's a single entry for all of our newer API.

# Risk assessment

Medium. While this affects every API, the tests are thorough.


