### PR TITLE
refactor(api): map physical port names to a more user friendly value

### DIFF
--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -9,20 +9,16 @@ from .types import USBPort
 
 class USBDriverInterface(Protocol):
 
-    _board_revision: BoardRevision
-
     @staticmethod
     def read_bus() -> List[str]:
         ...
 
     @staticmethod
-    def convert_port_path(
-            full_port_path: str,
-            board_revision: BoardRevision) -> USBPort:
+    def read_symlink(virtual_port: str) -> str:
         ...
 
-    @staticmethod
-    def read_symlink(virtual_port: str) -> str:
+    @property
+    def board_revision(self) -> BoardRevision:
         ...
 
     @property

--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -2,18 +2,23 @@ from typing import List, Set
 from typing_extensions import Protocol
 
 from opentrons.hardware_control.modules.types import ModuleAtPort
+from opentrons.hardware_control.types import BoardRevision
 
 from .types import USBPort
 
 
 class USBDriverInterface(Protocol):
 
+    _board_revision: BoardRevision
+
     @staticmethod
     def read_bus() -> List[str]:
         ...
 
     @staticmethod
-    def convert_port_path(full_port_path: str) -> USBPort:
+    def convert_port_path(
+            full_port_path: str,
+            board_revision: BoardRevision) -> USBPort:
         ...
 
     @staticmethod

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -61,19 +61,9 @@ class USBBus(USBDriverInterface):
             pass
         return symlink
 
-    @staticmethod
-    def convert_port_path(
-            full_port_path: str,
-            board_revision: BoardRevision) -> USBPort:
-        """
-        Convert port path.
-
-        Take the value returned from the USB bus and format
-        that information into a dataclass
-        :param full_port_path: The string port path
-        :returns: The USBPort dataclass
-        """
-        return USBPort.build(full_port_path.strip('/'), board_revision)
+    @property
+    def board_revision(self) -> BoardRevision:
+        return self._board_revision
 
     @property
     def usb_dev(self) -> List[USBPort]:
@@ -127,8 +117,9 @@ class USBBus(USBDriverInterface):
             match = USB_PORT_INFO.search(port)
             if match:
                 port_matches.append(
-                    self.convert_port_path(
-                        match.group(0), self._board_revision))
+                    USBPort.build(
+                        match.group(0).strip('/'),
+                        self.board_revision))
         return port_matches
 
     def find_port(self, device_path: str) -> USBPort:

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -30,24 +30,14 @@ class USBBusSimulator(USBDriverInterface):
         return ['']
 
     @staticmethod
-    def convert_port_path(
-            full_port_path: str,
-            board_revision: BoardRevision) -> USBPort:
-        """
-        Convert port path.
-
-        Take the value returned from the USB bus and format
-        that information into a dataclass
-        :param full_port_path: The string port path
-        :returns: The USBPort dataclass
-        """
-        pass
-
-    @staticmethod
     def read_symlink(virtual_port: str) -> str:
         """
         """
         return ''
+
+    @property
+    def board_revision(self) -> BoardRevision:
+        return self._board_revision
 
     @property
     def usb_dev(self) -> List[USBPort]:

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -4,18 +4,20 @@ USB Simulating Driver.
 A class to convert info from the usb bus into a
 more readable format.
 """
-from typing import List, Set
+from typing import List, Set, Union
 
 from opentrons.hardware_control.modules.types import ModuleAtPort
+from opentrons.hardware_control.types import BoardRevision
 
 from .interfaces import USBDriverInterface
 from .types import USBPort
 
 
 class USBBusSimulator(USBDriverInterface):
-    def __init__(self):
+    def __init__(self, board_revision: BoardRevision):
         self._usb_dev: List[USBPort] = self.read_usb_bus()
-        self._sorted = set()
+        self._sorted: Set[Union[int, str]] = set()
+        self._board_revision = board_revision
 
     @staticmethod
     def read_bus() -> List[str]:
@@ -28,7 +30,9 @@ class USBBusSimulator(USBDriverInterface):
         return ['']
 
     @staticmethod
-    def convert_port_path(full_port_path: str) -> USBPort:
+    def convert_port_path(
+            full_port_path: str,
+            board_revision: BoardRevision) -> USBPort:
         """
         Convert port path.
 

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -78,7 +78,7 @@ class Controller:
             config=self.config, gpio_chardev=self._gpio_chardev,
             handle_locks=False)
         self._cached_fw_version: Optional[str] = None
-        self._usb = usb.USBBus()
+        self._usb = usb.USBBus(self._board_revision)
         try:
             self._module_watcher = aionotify.Watcher()
             self._module_watcher.watch(

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -149,7 +149,8 @@ class Simulator:
         self._run_flag.set()
         self._log = MODULE_LOG.getChild(repr(self))
         self._strict_attached = bool(strict_attached_instruments)
-        self._usb = usb_simulator.USBBusSimulator()
+        self._board_revision = BoardRevision.OG
+        self._usb = usb_simulator.USBBusSimulator(self._board_revision)
 
     @property
     def gpio_chardev(self) -> GPIODriverLike:
@@ -302,7 +303,7 @@ class Simulator:
 
     @property
     def board_revision(self) -> BoardRevision:
-        return BoardRevision.OG
+        return self._board_revision
 
     async def update_firmware(self, filename, loop, modeset) -> str:
         return 'Did nothing (simulating)'

--- a/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
@@ -2,98 +2,150 @@ import pytest
 
 from mock import patch, MagicMock
 from opentrons.hardware_control.modules.types import ModuleAtPort
+from opentrons.hardware_control.types import BoardRevision
 from opentrons.drivers.rpi_drivers.usb import USBBus
 from opentrons.drivers.rpi_drivers.types import USBPort
 
-fake_bus = [
+fake_bus_og = [
     '/sys/bus/usb/devices/usb1/dev',
     '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev',
     '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.0/tty/ttyAMA0/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.4/1-1.4/1-1.4.1/1-1.4.1:1.0/tty/ttyAMA1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.4/1-1.4/1-1.4.3/1-1.4.3:1.0/tty/ttyACM2/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev',
     '/sys/bus/usb/devices/usb1/1-1/1-1.3/dev',
     '/sys/bus/usb/devices/usb1/1-1/1-1.1/dev',
     '/sys/bus/usb/devices/usb1/1-1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.4/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.4/1-1.4:1.2/0003:046D:C52B.0017/hidraw/hidraw0/dev',  # NOQA
-    '/sys/bus/usb/devices/usb1/1-1/1-1.4/1-1.4:1.2/usbmisc/hiddev0/dev'
+    '/sys/bus/usb/devices/usb1/1-1/1-1.5/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/0003:046D:C52B.0017/hidraw/hidraw0/dev',  # NOQA
+    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/usbmisc/hiddev0/dev'
 ]
 
-filtered_ports = [
+filtered_ports_og = [
     '1-1.3/1-1.3:1.0/tty/ttyACM1/dev',
     '1-1.5/1-1.5:1.0/tty/ttyAMA0/dev',
-    '1-1.4/1-1.4/1-1.4.1/1-1.4.1:1.0/tty/ttyAMA1/dev',
-    '1-1.4/1-1.4/1-1.4.3/1-1.4.3:1.0/tty/ttyACM2/dev'
+    '1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev',
+    '1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev'
+]
+
+fake_bus_refresh = [
+    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.3/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev',
+    '/sys/bus/usb/devices/usb1/1-1/1-1.1/dev',
+    '/sys/bus/usb/devices/usb1/1-1/dev'
+]
+
+filtered_port_refresh = [
+    '1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev',
+    '1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev'
 ]
 
 
 @pytest.fixture
-def usb_class() -> USBBus:
+def usb_bus() -> USBBus:
 
     @staticmethod
     def fake_read_bus():
-        return fake_bus
+        return fake_bus_og
 
     with patch.object(USBBus, 'read_bus', fake_read_bus):
-        yield USBBus()
+        yield USBBus(BoardRevision.OG)
 
 
-def test_usb_list_output(usb_class: USBBus) -> None:
-    expected_ports = [USBPort.build(p) for p in filtered_ports]
-    assert usb_class.usb_dev == expected_ports
+@pytest.fixture(params=[BoardRevision.OG, BoardRevision.A])
+def usb_revision(request) -> USBBus:
+    revision = request.param
+
+    @staticmethod
+    def fake_read_bus():
+        if revision == BoardRevision.OG:
+            return fake_bus_og
+        else:
+            return fake_bus_refresh
+
+    with patch.object(USBBus, 'read_bus', fake_read_bus):
+        yield USBBus(revision)
+
+
+def test_usb_list_output(usb_revision) -> None:
+    if usb_revision._board_revision == BoardRevision.OG:
+        filtered = filtered_ports_og
+    else:
+        filtered = filtered_port_refresh
+    expected_ports = [
+        USBPort.build(p, usb_revision._board_revision)
+        for p in filtered]
+    assert usb_revision.usb_dev == expected_ports
     regular_port = expected_ports[0]
-    hub_port = expected_ports[2]
 
-    assert regular_port.name == '1-1.3'
-    assert regular_port.hub is None
-    assert regular_port.sub_names == []
-    assert hub_port.name == '1-1.4.1'
-    assert hub_port.hub == 4
-    assert hub_port.sub_names == []
+    if usb_revision._board_revision == BoardRevision.OG:
+        assert regular_port.name == '1-1.3'
+        assert regular_port.hub is None
+        assert regular_port.port_number == 1
+        assert regular_port.sub_names == []
+
+        hub_port = expected_ports[2]
+        assert hub_port.name == '1-1.5.1'
+        assert hub_port.hub == 2
+        assert hub_port.port_number == 1
+        assert hub_port.sub_names == []
+    else:
+        regular_port2 = expected_ports[1]
+        assert regular_port.name == '1-1.3.1'
+        assert regular_port.hub is None
+        assert regular_port.port_number == 1
+
+        assert regular_port2.name == '1-1.3.2'
+        assert regular_port2.hub is None
+        assert regular_port2.port_number == 2
 
 
-def test_find_device(usb_class: USBBus) -> None:
+def test_find_device(usb_bus: USBBus) -> None:
     device_paths = [
         '/tty/ttyACM1/dev',
         '/tty/ttyAMA1/dev',
         '/tty/ttyAMA0/dev']
     for dp in device_paths:
-        port = usb_class.find_port(dp)
-        assert port in usb_class.usb_dev
+        port = usb_bus.find_port(dp)
+        assert port in usb_bus.usb_dev
 
 
-def test_unplug_device(usb_class: USBBus) -> None:
+def test_unplug_device(usb_bus: USBBus) -> None:
     import copy
 
-    copy_bus = copy.copy(fake_bus)
-    copy_ports = copy.copy(filtered_ports)
+    copy_bus = copy.copy(fake_bus_og)
+    copy_ports = copy.copy(filtered_ports_og)
     u = '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev'
     copy_bus.remove(u)
     copy_ports.remove('1-1.3/1-1.3:1.0/tty/ttyACM1/dev')
 
-    usb_class.read_bus = MagicMock(return_value=copy_bus)
-    usb_class.sort_ports()
+    usb_bus.read_bus = MagicMock(return_value=copy_bus)
+    usb_bus.sort_ports()
 
-    expected_ports = [USBPort.build(p) for p in copy_ports]
-    assert usb_class.usb_dev == expected_ports
-
-
-def test_sorted_usb_class(usb_class: USBBus) -> None:
-    expected_sorted = {'1-1.3', '1-1.4.1', '1-1.4.3', '1-1.5'}
-    assert usb_class.sorted_ports == expected_sorted
+    expected_ports = [
+        USBPort.build(p, usb_bus._board_revision)
+        for p in copy_ports]
+    assert usb_bus.usb_dev == expected_ports
 
 
-def test_modify_module_list(usb_class: USBBus):
-    usb_class.read_symlink = MagicMock(return_value='ttyACM1')
+def test_sorted_usb_bus(usb_bus: USBBus) -> None:
+    expected_sorted = {'1-1.3', '1-1.5.1', '1-1.5.3', '1-1.5'}
+    assert usb_bus.sorted_ports == expected_sorted
+
+
+def test_modify_module_list(usb_bus: USBBus):
+    usb_bus.read_symlink = MagicMock(return_value='ttyACM1')
     mod_at_port_list = [ModuleAtPort(
         name='temperature module',
         port='dev/ot_module_temperature_module')]
-    updated_list = usb_class.match_virtual_ports(mod_at_port_list)
-    assert updated_list[0].usb_port == usb_class.usb_dev[0]
+    updated_list = usb_bus.match_virtual_ports(mod_at_port_list)
+    assert updated_list[0].usb_port == usb_bus.usb_dev[0]
 
-    usb_class.read_symlink = MagicMock(return_value='ttyACM2')
+    usb_bus.read_symlink = MagicMock(return_value='ttyACM2')
     mod_at_port_list = [ModuleAtPort(
         name='magnetic module',
         port='dev/ot_module_magnetic_module')]
-    updated_list = usb_class.match_virtual_ports(mod_at_port_list)
-    assert updated_list[0].usb_port == usb_class.usb_dev[3]
+    updated_list = usb_bus.match_virtual_ports(mod_at_port_list)
+    assert updated_list[0].usb_port == usb_bus.usb_dev[3]


### PR DESCRIPTION
# Overview
Unfortunately, the raspberry pi's exposed usb ports are not numbered 1, 2, 3 etc. Instead, on the non-refresh robots the exposed ports are 3 and 5 respectively which will be converted to port 1 & 2. On the refresh robots, the exposed ports are a usb hub connected to port 3 of the robot -- in this case the hub will be ignored and only the port values used (which do happen to be labeled 1->4).

# Changelog

- Create a map in `USBPort` to convert port names depending the board revision
- Add the board revision to the usb bus driver

# Review requests

Test on a robot using @ahiuchingau's PRs.

# Risk assessment

Low, mapping numbers.
