### PR TITLE
feat(api): create ProtocolEngineImplementation class 

### DIFF
--- a/api/src/opentrons/protocols/implementations/engine/__init__.py
+++ b/api/src/opentrons/protocols/implementations/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Package for context implementations that use the Protocol Engine."""

--- a/api/src/opentrons/protocols/implementations/engine/protocol_context.py
+++ b/api/src/opentrons/protocols/implementations/engine/protocol_context.py
@@ -1,0 +1,117 @@
+"""Module containing protocol context interface that interacts with
+Protocol Engine"""
+
+from typing import Optional, Dict
+
+from opentrons import types, API
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocols.api_support.util import HardwareManager, AxisMaxSpeeds
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.protocols.geometry.deck_item import DeckItem
+from opentrons.protocols.implementations.interfaces.instrument_context import \
+    InstrumentContextInterface
+from opentrons.protocols.implementations.interfaces.labware import \
+    LabwareInterface
+from opentrons.protocols.implementations.interfaces.protocol_context import \
+    ProtocolContextInterface, InstrumentDict, LoadModuleResult
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+
+class ProtocolEngineContext(ProtocolContextInterface):
+    """ProtocolContextInterface that interacts with Protocol Engine"""
+
+    _protocol_engine: ProtocolEngine
+
+    def __init__(self, protocol_engine: ProtocolEngine) -> None:
+        """Constructor."""
+        self._protocol_engine = protocol_engine
+
+    def get_bundled_data(self) -> Dict[str, bytes]:
+        raise NotImplementedError()
+
+    def get_bundled_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+        raise NotImplementedError()
+
+    def get_extra_labware(self) -> Optional[Dict[str, LabwareDefinition]]:
+        raise NotImplementedError()
+
+    def cleanup(self) -> None:
+        raise NotImplementedError()
+
+    def get_max_speeds(self) -> AxisMaxSpeeds:
+        raise NotImplementedError()
+
+    def get_hardware(self) -> HardwareManager:
+        raise NotImplementedError()
+
+    def connect(self, hardware: API) -> None:
+        raise NotImplementedError()
+
+    def disconnect(self) -> None:
+        raise NotImplementedError()
+
+    def is_simulating(self) -> bool:
+        raise NotImplementedError()
+
+    def load_labware_from_definition(self, labware_def: LabwareDefinition,
+                                     location: types.DeckLocation,
+                                     label: Optional[
+                                         str] = None) -> LabwareInterface:
+        raise NotImplementedError()
+
+    def load_labware(self, load_name: str, location: types.DeckLocation,
+                     label: Optional[str] = None,
+                     namespace: Optional[str] = None,
+                     version: Optional[int] = None) -> LabwareInterface:
+        raise NotImplementedError()
+
+    def load_module(self, module_name: str,
+                    location: Optional[types.DeckLocation] = None,
+                    configuration: Optional[str] = None) -> Optional[LoadModuleResult]:
+        raise NotImplementedError()
+
+    def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
+        raise NotImplementedError()
+
+    def load_instrument(self, instrument_name: str, mount: types.Mount,
+                        replace: bool = False) -> InstrumentContextInterface:
+        raise NotImplementedError()
+
+    def get_loaded_instruments(self) -> InstrumentDict:
+        raise NotImplementedError()
+
+    def pause(self, msg: Optional[str] = None) -> None:
+        raise NotImplementedError()
+
+    def resume(self) -> None:
+        raise NotImplementedError()
+
+    def comment(self, msg: str) -> None:
+        raise NotImplementedError()
+
+    def delay(self, seconds=0, msg: Optional[str] = None) -> None:
+        raise NotImplementedError()
+
+    def home(self) -> None:
+        raise NotImplementedError()
+
+    def get_deck(self) -> Deck:
+        raise NotImplementedError()
+
+    def get_fixed_trash(self) -> DeckItem:
+        raise NotImplementedError()
+
+    def set_rail_lights(self, on: bool) -> None:
+        raise NotImplementedError()
+
+    def get_rail_lights_on(self) -> bool:
+        raise NotImplementedError()
+
+    def door_closed(self) -> bool:
+        raise NotImplementedError()
+
+    def get_last_location(self) -> Optional[types.Location]:
+        raise NotImplementedError()
+
+    def set_last_location(self, location: Optional[types.Location]) -> None:
+        raise NotImplementedError()

--- a/api/tests/opentrons/protocols/implementation/engine/test_protocol_context.py
+++ b/api/tests/opentrons/protocols/implementation/engine/test_protocol_context.py
@@ -1,0 +1,170 @@
+import pytest
+from mock import AsyncMock
+
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocols.implementations.engine.protocol_context import \
+    ProtocolEngineContext
+from opentrons.types import Mount
+
+
+@pytest.fixture
+def mock_protocol_engine() -> AsyncMock:
+    """Mock of ProtocolEngine"""
+    return AsyncMock(spec=ProtocolEngine)
+
+
+@pytest.fixture
+def protocol_engine_context(mock_protocol_engine) -> ProtocolEngineContext:
+    """Subject fixture."""
+    return ProtocolEngineContext(protocol_engine=mock_protocol_engine)
+
+
+def test_get_bundled_data(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_bundled_data()
+
+
+def test_get_bundled_labware(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_bundled_labware()
+
+
+def test_get_extra_labware(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_extra_labware()
+
+
+def test_cleanup(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.cleanup()
+
+
+def test_get_max_speeds(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_max_speeds()
+
+
+def test_get_hardware(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_hardware()
+
+
+def test_connect(protocol_engine_context: ProtocolEngineContext) -> None:
+    mock_hardware = AsyncMock()
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.connect(hardware=mock_hardware)
+
+
+def test_disconnect(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.disconnect()
+
+
+def test_is_simulating(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.is_simulating()
+
+
+def test_load_labware_from_definition(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.load_labware_from_definition({}, "")
+
+
+def test_load_labware(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.load_labware(load_name="name", location="")
+
+
+def test_load_module(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.load_module(module_name="name", location=None,
+                                            configuration="")
+
+
+def test_get_loaded_modules(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_loaded_modules()
+
+
+def test_load_instrument(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.load_instrument(
+            instrument_name="", mount=Mount.RIGHT
+        )
+
+
+def test_get_loaded_instruments(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_loaded_instruments()
+
+
+def test_pause(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.pause()
+
+
+def test_resume(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.resume()
+
+
+def test_comment(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.comment(msg="")
+
+
+def test_delay(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.delay(1)
+
+
+def test_home(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.home()
+
+
+def test_get_deck(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_deck()
+
+
+def test_get_fixed_trash(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_fixed_trash()
+
+
+def test_set_rail_lights(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.set_rail_lights(True)
+
+
+def test_get_rail_lights_on(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_rail_lights_on()
+
+
+def test_door_closed(protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.door_closed()
+
+
+def test_get_last_location(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.get_last_location()
+
+
+def test_set_last_location(
+        protocol_engine_context: ProtocolEngineContext) -> None:
+    with pytest.raises(NotImplementedError):
+        protocol_engine_context.set_last_location(None)


### PR DESCRIPTION
# Overview

`ProtocolContextInterface` is the abstract interface of an object supplied to `ProtocolContext` to implement hardware interaction.

`ProtocolEngineImplementation` will be an alternative implementation that will send commands to `ProtocolEngine` rather.

closes #7323 

# Changelog

- add opentrons.protocols.implementation.engine package.
- create `ProtocolEngineImplementation` class, an implementation of `ProtocolContextInterface`.
- every method raises `NotImplementedError`
- add test for each method

# Review requests

None

# Risk assessment

None