### PR TITLE
fix(protocol-designer): remove single-edit dependencies for PathField

### DIFF
--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -168,6 +168,7 @@
   color: var(--c-light-gray);
   opacity: 0.16;
   cursor: default;
+  pointer-events: inherit;
 }
 
 .path_options {

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
@@ -1,14 +1,14 @@
 // @flow
 import * as React from 'react'
 import cx from 'classnames'
-import { FormGroup, HoverTooltip } from '@opentrons/components'
+import { FormGroup, Tooltip, useHoverTooltip } from '@opentrons/components'
 import { i18n } from '../../../../localization'
 import SINGLE_IMAGE from '../../../../images/path_single_transfers.svg'
 import MULTI_DISPENSE_IMAGE from '../../../../images/path_multi_dispense.svg'
 import MULTI_ASPIRATE_IMAGE from '../../../../images/path_multi_aspirate.svg'
 import type { PathOption } from '../../../../form-types'
 import type { FieldProps } from '../../types'
-import type { ValuesForPath } from './getDisabledPathMap'
+import type { DisabledPathMap, ValuesForPath } from './getDisabledPathMap'
 import styles from '../../StepEditForm.css'
 
 const PATH_ANIMATION_IMAGES = {
@@ -35,65 +35,60 @@ const ALL_PATH_OPTIONS = [
 type PathFieldProps = {|
   ...FieldProps,
   ...ValuesForPath,
-  disabledPathMap: ?{ [PathOption]: string },
+  disabledPathMap: DisabledPathMap,
 |}
 
 type ButtonProps = {
   children?: React.Node,
-  disabled?: ?boolean,
-  selected?: boolean,
+  disabled: boolean,
+  selected: boolean,
   subtitle: string,
-  onClick?: (e: SyntheticMouseEvent<*>) => mixed,
+  onClick: (e: SyntheticMouseEvent<*>) => mixed,
   path: PathOption,
 }
 
 const PathButton = (buttonProps: ButtonProps) => {
-  const { disabled, children, path, selected, onClick, subtitle } = buttonProps
+  const { children, disabled, onClick, path, selected, subtitle } = buttonProps
+  const [targetProps, tooltipProps] = useHoverTooltip()
 
   const tooltip = (
-    <div>
-      <div
-        className={cx(styles.path_tooltip_title, {
-          [styles.disabled]: disabled,
-        })}
-      >
+    <Tooltip {...tooltipProps}>
+      <div className={styles.path_tooltip_title}>
         {i18n.t(`form.step_edit_form.field.path.title.${path}`)}
       </div>
       <img
-        className={cx(styles.path_tooltip_image, {
-          [styles.disabled]: disabled,
-        })}
+        className={styles.path_tooltip_image}
         src={PATH_ANIMATION_IMAGES[path]}
       />
       <div className={styles.path_tooltip_subtitle}>{subtitle}</div>
-    </div>
+    </Tooltip>
   )
 
   return (
-    <HoverTooltip tooltipComponent={tooltip}>
-      {hoverTooltipHandlers => (
-        <li
-          {...hoverTooltipHandlers}
-          className={cx(styles.path_option, {
-            [styles.selected]: selected,
-            [styles.disabled]: disabled,
-          })}
-          onClick={disabled ? null : onClick}
-        >
-          {children}
-        </li>
-      )}
-    </HoverTooltip>
+    <>
+      {tooltip}
+      <li
+        {...targetProps}
+        className={cx(styles.path_option, {
+          [styles.selected]: selected,
+          [styles.disabled]: disabled,
+        })}
+        onClick={disabled ? null : onClick}
+      >
+        {children}
+      </li>
+    </>
   )
 }
 
 const getSubtitle = (
   path: PathOption,
-  disabledPathMap: ?{ [PathOption]: string }
-) => {
+  disabledPathMap: DisabledPathMap
+): string => {
   const reasonForDisabled = disabledPathMap && disabledPathMap[path]
   return reasonForDisabled || ''
 }
+
 export const Path = (props: PathFieldProps): React.Node => {
   const { disabledPathMap, value, updateValue } = props
   return (
@@ -105,7 +100,7 @@ export const Path = (props: PathFieldProps): React.Node => {
             selected={option.name === value}
             path={option.name}
             disabled={
-              disabledPathMap && disabledPathMap.hasOwnProperty(option.name)
+              disabledPathMap !== null && option.name in disabledPathMap
             }
             subtitle={getSubtitle(option.name, disabledPathMap)}
             onClick={() => updateValue(option.name)}

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
@@ -3,12 +3,13 @@ import * as React from 'react'
 import cx from 'classnames'
 import { FormGroup, HoverTooltip } from '@opentrons/components'
 import { i18n } from '../../../../localization'
-import { FieldConnector } from '../FieldConnector'
-import styles from '../../StepEditForm.css'
-import type { PathOption } from '../../../../form-types'
 import SINGLE_IMAGE from '../../../../images/path_single_transfers.svg'
 import MULTI_DISPENSE_IMAGE from '../../../../images/path_multi_dispense.svg'
 import MULTI_ASPIRATE_IMAGE from '../../../../images/path_multi_aspirate.svg'
+import type { PathOption } from '../../../../form-types'
+import type { FieldProps } from '../../types'
+import type { ValuesForPath } from './getDisabledPathMap'
+import styles from '../../StepEditForm.css'
 
 const PATH_ANIMATION_IMAGES = {
   single: require('../../../../images/path_single.gif'),
@@ -32,6 +33,8 @@ const ALL_PATH_OPTIONS = [
 ]
 
 type PathFieldProps = {|
+  ...FieldProps,
+  ...ValuesForPath,
   disabledPathMap: ?{ [PathOption]: string },
 |}
 
@@ -92,30 +95,25 @@ const getSubtitle = (
   return reasonForDisabled || ''
 }
 export const Path = (props: PathFieldProps): React.Node => {
+  const { disabledPathMap, value, updateValue } = props
   return (
     <FormGroup label="Path">
-      <FieldConnector
-        name="path"
-        render={({ value, updateValue }) => (
-          <ul className={styles.path_options}>
-            {ALL_PATH_OPTIONS.map(option => (
-              <PathButton
-                key={option.name}
-                selected={option.name === value}
-                path={option.name}
-                disabled={
-                  props.disabledPathMap &&
-                  props.disabledPathMap.hasOwnProperty(option.name)
-                }
-                subtitle={getSubtitle(option.name, props.disabledPathMap)}
-                onClick={() => updateValue(option.name)}
-              >
-                <img src={option.image} className={styles.path_image} />
-              </PathButton>
-            ))}
-          </ul>
-        )}
-      />
+      <ul className={styles.path_options}>
+        {ALL_PATH_OPTIONS.map(option => (
+          <PathButton
+            key={option.name}
+            selected={option.name === value}
+            path={option.name}
+            disabled={
+              disabledPathMap && disabledPathMap.hasOwnProperty(option.name)
+            }
+            subtitle={getSubtitle(option.name, disabledPathMap)}
+            onClick={() => updateValue(option.name)}
+          >
+            <img src={option.image} className={styles.path_image} />
+          </PathButton>
+        ))}
+      </ul>
     </FormGroup>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.js
@@ -11,6 +11,8 @@ import type { ChangeTipOptions } from '../../../../step-generation/types'
 import type { PipetteEntities } from '../../../../step-forms'
 import type { PathOption } from '../../../../form-types'
 
+export type DisabledPathMap = { [PathOption]: string } | null
+
 export type ValuesForPath = {|
   aspirate_airGap_checkbox: ?boolean,
   aspirate_airGap_volume: ?string,
@@ -24,7 +26,7 @@ export type ValuesForPath = {|
 export function getDisabledPathMap(
   values: ValuesForPath,
   pipetteEntities: PipetteEntities
-): ?{ [PathOption]: string } {
+): DisabledPathMap {
   const {
     aspirate_airGap_checkbox,
     aspirate_wells,

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.js
@@ -1,0 +1,125 @@
+// @flow
+import { i18n } from '../../../../localization'
+import { getWellRatio } from '../../../../steplist/utils'
+import { getPipetteCapacity } from '../../../../pipettes/pipetteData'
+import {
+  volumeInCapacityForMultiDispense,
+  volumeInCapacityForMultiAspirate,
+} from '../../../../steplist/formLevel/handleFormChange/utils'
+
+import type { ChangeTipOptions } from '../../../../step-generation/types'
+import type { PipetteEntities } from '../../../../step-forms'
+import type { PathOption } from '../../../../form-types'
+
+export type ValuesForPath = {|
+  aspirate_airGap_checkbox: ?boolean,
+  aspirate_airGap_volume: ?string,
+  aspirate_wells: ?Array<string>,
+  changeTip: ChangeTipOptions,
+  dispense_wells: ?Array<string>,
+  pipette: ?string,
+  volume: ?string,
+|}
+
+export function getDisabledPathMap(
+  values: ValuesForPath,
+  pipetteEntities: PipetteEntities
+): ?{ [PathOption]: string } {
+  const {
+    aspirate_airGap_checkbox,
+    aspirate_wells,
+    changeTip,
+    dispense_wells,
+    pipette,
+  } = values
+
+  if (!pipette) return null
+
+  const wellRatio = getWellRatio(aspirate_wells, dispense_wells)
+
+  let disabledPathMap: { multiAspirate: string, multiAspirate: string } = {}
+
+  // changeTip is lowest priority disable reasoning
+  if (changeTip === 'perDest') {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiDispense: i18n.t(
+        'form.step_edit_form.field.path.subtitle.incompatible_with_per_dest'
+      ),
+    }
+  } else if (changeTip === 'perSource') {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiAspirate: i18n.t(
+        'form.step_edit_form.field.path.subtitle.incompatible_with_per_source'
+      ),
+    }
+  }
+
+  // transfer volume overwrites change tip disable reasoning
+  const pipetteEntity = pipetteEntities[pipette]
+  const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
+
+  const volume = Number(values.volume)
+  const airGapChecked = aspirate_airGap_checkbox
+  let airGapVolume = airGapChecked ? Number(values.aspirate_airGap_volume) : 0
+  airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
+
+  const withinCapacityForMultiDispense = volumeInCapacityForMultiDispense({
+    volume,
+    pipetteCapacity,
+    airGapVolume,
+  })
+
+  const withinCapacityForMultiAspirate = volumeInCapacityForMultiAspirate({
+    volume,
+    pipetteCapacity,
+    airGapVolume,
+  })
+
+  if (!withinCapacityForMultiDispense) {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiDispense: i18n.t(
+        'form.step_edit_form.field.path.subtitle.volume_too_high'
+      ),
+    }
+  }
+  if (!withinCapacityForMultiAspirate) {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiAspirate: i18n.t(
+        'form.step_edit_form.field.path.subtitle.volume_too_high'
+      ),
+    }
+  }
+
+  // wellRatio overwrites all other disable reasoning
+  if (wellRatio === '1:many') {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiAspirate: i18n.t(
+        'form.step_edit_form.field.path.subtitle.only_many_to_1'
+      ),
+    }
+  } else if (wellRatio === 'many:1') {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiDispense: i18n.t(
+        'form.step_edit_form.field.path.subtitle.only_1_to_many'
+      ),
+    }
+  } else {
+    disabledPathMap = {
+      ...disabledPathMap,
+      multiAspirate: i18n.t(
+        'form.step_edit_form.field.path.subtitle.only_many_to_1'
+      ),
+      multiDispense: i18n.t(
+        'form.step_edit_form.field.path.subtitle.only_1_to_many'
+      ),
+    }
+  }
+
+  return disabledPathMap
+}

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/index.js
@@ -2,125 +2,37 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { Path } from './Path'
-import { i18n } from '../../../../localization'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
-import { getWellRatio } from '../../../../steplist/utils'
-import { getPipetteCapacity } from '../../../../pipettes/pipetteData'
-import {
-  volumeInCapacityForMultiDispense,
-  volumeInCapacityForMultiAspirate,
-} from '../../../../steplist/formLevel/handleFormChange/utils'
-
-import type { PipetteEntities } from '../../../../step-forms'
-import type { FormData, PathOption } from '../../../../form-types'
+import { getDisabledPathMap } from './getDisabledPathMap'
 import type { BaseState } from '../../../../types'
 
 type Props = React.ElementProps<typeof Path>
 type SP = {| disabledPathMap: $PropertyType<Props, 'disabledPathMap'> |}
 type OP = $Diff<$Exact<Props>, SP>
 
-function getDisabledPathMap(
-  rawForm: ?FormData,
-  pipetteEntities: PipetteEntities
-): ?{ [PathOption]: string } {
-  if (!rawForm || !rawForm.pipette) return null
-
-  const wellRatio = getWellRatio(rawForm.aspirate_wells, rawForm.dispense_wells)
-  const changeTip = rawForm.changeTip
-
-  let disabledPathMap: { multiAspirate: string, multiAspirate: string } = {}
-
-  // changeTip is lowest priority disable reasoning
-  if (changeTip === 'perDest') {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiDispense: i18n.t(
-        'form.step_edit_form.field.path.subtitle.incompatible_with_per_dest'
-      ),
-    }
-  } else if (changeTip === 'perSource') {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiAspirate: i18n.t(
-        'form.step_edit_form.field.path.subtitle.incompatible_with_per_source'
-      ),
-    }
-  }
-
-  // transfer volume overwrites change tip disable reasoning
-  const pipetteEntity = pipetteEntities[rawForm.pipette]
-  const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
-
-  const volume = Number(rawForm.volume)
-  const airGapChecked = rawForm['aspirate_airGap_checkbox']
-  let airGapVolume = airGapChecked
-    ? Number(rawForm['aspirate_airGap_volume'])
-    : 0
-  airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
-
-  const withinCapacityForMultiDispense = volumeInCapacityForMultiDispense({
+function mapSTP(state: BaseState, ownProps: OP): SP {
+  const {
+    aspirate_airGap_checkbox,
+    aspirate_airGap_volume,
+    aspirate_wells,
+    changeTip,
+    dispense_wells,
+    pipette,
     volume,
-    pipetteCapacity,
-    airGapVolume,
-  })
-
-  const withinCapacityForMultiAspirate = volumeInCapacityForMultiAspirate({
-    volume,
-    pipetteCapacity,
-    airGapVolume,
-  })
-
-  if (!withinCapacityForMultiDispense) {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiDispense: i18n.t(
-        'form.step_edit_form.field.path.subtitle.volume_too_high'
-      ),
-    }
-  }
-  if (!withinCapacityForMultiAspirate) {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiAspirate: i18n.t(
-        'form.step_edit_form.field.path.subtitle.volume_too_high'
-      ),
-    }
-  }
-
-  // wellRatio overwrites all other disable reasoning
-  if (wellRatio === '1:many') {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiAspirate: i18n.t(
-        'form.step_edit_form.field.path.subtitle.only_many_to_1'
-      ),
-    }
-  } else if (wellRatio === 'many:1') {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiDispense: i18n.t(
-        'form.step_edit_form.field.path.subtitle.only_1_to_many'
-      ),
-    }
-  } else {
-    disabledPathMap = {
-      ...disabledPathMap,
-      multiAspirate: i18n.t(
-        'form.step_edit_form.field.path.subtitle.only_many_to_1'
-      ),
-      multiDispense: i18n.t(
-        'form.step_edit_form.field.path.subtitle.only_1_to_many'
-      ),
-    }
-  }
-
-  return disabledPathMap
-}
-
-function mapSTP(state: BaseState): SP {
-  const rawForm = stepFormSelectors.getUnsavedForm(state)
+  } = ownProps
   const pipetteEntities = stepFormSelectors.getPipetteEntities(state)
-  const disabledPathMap = getDisabledPathMap(rawForm, pipetteEntities)
+  const disabledPathMap = getDisabledPathMap(
+    {
+      aspirate_airGap_checkbox,
+      aspirate_airGap_volume,
+      aspirate_wells,
+      changeTip,
+      dispense_wells,
+      pipette,
+      volume,
+    },
+    pipetteEntities
+  )
   return {
     disabledPathMap,
   }

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
@@ -92,7 +92,16 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
             path={formData.path}
             stepType={formData.stepType}
           />
-          <PathField />
+          <PathField
+            {...propsForFields['path']}
+            aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
+            aspirate_airGap_volume={formData.aspirate_airGap_volume}
+            aspirate_wells={formData.aspirate_wells}
+            changeTip={formData.changeTip}
+            dispense_wells={formData.dispense_wells}
+            pipette={formData.pipette}
+            volume={formData.volume}
+          />
         </div>
         <div className={cx(styles.section_column, styles.disposal_vol_wrapper)}>
           {path === 'multiDispense' && (


### PR DESCRIPTION
# Overview

Addresses Path field part of #7301 and some of #7295 !

# Changelog

- Refactor Path field

# Review requests

- [ ] This is a `fix` because it restores some broken functionality (in production `5.2.3`) where the Path tooltips do not show when the PathButton is disabled, therefore not allowing the user to see the explanation for why the field is disabled (eg "Only compatible with many-to-1 well ratios" message etc). Confirm tooltips are working now with this PR
- [ ] Test path field, should otherwise have no changes vs prod

# Risk assessment

Low-med, PD-only