### PR TITLE
fix(api): return a simulated module for magnetic modules if they are not compatible

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1766,7 +1766,7 @@ class API(HardwareAPILike):
     async def find_modules(
             self, by_model: modules.types.ModuleModel,
             resolved_type: modules.types.ModuleType
-    ) -> List[modules.AbstractModule]:
+    ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
         """
         Find Modules.
 
@@ -1777,6 +1777,7 @@ class API(HardwareAPILike):
         module of the same type.
         """
         matching_modules = []
+        simulated_module = None
         mod_type = {
             modules.types.ModuleType.MAGNETIC: 'magdeck',
             modules.types.ModuleType.TEMPERATURE: 'tempdeck',
@@ -1785,7 +1786,7 @@ class API(HardwareAPILike):
         for module in self.attached_modules:
             if mod_type == module.name():
                 matching_modules.append(module)
-        if self.is_simulator and not matching_modules:
+        if self.is_simulator:
             mod_class = {
                 'magdeck': modules.MagDeck,
                 'tempdeck': modules.TempDeck,
@@ -1800,8 +1801,8 @@ class API(HardwareAPILike):
                     loop=self.loop),
                 sim_model=by_model.value)
             await simulating_module._connect()
-            matching_modules.append(simulating_module)
-        return matching_modules
+            simulated_module = simulating_module
+        return matching_modules, simulated_module
 
     def get_instrument_max_height(
             self,

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -190,7 +190,7 @@ class ProtocolContextImplementation(AbstractProtocol):
             configuration=configuration)
 
         # Try to find in the hardware instance
-        available_modules = self._hw_manager.hardware.find_modules(
+        available_modules, simulating_module = self._hw_manager.hardware.find_modules(
             resolved_model, resolved_type)
 
         hc_mod_instance = None
@@ -202,6 +202,9 @@ class ProtocolContextImplementation(AbstractProtocol):
                 self._loaded_modules.add(mod)
                 hc_mod_instance = SynchronousAdapter(mod)
                 break
+
+        if simulating_module and not hc_mod_instance:
+            hc_mod_instance = SynchronousAdapter(simulating_module)
 
         if not hc_mod_instance:
             return None

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -70,7 +70,7 @@ async def test_filtering_modules():
                         attached_modules=mods)
     await asyncio.sleep(0.5)
 
-    filtered_modules = await api.find_modules(
+    filtered_modules, _ = await api.find_modules(
         MagneticModuleModel.MAGNETIC_V1, ModuleType.MAGNETIC)
     assert len(filtered_modules) == 2
     assert filtered_modules == api.attached_modules[2:4]


### PR DESCRIPTION
# Overview
@ahiuchingau found a bug where non-compatible modules would not simulate properly while testing #7651. This change should only affect magnetic modules.


# Changelog

- Separate out simulated modules from physical modules
- Always send over a simulated module in case the physical module is not compatible with the requested module
- Fixed up test

# Review requests
Test on a robot if you have magnetic modules

# Risk assessment

Medium. We want to make sure we thoroughly test module compatibility loading again since there were changes to the code, and to make sure no other bugs make it to the release.
