### PR TITLE
fix(api): api location cache fix

### DIFF
--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 9)
+MAX_SUPPORTED_VERSION = APIVersion(2, 10)
 #: The maximum supported protocol API version in this release
 
 V2_MODULE_DEF_VERSION = APIVersion(2, 3)

--- a/api/src/opentrons/protocols/context/engine/protocol_context.py
+++ b/api/src/opentrons/protocols/context/engine/protocol_context.py
@@ -132,8 +132,15 @@ class ProtocolEngineContext(AbstractProtocol):
     def door_closed(self) -> bool:
         raise NotImplementedError()
 
-    def get_last_location(self) -> Optional[types.Location]:
+    def get_last_location(
+        self,
+        mount: Optional[types.Mount] = None,
+    ) -> Optional[types.Location]:
         raise NotImplementedError()
 
-    def set_last_location(self, location: Optional[types.Location]) -> None:
+    def set_last_location(
+        self,
+        location: Optional[types.Location],
+        mount: Optional[types.Mount] = None,
+    ) -> None:
         raise NotImplementedError()

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -160,9 +160,16 @@ class AbstractProtocol(ABC):
         ...
 
     @abstractmethod
-    def get_last_location(self) -> Optional[types.Location]:
+    def get_last_location(
+        self,
+        mount: Optional[types.Mount] = None,
+    ) -> Optional[types.Location]:
         ...
 
     @abstractmethod
-    def set_last_location(self, location: Optional[types.Location]) -> None:
+    def set_last_location(
+        self,
+        location: Optional[types.Location],
+        mount: Optional[types.Mount] = None,
+    ) -> None:
         ...

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -154,7 +154,17 @@ class InstrumentContextImplementation(AbstractInstrument):
                 minimum_z_height: Optional[float],
                 speed: Optional[float]) -> None:
         """Move the instrument."""
-        last_location = self._protocol_interface.get_last_location()
+        # prevent direct movement bugs in PAPI version >= 2.10
+        location_cache_mount = (
+            self._mount
+            if self._api_version >= APIVersion(2, 10) else
+            None
+        )
+
+        last_location = self._protocol_interface.get_last_location(
+            mount=location_cache_mount
+        )
+
         if last_location:
             from_lw = last_location.labware
         else:
@@ -190,7 +200,10 @@ class InstrumentContextImplementation(AbstractInstrument):
             self._protocol_interface.set_last_location(None)
             raise
         else:
-            self._protocol_interface.set_last_location(location)
+            self._protocol_interface.set_last_location(
+                location=location,
+                mount=location_cache_mount
+            )
 
     def get_mount(self) -> types.Mount:
         """Get the mount this pipette is attached to."""

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -86,6 +86,7 @@ class ProtocolContextImplementation(AbstractProtocol):
         self._bundled_data: Dict[str, bytes] = bundled_data or {}
         self._default_max_speeds = AxisMaxSpeeds()
         self._last_location: Optional[types.Location] = None
+        self._last_mount: Optional[types.Mount] = None
         self._loaded_modules: Set['AbstractModule'] = set()
 
     @classmethod
@@ -195,8 +196,8 @@ class ProtocolContextImplementation(AbstractProtocol):
         hc_mod_instance = None
         for mod in available_modules:
             compatible = module_geometry.models_compatible(
-                    module_geometry.module_model_from_string(mod.model()),
-                    resolved_model)
+                module_geometry.module_model_from_string(mod.model()),
+                resolved_model)
             if compatible and mod not in self._loaded_modules:
                 self._loaded_modules.add(mod)
                 hc_mod_instance = SynchronousAdapter(mod)
@@ -295,10 +296,21 @@ class ProtocolContextImplementation(AbstractProtocol):
         """Check if door is closed."""
         return DoorState.CLOSED == self._hw_manager.hardware.door_state
 
-    def get_last_location(self) -> Optional[types.Location]:
+    def get_last_location(
+        self,
+        mount: Optional[types.Mount] = None,
+    ) -> Optional[types.Location]:
         """Get the most recent moved to location."""
-        return self._last_location
+        if mount is None or mount == self._last_mount:
+            return self._last_location
 
-    def set_last_location(self, location: Optional[types.Location]) -> None:
+        return None
+
+    def set_last_location(
+        self,
+        location: Optional[types.Location],
+        mount: Optional[types.Mount] = None,
+    ) -> None:
         """Set the most recent moved to location."""
         self._last_location = location
+        self._last_mount = mount


### PR DESCRIPTION
# Overview

The location cache is used regardless of which pipette is moving. If left moves immediately after right, the left move's cached location will be used. This can cause jerky motion.

closes #7156 

# Changelog
- update protocol api version to 2.10
- maintain the last mount moved.

# Review requests

Test on a robot using example protocols in #7156 

# Risk assessment

High. 

