### PR TITLE
docs(api): Correct references to flow rate attributes

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -146,10 +146,11 @@ class InstrumentContext(CommandPublisher):
                          robot will aspirate from the exact specified location.
                          If unspecified, the robot will aspirate from the
                          current position.
-        :param rate: The relative plunger speed for this aspirate. During
-                     this aspirate, the speed of the plunger will be
-                     `rate` * :py:attr:`aspirate_speed`. If not specified,
-                     defaults to 1.0 (speed will not be modified).
+        :param rate: A relative modifier for how quickly to aspirate liquid.
+                     The flow rate for this aspirate will be
+                     `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`.
+                     If not specified, defaults to 1.0.
+                     
         :type rate: float
         :returns: This instance.
 
@@ -245,10 +246,10 @@ class InstrumentContext(CommandPublisher):
                          robot will dispense into the exact specified location.
                          If unspecified, the robot will dispense into the
                          current position.
-        :param rate: The relative plunger speed for this dispense. During
-                     this dispense, the speed of the plunger will be
-                     `rate` * :py:attr:`dispense_speed`. If not specified,
-                     defaults to 1.0 (speed will not be modified).
+        :param rate: A relative modifier for how quickly to dispense liquid.
+                     The flow rate for this dispense will be
+                     `rate` * :py:attr:`flow_rate.dispense <flow_rate>`.
+                     If not specified, defaults to 1.0.
         :type rate: float
 
         :returns: This instance.
@@ -315,8 +316,12 @@ class InstrumentContext(CommandPublisher):
                          e.g, `plate.rows()[0][0].bottom()`.  If unspecified,
                          the pipette will mix from its current position.
         :type location: types.Location
-        :param rate: Set plunger speed for this mix, where,
-                     ``speed = rate * (aspirate_speed or dispense_speed)``
+        :param rate: A relative modifier for how quickly to aspirate and
+                     dispense liquid during this mix. When aspirating, the flow
+                     rate will be
+                     `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`,
+                     and when dispensing, it will be
+                     `rate` * :py:attr:`flow_rate.dispense <flow_rate>`.
         :raises NoTipAttachedError: If no tip is attached to the pipette.
         :returns: This instance
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -150,7 +150,6 @@ class InstrumentContext(CommandPublisher):
                      The flow rate for this aspirate will be
                      `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`.
                      If not specified, defaults to 1.0.
-                     
         :type rate: float
         :returns: This instance.
 


### PR DESCRIPTION
# Overview

Close #7379.

# Changelog

In the API reference for the `rate` parameter to `mix()`, `dispense()`, and `aspirate()`...

* Correct references to the `aspirate_speed` and `dispense_speed` attributes, which don't exist. They should be `flow_rate.aspirate` and `flow_rate.dispense` instead.
* Use clickable links in those references.
* Rewrite this copy to consistently use the term *flow rate* instead of *speed*, in the spirit of #4837.

# Review requests

Does the copy look good?

* http://sandbox.docs.opentrons.com/docs-fix-flow-rate-references/v2/new_protocol_api.html#opentrons.protocol_api.contexts.InstrumentContext.mix
* http://sandbox.docs.opentrons.com/docs-fix-flow-rate-references/v2/new_protocol_api.html#opentrons.protocol_api.contexts.InstrumentContext.aspirate
* http://sandbox.docs.opentrons.com/docs-fix-flow-rate-references/v2/new_protocol_api.html#opentrons.protocol_api.contexts.InstrumentContext.dispense

# Risk assessment

Very low. Docstrings only.