### PR TITLE
feat(protocol-engine): InstrumentContext implements dispense

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/instrument_context.py
+++ b/api/src/opentrons/protocol_api_experimental/instrument_context.py
@@ -60,12 +60,12 @@ class InstrumentContext:  # noqa: D101
                  rate: float = 1.0) -> InstrumentContext:
         raise NotImplementedError()
 
-    def dispense(
+    def dispense(  # noqa: D102
             self,
             volume: Optional[float] = None,
             location: Union[types.Location, Well] = None,
             rate: float = 1.0) -> InstrumentContext:
-        """Dispense a volume of liquid (in microliters)."""
+
         if rate != 1:
             raise NotImplementedError("Flow rate adjustment not yet supported in PE.")
 

--- a/api/src/opentrons/protocol_api_experimental/instrument_context.py
+++ b/api/src/opentrons/protocol_api_experimental/instrument_context.py
@@ -66,15 +66,16 @@ class InstrumentContext:  # noqa: D101
                  rate: float = 1.0) -> InstrumentContext:
         """Dispense a volume of liquid (in microliters)."""
         if rate != 1:
-            raise NotImplementedError("Flow rate adjustment "
-                                      "not yet supported.")
+            raise NotImplementedError("Flow rate adjustment not yet supported in PE.")
+
+        if volume is None:
+            raise NotImplementedError("Volume tracking not yet supported in PE.")
 
         # TODO (spp:
         #  - Disambiguate location. Cases in point:
         #       1. location not specified; use current labware & well
         #       2. specified location is a Point)
-        #  - Use well_bottom_clearance as offset for well_location
-
+        #  - Use well_bottom_clearance as offset for well_location(?)
         if isinstance(location, Well):
             self._client.dispense(
                 pipette_id=self._resource_id,
@@ -86,7 +87,7 @@ class InstrumentContext:  # noqa: D101
             )
         else:
             raise NotImplementedError("Dispensing to a non-well location "
-                                      "not yet supported.")
+                                      "not yet supported in PE.")
         return self
 
     def mix(self,  # noqa: D102

--- a/api/src/opentrons/protocol_api_experimental/instrument_context.py
+++ b/api/src/opentrons/protocol_api_experimental/instrument_context.py
@@ -60,15 +60,16 @@ class InstrumentContext:  # noqa: D101
                  rate: float = 1.0) -> InstrumentContext:
         raise NotImplementedError()
 
-    def dispense(self,  # noqa: D102
-                 volume: Optional[float] = None,
-                 location: Union[types.Location, Well] = None,
-                 rate: float = 1.0) -> InstrumentContext:
+    def dispense(
+            self,
+            volume: Optional[float] = None,
+            location: Union[types.Location, Well] = None,
+            rate: float = 1.0) -> InstrumentContext:
         """Dispense a volume of liquid (in microliters)."""
         if rate != 1:
             raise NotImplementedError("Flow rate adjustment not yet supported in PE.")
 
-        if volume is None:
+        if volume is None or volume == 0:
             raise NotImplementedError("Volume tracking not yet supported in PE.")
 
         # TODO (spp:

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from .. import commands
 from ..state import StateView
-from ..types import DeckSlotLocation
+from ..types import DeckSlotLocation, WellLocation
 from .transports import AbstractSyncTransport
 
 
@@ -81,3 +81,25 @@ class SyncClient:
             command_id=self._create_command_id()
         )
         return cast(commands.DropTipResult, result)
+
+    def dispense(
+            self,
+            pipette_id: str,
+            labware_id: str,
+            well_name: str,
+            well_location: WellLocation,
+            volume: float
+    ) -> commands.DispenseResult:
+        """Execute a ``DispenseRequest``, returning the result."""
+        request = commands.DispenseRequest(
+            pipetteId=pipette_id,
+            labwareId=labware_id,
+            wellName=well_name,
+            wellLocation=well_location,
+            volume=volume,
+        )
+        result = self._transport.execute_command(
+            request=request,
+            command_id=self._create_command_id()
+        )
+        return cast(commands.DispenseResult, result)

--- a/api/tests/opentrons/protocol_api_experimental/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_instrument_context.py
@@ -5,6 +5,7 @@ from decoy import Decoy
 from opentrons.protocol_api_experimental.instrument_context import InstrumentContext
 from opentrons.protocol_api_experimental.labware import Well, Labware
 from opentrons.protocol_engine.clients import SyncClient
+from opentrons.protocol_engine.types import WellOrigin, WellLocation
 
 
 @pytest.fixture
@@ -74,4 +75,24 @@ def test_drop_tip(
         pipette_id=pipette_id,
         labware_id=well.parent.resource_id,
         well_name=well.well_name
+    ))
+
+
+def test_dispense(
+        decoy: Decoy,
+        sync_client: SyncClient,
+        pipette_id: str,
+        subject: InstrumentContext,
+        well: Well
+) -> None:
+    """It should send a dispense command."""
+    subject.dispense(volume=10, location=well)
+
+    decoy.verify(sync_client.dispense(
+        pipette_id=pipette_id,
+        labware_id=well.parent.resource_id,
+        well_name=well.well_name,
+        well_location=WellLocation(origin=WellOrigin.BOTTOM,
+                                   offset=(0, 0, 1)),
+        volume=10
     ))

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -15,6 +15,7 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import DeckSlotLocation, commands
 from opentrons.protocol_engine.clients import SyncClient, AbstractSyncTransport
+from opentrons.protocol_engine.types import WellOrigin, WellLocation
 
 
 UUID_MATCHER = matchers.StringMatching(
@@ -125,6 +126,35 @@ def test_drop_tip(
         pipette_id="123",
         labware_id="456",
         well_name="A2"
+    )
+
+    assert result == response
+
+
+def test_dispense(
+    decoy: Decoy,
+    transport: AbstractSyncTransport,
+    subject: SyncClient,
+) -> None:
+    """It should execute a dispense command."""
+    request = commands.DispenseRequest(
+        pipetteId="123", labwareId="456", wellName="A2",
+        wellLocation=WellLocation(origin=WellOrigin.BOTTOM,
+                                   offset=(0, 0, 1)),
+        volume=10
+    )
+
+    response = commands.DispenseResult(volume=1)
+
+    decoy.when(
+        transport.execute_command(request=request, command_id=UUID_MATCHER)
+    ).then_return(response)
+
+    result = subject.dispense(
+        pipette_id="123", labware_id="456", well_name="A2",
+        well_location=WellLocation(origin=WellOrigin.BOTTOM,
+                                   offset=(0, 0, 1)),
+        volume=10,
     )
 
     assert result == response


### PR DESCRIPTION
Closes #7329 

# Overview

Implement dispense command in experimental Protocol Engine InstrumentContext. 
As a first pass, the command has been simplified to perform the most basic dispense action with specific args; cases not covered are documented & guarded with error raises.

# Changelog

- Added `dispense` method to experimental InstrumentContext
- Added `SyncClient.dispense`

# Review requests

- Code & tests look ok
- Have all 'not implemented' cases been covered?

# Risk assessment

None.
