### PR TITLE
fix(api): bump pyserial dependency in setup.py

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -52,7 +52,7 @@ DESCRIPTION = (
     "writing automated biology lab protocols easy.")
 PACKAGES = find_packages(where='src')
 INSTALL_REQUIRES = [
-    'pyserial==3.4',
+    'pyserial==3.5',
     'numpy>=1.15.1',
     'jsonschema>=3.0.2,<4',
     'aionotify==0.2.0',


### PR DESCRIPTION
## Overview

The pyserial dependency was bumped to 3.5 (in the Pipfile and Builroot) in the v4.1.0 release, but `setup.py` still specifies 3.4, which means the package thinks it needs 3.4.

This PR fixes `setup.py` so the `opentrons` package knows what version of pyserial it actually wants.

## Changelog

- fix(api): bump pyserial dependency in setup.py

## Review requests

Pretty self explanatory

## Risk assessment

Bugfix
