### PR TITLE
chore(build): deploy PD to sandbox without e2e tests needing to pass

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -120,7 +120,7 @@ jobs:
   deploy-pd:
     name: 'deploy PD artifact to S3'
     runs-on: 'ubuntu-latest'
-    needs: ["js-unit-test", "e2e-test", "build-pd"]
+    needs: ["js-unit-test", "build-pd"]
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v2'


### PR DESCRIPTION
# Overview

We don't really need e2e tests to pass for us to play around with our code in the sandbox environment, so this PR removes this check before deploying PD artifacts to S3.

# Changelog

- Deploy PD to sandbox without e2e tests needing to pass

# Risk assessment
Low