### PR TITLE
fix(api, robot-server): fix a comical cascade of pipette config bugs

### DIFF
--- a/robot-server/robot_server/service/legacy/models/settings.py
+++ b/robot-server/robot_server/service/legacy/models/settings.py
@@ -213,7 +213,7 @@ class PipetteSettingsUpdate(BaseModel):
                 pass
             elif key in MUTABLE_CONFIGS:
                 if value.value is not None:
-                    # Make sure it's a float for
+                    # Must be a float for overriding a config field
                     value.value = float(value.value)
             elif key in VALID_QUIRKS:
                 if not isinstance(value.value, bool):

--- a/robot-server/robot_server/service/legacy/models/settings.py
+++ b/robot-server/robot_server/service/legacy/models/settings.py
@@ -217,7 +217,8 @@ class PipetteSettingsUpdate(BaseModel):
                     value.value = float(value.value)
             elif key in VALID_QUIRKS:
                 if not isinstance(value.value, bool):
-                    raise ValueError(f"{key} quirk value must be a boolean. Got {value.value}")
+                    raise ValueError(f"{key} quirk value must "
+                                     f"be a boolean. Got {value.value}")
             else:
                 raise ValueError(f"{key} is not a valid field or quirk name")
         return v

--- a/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_pipettes.tavern.yaml
@@ -79,7 +79,7 @@ stages:
       json:
         fields:
           dropTip:
-            value: -3.0
+            value: 1.0
     response:
       status_code: 200
       json: 
@@ -92,7 +92,7 @@ stages:
             min: -6.0
             max: 2.0
             default: -2.0
-            value: -3.0
+            value: 1.0
           dropTipCurrent: !anydict
           dropTipSpeed: !anydict
           pickUpCurrent: !anydict

--- a/robot-server/tests/service/legacy/models/test_settings.py
+++ b/robot-server/tests/service/legacy/models/test_settings.py
@@ -1,0 +1,64 @@
+import pytest
+
+from robot_server.service.legacy.models import settings
+
+
+@pytest.fixture(scope="session", params=[
+    "top",
+    "bottom",
+    "blowout",
+    "dropTip",
+    "pickUpCurrent",
+    "pickUpDistance",
+    "pickUpIncrement",
+    "pickUpPresses",
+    "pickUpSpeed",
+    "plungerCurrent",
+    "dropTipCurrent",
+    "dropTipSpeed",
+    "tipLength",
+    "quirks"
+])
+def mutable_config(request) -> str:
+    return request.param
+
+
+@pytest.fixture(scope="session", params=[
+    "pickupTipShake",
+    "dropTipShake",
+    "doubleDropTip",
+    "needsUnstick"
+])
+def valid_quirk(request) -> str:
+    return request.param
+
+
+def test_pipette_settings_update_fields_pass(mutable_config: str):
+    """Should make mutable config bool like values into a float."""
+    s = settings.PipetteSettingsUpdate(fields={mutable_config: {'value': 1.0}})
+    assert s.setting_fields[mutable_config].value == 1.0
+    assert isinstance(s.setting_fields[mutable_config].value, float)
+
+
+def test_pipette_settings_update_quirks_only_bool(valid_quirk: str):
+    """Should reject non-boolean quirk values."""
+    with pytest.raises(ValueError):
+        settings.PipetteSettingsUpdate(fields={valid_quirk: {'value': 1.3}})
+
+
+def test_pipette_settings_update_quirks_pass(valid_quirk: str):
+    """Should accept quirk bool."""
+    s = settings.PipetteSettingsUpdate(fields={valid_quirk: {'value': True}})
+    assert s.setting_fields[valid_quirk].value is True
+
+
+def test_pipette_settings_update_none(mutable_config: str):
+    """Should accept none values."""
+    s = settings.PipetteSettingsUpdate(fields={mutable_config: None})
+    assert s.setting_fields[mutable_config] is None
+
+
+def test_pipette_settings_update_none_value(mutable_config: str):
+    """Should accept none values."""
+    s = settings.PipetteSettingsUpdate(fields={mutable_config: {'value': None}})
+    assert s.setting_fields[mutable_config].value is None

--- a/robot-server/tests/service/legacy/models/test_settings.py
+++ b/robot-server/tests/service/legacy/models/test_settings.py
@@ -60,5 +60,6 @@ def test_pipette_settings_update_none(mutable_config: str):
 
 def test_pipette_settings_update_none_value(mutable_config: str):
     """Should accept none values."""
-    s = settings.PipetteSettingsUpdate(fields={mutable_config: {'value': None}})
+    s = settings.PipetteSettingsUpdate(
+        fields={mutable_config: {'value': None}})
     assert s.setting_fields[mutable_config].value is None

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -186,9 +186,9 @@ def test_modify_pipette_settings_call_override(api_client,
     changes = {
         'fields': {
             'pickUpCurrent': {'value': 1},
-            'otherField': {'value': True},
-            'noneField': {'value': None},
-            'otherNoneField': None
+            'dropTipShake': {'value': True},
+            'pickUpSpeed': {'value': None},
+            'pickUpDistance': None
         }
     }
 
@@ -197,8 +197,8 @@ def test_modify_pipette_settings_call_override(api_client,
         f'/settings/pipettes/{pipette_id}',
         json=changes)
     mock_pipette_config.override.assert_called_once_with(
-        fields={'pickUpCurrent': 1, 'otherField': True,
-                'noneField': None, 'otherNoneField': None},
+        fields={'pickUpCurrent': 1, 'dropTipShake': True,
+                'pickUpSpeed': None, 'pickUpDistance': None},
         pipette_id=pipette_id)
     patch_body = resp.json()
     assert resp.status_code == 200
@@ -235,9 +235,10 @@ def test_modify_pipette_settings_failure(api_client, mock_pipette_config):
 
     resp = api_client.patch(
         f'/settings/pipettes/{test_id}',
-        json={'fields': {'a': {'value': 1}}})
-    mock_pipette_config.override.assert_called_once_with(pipette_id=test_id,
-                                                         fields={'a': 1})
+        json={'fields': {'pickUpCurrent': {'value': 1}}})
+    mock_pipette_config.override.assert_called_once_with(
+        pipette_id=test_id,
+        fields={'pickUpCurrent': 1})
     patch_body = resp.json()
     assert resp.status_code == 412
     assert patch_body == {'message': "Failed!"}


### PR DESCRIPTION
# Overview

First bug: 
In the robot server, our validation of PATCH `/settings/pipettes/{pipette_id}` payload would coerce `1.0` to `True`.

Second bug:
When pipette config module receives an override value that is of type `boolean` it assigns it as a quirk. Regardless of whether it is a valid quirk.

Third bug:
The run app's treatment of quirks is odd. It seems to treat them as overrides of config fields. (i didn't address run app issues in this PR).

closes #7305 

# Changelog

- in robot-server: custom validator of PATCH `/settings/pipettes/{pipette_id}` to ensure that quirks get bools and other fields get floats.
- in api: do not assume that booleans are quirks. check that they have valid names.
- in api: do not report mis-categorized quirks. these inhibits the robot-server from giving bad quirks to the runapp leading to UI weirdness.

# Review requests

pipette_config is a complicated module and I think it deserves some reworking. I think it's more complex than it needs to be. Opinions? Did my fixes just make things worse?

The reproduction steps in #7305 are very clear. I reproduced it with the robot-server running on my mac.

# Risk assessment

Medium.
