### PR TITLE
chore(update-server): Fix some errors preventing `make dev` usage

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -28,7 +28,7 @@ setup:
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev:
-	$(python) -m otupdate --debug --port $(port)
+	$(python) -m otupdate --log-level debug --port $(port)
 
 .PHONY: clean
 clean:

--- a/update-server/otupdate/__main__.py
+++ b/update-server/otupdate/__main__.py
@@ -1,3 +1,3 @@
-from .balena import __main__ as balena_main
+from .buildroot.__main__ import main
 
-balena_main.main()
+main()


### PR DESCRIPTION
# Overview

Fix some, but not all, errors preventing update-server's `make dev` from working.

After fixing these, a remaining problem is that this:

https://github.com/Opentrons/opentrons/blob/2e4ad6a148b4d4bc7c41cd3ad15d9d7cfd566481/update-server/otupdate/buildroot/name_management.py#L124

...tries to read a file that doesn't exist locally. I gave up there.

# Changelog

* Fix `__main__` directing to the Balena dev server, which doesn't exist anymore.
* Fix the makefile passing in a wrong (likely outdated) command-line option.

# Review requests

Is this even worth doing? Should we just remove `make dev` from update-server?

# Risk assessment

Very low. Should affect local development only.
