### PR TITLE
refactor(api): find commonalities between JsonProtocol and PythonProtocol objects.

### DIFF
--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -80,7 +80,9 @@ def _parse_json(
     version, validated = validate_json(protocol_json)
     return JsonProtocol(
         text=protocol_contents, filename=filename, contents=validated,
-        schema_version=version, api_level=API_VERSION_FOR_JSON_V5_AND_BELOW)
+        schema_version=version, api_level=API_VERSION_FOR_JSON_V5_AND_BELOW,
+        metadata=validated['metadata']
+    )
 
 
 def _parse_python(

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -1,30 +1,34 @@
 from typing import Any, Dict, NamedTuple, Optional, Union, TYPE_CHECKING
+from dataclasses import dataclass
 from .api_support.definitions import MIN_SUPPORTED_VERSION
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
     from opentrons_shared_data.protocol.dev_types import (
-        JsonProtocol as JsonProtocolDef
+        JsonProtocol as JsonProtocolDef, Metadata as JsonProtocolMetadata
     )
     from .api_support.types import APIVersion
 
 Metadata = Dict[str, Union[str, int]]
 
 
-class JsonProtocol(NamedTuple):
+@dataclass(frozen=True)
+class ProtocolCommon:
     text: str
     filename: Optional[str]
-    contents: 'JsonProtocolDef'
+    api_level: 'APIVersion'
+    metadata: Union[Metadata, 'JsonProtocolMetadata']
+
+
+@dataclass(frozen=True)
+class JsonProtocol(ProtocolCommon):
     schema_version: int
-    api_level: 'APIVersion'
+    contents: 'JsonProtocolDef'
 
 
-class PythonProtocol(NamedTuple):
-    text: str
-    filename: Optional[str]
+@dataclass(frozen=True)
+class PythonProtocol(ProtocolCommon):
     contents: Any  # This is the output of compile() which we can't type
-    metadata: Metadata
-    api_level: 'APIVersion'
     # these 'bundled_' attrs should only be included when the protocol is a zip
     bundled_labware: Optional[Dict[str, 'LabwareDefinition']]
     bundled_data: Optional[Dict[str, bytes]]

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -255,6 +255,7 @@ def test_parse_json_details(get_json_protocol_fixture,
     assert isinstance(parsed, JsonProtocol)
     assert parsed.filename == fname
     assert parsed.contents == json.loads(protocol)
+    assert parsed.metadata == parsed.contents['metadata']
     assert parsed.schema_version == int(protocol_details[0])
     # TODO(IL, 2020-10-07): if schema v6 declares its own api_level,
     # then those v6 fixtures will need to be asserted differently

--- a/robot-server/tests/service/protocol/test_analyze.py
+++ b/robot-server/tests/service/protocol/test_analyze.py
@@ -181,7 +181,8 @@ def test__extract_metadata_json():
         api_level=APIVersion(major=2, minor=2),
         filename="",
         contents={},
-        schema_version=2
+        schema_version=2,
+        metadata={}
     )
 
     assert analyze._extract_metadata(protocol) == models.Meta(


### PR DESCRIPTION
# Overview

`JsonProtocol` and `PythonProtocol` types have more in common than not. 

closes #7174 

# Changelog

- `JsonProtocol` and `PythonProtocol`are now `dataclass` types
- merge the common attributes of `JsonProtocol` and `PythonProtocol` to a base class.
- `JsonProtocol` has `metadata` field.

# Review requests


# Risk assessment

Low
