### PR TITLE
fix(protocol-designer): track batch edit form change properties in mixpanel

### DIFF
--- a/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
+++ b/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
@@ -1,13 +1,13 @@
 // @flow
-import { when, resetAllWhenMocks } from 'jest-when'
+import { resetAllWhenMocks } from 'jest-when'
 import { reduxActionToAnalyticsEvent } from '../middleware'
 import { getFileMetadata } from '../../file-data/selectors'
 import {
   getArgsAndErrorsByStepId,
   getPipetteEntities,
-  getBatchEditFieldChanges,
 } from '../../step-forms/selectors'
 import type { FileMetadataFields } from '../../file-data/types'
+import type { SaveStepFormsMultiAction } from '../../step-forms/actions'
 
 jest.mock('../../file-data/selectors')
 jest.mock('../../step-forms/selectors')
@@ -18,10 +18,6 @@ const getArgsAndErrorsByStepIdMock: JestMockFn<
   any
 > = getArgsAndErrorsByStepId
 const getPipetteEntitiesMock: JestMockFn<any, any> = getPipetteEntities
-const getBatchEditFieldChangesMock: JestMockFn<
-  any,
-  any
-> = getBatchEditFieldChanges
 
 let fooState: any
 beforeEach(() => {
@@ -92,20 +88,17 @@ describe('reduxActionToAnalyticsEvent', () => {
     })
   })
   it('should convert a SAVE_STEP_FORMS_MULTI action into a saveStepsMulti action with additional properties', () => {
-    const changes = {
-      someField: 'someVal',
-      anotherField: 'anotherVal',
-      someNestedField: {
-        innerNestedField: true,
-      },
-    }
-    when(getBatchEditFieldChangesMock)
-      .calledWith(expect.anything())
-      .mockReturnValue(changes)
-    const action = {
+    const action: SaveStepFormsMultiAction = {
       type: 'SAVE_STEP_FORMS_MULTI',
       payload: {
-        selectedStepIds: [], // this does not matter
+        stepIds: [],
+        editedFields: {
+          someField: 'someVal',
+          anotherField: 'anotherVal',
+          someNestedField: {
+            innerNestedField: true,
+          },
+        },
       },
     }
 

--- a/protocol-designer/src/analytics/middleware.js
+++ b/protocol-designer/src/analytics/middleware.js
@@ -2,7 +2,6 @@
 import {
   getArgsAndErrorsByStepId,
   getPipetteEntities,
-  getBatchEditFieldChanges,
 } from '../step-forms/selectors'
 import { getFileMetadata } from '../file-data/selectors'
 import { trackEvent } from './mixpanel'
@@ -61,7 +60,7 @@ export const reduxActionToAnalyticsEvent = (
     const fileMetadata = getFileMetadata(state)
     const dateCreatedTimestamp = fileMetadata.created
 
-    const editedFields = getBatchEditFieldChanges(state)
+    const { editedFields } = action.payload
     const additionalProperties = flattenNestedProperties(editedFields)
 
     // (these fields are prefixed with double underscore only to make sure they


### PR DESCRIPTION
# Overview
While we are tracking use of batch edit in mixpanel using the `saveStepsMulti` key, the batch edit form changes were not being captured because `state.stepForms.batchEditFormChanges` is empty by the time it gets to analytics middleware. 

To be honest, I don't know why. From my understanding the analytics middleware should intercept redux state _before_ it gets to our reducers. `batchEditFormChanges` gets cleared in `SAVE_STEP_FORMS_MULTI`, but this should happen after analytics middleware...

Regardless, we have the batch edit form changes as part of the payload in a `SAVE_STEP_FORMS_MULTI` action, so I just pulled it off directly instead of trying to get it from the `getBatchEditFieldChanges` selector.

@IanLondon @Kadee80 do y'all know why this happened at all tho? I'm gonna dig into it more

# Changelog
- Track batch edit form change properties in mixpanel

# Review requests
Make sure batch edit form change properties show up in the dev mixpanel env (they were not before)


# Risk assessment
Low
