### PR TITLE
fix: For requests to upload an empty SSH key, respond with a helpful error message

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -1,7 +1,7 @@
-# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 include ../scripts/push.mk
 include ../scripts/python.mk
 
+# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
 
 PATH := $(shell cd .. && yarn bin):$(PATH)

--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -123,6 +123,11 @@ async def add(request: web.Request) -> web.Response:
     pubkey = body['key']
     # Do some fairly minor sanitization; dropbear will ignore invalid keys but
     # we still don’t want to have a bunch of invalid data in there
+    if len(pubkey.split()) == 0:
+        return web.json_response(
+            data={'error': 'bad-key',
+                  'message': 'Key is empty'},
+            status=400)
     alg = pubkey.split()[0]
     # We don’t allow dss so this has to be rsa or ecdsa and shouldn’t start
     # with restrictions

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -99,7 +99,7 @@ async def test_add_key(test_cli, dummy_authorized_keys):
     
     # Send a request with a non-string key
     resp = await test_cli.post('/server/ssh_keys',
-                               json={key: 123},
+                               json={'key': 123},
                                headers={'X-Host-IP': '169.254.1.1'})
     assert resp.status == 400
     body = await resp.json()

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -93,10 +93,10 @@ async def test_add_key_successes(test_cli, dummy_authorized_keys):
         ('bad-key', {'key': ''}),
         ('bad-key', {'key': '     '}),
         ('bad-key', {'key': 'not even close to a pubkey'}),
-        ('bad-key', {'key': 'ssh-rsa \ngotcha'}) # Bad because of embedded \n.
+        ('bad-key', {'key': 'ssh-rsa \ngotcha'})  # Bad because of embedded \n.
     ])
 async def test_add_key_errors(
-        test_cli, dummy_authorized_keys, expected_error, body):  
+        test_cli, dummy_authorized_keys, expected_error, body):
     resp = await test_cli.post('/server/ssh_keys',
                                json=body,
                                headers={'X-Host-IP': '169.254.1.1'})

--- a/update-server/tests/buildroot/test_ssh_key_management.py
+++ b/update-server/tests/buildroot/test_ssh_key_management.py
@@ -61,7 +61,7 @@ async def test_list_keys(test_cli, dummy_authorized_keys):
          'key': dummy_key}]
 
 
-async def test_add_key(test_cli, dummy_authorized_keys):
+async def test_add_key_successes(test_cli, dummy_authorized_keys):
     dummy_key = "ssh-rsa ahaubsfalsijdbalsjdhbfajsdbfafasdk test@opentrons.com"
     resp = await test_cli.post('/server/ssh_keys',
                                json={'key': dummy_key},
@@ -85,61 +85,24 @@ async def test_add_key(test_cli, dummy_authorized_keys):
         'md5', dummy_key.encode()).hexdigest()
     assert open(dummy_authorized_keys).read() == dummy_key + '\n'
 
-    # TODO: Valid-ish key but with duplicated whitespace?
-    # TODO: Refactor
-    
-    # Send a request with a missing key
-    resp = await test_cli.post('/server/ssh_keys',
-                               json={},
-                               headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 400
-    body = await resp.json()
-    assert body['error'] == 'no-key'
-    assert 'message' in body
-    
-    # Send a request with a non-string key
-    resp = await test_cli.post('/server/ssh_keys',
-                               json={'key': 123},
-                               headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 400
-    body = await resp.json()
-    assert body['error'] == 'no-key'
-    assert 'message' in body
-    
-    # Send an empty key
-    resp = await test_cli.post('/server/ssh_keys',
-                               json={'key': ''},
-                               headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 400
-    body = await resp.json()
-    assert body['error'] == 'bad-key'
-    assert 'message' in body
-    
-    # Send a whitespace-only key
-    resp = await test_cli.post('/server/ssh_keys',
-                               json={'key': '          '},
-                               headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 400
-    body = await resp.json()
-    assert body['error'] == 'bad-key'
-    assert 'message' in body
-        
-    # Send something that looks nothing like a key
-    resp = await test_cli.post('/server/ssh_keys',
-                               json={'key': 'not even close to a pubkey'},
-                               headers={'X-Host-IP': '169.254.1.1'})
-    assert resp.status == 400
-    body = await resp.json()
-    assert body['error'] == 'bad-key'
-    assert 'message' in body
 
-    # Send something that looks kinda like a key but with a newline
+@pytest.mark.parametrize(
+    'expected_error, body', [
+        ('no-key', {}),
+        ('no-key', {'key': 123}),
+        ('bad-key', {'key': ''}),
+        ('bad-key', {'key': '     '}),
+        ('bad-key', {'key': 'not even close to a pubkey'}),
+        ('bad-key', {'key': 'ssh-rsa \ngotcha'}) # Bad because of embedded \n.
+    ])
+async def test_add_key_errors(
+        test_cli, dummy_authorized_keys, expected_error, body):  
     resp = await test_cli.post('/server/ssh_keys',
-                               json={'key': 'ssh-rsa \ngotcha'},
+                               json=body,
                                headers={'X-Host-IP': '169.254.1.1'})
     assert resp.status == 400
     body = await resp.json()
-    assert body['error'] == 'bad-key'
+    assert body['error'] == expected_error
     assert 'message' in body
 
 


### PR DESCRIPTION
# Overview

Fix #7173.

# Changelog

* Return HTTP 400, not HTTP 500, if you try to upload an empty SSH key. Also provide an error message indicating the problem.
* Refactors of `add_key()` and its tests.
* New test cases for this bug.
* New test case for providing a `key` of the wrong *JSON type*. This was handled correctly, but not covered by tests.
* Fix a misplaced Makefile comment that I happened to notice while I was here.

# Review requests

Do the refactors in `ssh_key_management.add()` look good?

# Risk assessment

Low. Although the ability to upload SSH keys is critical, this code is isolated and covered by unit tests. I've also smoke-tested adding a valid key (which worked as expected) and an empty key (which errored as expected).