### PR TITLE
feat(protocol-designer): add tooltips when tip position disabled in batch edit mode

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -48,7 +48,14 @@ function TipPositionInput(props: Props) {
     setModalOpen(false)
   }
 
-  const { disabled, name, mmFromBottom, wellDepthMm, updateValue } = props
+  const {
+    disabled,
+    name,
+    mmFromBottom,
+    tooltipContent,
+    wellDepthMm,
+    updateValue,
+  } = props
   const isTouchTipField = getIsTouchTipField(name)
   const isDelayPositionField = getIsDelayPositionField(name)
   let value = ''
@@ -64,9 +71,7 @@ function TipPositionInput(props: Props) {
 
   return (
     <>
-      <Tooltip {...tooltipProps}>
-        {i18n.t('tooltip.step_fields.defaults.tipPosition')}
-      </Tooltip>
+      <Tooltip {...tooltipProps}>{tooltipContent}</Tooltip>
       <TipPositionModal
         name={name}
         closeModal={handleClose}

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -34,7 +34,8 @@
 
       "changeTip": "Choose when the robot picks up fresh tips",
       "preWetTip": "Pre-wet pipette tip by aspirating and dispensing 2/3 of the tip's max volume",
-      "tipPosition": "Distance from the bottom of the well",
+      "aspirate_mmFromBottom": "Distance from the bottom of the well",
+      "dispense_mmFromBottom": "Distance from the bottom of the well",
 
       "aspirate_touchTip_checkbox": "Touch tip to each side of well after aspirating",
       "dispense_touchTip_checkbox": "Touch tip to each side of well after dispensing",


### PR DESCRIPTION
# Overview

Closes #7450

# Review Requests
Make sure touch tip tooltip still works in single edit mode, and make sure bug detailed in the ticket (#7450) is fixed in batch edit mode. Be sure to make sure tooltip text shows up when both aspirate + dispense labware are different in batch edit mode.

# Risk assessment

Low