### PR TITLE
feat(protocol-designer): cancel well order changes when clicking cancel button

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.js
@@ -44,6 +44,27 @@ type State = {|
   secondValue: WellOrderOption,
 |}
 
+export const ResetButton = (props: {| onClick: () => void |}): React.Node => (
+  <OutlineButton className={modalStyles.button_medium} onClick={props.onClick}>
+    {i18n.t('button.reset')}
+  </OutlineButton>
+)
+
+export const CancelButton = (props: {| onClick: () => void |}): React.Node => (
+  <PrimaryButton
+    className={cx(modalStyles.button_medium, modalStyles.button_right_of_break)}
+    onClick={props.onClick}
+  >
+    {i18n.t('button.cancel')}
+  </PrimaryButton>
+)
+
+export const DoneButton = (props: {| onClick: () => void |}): React.Node => (
+  <PrimaryButton className={modalStyles.button_medium} onClick={props.onClick}>
+    {i18n.t('button.done')}
+  </PrimaryButton>
+)
+
 export class WellOrderModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
@@ -91,10 +112,10 @@ export class WellOrderModal extends React.Component<Props, State> {
       initialFirstValue,
       initialSecondValue,
     } = this.getInitialFirstValues()
-    this.setState(
-      { firstValue: initialFirstValue, secondValue: initialSecondValue },
-      this.applyChanges
-    )
+    this.setState({
+      firstValue: initialFirstValue,
+      secondValue: initialSecondValue,
+    })
     this.props.closeModal()
   }
 
@@ -125,6 +146,7 @@ export class WellOrderModal extends React.Component<Props, State> {
     }
     this.setState(nextState)
   }
+
   isSecondOptionDisabled: WellOrderOption => boolean = (
     value: WellOrderOption
   ) => {
@@ -136,6 +158,7 @@ export class WellOrderModal extends React.Component<Props, State> {
       return false
     }
   }
+
   render(): React.Node {
     if (!this.props.isOpen) return null
 
@@ -197,28 +220,10 @@ export class WellOrderModal extends React.Component<Props, State> {
             </FormGroup>
           </div>
           <div className={modalStyles.button_row_divided}>
-            <OutlineButton
-              className={modalStyles.button_medium}
-              onClick={this.handleReset}
-            >
-              {i18n.t('button.reset')}
-            </OutlineButton>
+            <ResetButton onClick={this.handleReset} />
             <div>
-              <PrimaryButton
-                className={cx(
-                  modalStyles.button_medium,
-                  modalStyles.button_right_of_break
-                )}
-                onClick={this.handleCancel}
-              >
-                {i18n.t('button.cancel')}
-              </PrimaryButton>
-              <PrimaryButton
-                className={modalStyles.button_medium}
-                onClick={this.handleDone}
-              >
-                {i18n.t('button.done')}
-              </PrimaryButton>
+              <CancelButton onClick={this.handleCancel} />
+              <DoneButton onClick={this.handleDone} />
             </div>
           </div>
         </Modal>

--- a/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
+++ b/protocol-designer/src/components/StepEditForm/fields/__tests__/WellOrderField.test.js
@@ -3,7 +3,11 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { act } from 'react-dom/test-utils'
 import { WellOrderField } from '../WellOrderField'
-import { WellOrderModal } from '../WellOrderField/WellOrderModal'
+import {
+  WellOrderModal,
+  CancelButton,
+  ResetButton,
+} from '../WellOrderField/WellOrderModal'
 
 describe('WellOrderField', () => {
   const render = _props => mount(<WellOrderField {..._props} />)
@@ -30,6 +34,47 @@ describe('WellOrderField', () => {
       })
       expect(props.updateFirstWellOrder).toHaveBeenCalledWith('l2r')
       expect(props.updateSecondWellOrder).toHaveBeenCalledWith('t2b')
+    })
+    it('should NOT update on cancel', () => {
+      const wellOrderModalProps = {
+        prefix: 'aspirate',
+        closeModal: jest.fn(),
+        isOpen: true,
+        updateValues: jest.fn(),
+        firstValue: 'l2r',
+        secondValue: 't2b',
+        firstName: 'firstName',
+        secondName: 'secondName',
+      }
+      const wrapper = mount(<WellOrderModal {...wellOrderModalProps} />)
+      const wellOrderModal = wrapper.find(WellOrderModal)
+      const cancelButton = wellOrderModal.find(CancelButton)
+      act(() => {
+        cancelButton.prop('onClick')()
+      })
+      expect(wellOrderModalProps.updateValues).not.toHaveBeenCalled()
+    })
+    it('should update to default values on reset', () => {
+      const wellOrderModalProps = {
+        prefix: 'aspirate',
+        closeModal: jest.fn(),
+        isOpen: true,
+        updateValues: jest.fn(),
+        firstValue: 'l2r',
+        secondValue: 't2b',
+        firstName: 'firstName',
+        secondName: 'secondName',
+      }
+      const wrapper = mount(<WellOrderModal {...wellOrderModalProps} />)
+      const wellOrderModal = wrapper.find(WellOrderModal)
+      const resetButton = wellOrderModal.find(ResetButton)
+      act(() => {
+        resetButton.prop('onClick')()
+      })
+      expect(wellOrderModalProps.updateValues).toHaveBeenCalledWith(
+        't2b',
+        'l2r'
+      )
     })
   })
 })


### PR DESCRIPTION
# Overview
This PR cancels well order changes when clicking `Cancel`. Note, this affects behavior in both single edit mode and batch edit mode.

Closes #7463
# Changelog

- Cancel well order changes when clicking cancel button

# Review requests
Make sure when you click cancel in well order modal that changes get cancelled (both single edit and batch edit). also make sure i didnt break the well order modal lol

# Risk assessment
Low/medium
