### PR TITLE
build: add top-level teardown-py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,13 @@ teardown:
 	$(MAKE) -C $(API_DIR) clean teardown
 	shx rm -rf '**/node_modules'
 
+.PHONY: teardown-py
+teardown-py:
+	$(MAKE) -C $(API_DIR) clean teardown
+	$(MAKE) -C $(ROBOT_SERVER_DIR) clean teardown
+	$(MAKE) -C $(NOTIFY_SERVER_DIR) clean teardown
+	$(MAKE) -C $(SHARED_DATA_DIR) clean-py teardown-py
+
 .PHONY: deploy-py
 deploy-py: export twine_repository_url = $(twine_repository_url)
 deploy-py: export pypi_username = $(pypi_username)

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -24,6 +24,8 @@ setup-py:
 	$(MAKE) -C python setup-py
 
 
+
+
 .PHONY: setup
 setup: setup-py setup-js
 
@@ -48,7 +50,9 @@ clean-py:
 clean: clean-py
 	shx rm -rf $(BUILD_DIR)
 
-
+.PHONY: teardown-py
+teardown-py:
+	$(MAKE) -C python teardown
 
 .PHONY: lint-py
 lint-py:

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -54,6 +54,13 @@ setup-py:
 	$(pipenv) sync $(pipenv_opts)
 	$(pipenv) run pip freeze
 
+.PHONY: teardown
+teardown: teardown-py
+
+.PHONY: teardown-py
+teardown-py:
+	$(pipenv) --rm
+
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Bit easier to deal with py dep changes that need full reinstalls.
