### PR TITLE
fix(api): fix mount critical point

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1154,7 +1154,7 @@ class API(HardwareAPILike):
         else:
             # This offset is required because the motor driver coordinate system is
             # configured such that the end of a p300 single gen1's tip is 0.
-            return top_types.Point(0, 0, -30)
+            return top_types.Point(0, 0, 30)
 
     # Gantry/frame (i.e. not pipette) config API
     def get_config(self) -> RobotConfig:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1152,12 +1152,9 @@ class API(HardwareAPILike):
         if pip is not None and cp_override != CriticalPoint.MOUNT:
             return pip.critical_point(cp_override)
         else:
-            # TODO: The smoothie’s z/a home position is calculated to provide
-            # the offset for a P300 single. Here we should decide whether we
-            # implicitly accept this as correct (by returning a null offset)
-            # or not (by returning an offset calculated to move back up the
-            # length of the P300 single).
-            return top_types.Point(0, 0, 0)
+            # This offset is required because the motor driver coordinate system is
+            # configured such that the end of a p300 single gen1's tip is 0.
+            return top_types.Point(0, 0, -30)
 
     # Gantry/frame (i.e. not pipette) config API
     def get_config(self) -> RobotConfig:

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -28,7 +28,7 @@ async def test_home_specific_sim(hardware_api, monkeypatch, is_robot):
     assert hardware_api._current_position == {Axis.X: 0,
                                               Axis.Y: 10,
                                               Axis.Z: 218,
-                                              Axis.A: 20,
+                                              Axis.A: -10,
                                               Axis.B: 19,
                                               Axis.C: 19}
 
@@ -51,7 +51,7 @@ async def test_move(hardware_api, is_robot, toggle_new_calibration):
     target_position1 = {Axis.X: 30,
                         Axis.Y: 20,
                         Axis.Z: 218,
-                        Axis.A: 10,
+                        Axis.A: -20,
                         Axis.B: 19,
                         Axis.C: 19}
     await hardware_api.home()
@@ -104,7 +104,7 @@ async def test_mount_offset_applied(
     mount = types.Mount.LEFT
     target_position = {Axis.X: 64,
                        Axis.Y: 20,
-                       Axis.Z: 10,
+                       Axis.Z: -20,
                        Axis.A: 218,
                        Axis.B: 19,
                        Axis.C: 19}
@@ -139,7 +139,7 @@ async def test_critical_point_applied(hardware_api, monkeypatch, is_robot):
                                critical_point=CriticalPoint.MOUNT)
     assert hardware_api._current_position == {Axis.X: 0.0, Axis.Y: 0.0,
                                               Axis.Z: 218,
-                                              Axis.A: 0,
+                                              Axis.A: -30,
                                               Axis.B: 19, Axis.C: 19}
     assert await hardware_api.current_position(
         types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT)\
@@ -205,7 +205,7 @@ async def test_new_critical_point_applied(
                                critical_point=CriticalPoint.MOUNT)
     assert hardware_api._current_position == {Axis.X: 0.0, Axis.Y: 0.0,
                                               Axis.Z: 218,
-                                              Axis.A: 0,
+                                              Axis.A: -30,
                                               Axis.B: 19, Axis.C: 19}
     assert await hardware_api.current_position(
         types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT)\
@@ -269,12 +269,12 @@ async def test_attitude_deck_cal_applied(
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
     assert called_with['X'] == 0.0
     assert called_with['Y'] == 0.0
-    assert called_with['A'] == 0.0
+    assert called_with['A'] == -30.0
     # Check that mount offset is also applied
     await hardware_api.move_to(types.Mount.LEFT, types.Point(0, 0, 0))
     assert round(called_with['X'], 2) == 34.16
     assert round(called_with['Y'], 2) == 0.04
-    assert round(called_with['Z'], 2) == 0.0
+    assert round(called_with['Z'], 2) == -30.0
 
 
 async def test_other_mount_retracted(
@@ -285,7 +285,7 @@ async def test_other_mount_retracted(
         == types.Point(0, 0, 0)
     await hardware_api.move_to(types.Mount.LEFT, types.Point(20, 20, 0))
     assert await hardware_api.gantry_position(types.Mount.RIGHT) \
-        == types.Point(54, 20, 218)
+        == types.Point(54, 20, 248)
 
 
 async def test_shake_during_pick_up(

--- a/api/tests/opentrons/hardware_control/test_paired_pipettes.py
+++ b/api/tests/opentrons/hardware_control/test_paired_pipettes.py
@@ -31,7 +31,7 @@ async def test_move_z_axis(hardware_api, monkeypatch):
     await hardware_api.home()
     await hardware_api.move_to(mount,
                                types.Point(0, 0, 0))
-    expected = {'X': 0.0, 'Y': 0.0, 'A': 0.0, 'Z': 0.0}
+    expected = {'X': 0.0, 'Y': 0.0, 'A': -30.0, 'Z': -30.0}
     assert mock_be_move.call_args_list[0][0][0] == expected
     mock_be_move.reset_mock()
 
@@ -39,7 +39,7 @@ async def test_move_z_axis(hardware_api, monkeypatch):
     await hardware_api.home()
     await hardware_api.move_to(mount,
                                types.Point(0, 0, 0))
-    expected = {'X': 34.0, 'Y': 0.0, 'A': 0.0, 'Z': 0.0}
+    expected = {'X': 34.0, 'Y': 0.0, 'A': -30.0, 'Z': -30.0}
     assert mock_be_move.call_args_list[0][0][0] == expected
 
 
@@ -48,8 +48,8 @@ async def test_move_gantry(hardware_api, is_robot, toggle_new_calibration):
     mount = PipettePair.PRIMARY_RIGHT
     target_position1 = {Axis.X: 30,
                         Axis.Y: 20,
-                        Axis.Z: 10,
-                        Axis.A: 10,
+                        Axis.Z: -20,
+                        Axis.A: -20,
                         Axis.B: 19,
                         Axis.C: 19}
     await hardware_api.home()
@@ -62,8 +62,8 @@ async def test_move_gantry(hardware_api, is_robot, toggle_new_calibration):
     mount2 = PipettePair.PRIMARY_LEFT
     target_position2 = {Axis.X: 60,
                         Axis.Y: 40,
-                        Axis.Z: 0,
-                        Axis.A: 0,
+                        Axis.Z: -30,
+                        Axis.A: -30,
                         Axis.B: 19,
                         Axis.C: 19}
     await hardware_api.move_rel(mount2, rel_position)


### PR DESCRIPTION
We used to consider the p300 gen 1 to be 0mm long. That means that the
smoothie coordinate system was set so 0 is with the end of such a
pipette touching a deck, and that's what the mount critical point was
set to work with.

We don't do that anymore. That means that _now_, our mount critical
point needs to have a -30mm offset unless we want to change the home
positions on the motor controller, which we very much don't.


Closes #7092 