### PR TITLE
fix(shared-data): fix data not being included in package build

### DIFF
--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -71,7 +71,7 @@ class BuildWithData(build_py.build_py):
         build_base = os.path.commonpath([f[2] for f in files])
         # We want a list of paths to only files relative to ../shared-data
         to_include = get_shared_data_files()
-        destination = os.path.join(build_base, DEST_BASE_PATH)
+        destination = os.path.join(build_base, 'opentrons_shared_data', DEST_BASE_PATH)
         # And finally, tell the system about our files, including package.json
         files.extend([('opentrons_shared_data', DATA_ROOT,
                        destination, to_include),


### PR DESCRIPTION
Commit 3bad6db646e22c0140838bca03ad6304dc0cd688 for some reason
broke the previous method of including the json data files in
the shared data python package. We now need to add the path for the
package explicitly.

Before this fix, running `python setup.py build` from inside `shared-data/python` would create a `build/lib/data` directory with the data file contents in it, instead of putting the `data` directory in `build/lib/opentrons_shared_data` as it did before 3bad6db646e22c0140838bca03ad6304dc0cd688 . This would then end up as `/usr/lib/python3.7/site-packages/data` instead of `/usr/lib/python3.7/site-packages/opentrons_shared_data/data` on the robot, and when the server started it would try and load the shared data and fail.

## Testing
Pull this pr, go to `shared-data/python`, and run `rm -rf ./build; python setup.py build`. The directory `build/lib/opentrons_shared_data/data` should exist and contain all the json data files.