### PR TITLE
refactor(api): remove parent check for tip length calibration

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -129,27 +129,21 @@ def get_labware_calibration(
 
 def load_tip_length_calibration(
         pip_id: str,
-        definition: 'LabwareDefinition',
-        parent: str) -> local_types.TipLengthCalibration:
+        definition: 'LabwareDefinition'
+        ) -> local_types.TipLengthCalibration:
     """
     Function used to grab the current tip length associated
     with a particular tiprack.
 
     :param pip_id: pipette you are using
     :param definition: full definition of the tiprack
-    :param parent: parent of the tiprack
     """
-    # TODO(lc, 07-14-2020) since we're trying not to utilize
-    # a labware object for these functions, the is tiprack
-    # check should happen outside of this function.
-    # assert labware._is_tiprack, \
-    #     'cannot save tip length for non-tiprack labware'
     labware_hash = helpers.hash_labware_def(definition)
     labware_uri = helpers.uri_from_definition(definition)
     load_name = definition['parameters']['loadName']
     return _get_tip_length_data(
         pip_id=pip_id,
-        labware_hash=labware_hash + parent,
+        labware_hash=labware_hash,
         labware_load_name=load_name,
         labware_uri=labware_uri)
 

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -107,7 +107,6 @@ def save_labware_calibration(
 
 def create_tip_length_data(
         definition: 'LabwareDefinition',
-        parent: str,
         length: float,
         cal_status: local_types.CalibrationStatus = None
         ) -> 'PipTipLengthCalibration':
@@ -115,15 +114,8 @@ def create_tip_length_data(
     Function to correctly format tip length data.
 
     :param definition: full labware definition
-    :param parent: the slot associated with the tiprack
-    [not yet implemented, so it is always an empty string]
     :param length: the tip length to save
     """
-    # TODO(lc, 07-14-2020) since we're trying not to utilize
-    # a labware object for these functions, the is tiprack
-    # check should happen outside of this function.
-    # assert labware._is_tiprack, \
-    #     'cannot save tip length for non-tiprack labware'
     labware_hash = helpers.hash_labware_def(definition)
     labware_uri = helpers.uri_from_definition(definition)
     if cal_status:
@@ -144,7 +136,7 @@ def create_tip_length_data(
     if not definition.get('namespace') == OPENTRONS_NAMESPACE:
         _save_custom_tiprack_definition(labware_uri, definition)
 
-    data = {labware_hash + parent: tip_length_data}
+    data = {labware_hash: tip_length_data}
     return data
 
 

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -51,14 +51,10 @@ def tip_length_for(pipette: PipetteDict, tiprack: Labware) -> float:
         return tip_length - tip_overlap
 
     try:
-        # For now, parent should be an empty string since we are
-        # not uniquely characterizing labware calibrations by
-        # slot number
-        parent = ''
         return get.load_tip_length_calibration(
             pipette['pipette_id'],
-            tiprack._implementation.get_definition(),
-            parent).tip_length
+            tiprack._implementation.get_definition()
+            ).tip_length
     except TipLengthCalNotFound:
         return _build_length_from_overlap()
 

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -917,10 +917,9 @@ def test_tip_length_for_load_caldata(ctx):
     pip_id = instr.hw_pipette['pipette_id']
     fake_tip_length = 31
 
-    parent = ''
     test_data = modify.create_tip_length_data(
         tiprack._implementation.get_definition(),
-        parent, fake_tip_length)
+        fake_tip_length)
     modify.save_tip_length_calibration(pip_id, test_data)
 
     assert instr._tip_length_for(tiprack) == fake_tip_length

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -170,7 +170,6 @@ def test_create_tip_length_calibration_data(monkeypatch, clear_custom_tiprack_di
         'hash_labware_def', mock_hash_labware)
 
     tip_length = 22.0
-    parent = ''
     expected_data = {
         MOCK_HASH: {
             'tipLength': tip_length,
@@ -182,7 +181,7 @@ def test_create_tip_length_calibration_data(monkeypatch, clear_custom_tiprack_di
     }
     assert not os.path.exists(custom_tiprack_path(URI))
     result = modify.create_tip_length_data(
-        minimalLabwareDef, parent, tip_length)
+        minimalLabwareDef, tip_length)
     assert result == expected_data
     assert os.path.exists(custom_tiprack_path(URI))
 
@@ -226,7 +225,7 @@ def test_load_nonexistent_tip_length_calibration_data(
 
     # file does not exist (FileNotFoundError)
     with pytest.raises(cs_types.TipLengthCalNotFound):
-        get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef, '')
+        get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef)
 
     # labware hash not in calibration file (KeyError)
     calpath = config.get_tip_length_cal_path()
@@ -239,7 +238,7 @@ def test_load_nonexistent_tip_length_calibration_data(
         }
         json.dump(test_offset, offset_file)
     with pytest.raises(cs_types.TipLengthCalNotFound):
-        get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef, '')
+        get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef)
 
 
 def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
@@ -250,12 +249,11 @@ def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
         'hash_labware_def', mock_hash_labware)
 
     tip_length = 22.0
-    parent = ''
     test_data = modify.create_tip_length_data(
-        minimalLabwareDef, parent, tip_length)
+        minimalLabwareDef, tip_length)
     modify.save_tip_length_calibration(PIPETTE_ID, test_data)
     result = get.load_tip_length_calibration(
-        PIPETTE_ID, minimalLabwareDef, parent)
+        PIPETTE_ID, minimalLabwareDef)
     expected = cs_types.TipLengthCalibration(
         tip_length=tip_length,
         pipette=PIPETTE_ID,

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -323,8 +323,7 @@ class CheckCalibrationUserFlow:
                 pip_offset.uri)
         return get.load_tip_length_calibration(
             pipette.pipette_id,
-            tiprack_def,
-            '')
+            tiprack_def)
 
     def _check_valid_calibrations(self):
         deck = self._deck_calibration
@@ -635,10 +634,8 @@ class CheckCalibrationUserFlow:
                 SourceType.calibration_check)
             tip_definition =\
                 self.active_tiprack._implementation.get_definition()
-            parent = self.active_tiprack.parent
             tip_length_dict = modify.create_tip_length_data(
                 definition=tip_definition,
-                parent=parent,
                 length=calibration.tip_length,
                 cal_status=calibration.status
             )
@@ -816,8 +813,8 @@ class CheckCalibrationUserFlow:
         try:
             return get.load_tip_length_calibration(
                 pip_id,
-                self.active_tiprack._implementation.get_definition(),
-                '').tip_length
+                self.active_tiprack._implementation.get_definition()
+                ).tip_length
         except TipLengthCalNotFound:
             tip_overlap = self.hw_pipette.config.tip_overlap.get(
                 self.active_tiprack.uri,

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -331,9 +331,8 @@ class DeckCalibrationUserFlow:
         try:
             return get.load_tip_length_calibration(
                 pip_id,
-                self._tip_rack._implementation.get_definition(),
-                ''
-            ).tip_length
+                self._tip_rack._implementation.get_definition()
+                ).tip_length
         except TipLengthCalNotFound:
             tip_overlap = self._hw_pipette.config.tip_overlap.get(
                 self._tip_rack.uri, 0)

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -295,8 +295,8 @@ class PipetteOffsetCalibrationUserFlow:
         try:
             return get.load_tip_length_calibration(
                 self._hw_pipette.pipette_id,
-                self._tip_rack._implementation.get_definition(),
-                '').tip_length
+                self._tip_rack._implementation.get_definition()
+                ).tip_length
         except TipLengthCalNotFound:
             return None
 

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -193,7 +193,7 @@ def save_tip_length_calibration(pipette_id: str,
     # tip length data, hence the empty string, we should remove it
     # from create_tip_length_data in a refactor
     tip_length_data = modify.create_tip_length_data(
-        tip_rack._implementation.get_definition(), '',
+        tip_rack._implementation.get_definition(),
         tip_length_offset
     )
     modify.save_tip_length_calibration(pipette_id, tip_length_data)

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -321,7 +321,7 @@ async def test_save_offsets(mock_user_flow):
             abs_position=Point(x=10, y=10, z=40),
             critical_point=uf.critical_point_override)
         await uf.save_offset()
-        create_tip_length_data_patch.assert_called_with(ANY, '', 30)
+        create_tip_length_data_patch.assert_called_with(ANY, 30)
 
 
 async def test_save_custom_tiprack_def(


### PR DESCRIPTION
# Overview
We should probably not be saving tip length calibration references with the slot value -- since it will only ever be in one slot. We should instead save labware calibrations with just their hash reference as the file name and then key value pairs of `parent: calibration` inside that file. This will require a few other PRs to refactor the rest of behavior.

# Changelog

- Remove the labware parent from the lookup key to save tip length calibrations by.

# Review requests
Check it out, let me know if I missed something.

# Risk assessment
Low, since we've only been appending an empty string, as long as we make the adjustments with the other parts of lw calibration.
