### PR TITLE
fix(protocol-designer): avoid StepList exception on keydown

### DIFF
--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -91,13 +91,6 @@ describe('Protocols with Modules', () => {
     })
 
     it('designs protocol with thermocycler', () => {
-      // Avoid failing the test on uncaught exception
-      // Happens when writing a nickname for the labware
-      Cypress.on('uncaught:exception', (err, runnable) => {
-        console.log(err.name)
-        return false
-      })
-
       cy.openDesignPage()
       // close "setting up" modal
       cy.contains('Setting up your protocol').should('exist')

--- a/protocol-designer/src/components/steplist/StepList.js
+++ b/protocol-designer/src/components/steplist/StepList.js
@@ -25,7 +25,7 @@ export class StepList extends React.Component<Props> {
   handleKeyDown: (e: SyntheticKeyboardEvent<>) => void = e => {
     const { reorderSelectedStep } = this.props
     const key = e.key
-    const altIsPressed = e.getModifierState('Alt')
+    const altIsPressed = e.altKey
 
     if (altIsPressed) {
       let delta = 0


### PR DESCRIPTION
# Overview

This PR serves as its own ticket.

No longer ignore exceptions in TC e2e test(this is the test that often fails on Mac in CI)

Apparently `KeyboardEvent.getModifierState` is "obsolete" though supported in browsers:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState#specifications and MDN recommends alternatives:

> using event.altKey, event.ctrlKey, event.metaKey and event.shiftKey may be more preferable.

When Cypress types in a new labware's name, it triggers `StepList`'s `keydown` while typing in the other component. That KeyboardEvent has no `getModifierState`, so `e.getModifierState()` throws an exception.

I don't know if this will fix the intermittent failing of this Cypress test on Mac in CI, but at least we might get clearer errors?

# Changelog


# Review requests

- The secret alt-arrow(up/down) thing to rearrange steps via the keyboard should still work
- E2E test should still pass

# Risk assessment

Low & PD only