### PR TITLE
refactor(robot-server): clean up tests using AsyncMock

### DIFF
--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import json
 import pathlib
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 import requests
 from fastapi import routing

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -1,5 +1,5 @@
 from typing import List, Tuple
-from unittest.mock import call, MagicMock, patch
+from mock import call, MagicMock, patch
 
 import pytest
 from opentrons.hardware_control import pipette

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -34,9 +34,6 @@ def mock_hw(hardware):
     hardware._attached_instruments = {Mount.RIGHT: pip, Mount.LEFT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
-    async def async_mock(*args, **kwargs):
-        pass
-
     async def async_mock_move_rel(*args, **kwargs):
         delta = kwargs.get('delta', Point(0, 0, 0))
         hardware._current_pos += delta
@@ -48,13 +45,10 @@ def mock_hw(hardware):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
-    hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.move_rel.side_effect = async_mock_move_rel
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
-    hardware.retract = MagicMock(side_effect=async_mock)
     return hardware
 
 

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, call
+from mock import MagicMock, call
 from typing import List, Tuple
 from opentrons.calibration_storage import types as cal_types
 from opentrons.types import Mount, Point

--- a/robot-server/tests/robot/calibration/deck/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/deck/test_user_flow.py
@@ -29,9 +29,6 @@ def mock_hw(hardware):
     hardware._attached_instruments = {Mount.RIGHT: pip, Mount.LEFT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
-    async def async_mock(*args, **kwargs):
-        pass
-
     async def async_mock_move_rel(*args, **kwargs):
         delta = kwargs.get('delta', Point(0, 0, 0))
         hardware._current_pos += delta
@@ -43,14 +40,10 @@ def mock_hw(hardware):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
-    hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.move_rel.side_effect = async_mock_move_rel
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
-    hardware.home_plunger = MagicMock(side_effect=async_mock)
-    hardware.home = MagicMock(side_effect=async_mock)
     return hardware
 
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -91,13 +91,6 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     hardware._attached_instruments = {mount: mock_hw_pipette_all_combos}
     hardware._current_pos = Point(0, 0, 0)
 
-    async def async_mock(*args, **kwargs):
-        pass
-
-    async def async_mock_move_rel(*args, **kwargs):
-        delta = kwargs.get('delta', Point(0, 0, 0))
-        hardware._current_pos += delta
-
     async def async_mock_move_to(*args, **kwargs):
         to_pt = kwargs.get('abs_position', Point(0, 0, 0))
         hardware._current_pos = to_pt
@@ -105,13 +98,9 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
-    hardware.move_rel = MagicMock(side_effect=async_mock)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
-    hardware.retract = MagicMock(side_effect=async_mock)
     return hardware
 
 
@@ -123,9 +112,6 @@ def mock_hw(hardware):
     hardware._attached_instruments = {Mount.RIGHT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
-    async def async_mock(*args, **kwargs):
-        pass
-
     async def async_mock_move_rel(*args, **kwargs):
         delta = kwargs.get('delta', Point(0, 0, 0))
         hardware._current_pos += delta
@@ -137,16 +123,10 @@ def mock_hw(hardware):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
-    hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.move_rel.side_effect = async_mock_move_rel
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
-    hardware.home_plunger = MagicMock(side_effect=async_mock)
-    hardware.home = MagicMock(side_effect=async_mock)
-    hardware.retract = MagicMock(side_effect=async_mock)
-
     return hardware
 
 

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import pytest
-from unittest.mock import MagicMock, call, patch
+from mock import MagicMock, call, patch
 from typing import List, Tuple, Dict, Any
 from opentrons import config
 from opentrons.calibration_storage import helpers, types as CSTypes

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import MagicMock, ANY, patch, call
+from unittest.mock import ANY, patch, call
 from typing import List, Tuple, Dict, Any
 from opentrons import config
 from opentrons.types import Mount, Point
@@ -52,13 +52,6 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     hardware._attached_instruments = {mount: mock_hw_pipette_all_combos}
     hardware._current_pos = Point(0, 0, 0)
 
-    async def async_mock(*args, **kwargs):
-        pass
-
-    async def async_mock_move_rel(*args, **kwargs):
-        delta = kwargs.get('delta', Point(0, 0, 0))
-        hardware._current_pos += delta
-
     async def async_mock_move_to(*args, **kwargs):
         to_pt = kwargs.get('abs_position', Point(0, 0, 0))
         hardware._current_pos = to_pt
@@ -66,12 +59,8 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     async def gantry_pos_mock(*args, **kwargs):
         return hardware._current_pos
 
-    hardware.move_rel = MagicMock(side_effect=async_mock)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
-    hardware.home_plunger = MagicMock(side_effect=async_mock)
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
     return hardware
 
@@ -83,9 +72,6 @@ def mock_hw(hardware):
                           'testId')
     hardware._attached_instruments = {Mount.RIGHT: pip}
     hardware._current_pos = Point(0, 0, 0)
-
-    async def async_mock(*args, **kwargs):
-        pass
 
     async def async_mock_move_rel(*args, **kwargs):
         delta = kwargs.get('delta', Point(0, 0, 0))
@@ -101,15 +87,11 @@ def mock_hw(hardware):
     async def async_mock_home_plunger(*args, **kwargs):
         pass
 
-    hardware.move_rel = MagicMock(side_effect=async_mock_move_rel)
-    hardware.pick_up_tip = MagicMock(side_effect=async_mock)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.gantry_position = MagicMock(side_effect=gantry_pos_mock)
-    hardware.move_to = MagicMock(side_effect=async_mock_move_to)
+    hardware.move_rel.side_effect = async_mock_move_rel
+    hardware.gantry_position.side_effect = gantry_pos_mock
+    hardware.move_to.side_effect = async_mock_move_to
     hardware.get_instrument_max_height.return_value = 180
-    hardware.home_plunger = MagicMock(side_effect=async_mock_home_plunger)
-    hardware.drop_tip = MagicMock(side_effect=async_mock)
-    hardware.home = MagicMock(side_effect=async_mock)
+    hardware.home_plunger.side_effect = async_mock_home_plunger
     return hardware
 
 

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from unittest.mock import ANY, patch, call
+from mock import ANY, patch, call
 from typing import List, Tuple, Dict, Any
 from opentrons import config
 from opentrons.types import Mount, Point

--- a/robot-server/tests/service/legacy/routers/test_camera.py
+++ b/robot-server/tests/service/legacy/routers/test_camera.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from mock import patch
 import pytest
 from opentrons.system import camera
 

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -1,5 +1,5 @@
 from asyncio import Event
-from unittest.mock import call, MagicMock
+from mock import call, MagicMock
 
 import pytest
 from opentrons.hardware_control.types import Axis, CriticalPoint

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -20,23 +20,12 @@ def test_robot_info(api_client):
     assert len(body['positions']['attach_tip']['point']) == 3
 
 
-@pytest.fixture
-def hardware_home(hardware):
-    """Fixture for home handlers"""
-    async def mock_func(*args, **kwargs):
-        pass
-
-    hardware.home.side_effect = mock_func
-    hardware.home_plunger.side_effect = mock_func
-    return hardware
-
-
 @pytest.mark.parametrize(argnames="mount_name,mount",
                          argvalues=[
                              ["left", Mount.LEFT],
                              ["right", Mount.RIGHT]
                          ])
-def test_home_pipette(api_client, hardware_home, mount_name, mount):
+def test_home_pipette(api_client, hardware, mount_name, mount):
     test_data = {
         'target': 'pipette',
         'mount': mount_name
@@ -46,11 +35,11 @@ def test_home_pipette(api_client, hardware_home, mount_name, mount):
     assert res.json() == {"message": f"Pipette on {mount_name}"
                                      f" homed successfully"}
     assert res.status_code == 200
-    hardware_home.home.assert_called_once_with([Axis.by_mount(mount)])
-    hardware_home.home_plunger.assert_called_once_with(mount)
+    hardware.home.assert_called_once_with([Axis.by_mount(mount)])
+    hardware.home_plunger.assert_called_once_with(mount)
 
 
-def test_home_robot(api_client, hardware_home):
+def test_home_robot(api_client, hardware):
     test_data = {
         'target': 'robot',
     }
@@ -58,7 +47,7 @@ def test_home_robot(api_client, hardware_home):
     res = api_client.post('/robot/home', json=test_data)
     assert res.json() == {"message": "Homing robot."}
     assert res.status_code == 200
-    hardware_home.home.assert_called_once()
+    hardware.home.assert_called_once()
 
 
 @pytest.mark.parametrize(argnames="test_data",
@@ -76,12 +65,6 @@ def test_home_pipette_bad_request(test_data, api_client):
 @pytest.fixture
 def hardware_move(hardware):
     """Fixture for move handler tests"""
-    async def mock_func(*args, **kwargs):
-        pass
-
-    hardware.cache_instruments.side_effect = mock_func
-    hardware.home_z.side_effect = mock_func
-
     state = {
         'cur_pos': Point(0, 0, 0)
     }
@@ -177,15 +160,6 @@ def test_move_pipette(api_client, hardware_move):
     ])
 
 
-@pytest.fixture
-def hardware_rail_lights(hardware):
-    async def mock_set_lights(*args, **kwargs):
-        pass
-
-    hardware.set_lights.side_effect = mock_set_lights
-    return hardware
-
-
 @pytest.mark.parametrize(
     argnames="on_value",
     argvalues=[
@@ -193,8 +167,8 @@ def hardware_rail_lights(hardware):
         False
     ]
 )
-def test_rail_lights_get(on_value, api_client, hardware_rail_lights):
-    hardware_rail_lights.get_lights.return_value = {'rails': on_value}
+def test_rail_lights_get(on_value, api_client, hardware):
+    hardware.get_lights.return_value = {'rails': on_value}
     resp = api_client.get('/robot/lights')
     assert resp.status_code == 200
     data = resp.json()
@@ -208,11 +182,11 @@ def test_rail_lights_get(on_value, api_client, hardware_rail_lights):
         {'on': 'not on'},
     ]
 )
-def test_robot_lights_set_bad(request_body, api_client, hardware_rail_lights):
+def test_robot_lights_set_bad(request_body, api_client, hardware):
     resp = api_client.post('/robot/lights',
                            json=request_body)
     assert resp.status_code == 422
-    hardware_rail_lights.set_lights.assert_not_called()
+    hardware.set_lights.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -222,23 +196,16 @@ def test_robot_lights_set_bad(request_body, api_client, hardware_rail_lights):
         False
     ]
 )
-def test_robot_lights_set(on_value, api_client, hardware_rail_lights):
-    async def mock_set_lights(*args, **kwargs):
-        pass
-
+def test_robot_lights_set(on_value, api_client, hardware):
     resp = api_client.post('/robot/lights',
                            json={'on': on_value})
     assert resp.status_code == 200
     data = resp.json()
     assert data == {'on': on_value}
-    hardware_rail_lights.set_lights.assert_called_once_with(rails=on_value)
+    hardware.set_lights.assert_called_once_with(rails=on_value)
 
 
 def test_identify(api_client, hardware):
-    async def mock_identify(duration_s):
-        pass
-
-    hardware.identify.side_effect = mock_identify
     res = api_client.post("/identify?seconds=100")
     assert res.status_code == 200
     assert res.json() == {"message": "identifying"}

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from unittest.mock import patch
+from mock import patch
 
 from opentrons.system.log_control import MAX_RECORDS, DEFAULT_RECORDS
 

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -389,8 +389,6 @@ def test_post_serial_update(api_client, hardware, tempdeck):
     tempdeck._bundled_fw = BundledFirmware("1234", Path("c:/aaa"))
 
     with patch("opentrons.hardware_control.modules.update_firmware") as p:
-        # p.side_effect = update
-
         resp = api_client.post('/modules/dummySerialTD/update')
 
         p.assert_called_once_with(tempdeck,

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch, PropertyMock, MagicMock
+from mock import patch, PropertyMock, MagicMock
 
 import pytest
 import asyncio
@@ -384,15 +384,12 @@ def test_post_serial_timeout_error(api_client, hardware, magdeck):
 
 
 def test_post_serial_update(api_client, hardware, tempdeck):
-    async def update(*args, **kwargs):
-        pass
-
     hardware.attached_modules = [tempdeck]
 
     tempdeck._bundled_fw = BundledFirmware("1234", Path("c:/aaa"))
 
     with patch("opentrons.hardware_control.modules.update_firmware") as p:
-        p.side_effect = update
+        # p.side_effect = update
 
         resp = api_client.post('/modules/dummySerialTD/update')
 

--- a/robot-server/tests/service/legacy/routers/test_motors.py
+++ b/robot-server/tests/service/legacy/routers/test_motors.py
@@ -1,5 +1,4 @@
 from opentrons.hardware_control.types import Axis
-import pytest
 
 
 def test_engage_axes(api_client, hardware):
@@ -39,53 +38,42 @@ def test_engage_invalid_axes(api_client, hardware):
     assert res0.status_code == 500
 
 
-@pytest.fixture
-def hardware_with_disengage_axes(hardware):
-    async def mock_disengage_axes(*args, **kwargs):
-        pass
-
-    hardware.disengage_axes.side_effect = mock_disengage_axes
-    return hardware
-
-
-def test_disengage_axes(api_client, hardware_with_disengage_axes):
+def test_disengage_axes(api_client, hardware):
     postres = api_client.post(
         '/motors/disengage', json={'axes': ['x', 'b']})
 
-    hardware_with_disengage_axes.disengage_axes.assert_called_once_with(
-        [Axis.X, Axis.B])
+    hardware.disengage_axes.assert_called_once_with([Axis.X, Axis.B])
 
     assert postres.status_code == 200
     assert postres.json() == {"message": "Disengaged axes: x, b"}
 
 
 def test_disengage_axes_case_insensitive(api_client,
-                                         hardware_with_disengage_axes):
+                                         hardware):
 
     postres = api_client.post(
         '/motors/disengage', json={'axes': ['Y', 'A']})
 
-    hardware_with_disengage_axes.disengage_axes.assert_called_once_with(
-        [Axis.Y, Axis.A])
+    hardware.disengage_axes.assert_called_once_with([Axis.Y, Axis.A])
 
     assert postres.status_code == 200
     assert postres.json() == {"message": "Disengaged axes: y, a"}
 
 
-def test_disengage_invalid_axes(api_client, hardware_with_disengage_axes):
+def test_disengage_invalid_axes(api_client, hardware):
     postres = api_client.post(
         '/motors/disengage', json={'axes': ['u']})
 
-    hardware_with_disengage_axes.disengage_axes.assert_not_called()
+    hardware.disengage_axes.assert_not_called()
 
     assert postres.status_code == 422
 
 
-def test_disengage_no_axes(api_client, hardware_with_disengage_axes):
+def test_disengage_no_axes(api_client, hardware):
     postres = api_client.post(
         '/motors/disengage', json={'axes': []})
 
-    hardware_with_disengage_axes.disengage_axes.assert_called_once_with([])
+    hardware.disengage_axes.assert_called_once_with([])
 
     assert postres.status_code == 200
     assert postres.json() == {"message": "Disengaged axes: "}

--- a/robot-server/tests/service/legacy/routers/test_networking.py
+++ b/robot-server/tests/service/legacy/routers/test_networking.py
@@ -1,7 +1,7 @@
 import os
 import random
 import tempfile
-from unittest.mock import patch
+from mock import patch
 
 import pytest
 from opentrons.system import nmcli, wifi
@@ -87,13 +87,8 @@ def test_wifi_configure(api_client):
     msg = "Device 'wlan0' successfully activated with" \
           " '076aa998-0275-4aa0-bf85-e9629021e267'."  # noqa
 
-    async def mock_configure(ssid, eapConfig, securityType=None,
-                             psk=None, hidden=False):
-        # Command: nmcli device wifi connect "{ssid}" password "{psk}"
-        return True, msg
-
     with patch("opentrons.system.nmcli.configure") as m:
-        m.side_effect = mock_configure
+        m.return_value = True, msg
 
         expected = {'ssid': 'Opentrons', 'message': msg}
 

--- a/robot-server/tests/service/legacy/routers/test_pipettes.py
+++ b/robot-server/tests/service/legacy/routers/test_pipettes.py
@@ -52,11 +52,6 @@ def test_get_pipettes_refresh_true(api_client, hardware, attached_pipettes):
     """Test that cache instruments is called when refresh is true"""
     hardware.attached_instruments = attached_pipettes
 
-    async def mock_cache_instruments():
-        pass
-
-    hardware.cache_instruments.side_effect = mock_cache_instruments
-
     resp = api_client.get('/pipettes?refresh=true')
 
     hardware.cache_instruments.assert_called_once()

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -393,9 +393,6 @@ def mock_is_restart_required():
 @pytest.fixture
 def mock_set_adv_setting():
     with patch("robot_server.service.legacy.routers.settings.advanced_settings.set_adv_setting") as p:  # noqa: E501
-        async def f(i, v):
-            pass
-        # p.side_effect = f
         yield p
 
 

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from unittest.mock import patch, call
+from mock import patch, call
 from dataclasses import make_dataclass
 
 from opentrons.config.reset import ResetOptionId
@@ -61,11 +61,8 @@ def test_post_log_level_upstream(
     syslog_level,
     expected_message
 ):
-    async def mock_set_syslog_level(syslog_level):
-        return 0, "stdout", "stderr"
-
     with patch("opentrons.system.log_control.set_syslog_level") as m:
-        m.side_effect = mock_set_syslog_level
+        m.return_value = 0, "stdout", "stderr"
         response = api_client.post(
             "/settings/log_level/upstream", json={"log_level": log_level}
         )
@@ -78,11 +75,8 @@ def test_post_log_level_upstream(
 def test_post_log_level_upstream_fails_reload(api_client):
     log_level = "debug"
 
-    async def mock_set_syslog_level(syslog_level):
-        return 1, "stdout", "stderr"
-
     with patch("opentrons.system.log_control.set_syslog_level") as m:
-        m.side_effect = mock_set_syslog_level
+        m.return_value = 1, "stdout", "stderr"
         response = api_client.post(
             "/settings/log_level/upstream", json={"log_level": log_level}
         )
@@ -316,15 +310,6 @@ def test_reset_invalid_option(api_client, mock_reset):
     # assert 'aksgjajhadjasl' in body['message']
 
 
-@pytest.fixture
-def hardware_log_level(hardware):
-    async def update_config(*args, **kwargs):
-        pass
-
-    hardware.update_config.side_effect = update_config
-    return hardware
-
-
 @pytest.fixture()
 def mock_robot_configs():
     with patch("robot_server.service.legacy.routers."
@@ -345,12 +330,12 @@ def mock_logging_set_level():
                              [{'log_level': 'oafajhshda'}]
                          ])
 def test_set_log_level_invalid(api_client, body,
-                               hardware_log_level, mock_logging_set_level,
+                               hardware, mock_logging_set_level,
                                mock_robot_configs):
     resp = api_client.post('/settings/log_level/local', json=body)
     assert resp.status_code == 422
     mock_logging_set_level.assert_not_called()
-    hardware_log_level.update_config.assert_not_called()
+    hardware.update_config.assert_not_called()
     mock_robot_configs.save_robot_settings.assert_not_called()
 
 
@@ -375,7 +360,7 @@ def test_set_log_level_invalid(api_client, body,
                              [{'log_level': 'ERROR'},
                               logging.ERROR, "ERROR"],
                          ])
-def test_set_log_level(api_client, hardware_log_level,
+def test_set_log_level(api_client, hardware,
                        mock_robot_configs, mock_logging_set_level,
                        body, expected_log_level, expected_log_level_name):
     resp = api_client.post('/settings/log_level/local', json=body)
@@ -384,7 +369,7 @@ def test_set_log_level(api_client, hardware_log_level,
     mock_logging_set_level.assert_has_calls([call(expected_log_level),
                                              call(expected_log_level),
                                              call(expected_log_level)])
-    hardware_log_level.update_config.assert_called_once_with(
+    hardware.update_config.assert_called_once_with(
         log_level=expected_log_level_name)
     mock_robot_configs.save_robot_settings.assert_called_once()
 
@@ -410,7 +395,7 @@ def mock_set_adv_setting():
     with patch("robot_server.service.legacy.routers.settings.advanced_settings.set_adv_setting") as p:  # noqa: E501
         async def f(i, v):
             pass
-        p.side_effect = f
+        # p.side_effect = f
         yield p
 
 

--- a/robot-server/tests/service/protocol/test_analyze.py
+++ b/robot-server/tests/service/protocol/test_analyze.py
@@ -1,6 +1,6 @@
 from json import JSONDecodeError
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from mock import patch, MagicMock
 
 import pytest
 from opentrons.protocols.api_support.types import APIVersion

--- a/robot-server/tests/service/protocol/test_contents.py
+++ b/robot-server/tests/service/protocol/test_contents.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from mock import patch, MagicMock
 
 import pytest
 from fastapi import UploadFile

--- a/robot-server/tests/service/protocol/test_environment.py
+++ b/robot-server/tests/service/protocol/test_environment.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import patch, MagicMock, PropertyMock
+from mock import patch, MagicMock, PropertyMock
 
 import pytest
 

--- a/robot-server/tests/service/protocol/test_manager.py
+++ b/robot-server/tests/service/protocol/test_manager.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from unittest.mock import MagicMock, patch
+from mock import MagicMock, patch
 
 from robot_server.service.protocol import errors
 from robot_server.service.protocol.contents import Contents

--- a/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/live_protocol/test_command_executor.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import MagicMock
+from mock import MagicMock
 from mock import AsyncMock
 import pytest
 from opentrons.protocol_engine import ProtocolEngine

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch, PropertyMock
+from mock import MagicMock, patch, PropertyMock, AsyncMock
 from datetime import datetime
 import pytest
 
@@ -18,16 +18,7 @@ from robot_server.service.session.session_types.protocol.models import \
 
 @pytest.fixture()
 def mock_worker():
-    async def async_mock():
-        pass
-
-    m = MagicMock(spec=_Worker)
-    m.handle_run.side_effect = async_mock
-    m.handle_simulate.side_effect = async_mock
-    m.handle_cancel.side_effect = async_mock
-    m.handle_pause.side_effect = async_mock
-    m.handle_resume.side_effect = async_mock
-    m.close.side_effect = async_mock
+    m = AsyncMock(spec=_Worker)
     return m
 
 

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_protocol_runner.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from mock import MagicMock, patch, PropertyMock
 import pytest
 from opentrons.api import Session
 from opentrons.hardware_control import ThreadedAsyncLock

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_worker.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_worker.py
@@ -1,6 +1,6 @@
 import asyncio
 import typing
-from unittest.mock import MagicMock
+from mock import MagicMock
 import pytest
 
 from robot_server.service.session.session_types.protocol \
@@ -14,16 +14,16 @@ class DelegatingWorkerListener(WorkerListener):
         self._delegate = delegate
 
     async def on_directive(self, directive: 'WorkerDirective'):
-        self._delegate.on_directive(directive)
+        await self._delegate.on_directive(directive)
 
     async def on_ready(self):
-        self._delegate.on_ready()
+        await self._delegate.on_ready()
 
     async def on_error(self, err):
-        self._delegate.on_error()
+        await self._delegate.on_error()
 
     async def on_protocol_event(self, cmd: typing.Any):
-        self._delegate.on_protocol_event(cmd)
+        await self._delegate.on_protocol_event(cmd)
 
 
 @pytest.fixture

--- a/robot-server/tests/service/session/test_router.py
+++ b/robot-server/tests/service/session/test_router.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from mock import MagicMock
 from mock import AsyncMock
 from datetime import datetime
 

--- a/robot-server/tests/service/system/test_router.py
+++ b/robot-server/tests/service/system/test_router.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch
+from mock import patch
 from datetime import datetime, timezone
 from robot_server.system import time, errors
 
@@ -65,10 +65,7 @@ def test_raise_system_exception(api_client,
 
 def test_set_system_time(api_client, mock_system_time,
                          mock_set_system_time, response_links):
-    async def mock_side_effect(*args, **kwargs):
-        return mock_system_time
-
-    mock_set_system_time.side_effect = mock_side_effect
+    mock_set_system_time.return_value = mock_system_time
 
     # Correct request
     response = api_client.put("/system/time",

--- a/robot-server/tests/service/test_logging.py
+++ b/robot-server/tests/service/test_logging.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from mock import patch, MagicMock
 import logging
 import pytest
 from robot_server.service import logging as rs_logging

--- a/robot-server/tests/system/test_time.py
+++ b/robot-server/tests/system/test_time.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from mock import MagicMock, patch
 from datetime import datetime, timezone
 from robot_server.system import time
 from robot_server.system import errors

--- a/robot-server/tests/test_main.py
+++ b/robot-server/tests/test_main.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from mock import patch
 from robot_server.main import run
 from robot_server.service.app import app
 

--- a/robot-server/tests/test_util.py
+++ b/robot-server/tests/test_util.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime
 
 import pytest
-from unittest.mock import patch, MagicMock
+from mock import patch, MagicMock
 
 from robot_server import util
 


### PR DESCRIPTION
# Overview

Many of the tests were written before I knew about `AsyncMock` being backported to 3.7. This PR removes the hoops run through with MagicMock.side_effects to support async methods.

# Changelog

- Make `hardware` fixture an `AsyncMock`.
- Remove unnecessary mocks 

# Review requests



# Risk assessment

None. Tests only.