### PR TITLE
refactor(protocol-designer): make nestedCombineReducers validate on init

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.js
+++ b/protocol-designer/src/step-forms/reducers/index.js
@@ -47,6 +47,7 @@ import {
   createInitialProfileStep,
 } from '../utils/createInitialProfileItems'
 import { getLabwareOnModule } from '../../ui/modules/utils'
+import { nestedCombineReducers } from './nestedCombineReducers'
 import { PROFILE_CYCLE, PROFILE_STEP } from '../../form-types'
 import type { Reducer } from 'redux'
 import type { LoadFileAction } from '../../load-file'
@@ -1373,9 +1374,8 @@ export type RootState = {
 // TODO Ian 2018-12-13: find some existing util to do this
 // semi-nested version of combineReducers?
 // TODO: Ian 2018-12-13 remove this 'action: any' type
-export const rootReducer: Reducer<RootState, any> = (state, action) => {
-  const prevStateFallback = state || {}
-  const nextState = {
+export const rootReducer: Reducer<RootState, any> = nestedCombineReducers(
+  ({ action, state, prevStateFallback }) => ({
     orderedStepIds: orderedStepIds(prevStateFallback.orderedStepIds, action),
     labwareInvariantProperties: labwareInvariantProperties(
       prevStateFallback.labwareInvariantProperties,
@@ -1403,15 +1403,5 @@ export const rootReducer: Reducer<RootState, any> = (state, action) => {
       prevStateFallback.batchEditFormChanges,
       action
     ),
-  }
-  if (
-    state &&
-    Object.keys(nextState).every(
-      stateKey => state[stateKey] === nextState[stateKey]
-    )
-  ) {
-    // no change
-    return state
-  }
-  return nextState
-}
+  })
+)

--- a/protocol-designer/src/step-forms/reducers/nestedCombineReducers.js
+++ b/protocol-designer/src/step-forms/reducers/nestedCombineReducers.js
@@ -1,0 +1,76 @@
+// @flow
+import type { Reducer } from 'redux'
+
+export type GetNextState = ({|
+  action: Object,
+  state: Object,
+  prevStateFallback: Object,
+|}) => Object
+
+export type NestedCombineReducers<T, A> = (
+  getNextState: GetNextState
+) => Reducer<T, A>
+
+// an arbitrary used to test for initialization
+const FAKE_INIT_ACTION = '@@redux/INITnestedCombineReducers'
+
+const getUndefinedStateErrorMessage = (key: string, action: Object) => {
+  const actionType = action && action.type
+  const actionDescription =
+    (actionType && `action "${String(actionType)}"`) || 'an action'
+
+  return (
+    `Given ${actionDescription}, reducer "${key}" returned undefined. ` +
+    `To ignore an action, you must explicitly return the previous state. ` +
+    `If you want this reducer to hold no value, you can return null instead of undefined.`
+  )
+}
+
+const assertReducerShape = (getNextState: GetNextState): void => {
+  const initialState = getNextState({
+    action: FAKE_INIT_ACTION,
+    state: undefined,
+    prevStateFallback: {},
+  })
+  Object.keys(initialState).forEach(key => {
+    if (typeof initialState[key] === 'undefined') {
+      throw new Error(
+        `Reducer "${key}" returned undefined during initialization. ` +
+          `If the state passed to the reducer is undefined, you must ` +
+          `explicitly return the initial state. The initial state may ` +
+          `not be undefined. If you don't want to set a value for this reducer, ` +
+          `you can use null instead of undefined.`
+      )
+    }
+  })
+}
+
+export const nestedCombineReducers: NestedCombineReducers<
+  any,
+  any
+> = getNextState => {
+  assertReducerShape(getNextState)
+
+  return (state, action) => {
+    const prevStateFallback = state || {}
+    const nextState = getNextState({ action, state, prevStateFallback })
+
+    // error if any reducers return undefined, just like redux combineReducers
+    Object.keys(nextState).forEach(key => {
+      const nextStateForKey = nextState[key]
+      if (typeof nextStateForKey === 'undefined') {
+        const errorMessage = getUndefinedStateErrorMessage(key, action)
+        throw new Error(errorMessage)
+      }
+    })
+
+    if (
+      state &&
+      Object.keys(nextState).every(key => state[key] === nextState[key])
+    ) {
+      // no change
+      return state
+    }
+    return nextState
+  }
+}

--- a/protocol-designer/src/step-forms/test/nestedCombineReducers.test.js
+++ b/protocol-designer/src/step-forms/test/nestedCombineReducers.test.js
@@ -67,7 +67,7 @@ describe('nestedCombineReducers', () => {
   it('should throw an error when any sub-reducer returns undefined', () => {
     // counts total fruits added, but we "accidentally" return undefined for any other actions
     const badCountReducer = (state, action) => {
-      if (typeof state === 'undefined') {
+      if (state === undefined) {
         // weird way to initialize, but otherwise this will fail b/c
         // the reducer initializes to undefined
         // (which we'll test for separately!)
@@ -76,7 +76,9 @@ describe('nestedCombineReducers', () => {
       if (action.type === 'ADD_FRUIT') {
         return state + 1
       }
-      // intentionally missing `return state` here
+      // should be `return state` here, but we're pretending we made a mistake writing this reducer
+      // and omitted `return state`, which would mean implicitly returning undefined
+      return undefined
     }
 
     const badCombinedReducer = nestedCombineReducers(

--- a/protocol-designer/src/step-forms/test/nestedCombineReducers.test.js
+++ b/protocol-designer/src/step-forms/test/nestedCombineReducers.test.js
@@ -1,0 +1,129 @@
+// @flow
+import { nestedCombineReducers } from '../reducers/nestedCombineReducers'
+
+// typical reducer, only gets its own substate
+const fruits = (state = [], action) => {
+  if (action.type === 'ADD_FRUIT') {
+    return [...state, action.payload]
+  }
+  return state
+}
+
+// "top-level" reducer, gets whole nestedCombineReducers state
+const warnings = (rootState, action) => {
+  const substate = rootState?.warnings || {}
+  if (action.type === 'ADD_FRUIT' && action.payload === 'durian') {
+    return { ...substate, durianWarning: 'Oh no not a durian' }
+  }
+  return substate
+}
+
+describe('nestedCombineReducers', () => {
+  const combinedReducer = nestedCombineReducers(
+    ({ action, state, prevStateFallback }) => ({
+      // fruits only gets its own state (always from prevStateFallback)
+      fruits: fruits(prevStateFallback.fruits, action),
+      // warnings gets the full state
+      warnings: warnings(state, action),
+    })
+  )
+
+  it('should populate with initial undefined state (unhandled action)', () => {
+    const result = combinedReducer(undefined, { type: 'FOO_WHATEVER_ACTION' })
+    expect(result).toStrictEqual({ fruits: [], warnings: {} })
+  })
+
+  it('should populate with initial undefined state (handled action)', () => {
+    const result = combinedReducer(undefined, {
+      type: 'ADD_FRUIT',
+      payload: 'durian',
+    })
+    expect(result).toEqual({
+      fruits: ['durian'],
+      warnings: { durianWarning: 'Oh no not a durian' },
+    })
+  })
+
+  it('should update the previous state according to the getNextState callback', () => {
+    const prevState = { fruits: ['banana'], warnings: {} }
+
+    const result = combinedReducer(prevState, {
+      type: 'ADD_FRUIT',
+      payload: 'durian',
+    })
+    expect(result).toEqual({
+      fruits: ['banana', 'durian'],
+      warnings: { durianWarning: 'Oh no not a durian' },
+    })
+  })
+
+  it('should return the same state when no reducers have updated', () => {
+    const prevState = { fruits: ['banana'], warnings: {} }
+
+    const result = combinedReducer(prevState, { type: 'NO_OP_ACTION_EXAMPLE' })
+    expect(result).toStrictEqual(prevState)
+  })
+
+  it('should throw an error when any sub-reducer returns undefined', () => {
+    // counts total fruits added, but we "accidentally" return undefined for any other actions
+    const badCountReducer = (state, action) => {
+      if (typeof state === 'undefined') {
+        // weird way to initialize, but otherwise this will fail b/c
+        // the reducer initializes to undefined
+        // (which we'll test for separately!)
+        return 0
+      }
+      if (action.type === 'ADD_FRUIT') {
+        return state + 1
+      }
+      // intentionally missing `return state` here
+    }
+
+    const badCombinedReducer = nestedCombineReducers(
+      ({ action, state, prevStateFallback }) => ({
+        // fruits only gets its own state (always from prevStateFallback)
+        fruits: fruits(prevStateFallback.fruits, action),
+        // warnings gets the full state
+        warnings: warnings(state, action),
+        badCountReducer: badCountReducer(
+          prevStateFallback.badCountReducer,
+          action
+        ),
+      })
+    )
+
+    expect(() => {
+      badCombinedReducer(
+        { fruits: [], warnings: {}, badCountReducer: 0 },
+        { type: 'UNHANDLED_ACTION', payload: 'foo' }
+      )
+    }).toThrowError(
+      'Given action "UNHANDLED_ACTION", reducer "badCountReducer" returned undefined. To ignore an action, you must explicitly return the previous state. If you want this reducer to hold no value, you can return null instead of undefined.'
+    )
+  })
+
+  it('should throw an error when any sub-reducer initializes to undefined', () => {
+    // counts fruits added, but we "forgot" to give it an initial state
+    const badCountReducer = (state, action) => {
+      if (action.type === 'ADD_FRUIT') {
+        return state + 1
+      }
+      return state
+    }
+
+    expect(() => {
+      // note that we're asserting on the factory call, it errors before
+      // we even get to the first actual action
+      nestedCombineReducers(({ action, state, prevStateFallback }) => ({
+        fruits: fruits(prevStateFallback.fruits, action),
+        warnings: warnings(state, action),
+        badCountReducer: badCountReducer(
+          prevStateFallback.badCountReducer,
+          action
+        ),
+      }))
+    }).toThrowError(
+      `Reducer "badCountReducer" returned undefined during initialization. If the state passed to the reducer is undefined, you must explicitly return the initial state. The initial state may not be undefined. If you don't want to set a value for this reducer, you can use null instead of undefined.`
+    )
+  })
+})


### PR DESCRIPTION
# Overview

Closes #7348

The idea is to match some of the developer validation as in https://github.com/reduxjs/redux/blob/master/src/combineReducers.ts

# Changelog


# Review requests

- [ ] Code review (esp tests)
- [ ] Ensure step-forms functionality doesn't have regressions

# Risk assessment

Low, PD-only, should be pure refactor