### PR TITLE
refactor(protocol-designer): clean up swatchColors util

### DIFF
--- a/protocol-designer/src/components/IngredientsList/index.js
+++ b/protocol-designer/src/components/IngredientsList/index.js
@@ -58,7 +58,7 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): React.Node => {
   return (
     <PDTitledList
       title={ingredGroup.name || i18n.t('card.unnamedLiquid')}
-      iconProps={{ style: { fill: swatchColors(Number(groupId)) } }}
+      iconProps={{ style: { fill: swatchColors(groupId) } }}
       iconName="circle"
       onCollapseToggle={toggleAccordion}
       collapsed={!expanded}

--- a/protocol-designer/src/components/LiquidsSidebar/index.js
+++ b/protocol-designer/src/components/LiquidsSidebar/index.js
@@ -34,7 +34,7 @@ function LiquidsSidebarComponent(props: Props) {
           selected={selectedLiquid === ingredientId}
           onClick={() => selectLiquid(ingredientId)}
           iconName="circle"
-          iconProps={{ style: { fill: swatchColors(Number(ingredientId)) } }}
+          iconProps={{ style: { fill: swatchColors(ingredientId) } }}
           title={name || `Unnamed Ingredient ${ingredientId}`} // fallback, should not happen
         />
       ))}

--- a/protocol-designer/src/components/labware/utils.js
+++ b/protocol-designer/src/components/labware/utils.js
@@ -5,11 +5,12 @@ import { swatchColors, MIXED_WELL_COLOR } from '../swatchColors'
 import type { WellFill } from '@opentrons/components'
 import type { ContentsByWell, WellContents } from '../../labware-ingred/types'
 
-export const ingredIdsToColor = (groupIds: Array<string>): ?string => {
+const ingredIdsToColor = (groupIds: Array<string>): ?string => {
   const filteredIngredIds = groupIds.filter(id => id !== AIR)
   if (filteredIngredIds.length === 0) return null
-  if (filteredIngredIds.length === 1)
-    return swatchColors(Number(filteredIngredIds[0]))
+  if (filteredIngredIds.length === 1) {
+    return swatchColors(filteredIngredIds[0])
+  }
   return MIXED_WELL_COLOR
 }
 

--- a/protocol-designer/src/components/steplist/IngredPill.js
+++ b/protocol-designer/src/components/steplist/IngredPill.js
@@ -2,11 +2,12 @@
 import * as React from 'react'
 import { Pill, type UseHoverTooltipResult } from '@opentrons/components'
 import { swatchColors, MIXED_WELL_COLOR } from '../swatchColors'
-import styles from './StepItem.css'
+import { AIR } from '../../step-generation/utils'
 import type {
   WellIngredientVolumeData,
   WellIngredientNames,
 } from '../../steplist'
+import styles from './StepItem.css'
 
 type Props = {
   ingreds: WellIngredientVolumeData,
@@ -15,16 +16,16 @@ type Props = {
 }
 
 export function IngredPill(props: Props): React.Node {
-  const { ingreds, ingredNames, targetProps } = props
-  if (!ingreds || Object.keys(ingreds).length === 0) {
+  const { ingredNames, targetProps } = props
+  const ingredIds: Array<string> = Object.keys(props.ingreds)
+
+  if (ingredIds.filter(id => id !== AIR).length === 0) {
     // Invisible Pill, but has correct height/margin/etc for spacing
     return <Pill />
   }
 
   const color =
-    Object.keys(ingreds).length === 1
-      ? swatchColors(Number(Object.keys(ingreds)[0]))
-      : MIXED_WELL_COLOR
+    ingredIds.length === 1 ? swatchColors(ingredIds[0]) : MIXED_WELL_COLOR
 
   return (
     <Pill
@@ -32,9 +33,7 @@ export function IngredPill(props: Props): React.Node {
       className={styles.ingred_pill}
       hoverTooltipHandlers={targetProps}
     >
-      {Object.keys(ingreds)
-        .map(groupId => ingredNames[groupId])
-        .join(',')}
+      {ingredIds.map(groupId => ingredNames[groupId]).join(',')}
     </Pill>
   )
 }

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -52,7 +52,7 @@ export const PillTooltipContents = (
               <td>
                 <div
                   className={styles.liquid_circle}
-                  style={{ backgroundColor: swatchColors(Number(groupId)) }}
+                  style={{ backgroundColor: swatchColors(groupId) }}
                 />
               </td>
               <td className={styles.ingred_name}>

--- a/protocol-designer/src/components/swatchColors.js
+++ b/protocol-designer/src/components/swatchColors.js
@@ -1,9 +1,10 @@
 // @flow
-
+import { AIR } from '../step-generation/utils'
 export const MIXED_WELL_COLOR = '#9b9b9b' // NOTE: matches `--c-med-gray` in colors.css
 
 // TODO factor into CSS or constants or elsewhere
-export const swatchColors = (n: number): string => {
+export const swatchColors = (ingredGroupId: string): string => {
+  const num = Number(ingredGroupId)
   const colors = [
     '#00d781',
     '#0076ff',
@@ -14,9 +15,13 @@ export const swatchColors = (n: number): string => {
     '#2a97dc',
     '#d24193',
   ]
-  if (!Number.isInteger(n)) {
-    // TODO: Ian 2018-07-20 use assert
-    console.warn(`swatchColors expected an integer, got ${n}`)
+  if (!Number.isInteger(num)) {
+    if (ingredGroupId !== AIR) {
+      console.warn(
+        `swatchColors expected an integer or ${AIR}, got ${ingredGroupId}`
+      )
+    }
+    return 'transparent'
   }
-  return colors[n % colors.length]
+  return colors[num % colors.length]
 }


### PR DESCRIPTION
# Overview

It came up in QA that it's confusing for PD to be doing `console.warn` logging "swatchColors expected an integer, got NaN" all the time. Nothing bad is happening except for some wrong logging.

# Changelog

- Cleanup use of `swatchColors` and related

# Review requests

- [ ] All liquid coloring (wells, IngredPill in steplist and substeps, and Add Liquid modal, View Liquids modal, Well Selection modal) should behave the same as in prod
- [ ] Code review
- [ ] Should stop console.warn logging "swatchColors expected an integer, got NaN" whenever there is AIR in a well

# Risk assessment

Low, PD-only