### PR TITLE
refactor(protocol-designer): Update step selection banner layout

### DIFF
--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
@@ -21,14 +21,12 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   DIRECTION_COLUMN,
   TEXT_TRANSFORM_UPPERCASE,
-  SIZE_1,
   SIZE_2,
   SPACING_3,
-  SPACING_4,
   POSITION_STICKY,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
-import { stepIconsByType } from '../../form-types'
+
 import type { FormData, StepType } from '../../form-types'
 
 type Props = {|
@@ -61,10 +59,7 @@ const StepPill = (props: StepPillProps): React.Node => {
   )} (${count})`
   return (
     <Flex css={stepPillStyles} key={stepType}>
-      <Icon name={stepIconsByType[stepType]} width={SIZE_1} />
-      <Text fontSize={FONT_SIZE_BODY_1} paddingLeft="0.5rem">
-        {label}
-      </Text>
+      <Text fontSize={FONT_SIZE_BODY_1}>{label}</Text>
     </Flex>
   )
 }
@@ -122,7 +117,7 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
             justifyContent={JUSTIFY_FLEX_START}
             flexWrap="wrap"
             flex="1"
-            paddingLeft={SPACING_4}
+            paddingLeft="1.5rem"
           >
             {stepTypes.map(stepType => (
               <StepPill

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import startCase from 'lodash/startCase'
+import { css } from 'styled-components'
 import {
   Box,
   Text,
@@ -12,14 +13,18 @@ import {
   BORDER_WIDTH_DEFAULT,
   C_BG_SELECTED,
   C_SELECTED_DARK,
-  C_TRANSPARENT,
+  C_WHITE,
+  C_DARK_GRAY,
   FONT_SIZE_BODY_1,
   FONT_WEIGHT_SEMIBOLD,
   JUSTIFY_FLEX_START,
+  JUSTIFY_SPACE_BETWEEN,
+  DIRECTION_COLUMN,
   TEXT_TRANSFORM_UPPERCASE,
   SIZE_1,
   SIZE_2,
   SPACING_3,
+  SPACING_4,
   POSITION_STICKY,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
@@ -33,21 +38,29 @@ type Props = {|
 
 type StepPillProps = {| stepType: StepType, count: number |}
 
+const stepPillStyles = css`
+  align-items: ${ALIGN_CENTER};
+  border-right: ${BORDER_WIDTH_DEFAULT} ${BORDER_STYLE_SOLID} ${C_DARK_GRAY};
+  padding: 0 1rem;
+  margin: 0.5rem 0;
+  color: ${C_DARK_GRAY};
+
+  &:first-child: {
+    padding-left: 0;
+  }
+
+  &:last-child {
+    border-right: none;
+  }
+`
+
 const StepPill = (props: StepPillProps): React.Node => {
   const { count, stepType } = props
   const label = `${startCase(
     i18n.t(`application.stepType.${stepType}`)
   )} (${count})`
   return (
-    <Flex
-      alignItems={ALIGN_CENTER}
-      border={`${BORDER_WIDTH_DEFAULT} ${BORDER_STYLE_SOLID} ${C_SELECTED_DARK}`}
-      borderRadius="20px"
-      padding="0.5rem"
-      marginRight="0.5rem"
-      marginBottom="0.5rem"
-      key={stepType}
-    >
+    <Flex css={stepPillStyles} key={stepType}>
       <Icon name={stepIconsByType[stepType]} width={SIZE_1} />
       <Text fontSize={FONT_SIZE_BODY_1} paddingLeft="0.5rem">
         {label}
@@ -59,10 +72,10 @@ const StepPill = (props: StepPillProps): React.Node => {
 export const ExitBatchEditButton = (props: {
   handleExitBatchEdit: $PropertyType<Props, 'handleExitBatchEdit'>,
 }): React.Node => (
-  <Box flex="0 1 auto" marginLeft="auto">
+  <Box flex="0 1 auto">
     <SecondaryBtn
-      color={C_SELECTED_DARK}
-      backgroundColor={C_TRANSPARENT}
+      color={C_WHITE}
+      backgroundColor={C_SELECTED_DARK}
       onClick={props.handleExitBatchEdit}
     >
       {i18n.t('application.exit_batch_edit')}
@@ -83,42 +96,45 @@ export const StepSelectionBannerComponent = (props: Props): React.Node => {
   const stepTypes: Array<StepType> = Object.keys(countPerType).sort()
 
   return (
-    <Flex
+    <Box
       backgroundColor={C_BG_SELECTED}
       padding={SPACING_3}
       color={C_SELECTED_DARK}
-      justifyContent={JUSTIFY_FLEX_START}
       position={POSITION_STICKY}
       border={`2px solid ${C_SELECTED_DARK}`}
     >
-      <Box flex="0 1 auto">
-        <Flex alignItems={ALIGN_CENTER}>
-          <Icon name="checkbox-multiple-marked-outline" width={SIZE_2} />
-          <Text
-            width="10rem"
-            marginLeft="0.5rem"
-            fontWeight={FONT_WEIGHT_SEMIBOLD}
-            textTransform={TEXT_TRANSFORM_UPPERCASE}
+      <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} maxWidth="54.5rem">
+        <Flex flexDirection={DIRECTION_COLUMN}>
+          <Box flex="0 1 auto">
+            <Flex alignItems={ALIGN_CENTER}>
+              <Icon name="checkbox-multiple-marked-outline" width={SIZE_2} />
+              <Text
+                width="10rem"
+                marginLeft="0.5rem"
+                fontWeight={FONT_WEIGHT_SEMIBOLD}
+                textTransform={TEXT_TRANSFORM_UPPERCASE}
+              >
+                {i18n.t('application.n_steps_selected', { n: numSteps })}
+              </Text>
+            </Flex>
+          </Box>
+          <Flex
+            justifyContent={JUSTIFY_FLEX_START}
+            flexWrap="wrap"
+            flex="1"
+            paddingLeft={SPACING_4}
           >
-            {i18n.t('application.n_steps_selected', { n: numSteps })}
-          </Text>
+            {stepTypes.map(stepType => (
+              <StepPill
+                count={countPerType[stepType]}
+                stepType={stepType}
+                key={stepType}
+              />
+            ))}
+          </Flex>
         </Flex>
-      </Box>
-      <Flex
-        justifyContent={JUSTIFY_FLEX_START}
-        flexWrap="wrap"
-        flex="1"
-        maxWidth="42.25rem"
-      >
-        {stepTypes.map(stepType => (
-          <StepPill
-            count={countPerType[stepType]}
-            stepType={stepType}
-            key={stepType}
-          />
-        ))}
         <ExitBatchEditButton handleExitBatchEdit={handleExitBatchEdit} />
       </Flex>
-    </Flex>
+    </Box>
   )
 }


### PR DESCRIPTION
# Overview

closes #7304 by updating the styles/layout for the step selection banner

# Changelog

- refactor(protocol-designer): Update step selection banner layout

# Review requests

 - [ ] Looks like the design
 - [ ] step types stack gracefully when they have to wrap

# Risk assessment

Low. CSS only in PD
