### PR TITLE
feat(api): fast simulation catches tip and volume errors

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -16,8 +16,8 @@ from .controller import Controller
 from .simulator import Simulator
 from .pipette import Pipette
 from .types import (HardwareAPILike, CriticalPoint,
-                    NoTipAttachedError, ExecutionState,
-                    ExecutionCancelledError)
+                    NoTipAttachedError, TipAttachedError,
+                    ExecutionState, ExecutionCancelledError)
 from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
@@ -26,7 +26,7 @@ from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
 __all__ = [
     'API', 'Controller', 'Simulator', 'Pipette',
     'SynchronousAdapter', 'HardwareAPILike', 'CriticalPoint',
-    'NoTipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
+    'NoTipAttachedError', 'TipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
     'ThreadManager', 'ExecutionManager', 'ExecutionState',
     'ExecutionCancelledError', 'ThreadedAsyncLock', 'ThreadedAsyncForbidden'
 ]

--- a/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
@@ -1,0 +1,119 @@
+"""Test instrument context simulation."""
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from opentrons.hardware_control import NoTipAttachedError
+from opentrons.hardware_control.types import TipAttachedError
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.context.protocol_api.labware import \
+    LabwareImplementation
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons import types
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.protocol_api.protocol_context import \
+    ProtocolContextImplementation
+from opentrons.protocols.context.simulator.instrument_context import \
+    InstrumentContextSimulation
+
+
+@pytest.fixture
+def protocol_context() -> ProtocolContextImplementation:
+    """Protocol context implementation fixture."""
+    return ProtocolContextImplementation()
+
+
+@pytest.fixture
+def instrument_context(
+        protocol_context: ProtocolContextImplementation) -> AbstractInstrument:
+    """Instrument context backed by hardware simulator."""
+    return protocol_context.load_instrument(
+        'p300_single_gen2', types.Mount.RIGHT, replace=False
+    )
+
+
+@pytest.fixture
+def simulating_context(protocol_context: ProtocolContextImplementation,
+                       instrument_context: AbstractInstrument) -> AbstractInstrument:
+    """A simulating instrument context."""
+    return InstrumentContextSimulation(
+        protocol_interface=protocol_context,
+        pipette_dict=instrument_context.get_pipette(),
+        mount=types.Mount.RIGHT, instrument_name='p300_single_gen2'
+    )
+
+
+@pytest.fixture
+def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
+    """Labware fixture."""
+    return LabwareImplementation(
+        definition=minimal_labware_def,
+        parent=types.Location(types.Point(0, 0, 0), "1"),
+    )
+
+
+@pytest.fixture(params=[lazy_fixture("instrument_context"),
+                        lazy_fixture("simulating_context")
+                        ])
+def subject(request) -> AbstractInstrument:
+    return request.param
+
+
+def test_same_pipette(instrument_context: AbstractInstrument,
+                      simulating_context: AbstractInstrument) -> None:
+    """It should have the same pipette as hardware backed instrument context."""
+    assert instrument_context.get_pipette() == simulating_context.get_pipette()
+
+
+def test_aspirate_no_tip(subject: AbstractInstrument) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform ASPIRATE"):
+        subject.aspirate(volume=1, rate=1)
+
+
+def test_prepare_to_aspirate_no_tip(subject: AbstractInstrument) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError,
+                       match="Cannot perform PREPARE_ASPIRATE"):
+        subject.prepare_for_aspirate()
+
+
+def test_dispense_no_tip(subject: AbstractInstrument) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform DISPENSE"):
+        subject.dispense(volume=1, rate=1)
+
+
+def test_drop_tip_no_tip(subject: AbstractInstrument) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform DROPTIP"):
+        subject.drop_tip(home_after=False)
+
+
+def test_blow_out_no_tip(subject: AbstractInstrument) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform BLOWOUT"):
+        subject.blow_out()
+
+
+def test_pick_up_tip_no_tip(subject: AbstractInstrument,
+                            labware: AbstractLabware) -> None:
+    """It should raise an error if a tip is already attached."""
+    subject.home()
+    subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1, presses=None,
+                        increment=None)
+    with pytest.raises(TipAttachedError):
+        subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1,
+                            presses=None,
+                            increment=None)
+
+
+def test_aspirate_too_much(subject: AbstractInstrument,
+                           labware: AbstractLabware) -> None:
+    """It should raise an error if try to aspirate more than possible."""
+    subject.home()
+    subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1, presses=None,
+                        increment=None)
+    subject.prepare_for_aspirate()
+    with pytest.raises(AssertionError,
+                       match="Cannot aspirate more than pipette max volume"):
+        subject.aspirate(subject.get_max_volume() + 1, rate=1)


### PR DESCRIPTION
# Overview

#7349 shed light on errors caught by slow sim that would not be caught by fast sim. This PR addresses the most common issues: 
- tip action without a tip
- no tip action with a tip
- trying to aspirate more than the max volume

closes #7627

# Changelog

- added unit test to demonstrate the disparities
- implement checks

# Review requests

I debated putting the checks in `protocol_api.instrument_context` rather than the simulating implementation. 

## Test protocols

Make sure to enable "fast upload" feature flag.

### drop tip without a tip
```
metadata = {"apiLevel": "2.8"}

def run(protocol):
    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 8)
    pipette = protocol.load_instrument("p300_single", mount="right", tip_racks=[tip_rack])

    for column in tip_rack.columns():
        pipette.drop_tip()
```

### aspirate more than max volume
```
metadata = {"apiLevel": "2.8"}

def run(protocol):
    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 8)
    pipette = protocol.load_instrument("p300_single", mount="right", tip_racks=[tip_rack])

    for column in tip_rack.columns():
        pipette.pick_up_tip(tip_rack["A1"])
        pipette.aspirate(1000)
        pipette.drop_tip()
```

### aspirate without a tip
```
metadata = {"apiLevel": "2.8"}

def run(protocol):
    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 8)
    pipette = protocol.load_instrument("p300_single", mount="right", tip_racks=[tip_rack])

    for column in tip_rack.columns():
        pipette.pick_up_tip(tip_rack["A1"])
        pipette.drop_tip()
        pipette.aspirate(1000)
```
# Risk assessment

None
