### PR TITLE
fix(protocol-designer): fix DropdownFormField

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -32,7 +32,7 @@ const DropdownFormField = (props: DropdownFormFieldProps) => {
       options={props.options}
       value={props.value ? String(props.value) : null}
       onBlur={props.onFieldBlur}
-      onChange={props.updateValue}
+      onChange={e => props.updateValue(e.currentTarget.value)}
       onFocus={props.onFieldFocus}
     />
   )


### PR DESCRIPTION
# Overview

D'oh

closes #7376

# Changelog


# Review requests

- Should fix issue described in #7376. All other dropdowns in PD be unaffected since `DropdownFormField` isn't exported, it's used only in `DisposalVolumeFieldComponent`, no not necessary to test

# Risk assessment

Low, PD-only, 1-liner to fix a bug