### PR TITLE
refactor(protocol-designer): Update batch edit copy to include mix

### DIFF
--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.js
@@ -105,7 +105,9 @@ export const announcements: Array<Announcement> = [
         <p>Starting today, you’ll be able to:</p>
         <ul>
           <li>Select, delete, and duplicate multiple steps at once</li>
-          <li>Edit advanced settings for multiple Transfer steps at once</li>
+          <li>
+            Edit advanced settings for multiple Transfer or Mix steps at once
+          </li>
         </ul>
 
         <p>
@@ -115,7 +117,7 @@ export const announcements: Array<Announcement> = [
 
         <p>
           From here, you can access the control bar at the top of the protocol
-          timeline, or edit advanced settings for Transfer steps!
+          timeline, or edit advanced settings for Transfer or Mix steps!
         </p>
       </>
     ),

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -30,5 +30,5 @@
   },
   "exit_batch_edit": "exit batch edit",
   "n_steps_selected": "{{n}} steps selected",
-  "no_batch_edit_shared_settings": "Batch editing of settings is only available for Transfers"
+  "no_batch_edit_shared_settings": "Batch editing of settings is only available for Transfer or Mix steps"
 }


### PR DESCRIPTION
# Overview

closes #7583 closes #7581 by updating copy for announcement modal and batch editing only available for transfer and mix steps.

# Changelog

- refactor(protocol-designer): Update batch edit copy to include mix

# Review requests

- [ ] Announcement modal now references mix
- [ ] Batch edit not available message now references mix

# Risk assessment

Low, PD copy changes
