### PR TITLE
feat(protocol-designer): move batch edit form redux types from shared types into own files

### DIFF
--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,25 +1,34 @@
 // @flow
 import { getBatchEditFieldChanges } from '../selectors'
-import type { StepIdType } from '../../form-types'
-import type { ThunkAction } from '../../types'
-import type {
-  ChangeBatchEditFieldAction,
-  ResetBatchEditFieldChangesAction,
-  SaveStepFormsMultiAction,
-} from '../types'
+import type { StepIdType, StepFieldName } from '../../form-types'
+import type { BatchEditFormChangesState } from '../reducers'
 export * from './modules'
 export * from './pipettes'
 
+export type ChangeBatchEditFieldAction = {|
+  type: 'CHANGE_BATCH_EDIT_FIELD',
+  payload: BatchEditFormChangesState,
+|}
 export const changeBatchEditField = (
   args: $PropertyType<ChangeBatchEditFieldAction, 'payload'>
 ): ChangeBatchEditFieldAction => ({
   type: 'CHANGE_BATCH_EDIT_FIELD',
   payload: args,
 })
+export type ResetBatchEditFieldChangesAction = {|
+  type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
+|}
 
 export const resetBatchEditFieldChanges = (): ResetBatchEditFieldChangesAction => ({
   type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
 })
+
+type EditedFields = { [StepFieldName]: mixed }
+
+export type SaveStepFormsMultiAction = {|
+  type: 'SAVE_STEP_FORMS_MULTI',
+  payload: { stepIds: Array<StepIdType>, editedFields: EditedFields },
+|}
 
 export const saveStepFormsMulti: (
   selectedStepIds: Array<StepIdType> | null

--- a/protocol-designer/src/step-forms/actions/index.js
+++ b/protocol-designer/src/step-forms/actions/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { getBatchEditFieldChanges } from '../selectors'
+import type { ThunkAction } from '../../types'
 import type { StepIdType, StepFieldName } from '../../form-types'
 import type { BatchEditFormChangesState } from '../reducers'
 export * from './modules'
@@ -18,18 +19,15 @@ export const changeBatchEditField = (
 export type ResetBatchEditFieldChangesAction = {|
   type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
 |}
-
 export const resetBatchEditFieldChanges = (): ResetBatchEditFieldChangesAction => ({
   type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
 })
 
 type EditedFields = { [StepFieldName]: mixed }
-
 export type SaveStepFormsMultiAction = {|
   type: 'SAVE_STEP_FORMS_MULTI',
   payload: { stepIds: Array<StepIdType>, editedFields: EditedFields },
 |}
-
 export const saveStepFormsMulti: (
   selectedStepIds: Array<StepIdType> | null
 ) => ThunkAction<SaveStepFormsMultiAction> = selectedStepIds => (

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -84,6 +84,7 @@ import type {
   DeleteProfileStepAction,
   EditProfileCycleAction,
   EditProfileStepAction,
+  FormPatch,
 } from '../../steplist/actions'
 import type {
   AddStepAction,
@@ -99,10 +100,6 @@ import type {
   NormalizedLabware,
   NormalizedLabwareById,
   ModuleEntities,
-  BatchEditFormChangesState,
-  ChangeBatchEditFieldAction,
-  ResetBatchEditFieldChangesAction,
-  SaveStepFormsMultiAction,
 } from '../types'
 import type {
   CreateModuleAction,
@@ -111,6 +108,9 @@ import type {
   DeletePipettesAction,
   EditModuleAction,
   SubstituteStepFormPipettesAction,
+  ChangeBatchEditFieldAction,
+  ResetBatchEditFieldChangesAction,
+  SaveStepFormsMultiAction,
 } from '../actions'
 
 type FormState = FormData | null
@@ -1043,6 +1043,8 @@ export const savedStepForms = (
       return savedStepForms
   }
 }
+
+export type BatchEditFormChangesState = FormPatch
 
 type BatchEditFormActions =
   | ChangeBatchEditFieldAction

--- a/protocol-designer/src/step-forms/selectors/index.js
+++ b/protocol-designer/src/step-forms/selectors/index.js
@@ -66,12 +66,12 @@ import type {
   FormPipettesByMount,
   TemperatureModuleState,
   ThermocyclerModuleState,
-  BatchEditFormChangesState,
 } from '../types'
 import type {
   PresavedStepFormState,
   RootState,
   SavedStepFormState,
+  BatchEditFormChangesState,
 } from '../reducers'
 import type { InvariantContext } from '../../step-generation'
 

--- a/protocol-designer/src/step-forms/types.js
+++ b/protocol-designer/src/step-forms/types.js
@@ -17,8 +17,6 @@ import typeof {
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import type { FormPatch } from '../steplist/actions'
-import type { StepIdType, StepFieldName } from '../form-types'
 export type FormPipette = {| pipetteName: ?string, tiprackDefURI: ?string |}
 export type FormPipettesByMount = {|
   left: FormPipette,
@@ -164,21 +162,3 @@ export type InitialDeckSetup = {
     [moduleId: string]: ModuleOnDeck,
   },
 }
-
-export type BatchEditFormChangesState = FormPatch
-
-export type ChangeBatchEditFieldAction = {|
-  type: 'CHANGE_BATCH_EDIT_FIELD',
-  payload: BatchEditFormChangesState,
-|}
-
-export type ResetBatchEditFieldChangesAction = {|
-  type: 'RESET_BATCH_EDIT_FIELD_CHANGES',
-|}
-
-export type EditedFields = { [StepFieldName]: mixed }
-
-export type SaveStepFormsMultiAction = {|
-  type: 'SAVE_STEP_FORMS_MULTI',
-  payload: { stepIds: Array<StepIdType>, editedFields: EditedFields },
-|}


### PR DESCRIPTION
Forgot to do [this suggestion](https://github.com/Opentrons/opentrons/pull/7346#discussion_r577765024) in the last redux infra PR!

# Overview
Move action/reducer types into their respective files instead of in shared types file. I was mistaken that this would cause circular dependency issues, but this is not true.

# Changelog

- Move batch edit form redux types from shared types into own files

# Risk assessment
Low
