### PR TITLE
feat(api): add enableProtocolEngine feature flag to opentrons.config

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -177,6 +177,16 @@ settings = [
                     'should only be used if a protocol has been simulated '
                     'before.',
         restart_required=False,
+    ),
+    SettingDefinition(
+        _id="enableProtocolEngine",
+        title="Enable Experimental Protocol Engine",
+        description=(
+            "Do not enable. This is an Opentrons-internal setting to test "
+            "new protocol execution logic. This feature is not yet complete; "
+            "your protocols will break if you enable this setting."
+        ),
+        restart_required=False,
     )
 ]
 
@@ -373,8 +383,19 @@ def _migrate7to8(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate8to9(previous: SettingsMap) -> SettingsMap:
+    """
+    Migration to version 8 of the feature flags file. Adds the
+    enableFastProtocolUpload config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableProtocolEngine"] = None
+    return newmap
+
+
 _MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4,
-               _migrate4to5, _migrate5to6, _migrate6to7, _migrate7to8]
+               _migrate4to5, _migrate5to6, _migrate6to7, _migrate7to8,
+               _migrate8to9]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should
@@ -416,7 +437,7 @@ def _ensure(data: Mapping[str, Any]) -> SettingsMap:
     return newdata
 
 
-def get_setting_with_env_overload(setting_name):
+def get_setting_with_env_overload(setting_name) -> bool:
     env_name = 'OT_API_FF_' + setting_name
     if env_name in os.environ:
         return os.environ[env_name].lower() in {'1', 'true', 'on'}

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,37 +1,43 @@
 from opentrons.config import advanced_settings as advs
 
 
-def short_fixed_trash():
+def short_fixed_trash() -> bool:
     return advs.get_setting_with_env_overload('shortFixedTrash')
 
 
-def calibrate_to_bottom():
+def calibrate_to_bottom() -> bool:
     return advs.get_setting_with_env_overload('calibrateToBottom')
 
 
-def dots_deck_type():
+def dots_deck_type() -> bool:
     return advs.get_setting_with_env_overload('deckCalibrationDots')
 
 
-def disable_home_on_boot():
+def disable_home_on_boot() -> bool:
     return advs.get_setting_with_env_overload('disableHomeOnBoot')
 
 
-def use_protocol_api_v2():
+def use_protocol_api_v2() -> bool:
     return not advs.get_setting_with_env_overload('useLegacyInternals')
 
 
-def use_old_aspiration_functions():
+def use_old_aspiration_functions() -> bool:
     return advs.get_setting_with_env_overload('useOldAspirationFunctions')
 
 
-def enable_door_safety_switch():
+def enable_door_safety_switch() -> bool:
     return advs.get_setting_with_env_overload('enableDoorSafetySwitch')
 
 
-def enable_http_protocol_sessions():
+def enable_http_protocol_sessions() -> bool:
     return advs.get_setting_with_env_overload('enableHttpProtocolSessions')
 
 
-def enable_fast_protocol_upload():
+def enable_fast_protocol_upload() -> bool:
     return advs.get_setting_with_env_overload('enableFastProtocolUpload')
+
+
+def enable_protocol_engine() -> bool:
+    """Get if the ProtocolEngine should be used to run protocol files."""
+
+    return advs.get_setting_with_env_overload("enableProtocolEngine")

--- a/api/tests/opentrons/config/__init__.py
+++ b/api/tests/opentrons/config/__init__.py
@@ -1,0 +1,1 @@
+"""Tests module for opentrons.config."""

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 8
+    return 9
 
 
 @pytest.fixture
@@ -26,6 +26,7 @@ def default_file_settings() -> Dict[str, Optional[bool]]:
         'enableTipLengthCalibration': None,
         'enableHttpProtocolSessions': None,
         'enableFastProtocolUpload': None,
+        'enableProtocolEngine': None,
     }
 
 
@@ -37,24 +38,24 @@ def empty_settings():
 @pytest.fixture
 def version_less():
     return {
-      'shortFixedTrash': True,
-      'calibrateToBottom': True,
-      'deckCalibrationDots': True,
-      'disableHomeOnBoot': True,
-      'useOldAspirationFunctions': True,
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': True,
+        'disableHomeOnBoot': True,
+        'useOldAspirationFunctions': True,
     }
 
 
 @pytest.fixture
 def v1_config():
     return {
-      '_version': 1,
-      'shortFixedTrash': True,
-      'calibrateToBottom': True,
-      'deckCalibrationDots': True,
-      'disableHomeOnBoot': True,
-      'useProtocolApi2': None,
-      'useOldAspirationFunctions': True,
+        '_version': 1,
+        'shortFixedTrash': True,
+        'calibrateToBottom': True,
+        'deckCalibrationDots': True,
+        'disableHomeOnBoot': True,
+        'useProtocolApi2': None,
+        'useOldAspirationFunctions': True,
     }
 
 
@@ -98,6 +99,46 @@ def v5_config(v4_config):
     return r
 
 
+@pytest.fixture
+def v6_config(v5_config):
+    r = v5_config
+    r.update({
+        '_version': 6,
+        'enableTipLengthCalibration': True,
+    })
+    return r
+
+
+@pytest.fixture
+def v7_config(v6_config):
+    r = v6_config
+    r.update({
+        '_version': 7,
+        'enableHttpProtocolSessions': True,
+    })
+    return r
+
+
+@pytest.fixture
+def v8_config(v7_config):
+    r = v7_config
+    r.update({
+        '_version': 8,
+        'enableFastProtocolUpload': True,
+    })
+    return r
+
+
+@pytest.fixture
+def v9_config(v8_config):
+    r = v8_config
+    r.update({
+        '_version': 9,
+        'enableProtocolEngine': True,
+    })
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -107,7 +148,11 @@ def v5_config(v4_config):
         lazy_fixture("v2_config"),
         lazy_fixture("v3_config"),
         lazy_fixture("v4_config"),
-        lazy_fixture("v5_config")
+        lazy_fixture("v5_config"),
+        lazy_fixture("v6_config"),
+        lazy_fixture("v7_config"),
+        lazy_fixture("v8_config"),
+        lazy_fixture("v9_config"),
     ]
 )
 def old_settings(request):
@@ -130,10 +175,10 @@ def test_migrations(
 def test_migrates_versionless_old_config(
         migrated_file_version, default_file_settings):
     settings, version = _migrate({
-      'short-fixed-trash': False,
-      'calibrate-to-bottom': False,
-      'dots-deck-type': True,
-      'disable-home-on-boot': False,
+        'short-fixed-trash': False,
+        'calibrate-to-bottom': False,
+        'dots-deck-type': True,
+        'disable-home-on-boot': False,
     })
 
     expected = default_file_settings
@@ -150,8 +195,8 @@ def test_migrates_versionless_old_config(
 
 def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
     settings, version = _migrate({
-      'split-labware-def': True,
-      'splitLabwareDefinitions': True
+        'split-labware-def': True,
+        'splitLabwareDefinitions': True,
     })
 
     assert version == migrated_file_version
@@ -159,21 +204,22 @@ def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
 
 
 def test_ensures_config(default_file_settings):
-    assert _ensure(
-        {'_version': 3,
-         'shortFixedTrash': False,
-         'disableLogAggregation': True})\
-         == {
-             '_version': 3,
-             'shortFixedTrash': False,
-             'calibrateToBottom': None,
-             'deckCalibrationDots': None,
-             'disableHomeOnBoot': None,
-             'useOldAspirationFunctions': None,
-             'disableLogAggregation': True,
-             'useProtocolApi2': None,
-             'enableDoorSafetySwitch': None,
-             'enableTipLengthCalibration': None,
-             'enableHttpProtocolSessions': None,
-             'enableFastProtocolUpload': None,
-         }
+    assert _ensure({
+        '_version': 3,
+        'shortFixedTrash': False,
+        'disableLogAggregation': True
+    }) == {
+        '_version': 3,
+        'shortFixedTrash': False,
+        'calibrateToBottom': None,
+        'deckCalibrationDots': None,
+        'disableHomeOnBoot': None,
+        'useOldAspirationFunctions': None,
+        'disableLogAggregation': True,
+        'useProtocolApi2': None,
+        'enableDoorSafetySwitch': None,
+        'enableTipLengthCalibration': None,
+        'enableHttpProtocolSessions': None,
+        'enableFastProtocolUpload': None,
+        'enableProtocolEngine': None,
+    }

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -4,74 +4,80 @@ marks:
   - usefixtures:
       - run_server
 stages:
-  - name: Settings GET request returns correct info 
+  - name: Settings GET request returns correct info
     request:
       method: GET
-      url: "{host:s}:{port:d}/settings"
+      url: '{host:s}:{port:d}/settings'
     response:
       status_code: 200
       json:
         settings:
-        - id: shortFixedTrash
-          old_id: short-fixed-trash
-          title: Short (55mm) fixed trash
-          description: !re_search "Trash box is 55mm tall"
-          restart_required: false
-          value: !anything
-        - id: calibrateToBottom
-          old_id: calibrate-to-bottom
-          title: Calibrate to bottom
-          description: !re_search "Calibrate using the bottom-center"
-          restart_required: false
-          value: !anything
-        - id: deckCalibrationDots
-          old_id: dots-deck-type
-          title: Deck calibration to dots
-          description: !re_search "Perform deck calibration to dots"
-          restart_required: false
-          value: !anything
-        - id: useProtocolApi2
-          old_id: Null
-          title: Use Protocol API version 2
-          description: Deprecated feature flag
-          restart_required: false
-          value: !anything
-        - id: disableHomeOnBoot
-          old_id: disable-home-on-boot
-          title: Disable home on boot
-          description: Prevent robot from homing motors on boot
-          restart_required: false
-          value: !anything
-        - id: useOldAspirationFunctions
-          old_id: Null
-          title: Use older aspirate behavior
-          description: !re_search "Aspirate with the less accurate volumetric calibrations"
-          restart_required: false
-          value: !anything
-        - id: enableDoorSafetySwitch
-          old_id: Null
-          title: Enable robot door safety switch
-          description: !re_search "Automatically pause protocols when robot door opens"
-          restart_required: false
-          value: !anything
-        - id: enableTipLengthCalibration
-          old_id: Null
-          title: Enable Under-Development Calibration Flows
-          description: !re_search "Enables the in-progress robot calibration flows"
-          restart_required: false
-          value: !anything
-        - id: enableHttpProtocolSessions
-          old_id: Null
-          title: Enable Experimental HTTP Protocol Sessions
-          description: !re_search "Activating this will disable protocol running from the Opentrons application"
-          restart_required: true
-          value: !anything
-        - id: enableFastProtocolUpload
-          old_id: Null
-          title: Enable Experimental Fast Protocol Upload
-          description: !re_search "Enabling this flag will skip simulation for a faster"
-          restart_required: false
-          value: !anything
+          - id: shortFixedTrash
+            old_id: short-fixed-trash
+            title: Short (55mm) fixed trash
+            description: !re_search 'Trash box is 55mm tall'
+            restart_required: false
+            value: !anything
+          - id: calibrateToBottom
+            old_id: calibrate-to-bottom
+            title: Calibrate to bottom
+            description: !re_search 'Calibrate using the bottom-center'
+            restart_required: false
+            value: !anything
+          - id: deckCalibrationDots
+            old_id: dots-deck-type
+            title: Deck calibration to dots
+            description: !re_search 'Perform deck calibration to dots'
+            restart_required: false
+            value: !anything
+          - id: useProtocolApi2
+            old_id: Null
+            title: Use Protocol API version 2
+            description: Deprecated feature flag
+            restart_required: false
+            value: !anything
+          - id: disableHomeOnBoot
+            old_id: disable-home-on-boot
+            title: Disable home on boot
+            description: Prevent robot from homing motors on boot
+            restart_required: false
+            value: !anything
+          - id: useOldAspirationFunctions
+            old_id: Null
+            title: Use older aspirate behavior
+            description: !re_search 'Aspirate with the less accurate volumetric calibrations'
+            restart_required: false
+            value: !anything
+          - id: enableDoorSafetySwitch
+            old_id: Null
+            title: Enable robot door safety switch
+            description: !re_search 'Automatically pause protocols when robot door opens'
+            restart_required: false
+            value: !anything
+          - id: enableTipLengthCalibration
+            old_id: Null
+            title: Enable Under-Development Calibration Flows
+            description: !re_search 'Enables the in-progress robot calibration flows'
+            restart_required: false
+            value: !anything
+          - id: enableHttpProtocolSessions
+            old_id: Null
+            title: Enable Experimental HTTP Protocol Sessions
+            description: !re_search 'Activating this will disable protocol running from the Opentrons application'
+            restart_required: true
+            value: !anything
+          - id: enableFastProtocolUpload
+            old_id: Null
+            title: Enable Experimental Fast Protocol Upload
+            description: !re_search 'Enabling this flag will skip simulation for a faster'
+            restart_required: false
+            value: !anything
+          - id: enableProtocolEngine
+            old_id: Null
+            title: Enable Experimental Protocol Engine
+            description: !re_search 'Opentrons-internal setting to test new protocol execution logic'
+            restart_required: false
+            value: !anything
         links: !anydict
 
 ---
@@ -83,35 +89,35 @@ marks:
   - parametrize:
       key: id
       vals:
-      - shortFixedTrash
-      - calibrateToBottom
-      - deckCalibrationDots
-      - useProtocolApi2
-      - disableHomeOnBoot
-      - useOldAspirationFunctions
-      - enableDoorSafetySwitch
-      - enableTipLengthCalibration
-      - enableHttpProtocolSessions
+        - shortFixedTrash
+        - calibrateToBottom
+        - deckCalibrationDots
+        - useProtocolApi2
+        - disableHomeOnBoot
+        - useOldAspirationFunctions
+        - enableDoorSafetySwitch
+        - enableTipLengthCalibration
+        - enableHttpProtocolSessions
   - parametrize:
       key: value
       vals:
-      - "True"
-      - "False"
+        - 'True'
+        - 'False'
 stages:
-  - name: Set each setting to acceptable values 
+  - name: Set each setting to acceptable values
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings"
-      json: 
-        id: "{id}"
-        value: "{value}"
+      url: '{host:s}:{port:d}/settings'
+      json:
+        id: '{id}'
+        value: '{value}'
     response:
       status_code: 200
       verify_response_with:
         function: tests.integration.utils:verify_settings_value
         extra_kwargs:
-          id: "{id}"
-          value: "{value}"
+          id: '{id}'
+          value: '{value}'
 
 ---
 # All Possible Settings with no values
@@ -122,28 +128,28 @@ marks:
   - parametrize:
       key: id
       vals:
-      - shortFixedTrash
-      - calibrateToBottom
-      - deckCalibrationDots
-      - useProtocolApi2
-      - disableHomeOnBoot
-      - useOldAspirationFunctions
-      - enableDoorSafetySwitch
-      - enableTipLengthCalibration
-      - enableHttpProtocolSessions
+        - shortFixedTrash
+        - calibrateToBottom
+        - deckCalibrationDots
+        - useProtocolApi2
+        - disableHomeOnBoot
+        - useOldAspirationFunctions
+        - enableDoorSafetySwitch
+        - enableTipLengthCalibration
+        - enableHttpProtocolSessions
 stages:
-  - name: Set each setting to acceptable values 
+  - name: Set each setting to acceptable values
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings"
-      json: 
-        id: "{id}"
+      url: '{host:s}:{port:d}/settings'
+      json:
+        id: '{id}'
     response:
       status_code: 200
       verify_response_with:
         function: tests.integration.utils:verify_settings_value
         extra_kwargs:
-          id: "{id}"
+          id: '{id}'
           value: Null
 
 ---
@@ -156,11 +162,11 @@ stages:
   - name: Post with incorrect ID
     request:
       method: POST
-      url: "{host:s}:{port:d}/settings"
-      json: 
+      url: '{host:s}:{port:d}/settings'
+      json:
         id: notARealID
         value: true
     response:
       status_code: 400
       json:
-        message: "{tavern.request_vars.json.id} is not recognized"
+        message: '{tavern.request_vars.json.id} is not recognized'


### PR DESCRIPTION
## Overview

This PR adds a robot-side [feature flag / advanced setting](https://github.com/Opentrons/opentrons/issues/7388) to enable the usage of a Protocol Engine in protocol file execution. This flag is not yet hooked to anything as of this PR.

Closes #7333

## Changelog

- feat(api): add enableProtocolEngine feature flag to opentrons.config

## Review requests

- Check config migration code
- Check config migration tests
- Check setting language for technical correctness, typos, tone, etc.

## Risk assessment

Very low. Any risk would be due to preexisting bugs in our advanced settings system, which would be out of scope for this PR.