### PR TITLE
refactor(docs): reduce visibility of from_center_cartesian in our documentation

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -289,20 +289,6 @@ control of positions within the well for unusual or custom labware.
 .. versionadded:: 2.0
 
 
-From Center Cartesian
----------------------
-
-The method :py:meth:`.Well.from_center_cartesian` specifies an arbitrary point
-in deck coordinates based on percentages of the radius in each axis.
-
-.. code-block:: python
-
-   plate['A1'].from_center_cartesian(1, 1, -0.5) # The back-right corner of a well at 1/4 of the well depth from the bottom
-
-.. versionadded:: 2.8
-
-
-
 Manipulating Positions
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -193,6 +193,7 @@ Version 2.8
 - You can now pass in a list of volumes to distribute and consolidate. See :ref:`distribute-consolidate-volume-list` for more information.
     - Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense
 - :py:meth:`.Well.from_center_cartesian` can be used to find a point within a well using normalized distance from the center in each axis.
+    - **Note** that you will need to create a location object to use this function in a protocol. See :ref:`protocol-api-labware` for more information.
 - You can now pass in a blowout location to transfer, distribute, and consolidate 
   with the ``blowout_location`` parameter. See :py:meth:`.InstrumentContext.transfer` for more detail!
 

--- a/api/src/opentrons/protocols/geometry/well_geometry.py
+++ b/api/src/opentrons/protocols/geometry/well_geometry.py
@@ -93,10 +93,24 @@ class WellGeometry:
         Specifies an arbitrary point in deck coordinates based
         on percentages of the radius in each axis. For example, to specify the
         back-right corner of a well at 1/4 of the well depth from the bottom,
-        the call would be `_from_center_cartesian(1, 1, -0.5)`.
+        the call would be `from_center_cartesian(1, 1, -0.5)`.
 
         No checks are performed to ensure that the resulting position will be
         inside of the well.
+
+        To use this point in a liquid handling command, you must create a
+        location object using the well such as,
+
+        .. code-block:: python
+
+            from opentrons import types
+
+            # Cannot be passed into a liquid handling function
+            point = well.from_center_cartesian(1, 1, -0.5)
+
+            # Can be passed into a liquid handling function
+            location = types.Location(
+                well.from_center_cartesian(1, 1, -0.5), well)
 
         :param x: a float in the range [-1.0, 1.0] for a percentage of half of
             the radius/length in the X axis


### PR DESCRIPTION
# Overview
We want to encourage users to use the `center()` + offset method when they are writing their own custom locations based on labware in protocols rather than using arbitrary percentages on a well. We should no longer call out `from_center_cartesian` in the `Labware` section of the docs, further explain how best to use the function in the docstring and point users interested in this function to read the API reference for more details.

# Changelog
- Remove reference to `from_center_cartesian` in `new_labware.rst`
- Further explain `from_center_cartesian` in the docstring
- Add a pointer to the API reference from `versioning.rst`

# Review requests

Check out everything and see that it makes sense to you.

# Risk assessment

Low. Changing around some docs.