### PR TITLE
feat(protocol-designer): Add expand/collapse animation to MutliSelectToolbar

### DIFF
--- a/components/src/primitives/style-props.js
+++ b/components/src/primitives/style-props.js
@@ -82,6 +82,8 @@ const LAYOUT_PROPS = [
 
 const POSITION_PROPS = ['position', 'zIndex', 'top', 'right', 'bottom', 'left']
 
+const TRANSITION_PROPS = ['transition']
+
 const STYLE_PROPS = [
   ...COLOR_PROPS,
   ...TYPOGRAPHY_PROPS,
@@ -91,6 +93,7 @@ const STYLE_PROPS = [
   ...GRID_PROPS,
   ...LAYOUT_PROPS,
   ...POSITION_PROPS,
+  ...TRANSITION_PROPS,
 ]
 
 const colorStyles = (props: { ...Types.ColorProps, ... }) => {
@@ -154,6 +157,10 @@ const positionStyles = (props: { ...Types.PositionProps, ... }) => {
   return (pick(props, POSITION_PROPS): Types.PositionProps)
 }
 
+const transitionStyles = (props: { ...Types.TransitionProps, ... }) => {
+  return (pick(props, TRANSITION_PROPS): Types.TransitionProps)
+}
+
 export const styleProps = (props: { ...Types.StyleProps, ... }): Styles => ({
   ...colorStyles(props),
   ...typographyStyles(props),
@@ -163,6 +170,7 @@ export const styleProps = (props: { ...Types.StyleProps, ... }): Styles => ({
   ...gridStyles(props),
   ...layoutStyles(props),
   ...positionStyles(props),
+  ...transitionStyles(props),
 })
 
 export const isntStyleProp = (prop: string): boolean =>

--- a/components/src/primitives/types.js
+++ b/components/src/primitives/types.js
@@ -85,6 +85,8 @@ export type PositionProps = {|
   left?: string | number,
 |}
 
+export type TransitionProps = {| transition?: string |}
+
 export type StyleProps = {|
   ...ColorProps,
   ...TypographyProps,
@@ -94,6 +96,7 @@ export type StyleProps = {|
   ...GridProps,
   ...LayoutProps,
   ...PositionProps,
+  ...TransitionProps,
   className?: string,
 |}
 

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { css } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import {
   useConditionalConfirm,
@@ -76,7 +76,19 @@ export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   )
 }
 
-export const MultiSelectToolbar = (): React.Node => {
+const AccordionBox = styled.div(props => ({
+  height: `${props.expanded ? SIZE_2 : 0}`,
+  transition: 'height 1s',
+  position: `${POSITION_STICKY}`,
+  top: 0,
+  overflow: 'hidden',
+}))
+
+type Props = {
+  isMultiSelectMode: boolean,
+}
+
+export const MultiSelectToolbar = (props: Props): React.Node => {
   const dispatch = useDispatch()
   const [isExpandState, setIsExpandState] = React.useState<boolean>(true)
   const stepCount = useSelector(stepFormSelectors.getOrderedStepIds).length
@@ -197,21 +209,21 @@ export const MultiSelectToolbar = (): React.Node => {
           onCancelClick={cancelDelete}
         />
       )}
-      <Flex
-        alignItems={ALIGN_CENTER}
-        height={SIZE_2}
-        padding={`0 ${SPACING_2}`}
-        borderBottom={BORDER_SOLID_MEDIUM}
-        position={POSITION_STICKY}
-        top="0"
-        backgroundColor={C_NEAR_WHITE}
-        zIndex="100"
-      >
-        <ClickableIcon id="ClickableIcon_select" {...selectProps} />
-        <ClickableIcon id="ClickableIcon_delete" {...deleteProps} />
-        <ClickableIcon id="ClickableIcon_duplicate" {...copyProps} />
-        <ClickableIcon id="ClickableIcon_expand" {...expandProps} />
-      </Flex>
+      <AccordionBox expanded={props.isMultiSelectMode}>
+        <Flex
+          alignItems={ALIGN_CENTER}
+          height={SIZE_2}
+          padding={`0 ${SPACING_2}`}
+          borderBottom={BORDER_SOLID_MEDIUM}
+          backgroundColor={C_NEAR_WHITE}
+          zIndex="100"
+        >
+          <ClickableIcon id="ClickableIcon_select" {...selectProps} />
+          <ClickableIcon id="ClickableIcon_delete" {...deleteProps} />
+          <ClickableIcon id="ClickableIcon_duplicate" {...copyProps} />
+          <ClickableIcon id="ClickableIcon_expand" {...expandProps} />
+        </Flex>
+      </AccordionBox>
     </>
   )
 }

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import styled, { css } from 'styled-components'
+import { css } from 'styled-components'
 
 import {
   useConditionalConfirm,
@@ -76,16 +76,27 @@ export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   )
 }
 
-const AccordionBox = styled.div(props => ({
-  height: `${props.expanded ? SIZE_2 : 0}`,
-  transition: 'height 1s',
-  position: `${POSITION_STICKY}`,
-  top: 0,
-  overflow: 'hidden',
-}))
-
-type Props = {
+type Props = {|
   isMultiSelectMode: boolean,
+|}
+
+type AccordionProps = {|
+  expanded: boolean,
+  children: React.Node,
+|}
+
+export const Accordion = (props: AccordionProps): React.Node => {
+  return (
+    <Box
+      height={props.expanded ? SIZE_2 : 0}
+      transition="height 1s"
+      position={POSITION_STICKY}
+      top="0"
+      overflow="hidden"
+    >
+      {props.children}
+    </Box>
+  )
 }
 
 export const MultiSelectToolbar = (props: Props): React.Node => {
@@ -209,7 +220,7 @@ export const MultiSelectToolbar = (props: Props): React.Node => {
           onCancelClick={cancelDelete}
         />
       )}
-      <AccordionBox expanded={props.isMultiSelectMode}>
+      <Accordion expanded={props.isMultiSelectMode}>
         <Flex
           alignItems={ALIGN_CENTER}
           height={SIZE_2}
@@ -223,7 +234,7 @@ export const MultiSelectToolbar = (props: Props): React.Node => {
           <ClickableIcon id="ClickableIcon_duplicate" {...copyProps} />
           <ClickableIcon id="ClickableIcon_expand" {...expandProps} />
         </Flex>
-      </AccordionBox>
+      </Accordion>
     </>
   )
 }

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -89,10 +89,12 @@ export const Accordion = (props: AccordionProps): React.Node => {
   return (
     <Box
       height={props.expanded ? SIZE_2 : 0}
-      transition="height 1s"
+      transition="all 0.5s"
       position={POSITION_STICKY}
       top="0"
       overflow="hidden"
+      borderBottom={props.expanded ? BORDER_SOLID_MEDIUM : 'none'}
+      opacity={props.expanded ? 1 : 0}
     >
       {props.children}
     </Box>
@@ -225,7 +227,6 @@ export const MultiSelectToolbar = (props: Props): React.Node => {
           alignItems={ALIGN_CENTER}
           height={SIZE_2}
           padding={`0 ${SPACING_2}`}
-          borderBottom={BORDER_SOLID_MEDIUM}
           backgroundColor={C_NEAR_WHITE}
           zIndex="100"
         >

--- a/protocol-designer/src/components/steplist/StepList.js
+++ b/protocol-designer/src/components/steplist/StepList.js
@@ -51,7 +51,10 @@ export class StepList extends React.Component<Props> {
     return (
       <React.Fragment>
         <SidePanel title="Protocol Timeline">
-          {this.props.isMultiSelectMode && <MultiSelectToolbar />}
+          <MultiSelectToolbar
+            isMultiSelectMode={Boolean(this.props.isMultiSelectMode)}
+          />
+
           <StartingDeckStateTerminalItem />
           <DraggableStepItems
             orderedStepIds={this.props.orderedStepIds.slice()}

--- a/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
@@ -53,7 +53,7 @@ describe('MultiSelectToolbar', () => {
   const render = () =>
     mount(
       <Provider store={store}>
-        <MultiSelectToolbar />
+        <MultiSelectToolbar isMultiSelectMode={true} />
       </Provider>
     )
 
@@ -119,7 +119,7 @@ describe('MultiSelectToolbar', () => {
     afterEach(() => {
       jest.restoreAllMocks()
     })
-    it('should expand/collapse the selected steps ', () => {
+    it('should expand/collapse the selected steps', () => {
       when(getMultiSelectItemIdsMock)
         .calledWith(expect.anything())
         .mockReturnValue(['id_1', 'id_2'])

--- a/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/MultiSelectToolbar.test.js
@@ -12,7 +12,11 @@ import * as stepFormSelectors from '../../../step-forms/selectors'
 import * as stepSelectors from '../../../ui/steps/selectors'
 import * as stepListActions from '../../../steplist/actions/actions'
 
-import { MultiSelectToolbar, ClickableIcon } from '../MultiSelectToolbar'
+import {
+  MultiSelectToolbar,
+  ClickableIcon,
+  Accordion,
+} from '../MultiSelectToolbar'
 import {
   ConfirmDeleteModal,
   CLOSE_BATCH_EDIT_FORM,
@@ -31,8 +35,12 @@ const getBatchEditFormHasUnsavedChangesMock =
 
 describe('MultiSelectToolbar', () => {
   let store
+  let props
   beforeEach(() => {
     store = mockStore()
+    props = {
+      isMultiSelectMode: true,
+    }
     when(getOrderedStepIdsMock)
       .calledWith(expect.anything())
       .mockReturnValue([])
@@ -53,9 +61,23 @@ describe('MultiSelectToolbar', () => {
   const render = () =>
     mount(
       <Provider store={store}>
-        <MultiSelectToolbar isMultiSelectMode={true} />
+        <MultiSelectToolbar {...props} />
       </Provider>
     )
+
+  it('should collapse the toolbar when isMultiSelectMode is FALSE', () => {
+    props.isMultiSelectMode = false
+    const wrapper = render()
+    const accordion = wrapper.find(Accordion)
+    expect(accordion.prop('expanded')).toBe(false)
+  })
+
+  it('should expand the toolbar when isMultiSelectMode is TRUE', () => {
+    props.isMultiSelectMode = true
+    const wrapper = render()
+    const accordion = wrapper.find(Accordion)
+    expect(accordion.prop('expanded')).toBe(true)
+  })
 
   it('should render the delete, copy, and exapand icons with the correct tooltips', () => {
     const wrapper = render()

--- a/protocol-designer/src/components/steplist/__tests__/StepList.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepList.test.js
@@ -16,14 +16,14 @@ describe('StepList', () => {
   })
   const render = props => shallow(<StepList {...props} />)
 
-  it('should render a MultiSelectToolbar when in multi select mode', () => {
+  it('should render the MultiSelectToolbar in MultiSelectMode', () => {
     props.isMultiSelectMode = true
     const wrapper = render(props)
-    expect(wrapper.find(MultiSelectToolbar).exists()).toBe(true)
+    expect(wrapper.find(MultiSelectToolbar).prop('isMultiSelectMode')).toBe(
+      true
+    )
   })
-  // TODO IMMEDIATELY (ka): This component is always present now due to css transitions,
-  // figure out a way to test collapsed style if animation is desired
-  it('should pass isMultiSelectMode prop to MultiSelectToolbar', () => {
+  it('should NOT render the MultiSelectToolbar in NOT MultiSelectMode', () => {
     props.isMultiSelectMode = false
     const wrapper = render(props)
     expect(wrapper.find(MultiSelectToolbar).prop('isMultiSelectMode')).toBe(

--- a/protocol-designer/src/components/steplist/__tests__/StepList.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepList.test.js
@@ -21,9 +21,13 @@ describe('StepList', () => {
     const wrapper = render(props)
     expect(wrapper.find(MultiSelectToolbar).exists()).toBe(true)
   })
-  it('should render NOT a MultiSelectToolbar when NOT in multi select mode', () => {
+  // TODO IMMEDIATELY (ka): This component is always present now due to css transitions,
+  // figure out a way to test collapsed style if animation is desired
+  it('should pass isMultiSelectMode prop to MultiSelectToolbar', () => {
     props.isMultiSelectMode = false
     const wrapper = render(props)
-    expect(wrapper.find(MultiSelectToolbar).exists()).toBe(false)
+    expect(wrapper.find(MultiSelectToolbar).prop('isMultiSelectMode')).toBe(
+      false
+    )
   })
 })


### PR DESCRIPTION
# Overview

This PR is an experimental branch to test MutliSelectToolbar animations

# Changelog

- Add expand/collapse animation to MutliSelectToolbar toolbar
- update tests
- add transition styles to primitives

# Review requests

None, WIP possibly throw away work at this time

# Risk assessment

Med, added transition styles to Primitives in CompLib to allow for animations

