### PR TITLE
chore(api): too many file errors in unit test 

### DIFF
--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -269,7 +269,8 @@ def _load_with_overrides(base) -> Dict[str, str]:
     should_write = False
     overrides = _get_environ_overrides()
     try:
-        index = json.load((base / _CONFIG_FILENAME).open())
+        with (base / _CONFIG_FILENAME).open() as file:
+            index = json.load(file)
     except (OSError, json.JSONDecodeError):
         should_write = True
         index = generate_config_index(overrides)
@@ -338,7 +339,8 @@ def _legacy_index() -> Union[None, Dict[str, str]]:
     for index in _LEGACY_INDICES:
         if index.exists():
             try:
-                return json.load(open(index))
+                with open(index) as file:
+                    return json.load(file)
             except (OSError, json.JSONDecodeError):
                 return None
     return None

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -335,7 +335,8 @@ def save_overrides(pipette_id: str,
             existing[key] = model_config_value
     assert model in config_models
     existing['model'] = model
-    json.dump(existing, (override_dir/f'{pipette_id}.json').open('w'))
+    with (override_dir/f'{pipette_id}.json').open('w') as file:
+        json.dump(existing, file)
 
 
 def change_quirks(override_quirks, existing, model_configs):
@@ -356,9 +357,9 @@ def change_quirks(override_quirks, existing, model_configs):
 
 def load_overrides(pipette_id: str) -> Dict[str, Any]:
     overrides = config.CONFIG['pipette_config_overrides_dir']
-    fi = (overrides/f'{pipette_id}.json').open()
     try:
-        return json.load(fi)
+        with (overrides/f'{pipette_id}.json').open() as fi:
+            return json.load(fi)
     except json.JSONDecodeError as e:
         log.warning(f'pipette override for {pipette_id} is corrupt: {e}')
         (overrides/f'{pipette_id}.json').unlink()

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -309,6 +309,7 @@ HardwareToManage = Union[ThreadManager,
 class HardwareManager:
     def __init__(self, hardware: Optional[HardwareToManage]):
         if hardware is None:
+            # TODO AL 20210209. This is a highly dangerous thread leak.
             self._current = ThreadManager(API.build_hardware_simulator).sync
         elif isinstance(hardware, SynchronousAdapter):
             self._current = hardware
@@ -335,6 +336,7 @@ class HardwareManager:
         return self._current
 
     def reset_hw(self):
+        # TODO AL 20210209. This is a highly dangerous thread leak.
         self._current = ThreadManager(API.build_hardware_simulator).sync
         return self._current
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -192,6 +192,7 @@ def protocol(request):
 
     file.close()
 
+
 @pytest.fixture
 def session_manager(main_router):
     return main_router.session_manager
@@ -271,9 +272,9 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
 
 
 @pytest.fixture
-def ctx(loop) -> ProtocolContext:
+async def ctx(loop, hardware) -> ProtocolContext:
     return ProtocolContext(
-        implementation=ProtocolContextImplementation(),
+        implementation=ProtocolContextImplementation(hardware=hardware),
         loop=loop
     )
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -187,22 +187,10 @@ def protocol(request):
     file = open(filename)
     text = ''.join(list(file))
     file.seek(0)
-    return Protocol(text=text, filename=filename, filelike=file)
 
+    yield Protocol(text=text, filename=filename, filelike=file)
 
-@pytest.fixture(params=["no_clear_tips.py"])
-def tip_clear_protocol(request):
-    try:
-        root = request.getfixturevalue('protocol_file')
-    except Exception:
-        root = request.param
-
-    filename = os.path.join(os.path.dirname(__file__), 'data', root)
-
-    file = open(filename)
-    text = ''.join(list(file))
-    return Protocol(text=text, filename=filename, filelike=file)
-
+    file.close()
 
 @pytest.fixture
 def session_manager(main_router):

--- a/api/tests/opentrons/system/test_wifi.py
+++ b/api/tests/opentrons/system/test_wifi.py
@@ -104,7 +104,8 @@ async def test_list_keys(loop, wifi_keys_tempdir):
     dummy_names = ['ad12d1df199bc912', 'cbdda8124128cf', '812410990c5412']
     for dn in dummy_names:
         os.mkdir(os.path.join(wifi_keys_tempdir, dn))
-        open(os.path.join(wifi_keys_tempdir, dn, 'test.pem'), 'w').write('hi')
+        with open(os.path.join(wifi_keys_tempdir, dn, 'test.pem'), 'w') as file:
+            file.write('hi')
 
     keys = list(wifi.list_keys())
     assert len(keys) == 3


### PR DESCRIPTION
# Overview

It is impossible to run the api unit test on a mac without using `ulimit -n` to increase the default of 256. 

This was a difficult issue to track. While there are many files we don't close, they were not the source of the issue. The issue was `ThreadManager` threads leaking due to how `HardwareManager` creates hardware objects.

This PR only addresses the unit test issue by avoiding having `HardwareManager` create hardware objects. 

I wrote TODOs and created a ticket to clean up `HardwareManager` (#7302). 

The non-unit test impact of this issue is in use of `HardwareManager.set_hw` and `HardwareManager.reset_hw`. Whenever we run or simulate a protocol we provide an existing `ThreadManager` to the `ProtocolContext`.

closes #6487 

# Changelog

- ctx fixture supplies hardware fixture to ProtocolContext
- close files that remain open

# Review requests

- Is my assessment of the risk of leaving the root cause in place correct?


# Risk assessment

Very low