### PR TITLE
fix(api): check the symlink of the virtual port to map to the physical port

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -14,6 +14,10 @@ class USBDriverInterface(Protocol):
     def convert_port_path(full_port_path: str) -> USBPort:
         ...
 
+    @staticmethod
+    def read_symlink(virtual_port: str) -> str:
+        ...
+
     @property
     def usb_dev(self) -> List[USBPort]:
         ...

--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -1,6 +1,8 @@
 from typing import List, Set
 from typing_extensions import Protocol
 
+from opentrons.hardware_control.modules.types import ModuleAtPort
+
 from .types import USBPort
 
 
@@ -41,4 +43,9 @@ class USBDriverInterface(Protocol):
         ...
 
     def sort_ports(self) -> None:
+        ...
+
+    def match_virtual_ports(
+            self, virtual_port: List[ModuleAtPort]
+            ) -> List[ModuleAtPort]:
         ...

--- a/api/src/opentrons/drivers/rpi_drivers/types.py
+++ b/api/src/opentrons/drivers/rpi_drivers/types.py
@@ -14,9 +14,9 @@ class PinDir(enum.Enum):
 
 @dataclass(frozen=True)
 class USBPort(GenericNode):
-    port_number: Optional[int]
-    device_path: str
-    hub: Optional[int]
+    port_number: Optional[int] = None
+    device_path: str = ''
+    hub: Optional[int] = None
 
     @classmethod
     def build(cls, port_path: str) -> 'USBPort':

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -7,6 +7,7 @@ more readable format.
 
 import subprocess
 import re
+import os
 from typing import List, Set
 
 from opentrons.algorithms.dfs import DFS
@@ -53,10 +54,8 @@ class USBBus(USBDriverInterface):
         """
         symlink = ''
         try:
-            read = subprocess.check_output(
-                ['readlink', virtual_port]).strip().decode()
-            symlink = f'dev/{read}'
-        except Exception:
+            symlink = os.readlink(virtual_port)
+        except OSError:
             pass
         return symlink
 
@@ -195,4 +194,4 @@ class USBBus(USBDriverInterface):
                     vp.usb_port = p
                     sorted_virtual_ports.append(vp)
                     break
-        return sorted_virtual_ports
+        return sorted_virtual_ports or virtual_ports

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -10,6 +10,7 @@ import re
 from typing import List, Set
 
 from opentrons.algorithms.dfs import DFS
+from opentrons.hardware_control.modules.types import ModuleAtPort
 
 from .interfaces import USBDriverInterface
 from .types import USBPort
@@ -165,3 +166,33 @@ class USBBus(USBDriverInterface):
                 self._dfs.graph.add_vertex(d)
             self.sorted_ports = self._dfs.dfs()
             self.usb_dev = updated_bus
+
+    def match_virtual_ports(
+            self, virtual_ports: List[ModuleAtPort]
+            ) -> List[ModuleAtPort]:
+        """
+        Match Virtual Ports
+
+        Given a list of virtual module ports, look up the
+        symlink to find the device path and link that to
+        the physical usb port information.
+        The virtual port path looks something like:
+        dev/ot_module_[MODULE NAME]
+        :param virtual_ports: A list of ModuleAtPort objects
+        that hold the name and virtual port of each module
+        connected to the robot.
+
+        :returns: The updated list of ModuleAtPort
+        dataclasses with the physical usb port
+        information updated.
+        """
+        self.sort_ports()
+        sorted_virtual_ports = []
+        for p in self.usb_dev:
+            for vp in virtual_ports:
+                serial_port = self.read_symlink(vp.port)
+                if serial_port in p.device_path:
+                    vp.usb_port = p
+                    sorted_virtual_ports.append(vp)
+                    break
+        return sorted_virtual_ports

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -47,6 +47,19 @@ class USBBus(USBDriverInterface):
         return read
 
     @staticmethod
+    def read_symlink(virtual_port: str) -> str:
+        """
+        """
+        symlink = ''
+        try:
+            read = subprocess.check_output(
+                ['readlink', virtual_port]).strip().decode()
+            symlink = f'dev/{read}'
+        except Exception:
+            pass
+        return symlink
+
+    @staticmethod
     def convert_port_path(full_port_path: str) -> USBPort:
         """
         Convert port path.

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -37,6 +37,12 @@ class USBBusSimulator(USBDriverInterface):
         """
         pass
 
+    @staticmethod
+    def read_symlink(virtual_port: str) -> str:
+        """
+        """
+        return ''
+
     @property
     def usb_dev(self) -> List[USBPort]:
         """

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -6,6 +6,8 @@ more readable format.
 """
 from typing import List, Set
 
+from opentrons.hardware_control.modules.types import ModuleAtPort
+
 from .interfaces import USBDriverInterface
 from .types import USBPort
 
@@ -102,8 +104,12 @@ class USBBusSimulator(USBDriverInterface):
         :returns: The matching port, or an empty port dataclass
         """
         return USBPort(
-            name='', sub_names=[], hub=None,
-            port_number=None, device_path=device_path)
+            name='', sub_names=[], device_path=device_path)
 
     def sort_ports(self) -> None:
         pass
+
+    def match_virtual_ports(
+            self, virtual_port: List[ModuleAtPort]
+            ) -> List[ModuleAtPort]:
+        return virtual_port

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1751,9 +1751,10 @@ class API(HardwareAPILike):
 
         # build new mods
         for mod in new_mods_at_ports:
+            serial_port = self._backend._usb.read_symlink(mod.port)
             new_instance = await self._backend.build_module(
                     port=mod.port,
-                    usb_port=self._backend._usb.find_port(mod.port),
+                    usb_port=self._backend._usb.find_port(serial_port),
                     model=mod.name,
                     interrupt_callback=self.pause_with_message,
                     loop=self.loop,

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1747,14 +1747,14 @@ class API(HardwareAPILike):
 
         # destroy removed mods
         self._unregister_modules(removed_mods_at_ports)
-        self._backend._usb.sort_ports()
+        sorted_mods_at_port =\
+            self._backend._usb.match_virtual_ports(new_mods_at_ports)
 
         # build new mods
-        for mod in new_mods_at_ports:
-            serial_port = self._backend._usb.read_symlink(mod.port)
+        for mod in sorted_mods_at_port:
             new_instance = await self._backend.build_module(
                     port=mod.port,
-                    usb_port=self._backend._usb.find_port(serial_port),
+                    usb_port=mod.usb_port,
                     model=mod.name,
                     interrupt_callback=self.pause_with_message,
                     loop=self.loop,

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 from typing import (
-    Dict, NamedTuple, Callable, Any, Tuple, Awaitable, Mapping, Union)
+    Dict, NamedTuple, Callable, Any, Tuple,
+    Awaitable, Mapping, Union)
 from pathlib import Path
+
+from opentrons.drivers.rpi_drivers.types import USBPort
 
 ThermocyclerStep = Dict[str, float]
 
@@ -13,10 +16,11 @@ UploadFunction = Callable[[str, str, Dict[str, Any]],
 LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]
 
 
-@dataclass(frozen=True)
+@dataclass
 class ModuleAtPort:
     port: str
     name: str
+    usb_port: USBPort = USBPort(name='', sub_names=[])
 
 
 class BundledFirmware(NamedTuple):


### PR DESCRIPTION
# Overview
When developing #7359 , I made the assumption that the port referred to the _serial_ or _device path_ name, something to the effect of tty*. However, the port we have information of on the hardware control side is the _virtual port_, which looks more like `dev/ot_module_[NAME OF MODULE]`. Unfortunately, the raspberry pi only does mapping from the serial port to the physical usb port information.
Since there is not a multi-way symlink (i.e. we cannot look up the virtual port via the device path), we need to do the reverse look up from the virtual port to get the device path and then match up the physical port to each individual module.

When looking into this, I also realized we weren't properly using the physical ports in a sorted order, so that is taken care of while we do the reverse look-up.

# Changelog
- Add in a function to read the symlink on the virtual port
- Actually sort attached modules by physical port order via the new function `match_virtual_port`
- Add a test to check the new behavior

# Review requests
Put on a robot, especially @ahiuchingau to double check this fixes the original problem. Look over the code and let me know if you would like any changes to be made and/or whether it's better to just add a symlink that maps the serial port to the virtual port on buildroot.

# Risk assessment

Medium. Please test on a robot and please think about the comment in the Review Requests section.