### PR TITLE
feat(protocol-designer): make CheckboxRowField handle isIndeterminate

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
@@ -23,6 +23,7 @@ export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
     children,
     className,
     disabled,
+    isIndeterminate,
     label,
     tooltipContent,
     updateValue,
@@ -38,14 +39,15 @@ export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
       <Tooltip {...tooltipProps}>{tooltipContent}</Tooltip>
       <div className={styles.checkbox_row}>
         <CheckboxField
-          labelProps={targetProps}
-          label={label}
-          disabled={disabled}
           className={cx(styles.checkbox_field, className)}
-          value={!!value}
+          disabled={disabled}
+          isIndeterminate={isIndeterminate}
+          label={label}
+          labelProps={targetProps}
           onChange={(e: SyntheticInputEvent<*>) => updateValue(!value)}
+          value={Boolean(value)}
         />
-        {value && !disabled ? children : null}
+        {value && !disabled && !isIndeterminate ? children : null}
       </div>
     </>
   )


### PR DESCRIPTION
# Overview

Closes #7392

# Changelog

# Review requests

- [ ] Shouldn't affect single edit forms
- [ ] If you select 2 Transfer forms, one with aspirate mix checkbox checked and the other with it unchecked, you should see the `[-]` indeterminate icon in the batch edit form

# Risk assessment

Low, shouldn't affect existing PD behavior