### PR TITLE
feat(components, protocol-designer): provide more e2e selectors

### DIFF
--- a/components/src/lists/TitledList.js
+++ b/components/src/lists/TitledList.js
@@ -15,6 +15,8 @@ export type TitledListProps = {|
   iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
   /** optional data test id for the container */
   'data-test'?: string,
+  /** id attribute */
+  id?: string,
   // TODO(mc, 2018-01-25): enforce <li> children requirement with flow
   /** children must all be `<li>` */
   children?: React.Node,
@@ -49,6 +51,7 @@ export type TitledListProps = {|
  */
 export function TitledList(props: TitledListProps): React.Node {
   const {
+    id,
     iconName,
     disabled,
     inert,
@@ -94,6 +97,7 @@ export function TitledList(props: TitledListProps): React.Node {
 
   return (
     <div
+      id={id}
       className={className}
       data-test={dataTest}
       {...{ onMouseEnter, onMouseLeave, onContextMenu }}

--- a/components/src/structure/TitleBar.js
+++ b/components/src/structure/TitleBar.js
@@ -10,6 +10,7 @@ import styles from './structure.css'
 import type { ButtonProps } from '../buttons'
 
 export type TitleBarProps = {|
+  id?: string,
   title: React.Node,
   subtitle?: React.Node,
   back?: ButtonProps,
@@ -29,6 +30,7 @@ export function TitleBar(props: TitleBarProps): React.Node {
     onBackClick,
     backClickDisabled,
     backButtonLabel,
+    id,
   } = props
   let { back } = props
 
@@ -52,7 +54,7 @@ export function TitleBar(props: TitleBarProps): React.Node {
   }
 
   return (
-    <header className={cx(styles.title_bar, className)}>
+    <header id={id} className={cx(styles.title_bar, className)}>
       {back && (
         <FlatButton
           inverted

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -100,6 +100,8 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
           secondValue={getWellOrderFieldValue(
             addFieldNamePrefix('wellOrder_second')
           )}
+          firstName={addFieldNamePrefix('wellOrder_first')}
+          secondName={addFieldNamePrefix('wellOrder_second')}
           updateFirstWellOrder={
             propsForFields[addFieldNamePrefix('wellOrder_first')].updateValue
           }

--- a/protocol-designer/src/components/DeckSetupManager.js
+++ b/protocol-designer/src/components/DeckSetupManager.js
@@ -29,7 +29,7 @@ const NoBatchEditSharedSettings = (): React.Node => {
       alignItems={ALIGN_CENTER}
       height="75%"
     >
-      <Text color={C_DARK_GRAY}>
+      <Text id="Text_noSharedSettings" color={C_DARK_GRAY}>
         {i18n.t('application.no_batch_edit_shared_settings')}
       </Text>
     </Flex>

--- a/protocol-designer/src/components/StepCreationButton.js
+++ b/protocol-designer/src/components/StepCreationButton.js
@@ -65,7 +65,11 @@ export const StepCreationButtonComponent = (
           {i18n.t(`tooltip.disabled_step_creation`)}
         </Tooltip>
       )}
-      <PrimaryButton onClick={() => setExpanded(!expanded)} disabled={disabled}>
+      <PrimaryButton
+        id="StepCreationButton"
+        onClick={() => setExpanded(!expanded)}
+        disabled={disabled}
+      >
         {i18n.t('button.add_step')}
       </PrimaryButton>
 

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
@@ -25,6 +25,7 @@ export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
     disabled,
     isIndeterminate,
     label,
+    name,
     tooltipContent,
     updateValue,
     value,
@@ -44,6 +45,7 @@ export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
           isIndeterminate={isIndeterminate}
           label={label}
           labelProps={targetProps}
+          name={name}
           onChange={(e: SyntheticInputEvent<*>) => updateValue(!value)}
           value={Boolean(value)}
         />

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
@@ -101,6 +101,7 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
       label,
       minFlowRate,
       maxFlowRate,
+      name,
       pipetteDisplayName,
     } = this.props
 
@@ -132,6 +133,7 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
 
     const FlowRateInput = (
       <InputField
+        name={`${name}_customFlowRate`}
         value={`${this.state.modalFlowRate || ''}`}
         units={i18n.t('application.units.microliterPerSec')}
         caption={rangeDescription}
@@ -190,6 +192,7 @@ export class FlowRateInput extends React.Component<FlowRateInputProps, State> {
       <React.Fragment>
         <FormGroup label={label || DEFAULT_LABEL} disabled={disabled}>
           <InputField
+            name={name}
             units="μL/s"
             readOnly
             disabled={disabled}

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -31,6 +31,8 @@ type Props = {|
   prefix: 'aspirate' | 'dispense' | 'mix',
   firstValue: ?WellOrderOption,
   secondValue: ?WellOrderOption,
+  firstName: string,
+  secondName: string,
   updateValues: (
     firstValue: ?WellOrderOption,
     secondValue: ?WellOrderOption
@@ -136,7 +138,10 @@ export class WellOrderModal extends React.Component<Props, State> {
   }
   render(): React.Node {
     if (!this.props.isOpen) return null
+
     const { firstValue, secondValue } = this.state
+    const { firstName, secondName } = this.props
+
     return (
       <Portal>
         <Modal
@@ -152,6 +157,7 @@ export class WellOrderModal extends React.Component<Props, State> {
             <FormGroup label={i18n.t('modal.well_order.field_label')}>
               <div className={styles.field_row}>
                 <DropdownField
+                  name={firstName}
                   value={firstValue}
                   className={cx(
                     stepEditStyles.field,
@@ -169,6 +175,7 @@ export class WellOrderModal extends React.Component<Props, State> {
                   {i18n.t('modal.well_order.then')}
                 </span>
                 <DropdownField
+                  name={secondName}
                   value={secondValue}
                   className={cx(
                     stepEditStyles.field,

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -23,6 +23,8 @@ type Props = {|
   prefix: 'aspirate' | 'dispense' | 'mix',
   firstValue: ?WellOrderOption,
   secondValue: ?WellOrderOption,
+  firstName: string,
+  secondName: string,
   updateFirstWellOrder: $PropertyType<FieldProps, 'updateValue'>,
   updateSecondWellOrder: $PropertyType<FieldProps, 'updateValue'>,
 |}
@@ -31,6 +33,8 @@ export const WellOrderField = (props: Props): React.Node => {
   const {
     firstValue,
     secondValue,
+    firstName,
+    secondName,
     updateFirstWellOrder,
     updateSecondWellOrder,
   } = props
@@ -80,6 +84,8 @@ export const WellOrderField = (props: Props): React.Node => {
             updateValues={updateValues}
             firstValue={firstValue}
             secondValue={secondValue}
+            firstName={firstName}
+            secondName={secondName}
           />
           {firstValue != null && secondValue != null ? (
             <img

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
@@ -14,6 +14,8 @@ describe('WellOrderField', () => {
       prefix: 'aspirate',
       firstValue: null,
       secondValue: null,
+      firstName: 'example_wellOrder_first',
+      secondName: 'example_wellOrder_second',
       updateFirstWellOrder: jest.fn(),
       updateSecondWellOrder: jest.fn(),
     }

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -120,6 +120,8 @@ export const MixForm = (props: StepFormProps): React.Node => {
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
                 firstValue={formData['mix_wellOrder_first']}
                 secondValue={formData['mix_wellOrder_second']}
+                firstName={'mix_wellOrder_first'}
+                secondName={'mix_wellOrder_second'}
               />
             </div>
             <DelayFields

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.js
@@ -92,6 +92,8 @@ export const SourceDestFields = (props: Props): React.Node => {
           }
           firstValue={formData[addFieldNamePrefix('wellOrder_first')]}
           secondValue={formData[addFieldNamePrefix('wellOrder_second')]}
+          firstName={addFieldNamePrefix('wellOrder_first')}
+          secondName={addFieldNamePrefix('wellOrder_second')}
         />
       </div>
 

--- a/protocol-designer/src/components/steplist/TerminalItem/index.js
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.js
@@ -63,6 +63,7 @@ export const TerminalItem = (props: Props): React.Node => {
       )}
       <PDTitledList
         {...{
+          id: `TerminalItem_${id}`,
           hovered,
           selected,
           title,

--- a/protocol-designer/src/containers/ConnectedTitleBar.js
+++ b/protocol-designer/src/containers/ConnectedTitleBar.js
@@ -204,7 +204,7 @@ function mergeProps(
 }
 
 const StickyTitleBar = (props: TitleBarProps) => (
-  <TitleBar {...props} className={styles.sticky_bar} />
+  <TitleBar id="TitleBar_main" {...props} className={styles.sticky_bar} />
 )
 
 export const ConnectedTitleBar: React.AbstractComponent<{||}> = connect<


### PR DESCRIPTION
# Overview

Closes #7384

# Changelog

- add `id` attr to TitleBar, use in PD's TitleBar `id=TitleBar_main`
- pass through `name` attr for `CheckboxRowField` down to the checkbox input of eg all the advanced settings `input[type=checkbox]` fields (note that these are accessibly hidden)
- add id `Text_noSharedSettings` to the "no shared settings" text for Batch Edit Mode (when you have multiple step types selected!)
- add id `StepCreationButton` to step creation button (ADD STEP +)
- add id `TerminalItem___initial_setup__` to STARTING DECK STATE
- add id `TerminalItem___end__` to FINAL DECK STATE
- add `name` attributes to all advanced settings fields, including fields that are inside modals

# Review requests

- [ ] Appropriate selectors should now be available for everything Neha needs as specified in #7384 --please test in browser (ids/names outlined above)
- [ ] Make sure none of the affected fields broke!
- [ ] Code review

# Risk assessment

Low, should just be adding `id` and `name` attrs