### PR TITLE
chore(build): add mixpanel id env variable to pd build

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -143,6 +143,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
+          OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'designer.opentrons.com'

--- a/protocol-designer/src/analytics/mixpanel.js
+++ b/protocol-designer/src/analytics/mixpanel.js
@@ -1,6 +1,7 @@
 // @flow
 // TODO(IL, 2020-09-09): reconcile with app/src/analytics/mixpanel.js, which this is derived from
 import mixpanel from 'mixpanel-browser'
+import { getIsProduction } from '../networking/opentronsWebApi'
 import { getHasOptedIn } from './selectors'
 import type { BaseState } from '../types'
 
@@ -37,7 +38,7 @@ export function initializeMixpanel(state: BaseState) {
 // NOTE: Do not use directly. Used in analytics Redux middleware: trackEventMiddleware.
 export function trackEvent(event: AnalyticsEvent, optedIn: boolean) {
   console.debug('Trackable event', { event, optedIn })
-  if (MIXPANEL_ID && optedIn) {
+  if (getIsProduction() && MIXPANEL_ID && optedIn) {
     if (event.superProperties) {
       mixpanel.register(event.superProperties)
     }

--- a/protocol-designer/src/analytics/mixpanel.js
+++ b/protocol-designer/src/analytics/mixpanel.js
@@ -49,7 +49,7 @@ export function trackEvent(event: AnalyticsEvent, optedIn: boolean) {
 }
 
 export function setMixpanelTracking(optedIn: boolean) {
-  if (MIXPANEL_ID) {
+  if (getIsProduction() && MIXPANEL_ID) {
     if (optedIn) {
       console.debug('User has opted into analytics; tracking with Mixpanel')
       mixpanel.opt_in_tracking()

--- a/protocol-designer/src/components/modals/GateModal/SignUpForm.js
+++ b/protocol-designer/src/components/modals/GateModal/SignUpForm.js
@@ -2,14 +2,14 @@
 
 import * as React from 'react'
 import { makeWidget } from '@typeform/embed'
-import { isProduction } from '../../../networking/opentronsWebApi'
+import { getIsProduction } from '../../../networking/opentronsWebApi'
 import styles from '../modal.css'
 
 // TODO: BC: 2019-03-05 this should be an env var fallback to staging after the initial prod deploy
 
 const STAGING_TYPEFORM_URL = 'https://opentrons-ux.typeform.com/to/Td95E9'
 const PROD_TYPEFORM_URL = 'https://opentrons-ux.typeform.com/to/kr4Bdf'
-const SIGNUP_TYPEFORM_URL = isProduction
+const SIGNUP_TYPEFORM_URL = getIsProduction()
   ? PROD_TYPEFORM_URL
   : STAGING_TYPEFORM_URL
 

--- a/protocol-designer/src/networking/opentronsWebApi.js
+++ b/protocol-designer/src/networking/opentronsWebApi.js
@@ -14,12 +14,13 @@ export type GateStage =
 
 type GateState = { gateStage: GateStage, errorMessage: ?string }
 
-export const isProduction = global.location.host === 'designer.opentrons.com'
+export const getIsProduction = (): boolean =>
+  global.location.host === 'designer.opentrons.com'
 
-const OPENTRONS_API_BASE_URL = isProduction
+const OPENTRONS_API_BASE_URL = getIsProduction()
   ? 'https://web-api.opentrons.com'
   : 'https://staging.web-api.opentrons.com'
-const PROTOCOL_DESIGNER_VERIFY_URL = isProduction
+const PROTOCOL_DESIGNER_VERIFY_URL = getIsProduction()
   ? global.location.origin
   : 'https://staging.designer.opentrons.com'
 


### PR DESCRIPTION
# Overview

Oops PD actually needs to be able to read it's mixpanel id... it should also only register events in prod 😄 

# Risk assessment

Low