### PR TITLE
fix(robot-server): fix health endpoint tavern test

### DIFF
--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -11,8 +11,8 @@ def check_health_response(response):
       'name': 'opentrons-dev',
       'api_version': __version__,
       'fw_version': 'Virtual Smoothie',
-      'board_revision': response.json().get('board_revision'),
-      'logs': ['/logs/serial.log', '/logs/api.log'],
+      'board_revision': "2.1",
+      'logs': ['/logs/serial.log', '/logs/api.log', '/logs/server.log'],
       'system_version': config.OT_SYSTEM_VERSION,
       'minimum_protocol_api_version': minimum_version,
       'maximum_protocol_api_version': maximum_version,
@@ -20,8 +20,9 @@ def check_health_response(response):
           'apiLog': '/logs/api.log',
           'serialLog': '/logs/serial.log',
           'apiSpec': '/openapi.json',
-          'systemTime': '/system/time'
+          'systemTime': '/system/time',
+          'serverLog': '/logs/server.log'
       }
     }
 
-    return response.json() == expected
+    assert response.json() == expected


### PR DESCRIPTION
# Overview

Health endpoint tavern test didn't actually perform validation of response. 

# Changelog

use `assert` to check that the response is what we expect.

# Review requests

Not sure this test is even useful, but if it exists it might as well do something.

# Risk assessment

None.