### PR TITLE
chore(build): actually feed mixpanel id environment variable into webpack build

### DIFF
--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -110,6 +110,8 @@ jobs:
           yarn config set cache-folder ./.yarn-cache
           make setup-js
       - name: 'build PD'
+        env:
+          OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
         run: |
           make -C protocol-designer
       - name: 'upload github artifact'
@@ -143,7 +145,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_SANDBOX_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SANDBOX_SECRET }}
-          OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
         uses: './.github/actions/webstack/deploy-to-sandbox'
         with:
           domain: 'designer.opentrons.com'


### PR DESCRIPTION
# Overview
Was feeding the environment variable for mixpanel into the deploy step, not the build step 🤦🏽 