### PR TITLE
feat(components): Add optional isIndeterminate prop to CheckBoxField

### DIFF
--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -80,7 +80,6 @@ exports[`CheckboxField renders correctly when unchecked 1`] = `
     </svg>
   </div>
   <input
-    checked={false}
     className="input_field accessibly_hidden"
     type="checkbox"
   />

--- a/components/src/__tests__/__snapshots__/forms.test.js.snap
+++ b/components/src/__tests__/__snapshots__/forms.test.js.snap
@@ -80,6 +80,7 @@ exports[`CheckboxField renders correctly when unchecked 1`] = `
     </svg>
   </div>
   <input
+    checked={false}
     className="input_field accessibly_hidden"
     type="checkbox"
   />

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -42,6 +42,8 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
     [styles.checkbox_disabled]: props.disabled,
   })
 
+  const indeterminate = props.isIndeterminate ? 'true' : undefined
+
   return (
     <label className={outerClassName}>
       <div className={innerDivClassName}>
@@ -60,11 +62,11 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
         className={cx(styles.input_field, styles.accessibly_hidden)}
         type="checkbox"
         name={props.name}
-        checked={props.value}
+        checked={props.value || false}
         disabled={props.disabled}
         onChange={props.onChange}
         tabIndex={props.tabIndex}
-        indeterminate={props.isIndeterminate}
+        indeterminate={indeterminate}
       />
       <div
         {...props.hoverTooltipHandlers}

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -27,6 +27,8 @@ export type CheckboxFieldProps = {|
   tabIndex?: number,
   /** handlers for HoverTooltipComponent */
   hoverTooltipHandlers?: ?HoverTooltipHandlers,
+  /** if true, render indeterminate icon */
+  isIndeterminate?: boolean,
 |}
 
 export function CheckboxField(props: CheckboxFieldProps): React.Node {
@@ -44,7 +46,13 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
     <label className={outerClassName}>
       <div className={innerDivClassName}>
         <Icon
-          name={props.value ? 'checkbox-marked' : 'checkbox-blank-outline'}
+          name={
+            props.isIndeterminate === true
+              ? 'minus-box'
+              : props.value
+              ? 'checkbox-marked'
+              : 'checkbox-blank-outline'
+          }
           width="100%"
         />
       </div>
@@ -52,7 +60,7 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
         className={cx(styles.input_field, styles.accessibly_hidden)}
         type="checkbox"
         name={props.name}
-        checked={props.value || false}
+        checked={props.value}
         disabled={props.disabled}
         onChange={props.onChange}
         tabIndex={props.tabIndex}

--- a/components/src/forms/CheckboxField.js
+++ b/components/src/forms/CheckboxField.js
@@ -47,7 +47,7 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
       <div className={innerDivClassName}>
         <Icon
           name={
-            props.isIndeterminate === true
+            props.isIndeterminate
               ? 'minus-box'
               : props.value
               ? 'checkbox-marked'
@@ -64,6 +64,7 @@ export function CheckboxField(props: CheckboxFieldProps): React.Node {
         disabled={props.disabled}
         onChange={props.onChange}
         tabIndex={props.tabIndex}
+        indeterminate={props.isIndeterminate}
       />
       <div
         {...props.hoverTooltipHandlers}

--- a/components/src/forms/CheckboxField.md
+++ b/components/src/forms/CheckboxField.md
@@ -19,3 +19,27 @@ const [state, setState] = React.useState({
   />
 </div>
 ```
+
+Optional interminate prop for mixed values
+
+```js
+const [state, setState] = React.useState({
+  isChecked: false,
+  isIndeterminate: true,
+})
+;<div>
+  <CheckboxField
+    label="Shared Feild Check Box"
+    className="display-block"
+    onChange={() =>
+      setState({
+        ...state,
+        isChecked: !state.isChecked,
+        isIndeterminate: false,
+      })
+    }
+    value={state.isChecked}
+    isIndeterminate={state.isIndeterminate}
+  />
+</div>
+```

--- a/components/src/forms/CheckboxField.md
+++ b/components/src/forms/CheckboxField.md
@@ -29,7 +29,7 @@ const [state, setState] = React.useState({
 })
 ;<div>
   <CheckboxField
-    label="Shared Feild Check Box"
+    label="Shared Field Check Box"
     className="display-block"
     onChange={() =>
       setState({

--- a/components/src/forms/__tests__/CheckboxField.test.js
+++ b/components/src/forms/__tests__/CheckboxField.test.js
@@ -1,0 +1,76 @@
+// @flow
+import * as React from 'react'
+import { mount } from 'enzyme'
+
+import { CheckboxField } from '../CheckboxField'
+import { Icon } from '../../icons'
+
+describe('CheckboxField', () => {
+  describe('CheckboxField', () => {
+    it('renders a checked icon when value === true', () => {
+      const wrapper = mount(<CheckboxField onChange={jest.fn()} value={true} />)
+      const icon = wrapper.find(Icon)
+
+      expect(icon.prop('name')).toEqual('checkbox-marked')
+    })
+
+    it('sets input checked attribute to true when value === true', () => {
+      const wrapper = mount(<CheckboxField onChange={jest.fn()} value={true} />)
+
+      const input = wrapper.find('input')
+      expect(input.prop('checked')).toBe(true)
+    })
+
+    it('renders an unchecked icon when value === false', () => {
+      const wrapper = mount(
+        <CheckboxField onChange={jest.fn()} value={false} />
+      )
+      const icon = wrapper.find(Icon)
+
+      expect(icon.prop('name')).toEqual('checkbox-blank-outline')
+    })
+
+    it('sets input checked attribute to false when value === false', () => {
+      const wrapper = mount(
+        <CheckboxField onChange={jest.fn()} value={false} />
+      )
+
+      const input = wrapper.find('input')
+      expect(input.prop('checked')).toBe(false)
+    })
+
+    it('renders an unchecked icon when no value prop', () => {
+      const wrapper = mount(<CheckboxField onChange={jest.fn()} />)
+      const icon = wrapper.find(Icon)
+
+      expect(icon).toBeDefined()
+      expect(icon.prop('name')).toEqual('checkbox-blank-outline')
+    })
+
+    it('sets input checked attribute to false when no value prop', () => {
+      const wrapper = mount(<CheckboxField onChange={jest.fn()} />)
+
+      const input = wrapper.find('input')
+      expect(input.prop('checked')).toBe(false)
+    })
+  })
+
+  describe('indeterminate Checkboxfield', () => {
+    it(' renders a minux box icon', () => {
+      const wrapper = mount(
+        <CheckboxField onChange={jest.fn()} isIndeterminate />
+      )
+      const icon = wrapper.find(Icon)
+      expect(icon.prop('name')).toEqual('minus-box')
+    })
+
+    it('passes isIndeterimate prop and adds input indeterminate attribute', () => {
+      const wrapper = mount(
+        <CheckboxField onChange={jest.fn()} isIndeterminate />
+      )
+
+      const input = wrapper.find('input')
+      expect(input.prop('indeterminate')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
# Overview

closes #7257 and #7154 (research ticket) by adding the optional `isIndeterminate` prop and rending the appropriate icon accordingly. It also adds the indeterminate html attribute to the hidden input.

# Changelog

- feat(components): Add optional `isIndeterminate` prop to CheckBoxField

# Review requests

- [ ] component library `.md` example behaves as expected
- [ ] regular checkboxes are unaffected

# Risk assessment

low, optional prop in components library but we should confirm we didn't break checkboxes in our apps
