### PR TITLE
feat(components): allow Tooltip to take style props

### DIFF
--- a/components/src/tooltips/Tooltip.js
+++ b/components/src/tooltips/Tooltip.js
@@ -4,9 +4,11 @@ import { css } from 'styled-components'
 
 import { FONT_BODY_1_LIGHT, C_DARK_GRAY } from '../styles'
 import { ARROW_SIZE_PX } from './styles'
+import { Box } from '../primitives'
 
 import type { CSSRules } from 'styled-components'
 import type { Placement } from './types'
+import type { StyleProps } from '../primitives'
 
 const TOOLTIP_CSS = css`
   position: absolute;
@@ -36,6 +38,7 @@ export type TooltipProps = {|
   arrowRef: (HTMLElement | null) => mixed,
   /** Inline styles to apply to arrow element (provided by useTooltip) */
   arrowStyle: $Shape<CSSStyleDeclaration>,
+  ...StyleProps,
 |}
 
 /**
@@ -54,13 +57,21 @@ export const Tooltip: React.AbstractComponent<
     arrowRef,
     arrowStyle,
     children,
+    ...boxProps
   } = props
 
   return visible ? (
-    <div role="tooltip" id={id} style={style} ref={ref} css={TOOLTIP_CSS}>
+    <Box
+      role="tooltip"
+      id={id}
+      style={style}
+      ref={ref}
+      css={TOOLTIP_CSS}
+      {...boxProps}
+    >
       {children}
       <Arrow {...{ arrowRef, arrowStyle, placement }} />
-    </div>
+    </Box>
   ) : null
 })
 

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.js
@@ -37,7 +37,9 @@ export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
 
   return (
     <>
-      <Tooltip {...tooltipProps}>{tooltipContent}</Tooltip>
+      <Tooltip maxWidth="18rem" lineHeight="1.5" {...tooltipProps}>
+        {tooltipContent}
+      </Tooltip>
       <div className={styles.checkbox_row}>
         <CheckboxField
           className={cx(styles.checkbox_field, className)}


### PR DESCRIPTION
# Overview

Also use these props in PD to set certain tooltip widths.

Closes #7461

# Changelog


# Review requests

- Is this the right way to do this? `Tooltip` is a bit weird bc it has its own css, `TOOLTIP_CSS`. The goal is that the inherent CSS should be overwritable/supplementable by style props.
- Design review: is this the max tooltip width we want for PD's advanced settings field tooltips?

# Risk assessment

Medium, change to components library, frequently used component. Should not globally change any styles of Tooltip, only change should be for PD's `CheckboxRowField` tooltip