### PR TITLE
fix(robot-server): save custom tiprack def on robot during tip length cal

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -4,6 +4,7 @@ This module has functions that you can import to load robot or
 labware calibration from its designated file location.
 """
 import itertools
+import json
 import typing
 from typing_extensions import Literal
 

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -289,11 +289,8 @@ def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> 'LabwareDefinitio
     Return the custom tiprack definition saved in the custom tiprack directory
     during tip length calibration
     """
-    import logging
-    MOD = logging.getLogger(__name__)
     custom_tiprack_dir = config.get_custom_tiprack_def_path()
     custom_tiprack_path = custom_tiprack_dir / f'{labware_uri}.json'
-    MOD.info(f'path: {custom_tiprack_path}')
     try:
         with open(custom_tiprack_path, 'rb') as f:
             return json.loads(f.read().decode('utf-8'))

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -282,3 +282,25 @@ def get_all_pipette_offset_calibrations() \
                         source=_get_calibration_source(data),
                         status=_get_calibration_status(data)))
     return all_calibrations
+
+
+def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> 'LabwareDefinition':
+    """
+    Return the custom tiprack definition saved in the custom tiprack directory
+    during tip length calibration
+    """
+    import logging
+    MOD = logging.getLogger(__name__)
+    custom_tiprack_dir = config.get_custom_tiprack_def_path()
+    custom_tiprack_path = custom_tiprack_dir / f'{labware_uri}.json'
+    MOD.info(f'path: {custom_tiprack_path}')
+    try:
+        with open(custom_tiprack_path, 'rb') as f:
+            return json.loads(f.read().decode('utf-8'))
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f'Custom tiprack {labware_uri} not found in the custom tiprack'
+            'directory on the robot. Please recalibrate tip length and '
+            'pipette offset with this tiprack before performing calibration '
+            'health check.'
+        )

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -201,7 +201,13 @@ CONFIG_ELEMENTS = (
                   'Pipette Calibration Directory',
                   Path('robot') / 'pipettes',
                   ConfigElementType.DIR,
-                  'The dir where pipette calibration is stored')
+                  'The dir where pipette calibration is stored'),
+    ConfigElement('custom_tiprack_dir',
+                  'Custom Tiprack Directory',
+                  Path('tip_lengths') / 'custom_tiprack_definitions',
+                  ConfigElementType.DIR,
+                  'The dir where custom tiprack definitions for tip length '
+                  'calibration are stored')
 )
 #: The available configuration file elements to modify. All of these can be
 #: changed by editing opentrons.json, where the keys are the name elements,
@@ -506,3 +512,7 @@ CONFIG = load_and_migrate()
 
 def get_tip_length_cal_path():
     return get_opentrons_path('tip_length_calibration_dir')
+
+
+def get_custom_tiprack_def_path():
+    return get_opentrons_path('custom_tiprack_dir')

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -256,9 +256,9 @@ def test_clear_tip_length_calibration_data(monkeypatch):
         }
         json.dump(test_offset, offset_file)
 
-    assert len(os.listdir(calpath)) > 0
+    assert len([f for f in os.listdir(calpath) if f.endswith('.json')]) > 0
     delete.clear_tip_length_calibration()
-    assert len(os.listdir(calpath)) == 0
+    assert len([f for f in os.listdir(calpath) if f.endswith('.json')]) == 0
 
 
 def test_schema_shape(monkeypatch, clear_calibration):

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -20,6 +20,7 @@ from opentrons.util.helpers import utc_now
 
 MOCK_HASH = 'mock_hash'
 PIPETTE_ID = 'pipette_id'
+URI = 'custom/minimal_labware_def/1'
 
 minimalLabwareDef = {
     "metadata": {
@@ -62,7 +63,7 @@ minimalLabwareDef = {
         "yDimension": 2.0,
         "zDimension": 3.0
     },
-    "namespace": "opentrons",
+    "namespace": "custom",
     "version": 1
 }
 
@@ -78,6 +79,11 @@ def tlc_path(pip_id):
         / '{}.json'.format(pip_id)
 
 
+def custom_tiprack_path(uri):
+    return config.get_custom_tiprack_def_path() \
+        / '{}.json'.format(uri)
+
+
 def mock_hash_labware(labware_def):
     return MOCK_HASH
 
@@ -91,6 +97,19 @@ def clear_calibration(monkeypatch):
     yield
     try:
         os.remove(path(MOCK_HASH))
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture
+def clear_custom_tiprack_dir(monkeypatch):
+    try:
+        os.remove(custom_tiprack_path(URI))
+    except FileNotFoundError:
+        pass
+    yield
+    try:
+        os.remove(custom_tiprack_path(URI))
     except FileNotFoundError:
         pass
 
@@ -139,7 +158,7 @@ def test_json_datetime_encoder():
     assert decoded == original
 
 
-def test_create_tip_length_calibration_data(monkeypatch):
+def test_create_tip_length_calibration_data(monkeypatch, clear_custom_tiprack_dir):
 
     fake_time = utc_now()
 
@@ -157,15 +176,18 @@ def test_create_tip_length_calibration_data(monkeypatch):
             'lastModified': fake_time,
             'source': cs_types.SourceType.user,
             'status': {'markedBad': False},
-            'uri': 'opentrons/minimal_labware_def/1'
+            'uri': URI
         }
     }
+    assert not os.path.exists(custom_tiprack_path(URI))
     result = modify.create_tip_length_data(
         minimalLabwareDef, parent, tip_length)
     assert result == expected_data
+    assert os.path.exists(custom_tiprack_path(URI))
 
 
-def test_save_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
+def test_save_tip_length_calibration_data(monkeypatch,
+                                          clear_tlc_calibration):
     assert not os.path.exists(tlc_path(PIPETTE_ID))
 
     test_data = {
@@ -239,7 +261,7 @@ def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
         source=cs_types.SourceType.user,
         status=cs_types.CalibrationStatus(markedBad=False),
         tiprack=MOCK_HASH,
-        uri='opentrons/minimal_labware_def/1',
+        uri='custom/minimal_labware_def/1',
         last_modified=test_data[MOCK_HASH]['lastModified']
     )
     assert result == expected

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -314,9 +314,9 @@ class CheckCalibrationUserFlow:
         position = self._deck.position_for(TIPRACK_SLOT)
         if details.namespace == OPENTRONS_NAMESPACE:
             tiprack = labware.load(load_name=details.load_name,
-                                namespace=details.namespace,
-                                version=details.version,
-                                parent=position)
+                                   namespace=details.namespace,
+                                   version=details.version,
+                                   parent=position)
             tiprack_def = tiprack._implementation.get_definition()
         else:
             tiprack_def = get.get_custom_tiprack_definition_for_tlc(

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -228,3 +228,66 @@ def get_labware_fixture():
             return json.loads(f.read().decode('utf-8'))
 
     return _get_labware_fixture
+
+
+@pytest.fixture
+def custom_tiprack_def():
+    return {
+        "metadata": {
+            "displayName": "minimal labware"
+        },
+        "cornerOffsetFromSlot": {
+            "x": 10,
+            "y": 10,
+            "z": 5
+        },
+        "parameters": {
+            "isTiprack": True,
+            "tipLength": 55.3,
+            "tipOverlap": 2.8,
+            "loadName": "minimal_labware_def"
+        },
+        "ordering": [["A1"], ["A2"]],
+        "wells": {
+            "A1": {
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
+            },
+            "A2": {
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 10,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
+            }
+        },
+        "dimensions": {
+            "xDimension": 1.0,
+            "yDimension": 2.0,
+            "zDimension": 3.0
+        },
+        "namespace": "custom",
+        "version": 1
+    }
+
+
+@pytest.fixture
+def clear_custom_tiprack_def_dir():
+    tiprack_path = config.get_custom_tiprack_def_path() \
+        / 'custom/minimal_labware_def/1.json'
+    try:
+        os.remove(tiprack_path)
+    except FileNotFoundError:
+        pass
+    yield
+    try:
+        os.remove(tiprack_path)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
# Overview
We need the custom tiprack definition in the robot's file system in order to load its tip length cal data in health check. 

This PR (1) saves custom tiprack definition in `/data/tip_length/custom_tiprack_definitions` when performing tip length calibration; (2) and loads the custom tiprack def to obtain the appropriate tip length cal in health check.