### PR TITLE
chore(api, update-server, robot-server): Correct our use of noqa

### DIFF
--- a/api/docs/v1/api_cache/pipette.py
+++ b/api/docs/v1/api_cache/pipette.py
@@ -88,7 +88,7 @@ class Pipette:
     ...     tip_racks=[tip_rack_300ul]) # doctest: +SKIP
     """
 
-    def __init__(  # noqa(C901)
+    def __init__(  # noqa: C901
             self,
             robot,
             model_offset=(0, 0, 0),

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -29,7 +29,7 @@ try:
 except (FileNotFoundError, OSError):
     __version__ = 'unknown'
 
-from opentrons import config  # noqa(E402)
+from opentrons import config  # noqa: E402
 
 LEGACY_MODULES = [
     'robot', 'reset', 'instruments', 'containers', 'labware', 'modules']

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -514,7 +514,7 @@ class Session(RobotBusy):
         else:
             self.blocked = False
 
-    @robot_is_busy  # noqa(C901)
+    @robot_is_busy  # noqa: C901
     def _run(self) -> None:
         def on_command(message: command_types.CommandMessage) -> None:
             if message['$'] == 'before':

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -10,7 +10,7 @@ from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 from opentrons.system import log_control
 
 if TYPE_CHECKING:
-    from pathlib import Path  # noqa(F401) - imported for types
+    from pathlib import Path  # noqa: F401 - imported for types
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -1363,7 +1363,7 @@ class SmoothieDriver_3_0_0:
     # ----------- END Private functions ----------- #
 
     # ----------- Public interface ---------------- #
-    def move(self, target: Dict[str, float], home_flagged_axes: bool = False,  # noqa(C901)
+    def move(self, target: Dict[str, float], home_flagged_axes: bool = False,  # noqa: C901, E501
              speed: float = None):
         """
         Move to the `target` Smoothieware coordinate, along any of the size
@@ -1960,7 +1960,7 @@ class SmoothieDriver_3_0_0:
             sleep(0.25)
             self.run_flag.set()
 
-    async def update_firmware(self,  # noqa(C901)
+    async def update_firmware(self,  # noqa: C901
                               filename: str,
                               loop: asyncio.AbstractEventLoop = None,
                               explicit_modeset: bool = True) -> str:

--- a/api/src/opentrons/hardware_control/__main__.py
+++ b/api/src/opentrons/hardware_control/__main__.py
@@ -43,7 +43,7 @@ async def arun(config: RobotConfig = None,
     :param port: Optional smoothie port override
     """
     rconf = config or rc.load()
-    hc = await API.build_hardware_controller(rconf, port) # noqa(F841)
+    hc = await API.build_hardware_controller(rconf, port)  # noqa: F841
 
 
 def run(config: RobotConfig = None,
@@ -68,5 +68,5 @@ if __name__ == '__main__':
         '-s', '--smoothie-port',
         help='Port on which to talk to smoothie, autodetected by default',
         default=None)
-    args = parser.parse_args()  # noqa(F841)
+    args = parser.parse_args()  # noqa: F841
     run(port=args.port)

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from .types import HardwareAPILike
 
 if TYPE_CHECKING:
-    from .dev_types import HasLoop # noqa (F501)
+    from .dev_types import HasLoop  # noqa: F501
 
 
 # TODO: BC 2020-02-25 instead of overwriting __get_attribute__ in this class

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         RegisterModules, AttachedInstrument, AttachedInstruments,
         InstrumentHardwareConfigs)
     from opentrons.drivers.rpi_drivers.dev_types\
-        import GPIODriverLike # noqa(F501)
+        import GPIODriverLike  # noqa: F501
 
 MODULE_LOG = logging.getLogger(__name__)
 

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from opentrons.config import IS_ROBOT, IS_LINUX
 # NOTE: Must import all modules so they actually create the subclasses
-from . import update, tempdeck, magdeck, thermocycler, types  # noqa(W0611)
+from . import update, tempdeck, magdeck, thermocycler, types  # noqa: F401
 from .mod_abc import AbstractModule
 from ..execution_manager import ExecutionManager
 from .types import InterruptCallback, ModuleAtPort

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         RegisterModules, AttachedInstrument,
         AttachedInstruments, InstrumentSpec, InstrumentHardwareConfigs)
     from opentrons.drivers.rpi_drivers.dev_types\
-        import GPIODriverLike  # noqa(F501)
+        import GPIODriverLike  # noqa: F501
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/api/src/opentrons/hardware_control/socket_server.py
+++ b/api/src/opentrons/hardware_control/socket_server.py
@@ -78,7 +78,7 @@ _SERDES = {
 }
 
 
-def _build_serializable_method(method_name, method):  # noqa(C901)
+def _build_serializable_method(method_name, method):  # noqa: C901
     """ Build the method to actually server over jsonrpc.
 
     To serve over jsonrpc, we need to have an interface that is fully
@@ -111,7 +111,7 @@ def _build_serializable_method(method_name, method):  # noqa(C901)
     if signature.return_annotation in _SERDES:
         return_transformer = _SERDES[signature.return_annotation].serializer
     else:
-        return_transformer = lambda ret: ret  # noqa(E371)
+        return_transformer = lambda ret: ret  # noqa: E731
 
     @functools.wraps(async_wrapper)
     async def wrapper(**kwargs):
@@ -246,7 +246,7 @@ class JsonRpcProtocol(asyncio.Protocol):
     def resume_writing(self):
         self._log.debug('resume writing')
 
-    def data_received(self, data: bytes):  # noqa(C901)
+    def data_received(self, data: bytes):  # noqa: C901
         self._log.debug(f'data received: {data!r}')
         self._buffer += data.decode()  # hope this isn't incomplete
         try:

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,9 +4,9 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION  # noqa(F401)
-from . import labware  # noqa(E402)
-from .contexts import (ProtocolContext,  # noqa(E402)
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION  # noqa: F401, E501
+from . import labware  # noqa: E402
+from .contexts import (ProtocolContext,  # noqa: E402
                        InstrumentContext,
                        PairedInstrumentContext,
                        TemperatureModuleContext,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -589,7 +589,7 @@ class InstrumentContext(CommandPublisher):
         return self
 
     @requires_version(2, 0)
-    def pick_up_tip(  # noqa(C901)
+    def pick_up_tip(  # noqa: C901
             self, location: Union[types.Location, Well] = None,
             presses: Optional[int] = None,
             increment: Optional[float] = None) -> InstrumentContext:
@@ -679,7 +679,7 @@ class InstrumentContext(CommandPublisher):
         return self
 
     @requires_version(2, 0)
-    def drop_tip(  # noqa(C901)
+    def drop_tip(  # noqa: C901
             self,
             location: Union[types.Location, Well] = None,
             home_after: bool = True)\
@@ -889,7 +889,7 @@ class InstrumentContext(CommandPublisher):
 
         return self.transfer(volume, source, dest, **kwargs)
 
-    @publish.both(command=cmds.transfer)  # noqa(C901)
+    @publish.both(command=cmds.transfer)  # noqa: C901
     @requires_version(2, 0)
     def transfer(self,
                  volume: Union[float, Sequence[float]],

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -30,7 +30,7 @@ from opentrons.protocols.api_support.definitions import (
     MAX_SUPPORTED_VERSION)
 from opentrons.protocols.geometry.deck_item import DeckItem
 if TYPE_CHECKING:
-    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa(F401)
+    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa: F401, E501
     from opentrons_shared_data.labware.dev_types import (
         LabwareDefinition, LabwareParameters)
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -37,7 +37,7 @@ STANDARD_MAGDECK_LABWARE = [
 MODULE_LOG = logging.getLogger(__name__)
 
 GeometryType = TypeVar('GeometryType', bound=ModuleGeometry)
-class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa(E302)
+class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
     """ An object representing a connected module.
 
 

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -202,10 +202,10 @@ class PairedInstrumentContext(CommandPublisher):
         .. code-block:: python
 
             >>> tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-            >>> left = ctx.load_instrument('p300_multi', 'left', tip_racks=[tiprack])  # noqa: E501
-            >>> right = ctx.load_instrument('p300_multi', 'right', tip_racks=[tiprack])  # noqa: E501
+            >>> left = ctx.load_instrument('p300_multi', 'left', tip_racks=[tiprack])
+            >>> right = ctx.load_instrument('p300_multi', 'right', tip_racks=[tiprack])
             >>> paired = right.pair_with(left)
-            >>> paired.pick_up_tip() # Pick up tips from the first and fifth column  # noqa: E501
+            >>> paired.pick_up_tip() # Pick up tips from the first and fifth column
             >>> paired.drop_tip()
             >>> left.pick_up_tip() # Pick up tips from the second column
             >>> left.drop_tip()

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -202,10 +202,10 @@ class PairedInstrumentContext(CommandPublisher):
         .. code-block:: python
 
             >>> tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-            >>> left = ctx.load_instrument('p300_multi', 'left', tip_racks=[tiprack])  # noqa(E501)
-            >>> right = ctx.load_instrument('p300_multi', 'right', tip_racks=[tiprack])  # noqa(E501)
+            >>> left = ctx.load_instrument('p300_multi', 'left', tip_racks=[tiprack])  # noqa: E501
+            >>> right = ctx.load_instrument('p300_multi', 'right', tip_racks=[tiprack])  # noqa: E501
             >>> paired = right.pair_with(left)
-            >>> paired.pick_up_tip() # Pick up tips from the first and fifth column  # noqa(E501)
+            >>> paired.pick_up_tip() # Pick up tips from the first and fifth column  # noqa: E501
             >>> paired.drop_tip()
             >>> left.pick_up_tip() # Pick up tips from the second column
             >>> left.drop_tip()

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -7,8 +7,8 @@ from opentrons import types
 from opentrons.protocols.api_support.types import APIVersion
 
 if TYPE_CHECKING:
-    from opentrons.protocol_api.contexts import InstrumentContext  # noqa (F501)
-    from opentrons.protocols.execution.dev_types import Dictable  # noqa(F501)
+    from opentrons.protocol_api.contexts import InstrumentContext  # noqa: F501
+    from opentrons.protocols.execution.dev_types import Dictable  # noqa: F501
 
 
 class MixStrategy(enum.Enum):
@@ -591,7 +591,7 @@ class TransferPlan:
         yield from self._new_tip_action()
 
     Target = TypeVar('Target')
-    @staticmethod  # noqa(E301)
+    @staticmethod  # noqa: E301
     def _expand_for_volume_constraints(
             volumes: Iterator[float],
             targets: Iterator[Target],
@@ -710,7 +710,7 @@ class TransferPlan:
         if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
             yield self._format_dict('touch_tip', kwargs=self._touch_tip_opts)
 
-    def _after_dispense(self, dest, src, is_disp_next=False):  # noqa(C901)
+    def _after_dispense(self, dest, src, is_disp_next=False):  # noqa: C901
         # This sequence of actions is subject to change
         if not is_disp_next:
             # If the next command is an aspirate, we are switching

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -90,11 +90,11 @@ def build_edges(
     # Determine the touch_tip edges/points
     offset_pt = top_types.Point(0, 0, offset)
     edge_list = EdgeList(
-        right=where.from_center_cartesian(x=radius, y=0, z=1) + offset_pt,  # noqa E501
-        left=where.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,  # noqa E501
-        center=where.from_center_cartesian(x=0, y=0, z=1) + offset_pt,  # noqa E501
-        up=where.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,  # noqa E501
-        down=where.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt  # noqa E501
+        right=where.from_center_cartesian(x=radius, y=0, z=1) + offset_pt,
+        left=where.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
+        center=where.from_center_cartesian(x=0, y=0, z=1) + offset_pt,
+        up=where.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
+        down=where.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
     )
 
     if version < APIVersion(2, 4):

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
         InstrumentContextInterface
     from opentrons.protocol_api.labware import Well, Labware
     from opentrons.protocols.geometry.deck import Deck
-    from opentrons.hardware_control.dev_types import HasLoop # noqa (F501)
+    from opentrons.hardware_control.dev_types import HasLoop  # noqa: F501
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -26,7 +26,7 @@ def _has_files_at_root(zipFile):
     return False
 
 
-def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa(C901)
+def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa: C901
     """ Extract a bundle and verify its contents and structure. """
     if not _has_files_at_root(bundle):
         raise RuntimeError(

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -379,7 +379,7 @@ def format_runlog(runlog: List[Mapping[str, Any]]) -> str:
             to_ret.extend(
                 ['\t' * command['level']
                  + f'{l.levelname} ({l.module}): {l.msg}' % l.args
-                 for l in command['logs']])  # noqa(E741)
+                 for l in command['logs']])  # noqa: E741
     return '\n'.join(to_ret)
 
 

--- a/api/src/opentrons/tools/factory_test.py
+++ b/api/src/opentrons/tools/factory_test.py
@@ -32,7 +32,7 @@ def _find_storage_device():
     if os.path.ismount(USB_MOUNT_FILEPATH) is False:
         sdn1_devices = [
             '/dev/sd{}1'.format(l)
-            for l in 'abcdefgh'  # noqa(E741)
+            for l in 'abcdefgh'  # noqa: E741
             if os.path.exists('/dev/sd{}1'.format(l))
         ]
         if len(sdn1_devices) == 0:

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -6,11 +6,11 @@ from typing import Any, NamedTuple, TYPE_CHECKING, Union
 from opentrons.protocols.api_support.labware_like import LabwareLike
 
 if TYPE_CHECKING:
-    from typing import (Optional,       # noqa(F401) Used for typechecking
+    from typing import (Optional,       # noqa: F401 Used for typechecking
                         Tuple)
-    from .protocol_api.labware import (  # noqa(F401) Used for typechecking
+    from .protocol_api.labware import (  # noqa: F401 Used for typechecking
         Labware, Well)
-    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa(F401)
+    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa: F401, E501
 
 
 class PipetteNotAttachedError(KeyError):

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -271,7 +271,7 @@ def test_plunger_commands(smoothie, monkeypatch):
         'C': 5.55})
     expected = [
         # Set active axes high
-        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],  # noqa: E501
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],
         ['M400'],
         # Set plunger current low
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005'],
@@ -607,7 +607,7 @@ def test_clear_limit_switch(smoothie, monkeypatch):
 
     assert [c.strip() for c in cmd_list] == [
         # attempt to move and fail
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',  # noqa: E501
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',
         # recover from failure
         'M999',
         'M400',

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -271,7 +271,7 @@ def test_plunger_commands(smoothie, monkeypatch):
         'C': 5.55})
     expected = [
         # Set active axes high
-        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'], # noqa(E501)
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005 G0.+[BC].+'],  # noqa: E501
         ['M400'],
         # Set plunger current low
         ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4P0.005'],
@@ -607,7 +607,7 @@ def test_clear_limit_switch(smoothie, monkeypatch):
 
     assert [c.strip() for c in cmd_list] == [
         # attempt to move and fail
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',  # noqa(E501)
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4P0.005 G0C100.3 G0C100',  # noqa: E501
         # recover from failure
         'M999',
         'M400',

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -76,20 +76,20 @@ def test_cp_blending():
     'xformed,deck,bounds,check,catch,phrase',
     [
         # acceptable moves, iterating through checks
-        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
-        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),  # noqa(E501)
-        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),  # noqa(E501)
-        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),  # noqa(E501)
+        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
+        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),  # noqa: E501
+        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),  # noqa: E501
+        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),  # noqa: E501
         # unacceptable low, with and without checking
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),  # noqa(E501)
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),  # noqa(E501)
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),  # noqa(E501)
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),  # noqa: E501
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),  # noqa: E501
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),  # noqa: E501
         # unacceptable high, with and without checking
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa(E501)
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),  # noqa(E501)
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),  # noqa(E501)
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')  # noqa(E501)
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),  # noqa: E501
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),  # noqa: E501
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')  # noqa: E501
     ])
 def test_check_motion_bounds(xformed, deck, bounds, check, catch, phrase):
     if catch:

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -76,20 +76,20 @@ def test_cp_blending():
     'xformed,deck,bounds,check,catch,phrase',
     [
         # acceptable moves, iterating through checks
-        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
-        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),  # noqa: E501
-        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),  # noqa: E501
-        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),  # noqa: E501
+        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),
+        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),
+        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),
         # unacceptable low, with and without checking
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),  # noqa: E501
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),  # noqa: E501
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),  # noqa: E501
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),
         # unacceptable high, with and without checking
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),  # noqa: E501
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),  # noqa: E501
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),  # noqa: E501
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')  # noqa: E501
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')
     ])
 def test_check_motion_bounds(xformed, deck, bounds, check, catch, phrase):
     if catch:

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -293,7 +293,7 @@ def test_extra_contents(
     assert parsed.bundled_data == extra_data
 
 
-# noqa(E122)
+# noqa: E122
 @pytest.mark.parametrize('bad_protocol', [
     '''
 metadata={"apiLevel": "2.0"}

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -52,8 +52,8 @@ def test_execute_function_apiv2(protocol,
     assert [item['payload']['text'] for item in entries
             if item['$'] == 'before'] == [
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa(E501),
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa(E501),
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa: E501,
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa: E501,
         'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
@@ -152,20 +152,20 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
         bundle['filelike'], 'simple_bundle.zip', emit_runlog=emit_runlog)
     assert [item['payload']['text']
             for item in entries if item['$'] == 'before'] == [
-        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at" \
         " 5.0 uL/sec",
         "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
         " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
         " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -22,8 +22,8 @@ def test_simulate_function_apiv2(protocol,
     assert isinstance(bundle, protocols.types.BundleContents)
     assert [item['payload']['text'] for item in runlog] == [
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa(E501),
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa(E501),
+        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa: E501,
+        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa: E501,
         'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
         ]
 
@@ -50,19 +50,19 @@ def test_simulate_function_bundle_apiv2(get_bundle_fixture):
         bundle['filelike'], 'simple_bundle.zip')
     assert bundle is None
     assert [item['payload']['text'] for item in runlog] == [
-        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
         " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
         " 10.0 uL/sec",
         'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa(E501)
+        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
         'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
         'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
         "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -1,4 +1,4 @@
-from .request import RequestModel  # noqa(W0611)
-from .response import ResponseModel, MultiResponseModel, ResponseDataModel  # noqa(W0611)
-from .errors import Error, ErrorSource, ErrorResponse  # noqa(W0611)
-from .resource_links import ResourceLink, ResourceLinks  # noqa(W0611)
+from .request import RequestModel  # noqa: W0611
+from .response import ResponseModel, MultiResponseModel, ResponseDataModel  # noqa: W0611
+from .errors import Error, ErrorSource, ErrorResponse  # noqa: W0611
+from .resource_links import ResourceLink, ResourceLinks  # noqa: W0611

--- a/robot-server/robot_server/service/legacy/rpc/__init__.py
+++ b/robot-server/robot_server/service/legacy/rpc/__init__.py
@@ -1,1 +1,1 @@
-from .rpc import RPCServer  # noqa(W0611)
+from .rpc import RPCServer  # noqa: W0611

--- a/robot-server/robot_server/service/session/command_execution/__init__.py
+++ b/robot-server/robot_server/service/session/command_execution/__init__.py
@@ -1,4 +1,4 @@
-from .base_command_queue import CommandQueue  # noqa(W0611)
-from .base_executor import CommandExecutor  # noqa(W0611)
-from .command import Command, CompletedCommand, create_command, CommandResult # noqa(W0611)
-from .callable_executor import CallableExecutor  # noqa(W0611)
+from .base_command_queue import CommandQueue  # noqa: W0611
+from .base_executor import CommandExecutor  # noqa: W0611
+from .command import Command, CompletedCommand, create_command, CommandResult # noqa: W0611
+from .callable_executor import CallableExecutor  # noqa: W0611

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -423,7 +423,7 @@ def mock_delete_pipette():
 
 @pytest.fixture
 def mock_save_tip_length():
-    with patch('robot_server.robot.calibration.util.save_tip_length_calibration',  # noqa(E501)
+    with patch('robot_server.robot.calibration.util.save_tip_length_calibration',  # noqa: E501
                autospec=True) as mock_save:
         yield mock_save
 

--- a/update-server/otupdate/buildroot/__main__.py
+++ b/update-server/otupdate/buildroot/__main__.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 
 try:
     # systemd journal is available, we can use its handler
-    import systemd.journal  # noqa(F401)
+    import systemd.journal  # noqa: F401
     import systemd.daemon
 
     def _handler_for(topic_name: str,


### PR DESCRIPTION
# Overview

As @mcous pointed out, we've been using `# noqa(E501)` which is incorrect. The correct syntax is `# noqa: E501`

Our `# noqa(E501)` directives ended up ignoring all errors.

# Changelog

Search and replaced noqa statements.
Fix/add codes as needed.

# Review requests

# Risk assessment

None