### PR TITLE
fix(api): do not search for a tip length calibration by slot name

### DIFF
--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -6,7 +6,6 @@ from opentrons.calibration_storage import get
 from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_api.labware import Labware, Well
-from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons_shared_data.protocol.dev_types import LiquidHandlingCommand, \
     BlowoutLocation

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -52,7 +52,10 @@ def tip_length_for(pipette: PipetteDict, tiprack: Labware) -> float:
         return tip_length - tip_overlap
 
     try:
-        parent = LabwareLike(tiprack).first_parent() or ''
+        # For now, parent should be an empty string since we are
+        # not uniquely characterizing labware calibrations by
+        # slot number
+        parent = ''
         return get.load_tip_length_calibration(
             pipette['pipette_id'],
             tiprack._implementation.get_definition(),


### PR DESCRIPTION
# Overview
This PR is part 1 of the fix for #7139. We should add back in the Z offset calculation for pipette offset.

# Changelog
- Do not search for the tip length based on the parent of the tip rack.

# Review requests

Should we just remove parent's completely from tip length? I don't ever see the need to save on a per-slot basis here.

# Risk assessment
Low, fixing incorrect tip length usage
