### PR TITLE
feat(api): upload using fast sim if feature flag enables feature

### DIFF
--- a/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/instrument_context.py
@@ -13,7 +13,7 @@ from opentrons.protocols.implementations.interfaces.protocol_context import \
 from opentrons.protocols.implementations.well import WellImplementation
 
 
-class SimInstrumentContext(InstrumentContextInterface):
+class InstrumentContextSimulation(InstrumentContextInterface):
     """A simulation of an instrument context."""
 
     def __init__(self,

--- a/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
+++ b/api/src/opentrons/protocols/implementations/simulators/protocol_context.py
@@ -4,10 +4,10 @@ from opentrons.protocols.implementations.interfaces.instrument_context import \
 from opentrons.protocols.implementations.protocol_context import \
     ProtocolContextImplementation
 from opentrons.protocols.implementations.simulators.instrument_context import \
-    SimInstrumentContext
+    InstrumentContextSimulation
 
 
-class SimProtocolContext(ProtocolContextImplementation):
+class ProtocolContextSimulation(ProtocolContextImplementation):
     def load_instrument(self,
                         instrument_name: str,
                         mount: types.Mount,
@@ -26,7 +26,7 @@ class SimProtocolContext(ProtocolContextImplementation):
         attached[mount] = instrument_name
         self._hw_manager.hardware.cache_instruments(attached)
 
-        new_instr = SimInstrumentContext(
+        new_instr = InstrumentContextSimulation(
             protocol_interface=self,
             pipette_dict=self._hw_manager.hardware.get_attached_instruments()[
                 mount

--- a/robot-server/robot_server/service/protocol/analyze.py
+++ b/robot-server/robot_server/service/protocol/analyze.py
@@ -7,7 +7,7 @@ from opentrons.protocol_api import ProtocolContext
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
 from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.implementations.simulators.protocol_context import \
-    SimProtocolContext
+    ProtocolContextSimulation
 from opentrons.protocols.parse import parse
 from opentrons.protocols.types import Protocol
 
@@ -164,7 +164,7 @@ def _simulate_protocol(protocol: Protocol) -> ProtocolContext:
     """
     try:
         ctx = ProtocolContext.build_using(
-            implementation=SimProtocolContext.build_using(protocol),
+            implementation=ProtocolContextSimulation.build_using(protocol),
             protocol=protocol,
         )
         run_protocol(protocol, context=ctx)


### PR DESCRIPTION
# Overview

Brings fast simulation to production behind a feature flag. Users can enable the feature flag to perform a faster yet not as thorough simulation.

closes #7286 

# Changelog

- `enableFastProtocolUpload` is inspected in `Session._simulate`. If `True` we use a `ProtocolContextSimulation` class instead of `ProtocolContextImplementation`.
- Renamed some classes.

# Review requests


# Risk assessment

None. This is behind a feature flag.