### PR TITLE
wip: use boot ID to track restarting status in app

### DIFF
--- a/app/src/redux/discovery/constants.js
+++ b/app/src/redux/discovery/constants.js
@@ -1,8 +1,16 @@
 // @flow
 
+// overall status constants
 export const CONNECTABLE: 'connectable' = 'connectable'
 export const REACHABLE: 'reachable' = 'reachable'
 export const UNREACHABLE: 'unreachable' = 'unreachable'
+
+// restart status constants
+export const RESTART_PENDING_STATUS: 'restart-pending' = 'restart-pending'
+export const RESTARTING_STATUS: 'restarting' = 'restarting'
+// export const RESTART_FAILED_STATUS: 'restart-failed' = 'restart-failed'
+// export const UP_STATUS: 'up' = 'up'
+// export const DOWN_STATUS: 'down' = 'down'
 
 // TODO(mc, 2021-02-17): values below duplicated from Discovery Client source
 // discovery-client/src/constants.ts

--- a/app/src/redux/discovery/reducer.js
+++ b/app/src/redux/discovery/reducer.js
@@ -2,6 +2,8 @@
 // robot discovery state
 import keyBy from 'lodash/keyBy'
 import { UI_INITIALIZED } from '../shell'
+import { RESTART_SUCCESS } from '../robot-admin'
+import * as Constants from './constants'
 import * as actions from './actions'
 
 import type { Action } from '../types'
@@ -10,6 +12,7 @@ import type { DiscoveryState } from './types'
 export const INITIAL_STATE: DiscoveryState = {
   scanning: false,
   robotsByName: {},
+  restartingByName: {},
 }
 
 export function discoveryReducer(
@@ -25,7 +28,67 @@ export function discoveryReducer(
       return { ...state, scanning: false }
 
     case actions.DISCOVERY_UPDATE_LIST: {
-      return { ...state, robotsByName: keyBy(action.payload.robots, 'name') }
+      const robotsByName = keyBy(action.payload.robots, 'name')
+
+      // if we have any robots that we are tracking restarts for, use bootId
+      // (if present) or health status set restart status accordingly
+      const restartingByName = Object.keys(state.restartingByName).reduce(
+        (restartMap, robotName) => {
+          const nextRobotState = robotsByName[robotName]
+          const restartState = restartMap[robotName]
+          const { bootId: prevBootId, status: restartStatus } = restartState
+
+          const apiServerIsUp =
+            nextRobotState?.addresses[0]?.healthStatus ===
+            Constants.HEALTH_STATUS_OK
+
+          const bootId = nextRobotState?.serverHealth?.bootId ?? null
+
+          if (bootId !== null && bootId !== prevBootId) {
+            // if the health server has reported a boot ID and it's different
+            // than the last one, then the robot has restarted
+            restartMap[robotName] = { ...restartState, status: null }
+          } else if (
+            restartStatus === Constants.RESTART_PENDING_STATUS &&
+            !apiServerIsUp
+          ) {
+            // if the robot has a restart pending, and we notice that it is no
+            // longer responding on its health endpoint, then we can mark it
+            // restarting
+            restartMap[robotName] = {
+              ...restartState,
+              status: Constants.RESTARTING_STATUS,
+            }
+          } else if (
+            restartStatus === Constants.RESTARTING_STATUS &&
+            apiServerIsUp
+          ) {
+            // if the robot is marked as restarting and we notice it is back
+            // online (and we didn't have a boot ID to check), optimistically
+            // mark it as no longer restarting
+            restartMap[robotName] = { ...restartState, status: null }
+          }
+
+          return restartMap
+        },
+        { ...state.restartingByName }
+      )
+
+      return { ...state, robotsByName, restartingByName }
+    }
+
+    case RESTART_SUCCESS: {
+      const { robotName } = action.payload
+      const robotState = state.robotsByName[robotName]
+      const restartingByName = {
+        ...state.restartingByName,
+        [robotName]: {
+          bootId: robotState?.serverHealth?.bootId ?? null,
+          status: Constants.RESTART_PENDING_STATUS,
+        },
+      }
+
+      return { ...state, restartingByName }
     }
   }
 

--- a/app/src/redux/discovery/types.js
+++ b/app/src/redux/discovery/types.js
@@ -11,15 +11,25 @@ import typeof {
   CONNECTABLE,
   REACHABLE,
   UNREACHABLE,
+  RESTART_PENDING_STATUS,
+  RESTARTING_STATUS,
 } from './constants'
 
 export type { DiscoveryClientRobot, HealthStatus }
 
 export type RobotsMap = $Shape<{| [name: string]: DiscoveryClientRobot |}>
 
+export type RestartingMap = {
+  [name: string]: {|
+    bootId: string | null,
+    status: RESTART_PENDING_STATUS | RESTARTING_STATUS | null,
+  |},
+  ...
+}
 export type DiscoveryState = {|
   scanning: boolean,
   robotsByName: RobotsMap,
+  restartingByName: RestartingMap,
 |}
 
 export type BaseRobot = {|

--- a/app/src/redux/robot-admin/actions.js
+++ b/app/src/redux/robot-admin/actions.js
@@ -84,3 +84,6 @@ export const resetConfigFailure = (
   payload: { robotName, error },
   meta,
 })
+
+// TODO(mc, 2021-04-05): add an action creator for discovery
+// list

--- a/discovery-client/lib/index.flow.js
+++ b/discovery-client/lib/index.flow.js
@@ -74,6 +74,7 @@ export type ServerHealthResponse = {
   smoothieVersion: string,
   systemVersion: string,
   capabilities?: CapabilityMap,
+  bootId?: string,
   ...
 }
 

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -37,6 +37,7 @@ export interface ServerHealthResponse {
   smoothieVersion: string
   systemVersion: string
   capabilities?: CapabilityMap
+  bootId?: string
 }
 
 export interface HealthErrorResponse {


### PR DESCRIPTION
## Overview

Incomplete front-end companion PR to #7404 in order to fully address #6585 

Currently, this PR is a first attempt at using boot ID in the app state to track restarting status. After getting to the "end" of this work, it's looking like we'll need a second pass to take an epic-based approach.

- Current restart detection relies on API server
    - Boot ID restart detection relies on update server, which is better!
    - But it means we need more state to present a different UI if the API server is booting rather than unexpectedly down
- A restart failure timeout is a pretty important part of a "proper" fix to the bug
    - This sort of feature is way more straightforward to implement in an epic 
    - As written, this PR is completely reducer based

## Changelog

TBD

## Review requests

TBD

This initial pass at this PR attempted to take the restart tracking state that exists in the `app/src/redux/robot-admin` module and move it to the `app/src/redux/discovery` module. For now, read through the code and the PR description to make sure you agree with the assessment we came to during CPX pairing on this PR.

## Risk assessment

TBD