### PR TITLE
feat(protocol-designer): Add layout styling to no editable settings

### DIFF
--- a/protocol-designer/src/components/DeckSetupManager.js
+++ b/protocol-designer/src/components/DeckSetupManager.js
@@ -1,6 +1,14 @@
 // @flow
 import * as React from 'react'
 import { useSelector } from 'react-redux'
+import { i18n } from '../localization'
+import {
+  Flex,
+  Text,
+  ALIGN_CENTER,
+  JUSTIFY_CENTER,
+  C_DARK_GRAY,
+} from '@opentrons/components'
 import { getBatchEditSelectedStepTypes } from '../ui/steps/selectors'
 import { DeckSetup } from './DeckSetup'
 import type { StepType } from '../form-types'
@@ -15,8 +23,17 @@ const hasSharedBatchEditSettings: (
 }
 
 const NoBatchEditSharedSettings = (): React.Node => {
-  // TOOD IMMEDIATELY: style & use i18n
-  return 'No advanced settings shared between selected steps'
+  return (
+    <Flex
+      justifyContent={JUSTIFY_CENTER}
+      alignItems={ALIGN_CENTER}
+      height="75%"
+    >
+      <Text color={C_DARK_GRAY}>
+        {i18n.t('application.no_batch_edit_shared_settings')}
+      </Text>
+    </Flex>
+  )
 }
 
 export const DeckSetupManager = (): React.Node => {

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -29,5 +29,6 @@
     "validation_server_failure": "There was a problem communicating with the Opentrons validation server. Please make sure you are still connected to the internet and try again. If this problem persists, please contact Opentrons support."
   },
   "exit_batch_edit": "exit batch edit",
-  "n_steps_selected": "{{n}} steps selected"
+  "n_steps_selected": "{{n}} steps selected",
+  "no_batch_edit_shared_settings": "No advanced settings shared between selected steps"
 }


### PR DESCRIPTION
# Overview

This PR closes #7129 (although the heavy lifting was done by Ian in #7350). This PR adds the layout to the no shared editable settings message and moves the message text to i18n.

# Changelog

- refactor(protocol-designer): Add layout styling to no editable settings
- refactor(protocol-designer): Add message to i18n

# Review requests

Multi Select several step types
- [ ] No shared editable settings message matches design

# Risk assessment

Low, layout and text changes only
