### PR TITLE
feat(protocol-designer):  disable context menu in batch edit mode

### DIFF
--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { css } from 'styled-components'
 
 import {
+  useConditionalConfirm,
   Flex,
   Box,
   Tooltip,
@@ -19,7 +20,6 @@ import {
   BORDER_SOLID_MEDIUM,
   POSITION_STICKY,
 } from '@opentrons/components'
-import { useConditionalConfirm } from '../../../../../components/src/hooks/useConditionalConfirm'
 import { selectors as stepFormSelectors } from '../../../step-forms'
 import {
   getMultiSelectItemIds,


### PR DESCRIPTION
# Overview
This PR refactors the context menu in PD to be a function component, and disables it during batch edit mode.

Closes #7385

# Changelog
- Disable context menu in batch edit mode


# Review requests
No tests for this one :( I couldn't figure out a good way to do this since the legacy code is pretty imperative and tangled. I'm open to reworking it and making it more testable, but that will take more effort and time.

That being said, please play around with this and make sure it works properly. 
# Risk assessment
Medium, no test coverage and could break existing functionality.
