### PR TITLE
refactor(protocol-designer): prepare Flow Rate field for batch edit mode

### DIFF
--- a/protocol-designer/fixtures/protocol/5/mix_5_2_0.json
+++ b/protocol-designer/fixtures/protocol/5/mix_5_2_0.json
@@ -75,7 +75,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/fixtures/protocol/5/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
+++ b/protocol-designer/fixtures/protocol/5/preFlexGrandfatheredProtocolMigratedFromV1_0_0.json
@@ -1279,7 +1279,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "984e26c0-1811-11e9-9608-8bed9be8868f": {
           "pipette": "01217421-180a-11e9-9608-8bed9be8868f",
@@ -1542,7 +1544,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "07c41640-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "never",
@@ -1590,7 +1594,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "7cd40b20-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "once",
@@ -1613,7 +1619,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "9cafddc0-1812-11e9-9608-8bed9be8868f": {
           "pauseAction": "untilTime",
@@ -1654,6 +1662,7 @@
           "wells": ["A8"],
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": null,
+
           "id": "b301d330-1812-11e9-9608-8bed9be8868f",
           "stepType": "mix",
           "stepName": "M misc settings",
@@ -1662,7 +1671,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "b9afe0a0-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "never",
@@ -1710,7 +1721,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         },
         "d7451ea0-1812-11e9-9608-8bed9be8868f": {
           "changeTip": "once",
@@ -1733,7 +1746,9 @@
           "aspirate_delay_checkbox": false,
           "aspirate_delay_seconds": "1",
           "dispense_delay_checkbox": false,
-          "dispense_delay_seconds": "1"
+          "dispense_delay_seconds": "1",
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null
         }
       },
       "orderedStepIds": [

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
@@ -12,23 +12,23 @@ import { Portal } from '../../../portals/MainPageModalPortal'
 import modalStyles from '../../../modals/modal.css'
 import stepFormStyles from '../../StepEditForm.css'
 import styles from './FlowRateInput.css'
+import type { FieldProps } from '../../types'
 
 const DEFAULT_LABEL = 'Flow Rate'
 const DECIMALS_ALLOWED = 1
 
-type Props = {
-  /** When flow rate is falsey (including 0), it means 'use default' */
+/** When flow rate is falsey (including 0), it means 'use default' */
+export type FlowRateInputProps = {|
+  ...FieldProps,
   defaultFlowRate: ?number,
-  disabled?: boolean,
   formFlowRate: ?number,
   flowRateType: 'aspirate' | 'dispense',
   label: ?string,
   minFlowRate: number,
   maxFlowRate: number,
-  updateValue: (flowRate: ?number) => mixed,
   pipetteDisplayName: ?string,
   className?: string,
-}
+|}
 
 type State = {
   showModal: boolean,
@@ -37,13 +37,13 @@ type State = {
   pristine: boolean,
 }
 
-export class FlowRateInput extends React.Component<Props, State> {
-  constructor(props: Props) {
+export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
+  constructor(props: FlowRateInputProps) {
     super(props)
     this.state = this.getStateFromProps(props)
   }
 
-  getStateFromProps: (props: Props) => State = props => {
+  getStateFromProps: (props: FlowRateInputProps) => State = props => {
     const { formFlowRate } = props
     return {
       showModal: false,

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
@@ -21,7 +21,6 @@ const DECIMALS_ALLOWED = 1
 export type FlowRateInputProps = {|
   ...FieldProps,
   defaultFlowRate: ?number,
-  formFlowRate: ?number,
   flowRateType: 'aspirate' | 'dispense',
   label: ?string,
   minFlowRate: number,
@@ -44,11 +43,11 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
   }
 
   getStateFromProps: (props: FlowRateInputProps) => State = props => {
-    const { formFlowRate } = props
+    const { value } = props
     return {
       showModal: false,
-      modalFlowRate: formFlowRate ? formFlowRate.toString() : null,
-      modalUseDefault: !formFlowRate,
+      modalFlowRate: value ? String(value) : null,
+      modalUseDefault: !value,
       pristine: true,
     }
   }
@@ -97,7 +96,7 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
     const {
       defaultFlowRate,
       disabled,
-      formFlowRate,
+      value,
       flowRateType,
       label,
       minFlowRate,
@@ -196,7 +195,7 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
             disabled={disabled}
             onClick={this.openModal}
             className={this.props.className || stepFormStyles.small_field}
-            value={formFlowRate ? `${formFlowRate}` : 'default'}
+            value={value ? String(value) : 'default'}
           />
         </FormGroup>
 

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
@@ -1,33 +1,35 @@
 // @flow
 import * as React from 'react'
-import { FlowRateInput } from './FlowRateInput'
+import { FlowRateInput, type FlowRateInputProps } from './FlowRateInput'
 import { connect } from 'react-redux'
-import { actions as steplistActions } from '../../../../steplist'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
-import { getDisabledFields } from '../../../../steplist/formLevel'
+import type { FieldProps } from '../../types'
+import type { FormData } from '../../../../form-types'
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
-import type { BaseState, ThunkDispatch } from '../../../../types'
-
-type Props = {|
-  ...$Exact<React.ElementProps<typeof FlowRateInput>>,
-  name: StepFieldName,
-  pipetteFieldName: StepFieldName,
-  innerKey: string,
-|}
+import type { BaseState } from '../../../../types'
 
 type OP = {|
-  name: StepFieldName,
+  ...FieldProps,
   pipetteFieldName: StepFieldName,
-  flowRateType: $PropertyType<Props, 'flowRateType'>,
-  label?: $PropertyType<Props, 'label'>,
-  className?: string,
+  formData: FormData,
+  className?: $PropertyType<FlowRateInputProps, 'className'>,
+  flowRateType: $PropertyType<FlowRateInputProps, 'flowRateType'>,
+  label?: $PropertyType<FlowRateInputProps, 'label'>,
 |}
 
-type DP = {|
-  updateValue: $PropertyType<Props, 'updateValue'>,
+type SP = {|
+  innerKey: string,
+  defaultFlowRate: ?number,
+  formFlowRate: number,
+  minFlowRate: number,
+  maxFlowRate: number,
+  pipetteDisplayName: string,
 |}
 
-type SP = $Rest<Props, {| ...OP, ...DP |}>
+type Props = {|
+  ...FlowRateInputProps,
+  innerKey: string,
+|}
 
 // Add a key to force re-constructing component when values change
 function FlowRateInputWithKey(props: Props) {
@@ -36,9 +38,7 @@ function FlowRateInputWithKey(props: Props) {
 }
 
 function mapStateToProps(state: BaseState, ownProps: OP): SP {
-  const { flowRateType, pipetteFieldName, name } = ownProps
-
-  const formData = stepFormSelectors.getUnsavedForm(state)
+  const { flowRateType, pipetteFieldName, name, formData } = ownProps
 
   const pipetteId = formData ? formData[pipetteFieldName] : null
   const pipette =
@@ -64,7 +64,6 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
   return {
     innerKey,
     defaultFlowRate,
-    disabled: formData ? getDisabledFields(formData).has(name) : false,
     formFlowRate,
     minFlowRate: 0,
     // NOTE: since we only have rule-of-thumb, max is entire volume in 1 second
@@ -73,27 +72,20 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
   }
 }
 
-function mapDispatchToProps(dispatch: ThunkDispatch<*>, ownProps: OP): DP {
-  return {
-    updateValue: (flowRate: ?number) =>
-      dispatch(
-        steplistActions.changeFormInput({
-          update: {
-            [ownProps.name]: flowRate,
-          },
-        })
-      ),
-  }
+const mergeProps = (stateProps: SP, dispatchProps, ownProps: OP): Props => {
+  const { formData, pipetteFieldName, ...passThruProps } = ownProps
+  return { ...stateProps, ...passThruProps }
 }
 
 export const FlowRateField: React.AbstractComponent<OP> = connect<
   Props,
   OP,
   SP,
-  DP,
+  {||},
   _,
   _
 >(
   mapStateToProps,
-  mapDispatchToProps
+  null,
+  mergeProps
 )(FlowRateInputWithKey)

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
@@ -20,7 +20,6 @@ type OP = {|
 type SP = {|
   innerKey: string,
   defaultFlowRate: ?number,
-  formFlowRate: number,
   minFlowRate: number,
   maxFlowRate: number,
   pipetteDisplayName: string,
@@ -56,15 +55,12 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
     }
   }
 
-  const formFlowRate = formData && formData[name]
-
   // force each field to have a new instance created when value is changed
-  const innerKey = `${name}:${formFlowRate || 0}`
+  const innerKey = `${name}:${String(ownProps.value || 0)}`
 
   return {
     innerKey,
     defaultFlowRate,
-    formFlowRate,
     minFlowRate: 0,
     // NOTE: since we only have rule-of-thumb, max is entire volume in 1 second
     maxFlowRate: pipette ? pipette.spec.maxVolume : Infinity,

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -93,9 +93,10 @@ export const MixForm = (props: StepFormProps): React.Node => {
           <div className={styles.section_column}>
             <div className={styles.form_row}>
               <FlowRateField
-                name="aspirate_flowRate"
+                {...propsForFields['aspirate_flowRate']}
                 pipetteFieldName="pipette"
                 flowRateType="aspirate"
+                formData={props.formData}
               />
               <TipPositionField fieldName="mix_mmFromBottom" />
               <WellOrderField
@@ -113,9 +114,10 @@ export const MixForm = (props: StepFormProps): React.Node => {
           <div className={styles.section_column}>
             <div className={styles.form_row}>
               <FlowRateField
-                name="dispense_flowRate"
+                {...propsForFields['dispense_flowRate']}
                 pipetteFieldName="pipette"
                 flowRateType="dispense"
+                formData={props.formData}
               />
             </div>
             <div className={styles.checkbox_column}>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -12,6 +12,7 @@ import {
   DelayFields,
 } from '../../fields'
 
+import type { FormData } from '../../../../form-types'
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { FieldPropsByName } from '../../types'
 
@@ -21,6 +22,7 @@ type Props = {|
   className?: ?string,
   prefix: 'aspirate' | 'dispense',
   propsForFields: FieldPropsByName,
+  formData: FormData,
 |}
 
 const makeAddFieldNamePrefix = (prefix: string) => (
@@ -67,7 +69,8 @@ export const SourceDestFields = (props: Props): React.Node => {
     <div className={className}>
       <div className={styles.form_row}>
         <FlowRateField
-          name={addFieldNamePrefix('flowRate')}
+          {...propsForFields[addFieldNamePrefix('flowRate')]}
+          formData={props.formData}
           pipetteFieldName="pipette"
           flowRateType={prefix}
         />

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
@@ -64,11 +64,13 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
           className={cx(styles.section_wrapper, styles.advanced_settings_panel)}
         >
           <SourceDestFields
+            formData={props.formData}
             className={styles.section_column}
             prefix="aspirate"
             propsForFields={propsForFields}
           />
           <SourceDestFields
+            formData={props.formData}
             className={styles.section_column}
             prefix="dispense"
             propsForFields={propsForFields}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -38,6 +38,7 @@ describe('SourceDestFields', () => {
   let props
   beforeEach(() => {
     props = {
+      formData: ({}: any),
       propsForFields: {
         aspirate_delay_checkbox: {
           onFieldFocus: (jest.fn(): any),

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.js
@@ -206,6 +206,8 @@ describe('createPresavedStepForm', () => {
         mix_touchTip_checkbox: false,
         times: null,
         volume: undefined,
+        aspirate_flowRate: null,
+        dispense_flowRate: null,
       })
     })
   })

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.js
@@ -27,6 +27,8 @@ export function getDefaultsForStepType(
         pipette: null,
         volume: undefined,
         wells: [],
+        aspirate_flowRate: null,
+        dispense_flowRate: null,
         aspirate_delay_checkbox: false,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_checkbox: false,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.js
@@ -57,12 +57,22 @@ describe('well selection should update', () => {
 
   it('pipette cleared', () => {
     const patch = { pipette: null }
-    expect(handleFormHelper(patch, form)).toEqual({ ...patch, wells: [] })
+    expect(handleFormHelper(patch, form)).toEqual({
+      ...patch,
+      wells: [],
+      aspirate_flowRate: null,
+      dispense_flowRate: null,
+    })
   })
 
   it('pipette single -> multi', () => {
     const patch = { pipette: 'pipetteMultiId' }
-    expect(handleFormHelper(patch, form)).toEqual({ ...patch, wells: [] })
+    expect(handleFormHelper(patch, form)).toEqual({
+      ...patch,
+      wells: [],
+      aspirate_flowRate: null,
+      dispense_flowRate: null,
+    })
   })
 
   it('pipette multi -> single', () => {
@@ -75,6 +85,8 @@ describe('well selection should update', () => {
     expect(handleFormHelper(patch, multiChForm)).toEqual({
       ...patch,
       wells: ['A10', 'B10', 'C10', 'D10', 'E10', 'F10', 'G10', 'H10'],
+      aspirate_flowRate: null,
+      dispense_flowRate: null,
     })
   })
 

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.js
@@ -85,6 +85,8 @@ describe('getDefaultsForStepType', () => {
         volume: undefined,
         times: null,
         wells: [],
+        aspirate_flowRate: null,
+        dispense_flowRate: null,
       })
     })
   })


### PR DESCRIPTION
# Overview

Closes #7206 though the implementation is different since now we have the `FieldProps` interface and we have `formData` available in the form.

Addresses part of #7301

# Changelog

Remove all dependencies from Flow Rate field that are bound to single-edit mode. The component is "smart" enough to get the pipette spec it needs, but without `getUnsavedForm` or dispatching `'CHANGE_FORM_INPUT'` on its own. Instead, it relies on getting the form data and the updateValue handler passed down into it.

# Review requests

- [ ] Code review. Are there any remaining dependencies on single-edit mode?
- [ ] The flow rate fields in Transfer and Mix forms should work the same: min/max should match pipette (though min is always 0.1), validation should work the same, saving the modal should update the form field. Compare to prod side-by-side.
- [ ] Once again, discovered some missing fields in the mix form `getDefaultsForStepType` :grimacing:. This SHOULD change a buggy behavior where changing the pipette in the mix form may not have reset the flow rates. This should not (AFAIK... and please think this through) cause any kind of problems where importing protocols would change the flow rates.

# Risk assessment

Medium, messing with Flow Rate field
Medium-high, adding missing fields to getDefaultsForStepType