### PR TITLE
fix(api): Sleeps do not happen in thermocycler and tempdeck when simulating.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -153,6 +153,9 @@ class TempDeck(mod_abc.AbstractModule):
         Polls temperature module's temperature until
         the specified temperature is reached
         """
+        if self.is_simulated:
+            return
+
         await self.wait_for_is_running()
 
         async def _await_temperature(awaiting_temperature: float):

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -197,6 +197,9 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
+        if self.is_simulated:
+            return
+
         while self._driver.lid_temp_status != 'holding at target':
             await asyncio.sleep(0.1)
 
@@ -206,6 +209,9 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
+        if self.is_simulated:
+            return
+
         while self.status != 'holding at target':
             await asyncio.sleep(0.1)
 
@@ -213,6 +219,9 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         This method returns only when hold time has elapsed
         """
+        if self.is_simulated:
+            return
+
         # If hold time is within the HOLD_TIME_FUZZY_SECONDS time gap, then,
         # because of the driver's status poller delays, it is impossible to
         # know for certain if self.hold_time holds the most recent value.

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -1,6 +1,6 @@
 import pytest
 import asyncio
-from unittest import mock
+import mock
 from opentrons.hardware_control import modules, ExecutionManager
 
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -161,13 +161,11 @@ async def test_set_temperature(monkeypatch, loop, usb_port):
     set_temp_driver_mock.reset_mock()
 
     # Test hold_time < HOLD_TIME_FUZZY_SECONDS. Here we know
-    # that asyncio.sleep will be called with the direct hold
+    # that wait_for_hold will be called with the direct hold
     # time rather than increments of 0.1
-    sleep_mock = mock.Mock()
-    async_sleep_mock = mock.Mock(side_effect=asyncio.coroutine(sleep_mock))
-    monkeypatch.setattr(asyncio, 'sleep', async_sleep_mock)
+    hw_tc.wait_for_hold = mock.AsyncMock()
     await hw_tc.set_temperature(40, hold_time_seconds=2)
-    async_sleep_mock.assert_called_once_with(2)
+    hw_tc.wait_for_hold.assert_called_once_with(2)
     set_temp_driver_mock.assert_called_once_with(temp=40,
                                                  hold_time=2,
                                                  volume=None,


### PR DESCRIPTION
# Overview

An issue discovered during testing of fast simulation: `asyncio.sleep` calls in `Thermocycler` and `Tempdeck` caused needless delays in simulation. 

This is a simple solution that eliminates the simulation issue.  More broadly, we should strive to not use `asyncio.sleep` or `time.sleep` in our codebase. Sleep intervals are almost always estimates that can lead to unnecessary delays. 

closes #7506 

# Changelog

- skip sleep calls when simulating

# Review requests


# Risk assessment

None