### PR TITLE
refactor(api): Don't try to guess the transfer mode in TransferPlan

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -367,7 +367,7 @@ class TransferPlan:
                  instr: 'InstrumentContext',
                  max_volume: float,
                  api_version: APIVersion,
-                 mode: Optional[str] = None,
+                 mode: str,
                  options: Optional[TransferOptions] = None
                  ) -> None:
         """ Build the transfer plan.
@@ -414,15 +414,7 @@ class TransferPlan:
         self._mix_after_opts = self._options.mix.mix_after
         self._max_volume = max_volume
 
-        if not mode:
-            if len(sources) < len(dests):
-                self._mode = TransferMode.DISTRIBUTE
-            elif len(sources) > len(dests):
-                self._mode = TransferMode.CONSOLIDATE
-            else:
-                self._mode = TransferMode.TRANSFER
-        else:
-            self._mode = TransferMode[mode.upper()]
+        self._mode = TransferMode[mode.upper()]
 
     def __iter__(self):
         if self._strategy.new_tip == types.TransferTipPolicy.ONCE:

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -978,7 +978,7 @@ def test_multichannel_transfer_old_version(loop):
             {'method': 'aspirate',
              'args': [100, lw1.wells_by_name()['A1'], 1.0], 'kwargs': {}},
             {'method': 'dispense',
-            'args': [100, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
+             'args': [100, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
             {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
     assert xfer_plan_list == exp1
 
@@ -1260,7 +1260,7 @@ def test_blowout_to_source(_instr_labware):
             disposal_volume=_instr_labware['instr'].min_volume,
             blow_out_strategy=tx.BlowOutStrategy.SOURCE))
 
-    dist_plan = tx.TransferPlan(
+    xfer_plan = tx.TransferPlan(
         30, [lw1['A1'], lw1['A2']], [lw2['B1'], lw2['B2']],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
@@ -1277,7 +1277,7 @@ def test_blowout_to_source(_instr_labware):
         {'method': 'dispense', 'args': [30, lw2['B2'], 1.0], 'kwargs': {}},
         {'method': 'blow_out', 'args': [lw1['A2']], 'kwargs': {}},
         {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
-    for step, expected in zip(dist_plan, exp):
+    for step, expected in zip(xfer_plan, exp):
         assert step == expected
 
     # ========== Distribute ===========
@@ -1319,7 +1319,7 @@ def test_blowout_to_dest(_instr_labware):
             disposal_volume=_instr_labware['instr'].min_volume,
             blow_out_strategy=tx.BlowOutStrategy.DEST))
 
-    dist_plan = tx.TransferPlan(
+    xfer_plan = tx.TransferPlan(
         30, [lw1['A1'], lw1['A2']], [lw2['B1'], lw2['B2']],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
@@ -1336,7 +1336,7 @@ def test_blowout_to_dest(_instr_labware):
         {'method': 'dispense', 'args': [30, lw2['B2'], 1.0], 'kwargs': {}},
         {'method': 'blow_out', 'args': [lw2['B2']], 'kwargs': {}},
         {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
-    for step, expected in zip(dist_plan, exp):
+    for step, expected in zip(xfer_plan, exp):
         assert step == expected
 
     # ========== Consolidate ===========
@@ -1345,7 +1345,7 @@ def test_blowout_to_dest(_instr_labware):
         transfer=options.transfer._replace(
             blow_out_strategy=tx.BlowOutStrategy.DEST))
 
-    dist_plan = tx.TransferPlan(
+    consd_plan = tx.TransferPlan(
         30, lw2.rows()[0][1:3], lw1.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
@@ -1360,5 +1360,5 @@ def test_blowout_to_dest(_instr_labware):
         {'method': 'dispense', 'args': [60, lw1['A1'], 1.0], 'kwargs': {}},
         {'method': 'blow_out', 'args': [lw1['A1']], 'kwargs': {}},
         {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
-    for step, expected in zip(dist_plan, exp):
+    for step, expected in zip(consd_plan, exp):
         assert step == expected

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -989,9 +989,11 @@ def test_multichannel_transfer_old_version(loop):
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
             api_version=ctx.api_version,
-            # todo(mm, 2021-03-17): This should be mode='transfer', but that
-            # raises a division by zero error. Bug in how sources+targets lists
-            # are expanded for 8-channel pipettes?
+            # todo(mm, 2021-03-17): This test intends to test mode='transfer',
+            # but it's always accidentally tested mode='consolidate' because of
+            # a quirk in how TransferPlan used to guess the mode when not
+            # explicitly specified. If this is changed to mode='transfer' now,
+            # it raises ZeroDivisionError instead of IndexError. Bug #7516.
             mode='consolidate')
         xfer_plan_list = []
         for step in xfer_plan:

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -45,7 +45,8 @@ def test_default_transfers(_instr_labware):
         100, lw1.columns()[0], lw2.columns()[0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='transfer')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -90,7 +91,8 @@ def test_default_transfers(_instr_labware):
         50, lw1.columns()[0][0], lw2.columns()[0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='distribute')
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
@@ -123,7 +125,8 @@ def test_default_transfers(_instr_labware):
         50, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='consolidate')
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
@@ -310,6 +313,7 @@ def test_no_new_tip(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     for step in xfer_plan:
         assert step['method'] != 'pick_up_tip'
@@ -321,6 +325,7 @@ def test_no_new_tip(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='distribute',
         options=options)
     for step in dist_plan:
         assert step['method'] != 'pick_up_tip'
@@ -332,6 +337,7 @@ def test_no_new_tip(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     for step in consd_plan:
         assert step['method'] != 'pick_up_tip'
@@ -357,6 +363,7 @@ def test_new_tip_always(_instr_labware, monkeypatch):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -409,6 +416,7 @@ def test_transfer_w_touchtip_blowout(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -455,6 +463,7 @@ def test_transfer_w_touchtip_blowout(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='distribute',
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -494,6 +503,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -537,6 +547,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='distribute',
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -570,6 +581,7 @@ def test_transfer_w_airgap_blowout(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='consolidate',
         options=options)
     consd_plan_list = []
     for step in consd_plan:
@@ -625,6 +637,7 @@ def test_touchtip_mix(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -669,6 +682,7 @@ def test_touchtip_mix(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='distribute',
         options=options)
     dist_plan_list = []
     for step in dist_plan:
@@ -702,6 +716,7 @@ def test_touchtip_mix(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='consolidate',
         options=options)
     consd_plan_list = []
     for step in consd_plan:
@@ -773,6 +788,7 @@ def test_all_options(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=_instr_labware['ctx'].api_version,
+        mode='transfer',
         options=options)
     xfer_plan_list = []
     for step in xfer_plan:
@@ -816,7 +832,8 @@ def test_oversized_distribute(_instr_labware):
         700, lw1.columns()[0][0], lw2.rows()[0][1:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='distribute')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -859,7 +876,8 @@ def test_oversized_consolidate(_instr_labware):
         lw1.wells_by_index()['A1'],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='consolidate')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -901,7 +919,8 @@ def test_oversized_transfer(_instr_labware):
         700, lw2.rows()[0][1:3], lw1.columns()[0][1:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version)
+        api_version=_instr_labware['ctx'].api_version,
+        mode='transfer')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -950,7 +969,8 @@ def test_multichannel_transfer_old_version(loop):
             100, lw1.rows()[0][0], [lw2.rows()[0][1], lw2.rows()[1][1]],
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version)
+            api_version=ctx.api_version,
+            mode='distribute')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -968,7 +988,11 @@ def test_multichannel_transfer_old_version(loop):
             100, lw1.rows()[0][1], lw2.rows()[1][1],
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version)
+            api_version=ctx.api_version,
+            # todo(mm, 2021-03-17): This should be mode='transfer', but that
+            # raises a division by zero error. Bug in how sources+targets lists
+            # are expanded for 8-channel pipettes?
+            mode='consolidate')
         xfer_plan_list = []
         for step in xfer_plan:
             xfer_plan_list.append(step)
@@ -992,7 +1016,8 @@ def test_multichannel_transfer_locs(loop):
             100, lw1.rows()[0][1], lw2.rows()[1][1],
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version)
+            api_version=ctx.api_version,
+            mode='transfer')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -1009,7 +1034,8 @@ def test_multichannel_transfer_locs(loop):
         100, lw1.rows()[0][1], [lw2.rows()[1][1], lw2.rows()[2][1]],
         instr_multi,
         max_volume=instr_multi.hw_pipette['working_volume'],
-        api_version=ctx.api_version)
+        api_version=ctx.api_version,
+        mode='transfer')
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -1021,7 +1047,8 @@ def test_multichannel_transfer_locs(loop):
             100, lw1.rows()[0][1], lw2.rows()[2][1],
             instr_multi,
             max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version)
+            api_version=ctx.api_version,
+            mode='transfer')
 
 
 def test_zero_volume_results_in_no_transfer(_instr_labware):
@@ -1038,7 +1065,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         0, lw1.columns()[0], lw2.columns()[0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='transfer')
     for step, expected in zip(xfer_plan, exp_no_vol):
         assert step == expected
 
@@ -1046,7 +1074,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         [100, 0, 200], lw1.wells()[0:3], lw2.wells()[0:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='transfer')
     exp2 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
             {'method': 'aspirate',
              'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
@@ -1065,7 +1094,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         0, lw1.columns()[0][0], lw2.rows()[0][1:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='distribute')
     for step, expected in zip(dist_plan, exp_no_vol):
         assert step == expected
 
@@ -1073,7 +1103,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         [100, 0], lw1.columns()[0][0], lw2.rows()[0][1:3],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='distribute')
     exp3 = [
         {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
         {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
@@ -1087,7 +1118,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         0, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='consolidate')
     for step, expected in zip(consd_plan, exp_no_vol):
         assert step == expected
 
@@ -1096,7 +1128,8 @@ def test_zero_volume_results_in_no_transfer(_instr_labware):
         cons_list, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='consolidate')
     exp4 = [
         {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
         {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
@@ -1136,6 +1169,7 @@ def test_zero_volume_causes_transfer_of_disposal_vol(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='distribute',
         options=options)
 
     exp_no_vol = [
@@ -1153,6 +1187,7 @@ def test_zero_volume_causes_transfer_of_disposal_vol(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='distribute',
         options=options)
     exp = [
         {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
@@ -1169,7 +1204,8 @@ def test_zero_volume_causes_transfer_of_disposal_vol(_instr_labware):
         0, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='consolidate')
     exp_no_vol = [
         {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
         {'method': 'aspirate', 'args': [0, lw1['A1'], 1.0], 'kwargs': {}},
@@ -1190,7 +1226,8 @@ def test_zero_volume_causes_transfer_of_disposal_vol(_instr_labware):
         cons_list, lw1.columns()[0], lw2.columns()[0][0],
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=API_VERSION)
+        api_version=API_VERSION,
+        mode='consolidate')
     exp2 = [
         {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
         {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
@@ -1228,6 +1265,7 @@ def test_blowout_to_source(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='transfer',
         options=options)
 
     exp = [
@@ -1254,6 +1292,7 @@ def test_blowout_to_source(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='distribute',
         options=options)
 
     exp = [
@@ -1285,6 +1324,7 @@ def test_blowout_to_dest(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='transfer',
         options=options)
 
     exp = [
@@ -1310,6 +1350,7 @@ def test_blowout_to_dest(_instr_labware):
         _instr_labware['instr'],
         max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
         api_version=API_VERSION,
+        mode='consolidate',
         options=options)
 
     exp = [


### PR DESCRIPTION
# Background

The `TransferPlan` class is responsible for figuring out how to break a high-level transfer, distribute, or consolidate into a series of building block commands.

It's constructed with a `mode` argument, like `mode='transfer'` or `mode='distribute'`.

Currently, the `mode` argument is optional. If unspecified, `TransferPlan` will try to infer it on its own, in a nontrivial way. This seems a little error-prone.

Our production code universally specifies `mode` explicitly, whereas `TransferPlan`'s *unit tests* let `TransferPlan` infer it on its own. This inconsistency can make the tests less realistic and let bugs squeak through. In bug #7516, for example, a unit test is actually checking a different mode than what was intended.

# Changelog

* Change `mode: Optional[str] = None` to `mode: str`.
* Update unit tests to always explicitly specify the mode.
  * For tests that had comments, I followed those to figure out what the mode should be.
  * Otherwise, I used common sense.
  * One test fails when the common-sense `mode` argument is added. It passes when `TransferPlan` infers the mode automatically; it infers it as something surprising. I got the test passing in this PR by setting `mode` to the surprising thing that `TransferPlan` would infer automatically. See the `# todo` comment in this diff, and bug #7516.

# Review requests

* Did I make any dumb mistakes updating the tests?

# Risk assessment

Low. The only places that construct `TransferPlan`s are:

* `InstrumentContext`'s `transfer()`, `distribute()`, and `consolidate()`. These each explicitly specify `mode`, so their behavior shouldn't change because of this PR.
* The unit tests.
