### PR TITLE
feat(protocol-designer): add redux infrastructure for batch edit form

### DIFF
--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,7 +1,11 @@
 // @flow
+import { getBatchEditFieldChanges } from '../selectors'
+import type { StepIdType } from '../../form-types'
+import type { ThunkAction } from '../../types'
 import type {
   ChangeBatchEditFieldAction,
   ResetBatchEditFieldChangesAction,
+  SaveStepFormsMultiAction,
 } from '../types'
 export * from './modules'
 export * from './pipettes'
@@ -16,3 +20,23 @@ export const changeBatchEditField = (
 export const resetBatchEditFieldChanges = (): ResetBatchEditFieldChangesAction => ({
   type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
 })
+
+export const saveStepFormsMulti: (
+  selectedStepIds: Array<StepIdType> | null
+) => ThunkAction<SaveStepFormsMultiAction> = selectedStepIds => (
+  dispatch,
+  getState
+) => {
+  const state = getState()
+
+  const batchEditFieldChanges = getBatchEditFieldChanges(state)
+  const saveStepFormsMultiAction = {
+    type: 'SAVE_STEP_FORMS_MULTI',
+    payload: {
+      editedFields: batchEditFieldChanges,
+      stepIds: selectedStepIds || [],
+    },
+  }
+
+  dispatch(saveStepFormsMultiAction)
+}

--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,3 +1,18 @@
 // @flow
+import type {
+  ChangeBatchEditFieldAction,
+  ResetBatchEditFieldChangesAction,
+} from '../types'
 export * from './modules'
 export * from './pipettes'
+
+export const changeBatchEditField = (
+  args: $PropertyType<ChangeBatchEditFieldAction, 'payload'>
+): ChangeBatchEditFieldAction => ({
+  type: 'CHANGE_BATCH_EDIT_FIELD',
+  payload: args,
+})
+
+export const resetBatchEditFieldChanges = (): ResetBatchEditFieldChangesAction => ({
+  type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
+})

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -1051,7 +1051,7 @@ type BatchEditFormActions =
   | SelectStepAction
 
 export const batchEditFormChanges = (
-  state: BatchEditFormChangesState,
+  state: BatchEditFormChangesState = {},
   action: BatchEditFormActions
 ): BatchEditFormChangesState => {
   switch (action.type) {

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -467,6 +467,7 @@ export const initialSavedStepFormsState: SavedStepFormState = {
 }
 type SavedStepFormsActions =
   | SaveStepFormAction
+  | SaveStepFormsMultiAction
   | DeleteStepAction
   | DeleteMultipleStepsAction
   | LoadFileAction
@@ -561,6 +562,20 @@ export const savedStepForms = (
         ...savedStepForms,
         [action.payload.id]: action.payload,
       }
+    }
+    case 'SAVE_STEP_FORMS_MULTI': {
+      const { editedFields, stepIds } = action.payload
+      return stepIds.reduce(
+        (acc, stepId) => ({
+          ...acc,
+          // $FlowFixMe(sa, 2021-02-16): spreading editedFields can overwrite properties with explicit keys in a way that Flow cannot track
+          [stepId]: {
+            ...savedStepForms[stepId],
+            ...editedFields,
+          },
+        }),
+        { ...savedStepForms }
+      )
     }
     case 'DELETE_STEP': {
       return omit(savedStepForms, action.payload)
@@ -1339,6 +1354,7 @@ export type RootState = {
   presavedStepForm: PresavedStepFormState,
   savedStepForms: SavedStepFormState,
   unsavedForm: FormState,
+  batchEditFormChanges: BatchEditFormChangesState,
 }
 
 // TODO Ian 2018-12-13: find some existing util to do this
@@ -1368,6 +1384,10 @@ export const rootReducer: Reducer<RootState, any> = (state, action) => {
     unsavedForm: unsavedForm(state, action),
     presavedStepForm: presavedStepForm(
       prevStateFallback.presavedStepForm,
+      action
+    ),
+    batchEditFormChanges: batchEditFormChanges(
+      prevStateFallback.batchEditFormChanges,
       action
     ),
   }

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -99,6 +99,10 @@ import type {
   NormalizedLabware,
   NormalizedLabwareById,
   ModuleEntities,
+  BatchEditFormChangesState,
+  ChangeBatchEditFieldAction,
+  ResetBatchEditFieldChangesAction,
+  SaveStepFormsMultiAction,
 } from '../types'
 import type {
   CreateModuleAction,
@@ -1022,6 +1026,34 @@ export const savedStepForms = (
 
     default:
       return savedStepForms
+  }
+}
+
+type BatchEditFormActions =
+  | ChangeBatchEditFieldAction
+  | ResetBatchEditFieldChangesAction
+  | SaveStepFormsMultiAction
+  | SelectStepAction
+
+export const batchEditFormChanges = (
+  state: BatchEditFormChangesState,
+  action: BatchEditFormActions
+): BatchEditFormChangesState => {
+  switch (action.type) {
+    case 'CHANGE_BATCH_EDIT_FIELD': {
+      return {
+        ...state,
+        ...action.payload,
+      }
+    }
+    case 'SELECT_STEP':
+    case 'SAVE_STEP_FORMS_MULTI':
+    case 'RESET_BATCH_EDIT_FIELD_CHANGES': {
+      return {}
+    }
+    default: {
+      return state
+    }
   }
 }
 

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -65,6 +65,7 @@ import type {
   FormPipettesByMount,
   TemperatureModuleState,
   ThermocyclerModuleState,
+  BatchEditFormChangesState,
 } from '../types'
 import type {
   PresavedStepFormState,
@@ -419,6 +420,11 @@ export const getCurrentFormHasUnsavedChanges: Selector<boolean> = createSelector
 )
 
 export const getBatchEditFormHasUnsavedChanges = (): boolean => false
+
+export const getBatchEditFieldChanges: Selector<BatchEditFormChangesState> = createSelector(
+  rootSelector,
+  state => state.batchEditFormChanges
+)
 
 const getModuleEntity = (state: InvariantContext, id: string): ModuleEntity => {
   return state.moduleEntities[id]

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -4,6 +4,7 @@ import assert from 'assert'
 import isEqual from 'lodash/isEqual'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import isEmpty from 'lodash/isEmpty'
 import { createSelector } from 'reselect'
 import {
   getPipetteNameSpecs,
@@ -419,11 +420,14 @@ export const getCurrentFormHasUnsavedChanges: Selector<boolean> = createSelector
   }
 )
 
-export const getBatchEditFormHasUnsavedChanges = (): boolean => false
-
 export const getBatchEditFieldChanges: Selector<BatchEditFormChangesState> = createSelector(
   rootSelector,
   state => state.batchEditFormChanges
+)
+
+export const getBatchEditFormHasUnsavedChanges: Selector<boolean> = createSelector(
+  getBatchEditFieldChanges,
+  changes => !isEmpty(changes)
 )
 
 const getModuleEntity = (state: InvariantContext, id: string): ModuleEntity => {

--- a/protocol-designer/src/step-forms/test/actions.test.js
+++ b/protocol-designer/src/step-forms/test/actions.test.js
@@ -1,0 +1,46 @@
+// @flow
+import thunk from 'redux-thunk'
+import configureMockStore from 'redux-mock-store'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { saveStepFormsMulti } from '../actions'
+import { getBatchEditFieldChanges } from '../selectors'
+
+jest.mock('../selectors')
+const mockStore = configureMockStore([thunk])
+const mockGetBatchEditFieldChanges = getBatchEditFieldChanges
+
+describe('saveStepFormsMulti', () => {
+  let store
+  beforeEach(() => {
+    store = mockStore()
+    when(mockGetBatchEditFieldChanges)
+      .calledWith(expect.anything())
+      .mockReturnValue({ someField: 'someVal' })
+  })
+  afterEach(() => resetAllWhenMocks())
+  it('should dispatch SAVE_STEP_FORMS_MULTI with edited fields and step ids when step ids are passed in', () => {
+    const stepIds = ['1', '2']
+    store.dispatch(saveStepFormsMulti(stepIds))
+    expect(store.getActions()).toEqual([
+      {
+        type: 'SAVE_STEP_FORMS_MULTI',
+        payload: {
+          editedFields: { someField: 'someVal' },
+          stepIds: stepIds,
+        },
+      },
+    ])
+  })
+  it('should dispatch SAVE_STEP_FORMS_MULTI with edited fields and step ids when step ids are NOT passed in', () => {
+    store.dispatch(saveStepFormsMulti())
+    expect(store.getActions()).toEqual([
+      {
+        type: 'SAVE_STEP_FORMS_MULTI',
+        payload: {
+          editedFields: { someField: 'someVal' },
+          stepIds: [],
+        },
+      },
+    ])
+  })
+})

--- a/protocol-designer/src/step-forms/test/actions.test.js
+++ b/protocol-designer/src/step-forms/test/actions.test.js
@@ -18,7 +18,7 @@ describe('saveStepFormsMulti', () => {
       .mockReturnValue({ someField: 'someVal' })
   })
   afterEach(() => resetAllWhenMocks())
-  it('should dispatch SAVE_STEP_FORMS_MULTI with edited fields and step ids when step ids are passed in', () => {
+  it('should dispatch SAVE_STEP_FORMS_MULTI with edited fields and step ids', () => {
     const stepIds = ['1', '2']
     store.dispatch(saveStepFormsMulti(stepIds))
     expect(store.getActions()).toEqual([
@@ -31,7 +31,7 @@ describe('saveStepFormsMulti', () => {
       },
     ])
   })
-  it('should dispatch SAVE_STEP_FORMS_MULTI with edited fields and step ids when step ids are NOT passed in', () => {
+  it('should dispatch SAVE_STEP_FORMS_MULTI with step ids as empty list when step ids are NOT passed in', () => {
     store.dispatch(saveStepFormsMulti())
     expect(store.getActions()).toEqual([
       {

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -13,6 +13,7 @@ import {
   presavedStepForm,
   savedStepForms,
   unsavedForm,
+  batchEditFormChanges,
 } from '../reducers'
 import {
   _getPipetteEntitiesRootState,
@@ -1724,5 +1725,43 @@ describe('presavedStepForm reducer', () => {
       const prevState = { id: 'someId', stepType: 'transfer' }
       expect(presavedStepForm(prevState, { type: actionType })).toEqual(null)
     })
+  })
+})
+
+describe('batchEditFormChanges reducer', () => {
+  it('should add the new fields into empty state on CHANGE_BATCH_EDIT_FIELD', () => {
+    const state = {}
+    const action = {
+      type: 'CHANGE_BATCH_EDIT_FIELD',
+      payload: { someFieldName: 'someFieldValue' },
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({
+      someFieldName: 'someFieldValue',
+    })
+  })
+  it('should add the new fields into existing state on CHANGE_BATCH_EDIT_FIELD', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'CHANGE_BATCH_EDIT_FIELD',
+      payload: { anotherFieldName: 'anotherFieldValue' },
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({
+      someFieldName: 'someFieldValue',
+      anotherFieldName: 'anotherFieldValue',
+    })
+  })
+  it('should reset state on RESET_BATCH_EDIT_FIELD_CHANGES', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
+  })
+  it('should reset state on SAVE_STEP_FORMS_MULTI', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'SAVE_STEP_FORMS_MULTI',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
   })
 })

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1242,6 +1242,54 @@ describe('savedStepForms reducer: initial deck setup step', () => {
       })
     })
   })
+  describe('saving multiple steps', () => {
+    it('should apply the form patch to all of the step ids', () => {
+      const prevState = {
+        savedStepForms: {
+          some_transfer_step_id: {
+            stepType: 'moveLiquid',
+            blowout_location: 'someLocation',
+            dispense_mix_checkbox: true,
+            dispense_mix_volume: '10',
+          },
+          another_transfer_step_id: {
+            stepType: 'moveLiquid',
+            blowout_location: 'anotherLocation',
+            dispense_mix_checkbox: true,
+            dispense_mix_volume: '20',
+          },
+        },
+      }
+      const action = {
+        type: 'SAVE_STEP_FORMS_MULTI',
+        payload: {
+          editedFields: {
+            blowout_location: 'newLocation',
+            dispense_mix_volume: '30',
+          },
+          stepIds: ['some_transfer_step_id', 'another_transfer_step_id'],
+        },
+      }
+
+      const expectedSavedStepFormState = {
+        some_transfer_step_id: {
+          stepType: 'moveLiquid',
+          blowout_location: 'newLocation',
+          dispense_mix_checkbox: true,
+          dispense_mix_volume: '30',
+        },
+        another_transfer_step_id: {
+          stepType: 'moveLiquid',
+          blowout_location: 'newLocation',
+          dispense_mix_checkbox: true,
+          dispense_mix_volume: '30',
+        },
+      }
+      expect(savedStepForms(prevState, action)).toEqual(
+        expectedSavedStepFormState
+      )
+    })
+  })
 })
 
 describe('unsavedForm reducer', () => {

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1812,4 +1812,11 @@ describe('batchEditFormChanges reducer', () => {
     }
     expect(batchEditFormChanges(state, { ...action })).toEqual({})
   })
+  it('should reset state on SELECT_STEP', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'SELECT_STEP',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
+  })
 })

--- a/protocol-designer/src/step-forms/test/selectors.test.js
+++ b/protocol-designer/src/step-forms/test/selectors.test.js
@@ -128,8 +128,12 @@ describe('getEquippedPipetteOptions', () => {
 })
 
 describe('getBatchEditFormHasUnsavedChanges', () => {
-  // TODO(sa, 2021-01-22): update tests when this selector actually gets implemented
-  it('should always return false', () => {
-    expect(getBatchEditFormHasUnsavedChanges()).toBe(false)
+  it('should return true if there are unsaved changes ', () => {
+    expect(
+      getBatchEditFormHasUnsavedChanges.resultFunc({ someField: 'someVal' })
+    ).toBe(true)
+  })
+  it('should return false if there are no unsaved changes ', () => {
+    expect(getBatchEditFormHasUnsavedChanges.resultFunc({})).toBe(false)
   })
 })

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -17,7 +17,8 @@ import typeof {
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-
+import type { FormPatch } from '../steplist/actions'
+import type { StepIdType, StepFieldName } from '../form-types'
 export type FormPipette = {| pipetteName: ?string, tiprackDefURI: ?string |}
 export type FormPipettesByMount = {|
   left: FormPipette,
@@ -163,3 +164,21 @@ export type InitialDeckSetup = {
     [moduleId: string]: ModuleOnDeck,
   },
 }
+
+export type BatchEditFormChangesState = FormPatch
+
+export type ChangeBatchEditFieldAction = {|
+  type: 'CHANGE_BATCH_EDIT_FIELD',
+  payload: BatchEditFormChangesState,
+|}
+
+export type ResetBatchEditFieldChangesAction = {|
+  type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
+|}
+
+export type EditedFields = { [StepFieldName]: mixed }
+
+export type SaveStepFormsMultiAction = {|
+  type: 'SAVE_STEP_FORMS_MULTI',
+  payload: { stepIds: Array<StepIdType>, editedFields: EditedFields },
+|}


### PR DESCRIPTION
# Overview
This PR adds redux infra for the batch edit form. See #7245 for the new reducer + actions + selectors that should be in here.

Closes #7245

# Changelog
- Add redux infrastructure for batch edit form

# Review requests
Code review
Go through the checklist in #7245. Note, I did not make an assert when  attempting to save a non transfer form, but if we think that's important I can.

# Risk assessment
Low