### PR TITLE
refactor(protocol-designer): Update no shared settings text

### DIFF
--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -30,5 +30,5 @@
   },
   "exit_batch_edit": "exit batch edit",
   "n_steps_selected": "{{n}} steps selected",
-  "no_batch_edit_shared_settings": "No advanced settings shared between selected steps"
+  "no_batch_edit_shared_settings": "No editable settings shared between selected steps"
 }


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. We accidentally left the legacy text in the no editable fields message.

# Changelog

- fix(protocol-designer): Update no shared settings text

# Review requests

- [ ] Final copy approval

# Risk assessment

Low, PD text change only