### PR TITLE
fix(protocol-designer): fix probs with typing zero in tip position

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -162,7 +162,7 @@ export const TipPositionModal = (props: Props): React.Node => {
         ? newValueRaw.replace(/[^.0-9]/, '')
         : String(newValueRaw)
 
-    setValue(Number(newValue) > 0 ? newValue : '0')
+    setValue(Number(newValue) >= 0 ? newValue : '0')
   }
 
   const handleInputFieldChange = (

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -162,7 +162,11 @@ export const TipPositionModal = (props: Props): React.Node => {
         ? newValueRaw.replace(/[^.0-9]/, '')
         : String(newValueRaw)
 
-    setValue(Number(newValue) >= 0 ? newValue : '0')
+    if (newValue === '.') {
+      setValue('0.')
+    } else {
+      setValue(Number(newValue) >= 0 ? newValue : '0')
+    }
   }
 
   const handleInputFieldChange = (


### PR DESCRIPTION
# Overview

Closes #7485

# Changelog

# Review requests

- In Tip Position modal "custom" mm field, you should be able to:
- type `0`
- delete all numbers in the field
- type `0.`
- type just a decimal eg `.`, eg on your way to typing `.5`. (The `.` will turn to `0.` so that it's a valid number)
- 
Before, you couldn't do those!

# Risk assessment

Low, PD only