### PR TITLE
refactor(api): add back private members used in protocol development

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -344,13 +344,12 @@ For example:
 
 Well Properties
 ^^^^^^^^^^^^^^^
-
-
 Sometimes you may need access to information about a given well in a labware, such as the depth or diameter.
 
 Depth
 -----
-The depth of a given well
+The distance, in mm, between the very top of the well and the very bottom. For example, if you have a conical
+shaped well the depth is measured from the top to bottom-center of the cone well.
 
 .. code-block:: python
     :substitutions:
@@ -363,7 +362,8 @@ The depth of a given well
 
 Diameter
 --------
-The diameter of a given well, which is only relevant for labware with circular wells.
+The diameter of a given well, in mm, which is only relevant for labware with circular wells. If
+the well is not circular, the value returned will be ``None``.
 
 .. code-block:: python
     :substitutions:
@@ -377,7 +377,8 @@ The diameter of a given well, which is only relevant for labware with circular w
 
 Length
 ------
-The length of a given well, which is only relevant for labware with square wells.
+The length of a given well, which is only relevant for labware with square wells. If
+the well is not rectangular, the value returned will be ``None``.
 
 .. code-block:: python
     :substitutions:
@@ -391,7 +392,8 @@ The length of a given well, which is only relevant for labware with square wells
 
 Width
 -----
-The width of a given well, which is only relevant for labware with square wells.
+The width of a given well, which is only relevant for labware with square wells. If
+the well is not rectangular, the value returned will be ``None``.
 
 .. code-block:: python
     :substitutions:

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -342,6 +342,8 @@ For example:
 .. versionadded:: 2.0
 
 
+.. _new-labware-well-properties:
+
 Well Properties
 ^^^^^^^^^^^^^^^
 Sometimes you may need access to information about a given well in a labware, such as the depth or diameter.

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -340,3 +340,71 @@ For example:
         pipette.move_to(adjusted_location)
 
 .. versionadded:: 2.0
+
+
+Well Properties
+^^^^^^^^^^^^^^^
+
+
+Sometimes you may need access to information about a given well in a labware, such as the depth or diameter.
+
+Depth
+-----
+The depth of a given well
+
+.. code-block:: python
+    :substitutions:
+
+    metadata = {'apiLevel': '|apiLevel|'}
+
+    def run(protocol):
+        plate = protocol.load_labware('corning_96_wellplate_360ul_flat', '1')
+        depth = plate['A1'].depth
+
+Diameter
+--------
+The diameter of a given well, which is only relevant for labware with circular wells.
+
+.. code-block:: python
+    :substitutions:
+
+    metadata = {'apiLevel': '|apiLevel|'}
+
+    def run(protocol):
+        plate = protocol.load_labware('corning_96_wellplate_360ul_flat', '1')
+        depth = plate['A1'].diameter
+
+
+Length
+------
+The length of a given well, which is only relevant for labware with square wells.
+
+.. code-block:: python
+    :substitutions:
+
+    metadata = {'apiLevel': '|apiLevel|'}
+
+    def run(protocol):
+        plate = protocol.load_labware('nest_12_reservoir_15ml', '1')
+        length = plate['A1'].length
+
+
+Width
+-----
+The width of a given well, which is only relevant for labware with square wells.
+
+.. code-block:: python
+    :substitutions:
+
+    metadata = {'apiLevel': '|apiLevel|'}
+
+    def run(protocol):
+        plate = protocol.load_labware('nest_12_reservoir_15ml', '1')
+        width = plate['A1'].width
+
+
+These properties can be used for different applications, such as customizing tip location
+or calculating the volume of a well.
+
+
+.. versionadded:: 2.9

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -11,7 +11,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.contexts.ProtocolContext
    :members:
-   :exclude-members: location_cache
+   :exclude-members: location_cache, _hw_manager
 
 .. autoclass:: opentrons.protocol_api.contexts.InstrumentContext
    :members:
@@ -22,6 +22,7 @@ Labware and Wells
 -----------------
 .. automodule:: opentrons.protocol_api.labware
    :members:
+   :exclude-members: _depth, _width, _length
 
 .. _protocol-api-modules:
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -110,6 +110,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.8     |          4.0.0              |
 +-------------+-----------------------------+
+|     2.9     |          4.1.0              |
++-------------+-----------------------------+
 
 
 Changes in API Versions
@@ -193,3 +195,8 @@ Version 2.8
 - :py:meth:`.Well.from_center_cartesian` can be used to find a point within a well using normalized distance from the center in each axis.
 - You can now pass in a blowout location to transfer, distribute, and consolidate 
   with the ``blowout_location`` parameter. See :py:meth:`.InstrumentContext.transfer` for more detail!
+
+
+Version 2.9
++++++++++++
+- You can now access certain geometry data regarding a labware's well via a Well Object. See :ref:`new-labware-well-properties` for more information.

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -125,23 +125,6 @@ class Well:
         return self._geometry._depth
 
     @property
-    def _depth(self) -> float:
-        MODULE_LOG.warning("This attribute is deprecated."
-                           "Please use 'depth' instead.")
-        return self.depth
-
-    @property
-    def _width(self) -> float:
-        MODULE_LOG.warning("This attribute is deprecated."
-                           "Please use 'width' instead.")
-        return self.width
-
-    def _length(self) -> float:
-        MODULE_LOG.warning("This attribute is deprecated."
-                           "Please use 'length' instead.")
-        return self.length
-
-    @property
     def display_name(self):
         return self._impl.get_display_name()
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -98,6 +98,49 @@ class Well:
     def diameter(self) -> Optional[float]:
         return self._geometry.diameter
 
+    @property  # type: ignore
+    @requires_version(2, 9)
+    def length(self) -> Optional[float]:
+        """
+        The length of a well, if the labware has
+        square wells.
+        """
+        return self._geometry._length
+
+    @property  # type: ignore
+    @requires_version(2, 9)
+    def width(self) -> Optional[float]:
+        """
+        The width of a well, if the labware has
+        square wells.
+        """
+        return self._geometry._width
+
+    @property  # type: ignore
+    @requires_version(2, 9)
+    def depth(self) -> float:
+        """
+        The depth of a well in a labware.
+        """
+        return self._geometry._depth
+
+    @property
+    def _depth(self) -> float:
+        MODULE_LOG.warning("This attribute is deprecated."
+                           "Please use 'depth' instead.")
+        return self.depth
+
+    @property
+    def _width(self) -> float:
+        MODULE_LOG.warning("This attribute is deprecated."
+                           "Please use 'width' instead.")
+        return self.width
+
+    def _length(self) -> float:
+        MODULE_LOG.warning("This attribute is deprecated."
+                           "Please use 'length' instead.")
+        return self.length
+
     @property
     def display_name(self):
         return self._impl.get_display_name()

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -117,6 +117,15 @@ class ProtocolContext(CommandPublisher):
         """
         return self._api_version
 
+    @property
+    def _hw_manager(self):
+        # TODO (lc 01-05-2021) remove this once we have a more
+        # user facing hardware control http api.
+        self._log.warning(
+            "This function will be deprecated in later versions."
+            "Please use with caution.")
+        return self._implementation.get_hardware()
+
     @property  # type: ignore
     @requires_version(2, 0)
     def bundled_data(self) -> Dict[str, bytes]:

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 8)
+MAX_SUPPORTED_VERSION = APIVersion(2, 9)
 #: The maximum supported protocol API version in this release
 
 V2_MODULE_DEF_VERSION = APIVersion(2, 3)


### PR DESCRIPTION
# Overview

This PR adds back in private members, and adds public counterparts, used in protocol development by our customer facing teams. If I missed anything, please let me know.

Moving forward @ncdiehl11 and @chazmanc, the software team has created [this coda doc](https://coda.io/d/Workaround-Request-from-Apps-eng_deCLqWp5mMx/Known-Recommended-Workarounds_suQaU#_luDDj) for us to reference either 1. workarounds we've given you and/or 2. feature requests from the apps eng team to make protocol development easier. We want to make sure we are not breaking future protocols!

# Changelog

- Added well parameters back in on the `Well` class. The private members are explicitly not versioned.
- Added docs around the above
- Added in a private member for hardware manager access in the protocol context.

# Review requests

Check if I should add other things. If you have arguments _against_ back in certain things, please leave a comment below. 

# Risk assessment

Low. Adding back in previously existing behavior.
