### PR TITLE
fix(robot-server): disable overlap for custom tips

### DIFF
--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -336,8 +336,7 @@ class DeckCalibrationUserFlow:
             ).tip_length
         except TipLengthCalNotFound:
             tip_overlap = self._hw_pipette.config.tip_overlap.get(
-                self._tip_rack.uri,
-                self._hw_pipette.config.tip_overlap['default'])
+                self._tip_rack.uri, 0)
             tip_length = self._tip_rack.tip_length
             return tip_length - tip_overlap
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -310,8 +310,7 @@ class PipetteOffsetCalibrationUserFlow:
         stored_tip_length_cal = self._get_stored_tip_length_cal()
         if stored_tip_length_cal is None or self._should_perform_tip_length:
             tip_overlap = self._hw_pipette.config.tip_overlap.get(
-                self._tip_rack.uri,
-                self._hw_pipette.config.tip_overlap['default'])
+                self._tip_rack.uri, 0)
             tip_length = self._tip_rack.tip_length
             return tip_length - tip_overlap
         else:

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -194,8 +194,7 @@ class TipCalibrationUserFlow:
         full_length = tiprack.tip_length
         overlap_dict: Dict = \
             self._hw_pipette.config.tip_overlap
-        default = overlap_dict['default']
-        overlap = overlap_dict.get(tiprack.uri, default)
+        overlap = overlap_dict.get(tiprack.uri, 0)
         return full_length - overlap
 
     @property


### PR DESCRIPTION
When calibrating a custom tiprack, you need to leave extra space since
the default tip overlap doesn't really apply. This removes overlap for
unknown tips rather than using the default.
