### PR TITLE
feat(protocol-designer): Disable step creation button when in batch edit

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -7,6 +7,7 @@ import {
   PrimaryButton,
   useHoverTooltip,
   TOOLTIP_RIGHT,
+  TOOLTIP_TOP,
   TOOLTIP_FIXED,
 } from '@opentrons/components'
 import {
@@ -15,7 +16,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { i18n } from '../localization'
-import { actions as stepsActions } from '../ui/steps'
+import { actions as stepsActions, getIsMultiSelectMode } from '../ui/steps'
 import {
   selectors as stepFormSelectors,
   getIsModuleOnDeck,
@@ -31,6 +32,7 @@ import styles from './listButtons.css'
 type StepButtonComponentProps = {|
   children: React.Node,
   expanded: boolean,
+  disabled: boolean,
   setExpanded: boolean => mixed,
 |}
 
@@ -45,14 +47,23 @@ const getSupportedSteps = () => [
 ]
 
 const StepCreationButtonComponent = (props: StepButtonComponentProps) => {
-  const { children, expanded, setExpanded } = props
-
+  const { children, expanded, setExpanded, disabled } = props
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_TOP,
+    strategy: TOOLTIP_FIXED,
+  })
   return (
     <div
       className={styles.list_item_button}
       onMouseLeave={() => setExpanded(false)}
+      {...targetProps}
     >
-      <PrimaryButton onClick={() => setExpanded(!expanded)}>
+      {disabled && (
+        <Tooltip {...tooltipProps}>
+          {i18n.t(`tooltip.disabled_step_creation`)}
+        </Tooltip>
+      )}
+      <PrimaryButton onClick={() => setExpanded(!expanded)} disabled={disabled}>
         {i18n.t('button.add_step')}
       </PrimaryButton>
 
@@ -100,6 +111,7 @@ export const StepCreationButton = (): React.Node => {
   const formHasChanges = useSelector(
     stepFormSelectors.getCurrentFormHasUnsavedChanges
   )
+  const isStepCreationDisabled = useSelector(getIsMultiSelectMode)
   const modules = useSelector(stepFormSelectors.getInitialDeckSetup).modules
   const isStepTypeEnabled = {
     moveLiquid: true,
@@ -156,6 +168,7 @@ export const StepCreationButton = (): React.Node => {
       <StepCreationButtonComponent
         expanded={expanded}
         setExpanded={setExpanded}
+        disabled={isStepCreationDisabled}
       >
         {items}
       </StepCreationButtonComponent>

--- a/protocol-designer/src/components/__tests__/StepCreationButton.test.js
+++ b/protocol-designer/src/components/__tests__/StepCreationButton.test.js
@@ -1,0 +1,83 @@
+// @flow
+import React from 'react'
+import { Provider } from 'react-redux'
+import thunk from 'redux-thunk'
+import { mount } from 'enzyme'
+import configureMockStore from 'redux-mock-store'
+import { when, resetAllWhenMocks } from 'jest-when'
+
+import { getIsMultiSelectMode } from '../../ui/steps'
+import * as stepFormSelectors from '../../step-forms/selectors'
+
+import { PrimaryButton } from '@opentrons/components'
+import { StepCreationButton } from '../StepCreationButton'
+
+jest.mock('../../step-forms/selectors')
+jest.mock('../../ui/steps/selectors')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+const getCurrentFormIsPresavedMock = stepFormSelectors.getCurrentFormIsPresaved
+const getCurrentFormHasUnsavedChangesMock =
+  stepFormSelectors.getCurrentFormHasUnsavedChanges
+const getInitialDeckSetupMock = stepFormSelectors.getInitialDeckSetup
+const getIsMultiSelectModeMock = getIsMultiSelectMode
+
+describe('StepCreationButton', () => {
+  let store
+  beforeEach(() => {
+    store = mockStore()
+    when(getCurrentFormIsPresavedMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+
+    when(getCurrentFormHasUnsavedChangesMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+
+    when(getInitialDeckSetupMock)
+      .calledWith(expect.anything())
+      .mockReturnValue({
+        labware: {},
+        pipettes: {},
+        modules: {},
+      })
+
+    when(getIsMultiSelectModeMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    resetAllWhenMocks()
+    jest.resetAllMocks()
+  })
+  const render = () =>
+    mount(
+      <Provider store={store}>
+        <StepCreationButton />
+      </Provider>
+    )
+
+  it('should be ENABLED when in SINGLE select mode', () => {
+    when(getIsMultiSelectModeMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+
+    const wrapper = render()
+    const button = wrapper.find(PrimaryButton)
+    expect(button.prop('disabled')).toBe(false)
+  })
+
+  it('should be DISABLED when in MULTI select mode', () => {
+    when(getIsMultiSelectModeMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(true)
+
+    const wrapper = render()
+    const button = wrapper.find(PrimaryButton)
+    expect(button.prop('disabled')).toBe(true)
+  })
+
+  // TODO (ka 2021-2-10): Add comprehensive tests for StepCreationButton
+})

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -2,6 +2,8 @@
   "not_in_beta": "ⓘ Coming Soon",
   "advanced_settings": "Advanced Settings",
 
+  "disabled_step_creation": "New steps cannot be added in Batch Edit mode.",
+
   "step_description": {
     "mix": "Mix contents of wells/tubes.",
     "pause": "Enable pause within protocol.",


### PR DESCRIPTION
# Overview

closes #7294 by disabling the `StepCreationButton` once a user enters batch edit. It also sneaks in a helpful tooltip when the button is disabled to explain why (copy cleared with Morgan)

# Changelog

- feat(protocol-designer): Disable step creation button when in batch edit

# Review requests

Make/import a protocol and go to design tab
- [ ] [Add Step] button is enabled in single select/edit mode
- [ ] No tooltip for enabled top level button

Enter batch edit by selecting multiple steps
- [ ] [Add Step] button is now disabled
- [ ] [Add Step] button has tooltip explaining "New steps cannot be added in Batch Edit mode."

Exit batch edit
- [ ] [Add Step] button is now enabled, functioning, and no tooltip for top level (unexpanded) button

# Risk assessment

Low, PD only, small refactor