### PR TITLE
fix(protocol-designer): Restore hidden tooltips on MultiSelectToolbar

### DIFF
--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -59,6 +59,7 @@ export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   const { id, iconName, onClick, tooltipText, width } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'top',
+    strategy: 'fixed',
   })
 
   const boxStyles = {


### PR DESCRIPTION
# Overview

This PR fixes an issue found in UI walkthrough. Tooltips were hidden (z index nonsense) on the multi select toolbar. 

# Changelog

- fix(protocol-designer): Restore hidden tooltips on MultiSelectToolbar

# Review requests

Enter batch edit mode
Hover on toolbar icons
- [ ] Tooltips are visible on hover

# Risk assessment

Low, CSS
