### PR TITLE
feat(protocol-designer): add user prompts when exiting batch edit form

### DIFF
--- a/protocol-designer/src/components/StepSelectionBanner/index.js
+++ b/protocol-designer/src/components/StepSelectionBanner/index.js
@@ -6,8 +6,8 @@ import { selectors as stepFormSelectors } from '../../step-forms'
 import { actions as stepActions } from '../../ui/steps'
 import { getCountPerStepType } from '../../ui/steps/selectors'
 import {
-  CLOSE_STEP_FORM_WITH_CHANGES,
   ConfirmDeleteModal,
+  CLOSE_BATCH_EDIT_FORM,
 } from '../modals/ConfirmDeleteModal'
 import { StepSelectionBannerComponent } from './StepSelectionBannerComponent'
 
@@ -31,7 +31,7 @@ export const StepSelectionBanner = (): React.Node => {
     <>
       {showConfirmation && (
         <ConfirmDeleteModal
-          modalType={CLOSE_STEP_FORM_WITH_CHANGES}
+          modalType={CLOSE_BATCH_EDIT_FORM}
           onContinueClick={confirm}
           onCancelClick={cancel}
         />

--- a/protocol-designer/src/components/modals/ConfirmDeleteModal.js
+++ b/protocol-designer/src/components/modals/ConfirmDeleteModal.js
@@ -10,6 +10,7 @@ export const CLOSE_STEP_FORM_WITH_CHANGES: 'closeStepFormWithChanges' =
   'closeStepFormWithChanges'
 export const CLOSE_UNSAVED_STEP_FORM: 'closeUnsavedStepForm' =
   'closeUnsavedStepForm'
+export const CLOSE_BATCH_EDIT_FORM: 'closeBatchEditForm' = 'closeBatchEditForm'
 export const DELETE_STEP_FORM: 'deleteStepForm' = 'deleteStepForm'
 
 export type DeleteModalType =
@@ -17,6 +18,7 @@ export type DeleteModalType =
   | typeof CLOSE_STEP_FORM_WITH_CHANGES
   | typeof CLOSE_UNSAVED_STEP_FORM
   | typeof DELETE_STEP_FORM
+  | typeof CLOSE_UNSAVED_STEP_FORM
 
 type Props = {|
   modalType: DeleteModalType,

--- a/protocol-designer/src/components/modals/ConfirmDeleteModal.js
+++ b/protocol-designer/src/components/modals/ConfirmDeleteModal.js
@@ -12,13 +12,16 @@ export const CLOSE_UNSAVED_STEP_FORM: 'closeUnsavedStepForm' =
   'closeUnsavedStepForm'
 export const CLOSE_BATCH_EDIT_FORM: 'closeBatchEditForm' = 'closeBatchEditForm'
 export const DELETE_STEP_FORM: 'deleteStepForm' = 'deleteStepForm'
+export const DELETE_MULTIPLE_STEP_FORMS: 'deleteMultipleStepForms' =
+  'deleteMultipleStepForms'
 
 export type DeleteModalType =
   | typeof DELETE_PROFILE_CYCLE
   | typeof CLOSE_STEP_FORM_WITH_CHANGES
   | typeof CLOSE_UNSAVED_STEP_FORM
   | typeof DELETE_STEP_FORM
-  | typeof CLOSE_UNSAVED_STEP_FORM
+  | typeof CLOSE_BATCH_EDIT_FORM
+  | typeof DELETE_MULTIPLE_STEP_FORMS
 
 type Props = {|
   modalType: DeleteModalType,

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -30,6 +30,7 @@ import { deleteMultipleSteps } from '../../../steplist/actions'
 import {
   CLOSE_BATCH_EDIT_FORM,
   ConfirmDeleteModal,
+  DELETE_MULTIPLE_STEP_FORMS,
 } from '../../modals/ConfirmDeleteModal'
 
 import type { IconName } from '@opentrons/components'
@@ -85,19 +86,55 @@ export const MultiSelectToolbar = (): React.Node => {
   const selectedStepIds = useSelector(getMultiSelectItemIds)
   const isAllStepsSelected = stepCount === selectedStepCount
 
-  const onClickAction = isAllStepsSelected
+  const onSelectClickAction = isAllStepsSelected
     ? () => dispatch(stepActions.deselectAllSteps())
     : () => dispatch(stepActions.selectAllSteps())
 
-  const { confirm, showConfirmation, cancel } = useConditionalConfirm(
-    onClickAction,
+  const onDuplicateClickAction = () => {
+    if (selectedStepIds) {
+      dispatch(stepActions.duplicateMultipleSteps(selectedStepIds))
+    } else {
+      console.warn(
+        'something went wrong, you cannot duplicate multiple steps if none are selected'
+      )
+    }
+  }
+
+  const onDeleteClickAction = () => {
+    if (selectedStepIds) {
+      dispatch(deleteMultipleSteps(selectedStepIds))
+    } else {
+      console.warn(
+        'something went wrong, you cannot delete multiple steps if none are selected'
+      )
+    }
+  }
+
+  const {
+    confirm: confirmSelect,
+    showConfirmation: showSelectConfirmation,
+    cancel: cancelSelect,
+  } = useConditionalConfirm(onSelectClickAction, batchEditFormHasUnsavedChanges)
+
+  const {
+    confirm: confirmDuplicate,
+    showConfirmation: showDuplicateConfirmation,
+    cancel: cancelDuplicate,
+  } = useConditionalConfirm(
+    onDuplicateClickAction,
     batchEditFormHasUnsavedChanges
   )
+
+  const {
+    confirm: confirmDelete,
+    showConfirmation: showDeleteConfirmation,
+    cancel: cancelDelete,
+  } = useConditionalConfirm(onDeleteClickAction, batchEditFormHasUnsavedChanges)
 
   const selectProps = {
     iconName: isAllStepsSelected ? 'checkbox-marked' : 'minus-box',
     tooltipText: isAllStepsSelected ? 'Deselect All' : 'Select All',
-    onClick: confirm,
+    onClick: confirmSelect,
   }
 
   const deleteProps = {
@@ -105,29 +142,13 @@ export const MultiSelectToolbar = (): React.Node => {
     tooltipText: 'Delete',
     width: '1.5rem',
     alignRight: true,
-    onClick: () => {
-      if (selectedStepIds) {
-        dispatch(deleteMultipleSteps(selectedStepIds))
-      } else {
-        console.warn(
-          'something went wrong, you cannot delete multiple steps if none are selected'
-        )
-      }
-    },
+    onClick: confirmDelete,
   }
 
   const copyProps = {
     iconName: 'content-copy',
     tooltipText: 'Duplicate',
-    onClick: () => {
-      if (selectedStepIds) {
-        dispatch(stepActions.duplicateMultipleSteps(selectedStepIds))
-      } else {
-        console.warn(
-          'something went wrong, you cannot duplicate multiple steps if none are selected'
-        )
-      }
-    },
+    onClick: confirmDuplicate,
   }
 
   const expandProps = {
@@ -154,11 +175,25 @@ export const MultiSelectToolbar = (): React.Node => {
 
   return (
     <>
-      {showConfirmation && (
+      {showSelectConfirmation && (
         <ConfirmDeleteModal
           modalType={CLOSE_BATCH_EDIT_FORM}
-          onContinueClick={confirm}
-          onCancelClick={cancel}
+          onContinueClick={confirmSelect}
+          onCancelClick={cancelSelect}
+        />
+      )}
+      {showDuplicateConfirmation && (
+        <ConfirmDeleteModal
+          modalType={CLOSE_BATCH_EDIT_FORM}
+          onContinueClick={confirmDuplicate}
+          onCancelClick={cancelDuplicate}
+        />
+      )}
+      {showDeleteConfirmation && (
+        <ConfirmDeleteModal
+          modalType={DELETE_MULTIPLE_STEP_FORMS}
+          onContinueClick={confirmDelete}
+          onCancelClick={cancelDelete}
         />
       )}
       <Flex

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -28,7 +28,7 @@ import {
 import { getBatchEditFormHasUnsavedChanges } from '../../../step-forms/selectors'
 import { deleteMultipleSteps } from '../../../steplist/actions'
 import {
-  CLOSE_STEP_FORM_WITH_CHANGES,
+  CLOSE_BATCH_EDIT_FORM,
   ConfirmDeleteModal,
 } from '../../modals/ConfirmDeleteModal'
 
@@ -156,7 +156,7 @@ export const MultiSelectToolbar = (): React.Node => {
     <>
       {showConfirmation && (
         <ConfirmDeleteModal
-          modalType={CLOSE_STEP_FORM_WITH_CHANGES}
+          modalType={CLOSE_BATCH_EDIT_FORM}
           onContinueClick={confirm}
           onCancelClick={cancel}
         />

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -129,7 +129,7 @@ export const MultiSelectToolbar = (): React.Node => {
     confirm: confirmDelete,
     showConfirmation: showDeleteConfirmation,
     cancel: cancelDelete,
-  } = useConditionalConfirm(onDeleteClickAction, batchEditFormHasUnsavedChanges)
+  } = useConditionalConfirm(onDeleteClickAction, true)
 
   const selectProps = {
     iconName: isAllStepsSelected ? 'checkbox-marked' : 'minus-box',

--- a/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
@@ -13,6 +13,11 @@ import * as stepSelectors from '../../../ui/steps/selectors'
 import * as stepListActions from '../../../steplist/actions/actions'
 
 import { MultiSelectToolbar, ClickableIcon } from '../MultiSelectToolbar'
+import {
+  ConfirmDeleteModal,
+  CLOSE_BATCH_EDIT_FORM,
+  DELETE_MULTIPLE_STEP_FORMS,
+} from '../../modals/ConfirmDeleteModal'
 
 jest.mock('../../../step-forms/selectors')
 jest.mock('../../../ui/steps/selectors')
@@ -21,6 +26,8 @@ const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
 const getOrderedStepIdsMock = stepFormSelectors.getOrderedStepIds
 const getMultiSelectItemIdsMock = stepSelectors.getMultiSelectItemIds
+const getBatchEditFormHasUnsavedChangesMock =
+  stepFormSelectors.getBatchEditFormHasUnsavedChanges
 
 describe('MultiSelectToolbar', () => {
   let store
@@ -33,11 +40,15 @@ describe('MultiSelectToolbar', () => {
     when(getMultiSelectItemIdsMock)
       .calledWith(expect.anything())
       .mockReturnValue([])
+
+    when(getBatchEditFormHasUnsavedChangesMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
   })
 
   afterEach(() => {
     resetAllWhenMocks()
-    jest.resetAllMocks()
+    jest.restoreAllMocks()
   })
   const render = () =>
     mount(
@@ -154,7 +165,7 @@ describe('MultiSelectToolbar', () => {
     })
   })
   describe('when clicking on delete', () => {
-    it('should delete all of the steps selected', () => {
+    it('should delete all of the steps selected when there are NO changes to the batch edit form', () => {
       when(getOrderedStepIdsMock)
         .calledWith(expect.anything())
         .mockReturnValue(['id_1', 'id_2'])
@@ -176,9 +187,49 @@ describe('MultiSelectToolbar', () => {
       })
       expect(deleteMultipleStepsSpy).toHaveBeenCalledWith(['id_1'])
     })
+    it('should show a confirm delete modal when there are changes to the batch edit form', () => {
+      when(getBatchEditFormHasUnsavedChangesMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(true)
+
+      when(getOrderedStepIdsMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(['id_1', 'id_2'])
+
+      when(getMultiSelectItemIdsMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(['id_1'])
+
+      const deleteMultipleStepsSpy = jest.spyOn(
+        stepListActions,
+        'deleteMultipleSteps'
+      )
+
+      const wrapper = render()
+      const deleteIcon = wrapper.find(ClickableIcon).at(1)
+
+      act(() => {
+        deleteIcon.prop('onClick')()
+      })
+
+      wrapper.update()
+      const confirmDeleteModal = wrapper.find(ConfirmDeleteModal)
+      expect(deleteMultipleStepsSpy).not.toHaveBeenCalled()
+      expect(confirmDeleteModal.prop('modalType')).toBe(
+        DELETE_MULTIPLE_STEP_FORMS
+      )
+
+      act(() => {
+        confirmDeleteModal.prop('onContinueClick')()
+      })
+      wrapper.update()
+
+      expect(wrapper.find(ConfirmDeleteModal).length).toBe(0)
+      expect(deleteMultipleStepsSpy).toHaveBeenCalledWith(['id_1'])
+    })
   })
   describe('when clicking on duplicate', () => {
-    it('should duplicate all of the steps selected', () => {
+    it('should duplicate all of the steps selected when there are NO changes to the batch edit form', () => {
       when(getOrderedStepIdsMock)
         .calledWith(expect.anything())
         .mockReturnValue(['id_1', 'id_2'])
@@ -198,6 +249,46 @@ describe('MultiSelectToolbar', () => {
       act(() => {
         copyIcon.prop('onClick')()
       })
+
+      expect(duplicateMultipleStepsSpy).toHaveBeenCalledWith(['id_1'])
+    })
+
+    it('should show a confirm delete modal when there are changes to the batch edit form', () => {
+      when(getBatchEditFormHasUnsavedChangesMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(true)
+
+      when(getOrderedStepIdsMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(['id_1', 'id_2'])
+
+      when(getMultiSelectItemIdsMock)
+        .calledWith(expect.anything())
+        .mockReturnValue(['id_1'])
+
+      const duplicateMultipleStepsSpy = jest.spyOn(
+        stepActions,
+        'duplicateMultipleSteps'
+      )
+
+      const wrapper = render()
+      const copyIcon = wrapper.find(ClickableIcon).at(2)
+
+      act(() => {
+        copyIcon.prop('onClick')()
+      })
+
+      wrapper.update()
+      const confirmDeleteModal = wrapper.find(ConfirmDeleteModal)
+      expect(duplicateMultipleStepsSpy).not.toHaveBeenCalled()
+      expect(confirmDeleteModal.prop('modalType')).toBe(CLOSE_BATCH_EDIT_FORM)
+
+      act(() => {
+        confirmDeleteModal.prop('onContinueClick')()
+      })
+      wrapper.update()
+
+      expect(wrapper.find(ConfirmDeleteModal).length).toBe(0)
       expect(duplicateMultipleStepsSpy).toHaveBeenCalledWith(['id_1'])
     })
   })

--- a/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
@@ -165,33 +165,7 @@ describe('MultiSelectToolbar', () => {
     })
   })
   describe('when clicking on delete', () => {
-    it('should delete all of the steps selected when there are NO changes to the batch edit form', () => {
-      when(getOrderedStepIdsMock)
-        .calledWith(expect.anything())
-        .mockReturnValue(['id_1', 'id_2'])
-
-      when(getMultiSelectItemIdsMock)
-        .calledWith(expect.anything())
-        .mockReturnValue(['id_1'])
-
-      const deleteMultipleStepsSpy = jest.spyOn(
-        stepListActions,
-        'deleteMultipleSteps'
-      )
-
-      const wrapper = render()
-
-      const deleteIcon = wrapper.find(ClickableIcon).at(1)
-      act(() => {
-        deleteIcon.prop('onClick')()
-      })
-      expect(deleteMultipleStepsSpy).toHaveBeenCalledWith(['id_1'])
-    })
-    it('should show a confirm delete modal when there are changes to the batch edit form', () => {
-      when(getBatchEditFormHasUnsavedChangesMock)
-        .calledWith(expect.anything())
-        .mockReturnValue(true)
-
+    it('should show a confirm delete modal before deleting the steps', () => {
       when(getOrderedStepIdsMock)
         .calledWith(expect.anything())
         .mockReturnValue(['id_1', 'id_2'])

--- a/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
+++ b/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
@@ -14,6 +14,7 @@ import {
   ConfirmDeleteModal,
   CLOSE_UNSAVED_STEP_FORM,
   CLOSE_STEP_FORM_WITH_CHANGES,
+  CLOSE_BATCH_EDIT_FORM,
 } from '../../components/modals/ConfirmDeleteModal'
 
 import * as stepFormSelectors from '../../step-forms/selectors/index.js'
@@ -38,6 +39,8 @@ const getArgsAndErrorsByStepIdMock = stepFormSelectors.getArgsAndErrorsByStepId
 const getCurrentFormIsPresavedMock = stepFormSelectors.getCurrentFormIsPresaved
 const getCurrentFormHasUnsavedChangesMock =
   stepFormSelectors.getCurrentFormHasUnsavedChanges
+const getBatchEditFormHasUnsavedChangesMock =
+  stepFormSelectors.getBatchEditFormHasUnsavedChanges
 const getHasTimelineWarningsPerStepMock =
   timelineWarningSelectors.getHasTimelineWarningsPerStep
 const getHasFormLevelWarningsPerStepMock =
@@ -50,6 +53,7 @@ const getMultiSelectItemIdsMock = uiStepSelectors.getMultiSelectItemIds
 const getSubstepsMock = fileDataSelectors.getSubsteps
 const getErrorStepId = fileDataSelectors.getErrorStepId
 const getBatchEditEnabledMock = featureFlagSelectors.getBatchEditEnabled
+const getIsMultiSelectModeMock = uiStepSelectors.getIsMultiSelectMode
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares)
@@ -82,6 +86,10 @@ describe('ConnectedStepItem', () => {
       .mockReturnValue(false)
 
     when(getCurrentFormHasUnsavedChangesMock)
+      .calledWith(expect.anything())
+      .mockReturnValue(false)
+
+    when(getIsMultiSelectModeMock)
       .calledWith(expect.anything())
       .mockReturnValue(false)
 
@@ -156,8 +164,26 @@ describe('ConnectedStepItem', () => {
         )
         expect(store.getActions().length).toBe(0)
       })
+      it('should display the "unsaved changes to multiple steps" modal when batch edit form has unsaved changes', () => {
+        when(getBatchEditFormHasUnsavedChangesMock)
+          .calledWith(expect.anything())
+          .mockReturnValue(true)
 
-      it('should display the "close form with changes" modal when form has unsaved changes', () => {
+        when(getIsMultiSelectModeMock)
+          .calledWith(expect.anything())
+          .mockReturnValue(true)
+        const props = { stepId: mockId, stepNumber: 1 }
+        const wrapper = render(props)
+        act(() => {
+          wrapper.find(StepItem).prop('handleClick')(mockClickEvent)
+        })
+        wrapper.update()
+        const confirmDeleteModal = wrapper.find(ConfirmDeleteModal)
+        expect(confirmDeleteModal).toHaveLength(1)
+        expect(confirmDeleteModal.prop('modalType')).toBe(CLOSE_BATCH_EDIT_FORM)
+        expect(store.getActions().length).toBe(0)
+      })
+      it('should display the "unsaved changes to step" modal when single edit form has unsaved changes', () => {
         when(getCurrentFormHasUnsavedChangesMock)
           .calledWith(expect.anything())
           .mockReturnValue(true)
@@ -243,7 +269,7 @@ describe('ConnectedStepItem', () => {
           expect(store.getActions().length).toBe(0)
         })
 
-        it('should display the "close form with changes" modal when form has unsaved changes', () => {
+        it('should display the "unsaved changes to step" modal when single edit form has unsaved changes', () => {
           when(getCurrentFormHasUnsavedChangesMock)
             .calledWith(expect.anything())
             .mockReturnValue(true)
@@ -538,7 +564,7 @@ describe('ConnectedStepItem', () => {
           expect(store.getActions().length).toBe(0)
         })
 
-        it('should display the "close form with changes" modal when form has unsaved changes', () => {
+        it('should display the "unsaved changes to step" modal when single edit form has unsaved changes', () => {
           when(getCurrentFormHasUnsavedChangesMock)
             .calledWith(expect.anything())
             .mockReturnValue(true)

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -87,6 +87,11 @@
       "body": "You have not saved this step form. If you navigate away without saving, this step will be deleted.",
       "confirm_button": "delete step"
     },
+    "closeBatchEditForm": {
+      "title": "Unsaved changes to multiple steps",
+      "body": "You have unsaved changes in this form. If you change your step selection without saving you will lose these changes.",
+      "confirm_button": "discard changes"
+    },
     "closeStepFormWithChanges": {
       "title": "Unsaved changes to step",
       "body": "You have unsaved changes in this step. If you navigate away without saving you will lose these changes.",

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -102,6 +102,11 @@
       "body": "Are you sure you want to delete this step?",
       "confirm_button": "delete step"
     },
+    "deleteMultipleStepForms": {
+      "title": "Delete multiple steps",
+      "body": "Are you sure you want to delete these steps?",
+      "confirm_button": "delete steps"
+    },
     "deleteProfileCycle": {
       "title": "Delete cycle",
       "body": "This will delete the cycle and all profile steps inside.",

--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -1054,6 +1054,9 @@ type BatchEditFormActions =
   | ResetBatchEditFieldChangesAction
   | SaveStepFormsMultiAction
   | SelectStepAction
+  | SelectMultipleStepsAction
+  | DuplicateMultipleStepsAction
+  | DeleteMultipleStepsAction
 
 export const batchEditFormChanges = (
   state: BatchEditFormChangesState = {},
@@ -1068,6 +1071,9 @@ export const batchEditFormChanges = (
     }
     case 'SELECT_STEP':
     case 'SAVE_STEP_FORMS_MULTI':
+    case 'SELECT_MULTIPLE_STEPS':
+    case 'DUPLICATE_MULTIPLE_STEPS':
+    case 'DELETE_MULTIPLE_STEPS':
     case 'RESET_BATCH_EDIT_FIELD_CHANGES': {
       return {}
     }

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1820,4 +1820,25 @@ describe('batchEditFormChanges reducer', () => {
     }
     expect(batchEditFormChanges(state, { ...action })).toEqual({})
   })
+  it('should reset state on SELECT_MULTIPLE_STEPS', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'SELECT_MULTIPLE_STEPS',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
+  })
+  it('should reset state on DUPLICATE_MULTIPLE_STEPS', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'DUPLICATE_MULTIPLE_STEPS',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
+  })
+  it('should reset state on DELETE_MULTIPLE_STEPS', () => {
+    const state = { someFieldName: 'someFieldValue' }
+    const action = {
+      type: 'DELETE_MULTIPLE_STEPS',
+    }
+    expect(batchEditFormChanges(state, { ...action })).toEqual({})
+  })
 })


### PR DESCRIPTION
# Overview
This PR adds triggers that force a user to confirm or cancel loss of changes to a step form.

Pairing credit to @IanLondon!
Closes #7138

# Changelog
- Add triggers that force a user to confirm or cancel loss of changes to a step form

# Review requests
Kinda weird to test right now cuz the batch edit form is not done yet, but you can simulate the batch edit form having changes by opening up redux dev tools and using the dispatcher to dispatch this action:
```js
{
  type: 'CHANGE_BATCH_EDIT_FIELD',
  payload: {'foo': 123},
}
```

Enter batch edit mode, and then dispatch the action above. Once you've done that, make sure all of the ACs in the [ticket](https://github.com/Opentrons/opentrons/issues/7138) have been met.
# Risk assessment
Low
