### PR TITLE
chore(pe): context duplication noodling InstrumentContext

### DIFF
--- a/api/.flake8
+++ b/api/.flake8
@@ -36,6 +36,7 @@ per-file-ignores =
     src/opentrons/data_storage/*:ANN,D
     src/opentrons/deck_calibration/*:ANN,D
     src/opentrons/drivers/*:ANN,D
+    src/opentrons/experimental_protocol_api/*:ANN,D
     src/opentrons/hardware_control/*:ANN,D
     src/opentrons/helpers/*:ANN,D
     src/opentrons/protocol_api/*:ANN,D

--- a/api/.flake8
+++ b/api/.flake8
@@ -36,7 +36,6 @@ per-file-ignores =
     src/opentrons/data_storage/*:ANN,D
     src/opentrons/deck_calibration/*:ANN,D
     src/opentrons/drivers/*:ANN,D
-    src/opentrons/experimental_protocol_api/*:ANN,D
     src/opentrons/hardware_control/*:ANN,D
     src/opentrons/helpers/*:ANN,D
     src/opentrons/protocol_api/*:ANN,D

--- a/api/src/opentrons/experimental_protocol_api/__init__.py
+++ b/api/src/opentrons/experimental_protocol_api/__init__.py
@@ -1,1 +1,2 @@
+# noqa: D104
 # Fix before merge: Docstring

--- a/api/src/opentrons/experimental_protocol_api/instrument_context.py
+++ b/api/src/opentrons/experimental_protocol_api/instrument_context.py
@@ -1,3 +1,4 @@
+# noqa: D100
 from __future__ import annotations
 
 from typing import Optional, Union, Sequence, List
@@ -7,899 +8,254 @@ from opentrons.experimental_protocol_api.labware import Well, Labware
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_api import PairedInstrumentContext
 from opentrons.protocol_api.instrument_context import AdvancedLiquidHandling
-from opentrons.protocols.api_support.util import requires_version, \
+from opentrons.protocols.api_support.util import (
     PlungerSpeeds, FlowRates, Clearances
+)
 
 
 class InstrumentContext:
-    """ A context for a specific pipette or instrument.
+    # noqa: D101
 
-    This can be used to call methods related to pipettes - moves or
-    aspirates or dispenses, or higher-level methods.
-
-    Instances of this class bundle up state and config changes to a
-    pipette - for instance, changes to flow rates or trash containers.
-    Action methods (like :py:meth:`aspirate` or :py:meth:`distribute`) are
-    defined here for convenience.
-
-    In general, this class should not be instantiated directly; rather,
-    instances are returned from :py:meth:`ProtocolContext.load_instrument`.
-
-    .. versionadded:: 2.0
-
-    """
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def api_version(self) -> APIVersion:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def starting_tip(self) -> Optional[Well]:
-        """ The starting tip from which the pipette pick up
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     @starting_tip.setter
-    def starting_tip(self, location: Optional[Well]):
+    def starting_tip(self, location: Optional[Well]) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def reset_tipracks(self):
-        """ Reload all tips in each tip rack and reset starting tip
-        """
+    def reset_tipracks(self) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def default_speed(self) -> float:
-        """ The speed at which the robot's gantry moves.
-
-        By default, 400 mm/s. Changing this value will change the speed of the
-        pipette when moving between labware. In addition to changing the
-        default, the speed of individual motions can be changed with the
-        ``speed`` argument to :py:meth:`InstrumentContext.move_to`.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     @default_speed.setter
     def default_speed(self, speed: float) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def aspirate(self,
                  volume: Optional[float] = None,
                  location: Union[types.Location, Well] = None,
                  rate: float = 1.0) -> InstrumentContext:
-        """
-        Aspirate a given volume of liquid from the specified location, using
-        this pipette.
-
-        :param volume: The volume to aspirate, in microliters (µL).  If 0 or
-                       unspecified, defaults to the highest volume possible
-                       with this pipette and its currently attached tip.
-        :type volume: int or float
-        :param location: Where to aspirate from. If `location` is a
-                         :py:class:`.Well`, the robot will aspirate from
-                         :py:obj:`well_bottom_clearance.aspirate` mm
-                         above the bottom of the well. If `location` is a
-                         :py:class:`.Location` (i.e. the result of
-                         :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the
-                         robot will aspirate from the exact specified location.
-                         If unspecified, the robot will aspirate from the
-                         current position.
-        :param rate: A relative modifier for how quickly to aspirate liquid.
-                     The flow rate for this aspirate will be
-                     `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`.
-                     If not specified, defaults to 1.0.
-        :type rate: float
-        :returns: This instance.
-
-        .. note::
-
-            If ``aspirate`` is called with a single argument, it will not try
-            to guess whether the argument is a volume or location - it is
-            required to be a volume. If you want to call ``aspirate`` with only
-            a location, specify it as a keyword argument:
-            ``instr.aspirate(location=wellplate['A1'])``
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def dispense(self,
                  volume: Optional[float] = None,
                  location: Union[types.Location, Well] = None,
                  rate: float = 1.0) -> InstrumentContext:
-        """
-        Dispense a volume of liquid (in microliters/uL) using this pipette
-        into the specified location.
-
-        If only a volume is passed, the pipette will dispense from its current
-        position. If only a location is passed (as in
-        ``instr.dispense(location=wellplate['A1'])``), all of the liquid
-        aspirated into the pipette will be dispensed (this volume is accessible
-        through :py:attr:`current_volume`).
-
-        :param volume: The volume of liquid to dispense, in microliters. If not
-                       specified, defaults to :py:attr:`current_volume`.
-        :type volume: int or float
-
-        :param location: Where to dispense into. If `location` is a
-                         :py:class:`.Well`, the robot will dispense into
-                         :py:obj:`well_bottom_clearance.dispense` mm
-                         above the bottom of the well. If `location` is a
-                         :py:class:`.Location` (i.e. the result of
-                         :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the
-                         robot will dispense into the exact specified location.
-                         If unspecified, the robot will dispense into the
-                         current position.
-        :param rate: A relative modifier for how quickly to dispense liquid.
-                     The flow rate for this dispense will be
-                     `rate` * :py:attr:`flow_rate.dispense <flow_rate>`.
-                     If not specified, defaults to 1.0.
-        :type rate: float
-
-        :returns: This instance.
-
-        .. note::
-
-            If ``dispense`` is called with a single argument, it will not try
-            to guess whether the argument is a volume or location - it is
-            required to be a volume. If you want to call ``dispense`` with only
-            a location, specify it as a keyword argument:
-            ``instr.dispense(location=wellplate['A1'])``
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def mix(self,
             repetitions: int = 1,
             volume: Optional[float] = None,
             location: Union[types.Location, Well] = None,
             rate: float = 1.0) -> InstrumentContext:
-        """
-        Mix a volume of liquid (uL) using this pipette, by repeatedly
-        aspirating and dispensing in the same place.
-
-        :param repetitions: how many times the pipette should mix (default: 1)
-        :param volume: number of microliters to mix.  If 0 or unspecified,
-                       defaults to the highest volume possible with this
-                       pipette and its currently attached tip.
-        :param location: a Well or a position relative to well.
-                         e.g, `plate.rows()[0][0].bottom()`.  If unspecified,
-                         the pipette will mix from its current position.
-        :type location: types.Location
-        :param rate: A relative modifier for how quickly to aspirate and
-                     dispense liquid during this mix. When aspirating, the flow
-                     rate will be
-                     `rate` * :py:attr:`flow_rate.aspirate <flow_rate>`,
-                     and when dispensing, it will be
-                     `rate` * :py:attr:`flow_rate.dispense <flow_rate>`.
-        :raises NoTipAttachedError: If no tip is attached to the pipette.
-        :returns: This instance
-
-        .. note::
-
-            All the arguments to ``mix`` are optional; however, if you do
-            not want to specify one of them, all arguments after that one
-            should be keyword arguments. For instance, if you do not want
-            to specify volume, you would call
-            ``pipette.mix(1, location=wellplate['A1'])``. If you do not
-            want to specify repetitions, you would call
-            ``pipette.mix(volume=10, location=wellplate['A1'])``. Unlike
-            previous API versions, ``mix`` will not attempt to guess your
-            inputs; the first argument will always be interpreted as
-            ``repetitions``, the second as ``volume``, and the third as
-            ``location`` unless you use keywords.
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def blow_out(self,
                  location: Union[types.Location, Well] = None
                  ) -> InstrumentContext:
-        """
-        Blow liquid out of the tip.
-
-        If :py:attr:`dispense` is used to completely empty a pipette,
-        usually a small amount of liquid will remain in the tip. This
-        method moves the plunger past its usual stops to fully remove
-        any remaining liquid from the tip. Regardless of how much liquid
-        was in the tip when this function is called, after it is done
-        the tip will be empty.
-
-        :param location: The location to blow out into. If not specified,
-                         defaults to the current location of the pipette
-        :type location: :py:class:`.Well` or :py:class:`.Location` or None
-
-        :raises RuntimeError: If no location is specified and location cache is
-                              None. This should happen if `blow_out` is called
-                              without first calling a method that takes a
-                              location (eg, :py:meth:`.aspirate`,
-                              :py:meth:`dispense`)
-        :returns: This instance
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def touch_tip(self,
                   location: Optional[Well] = None,
                   radius: float = 1.0,
                   v_offset: float = -1.0,
                   speed: float = 60.0) -> InstrumentContext:
-        """
-        Touch the pipette tip to the sides of a well, with the intent of
-        removing left-over droplets
-
-        :param location: If no location is passed, pipette will
-                         touch tip at current well's edges
-        :type location: :py:class:`.Well` or None
-        :param radius: Describes the proportion of the target well's
-                       radius. When `radius=1.0`, the pipette tip will move to
-                       the edge of the target well; when `radius=0.5`, it will
-                       move to 50% of the well's radius. Default: 1.0 (100%)
-        :type radius: float
-        :param v_offset: The offset in mm from the top of the well to touch tip
-                         A positive offset moves the tip higher above the well,
-                         while a negative offset moves it lower into the well
-                         Default: -1.0 mm
-        :type v_offset: float
-        :param speed: The speed for touch tip motion, in mm/s.
-                      Default: 60.0 mm/s, Max: 80.0 mm/s, Min: 20.0 mm/s
-        :type speed: float
-        :raises NoTipAttachedError: if no tip is attached to the pipette
-        :raises RuntimeError: If no location is specified and location cache is
-                              None. This should happen if `touch_tip` is called
-                              without first calling a method that takes a
-                              location (eg, :py:meth:`.aspirate`,
-                              :py:meth:`dispense`)
-        :returns: This instance
-
-        .. note::
-
-            This is behavior change from legacy API (which accepts any
-            :py:class:`.Placeable` as the ``location`` parameter)
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def air_gap(self,
                 volume: Optional[float] = None,
                 height: Optional[float] = None) -> InstrumentContext:
-        """
-        Pull air into the pipette current tip at the current location
-
-        :param volume: The amount in uL to aspirate air into the tube.
-                       (Default will use all remaining volume in tip)
-        :type volume: float
-
-        :param height: The number of millimiters to move above the current Well
-                       to air-gap aspirate. (Default: 5mm above current Well)
-        :type height: float
-
-        :raises NoTipAttachedError: If no tip is attached to the pipette
-
-        :raises RuntimeError: If location cache is None.
-                              This should happen if `touch_tip` is called
-                              without first calling a method that takes a
-                              location (eg, :py:meth:`.aspirate`,
-                              :py:meth:`dispense`)
-
-        :returns: This instance
-
-        .. note::
-
-            Both ``volume`` and height are optional, but unlike previous API
-            versions, if you want to specify only ``height`` you must do it
-            as a keyword argument: ``pipette.air_gap(height=2)``. If you
-            call ``air_gap`` with only one unnamed argument, it will always
-            be interpreted as a volume.
-
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def return_tip(self, home_after: bool = True) -> InstrumentContext:
-        """
-        If a tip is currently attached to the pipette, then it will return the
-        tip to it's location in the tiprack.
-
-        It will not reset tip tracking so the well flag will remain False.
-
-        :returns: This instance
-
-        :param home_after:
-            See the ``home_after`` parameter in :py:obj:`drop_tip`.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def pick_up_tip(  # noqa: C901
-            self, location: Union[types.Location, Well] = None,
+    def pick_up_tip(
+            self,
+            location: Union[types.Location, Well] = None,
             presses: Optional[int] = None,
             increment: Optional[float] = None) -> InstrumentContext:
-        """
-        Pick up a tip for the pipette to run liquid-handling commands with
-
-        If no location is passed, the Pipette will pick up the next available
-        tip in its :py:attr:`InstrumentContext.tip_racks` list.
-
-        The tip to pick up can be manually specified with the `location`
-        argument. The `location` argument can be specified in several ways:
-
-        * If the only thing to specify is which well from which to pick
-          up a tip, `location` can be a :py:class:`.Well`. For instance,
-          if you have a tip rack in a variable called `tiprack`, you can
-          pick up a specific tip from it with
-          ``instr.pick_up_tip(tiprack.wells()[0])``. This style of call can
-          be used to make the robot pick up a tip from a tip rack that
-          was not specified when creating the :py:class:`.InstrumentContext`.
-
-        * If the position to move to in the well needs to be specified,
-          for instance to tell the robot to run its pick up tip routine
-          starting closer to or farther from the top of the tip,
-          `location` can be a :py:class:`.types.Location`; for instance,
-          you can call ``instr.pick_up_tip(tiprack.wells()[0].top())``.
-
-        :param location: The location from which to pick up a tip.
-        :type location: :py:class:`.types.Location` or :py:class:`.Well` to
-                        pick up a tip from.
-        :param presses: The number of times to lower and then raise the pipette
-                        when picking up a tip, to ensure a good seal (0 [zero]
-                        will result in the pipette hovering over the tip but
-                        not picking it up--generally not desireable, but could
-                        be used for dry-run).
-        :type presses: int
-        :param increment: The additional distance to travel on each successive
-                          press (e.g.: if `presses=3` and `increment=1.0`, then
-                          the first press will travel down into the tip by
-                          3.5mm, the second by 4.5mm, and the third by 5.5mm).
-        :type increment: float
-
-        :returns: This instance
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def drop_tip(  # noqa: C901
+    def drop_tip(
             self,
             location: Union[types.Location, Well] = None,
             home_after: bool = True) -> InstrumentContext:
-        """
-        Drop the current tip.
-
-        If no location is passed, the Pipette will drop the tip into its
-        :py:attr:`trash_container`, which if not specified defaults to
-        the fixed trash in slot 12.
-
-        The location in which to drop the tip can be manually specified with
-        the `location` argument. The `location` argument can be specified in
-        several ways:
-
-            - If the only thing to specify is which well into which to drop
-              a tip, `location` can be a :py:class:`.Well`. For instance,
-              if you have a tip rack in a variable called `tiprack`, you can
-              drop a tip into a specific well on that tiprack with the call
-              `instr.drop_tip(tiprack.wells()[0])`. This style of call can
-              be used to make the robot drop a tip into arbitrary labware.
-            - If the position to drop the tip from as well as the
-              :py:class:`.Well` to drop the tip into needs to be specified,
-              for instance to tell the robot to drop a tip from an unusually
-              large height above the tiprack, `location`
-              can be a :py:class:`.types.Location`; for instance, you can call
-              `instr.drop_tip(tiprack.wells()[0].top())`.
-
-        :param location:
-            The location to drop the tip
-        :type location:
-            :py:class:`.types.Location` or :py:class:`.Well` or None
-        :param home_after:
-            Whether to home this pipette's plunger after dropping the tip.
-            Defaults to ``True``.
-
-            Setting ``home_after=False`` saves waiting a couple of seconds
-            after the pipette drops the tip, but risks causing other problems.
-
-            .. warning::
-                Only set ``home_after=False`` if:
-
-                * You're using a GEN2 pipette, not a GEN1 pipette.
-                * You've tested ``home_after=False`` extensively with your
-                  particular pipette and your particular tips.
-                * You understand the risks described below.
-
-            The ejector shroud that pops the tip off the end of the pipette is
-            driven by the plunger's stepper motor. Sometimes, the strain of
-            ejecting the tip can make that motor *skip* and fall out of sync
-            with where the robot thinks it is.
-
-            Homing the plunger fixes this, so, to be safe, we normally do it
-            after every tip drop.
-
-            If you set ``home_after=False`` to disable homing the plunger, and
-            the motor happens to skip, you might see problems like these until
-            the next time the plunger is homed:
-
-            * The run might halt with a "hard limit" error message.
-            * The pipette might aspirate or dispense the wrong volumes.
-            * The pipette might not fully drop subsequent tips.
-
-            GEN1 pipettes are especially vulnerable to this skipping, so you
-            should never set ``home_after=False`` with a GEN1 pipette.
-
-            Even on GEN2 pipettes, the motor can still skip. So, always
-            extensively test ``home_after=False`` with your particular pipette
-            and your particular tips before relying on it.
-
-        :returns: This instance
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def home(self) -> InstrumentContext:
-        """ Home the robot.
-
-        :returns: This instance.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def home_plunger(self) -> InstrumentContext:
-        """ Home the plunger associated with this mount
-
-        :returns: This instance.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def distribute(self,
                    volume: Union[float, Sequence[float]],
                    source: Well,
                    dest: List[Well],
-                   *args, **kwargs) -> InstrumentContext:
-        """
-        Move a volume of liquid from one source to multiple destinations.
-
-        :param volume: The amount of volume to distribute to each destination
-                       well.
-        :type volume: float or sequence of floats
-        :param source: A single well from where liquid will be aspirated.
-        :param dest: List of Wells where liquid will be dispensed to.
-        :param kwargs: See :py:meth:`transfer`. Some arguments are changed.
-                       Specifically, ``mix_after``, if specified, is ignored
-                       and ``disposal_volume``, if not specified, is set to the
-                       minimum volume of the pipette
-        :returns: This instance
-        """
+                   *args,  # noqa: ANN002
+                   **kwargs,  # noqa: ANN003
+                   ) -> InstrumentContext:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def consolidate(self,
                     volume: Union[float, Sequence[float]],
                     source: List[Well],
                     dest: Well,
-                    *args, **kwargs) -> InstrumentContext:
-        """
-        Move liquid from multiple wells (sources) to a single well(destination)
-
-        :param volume: The amount of volume to consolidate from each source
-                       well.
-        :type volume: float or sequence of floats
-        :param source: List of wells from where liquid will be aspirated.
-        :param dest: The single well into which liquid will be dispensed.
-        :param kwargs: See :py:meth:`transfer`. Some arguments are changed.
-                       Specifically, ``mix_before``, if specified, is ignored
-                       and ``disposal_volume`` is ignored and set to 0.
-        :returns: This instance
-        """
+                    *args,  # noqa: ANN002
+                    **kwargs  # noqa: ANN003
+                    ) -> InstrumentContext:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def transfer(self,
                  volume: Union[float, Sequence[float]],
                  source: AdvancedLiquidHandling,
                  dest: AdvancedLiquidHandling,
-                 trash=True,
-                 **kwargs) -> InstrumentContext:
-        # source: Union[Well, List[Well], List[List[Well]]],
-        # dest: Union[Well, List[Well], List[List[Well]]],
-        # TODO: Reach consensus on kwargs
-        # TODO: Decide if to use a disposal_volume
-        # TODO: Accordingly decide if remaining liquid should be blown out to
-        # TODO: ..trash or the original well.
-        # TODO: What should happen if the user passes a non-first-row well
-        # TODO: ..as src/dest *while using multichannel pipette?
-        r"""
-        Transfer will move a volume of liquid from a source location(s)
-        to a dest location(s). It is a higher-level command, incorporating
-        other :py:class:`InstrumentContext` commands, like :py:meth:`aspirate`
-        and :py:meth:`dispense`, designed to make protocol writing easier at
-        the cost of specificity.
-
-        :param volume: The amount of volume to aspirate from each source and
-                       dispense to each destination.
-                       If volume is a list, each volume will be used for the
-                       sources/targets at the matching index. If volumes is a
-                       tuple with two elements, like `(20, 100)`, then a list
-                       of volumes will be generated with a linear gradient
-                       between the two volumes in the tuple.
-        :param source: A single well or a list of wells from where liquid
-                       will be aspirated.
-        :param dest: A single well or a list of wells where liquid
-                     will be dispensed to.
-        :param \**kwargs: See below
-
-        :Keyword Arguments:
-
-            * *new_tip* (``string``) --
-
-                - 'never': no tips will be picked up or dropped during transfer
-                - 'once': (default) a single tip will be used for all commands.
-                - 'always': use a new tip for each transfer.
-
-            * *trash* (``boolean``) --
-              If `True` (default behavior), tips will be
-              dropped in the trash container attached this `Pipette`.
-              If `False` tips will be returned to tiprack.
-
-            * *touch_tip* (``boolean``) --
-              If `True`, a :py:meth:`touch_tip` will occur following each
-              :py:meth:`aspirate` and :py:meth:`dispense`. If set to `False`
-              (default behavior), no :py:meth:`touch_tip` will occur.
-
-            * *blow_out* (``boolean``) --
-              If `True`, a :py:meth:`blow_out` will occur following each
-              :py:meth:`dispense`, but only if the pipette has no liquid left
-              in it. If set to `False` (default), no :py:meth:`blow_out` will
-              occur.
-
-            * *blowout_location* (``string``) --
-                - 'source well': blowout excess liquid into source well
-                - 'destintation well': blowout excess liquid into destination
-                   well
-                - 'trash': blowout excess liquid into the trash
-                If no `blowout_location` specified, no `disposal_volume`
-                specified, and the pipette contains liquid,
-                a :py:meth:`blow_out` will occur into the source well
-
-                If no `blowout_location` specified and either
-                `disposal_volume` is specified or the pipette is empty,
-                a :py:meth:`blow_out` will occur into the trash
-
-                If `blow_out` is set to `False`, this parameter will be ignored
-
-            * *mix_before* (``tuple``) --
-              The tuple, if specified, gives the amount of volume to
-              :py:meth:`mix` preceding each :py:meth:`aspirate` during the
-              transfer. The tuple is interpreted as (repetitions, volume).
-
-            * *mix_after* (``tuple``) --
-              The tuple, if specified, gives the amount of volume to
-              :py:meth:`mix` after each :py:meth:`dispense` during the
-              transfer. The tuple is interpreted as (repetitions, volume).
-
-            * *disposal_volume* (``float``) --
-              (:py:meth:`distribute` only) Volume of liquid to be disposed off
-              after distributing. When dispensing multiple times from the same
-              tip, it is recommended to aspirate an extra amount of liquid to
-              be disposed off after distributing.
-
-            * *carryover* (``boolean``) --
-              If `True` (default), any `volume` that exceeds the maximum volume
-              of this Pipette will be split into multiple smaller volumes.
-
-            * *gradient* (``lambda``) --
-              Function for calculating the curve used for gradient volumes.
-              When `volume` is a tuple of length 2, its values are used to
-              create a list of gradient volumes. The default curve for this
-              gradient is linear (lambda x: x), however a method can be passed
-              with the `gradient` keyword argument to create a custom curve.
-
-        :returns: This instance
-
-        Args:
-            trash:
-        """
+                 trash: bool = True,
+                 **kwargs  # noqa: ANN003
+                 ) -> InstrumentContext:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def delay(self) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def move_to(self,
                 location: types.Location,
                 force_direct: bool = False,
                 minimum_z_height: Optional[float] = None,
                 speed: Optional[float] = None
                 ) -> InstrumentContext:
-        """ Move the instrument.
-
-        :param location: The location to move to.
-        :type location: :py:class:`.types.Location`
-        :param force_direct: If set to true, move directly to destination
-                        without arc motion.
-        :param minimum_z_height: When specified, this Z margin is able to raise
-                                 (but never lower) the mid-arc height.
-        :param speed: The speed at which to move. By default,
-                      :py:attr:`InstrumentContext.default_speed`. This controls
-                      the straight linear speed of the motion; to limit
-                      individual axis speeds, you can use
-                      :py:attr:`.ProtocolContext.max_speeds`.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def mount(self) -> str:
-        """ Return the name of the mount this pipette is attached to """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def speed(self) -> PlungerSpeeds:
-        """ The speeds (in mm/s) configured for the pipette plunger.
-
-        This is an object with attributes ``aspirate``, ``dispense``, and
-        ``blow_out`` holding the plunger speeds for the corresponding
-        operation.
-
-        .. note::
-            This property is equivalent to :py:attr:`flow_rate`; the only
-            difference is the units in which this property is specified.
-            Specifying this attribute uses the units of the linear speed of
-            the plunger inside the pipette, while :py:attr:`flow_rate` uses
-            the units of the volumetric flow rate of liquid into or out of the
-            tip. Because :py:attr:`speed` and :py:attr:`flow_rate` modify the
-            same values, setting one will override the other.
-
-        For instance, to set the plunger speed during an aspirate action, do
-
-        .. code-block :: python
-
-            instrument.speed.aspirate = 50
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def flow_rate(self) -> FlowRates:
-        """ The speeds (in uL/s) configured for the pipette.
-
-        This is an object with attributes ``aspirate``, ``dispense``, and
-        ``blow_out`` holding the flow rates for the corresponding operation.
-
-        .. note::
-          This property is equivalent to :py:attr:`speed`; the only
-          difference is the units in which this property is specified.
-          specifiying this property uses the units of the volumetric flow rate
-          of liquid into or out of the tip, while :py:attr:`speed` uses the
-          units of the linear speed of the plunger inside the pipette.
-          Because :py:attr:`speed` and :py:attr:`flow_rate` modify the
-          same values, setting one will override the other.
-
-        For instance, to change the flow rate for aspiration on an instrument
-        you would do
-
-        .. code-block :: python
-
-            instrument.flow_rate.aspirate = 50
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def type(self) -> str:
-        """ One of `'single'` or `'multi'`.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def tip_racks(self) -> List[Labware]:
-        """
-        The tip racks that have been linked to this pipette.
-
-        This is the property used to determine which tips to pick up next when
-        calling :py:meth:`pick_up_tip` without arguments.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     @tip_racks.setter
     def tip_racks(self, racks: List[Labware]) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def trash_container(self) -> Labware:
-        """ The trash container associated with this pipette.
-
-        This is the property used to determine where to drop tips and blow out
-        liquids when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without
-        arguments.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     @trash_container.setter
     def trash_container(self, trash: Labware) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def name(self) -> str:
-        """
-        The name string for the pipette (e.g. 'p300_single')
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def model(self) -> str:
-        """
-        The model string for the pipette (e.g. 'p300_single_v1.3')
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def min_volume(self) -> float:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def max_volume(self) -> float:
-        """
-        The maximum volume, in microliters (µL), that this pipette can hold.
-
-        The maximum volume that you can actually aspirate might be lower than
-        this, depending on what kind of tip is attached to this pipette.  For
-        example, a P300 Single-Channel pipette always has a ``max_volume`` of
-        300 µL, but if it's using a 200 µL filter tip, its usable volume would
-        be limited to 200 µL.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def current_volume(self) -> float:
-        """
-        The current amount of liquid, in microliters, held in the pipette.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 7)
+    @property
     def has_tip(self) -> bool:
-        """
-        :returns: Whether this instrument has a tip attached or not.
-        :type: bool
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def hw_pipette(self) -> PipetteDict:
-        """ View the information returned by the hardware API directly.
-
-        :raises: a :py:class:`.types.PipetteNotAttachedError` if the pipette is
-                 no longer attached (should not happen).
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def channels(self) -> int:
-        """ The number of channels on the pipette. """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 2)
+    @property
     def return_height(self) -> float:
-        """ The height to return a tip to its tiprack. """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def well_bottom_clearance(self) -> Clearances:
-        """ The distance above the bottom of a well to aspirate or dispense.
-
-        This is an object with attributes ``aspirate`` and ``dispense``,
-        describing the default heights of the corresponding operation. The
-        default is 1.0mm for both aspirate and dispense.
-
-        When :py:meth:`aspirate` or :py:meth:`dispense` is given a
-        :py:class:`.Well` rather than a full :py:class:`.Location`, the robot
-        will move this distance above the bottom of the well to aspirate or
-        dispense.
-
-        To change, set the corresponding attribute. For instance,
-
-        .. code-block:: python
-
-            instr.well_bottom_clearance.aspirate = 1
-
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     def __repr__(self) -> str:
+        # noqa: D105
         raise NotImplementedError()
 
     def __str__(self) -> str:
+        # noqa: D105
         raise NotImplementedError()
 
-    @requires_version(2, 7)
     def pair_with(
             self, instrument: InstrumentContext) -> PairedInstrumentContext:
-        """ This function allows you to pair both of your pipettes and use
-        them simultaneously. The function implicitly decides a primary
-        and secondary pipette based on which instrument you call this
-        function on.
-
-        :param instrument: The secondary instrument you wish to use
-
-        :raises UnsupportedInstrumentPairingError: If you try to pair
-        pipettes that are not currently supported together.
-        :returns: PairedInstrumentContext: This is the object you
-        will call commands on.
-
-        This function returns a :py:class:`PairedInstrumentContext`.
-        The building block commands are the same as an individual pipette's
-        building block commands found at :ref:`v2-atomic-commands`,
-        and when you want to move pipettes simultaneously you need to use the
-        :py:class:`PairedInstrumentContext`.
-
-
-        Limitations:
-        1. This function utilizes a "primary" and "secondary" pipette to make
-        positional decisions. The consequence of doing this is that all X & Y
-        positions are based on the primary pipette only.
-        2. At this time, only pipettes of the same type are supported for
-        pipette pairing. This means that you cannot utilize a P1000 Single
-        channel and a P300 Single channel at the same time.
-
-        .. code-block :: python
-            :substitutions:
-
-            from opentrons import protocol_api
-
-            # metadata
-            metadata = {
-                'protocolName': 'My Protocol',
-                'author': 'Name <email@address.com>',
-                'description': 'Simple paired pipette protocol,
-                'apiLevel': '|apiLevel|'
-            }
-
-            def run(ctx: protocol_api.ProtocolContext):
-                right_pipette = ctx.load_instrument(
-                    'p300_single_gen2', 'right')
-                left_pipette = ctx.load_instrument('p300_single_gen2', 'left')
-
-                # In this scenario, the right pipette is the primary pipette
-                # while the left pipette is the secondary pipette. All XY
-                # locations will be based on the right pipette.
-                right_paired_with_left = right_pipette.pair_with(left_pipette)
-                right_paired_with_left.pick_up_tip()
-                right_paired_with_left.drop_tip()
-
-                # In this scenario, the left pipette is the primary pipette
-                # while the right pipette is the secondary pipette. All XY
-                # locations will be based on the left pipette.
-                left_paired_with_right = left_pipette.pair_with(right_pipette)
-                left_paired_with_right.pick_up_tip()
-                left_paired_with_right.drop_tip()
-
-        .. note::
-
-            Before using this method, you should seriously consider whether
-            this is the best fit for your use-case especially given the
-            limitations listed above.
-        """
+        # noqa: D102
         raise NotImplementedError()

--- a/api/src/opentrons/experimental_protocol_api/labware.py
+++ b/api/src/opentrons/experimental_protocol_api/labware.py
@@ -1,434 +1,241 @@
-""" opentrons.protocol_api.labware: classes and functions for labware handling
-
-This module provides things like :py:class:`Labware`, and :py:class:`Well`
-to encapsulate labware instances used in protocols
-and their wells. It also provides helper functions to load and save labware
-and labware calibration offsets. It contains all the code necessary to
-transform from labware symbolic points (such as "well a1 of an opentrons
-tiprack") to points in deck coordinates.
-"""
+# noqa: D100
+from __future__ import annotations
 import logging
 
 from typing import (
-    List, Dict, Optional, TYPE_CHECKING
+    List, Dict, Optional
 )
 
-from opentrons.protocols.api_support.util import (
-    requires_version)
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.geometry.deck_item import DeckItem
-if TYPE_CHECKING:
-    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa: F401, E501
-    from opentrons_shared_data.labware.dev_types import (
-        LabwareParameters)
+from opentrons_shared_data.labware.dev_types import LabwareParameters
 
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 class TipSelectionError(Exception):
+    # noqa: D101
     pass
 
 
 class OutOfTipsError(Exception):
+    # noqa: D101
     pass
 
 
 class Well:
-    """
-    The Well class represents a  single well in a :py:class:`Labware`
+    # noqa: D101
 
-    It provides functions to return positions used in operations on the well
-    such as :py:meth:`top`, :py:meth:`bottom`
-    """
-
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def api_version(self) -> APIVersion:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
-    def parent(self) -> 'Labware':
+    @property
+    def parent(self) -> Labware:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def has_tip(self) -> bool:
+        # noqa: D102
         raise NotImplementedError()
 
     @has_tip.setter
-    def has_tip(self, value: bool):
+    def has_tip(self, value: bool) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
     @property
     def max_volume(self) -> float:
+        # noqa: D102
         raise NotImplementedError()
 
     @property
     def geometry(self) -> WellGeometry:
-        raise NotImplementedError()
-
-    @property  # type: ignore
-    @requires_version(2, 0)
-    def diameter(self) -> Optional[float]:
-        raise NotImplementedError()
-
-    @property  # type: ignore
-    @requires_version(2, 9)
-    def length(self) -> Optional[float]:
-        """
-        The length of a well, if the labware has
-        square wells.
-        """
-        raise NotImplementedError()
-
-    @property  # type: ignore
-    @requires_version(2, 9)
-    def width(self) -> Optional[float]:
-        """
-        The width of a well, if the labware has
-        square wells.
-        """
-        raise NotImplementedError()
-
-    @property  # type: ignore
-    @requires_version(2, 9)
-    def depth(self) -> float:
-        """
-        The depth of a well in a labware.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     @property
-    def display_name(self):
+    def diameter(self) -> Optional[float]:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 7)
+    @property
+    def length(self) -> Optional[float]:
+        # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def width(self) -> Optional[float]:
+        # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def depth(self) -> float:
+        # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def display_name(self) -> str:
+        # noqa: D102
+        raise NotImplementedError()
+
+    @property
     def well_name(self) -> str:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def top(self, z: float = 0.0) -> Location:
-        """
-        :param z: the z distance in mm
-        :return: a Point corresponding to the absolute position of the
-                 top-center of the well relative to the deck (with the
-                 front-left corner of slot 1 as (0,0,0)). If z is specified,
-                 returns a point offset by z mm from top-center
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def bottom(self, z: float = 0.0) -> Location:
-        """
-        :param z: the z distance in mm
-        :return: a Point corresponding to the absolute position of the
-                 bottom-center of the well (with the front-left corner of
-                 slot 1 as (0,0,0)). If z is specified, returns a point
-                 offset by z mm from bottom-center
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def center(self) -> Location:
-        """
-        :return: a Point corresponding to the absolute position of the center
-                 of the well relative to the deck (with the front-left corner
-                 of slot 1 as (0,0,0))
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
-        """
-        Specifies an arbitrary point in deck coordinates based
-        on percentages of the radius in each axis. For example, to specify the
-        back-right corner of a well at 1/4 of the well depth from the bottom,
-        the call would be `from_center_cartesian(1, 1, -0.5)`.
-
-        No checks are performed to ensure that the resulting position will be
-        inside of the well.
-
-        :param x: a float in the range [-1.0, 1.0] for a percentage of half of
-            the radius/length in the X axis
-        :param y: a float in the range [-1.0, 1.0] for a percentage of half of
-            the radius/width in the Y axis
-        :param z: a float in the range [-1.0, 1.0] for a percentage of half of
-            the height above/below the center
-
-        :return: a Point representing the specified location in absolute deck
-        coordinates
-        """
+        # noqa: D102
         raise NotImplementedError()
 
     def __repr__(self) -> str:
+        # noqa: D105
         raise NotImplementedError()
 
     def __eq__(self, other: object) -> bool:
-        """
-        Assuming that equality of wells in this system is having the same
-        absolute coordinates for the top.
-        """
+        # noqa: D105
         raise NotImplementedError()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        # noqa: D105
         raise NotImplementedError()
 
 
 class Labware(DeckItem):
-    """
-    This class represents a labware, such as a PCR plate, a tube rack,
-    reservoir, tip rack, etc. It defines the physical geometry of the labware,
-    and provides methods for accessing wells within the labware.
+    # noqa: D101
 
-    It is commonly created by calling :py:meth:`ProtocolContext.load_labware`.
-
-    To access a labware's wells, you can use its well accessor methods:
-    :py:meth:`wells_by_name`, :py:meth:`wells`, :py:meth:`columns`,
-    :py:meth:`rows`, :py:meth:`rows_by_name`, and :py:meth:`columns_by_name`.
-    You can also use an instance of a labware as a Python dictionary, accessing
-    wells by their names. The following example shows how to use all of these
-    methods to access well A1:
-
-    .. code-block :: python
-
-       labware = context.load_labware('corning_96_wellplate_360ul_flat', 1)
-       labware['A1']
-       labware.wells_by_name()['A1']
-       labware.wells()[0]
-       labware.rows()[0][0]
-       labware.columns()[0][0]
-       labware.rows_by_name()['A'][0]
-       labware.columns_by_name()[0][0]
-
-    """
     @property
     def separate_calibration(self) -> bool:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def api_version(self) -> APIVersion:
+        # noqa: D102
         raise NotImplementedError()
 
     def __getitem__(self, key: str) -> Well:
+        # noqa: D105
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def uri(self) -> str:
-        """ A string fully identifying the labware.
-
-        :returns: The uri, ``"namespace/loadname/version"``
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def parent(self) -> LocationLabware:
-        """ The parent of this labware. Usually a slot name.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def name(self) -> str:
-        """ Can either be the canonical name of the labware, which is used to
-        load it, or the label of the labware specified by a user. """
+        # noqa: D102
         raise NotImplementedError()
 
-    @name.setter  # type: ignore
-    def name(self, new_name) -> None:
-        """ Set the labware name"""
+    @name.setter
+    def name(self, new_name: str) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def load_name(self) -> str:
-        """ The API load name of the labware definition """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
-    def parameters(self) -> 'LabwareParameters':
-        """Internal properties of a labware including type and quirks"""
+    @property
+    def parameters(self) -> LabwareParameters:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def quirks(self) -> List[str]:
-        """ Quirks specific to this labware. """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def magdeck_engage_height(self) -> Optional[float]:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def calibrated_offset(self) -> Point:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def well(self, idx) -> Well:
-        """Deprecated---use result of `wells` or `wells_by_name`"""
+    def well(self, idx: int) -> Well:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def wells(self, *args) -> List[Well]:
-        """
-        Accessor function used to generate a list of wells in top -> down,
-        left -> right order. This is representative of moving down `rows` and
-        across `columns` (e.g. 'A1', 'B1', 'C1'...'A2', 'B2', 'C2')
-
-        With indexing one can treat it as a typical python
-        list. To access well A1, for example, simply write: labware.wells()[0]
-
-        Note that this method takes args for backward-compatibility, but use
-        of args is deprecated and will be removed in future versions. Args
-        can be either strings or integers, but must all be the same type (e.g.:
-        `self.wells(1, 4, 8)` or `self.wells('A1', 'B2')`, but
-        `self.wells('A1', 4)` is invalid.
-
-        :return: Ordered list of all wells in a labware
-        """
+    def wells(self) -> List[Well]:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
     def wells_by_name(self) -> Dict[str, Well]:
-        """
-        Accessor function used to create a look-up table of Wells by name.
-
-        With indexing one can treat it as a typical python
-        dictionary whose keys are well names. To access well A1, for example,
-        simply write: labware.wells_by_name()['A1']
-
-        :return: Dictionary of well objects keyed by well name
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def wells_by_index(self) -> Dict[str, Well]:
-        MODULE_LOG.warning(
-            'wells_by_index is deprecated and will be deleted in version '
-            '3.12.0. please wells_by_name or dict access')
+    def rows(self) -> List[List[Well]]:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def rows(self, *args) -> List[List[Well]]:
-        """
-        Accessor function used to navigate through a labware by row.
-
-        With indexing one can treat it as a typical python nested list.
-        To access row A for example, simply write: labware.rows()[0]. This
-        will output ['A1', 'A2', 'A3', 'A4'...]
-
-        Note that this method takes args for backward-compatibility, but use
-        of args is deprecated and will be removed in future versions. Args
-        can be either strings or integers, but must all be the same type (e.g.:
-        `self.rows(1, 4, 8)` or `self.rows('A', 'B')`, but  `self.rows('A', 4)`
-        is invalid.
-
-        :return: A list of row lists
-        """
-        raise NotImplementedError()
-
-    @requires_version(2, 0)
     def rows_by_name(self) -> Dict[str, List[Well]]:
-        """
-        Accessor function used to navigate through a labware by row name.
-
-        With indexing one can treat it as a typical python dictionary.
-        To access row A for example, simply write: labware.rows_by_name()['A']
-        This will output ['A1', 'A2', 'A3', 'A4'...].
-
-        :return: Dictionary of Well lists keyed by row name
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def rows_by_index(self) -> Dict[str, List[Well]]:
-        MODULE_LOG.warning(
-            'rows_by_index is deprecated and will be deleted in version '
-            '3.12.0. please use rows_by_name')
+    def columns(self) -> List[List[Well]]:
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def columns(self, *args) -> List[List[Well]]:
-        """
-        Accessor function used to navigate through a labware by column.
-
-        With indexing one can treat it as a typical python nested list.
-        To access row A for example,
-        simply write: labware.columns()[0]
-        This will output ['A1', 'B1', 'C1', 'D1'...].
-
-        Note that this method takes args for backward-compatibility, but use
-        of args is deprecated and will be removed in future versions. Args
-        can be either strings or integers, but must all be the same type (e.g.:
-        `self.columns(1, 4, 8)` or `self.columns('1', '2')`, but
-        `self.columns('1', 4)` is invalid.
-
-        :return: A list of column lists
-        """
-        raise NotImplementedError()
-
-    @requires_version(2, 0)
     def columns_by_name(self) -> Dict[str, List[Well]]:
-        """
-        Accessor function used to navigate through a labware by column name.
-
-        With indexing one can treat it as a typical python dictionary.
-        To access row A for example,
-        simply write: labware.columns_by_name()['1']
-        This will output ['A1', 'B1', 'C1', 'D1'...].
-
-        :return: Dictionary of Well lists keyed by column name
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @requires_version(2, 0)
-    def columns_by_index(self) -> Dict[str, List[Well]]:
-        MODULE_LOG.warning(
-            'columns_by_index is deprecated and will be deleted in version '
-            '3.12.0. please use columns_by_name')
-        raise NotImplementedError()
-
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def highest_z(self) -> float:
-        """
-        The z-coordinate of the tallest single point anywhere on the labware.
-
-        This is drawn from the 'dimensions'/'zDimension' elements of the
-        labware definition and takes into account the calibration offset.
-        """
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def is_tiprack(self) -> bool:
+        # noqa: D102
         raise NotImplementedError()
 
-    @property  # type: ignore
-    @requires_version(2, 0)
+    @property
     def tip_length(self) -> float:
+        # noqa: D102
         raise NotImplementedError()
 
     @tip_length.setter
-    def tip_length(self, length: float):
+    def tip_length(self, length: float) -> None:
+        # noqa: D102
         raise NotImplementedError()
 
     def __repr__(self) -> str:
+        # noqa: D105
         raise NotImplementedError()
 
     def __eq__(self, other: object) -> bool:
+        # noqa: D105
         raise NotImplementedError()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
+        # noqa: D105
         raise NotImplementedError()

--- a/api/src/opentrons/experimental_protocol_api/labware.py
+++ b/api/src/opentrons/experimental_protocol_api/labware.py
@@ -9,30 +9,20 @@ tiprack") to points in deck coordinates.
 """
 import logging
 
-from pathlib import Path
-from itertools import dropwhile
 from typing import (
-    Any, AnyStr, List, Dict,
-    Optional, Union, Tuple,
-    TYPE_CHECKING)
-
+    List, Dict, Optional, TYPE_CHECKING
+)
 
 from opentrons.protocols.api_support.util import (
-    requires_version, labware_column_shift)
-from opentrons.protocols.context.labware import \
-    AbstractLabware
+    requires_version)
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocols import labware as labware_module
-from opentrons.protocols.context.well import WellImplementation
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.definitions import (
-    MAX_SUPPORTED_VERSION)
 from opentrons.protocols.geometry.deck_item import DeckItem
 if TYPE_CHECKING:
     from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa: F401, E501
     from opentrons_shared_data.labware.dev_types import (
-        LabwareDefinition, LabwareParameters)
+        LabwareParameters)
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -53,50 +43,38 @@ class Well:
     It provides functions to return positions used in operations on the well
     such as :py:meth:`top`, :py:meth:`bottom`
     """
-    def __init__(self,
-                 well_implementation: WellImplementation,
-                 api_level: Optional[APIVersion] = None):
-        """
-        Create a well, and track the Point corresponding to the top-center of
-        the well (this Point is in absolute deck coordinates)
-
-        """
-        self._api_version = api_level or MAX_SUPPORTED_VERSION
-        self._impl = well_implementation
-        self._geometry = well_implementation.get_geometry()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def api_version(self) -> APIVersion:
-        return self._api_version
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def parent(self) -> 'Labware':
-        return Labware(implementation=self._geometry.parent,
-                       api_level=self.api_version)
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        return self._impl.has_tip()
+        raise NotImplementedError()
 
     @has_tip.setter
     def has_tip(self, value: bool):
-        self._impl.set_has_tip(value)
+        raise NotImplementedError()
 
     @property
     def max_volume(self) -> float:
-        return self._geometry.max_volume
+        raise NotImplementedError()
 
     @property
     def geometry(self) -> WellGeometry:
-        return self._geometry
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def diameter(self) -> Optional[float]:
-        return self._geometry.diameter
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -105,7 +83,7 @@ class Well:
         The length of a well, if the labware has
         square wells.
         """
-        return self._geometry._length
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -114,7 +92,7 @@ class Well:
         The width of a well, if the labware has
         square wells.
         """
-        return self._geometry._width
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 9)
@@ -122,16 +100,16 @@ class Well:
         """
         The depth of a well in a labware.
         """
-        return self._geometry._depth
+        raise NotImplementedError()
 
     @property
     def display_name(self):
-        return self._impl.get_display_name()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 7)
     def well_name(self) -> str:
-        return self._impl.get_name()
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def top(self, z: float = 0.0) -> Location:
@@ -142,7 +120,7 @@ class Well:
                  front-left corner of slot 1 as (0,0,0)). If z is specified,
                  returns a point offset by z mm from top-center
         """
-        return Location(self._geometry.top(z), self)
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def bottom(self, z: float = 0.0) -> Location:
@@ -153,7 +131,7 @@ class Well:
                  slot 1 as (0,0,0)). If z is specified, returns a point
                  offset by z mm from bottom-center
         """
-        return Location(self._geometry.bottom(z), self)
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def center(self) -> Location:
@@ -162,7 +140,7 @@ class Well:
                  of the well relative to the deck (with the front-left corner
                  of slot 1 as (0,0,0))
         """
-        return Location(self._geometry.center(), self)
+        raise NotImplementedError()
 
     @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
@@ -185,31 +163,20 @@ class Well:
         :return: a Point representing the specified location in absolute deck
         coordinates
         """
-        return self._geometry.from_center_cartesian(x, y, z)
+        raise NotImplementedError()
 
-    def _from_center_cartesian(self, x: float, y: float, z: float) -> Point:
-        """
-        Private version of from_center_cartesian. Present only for backward
-        compatibility.
-        """
-        MODULE_LOG.warning("This method is deprecated. Please use "
-                           "'from_center_cartesian' instead.")
-        return self.from_center_cartesian(x, y, z)
-
-    def __repr__(self):
-        return self._impl.get_display_name()
+    def __repr__(self) -> str:
+        raise NotImplementedError()
 
     def __eq__(self, other: object) -> bool:
         """
         Assuming that equality of wells in this system is having the same
         absolute coordinates for the top.
         """
-        if not isinstance(other, Well):
-            return NotImplemented
-        return self.top().point == other.top().point
+        raise NotImplementedError()
 
     def __hash__(self):
-        return hash(self.top().point)
+        raise NotImplementedError()
 
 
 class Labware(DeckItem):
@@ -239,40 +206,17 @@ class Labware(DeckItem):
        labware.columns_by_name()[0][0]
 
     """
-    def __init__(
-            self,
-            implementation: AbstractLabware,
-            api_level: Optional[APIVersion] = None) -> None:
-        """
-        :param implementation: The class that implements the public interface
-                               of the class.
-        :param APIVersion api_level: the API version to set for the instance.
-                                     The :py:class:`.Labware` will
-                                     conform to this level. If not specified,
-                                     defaults to
-                                     :py:attr:`.MAX_SUPPORTED_VERSION`.
-        """
-        if not api_level:
-            api_level = MAX_SUPPORTED_VERSION
-        if api_level > MAX_SUPPORTED_VERSION:
-            raise RuntimeError(
-                f'API version {api_level} is not supported by this '
-                f'robot software. Please either reduce your requested API '
-                f'version or update your robot.')
-        self._api_version = api_level
-        self._implementation = implementation
-
     @property
     def separate_calibration(self) -> bool:
-        return self._implementation.separate_calibration
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def api_version(self) -> APIVersion:
-        return self._api_version
+        raise NotImplementedError()
 
     def __getitem__(self, key: str) -> Well:
-        return self.wells_by_name()[key]
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -281,75 +225,59 @@ class Labware(DeckItem):
 
         :returns: The uri, ``"namespace/loadname/version"``
         """
-        return self._implementation.get_uri()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def parent(self) -> LocationLabware:
         """ The parent of this labware. Usually a slot name.
         """
-        return self._implementation.get_geometry().parent.labware.object
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def name(self) -> str:
         """ Can either be the canonical name of the labware, which is used to
         load it, or the label of the labware specified by a user. """
-        return self._implementation.get_name()
+        raise NotImplementedError()
 
     @name.setter  # type: ignore
-    def name(self, new_name):
+    def name(self, new_name) -> None:
         """ Set the labware name"""
-        self._implementation.set_name(new_name)
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def load_name(self) -> str:
         """ The API load name of the labware definition """
-        return self._implementation.load_name
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def parameters(self) -> 'LabwareParameters':
         """Internal properties of a labware including type and quirks"""
-        return self._implementation.get_parameters()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def quirks(self) -> List[str]:
         """ Quirks specific to this labware. """
-        return self._implementation.get_quirks()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def magdeck_engage_height(self) -> Optional[float]:
-        p = self._implementation.get_parameters()
-        if not p['isMagneticModuleCompatible']:
-            return None
-        else:
-            return p['magneticModuleEngageHeight']
-
-    def set_calibration(self, delta: Point):
-        """
-        Called by save calibration in order to update the offset on the object.
-        """
-        self._implementation.set_calibration(delta)
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def calibrated_offset(self) -> Point:
-        return self._implementation.get_calibrated_offset()
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def well(self, idx) -> Well:
         """Deprecated---use result of `wells` or `wells_by_name`"""
-        if isinstance(idx, int):
-            res = self._implementation.get_wells()[idx]
-        elif isinstance(idx, str):
-            res = self._implementation.get_wells_by_name()[idx]
-        else:
-            res = NotImplemented
-        return self._well_from_impl(res)
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def wells(self, *args) -> List[Well]:
@@ -369,16 +297,7 @@ class Labware(DeckItem):
 
         :return: Ordered list of all wells in a labware
         """
-        if not args:
-            res = self._implementation.get_wells()
-        elif isinstance(args[0], int):
-            res = [self._implementation.get_wells()[idx] for idx in args]
-        elif isinstance(args[0], str):
-            by_name = self._implementation.get_wells_by_name()
-            res = [by_name[idx] for idx in args]
-        else:
-            raise TypeError
-        return [self._well_from_impl(w) for w in res]
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def wells_by_name(self) -> Dict[str, Well]:
@@ -391,18 +310,14 @@ class Labware(DeckItem):
 
         :return: Dictionary of well objects keyed by well name
         """
-        wells = self._implementation.get_wells_by_name()
-        return {
-            k: self._well_from_impl(v)
-            for k, v in wells.items()
-        }
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def wells_by_index(self) -> Dict[str, Well]:
         MODULE_LOG.warning(
             'wells_by_index is deprecated and will be deleted in version '
             '3.12.0. please wells_by_name or dict access')
-        return self.wells_by_name()
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def rows(self, *args) -> List[List[Well]]:
@@ -421,16 +336,7 @@ class Labware(DeckItem):
 
         :return: A list of row lists
         """
-        grid = self._implementation.get_well_grid()
-        if not args:
-            res = grid.get_rows()
-        elif isinstance(args[0], int):
-            res = [grid.get_rows()[idx] for idx in args]
-        elif isinstance(args[0], str):
-            res = [grid.get_row(idx) for idx in args]
-        else:
-            raise TypeError
-        return [[self._well_from_impl(w) for w in row] for row in res]
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def rows_by_name(self) -> Dict[str, List[Well]]:
@@ -443,19 +349,14 @@ class Labware(DeckItem):
 
         :return: Dictionary of Well lists keyed by row name
         """
-        row_dict = self._implementation.get_well_grid().get_row_dict()
-        return {
-            k: [
-                self._well_from_impl(w) for w in v
-            ] for k, v in row_dict.items()
-        }
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def rows_by_index(self) -> Dict[str, List[Well]]:
         MODULE_LOG.warning(
             'rows_by_index is deprecated and will be deleted in version '
             '3.12.0. please use rows_by_name')
-        return self.rows_by_name()
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def columns(self, *args) -> List[List[Well]]:
@@ -475,16 +376,7 @@ class Labware(DeckItem):
 
         :return: A list of column lists
         """
-        grid = self._implementation.get_well_grid()
-        if not args:
-            res = grid.get_columns()
-        elif isinstance(args[0], int):
-            res = [grid.get_columns()[idx] for idx in args]
-        elif isinstance(args[0], str):
-            res = [grid.get_column(idx) for idx in args]
-        else:
-            raise TypeError
-        return [[self._well_from_impl(w) for w in col] for col in res]
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def columns_by_name(self) -> Dict[str, List[Well]]:
@@ -498,19 +390,14 @@ class Labware(DeckItem):
 
         :return: Dictionary of Well lists keyed by column name
         """
-        column_dict = self._implementation.get_well_grid().get_column_dict()
-        return {
-            k: [
-                self._well_from_impl(w) for w in v
-            ] for k, v in column_dict.items()
-        }
+        raise NotImplementedError()
 
     @requires_version(2, 0)
     def columns_by_index(self) -> Dict[str, List[Well]]:
         MODULE_LOG.warning(
             'columns_by_index is deprecated and will be deleted in version '
             '3.12.0. please use columns_by_name')
-        return self.columns_by_name()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -521,426 +408,27 @@ class Labware(DeckItem):
         This is drawn from the 'dimensions'/'zDimension' elements of the
         labware definition and takes into account the calibration offset.
         """
-        return self._implementation.highest_z
-
-    @property
-    def _is_tiprack(self) -> bool:
-        """ as is_tiprack but not subject to version checking for speed """
-        return self._implementation.is_tiprack()
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def is_tiprack(self) -> bool:
-        return self._is_tiprack
+        raise NotImplementedError()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def tip_length(self) -> float:
-        return self._implementation.get_tip_length()
+        raise NotImplementedError()
 
     @tip_length.setter
     def tip_length(self, length: float):
-        self._implementation.set_tip_length(length)
+        raise NotImplementedError()
 
-    def next_tip(self,
-                 num_tips: int = 1,
-                 starting_tip: Optional[Well] = None) -> Optional[Well]:
-        """
-        Find the next valid well for pick-up.
-
-        Determines the next valid start tip from which to retrieve the
-        specified number of tips. There must be at least `num_tips` sequential
-        wells for which all wells have tips, in the same column.
-
-        :param num_tips: target number of sequential tips in the same column
-        :type num_tips: int
-        :param starting_tip: The :py:class:`.Well` from which to start search.
-                for an available tip.
-        :type starting_tip: :py:class:`.Well`
-        :return: the :py:class:`.Well` meeting the target criteria, or None
-        """
-        assert num_tips > 0, 'Bad call to next_tip: num_tips <= 0'
-
-        well = self._implementation.get_tip_tracker().next_tip(
-            num_tips=num_tips,
-            starting_tip=starting_tip._impl if starting_tip else None
-        )
-        return self._well_from_impl(well) if well else None
-
-    def use_tips(self, start_well: Well, num_channels: int = 1):
-        """
-        Removes tips from the tip tracker.
-
-        This method should be called when a tip is picked up. Generally, it
-        will be called with `num_channels=1` or `num_channels=8` for single-
-        and multi-channel respectively. If picking up with more than one
-        channel, this method will automatically determine which tips are used
-        based on the start well, the number of channels, and the geometry of
-        the tiprack.
-
-        :param start_well: The :py:class:`.Well` from which to pick up a tip.
-                           For a single-channel pipette, this is the well to
-                           send the pipette to. For a multi-channel pipette,
-                           this is the well to send the back-most nozzle of the
-                           pipette to.
-        :type start_well: :py:class:`.Well`
-        :param num_channels: The number of channels for the current pipette
-        :type num_channels: int
-        """
-        assert num_channels > 0, 'Bad call to use_tips: num_channels<=0'
-
-        fail_if_full = self._api_version < APIVersion(2, 2)
-
-        self._implementation.get_tip_tracker().use_tips(
-            start_well=start_well._impl,
-            num_channels=num_channels,
-            fail_if_full=fail_if_full
-        )
-
-    def __repr__(self):
-        return self._implementation.get_display_name()
+    def __repr__(self) -> str:
+        raise NotImplementedError()
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Labware):
-            return NotImplemented
-        return self._implementation == other._implementation
+        raise NotImplementedError()
 
     def __hash__(self):
-        return hash((self._implementation, self._api_version))
-
-    def previous_tip(self, num_tips: int = 1) -> Optional[Well]:
-        """
-        Find the best well to drop a tip in.
-
-        This is the well from which the last tip was picked up, if there's
-        room. It can be used to return tips to the tip tracker.
-
-        :param num_tips: target number of tips to return, sequential in a
-                         column
-        :type num_tips: int
-        :return: The :py:class:`.Well` meeting the target criteria, or ``None``
-        """
-        # This logic is the inverse of :py:meth:`next_tip`
-        assert num_tips > 0, 'Bad call to previous_tip: num_tips <= 0'
-
-        well = self._implementation.get_tip_tracker().previous_tip(
-            num_tips=num_tips
-        )
-        return self._well_from_impl(well) if well else None
-
-    def return_tips(self, start_well: Well, num_channels: int = 1):
-        """
-        Re-adds tips to the tip tracker
-
-        This method should be called when a tip is dropped in a tiprack. It
-        should be called with ``num_channels=1`` or ``num_channels=8`` for
-        single- and multi-channel respectively. If returning more than one
-        channel, this method will automatically determine which tips are
-        returned based on the start well, the number of channels,
-        and the tiprack geometry.
-
-        Note that unlike :py:meth:`use_tips`, calling this method in a way
-        that would drop tips into wells with tips in them will raise an
-        exception; this should only be called on a valid return of
-        :py:meth:`previous_tip`.
-
-        :param start_well: The :py:class:`.Well` into which to return a tip.
-        :type start_well: :py:class:`.Well`
-        :param num_channels: The number of channels for the current pipette
-        :type num_channels: int
-        """
-        # This logic is the inverse of :py:meth:`use_tips`
-        assert num_channels > 0, 'Bad call to return_tips: num_channels <= 0'
-
-        self._implementation.get_tip_tracker().return_tips(
-            start_well=start_well._impl,
-            num_channels=num_channels
-        )
-
-    @requires_version(2, 0)
-    def reset(self):
-        """Reset all tips in a tiprack
-        """
-        if self._is_tiprack:
-            self._implementation.reset_tips()
-
-    def _well_from_impl(self, well: WellImplementation) -> Well:
-        return Well(well_implementation=well,
-                    api_level=self._api_version)
-
-
-def save_definition(
-    labware_def: 'LabwareDefinition',
-    force: bool = False,
-    location: Optional[Path] = None
-) -> None:
-    """
-    Save a labware definition
-
-    :param labware_def: A deserialized JSON labware definition
-    :param bool force: If true, overwrite an existing definition if found.
-        Cannot overwrite Opentrons definitions.
-    :param location: The path of the labware definition.
-    """
-    labware_module.save_definition(labware_def=labware_def,
-                                   force=force,
-                                   location=location)
-
-
-def verify_definition(contents: Union[
-        AnyStr, 'LabwareDefinition', Dict[str, Any]])\
-        -> 'LabwareDefinition':
-    """ Verify that an input string is a labware definition and return it.
-
-    If the definition is invalid, an exception is raised; otherwise parse the
-    json and return the valid definition.
-
-    :raises json.JsonDecodeError: If the definition is not valid json
-    :raises jsonschema.ValidationError: If the definition is not valid.
-    :returns: The parsed definition
-    """
-    return labware_module.verify_definition(contents=contents)
-
-
-def get_labware_definition(
-    load_name: str,
-    namespace: Optional[str] = None,
-    version: Optional[int] = None,
-    bundled_defs: Dict[str, 'LabwareDefinition'] = None,
-    extra_defs: Dict[str, 'LabwareDefinition'] = None
-) -> 'LabwareDefinition':
-    """
-    Look up and return a definition by load_name + namespace + version and
-        return it or raise an exception
-
-    :param str load_name: corresponds to 'loadName' key in definition
-    :param str namespace: The namespace the labware definition belongs to.
-        If unspecified, will search 'opentrons' then 'custom_beta'
-    :param int version: The version of the labware definition. If unspecified,
-        will use version 1.
-    :param bundled_defs: A bundle of labware definitions to exlusively use for
-        finding labware definitions, if specified
-    :param extra_defs: An extra set of definitions (in addition to the system
-        definitions) in which to search
-    """
-    return labware_module.get_labware_definition(
-        load_name=load_name,
-        namespace=namespace,
-        version=version,
-        bundled_defs=bundled_defs,
-        extra_defs=extra_defs
-    )
-
-
-def get_all_labware_definitions() -> List[str]:
-    """
-    Return a list of standard and custom labware definitions with load_name +
-        name_space + version existing on the robot
-    """
-    return labware_module.get_all_labware_definitions()
-
-
-def split_tipracks(tip_racks: List[Labware]) -> Tuple[Labware, List[Labware]]:
-    try:
-        rest = tip_racks[1:]
-    except IndexError:
-        rest = []
-    return tip_racks[0], rest
-
-
-def select_tiprack_from_list(
-        tip_racks: List[Labware],
-        num_channels: int,
-        starting_point: Optional[Well] = None) -> Tuple[Labware, Well]:
-
-    try:
-        first, rest = split_tipracks(tip_racks)
-    except IndexError:
-        raise OutOfTipsError
-
-    if starting_point and starting_point.parent != first:
-        raise TipSelectionError(
-            'The starting tip you selected '
-            f'does not exist in {first}')
-    elif starting_point:
-        first_well = starting_point
-    else:
-        first_well = first.wells()[0]
-
-    next_tip = first.next_tip(num_channels, first_well)
-    if next_tip:
-        return first, next_tip
-    else:
-        return select_tiprack_from_list(rest, num_channels)
-
-
-def select_tiprack_from_list_paired_pipettes(
-        tip_racks: List[Labware],
-        p_channels: int,
-        s_channels: int,
-        starting_point: Optional[Well] = None) -> Tuple[Labware, Well]:
-    """
-    Helper function utilized in :py:attr:`PairedInstrumentContext`
-    to determine which pipette tiprack to pick up from.
-
-    If a starting point is specified, this method with check
-    that the parent of that tip was correctly filtered.
-
-    If a starting point is not specified, this method will filter
-    tipracks until it finds a well that is not empty.
-
-    :return: A Tuple of the tiprack and well to move to. In this
-    instance the starting well is specific to the primary pipette.
-    :raises TipSelectionError: if the starting tip specified
-    does not exist in the filtered tipracks.
-    """
-    try:
-        first, rest = split_tipracks(tip_racks)
-    except IndexError:
-        raise OutOfTipsError
-
-    if starting_point and starting_point.parent != first:
-        raise TipSelectionError(
-            'The starting tip you selected '
-            f'does not exist in {first}')
-    elif starting_point:
-        primary_well = starting_point
-    else:
-        primary_well = first.wells()[0]
-
-    try:
-        secondary_point = labware_column_shift(primary_well, first)
-    except IndexError:
-        return select_tiprack_from_list_paired_pipettes(
-            rest, p_channels, s_channels)
-
-    primary_next_tip = first.next_tip(p_channels, starting_point)
-    secondary_next_tip = first.next_tip(s_channels, secondary_point)
-    if primary_next_tip and secondary_next_tip:
-        return first, primary_next_tip
-    else:
-        return select_tiprack_from_list_paired_pipettes(
-            rest, p_channels, s_channels)
-
-
-def filter_tipracks_to_start(
-        starting_point: Well,
-        tipracks: List[Labware]) -> List[Labware]:
-    return list(dropwhile(
-        lambda tr: starting_point.parent != tr, tipracks))
-
-
-def next_available_tip(
-        starting_tip: Optional[Well],
-        tip_racks: List[Labware],
-        channels: int) -> Tuple[Labware, Well]:
-    start = starting_tip
-    if start is None:
-        return select_tiprack_from_list(
-            tip_racks, channels)
-    else:
-        return select_tiprack_from_list(
-            filter_tipracks_to_start(start, tip_racks),
-            channels, start)
-
-
-def get_labware_hash(labware: 'Labware') -> str:
-    return labware_module.get_labware_hash(
-        labware._implementation
-    )
-
-
-def get_labware_hash_with_parent(labware: 'Labware') -> str:
-    return labware_module.get_labware_hash_with_parent(
-        labware._implementation
-    )
-
-
-def load_from_definition(
-        definition: 'LabwareDefinition',
-        parent: Location,
-        label: Optional[str] = None,
-        api_level: Optional[APIVersion] = None) -> Labware:
-    """
-    Return a labware object constructed from a provided labware definition dict
-
-    :param definition: A dict representing all required data for a labware,
-        including metadata such as the display name of the labware, a
-        definition of the order to iterate over wells, the shape of wells
-        (shape, physical dimensions, etc), and so on. The correct shape of
-        this definition is governed by the "labware-designer" project in
-        the Opentrons/opentrons repo.
-    :param parent: A :py:class:`.Location` representing the location where
-                   the front and left most point of the outside of labware is
-                   (often the front-left corner of a slot on the deck).
-    :param str label: An optional label that will override the labware's
-                      display name from its definition
-    :param APIVersion api_level: the API version to set for the loaded labware
-                                 instance. The :py:class:`.Labware` will
-                                 conform to this level. If not specified,
-                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
-    """
-    return Labware(
-        implementation=labware_module.load_from_definition(
-            definition=definition,
-            parent=parent,
-            label=label
-        ),
-        api_level=api_level
-    )
-
-
-def save_calibration(labware: 'Labware', delta: Point):
-    labware_module.save_calibration(labware._implementation, delta)
-
-
-def load(
-    load_name: str,
-    parent: Location,
-    label: Optional[str] = None,
-    namespace: Optional[str] = None,
-    version: int = 1,
-    bundled_defs: Optional[Dict[str, 'LabwareDefinition']] = None,
-    extra_defs: Optional[Dict[str, 'LabwareDefinition']] = None,
-    api_level: Optional[APIVersion] = None
-) -> Labware:
-    """
-    Return a labware object constructed from a labware definition dict looked
-    up by name (definition must have been previously stored locally on the
-    robot)
-
-    :param load_name: A string to use for looking up a labware definition
-        previously saved to disc. The definition file must have been saved in a
-        known location
-    :param parent: A :py:class:`.Location` representing the location where
-                   the front and left most point of the outside of labware is
-                   (often the front-left corner of a slot on the deck).
-    :param str label: An optional label that will override the labware's
-                      display name from its definition
-    :param str namespace: The namespace the labware definition belongs to.
-        If unspecified, will search 'opentrons' then 'custom_beta'
-    :param int version: The version of the labware definition. If unspecified,
-        will use version 1.
-    :param bundled_defs: If specified, a mapping of labware names to labware
-        definitions. Only the bundle will be searched for definitions.
-    :param extra_defs: If specified, a mapping of labware names to labware
-        definitions. If no bundle is passed, these definitions will also be
-        searched.
-    :param APIVersion api_level: the API version to set for the loaded labware
-                                 instance. The :py:class:`.Labware` will
-                                 conform to this level. If not specified,
-                                 defaults to :py:attr:`.MAX_SUPPORTED_VERSION`.
-    """
-
-    return Labware(
-        implementation=labware_module.load(
-            load_name=load_name,
-            parent=parent,
-            label=label,
-            namespace=namespace,
-            version=version,
-            bundled_defs=bundled_defs,
-            extra_defs=extra_defs
-        ),
-        api_level=api_level,
-    )
+        raise NotImplementedError()

--- a/api/src/opentrons/experimental_protocol_api/protocol_context.py
+++ b/api/src/opentrons/experimental_protocol_api/protocol_context.py
@@ -1,3 +1,4 @@
+# noqa: D100
 # Todo: Move to different top-level dir for different linting and typing rules
 
 # Notable differences between legacy context:
@@ -6,18 +7,26 @@
 
 import typing
 
+from opentrons.experimental_protocol_api.instrument_context import \
+    InstrumentContext
+from opentrons.experimental_protocol_api.labware import Labware
+
 
 class ProtocolContext:
+    # noqa: D101
+
     def load_instrument(
         self,
         instrument_name: str,
         mount: str,
         tip_racks: typing.Sequence[typing.Any] = tuple(),  # Todo: Tip rack type
         replace: bool = False
-    ):
+    ) -> InstrumentContext:
+        # noqa: D102
         raise NotImplementedError()
 
-    def load_labware(self):
+    def load_labware(self) -> Labware:
+        # noqa: D102
         raise NotImplementedError()
 
     # All else todo

--- a/api/src/opentrons/experimental_protocol_api/protocol_context.py
+++ b/api/src/opentrons/experimental_protocol_api/protocol_context.py
@@ -13,14 +13,11 @@ class ProtocolContext:
         instrument_name: str,
         mount: str,
         tip_racks: typing.Sequence[typing.Any] = tuple(),  # Todo: Tip rack type
-        replace: bool
+        replace: bool = False
     ):
         raise NotImplementedError()
-    
-    def load_labware():
+
+    def load_labware(self):
         raise NotImplementedError()
-    
+
     # All else todo
-
-
-        


### PR DESCRIPTION
# Overview

A PR into the noodling branch. Primarily this is about removing the contents of the duplicated `InstrumentContext`, `Well` and `Labware`.

# Changelog

- remove all private methods from `InstrumentContext`, `Labware` and `Well`.
- replace implementations of all public methods in `InstrumentContext`, `Labware` and `Well`. with `raise NotImplementedError()`


# Review requests

Should I also remove docstrings? 

# Risk assessment

None