### PR TITLE
chore(build): specify virtual env ubuntu version

### DIFF
--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
   lint:
     name: 'opentrons package linting'
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -55,7 +55,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'
@@ -83,7 +83,7 @@ jobs:
   deploy:
     name: 'deploy opentrons package'
     needs: [test]
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: github.event_name == 'push'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -48,7 +48,7 @@ jobs:
   js-unit-test:
     # unit tests for js frontend projects (e.g. not app-shell or discovery-client) do not need
     # to run cross-platform
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     name: 'opentrons app frontend unit tests'
     timeout-minutes: 30
     steps:
@@ -86,7 +86,7 @@ jobs:
     # to run cross-platform just like builds, might as well do them in the same job
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
     name: 'opentrons app backend unit tests and build'
     runs-on: ${{ matrix.os }}
     steps:
@@ -144,7 +144,7 @@ jobs:
           path: app-shell/dist/publish
   deploy-app:
     name: 'Deploy built app artifacts to S3'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     needs: build-app-test-backend
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -31,7 +31,7 @@ jobs:
   js-unit-test:
     name: 'components unit tests'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -56,7 +56,7 @@ jobs:
           yarn jest --coverage=true --ci=true components/
   build-components:
     name: 'build components artifact'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v2'
@@ -87,7 +87,7 @@ jobs:
           path: components/dist
   deploy-components:
     name: 'deploy components artifact to S3'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     needs: ["js-unit-test", "build-components"]
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -28,7 +28,7 @@ defaults:
 jobs:
   build:
     name: opentrons documentation build
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -31,7 +31,7 @@ env:
 jobs:
   checks:
     name: 'js checks'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     timeout-minutes: 20
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/labware-library-e2e-test.yaml
+++ b/.github/workflows/labware-library-e2e-test.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -35,7 +35,7 @@ jobs:
   js-unit-test:
     name: 'labware library unit tests'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'
@@ -88,7 +88,7 @@ jobs:
         run: make -C labware-library test-e2e
   build-ll:
     name: 'build labware library artifact'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v2'
@@ -119,7 +119,7 @@ jobs:
           path: labware-library/dist
   deploy-ll:
     name: 'deploy LL artifact to S3'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     needs: ["js-unit-test", "e2e-test", "build-ll"]
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/notify-server-lint-test.yaml
+++ b/.github/workflows/notify-server-lint-test.yaml
@@ -27,7 +27,7 @@ jobs:
   lint-test:
     name: 'notify server package linting and tests'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -34,7 +34,7 @@ env:
 jobs:
   js-unit-test:
     name: 'protocol designer unit tests'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     timeout-minutes: 30
     steps:
       - uses: 'actions/checkout@v2'
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'
@@ -88,7 +88,7 @@ jobs:
         run: make -C protocol-designer test-e2e
   build-pd:
     name: 'build protocol designer artifact'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: github.event_name != 'pull_request'
     steps:
       - uses: 'actions/checkout@v2'
@@ -121,7 +121,7 @@ jobs:
           path: protocol-designer/dist
   deploy-pd:
     name: 'deploy PD artifact to S3'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     needs: ["js-unit-test", "build-pd"]
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -36,7 +36,7 @@ jobs:
   lint-test:
     name: 'robot server package linting and tests'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
   python-lint:
     name: 'shared-data package python lint'
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -51,7 +51,7 @@ jobs:
     needs: [python-lint]
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-18.04', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v2'
@@ -75,7 +75,7 @@ jobs:
   python-deploy:
     name: 'shared-data package deploy'
     needs: [python-test]
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: github.event_name == 'push'
     steps:
       - uses: 'actions/checkout@v2'

--- a/.github/workflows/update-server-lint-test.yaml
+++ b/.github/workflows/update-server-lint-test.yaml
@@ -34,7 +34,7 @@ jobs:
   lint:
     name: 'update server linting'
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'
@@ -53,7 +53,7 @@ jobs:
     name: 'update server package tests'
     timeout-minutes: 10
     needs: [lint]
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     steps:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-node@v1'

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -109,6 +109,9 @@ dist-macos-latest: dist-osx
 .PHONY: dist-ubuntu-latest
 dist-ubuntu-latest: dist-linux
 
+.PHONY: dist-ubuntu-18.04
+dist-ubuntu-latest: dist-linux
+
 .PHONY: dist-windows-latest
 dist-windows-latest: dist-win
 


### PR DESCRIPTION
# Overview
Seems as though the latest ubuntu version is [causing aws deployment issues](https://github.com/aws/aws-cli/issues/5262). 
[PD deploys aren't working right now](https://github.com/Opentrons/opentrons/runs/2088270455?check_suite_focus=true), though the other aws deploys seem to be fine. I think this is cuz github is still in the migration process.

This PR specifies ubuntu versions to the previously used "latest" version which is `ubuntu-18.04`. The other option is to  add `AWS_EC2_METADATA_DISABLED` as an env variable (see the issue above), but as @genehack mentioned in [slack](https://opentrons.slack.com/archives/C0F0JV9GS/p1615486322001600?thread_ts=1615483102.000600&cid=C0F0JV9GS) it's probably a good idea to specify versions so we don't wind up with more surprises.

# Changelog

- Specify virtual env ubuntu version

# Review requests
Make sure builds still work

# Risk assessment
Med