### PR TITLE
refactor(api): remove defaults from protocol context interfaces

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -589,7 +589,7 @@ class ProtocolContext(CommandPublisher):
 
         :param str msg: A message to echo back to connected clients.
         """
-        self._implementation.pause()
+        self._implementation.pause(msg=msg)
 
     @publish.both(command=cmds.resume)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocols/context/instrument.py
+++ b/api/src/opentrons/protocols/context/instrument.py
@@ -25,13 +25,13 @@ class AbstractInstrument(ABC):
     @abstractmethod
     def aspirate(self,
                  volume: float,
-                 rate: float = 1.0) -> None:
+                 rate: float) -> None:
         ...
 
     @abstractmethod
     def dispense(self,
                  volume: float,
-                 rate: float = 1.0) -> None:
+                 rate: float) -> None:
         ...
 
     @abstractmethod
@@ -41,22 +41,21 @@ class AbstractInstrument(ABC):
     @abstractmethod
     def touch_tip(self,
                   location: WellImplementation,
-                  radius: float = 1.0,
-                  v_offset: float = -1.0,
-                  speed: float = 60.0) -> None:
+                  radius: float,
+                  v_offset: float,
+                  speed: float) -> None:
         ...
 
     @abstractmethod
     def pick_up_tip(self,
                     well: WellImplementation,
                     tip_length: float,
-                    presses: typing.Optional[int] = None,
-                    increment: typing.Optional[float] = None) -> None:
+                    presses: typing.Optional[int],
+                    increment: typing.Optional[float]) -> None:
         ...
 
     @abstractmethod
-    def drop_tip(self,
-                 home_after: bool = True) -> None:
+    def drop_tip(self, home_after: bool) -> None:
         ...
 
     @abstractmethod
@@ -74,9 +73,9 @@ class AbstractInstrument(ABC):
     @abstractmethod
     def move_to(self,
                 location: types.Location,
-                force_direct: bool = False,
-                minimum_z_height: typing.Optional[float] = None,
-                speed: typing.Optional[float] = None) -> None:
+                force_direct: bool,
+                minimum_z_height: typing.Optional[float],
+                speed: typing.Optional[float]) -> None:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -76,7 +76,7 @@ class AbstractProtocol(ABC):
             self,
             labware_def: LabwareDefinition,
             location: types.DeckLocation,
-            label: Optional[str] = None,
+            label: Optional[str],
     ) -> AbstractLabware:
         ...
 
@@ -85,9 +85,9 @@ class AbstractProtocol(ABC):
             self,
             load_name: str,
             location: types.DeckLocation,
-            label: Optional[str] = None,
-            namespace: Optional[str] = None,
-            version: Optional[int] = None,
+            label: Optional[str],
+            namespace: Optional[str],
+            version: Optional[int],
     ) -> AbstractLabware:
         ...
 
@@ -95,8 +95,8 @@ class AbstractProtocol(ABC):
     def load_module(
             self,
             module_name: str,
-            location: Optional[types.DeckLocation] = None,
-            configuration: Optional[str] = None) -> Optional[LoadModuleResult]:
+            location: Optional[types.DeckLocation],
+            configuration: Optional[str]) -> Optional[LoadModuleResult]:
         ...
 
     @abstractmethod
@@ -108,7 +108,7 @@ class AbstractProtocol(ABC):
             self,
             instrument_name: str,
             mount: types.Mount,
-            replace: bool = False) -> AbstractInstrument:
+            replace: bool) -> AbstractInstrument:
         ...
 
     @abstractmethod
@@ -117,7 +117,7 @@ class AbstractProtocol(ABC):
 
     @abstractmethod
     def pause(self,
-              msg: Optional[str] = None) -> None:
+              msg: Optional[str]) -> None:
         ...
 
     @abstractmethod
@@ -131,8 +131,8 @@ class AbstractProtocol(ABC):
 
     @abstractmethod
     def delay(self,
-              seconds=0,
-              msg: Optional[str] = None) -> None:
+              seconds: float,
+              msg: Optional[str]) -> None:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -57,17 +57,14 @@ class InstrumentContextImplementation(AbstractInstrument):
         """Sets the speed at which the robot's gantry moves."""
         self._default_speed = speed
 
-    def aspirate(self,
-                 volume: float,
-                 rate: float = 1.0) -> None:
+    def aspirate(self, volume: float, rate: float) -> None:
         """Aspirate a given volume of liquid from the specified location, using
         this pipette."""
         self._protocol_interface.get_hardware().hardware.aspirate(
             self._mount, volume, rate
         )
 
-    def dispense(self, volume: float,
-                 rate: float = 1.0) -> None:
+    def dispense(self, volume: float, rate: float) -> None:
         """Dispense a volume of liquid (in microliters/uL) using this pipette
         into the specified location."""
         self._protocol_interface.get_hardware().hardware.dispense(
@@ -80,9 +77,9 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def touch_tip(self,
                   location: WellImplementation,
-                  radius: float = 1.0,
-                  v_offset: float = -1.0,
-                  speed: float = 60.0) -> None:
+                  radius: float,
+                  v_offset: float,
+                  speed: float) -> None:
         """
         Touch the pipette tip to the sides of a well, with the intent of
         removing left-over droplets
@@ -111,8 +108,8 @@ class InstrumentContextImplementation(AbstractInstrument):
     def pick_up_tip(self,
                     well: WellImplementation,
                     tip_length: float,
-                    presses: Optional[int] = None,
-                    increment: Optional[float] = None) -> None:
+                    presses: Optional[int],
+                    increment: Optional[float]) -> None:
         """Pick up a tip for the pipette to run liquid-handling commands."""
         hw = self._protocol_interface.get_hardware().hardware
         geometry = well.get_geometry()
@@ -129,8 +126,7 @@ class InstrumentContextImplementation(AbstractInstrument):
         hw.set_working_volume(
             self._mount, geometry.max_volume)
 
-    def drop_tip(self,
-                 home_after: bool = True) -> None:
+    def drop_tip(self, home_after: bool) -> None:
         """Drop the tip."""
         self._protocol_interface.get_hardware().hardware.drop_tip(
             self._mount,
@@ -150,13 +146,13 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def delay(self) -> None:
         """Delay protocol execution."""
-        self._protocol_interface.delay()
+        self._protocol_interface.delay(seconds=0, msg=None)
 
     def move_to(self,
                 location: types.Location,
-                force_direct: bool = False,
-                minimum_z_height: Optional[float] = None,
-                speed: Optional[float] = None) -> None:
+                force_direct: bool,
+                minimum_z_height: Optional[float],
+                speed: Optional[float]) -> None:
         """Move the instrument."""
         last_location = self._protocol_interface.get_last_location()
         if last_location:
@@ -266,10 +262,11 @@ class InstrumentContextImplementation(AbstractInstrument):
     def get_speed(self) -> PlungerSpeeds:
         return self._speeds
 
-    def set_flow_rate(self,
-                      aspirate: Optional[float] = None,
-                      dispense: Optional[float] = None,
-                      blow_out: Optional[float] = None) -> None:
+    def set_flow_rate(
+            self,
+            aspirate: Optional[float] = None,
+            dispense: Optional[float] = None,
+            blow_out: Optional[float] = None) -> None:
         """Set the flow rates."""
         self._protocol_interface.get_hardware().hardware.set_flow_rate(
             mount=self._mount,

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -145,7 +145,7 @@ class ProtocolContextImplementation(AbstractProtocol):
             self,
             labware_def: LabwareDefinition,
             location: types.DeckLocation,
-            label: Optional[str] = None) -> AbstractLabware:
+            label: Optional[str]) -> AbstractLabware:
         """Load a labware from definition"""
         parent = self.get_deck().position_for(location)
         labware_obj = load_from_definition(labware_def, parent, label)
@@ -156,9 +156,9 @@ class ProtocolContextImplementation(AbstractProtocol):
             self,
             load_name: str,
             location: types.DeckLocation,
-            label: Optional[str] = None,
-            namespace: Optional[str] = None,
-            version: Optional[int] = None) -> AbstractLabware:
+            label: Optional[str],
+            namespace: Optional[str],
+            version: Optional[int]) -> AbstractLabware:
         """Load a labware."""
         labware_def = get_labware_definition(
             load_name, namespace, version,
@@ -170,8 +170,8 @@ class ProtocolContextImplementation(AbstractProtocol):
     def load_module(
             self,
             module_name: str,
-            location: Optional[types.DeckLocation] = None,
-            configuration: Optional[str] = None) -> Optional[LoadModuleResult]:
+            location: Optional[types.DeckLocation],
+            configuration: Optional[str]) -> Optional[LoadModuleResult]:
         """Load a module."""
         resolved_model = module_geometry.resolve_module_model(module_name)
         resolved_type = module_geometry.resolve_module_type(resolved_model)
@@ -232,7 +232,7 @@ class ProtocolContextImplementation(AbstractProtocol):
     def load_instrument(self,
                         instrument_name: str,
                         mount: types.Mount,
-                        replace: bool = False) -> AbstractInstrument:
+                        replace: bool) -> AbstractInstrument:
         """Load an instrument."""
         instr = self._instruments[mount]
         if instr and not replace:
@@ -262,7 +262,7 @@ class ProtocolContextImplementation(AbstractProtocol):
         """Get a mapping of mount to instrument."""
         return self._instruments
 
-    def pause(self, msg: Optional[str] = None) -> None:
+    def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""
         self._hw_manager.hardware.pause()
 
@@ -274,7 +274,7 @@ class ProtocolContextImplementation(AbstractProtocol):
         """Add comment to run log."""
         pass
 
-    def delay(self, seconds=0, msg: Optional[str] = None) -> None:
+    def delay(self, seconds: float, msg: Optional[str]) -> None:
         """Delay execution for x seconds."""
         self._hw_manager.hardware.delay(seconds)
 

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -40,27 +40,27 @@ class InstrumentContextSimulation(AbstractInstrument):
     def set_default_speed(self, speed: float) -> None:
         self._default_speed = speed
 
-    def aspirate(self, volume: float, rate: float = 1.0) -> None:
+    def aspirate(self, volume: float, rate: float) -> None:
         self._pipette_dict['current_volume'] += volume
 
-    def dispense(self, volume: float, rate: float = 1.0) -> None:
+    def dispense(self, volume: float, rate: float) -> None:
         self._pipette_dict['current_volume'] -= volume
 
     def blow_out(self) -> None:
         self._pipette_dict['current_volume'] = 0
         self._pipette_dict['ready_to_aspirate'] = False
 
-    def touch_tip(self, location: WellImplementation, radius: float = 1.0,
-                  v_offset: float = -1.0, speed: float = 60.0) -> None:
+    def touch_tip(self, location: WellImplementation, radius: float,
+                  v_offset: float, speed: float) -> None:
         pass
 
     def pick_up_tip(self, well: WellImplementation, tip_length: float,
-                    presses: typing.Optional[int] = None,
-                    increment: typing.Optional[float] = None) -> None:
+                    presses: typing.Optional[int],
+                    increment: typing.Optional[float]) -> None:
         self._pipette_dict['has_tip'] = True
         self._pipette_dict['current_volume'] = 0
 
-    def drop_tip(self, home_after: bool = True) -> None:
+    def drop_tip(self, home_after: bool) -> None:
         self._pipette_dict['has_tip'] = False
 
     def home(self) -> None:
@@ -72,9 +72,9 @@ class InstrumentContextSimulation(AbstractInstrument):
     def delay(self) -> None:
         pass
 
-    def move_to(self, location: types.Location, force_direct: bool = False,
-                minimum_z_height: typing.Optional[float] = None,
-                speed: typing.Optional[float] = None) -> None:
+    def move_to(self, location: types.Location, force_direct: bool,
+                minimum_z_height: typing.Optional[float],
+                speed: typing.Optional[float]) -> None:
         """Simulation of only the motion planning portion of move_to."""
         last_location = self._protocol_interface.get_last_location()
         if last_location:

--- a/api/src/opentrons/protocols/context/simulator/protocol_context.py
+++ b/api/src/opentrons/protocols/context/simulator/protocol_context.py
@@ -11,7 +11,7 @@ class ProtocolContextSimulation(ProtocolContextImplementation):
     def load_instrument(self,
                         instrument_name: str,
                         mount: types.Mount,
-                        replace: bool = False) -> AbstractInstrument:
+                        replace: bool) -> AbstractInstrument:
         """Create a simulating instrument context."""
         instr = self._instruments[mount]
         if instr and not replace:


### PR DESCRIPTION
# Overview

Removes almost all default parameters from abstract base classes.

Left a lot of `Optional` parameters present due to being resolved in the hardware controller. 

The `namespace`, `version`, and `label` parameters to labware methods appear rather tricky and risky to define.  A None `namespace` is treated differently in `_get_labware_definition_from_bundle` and `_get_standard_labware_definition`. It is either ignored or a key to try either `opentrons` or `custom_beta`. `version` is similar.

I want to avoid a lot of refactoring.

closes #7395 

# Changelog

- remove all numerical and boolean default values in `AbstractInstrument`. These are already defined in `InstrumentContext`. 

# Review requests

Did I do enough? 

# Risk assessment

None