### PR TITLE
refactor(protocol-designer): remove TipPositionField's single-edit mode dependencies

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
@@ -10,13 +10,15 @@ import type {
   DelayCheckboxFields,
   DelaySecondFields,
   TipOffsetFields,
+  FormData,
 } from '../../../form-types'
 
 export type DelayFieldProps = {|
   checkboxFieldName: DelayCheckboxFields,
+  formData: FormData,
+  propsForFields: FieldPropsByName,
   secondsFieldName: DelaySecondFields,
   tipPositionFieldName?: TipOffsetFields,
-  propsForFields: FieldPropsByName,
 |}
 
 export const DelayFields = (props: DelayFieldProps): React.Node => {
@@ -25,6 +27,7 @@ export const DelayFields = (props: DelayFieldProps): React.Node => {
     secondsFieldName,
     tipPositionFieldName,
     propsForFields,
+    formData,
   } = props
 
   return (
@@ -42,7 +45,10 @@ export const DelayFields = (props: DelayFieldProps): React.Node => {
         units={i18n.t('application.units.seconds')}
       />
       {tipPositionFieldName && (
-        <TipPositionField fieldName={tipPositionFieldName} />
+        <TipPositionField
+          {...propsForFields[tipPositionFieldName]}
+          formData={formData}
+        />
       )}
     </CheckboxRowField>
   )

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.js
@@ -6,19 +6,16 @@ import {
   DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP,
 } from '../../../../constants'
 
-import {
-  getIsTouchTipField,
-  type TipOffsetFields,
-} from '../../../../form-types'
+import { getIsTouchTipField, type StepFieldName } from '../../../../form-types'
 
 // TODO: Ian + Brian 2019-02-13 this should switch on stepType, not use field
 // name to infer step type!
 export function getDefaultMmFromBottom(args: {
-  fieldName: TipOffsetFields,
+  name: StepFieldName,
   wellDepthMm: number,
 }): number {
-  const { fieldName, wellDepthMm } = args
-  switch (fieldName) {
+  const { name, wellDepthMm } = args
+  switch (name) {
     case 'aspirate_mmFromBottom':
       return DEFAULT_MM_FROM_BOTTOM_ASPIRATE
     case 'aspirate_delay_mmFromBottom':
@@ -33,8 +30,8 @@ export function getDefaultMmFromBottom(args: {
     default:
       // touch tip fields
       assert(
-        getIsTouchTipField(fieldName),
-        `getDefaultMmFromBottom fn does not know what to do with field ${fieldName}`
+        getIsTouchTipField(name),
+        `getDefaultMmFromBottom fn does not know what to do with field ${name}`
       )
       return DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP + wellDepthMm
   }

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
@@ -1,4 +1,5 @@
 // @flow
+import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
@@ -15,11 +16,43 @@ jest.mock('../../../../step-forms/selectors')
 const getUnsavedFormMock: JestMockFn<[BaseState], ?FormData> =
   stepFormSelectors.getUnsavedForm
 
+const getLabwareEntitiesMock: JestMockFn<[BaseState], any> =
+  stepFormSelectors.getLabwareEntities
+
 const mockStore = {
   dispatch: jest.fn(),
   subscribe: jest.fn(),
   getState: () => ({}),
 }
+
+beforeEach(() => {
+  getUnsavedFormMock.mockReturnValue({
+    id: 'stepId',
+    stepType: 'moveLiquid',
+  })
+
+  getLabwareEntitiesMock.mockReturnValue({
+    labware123asp: {
+      id: 'labware123asp',
+      labwareDefURI: fixture_96_plate.labwareDefURI,
+      def: fixture_96_plate,
+    },
+    labware123disp: {
+      id: 'labware123disp',
+      labwareDefURI: fixture_96_plate.labwareDefURI,
+      def: fixture_96_plate,
+    },
+    labware123: {
+      id: 'labware123',
+      labwareDefURI: fixture_96_plate.labwareDefURI,
+      def: fixture_96_plate,
+    },
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
 
 describe('DelayFields', () => {
   const render = (_props: DelayFieldProps) =>
@@ -34,6 +67,12 @@ describe('DelayFields', () => {
       props = {
         checkboxFieldName: 'aspirate_delay_checkbox',
         secondsFieldName: 'aspirate_delay_seconds',
+        formData: ({
+          stepType: 'moveLiquid',
+          aspirate_labware: 'labware123asp',
+          dispense_labware: 'labware123disp',
+          labware: 'labware123',
+        }: any),
         propsForFields: {
           aspirate_delay_checkbox: {
             onFieldFocus: (jest.fn(): any),
@@ -62,13 +101,26 @@ describe('DelayFields', () => {
             updateValue: (jest.fn(): any),
             value: true,
           },
+          aspirate_mmFromBottom: {
+            onFieldFocus: (jest.fn(): any),
+            onFieldBlur: (jest.fn(): any),
+            errorToShow: null,
+            disabled: false,
+            name: 'aspirate_mmFromBottom',
+            updateValue: (jest.fn(): any),
+            value: true,
+          },
+          aspirate_delay_mmFromBottom: {
+            onFieldFocus: (jest.fn(): any),
+            onFieldBlur: (jest.fn(): any),
+            errorToShow: null,
+            disabled: false,
+            name: 'aspirate_delay_mmFromBottom',
+            updateValue: (jest.fn(): any),
+            value: true,
+          },
         },
       }
-
-      getUnsavedFormMock.mockReturnValue({
-        id: 'stepId',
-        stepType: 'pause',
-      })
     })
 
     it('should render an aspirate delay field with a tip position field', () => {
@@ -92,7 +144,7 @@ describe('DelayFields', () => {
 
       const tipPosField = wrapper.find(TipPositionField)
       expect(tipPosField.is(TipPositionField)).toBe(true)
-      expect(tipPosField.prop('fieldName')).toBe(props.tipPositionFieldName)
+      expect(tipPosField.prop('name')).toBe(props.tipPositionFieldName)
     })
     it('should render an aspirate delay field WITHOUT a tip position field', () => {
       const wrapper = render(props)
@@ -118,6 +170,7 @@ describe('DelayFields', () => {
       props = {
         checkboxFieldName: 'dispense_delay_checkbox',
         secondsFieldName: 'dispense_delay_seconds',
+        formData: ({}: any),
         propsForFields: {
           dispense_delay_checkbox: {
             onFieldFocus: (jest.fn(): any),
@@ -146,18 +199,30 @@ describe('DelayFields', () => {
             updateValue: (jest.fn(): any),
             value: true,
           },
+          dispense_mmFromBottom: {
+            onFieldFocus: (jest.fn(): any),
+            onFieldBlur: (jest.fn(): any),
+            errorToShow: null,
+            disabled: false,
+            name: 'dispense_mmFromBottom',
+            updateValue: (jest.fn(): any),
+            value: true,
+          },
+          dispense_delay_mmFromBottom: {
+            onFieldFocus: (jest.fn(): any),
+            onFieldBlur: (jest.fn(): any),
+            errorToShow: null,
+            disabled: false,
+            name: 'dispense_delay_mmFromBottom',
+            updateValue: (jest.fn(): any),
+            value: true,
+          },
         },
       }
-
-      getUnsavedFormMock.mockReturnValue({
-        id: 'stepId',
-        stepType: 'pause',
-      })
     })
 
-    it('should render an dispense delay field with a tip position field', () => {
+    it('should render a dispense delay field with a tip position field', () => {
       props = { ...props, tipPositionFieldName: 'dispense_delay_mmFromBottom' }
-
       const wrapper = render(props)
 
       const checkboxField = wrapper.find(CheckboxRowField)
@@ -173,7 +238,7 @@ describe('DelayFields', () => {
 
       const tipPosField = wrapper.find(TipPositionField)
       expect(tipPosField.is(TipPositionField)).toBe(true)
-      expect(tipPosField.prop('fieldName')).toBe(props.tipPositionFieldName)
+      expect(tipPosField.prop('name')).toBe(props.tipPositionFieldName)
     })
 
     it('should render an dispense delay field WITHOUT a tip position field', () => {

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -26,7 +26,7 @@ import styles from '../StepEditForm.css'
 export const MixForm = (props: StepFormProps): React.Node => {
   const [collapsed, setCollapsed] = React.useState(true)
 
-  const { propsForFields } = props
+  const { propsForFields, formData } = props
 
   const toggleCollapsed = (): void =>
     setCollapsed(prevCollapsed => !prevCollapsed)
@@ -97,7 +97,10 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 pipetteFieldName="pipette"
                 flowRateType="aspirate"
               />
-              <TipPositionField fieldName="mix_mmFromBottom" />
+              <TipPositionField
+                {...propsForFields['mix_mmFromBottom']}
+                formData={formData}
+              />
               <WellOrderField
                 prefix="mix"
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
@@ -107,6 +110,7 @@ export const MixForm = (props: StepFormProps): React.Node => {
               checkboxFieldName={'aspirate_delay_checkbox'}
               secondsFieldName={'aspirate_delay_seconds'}
               propsForFields={propsForFields}
+              formData={formData}
             />
           </div>
 
@@ -123,6 +127,7 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 checkboxFieldName={'dispense_delay_checkbox'}
                 secondsFieldName={'dispense_delay_seconds'}
                 propsForFields={propsForFields}
+                formData={formData}
               />
               <CheckboxRowField
                 {...propsForFields['mix_touchTip_checkbox']}
@@ -132,7 +137,10 @@ export const MixForm = (props: StepFormProps): React.Node => {
                   'tooltip.step_fields.defaults.mix_touchTip_checkbox'
                 )}
               >
-                <TipPositionField fieldName={'mix_touchTip_mmFromBottom'} />
+                <TipPositionField
+                  {...propsForFields['mix_touchTip_mmFromBottom']}
+                  formData={formData}
+                />
               </CheckboxRowField>
 
               <CheckboxRowField

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -14,11 +14,12 @@ import {
 
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { FieldPropsByName } from '../../types'
-
+import type { FormData } from '../../../../form-types'
 import styles from '../../StepEditForm.css'
 
 type Props = {|
   className?: ?string,
+  formData: FormData,
   prefix: 'aspirate' | 'dispense',
   propsForFields: FieldPropsByName,
 |}
@@ -28,7 +29,7 @@ const makeAddFieldNamePrefix = (prefix: string) => (
 ): StepFieldName => `${prefix}_${fieldName}`
 
 export const SourceDestFields = (props: Props): React.Node => {
-  const { className, prefix, propsForFields } = props
+  const { className, formData, prefix, propsForFields } = props
 
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
 
@@ -60,6 +61,7 @@ export const SourceDestFields = (props: Props): React.Node => {
       secondsFieldName={addFieldNamePrefix('delay_seconds')}
       tipPositionFieldName={addFieldNamePrefix('delay_mmFromBottom')}
       propsForFields={propsForFields}
+      formData={formData}
     />
   )
 
@@ -71,7 +73,10 @@ export const SourceDestFields = (props: Props): React.Node => {
           pipetteFieldName="pipette"
           flowRateType={prefix}
         />
-        <TipPositionField fieldName={addFieldNamePrefix('mmFromBottom')} />
+        <TipPositionField
+          {...propsForFields[addFieldNamePrefix('mmFromBottom')]}
+          formData={formData}
+        />
         <WellOrderField
           prefix={prefix}
           label={i18n.t('form.step_edit_form.field.well_order.label')}
@@ -108,7 +113,8 @@ export const SourceDestFields = (props: Props): React.Node => {
           className={styles.small_field}
         >
           <TipPositionField
-            fieldName={addFieldNamePrefix('touchTip_mmFromBottom')}
+            {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}
+            formData={formData}
           />
         </CheckboxRowField>
 

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
@@ -22,7 +22,7 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
 
   const toggleCollapsed = () => _setCollapsed(!collapsed)
 
-  const { propsForFields } = props
+  const { propsForFields, formData } = props
   const { stepType, path } = props.formData
 
   return (
@@ -67,11 +67,13 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
             className={styles.section_column}
             prefix="aspirate"
             propsForFields={propsForFields}
+            formData={formData}
           />
           <SourceDestFields
             className={styles.section_column}
             prefix="dispense"
             propsForFields={propsForFields}
+            formData={formData}
           />
         </div>
       )}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -38,6 +38,7 @@ describe('SourceDestFields', () => {
   let props
   beforeEach(() => {
     props = {
+      formData: ({}: any),
       propsForFields: {
         aspirate_delay_checkbox: {
           onFieldFocus: (jest.fn(): any),

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -345,7 +345,7 @@ export type DelaySecondFields =
   | 'aspirate_delay_seconds'
   | 'dispense_delay_seconds'
 
-export function getIsTouchTipField(fieldName: string): boolean {
+export function getIsTouchTipField(fieldName: StepFieldName): boolean {
   const touchTipFields = [
     'aspirate_touchTip_mmFromBottom',
     'dispense_touchTip_mmFromBottom',


### PR DESCRIPTION
# Overview

Closes #7227 to prepare TipPositionField for use in batch edit Transfer form

# Changelog

- Refactor TipPositionField so that it takes `FieldProps` instead of using its own selectors/actions tied to single-edit mode

# Review requests

- [ ] TipPositionField functions normally in all existing forms (no user-facing changes)
- [ ] Code looks good, tests look good

# Risk assessment

Med-high, refactor of TipPositionField