### PR TITLE
refactor(protocol-designer): add selectors for e2e tests

### DIFF
--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.js
@@ -108,6 +108,7 @@ export const StepSelectionBannerComponent = (
                 marginLeft="0.5rem"
                 fontWeight={FONT_WEIGHT_SEMIBOLD}
                 textTransform={TEXT_TRANSFORM_UPPERCASE}
+                id="StepSelectionBannerComponent_numberStepsSelected"
               >
                 {i18n.t('application.n_steps_selected', { n: numSteps })}
               </Text>

--- a/protocol-designer/src/components/steplist/SubstepRow.js
+++ b/protocol-designer/src/components/steplist/SubstepRow.js
@@ -138,13 +138,19 @@ function SubstepRowComponent(props: SubstepRowProps) {
           ingreds={compactedSourcePreIngreds}
         />
 
-        <span className={styles.emphasized_cell}>
+        <span
+          className={styles.emphasized_cell}
+          data-test="SubstepRow_aspirateWell"
+        >
           {props.source && props.source.well}
         </span>
-        <span className={styles.volume_cell}>{`${formatVolume(
-          props.volume
-        )} μL`}</span>
-        <span className={styles.emphasized_cell}>
+        <span className={styles.volume_cell} data-test="SubstepRow_volume">
+          {`${formatVolume(props.volume)} μL`}
+        </span>
+        <span
+          className={styles.emphasized_cell}
+          data-test="SubstepRow_dispenseWell"
+        >
           {props.dest && props.dest.well}
         </span>
 


### PR DESCRIPTION
# Overview / Changelog

Some new selectors for @reachojhaneha ! Serves as its own ticket.

- Add SubstepRow_aspirateWell, SubstepRow_volume, and SubstepRow_dispenseWell data-test attrs
- Add StepSelectionBannerComponent_numberStepsSelected id

# Review requests

- The 3 data-test selectors should be available on substeps
- `StepSelectionBannerComponent_numberStepsSelected` should select the element containing the "N STEPS SELECTED" in multi-select mode

# Risk assessment

Low, PD-only, just adding attrs