### PR TITLE
fix(protocol-designer): Update cancel/save button tooltip placement

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -7,6 +7,8 @@ import {
   OutlineButton,
   Tooltip,
   useHoverTooltip,
+  TOOLTIP_BOTTOM,
+  TOOLTIP_FIXED,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
 import {
@@ -191,12 +193,12 @@ export const BatchEditMoveLiquid = (
 ): React.Node => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
-    placement: 'top',
-    strategy: 'fixed',
+    placement: TOOLTIP_BOTTOM,
+    strategy: TOOLTIP_FIXED,
   })
   const [saveButtonTargetProps, saveButtonTooltipProps] = useHoverTooltip({
-    placement: 'top',
-    strategy: 'fixed',
+    placement: TOOLTIP_BOTTOM,
+    strategy: TOOLTIP_FIXED,
   })
   const disableSave = !props.batchEditFormHasChanges
 

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -7,7 +7,7 @@ import {
   OutlineButton,
   Tooltip,
   useHoverTooltip,
-  TOOLTIP_BOTTOM,
+  TOOLTIP_TOP,
   TOOLTIP_FIXED,
 } from '@opentrons/components'
 import { i18n } from '../../localization'
@@ -193,11 +193,11 @@ export const BatchEditMoveLiquid = (
 ): React.Node => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
-    placement: TOOLTIP_BOTTOM,
+    placement: TOOLTIP_TOP,
     strategy: TOOLTIP_FIXED,
   })
   const [saveButtonTargetProps, saveButtonTooltipProps] = useHoverTooltip({
-    placement: TOOLTIP_BOTTOM,
+    placement: TOOLTIP_TOP,
     strategy: TOOLTIP_FIXED,
   })
   const disableSave = !props.batchEditFormHasChanges
@@ -216,7 +216,7 @@ export const BatchEditMoveLiquid = (
           />
         </Box>
 
-        <Box textAlign="right" maxWidth="55rem" marginTop="2rem">
+        <Box textAlign="right" maxWidth="55rem" marginTop="3rem">
           <Box
             {...cancelButtonTargetProps}
             marginRight="0.625rem"

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.css
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.css
@@ -2,6 +2,7 @@
 
 .deck_wrapper {
   flex: 1;
+  z-index: -10;
 }
 
 .deck_header {

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.css
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.css
@@ -2,7 +2,6 @@
 
 .deck_wrapper {
   flex: 1;
-  z-index: -10;
 }
 
 .deck_header {


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. Moving the tooltips on the discard/save buttons for batch edit solved the deckmap overlap issue, but created an air gap additional fields overlap. This PR bumps the z-index down so the trash svg in the deckmap no longer conflicts with the save button tooltip. While i was in there I swapped out some strings for some constants regarding tooltip placement.

# Changelog

- fix(protocol-designer): Update cancel/save button tooltip placement
- refactor: Use tooltip constants from complib

# Review requests

- [ ] no more tooltip overlap issues for batch edit cancel/save buttons!

# Risk assessment

low, PD CSS and constants only.
