### PR TITLE
fix(protocol-designer): clear presaved form on multiselect

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -1336,6 +1336,7 @@ type PresavedStepFormAction =
   | SaveStepFormAction
   | SelectTerminalItemAction
   | SelectStepAction
+  | SelectMultipleStepsAction
 export const presavedStepForm = (
   state: PresavedStepFormState = null,
   action: PresavedStepFormAction
@@ -1350,6 +1351,7 @@ export const presavedStepForm = (
     case 'DELETE_MULTIPLE_STEPS':
     case 'SAVE_STEP_FORM':
     case 'SELECT_STEP':
+    case 'SELECT_MULTIPLE_STEPS':
       return null
     default:
       return state

--- a/protocol-designer/src/step-forms/test/reducers.test.js
+++ b/protocol-designer/src/step-forms/test/reducers.test.js
@@ -1768,6 +1768,7 @@ describe('presavedStepForm reducer', () => {
     'DELETE_MULTIPLE_STEPS',
     'SAVE_STEP_FORM',
     'SELECT_STEP',
+    'SELECT_MULTIPLE_STEPS',
   ]
   clearingActions.forEach(actionType => {
     it(`should clear upon ${actionType}`, () => {


### PR DESCRIPTION
# Overview

Serves as its own ticket. Fixes bug where going into multiselect mode while a presaved step was still open would leave the presaved step there until multiselect mode was exited.

# Changelog

# Review requests

- Have a protocol with some steps
- Create a new step and do not save it (this is a "presaved" step)
- Shift+click or cmd/ctrl+click on another step to enter batch edit mode. A confirmation modal should appear. Confirm it
- You should now be in batch edit mode, and the presaved step should be gone! Before this PR fix, the presaved step would hang around until you exited batch edit mode

# Risk assessment

Low, PD only