### PR TITLE
fix(shared-data): fix p1000_single_gen2 literal in type union

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -16,7 +16,7 @@ PipetteName = Union[Literal['p10_single'], Literal['p10_multi'],
                     Literal['p50_single'], Literal['p50_multi'],
                     Literal['p300_single'], Literal['p300_multi'],
                     Literal['p300_single_gen2'], Literal['p300_multi_gen2'],
-                    Literal['p1000_single'], Literal['p100_single_gen2']]
+                    Literal['p1000_single'], Literal['p1000_single_gen2']]
 
 # Generic NewType for models because we get new ones frequently and theres
 # a huge number of them
@@ -67,10 +67,10 @@ PipetteCustomizableConfigElement = Union[
     PipetteCustomizableConfigElementFloat, PipetteCustomizableConfigElementInt]
 
 SmoothieConfigs = TypedDict(
-        'SmoothieConfigs',
-        {'stepsPerMM': float,
-         'homePosition': float,
-         'travelDistance': float})
+    'SmoothieConfigs',
+    {'stepsPerMM': float,
+     'homePosition': float,
+     'travelDistance': float})
 
 
 class PipetteNameSpec(TypedDict):


### PR DESCRIPTION
## Overview

Little bug and little fix found while working on load pipette

## Changelog

- fix(shared-data): fix p1000_single_gen2 literal in type union

## Review requests

Self-explanatory

## Risk assessment

Very low. Type definitions do not affect runtime
