### PR TITLE
fix(protocol-designer): Move save/discard buttons down

### DIFF
--- a/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
+++ b/protocol-designer/src/analytics/__tests__/reduxActionToAnalyticsEvent.test.js
@@ -1,13 +1,13 @@
 // @flow
-import { when, resetAllWhenMocks } from 'jest-when'
+import { resetAllWhenMocks } from 'jest-when'
 import { reduxActionToAnalyticsEvent } from '../middleware'
 import { getFileMetadata } from '../../file-data/selectors'
 import {
   getArgsAndErrorsByStepId,
   getPipetteEntities,
-  getBatchEditFieldChanges,
 } from '../../step-forms/selectors'
 import type { FileMetadataFields } from '../../file-data/types'
+import type { SaveStepFormsMultiAction } from '../../step-forms/actions'
 
 jest.mock('../../file-data/selectors')
 jest.mock('../../step-forms/selectors')
@@ -18,10 +18,6 @@ const getArgsAndErrorsByStepIdMock: JestMockFn<
   any
 > = getArgsAndErrorsByStepId
 const getPipetteEntitiesMock: JestMockFn<any, any> = getPipetteEntities
-const getBatchEditFieldChangesMock: JestMockFn<
-  any,
-  any
-> = getBatchEditFieldChanges
 
 let fooState: any
 beforeEach(() => {
@@ -92,20 +88,17 @@ describe('reduxActionToAnalyticsEvent', () => {
     })
   })
   it('should convert a SAVE_STEP_FORMS_MULTI action into a saveStepsMulti action with additional properties', () => {
-    const changes = {
-      someField: 'someVal',
-      anotherField: 'anotherVal',
-      someNestedField: {
-        innerNestedField: true,
-      },
-    }
-    when(getBatchEditFieldChangesMock)
-      .calledWith(expect.anything())
-      .mockReturnValue(changes)
-    const action = {
+    const action: SaveStepFormsMultiAction = {
       type: 'SAVE_STEP_FORMS_MULTI',
       payload: {
-        selectedStepIds: [], // this does not matter
+        stepIds: [],
+        editedFields: {
+          someField: 'someVal',
+          anotherField: 'anotherVal',
+          someNestedField: {
+            innerNestedField: true,
+          },
+        },
       },
     }
 

--- a/protocol-designer/src/analytics/middleware.js
+++ b/protocol-designer/src/analytics/middleware.js
@@ -2,7 +2,6 @@
 import {
   getArgsAndErrorsByStepId,
   getPipetteEntities,
-  getBatchEditFieldChanges,
 } from '../step-forms/selectors'
 import { getFileMetadata } from '../file-data/selectors'
 import { trackEvent } from './mixpanel'
@@ -61,7 +60,7 @@ export const reduxActionToAnalyticsEvent = (
     const fileMetadata = getFileMetadata(state)
     const dateCreatedTimestamp = fileMetadata.created
 
-    const editedFields = getBatchEditFieldChanges(state)
+    const { editedFields } = action.payload
     const additionalProperties = flattenNestedProperties(editedFields)
 
     // (these fields are prefixed with double underscore only to make sure they

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -203,7 +203,7 @@ export const BatchEditMoveLiquid = (
           />
         </Box>
 
-        <Box textAlign="right" maxWidth="55rem" marginTop="2rem">
+        <Box textAlign="right" maxWidth="55rem" marginTop="3rem">
           <Box
             {...cancelButtonTargetProps}
             marginRight="0.625rem"

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -14,7 +14,6 @@ import {
   CheckboxRowField,
   DelayFields,
   FlowRateField,
-  TextField,
   TipPositionField,
   WellOrderField,
 } from '../StepEditForm/fields'
@@ -37,12 +36,13 @@ import {
   resetBatchEditFieldChanges,
   saveStepFormsMulti,
 } from '../../step-forms/actions'
-import type { FieldPropsByName } from '../StepEditForm/types'
-import type { WellOrderOption } from '../../form-types'
 // TODO(IL, 2021-03-01): refactor these fragmented style rules (see #7402)
 import formStyles from '../forms/forms.css'
 import styles from '../StepEditForm/StepEditForm.css'
 import buttonStyles from '../StepEditForm/ButtonRow/styles.css'
+import { maskField } from '../../steplist/fieldLevel'
+import type { FieldPropsByName } from '../StepEditForm/types'
+import type { WellOrderOption } from '../../form-types'
 
 export type BatchEditFormProps = {||}
 
@@ -251,7 +251,8 @@ export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
   const batchEditFormHasChanges = useSelector(getBatchEditFormHasUnsavedChanges)
 
   const handleChangeFormInput = (name, value) => {
-    dispatch(changeBatchEditField({ [name]: value }))
+    const maskedValue = maskField(name, value)
+    dispatch(changeBatchEditField({ [name]: maskedValue }))
   }
 
   const handleSave = () => {

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -165,17 +165,6 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
           />
         </CheckboxRowField>
       )}
-      <CheckboxRowField
-        {...propsForFields[addFieldNamePrefix('airGap_checkbox')]}
-        label={i18n.t('form.step_edit_form.field.airGap.label')}
-        className={styles.small_field}
-      >
-        <TextField
-          {...propsForFields[addFieldNamePrefix('airGap_volume')]}
-          className={styles.small_field}
-          units={i18n.t('application.units.microliter')}
-        />
-      </CheckboxRowField>
     </Box>
   )
 }

--- a/protocol-designer/src/components/BatchEditForm/index.js
+++ b/protocol-designer/src/components/BatchEditForm/index.js
@@ -190,8 +190,14 @@ export const BatchEditMoveLiquid = (
   props: BatchEditMoveLiquidProps
 ): React.Node => {
   const { propsForFields, handleCancel, handleSave } = props
-  const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip()
-  const [saveButtonTargetProps, saveButtonTooltipProps] = useHoverTooltip()
+  const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
+    placement: 'top',
+    strategy: 'fixed',
+  })
+  const [saveButtonTargetProps, saveButtonTooltipProps] = useHoverTooltip({
+    placement: 'top',
+    strategy: 'fixed',
+  })
   const disableSave = !props.batchEditFormHasChanges
 
   return (

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.js
@@ -94,6 +94,7 @@ export const Accordion = (props: AccordionProps): React.Node => {
       position={POSITION_STICKY}
       top="0"
       overflow="hidden"
+      zIndex="10"
       borderBottom={props.expanded ? BORDER_SOLID_MEDIUM : 'none'}
       opacity={props.expanded ? 1 : 0}
     >

--- a/protocol-designer/src/containers/ConnectedStepItem.js
+++ b/protocol-designer/src/containers/ConnectedStepItem.js
@@ -239,15 +239,25 @@ export const ConnectedStepItem = (props: Props): React.Node => {
     </>
   )
 }
-function getMetaSelectedSteps(multiSelectItemIds, stepId, selectedStepId) {
+export function getMetaSelectedSteps(
+  multiSelectItemIds: Array<StepIdType> | null,
+  stepId: StepIdType,
+  selectedStepId: StepIdType | null
+): Array<StepIdType> {
   let stepsToSelect: Array<StepIdType> = []
   if (multiSelectItemIds?.length) {
+    // already have a selection, add/remove the meta-clicked item
     stepsToSelect = multiSelectItemIds.includes(stepId)
       ? multiSelectItemIds.filter(id => id !== stepId)
       : [...multiSelectItemIds, stepId]
+  } else if (selectedStepId && selectedStepId === stepId) {
+    // meta-clicked on the selected single step
+    stepsToSelect = [selectedStepId]
   } else if (selectedStepId) {
+    // meta-clicked on a different step, multi-select both
     stepsToSelect = [selectedStepId, stepId]
   } else {
+    // meta-clicked on a step when a terminal item was selected
     stepsToSelect = [stepId]
   }
   return stepsToSelect

--- a/protocol-designer/webpack.config.js
+++ b/protocol-designer/webpack.config.js
@@ -16,7 +16,7 @@ const PROTOCOL_DESIGNER_ENV_VAR_PREFIX = 'OT_PD_'
 // Also remove all OT_PD_VERSION env vars, the version should always
 // be gleaned from the package.json
 
-const OT_PD_VERSION = '5.2.4'
+const OT_PD_VERSION = '5.2.5'
 const OT_PD_BUILD_DATE = new Date().toUTCString()
 
 const JS_ENTRY = path.join(__dirname, 'src/index.js')


### PR DESCRIPTION

# Overview

Fixes a tooltip overlap issue introduced when we removed air gap from batch edit forms

# Changelog

fix(protocol-designer): Move save/discard buttons down

# Review requests

- [ ] no more overlap

# Risk assessment

low CSS only