### PR TITLE
fix(app): use correct module order to get usb port

### DIFF
--- a/app/src/organisms/ProtocolModuleList/__tests__/ProtocolModuleList.test.js
+++ b/app/src/organisms/ProtocolModuleList/__tests__/ProtocolModuleList.test.js
@@ -34,12 +34,14 @@ const mockMagneticModule1 = {
   model: 'magneticModuleV1',
   slot: '1',
   _id: 1234,
+  protocolLoadOrder: 0,
 }
 
 const mockMagneticModule2 = {
   model: 'magneticModuleV2',
   slot: '3',
   _id: 2345,
+  protocolLoadOrder: 1,
 }
 
 const mockMatchedModule1 = {

--- a/app/src/redux/analytics/__tests__/selectors.test.js
+++ b/app/src/redux/analytics/__tests__/selectors.test.js
@@ -248,8 +248,13 @@ describe('analytics selectors', () => {
 
     it('should collect module models', () => {
       getModules.mockReturnValue([
-        { _id: 0, slot: '1', model: 'temperatureModuleV1' },
-        { _id: 1, slot: '2', model: 'magneticModuleV2' },
+        {
+          _id: 0,
+          slot: '1',
+          model: 'temperatureModuleV1',
+          protocolLoadOrder: 0,
+        },
+        { _id: 1, slot: '2', model: 'magneticModuleV2', protocolLoadOrder: 1 },
       ])
 
       const result = Selectors.getProtocolAnalyticsData(mockState)

--- a/app/src/redux/calibration/labware/__tests__/selectors.test.js
+++ b/app/src/redux/calibration/labware/__tests__/selectors.test.js
@@ -99,6 +99,7 @@ describe('labware calibration selectors', () => {
             model: 'magneticModuleV1',
             slot: '3',
             _id: 1945365648,
+            protocolLoadOrder: 0,
           },
         }
       })
@@ -407,6 +408,7 @@ describe('labware calibration selectors', () => {
             model: 'magneticModuleV1',
             slot: '3',
             _id: 1945365648,
+            protocolLoadOrder: 0,
           },
         }
       })
@@ -515,6 +517,7 @@ describe('labware calibration selectors', () => {
             model: 'magneticModuleV1',
             slot: '3',
             _id: 1945365648,
+            protocolLoadOrder: 0,
           },
         }
       })

--- a/app/src/redux/modules/__tests__/selectors.test.js
+++ b/app/src/redux/modules/__tests__/selectors.test.js
@@ -87,7 +87,12 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
+        {
+          _id: 0,
+          slot: '1',
+          model: 'thermocyclerModuleV1',
+          protocolLoadOrder: 0,
+        },
       ])
     },
     expected: [
@@ -116,14 +121,29 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
-        { _id: 1, slot: '2', model: 'temperatureModuleV1' },
-        { _id: 2, slot: '3', model: 'magneticModuleV1' },
+        {
+          _id: 0,
+          slot: '1',
+          model: 'thermocyclerModuleV1',
+          protocolLoadOrder: 0,
+        },
+        {
+          _id: 1,
+          slot: '2',
+          model: 'temperatureModuleV1',
+          protocolLoadOrder: 1,
+        },
+        { _id: 2, slot: '3', model: 'magneticModuleV1', protocolLoadOrder: 2 },
       ])
     },
     expected: [
-      { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
-      { _id: 2, slot: '3', model: 'magneticModuleV1' },
+      {
+        _id: 0,
+        slot: '1',
+        model: 'thermocyclerModuleV1',
+        protocolLoadOrder: 0,
+      },
+      { _id: 2, slot: '3', model: 'magneticModuleV1', protocolLoadOrder: 2 },
     ],
   },
   {
@@ -143,14 +163,29 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
-        { _id: 1, slot: '2', model: 'temperatureModuleV1' },
-        { _id: 2, slot: '3', model: 'magneticModuleV2' },
+        {
+          _id: 0,
+          slot: '1',
+          model: 'thermocyclerModuleV1',
+          protocolLoadOrder: 0,
+        },
+        {
+          _id: 1,
+          slot: '2',
+          model: 'temperatureModuleV1',
+          protocolLoadOrder: 1,
+        },
+        { _id: 2, slot: '3', model: 'magneticModuleV2', protocolLoadOrder: 2 },
       ])
     },
     expected: [
-      { _id: 0, slot: '1', model: 'thermocyclerModuleV1' },
-      { _id: 2, slot: '3', model: 'magneticModuleV2' },
+      {
+        _id: 0,
+        slot: '1',
+        model: 'thermocyclerModuleV1',
+        protocolLoadOrder: 0,
+      },
+      { _id: 2, slot: '3', model: 'magneticModuleV2', protocolLoadOrder: 2 },
     ],
   },
   {
@@ -173,15 +208,15 @@ const SPECS: Array<SelectorSpec> = [
     before: () => {
       mockGetConnectedRobotName.mockReturnValue('robotName')
       mockGetProtocolModules.mockReturnValue([
-        { _id: 0, slot: '1', model: 'magneticModuleV2' },
-        { _id: 1, slot: '2', model: 'magneticModuleV1' },
-        { _id: 2, slot: '3', model: 'magneticModuleV1' },
-        { _id: 3, slot: '4', model: 'magneticModuleV1' },
+        { _id: 0, slot: '1', model: 'magneticModuleV2', protocolLoadOrder: 0 },
+        { _id: 1, slot: '2', model: 'magneticModuleV1', protocolLoadOrder: 1 },
+        { _id: 2, slot: '3', model: 'magneticModuleV1', protocolLoadOrder: 2 },
+        { _id: 3, slot: '4', model: 'magneticModuleV1', protocolLoadOrder: 3 },
       ])
     },
     expected: [
-      { _id: 0, slot: '1', model: 'magneticModuleV2' },
-      { _id: 3, slot: '4', model: 'magneticModuleV1' },
+      { _id: 0, slot: '1', model: 'magneticModuleV2', protocolLoadOrder: 0 },
+      { _id: 3, slot: '4', model: 'magneticModuleV1', protocolLoadOrder: 3 },
     ],
   },
   {

--- a/app/src/redux/modules/selectors.js
+++ b/app/src/redux/modules/selectors.js
@@ -64,7 +64,7 @@ export const getMatchedModules: (
   state: State
 ) => Array<Types.MatchedModule> = createSelector(
   getAttachedModulesForConnectedRobot,
-  RobotSelectors.getModules,
+  RobotSelectors.getModulesByProtocolLoadOrder,
   (attachedModules, protocolModules) => {
     const matchedAmod: Array<Types.MatchedModule> = []
     const matchedPmod = []

--- a/app/src/redux/robot/api-client/client.js
+++ b/app/src/redux/robot/api-client/client.js
@@ -643,11 +643,12 @@ export function client(dispatch) {
       update.labwareBySlot[slot] = labware
     }
 
-    function addApiModuleToModules(apiModule) {
+    function addApiModuleToModules(apiModule, index) {
       const { name, ...noName } = apiModule
       update.modulesBySlot[apiModule.slot] = {
         ...noName,
         model: apiModule?.model ?? normalizeModuleModel(apiModule.name),
+        protocolLoadOrder: index,
       }
     }
   }

--- a/app/src/redux/robot/api-types.js
+++ b/app/src/redux/robot/api-types.js
@@ -28,6 +28,7 @@ export type ApiSessionModule = {|
   // name identifier of the module
   name: TEMPDECK | MAGDECK | THERMOCYCLER,
   model: ModuleModel,
+  protocolLoadOrder: number,
 |}
 
 export type ApiSessionModuleLegacy = {|

--- a/app/src/redux/robot/selectors.js
+++ b/app/src/redux/robot/selectors.js
@@ -321,7 +321,8 @@ export const getModules: State => Array<SessionModule> = createSelector(
 
 export const getModulesByProtocolLoadOrder: State => Array<SessionModule> = createSelector(
   getModules,
-  modules => modules.slice().sort((a, b) => a.protocolLoadOrder - b.protocolLoadOrder)
+  modules =>
+    modules.slice().sort((a, b) => a.protocolLoadOrder - b.protocolLoadOrder)
 )
 
 export const getModulesByModel: State => {

--- a/app/src/redux/robot/selectors.js
+++ b/app/src/redux/robot/selectors.js
@@ -321,7 +321,7 @@ export const getModules: State => Array<SessionModule> = createSelector(
 
 export const getModulesByProtocolLoadOrder: State => Array<SessionModule> = createSelector(
   getModules,
-  modules => modules.sort((a, b) => a.protocolLoadOrder - b.protocolLoadOrder)
+  modules => modules.slice().sort((a, b) => a.protocolLoadOrder - b.protocolLoadOrder)
 )
 
 export const getModulesByModel: State => {

--- a/app/src/redux/robot/selectors.js
+++ b/app/src/redux/robot/selectors.js
@@ -315,10 +315,13 @@ export function getModulesBySlot(state: State): { [Slot]: SessionModule } {
 
 export const getModules: State => Array<SessionModule> = createSelector(
   getModulesBySlot,
-  // TODO (ka 2019-3-26): can't import getConfig due to circular dependency
-  state => state.config,
-  (modulesBySlot, config) =>
+  modulesBySlot =>
     Object.keys(modulesBySlot).map((slot: Slot) => modulesBySlot[slot])
+)
+
+export const getModulesByProtocolLoadOrder: State => Array<SessionModule> = createSelector(
+  getModules,
+  modules => modules.sort((a, b) => a.protocolLoadOrder - b.protocolLoadOrder)
 )
 
 export const getModulesByModel: State => {

--- a/app/src/redux/robot/test/api-client.test.js
+++ b/app/src/redux/robot/test/api-client.test.js
@@ -717,11 +717,13 @@ describe('api client', () => {
               _id: 1,
               slot: '1',
               model: 'temperatureModuleV1',
+              protocolLoadOrder: 0,
             },
             9: {
               _id: 9,
               slot: '9',
               model: 'magneticModuleV2',
+              protocolLoadOrder: 1,
             },
           },
         }),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The Multiples of a Module feature relies on following the prescribed order of the modules called in a protocol. 

The protocol modules are currently sorted by the slot number when matching to the physical modules on the client side, which does not match the backend work implemented in #7532. This PR fixes that.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
- added `getModulesByProtocolLoadOrder` to ApiSessionModules
- use the new selector in `getMatchedModules`
- removed unused declaration in the `getModules` selector

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Upload a protocol with multiple modules of the same type, and verify that the one plugged in to the lower port number is actually the first loaded module.

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, very small changes and the moam feature is not released yet so no user should be affected by this. 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
