### PR TITLE
refactor(protocol-designer): remove single-edit dependencies in DisposalVolumeField

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -69,7 +69,7 @@ const DisposalVolumeFieldComponent = (props: Props) => {
 
   return (
     <FormGroup label={i18n.t('form.step_edit_form.multiDispenseOptionsLabel')}>
-      <React.Fragment>
+      <>
         <div
           className={cx(styles.checkbox_row, {
             [styles.captioned_field]: volumeBoundsCaption,
@@ -93,27 +93,34 @@ const DisposalVolumeFieldComponent = (props: Props) => {
             />
           </div>
         ) : null}
-      </React.Fragment>
+      </>
     </FormGroup>
   )
 }
-const mapSTP = (state: BaseState): SP => {
-  const rawForm = stepFormSelectors.getUnsavedForm(state)
+const mapSTP = (state: BaseState, ownProps: OP): SP => {
+  const formValues = {
+    path: ownProps.path.value,
+    stepType: ownProps.stepType.value,
+    volume: ownProps.volume.value,
+    aspirate_airGap_checkbox: ownProps.aspirate_airGap_checkbox.value,
+    aspirate_airGap_volume: ownProps.aspirate_airGap_volume.value,
+  }
+  const blowoutLocationOptions = getBlowoutLocationOptionsForForm({
+    path: formValues.path,
+    stepType: formValues.stepType,
+  })
+
   const disposalLabwareOptions = uiLabwareSelectors.getDisposalLabwareOptions(
     state
   )
-  const blowoutLocationOptions = rawForm
-    ? getBlowoutLocationOptionsForForm({
-        path: rawForm.path,
-        stepType: rawForm.stepType,
-      })
-    : []
+
+  const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
+    formValues,
+    stepFormSelectors.getPipetteEntities(state)
+  )
 
   return {
-    maxDisposalVolume: getMaxDisposalVolumeForMultidispense(
-      rawForm,
-      stepFormSelectors.getPipetteEntities(state)
-    ),
+    maxDisposalVolume,
     disposalDestinationOptions: [
       ...disposalLabwareOptions,
       ...blowoutLocationOptions,

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -100,12 +100,12 @@ const DisposalVolumeFieldComponent = (props: Props) => {
 const mapSTP = (state: BaseState, ownProps: OP): SP => {
   const { propsForFields } = ownProps
   const stepType = 'moveLiquid' // TODO IMMEDIATELY -- HACK!
-  const formValues = {
-    path: propsForFields.path.value,
-    volume: propsForFields.volume.value,
-    pipette: propsForFields.pipette.value,
-    aspirate_airGap_checkbox: propsForFields.aspirate_airGap_checkbox.value,
-    aspirate_airGap_volume: propsForFields.aspirate_airGap_volume.value,
+  const formValues: any = {
+    aspirate_airGap_checkbox: propsForFields.aspirate_airGap_checkbox?.value,
+    aspirate_airGap_volume: propsForFields.aspirate_airGap_volume?.value,
+    path: propsForFields.path?.value,
+    pipette: propsForFields.pipette?.value,
+    volume: propsForFields.volume?.value,
   }
   const blowoutLocationOptions = getBlowoutLocationOptionsForForm({
     path: formValues.path,

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -98,16 +98,18 @@ const DisposalVolumeFieldComponent = (props: Props) => {
   )
 }
 const mapSTP = (state: BaseState, ownProps: OP): SP => {
+  const { propsForFields } = ownProps
+  const stepType = 'moveLiquid' // TODO IMMEDIATELY -- HACK!
   const formValues = {
-    path: ownProps.path.value,
-    stepType: ownProps.stepType.value,
-    volume: ownProps.volume.value,
-    aspirate_airGap_checkbox: ownProps.aspirate_airGap_checkbox.value,
-    aspirate_airGap_volume: ownProps.aspirate_airGap_volume.value,
+    path: propsForFields.path.value,
+    volume: propsForFields.volume.value,
+    pipette: propsForFields.pipette.value,
+    aspirate_airGap_checkbox: propsForFields.aspirate_airGap_checkbox.value,
+    aspirate_airGap_volume: propsForFields.aspirate_airGap_volume.value,
   }
   const blowoutLocationOptions = getBlowoutLocationOptionsForForm({
     path: formValues.path,
-    stepType: formValues.stepType,
+    stepType,
   })
 
   const disposalLabwareOptions = uiLabwareSelectors.getDisposalLabwareOptions(

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -17,6 +17,7 @@ import { getBlowoutLocationOptionsForForm } from '../utils'
 import { TextField } from './TextField'
 
 import type { FieldProps, FieldPropsByName } from '../types'
+import type { PathOption, StepType } from '../../../form-types'
 import type { BaseState } from '../../../types'
 
 import styles from '../StepEditForm.css'
@@ -42,7 +43,15 @@ type SP = {|
   disposalDestinationOptions: Options,
   maxDisposalVolume: ?number,
 |}
-type OP = {| propsForFields: FieldPropsByName |}
+type OP = {|
+  aspirate_airGap_checkbox?: boolean | null,
+  aspirate_airGap_volume?: string | null,
+  path: PathOption,
+  pipette: string | null,
+  propsForFields: FieldPropsByName,
+  stepType: StepType,
+  volume: string | null,
+|}
 type Props = { ...SP, ...OP }
 
 const DisposalVolumeFieldComponent = (props: Props) => {
@@ -98,17 +107,17 @@ const DisposalVolumeFieldComponent = (props: Props) => {
   )
 }
 const mapSTP = (state: BaseState, ownProps: OP): SP => {
-  const { propsForFields } = ownProps
-  const stepType = 'moveLiquid' // TODO IMMEDIATELY -- HACK!
-  const formValues: any = {
-    aspirate_airGap_checkbox: propsForFields.aspirate_airGap_checkbox?.value,
-    aspirate_airGap_volume: propsForFields.aspirate_airGap_volume?.value,
-    path: propsForFields.path?.value,
-    pipette: propsForFields.pipette?.value,
-    volume: propsForFields.volume?.value,
-  }
+  const {
+    aspirate_airGap_checkbox,
+    aspirate_airGap_volume,
+    path,
+    pipette,
+    stepType,
+    volume,
+  } = ownProps
+
   const blowoutLocationOptions = getBlowoutLocationOptionsForForm({
-    path: formValues.path,
+    path,
     stepType,
   })
 
@@ -117,7 +126,13 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
   )
 
   const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
-    formValues,
+    {
+      aspirate_airGap_checkbox,
+      aspirate_airGap_volume,
+      path,
+      pipette,
+      volume,
+    },
     stepFormSelectors.getPipetteEntities(state)
   )
 

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
@@ -96,7 +96,15 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
         </div>
         <div className={cx(styles.section_column, styles.disposal_vol_wrapper)}>
           {path === 'multiDispense' && (
-            <DisposalVolumeField propsForFields={propsForFields} />
+            <DisposalVolumeField
+              aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+              aspirate_airGap_volume={formData.aspirate_airGap_volume}
+              path={formData.path}
+              pipette={formData.pipette}
+              propsForFields={propsForFields}
+              stepType={formData.stepType}
+              volume={formData.volume}
+            />
           )}
         </div>
       </div>

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -358,7 +358,7 @@ const clampDisposalVolume = (
   if (appliedPatch.path !== 'multiDispense' || isDecimalString) return patch
 
   const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
-    appliedPatch,
+    (appliedPatch: any),
     pipetteEntities
   )
   if (maxDisposalVolume == null) {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.js
@@ -358,7 +358,8 @@ const clampDisposalVolume = (
   if (appliedPatch.path !== 'multiDispense' || isDecimalString) return patch
 
   const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
-    (appliedPatch: any),
+    // $FlowFixMe(IL, 2021-03-22): appliedPath isn't well-typed, address in #3161
+    appliedPatch,
     pipetteEntities
   )
   if (maxDisposalVolume == null) {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -57,7 +57,7 @@ export function getChannels(
 export const DISPOSAL_VOL_DIGITS = 1
 
 export function getMaxDisposalVolumeForMultidispense(
-  rawForm: {|
+  values: {|
     aspirate_airGap_checkbox?: boolean | null,
     aspirate_airGap_volume?: string | null,
     path: PathOption,
@@ -67,19 +67,19 @@ export function getMaxDisposalVolumeForMultidispense(
   pipetteEntities: PipetteEntities
 ): ?number {
   // calculate max disposal volume for given volume & pipette. Might be negative!
-  const pipetteId = rawForm?.pipette
-  if (!rawForm || !pipetteId) return null
+  const pipetteId = values?.pipette
+  if (!values || !pipetteId) return null
   assert(
-    rawForm.path === 'multiDispense',
-    `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${rawForm.path}`
+    values.path === 'multiDispense',
+    `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${values.path}`
   )
   const pipetteEntity = pipetteEntities[pipetteId]
   const pipetteCapacity = getPipetteCapacity(pipetteEntity)
 
-  const volume = Number(rawForm.volume)
-  const airGapChecked = rawForm['aspirate_airGap_checkbox']
+  const volume = Number(values.volume)
+  const airGapChecked = values['aspirate_airGap_checkbox']
   let airGapVolume = airGapChecked
-    ? Number(rawForm['aspirate_airGap_volume'])
+    ? Number(values['aspirate_airGap_volume'])
     : 0
   airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
   return round(pipetteCapacity - volume * 2 - airGapVolume, DISPOSAL_VOL_DIGITS)

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -9,7 +9,7 @@ import type {
   PipetteChannels,
 } from '@opentrons/shared-data'
 import type { FormPatch } from '../../actions/types'
-import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormData, PathOption, StepFieldName } from '../../../form-types'
 import type { LabwareEntities, PipetteEntities } from '../../../step-forms'
 
 export function chainPatchUpdaters(
@@ -58,21 +58,22 @@ export const DISPOSAL_VOL_DIGITS = 1
 
 export function getMaxDisposalVolumeForMultidispense(
   rawForm: {|
-    path: PathType,
-    volume: string | null,
-    pipette: string | null,
     aspirate_airGap_checkbox?: boolean | null,
     aspirate_airGap_volume?: string | null,
+    path: PathOption,
+    pipette: string | null,
+    volume: string | null,
   |},
   pipetteEntities: PipetteEntities
 ): ?number {
   // calculate max disposal volume for given volume & pipette. Might be negative!
-  if (!rawForm) return null
+  const pipetteId = rawForm?.pipette
+  if (!rawForm || !pipetteId) return null
   assert(
     rawForm.path === 'multiDispense',
     `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${rawForm.path}`
   )
-  const pipetteEntity = pipetteEntities[rawForm.pipette]
+  const pipetteEntity = pipetteEntities[pipetteId]
   const pipetteCapacity = getPipetteCapacity(pipetteEntity)
 
   const volume = Number(rawForm.volume)

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.js
@@ -57,7 +57,13 @@ export function getChannels(
 export const DISPOSAL_VOL_DIGITS = 1
 
 export function getMaxDisposalVolumeForMultidispense(
-  rawForm: ?FormData,
+  rawForm: {|
+    path: PathType,
+    volume: string | null,
+    pipette: string | null,
+    aspirate_airGap_checkbox?: boolean | null,
+    aspirate_airGap_volume?: string | null,
+  |},
   pipetteEntities: PipetteEntities
 ): ?number {
   // calculate max disposal volume for given volume & pipette. Might be negative!


### PR DESCRIPTION
# Overview

Addresses #7301 for `DisposalVolumeField`

# Changelog

Refactor DisposalVolumeField to remove dependency on single edit mode (saved step form)

# Review requests

- Code review
- No regressions on the Disposal Volume field (must select one-to-many well path to get the option)

# Risk assessment

Low to med, PD only