### PR TITLE
feat(protocol-designer): clear unsaved form state in batch edit mode

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -93,6 +93,7 @@ import type {
   ReorderSelectedStepAction,
   SelectStepAction,
   SelectTerminalItemAction,
+  SelectMultipleStepsAction,
 } from '../../ui/steps/actions/types'
 import type { SaveStepFormAction } from '../../ui/steps/actions/thunks'
 import type {
@@ -136,6 +137,7 @@ type UnsavedFormActions =
   | DeleteProfileCycleAction
   | EditProfileCycleAction
   | EditProfileStepAction
+  | SelectMultipleStepsAction
 export const unsavedForm = (
   rootState: RootState,
   action: UnsavedFormActions
@@ -195,6 +197,7 @@ export const unsavedForm = (
     case 'DELETE_MODULE':
     case 'DELETE_STEP':
     case 'DELETE_MULTIPLE_STEPS':
+    case 'SELECT_MULTIPLE_STEPS':
     case 'EDIT_MODULE':
     case 'SAVE_STEP_FORM':
     case 'SELECT_TERMINAL_ITEM':

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1381,6 +1381,7 @@ describe('unsavedForm reducer', () => {
     'EDIT_MODULE',
     'SAVE_STEP_FORM',
     'SELECT_TERMINAL_ITEM',
+    'SELECT_MULTIPLE_STEPS',
   ]
   actionTypes.forEach(actionType => {
     it(`should clear the unsaved form when any ${actionType} action is dispatched`, () => {


### PR DESCRIPTION
# Overview

Clear out `state.unsavedForm` when entering batch edit mode so that single edit form state is accurately reflected.

Closes #7360

# Changelog
- Clear unsaved form state in batch edit mode

# Review requests
Open up redux dev tools and make sure `state.unsavedForm` gets cleared when selecting multiple steps.

# Risk assessment
Low 