### PR TITLE
refactor(protocol-designer): StepItem 'stepType' and 'subStepType typing cleanup

### DIFF
--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
@@ -2,10 +2,10 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
+import { THERMOCYCLER_STATE } from '../../../constants'
 import { StepItemContents } from '../StepItem'
 import { ModuleStepItems } from '../ModuleStepItems'
 import type { StepItemContentsProps } from '../StepItem'
-import { THERMOCYCLER_STATE } from '../../../constants'
 
 describe('StepItemContents', () => {
   let props
@@ -118,7 +118,6 @@ describe('StepItemContents', () => {
 
   describe('awaitTemperature step type', () => {
     let awaitTemperatureProps: StepItemContentsProps
-    // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
     const stepType: 'temperature' = 'temperature'
     beforeEach(() => {
       awaitTemperatureProps = {
@@ -154,7 +153,6 @@ describe('StepItemContents', () => {
 
   describe('thermocyclerState substep type', () => {
     let thermocyclerStateProps: StepItemContentsProps
-    // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
     const stepType: 'thermocycler' = 'thermocycler'
 
     beforeEach(() => {

--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
@@ -5,6 +5,7 @@ import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
 import { StepItemContents } from '../StepItem'
 import { ModuleStepItems } from '../ModuleStepItems'
 import type { StepItemContentsProps } from '../StepItem'
+import { THERMOCYCLER_STATE } from '../../../constants'
 
 describe('StepItemContents', () => {
   let props
@@ -19,7 +20,7 @@ describe('StepItemContents', () => {
   describe('magnet step type', () => {
     let magnetProps
     beforeEach(() => {
-      const stepType = 'magnet'
+      const stepType: 'magnet' = 'magnet'
       magnetProps = {
         ...props,
         rawForm: {
@@ -118,7 +119,7 @@ describe('StepItemContents', () => {
   describe('awaitTemperature step type', () => {
     let awaitTemperatureProps: StepItemContentsProps
     // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
-    const stepType: 'awaitTemperature' = 'awaitTemperature'
+    const stepType: 'temperature' = 'temperature'
     beforeEach(() => {
       awaitTemperatureProps = {
         ...props,
@@ -137,7 +138,7 @@ describe('StepItemContents', () => {
 
     it('module is rendered with temperature and only labware nick name', () => {
       awaitTemperatureProps.substeps = {
-        substepType: stepType,
+        substepType: 'awaitTemperature',
         temperature: 45,
         labwareNickname: 'temperature nickname',
         message: 'message',
@@ -154,7 +155,7 @@ describe('StepItemContents', () => {
   describe('thermocyclerState substep type', () => {
     let thermocyclerStateProps: StepItemContentsProps
     // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
-    const stepType: 'thermocyclerState' = 'thermocyclerState'
+    const stepType: 'thermocycler' = 'thermocycler'
 
     beforeEach(() => {
       thermocyclerStateProps = {
@@ -174,7 +175,7 @@ describe('StepItemContents', () => {
 
     it('module is rendered with temperature and lid state and only labware nick name', () => {
       thermocyclerStateProps.substeps = {
-        substepType: stepType,
+        substepType: THERMOCYCLER_STATE,
         blockTargetTemp: 55,
         lidTargetTemp: 45,
         lidOpen: false,

--- a/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
+++ b/protocol-designer/src/components/steplist/__tests__/StepItemContents.test.js
@@ -2,7 +2,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { THERMOCYCLER_MODULE_TYPE } from '@opentrons/shared-data'
-import { THERMOCYCLER_STATE } from '../../../constants'
 import { StepItemContents } from '../StepItem'
 import { ModuleStepItems } from '../ModuleStepItems'
 import type { StepItemContentsProps } from '../StepItem'
@@ -119,7 +118,7 @@ describe('StepItemContents', () => {
   describe('awaitTemperature step type', () => {
     let awaitTemperatureProps: StepItemContentsProps
     // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
-    const stepType: any = 'awaitTemperature'
+    const stepType: 'awaitTemperature' = 'awaitTemperature'
     beforeEach(() => {
       awaitTemperatureProps = {
         ...props,
@@ -155,7 +154,7 @@ describe('StepItemContents', () => {
   describe('thermocyclerState substep type', () => {
     let thermocyclerStateProps: StepItemContentsProps
     // TODO(IL, 2021-02-04) that's not a stepType?!? See #7285
-    const stepType: any = THERMOCYCLER_STATE
+    const stepType: 'thermocyclerState' = 'thermocyclerState'
 
     beforeEach(() => {
       thermocyclerStateProps = {

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -80,9 +80,7 @@ export type StepType =
   | 'manualIntervention'
   | 'magnet'
   | 'temperature'
-  | 'awaitTemperature'
   | 'thermocycler'
-  | 'thermocyclerState'
 export const stepIconsByType: { [StepType]: IconName } = {
   moveLiquid: 'ot-transfer',
   mix: 'ot-mix',

--- a/protocol-designer/src/form-types.js
+++ b/protocol-designer/src/form-types.js
@@ -80,7 +80,9 @@ export type StepType =
   | 'manualIntervention'
   | 'magnet'
   | 'temperature'
+  | 'awaitTemperature'
   | 'thermocycler'
+  | 'thermocyclerState'
 export const stepIconsByType: { [StepType]: IconName } = {
   moveLiquid: 'ot-transfer',
   mix: 'ot-mix',


### PR DESCRIPTION
# Overview

closes #7285. Turns out the tests some of the tests were using a `SubStepType` as a `StepType`. 

For example `stepType` should be `'temperature'` and `subStepType` should be `'awaitTemperature'` for the StepItemContents tests.

Shout out to Ian for logicing this out with me.

# Changelog

- refactor(protocol-designer): StepItem 'stepType' and 'subStepType typing cleanup

# Review requests

- [ ] Changes reflect reflect actual stepType names and subStepType names
- [ ] Code looks sane
- [ ] Checks pass

# Risk assessment

low, fixing broken tests in 1 file of PD
