### PR TITLE
fix(components): bump the components library version manually

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -21,7 +21,7 @@
     "react-router-dom": "5.1.1"
   },
   "dependencies": {
-    "@opentrons/shared-data": "4.2.0",
+    "@opentrons/shared-data": "4.2.1",
     "@popperjs/core": "2.1.1",
     "@types/classnames": "^2.2.5",
     "@types/lodash": "^4.14.168",


### PR DESCRIPTION
For some reason, during the merge of release into edge, the component library package.json file did
not get updated with shared-data's correct version.

I've verified that the shared data version was updated correctly in the release branch. Please review asap as edge is currently broken.
