### PR TITLE
feat(protocol-designer): add modal fields

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -63,7 +63,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
   }
 
   const getWellOrderFieldValue = (name: string): ?WellOrderOption => {
-    const val = propsForFields[addFieldNamePrefix('wellOrder_first')]?.value
+    const val = propsForFields[name]?.value
     if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
       return val
     } else {

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -12,8 +12,10 @@ import {
   BlowoutLocationField,
   CheckboxRowField,
   DelayFields,
-  TipPositionField,
+  FlowRateField,
   TextField,
+  TipPositionField,
+  WellOrderField,
 } from '../StepEditForm/fields'
 import { MixFields } from '../StepEditForm/fields/MixFields'
 import {
@@ -34,6 +36,7 @@ import {
   saveStepFormsMulti,
 } from '../../step-forms/actions'
 import type { FieldPropsByName } from '../StepEditForm/types'
+import type { WellOrderOption } from '../../form-types'
 // TODO(IL, 2021-03-01): refactor these fragmented style rules (see #7402)
 import formStyles from '../forms/forms.css'
 import styles from '../StepEditForm/StepEditForm.css'
@@ -48,10 +51,24 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
   const { prefix, propsForFields } = props
   const addFieldNamePrefix = name => `${prefix}_${name}`
 
-  const getLabwareIdForField = (name: string): string | null => {
+  const getLabwareIdForPositioningField = (name: string): string | null => {
     const labwareField = getLabwareFieldForPositioningField(name)
     const labwareId = propsForFields[labwareField]?.value
     return labwareId ? String(labwareId) : null
+  }
+
+  const getPipetteIdForForm = (): string | null => {
+    const pipetteId = propsForFields.pipette?.value
+    return pipetteId ? String(pipetteId) : null
+  }
+
+  const getWellOrderFieldValue = (name: string): ?WellOrderOption => {
+    const val = propsForFields[addFieldNamePrefix('wellOrder_first')]?.value
+    if (val === 'l2r' || val === 'r2l' || val === 't2b' || val === 'b2t') {
+      return val
+    } else {
+      return null
+    }
   }
 
   return (
@@ -61,6 +78,37 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
           {i18n.t('form.batch_edit_form.settings_for', { prefix })}
         </span>
       </Box>
+
+      <Box className={styles.form_row}>
+        <FlowRateField
+          {...propsForFields[addFieldNamePrefix('flowRate')]}
+          pipetteId={getPipetteIdForForm()}
+          flowRateType={prefix}
+        />
+        <TipPositionField
+          {...propsForFields[addFieldNamePrefix('mmFromBottom')]}
+          labwareId={getLabwareIdForPositioningField(
+            addFieldNamePrefix('mmFromBottom')
+          )}
+        />
+        <WellOrderField
+          prefix={prefix}
+          label={i18n.t('form.step_edit_form.field.well_order.label')}
+          firstValue={getWellOrderFieldValue(
+            addFieldNamePrefix('wellOrder_first')
+          )}
+          secondValue={getWellOrderFieldValue(
+            addFieldNamePrefix('wellOrder_second')
+          )}
+          updateFirstWellOrder={
+            propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
+          }
+          updateSecondWellOrder={
+            propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
+          }
+        />
+      </Box>
+
       {prefix === 'aspirate' && (
         <CheckboxRowField
           {...propsForFields['preWetTip']}
@@ -78,7 +126,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
         checkboxFieldName={addFieldNamePrefix('delay_checkbox')}
         secondsFieldName={addFieldNamePrefix('delay_seconds')}
         tipPositionFieldName={addFieldNamePrefix('delay_mmFromBottom')}
-        labwareId={getLabwareIdForField(
+        labwareId={getLabwareIdForPositioningField(
           addFieldNamePrefix('delay_mmFromBottom')
         )}
         propsForFields={propsForFields}
@@ -90,7 +138,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
       >
         <TipPositionField
           {...propsForFields[addFieldNamePrefix('touchTip_mmFromBottom')]}
-          labwareId={getLabwareIdForField(
+          labwareId={getLabwareIdForPositioningField(
             addFieldNamePrefix('touchTip_mmFromBottom')
           )}
         />

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.js
@@ -4,14 +4,11 @@ import { FlowRateInput, type FlowRateInputProps } from './FlowRateInput'
 import { connect } from 'react-redux'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
 import type { FieldProps } from '../../types'
-import type { FormData } from '../../../../form-types'
-import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { BaseState } from '../../../../types'
 
 type OP = {|
   ...FieldProps,
-  pipetteFieldName: StepFieldName,
-  formData: FormData,
+  pipetteId: ?string,
   className?: $PropertyType<FlowRateInputProps, 'className'>,
   flowRateType: $PropertyType<FlowRateInputProps, 'flowRateType'>,
   label?: $PropertyType<FlowRateInputProps, 'label'>,
@@ -37,9 +34,8 @@ function FlowRateInputWithKey(props: Props) {
 }
 
 function mapStateToProps(state: BaseState, ownProps: OP): SP {
-  const { flowRateType, pipetteFieldName, name, formData } = ownProps
+  const { flowRateType, pipetteId, name } = ownProps
 
-  const pipetteId = formData ? formData[pipetteFieldName] : null
   const pipette =
     pipetteId != null
       ? stepFormSelectors.getPipetteEntities(state)[pipetteId]
@@ -69,7 +65,7 @@ function mapStateToProps(state: BaseState, ownProps: OP): SP {
 }
 
 const mergeProps = (stateProps: SP, dispatchProps, ownProps: OP): Props => {
-  const { formData, pipetteFieldName, ...passThruProps } = ownProps
+  const { pipetteId, ...passThruProps } = ownProps
   return { ...stateProps, ...passThruProps }
 }
 

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -37,10 +37,10 @@ type Props = {|
   ) => void,
 |}
 
-type State = {
-  firstValue: ?WellOrderOption,
-  secondValue: ?WellOrderOption,
-}
+type State = {|
+  firstValue: WellOrderOption,
+  secondValue: WellOrderOption,
+|}
 
 export class WellOrderModal extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -56,18 +56,26 @@ export class WellOrderModal extends React.Component<Props, State> {
   }
 
   getInitialFirstValues: () => {|
-    initialFirstValue: ?WellOrderOption,
-    initialSecondValue: ?WellOrderOption,
+    initialFirstValue: WellOrderOption,
+    initialSecondValue: WellOrderOption,
   |} = () => {
     const { firstValue, secondValue } = this.props
+    if (firstValue == null || secondValue == null) {
+      return {
+        initialFirstValue: DEFAULT_FIRST,
+        initialSecondValue: DEFAULT_SECOND,
+      }
+    }
     return {
       initialFirstValue: firstValue,
       initialSecondValue: secondValue,
     }
   }
+
   applyChanges: () => void = () => {
     this.props.updateValues(this.state.firstValue, this.state.secondValue)
   }
+
   handleReset: () => void = () => {
     this.setState(
       { firstValue: DEFAULT_FIRST, secondValue: DEFAULT_SECOND },
@@ -75,6 +83,7 @@ export class WellOrderModal extends React.Component<Props, State> {
     )
     this.props.closeModal()
   }
+
   handleCancel: () => void = () => {
     const {
       initialFirstValue,
@@ -86,10 +95,12 @@ export class WellOrderModal extends React.Component<Props, State> {
     )
     this.props.closeModal()
   }
+
   handleDone: () => void = () => {
     this.applyChanges()
     this.props.closeModal()
   }
+
   makeOnChange: (
     ordinality: 'first' | 'second'
   ) => (
@@ -175,11 +186,7 @@ export class WellOrderModal extends React.Component<Props, State> {
               </div>
             </FormGroup>
             <FormGroup label={i18n.t('modal.well_order.viz_label')}>
-              <WellOrderViz
-                prefix={this.props.prefix}
-                firstValue={firstValue}
-                secondValue={secondValue}
-              />
+              <WellOrderViz firstValue={firstValue} secondValue={secondValue} />
             </FormGroup>
           </div>
           <div className={modalStyles.button_row_divided}>

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -11,7 +11,7 @@ import {
   DropdownField,
 } from '@opentrons/components'
 import modalStyles from '../../../modals/modal.css'
-import type { WellOrderOption, FormData } from '../../../../form-types'
+import type { WellOrderOption } from '../../../../form-types'
 
 import { WellOrderViz } from './WellOrderViz'
 import styles from './WellOrderInput.css'
@@ -29,7 +29,8 @@ type Props = {|
   isOpen: boolean,
   closeModal: () => mixed,
   prefix: 'aspirate' | 'dispense' | 'mix',
-  formData: FormData,
+  firstValue: ?WellOrderOption,
+  secondValue: ?WellOrderOption,
   updateValues: (
     firstValue: ?WellOrderOption,
     secondValue: ?WellOrderOption
@@ -58,10 +59,10 @@ export class WellOrderModal extends React.Component<Props, State> {
     initialFirstValue: ?WellOrderOption,
     initialSecondValue: ?WellOrderOption,
   |} = () => {
-    const { formData, prefix } = this.props
+    const { firstValue, secondValue } = this.props
     return {
-      initialFirstValue: formData && formData[`${prefix}_wellOrder_first`],
-      initialSecondValue: formData && formData[`${prefix}_wellOrder_second`],
+      initialFirstValue: firstValue,
+      initialSecondValue: secondValue,
     }
   }
   applyChanges: () => void = () => {

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.js
@@ -9,22 +9,25 @@ import type { WellOrderOption } from '../../../../form-types'
 
 import styles from './WellOrderInput.css'
 
-type Props = {
-  prefix: 'aspirate' | 'dispense' | 'mix',
-  firstValue: ?WellOrderOption,
-  secondValue: ?WellOrderOption,
-}
+type Props = {|
+  firstValue: WellOrderOption,
+  secondValue: WellOrderOption,
+|}
 
-export const WellOrderViz = (props: Props): React.Node => (
-  <div className={styles.viz_wrapper}>
-    <img src={WELLS_IMAGE} className={styles.wells_image} />
-    <img
-      src={PATH_IMAGE}
-      className={cx(
-        styles.path_image,
-        styles[`${props.firstValue || ''}_first`],
-        styles[`${props.secondValue || ''}_second`]
-      )}
-    />
-  </div>
-)
+export const WellOrderViz = (props: Props): React.Node => {
+  const { firstValue, secondValue } = props
+
+  return (
+    <div className={styles.viz_wrapper}>
+      <img src={WELLS_IMAGE} className={styles.wells_image} />
+      <img
+        src={PATH_IMAGE}
+        className={cx(
+          styles.path_image,
+          styles[`${firstValue || ''}_first`],
+          styles[`${secondValue || ''}_second`]
+        )}
+      />
+    </div>
+  )
+}

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -1,6 +1,13 @@
 // @flow
 import * as React from 'react'
-import { FormGroup, Tooltip, useHoverTooltip } from '@opentrons/components'
+import {
+  Text,
+  FormGroup,
+  Tooltip,
+  useHoverTooltip,
+  FONT_WEIGHT_SEMIBOLD,
+  FONT_SIZE_BODY_1,
+} from '@opentrons/components'
 import cx from 'classnames'
 import { i18n } from '../../../../localization'
 import ZIG_ZAG_IMAGE from '../../../../images/zig_zag_icon.svg'
@@ -74,15 +81,26 @@ export const WellOrderField = (props: Props): React.Node => {
             firstValue={firstValue}
             secondValue={secondValue}
           />
-          <img
-            onClick={handleOpen}
-            src={ZIG_ZAG_IMAGE}
-            className={cx(
-              styles.well_order_icon,
-              { [styles.icon_with_label]: props.label },
-              getIconClassNames()
-            )}
-          />
+          {firstValue != null && secondValue != null ? (
+            <img
+              onClick={handleOpen}
+              src={ZIG_ZAG_IMAGE}
+              className={cx(
+                styles.well_order_icon,
+                { [styles.icon_with_label]: props.label },
+                getIconClassNames()
+              )}
+            />
+          ) : (
+            <Text
+              onClick={handleOpen}
+              fontWeight={FONT_WEIGHT_SEMIBOLD}
+              fontSize={FONT_SIZE_BODY_1}
+              paddingTop="0.5rem"
+            >
+              {i18n.t('form.step_edit_form.field.well_order.mixed')}
+            </Text>
+          )}
         </FormGroup>
       </div>
     </>

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react'
 import {
-  Text,
   FormGroup,
+  Text,
   Tooltip,
   useHoverTooltip,
   FONT_WEIGHT_SEMIBOLD,
@@ -97,6 +97,7 @@ export const WellOrderField = (props: Props): React.Node => {
               fontWeight={FONT_WEIGHT_SEMIBOLD}
               fontSize={FONT_SIZE_BODY_1}
               paddingTop="0.5rem"
+              paddingBottom="0.325rem"
             >
               {i18n.t('form.step_edit_form.field.well_order.mixed')}
             </Text>

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -7,20 +7,26 @@ import ZIG_ZAG_IMAGE from '../../../../images/zig_zag_icon.svg'
 import { WellOrderModal } from './WellOrderModal'
 import stepEditStyles from '../../StepEditForm.css'
 import styles from './WellOrderInput.css'
-import type { FormData } from '../../../../form-types'
 import type { FieldProps } from '../../types'
+import type { WellOrderOption } from '../../../../form-types'
 
 type Props = {|
   className?: ?string,
   label?: string,
   prefix: 'aspirate' | 'dispense' | 'mix',
-  formData: FormData,
+  firstValue: ?WellOrderOption,
+  secondValue: ?WellOrderOption,
   updateFirstWellOrder: $PropertyType<FieldProps, 'updateValue'>,
   updateSecondWellOrder: $PropertyType<FieldProps, 'updateValue'>,
 |}
 
 export const WellOrderField = (props: Props): React.Node => {
-  const { formData, updateFirstWellOrder, updateSecondWellOrder } = props
+  const {
+    firstValue,
+    secondValue,
+    updateFirstWellOrder,
+    updateSecondWellOrder,
+  } = props
   const [isModalOpen, setModalOpen] = React.useState(false)
 
   const handleOpen = () => {
@@ -36,11 +42,12 @@ export const WellOrderField = (props: Props): React.Node => {
   }
 
   const getIconClassNames = () => {
-    let iconClassNames = []
-    if (formData) {
-      const first = formData[`${props.prefix}_wellOrder_first`]
-      const second = formData[`${props.prefix}_wellOrder_second`]
-      iconClassNames = [styles[`${first}_first`], styles[`${second}_second`]]
+    const iconClassNames = []
+    if (firstValue) {
+      iconClassNames.push(styles[`${firstValue}_first`])
+    }
+    if (secondValue) {
+      iconClassNames.push(styles[`${secondValue}_second`])
     }
     return iconClassNames
   }
@@ -63,8 +70,9 @@ export const WellOrderField = (props: Props): React.Node => {
             prefix={props.prefix}
             closeModal={handleClose}
             isOpen={isModalOpen}
-            formData={formData}
             updateValues={updateValues}
+            firstValue={firstValue}
+            secondValue={secondValue}
           />
           <img
             onClick={handleOpen}

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
@@ -12,7 +12,8 @@ describe('WellOrderField', () => {
   beforeEach(() => {
     props = {
       prefix: 'aspirate',
-      formData: ({}: any),
+      firstValue: null,
+      secondValue: null,
       updateFirstWellOrder: jest.fn(),
       updateSecondWellOrder: jest.fn(),
     }

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -98,9 +98,8 @@ export const MixForm = (props: StepFormProps): React.Node => {
             <div className={styles.form_row}>
               <FlowRateField
                 {...propsForFields['aspirate_flowRate']}
-                pipetteFieldName="pipette"
+                pipetteId={formData.pipette}
                 flowRateType="aspirate"
-                formData={props.formData}
               />
               <TipPositionField
                 {...propsForFields['mix_mmFromBottom']}
@@ -119,7 +118,8 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 }
                 prefix="mix"
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
-                formData={props.formData}
+                firstValue={formData['mix_wellOrder_first']}
+                secondValue={formData['mix_wellOrder_second']}
               />
             </div>
             <DelayFields
@@ -140,9 +140,8 @@ export const MixForm = (props: StepFormProps): React.Node => {
             <div className={styles.form_row}>
               <FlowRateField
                 {...propsForFields['dispense_flowRate']}
-                pipetteFieldName="pipette"
+                pipetteId={formData.pipette}
                 flowRateType="dispense"
-                formData={props.formData}
               />
             </div>
             <div className={styles.checkbox_column}>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -66,10 +66,10 @@ export const SourceDestFields = (props: Props): React.Node => {
   return (
     <div className={className}>
       <div className={styles.form_row}>
+        {/* TODO IMMEDIATELY extract and reuse in Batch Edit Form!!! Might need very explicit props, no formData there. */}
         <FlowRateField
           {...propsForFields[addFieldNamePrefix('flowRate')]}
-          formData={formData}
-          pipetteFieldName="pipette"
+          pipetteId={formData.pipette}
           flowRateType={prefix}
         />
         <TipPositionField
@@ -85,13 +85,14 @@ export const SourceDestFields = (props: Props): React.Node => {
         <WellOrderField
           prefix={prefix}
           label={i18n.t('form.step_edit_form.field.well_order.label')}
-          formData={formData}
           updateFirstWellOrder={
             propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
           }
           updateSecondWellOrder={
             propsForFields[addFieldNamePrefix('wellOrder_second')].updateValue
           }
+          firstValue={formData[addFieldNamePrefix('wellOrder_first')]}
+          secondValue={formData[addFieldNamePrefix('wellOrder_second')]}
         />
       </div>
 

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -66,7 +66,6 @@ export const SourceDestFields = (props: Props): React.Node => {
   return (
     <div className={className}>
       <div className={styles.form_row}>
-        {/* TODO IMMEDIATELY extract and reuse in Batch Edit Form!!! Might need very explicit props, no formData there. */}
         <FlowRateField
           {...propsForFields[addFieldNamePrefix('flowRate')]}
           pipetteId={formData.pipette}

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.js
@@ -62,6 +62,8 @@ describe('MixForm', () => {
     props = {
       formData: ({
         stepType: 'mix',
+        mix_wellOrder_first: 'r2l',
+        mix_wellOrder_second: 'b2t',
       }: any),
       focusHandlers: {
         blur: jest.fn(),
@@ -152,7 +154,8 @@ describe('MixForm', () => {
       expect(wellOrderField.props()).toMatchObject({
         prefix: 'mix',
         label: 'Well order',
-        formData: props.formData,
+        firstValue: 'r2l',
+        secondValue: 'b2t',
         updateFirstWellOrder:
           props.propsForFields['mix_wellOrder_first'].updateValue,
         updateSecondWellOrder:

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.js
@@ -38,7 +38,12 @@ describe('SourceDestFields', () => {
   let props
   beforeEach(() => {
     props = {
-      formData: ({}: any),
+      formData: ({
+        aspirate_wellOrder_first: 'r2l',
+        aspirate_wellOrder_second: 'b2t',
+        dispense_wellOrder_first: 'l2r',
+        dispense_wellOrder_second: 't2b',
+      }: any),
       propsForFields: {
         aspirate_delay_checkbox: {
           onFieldFocus: (jest.fn(): any),
@@ -210,7 +215,8 @@ describe('SourceDestFields', () => {
       expect(wellOrderField.props()).toMatchObject({
         prefix: 'aspirate',
         label: 'Well order',
-        formData: props.formData,
+        firstValue: 'r2l',
+        secondValue: 'b2t',
         updateFirstWellOrder:
           props.propsForFields['aspirate_wellOrder_first'].updateValue,
         updateSecondWellOrder:
@@ -244,7 +250,8 @@ describe('SourceDestFields', () => {
       expect(wellOrderField.props()).toMatchObject({
         prefix: 'dispense',
         label: 'Well order',
-        formData: props.formData,
+        firstValue: 'l2r',
+        secondValue: 't2b',
         updateFirstWellOrder:
           props.propsForFields['dispense_wellOrder_first'].updateValue,
         updateSecondWellOrder:

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -69,6 +69,7 @@
       "volume": { "label": "volume per well" },
       "well_order": {
         "label": "Well order",
+        "mixed": "mixed",
         "option": {
           "l2r": "Left to right",
           "r2l": "Right to left",


### PR DESCRIPTION
# Overview

Closes #7239

Pairing credit to @Kadee80 and @shlokamin !!

# Changelog


# Review requests

- [ ] `WellOrderModal` in single-edit mode should work the same as on prod (Transfer + Mix)
- [ ] `FlowRateField` in single-edit mode should work the same as on prod (Transfer + Mix)
- [ ] WellOrderModal should show the text "mixed" in batch edit when either first or second or both well order fields are indeterminate (due to being heterogeneous across the selected steps)
- [ ] Well Order field should work in batch edit mode
- [ ] Tip position field should work in batch edit mode
- [ ] Flow rate field should work in batch edit mode

# Risk assessment

Medium, changes fields that are used in single-edit forms