### PR TITLE
feat(protocol-designer): Add tooltip for indeterminate checkboxes

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/__tests__/makeBatchEditFieldProps.test.js
+++ b/protocol-designer/src/components/BatchEditForm/__tests__/makeBatchEditFieldProps.test.js
@@ -8,8 +8,14 @@ const getFieldDefaultTooltipSpy = jest.spyOn(
   'getFieldDefaultTooltip'
 )
 
+const getIndeterminateTooltipSpy = jest.spyOn(
+  stepEditFormUtils,
+  'getFieldIndeterminateTooltip'
+)
+
 beforeEach(() => {
   getFieldDefaultTooltipSpy.mockImplementation(name => `tooltip for ${name}`)
+  getIndeterminateTooltipSpy.mockImplementation(name => `tooltip for ${name}`)
 })
 
 afterEach(() => {
@@ -98,5 +104,54 @@ describe('makeBatchEditFieldProps', () => {
     )
 
     expect(result.aspirate_flowRate.isIndeterminate).toBe(true)
+  })
+
+  it('should show indeterminate tooltip content for indeterminate checkboxes', () => {
+    const fieldValues = {
+      preWetTip: {
+        value: 'mixed',
+        isIndeterminate: true,
+      },
+    }
+    const handleChangeFormInput: any = jest.fn()
+
+    const disabledFields = {}
+
+    const result = makeBatchEditFieldProps(
+      fieldValues,
+      disabledFields,
+      handleChangeFormInput
+    )
+
+    expect(result.preWetTip.isIndeterminate).toBe(true)
+    expect(result.preWetTip.tooltipContent).toBe(
+      'Not all selected steps are using this setting'
+    )
+  })
+
+  it('should override indeterminate tooltip content if field is also disabled', () => {
+    const fieldValues = {
+      preWetTip: {
+        value: 'mixed',
+        isIndeterminate: true,
+      },
+    }
+    const handleChangeFormInput: any = jest.fn()
+
+    const disabledFields = {
+      preWetTip: 'Disabled explanation text here',
+    }
+
+    const result = makeBatchEditFieldProps(
+      fieldValues,
+      disabledFields,
+      handleChangeFormInput
+    )
+
+    expect(result.preWetTip.isIndeterminate).toBe(true)
+    expect(result.preWetTip.disabled).toBe(true)
+    expect(result.preWetTip.tooltipContent).toBe(
+      'Disabled explanation text here'
+    )
   })
 })

--- a/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
+++ b/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
@@ -4,7 +4,10 @@ import type {
   DisabledFields,
   MultiselectFieldValues,
 } from '../../ui/steps/selectors'
-import { getFieldDefaultTooltip } from '../StepEditForm/utils'
+import {
+  getFieldDefaultTooltip,
+  getFieldIndeterminateTooltip,
+} from '../StepEditForm/utils'
 import type { FieldPropsByName } from '../StepEditForm/types'
 import type { StepFieldName } from '../../form-types'
 
@@ -16,6 +19,16 @@ export const makeBatchEditFieldProps = (
   const fieldNames: Array<StepFieldName> = Object.keys(fieldValues)
   return fieldNames.reduce<FieldPropsByName>((acc, name) => {
     const defaultTooltip = getFieldDefaultTooltip(name)
+    const isIndeterminate = fieldValues[name].isIndeterminate
+    const indeterminateTooltip = getFieldIndeterminateTooltip(name)
+
+    let tooltipContent = defaultTooltip // Default to the default content (or blank)
+    if (isIndeterminate) {
+      tooltipContent = indeterminateTooltip // If field is not disabled and is interderminate
+    } else if (name in disabledFields) {
+      tooltipContent = disabledFields[name] // Use disabled content if field is disabled
+    }
+
     acc[name] = {
       disabled: name in disabledFields,
       name,
@@ -24,9 +37,8 @@ export const makeBatchEditFieldProps = (
       errorToShow: null,
       onFieldBlur: noop,
       onFieldFocus: noop,
-      isIndeterminate: fieldValues[name].isIndeterminate,
-      tooltipContent:
-        name in disabledFields ? disabledFields[name] : defaultTooltip,
+      isIndeterminate: isIndeterminate,
+      tooltipContent: tooltipContent,
     }
     return acc
   }, {})

--- a/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
+++ b/protocol-designer/src/components/BatchEditForm/makeBatchEditFieldProps.js
@@ -25,8 +25,9 @@ export const makeBatchEditFieldProps = (
     let tooltipContent = defaultTooltip // Default to the default content (or blank)
     if (isIndeterminate) {
       tooltipContent = indeterminateTooltip // If field is not disabled and is interderminate
-    } else if (name in disabledFields) {
-      tooltipContent = disabledFields[name] // Use disabled content if field is disabled
+    }
+    if (name in disabledFields) {
+      tooltipContent = disabledFields[name] // Use disabled content if field is disabled, override indeterminate tooltip if applicable
     }
 
     acc[name] = {

--- a/protocol-designer/src/components/StepEditForm/utils.js
+++ b/protocol-designer/src/components/StepEditForm/utils.js
@@ -171,6 +171,9 @@ export const getVisibleProfileFormLevelErrors = (args: {|
 export const getFieldDefaultTooltip = (name: string): string =>
   i18n.t([`tooltip.step_fields.defaults.${name}`, ''])
 
+export const getFieldIndeterminateTooltip = (name: string): string =>
+  i18n.t([`tooltip.step_fields.indeterminate.${name}`, ''])
+
 export const getSingleSelectDisabledTooltip = (
   name: string,
   stepType: string

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -47,6 +47,17 @@
 
       "volume": "Volume to dispense in each well"
     },
+    "indeterminate": {
+      "aspirate_airGap_checkbox": "Not all selected Transfers are using this setting",
+      "dispense_airGap_checkbox": "Not all selected Transfers are using this setting",
+      "aspirate_mix_checkbox": "Not all selected Transfers are using this setting",
+      "dispense_mix_checkbox": "Not all selected Transfers are using this setting",
+      "aspirate_delay_checkbox": "Not all selected Transfers are using this setting",
+      "dispense_delay_checkbox": "Not all selected Transfers are using this setting",
+      "preWetTip": "Not all selected Transfers are using this setting",
+      "aspirate_touchTip_checkbox": "Not all selected Transfers are using this setting",
+      "dispense_touchTip_checkbox": "Not all selected Transfers are using this setting"
+    },
     "moveLiquid": {
       "disabled": {
         "$generic": "Incompatible with current path",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -48,15 +48,16 @@
       "volume": "Volume to dispense in each well"
     },
     "indeterminate": {
-      "aspirate_airGap_checkbox": "Not all selected Transfers are using this setting",
-      "dispense_airGap_checkbox": "Not all selected Transfers are using this setting",
-      "aspirate_mix_checkbox": "Not all selected Transfers are using this setting",
-      "dispense_mix_checkbox": "Not all selected Transfers are using this setting",
-      "aspirate_delay_checkbox": "Not all selected Transfers are using this setting",
-      "dispense_delay_checkbox": "Not all selected Transfers are using this setting",
-      "preWetTip": "Not all selected Transfers are using this setting",
-      "aspirate_touchTip_checkbox": "Not all selected Transfers are using this setting",
-      "dispense_touchTip_checkbox": "Not all selected Transfers are using this setting"
+      "aspirate_airGap_checkbox": "Not all selected steps are using this setting",
+      "dispense_airGap_checkbox": "Not all selected steps are using this setting",
+      "aspirate_mix_checkbox": "Not all selected steps are using this setting",
+      "dispense_mix_checkbox": "Not all selected steps are using this setting",
+      "aspirate_delay_checkbox": "Not all selected steps are using this setting",
+      "dispense_delay_checkbox": "Not all selected steps are using this setting",
+      "preWetTip": "Not all selected steps are using this setting",
+      "aspirate_touchTip_checkbox": "Not all selected steps are using this setting",
+      "dispense_touchTip_checkbox": "Not all selected steps are using this setting",
+      "mix_touchTip_checkbox": "Not all selected steps are using this setting"
     },
     "moveLiquid": {
       "disabled": {


### PR DESCRIPTION
# Overview
closes #7491

- default to default tooltip text (if any)
- if isIndeterminate use indeterminate tooltip content
- if disabled, overwrite yet again and show the disabled reason tooltip

# Changelog

- Add tooltip for indeterminate checkboxes

# Review requests

[indeterminate_tooltip_test.json.zip](https://github.com/Opentrons/opentrons/files/6298882/indeterminate_tooltip_test.json.zip)

Please test for both Transfer and Mix!

- [ ] default show when not indeterminate or disabled
- [ ] if indeterminate checkboxes tooltip text reads "Not all selected Transfers are using this setting"
- [ ] if disabled (regardless of indeterminate state) show disabled reason  

# Risk assessment
Low PD tooltips

