### PR TITLE
fix(api): fix return code of set_syslog_level

### DIFF
--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -58,4 +58,8 @@ async def set_syslog_level(level: str) -> Tuple[int, str, str]:
         'syslog-ng-ctl', 'reload',
         stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
     stdout, stderr = await proc.communicate()
-    return int(proc.returncode or -1), stdout.decode(), stderr.decode()
+    if proc.returncode is None:
+        snc_reload_result = -1
+    else:
+        snc_reload_result: int = proc.returncode  # type: ignore
+    return snc_reload_result, stdout.decode(), stderr.decode()


### PR DESCRIPTION
If you use (val or -1) when the happy path of val is 0, you're always
going to get -1! And that's gonna make the caller think that the call
failed! Incredible!

## Testing
Upload this build and toggle the "forward logs to Opentrons" setting in the robot panel. It should no longer always give you an error.