### PR TITLE
refactor(api): refactor smoothie and module response parsing

### DIFF
--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -71,8 +71,9 @@ def _parse_distance_response(distance_string) -> float:
     val = data.get('Z', data.get('height'))
     if val is None:
         raise utils.ParseError(
-            f'Unexpected argument to _parse_distance_response: '
-            f'{distance_string}')
+            error_message='Unexpected argument to _parse_distance_response',
+            parse_source=distance_string
+        )
 
     return utils.parse_number(val, GCODE_ROUNDING_PRECISION)
 

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -17,8 +17,7 @@ from opentrons.config.robot_configs import current_for_revision
 from opentrons.drivers import serial_communication
 from opentrons.drivers.types import MoveSplits
 from opentrons.drivers.utils import (
-    AxisMoveTimestamp, parse_key_from_substring, parse_number_from_substring,
-    parse_key_values, parse_number
+    AxisMoveTimestamp, parse_key_values, parse_number, parse_optional_number
 )
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
@@ -175,25 +174,6 @@ class ParseError(Exception):
     pass
 
 
-def _parse_number_from_substring(smoothie_substring):
-    """
-    Returns the number in the expected string "N:12.3", where "N" is the
-    axis, and "12.3" is a floating point value for the axis' position
-    """
-    return parse_number_from_substring(smoothie_substring,
-                                       GCODE_ROUNDING_PRECISION)
-
-
-def _parse_axis_from_substring(smoothie_substring):
-    """
-    Returns the axis in the expected string "N:12.3", where "N" is the
-    axis, and "12.3" is a floating point value for the axis' position
-    """
-    return parse_key_from_substring(
-        smoothie_substring
-    ).title()  # upper 1st letter
-
-
 def _parse_position_response(raw_axis_values) -> Dict[str, float]:
     parsed_values = parse_key_values(raw_axis_values)
     if len(parsed_values) < 6:
@@ -260,11 +240,11 @@ def _parse_switch_values(raw_switch_values: str) -> Dict[str, bool]:
     if 'Probe: ' in raw_switch_values:
         raw_switch_values = raw_switch_values.replace('Probe: ', 'Probe:')
 
-    parsed_values = raw_switch_values.strip().split(' ')
+    parsed_values = parse_key_values(raw_switch_values)
     res = {
-        _parse_axis_from_substring(s): bool(_parse_number_from_substring(s))
-        for s in parsed_values
-        if any([n in s for n in ['max', 'Probe']])
+        k.title(): bool(parse_optional_number(v, rounding_val=GCODE_ROUNDING_PRECISION))
+        for (k, v) in parsed_values.items()
+        if any(n in k for n in ['max', 'Probe'])
     }
     # remove the extra "_max" character from each axis key in the dict
     res = {

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -195,10 +195,8 @@ class TempDeck:
 
     def update_temperature(self) -> str:
         if self._update_thread and self._update_thread.is_alive():
+            # No need to do anything. The updater is already running.
             pass
-            # TODO AL 20210320 - I don't know what this for. default was never used.
-            # updated_temperature = default or self._temperature.copy()
-            # self._temperature.update(updated_temperature)
         else:
             def _update():
                 try:

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -8,15 +8,16 @@ from serial.serialutil import SerialException  # type: ignore
 
 from opentrons.drivers import serial_communication, utils
 from opentrons.drivers.serial_communication import SerialNoResponse
+from opentrons.drivers.types import Temperature
 
-'''
+"""
 - Driver is responsible for providing an interface for the temp-deck
 - Driver is the only system component that knows about the temp-deck's GCODES
   or how the temp-deck communications
 
 - Driver is NOT responsible interpreting the temperatures or states in any way
   or knowing anything about what the device is being used for
-'''
+"""
 
 log = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ class TempDeck:
         self._connection = None
         self._config = config
 
-        self._temperature = {'current': 25, 'target': None}
+        self._temperature = Temperature(current=25, target=None)
         self._update_thread = None
         self._port = None
         self._lock = None
@@ -178,7 +179,7 @@ class TempDeck:
                 '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
         except (TempDeckError, SerialException, SerialNoResponse) as e:
             return str(e)
-        self._temperature.update({'target': celsius})
+        self._temperature.target = celsius
         while self.status != 'holding at target':
             await asyncio.sleep(0.1)
         return ''
@@ -189,26 +190,15 @@ class TempDeck:
                         utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
         self._send_command(
                 '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
-        self._temperature.update({'target': celsius})
+        self._temperature.target = celsius
         return ''
 
-    # NOTE: only present to support apiV1 non-blocking by default behavior
-    def legacy_set_temperature(self, celsius) -> str:
-        self.run_flag.wait()
-        celsius = round(float(celsius),
-                        utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
-        try:
-            self._send_command(
-                '{0} S{1}'.format(GCODES['SET_TEMP'], celsius))
-        except (TempDeckError, SerialException, SerialNoResponse) as e:
-            return str(e)
-        self._temperature.update({'target': celsius})
-        return ''
-
-    def update_temperature(self, default=None) -> str:
+    def update_temperature(self) -> str:
         if self._update_thread and self._update_thread.is_alive():
-            updated_temperature = default or self._temperature.copy()
-            self._temperature.update(updated_temperature)
+            pass
+            # TODO AL 20210320 - I don't know what this for. default was never used.
+            # updated_temperature = default or self._temperature.copy()
+            # self._temperature.update(updated_temperature)
         else:
             def _update():
                 try:
@@ -223,17 +213,17 @@ class TempDeck:
         return ''
 
     @property
-    def target(self) -> Optional[int]:
-        return self._temperature.get('target')
+    def target(self) -> Optional[float]:
+        return self._temperature.target
 
     @property
-    def temperature(self) -> int:
-        return self._temperature['current']  # type: ignore
+    def temperature(self) -> float:
+        return self._temperature.current  # type: ignore
 
     def _get_status(self) -> str:
         # Separate function for testability
-        current = self._temperature['current']
-        target = self._temperature.get('target')
+        current = self._temperature.current
+        target = self._temperature.target
         delta = 0.7
         if target:
             diff = target - current  # type: ignore
@@ -251,7 +241,7 @@ class TempDeck:
         return self._get_status()
 
     def get_device_info(self) -> Mapping[str, str]:
-        '''
+        """
         Queries Temp-Deck for its build version, model, and serial number
 
         returns: dict
@@ -266,7 +256,7 @@ class TempDeck:
 
         Example input from Temp-Deck's serial response:
             "serial:aa11bb22 model:aa11bb22 version:aa11bb22"
-        '''
+        """
         return self._get_info(DEFAULT_COMMAND_RETRIES)
 
     def pause(self):
@@ -301,18 +291,15 @@ class TempDeck:
             raise SerialException(error_msg)
 
     def _wait_for_ack(self):
-        '''
+        """
         This methods writes a sequence of newline characters, which will
         guarantee temp-deck responds with 'ok\r\nok\r\n' within 1 seconds
-        '''
+        """
         self._send_command('\r\n', timeout=DEFAULT_TEMP_DECK_TIMEOUT)
 
     # Potential place for command optimization (buffering, flushing, etc)
     def _send_command(
             self, command, timeout=DEFAULT_TEMP_DECK_TIMEOUT, tag=None):
-        """
-
-        """
         assert self._lock, 'not connected'
         with self._lock:
             command_line = command + ' ' + TEMP_DECK_COMMAND_TERMINATOR
@@ -353,9 +340,8 @@ class TempDeck:
             res = self._send_command(
                 GCODES['GET_TEMP'],
                 tag=f'tempdeck {id(self)} rut')
-            res = utils.parse_temperature_response(
+            self._temperature = utils.parse_temperature_response(
                 res, utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
-            self._temperature.update(res)
             return None
         except utils.ParseError as e:
             retries -= 1

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -483,33 +483,24 @@ class Thermocycler:
         # Payload is shaped like `T:95.0 C:77.4 H:600` where T is the
         # target temperature, C is the current temperature, and H is the
         # hold time remaining
-        val_dict = {}
-        data_substrs = [d for d in temperature_response.split()]
-
-        for substr in data_substrs:
-            key = utils.parse_key_from_substring(substr)
-            value = utils.parse_number_from_substring(
-                substr, utils.TC_GCODE_ROUNDING_PRECISION)
-            val_dict[key] = value
-
-        self._current_temp = val_dict['C']
-        self._target_temp = val_dict['T']
-        self._hold_time = val_dict['H']
+        temp = utils.parse_plate_temperature_response(
+            temperature_string=temperature_response,
+            rounding_val=utils.TC_GCODE_ROUNDING_PRECISION
+        )
+        self._current_temp = temp.current
+        self._target_temp = temp.target
+        self._hold_time = temp.hold
         self._block_temp_buffer.append(self._current_temp)
 
     def _lid_temp_status_callback(self, lid_temp_res):
         # Payload is shaped like `T:95.0 C:77.4` where T is the
         # target temperature, C is the current temperature
-        val_dict = {}
-        data_substrs = [d for d in lid_temp_res.split()]
-
-        for substr in data_substrs:
-            key = utils.parse_key_from_substring(substr)
-            value = utils.parse_number_from_substring(
-                substr, utils.TC_GCODE_ROUNDING_PRECISION)
-            val_dict[key] = value
-        self._lid_temp = val_dict['C']
-        self._lid_target = val_dict['T']
+        temp = utils.parse_temperature_response(
+            temperature_string=lid_temp_res,
+            rounding_val=utils.TC_GCODE_ROUNDING_PRECISION
+        )
+        self._lid_temp = temp.current
+        self._lid_target = temp.target
 
     def _interrupt_callback(self, interrupt_response):
         # TODO sanitize response and then call the callback

--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -32,4 +32,3 @@ class PlateTemperature(Temperature):
 class LidStatus(str, Enum):
     OPEN = "open"
     CLOSED = "closed"
-

--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -1,6 +1,7 @@
 """ Type definitions for modules in this tree """
-
-from typing import Dict, NamedTuple
+from dataclasses import dataclass
+from typing import Dict, NamedTuple, Optional
+from enum import Enum
 
 
 class MoveSplit(NamedTuple):
@@ -13,3 +14,22 @@ class MoveSplit(NamedTuple):
 
 MoveSplits = Dict[str, MoveSplit]
 #: Dict mapping axes to their split parameters
+
+
+@dataclass
+class Temperature:
+    """Tempdeck temperature and thermocycler plate temperature."""
+    current: Optional[float]
+    target: Optional[float]
+
+
+@dataclass
+class PlateTemperature(Temperature):
+    """Thermocycler lid temperature"""
+    hold: Optional[float]
+
+
+class LidStatus(str, Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -71,7 +71,7 @@ def parse_key_from_substring(substring) -> str:
 
 def parse_temperature_response(
         temperature_string: str, rounding_val: int
-    ) -> Temperature:
+) -> Temperature:
     """Example input: "T:none C:25"""
     data = parse_key_values(temperature_string)
     try:
@@ -88,7 +88,7 @@ def parse_temperature_response(
 
 def parse_plate_temperature_response(
         temperature_string: str, rounding_val: int
-    ) -> PlateTemperature:
+) -> PlateTemperature:
     """Example input: "T:none C:25 H:123"""
     data = parse_key_values(temperature_string)
     try:
@@ -98,9 +98,8 @@ def parse_plate_temperature_response(
             hold=parse_optional_number(data['H'], rounding_val)
         )
     except KeyError:
-        raise ParseError(
-            f'Unexpected argument to parse_lid_temperature_response: {temperature_string}'
-        )
+        raise ParseError(f'Unexpected argument to'
+                         f' parse_lid_temperature_response: {temperature_string}')
 
 
 def parse_device_information(

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -35,40 +35,6 @@ def parse_string_value_from_substring(substring) -> str:
                 substring))
 
 
-def parse_number_from_substring(substring, rounding_val) -> Optional[float]:
-    """
-    Returns the number in the expected string "N:12.3", where "N" is the
-    key, and "12.3" is a floating point value
-
-    For the temp-deck or thermocycler's temperature response, one expected
-    input is something like "T:none", where "none" should return a None value
-    """
-    try:
-        value = substring.split(':')[1]
-        if value.strip().lower() == 'none':
-            return None
-        return round(float(value), rounding_val)
-    except (ValueError, IndexError, TypeError, AttributeError):
-        log.exception('Unexpected argument to parse_number_from_substring:')
-        raise ParseError(
-            'Unexpected argument to parse_number_from_substring: {}'.format(
-                substring))
-
-
-def parse_key_from_substring(substring) -> str:
-    """
-    Returns the axis in the expected string "N:12.3", where "N" is the
-    key, and "12.3" is a floating point value
-    """
-    try:
-        return substring.split(':')[0]
-    except (ValueError, IndexError, TypeError, AttributeError):
-        log.exception('Unexpected argument to parse_key_from_substring:')
-        raise ParseError(
-            'Unexpected argument to parse_key_from_substring: {}'.format(
-                substring))
-
-
 def parse_temperature_response(
         temperature_string: str, rounding_val: int
 ) -> Temperature:

--- a/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
@@ -1,5 +1,4 @@
 import pytest
-from mock.mock import MagicMock
 from opentrons.drivers.mag_deck import driver
 from opentrons.drivers.utils import ParseError
 

--- a/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
@@ -1,0 +1,34 @@
+import pytest
+from mock.mock import MagicMock
+from opentrons.drivers.mag_deck import driver
+from opentrons.drivers.utils import ParseError
+
+
+@pytest.mark.parametrize(
+    argnames=["input_str", "expected"],
+    argvalues=[
+        ["height:12.34", 12.34],
+        ["Z:32.2", 32.2],
+        ["  Z:32.2  ", 32.2],
+    ]
+)
+def test_parse_distance_response_success(
+        input_str: str, expected: float) -> None:
+    """Test successful parsing"""
+    assert expected == driver._parse_distance_response(input_str)
+
+
+@pytest.mark.parametrize(
+    argnames=["input_str"],
+    argvalues=[
+        ["heigt:12.34"],
+        ["height:wolf"],
+        ["Z :32.2"],
+        [None],
+        [''],
+    ]
+)
+def test_parse_distance_response_failure(input_str: str) -> None:
+    """Test failed parsing"""
+    with pytest.raises(ParseError):
+        driver._parse_distance_response(input_str)

--- a/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_mag_deck_driver.py
@@ -23,7 +23,6 @@ def test_parse_distance_response_success(
         ["heigt:12.34"],
         ["height:wolf"],
         ["Z :32.2"],
-        [None],
         [''],
     ]
 )

--- a/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_temp_deck_driver.py
@@ -14,6 +14,7 @@ from threading import Lock
 from opentrons.drivers import serial_communication
 from opentrons.drivers.temp_deck import TempDeck
 from opentrons.drivers import utils
+from opentrons.drivers.types import Temperature
 
 
 @pytest.fixture
@@ -72,7 +73,7 @@ def test_fail_get_temp_deck_temperature(monkeypatch, temp_deck):
     while not done:
         time.sleep(0.25)
 
-    assert temp_deck._temperature == {'current': 90, 'target': None}
+    assert temp_deck._temperature == Temperature(current=90, target=None)
 
     def _mock_send_command2(command, timeout=None, tag=None):
         nonlocal done
@@ -85,7 +86,7 @@ def test_fail_get_temp_deck_temperature(monkeypatch, temp_deck):
     time.sleep(0.25)
     while not done:
         time.sleep(0.25)
-    assert temp_deck._temperature == {'current': 90, 'target': None}
+    assert temp_deck._temperature == Temperature(current=90, target=None)
 
 
 async def test_set_temp_deck_temperature(monkeypatch, temp_deck):

--- a/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
+++ b/api/tests/opentrons/drivers/module_drivers/test_thermocycler_driver.py
@@ -192,3 +192,20 @@ def test_holding_at_target(patch_poller_wait):
     # not enough history
     tc._block_temp_buffer = [29.8, 30, 30, 30.1]
     assert not tc._is_holding_at_target()
+
+
+def test_temp_status_update_callback():
+    tc = Thermocycler(lambda x: None)
+    tc._temp_status_update_callback('T:95.0 C:77.4 H:600')
+
+    assert tc.target == 95
+    assert tc.temperature == 77.4
+    assert tc.hold_time == 600
+
+
+def test_lid_temp_status_callback():
+    tc = Thermocycler(lambda x: None)
+    tc._lid_temp_status_callback('T:96 C:78')
+
+    assert tc.lid_temp == 78
+    assert tc.lid_target == 96

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -49,6 +49,8 @@ def test_parse_device_information_failure(input_str: str) -> None:
          Temperature(target=123.57, current=123.45)],
         ['T:-123.566 C:-123.446',
          Temperature(target=-123.57, current=-123.45)],
+        ['a:3 T:2. C:3 H:0 G:1',
+         Temperature(target=2, current=3)],
     ]
 )
 def test_parse_temperature_response_success(
@@ -80,6 +82,8 @@ def test_parse_temperature_response_failure(input_str: str) -> None:
          PlateTemperature(target=321.4, current=45, hold=123.22)],
         ['T:-44.2442 C:-22.233 H:0',
          PlateTemperature(target=-44.24, current=-22.23, hold=0)],
+        ['a:3 T:2. C:3 H:0 G:1',
+         PlateTemperature(target=2, current=3, hold=0)],
     ]
 )
 def test_parse_plate_temperature_response_success(

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -12,7 +12,10 @@ from opentrons.drivers.types import Temperature, PlateTemperature
         ['serial:serial_v model:m version:123-2 ',
          {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
         ['   serial:serial_v model:m    version:123-2   ',
+         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
+        ['something:extra serial:serial_v model:m version:123-2',
          {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}]
+
     ]
 )
 def test_parse_device_information_success(
@@ -27,7 +30,6 @@ def test_parse_device_information_success(
         ['version:123 serial:serial_v'],
         ['version:123 serialg:serial_v model:123'],
         [''],
-        [None]
     ]
 )
 def test_parse_device_information_failure(input_str: str) -> None:
@@ -61,7 +63,6 @@ def test_parse_temperature_response_success(
         ['T:not_a_float C:123'],
         ['C:not_a_float T:123'],
         [''],
-        [None]
     ]
 )
 def test_parse_temperature_response_failure(input_str: str) -> None:
@@ -95,7 +96,6 @@ def test_parse_plate_temperature_response_success(
         ['C:not_a_float T:123 H:321'],
         ['H:not_a_float C:123 T:321'],
         [''],
-        [None]
     ]
 )
 def test_parse_plate_temperature_response_failure(input_str: str) -> None:

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -1,0 +1,104 @@
+from typing import Dict
+import pytest
+from opentrons.drivers import utils
+from opentrons.drivers.types import Temperature, PlateTemperature
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str', 'expected_result'],
+    argvalues=[
+        ['version:123-2 serial:serial_v model:m',
+         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
+        ['serial:serial_v model:m version:123-2 ',
+         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
+        ['   serial:serial_v model:m    version:123-2   ',
+         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}]
+    ]
+)
+def test_parse_device_information_success(
+        input_str: str, expected_result: Dict[str, str]) -> None:
+    """Test parse device information."""
+    assert utils.parse_device_information(input_str) == expected_result
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str'],
+    argvalues=[
+        ['version:123 serial:serial_v'],
+        ['version:123 serialg:serial_v model:123'],
+        [''],
+        [None]
+    ]
+)
+def test_parse_device_information_failure(input_str: str) -> None:
+    """Test parse device information."""
+    with pytest.raises(utils.ParseError):
+        utils.parse_device_information(input_str)
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str', 'expected_result'],
+    argvalues=[
+        ['T:none C:123.4',
+         Temperature(target=None, current=123.4)],
+        ['T:321.4 C:none',
+         Temperature(target=321.4, current=None)],
+        ['T:123.566 C:123.446',
+         Temperature(target=123.57, current=123.45)],
+        ['T:-123.566 C:-123.446',
+         Temperature(target=-123.57, current=-123.45)],
+    ]
+)
+def test_parse_temperature_response_success(
+        input_str: str, expected_result: Temperature) -> None:
+    """It should parse temperature response."""
+    assert utils.parse_temperature_response(input_str, 2) == expected_result
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str'],
+    argvalues=[
+        ['T:not_a_float C:123'],
+        ['C:not_a_float T:123'],
+        [''],
+        [None]
+    ]
+)
+def test_parse_temperature_response_failure(input_str: str) -> None:
+    """It should fail to parse temperature response."""
+    with pytest.raises(utils.ParseError):
+        utils.parse_temperature_response(input_str, 2)
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str', 'expected_result'],
+    argvalues=[
+        ['T:none C:none H:none',
+         PlateTemperature(target=None, current=None, hold=None)],
+        ['T:321.4 C:45 H:123.222',
+         PlateTemperature(target=321.4, current=45, hold=123.22)],
+        ['T:-44.2442 C:-22.233 H:0',
+         PlateTemperature(target=-44.24, current=-22.23, hold=0)],
+    ]
+)
+def test_parse_plate_temperature_response_success(
+        input_str: str, expected_result: PlateTemperature
+    ) -> None:
+    """It should parse plate temperature response"""
+    assert utils.parse_plate_temperature_response(input_str, 2) == expected_result
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str'],
+    argvalues=[
+        ['T:not_a_float C:123 H:321'],
+        ['C:not_a_float T:123 H:321'],
+        ['H:not_a_float C:123 T:321'],
+        [''],
+        [None]
+    ]
+)
+def test_parse_plate_temperature_response_failure(input_str: str) -> None:
+    """It should faile to parse plate temperature response"""
+    with pytest.raises(utils.ParseError):
+        utils.parse_plate_temperature_response(input_str, 2)

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -99,6 +99,6 @@ def test_parse_plate_temperature_response_success(
     ]
 )
 def test_parse_plate_temperature_response_failure(input_str: str) -> None:
-    """It should faile to parse plate temperature response"""
+    """It should fail to parse plate temperature response"""
     with pytest.raises(utils.ParseError):
         utils.parse_plate_temperature_response(input_str, 2)

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -83,7 +83,7 @@ def test_parse_temperature_response_failure(input_str: str) -> None:
 )
 def test_parse_plate_temperature_response_success(
         input_str: str, expected_result: PlateTemperature
-    ) -> None:
+) -> None:
     """It should parse plate temperature response"""
     assert utils.parse_plate_temperature_response(input_str, 2) == expected_result
 


### PR DESCRIPTION
# Overview

Reduces duplication of much of the smoothie response parsing across smoothie and module drivers. 

Much of our parsing was inefficient: splitting strings twice at `:`, once for each side.

# Changelog

- added methods to `opentrons.drivers.utils`:
`parse_key_values` to convert from `"X:1 Y:2"` to `{"X":1, "Y":2}`
`parse_temperature_response` to parse a `Temperature` object (thermocycler and tempdeck)
`parse_plate_temperature_response`  to parse a `PlateTemperature` object (thermocycler)
`parse_optional_number` to parse an int that maybe "none"
`parse_number` - to parse a number
- removed methods from `opentrons.drivers.utils`:
`parse_number_from_substring` - deprecated  by `parse_key_values`
`parse_key_from_substring` - deprecated  by `parse_key_values`
- removed methods from `opentrons.drivers.magdeck.driver`:
`_parse_string_value_from_substring` - deprecated  by `parse_key_values`
`_parse_number_from_substring` - deprecated  by `parse_key_values`
`_parse_key_from_substring` - deprecated  by `parse_key_values`
`_parse_device_information` - duplicated by `driver.utils.parse_device_information`
- modify modules and smoothie drivers to use the new functions.

# Review requests

This needs to be tested to ensure that smoothie, magdeck, tempdeck, and thermocycler behaviour is unchanged. 

# Risk assessment

**Very high**. Affects parsing smoothie and module responses.