### PR TITLE
feat(protocol-designer): Add test coverage to StepCreationButton

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -46,7 +46,9 @@ const getSupportedSteps = () => [
   'thermocycler',
 ]
 
-const StepCreationButtonComponent = (props: StepButtonComponentProps) => {
+export const StepCreationButtonComponent = (
+  props: StepButtonComponentProps
+): React.Node => {
   const { children, expanded, setExpanded, disabled } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,
@@ -72,13 +74,13 @@ const StepCreationButtonComponent = (props: StepButtonComponentProps) => {
   )
 }
 
-type StepButtonItemProps = {|
+export type StepButtonItemProps = {|
   onClick: () => mixed,
   disabled: boolean,
   stepType: StepType,
 |}
 
-function StepButtonItem(props: StepButtonItemProps) {
+export function StepButtonItem(props: StepButtonItemProps): React.Node {
   const { onClick, disabled, stepType } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_RIGHT,

--- a/protocol-designer/src/components/__tests__/StepCreationButton.test.js
+++ b/protocol-designer/src/components/__tests__/StepCreationButton.test.js
@@ -1,16 +1,26 @@
 // @flow
 import React from 'react'
 import { Provider } from 'react-redux'
+import { act } from 'react-dom/test-utils'
 import thunk from 'redux-thunk'
 import { mount } from 'enzyme'
 import configureMockStore from 'redux-mock-store'
 import { when, resetAllWhenMocks } from 'jest-when'
 
-import { getIsMultiSelectMode } from '../../ui/steps'
-import * as stepFormSelectors from '../../step-forms/selectors'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V1,
+} from '@opentrons/shared-data'
 
-import { PrimaryButton } from '@opentrons/components'
-import { StepCreationButton } from '../StepCreationButton'
+import * as stepFormSelectors from '../../step-forms/selectors'
+import { actions as stepsActions, getIsMultiSelectMode } from '../../ui/steps'
+
+import { PrimaryButton, Tooltip } from '@opentrons/components'
+import {
+  StepCreationButton,
+  StepCreationButtonComponent,
+  StepButtonItem,
+} from '../StepCreationButton'
 
 jest.mock('../../step-forms/selectors')
 jest.mock('../../ui/steps/selectors')
@@ -25,8 +35,10 @@ const getIsMultiSelectModeMock = getIsMultiSelectMode
 
 describe('StepCreationButton', () => {
   let store
+
   beforeEach(() => {
     store = mockStore()
+
     when(getCurrentFormIsPresavedMock)
       .calledWith(expect.anything())
       .mockReturnValue(false)
@@ -52,6 +64,7 @@ describe('StepCreationButton', () => {
     resetAllWhenMocks()
     jest.resetAllMocks()
   })
+
   const render = () =>
     mount(
       <Provider store={store}>
@@ -79,5 +92,103 @@ describe('StepCreationButton', () => {
     expect(button.prop('disabled')).toBe(true)
   })
 
-  // TODO (ka 2021-2-10): Add comprehensive tests for StepCreationButton
+  describe('when clicking add step', () => {
+    it('expands StepCreationButtonComponent onClick', () => {
+      const wrapper = render()
+      const button = wrapper.find(PrimaryButton)
+      const initAddStepButton = wrapper.find(StepCreationButtonComponent)
+      // component starts off !expanded until click
+      expect(initAddStepButton.prop('expanded')).toBe(false)
+
+      act(() => {
+        button.simulate('click')
+      })
+
+      wrapper.update()
+      // expanded prop now set to true
+      expect(wrapper.find(StepCreationButtonComponent).prop('expanded')).toBe(
+        true
+      )
+    })
+
+    it('renders step button items when expanded', () => {
+      const wrapper = render()
+      const button = wrapper.find(PrimaryButton)
+      act(() => {
+        button.simulate('click')
+      })
+      wrapper.update()
+      const updatedAddStepButton = wrapper.find(StepCreationButtonComponent)
+      // all 6 step button items render as children
+      const stepButtonItems = updatedAddStepButton.find(StepButtonItem)
+      expect(stepButtonItems).toHaveLength(6)
+      // modules are disabled since there are no modules on deck
+      const disabledModuleSteps = stepButtonItems.find({ disabled: true })
+      expect(disabledModuleSteps).toHaveLength(3)
+      // enabled button tooltip
+      const mixTooltip = stepButtonItems.at(1).find(Tooltip)
+      expect(mixTooltip.prop('children')).toBe('Mix contents of wells/tubes.')
+      // disabled module step button tooltip
+      const disabledButtonTooltip = stepButtonItems.at(3).find(Tooltip)
+      expect(disabledButtonTooltip.prop('children')).toBe(
+        'Add a relevant module to use this step'
+      )
+    })
+
+    it('enables module step types when present on the deck', () => {
+      when(getInitialDeckSetupMock)
+        .calledWith(expect.anything())
+        .mockReturnValue({
+          labware: {},
+          pipettes: {},
+          modules: {
+            abcdef: {
+              id: 'abcdef',
+              model: TEMPERATURE_MODULE_V1,
+              type: TEMPERATURE_MODULE_TYPE,
+              slot: '3',
+            },
+          },
+        })
+      const wrapper = render()
+      const button = wrapper.find(PrimaryButton)
+
+      act(() => {
+        button.simulate('click')
+      })
+      wrapper.update()
+      const updatedAddStepButton = wrapper.find(StepCreationButtonComponent)
+      const stepButtonItems = updatedAddStepButton.find(StepButtonItem)
+
+      // temperature step enabled since it is on the deck
+      const disabledModuleSteps = stepButtonItems.find({ disabled: true })
+      expect(disabledModuleSteps).toHaveLength(2)
+      // enabled temperature module step tooltip
+      const enabledButtonTooltip = stepButtonItems.at(4).find(Tooltip)
+      expect(enabledButtonTooltip.prop('children')).toBe(
+        'Set temperature command for Temperature module.'
+      )
+    })
+  })
+  describe('StepButtonItem', () => {
+    it('should dispatch add step action onClick', () => {
+      const addStepSpy = jest
+        .spyOn(stepsActions, 'addAndSelectStepWithHints')
+        .mockImplementation(() => () => null) // mockImplementation is just to avoid calling the real action creator
+
+      const wrapper = render()
+      const button = wrapper.find(PrimaryButton)
+
+      act(() => {
+        button.simulate('click')
+      })
+      wrapper.update()
+
+      const stepButtonItem = wrapper.find(StepButtonItem).first()
+      act(() => {
+        stepButtonItem.prop('onClick')()
+      })
+      expect(addStepSpy).toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
# Overview

This PR closes #7355 by adding missing tests to the `StepCreationButton`

# Changelog

- feat(protocol-designer): Add test coverage to StepCreationButton

# Review requests

code review

# Risk assessment

Low. PD single component test coverage only