### PR TITLE
feat(protocol-designer): fix batch edit step count bug

### DIFF
--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -239,16 +239,25 @@ export const ConnectedStepItem = (props: Props): React.Node => {
     </>
   )
 }
-function getMetaSelectedSteps(multiSelectItemIds, stepId, selectedStepId) {
+export function getMetaSelectedSteps(
+  multiSelectItemIds: Array<StepIdType> | null,
+  stepId: StepIdType,
+  selectedStepId: StepIdType | null
+): Array<StepIdType> {
   let stepsToSelect: Array<StepIdType> = []
   if (multiSelectItemIds?.length) {
+    // already have a selection, add/remove the meta-clicked item
     stepsToSelect = multiSelectItemIds.includes(stepId)
       ? multiSelectItemIds.filter(id => id !== stepId)
       : [...multiSelectItemIds, stepId]
+  } else if (selectedStepId && selectedStepId === stepId) {
+    // meta-clicked on the selected single step
+    stepsToSelect = [selectedStepId]
   } else if (selectedStepId) {
-    stepsToSelect =
-      selectedStepId === stepId ? [selectedStepId] : [selectedStepId, stepId]
+    // meta-clicked on a different step, multi-select both
+    stepsToSelect = [selectedStepId, stepId]
   } else {
+    // meta-clicked on a step when a terminal item was selected
     stepsToSelect = [stepId]
   }
   return stepsToSelect

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -246,7 +246,8 @@ function getMetaSelectedSteps(multiSelectItemIds, stepId, selectedStepId) {
       ? multiSelectItemIds.filter(id => id !== stepId)
       : [...multiSelectItemIds, stepId]
   } else if (selectedStepId) {
-    stepsToSelect = [selectedStepId, stepId]
+    stepsToSelect =
+      selectedStepId === stepId ? [selectedStepId] : [selectedStepId, stepId]
   } else {
     stepsToSelect = [stepId]
   }

--- a/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
+++ b/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
@@ -8,7 +8,7 @@ import { when, resetAllWhenMocks } from 'jest-when'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 
-import { ConnectedStepItem } from '../ConnectedStepItem'
+import { ConnectedStepItem, getMetaSelectedSteps } from '../ConnectedStepItem'
 import { StepItem } from '../../components/steplist'
 import {
   ConfirmDeleteModal,
@@ -820,6 +820,55 @@ describe('ConnectedStepItem', () => {
           })
         }
       )
+    })
+  })
+})
+
+describe('getMetaSelectedSteps', () => {
+  describe('when already in multi select mode', () => {
+    it('should return the new steps and the original selected step', () => {
+      const multiSelectItemIds = ['1', '2']
+      const stepId = '3'
+      const singleSelectedId = null
+      expect(
+        getMetaSelectedSteps(multiSelectItemIds, stepId, singleSelectedId)
+      ).toEqual(['1', '2', '3'])
+    })
+    it('should remove the step if its already been selected', () => {
+      const multiSelectItemIds = ['1', '2']
+      const stepId = '2'
+      const singleSelectedId = null
+      expect(
+        getMetaSelectedSteps(multiSelectItemIds, stepId, singleSelectedId)
+      ).toEqual(['1'])
+    })
+  })
+  describe('when one step is selected (in single edit mode)', () => {
+    it('should return the original step and the new step', () => {
+      const multiSelectItemIds = null
+      const stepId = '2'
+      const singleSelectedId = '1'
+      expect(
+        getMetaSelectedSteps(multiSelectItemIds, stepId, singleSelectedId)
+      ).toEqual(['1', '2'])
+    })
+    it('should only return the original step once when it is the same as the selected step id', () => {
+      const multiSelectItemIds = null
+      const stepId = '2'
+      const singleSelectedId = '2'
+      expect(
+        getMetaSelectedSteps(multiSelectItemIds, stepId, singleSelectedId)
+      ).toEqual(['2'])
+    })
+  })
+  describe('when no steps are selected', () => {
+    it('should return the given step id', () => {
+      const multiSelectItemIds = null
+      const stepId = '2'
+      const singleSelectedId = null
+      expect(
+        getMetaSelectedSteps(multiSelectItemIds, stepId, singleSelectedId)
+      ).toEqual(['2'])
     })
   })
 })

--- a/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
+++ b/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.js
@@ -337,6 +337,32 @@ describe('ConnectedStepItem', () => {
       },
       {
         name:
+          'should select just one step when the clicked step is already selected',
+        props: { stepId: mockId, stepNumber: 1 },
+        mockClickEvent: {
+          shiftKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          persist: jest.fn(),
+        },
+        setupMocks: () => {
+          when(getSelectedStepIdMock)
+            .calledWith(expect.anything())
+            .mockReturnValue(mockId)
+          when(getOrderedStepIdsMock)
+            .calledWith(expect.anything())
+            .mockReturnValue(['ANOTHER_ID', 'YET_ANOTHER_ID', mockId])
+        },
+        expectedAction: {
+          type: 'SELECT_MULTIPLE_STEPS',
+          payload: {
+            stepIds: [mockId],
+            lastSelected: mockId,
+          },
+        },
+      },
+      {
+        name:
           'should select a range when the selected step is earlier than the last selected step (single => multi)',
         props: { stepId: mockId, stepNumber: 1 },
         mockClickEvent: {
@@ -609,6 +635,27 @@ describe('ConnectedStepItem', () => {
             metaKey: true,
           },
           setupMocks: null,
+          expectedAction: {
+            type: 'SELECT_MULTIPLE_STEPS',
+            payload: {
+              stepIds: [mockId],
+              lastSelected: mockId,
+            },
+          },
+        },
+        {
+          name:
+            'should enter batch edit mode with just step (when clicking the same step that is already selected)',
+          props: { stepId: mockId, stepNumber: 1 },
+          clickEvent: {
+            ...mockClickEvent,
+            metaKey: true,
+          },
+          setupMocks: () => {
+            when(getSelectedStepIdMock)
+              .calledWith(expect.anything())
+              .mockReturnValue(mockId)
+          },
           expectedAction: {
             type: 'SELECT_MULTIPLE_STEPS',
             payload: {


### PR DESCRIPTION
# Overview

Closes #7509

If you are in single select mode and have a step selected, lets call it `Step 1` , and then you enter batch edit mode by cmd+ clicking that very same step (`Step 1`), you will enter batch edit mode with the selected steps being `[Step 1, Step 1]`. 


# Review requests
Make sure bug is fixed and stepcount isn't broken

# Risk assessment
Low
