### PR TITLE
fix(api): unit tests hang due to too many open files

### DIFF
--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -879,7 +879,7 @@ def test_loaded_modules(ctx, monkeypatch):
     assert ctx.loaded_modules[7] == mod2
 
 
-def test_order_of_module_load(loop):
+def test_order_of_module_load(loop, hardware):
     import opentrons.hardware_control as hardware_control
     import opentrons.protocol_api as protocol_api
 
@@ -894,7 +894,7 @@ def test_order_of_module_load(loop):
     hw_temp2 = attached_modules[2]
 
     ctx1 = protocol_api.ProtocolContext(
-        implementation=ProtocolContextImplementation(),
+        implementation=ProtocolContextImplementation(hardware=hardware),
         loop=loop)
     with ctx1.temp_connect(fake_hardware) as c:
         temp1 = c.load_module('tempdeck', 4)
@@ -910,7 +910,7 @@ def test_order_of_module_load(loop):
     # hardware modules regardless of the slot it
     # was loaded into
     ctx2 = protocol_api.ProtocolContext(
-        implementation=ProtocolContextImplementation(),
+        implementation=ProtocolContextImplementation(hardware=hardware),
         loop=loop)
 
     with ctx2.temp_connect(fake_hardware) as c:
@@ -973,7 +973,7 @@ def test_tip_length_for_load_caldata(ctx):
     delete.clear_tip_length_calibration()
 
 
-def test_bundled_labware(loop, get_labware_fixture):
+def test_bundled_labware(loop, get_labware_fixture, hardware):
     fixture_96_plate = get_labware_fixture('fixture_96_plate')
     bundled_labware = {
         'fixture/fixture_96_plate/1': fixture_96_plate
@@ -981,6 +981,7 @@ def test_bundled_labware(loop, get_labware_fixture):
 
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
+            hardware=hardware,
             bundled_labware=bundled_labware),
         loop=loop
     )
@@ -991,7 +992,7 @@ def test_bundled_labware(loop, get_labware_fixture):
         fixture_96_plate
 
 
-def test_bundled_labware_missing(loop, get_labware_fixture):
+def test_bundled_labware_missing(loop, get_labware_fixture, hardware):
     bundled_labware = {}
     with pytest.raises(
         RuntimeError,
@@ -999,7 +1000,9 @@ def test_bundled_labware_missing(loop, get_labware_fixture):
     ):
         ctx = papi.ProtocolContext(
             implementation=ProtocolContextImplementation(
-                bundled_labware=bundled_labware),
+                bundled_labware=bundled_labware,
+                hardware=hardware
+            ),
             loop=loop)
         ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
 
@@ -1014,29 +1017,35 @@ def test_bundled_labware_missing(loop, get_labware_fixture):
         ctx = papi.ProtocolContext(
             implementation=ProtocolContextImplementation(
                 bundled_labware={},
-                extra_labware=bundled_labware),
+                extra_labware=bundled_labware,
+                hardware=hardware
+            ),
             loop=loop
         )
         ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
 
 
-def test_bundled_data(loop):
+def test_bundled_data(loop, hardware):
     bundled_data = {'foo': b'1,2,3'}
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
-            bundled_data=bundled_data),
+            bundled_data=bundled_data,
+            hardware=hardware
+        ),
         loop=loop
     )
     assert ctx.bundled_data == bundled_data
 
 
-def test_extra_labware(loop, get_labware_fixture):
+def test_extra_labware(loop, get_labware_fixture, hardware):
     fixture_96_plate = get_labware_fixture('fixture_96_plate')
     bundled_labware = {
         'fixture/fixture_96_plate/1': fixture_96_plate
     }
     ctx = papi.ProtocolContext(
-        implementation=ProtocolContextImplementation(extra_labware=bundled_labware),
+        implementation=ProtocolContextImplementation(
+            extra_labware=bundled_labware, hardware=hardware
+        ),
         loop=loop
     )
 
@@ -1046,22 +1055,26 @@ def test_extra_labware(loop, get_labware_fixture):
         fixture_96_plate
 
 
-def test_api_version_checking():
+def test_api_version_checking(hardware):
     minor_over = (papi.MAX_SUPPORTED_VERSION.major,
                   papi.MAX_SUPPORTED_VERSION.minor + 1)
     with pytest.raises(RuntimeError):
         papi.ProtocolContext(api_version=minor_over,
-                             implementation=ProtocolContextImplementation())
+                             implementation=ProtocolContextImplementation(
+                                 hardware=hardware
+                             ))
 
     major_over = (papi.MAX_SUPPORTED_VERSION.major + 1,
                   papi.MAX_SUPPORTED_VERSION.minor)
     with pytest.raises(RuntimeError):
         papi.ProtocolContext(api_version=major_over,
-                             implementation=ProtocolContextImplementation())
+                             implementation=ProtocolContextImplementation(
+                                 hardware=hardware
+                             ))
 
 
-def test_api_per_call_checking(monkeypatch):
-    implementation = ProtocolContextImplementation()
+def test_api_per_call_checking(monkeypatch, hardware):
+    implementation = ProtocolContextImplementation(hardware=hardware)
 
     ctx = papi.ProtocolContext(implementation=implementation,
                                api_version=APIVersion(1, 9))
@@ -1082,9 +1095,13 @@ def test_api_per_call_checking(monkeypatch):
         ctx.disconnect()
 
 
-def test_home_plunger(monkeypatch):
-    ctx = papi.ProtocolContext(implementation=ProtocolContextImplementation(),
-                               api_version=APIVersion(2, 0))
+def test_home_plunger(monkeypatch, hardware):
+    ctx = papi.ProtocolContext(
+        implementation=ProtocolContextImplementation(
+            hardware=hardware
+        ),
+        api_version=APIVersion(2, 0)
+    )
     ctx.home()
     instr = ctx.load_instrument('p1000_single', 'left')
     instr.home_plunger()
@@ -1107,7 +1124,7 @@ def test_move_to_with_thermocycler(ctx):
         [ProtocolContextImplementation],
         [ProtocolContextSimulation],
     ])
-def test_temp_connect(implementation_class):
+def test_temp_connect(implementation_class, hardware):
     """Test that temp_connect can be used to assign hardware controller to
     protocol implementation."""
 
@@ -1121,22 +1138,22 @@ def test_temp_connect(implementation_class):
     }
 
     # Create the SynchronousAdapter wrapping the wrappable_hardware.
-    hardware = SynchronousAdapter(wrappable_hardware)
+    temp_hardware = SynchronousAdapter(wrappable_hardware)
 
-    ctx = papi.ProtocolContext(implementation=implementation_class(),
+    ctx = papi.ProtocolContext(implementation=implementation_class(hardware=hardware),
                                api_version=APIVersion(2, 0))
     instr = ctx.load_instrument('p1000_single', 'left')
 
-    with ctx.temp_connect(hardware):
+    with ctx.temp_connect(temp_hardware):
         instr.home()
 
     # Was home_z called on the hardware passed to temp_connect?
-    hardware.home_z.assert_called_once_with(Mount.LEFT)
+    temp_hardware.home_z.assert_called_once_with(Mount.LEFT)
 
     # Clear mock history.
-    hardware.home_z.reset_mock()
+    temp_hardware.home_z.reset_mock()
 
     # Calling. outside context manager will not call temp hardware method.
     instr.home()
 
-    hardware.home_z.assert_not_called()
+    temp_hardware.home_z.assert_not_called()

--- a/api/tests/opentrons/protocol_api/test_instrument.py
+++ b/api/tests/opentrons/protocol_api/test_instrument.py
@@ -10,10 +10,11 @@ from opentrons.protocols.api_support.types import APIVersion
 
 
 @pytest.fixture
-def make_context_and_labware():
+def make_context_and_labware(hardware):
     def _make_context_and_labware(api_version):
         ctx = papi.ProtocolContext(
             implementation=ProtocolContextImplementation(
+                hardware=hardware,
                 api_version=api_version
             ),
             api_version=api_version

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -953,12 +953,14 @@ def test_oversized_transfer(_instr_labware):
     assert xfer_plan_list == exp1
 
 
-def test_multichannel_transfer_old_version(loop):
+def test_multichannel_transfer_old_version(loop, hardware):
     # for API version below 2.2, multichannel pipette can only
     # reach row A of 384-well plates
-    ctx = papi.ProtocolContext(implementation=ProtocolContextImplementation(),
-                               loop=loop,
-                               api_version=APIVersion(2, 1))
+    ctx = papi.ProtocolContext(
+        implementation=ProtocolContextImplementation(hardware=hardware),
+        loop=loop,
+        api_version=APIVersion(2, 1)
+    )
     lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
     lw2 = ctx.load_labware('corning_384_wellplate_112ul_flat', 2)
     tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
@@ -1000,10 +1002,13 @@ def test_multichannel_transfer_old_version(loop):
             xfer_plan_list.append(step)
 
 
-def test_multichannel_transfer_locs(loop):
+def test_multichannel_transfer_locs(loop, hardware):
     api_version = APIVersion(2, 2)
     ctx = papi.ProtocolContext(
-        implementation=ProtocolContextImplementation(api_version=api_version),
+        implementation=ProtocolContextImplementation(
+            api_version=api_version,
+            hardware=hardware
+        ),
         loop=loop,
         api_version=api_version
     )

--- a/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
@@ -8,7 +8,7 @@ from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.context.protocol_api.labware import \
     LabwareImplementation
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons import types
+from opentrons import types, ThreadManager
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol_api.protocol_context import \
     ProtocolContextImplementation
@@ -17,9 +17,9 @@ from opentrons.protocols.context.simulator.instrument_context import \
 
 
 @pytest.fixture
-def protocol_context() -> ProtocolContextImplementation:
+def protocol_context(hardware: ThreadManager) -> ProtocolContextImplementation:
     """Protocol context implementation fixture."""
-    return ProtocolContextImplementation()
+    return ProtocolContextImplementation(hardware=hardware)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

A recent merge brought back the ol' unit tests hang on Mac due to too many open file descriptors.

eliminate implicit creations of ThreadManager objects to avoid thread leaks leading to unit tests hanging due to too many open file descriptors.

# Changelog

- use `hardware` fixture in `ProtocolContextImplementation` fixtures to avoid thread leaks.

# Review requests


# Risk assessment

None