### PR TITLE
refactor(components): remove unused tooltip prop from CheckboxField

### DIFF
--- a/components/flow-types/forms/CheckboxField.js.flow
+++ b/components/flow-types/forms/CheckboxField.js.flow
@@ -5,8 +5,7 @@
  * @flow
  */
 
-import * as React from "react";
-import type { HoverTooltipHandlers } from "../tooltips";
+import * as React from 'react'
 export type CheckboxFieldProps = {|
   /**
    * change handler
@@ -56,16 +55,11 @@ export type CheckboxFieldProps = {|
   /**
    * props passed into label div. TODO IMMEDIATELY what is the Flow type?
    */
-  labelProps?: React.ComponentProps<"div">,
-
-  /**
-   * handlers for HoverTooltipComponent
-   */
-  hoverTooltipHandlers?: HoverTooltipHandlers | null | void,
+  labelProps?: React.ComponentProps<'div'>,
 
   /**
    * if true, render indeterminate icon
    */
   isIndeterminate?: boolean,
-|};
-declare export function CheckboxField(props: CheckboxFieldProps): React$Node;
+|}
+declare export function CheckboxField(props: CheckboxFieldProps): React$Node

--- a/components/flow-types/forms/CheckboxField.js.flow
+++ b/components/flow-types/forms/CheckboxField.js.flow
@@ -5,7 +5,7 @@
  * @flow
  */
 
-import * as React from 'react'
+import * as React from "react";
 export type CheckboxFieldProps = {|
   /**
    * change handler
@@ -55,11 +55,11 @@ export type CheckboxFieldProps = {|
   /**
    * props passed into label div. TODO IMMEDIATELY what is the Flow type?
    */
-  labelProps?: React.ComponentProps<'div'>,
+  labelProps?: React.ComponentProps<"div">,
 
   /**
    * if true, render indeterminate icon
    */
   isIndeterminate?: boolean,
-|}
-declare export function CheckboxField(props: CheckboxFieldProps): React$Node
+|};
+declare export function CheckboxField(props: CheckboxFieldProps): React$Node;

--- a/components/src/forms/CheckboxField.tsx
+++ b/components/src/forms/CheckboxField.tsx
@@ -3,7 +3,6 @@ import cx from 'classnames'
 import { Icon } from '../icons'
 
 import styles from './forms.css'
-import type { HoverTooltipHandlers } from '../tooltips'
 
 export interface CheckboxFieldProps {
   /** change handler */
@@ -26,8 +25,6 @@ export interface CheckboxFieldProps {
   tabIndex?: number
   /** props passed into label div. TODO IMMEDIATELY what is the Flow type? */
   labelProps?: React.ComponentProps<'div'>
-  /** handlers for HoverTooltipComponent */
-  hoverTooltipHandlers?: HoverTooltipHandlers | null | undefined
   /** if true, render indeterminate icon */
   isIndeterminate?: boolean
 }


### PR DESCRIPTION
# Overview

Closes #7307 -- this prop is never used in `CheckboxField`

# Changelog


# Review requests

- I manually updated the flow def, looks ok?
- Code review

# Risk assessment

Low, shouldn't affect anything