### PR TITLE
feat(protocol-designer): Add batch edit hint modal

### DIFF
--- a/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithModules.spec.js
@@ -275,7 +275,13 @@ describe('Protocols with Modules', () => {
         cy.get('button[disabled]').should('not.exist')
         cy.get('textarea').type('heating up')
         cy.get('button').contains('save', { matchCase: false }).click()
+        // close "batch edit hint" modal
+        cy.contains('Editing multiple steps').should('exist')
+        // force option used because checkbox is hidden
+        cy.get('input[type="checkbox"]').click({ force: true })
+        cy.get('button').contains('ok').click()
       })
+
       cy.get('[data-test="StepItem_2"]').within(() => {
         cy.contains('Pause Until', { matchCase: false }).should('exist')
         cy.contains('heating up').should('exist')

--- a/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
+++ b/protocol-designer/cypress/integration/newProtocolWithTC.spec.js
@@ -35,7 +35,7 @@ describe('Protocols with Modules', () => {
     cy.closeAnnouncementModal()
   })
 
-  describe('builds a new protocol with mag deck', () => {
+  describe('builds a new protocol with a thermocycler', () => {
     it('sets up pipettes, tips, and module', () => {
       cy.get('button').contains('Create New').click()
       // Give it a name
@@ -226,7 +226,13 @@ describe('Protocols with Modules', () => {
           cy.get('input[type="checkbox"]').click({ force: true })
         })
         cy.get('button').contains('save').click()
+        // close "batch edit hint" modal
+        cy.contains('Editing multiple steps').should('exist')
+        // force option used because checkbox is hidden
+        cy.get('input[type="checkbox"]').click({ force: true })
+        cy.get('button').contains('ok').click()
       })
+
       // Verify Second State Added
       cy.get(sidePanel).within(() => {
         cy.contains('Lid (closed)').should('exist')

--- a/protocol-designer/src/components/Hints/index.js
+++ b/protocol-designer/src/components/Hints/index.js
@@ -10,6 +10,7 @@ import { Portal } from '../portals/MainPageModalPortal'
 import styles from './hints.css'
 import EXAMPLE_ADD_LIQUIDS_IMAGE from '../../images/example_add_liquids.png'
 import EXAMPLE_WATCH_LIQUIDS_MOVE_IMAGE from '../../images/example_watch_liquids_move.png'
+import EXAMPLE_BATCH_EDIT_IMAGE from '../../images/announcements/multi_select.gif'
 import type { HintKey } from '../../tutorial'
 import type { BaseState, ThunkDispatch } from '../../types'
 
@@ -105,6 +106,44 @@ class HintsComponent extends React.Component<Props, State> {
                 <span>{i18n.t(`alert.hint.${hintKey}.li2`)}</span>
               </li>
             </ol>
+          </>
+        )
+      case 'protocol_can_enter_batch_edit':
+        return (
+          <>
+            <span className={styles.column_left}>
+              <img src={EXAMPLE_BATCH_EDIT_IMAGE} />
+            </span>
+            <span className={styles.column_right}>
+              <p>{i18n.t(`alert.hint.${hintKey}.body1`)}</p>
+              <p>
+                {i18n.t(`alert.hint.${hintKey}.body2`)}
+                <ol className={styles.numbered_list}>
+                  <li>
+                    {i18n.t(`alert.hint.${hintKey}.li1a`)}
+                    <strong>
+                      {i18n.t(`alert.hint.${hintKey}.strong_li1`)}
+                    </strong>
+                    {i18n.t(`alert.hint.${hintKey}.li1b`)}
+                  </li>
+                  <li>
+                    {i18n.t(`alert.hint.${hintKey}.li2a`)}
+                    <strong>
+                      {i18n.t(`alert.hint.${hintKey}.strong_li2`)}
+                    </strong>
+                    {i18n.t(`alert.hint.${hintKey}.li2b`)}
+                  </li>
+                </ol>
+              </p>
+              <p>
+                {i18n.t(`alert.hint.${hintKey}.body3a`)} <br />
+                {i18n.t(`alert.hint.${hintKey}.body3b`)}
+              </p>
+              <p>
+                {i18n.t(`alert.hint.${hintKey}.body4a`)} <br />
+                {i18n.t(`alert.hint.${hintKey}.body4b`)}
+              </p>
+            </span>
           </>
         )
       default:

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -88,8 +88,8 @@
       "body3a": "To delete or duplicate multiple steps:",
       "body3b": "Use the control bar at the top of the Protocol Timeline.",
 
-      "body4a": "To batch edit Transfer advanced settings:",
-      "body4b": "Only include Transfer steps in your selection."
+      "body4a": "To batch edit Transfer or Mix advanced settings:",
+      "body4b": "Only include Transfer or Mix steps in your selection."
     }
   },
   "timeline": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -71,6 +71,25 @@
       "body1b": ". When entering a temperature lower than the previous temperature, keep in mind the following:",
       "li1": "If the Thermocycler lid is closed it may take a very long time to reach a cooler temperature.",
       "li2": "If the room temperature in your lab is higher than the temperature you have defined, the lid will never reach it. This will stall your protocol indefinitely."
+    },
+    "protocol_can_enter_batch_edit": {
+      "title": "Editing multiple steps",
+      "body1": "Now that your protocol has multiple steps, you can try using Protocol Designer’s batch edit features.",
+
+      "body2": "To select multiple steps:",
+      "li1a": "Hold ",
+      "strong_li1": "SHIFT + Click ",
+      "li1b": "to select a range of steps",
+
+      "li2a": "Use ",
+      "strong_li2": "CTRL + Click (PC) or ⌘ + Click (Mac) ",
+      "li2b": "to select a single additional step.",
+
+      "body3a": "To delete or duplicate multiple steps:",
+      "body3b": "Use the control bar at the top of the Protocol Timeline.",
+
+      "body4a": "To batch edit Transfer advanced settings:",
+      "body4b": "Only include Transfer steps in your selection."
     }
   },
   "timeline": {

--- a/protocol-designer/src/tutorial/index.js
+++ b/protocol-designer/src/tutorial/index.js
@@ -9,6 +9,7 @@ type HintKey =
   | 'deck_setup_explanation'
   | 'module_without_labware'
   | 'thermocycler_lid_passive_cooling'
+  | 'protocol_can_enter_batch_edit'
   // blocking hints
   | 'custom_labware_with_modules'
   | 'export_v4_protocol_3_18'

--- a/protocol-designer/src/tutorial/selectors.js
+++ b/protocol-designer/src/tutorial/selectors.js
@@ -65,10 +65,5 @@ export const shouldShowCoolingHint: Selector<boolean> = createSelector(
 
 export const shouldShowBatchEditHint: Selector<boolean> = createSelector(
   getOrderedStepIds,
-  orderedStepIds => {
-    if (orderedStepIds.length >= 1) {
-      return true
-    }
-    return false
-  }
+  orderedStepIds => orderedStepIds.length >= 1
 )

--- a/protocol-designer/src/tutorial/selectors.js
+++ b/protocol-designer/src/tutorial/selectors.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import { timelineFrameBeforeActiveItem } from '../top-selectors/timelineFrames'
-import { getUnsavedForm } from '../step-forms/selectors'
+import { getUnsavedForm, getOrderedStepIds } from '../step-forms/selectors'
 import isEmpty from 'lodash/isEmpty'
 import type { BaseState, Selector } from '../types'
 import type { HintKey } from '.'
@@ -58,6 +58,16 @@ export const shouldShowCoolingHint: Selector<boolean> = createSelector(
       return nextLidTemp < prevLidTemp
     } else {
       console.error('expected thermocycler module')
+    }
+    return false
+  }
+)
+
+export const shouldShowBatchEditHint: Selector<boolean> = createSelector(
+  getOrderedStepIds,
+  orderedStepIds => {
+    if (orderedStepIds.length >= 1) {
+      return true
     }
     return false
   }

--- a/protocol-designer/src/ui/steps/actions/thunks/index.js
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.js
@@ -182,6 +182,10 @@ export const saveStepForm: () => ThunkAction<any> = () => (
     dispatch(tutorialActions.addHint('thermocycler_lid_passive_cooling'))
   }
 
+  if (tutorialSelectors.shouldShowBatchEditHint(initialState)) {
+    dispatch(tutorialActions.addHint('protocol_can_enter_batch_edit'))
+  }
+
   // save the form
   dispatch(_saveStepForm(unsavedForm))
 }


### PR DESCRIPTION
# Overview

closes #7488 by showing multi-select/batch edit hint modal upon saving of second step. Calling this a WIP until copy and behavior questions are sorted out.

# Changelog

- feat(protocol-designer): Add batch edit hint modal

# Review requests


-  [ ] Show hint modal on saving second step, or saving a new step to an imported protocol.


# Risk assessment

Low PD dismissable hint
