### PR TITLE
fix(robot-server): do not update state machine for tiprack select

### DIFF
--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -162,7 +162,7 @@ class PipetteOffsetCalibrationUserFlow:
         # using python's built-in typing methods
         # correctly reveals that this is an enum,
         # mypy believes it is a string.
-        return self._current_state
+        return self._sm.current_state
 
     @property
     def has_calibrated_tip_length(self) -> bool:
@@ -200,9 +200,6 @@ class PipetteOffsetCalibrationUserFlow:
         elif hasBlock and not self._has_calibration_block:
             self._load_calibration_block()
         self._has_calibration_block = hasBlock
-
-    def _set_current_state(self, to_state: PipetteOffsetState):
-        self._current_state = to_state
 
     def _get_tip_rack_lw(self) -> labware.Labware:
         pip_vol = self._hw_pipette.config.max_volume

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -253,12 +253,6 @@ class PipetteOffsetCalibrationUserFlow:
             self._load_tip_rack(
                 verified_definition,
                 existing_offset_calibration)
-            perform_tip_length = not self._get_stored_tip_length_cal()
-            self._sm =\
-                self._determine_state_machine(perform_tip_length)
-            self._set_current_state(self._sm.state.labwareLoaded)
-
-            self.should_perform_tip_length = perform_tip_length
 
     async def jog(self, vector):
         await self._hardware.move_rel(mount=self._mount,

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -408,7 +408,9 @@ async def test_load_labware(mock_user_flow, monkeypatch):
     assert mock_user_flow._tip_rack.uri ==\
         'opentrons/opentrons_96_tiprack_300ul/1'
     assert mock_user_flow._tip_rack != old_tiprack
-    assert mock_user_flow.should_perform_tip_length is True
+    # We should explicitly not change whether to perform tip length
+    # as that will be decided by the client.
+    assert mock_user_flow.should_perform_tip_length is False
 
 
 @pytest.mark.parametrize(argnames="mount",


### PR DESCRIPTION
# Overview

Since we are never in a scenario that does not require you to calibrate your tiprack when selecting a new one, remove that logic in the backend.

@ahiuchingau and @nusrat813 found a bug when clicking on 'recalibrate tip length' which should always be a tip length + pip offset flow. Remove this issue by not updating `should_recalibrate_tip_length` when there is/isn't calibration data for a given tiprack.
