### PR TITLE
fix(app): do not resume when clicking "back" from confirm cancel modal

### DIFF
--- a/app/src/components/RunLog/ConfirmCancelModal.js
+++ b/app/src/components/RunLog/ConfirmCancelModal.js
@@ -1,41 +1,46 @@
 // @flow
 import * as React from 'react'
 import { useDispatch } from 'react-redux'
-import { push } from 'connected-react-router'
 import { AlertModal } from '@opentrons/components'
 
-import type { Dispatch } from '../../redux/types'
 import { actions as robotActions } from '../../redux/robot'
+import { Portal } from '../portal'
+
+import type { Dispatch } from '../../redux/types'
 
 const HEADING = 'Are you sure you want to cancel this run?'
 const CANCEL_TEXT = 'cancel run'
 const BACK_TEXT = 'go back'
 
-export function ConfirmCancelModal(): React.Node {
+export type ConfirmCancelModalProps = {|
+  onClose: () => mixed,
+|}
+
+export function ConfirmCancelModal(props: ConfirmCancelModalProps): React.Node {
+  const { onClose } = props
   const dispatch = useDispatch<Dispatch>()
-  const back = () => {
-    dispatch(robotActions.resume())
-    dispatch(push('/run'))
-  }
+
   const cancel = () => {
     dispatch(robotActions.cancel())
-    dispatch(push('/run'))
+    onClose()
   }
 
   return (
-    <AlertModal
-      heading={HEADING}
-      buttons={[
-        { children: BACK_TEXT, onClick: back },
-        { children: CANCEL_TEXT, onClick: cancel },
-      ]}
-      alertOverlay
-    >
-      <p>Doing so will terminate this run and home your robot.</p>
-      <p>
-        Additionally, any hardware modules used within the protocol will remain
-        active and maintain their current states until deactivated.
-      </p>
-    </AlertModal>
+    <Portal>
+      <AlertModal
+        heading={HEADING}
+        buttons={[
+          { children: BACK_TEXT, onClick: onClose },
+          { children: CANCEL_TEXT, onClick: cancel },
+        ]}
+        alertOverlay
+      >
+        <p>Doing so will terminate this run and home your robot.</p>
+        <p>
+          Additionally, any hardware modules used within the protocol will
+          remain active and maintain their current states until deactivated.
+        </p>
+      </AlertModal>
+    </Portal>
   )
 }

--- a/app/src/components/RunLog/__tests__/ConfirmCancelModal.test.js
+++ b/app/src/components/RunLog/__tests__/ConfirmCancelModal.test.js
@@ -1,0 +1,49 @@
+// @flow
+import * as React from 'react'
+import { mountWithStore } from '@opentrons/components/__utils__'
+import { AlertModal } from '@opentrons/components'
+
+import { actions as robotActions } from '../../../redux/robot'
+import { Portal } from '../../portal'
+import { ConfirmCancelModal } from '../ConfirmCancelModal'
+
+describe('ConfirmCancelModal', () => {
+  const onClose = jest.fn()
+
+  const render = () => {
+    return mountWithStore(<ConfirmCancelModal onClose={onClose} />)
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render an AlertModal inside a Portal', () => {
+    const { wrapper: subject } = render()
+
+    expect(subject.find(Portal).exists(AlertModal)).toBe(true)
+  })
+
+  it('should render a cancel button that calls props.onClose and dispatches run cancellation', () => {
+    const { wrapper: subject, store } = render()
+    const cancelButton = subject
+      .find('button')
+      .filterWhere(btn => btn.html().includes('cancel'))
+
+    cancelButton.invoke('onClick')()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(store.dispatch).toHaveBeenCalledWith(robotActions.cancel())
+  })
+
+  it('should render a back button that calls props.onClose', () => {
+    const { wrapper: subject } = render()
+    const backButton = subject
+      .find('button')
+      .filterWhere(btn => btn.html().includes('back'))
+
+    backButton.invoke('onClick')()
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/components/RunPanel/RunControls.js
+++ b/app/src/components/RunPanel/RunControls.js
@@ -1,9 +1,9 @@
 // @flow
 // play pause run buttons for sidepanel
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { OutlineButton, HoverTooltip } from '@opentrons/components'
 
+import { ConfirmCancelModal } from '../RunLog'
 import styles from './styles.css'
 
 const MISSING_MODULES =
@@ -40,9 +40,15 @@ export function RunControls(props: RunControlsProps): React.Node {
     onResetClick,
   } = props
 
+  const [isConfirmCancelOpen, setConfirmCancelOpen] = React.useState(false)
   const onPauseResumeClick = isPaused ? onResumeClick : onPauseClick
-
   const pauseResumeText = isPaused ? 'Resume' : 'Pause'
+  const controlsDisabled = isConfirmCancelOpen || disabled
+
+  const handleCancelClick = () => {
+    onPauseClick()
+    setConfirmCancelOpen(true)
+  }
 
   let runButton
   let pauseResumeButton
@@ -75,7 +81,7 @@ export function RunControls(props: RunControlsProps): React.Node {
       </HoverTooltip>
     )
   } else if (isRunning) {
-    const pauseDisabled = disabled || isBlocked
+    const pauseDisabled = disabled || isBlocked || controlsDisabled
     const pauseTooltip = isBlocked ? DOOR_OPEN_RESUME : null
 
     pauseResumeButton = (
@@ -95,11 +101,9 @@ export function RunControls(props: RunControlsProps): React.Node {
     )
     cancelButton = (
       <OutlineButton
-        Component={Link}
-        to={'/run/cancel'}
-        onClick={onPauseClick}
+        onClick={handleCancelClick}
         className={styles.run_button}
-        disabled={disabled}
+        disabled={controlsDisabled}
       >
         Cancel Run
       </OutlineButton>
@@ -122,6 +126,9 @@ export function RunControls(props: RunControlsProps): React.Node {
       {pauseResumeButton}
       {cancelButton}
       {resetButton}
+      {isConfirmCancelOpen === true ? (
+        <ConfirmCancelModal onClose={() => setConfirmCancelOpen(false)} />
+      ) : null}
     </>
   )
 }

--- a/app/src/components/RunPanel/__tests__/RunControls.test.js
+++ b/app/src/components/RunPanel/__tests__/RunControls.test.js
@@ -1,0 +1,97 @@
+// @flow
+import * as React from 'react'
+import { shallow } from 'enzyme'
+
+import { OutlineButton } from '@opentrons/components'
+import { RunControls } from '../RunControls'
+import { ConfirmCancelModal } from '../../RunLog'
+
+import type { RunControlsProps } from '../RunControls'
+
+describe('run controls component', () => {
+  const onRunClick = jest.fn()
+  const onPauseClick = jest.fn()
+  const onResumeClick = jest.fn()
+  const onResetClick = jest.fn()
+
+  const render = (props: $Shape<RunControlsProps> = {}) => {
+    const {
+      disabled = false,
+      modulesReady = false,
+      isReadyToRun = false,
+      isPaused = false,
+      isRunning = false,
+      isBlocked = false,
+    } = props
+
+    return shallow(
+      <RunControls
+        {...{
+          disabled,
+          modulesReady,
+          isReadyToRun,
+          isPaused,
+          isRunning,
+          isBlocked,
+          onRunClick,
+          onPauseClick,
+          onResumeClick,
+          onResetClick,
+        }}
+      />
+    )
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should not render a ConfirmCancelModal by default', () => {
+    const subject = render()
+    expect(subject.exists(ConfirmCancelModal)).toBe(false)
+  })
+
+  // TODO(mc, 2021-02-16): implement test once run controls tooltips use
+  // useHoverTooltip rather than legacy HoverTooltip HoC
+  it.todo('should render a pause button if the protocol is running')
+
+  it('should render a cancel button if the protocol is running', () => {
+    const subject = render({ isRunning: true })
+    const button = subject
+      .find(OutlineButton)
+      .filterWhere(btn => btn.html().includes('Cancel'))
+
+    button.invoke('onClick')()
+    expect(onPauseClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render a ConfirmCancelModal when cancel button clicked', () => {
+    const subject = render({ isRunning: true })
+
+    subject
+      .find(OutlineButton)
+      .filterWhere(btn => btn.html().includes('Cancel'))
+      .invoke('onClick')()
+
+    const modal = subject.find(ConfirmCancelModal)
+
+    expect(modal.exists()).toBe(true)
+    modal.invoke('onClose')()
+    expect(subject.exists(ConfirmCancelModal)).toBe(false)
+  })
+
+  it('should disable run controls when cancel modal open', () => {
+    const subject = render({ isRunning: true })
+
+    subject
+      .find(OutlineButton)
+      .filterWhere(btn => btn.html().includes('Cancel'))
+      .invoke('onClick')()
+
+    const allButtons = subject.find(OutlineButton)
+
+    allButtons.forEach(btn => {
+      expect(btn.prop('disabled')).toBe(true)
+    })
+  })
+})

--- a/app/src/pages/Run.js
+++ b/app/src/pages/Run.js
@@ -1,18 +1,14 @@
 // @flow
 // run task component
 import * as React from 'react'
-import { Route } from 'react-router-dom'
 import { Page } from '../components/Page'
 import { SessionHeader } from '../components/SessionHeader'
-import { RunLog, ConfirmCancelModal } from '../components/RunLog'
+import { RunLog } from '../components/RunLog'
 
 export function Run(): React.Node {
   return (
-    <>
-      <Page titleBarProps={{ title: <SessionHeader /> }}>
-        <RunLog />
-      </Page>
-      <Route path="/run/cancel" component={ConfirmCancelModal} />
-    </>
+    <Page titleBarProps={{ title: <SessionHeader /> }}>
+      <RunLog />
+    </Page>
   )
 }


### PR DESCRIPTION
## Overview

This PR fixes up a couple UI bugs with the run controls. See tickets for details

- Fixes #5924 
- Fixes #5923

![2021-02-16 17 24 37](https://user-images.githubusercontent.com/2963448/108129283-f8a84e00-707b-11eb-82ac-6faca6b2b2f4.gif)


## Changelog

- fix(app): do not resume when clicking "back" from confirm cancel modal
- fix(app): disable "resume" and "cancel" buttons when confirm cancel modal is open

## Review requests

This PR **removes the auto-resume behavior of the confirm cancel modal's "go back" button**. Due to the limitations presented by the RPC API and the age of this UI code, answering the question "is the protocol currently paused?" is not simple enough to be worth the risk of trying to both a) preserve the auto-resume behavior and b) prevent auto-resume if the protocol was already paused when the confirm cancel modal was opened.

We made the call to go the safest route, which means **the user must always explicitly click "resume", even if the protocol was paused implicitly by opening the confirm cancel modal.***

## Risk assessment

Low. Behavior scoped to remove complexity, and changes include unit tests