### PR TITLE
fix(app): restrict size of reset config modal

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -35,7 +35,7 @@ _settings_reset_options = {
     ResetOptionId.labware_calibration:
         CommonResetOption(
             name='Labware Calibration',
-            description='Clear labware calibration and Protocol API v1 custom labware (created with labware.create())'   # noqa(E501)
+            description='Clear labware calibration'
         ),
     ResetOptionId.boot_scripts:
         CommonResetOption(

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -19,13 +19,11 @@ import {
 import {
   BaseModal,
   LabeledCheckbox,
-  Box,
   Flex,
   Text,
   Icon,
   SecondaryBtn,
   JUSTIFY_FLEX_END,
-  DIRECTION_COLUMN,
   DISPLAY_FLEX,
   ALIGN_CENTER,
   FONT_SIZE_HEADER,
@@ -109,26 +107,22 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
           configurations and <strong>restart your robot</strong>. This cannot be
           undone
         </p>
-        <Flex flexDirection={DIRECTION_COLUMN}>
-          <Box>
-            {options.map(o => (
-              <LabeledCheckbox
-                label={o.name}
-                onChange={() => {
-                  setResetOptions({
-                    ...resetOptions,
-                    [o.id]: !resetOptions[o.id],
-                  })
-                }}
-                name={o.id}
-                value={resetOptions[o.id]}
-                key={o.id}
-              >
-                <p>{o.description}</p>
-              </LabeledCheckbox>
-            ))}
-          </Box>
-        </Flex>
+        {options.map(o => (
+          <LabeledCheckbox
+            label={o.name}
+            onChange={() => {
+              setResetOptions({
+                ...resetOptions,
+                [o.id]: !resetOptions[o.id],
+              })
+            }}
+            name={o.id}
+            value={resetOptions[o.id]}
+            key={o.id}
+          >
+            <p>{o.description}</p>
+          </LabeledCheckbox>
+        ))}
       </BaseModal>
     </Portal>
   )

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
 import last from 'lodash/last'
 
@@ -16,8 +17,20 @@ import {
   resetConfig,
 } from '../../robot-admin'
 
-import { AlertModal, LabeledCheckbox } from '@opentrons/components'
+import {
+  AlertModal,
+  LabeledCheckbox,
+  Box,
+  Flex,
+  OutlineButton,
+  OVERFLOW_SCROLL,
+  JUSTIFY_FLEX_END,
+  DIRECTION_COLUMN,
+  SIZE_5,
+} from '@opentrons/components'
 import { Portal } from '../portal'
+
+import styles from './styles.css'
 
 import type { State, Dispatch } from '../../types'
 import type { ResetConfigRequest } from '../../robot-admin/types'
@@ -65,25 +78,41 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
 
   return (
     <Portal>
-      <AlertModal heading={TITLE} buttons={buttons} alertOverlay>
+      <AlertModal heading={TITLE} alertOverlay>
         <p>
           Warning! Clicking <strong>restart</strong> will erase your selected
           configurations and <strong>restart your robot</strong>. This cannot be
           undone
         </p>
-        {options.map(o => (
-          <LabeledCheckbox
-            label={o.name}
-            onChange={() => {
-              setResetOptions({ ...resetOptions, [o.id]: !resetOptions[o.id] })
-            }}
-            name={o.id}
-            value={resetOptions[o.id]}
-            key={o.id}
-          >
-            <p>{o.description}</p>
-          </LabeledCheckbox>
-        ))}
+        <Flex maxHeight={SIZE_5} flexDirection={DIRECTION_COLUMN}>
+          <Box overflow={OVERFLOW_SCROLL}>
+            {options.map(o => (
+              <LabeledCheckbox
+                label={o.name}
+                onChange={() => {
+                  setResetOptions({
+                    ...resetOptions,
+                    [o.id]: !resetOptions[o.id],
+                  })
+                }}
+                name={o.id}
+                value={resetOptions[o.id]}
+                key={o.id}
+              >
+                <p>{o.description}</p>
+              </LabeledCheckbox>
+            ))}
+          </Box>
+          <Flex justifyContent={JUSTIFY_FLEX_END}>
+            {buttons.filter(Boolean).map((button, index) => (
+              <OutlineButton
+                {...button}
+                className={cx(styles.alert_modal_button, button.className)}
+                key={index}
+              />
+            ))}
+          </Flex>
+        </Flex>
       </AlertModal>
     </Portal>
   )

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import cx from 'classnames'
 import { useSelector, useDispatch } from 'react-redux'
 import last from 'lodash/last'
 
@@ -107,7 +106,7 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
             {buttons.filter(Boolean).map((button, index) => (
               <OutlineButton
                 {...button}
-                className={cx(styles.alert_modal_button, button.className)}
+                className={styles.alert_modal_button}
                 key={index}
               />
             ))}

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -23,7 +23,7 @@ import {
   Flex,
   Text,
   Icon,
-  OutlineButton,
+  SecondaryBtn,
   JUSTIFY_FLEX_END,
   DIRECTION_COLUMN,
   DISPLAY_FLEX,
@@ -31,10 +31,9 @@ import {
   FONT_SIZE_HEADER,
   FONT_WEIGHT_REGULAR,
   SPACING_2,
+  SIZE_2,
 } from '@opentrons/components'
 import { Portal } from '../portal'
-
-import styles from './styles.css'
 
 import type { State, Dispatch } from '../../types'
 import type { ResetConfigRequest } from '../../robot-admin/types'
@@ -71,14 +70,9 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
     if (resetRequestStatus === SUCCESS) closeModal()
   }, [resetRequestStatus, closeModal])
 
-  const buttons = [
-    { onClick: closeModal, children: 'close' },
-    {
-      onClick: triggerReset,
-      disabled: resetRequestStatus === PENDING,
-      children: 'restart',
-    },
-  ]
+  const CLOSE = 'close'
+  const RESTART = 'restart'
+  const PENDING_STATUS = resetRequestStatus === PENDING
 
   return (
     <Portal>
@@ -91,19 +85,22 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
             fontSize={FONT_SIZE_HEADER}
             fontWeight={FONT_WEIGHT_REGULAR}
           >
-            <Icon name="alert" width="2rem" marginRight={SPACING_2} />
+            <Icon name="alert" width={SIZE_2} marginRight={SPACING_2} />
             {TITLE}
           </Text>
         }
         footer={
           <Flex justifyContent={JUSTIFY_FLEX_END}>
-            {buttons.filter(Boolean).map((button, index) => (
-              <OutlineButton
-                {...button}
-                className={styles.alert_modal_button}
-                key={index}
-              />
-            ))}
+            <SecondaryBtn marginLeft={SPACING_2} onClick={closeModal}>
+              {CLOSE}
+            </SecondaryBtn>
+            <SecondaryBtn
+              marginLeft={SPACING_2}
+              onClick={triggerReset}
+              disabled={PENDING_STATUS}
+            >
+              {RESTART}
+            </SecondaryBtn>
           </Flex>
         }
       >

--- a/app/src/components/RobotSettings/ResetRobotModal.js
+++ b/app/src/components/RobotSettings/ResetRobotModal.js
@@ -17,15 +17,20 @@ import {
 } from '../../robot-admin'
 
 import {
-  AlertModal,
+  BaseModal,
   LabeledCheckbox,
   Box,
   Flex,
+  Text,
+  Icon,
   OutlineButton,
-  OVERFLOW_SCROLL,
   JUSTIFY_FLEX_END,
   DIRECTION_COLUMN,
-  SIZE_5,
+  DISPLAY_FLEX,
+  ALIGN_CENTER,
+  FONT_SIZE_HEADER,
+  FONT_WEIGHT_REGULAR,
+  SPACING_2,
 } from '@opentrons/components'
 import { Portal } from '../portal'
 
@@ -77,14 +82,38 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
 
   return (
     <Portal>
-      <AlertModal heading={TITLE} alertOverlay>
+      <BaseModal
+        header={
+          <Text
+            as="h2"
+            display={DISPLAY_FLEX}
+            alignItems={ALIGN_CENTER}
+            fontSize={FONT_SIZE_HEADER}
+            fontWeight={FONT_WEIGHT_REGULAR}
+          >
+            <Icon name="alert" width="2rem" marginRight={SPACING_2} />
+            {TITLE}
+          </Text>
+        }
+        footer={
+          <Flex justifyContent={JUSTIFY_FLEX_END}>
+            {buttons.filter(Boolean).map((button, index) => (
+              <OutlineButton
+                {...button}
+                className={styles.alert_modal_button}
+                key={index}
+              />
+            ))}
+          </Flex>
+        }
+      >
         <p>
           Warning! Clicking <strong>restart</strong> will erase your selected
           configurations and <strong>restart your robot</strong>. This cannot be
           undone
         </p>
-        <Flex maxHeight={SIZE_5} flexDirection={DIRECTION_COLUMN}>
-          <Box overflow={OVERFLOW_SCROLL}>
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Box>
             {options.map(o => (
               <LabeledCheckbox
                 label={o.name}
@@ -102,17 +131,8 @@ export function ResetRobotModal(props: ResetRobotModalProps): React.Node {
               </LabeledCheckbox>
             ))}
           </Box>
-          <Flex justifyContent={JUSTIFY_FLEX_END}>
-            {buttons.filter(Boolean).map((button, index) => (
-              <OutlineButton
-                {...button}
-                className={styles.alert_modal_button}
-                key={index}
-              />
-            ))}
-          </Flex>
         </Flex>
-      </AlertModal>
+      </BaseModal>
     </Portal>
   )
 }

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -92,7 +92,3 @@
 .confirm_start_deck_cal_modal {
   padding: 4rem 2rem;
 }
-
-.alert_modal_button {
-  margin-right: 1rem;
-}

--- a/app/src/components/RobotSettings/styles.css
+++ b/app/src/components/RobotSettings/styles.css
@@ -92,3 +92,7 @@
 .confirm_start_deck_cal_modal {
   padding: 4rem 2rem;
 }
+
+.alert_modal_button {
+  margin-right: 1rem;
+}

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -14,7 +14,7 @@ stages:
         options:
         - id: labwareCalibration
           name: Labware Calibration
-          description: !re_search "Clear labware calibration and Protocol API v1 custom labware"
+          description: !re_search "Clear labware calibration"
         - id: bootScripts
           name: Boot Scripts
           description: Clear custom boot scripts


### PR DESCRIPTION
# Overview

closes #7157. Restrict the size of the modal to avoid the contents of the modal box from spilling over when shrinking the app screen. Please note that it doesn't fully resolve the problem, only makes it slightly better. The main fix would be to refactor the `AlertModal` component to somehow force the actual modal to be the parent of its contents as opposed to the overlay screen.


Would love input here which is why I'm making this a draft PR.

<img width="658" alt="Screen Shot 2021-01-11 at 4 37 23 PM" src="https://user-images.githubusercontent.com/31892318/104241221-54533c00-542b-11eb-897d-5bdd4a55f6af.png">


# Changelog

- Restrict size of alert modal
- Pull buttons out into a flex box

# Review requests

Are there better small adjustments I can make outside of refactoring all of the alert modals? Should I just refactor all of the alert modals? (side note, scared about doing that).

# Risk assessment

Low, just adjusting one modal.
