### PR TITLE
feat(protocol-designer): implement makeBatchEditFieldProps and save/cancel buttons

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/__tests__/makeBatchEditFieldProps.test.js
+++ b/protocol-designer/src/components/BatchEditForm/__tests__/makeBatchEditFieldProps.test.js
@@ -1,0 +1,102 @@
+// @flow
+import noop from 'lodash/noop'
+import { makeBatchEditFieldProps } from '../makeBatchEditFieldProps'
+import * as stepEditFormUtils from '../../StepEditForm/utils'
+
+const getFieldDefaultTooltipSpy = jest.spyOn(
+  stepEditFormUtils,
+  'getFieldDefaultTooltip'
+)
+
+beforeEach(() => {
+  getFieldDefaultTooltipSpy.mockImplementation(name => `tooltip for ${name}`)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('makeBatchEditFieldProps', () => {
+  it('should create correct props for all fields with the given MultiselectFieldValues obj', () => {
+    const fieldValues = {
+      aspirate_flowRate: {
+        isIndeterminate: false,
+        value: '1.2',
+      },
+    }
+    const handleChangeFormInput: any = jest.fn()
+
+    const disabledFields = {}
+
+    const result = makeBatchEditFieldProps(
+      fieldValues,
+      disabledFields,
+      handleChangeFormInput
+    )
+
+    expect(result).toEqual({
+      aspirate_flowRate: {
+        disabled: false,
+        errorToShow: null,
+        isIndeterminate: false,
+        name: 'aspirate_flowRate',
+        onFieldBlur: noop,
+        onFieldFocus: noop,
+        updateValue: expect.anything(),
+        value: '1.2',
+        tooltipContent: 'tooltip for aspirate_flowRate',
+      },
+    })
+
+    result.aspirate_flowRate.updateValue('42')
+    expect(handleChangeFormInput).toHaveBeenCalledWith(
+      'aspirate_flowRate',
+      '42'
+    )
+  })
+
+  it('should make field disabled if it is represented in disabledFields, and show disabled explanation tooltip', () => {
+    const fieldValues = {
+      aspirate_flowRate: {
+        value: '1.2',
+        isIndeterminate: false,
+      },
+    }
+    const handleChangeFormInput: any = jest.fn()
+
+    const disabledFields = {
+      aspirate_flowRate: 'Disabled explanation text here',
+    }
+
+    const result = makeBatchEditFieldProps(
+      fieldValues,
+      disabledFields,
+      handleChangeFormInput
+    )
+
+    expect(result.aspirate_flowRate.disabled).toBe(true)
+    expect(result.aspirate_flowRate.tooltipContent).toBe(
+      'Disabled explanation text here'
+    )
+  })
+
+  it('should make field indeterminate if it is indeterminate', () => {
+    const fieldValues = {
+      aspirate_flowRate: {
+        value: '1.2',
+        isIndeterminate: true,
+      },
+    }
+    const handleChangeFormInput: any = jest.fn()
+
+    const disabledFields = {}
+
+    const result = makeBatchEditFieldProps(
+      fieldValues,
+      disabledFields,
+      handleChangeFormInput
+    )
+
+    expect(result.aspirate_flowRate.isIndeterminate).toBe(true)
+  })
+})

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -3,12 +3,16 @@ import * as React from 'react'
 import { i18n } from '../../localization'
 import { CheckboxRowField, TextField } from '../StepEditForm/fields'
 import { makeBatchEditFieldProps } from './makeBatchEditFieldProps'
-import type { MultiselectFieldValues } from '../../ui/steps/selectors'
+import type {
+  DisabledFields,
+  MultiselectFieldValues,
+} from '../../ui/steps/selectors'
 import type { StepType } from '../../form-types'
 import type { FieldPropsByName } from '../StepEditForm/types'
 import styles from '../StepEditForm/StepEditForm.css'
 
 export type BatchEditFormProps = {|
+  disabledFields: DisabledFields | null,
   stepTypes: Array<StepType>,
   fieldValues: MultiselectFieldValues | null,
   handleChangeFormInput: (name: string, value: mixed) => void,
@@ -30,9 +34,6 @@ export const BatchEditMoveLiquid = (
         {...propsForFields['aspirate_mix_checkbox']}
         label={i18n.t('form.step_edit_form.field.mix.label')}
         className={styles.small_field}
-        tooltipContent={i18n.t(
-          `tooltip.step_fields.defaults.${'aspirate_mix_checkbox'}`
-        )}
       >
         <TextField
           {...propsForFields['aspirate_mix_volume']}
@@ -53,16 +54,23 @@ export const BatchEditMoveLiquid = (
 }
 
 export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
-  const { stepTypes, fieldValues, handleChangeFormInput } = props
+  const {
+    disabledFields,
+    stepTypes,
+    fieldValues,
+    handleChangeFormInput,
+  } = props
 
   if (
     stepTypes.length === 1 &&
     stepTypes.includes('moveLiquid') &&
-    fieldValues !== null
+    fieldValues !== null &&
+    disabledFields !== null
   ) {
     // Valid state for using makeBatchEditFieldProps
     const propsForFields = makeBatchEditFieldProps(
       fieldValues,
+      disabledFields,
       handleChangeFormInput
     )
     return (

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -16,6 +16,8 @@ export type BatchEditFormProps = {|
   stepTypes: Array<StepType>,
   fieldValues: MultiselectFieldValues | null,
   handleChangeFormInput: (name: string, value: mixed) => void,
+  handleClose: () => mixed,
+  handleSave: () => mixed,
 |}
 
 type BatchEditMoveLiquidProps = {|
@@ -59,6 +61,8 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
     stepTypes,
     fieldValues,
     handleChangeFormInput,
+    handleClose,
+    handleSave,
   } = props
 
   if (
@@ -74,16 +78,7 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
       handleChangeFormInput
     )
     return (
-      <BatchEditMoveLiquid
-        propsForFields={propsForFields}
-        handleClose={() => {
-          // TODO(IL, 2021-02-17): implement in #7138
-          console.log('TODO: close')
-        }}
-        handleSave={() => {
-          console.log('TODO: save')
-        }}
-      />
+      <BatchEditMoveLiquid {...{ propsForFields, handleClose, handleSave }} />
     )
   }
 

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -16,19 +16,19 @@ export type BatchEditFormProps = {|
   stepTypes: Array<StepType>,
   fieldValues: MultiselectFieldValues | null,
   handleChangeFormInput: (name: string, value: mixed) => void,
-  handleClose: () => mixed,
+  handleCancel: () => mixed,
   handleSave: () => mixed,
 |}
 
 type BatchEditMoveLiquidProps = {|
   propsForFields: FieldPropsByName,
-  handleClose: () => mixed,
+  handleCancel: () => mixed,
   handleSave: () => mixed,
 |}
 export const BatchEditMoveLiquid = (
   props: BatchEditMoveLiquidProps
 ): React.Node => {
-  const { propsForFields, handleClose, handleSave } = props
+  const { propsForFields, handleCancel, handleSave } = props
   return (
     // TOOD IMMEDIATELY copied from SourceDestFields. Refactor to be DRY
     <div>
@@ -49,7 +49,7 @@ export const BatchEditMoveLiquid = (
         />
       </CheckboxRowField>
       <p>TODO batch edit form for Transfer step goes here</p>
-      <button onClick={handleClose}>Close</button>
+      <button onClick={handleCancel}>Cancel</button>
       <button onClick={handleSave}>Save</button>
     </div>
   )
@@ -61,7 +61,7 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
     stepTypes,
     fieldValues,
     handleChangeFormInput,
-    handleClose,
+    handleCancel,
     handleSave,
   } = props
 
@@ -78,7 +78,7 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
       handleChangeFormInput
     )
     return (
-      <BatchEditMoveLiquid {...{ propsForFields, handleClose, handleSave }} />
+      <BatchEditMoveLiquid {...{ propsForFields, handleCancel, handleSave }} />
     )
   }
 

--- a/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
+++ b/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
@@ -1,36 +1,33 @@
 // @flow
-import type { MultiselectFieldValues } from '../../ui/steps/selectors'
+import noop from 'lodash/noop'
+import type {
+  DisabledFields,
+  MultiselectFieldValues,
+} from '../../ui/steps/selectors'
+import { getFieldDefaultTooltip } from '../StepEditForm/utils'
 import type { FieldPropsByName } from '../StepEditForm/types'
+import type { MultiSelectFieldName } from '../../form-types'
 
-// TODO(IL, 2021-02-17): this is a placeholder. Actually implement in #7222
 export const makeBatchEditFieldProps = (
   fieldValues: MultiselectFieldValues,
+  disabledFields: DisabledFields,
   handleChangeFormInput: (name: string, value: mixed) => void
 ): FieldPropsByName => {
-  const junk = {
-    isIndeterminate: false,
-    disabled: false,
-    updateValue: () => {},
-    errorToShow: null,
-    onFieldBlur: () => {},
-    onFieldFocus: () => {},
-  }
-  return {
-    aspirate_mix_checkbox: {
-      name: 'aspirate_mix_checkbox',
-      value: true,
-      ...junk,
-    },
-    aspirate_mix_volume: {
-      name: 'aspirate_mix_volume',
-      value: '12',
-      isIndeterminate: true,
-      ...junk,
-    },
-    aspirate_mix_times: {
-      name: 'aspirate_mix_times',
-      value: '',
-      ...junk,
-    },
-  }
+  const fieldNames: Array<MultiSelectFieldName> = Object.keys(fieldValues)
+  return fieldNames.reduce<FieldPropsByName>((acc, name) => {
+    const defaultTooltip = getFieldDefaultTooltip(name)
+    acc[name] = {
+      disabled: name in disabledFields,
+      name,
+      updateValue: value => handleChangeFormInput(name, value),
+      value: fieldValues[name].value,
+      errorToShow: null,
+      onFieldBlur: noop,
+      onFieldFocus: noop,
+      isIndeterminate: fieldValues[name].isIndeterminate,
+      tooltipContent:
+        name in disabledFields ? disabledFields[name] : defaultTooltip,
+    }
+    return acc
+  }, {})
 }

--- a/protocol-designer/src/components/FormManager/index.js
+++ b/protocol-designer/src/components/FormManager/index.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { StepEditForm } from '../StepEditForm'
 import { BatchEditForm } from '../BatchEditForm'
 import { StepSelectionBanner } from '../StepSelectionBanner'
@@ -10,16 +10,17 @@ import {
   getMultiSelectDisabledFields,
   getMultiSelectFieldValues,
 } from '../../ui/steps/selectors'
+import { changeBatchEditField } from '../../step-forms/actions'
 
 export const FormManager = (): React.Node => {
   const fieldValues = useSelector(getMultiSelectFieldValues)
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
   const stepTypes = useSelector(getBatchEditSelectedStepTypes)
   const disabledFields = useSelector(getMultiSelectDisabledFields)
+  const dispatch = useDispatch()
 
-  // TODO(IL, 2021-02-17): dispatch changeBatchEditField here in #7222
   const handleChangeFormInput = (name, value) => {
-    console.log(`TODO: update ${name}: ${String(value)}`)
+    dispatch(changeBatchEditField({ [name]: value }))
   }
 
   if (isMultiSelectMode) {

--- a/protocol-designer/src/components/FormManager/index.js
+++ b/protocol-designer/src/components/FormManager/index.js
@@ -7,6 +7,7 @@ import { StepSelectionBanner } from '../StepSelectionBanner'
 import {
   getBatchEditSelectedStepTypes,
   getIsMultiSelectMode,
+  getMultiSelectDisabledFields,
   getMultiSelectFieldValues,
 } from '../../ui/steps/selectors'
 
@@ -14,6 +15,7 @@ export const FormManager = (): React.Node => {
   const fieldValues = useSelector(getMultiSelectFieldValues)
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
   const stepTypes = useSelector(getBatchEditSelectedStepTypes)
+  const disabledFields = useSelector(getMultiSelectDisabledFields)
 
   // TODO(IL, 2021-02-17): dispatch changeBatchEditField here in #7222
   const handleChangeFormInput = (name, value) => {
@@ -26,6 +28,7 @@ export const FormManager = (): React.Node => {
         <StepSelectionBanner />
         <BatchEditForm
           fieldValues={fieldValues}
+          disabledFields={disabledFields}
           handleChangeFormInput={handleChangeFormInput}
           stepTypes={stepTypes}
         />

--- a/protocol-designer/src/components/FormManager/index.js
+++ b/protocol-designer/src/components/FormManager/index.js
@@ -33,7 +33,7 @@ export const FormManager = (): React.Node => {
     dispatch(saveStepFormsMulti(selectedStepIds))
   }
 
-  const handleClose = () => dispatch(resetBatchEditFieldChanges())
+  const handleCancel = () => dispatch(resetBatchEditFieldChanges())
 
   if (isMultiSelectMode) {
     return (
@@ -44,7 +44,7 @@ export const FormManager = (): React.Node => {
           disabledFields={disabledFields}
           handleChangeFormInput={handleChangeFormInput}
           stepTypes={stepTypes}
-          handleClose={handleClose}
+          handleCancel={handleCancel}
           handleSave={handleSaveMultiSelect}
         />
       </>

--- a/protocol-designer/src/components/FormManager/index.js
+++ b/protocol-designer/src/components/FormManager/index.js
@@ -9,8 +9,13 @@ import {
   getIsMultiSelectMode,
   getMultiSelectDisabledFields,
   getMultiSelectFieldValues,
+  getMultiSelectItemIds,
 } from '../../ui/steps/selectors'
-import { changeBatchEditField } from '../../step-forms/actions'
+import {
+  changeBatchEditField,
+  resetBatchEditFieldChanges,
+  saveStepFormsMulti,
+} from '../../step-forms/actions'
 
 export const FormManager = (): React.Node => {
   const fieldValues = useSelector(getMultiSelectFieldValues)
@@ -18,10 +23,17 @@ export const FormManager = (): React.Node => {
   const stepTypes = useSelector(getBatchEditSelectedStepTypes)
   const disabledFields = useSelector(getMultiSelectDisabledFields)
   const dispatch = useDispatch()
+  const selectedStepIds = useSelector(getMultiSelectItemIds)
 
   const handleChangeFormInput = (name, value) => {
     dispatch(changeBatchEditField({ [name]: value }))
   }
+
+  const handleSaveMultiSelect = () => {
+    dispatch(saveStepFormsMulti(selectedStepIds))
+  }
+
+  const handleClose = () => dispatch(resetBatchEditFieldChanges())
 
   if (isMultiSelectMode) {
     return (
@@ -32,6 +44,8 @@ export const FormManager = (): React.Node => {
           disabledFields={disabledFields}
           handleChangeFormInput={handleChangeFormInput}
           stepTypes={stepTypes}
+          handleClose={handleClose}
+          handleSave={handleSaveMultiSelect}
         />
       </>
     )

--- a/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DelayFields.js
@@ -35,9 +35,6 @@ export const DelayFields = (props: DelayFieldProps): React.Node => {
       {...propsForFields[checkboxFieldName]}
       label={i18n.t('form.step_edit_form.field.delay.label')}
       className={styles.small_field}
-      tooltipContent={i18n.t(
-        `tooltip.step_fields.defaults.${checkboxFieldName}`
-      )}
     >
       <TextField
         {...propsForFields[secondsFieldName]}

--- a/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.js
@@ -13,15 +13,16 @@ type RadioGroupFieldProps = {|
 
 export const RadioGroupField = (props: RadioGroupFieldProps): React.Node => {
   const {
-    name,
-    value,
-    errorToShow,
-    updateValue,
-    onFieldFocus,
-    onFieldBlur,
     className,
-    isIndeterminate, // TODO(IL, 2021-02-05): if we need indeterminate RadioGroupField, we'll want to pass this down into RadioGroup
     disabled, // NOTE: not used
+    errorToShow,
+    isIndeterminate, // TODO(IL, 2021-02-05): if we need indeterminate RadioGroupField, we'll want to pass this down into RadioGroup
+    name,
+    onFieldBlur,
+    onFieldFocus,
+    tooltipContent,
+    updateValue,
+    value,
     ...radioGroupProps
   } = props
   return (

--- a/protocol-designer/src/components/StepEditForm/fields/TextField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TextField.js
@@ -12,10 +12,11 @@ type TextFieldProps = {|
 
 export const TextField = (props: TextFieldProps): React.Node => {
   const {
-    updateValue,
-    onFieldFocus,
-    onFieldBlur,
     errorToShow,
+    onFieldBlur,
+    onFieldFocus,
+    tooltipContent,
+    updateValue,
     value,
     ...otherProps
   } = props

--- a/protocol-designer/src/components/StepEditForm/fields/VolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/VolumeField.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { FormGroup, HoverTooltip } from '@opentrons/components'
 import { i18n } from '../../../localization'
-import { getTooltipForField } from '../utils'
+import { getFieldDefaultTooltip } from '../utils'
 import { TextField } from './TextField'
 import type { StepType } from '../../../form-types'
 import type { FieldProps } from '../types'
@@ -20,7 +20,7 @@ export const VolumeField = (props: Props): React.Node => {
   // TODO(IL, 2021-02-08): use the useHoverTooltip hook instead of deprecated HoverTooltip (see #7295)
   return (
     <HoverTooltip
-      tooltipComponent={getTooltipForField(stepType, 'volume', false)}
+      tooltipComponent={getFieldDefaultTooltip(propsForVolumeField.name)}
       placement="top-start"
     >
       {hoverTooltipHandlers => (

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/DelayFields.test.js
@@ -3,7 +3,6 @@ import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_
 import React from 'react'
 import { Provider } from 'react-redux'
 import { mount } from 'enzyme'
-import FormTooltipText from '../../../../localization/en/tooltip'
 import ApplicationText from '../../../../localization/en/application'
 import * as stepFormSelectors from '../../../../step-forms/selectors'
 import { CheckboxRowField, TextField, TipPositionField } from '../../fields'
@@ -82,6 +81,7 @@ describe('DelayFields', () => {
             name: 'aspirate_delay_checkbox',
             updateValue: (jest.fn(): any),
             value: true,
+            tooltipContent: 'tooltip for aspirate_delay_checkbox',
           },
           aspirate_delay_seconds: {
             onFieldFocus: (jest.fn(): any),
@@ -134,7 +134,7 @@ describe('DelayFields', () => {
       expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
       expect(checkboxField.prop('label')).toBe('delay')
       expect(checkboxField.prop('tooltipContent')).toBe(
-        FormTooltipText.step_fields.defaults.aspirate_delay_checkbox
+        `tooltip for ${props.checkboxFieldName}`
       )
 
       const secondsField = wrapper.find(TextField)
@@ -153,7 +153,7 @@ describe('DelayFields', () => {
       expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
       expect(checkboxField.prop('label')).toBe('delay')
       expect(checkboxField.prop('tooltipContent')).toBe(
-        FormTooltipText.step_fields.defaults.aspirate_delay_checkbox
+        `tooltip for ${props.checkboxFieldName}`
       )
       const secondsField = wrapper.find(TextField)
       expect(secondsField.is(TextField)).toBe(true)
@@ -180,6 +180,7 @@ describe('DelayFields', () => {
             name: 'dispense_delay_checkbox',
             updateValue: (jest.fn(): any),
             value: true,
+            tooltipContent: 'tooltip for dispense_delay_checkbox',
           },
           dispense_delay_seconds: {
             onFieldFocus: (jest.fn(): any),
@@ -229,7 +230,7 @@ describe('DelayFields', () => {
       expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
       expect(checkboxField.prop('label')).toBe('delay')
       expect(checkboxField.prop('tooltipContent')).toBe(
-        FormTooltipText.step_fields.defaults.dispense_delay_checkbox
+        `tooltip for ${props.checkboxFieldName}`
       )
       const secondsField = wrapper.find(TextField)
       expect(secondsField.is(TextField)).toBe(true)
@@ -248,7 +249,7 @@ describe('DelayFields', () => {
       expect(checkboxField.prop('name')).toBe(props.checkboxFieldName)
       expect(checkboxField.prop('label')).toBe('delay')
       expect(checkboxField.prop('tooltipContent')).toBe(
-        FormTooltipText.step_fields.defaults.dispense_delay_checkbox
+        `tooltip for ${props.checkboxFieldName}`
       )
       const secondsField = wrapper.find(TextField)
       expect(secondsField.is(TextField)).toBe(true)

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/makeSingleEditFieldProps.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/makeSingleEditFieldProps.test.js
@@ -5,9 +5,14 @@ import {
   getDefaultsForStepType,
 } from '../../../../steplist/formLevel'
 import { getFieldErrors } from '../../../../steplist/fieldLevel'
-
+import * as stepEditFormUtils from '../../utils'
 jest.mock('../../../../steplist/formLevel')
 jest.mock('../../../../steplist/fieldLevel')
+
+const getFieldDefaultTooltipSpy = jest.spyOn(
+  stepEditFormUtils,
+  'getFieldDefaultTooltip'
+)
 
 const getDisabledFieldsMock: JestMockFn<any, Set<string>> = getDisabledFields
 const getDefaultsForStepTypeMock: JestMockFn<
@@ -19,8 +24,12 @@ const getFieldErrorsMock: JestMockFn<
   Array<string>
 > = getFieldErrors
 
+beforeEach(() => {
+  getFieldDefaultTooltipSpy.mockImplementation(name => `tooltip for ${name}`)
+})
+
 afterEach(() => {
-  jest.resetAllMocks()
+  jest.restoreAllMocks()
 })
 
 describe('makeSingleEditFieldProps', () => {
@@ -93,6 +102,7 @@ describe('makeSingleEditFieldProps', () => {
         onFieldFocus: expect.anything(),
         updateValue: expect.anything(),
         value: '123',
+        tooltipContent: 'tooltip for some_field',
       },
       disabled_field: {
         disabled: true,
@@ -102,6 +112,7 @@ describe('makeSingleEditFieldProps', () => {
         onFieldFocus: expect.anything(),
         updateValue: expect.anything(),
         value: '404',
+        tooltipContent: 'tooltip for disabled_field',
       },
       pristine_error_field: {
         disabled: false,
@@ -111,6 +122,7 @@ describe('makeSingleEditFieldProps', () => {
         onFieldFocus: expect.anything(),
         updateValue: expect.anything(),
         value: '',
+        tooltipContent: 'tooltip for pristine_error_field',
       },
       dirty_error_field: {
         disabled: false,
@@ -120,6 +132,7 @@ describe('makeSingleEditFieldProps', () => {
         onFieldFocus: expect.anything(),
         updateValue: expect.anything(),
         value: '',
+        tooltipContent: 'tooltip for dirty_error_field',
       },
       focused_error_field: {
         disabled: false,
@@ -129,6 +142,7 @@ describe('makeSingleEditFieldProps', () => {
         onFieldFocus: expect.anything(),
         updateValue: expect.anything(),
         value: '',
+        tooltipContent: 'tooltip for focused_error_field',
       },
     })
 

--- a/protocol-designer/src/components/StepEditForm/fields/makeSingleEditFieldProps.js
+++ b/protocol-designer/src/components/StepEditForm/fields/makeSingleEditFieldProps.js
@@ -4,6 +4,7 @@ import {
   getDisabledFields,
   getDefaultsForStepType,
 } from '../../../steplist/formLevel'
+import { getFieldDefaultTooltip } from '../utils'
 import type { StepFieldName, FormData } from '../../../form-types'
 import type { FieldProps, FieldPropsByName, FocusHandlers } from '../types'
 
@@ -59,6 +60,7 @@ export const makeSingleEditFieldProps = (
       value,
       onFieldBlur,
       onFieldFocus,
+      tooltipContent: getFieldDefaultTooltip(name),
     }
     return {
       ...acc,

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -142,9 +142,6 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 {...propsForFields['mix_touchTip_checkbox']}
                 className={styles.small_field}
                 label={i18n.t('form.step_edit_form.field.touchTip.label')}
-                tooltipContent={i18n.t(
-                  'tooltip.step_fields.defaults.mix_touchTip_checkbox'
-                )}
               >
                 <TipPositionField
                   {...propsForFields['mix_touchTip_mmFromBottom']}
@@ -156,9 +153,6 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 {...propsForFields['blowout_checkbox']}
                 className={styles.small_field}
                 label={i18n.t('form.step_edit_form.field.blowout.label')}
-                tooltipContent={i18n.t(
-                  'tooltip.step_fields.defaults.blowout_checkbox'
-                )}
               >
                 <BlowoutLocationField
                   {...propsForFields['blowout_location']}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -38,9 +38,6 @@ export const SourceDestFields = (props: Props): React.Node => {
       {...propsForFields[addFieldNamePrefix('mix_checkbox')]}
       label={i18n.t('form.step_edit_form.field.mix.label')}
       className={styles.small_field}
-      tooltipContent={i18n.t(
-        `tooltip.step_fields.defaults.${addFieldNamePrefix('mix_checkbox')}`
-      )}
     >
       <TextField
         {...propsForFields[addFieldNamePrefix('mix_volume')]}
@@ -98,7 +95,6 @@ export const SourceDestFields = (props: Props): React.Node => {
               {...propsForFields['preWetTip']}
               label={i18n.t('form.step_edit_form.field.preWetTip.label')}
               className={styles.small_field}
-              tooltipContent={i18n.t(`tooltip.step_fields.defaults.preWetTip`)}
             />
             {getMixFields()}
             {getDelayFields()}
@@ -112,11 +108,6 @@ export const SourceDestFields = (props: Props): React.Node => {
         )}
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
-          tooltipContent={i18n.t(
-            `tooltip.step_fields.defaults.${addFieldNamePrefix(
-              'touchTip_checkbox'
-            )}`
-          )}
           label={i18n.t('form.step_edit_form.field.touchTip.label')}
           className={styles.small_field}
         >
@@ -131,9 +122,6 @@ export const SourceDestFields = (props: Props): React.Node => {
             {...propsForFields['blowout_checkbox']}
             label={i18n.t('form.step_edit_form.field.blowout.label')}
             className={styles.small_field}
-            tooltipContent={i18n.t(
-              `tooltip.step_fields.defaults.blowout_checkbox`
-            )}
           >
             <BlowoutLocationField
               {...propsForFields['blowout_location']}
@@ -144,11 +132,6 @@ export const SourceDestFields = (props: Props): React.Node => {
         )}
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('airGap_checkbox')]}
-          tooltipContent={i18n.t(
-            `tooltip.step_fields.defaults.${addFieldNamePrefix(
-              'airGap_checkbox'
-            )}`
-          )}
           label={i18n.t('form.step_edit_form.field.airGap.label')}
           className={styles.small_field}
         >

--- a/protocol-designer/src/components/StepEditForm/types.js
+++ b/protocol-designer/src/components/StepEditForm/types.js
@@ -11,13 +11,14 @@ export type FocusHandlers = {|
 
 export type FieldProps = {|
   disabled: boolean,
-  name: string,
-  updateValue: mixed => void,
-  value: mixed,
   errorToShow: ?string,
+  isIndeterminate?: boolean,
+  name: string,
   onFieldBlur: () => mixed,
   onFieldFocus: () => mixed,
-  isIndeterminate?: boolean,
+  tooltipContent?: ?string,
+  updateValue: mixed => void,
+  value: mixed,
 |}
 
 export type FieldPropsByName = {

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -177,9 +177,7 @@ export const getVisibleProfileFormLevelErrors = (args: {|
   })
 }
 
-// NOTE: some field components get their tooltips directly from i18n, and do not use `getTooltipForField`.
-// TODO: Ian 2019-03-29 implement tooltip-content-getting in a more organized way
-// once we have more comprehensive requirements about tooltips
+// TODO(IL, 2021-02-25): DEPRECATED. this is only used by FieldConnector. Remove in #7298
 export function getTooltipForField(
   stepType: ?string,
   name: string,
@@ -220,3 +218,6 @@ export function getTooltipForField(
 
   return text ? <div className={styles.tooltip}>{text}</div> : null
 }
+
+export const getFieldDefaultTooltip = (name: string): string =>
+  i18n.t([`tooltip.step_fields.defaults.${name}`, ''])

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -286,7 +286,7 @@ const dependentFieldCheckboxMap: {
   blowout_location: 'blowout_checkbox',
 }
 
-export const getMultiSelectFieldValues: Selector<MultiselectFieldValues | null> = createSelector(
+export const _getSavedMultiSelectFieldValues: Selector<MultiselectFieldValues | null> = createSelector(
   stepFormSelectors.getSavedStepForms,
   getMultiSelectItemIds,
   (savedStepForms, multiSelectItemIds) => {
@@ -321,6 +321,21 @@ export const getMultiSelectFieldValues: Selector<MultiselectFieldValues | null> 
       },
       {}
     )
+  }
+)
+
+export const getMultiSelectFieldValues: Selector<MultiselectFieldValues | null> = createSelector(
+  _getSavedMultiSelectFieldValues,
+  stepFormSelectors.getBatchEditFieldChanges,
+  (savedValues, changes) => {
+    const multiselectChanges = Object.keys(changes).reduce((acc, name) => {
+      acc[name] = {
+        value: changes[name],
+        isIndeterminate: false,
+      }
+      return acc
+    }, {})
+    return { ...savedValues, ...multiselectChanges }
   }
 )
 

--- a/protocol-designer/src/ui/steps/selectors.js
+++ b/protocol-designer/src/ui/steps/selectors.js
@@ -324,8 +324,10 @@ export const getMultiSelectFieldValues: Selector<MultiselectFieldValues | null> 
   }
 )
 
-type DisabledFields = {
-  [fieldName: string]: string,
+// NOTE: the value is the tooltip text explaining why the field is disabled
+type TooltipText = string
+export type DisabledFields = {
+  [fieldName: string]: TooltipText,
 }
 export const getMultiSelectDisabledFields: Selector<DisabledFields | null> = createSelector(
   stepFormSelectors.getSavedStepForms,

--- a/protocol-designer/src/ui/steps/test/selectors.test.js
+++ b/protocol-designer/src/ui/steps/test/selectors.test.js
@@ -16,6 +16,7 @@ import {
   getSelectedStepTitleInfo,
   getActiveItem,
   getMultiSelectLastSelected,
+  _getSavedMultiSelectFieldValues,
   getMultiSelectFieldValues,
   getMultiSelectDisabledFields,
   getCountPerStepType,
@@ -326,7 +327,7 @@ describe('getMultiSelectLastSelected', () => {
   })
 })
 
-describe('getMultiSelectFieldValues', () => {
+describe('_getSavedMultiSelectFieldValues', () => {
   let mockSavedStepForms
   let mockmultiSelectItemIds
 
@@ -353,7 +354,7 @@ describe('getMultiSelectFieldValues', () => {
       },
     }
     expect(
-      getMultiSelectFieldValues.resultFunc(
+      _getSavedMultiSelectFieldValues.resultFunc(
         savedStepForms,
         mockmultiSelectItemIds
       )
@@ -362,7 +363,7 @@ describe('getMultiSelectFieldValues', () => {
   describe('when fields are NOT indeterminate', () => {
     it('should return the fields with the indeterminate boolean', () => {
       expect(
-        getMultiSelectFieldValues.resultFunc(
+        _getSavedMultiSelectFieldValues.resultFunc(
           mockSavedStepForms,
           mockmultiSelectItemIds
         )
@@ -537,7 +538,7 @@ describe('getMultiSelectFieldValues', () => {
     })
     it('should return the fields with the indeterminate boolean', () => {
       expect(
-        getMultiSelectFieldValues.resultFunc(
+        _getSavedMultiSelectFieldValues.resultFunc(
           mockSavedStepFormsIndeterminate,
           mockmultiSelectItemIds
         )
@@ -639,6 +640,22 @@ describe('getMultiSelectFieldValues', () => {
         },
       })
     })
+  })
+})
+
+describe('getMultiSelectFieldValues', () => {
+  it('should pass through saved changes when there are no saved', () => {
+    const savedValues = { a: { value: 'blah', isIndeterminate: true } }
+    const changes = {}
+    const result = getMultiSelectFieldValues.resultFunc(savedValues, changes)
+    expect(result).toEqual(savedValues)
+  })
+
+  it('should apply unsaved changes to override saved changes', () => {
+    const savedValues = { a: { value: 'blah', isIndeterminate: true } }
+    const changes = { a: '123' }
+    const result = getMultiSelectFieldValues.resultFunc(savedValues, changes)
+    expect(result).toEqual({ a: { value: '123', isIndeterminate: false } })
   })
 })
 


### PR DESCRIPTION
# Overview

Pairing credit to @shlokamin !

Closes #7222

# Changelog

- pass tooltips into FieldProps instead of i18n (also affects single-edit mode tooltips!)
- implement makeBatchEditFieldProps, including tooltips and disabled tooltips
- make it possible to see and update values in the batch edit form fields
- save and cancel the batch edit form

# Review requests

- [ ] Confirm no regression with single-edit mode tooltips
- [ ] Code review
- [ ] Tooltips for placeholder batch edit form's aspirate mix fields should work as expected
- [ ] Should be able to actually save batch edit changes to aspirate mix fields, when you have multiple Transfer forms selected
- [ ] CheckboxRowField isn't showing indeterminate state yet, but the text fields should show the indeterminate placeholder when your selected forms have mixed values in those fields

# Risk assessment

Med, might mess up single-edit mode tooltips