### PR TITLE
feat(robot-server): extract author and protocol name from JSON protocol metadata.

### DIFF
--- a/robot-server/robot_server/service/protocol/analyze.py
+++ b/robot-server/robot_server/service/protocol/analyze.py
@@ -9,7 +9,7 @@ from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.implementations.simulators.protocol_context import \
     SimProtocolContext
 from opentrons.protocols.parse import parse
-from opentrons.protocols.types import PythonProtocol, Protocol
+from opentrons.protocols.types import Protocol
 
 from robot_server.service.legacy.models.control import Mount
 from robot_server.service.protocol import contents, models
@@ -73,9 +73,10 @@ def _analyze(protocol_contents: contents.Contents) -> AnalysisResult:
 
 def _extract_metadata(protocol: typing.Optional[Protocol]) -> models.Meta:
     """Extract protocol metadata"""
-    metadata = protocol.metadata \
-        if isinstance(protocol, PythonProtocol) else {}
-    protocol_name = metadata.get('protocolName')
+    metadata = protocol.metadata if protocol else {}
+    # Two alternatives for protocol name key
+    protocol_name = metadata.get('protocolName',
+                                 metadata.get('protocol-name'))
     author = metadata.get('author')
     return models.Meta(
         name=str(protocol_name) if protocol_name else None,

--- a/robot-server/tests/service/protocol/test_analyze.py
+++ b/robot-server/tests/service/protocol/test_analyze.py
@@ -174,7 +174,19 @@ def test__extract_metadata_python():
     )
 
 
-def test__extract_metadata_json():
+@pytest.mark.parametrize(
+    argnames="metadata",
+    argvalues=[
+        {
+            "author": "some author",
+            "protocolName": "my protocol"
+        },
+        {
+            "author": "some author",
+            "protocol-name": "my protocol"
+        }
+    ])
+def test__extract_metadata_json(metadata):
     """It returns complete metadata when passed JSONProtocol"""
     protocol = JsonProtocol(
         text="abc",
@@ -182,12 +194,12 @@ def test__extract_metadata_json():
         filename="",
         contents={},
         schema_version=2,
-        metadata={}
+        metadata=metadata
     )
 
     assert analyze._extract_metadata(protocol) == models.Meta(
-        name=None,
-        author=None,
+        name="my protocol",
+        author="some author",
         apiLevel="2.2"
     )
 


### PR DESCRIPTION
# Overview

Include metadata from JSON protocol in analysis result.


# Changelog

- `JsonProtocol` and `PythonProtocol` have a common base class that includes a `metadata` attribute. Extract name and author from `metadata` attribute. 

# Review requests

To test
```
curl -X POST "http://localhost:31950/protocols" -H  "accept: application/json" -H  "Content-Type: multipart/form-data" -H "Opentrons-Version:2"  -F "protocolFile=@PATH_TO_PD_PROTO.json""
```
The response should contain `author` and `name` in the `metadata` object.

# Risk assessment

None.