### PR TITLE
feat(api): protocol engine labware interface implementationn

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -54,8 +54,12 @@ class LabwareState:
 
     def get_labware_has_quirk(self, labware_id: str, quirk: str) -> bool:
         """Get if a labware has a certain quirk."""
+        return quirk in self.get_quirks(labware_id=labware_id)
+
+    def get_quirks(self, labware_id: str) -> List[str]:
+        """Get a labware's quirks."""
         data = self.get_labware_data_by_id(labware_id)
-        return quirk in data.definition["parameters"].get("quirks", ())
+        return data.definition["parameters"].get("quirks", [])
 
     def get_well_definition(
         self,
@@ -85,6 +89,16 @@ class LabwareState:
     def get_definition_uri(self, labware_id: str) -> str:
         """Get a labware's definition URI."""
         return uri_from_definition(self.get_labware_data_by_id(labware_id).definition)
+
+    def is_tiprack(self, labware_id: str) -> bool:
+        """Get whether labware is a tiprack."""
+        labware_data = self.get_labware_data_by_id(labware_id)
+        return labware_data.definition["parameters"]["isTiprack"]
+
+    def get_load_name(self, labware_id: str) -> str:
+        """Get the labware's load name."""
+        labware_data = self.get_labware_data_by_id(labware_id)
+        return labware_data.definition["parameters"]["loadName"]
 
 
 class LabwareStore(Substore[LabwareState], CommandReactive):

--- a/api/src/opentrons/protocols/implementations/engine/labware_context.py
+++ b/api/src/opentrons/protocols/implementations/engine/labware_context.py
@@ -1,6 +1,7 @@
 """Module containing labware interface that works with Protocol Engine."""
 from typing import Dict, List
 
+from opentrons.protocol_engine import StateView
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.implementations.tip_tracker import TipTracker
 from opentrons.protocols.implementations.well import WellImplementation
@@ -16,38 +17,61 @@ from opentrons.protocols.implementations.interfaces.labware\
 class LabwareContext(LabwareInterface):
     """LabwareInterface implementation that works with the Protocol Engine."""
 
+    def __init__(self, labware_id: str, state_view: StateView):
+        self._id = labware_id
+        self._state_view = state_view
+
     def get_uri(self) -> str:
-        raise NotImplementedError()
+        """Get the labware uri."""
+        return self._state_view.labware.get_definition_uri(labware_id=self._id)
 
     def get_display_name(self) -> str:
-        raise NotImplementedError()
+        """Get the display name."""
+        lw = self._state_view.labware.get_labware_data_by_id(labware_id=self._id)
+        # TODO AL 20210225 - this is not consistent with reference
+        #  implementation. It is either the supplied label or displayName in
+        #  definition on the location, which is either a slot or module.
+        return f"{lw.definition['metadata']['displayName']} on {lw.location.slot}"
 
     def get_name(self) -> str:
-        raise NotImplementedError()
+        """Get the name."""
+        # TODO AL 20210225 - this is not consistent with reference
+        #  implementation. It is either the supplied label or loadName in
+        #  definition.
+        return self.get_parameters()['loadName']
 
     def set_name(self, new_name: str) -> None:
         raise NotImplementedError()
 
     def get_definition(self) -> LabwareDefinition:
-        raise NotImplementedError()
+        """Get the labware definition."""
+        return self._state_view.labware.get_labware_data_by_id(
+            labware_id=self._id).definition
 
     def get_parameters(self) -> LabwareParameters:
-        raise NotImplementedError()
+        """Get the labware definition parameters."""
+        return self.get_definition()['parameters']
 
     def get_quirks(self) -> List[str]:
-        raise NotImplementedError()
+        """Get the labware quirks."""
+        return self.get_parameters()['quirks']
 
     def set_calibration(self, delta: Point) -> None:
         raise NotImplementedError()
 
     def get_calibrated_offset(self) -> Point:
-        raise NotImplementedError()
+        """Get the calibrated offset."""
+        x, y, z = self._state_view.labware.get_labware_data_by_id(
+            labware_id=self._id).calibration
+        return Point(x=x, y=y, z=z)
 
     def is_tiprack(self) -> bool:
-        raise NotImplementedError()
+        """Return whether this labware is a tiprack."""
+        return self.get_parameters()['isTiprack']
 
     def get_tip_length(self) -> float:
-        raise NotImplementedError()
+        """Get the tip length."""
+        return self._state_view.labware.get_tip_length(labware_id=self._id)
 
     def set_tip_length(self, length: float):
         raise NotImplementedError()
@@ -80,4 +104,5 @@ class LabwareContext(LabwareInterface):
 
     @property
     def load_name(self) -> str:
-        raise NotImplementedError()
+        """Get the load name."""
+        return self.get_parameters()['loadName']

--- a/api/src/opentrons/protocols/implementations/engine/labware_context.py
+++ b/api/src/opentrons/protocols/implementations/engine/labware_context.py
@@ -1,0 +1,83 @@
+"""Module containing labware interface that works with Protocol Engine."""
+from typing import Dict, List
+
+from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
+from opentrons.protocols.implementations.tip_tracker import TipTracker
+from opentrons.protocols.implementations.well import WellImplementation
+from opentrons.protocols.implementations.well_grid import WellGrid
+from opentrons.types import Point
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition, LabwareParameters
+)
+from opentrons.protocols.implementations.interfaces.labware\
+    import LabwareInterface
+
+
+class LabwareContext(LabwareInterface):
+    """LabwareInterface implementation that works with the Protocol Engine."""
+
+    def get_uri(self) -> str:
+        raise NotImplementedError()
+
+    def get_display_name(self) -> str:
+        raise NotImplementedError()
+
+    def get_name(self) -> str:
+        raise NotImplementedError()
+
+    def set_name(self, new_name: str) -> None:
+        raise NotImplementedError()
+
+    def get_definition(self) -> LabwareDefinition:
+        raise NotImplementedError()
+
+    def get_parameters(self) -> LabwareParameters:
+        raise NotImplementedError()
+
+    def get_quirks(self) -> List[str]:
+        raise NotImplementedError()
+
+    def set_calibration(self, delta: Point) -> None:
+        raise NotImplementedError()
+
+    def get_calibrated_offset(self) -> Point:
+        raise NotImplementedError()
+
+    def is_tiprack(self) -> bool:
+        raise NotImplementedError()
+
+    def get_tip_length(self) -> float:
+        raise NotImplementedError()
+
+    def set_tip_length(self, length: float):
+        raise NotImplementedError()
+
+    def reset_tips(self) -> None:
+        raise NotImplementedError()
+
+    def get_tip_tracker(self) -> TipTracker:
+        raise NotImplementedError()
+
+    def get_well_grid(self) -> WellGrid:
+        raise NotImplementedError()
+
+    def get_wells(self) -> List[WellImplementation]:
+        raise NotImplementedError()
+
+    def get_wells_by_name(self) -> Dict[str, WellImplementation]:
+        raise NotImplementedError()
+
+    def get_geometry(self) -> LabwareGeometry:
+        raise NotImplementedError()
+
+    @property
+    def highest_z(self):
+        raise NotImplementedError()
+
+    @property
+    def separate_calibration(self) -> bool:
+        raise NotImplementedError()
+
+    @property
+    def load_name(self) -> str:
+        raise NotImplementedError()

--- a/api/src/opentrons/protocols/implementations/labware.py
+++ b/api/src/opentrons/protocols/implementations/labware.py
@@ -33,8 +33,8 @@ class LabwareImplementation(LabwareInterface):
                        the front and left most point of the outside of the
                        labware is (often the front-left corner of a slot on the
                        deck).
-        :param str label: An optional label to use instead of the displayName
-                          from the definition's metadata element
+        :param label: An optional label to use instead of the displayName
+                      from the definition's metadata element
         """
         if label:
             dn = label

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -534,7 +534,8 @@ def minimal_labware_def():
         },
         "parameters": {
             "isTiprack": False,
-            "loadName": "minimal_labware_def"
+            "loadName": "minimal_labware_def",
+            "quirks": ["a quirk"]
         },
         "ordering": [["A1"], ["A2"]],
         "wells": {

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_state.py
@@ -146,6 +146,31 @@ def test_get_all_labware_highest_z(
     assert all_z == max(plate_z, reservoir_z)
 
 
+def test_get_labware_position(
+    minimal_labware_def: LabwareDefinition,
+    standard_deck_def: DeckDefinitionV2,
+    mock_labware_store: MagicMock,
+    geometry_store: GeometryStore,
+) -> None:
+    """It should return the slot position plus calibrated offset."""
+    labware_data = LabwareData(
+        definition=minimal_labware_def,
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
+        calibration=(1, -2, 3)
+    )
+    slot_pos = standard_deck_def["locations"]["orderedSlots"][3]["position"]
+
+    mock_labware_store.state.get_labware_data_by_id.return_value = labware_data
+
+    position = geometry_store.state.get_labware_position(labware_id="abc")
+
+    assert position == Point(
+        x=slot_pos[0] + 1,
+        y=slot_pos[1] - 2,
+        z=slot_pos[2] + 3,
+    )
+
+
 def test_get_well_position(
     well_plate_def: LabwareDefinition,
     standard_deck_def: DeckDefinitionV2,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -97,7 +97,7 @@ def test_get_all_labware(
     reservoir_def: LabwareDefinition,
     store: StateStore,
 ) -> None:
-    """It should return whether a labware by ID has a given quirk."""
+    """It should return all labware."""
     load_labware(
         store=store,
         labware_id="plate-id",
@@ -156,6 +156,35 @@ def test_get_labware_has_quirk(
 
     assert well_plate_has_center_quirk is False
     assert reservoir_has_center_quirk is True
+
+
+def test_quirks(
+    well_plate_def: LabwareDefinition,
+    reservoir_def: LabwareDefinition,
+    store: StateStore,
+) -> None:
+    """It should return a labware's quirks."""
+    load_labware(
+        store=store,
+        labware_id="plate-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        definition=well_plate_def,
+        calibration=(1, 2, 3),
+    )
+
+    load_labware(
+        store=store,
+        labware_id="reservoir-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
+        definition=reservoir_def,
+        calibration=(4, 5, 6),
+    )
+
+    well_plate_quirks = store.labware.get_quirks("plate-id")
+    reservoir_quirks = store.labware.get_quirks("reservoir-id")
+
+    assert well_plate_quirks == []
+    assert reservoir_quirks == ['centerMultichannelOnWells', 'touchTipDisabled']
 
 
 def test_get_well_definition_bad_id(
@@ -246,3 +275,51 @@ def test_get_labware_uri_from_definition(
 
     uri = store.labware.get_definition_uri("tip-rack-id")
     assert uri == "opentrons/opentrons_96_tiprack_300ul/1"
+
+
+def test_is_tiprack_true(
+    tip_rack_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should return true."""
+    load_labware(
+        store=store,
+        labware_id="tip-rack-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        definition=tip_rack_def,
+        calibration=(1, 2, 3),
+    )
+
+    assert store.labware.is_tiprack("tip-rack-id") is True
+
+
+def test_is_tiprack_false(
+    reservoir_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should return false."""
+    load_labware(
+        store=store,
+        labware_id="res-rack-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        definition=reservoir_def,
+        calibration=(1, 2, 3),
+    )
+
+    assert store.labware.is_tiprack("res-rack-id") is False
+
+
+def test_get_load_name(
+    reservoir_def: LabwareDefinition,
+    store: StateStore
+) -> None:
+    """It should return the load name."""
+    load_labware(
+        store=store,
+        labware_id="res-rack-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        definition=reservoir_def,
+        calibration=(1, 2, 3),
+    )
+
+    assert store.labware.get_load_name("res-rack-id") == 'nest_12_reservoir_15ml'

--- a/api/tests/opentrons/protocols/implementation/engine/test_labware_context.py
+++ b/api/tests/opentrons/protocols/implementation/engine/test_labware_context.py
@@ -1,0 +1,118 @@
+import pytest
+
+from opentrons.protocols.implementations.engine.labware_context import \
+    LabwareContext
+from opentrons.types import Point
+
+
+@pytest.fixture
+def labware_context() -> LabwareContext:
+    return LabwareContext()
+
+
+def test_get_uri(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_uri()
+
+
+def test_get_display_name(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_display_name()
+
+
+def test_get_name(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_name()
+
+
+def test_set_name(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        name = "some_name"
+        labware_context.set_name(name)
+
+
+def test_get_definition(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_definition()
+
+
+def test_get_parameters(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_parameters()
+
+
+def test_get_quirks(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_quirks()
+
+
+def test_set_calibration(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        point = Point(1, 2, 3)
+        labware_context.set_calibration(point)
+
+
+def test_get_calibrated_offset(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_calibrated_offset()
+
+
+def test_is_tiprack(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.is_tiprack()
+
+
+def test_get_tip_length(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_tip_length()
+
+
+def test_set_tip_length(labware_context: LabwareContext):
+    with pytest.raises(NotImplementedError):
+        length = 1.2
+        labware_context.set_tip_length(length)
+
+
+def test_reset_tips(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.reset_tips()
+
+
+def test_get_tip_tracker(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_tip_tracker()
+
+
+def test_get_well_grid(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_well_grid()
+
+
+def test_get_wells(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_wells()
+
+
+def test_get_wells_by_name(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_wells_by_name()
+
+
+def test_get_geometry(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        labware_context.get_geometry()
+
+
+def test_highest_z(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        h = labware_context.highest_z
+
+
+def test_separate_calibration(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        s = labware_context.separate_calibration
+
+
+def test_load_name(labware_context: LabwareContext) -> None:
+    with pytest.raises(NotImplementedError):
+        ln = labware_context.load_name

--- a/api/tests/opentrons/protocols/implementation/engine/test_labware_context.py
+++ b/api/tests/opentrons/protocols/implementation/engine/test_labware_context.py
@@ -1,28 +1,81 @@
 import pytest
+from decoy import Decoy
+from opentrons.protocol_engine import StateView
+from opentrons.protocol_engine.state import LabwareData
+from opentrons.protocol_engine.types import DeckSlotLocation
 
 from opentrons.protocols.implementations.engine.labware_context import \
     LabwareContext
-from opentrons.types import Point
+from opentrons.types import Point, DeckSlotName
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 @pytest.fixture
-def labware_context() -> LabwareContext:
-    return LabwareContext()
+def decoy() -> Decoy:
+    """Create a decoy fixture."""
+    return Decoy()
 
 
-def test_get_uri(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_uri()
+@pytest.fixture
+def mock_state_view(decoy: Decoy) -> StateView:
+    """Mock state view."""
+    return decoy.create_decoy(spec=StateView)
 
 
-def test_get_display_name(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_display_name()
+@pytest.fixture
+def labware_id() -> str:
+    """The labware id fixture."""
+    return "labware id"
 
 
-def test_get_name(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_name()
+@pytest.fixture
+def labware_data(minimal_labware_def: LabwareDefinition) -> LabwareData:
+    """LabwareData fixture."""
+    return LabwareData(
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+        calibration=(1.2, 3.2, 3.1,),
+        definition=minimal_labware_def
+    )
+
+
+@pytest.fixture
+def labware_context(labware_id: str,
+                    mock_state_view: StateView) -> LabwareContext:
+    """LabwareContext fixture"""
+    return LabwareContext(labware_id=labware_id, state_view=mock_state_view)
+
+
+def test_get_uri(decoy: Decoy, labware_id: str, mock_state_view: StateView,
+                 labware_context: LabwareContext) -> None:
+    """Should return the labware uri."""
+    decoy.when(
+        mock_state_view.labware.get_definition_uri(labware_id=labware_id)
+    ).then_return("some uri")
+    assert labware_context.get_uri() == "some uri"
+
+
+def test_get_display_name(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData
+) -> None:
+    """Should return the labware's display name."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.get_display_name() == "minimal labware on 3"
+
+
+def test_get_name(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData
+) -> None:
+    """Should return the labware's name."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.get_name() == "minimal_labware_def"
 
 
 def test_set_name(labware_context: LabwareContext) -> None:
@@ -31,19 +84,43 @@ def test_set_name(labware_context: LabwareContext) -> None:
         labware_context.set_name(name)
 
 
-def test_get_definition(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_definition()
+def test_get_definition(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+        minimal_labware_def: LabwareDefinition
+) -> None:
+    """Should return the labware's definition."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.get_definition() == minimal_labware_def
 
 
-def test_get_parameters(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_parameters()
+def test_get_parameters(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+        minimal_labware_def: LabwareDefinition
+) -> None:
+    """Should return the labware definition's parameters"""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.get_parameters() == minimal_labware_def['parameters']
 
 
-def test_get_quirks(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_quirks()
+def test_get_quirks(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+        minimal_labware_def: LabwareDefinition
+) -> None:
+    """Should return the labware quirks."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.get_quirks() == minimal_labware_def['parameters']['quirks']
 
 
 def test_set_calibration(labware_context: LabwareContext) -> None:
@@ -52,19 +129,42 @@ def test_set_calibration(labware_context: LabwareContext) -> None:
         labware_context.set_calibration(point)
 
 
-def test_get_calibrated_offset(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_calibrated_offset()
+def test_get_calibrated_offset(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+) -> None:
+    """Should return the calibrated offset."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert Point(*labware_data.calibration) == labware_context.get_calibrated_offset()
 
 
-def test_is_tiprack(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.is_tiprack()
+def test_is_tiprack(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+        minimal_labware_def: LabwareDefinition
+) -> None:
+    """Should return whether labware is a tiprack"""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.is_tiprack() ==\
+           labware_data.definition['parameters']['isTiprack']
 
 
-def test_get_tip_length(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        labware_context.get_tip_length()
+def test_get_tip_length(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+) -> None:
+    """Should return the tip length."""
+    decoy.when(
+        mock_state_view.labware.get_tip_length(labware_id=labware_id)
+    ).then_return(22)
+
+    assert labware_context.get_tip_length() == 22
 
 
 def test_set_tip_length(labware_context: LabwareContext):
@@ -105,14 +205,22 @@ def test_get_geometry(labware_context: LabwareContext) -> None:
 
 def test_highest_z(labware_context: LabwareContext) -> None:
     with pytest.raises(NotImplementedError):
-        h = labware_context.highest_z
+        h = labware_context.highest_z  # noqa: F841
 
 
 def test_separate_calibration(labware_context: LabwareContext) -> None:
     with pytest.raises(NotImplementedError):
-        s = labware_context.separate_calibration
+        s = labware_context.separate_calibration  # noqa: F841
 
 
-def test_load_name(labware_context: LabwareContext) -> None:
-    with pytest.raises(NotImplementedError):
-        ln = labware_context.load_name
+def test_load_name(
+        decoy: Decoy, labware_id: str, mock_state_view:
+        StateView, labware_context: LabwareContext, labware_data: LabwareData,
+        minimal_labware_def: LabwareDefinition
+) -> None:
+    """Should return the load name."""
+    decoy.when(
+        mock_state_view.labware.get_labware_data_by_id(labware_id=labware_id)
+    ).then_return(labware_data)
+
+    assert labware_context.load_name == minimal_labware_def['parameters']['loadName']


### PR DESCRIPTION
# Overview

Create a `LabwareInterface` derived class that delegates to the Protocol Engine.

closes #7332 

# Changelog

- added `GeometryState.get_labware_position` to get calibrated position.
- added `LabwareState.get_quirks`, `LabwareState.is_tiprack`, and `LabwareState.get_load_name`
- Create `LabwareInterface` derived class `LabwareContext`. 

# Review requests

There are several TODO comments and tickets that were created as future work related to this ticket.

# Risk assessment

None