### PR TITLE
fix(protocol-designer): remove air gap fields from batch edit form

### DIFF
--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.js
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.js
@@ -146,17 +146,6 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
           />
         </CheckboxRowField>
       )}
-      <CheckboxRowField
-        {...propsForFields[addFieldNamePrefix('airGap_checkbox')]}
-        label={i18n.t('form.step_edit_form.field.airGap.label')}
-        className={styles.small_field}
-      >
-        <TextField
-          {...propsForFields[addFieldNamePrefix('airGap_volume')]}
-          className={styles.small_field}
-          units={i18n.t('application.units.microliter')}
-        />
-      </CheckboxRowField>
     </FormColumn>
   )
 }

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.js
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.js
@@ -15,7 +15,6 @@ import {
   CheckboxRowField,
   DelayFields,
   FlowRateField,
-  TextField,
   TipPositionField,
   WellOrderField,
 } from '../StepEditForm/fields'


### PR DESCRIPTION
# Overview

Air gap fields can cause changes to other parts of transfer forms (path, disposal volume), so they cannot be in the batch
edit form

# Changelog

- Remove air gap fields from batch edit form


# Review requests
Make sure air gap fields are gone in batch edit form

# Risk assessment
Low