### PR TITLE
fix(api): Correctly restore serial timeouts in the face of exceptions

### DIFF
--- a/api/src/opentrons/drivers/serial_communication.py
+++ b/api/src/opentrons/drivers/serial_communication.py
@@ -37,8 +37,10 @@ def serial_with_temp_timeout(serial_connection, timeout):
     saved_timeout = serial_connection.timeout
     if timeout is not None:
         serial_connection.timeout = timeout
-    yield serial_connection
-    serial_connection.timeout = saved_timeout
+    try:
+        yield serial_connection
+    finally:
+        serial_connection.timeout = saved_timeout
 
 
 def _parse_serial_response(response, ack):


### PR DESCRIPTION
# Overview

Currently, in code like this:

```python
with serial_with_temp_timeout(serial_connection, new_timeout) as device_connection:
    foo(device_connection)

```

If `foo()` throws an exception, the block will exit *with `serial_connection`'s timeout still set to `new_timeout`,* contrary to how you would expect a context manager to safely clean up after itself.

Change it so that if the `with` block exits by exception, the original timeout is restored. Based on [this example](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager).

# Risk assessment

Low. This function is only used in a couple of places, and neither of them appear to rely on the existing exception-handling behavior.