### PR TITLE
refactor(api): Add todo comments calling out some TransferPlan questions

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -364,6 +364,9 @@ class TransferPlan:
                  volume,
                  sources,
                  dests,
+                 # todo(mm, 2021-03-10):
+                 # Refactor to not need an InstrumentContext, so we can more
+                 # easily test this class's logic on its own.
                  instr: 'InstrumentContext',
                  max_volume: float,
                  api_version: APIVersion,
@@ -546,6 +549,9 @@ class TransferPlan:
         # the other maintains consistency in default behaviors of all functions
         plan_iter = self._expand_for_volume_constraints(
             self._volumes, self._dests,
+            # todo(mm, 2021-03-09): Is it right for this to be
+            # _instr_.max_volume? Does/should this take the tip maximum volume
+            # into account?
             self._instr.max_volume
             - self._strategy.disposal_volume
             - self._strategy.air_gap)
@@ -640,6 +646,9 @@ class TransferPlan:
                .. Aspirate -> .....*
         """
         plan_iter = self._expand_for_volume_constraints(
+            # todo(mm, 2021-03-09): Is it right to use _instr.max_volume here?
+            # Why don't we account for tip max volume, disposal volume, or air
+            # gap?
             self._volumes, self._sources, self._instr.max_volume)
         current_xfer = next(plan_iter)
         if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:


### PR DESCRIPTION
# Overview

This PR carries over some `todo` comments from #6754, which was closed without merging.

The comments point out questionable things that I noticed while working on #6754. CPX might rewrite or heavily rework this code for Protocol Engine, so I felt it was important to retain these notes so we avoid repeating the same mistakes.

# Review requests

* I haven't ticketed any of these todos. It didn't feel worthwhile, because of where https://github.com/Opentrons/opentrons/pull/6754#issuecomment-804499335 ended up: we're probably waiting for a rewrite of this code, anyway. But let me know if you disagree.
* When I wrote these `todo`s, did I miss anything fundamental and obvious that makes them moot?
* Anything else look questionable that we want to call out in this PR?

# Risk assessment

No risk. Comments only.
