### PR TITLE
refactor(app): split Pipettes and Modules tab into two subpages

### DIFF
--- a/app/src/assets/localization/en/top_navigation.json
+++ b/app/src/assets/localization/en/top_navigation.json
@@ -1,3 +1,4 @@
 {
-  "pipettes_and_modules": "pipettes & modules"
+  "pipettes": "pipettes",
+  "modules": "modules"
 }

--- a/app/src/components/ConnectPanel/RobotListItem.js
+++ b/app/src/components/ConnectPanel/RobotListItem.js
@@ -51,13 +51,22 @@ export function RobotListItem(props: RobotListItemProps): React.Node {
         )}
       </RobotLink>
       {isConnectable && isSelected && (
-        <RobotLink
-          url={`/robots/${name}/instruments`}
-          className={styles.instrument_item}
-        >
-          <p className={styles.link_text}>{t('pipettes_and_modules')}</p>
-          <Icon name="chevron-right" className={styles.robot_item_icon} />
-        </RobotLink>
+        <>
+          <RobotLink
+            url={`/robots/${name}/instruments`}
+            className={styles.instrument_item}
+          >
+            <p className={styles.link_text}>{t('pipettes')}</p>
+            <Icon name="chevron-right" className={styles.robot_item_icon} />
+          </RobotLink>
+          <RobotLink
+            url={`/robots/${name}/modules`}
+            className={styles.instrument_item}
+          >
+            <p className={styles.link_text}>{t('modules')}</p>
+            <Icon name="chevron-right" className={styles.robot_item_icon} />
+          </RobotLink>
+        </>
       )}
     </li>
   )

--- a/app/src/components/ConnectPanel/__tests__/RobotListItem.test.js
+++ b/app/src/components/ConnectPanel/__tests__/RobotListItem.test.js
@@ -69,7 +69,7 @@ describe('ConnectPanel RobotListItem', () => {
     let wrapper = render({ isConnectable: true, isSelected: true })
     let link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
 
-    expect(link.find('p').html()).toMatch(/pipettes.+modules/i)
+    expect(link.find('p').html()).toMatch(/pipettes/i)
 
     wrapper = render({ isConnectable: true, isSelected: false })
     link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
@@ -78,6 +78,23 @@ describe('ConnectPanel RobotListItem', () => {
 
     wrapper = render({ isConnectable: false, isSelected: true })
     link = wrapper.find('RobotLink[url="/robots/robot-name/instruments"]')
+
+    expect(link).toHaveLength(0)
+  })
+
+  it('renders a modules link if connectable and selected', () => {
+    let wrapper = render({ isConnectable: true, isSelected: true })
+    let link = wrapper.find('RobotLink[url="/robots/robot-name/modules"]')
+
+    expect(link.find('p').html()).toMatch(/modules/i)
+
+    wrapper = render({ isConnectable: true, isSelected: false })
+    link = wrapper.find('RobotLink[url="/robots/robot-name/modules"]')
+
+    expect(link).toHaveLength(0)
+
+    wrapper = render({ isConnectable: false, isSelected: true })
+    link = wrapper.find('RobotLink[url="/robots/robot-name/modules"]')
 
     expect(link).toHaveLength(0)
   })

--- a/app/src/components/FileInfo/ProtocolModulesCard.js
+++ b/app/src/components/FileInfo/ProtocolModulesCard.js
@@ -151,6 +151,6 @@ function mapStateToProps(state: State, ownProps: OP): SP {
     actualModules,
     modules: robotSelectors.getModules(state),
     // TODO(mc, 2018-10-10): pass this prop down from page
-    attachModulesUrl: `/robots/${robot.name}/instruments`,
+    attachModulesUrl: `/robots/${robot.name}/modules`,
   }
 }

--- a/app/src/components/InstrumentSettings/index.js
+++ b/app/src/components/InstrumentSettings/index.js
@@ -3,7 +3,6 @@
 import * as React from 'react'
 
 import { AttachedPipettesCard } from './AttachedPipettesCard'
-import { AttachedModulesCard } from './AttachedModulesCard'
 import { CardContainer, CardRow } from '../layout'
 
 import type { Mount } from '../../pipettes/types'
@@ -32,9 +31,6 @@ export function InstrumentSettings(props: Props): React.Node {
           makeConfigureUrl={makeConfigurePipetteUrl}
           isChangingOrConfiguringPipette={isChangingOrConfiguringPipette}
         />
-      </CardRow>
-      <CardRow>
-        <AttachedModulesCard robotName={robotName} />
       </CardRow>
     </CardContainer>
   )

--- a/app/src/components/ModuleSettings/AttachedModulesCard.js
+++ b/app/src/components/ModuleSettings/AttachedModulesCard.js
@@ -10,7 +10,7 @@ import {
   getModuleControlsDisabled,
 } from '../../modules'
 import { getConnectedRobotName } from '../../robot/selectors'
-import { ModulesCardContents } from './ModulesCardContents'
+import { ModulesCardContents } from '../InstrumentSettings/ModulesCardContents'
 
 import type { State, Dispatch } from '../../types'
 

--- a/app/src/components/ModuleSettings/index.js
+++ b/app/src/components/ModuleSettings/index.js
@@ -1,0 +1,19 @@
+// @flow
+import * as React from 'react'
+import { AttachedModulesCard } from './AttachedModulesCard'
+
+import { CardContainer, CardRow } from '../layout'
+
+type Props = {| robotName: string |}
+
+export function ModuleSettings(props: Props): React.Node {
+  const { robotName } = props
+
+  return (
+    <CardContainer>
+      <CardRow>
+        <AttachedModulesCard robotName={robotName} />
+      </CardRow>
+    </CardContainer>
+  )
+}

--- a/app/src/pages/Robots/ModuleSettings.js
+++ b/app/src/pages/Robots/ModuleSettings.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react'
+
+import { ModuleSettings as SettingsContent } from '../../components/ModuleSettings'
+import { Page } from '../../components/Page'
+
+export type ModuleSettingsProps = {|
+  robotName: string,
+  robotDisplayName: string,
+|}
+
+export function ModuleSettings(props: ModuleSettingsProps): React.Node {
+  const { robotName, robotDisplayName } = props
+  const titleBarProps = { title: robotDisplayName }
+
+  return (
+    <>
+      <Page titleBarProps={titleBarProps}>
+        <SettingsContent robotName={robotName} />
+      </Page>
+    </>
+  )
+}

--- a/app/src/pages/Robots/index.js
+++ b/app/src/pages/Robots/index.js
@@ -17,10 +17,12 @@ import { Splash } from '@opentrons/components'
 import { Page } from '../../components/Page'
 import { RobotSettings } from './RobotSettings'
 import { InstrumentSettings } from './InstrumentSettings'
+import { ModuleSettings } from './ModuleSettings'
 
 export function Robots(): React.Node {
   const { path, url, params } = useRouteMatch()
   const instrumentsMatch = useRouteMatch(`${path}/instruments`)
+  const modulesMatch = useRouteMatch(`${path}/modules`)
   const location = useLocation()
   const { name } = params
 
@@ -55,6 +57,11 @@ export function Robots(): React.Node {
       url={instrumentsMatch.url}
       path={instrumentsMatch.path}
       pathname={location && location.pathname}
+    />
+  ) : robot.status === CONNECTABLE && modulesMatch ? (
+    <ModuleSettings
+      robotName={robot.name}
+      robotDisplayName={robot.displayName}
     />
   ) : (
     <RobotSettings robot={robot} appUpdate={appUpdate} />


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR separates the Pipettes and Modules settings tab into two independent pages, as the first step of the frontapp refactor for the Multiples of a Module (MoaM) project. See design [here](https://www.figma.com/file/GWe9EvcpyehHSAb4bfEKrK/Multiples-of-a-Module-(MoaM)?node-id=77%3A1289).

closes #7200

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- moved the `AttachedModulesCard` to a new Modules tab

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->


<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Small, mainly just moving some code around
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
