### PR TITLE
fix(protocol-designer): mask batch edit form fields

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -16,6 +16,7 @@ import {
   resetBatchEditFieldChanges,
   saveStepFormsMulti,
 } from '../../step-forms/actions'
+import { maskField } from '../../steplist/fieldLevel'
 import { BatchEditMoveLiquid } from './BatchEditMoveLiquid'
 import { BatchEditMix } from './BatchEditMix'
 
@@ -31,7 +32,8 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
   const batchEditMixEnabled = useSelector(getBatchEditMixEnabled)
 
   const handleChangeFormInput = (name, value) => {
-    dispatch(changeBatchEditField({ [name]: value }))
+    const maskedValue = maskField(name, value)
+    dispatch(changeBatchEditField({ [name]: maskedValue }))
   }
 
   const handleSave = () => {


### PR DESCRIPTION
# Overview

We're currently not masking batch edit form field values, which means you can enter nonsense values for the fields below (in the batch edit form):

```js
aspirate_airGap_volume
aspirate_mix_times
aspirate_mix_volume
aspirate_wells
dispense_mix_times
dispense_mix_volume
dispense_wells
disposalVolume_volume
aspirate_delay_seconds
dispense_delay_seconds
```

This PR masks form fields values using the same masker as in single edit mode. 

Note: this bug is in production

# Changelog

- Mask batch edit form field values

# Review requests
Go through the fields we mask above and make sure you can only enter values that make sense, and that behavior is the same as in single edit mode

# Risk assessment
Low