### PR TITLE
fix(api): represent Location correctly in log

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -135,6 +135,9 @@ class Location:
         return Location(point=self.point + point,
                         labware=self._labware.object)
 
+    def __repr__(self) -> str:
+        return f"Location(point={repr(self._point)}, labware={self._labware})"
+
 
 # TODO(mc, 2020-10-22): use MountType implementation for Mount
 class Mount(enum.Enum):

--- a/api/tests/opentrons/test_types.py
+++ b/api/tests/opentrons/test_types.py
@@ -1,5 +1,5 @@
 import pytest
-from opentrons.types import Point
+from opentrons.types import Point, Location
 
 
 def test_point_mul():
@@ -21,3 +21,24 @@ def test_point_rmul():
 
     b = 3.1
     assert b * a == Point(3.1, 6.2, 9.3)
+
+
+def test_location_repr_labware(min_lw):
+    """It should represent labware as Labware"""
+    loc = Location(point=Point(x=1.1, y=2.1, z=3.5), labware=min_lw)
+    assert f'{loc}' ==\
+           "Location(point=Point(x=1.1, y=2.1, z=3.5), labware=minimal labware on deck)"
+
+
+def test_location_repr_well(min_lw):
+    """It should represent labware as Well"""
+    loc = Location(point=Point(x=1, y=2, z=3), labware=min_lw.wells()[0])
+    assert f'{loc}' == \
+           "Location(point=Point(x=1, y=2, z=3), labware=A1 of minimal labware on deck)"
+
+
+def test_location_repr_slot():
+    """It should represent labware as a slot"""
+    loc = Location(point=Point(x=-1, y=2, z=3), labware="1")
+    assert f'{loc}' == \
+           "Location(point=Point(x=-1, y=2, z=3), labware=1)"


### PR DESCRIPTION
# Overview

Location used to be a namedtuple instead of a class. There's no __repr__ function so Location objects are meaningless in run logging.

closes #7564 

# Changelog

Implement __repr__ for Location class with tests

# Review requests


# Risk assessment

Low