### PR TITLE
feat(protocol-designer): Update Multiselect UI based off feedback

### DIFF
--- a/components/src/styles/borders.js
+++ b/components/src/styles/borders.js
@@ -11,3 +11,6 @@ export const BORDER_STYLE_SOLID = 'solid'
 
 export const BORDER_SOLID_LIGHT = `${BORDER_WIDTH_DEFAULT} ${BORDER_STYLE_SOLID} ${C_LIGHT_GRAY}`
 export const BORDER_SOLID_MEDIUM = `${BORDER_WIDTH_DEFAULT} ${BORDER_STYLE_SOLID} ${C_MED_GRAY}`
+
+export const SHADOW_LIGHT =
+  '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.2)'

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
@@ -94,16 +94,16 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
             key={stepType}
           />
         ))}
+        <Box flex="0 1 auto" marginLeft={SPACING_3}>
+          <SecondaryBtn
+            color={C_SELECTED_DARK}
+            backgroundColor={C_TRANSPARENT}
+            onClick={handleExitBatchEdit}
+          >
+            {i18n.t('application.exit_batch_edit')}
+          </SecondaryBtn>
+        </Box>
       </Flex>
-      <Box flex="0 1 auto">
-        <SecondaryBtn
-          color={C_SELECTED_DARK}
-          backgroundColor={C_TRANSPARENT}
-          onClick={handleExitBatchEdit}
-        >
-          {i18n.t('application.exit_batch_edit')}
-        </SecondaryBtn>
-      </Box>
     </Flex>
   )
 }

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
@@ -16,11 +16,11 @@ import {
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_FLEX_START,
-  JUSTIFY_SPACE_BETWEEN,
   TEXT_TRANSFORM_UPPERCASE,
   SIZE_1,
   SIZE_2,
   SPACING_3,
+  POSITION_STICKY,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
 import { stepIconsByType } from '../../form-types'
@@ -71,7 +71,9 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
       backgroundColor={C_BG_SELECTED}
       padding={SPACING_3}
       color={C_SELECTED_DARK}
-      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      justifyContent={JUSTIFY_FLEX_START}
+      position={POSITION_STICKY}
+      border={`2px solid ${C_SELECTED_DARK}`}
     >
       <Box flex="0 1 auto">
         <Flex alignItems={ALIGN_CENTER}>
@@ -86,7 +88,12 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
           </Text>
         </Flex>
       </Box>
-      <Flex justifyContent={JUSTIFY_FLEX_START} flexWrap="wrap" flex="1">
+      <Flex
+        justifyContent={JUSTIFY_FLEX_START}
+        flexWrap="wrap"
+        flex="1"
+        maxWidth="42.25rem"
+      >
         {stepTypes.map(stepType => (
           <StepPill
             count={countPerType[stepType]}
@@ -94,7 +101,7 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
             key={stepType}
           />
         ))}
-        <Box flex="0 1 auto" marginLeft={SPACING_3}>
+        <Box flex="0 1 auto" marginLeft="auto">
           <SecondaryBtn
             color={C_SELECTED_DARK}
             backgroundColor={C_TRANSPARENT}

--- a/protocol-designer/src/components/lists/TitledStepList.js
+++ b/protocol-designer/src/components/lists/TitledStepList.js
@@ -39,6 +39,8 @@ export type Props = {|
   hovered?: boolean,
   /** show checkbox icons if true */
   isMultiSelectMode?: boolean,
+  /** set to true when Step is the last selected in multi select mode */
+  isLastSelected?: boolean,
 |}
 
 export function TitledStepList(props: Props): React.Node {
@@ -51,6 +53,7 @@ export function TitledStepList(props: Props): React.Node {
     onMouseLeave,
     onContextMenu,
     isMultiSelectMode,
+    isLastSelected,
   } = props
   const collapsible = onCollapseToggle != null
 
@@ -76,6 +79,7 @@ export function TitledStepList(props: Props): React.Node {
 
   const titleBarClass = cx(styles.step_title_bar, {
     [styles.clickable]: props.onClick,
+    [styles.multiselect_title_bar]: props.isMultiSelectMode,
   })
 
   const iconClass = cx(
@@ -96,10 +100,16 @@ export function TitledStepList(props: Props): React.Node {
     >
       <div onClick={onClick} className={titleBarClass}>
         {isMultiSelectMode && (
-          <Icon
-            name={multiSelectIconName}
-            className={styles.icon_multiselect}
-          />
+          <div
+            className={cx(styles.multiselect_wrapper, {
+              [styles.last_selected]: isLastSelected,
+            })}
+          >
+            <Icon
+              name={multiSelectIconName}
+              className={styles.icon_multiselect}
+            />
+          </div>
         )}
         {iconName && (
           <Icon {...iconProps} className={iconClass} name={iconName} />

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -48,8 +48,9 @@
   width: 1.25rem;
 }
 
-.last_selected {
-  background-color: color-mod(var(--c-black) alpha(5%));
+.last_selected svg {
+  background-color: color-mod(var(--c-black) alpha(10%));
+  outline: 2px solid color-mod(var(--c-black) alpha(15%));
 }
 
 .title_bar_carat {

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -10,6 +10,10 @@
   background-color: var(--c-white);
 }
 
+.multiselect_title_bar {
+  padding-left: 0;
+}
+
 .title {
   font-size: var(--fs-body-2);
   font-weight: var(--fw-regular);
@@ -34,10 +38,18 @@
   margin-right: 0.5rem;
 }
 
+.multiselect_wrapper {
+  padding: calc(var(--list-padding-small) - var(--bd-width-default));
+  padding-top: 1rem;
+  align-self: stretch;
+}
+
 .icon_multiselect {
-  margin-right: 0.5rem;
-  margin-bottom: 0.25rem;
   width: 1.25rem;
+}
+
+.last_selected {
+  background-color: color-mod(var(--c-black) alpha(5%));
 }
 
 .title_bar_carat {

--- a/protocol-designer/src/components/lists/styles.css
+++ b/protocol-designer/src/components/lists/styles.css
@@ -68,6 +68,7 @@
   margin: 0.4rem 0.125rem;
   color: var(--c-dark-gray);
   box-shadow: var(--shadow-lvl-1);
+  background-color: var(--c-white);
 }
 
 .pd_titled_list_title {

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
-import { useSelector } from 'react-redux'
 
 import {
   Flex,
@@ -14,9 +13,11 @@ import {
   SIZE_2,
   SPACING_1,
   SPACING_2,
+  C_NEAR_WHITE,
   C_LIGHT_GRAY,
   C_DARK_GRAY,
   BORDER_SOLID_MEDIUM,
+  POSITION_STICKY,
 } from '@opentrons/components'
 import { useConditionalConfirm } from '../../../../../components/src/hooks/useConditionalConfirm'
 import { selectors as stepFormSelectors } from '../../../step-forms'
@@ -165,6 +166,10 @@ export const MultiSelectToolbar = (): React.Node => {
         height={SIZE_2}
         padding={`0 ${SPACING_2}`}
         borderBottom={BORDER_SOLID_MEDIUM}
+        position={POSITION_STICKY}
+        top="0"
+        backgroundColor={C_NEAR_WHITE}
+        zIndex="100"
       >
         <ClickableIcon {...selectProps} />
         <ClickableIcon {...deleteProps} />

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -11,6 +11,7 @@ import {
   SIZE_2,
   SPACING_2,
   C_DARK_GRAY,
+  BORDER_SOLID_MEDIUM,
 } from '@opentrons/components'
 import { useConditionalConfirm } from '../../../../../components/src/hooks/useConditionalConfirm'
 import { selectors as stepFormSelectors } from '../../../step-forms'
@@ -144,7 +145,12 @@ export const MultiSelectToolbar = (): React.Node => {
           onCancelClick={cancel}
         />
       )}
-      <Flex alignItems={ALIGN_CENTER} height={SIZE_2} padding={'0 0.75rem'}>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        height={SIZE_2}
+        padding={'0 0.75rem'}
+        borderBottom={BORDER_SOLID_MEDIUM}
+      >
         <ClickableIcon {...selectProps} />
         <ClickableIcon {...deleteProps} />
         <ClickableIcon {...copyProps} />

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -1,6 +1,9 @@
 // @flow
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { css } from 'styled-components'
+import { useSelector } from 'react-redux'
+
 import {
   Flex,
   Box,
@@ -9,7 +12,9 @@ import {
   Icon,
   ALIGN_CENTER,
   SIZE_2,
+  SPACING_1,
   SPACING_2,
+  C_LIGHT_GRAY,
   C_DARK_GRAY,
   BORDER_SOLID_MEDIUM,
 } from '@opentrons/components'
@@ -37,6 +42,16 @@ type ClickableIconProps = {|
   onClick?: (event: SyntheticMouseEvent<>) => mixed,
 |}
 
+const iconBoxStyles = css`
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background-color: ${C_LIGHT_GRAY};
+  }
+`
+
 export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   const { iconName, onClick, tooltipText, width } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
@@ -44,12 +59,12 @@ export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   })
 
   const boxStyles = {
-    marginRight: props.isLast ? 0 : SPACING_2,
+    padding: SPACING_1,
     marginLeft: props.alignRight ? 'auto' : 0,
   }
 
   return (
-    <Box {...boxStyles} {...targetProps}>
+    <Box {...boxStyles} {...targetProps} css={iconBoxStyles}>
       <Tooltip {...tooltipProps}>{tooltipText}</Tooltip>
       <Box onClick={onClick}>
         <Icon name={iconName} width={width || '1.25rem'} color={C_DARK_GRAY} />
@@ -148,7 +163,7 @@ export const MultiSelectToolbar = (): React.Node => {
       <Flex
         alignItems={ALIGN_CENTER}
         height={SIZE_2}
-        padding={'0 0.75rem'}
+        padding={`0 ${SPACING_2}`}
         borderBottom={BORDER_SOLID_MEDIUM}
       >
         <ClickableIcon {...selectProps} />

--- a/protocol-designer/src/components/steplist/StepItem.js
+++ b/protocol-designer/src/components/steplist/StepItem.js
@@ -45,6 +45,7 @@ export type StepItemProps = {|
   error?: ?boolean,
   warning?: ?boolean,
   selected?: boolean,
+  isLastSelected?: boolean,
   hovered?: boolean,
   isMultiSelectMode?: boolean,
 
@@ -65,6 +66,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
     error,
     warning,
     selected,
+    isLastSelected,
     hovered,
 
     unhighlightStep,
@@ -101,7 +103,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
       onMouseEnter={highlightStep}
       onMouseLeave={unhighlightStep}
       onCollapseToggle={toggleStepCollapsed}
-      {...{ selected, collapsed, hovered, isMultiSelectMode }}
+      {...{ selected, collapsed, hovered, isMultiSelectMode, isLastSelected }}
     >
       {props.children}
     </TitledStepList>

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -190,6 +190,7 @@ export const ConnectedStepItem = (props: Props): React.Node => {
     error: hasError,
     warning: hasWarnings,
     selected,
+    isLastSelected: lastMultiSelectedStepId === stepId,
     // no double-highlighting: whole step is only "hovered" when
     // user is not hovering on substep.
     hovered: hoveredStep === stepId && !hoveredSubstep,


### PR DESCRIPTION
# Overview

Closes #7270 and adds in some additional UI tweaks made for our latest round of user testing that were never merged into edge.

# Changelog

- feat(protocol-designer): Update Multiselect UI based off feedback

# Review requests

http://sandbox.designer.opentrons.com/pd_alt-multiselect-ui/

- [ ] multiselect toolbar is sticky
- [ ] exit batch edit mode button aligns with save button
- [ ] hover states for toolbar icons
- [ ] toolbar functionality is unaffected
- [ ] last selected step has gray square around checkbox


# Risk assessment
Low, mainly style updates