### PR TITLE
feat(protocol-designer): add DOM identifiers for e2e tests

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.js
@@ -35,6 +35,7 @@ export const BlowoutLocationField = (
       className={cx(styles.large_field, className)}
       options={options}
       disabled={disabled}
+      id={'BlowoutLocationField_dropdown'}
       onBlur={onFieldBlur}
       onFocus={onFieldFocus}
       value={value ? String(value) : null}

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.js
@@ -31,6 +31,7 @@ const DropdownFormField = (props: DropdownFormFieldProps) => {
   return (
     <DropdownField
       options={props.options}
+      id={`DisposalVolumeField_dropdown`}
       value={props.value ? String(props.value) : null}
       onBlur={props.onFieldBlur}
       onChange={e => props.updateValue(e.currentTarget.value)}

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
@@ -73,6 +73,10 @@ const PathButton = (buttonProps: ButtonProps) => {
     </Tooltip>
   )
 
+  const pathButtonData = `PathButton_${selected ? 'selected' : 'deselected'}_${
+    disabled ? 'disabled' : 'enabled'
+  }`
+
   return (
     <>
       {tooltip}
@@ -84,6 +88,7 @@ const PathButton = (buttonProps: ButtonProps) => {
         })}
         onClick={disabled ? null : onClick}
         id={id}
+        data-test={pathButtonData}
       >
         {children}
       </li>
@@ -99,9 +104,6 @@ const getSubtitle = (
   return reasonForDisabled || ''
 }
 
-const getPathButtonId = (name, selectedValue) =>
-  `PathButton_${name}_${name === selectedValue ? 'selected' : 'deselected'}`
-
 export const Path = (props: PathFieldProps): React.Node => {
   const { disabledPathMap, value, updateValue } = props
   return (
@@ -109,7 +111,7 @@ export const Path = (props: PathFieldProps): React.Node => {
       <ul className={styles.path_options}>
         {ALL_PATH_OPTIONS.map(option => (
           <PathButton
-            id={getPathButtonId(option.name, value)}
+            id={`PathButton_${option.name}`}
             key={option.name}
             selected={option.name === value}
             path={option.name}

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.js
@@ -41,6 +41,7 @@ type PathFieldProps = {|
 type ButtonProps = {
   children?: React.Node,
   disabled: boolean,
+  id?: string,
   selected: boolean,
   subtitle: string,
   onClick: (e: SyntheticMouseEvent<*>) => mixed,
@@ -48,7 +49,15 @@ type ButtonProps = {
 }
 
 const PathButton = (buttonProps: ButtonProps) => {
-  const { children, disabled, onClick, path, selected, subtitle } = buttonProps
+  const {
+    children,
+    disabled,
+    onClick,
+    id,
+    path,
+    selected,
+    subtitle,
+  } = buttonProps
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   const tooltip = (
@@ -74,6 +83,7 @@ const PathButton = (buttonProps: ButtonProps) => {
           [styles.disabled]: disabled,
         })}
         onClick={disabled ? null : onClick}
+        id={id}
       >
         {children}
       </li>
@@ -89,6 +99,9 @@ const getSubtitle = (
   return reasonForDisabled || ''
 }
 
+const getPathButtonId = (name, selectedValue) =>
+  `PathButton_${name}_${name === selectedValue ? 'selected' : 'deselected'}`
+
 export const Path = (props: PathFieldProps): React.Node => {
   const { disabledPathMap, value, updateValue } = props
   return (
@@ -96,6 +109,7 @@ export const Path = (props: PathFieldProps): React.Node => {
       <ul className={styles.path_options}>
         {ALL_PATH_OPTIONS.map(option => (
           <PathButton
+            id={getPathButtonId(option.name, value)}
             key={option.name}
             selected={option.name === value}
             path={option.name}

--- a/protocol-designer/src/components/StepEditForm/fields/PipetteField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PipetteField.js
@@ -37,6 +37,7 @@ export const PipetteField: React.AbstractComponent<OP> = connect<
     >
       <DropdownField
         options={props.pipetteOptions}
+        id={'PipetteField_dropdown'}
         value={value ? String(value) : null}
         onBlur={onFieldBlur}
         onFocus={onFieldFocus}

--- a/protocol-designer/src/components/StepEditForm/fields/PipetteField.js
+++ b/protocol-designer/src/components/StepEditForm/fields/PipetteField.js
@@ -37,7 +37,7 @@ export const PipetteField: React.AbstractComponent<OP> = connect<
     >
       <DropdownField
         options={props.pipetteOptions}
-        id={'PipetteField_dropdown'}
+        name={props.name}
         value={value ? String(value) : null}
         onBlur={onFieldBlur}
         onFocus={onFieldFocus}

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -194,6 +194,7 @@ export const TipPositionModal = (props: Props): React.Node => {
       caption={`between ${minMmFromBottom} and ${maxMmFromBottom}`}
       className={styles.position_from_bottom_input}
       error={errorText}
+      id={'TipPositionModal_custom-input'}
       isIndeterminate={value === null && isIndeterminate}
       onChange={handleInputFieldChange}
       units="mm"

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -194,7 +194,7 @@ export const TipPositionModal = (props: Props): React.Node => {
       caption={`between ${minMmFromBottom} and ${maxMmFromBottom}`}
       className={styles.position_from_bottom_input}
       error={errorText}
-      id={'TipPositionModal_custom-input'}
+      id={'TipPositionModal_custom_input'}
       isIndeterminate={value === null && isIndeterminate}
       onChange={handleInputFieldChange}
       units="mm"

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.js
@@ -269,6 +269,7 @@ export const TipPositionModal = (props: Props): React.Node => {
                       value: 'custom',
                     },
                   ]}
+                  name="TipPositionOptions"
                 />
                 {TipPositionInputField}
               </div>
@@ -277,12 +278,14 @@ export const TipPositionModal = (props: Props): React.Node => {
                 {!isDefault && (
                   <div className={styles.adjustment_buttons}>
                     <OutlineButton
+                      id="Increment_tipPosition"
                       className={styles.adjustment_button}
                       onClick={makeHandleIncrement(SMALL_STEP_MM)}
                     >
                       <Icon name="plus" />
                     </OutlineButton>
                     <OutlineButton
+                      id="Decrement_tipPosition"
                       className={styles.adjustment_button}
                       onClick={makeHandleDecrement(SMALL_STEP_MM)}
                     >

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -97,6 +97,7 @@ function TipPositionInput(props: Props) {
           value={String(value)}
           isIndeterminate={isIndeterminate}
           units={i18n.t('application.units.millimeter')}
+          id={`TipPositionField_${name}`}
         />
       </Wrapper>
     </>

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -109,13 +109,13 @@ export const WellOrderField = (props: Props): React.Node => {
                 { [styles.icon_with_label]: props.label },
                 getIconClassNames()
               )}
-              id="WellOrderField_button"
+              id={`WellOrderField_button_${props.prefix}`}
             />
           ) : (
             <Text
               onClick={handleOpen}
               css={mixedWellOrderStyles}
-              id="WellOrderField_button"
+              id={`WellOrderField_button_${props.prefix}`}
             >
               {i18n.t('form.step_edit_form.field.well_order.mixed')}
             </Text>

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -109,9 +109,14 @@ export const WellOrderField = (props: Props): React.Node => {
                 { [styles.icon_with_label]: props.label },
                 getIconClassNames()
               )}
+              id="WellOrderField_button"
             />
           ) : (
-            <Text onClick={handleOpen} css={mixedWellOrderStyles}>
+            <Text
+              onClick={handleOpen}
+              css={mixedWellOrderStyles}
+              id="WellOrderField_button"
+            >
               {i18n.t('form.step_edit_form.field.well_order.mixed')}
             </Text>
           )}

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.js
@@ -110,12 +110,18 @@ export const WellOrderField = (props: Props): React.Node => {
                 getIconClassNames()
               )}
               id={`WellOrderField_button_${props.prefix}`}
+              data-test={`WellOrderField_button_${String(firstValue)}_${String(
+                secondValue
+              )}`}
             />
           ) : (
             <Text
               onClick={handleOpen}
               css={mixedWellOrderStyles}
               id={`WellOrderField_button_${props.prefix}`}
+              data-test={`WellOrderField_button_${String(firstValue)}_${String(
+                secondValue
+              )}`}
             >
               {i18n.t('form.step_edit_form.field.well_order.mixed')}
             </Text>

--- a/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
+++ b/protocol-designer/src/components/StepEditForm/forms/AspDispSection.js
@@ -32,6 +32,7 @@ export const AspDispSection = (props: Props): React.Node => {
         >
           <IconButton
             className={styles.advanced_settings_button}
+            id={`AspDispSection_settings_button_${props.prefix}`}
             name="settings"
             hover={!collapsed}
           />


### PR DESCRIPTION
# Overview

This PR adds a bunch of identifiers to be used by e2e tests.

closes #7607

# Changelog
- Add DOM identifiers for e2e tests

# Review requests
Code review, make sure names and all that make sense
Make sure identifiers show up on the DOM

# Risk assessment
Low
