### PR TITLE
fix(api): do not call a method dependent on the Python API Version directly

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -575,11 +575,10 @@ class InstrumentContext(CommandPublisher):
         if not isinstance(loc, Well):
             raise TypeError('Last tip location should be a Well but it is: '
                             '{}'.format(loc))
+        return_height = self._implementation.get_return_height()
         drop_loc = determine_drop_target(self.api_version,
                                          loc,
-                                         self.hw_pipette.get(
-                                             'return_tip_height', 0.5
-                                         ),
+                                         return_height,
                                          APIVersion(2, 3))
         self.drop_tip(drop_loc, home_after=home_after)
 
@@ -764,9 +763,10 @@ class InstrumentContext(CommandPublisher):
             if LabwareLike(location).is_fixed_trash():
                 target = location.top()
             else:
+                return_height = self._implementation.get_return_height()
                 target = determine_drop_target(self.api_version,
                                                location,
-                                               self.return_height)
+                                               return_height)
         elif not location:
             target = self.trash_container.wells()[0].top()
         else:


### PR DESCRIPTION
# Overview

The return tip property was added in 2.2 of the python api. If you are on an API version earlier than 2.2, and you try to calibrate your labware in subsequent versions you will get an error and the robot will appear to not be able to move forward in labware calibration.

# Changelog

- Use `get_return_height` directly from the instrument context implementation

# Review requests

Test on a robot. Try to calibrate a tiprack in 4.0.0 using a protocol at python API version 2.0, you will get an error. Push this branch to your robot and try the same thing, you should no longer get an error.

# Risk assessment

Low, this is fixing a bug that has been in our code-base for awhile. I'm not sure how many people this has actually affected.