### PR TITLE
feat(api): add dispense command to the Protocol Engine

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -24,6 +24,7 @@ from .move_to_well import MoveToWellRequest, MoveToWellResult
 from .pick_up_tip import PickUpTipRequest, PickUpTipResult
 from .drop_tip import DropTipRequest, DropTipResult
 from .aspirate import AspirateRequest, AspirateResult
+from .dispense import DispenseRequest, DispenseResult
 
 CommandRequestType = Union[
     LoadLabwareRequest,
@@ -32,6 +33,7 @@ CommandRequestType = Union[
     PickUpTipRequest,
     DropTipRequest,
     AspirateRequest,
+    DispenseRequest,
 ]
 
 CommandResultType = Union[
@@ -41,6 +43,7 @@ CommandResultType = Union[
     PickUpTipResult,
     DropTipResult,
     AspirateResult,
+    DispenseResult,
 ]
 
 PendingCommandType = Union[
@@ -50,6 +53,7 @@ PendingCommandType = Union[
     PendingCommand[PickUpTipRequest, PickUpTipResult],
     PendingCommand[DropTipRequest, DropTipResult],
     PendingCommand[AspirateRequest, AspirateResult],
+    PendingCommand[DispenseRequest, DispenseResult],
 ]
 
 RunningCommandType = Union[
@@ -59,6 +63,7 @@ RunningCommandType = Union[
     RunningCommand[PickUpTipRequest, PickUpTipResult],
     RunningCommand[DropTipRequest, DropTipResult],
     RunningCommand[AspirateRequest, AspirateResult],
+    RunningCommand[DispenseRequest, DispenseResult],
 ]
 
 CompletedCommandType = Union[
@@ -68,6 +73,7 @@ CompletedCommandType = Union[
     CompletedCommand[PickUpTipRequest, PickUpTipResult],
     CompletedCommand[DropTipRequest, DropTipResult],
     CompletedCommand[AspirateRequest, AspirateResult],
+    CompletedCommand[DispenseRequest, DispenseResult],
 ]
 
 FailedCommandType = Union[
@@ -77,6 +83,7 @@ FailedCommandType = Union[
     FailedCommand[PickUpTipRequest],
     FailedCommand[DropTipRequest],
     FailedCommand[AspirateRequest],
+    FailedCommand[DispenseRequest],
 ]
 
 CommandType = Union[
@@ -116,5 +123,7 @@ __all__ = [
     "DropTipRequest",
     "DropTipResult",
     "AspirateRequest",
-    "AspirateResult"
+    "AspirateResult",
+    "DispenseRequest",
+    "DispenseResult",
 ]

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -1,38 +1,28 @@
 """Aspirate command request, result, and implementation models."""
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from typing_extensions import final
 
-from ..types import WellLocation
 from .command import CommandImplementation, CommandHandlers
-from .pipetting_common import BasePipettingRequest
+from .pipetting_common import BaseLiquidHandlingRequest, BaseLiquidHandlingResult
 
 
-class AspirateRequest(BasePipettingRequest):
+@final
+class AspirateRequest(BaseLiquidHandlingRequest):
     """A request to aspirate from a specific well."""
-
-    wellLocation: WellLocation = Field(
-        ...,
-        description="Relative well location to aspirate from.",
-    )
-    volume: float = Field(
-        ...,
-        description="Volume of liquid to aspirate.",
-    )
 
     def get_implementation(self) -> AspirateImplementation:
         """Get the execution implementation of the AspirateRequest."""
         return AspirateImplementation(self)
 
 
-class AspirateResult(BaseModel):
+@final
+class AspirateResult(BaseLiquidHandlingResult):
     """Result data from the execution of a AspirateRequest."""
 
-    volume: float = Field(
-        ...,
-        description="Volume of liquid aspirated.",
-    )
+    pass
 
 
+@final
 class AspirateImplementation(
     CommandImplementation[AspirateRequest, AspirateResult]
 ):

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -1,0 +1,41 @@
+"""Dispense command request, result, and implementation models."""
+from __future__ import annotations
+from typing_extensions import final
+
+from .command import CommandImplementation, CommandHandlers
+from .pipetting_common import BaseLiquidHandlingRequest, BaseLiquidHandlingResult
+
+
+@final
+class DispenseRequest(BaseLiquidHandlingRequest):
+    """A request to aspirate from a specific well."""
+
+    def get_implementation(self) -> DispenseImplementation:
+        """Get the execution implementation of the DispenseRequest."""
+        return DispenseImplementation(self)
+
+
+@final
+class DispenseResult(BaseLiquidHandlingResult):
+    """Result data from the execution of a DispenseRequest."""
+
+    pass
+
+
+@final
+class DispenseImplementation(
+    CommandImplementation[DispenseRequest, DispenseResult]
+):
+    """Dispense command implementation."""
+
+    async def execute(self, handlers: CommandHandlers) -> DispenseResult:
+        """Move to and dispense to the requested well."""
+        volume = await handlers.pipetting.dispense(
+            pipette_id=self._request.pipetteId,
+            labware_id=self._request.labwareId,
+            well_name=self._request.wellName,
+            well_location=self._request.wellLocation,
+            volume=self._request.volume,
+        )
+
+        return DispenseResult(volume=volume)

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -1,6 +1,8 @@
 """Common pipetting command base models."""
 from pydantic import BaseModel, Field
 
+from ..types import WellLocation
+
 
 class BasePipettingRequest(BaseModel):
     """Base class for pipetting requests that interact with wells."""
@@ -15,7 +17,7 @@ class BasePipettingRequest(BaseModel):
     )
     wellName: str = Field(
         ...,
-        description="Identifier of well to use.",
+        description="Name of well to use in labware.",
     )
 
 
@@ -28,10 +30,17 @@ class BaseLiquidHandlingRequest(BasePipettingRequest):
                     "than a pipette-specific maximum volume.",
         gt=0,
     )
-    flowRate: float = Field(
+    wellLocation: WellLocation = Field(
         ...,
-        description="The absolute flow rate in uL/second. Must be greater "
-                    "than 0 and less than a pipette-specific maximum flow "
-                    "rate.",
-        gt=0
+        description="Relative well location at which to perform the operation",
+    )
+
+
+class BaseLiquidHandlingResult(BaseModel):
+    """Base properties of a liquid handling result."""
+
+    volume: float = Field(
+        ...,
+        description="Amount of liquid in uL handled in the operation.",
+        gt=0,
     )

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -151,3 +151,28 @@ class PipettingHandler:
         await self._hardware.aspirate(mount=hw_pipette.mount, volume=volume)
 
         return volume
+
+    async def dispense(
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
+        well_location: WellLocation,
+        volume: float,
+    ) -> float:
+        """Dispense liquid to a well."""
+        hw_pipette = self._state.pipettes.get_hardware_pipette(
+            pipette_id=pipette_id,
+            attached_pipettes=self._hardware.attached_instruments
+        )
+
+        await self._movement_handler.move_to_well(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+        )
+
+        await self._hardware.dispense(mount=hw_pipette.mount, volume=volume)
+
+        return volume

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -167,6 +167,8 @@ class MotionStore(Substore[MotionState], CommandReactive):
                 commands.MoveToWellResult,
                 commands.PickUpTipResult,
                 commands.DropTipResult,
+                commands.AspirateResult,
+                commands.DispenseResult,
             ),
         ):
             self._state._current_location = DeckLocation(

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -8,7 +8,12 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.types import MountType, Mount as HwMount
 
 from .. import errors
-from ..commands import CompletedCommandType, LoadPipetteResult, AspirateResult
+from ..commands import (
+    CompletedCommandType,
+    LoadPipetteResult,
+    AspirateResult,
+    DispenseResult,
+)
 from .substore import Substore, CommandReactive
 
 
@@ -133,5 +138,12 @@ class PipetteStore(Substore[PipetteState], CommandReactive):
             pipette_id = command.request.pipetteId
             previous_volume = self._state._aspirated_volume_by_id[pipette_id]
             next_volume = previous_volume + command.result.volume
+
+            self._state._aspirated_volume_by_id[pipette_id] = next_volume
+
+        elif isinstance(command.result, DispenseResult):
+            pipette_id = command.request.pipetteId
+            previous_volume = self._state._aspirated_volume_by_id[pipette_id]
+            next_volume = max(0, previous_volume - command.result.volume)
 
             self._state._aspirated_volume_by_id[pipette_id] = next_volume

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -1,0 +1,63 @@
+"""Test dispense commands."""
+from decoy import Decoy
+
+from opentrons.protocol_engine import CommandHandlers, WellLocation, WellOrigin
+from opentrons.protocol_engine.commands import DispenseRequest, DispenseResult
+
+
+def test_dispense_request() -> None:
+    """It should be able to create a DispenseRequest."""
+    request = DispenseRequest(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+        wellLocation=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
+        volume=50,
+    )
+
+    assert request.pipetteId == "abc"
+    assert request.labwareId == "123"
+    assert request.wellName == "A3"
+    assert request.wellLocation == WellLocation(
+        origin=WellOrigin.BOTTOM,
+        offset=(0, 0, 1),
+    )
+    assert request.volume == 50
+
+
+def test_dispense_result() -> None:
+    """It should be able to create a DispenseResult."""
+    result = DispenseResult(volume=50)
+
+    assert result.volume == 50
+
+
+async def test_dispense_implementation(
+    decoy: Decoy,
+    mock_cmd_handlers: CommandHandlers,
+) -> None:
+    """A PickUpTipRequest should have an execution implementation."""
+    location = WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1))
+
+    request = DispenseRequest(
+        pipetteId="abc",
+        labwareId="123",
+        wellName="A3",
+        wellLocation=location,
+        volume=50,
+    )
+
+    decoy.when(
+        await mock_cmd_handlers.pipetting.dispense(
+            pipette_id="abc",
+            labware_id="123",
+            well_name="A3",
+            well_location=location,
+            volume=50,
+        )
+    ).then_return(42)
+
+    impl = request.get_implementation()
+    result = await impl.execute(mock_cmd_handlers)
+
+    assert result == DispenseResult(volume=42)

--- a/api/tests/opentrons/protocol_engine/state/conftest.py
+++ b/api/tests/opentrons/protocol_engine/state/conftest.py
@@ -1,0 +1,25 @@
+"""State test fixtures."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine.state.labware import LabwareStore
+from opentrons.protocol_engine.state.pipettes import PipetteStore
+from opentrons.protocol_engine.state.geometry import GeometryStore
+
+
+@pytest.fixture
+def mock_labware_store(decoy: Decoy) -> LabwareStore:
+    """Get a mock in the shape of a LabwareStore."""
+    return decoy.create_decoy(spec=LabwareStore)
+
+
+@pytest.fixture
+def mock_pipette_store(decoy: Decoy) -> PipetteStore:
+    """Get a mock in the shape of a PipetteStore."""
+    return decoy.create_decoy(spec=PipetteStore)
+
+
+@pytest.fixture
+def mock_geometry_store(decoy: Decoy) -> GeometryStore:
+    """Get a mock in the shape of a GeometryStore."""
+    return decoy.create_decoy(spec=GeometryStore)

--- a/api/tests/opentrons/protocol_engine/state/test_motion_getters.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_getters.py
@@ -1,5 +1,5 @@
 """Test state getters for retrieving motion planning views of state."""
-# TODO(mc, 2020-01-08): rewrite tests using Decoy
+# TODO(mc, 2021-01-08): rewrite tests using Decoy
 
 import pytest
 from dataclasses import dataclass, field
@@ -50,6 +50,10 @@ def motion_store(
     )
 
 
+# TODO(mc, 2021-01-14): this testing pain is code smell and probably an
+# indication that the "current deck location" data needs to be in a
+# different store. Alternatively, this data should be fed in via a public
+# interface, like handling a MoveToWellResult.
 def mock_location_data(
     motion_store: MotionStore,
     data: Optional[DeckLocation]
@@ -196,6 +200,9 @@ class WaypointSpec:
     max_travel_z: float = 50
 
 
+# TODO(mc, 2021-01-14): these tests probably need to be rethought; this fixture
+# is impossible to reason with. The test is really just trying to be a collaborator
+# test for the `get_waypoints` function, so we should rewrite it as such.
 @pytest.mark.parametrize("spec", [
     WaypointSpec(
         name="General arc if moving from unknown location",
@@ -239,7 +246,7 @@ class WaypointSpec:
         well_location=WellLocation(origin=WellOrigin.TOP, offset=(0, 0, 1)),
         expected_move_type=MoveType.GENERAL_ARC,
     ),
-    # TODO(mc, 2020-01-06): add test for override current location
+    # TODO(mc, 2021-01-08): add test for override current location
 ])
 def test_get_movement_waypoints(
     mock_labware_store: MagicMock,

--- a/api/tests/opentrons/protocol_engine/state/test_motion_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_state.py
@@ -2,49 +2,87 @@
 import pytest
 from datetime import datetime
 
-from opentrons.protocol_engine import commands as cmd, StateStore, DeckLocation
+from opentrons.protocol_engine import commands, DeckLocation, WellLocation
+from opentrons.protocol_engine.state.labware import LabwareStore
+from opentrons.protocol_engine.state.pipettes import PipetteStore
+from opentrons.protocol_engine.state.geometry import GeometryStore
+from opentrons.protocol_engine.state.motion import MotionStore
 
 
-def test_initial_location(store: StateStore) -> None:
+@pytest.fixture
+def motion_store(
+    mock_labware_store: LabwareStore,
+    mock_pipette_store: PipetteStore,
+    mock_geometry_store: GeometryStore,
+) -> MotionStore:
+    """Get a motion store with its dependencies mocked out."""
+    return MotionStore(
+        labware_store=mock_labware_store,
+        pipette_store=mock_pipette_store,
+        geometry_store=mock_geometry_store,
+    )
+
+
+def test_initial_location(motion_store: MotionStore) -> None:
     """get_current_location should return None initially."""
-    assert store.motion.get_current_deck_location() is None
+    assert motion_store.state.get_current_deck_location() is None
 
 
 @pytest.mark.parametrize("req,res", [
     (
-        cmd.MoveToWellRequest(
+        commands.MoveToWellRequest(
             pipetteId="pipette-id",
             labwareId="labware-id",
-            wellName="B4"
+            wellName="B4",
         ),
-        cmd.MoveToWellResult()
+        commands.MoveToWellResult()
     ),
     (
-        cmd.PickUpTipRequest(
+        commands.PickUpTipRequest(
             pipetteId="pipette-id",
             labwareId="labware-id",
-            wellName="B4"
+            wellName="B4",
         ),
-        cmd.PickUpTipResult()
+        commands.PickUpTipResult()
     ),
     (
-        cmd.DropTipRequest(
+        commands.DropTipRequest(
             pipetteId="pipette-id",
             labwareId="labware-id",
-            wellName="B4"
+            wellName="B4",
         ),
-        cmd.DropTipResult()
+        commands.DropTipResult()
+    ),
+    (
+        commands.AspirateRequest(
+            pipetteId="pipette-id",
+            labwareId="labware-id",
+            wellName="B4",
+            wellLocation=WellLocation(),
+            volume=42,
+        ),
+        commands.AspirateResult(volume=42)
+    ),
+    (
+        commands.DispenseRequest(
+            pipetteId="pipette-id",
+            labwareId="labware-id",
+            wellName="B4",
+            wellLocation=WellLocation(),
+            volume=42,
+        ),
+        commands.DispenseResult(volume=42)
     ),
 ])
 def test_handles_move_to_well_result(
-    store: StateStore,
+    motion_store: MotionStore,
     now: datetime,
-    req: cmd.CommandRequestType,
-    res: cmd.CommandResultType,
+    req: commands.CommandRequestType,
+    res: commands.CommandResultType,
 ) -> None:
     """A pipetting command should update the current location."""
-    command: cmd.CompletedCommandType = \
-        cmd.CompletedCommand(  # type: ignore[assignment]
+    cmd: commands.CompletedCommandType = \
+        commands.CompletedCommand(  # type: ignore[assignment]
             created_at=now,
             started_at=now,
             completed_at=now,
@@ -52,8 +90,9 @@ def test_handles_move_to_well_result(
             result=res
         )
 
-    store.handle_command(command, "command-id")
-    assert store.motion.get_current_deck_location() == DeckLocation(
+    motion_store.handle_completed_command(cmd)
+
+    assert motion_store.state.get_current_deck_location() == DeckLocation(
         pipette_id="pipette-id",
         labware_id="labware-id",
         well_name="B4"


### PR DESCRIPTION
## Overview

This PR finishes up "basic pipetting" support in the Protocol Engine by adding support for a "dispense" command. This means the engine is now has basic support for:

- Load labware on deck
- Load pipette
- Move to well top
- Aspirate from well
- Dispense to well

Be sure to check out the [Protocol Engine Cookbook](https://coda.io/d/Protocol-Engine_dKsxOIJgBlG) for extra context, especially the pages:

- Known Deviations and To Do's (if you see something in this PR that you think is missing, it might already be noted here)
- Developer Guide > Adding a new command (How the "aspirate" command was added in #7191)

Closes #6599

## Changelog

- feat(api): add dispense command to the Protocol Engine

## Review requests

### Risk assessment

No immediate risk because this code is unused, but dispense is a foundational command, so we want to make sure this is right for our future where we switch over to the Protocol Engine.

### Code review

The dispense implementation is pretty simple, and was copied from the existing Protocol Context (while leaving behind stuff like location checking, optional volume, etc.).

Standard code review:

- Do the tests make sense?
- Does the code (especially compared to the Developer Guide) make sense
- Do we have all necessary state tracking so that a "full" basic pipetting protocol would work?

### Smoke testing

I've tested this using Jupyter with the following "protocol". `make push` this branch to your robot and this should run properly:

1. Picks up a tip
2. Aspirates from a reservoir in slot 2
3. Dispenses into a reservoir in slot 3
4. Trashes the tip
5. Repeats steps 1-4

(If you're not familiar with the Protocol Engine work and you come across this example, please rest assured that the methods and structures below are internal logic that will be safely hidden behind the existing Protocol API in actual usage)

```py
import asyncio
import opentrons.execute

from datetime import datetime
from uuid import uuid4
from typing import Optional

from opentrons.types import DeckSlotName, MountType
from opentrons.protocol_api import ProtocolContext
from opentrons.protocol_engine import ProtocolEngine, commands
from opentrons.protocol_engine.types import DeckSlotLocation, WellLocation, WellOrigin

opentrons.execute._clear_cached_hardware_controller() 
protocol = opentrons.execute.get_protocol_api('2.7')
protocol.home()
engine = None
hw_api = None


async def run_protocol(ctx: ProtocolContext) -> None:
    global engine
    global hw_api
    
    # HACK(mc, 2020-11-06): don't ever do this in a real protocol
    hw_api = ctx._hw_manager.hardware._obj_to_adapt
    engine = await ProtocolEngine.create(hardware=hw_api)

    async def execute_command(
        request: commands.CommandRequestType
    ) -> Optional[commands.CommandResultType]:
        command_id = str(uuid4())
        
        print(f"{type(request).__name__} - {command_id}")
        print(f"{request}")
        
        try:    
            command = await engine.execute_command(request, command_id=command_id)
        
            if isinstance(command, commands.FailedCommand):
                print(f"error: {command.error}")
                return None

            print(f"result: {command.result}")
            return command.result
        
        except Exception as e:
            print(f"Unhandled exception during execute: {str(e)}")

    result = await execute_command(
        commands.LoadPipetteRequest(
            pipetteName="p300_single_gen2",
            mount=MountType.RIGHT,
        ),
    )

    p300 = result.pipetteId  # type: ignore[union-attr]

            
    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_5),
            loadName="opentrons_96_tiprack_300ul",
            namespace="opentrons",
            version=1
        ),
    )

    rack_5 = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_2),
            loadName="agilent_1_reservoir_290ml",
            namespace="opentrons",
            version=1
        ),
    )

    source = result.labwareId  # type: ignore[union-attr]

    result = await execute_command(
        commands.LoadLabwareRequest(
            location=DeckSlotLocation(DeckSlotName.SLOT_3),
            loadName="agilent_1_reservoir_290ml",
            namespace="opentrons",
            version=1
        ),
    )

    dest = result.labwareId  # type: ignore[union-attr]
    
    try:
        command_list = [
            commands.PickUpTipRequest(pipetteId=p300, labwareId=rack_5, wellName="A1"),
            commands.AspirateRequest(
                pipetteId=p300,
                labwareId=source,
                wellName="A1",
                wellLocation=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
                volume=100,
            ),
            commands.DispenseRequest(
                pipetteId=p300,
                labwareId=dest,
                wellName="A1",
                wellLocation=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
                volume=100,
            ),
            commands.DropTipRequest(pipetteId=p300, labwareId="fixedTrash", wellName="A1"),
            commands.PickUpTipRequest(pipetteId=p300, labwareId=rack_5, wellName="A2"),
            commands.AspirateRequest(
                pipetteId=p300,
                labwareId=source,
                wellName="A1",
                wellLocation=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
                volume=100,
            ),
            commands.DispenseRequest(
                pipetteId=p300,
                labwareId=dest,
                wellName="A1",
                wellLocation=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
                volume=100,
            ),
            commands.DropTipRequest(pipetteId=p300, labwareId="fixedTrash", wellName="A1")
        ]
        
    except Exception as e:
        print(f"Exception during command creation: {str(e)}")
    
    for cmd in command_list:
        await execute_command(cmd)
    
loop = asyncio.get_event_loop()
loop.create_task(run_protocol(protocol))
```

