### PR TITLE
refactor(robot-server): Catch protocol analysis errors and rework IO errors.

### DIFF
--- a/robot-server/robot_server/service/errors.py
+++ b/robot-server/robot_server/service/errors.py
@@ -32,7 +32,7 @@ class ErrorCreateDef:
 
 class ErrorDef(ErrorCreateDef, Enum):
     """An enumeration of ErrorCreateDef Error definitions for use by
-    RobotServerErrorDefined"""
+    RobotServerError"""
     def __init__(self, e) -> None:
         super().__init__(**(asdict(e)))
 
@@ -40,7 +40,7 @@ class ErrorDef(ErrorCreateDef, Enum):
 class RobotServerError(BaseRobotServerError):
     """A BaseRobotServerError that uses an ErrorDef enum"""
     def __init__(self,
-                 definition: ErrorDef,
+                 definition: ErrorCreateDef,
                  error_id: str = None,
                  links: Optional[ResourceLinks] = None,
                  source: Optional[ErrorSource] = None,
@@ -169,4 +169,9 @@ class CommonErrorDef(ErrorDef):
         status_code=status_codes.HTTP_403_FORBIDDEN,
         title='Resource Exists',
         format_string="A '{resource}' with id '{id}' already exists"
+    )
+    BAD_REQUEST = ErrorCreateDef(
+        status_code=status_codes.HTTP_400_BAD_REQUEST,
+        title="Bad request",
+        format_string='{reason}'
     )

--- a/robot-server/robot_server/service/protocol/errors.py
+++ b/robot-server/robot_server/service/protocol/errors.py
@@ -34,3 +34,9 @@ class ProtocolUploadCountLimitReached(ProtocolException):
     def __init__(self, msg: str):
         super().__init__(definition=CommonErrorDef.ACTION_FORBIDDEN,
                          reason=msg)
+
+
+class ProtocolAnalysisException(ProtocolException):
+    def __init__(self, msg: str):
+        super().__init__(definition=CommonErrorDef.BAD_REQUEST,
+                         reason=msg)

--- a/robot-server/robot_server/service/protocol/manager.py
+++ b/robot-server/robot_server/service/protocol/manager.py
@@ -33,13 +33,12 @@ class ProtocolManager:
                 f"Upload limit of {ProtocolManager.MAX_COUNT} has "
                 f"been reached.")
 
-        try:
-            new_protocol = UploadedProtocol.create(
-                protocol_id, protocol_file, support_files)
-            log.debug(f"Created new protocol: {new_protocol.data}")
-        except (TypeError, IOError) as e:
-            log.exception("Failed to create protocol")
-            raise errors.ProtocolIOException(str(e))
+        new_protocol = UploadedProtocol.create(
+            protocol_id=protocol_id,
+            protocol_file=protocol_file,
+            support_files=support_files
+        )
+        log.debug(f"Created new protocol: {new_protocol.data}")
 
         self._protocols[new_protocol.data.identifier] = new_protocol
         return new_protocol

--- a/robot-server/robot_server/service/protocol/protocol.py
+++ b/robot-server/robot_server/service/protocol/protocol.py
@@ -36,11 +36,14 @@ class UploadedProtocol:
             protocol_file: UploadFile,
             support_files: typing.List[UploadFile]) -> 'UploadedProtocol':
         """
-        create
+        Save the protocol files and
 
         :param protocol_id: The id assigned to this protocol
         :param protocol_file: The uploaded protocol file
         :param support_files: Optional support files
+
+        :raise ProtocolIOException: On failure to save uploaded files.
+        :raise ProtocolAnalysisException: On failure to analyze the protocol.
         """
         protocol_contents = contents.create(
             protocol_file=protocol_file,
@@ -57,9 +60,15 @@ class UploadedProtocol:
         )
 
     def add(self, support_file: UploadFile):
-        """Add a support file to protocol temp directory"""
+        """
+        Add a support file to protocol temp directory
+
+        :raise ProtocolIOException: On failure to save uploaded files.
+        :raise ProtocolAnalysisException: On failure to analyze the protocol.
+        """
         c = contents.add(self._data.contents, support_file)
 
+        # Re-analyze protocol
         self._data.analysis_result = analyze.analyze_protocol(c)
         self._data.last_modified_at = utc_now()
         self._data.contents = c

--- a/robot-server/robot_server/service/session/command_execution/base_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/base_executor.py
@@ -10,7 +10,7 @@ class CommandExecutor:
         """
         Execute a command
 
-        :raises: SessionCommandException
+        :raise SessionCommandException:
         """
         raise UnsupportedCommandException(
             f"'{command.content.name}' is not supported"

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -49,7 +49,7 @@ class BaseSession(ABC):
         :param configuration: Data and utilities common to all session types
         :param instance_meta: Session metadata
         :return: A new session
-        :raises: SessionCreationException
+        :raise SessionCreationException:
         """
         return cls(configuration=configuration,
                    instance_meta=instance_meta)

--- a/robot-server/tests/service/protocol/test_manager.py
+++ b/robot-server/tests/service/protocol/test_manager.py
@@ -55,7 +55,9 @@ class TestCreate:
         manager = ProtocolManager()
         p = manager.create(mock_upload_file, [])
         mock_uploaded_control_constructor.assert_called_once_with(
-            Path(mock_upload_file.filename).stem, mock_upload_file, [])
+            protocol_id=Path(mock_upload_file.filename).stem,
+            protocol_file=mock_upload_file,
+            support_files=[])
         assert p == mock_uploaded_protocol
         assert manager._protocols[mock_uploaded_protocol.data.identifier] == p
 
@@ -75,7 +77,8 @@ class TestCreate:
             manager_with_mock_protocol.create(m, [])
 
     @pytest.mark.parametrize(argnames="exception", argvalues=[
-        TypeError, IOError
+        errors.ProtocolIOException,
+        errors.ProtocolAnalysisException
     ])
     def test_create_raises(self,
                            exception,
@@ -85,11 +88,11 @@ class TestCreate:
                    "manager.UploadedProtocol.create") \
                 as mock_construct:
             def raiser(*args, **kwargs):
-                raise exception()
+                raise exception("error")
 
             mock_construct.side_effect = raiser
 
-            with pytest.raises(errors.ProtocolIOException):
+            with pytest.raises(errors.ProtocolException):
                 manager = ProtocolManager()
                 manager.create(mock_upload_file, [])
 


### PR DESCRIPTION
# Overview

An addition to the [protocol analysis PR](https://github.com/Opentrons/opentrons/pull/7146) that adds HTTP error responses when uploading a protocol that fails simulation.


# Changelog

- Catch errors raised during protocol simulation during protocol upload. 
- Rework IOError handling to clean up temporary directory if saving of upload fails.

# Review requests

I kind of think that this isn't the way to go. That `POST` should return 201 with a message if there are analysis errors.  This would require a `PATCH` and/or `PUT` to correct error causing files.

# Risk assessment

None. This is not in use.