### PR TITLE
chore(ci): use number for timeout minutes

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -26,16 +26,14 @@ on:
       - 'v*'
   workflow_dispatch:
 
-
 defaults:
   run:
     shell: bash
 
-
 jobs:
   lint:
     name: 'opentrons package linting'
-    timeout-minutes: '10'
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'
@@ -53,7 +51,7 @@ jobs:
         run: make -C api lint
   test:
     name: 'opentrons package tests'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     needs: [lint]
     strategy:
       matrix:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -50,7 +50,7 @@ jobs:
     # to run cross-platform
     runs-on: 'ubuntu-latest'
     name: 'opentrons app frontend unit tests'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   js-unit-test:
     name: 'components unit tests'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -32,7 +32,7 @@ jobs:
   checks:
     name: 'js checks'
     runs-on: 'ubuntu-latest'
-    timeout-minutes: '20'
+    timeout-minutes: 20
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -32,7 +32,7 @@ env:
 jobs:
   checks:
     name: 'LL e2e tests'
-    timeout-minutes: '40'
+    timeout-minutes: 40
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   js-unit-test:
     name: 'labware library unit tests'
-    timeout-minutes: '20'
+    timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'
@@ -60,7 +60,7 @@ jobs:
           yarn jest --coverage=true --ci=true labware-library/
   e2e-test:
     name: 'labware library e2e tests on ${{ matrix.os }}'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   lint-test:
     name: 'notify server package linting and tests'
-    timeout-minutes: '20'
+    timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -35,7 +35,7 @@ jobs:
   js-unit-test:
     name: 'protocol designer unit tests'
     runs-on: 'ubuntu-latest'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -60,7 +60,7 @@ jobs:
           yarn jest --coverage=true --ci=true protocol-designer/
   e2e-test:
     name: 'pd e2e tests'
-    timeout-minutes: '30'
+    timeout-minutes: 30
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -35,7 +35,7 @@ defaults:
 jobs:
   lint-test:
     name: 'robot server package linting and tests'
-    timeout-minutes: '20'
+    timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   python-lint:
     name: 'shared-data package python lint'
-    timeout-minutes: '10'
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'
@@ -47,7 +47,7 @@ jobs:
         run: make -C shared-data/python lint
   python-test:
     name: 'shared-data package python tests'
-    timeout-minutes: '20'
+    timeout-minutes: 20
     needs: [python-lint]
     strategy:
       matrix:

--- a/.github/workflows/update-server-lint-test.yaml
+++ b/.github/workflows/update-server-lint-test.yaml
@@ -33,7 +33,7 @@ defaults:
 jobs:
   lint:
     name: 'update server linting'
-    timeout-minutes: '10'
+    timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v2'
@@ -51,7 +51,7 @@ jobs:
         run: make -C update-server lint
   test:
     name: 'update server package tests'
-    timeout-minutes: '10'
+    timeout-minutes: 10
     needs: [lint]
     runs-on: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
# Overview

CI is broken because the value associated with `timeout-minutes` [is not being recognized](https://github.com/Opentrons/opentrons/actions/runs/555121511/workflow). I think it's supposed to be a number, so I've updated the values accordingly.

# Changelog
- Use number for timeout-minutes in gh workflows

# Risk assessment
Low
