### PR TITLE
refactor(protocol-designer): Make discard changes button secondary

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/__tests__/BatchEditMoveLiquid.test.js
+++ b/protocol-designer/src/components/BatchEditForm/__tests__/BatchEditMoveLiquid.test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { shallow } from 'enzyme'
-import { PrimaryButton, Tooltip } from '@opentrons/components'
+import { PrimaryButton, OutlineButton, Tooltip } from '@opentrons/components'
 import { i18n } from '../../../localization'
 import { BatchEditMoveLiquid } from '../'
 
@@ -78,7 +78,7 @@ describe('BatchEditMoveLiquid', () => {
       const tooltipPath = 'tooltip.cancel_batch_edit'
 
       const cancelButton = wrapper
-        .find(PrimaryButton)
+        .find(OutlineButton)
         .filterWhere(el => el.prop('children') === cancelButtonText)
 
       const cancelButtonTooltip = cancelButton.parent().dive().find(Tooltip)
@@ -90,7 +90,7 @@ describe('BatchEditMoveLiquid', () => {
       const wrapper = shallow(<BatchEditMoveLiquid {...props} />)
 
       const cancelButton = wrapper
-        .find(PrimaryButton)
+        .find(OutlineButton)
         .filterWhere(el => el.prop('children') === cancelButtonText)
 
       expect(handleCancel).not.toHaveBeenCalled()

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import {
   Box,
   PrimaryButton,
+  OutlineButton,
   Tooltip,
   useHoverTooltip,
 } from '@opentrons/components'
@@ -207,16 +208,18 @@ export const BatchEditMoveLiquid = (
           />
         </Box>
 
-        <Box textAlign="right" maxWidth="55rem">
+        <Box textAlign="right" maxWidth="55rem" marginTop="2rem">
           <Box
             {...cancelButtonTargetProps}
-            width="11rem"
             marginRight="0.625rem"
             display="inline-block"
           >
-            <PrimaryButton onClick={handleCancel}>
+            <OutlineButton
+              onClick={handleCancel}
+              className={buttonStyles.button_auto}
+            >
               {i18n.t('button.discard_changes')}
-            </PrimaryButton>
+            </OutlineButton>
             <Tooltip {...cancelButtonTooltipProps}>
               {i18n.t('tooltip.cancel_batch_edit')}
             </Tooltip>

--- a/protocol-designer/src/components/StepEditForm/ButtonRow/styles.css
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow/styles.css
@@ -15,3 +15,7 @@
 .form_button:not(:last-child) {
   margin-right: var(--form-button-margin);
 }
+
+.button_auto {
+  width: auto;
+}


### PR DESCRIPTION
# Overview

This PR makes the discard changes button secondary and adds more padding to the bottom button row.

# Changelog

- refactor(protocol-designer): Make discard changes button secondary
# Review requests

- [ ] [Discard Changes] button is secondary
- [ ] More space between buttons and form fields

# Risk assessment

Low CSS in PD