### PR TITLE
fix(protocol-designer): Fix starting deck state button toolbar overlap

### DIFF
--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -94,6 +94,7 @@ export const Accordion = (props: AccordionProps): React.Node => {
       position={POSITION_STICKY}
       top="0"
       overflow="hidden"
+      zIndex="10"
       borderBottom={props.expanded ? BORDER_SOLID_MEDIUM : 'none'}
       opacity={props.expanded ? 1 : 0}
     >


### PR DESCRIPTION
# Overview

closes #7611 by making sure the starting deck state button scrolls behind not in front of the MultiSelectToolbar

<img width="528" alt="Screen Shot 2021-04-09 at 12 04 27 PM" src="https://user-images.githubusercontent.com/3430313/114210162-7165b100-992d-11eb-8494-8d2281197e86.png"> 

# Changelog

- fix(protocol-designer): Fix starting deck state button toolbar overlap

# Review requests

- [ ] Functionality unaffected
- [ ] No more overlap

# Risk assessment

Low 1 line of CSS but since its z-index lets make sure everything is still clickable!

