### PR TITLE
build: Fix Makefile syntax errors preventing `make push`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ ifeq ($(watch), true)
 endif
 
 # run at usage (=), not on makefile parse (:=)
-usb_host=$(shell yarn run -s discovery find -i 169.254")
+# todo(mm, 2021-03-17): Deduplicate with scripts/python.mk.
+usb_host=$(shell yarn run -s discovery find -i 169.254)
 
 
 # install all project dependencies

--- a/scripts/push.mk
+++ b/scripts/push.mk
@@ -1,6 +1,6 @@
 # utilities for pushing things to robots in a reusable fashion
 
-find_robot=$(shell yarn run -s discovery find -i 169.254")
+find_robot=$(shell yarn run -s discovery find -i 169.254)
 default_ssh_key := ~/.ssh/robot_key
 default_ssh_opts := -o stricthostkeychecking=no -o userknownhostsfile=/dev/null
 


### PR DESCRIPTION
Fix `make push` (without an explicit `host=` variable) failing to automatically detect a connected robot.

The `shell` invocations to autodetect a robot IP address had shell syntax errors, so they would always return an empty string.


-----

Edit:

@sanni-t brought up that if you're testing this, you might run into a discovery-client error. That's because `discovery-client` needs to be built first—it should work after `make setup && make -C discovery-client`. Whether or not this should happen automatically is a separate question IMO, not addressed in this PR.