### PR TITLE
docs(robot-server): Fix swapped summaries and descriptions

### DIFF
--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -101,10 +101,10 @@ def _check_parent(
 
 
 @router.get("/labware/calibrations",
-            description="Fetch all saved labware calibrations from the robot",
-            summary="Search the robot for any saved labware offsets"
-                    "which allows you to check whether a particular"
-                    "labware has been calibrated or not.",
+            summary="Fetch all saved labware calibrations from the robot",
+            description="Search the robot for any saved labware offsets "
+                        "which allows you to check whether a particular "
+                        "labware has been calibrated or not.",
             response_model=lw_models.MultipleCalibrationsResponse)
 async def get_all_labware_calibrations(
         loadName: str = None,

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -14,11 +14,11 @@ router = APIRouter()
             response_model=Health,
             summary="Retrieve some useful information about supported API "
                     "versions, names, and so on",
-            description="The /health endpoint is a good one to check to see if "
-                        "you're communicating with an OT-2 with a properly booted "
-                        "API server. If it returns OK, all is well. It also can "
-                        "be used to pull information like the robot software "
-                        "version and name.",
+            description="The /health endpoint is a good one to check to see "
+                        "if you're communicating with an OT-2 with a properly "
+                        "booted API server. If it returns OK, all is well. "
+                        "It also can be used to pull information like the "
+                        "robot software version and name.",
             response_description="OT-2 /health response")
 async def get_health(
         hardware: ThreadManager = Depends(get_hardware)) -> Health:

--- a/robot-server/robot_server/service/legacy/routers/health.py
+++ b/robot-server/robot_server/service/legacy/routers/health.py
@@ -12,13 +12,13 @@ router = APIRouter()
 
 @router.get("/health",
             response_model=Health,
-            description="Retrieve some useful information about supported API "
-                        "versions, names, and so on",
-            summary="The /health endpoint is a good one to check to see if "
-                    "you're communicating with an OT-2 with a properly booted "
-                    "API server. If it returns OK, all is well. It also can "
-                    "be used to pull information like the robot software "
-                    "version and name.",
+            summary="Retrieve some useful information about supported API "
+                    "versions, names, and so on",
+            description="The /health endpoint is a good one to check to see if "
+                        "you're communicating with an OT-2 with a properly booted "
+                        "API server. If it returns OK, all is well. It also can "
+                        "be used to pull information like the robot software "
+                        "version and name.",
             response_description="OT-2 /health response")
 async def get_health(
         hardware: ThreadManager = Depends(get_hardware)) -> Health:

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -43,9 +43,9 @@ async def get_modules(hardware: ThreadManager = Depends(get_hardware))\
 
 
 @router.get("/modules/{serial}/data",
-            description="Get live data for a specific module",
-            summary="This is similar to the values in GET /modules, but for "
-                    "only a specific currently-attached module",
+            summary="Get live data for a specific module",
+            description="This is similar to the values in GET /modules, but "
+                        "for only a specific currently-attached module",
             response_model=ModuleSerial,
             responses={status.HTTP_404_NOT_FOUND: {"model": V1BasicResponse}}
             )
@@ -74,10 +74,11 @@ async def get_module_serial(
 
 
 @router.post("/modules/{serial}",
-             description="Execute a command on a specific module",
-             summary="Command a module to take an action. Valid actions depend"
-                     " on the specific module attached, which is the model "
-                     "value from GET /modules/{serial}/data or GET /modules",
+             summary="Execute a command on a specific module",
+             description="Command a module to take an action. Valid actions "
+                         "depend on the specific module attached, which is "
+                         "the model value from GET /modules/{serial}/data or "
+                         "GET /modules",
              response_model=SerialCommandResponse,
              responses={
                  status.HTTP_404_NOT_FOUND: {"model": V1BasicResponse}
@@ -124,9 +125,9 @@ async def post_serial_command(
 
 
 @router.post("/modules/{serial}/update",
-             description="Initiate a firmware update on a specific module",
-             summary="Command robot to flash its bundled firmware file for "
-                     "this module's type to this specific module",
+             summary="Initiate a firmware update on a specific module",
+             description="Command robot to flash its bundled firmware file "
+                         "for this module's type to this specific module",
              response_model=V1BasicResponse,
              responses={status.HTTP_404_NOT_FOUND: {"model": V1BasicResponse}}
              )

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -22,10 +22,10 @@ router = APIRouter()
 
 
 @router.get("/networking/status",
-            description="Query the current network connectivity state",
-            summary="Gets information about the OT-2's network interfaces "
-                    "including their connectivity, their "
-                    "addresses, and their networking info",
+            summary="Query the current network connectivity state",
+            description="Gets information about the OT-2's network interfaces "
+                        "including their connectivity, their "
+                        "addresses, and their networking info",
             response_model=NetworkingStatus)
 async def get_networking_status() -> NetworkingStatus:
     try:
@@ -45,10 +45,10 @@ async def get_networking_status() -> NetworkingStatus:
 
 
 @router.get("/wifi/list",
-            description="Scan for visible WiFi networks",
-            summary="Scans for beaconing WiFi networks and returns the list of"
-                    " visible ones along with some data about their security "
-                    "and strength",
+            summary="Scan for visible Wi-Fi networks",
+            description="Scans for beaconing WiFi networks and returns the list of "
+                        "visible ones along with some data about their security "
+                        "and strength",
             response_model=WifiNetworks)
 async def get_wifi_networks() -> WifiNetworks:
     networks = await nmcli.available_ssids()
@@ -56,9 +56,9 @@ async def get_wifi_networks() -> WifiNetworks:
 
 
 @router.post("/wifi/configure",
-             description="Configure the OT-2's WiFi",
-             summary="Configures the wireless network interface to connect to"
-                     " a network",
+             summary="Configure the OT-2's Wi-Fi",
+             description="Configures the wireless network interface to connect to"
+                         " a network",
              response_model=WifiConfigurationResponse,
              responses={
                  status.HTTP_401_UNAUTHORIZED: {"model": V1BasicResponse}
@@ -181,9 +181,9 @@ async def get_eap_options() -> EapOptions:
 
 
 @router.post("/wifi/disconnect",
-             description="Disconnect the OT-2 from WiFi network",
-             summary="Deactivates the wifi connection and removes it from "
-                     "known connections",
+             summary="Disconnect the OT-2 from Wi-Fi",
+             description="Deactivates the Wi-Fi connection and removes it from "
+                         "known connections",
              response_model=V1BasicResponse,
              responses={status.HTTP_200_OK: {"model": V1BasicResponse}},
              status_code=status.HTTP_207_MULTI_STATUS)

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -46,9 +46,9 @@ async def get_networking_status() -> NetworkingStatus:
 
 @router.get("/wifi/list",
             summary="Scan for visible Wi-Fi networks",
-            description="Scans for beaconing WiFi networks and returns the list of "
-                        "visible ones along with some data about their security "
-                        "and strength",
+            description="Scans for beaconing WiFi networks and returns the "
+                        "list of visible ones along with some data about "
+                        "their security and strength",
             response_model=WifiNetworks)
 async def get_wifi_networks() -> WifiNetworks:
     networks = await nmcli.available_ssids()
@@ -57,8 +57,8 @@ async def get_wifi_networks() -> WifiNetworks:
 
 @router.post("/wifi/configure",
              summary="Configure the OT-2's Wi-Fi",
-             description="Configures the wireless network interface to connect to"
-                         " a network",
+             description="Configures the wireless network interface to "
+                         "connect to a network",
              response_model=WifiConfigurationResponse,
              responses={
                  status.HTTP_401_UNAUTHORIZED: {"model": V1BasicResponse}
@@ -182,8 +182,8 @@ async def get_eap_options() -> EapOptions:
 
 @router.post("/wifi/disconnect",
              summary="Disconnect the OT-2 from Wi-Fi",
-             description="Deactivates the Wi-Fi connection and removes it from "
-                         "known connections",
+             description="Deactivates the Wi-Fi connection and removes it "
+                         "from known connections",
              response_model=V1BasicResponse,
              responses={status.HTTP_200_OK: {"model": V1BasicResponse}},
              status_code=status.HTTP_207_MULTI_STATUS)

--- a/robot-server/robot_server/service/legacy/routers/pipettes.py
+++ b/robot-server/robot_server/service/legacy/routers/pipettes.py
@@ -11,14 +11,14 @@ router = APIRouter()
 
 
 @router.get("/pipettes",
-            description="Get the pipettes currently attached",
-            summary="This endpoint lists properties of the pipettes currently "
-                    "attached to the robot like name, model, and mount. It "
-                    "queries a cached value unless the refresh query parameter"
-                    " is set to true, in which case it will actively scan for "
-                    "pipettes. This requires disabling the pipette motors "
-                    "(which is done automatically) and therefore should only "
-                    "be done through user intent",
+            summary="Get the pipettes currently attached",
+            description="This endpoint lists properties of the pipettes currently "
+                        "attached to the robot like name, model, and mount. It "
+                        "queries a cached value unless the refresh query parameter"
+                        " is set to true, in which case it will actively scan for "
+                        "pipettes. This requires disabling the pipette motors "
+                        "(which is done automatically) and therefore should only "
+                        "be done through user intent",
             response_model=pipettes.PipettesByMount)
 async def get_pipettes(
         refresh: typing.Optional[bool] = Query(

--- a/robot-server/robot_server/service/legacy/routers/pipettes.py
+++ b/robot-server/robot_server/service/legacy/routers/pipettes.py
@@ -12,13 +12,14 @@ router = APIRouter()
 
 @router.get("/pipettes",
             summary="Get the pipettes currently attached",
-            description="This endpoint lists properties of the pipettes currently "
-                        "attached to the robot like name, model, and mount. It "
-                        "queries a cached value unless the refresh query parameter"
-                        " is set to true, in which case it will actively scan for "
-                        "pipettes. This requires disabling the pipette motors "
-                        "(which is done automatically) and therefore should only "
-                        "be done through user intent",
+            description="This endpoint lists properties of the pipettes "
+                        "currently attached to the robot like name, model, "
+                        "and mount. It queries a cached value unless the "
+                        "refresh query parameter is set to true, in which "
+                        "case it will actively scan for pipettes. This "
+                        "requires disabling the pipette motors (which is done "
+                        "automatically) and therefore should only be done "
+                        "through user intent.",
             response_model=pipettes.PipettesByMount)
 async def get_pipettes(
         refresh: typing.Optional[bool] = Query(

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -32,8 +32,8 @@ def _create_response(dt: datetime) \
 @router.get("/system/time",
             summary="Fetch system time & date",
             description="Get robot's time status, which includes- current UTC "
-                        "date & time, local timezone, whether robot time is synced "
-                        "with an NTP server &/or it has an active RTC.",
+                        "date & time, local timezone, whether robot time is "
+                        "synced with an NTP server &/or it has an active RTC.",
             response_model=time_models.SystemTimeResponse
             )
 async def get_time() -> time_models.SystemTimeResponse:

--- a/robot-server/robot_server/service/system/router.py
+++ b/robot-server/robot_server/service/system/router.py
@@ -30,10 +30,10 @@ def _create_response(dt: datetime) \
 
 
 @router.get("/system/time",
-            description="Fetch system time & date",
-            summary="Get robot's time status, which includes- current UTC "
-                    "date & time, local timezone, whether robot time is synced"
-                    " with an NTP server &/or it has an active RTC.",
+            summary="Fetch system time & date",
+            description="Get robot's time status, which includes- current UTC "
+                        "date & time, local timezone, whether robot time is synced "
+                        "with an NTP server &/or it has an active RTC.",
             response_model=time_models.SystemTimeResponse
             )
 async def get_time() -> time_models.SystemTimeResponse:


### PR DESCRIPTION
# Overview

Fixes #7383.

# Changelog

* For endpoints that had a `summary` and `description` that were swapped, un-swap them.

# Not addressed in this PR

* Inconsistencies in what we put in an endpoint's `summary` vs. what we put in its `description`.
* Style inconsistencies. (Imperative vs. descriptive style, whether we end summaries with periods, etc.)
* Whether some of our field `description`s should really be `title`s.
* Whether we should ever allow FastAPI to autogenerate its useless field `title`s and endpoint `summary`s.

To address these, we'd want to investigate existing OpenAPI and JSON Schema conventions.

# Review requests

If you care to, run `make -C robot-server dev` and view http://localhost:31950/docs or http://localhost:31950/redoc to make sure there are no remaining walls of text in the headings and table of contents.

# Risk assessment

Low. This should only affect the autogenerated `/docs` and `/redoc` pages.
