### PR TITLE
fix(robot-server): Do not save the z offset for pipette calibration

### DIFF
--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -402,18 +402,15 @@ class PipetteOffsetCalibrationUserFlow:
         self._should_perform_tip_length = False
 
     async def move_to_point_one(self):
-        assert self._z_height_reference is not None, \
-            "saveOffset has not been called yet"
         target_loc = Location(self._cal_ref_point, None)
-        target = target_loc.move(
-                point=Point(0, 0, self._z_height_reference))
-        await self._move(target)
+        await self._move(target_loc)
 
     async def save_offset(self):
         cur_pt = await self.get_current_point(critical_point=None)
         current_state = self._sm.current_state
         if current_state == self._sm.state.joggingToDeck:
-            self._z_height_reference = cur_pt.z
+            updated_z = Point(0, 0, cur_pt.z)
+            self._cal_ref_point = self._cal_ref_point + updated_z
         elif current_state == self._sm.state.savingPointOne:
             if self._hw_pipette.config.channels > 1:
                 cur_pt = await self.get_current_point(

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -469,6 +469,11 @@ async def test_save_custom_tiprack_def(
 
 async def test_save_pipette_calibration(mock_user_flow, mock_save_pipette):
     uf = mock_user_flow
+    uf._sm.set_state(uf._sm.state.joggingToDeck)
+    assert uf._cal_ref_point == Point(12.13, 9.0, 0.0)
+    await uf.jog(vector=(0, 0, 10))
+    await uf.save_offset()
+    assert uf._cal_ref_point == Point(12.13, 9.0, 10.0)
 
     uf._sm.set_state(uf._sm.state.savingPointOne)
     await uf._hardware.move_to(


### PR DESCRIPTION
# Overview

Since the release of the new calibration overhaul system, we have seen a number of cases where the offsets between the two pipettes is egregiously different. When you calibrate your labware with only one of these pipettes, then you will start to see crashing during your protocol with the other pipette. A number of avenues were investigated, and it is believed that the pipette offset is an offset that is too large in the Z.

# Changelog
- Add the saved z height from slot 5 to the comparison point for slot 1 to remove any offsets resulting from that.

# Review requests

Please test on as many robots as possible! Below are the testing steps.

To Test
--------
1. First, calibrate your robot on 4.1.1 with two pipettes. The type doesn't really matter here.
2. Run the protocol provided in this PR which will move both pipettes to the calibration block. Record the distance from the calibration block, if any.
3. Then, update your robot with this branch.
4. Run the protocol provided again with this PR _without_ changing the pipette types. Record the distance from the calibration block, if any.

If the distance for the pipettes is the same in both 4.1.1 and this branch, that is OK. If the distance is higher in this branch, please comment on this PR with those results. 

```
metadata = {
    'apiLevel': '2.0',
}
from opentrons.hardware_control.types import CriticalPoint


def run(ctx):
    tr = ctx.load_labware('opentrons_96_tiprack_20ul', '8')
    tr1 = ctx.load_labware('opentrons_96_tiprack_300ul', '7')
    p300 = ctx.load_instrument('p300_multi_gen2', 'left', tip_racks=[tr1])
    m20 = ctx.load_instrument('p20_single_gen2', 'right', tip_racks=[tr])

    trough = ctx.load_labware('opentrons_calibrationblock_short_side_left', '2')
    trough2 = ctx.load_labware('opentrons_calibrationblock_short_side_left', '5')
    p300.pick_up_tip()
    p300.move_to(trough2.wells()[1].top())
    ctx.pause()
    p300.return_tip()
    m20.pick_up_tip()
    m20.move_to(trough.wells()[1].top())
    ctx.pause()
    m20.return_tip()
```

# Risk assessment
High, we are slightly changing the data model with this modification. I would like it tested physically on as many robot as possible.

