### PR TITLE
revert(robot-server): Save the z offset for pipette calibration

### DIFF
--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -402,15 +402,18 @@ class PipetteOffsetCalibrationUserFlow:
         self._should_perform_tip_length = False
 
     async def move_to_point_one(self):
+        assert self._z_height_reference is not None, \
+            "saveOffset has not been called yet"
         target_loc = Location(self._cal_ref_point, None)
-        await self._move(target_loc)
+        target = target_loc.move(
+                point=Point(0, 0, self._z_height_reference))
+        await self._move(target)
 
     async def save_offset(self):
         cur_pt = await self.get_current_point(critical_point=None)
         current_state = self._sm.current_state
         if current_state == self._sm.state.joggingToDeck:
-            updated_z = Point(0, 0, cur_pt.z)
-            self._cal_ref_point = self._cal_ref_point + updated_z
+            self._z_height_reference = cur_pt.z
         elif current_state == self._sm.state.savingPointOne:
             if self._hw_pipette.config.channels > 1:
                 cur_pt = await self.get_current_point(

--- a/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_user_flow.py
@@ -469,11 +469,6 @@ async def test_save_custom_tiprack_def(
 
 async def test_save_pipette_calibration(mock_user_flow, mock_save_pipette):
     uf = mock_user_flow
-    uf._sm.set_state(uf._sm.state.joggingToDeck)
-    assert uf._cal_ref_point == Point(12.13, 9.0, 0.0)
-    await uf.jog(vector=(0, 0, 10))
-    await uf.save_offset()
-    assert uf._cal_ref_point == Point(12.13, 9.0, 10.0)
 
     uf._sm.set_state(uf._sm.state.savingPointOne)
     await uf._hardware.move_to(


### PR DESCRIPTION
Reverts Opentrons/opentrons#7417.

This was not the reason why pipettes were crashing in the Z. See #7574. We should still save the Z in pipette offset.