### PR TITLE
feat(app): track deck & pipette offset cal tiprack selection

### DIFF
--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -372,5 +372,36 @@ describe('analytics events map', () => {
         properties: { step: 'session-step' },
       })
     })
+
+    it('sessions:CREATE_SESSION_COMMAND for loadLabware -> {type}Exit', () => {
+      const state = {}
+      const action = {
+        type: 'sessions:CREATE_SESSION_COMMAND',
+        payload: {
+          robotName: 'my-robot',
+          sessionId: 'seshid',
+          command: {
+            command: 'calibration.loadLabware',
+            data: {
+              tiprackDefinition: {
+                metadata: { displayName: 'some display name' },
+              },
+            },
+          },
+        },
+      }
+      selectors.getTipRackSelectAnalyticsData.mockReturnValue({
+        sessionType: 'my-session-type',
+        pipetteModel: 'my-pipette-model',
+      })
+
+      return expect(makeEvent(action, state)).resolves.toEqual({
+        name: 'my-session-typeTipRackSelect',
+        properties: {
+          pipetteModel: 'my-pipette-model',
+          tipRackDisplayName: 'some display name',
+        },
+      })
+    })
   })
 })

--- a/app/src/analytics/__tests__/make-event.test.js
+++ b/app/src/analytics/__tests__/make-event.test.js
@@ -390,7 +390,7 @@ describe('analytics events map', () => {
           },
         },
       }
-      selectors.getTipRackSelectAnalyticsData.mockReturnValue({
+      selectors.getSessionInstrumentAnalyticsData.mockReturnValue({
         sessionType: 'my-session-type',
         pipetteModel: 'my-pipette-model',
       })

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -21,7 +21,7 @@ import {
   getAnalyticsHealthCheckData,
   getAnalyticsDeckCalibrationData,
   getAnalyticsSessionExitDetails,
-  getTipRackSelectAnalyticsData,
+  getSessionInstrumentAnalyticsData,
 } from './selectors'
 
 import type { State, Action } from '../types'
@@ -332,17 +332,17 @@ export function makeEvent(
         case sharedCalCommands.LOAD_LABWARE:
           const commandData = action.payload.command.data
           if (commandData) {
-            const tipRackSelectData = getTipRackSelectAnalyticsData(
+            const instrData = getSessionInstrumentAnalyticsData(
               state,
               action.payload.robotName,
               action.payload.sessionId
             )
             return Promise.resolve(
-              tipRackSelectData
+              instrData
                 ? {
-                    name: `${tipRackSelectData.sessionType}TipRackSelect`,
+                    name: `${instrData.sessionType}TipRackSelect`,
                     properties: {
-                      pipetteModel: tipRackSelectData.pipetteModel,
+                      pipetteModel: instrData.pipetteModel,
                       tipRackDisplayName: commandData.tiprackDefinition
                         ? commandData.tiprackDefinition.metadata.displayName
                         : null,

--- a/app/src/analytics/make-event.js
+++ b/app/src/analytics/make-event.js
@@ -21,6 +21,7 @@ import {
   getAnalyticsHealthCheckData,
   getAnalyticsDeckCalibrationData,
   getAnalyticsSessionExitDetails,
+  getTipRackSelectAnalyticsData,
 } from './selectors'
 
 import type { State, Action } from '../types'
@@ -311,24 +312,49 @@ export function makeEvent(
     }
 
     case Sessions.CREATE_SESSION_COMMAND: {
-      if (action.payload.command.command === sharedCalCommands.EXIT) {
-        const sessionDetails = getAnalyticsSessionExitDetails(
-          state,
-          action.payload.robotName,
-          action.payload.sessionId
-        )
-        return Promise.resolve(
-          sessionDetails
-            ? {
-                name: `${sessionDetails.sessionType}Exit`,
-                properties: {
-                  step: sessionDetails.step,
-                },
-              }
-            : null
-        )
-      } else {
-        return Promise.resolve(null)
+      switch (action.payload.command.command) {
+        case sharedCalCommands.EXIT:
+          const sessionDetails = getAnalyticsSessionExitDetails(
+            state,
+            action.payload.robotName,
+            action.payload.sessionId
+          )
+          return Promise.resolve(
+            sessionDetails
+              ? {
+                  name: `${sessionDetails.sessionType}Exit`,
+                  properties: {
+                    step: sessionDetails.step,
+                  },
+                }
+              : null
+          )
+        case sharedCalCommands.LOAD_LABWARE:
+          const commandData = action.payload.command.data
+          if (commandData) {
+            const tipRackSelectData = getTipRackSelectAnalyticsData(
+              state,
+              action.payload.robotName,
+              action.payload.sessionId
+            )
+            return Promise.resolve(
+              tipRackSelectData
+                ? {
+                    name: `${tipRackSelectData.sessionType}TipRackSelect`,
+                    properties: {
+                      pipetteModel: tipRackSelectData.pipetteModel,
+                      tipRackDisplayName: commandData.tiprackDefinition
+                        ? commandData.tiprackDefinition.metadata.displayName
+                        : null,
+                    },
+                  }
+                : null
+            )
+          } else {
+            return Promise.resolve(null)
+          }
+        default:
+          return Promise.resolve(null)
       }
     }
 

--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -59,7 +59,7 @@ import type {
   CalibrationHealthCheckAnalyticsData,
   ModelsByMount,
   AnalyticsSessionExitDetails,
-  TipRackSelectAnalyticsData,
+  SessionInstrumentAnalyticsData,
 } from './types'
 
 type ProtocolDataSelector = OutputSelector<State, void, ProtocolAnalyticsData>
@@ -293,21 +293,21 @@ export function getAnalyticsSessionExitDetails(
   return null
 }
 
-export function getTipRackSelectAnalyticsData(
+export function getSessionInstrumentAnalyticsData(
   state: State,
   robotName: string,
   sessionId: string
-): TipRackSelectAnalyticsData | null {
+): SessionInstrumentAnalyticsData | null {
   const session = getRobotSessionById(state, robotName, sessionId)
   if (session) {
-    if (
+    const pipModel =
       session.sessionType === Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK
-    ) {
-      return null
-    }
+        ? session.details.activePipette.model
+        : session.details.instrument.model
+
     return {
       sessionType: session.sessionType,
-      pipetteModel: session.details.instrument.model,
+      pipetteModel: pipModel,
     }
   }
   return null

--- a/app/src/analytics/selectors.js
+++ b/app/src/analytics/selectors.js
@@ -2,6 +2,7 @@
 import { createSelector } from 'reselect'
 import pick from 'lodash/pick'
 import some from 'lodash/some'
+import * as Sessions from '../sessions'
 
 import {
   getProtocolType,
@@ -58,6 +59,7 @@ import type {
   CalibrationHealthCheckAnalyticsData,
   ModelsByMount,
   AnalyticsSessionExitDetails,
+  TipRackSelectAnalyticsData,
 } from './types'
 
 type ProtocolDataSelector = OutputSelector<State, void, ProtocolAnalyticsData>
@@ -286,6 +288,26 @@ export function getAnalyticsSessionExitDetails(
     return {
       step: session.details.currentStep,
       sessionType: session.sessionType,
+    }
+  }
+  return null
+}
+
+export function getTipRackSelectAnalyticsData(
+  state: State,
+  robotName: string,
+  sessionId: string
+): TipRackSelectAnalyticsData | null {
+  const session = getRobotSessionById(state, robotName, sessionId)
+  if (session) {
+    if (
+      session.sessionType === Sessions.SESSION_TYPE_CALIBRATION_HEALTH_CHECK
+    ) {
+      return null
+    }
+    return {
+      sessionType: session.sessionType,
+      pipetteModel: session.details.instrument.model,
     }
   }
   return null

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -123,7 +123,7 @@ export type AnalyticsTriggerAction =
   | PipetteOffsetStartedAnalyticsAction
   | TipLengthStartedAnalyticsAction
 
-export type TipRackSelectAnalyticsData = {|
+export type SessionInstrumentAnalyticsData = {|
   sessionType: string,
   pipetteModel: string,
 |}

--- a/app/src/analytics/types.js
+++ b/app/src/analytics/types.js
@@ -122,3 +122,8 @@ export type TipLengthStartedAnalyticsAction = {|
 export type AnalyticsTriggerAction =
   | PipetteOffsetStartedAnalyticsAction
   | TipLengthStartedAnalyticsAction
+
+export type TipRackSelectAnalyticsData = {|
+  sessionType: string,
+  pipetteModel: string,
+|}


### PR DESCRIPTION
# Overview
Add analytics event to track tip rack selected in deck calibration and pipette calibration, during load labware command.
closes #7147



# Risk assessment
Low, add a small feature