### PR TITLE
chore(robot-server): update service unit file

### DIFF
--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -2,6 +2,7 @@
 Description=Opentrons Robot HTTP Server
 Requires=nginx.service
 After=nginx.service
+After=opentrons-status-leds.service
 
 [Service]
 Type=notify


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This is a follow-up PR for [#116](https://github.com/Opentrons/buildroot/pull/116). It makes sure that opentrons-robot-server.service is started after opentrons-status-leds.service. Required in order to stagger access to gpio revision pins by the two services.

# Review requests

Test that this service starts after opentrons-status-leds.service and that neither service runs into gpio access errors.

# Risk assessment

Low. Since an `After` only implies start order and not a dependency, the robot-server should still start even if the status leds service fails.
