### PR TITLE
refactor(protocol-designer): remove single-edit dependency of WellSelectionField

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.js
@@ -63,6 +63,7 @@ class WellSelectionInputComponent extends React.Component<Props> {
       labwareId || 'noLabware'
     }`
   }
+
   render() {
     const modalKey = this.getModalKey()
     const label = this.props.isMulti

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.js
@@ -88,12 +88,14 @@ class WellSelectionInputComponent extends React.Component<Props> {
         />
         <Portal>
           <WellSelectionModal
-            key={modalKey}
-            pipetteId={this.props.pipetteId}
-            labwareId={this.props.labwareId}
             isOpen={this.props.wellSelectionLabwareKey === modalKey}
-            onCloseClick={this.handleClose}
+            key={modalKey}
+            labwareId={this.props.labwareId}
             name={this.props.name}
+            onCloseClick={this.handleClose}
+            pipetteId={this.props.pipetteId}
+            updateValue={this.props.updateValue}
+            value={this.props.value}
           />
         </Portal>
       </FormGroup>

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/index.js
@@ -3,44 +3,34 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import { WellSelectionInput } from './WellSelectionInput'
 import { selectors as stepFormSelectors } from '../../../../step-forms'
-import { getDisabledFields } from '../../../../steplist/formLevel'
 import type { BaseState, ThunkDispatch } from '../../../../types'
-import type { StepFieldName } from '../../../../form-types'
 import type { FieldProps } from '../../types'
 
 type Props = React.ElementConfig<typeof WellSelectionInput>
 
 type OP = {|
   ...FieldProps,
-  pipetteFieldName: StepFieldName,
-  labwareFieldName: StepFieldName,
+  labwareId: ?string,
+  pipetteId: ?string,
 |}
 
 type SP = {|
-  disabled: boolean,
   isMulti: $PropertyType<Props, 'isMulti'>,
   primaryWellCount: $PropertyType<Props, 'primaryWellCount'>,
-  _pipetteId: ?string,
-  _selectedLabwareId: ?string,
 |}
 
 const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
-  const formData = stepFormSelectors.getUnsavedForm(state)
-  const pipetteId = formData && formData[ownProps.pipetteFieldName]
-  const selectedWells = formData ? formData[ownProps.name] : []
-  const disabled = formData
-    ? getDisabledFields(formData).has(ownProps.name)
-    : false
+  const { pipetteId } = ownProps
+  const selectedWells = ownProps.value
 
   const pipette =
     pipetteId && stepFormSelectors.getPipetteEntities(state)[pipetteId]
   const isMulti = pipette ? pipette.spec.channels > 1 : false
 
   return {
-    disabled,
-    _pipetteId: pipetteId,
-    _selectedLabwareId: formData && formData[ownProps.labwareFieldName],
-    primaryWellCount: selectedWells && selectedWells.length,
+    primaryWellCount: Array.isArray(selectedWells)
+      ? selectedWells.length
+      : undefined,
     isMulti,
   }
 }
@@ -50,28 +40,30 @@ function mergeProps(
   dispatchProps: { dispatch: ThunkDispatch<*> },
   ownProps: OP
 ): Props {
-  const { _pipetteId, _selectedLabwareId } = stateProps
   const {
+    disabled,
+    errorToShow,
+    labwareId,
     name,
     onFieldBlur,
     onFieldFocus,
-    errorToShow,
-    value,
+    pipetteId,
     updateValue,
+    value,
   } = ownProps
 
   return {
-    name,
-    disabled: stateProps.disabled,
-    pipetteId: _pipetteId,
-    labwareId: _selectedLabwareId,
-    isMulti: stateProps.isMulti,
-    primaryWellCount: stateProps.primaryWellCount,
-    value,
+    disabled,
     errorToShow,
+    isMulti: stateProps.isMulti,
+    labwareId,
+    name,
     onFieldBlur,
     onFieldFocus,
+    pipetteId,
+    primaryWellCount: stateProps.primaryWellCount,
     updateValue,
+    value,
   }
 }
 

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.js
@@ -69,8 +69,8 @@ export const MixForm = (props: StepFormProps): React.Node => {
         </FormGroup>
         <WellSelectionField
           {...propsForFields['wells']}
-          labwareFieldName="labware"
-          pipetteFieldName="pipette"
+          labwareId={formData['labware']}
+          pipetteId={formData['pipette']}
         />
       </div>
       <div className={styles.section_divider} />

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.js
@@ -5,6 +5,7 @@ import { i18n } from '../../../../localization'
 import { LabwareField, WellSelectionField } from '../../fields'
 import { AspDispSection } from '../AspDispSection'
 import type { StepFieldName } from '../../../../steplist/fieldLevel'
+import type { FormData } from '../../../../form-types'
 import type { FieldPropsByName } from '../../types'
 
 import styles from '../../StepEditForm.css'
@@ -12,9 +13,10 @@ import styles from '../../StepEditForm.css'
 type Props = {|
   className?: ?string,
   collapsed?: ?boolean,
-  toggleCollapsed: () => void,
+  formData: FormData,
   prefix: 'aspirate' | 'dispense',
   propsForFields: FieldPropsByName,
+  toggleCollapsed: () => void,
 |}
 
 const makeAddFieldNamePrefix = (prefix: string) => (
@@ -28,6 +30,7 @@ export const SourceDestHeaders = (props: Props): React.Node => {
     toggleCollapsed,
     prefix,
     propsForFields,
+    formData,
   } = props
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)
   const labwareLabel = i18n.t(`form.step_edit_form.labwareLabel.${prefix}`)
@@ -40,8 +43,8 @@ export const SourceDestHeaders = (props: Props): React.Node => {
         </FormGroup>
         <WellSelectionField
           {...propsForFields[addFieldNamePrefix('wells')]}
-          labwareFieldName={addFieldNamePrefix('labware')}
-          pipetteFieldName="pipette"
+          labwareId={formData[addFieldNamePrefix('labware')]}
+          pipetteId={formData['pipette']}
         />
       </div>
     </AspDispSection>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.js
@@ -45,17 +45,19 @@ export const MoveLiquidForm = (props: StepFormProps): React.Node => {
       <div className={styles.section_wrapper}>
         <SourceDestHeaders
           className={styles.section_column}
-          propsForFields={propsForFields}
           collapsed={collapsed}
-          toggleCollapsed={toggleCollapsed}
+          formData={formData}
           prefix="aspirate"
+          propsForFields={propsForFields}
+          toggleCollapsed={toggleCollapsed}
         />
         <SourceDestHeaders
           className={styles.section_column}
-          propsForFields={propsForFields}
           collapsed={collapsed}
-          toggleCollapsed={toggleCollapsed}
+          formData={formData}
           prefix="dispense"
+          propsForFields={propsForFields}
+          toggleCollapsed={toggleCollapsed}
         />
       </div>
 


### PR DESCRIPTION
# Overview

Addresses #7301 

# Changelog

Refactor `WellSelectionField`

# Review requests

- [ ] Code review
- [ ] No regressions with Transfer form asp or disp well selection field
  - Check with single-channel, and with 8-channel
- [ ] No regressions with Mix form well selection field
  - Check with single-channel, and with 8-channel

# Risk assessment

Low-med, PD-only