### PR TITLE
refactor(protocol-designer): remove deprecated HoverTooltip from PD

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/VolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/VolumeField.js
@@ -1,6 +1,12 @@
 // @flow
 import * as React from 'react'
-import { FormGroup, HoverTooltip } from '@opentrons/components'
+import {
+  FormGroup,
+  Tooltip,
+  useHoverTooltip,
+  TOOLTIP_TOP,
+  TOOLTIP_FIXED,
+} from '@opentrons/components'
 import { i18n } from '../../../localization'
 import { getFieldDefaultTooltip } from '../utils'
 import { TextField } from './TextField'
@@ -16,26 +22,23 @@ type Props = {|
 |}
 export const VolumeField = (props: Props): React.Node => {
   const { stepType, label, className, ...propsForVolumeField } = props
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_TOP,
+    strategy: TOOLTIP_FIXED,
+  })
 
-  // TODO(IL, 2021-02-08): use the useHoverTooltip hook instead of deprecated HoverTooltip (see #7295)
   return (
-    <HoverTooltip
-      tooltipComponent={getFieldDefaultTooltip(propsForVolumeField.name)}
-      placement="top-start"
-    >
-      {hoverTooltipHandlers => (
-        <FormGroup
-          label={label}
-          className={className}
-          hoverTooltipHandlers={hoverTooltipHandlers}
-        >
-          <TextField
-            {...propsForVolumeField}
-            className={styles.small_field}
-            units={i18n.t('application.units.microliter')}
-          />
-        </FormGroup>
-      )}
-    </HoverTooltip>
+    <div {...targetProps}>
+      <Tooltip {...tooltipProps}>
+        {getFieldDefaultTooltip(propsForVolumeField.name)}
+      </Tooltip>
+      <FormGroup label={label} className={className}>
+        <TextField
+          {...propsForVolumeField}
+          className={styles.small_field}
+          units={i18n.t('application.units.microliter')}
+        />
+      </FormGroup>
+    </div>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
+++ b/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import { IconButton, HoverTooltip } from '@opentrons/components'
+import { IconButton, Tooltip, useHoverTooltip } from '@opentrons/components'
 import { i18n } from '../../../localization'
 import styles from '../StepEditForm.css'
 
@@ -14,29 +14,28 @@ type Props = {
 
 export const AspDispSection = (props: Props): React.Node => {
   const { children, className, collapsed, toggleCollapsed, prefix } = props
-
+  const [targetProps, tooltipProps] = useHoverTooltip()
   return (
     <div className={className}>
       <div className={styles.section_header}>
         <span className={styles.section_header_text}>{prefix}</span>
-        <HoverTooltip
+        <Tooltip
+          {...tooltipProps}
           key={collapsed ? 'collapsed' : 'expanded'} // NOTE: without this key, the IconButton will not re-render unless clicked
-          tooltipComponent={i18n.t('tooltip.advanced_settings')}
         >
-          {hoverTooltipHandlers => (
-            <div
-              {...hoverTooltipHandlers}
-              onClick={toggleCollapsed}
-              className={styles.advanced_settings_button_wrapper}
-            >
-              <IconButton
-                className={styles.advanced_settings_button}
-                name="settings"
-                hover={!collapsed}
-              />
-            </div>
-          )}
-        </HoverTooltip>
+          {i18n.t('tooltip.advanced_settings')}
+        </Tooltip>
+        <div
+          {...targetProps}
+          onClick={toggleCollapsed}
+          className={styles.advanced_settings_button_wrapper}
+        >
+          <IconButton
+            className={styles.advanced_settings_button}
+            name="settings"
+            hover={!collapsed}
+          />
+        </div>
       </div>
       {children}
     </div>

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.js
@@ -4,7 +4,13 @@ import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { selectors as uiModuleSelectors } from '../../../ui/modules'
 
-import { FormGroup, HoverTooltip } from '@opentrons/components'
+import {
+  FormGroup,
+  useHoverTooltip,
+  Tooltip,
+  TOOLTIP_BOTTOM,
+  TOOLTIP_FIXED,
+} from '@opentrons/components'
 import { i18n } from '../../../localization'
 import {
   PAUSE_UNTIL_RESUME,
@@ -17,10 +23,6 @@ import styles from '../StepEditForm.css'
 
 import type { StepFormProps } from '../types'
 
-const PauseUntilTempTooltip = () => (
-  <div>{getSingleSelectDisabledTooltip('wait_until_temp', 'pauseAction')}</div>
-)
-
 export const PauseForm = (props: StepFormProps): React.Node => {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
@@ -29,6 +31,11 @@ export const PauseForm = (props: StepFormProps): React.Node => {
   const pauseUntilTempEnabled = useSelector(
     uiModuleSelectors.getTempModuleIsOnDeck
   )
+
+  const [targetProps, tooltipProps] = useHoverTooltip({
+    placement: TOOLTIP_BOTTOM,
+    strategy: TOOLTIP_FIXED,
+  })
 
   const { propsForFields } = props
   const { pauseAction } = props.formData
@@ -89,58 +96,54 @@ export const PauseForm = (props: StepFormProps): React.Node => {
             </div>
           )}
 
-          <HoverTooltip
-            placement="bottom"
-            tooltipComponent={
-              pauseUntilTempEnabled ? null : <PauseUntilTempTooltip />
-            }
-          >
-            {hoverTooltipHandlers => (
-              <div {...hoverTooltipHandlers}>
-                <div className={styles.checkbox_row}>
-                  <RadioGroupField
-                    {...propsForFields['pauseAction']}
-                    className={cx({
-                      [styles.disabled]: !pauseUntilTempEnabled,
-                    })}
-                    options={[
-                      {
-                        name: i18n.t(
-                          'form.step_edit_form.field.pauseAction.options.untilTemperature'
-                        ),
-                        value: PAUSE_UNTIL_TEMP,
-                      },
-                    ]}
+          {pauseUntilTempEnabled ? null : (
+            <Tooltip {...tooltipProps}>
+              {getSingleSelectDisabledTooltip('wait_until_temp', 'pauseAction')}
+            </Tooltip>
+          )}
+          <div {...targetProps}>
+            <div className={styles.checkbox_row}>
+              <RadioGroupField
+                {...propsForFields['pauseAction']}
+                className={cx({
+                  [styles.disabled]: !pauseUntilTempEnabled,
+                })}
+                options={[
+                  {
+                    name: i18n.t(
+                      'form.step_edit_form.field.pauseAction.options.untilTemperature'
+                    ),
+                    value: PAUSE_UNTIL_TEMP,
+                  },
+                ]}
+              />
+            </div>
+            {pauseAction === PAUSE_UNTIL_TEMP && (
+              <div className={styles.form_row}>
+                <FormGroup
+                  label={i18n.t(
+                    'form.step_edit_form.field.moduleActionLabware.label'
+                  )}
+                >
+                  <StepFormDropdown
+                    {...propsForFields['moduleId']}
+                    options={moduleLabwareOptions}
                   />
-                </div>
-                {pauseAction === PAUSE_UNTIL_TEMP && (
-                  <div className={styles.form_row}>
-                    <FormGroup
-                      label={i18n.t(
-                        'form.step_edit_form.field.moduleActionLabware.label'
-                      )}
-                    >
-                      <StepFormDropdown
-                        {...propsForFields['moduleId']}
-                        options={moduleLabwareOptions}
-                      />
-                    </FormGroup>
-                    <FormGroup
-                      label={i18n.t(
-                        'form.step_edit_form.field.pauseTemperature.label'
-                      )}
-                    >
-                      <TextField
-                        {...propsForFields['pauseTemperature']}
-                        className={styles.small_field}
-                        units={i18n.t('application.units.degrees')}
-                      />
-                    </FormGroup>
-                  </div>
-                )}
+                </FormGroup>
+                <FormGroup
+                  label={i18n.t(
+                    'form.step_edit_form.field.pauseTemperature.label'
+                  )}
+                >
+                  <TextField
+                    {...propsForFields['pauseTemperature']}
+                    className={styles.small_field}
+                    units={i18n.t('application.units.degrees')}
+                  />
+                </FormGroup>
               </div>
             )}
-          </HoverTooltip>
+          </div>
         </div>
         <div className={styles.section_column}>
           <div className={styles.form_row}>


### PR DESCRIPTION
# Overview

Closes #7295 -- removes last instances of `HoverTooltip` component from PD

# Changelog


# Review requests

Compare vs prod (or edge): the 3 component tooltips should look the same:
- Volume field
- Advanced settings cog button (part of AspDispSection)
- Pause form's "Pause until temperature reached" button row -- like prod, should only show tooltip when the option is disabled (it is disabled when there's no temperature module, and the tooltip explains that)

# Risk assessment

Low, PD-only
