### PR TITLE
refactor(protocol-designer): refactor well order modal to remove single edit dependencies

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -30,7 +30,10 @@ type Props = {|
   closeModal: () => mixed,
   prefix: 'aspirate' | 'dispense' | 'mix',
   formData: FormData,
-  updateValues: (firstValue: ?WellOrderOption, ?WellOrderOption) => void,
+  updateValues: (
+    firstValue: ?WellOrderOption,
+    secondValue: ?WellOrderOption
+  ) => void,
 |}
 
 type State = {

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import { WellOrderField } from '../WellOrderField'
+import { WellOrderModal } from '../WellOrderField/WellOrderModal'
+
+describe('WellOrderField', () => {
+  const render = _props => mount(<WellOrderField {..._props} />)
+
+  let props
+  beforeEach(() => {
+    props = {
+      prefix: 'aspirate',
+      formData: ({}: any),
+      updateFirstWellOrder: jest.fn(),
+      updateSecondWellOrder: jest.fn(),
+    }
+  })
+
+  describe('WellOrderModal', () => {
+    it('should call correct updater fns passed in', () => {
+      const wrapper = render(props)
+      const wellOrderModal = wrapper.find(WellOrderModal)
+      act(() => {
+        wellOrderModal.prop('updateValues')('l2r', 't2b')
+      })
+      expect(props.updateFirstWellOrder).toHaveBeenCalledWith('l2r')
+      expect(props.updateSecondWellOrder).toHaveBeenCalledWith('t2b')
+    })
+  })
+})

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -103,8 +103,15 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 formData={formData}
               />
               <WellOrderField
+                updateFirstWellOrder={
+                  propsForFields['mix_wellOrder_first'].updateValue
+                }
+                updateSecondWellOrder={
+                  propsForFields['mix_wellOrder_second'].updateValue
+                }
                 prefix="mix"
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
+                formData={props.formData}
               />
             </div>
             <DelayFields

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -81,6 +81,13 @@ export const SourceDestFields = (props: Props): React.Node => {
         <WellOrderField
           prefix={prefix}
           label={i18n.t('form.step_edit_form.field.well_order.label')}
+          formData={formData}
+          updateFirstWellOrder={
+            propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
+          }
+          updateSecondWellOrder={
+            propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
+          }
         />
       </div>
 

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import { MixForm } from '../MixForm'
 import { AspDispSection } from '../AspDispSection'
 import * as stepFormSelectors from '../../../../step-forms/selectors'
+import { WellOrderField } from '../../fields'
 import type { BaseState } from '../../../../types'
 
 const { DelayFields } = jest.requireActual('../../fields')
@@ -78,6 +79,24 @@ describe('MixForm', () => {
           updateValue: (jest.fn(): any),
           value: null,
         },
+        mix_wellOrder_first: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'mix_wellOrder_first',
+          updateValue: (jest.fn(): any),
+          value: null,
+        },
+        mix_wellOrder_second: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'mix_wellOrder_second',
+          updateValue: (jest.fn(): any),
+          value: null,
+        },
       },
     }
   })
@@ -94,7 +113,7 @@ describe('MixForm', () => {
   })
 
   describe('when advanced settings are visible', () => {
-    it('should render the aspirate delay fields when advanced settings are visible', () => {
+    it('should render the aspirate delay fields', () => {
       const wrapper = render(props)
 
       showAdvancedSettings(wrapper)
@@ -125,6 +144,20 @@ describe('MixForm', () => {
       )
       // no tip position field
       expect(aspirateDelayFields.prop('tipPositionFieldName')).toBe(undefined)
+    })
+    it('should render the mix well order field', () => {
+      const wrapper = render(props)
+      showAdvancedSettings(wrapper)
+      const wellOrderField = wrapper.find(WellOrderField)
+      expect(wellOrderField.props()).toMatchObject({
+        prefix: 'mix',
+        label: 'Well order',
+        formData: props.formData,
+        updateFirstWellOrder:
+          props.propsForFields['mix_wellOrder_first'].updateValue,
+        updateSecondWellOrder:
+          props.propsForFields['mix_wellOrder_second'].updateValue,
+      })
     })
   })
 })

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
-import { CheckboxRowField, DelayFields } from '../../fields'
+import { CheckboxRowField, DelayFields, WellOrderField } from '../../fields'
 import { SourceDestFields } from '../MoveLiquidForm/SourceDestFields'
 import type { BaseState } from '../../../../types'
 
@@ -76,6 +76,24 @@ describe('SourceDestFields', () => {
           updateValue: (jest.fn(): any),
           value: true,
         },
+        aspirate_wellOrder_first: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'aspirate_wellOrder_first',
+          updateValue: (jest.fn(): any),
+          value: true,
+        },
+        aspirate_wellOrder_second: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'aspirate_wellOrder_second',
+          updateValue: (jest.fn(): any),
+          value: true,
+        },
         dispense_airGap_checkbox: {
           onFieldFocus: (jest.fn(): any),
           onFieldBlur: (jest.fn(): any),
@@ -109,6 +127,24 @@ describe('SourceDestFields', () => {
           errorToShow: null,
           disabled: false,
           name: 'dispense_touchTip_checkbox',
+          updateValue: (jest.fn(): any),
+          value: true,
+        },
+        dispense_wellOrder_first: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'dispense_wellOrder_first',
+          updateValue: (jest.fn(): any),
+          value: true,
+        },
+        dispense_wellOrder_second: {
+          onFieldFocus: (jest.fn(): any),
+          onFieldBlur: (jest.fn(): any),
+          errorToShow: null,
+          disabled: false,
+          name: 'dispense_wellOrder_second',
           updateValue: (jest.fn(): any),
           value: true,
         },
@@ -167,10 +203,26 @@ describe('SourceDestFields', () => {
       expect(checkboxes.at(2).prop('name')).toBe('aspirate_touchTip_checkbox')
       expect(checkboxes.at(3).prop('name')).toBe('aspirate_airGap_checkbox')
     })
+    it('should render a well order field', () => {
+      const wrapper = render(props)
+      const wellOrderField = wrapper.find(WellOrderField)
+
+      expect(wellOrderField.props()).toMatchObject({
+        prefix: 'aspirate',
+        label: 'Well order',
+        formData: props.formData,
+        updateFirstWellOrder:
+          props.propsForFields['aspirate_wellOrder_first'].updateValue,
+        updateSecondWellOrder:
+          props.propsForFields['aspirate_wellOrder_second'].updateValue,
+      })
+    })
   })
   describe('Dispense section', () => {
+    beforeEach(() => {
+      props = { ...props, prefix: 'dispense' }
+    })
     it('should render the correct checkboxes', () => {
-      props.prefix = 'dispense'
       const wrapper = render(props)
       const checkboxes = wrapper.find(CheckboxRowField)
 
@@ -184,6 +236,20 @@ describe('SourceDestFields', () => {
       expect(checkboxes.at(1).prop('name')).toBe('dispense_touchTip_checkbox')
       expect(checkboxes.at(2).prop('name')).toBe('blowout_checkbox')
       expect(checkboxes.at(3).prop('name')).toBe('dispense_airGap_checkbox')
+    })
+    it('should render a well order field', () => {
+      const wrapper = render(props)
+      const wellOrderField = wrapper.find(WellOrderField)
+
+      expect(wellOrderField.props()).toMatchObject({
+        prefix: 'dispense',
+        label: 'Well order',
+        formData: props.formData,
+        updateFirstWellOrder:
+          props.propsForFields['dispense_wellOrder_first'].updateValue,
+        updateSecondWellOrder:
+          props.propsForFields['dispense_wellOrder_second'].updateValue,
+      })
     })
   })
 })


### PR DESCRIPTION
# Overview

Closes #7228

# Changelog

- Refactor well order modal to remove single edit dependencies

# Review requests

- [ ] Code review
- [ ] Well order field in transfer form should work the same as on prod
- [ ] Well order field in mix form should work the same as on prod

# Risk assessment
Low