### PR TITLE
refactor(app): hide app module changes behind a feature flag

### DIFF
--- a/app/src/pages/Calibrate/CalibratePanel/index.js
+++ b/app/src/pages/Calibrate/CalibratePanel/index.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 
 import { SidePanel } from '@opentrons/components'
 import { selectors as robotSelectors } from '../../../redux/robot'
+import { useFeatureFlag } from '../../../redux/config'
 import { getProtocolLabwareList } from '../../../redux/calibration/labware'
 import { ProtocolModuleList } from '../../../organisms/ProtocolModuleList'
 import { PipetteList } from './PipetteList'
@@ -26,12 +27,13 @@ export function CalibratePanel(): React.Node {
     allLabware,
     lw => lw.type && lw.isTiprack
   )
+  const showModuleList = useFeatureFlag('moduleAugmentation')
 
   return (
     <SidePanel title={t('cal_panel_title')}>
       <div className={styles.setup_panel}>
         <PipetteList robotName={robotName} tipracks={tipracks} />
-        <ProtocolModuleList />
+        {showModuleList && <ProtocolModuleList />}
         <LabwareGroup
           robotName={robotName}
           tipracks={tipracks}

--- a/app/src/pages/Robots/RobotSettings/__tests__/CalibrationCard.test.js
+++ b/app/src/pages/Robots/RobotSettings/__tests__/CalibrationCard.test.js
@@ -142,6 +142,7 @@ describe('CalibrationCard', () => {
     getFeatureFlags.mockReturnValue({
       allPipetteConfig: false,
       enableBundleUpload: false,
+      moduleAugmentation: false,
     })
     getAttachedPipettes.mockReturnValue(mockAttachedPipettes)
     getAttachedPipetteCalibrations.mockReturnValue(

--- a/app/src/redux/config/constants.js
+++ b/app/src/redux/config/constants.js
@@ -7,6 +7,7 @@ export const CONFIG_VERSION_LATEST: 1 = 1
 export const DEV_INTERNAL_FLAGS: Array<DevInternalFlag> = [
   'allPipetteConfig',
   'enableBundleUpload',
+  'moduleAugmentation',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.js
+++ b/app/src/redux/config/schema-types.js
@@ -7,7 +7,10 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string | Array<string>
 
-export type DevInternalFlag = 'allPipetteConfig' | 'enableBundleUpload'
+export type DevInternalFlag =
+  | 'allPipetteConfig'
+  | 'enableBundleUpload'
+  | 'moduleAugmentation'
 
 export type FeatureFlags = $Shape<{|
   [DevInternalFlag]: boolean | void,


### PR DESCRIPTION
# Overview

Remove some new app features that are not fully connected and have to do with MoAM which will not be released until 4.3.0