### PR TITLE
feat(protocol-engine): add load_pipette method to engine-backed ProtocolContext

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -19,9 +19,19 @@ This code is totally unsupported. To do science on a robot, use the stable
 
 from .protocol_context import ProtocolContext
 from .pipette_context import PipetteContext, InstrumentContext
+from .errors import InvalidPipetteNameError, InvalidMountError
+from .types import PipetteName, Mount, DeprecatedMount
 
 __all__ = [
+    # Protocol API classes
     "ProtocolContext",
     "PipetteContext",
     "InstrumentContext",
+    # Protocol API errors
+    "InvalidPipetteNameError",
+    "InvalidMountError",
+    # Protocol API types and data classes
+    "PipetteName",
+    "Mount",
+    "DeprecatedMount",
 ]

--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -16,3 +16,12 @@ This code is totally unsupported. To do science on a robot, use the stable
 # all, package members at the top level. For example, you can access
 # protocol_api.InstrumentContext, but not protocol_api.Point. We should take
 # advantage of the APIv3 break to consolidate the API namespaces.
+
+from .protocol_context import ProtocolContext
+from .pipette_context import PipetteContext, InstrumentContext
+
+__all__ = [
+    "ProtocolContext",
+    "PipetteContext",
+    "InstrumentContext",
+]

--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -18,7 +18,8 @@ This code is totally unsupported. To do science on a robot, use the stable
 # advantage of the APIv3 break to consolidate the API namespaces.
 
 from .protocol_context import ProtocolContext
-from .pipette_context import PipetteContext, InstrumentContext
+from .pipette_context import PipetteContext
+from .instrument_context import InstrumentContext
 from .errors import InvalidPipetteNameError, InvalidMountError
 from .types import PipetteName, Mount, DeprecatedMount
 

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -1,0 +1,19 @@
+"""Python Protocol API v3 errors."""
+
+
+class InvalidPipetteNameError(ValueError):
+    """Error raised if an invalid pipette name is used."""
+
+    def __init__(self, invalid_value: str) -> None:
+        """Initialize the error and message with the invalid value."""
+        super().__init__(f"{invalid_value} is not a valid pipette name.")
+        self.invalid_value = invalid_value
+
+
+class InvalidMountError(ValueError):
+    """Error raised if an invalid mount is used."""
+
+    def __init__(self, invalid_value: str) -> None:
+        """Initialize the error and message with the invalid value."""
+        super().__init__(f"{invalid_value} is not a valid mount.")
+        self.invalid_value = invalid_value

--- a/api/src/opentrons/protocol_api_experimental/instrument_context.py
+++ b/api/src/opentrons/protocol_api_experimental/instrument_context.py
@@ -1,0 +1,16 @@
+"""Deprecated pipette module for the Python Protocol API.
+
+Previous versions of the Python Protocol API referred to pipettes by
+the name "instrument." This module exists to preserve backwards
+compatibilty with old import paths.
+
+This module will be removed in Protocol API v4.
+"""
+from .pipette_context import PipetteContext
+
+InstrumentContext = PipetteContext
+"""Alias of PipetteContext to preserve compatibility with Protocol API v2.
+
+.. deprecated:: Protocol API v3.0
+    Use :py:class:`PipetteContext` instead.
+"""

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -85,7 +85,7 @@ class PipetteContext:  # noqa: D101
         volume: Optional[float] = None,
         location: Union[types.Location, Well] = None,
         rate: float = 1.0,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
 
         if volume is None or volume == 0:
             # todo(mm, 2021-04-14): If None or 0, use highest volume possible.
@@ -125,7 +125,7 @@ class PipetteContext:  # noqa: D101
         volume: Optional[float] = None,
         location: Union[types.Location, Well] = None,
         rate: float = 1.0,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
 
         if rate != 1:
             raise NotImplementedError("Flow rate adjustment not yet supported in PE.")
@@ -158,13 +158,13 @@ class PipetteContext:  # noqa: D101
         volume: Optional[float] = None,
         location: Union[types.Location, Well] = None,
         rate: float = 1.0,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def blow_out(  # noqa: D102
         self,
         location: Union[types.Location, Well] = None,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def touch_tip(  # noqa: D102
@@ -173,17 +173,17 @@ class PipetteContext:  # noqa: D101
         radius: float = 1.0,
         v_offset: float = -1.0,
         speed: float = 60.0,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def air_gap(  # noqa: D102
         self,
         volume: Optional[float] = None,
         height: Optional[float] = None,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
-    def return_tip(self, home_after: bool = True) -> InstrumentContext:  # noqa: D102
+    def return_tip(self, home_after: bool = True) -> PipetteContext:  # noqa: D102
         raise NotImplementedError()
 
     def pick_up_tip(  # noqa: D102
@@ -191,7 +191,7 @@ class PipetteContext:  # noqa: D101
         location: Union[types.Location, Well] = None,
         presses: Optional[int] = None,
         increment: Optional[float] = None,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         # TODO(al, 2021-04-12): What about presses and increment? They are not
         #  supported by PE command. They are also not supported by PD protocols
         #  either.
@@ -214,7 +214,7 @@ class PipetteContext:  # noqa: D101
         self,
         location: Union[types.Location, Well] = None,
         home_after: bool = True,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         # TODO(al, 2021-04-12): What about home_after?
         if not home_after:
             raise NotImplementedError()
@@ -230,10 +230,10 @@ class PipetteContext:  # noqa: D101
 
         return self
 
-    def home(self) -> InstrumentContext:  # noqa: D102
+    def home(self) -> PipetteContext:  # noqa: D102
         raise NotImplementedError()
 
-    def home_plunger(self) -> InstrumentContext:  # noqa: D102
+    def home_plunger(self) -> PipetteContext:  # noqa: D102
         raise NotImplementedError()
 
     def distribute(  # noqa: D102
@@ -243,7 +243,7 @@ class PipetteContext:  # noqa: D101
         dest: List[Well],
         *args,  # noqa: ANN002
         **kwargs,  # noqa: ANN003
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def consolidate(  # noqa: D102
@@ -253,7 +253,7 @@ class PipetteContext:  # noqa: D101
         dest: Well,
         *args,  # noqa: ANN002
         **kwargs,  # noqa: ANN003
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def transfer(  # noqa: D102
@@ -263,7 +263,7 @@ class PipetteContext:  # noqa: D101
         dest: AdvancedLiquidHandling,
         trash: bool = True,
         **kwargs,  # noqa: ANN003
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     def delay(self) -> None:  # noqa: D102
@@ -275,7 +275,7 @@ class PipetteContext:  # noqa: D101
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
-    ) -> InstrumentContext:
+    ) -> PipetteContext:
         raise NotImplementedError()
 
     @property
@@ -351,14 +351,6 @@ class PipetteContext:  # noqa: D101
         raise NotImplementedError()
 
     def pair_with(  # noqa: D102
-        self, instrument: InstrumentContext
+        self, instrument: PipetteContext
     ) -> PairedInstrumentContext:
         raise NotImplementedError()
-
-
-InstrumentContext = PipetteContext
-"""Alias of PipetteContext to preserve compatibility with Protocol API v2.
-
-.. deprecated:: Protocol API v3.0
-    Use :py:class:`PipetteContext` instead.
-"""

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -148,7 +148,7 @@ class PipetteContext:  # noqa: D101
             )
         else:
             raise NotImplementedError(
-                "Dispensing to a non-well location " "not yet supported in PE."
+                "Dispensing to a non-well location not yet supported in PE."
             )
         return self
 

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -1,25 +1,76 @@
 # noqa: D100
 
-import typing
+from typing import Sequence, Union
 
-from .instrument_context import InstrumentContext
+from opentrons.protocol_engine.clients import SyncClient
+
+from .pipette_context import PipetteContext, InstrumentContext
 from .labware import Labware
+from .types import Mount, DeprecatedMount, PipetteName
+from . import errors
 
 
 class ProtocolContext:  # noqa: D101
+    def __init__(self, engine_client: SyncClient) -> None:
+        """Initialize a ProtocolContext API provider.
 
-    def load_instrument(  # noqa: D102
+        You do not need to initialize the ProtocolContext yourself; the system
+        will create one and pass it to your protocol's `run` method.
+
+        Args:
+            engine_client: A ProtocolEngine client to issue protocol commands.
+        """
+        self._engine_client = engine_client
+
+    def load_pipette(  # noqa: D102
+        self,
+        pipette_name: str,
+        mount: str,
+        tip_racks: Sequence[Labware] = (),
+        replace: bool = False,
+    ) -> PipetteContext:
+        if pipette_name not in list(PipetteName):
+            raise errors.InvalidPipetteNameError(pipette_name)
+
+        if mount not in list(Mount):
+            raise errors.InvalidMountError(mount)
+
+        if len(tip_racks) > 0:
+            # TODO(mc, 2021-04-16): figure out what to do with `tip_racks`
+            raise NotImplementedError()
+
+        if replace:
+            # TODO(mc, 2021-04-16): figure out what to do with `replace`
+            raise NotImplementedError()
+
+        result = self._engine_client.load_pipette(
+            pipette_name=PipetteName(pipette_name),
+            mount=Mount(mount),
+        )
+
+        return PipetteContext(
+            engine_client=self._engine_client,
+            resource_id=result.pipetteId,
+        )
+
+    def load_instrument(
         self,
         instrument_name: str,
-        mount: str,
-        tip_racks: typing.Sequence[Labware] = tuple(),
-        replace: bool = False
+        mount: Union[DeprecatedMount, str],
+        tip_racks: Sequence[Labware] = (),
+        replace: bool = False,
     ) -> InstrumentContext:
-        # Changes from APIv2:
-        #   * mount must be a str, not types.Mount.
-        #   * tip_racks is a Sequence[Labware] defaulting to empty, not an
-        #     implicitly optional List[Labware].
-        raise NotImplementedError()
+        """Load a pipette into the protocol.
+
+        .. deprecated:: Protocol API v3.0
+            Use :py:meth:`load_pipette` instead.
+        """
+        return self.load_pipette(
+            pipette_name=instrument_name,
+            mount=(mount if isinstance(mount, str) else str(mount).lower()),
+            tip_racks=tip_racks,
+            replace=replace,
+        )
 
     def load_labware(self) -> Labware:  # noqa: D102
         raise NotImplementedError()

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -4,7 +4,8 @@ from typing import Sequence, Union
 
 from opentrons.protocol_engine.clients import SyncClient
 
-from .pipette_context import PipetteContext, InstrumentContext
+from .pipette_context import PipetteContext
+from .instrument_context import InstrumentContext
 from .labware import Labware
 from .types import Mount, DeprecatedMount, PipetteName
 from . import errors

--- a/api/src/opentrons/protocol_api_experimental/protocol_context.py
+++ b/api/src/opentrons/protocol_api_experimental/protocol_context.py
@@ -1,6 +1,6 @@
 # noqa: D100
 
-from typing import Sequence, Union
+from typing import List, Optional, Sequence, Union
 
 from opentrons.protocol_engine.clients import SyncClient
 
@@ -58,7 +58,7 @@ class ProtocolContext:  # noqa: D101
         self,
         instrument_name: str,
         mount: Union[DeprecatedMount, str],
-        tip_racks: Sequence[Labware] = (),
+        tip_racks: Optional[List[Labware]] = None,
         replace: bool = False,
     ) -> InstrumentContext:
         """Load a pipette into the protocol.
@@ -69,7 +69,7 @@ class ProtocolContext:  # noqa: D101
         return self.load_pipette(
             pipette_name=instrument_name,
             mount=(mount if isinstance(mount, str) else str(mount).lower()),
-            tip_racks=tip_racks,
+            tip_racks=(tip_racks if tip_racks is not None else ()),
             replace=replace,
         )
 

--- a/api/src/opentrons/protocol_api_experimental/types.py
+++ b/api/src/opentrons/protocol_api_experimental/types.py
@@ -1,0 +1,5 @@
+"""Python Protocol API v3 type definitions and value classes."""
+from opentrons.types import MountType as Mount, Mount as DeprecatedMount
+from opentrons.protocol_engine import PipetteName
+
+__all__ = ["PipetteName", "Mount", "DeprecatedMount"]

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -19,12 +19,17 @@ from .types import (
 )
 
 __all__ = [
+    # main export
     "ProtocolEngine",
+    # state interfaces and models
     "StateStore",
     "StateView",
     "LabwareData",
+    # command execution interfaces
     "CommandHandlers",
+    # resource management interfaces
     "ResourceProviders",
+    # type definitions and other value models
     "DeckLocation",
     "DeckSlotLocation",
     "Dimensions",

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -9,18 +9,26 @@ from .protocol_engine import ProtocolEngine
 from .state import StateStore, StateView, LabwareData
 from .execution import CommandHandlers
 from .resources import ResourceProviders
-from .types import DeckLocation, DeckSlotLocation, Dimensions, WellLocation, WellOrigin
+from .types import (
+    DeckLocation,
+    DeckSlotLocation,
+    Dimensions,
+    PipetteName,
+    WellLocation,
+    WellOrigin,
+)
 
 __all__ = [
     "ProtocolEngine",
     "StateStore",
     "StateView",
+    "LabwareData",
     "CommandHandlers",
     "ResourceProviders",
     "DeckLocation",
     "DeckSlotLocation",
     "Dimensions",
-    "LabwareData",
+    "PipetteName",
     "WellLocation",
     "WellOrigin",
 ]

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -2,9 +2,11 @@
 from uuid import uuid4
 from typing import cast
 
+from opentrons.types import MountType
+
 from .. import commands
 from ..state import StateView
-from ..types import DeckSlotLocation, WellLocation
+from ..types import DeckSlotLocation, PipetteName, WellLocation
 from .transports import AbstractSyncTransport
 
 
@@ -31,7 +33,7 @@ class SyncClient:
         namespace: str,
         version: int,
     ) -> commands.LoadLabwareResult:
-        """Execute a LoadLabwareRequest, returning the result."""
+        """Execute a LoadLabwareRequest and return the result."""
         request = commands.LoadLabwareRequest(
             location=location,
             loadName=load_name,
@@ -45,17 +47,32 @@ class SyncClient:
 
         return cast(commands.LoadLabwareResult, result)
 
+    def load_pipette(
+        self,
+        pipette_name: PipetteName,
+        mount: MountType,
+    ) -> commands.LoadPipetteResult:
+        """Execute a LoadPipetteRequest and return the result."""
+        request = commands.LoadPipetteRequest(
+            pipetteName=pipette_name,
+            mount=mount,
+        )
+        result = self._transport.execute_command(
+            request=request,
+            command_id=self._create_command_id(),
+        )
+
+        return cast(commands.LoadPipetteResult, result)
+
     def pick_up_tip(
-            self,
-            pipette_id: str,
-            labware_id: str,
-            well_name: str
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
     ) -> commands.PickUpTipResult:
-        """Execute a PickUpTipRequest."""
+        """Execute a PickUpTipRequest and return the result."""
         request = commands.PickUpTipRequest(
-            pipetteId=pipette_id,
-            labwareId=labware_id,
-            wellName=well_name
+            pipetteId=pipette_id, labwareId=labware_id, wellName=well_name
         )
         result = self._transport.execute_command(
             request=request,
@@ -65,20 +82,17 @@ class SyncClient:
         return cast(commands.PickUpTipResult, result)
 
     def drop_tip(
-            self,
-            pipette_id: str,
-            labware_id: str,
-            well_name: str
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
     ) -> commands.DropTipResult:
-        """Execute a DropTipRequest."""
+        """Execute a DropTipRequest and return the result."""
         request = commands.DropTipRequest(
-            pipetteId=pipette_id,
-            labwareId=labware_id,
-            wellName=well_name
+            pipetteId=pipette_id, labwareId=labware_id, wellName=well_name
         )
         result = self._transport.execute_command(
-            request=request,
-            command_id=self._create_command_id()
+            request=request, command_id=self._create_command_id()
         )
         return cast(commands.DropTipResult, result)
 
@@ -106,12 +120,12 @@ class SyncClient:
         return cast(commands.AspirateResult, result)
 
     def dispense(
-            self,
-            pipette_id: str,
-            labware_id: str,
-            well_name: str,
-            well_location: WellLocation,
-            volume: float
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
+        well_location: WellLocation,
+        volume: float,
     ) -> commands.DispenseResult:
         """Execute a ``DispenseRequest``, returning the result."""
         request = commands.DispenseRequest(
@@ -122,7 +136,6 @@ class SyncClient:
             volume=volume,
         )
         result = self._transport.execute_command(
-            request=request,
-            command_id=self._create_command_id()
+            request=request, command_id=self._create_command_id()
         )
         return cast(commands.DispenseResult, result)

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 
-from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons.types import MountType
 
+from ..types import PipetteName
 from .command import CommandImplementation, CommandHandlers
 
 

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -3,14 +3,13 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons.types import MountType
 from opentrons.hardware_control.api import API as HardwareAPI
 
 from ..errors import FailedToLoadPipetteError
 from ..resources import ResourceProviders
 from ..state import StateView
-from ..types import LabwareLocation
+from ..types import LabwareLocation, PipetteName
 
 
 @dataclass(frozen=True)
@@ -87,15 +86,14 @@ class EquipmentHandler:
 
         cache_request = {mount.to_hw_mount(): pipette_name}
         if other_pipette is not None:
-            cache_request[
-                other_mount.to_hw_mount()
-            ] = other_pipette.pipette_name
+            cache_request[other_mount.to_hw_mount()] = other_pipette.pipette_name
 
         # TODO(mc, 2020-10-18): calling `cache_instruments` mirrors the
         # behavior of protocol_context.load_instrument, and is used here as a
         # pipette existence check
+        # TODO(mc, 2021-04-16): reconcile PipetteName enum with PipetteName union
         try:
-            await self._hardware.cache_instruments(cache_request)
+            await self._hardware.cache_instruments(cache_request)  # type: ignore[arg-type]  # noqa: E501
         except RuntimeError as e:
             raise FailedToLoadPipetteError(str(e)) from e
 

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Tuple
 from typing_extensions import final
 
-from opentrons_shared_data.pipette.dev_types import PipetteName
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.types import MountType, Mount as HwMount
 
 from .. import errors
+from ..types import PipetteName
 from ..commands import (
     CompletedCommandType,
     LoadPipetteResult,
@@ -51,18 +51,13 @@ class PipetteState:
         try:
             return self._pipettes_by_id[pipette_id]
         except KeyError:
-            raise errors.PipetteDoesNotExistError(
-                f"Pipette {pipette_id} not found."
-            )
+            raise errors.PipetteDoesNotExistError(f"Pipette {pipette_id} not found.")
 
     def get_all_pipettes(self) -> List[Tuple[str, PipetteData]]:
         """Get a list of all pipette entries in state."""
         return [entry for entry in self._pipettes_by_id.items()]
 
-    def get_pipette_data_by_mount(
-        self,
-        mount: MountType
-    ) -> Optional[PipetteData]:
+    def get_pipette_data_by_mount(self, mount: MountType) -> Optional[PipetteData]:
         """Get pipette data by the pipette's mount."""
         for pipette in self._pipettes_by_id.values():
             if pipette.mount == mount:
@@ -129,8 +124,7 @@ class PipetteStore(Substore[PipetteState], CommandReactive):
             pipette_id = command.result.pipetteId
 
             self._state._pipettes_by_id[pipette_id] = PipetteData(
-                pipette_name=command.request.pipetteName,
-                mount=command.request.mount
+                pipette_name=command.request.pipetteName, mount=command.request.mount
             )
             self._state._aspirated_volume_by_id[pipette_id] = 0
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -54,3 +54,22 @@ class Dimensions:
     x: float
     y: float
     z: float
+
+
+# TODO(mc, 2021-04-16): reconcile with opentrons_shared_data
+# shared-data/python/opentrons_shared_data/pipette/dev_types.py
+class PipetteName(str, Enum):
+    """Pipette load name values."""
+
+    P10_SINGLE = "p10_single"
+    P10_MULTI = "p10_multi"
+    P20_SINGLE_GEN2 = "p20_single_gen2"
+    P20_MULTI_GEN2 = "p20_multi_gen2"
+    P50_SINGLE = "p50_single"
+    P50_MULTI = "p50_multi"
+    P300_SINGLE = "p300_single"
+    P300_MULTI = "p300_multi"
+    P300_SINGLE_GEN2 = "p300_single_gen2"
+    P300_MULTI_GEN2 = "p300_multi_gen2"
+    P1000_SINGLE = "p1000_single"
+    P1000_SINGLE_GEN2 = "p1000_single_gen2"

--- a/api/tests/opentrons/protocol_api_experimental/__init__.py
+++ b/api/tests/opentrons/protocol_api_experimental/__init__.py
@@ -1,1 +1,1 @@
-"""Tests."""
+"""Tests module for Python Protocol API v3."""

--- a/api/tests/opentrons/protocol_api_experimental/test_pipette_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_pipette_context.py
@@ -2,10 +2,10 @@
 import pytest
 from decoy import Decoy
 
-from opentrons.protocol_api_experimental.instrument_context import InstrumentContext
+from opentrons.protocol_api_experimental.pipette_context import PipetteContext
 from opentrons.protocol_api_experimental.labware import Well, Labware
 from opentrons.protocol_engine.clients import SyncClient
-from opentrons.protocol_engine.types import WellLocation, WellOrigin
+from opentrons.protocol_engine.types import WellOrigin, WellLocation
 
 
 @pytest.fixture
@@ -27,9 +27,9 @@ def pipette_id() -> str:
 
 
 @pytest.fixture
-def subject(sync_client: SyncClient, pipette_id: str) -> InstrumentContext:
+def subject(sync_client: SyncClient, pipette_id: str) -> PipetteContext:
     """Test subject."""
-    return InstrumentContext(client=sync_client, resource_id=pipette_id)
+    return PipetteContext(engine_client=sync_client, resource_id=pipette_id)
 
 
 @pytest.fixture
@@ -45,63 +45,66 @@ def well(labware: Labware) -> Well:
 
 
 def test_pick_up_tip(
-        decoy: Decoy,
-        sync_client: SyncClient,
-        pipette_id: str,
-        subject: InstrumentContext,
-        well: Well
+    decoy: Decoy,
+    sync_client: SyncClient,
+    pipette_id: str,
+    subject: PipetteContext,
+    well: Well,
 ) -> None:
     """It should send a pick up tip command."""
     subject.pick_up_tip(location=well)
 
-    decoy.verify(sync_client.pick_up_tip(
-        pipette_id=pipette_id,
-        labware_id=well.parent.resource_id,
-        well_name=well.well_name
-    ))
+    decoy.verify(
+        sync_client.pick_up_tip(
+            pipette_id=pipette_id,
+            labware_id=well.parent.resource_id,
+            well_name=well.well_name,
+        )
+    )
 
 
 def test_drop_tip(
-        decoy: Decoy,
-        sync_client: SyncClient,
-        pipette_id: str,
-        subject: InstrumentContext,
-        well: Well
+    decoy: Decoy,
+    sync_client: SyncClient,
+    pipette_id: str,
+    subject: PipetteContext,
+    well: Well,
 ) -> None:
-    """It should send a pick up tip command."""
+    """It should send a drop tip command."""
     subject.drop_tip(location=well)
 
-    decoy.verify(sync_client.drop_tip(
-        pipette_id=pipette_id,
-        labware_id=well.parent.resource_id,
-        well_name=well.well_name
-    ))
+    decoy.verify(
+        sync_client.drop_tip(
+            pipette_id=pipette_id,
+            labware_id=well.parent.resource_id,
+            well_name=well.well_name,
+        )
+    )
 
 
 def test_aspirate(
     decoy: Decoy,
     sync_client: SyncClient,
     pipette_id: str,
-    subject: InstrumentContext,
-    well: Well
+    subject: PipetteContext,
+    well: Well,
 ) -> None:
     """It should send an aspirate command to the SyncClient."""
     subject.aspirate(volume=12345.6789, location=well, rate=1.0)
 
-    decoy.verify(sync_client.aspirate(
-        pipette_id=pipette_id,
-        labware_id=well.parent.resource_id,
-        well_name=well.well_name,
-        well_location=WellLocation(
-            origin=WellOrigin.BOTTOM,
-            offset=(0, 0, 1)
-        ),
-        volume=12345.6789
-    ))
+    decoy.verify(
+        sync_client.aspirate(
+            pipette_id=pipette_id,
+            labware_id=well.parent.resource_id,
+            well_name=well.well_name,
+            well_location=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
+            volume=12345.6789,
+        )
+    )
 
 
 def test_aspirate_not_implemented_errors(
-    subject: InstrumentContext,
+    subject: PipetteContext,
     well: Well,
 ) -> None:
     """It should raise NotImplementedError when appropriate."""
@@ -120,20 +123,21 @@ def test_aspirate_not_implemented_errors(
 
 
 def test_dispense(
-        decoy: Decoy,
-        sync_client: SyncClient,
-        pipette_id: str,
-        subject: InstrumentContext,
-        well: Well
+    decoy: Decoy,
+    sync_client: SyncClient,
+    pipette_id: str,
+    subject: PipetteContext,
+    well: Well,
 ) -> None:
     """It should send a dispense command."""
     subject.dispense(volume=10, location=well)
 
-    decoy.verify(sync_client.dispense(
-        pipette_id=pipette_id,
-        labware_id=well.parent.resource_id,
-        well_name=well.well_name,
-        well_location=WellLocation(origin=WellOrigin.BOTTOM,
-                                   offset=(0, 0, 1)),
-        volume=10
-    ))
+    decoy.verify(
+        sync_client.dispense(
+            pipette_id=pipette_id,
+            labware_id=well.parent.resource_id,
+            well_name=well.well_name,
+            well_location=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
+            volume=10,
+        )
+    )

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -1,0 +1,118 @@
+"""Tests for ProtocolContext in Python Protocol API v3."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import commands
+from opentrons.protocol_engine.clients import SyncClient
+from opentrons.protocol_api_experimental import ProtocolContext, PipetteContext, errors
+from opentrons.protocol_api_experimental.types import (
+    PipetteName,
+    Mount,
+    DeprecatedMount,
+)
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy test-double container fixture."""
+    return Decoy()
+
+
+@pytest.fixture
+def engine_client(decoy: Decoy) -> SyncClient:
+    """Get a fake ProtocolEngine client."""
+    return decoy.create_decoy(spec=SyncClient)
+
+
+@pytest.fixture
+def subject(engine_client: SyncClient) -> ProtocolContext:
+    """Get a ProtocolContext with its dependencies mocked out."""
+    return ProtocolContext(engine_client=engine_client)
+
+
+def test_load_pipette(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject: ProtocolContext,
+) -> None:
+    """It should be able to load a pipette into the protocol."""
+    decoy.when(
+        engine_client.load_pipette(
+            pipette_name=PipetteName.P300_SINGLE,
+            mount=Mount.LEFT,
+        )
+    ).then_return(commands.LoadPipetteResult(pipetteId="pipette-id"))
+
+    result = subject.load_pipette(pipette_name="p300_single", mount="left")
+
+    assert result == PipetteContext(
+        engine_client=engine_client,
+        resource_id="pipette-id",
+    )
+
+
+def test_load_instrument(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject: ProtocolContext,
+) -> None:
+    """It should be able to load a pipette with legacy load_instrument method."""
+    decoy.when(
+        engine_client.load_pipette(
+            pipette_name=PipetteName.P300_MULTI,
+            mount=Mount.LEFT,
+        )
+    ).then_return(commands.LoadPipetteResult(pipetteId="left-pipette-id"))
+
+    decoy.when(
+        engine_client.load_pipette(
+            pipette_name=PipetteName.P300_SINGLE,
+            mount=Mount.RIGHT,
+        )
+    ).then_return(commands.LoadPipetteResult(pipetteId="right-pipette-id"))
+
+    left_result = subject.load_instrument(instrument_name="p300_multi", mount="left")
+
+    right_result = subject.load_instrument(
+        instrument_name="p300_single",
+        mount=DeprecatedMount.RIGHT,
+    )
+
+    assert left_result == PipetteContext(
+        engine_client=engine_client,
+        resource_id="left-pipette-id",
+    )
+
+    assert right_result == PipetteContext(
+        engine_client=engine_client,
+        resource_id="right-pipette-id",
+    )
+
+
+def test_load_pipette_with_bad_args(
+    decoy: Decoy,
+    engine_client: SyncClient,
+    subject: ProtocolContext,
+) -> None:
+    """It should raise if an invalid pipette name or mount is used."""
+    with pytest.raises(errors.InvalidPipetteNameError, match="electronic-thumb"):
+        subject.load_pipette(pipette_name="electronic-thumb", mount="left")
+
+    with pytest.raises(errors.InvalidMountError, match="west"):
+        subject.load_pipette(pipette_name="p300_single", mount="west")
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_load_pipette_with_tipracks_list(subject: ProtocolContext) -> None:
+    """TODO: it should do something with the `tip_racks` parameter to load_pipette."""
+    subject.load_pipette(
+        pipette_name="p300_single",
+        mount="left",
+        tip_racks=("something"),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_load_pipette_with_replace(subject: ProtocolContext) -> None:
+    """TODO: it should do something with the `replace` parameter to load_pipette."""
+    subject.load_pipette(pipette_name="p300_single", mount="left", replace=True)

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -2,6 +2,7 @@
 from mock import AsyncMock  # type: ignore[attr-defined]
 
 from opentrons.types import MountType
+from opentrons.protocol_engine.types import PipetteName
 from opentrons.protocol_engine.execution import LoadedPipette
 from opentrons.protocol_engine.commands import (
     LoadPipetteRequest,
@@ -12,8 +13,8 @@ from opentrons.protocol_engine.commands import (
 def test_load_pipette_request() -> None:
     """It should have a LoadPipetteRequest model."""
     request = LoadPipetteRequest(
-        pipetteName="p300_single",
-        mount=MountType.LEFT
+        pipetteName=PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
     )
 
     assert request.pipetteName == "p300_single"
@@ -33,7 +34,10 @@ async def test_load_pipette_implementation(mock_handlers: AsyncMock) -> None:
         pipette_id="pipette-id",
     )
 
-    request = LoadPipetteRequest(pipetteName="p300_single", mount=MountType.LEFT)
+    request = LoadPipetteRequest(
+        pipetteName=PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
     impl = request.get_implementation()
     result = await impl.execute(mock_handlers)
 

--- a/api/tests/opentrons/protocol_engine/state/test_motion_getters.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_getters.py
@@ -10,12 +10,19 @@ from opentrons.types import Point, MountType
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocols.geometry.planning import MoveType, get_waypoints
 
-from opentrons.protocol_engine import errors, DeckLocation, WellLocation, WellOrigin
+from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.state import PipetteData, PipetteLocationData
 from opentrons.protocol_engine.state.labware import LabwareStore
 from opentrons.protocol_engine.state.pipettes import PipetteStore
 from opentrons.protocol_engine.state.geometry import GeometryStore
 from opentrons.protocol_engine.state.motion import MotionStore
+
+from opentrons.protocol_engine.types import (
+    DeckLocation,
+    WellLocation,
+    WellOrigin,
+    PipetteName,
+)
 
 
 @pytest.fixture
@@ -54,10 +61,7 @@ def motion_store(
 # indication that the "current deck location" data needs to be in a
 # different store. Alternatively, this data should be fed in via a public
 # interface, like handling a MoveToWellResult.
-def mock_location_data(
-    motion_store: MotionStore,
-    data: Optional[DeckLocation]
-) -> None:
+def mock_location_data(motion_store: MotionStore, data: Optional[DeckLocation]) -> None:
     """Insert mock location data into the store."""
     motion_store.state._current_location = data
     assert motion_store.state.get_current_deck_location() == data
@@ -70,39 +74,32 @@ def test_get_pipette_location_with_no_current_location(
     """It should return mount and critical_point=None if no location."""
     mock_pipette_store.state.get_pipette_data_by_id.return_value = PipetteData(
         mount=MountType.LEFT,
-        pipette_name="p300_single"
+        pipette_name=PipetteName.P300_SINGLE,
     )
 
     result = motion_store.state.get_pipette_location("pipette-id")
 
-    mock_pipette_store.state.get_pipette_data_by_id.assert_called_with(
-        "pipette-id"
-    )
-    assert result == PipetteLocationData(
-        mount=MountType.LEFT,
-        critical_point=None
-    )
+    mock_pipette_store.state.get_pipette_data_by_id.assert_called_with("pipette-id")
+    assert result == PipetteLocationData(mount=MountType.LEFT, critical_point=None)
 
 
 def test_get_pipette_location_with_current_location_with_quirks(
     mock_pipette_store: MagicMock,
     mock_labware_store: MagicMock,
-    motion_store: MotionStore
+    motion_store: MotionStore,
 ) -> None:
     """It should return cp=XY_CENTER if location labware has center quirk."""
     mock_location_data(
         motion_store,
         DeckLocation(
-            pipette_id="pipette-id",
-            labware_id="reservoir-id",
-            well_name="A1"
+            pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1"
         ),
     )
 
     mock_labware_store.state.get_labware_has_quirk.return_value = True
     mock_pipette_store.state.get_pipette_data_by_id.return_value = PipetteData(
         mount=MountType.RIGHT,
-        pipette_name="p300_single"
+        pipette_name=PipetteName.P300_SINGLE,
     )
 
     result = motion_store.state.get_pipette_location("pipette-id")
@@ -120,22 +117,20 @@ def test_get_pipette_location_with_current_location_with_quirks(
 def test_get_pipette_location_with_current_location_different_pipette(
     mock_pipette_store: MagicMock,
     mock_labware_store: MagicMock,
-    motion_store: MotionStore
+    motion_store: MotionStore,
 ) -> None:
     """It should return mount and cp=None if location used other pipette."""
     mock_location_data(
         motion_store,
         DeckLocation(
-            pipette_id="other-pipette-id",
-            labware_id="reservoir-id",
-            well_name="A1"
+            pipette_id="other-pipette-id", labware_id="reservoir-id", well_name="A1"
         ),
     )
 
     mock_labware_store.state.get_labware_has_quirk.return_value = False
     mock_pipette_store.state.get_pipette_data_by_id.return_value = PipetteData(
         mount=MountType.LEFT,
-        pipette_name="p300_single"
+        pipette_name=PipetteName.P300_SINGLE,
     )
 
     result = motion_store.state.get_pipette_location("pipette-id")
@@ -149,19 +144,17 @@ def test_get_pipette_location_with_current_location_different_pipette(
 def test_get_pipette_location_override_current_location(
     mock_pipette_store: MagicMock,
     mock_labware_store: MagicMock,
-    motion_store: MotionStore
+    motion_store: MotionStore,
 ) -> None:
     """It should calculate pipette location from a passed in deck location."""
     current_location = DeckLocation(
-        pipette_id="pipette-id",
-        labware_id="reservoir-id",
-        well_name="A1"
+        pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1"
     )
 
     mock_labware_store.state.get_labware_has_quirk.return_value = True
     mock_pipette_store.state.get_pipette_data_by_id.return_value = PipetteData(
         mount=MountType.RIGHT,
-        pipette_name="p300_single"
+        pipette_name=PipetteName.P300_SINGLE,
     )
 
     result = motion_store.state.get_pipette_location(
@@ -203,81 +196,81 @@ class WaypointSpec:
 # TODO(mc, 2021-01-14): these tests probably need to be rethought; this fixture
 # is impossible to reason with. The test is really just trying to be a collaborator
 # test for the `get_waypoints` function, so we should rewrite it as such.
-@pytest.mark.parametrize("spec", [
-    WaypointSpec(
-        name="General arc if moving from unknown location",
-        all_labware_z=20,
-        expected_move_type=MoveType.GENERAL_ARC,
-    ),
-    WaypointSpec(
-        name="General arc if moving from other labware",
-        location=DeckLocation(
-            pipette_id="pipette-id",
-            labware_id="other-labware-id",
-            well_name="A1"),
-        all_labware_z=20,
-        expected_move_type=MoveType.GENERAL_ARC,
-    ),
-    WaypointSpec(
-        name="In-labware arc if moving to same labware",
-        location=DeckLocation(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="B2"),
-        labware_z=10,
-        expected_move_type=MoveType.IN_LABWARE_ARC,
-    ),
-    WaypointSpec(
-        name="General arc if moving to same labware with different pipette",
-        location=DeckLocation(
-            pipette_id="other-pipette-id",
-            labware_id="labware-id",
-            well_name="A1"),
-        all_labware_z=20,
-        expected_move_type=MoveType.GENERAL_ARC,
-    ),
-    WaypointSpec(
-        name="Direct movement from well to same well",
-        location=DeckLocation(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="A1"),
-        labware_z=10,
-        expected_move_type=MoveType.DIRECT,
-    ),
-    WaypointSpec(
-        name="General arc with XY_CENTER destination CP",
-        has_center_multichannel_quirk=True,
-        all_labware_z=20,
-        expected_move_type=MoveType.GENERAL_ARC,
-        expected_dest_cp=CriticalPoint.XY_CENTER,
-    ),
-    WaypointSpec(
-        name="General arc with a well offset",
-        all_labware_z=20,
-        well_location=WellLocation(origin=WellOrigin.TOP, offset=(0, 0, 1)),
-        expected_move_type=MoveType.GENERAL_ARC,
-    ),
-    # TODO(mc, 2021-01-08): add test for override current location
-])
+@pytest.mark.parametrize(
+    "spec",
+    [
+        WaypointSpec(
+            name="General arc if moving from unknown location",
+            all_labware_z=20,
+            expected_move_type=MoveType.GENERAL_ARC,
+        ),
+        WaypointSpec(
+            name="General arc if moving from other labware",
+            location=DeckLocation(
+                pipette_id="pipette-id", labware_id="other-labware-id", well_name="A1"
+            ),
+            all_labware_z=20,
+            expected_move_type=MoveType.GENERAL_ARC,
+        ),
+        WaypointSpec(
+            name="In-labware arc if moving to same labware",
+            location=DeckLocation(
+                pipette_id="pipette-id", labware_id="labware-id", well_name="B2"
+            ),
+            labware_z=10,
+            expected_move_type=MoveType.IN_LABWARE_ARC,
+        ),
+        WaypointSpec(
+            name="General arc if moving to same labware with different pipette",
+            location=DeckLocation(
+                pipette_id="other-pipette-id", labware_id="labware-id", well_name="A1"
+            ),
+            all_labware_z=20,
+            expected_move_type=MoveType.GENERAL_ARC,
+        ),
+        WaypointSpec(
+            name="Direct movement from well to same well",
+            location=DeckLocation(
+                pipette_id="pipette-id", labware_id="labware-id", well_name="A1"
+            ),
+            labware_z=10,
+            expected_move_type=MoveType.DIRECT,
+        ),
+        WaypointSpec(
+            name="General arc with XY_CENTER destination CP",
+            has_center_multichannel_quirk=True,
+            all_labware_z=20,
+            expected_move_type=MoveType.GENERAL_ARC,
+            expected_dest_cp=CriticalPoint.XY_CENTER,
+        ),
+        WaypointSpec(
+            name="General arc with a well offset",
+            all_labware_z=20,
+            well_location=WellLocation(origin=WellOrigin.TOP, offset=(0, 0, 1)),
+            expected_move_type=MoveType.GENERAL_ARC,
+        ),
+        # TODO(mc, 2021-01-08): add test for override current location
+    ],
+)
 def test_get_movement_waypoints(
     mock_labware_store: MagicMock,
     mock_geometry_store: MagicMock,
     motion_store: MotionStore,
-    spec: WaypointSpec
+    spec: WaypointSpec,
 ) -> None:
     """It should calculate the correct set of waypoints for a move."""
-    mock_labware_store.state.get_labware_has_quirk.return_value = \
+    mock_labware_store.state.get_labware_has_quirk.return_value = (
         spec.has_center_multichannel_quirk
+    )
 
     if spec.labware_z is not None:
         min_travel_z = spec.labware_z
-        mock_geometry_store.state.get_labware_highest_z.return_value = \
-            spec.labware_z
+        mock_geometry_store.state.get_labware_highest_z.return_value = spec.labware_z
     elif spec.all_labware_z is not None:
         min_travel_z = spec.all_labware_z
-        mock_geometry_store.state.get_all_labware_highest_z.return_value = \
+        mock_geometry_store.state.get_all_labware_highest_z.return_value = (
             spec.all_labware_z
+        )
     else:
         assert False, "One of spec.labware_z or all_labware_z must be defined."
 
@@ -306,8 +299,7 @@ def test_get_movement_waypoints(
     )
 
     mock_labware_store.state.get_labware_has_quirk.assert_called_with(
-        spec.labware_id,
-        "centerMultichannelOnWells"
+        spec.labware_id, "centerMultichannelOnWells"
     )
     mock_geometry_store.state.get_well_position.assert_called_with(
         spec.labware_id,

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_state.py
@@ -5,23 +5,17 @@ from typing import cast, Dict, Optional
 
 from opentrons.types import MountType, Mount as HwMount
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocol_engine import commands as cmd, errors, StateStore, WellLocation
+from opentrons.protocol_engine import commands as cmd, errors, StateStore
+from opentrons.protocol_engine.types import PipetteName, WellLocation
 
 
 CompletedLoadLabware = cmd.CompletedCommand[
-    cmd.LoadPipetteRequest,
-    cmd.LoadPipetteResult
+    cmd.LoadPipetteRequest, cmd.LoadPipetteResult
 ]
 
-CompletedAspirate = cmd.CompletedCommand[
-    cmd.AspirateRequest,
-    cmd.AspirateResult
-]
+CompletedAspirate = cmd.CompletedCommand[cmd.AspirateRequest, cmd.AspirateResult]
 
-CompletedDispense = cmd.CompletedCommand[
-    cmd.DispenseRequest,
-    cmd.DispenseResult
-]
+CompletedDispense = cmd.CompletedCommand[cmd.DispenseRequest, cmd.DispenseResult]
 
 
 @pytest.fixture
@@ -29,7 +23,7 @@ def load_pipette_command(now: datetime) -> CompletedLoadLabware:
     """Get a completed load pipette command."""
     return cmd.CompletedCommand(
         request=cmd.LoadPipetteRequest(
-            pipetteName="p300_single",
+            pipetteName=PipetteName.P300_SINGLE,
             mount=MountType.LEFT,
         ),
         result=cmd.LoadPipetteResult(pipetteId="pipette-id"),
@@ -228,8 +222,7 @@ def test_pipette_is_ready_to_aspirate_if_has_volume(
 
     loaded_store.handle_command(aspirate_command, "aspirate-command-1")
     is_ready = loaded_store.pipettes.get_is_ready_to_aspirate(
-        pipette_id="pipette-id",
-        pipette_config=pipette_config
+        pipette_id="pipette-id", pipette_config=pipette_config
     )
 
     assert is_ready is True
@@ -242,8 +235,7 @@ def test_pipette_is_ready_to_aspirate_if_no_volume_and_hc_says_ready(
     pipette_config = cast(PipetteDict, {"ready_to_aspirate": True})
 
     is_ready = loaded_store.pipettes.get_is_ready_to_aspirate(
-        pipette_id="pipette-id",
-        pipette_config=pipette_config
+        pipette_id="pipette-id", pipette_config=pipette_config
     )
 
     assert is_ready is True
@@ -256,8 +248,7 @@ def test_pipette_not_ready_to_aspirate_if_no_volume_and_hc_says_not_ready(
     pipette_config = cast(PipetteDict, {"ready_to_aspirate": False})
 
     is_ready = loaded_store.pipettes.get_is_ready_to_aspirate(
-        pipette_id="pipette-id",
-        pipette_config=pipette_config
+        pipette_id="pipette-id", pipette_config=pipette_config
     )
 
     assert is_ready is False


### PR DESCRIPTION
## Overview 

This PR implements `load_pipette` (and `load_instrument` alias) in the engine-backed `ProtocolContext`.

I got a little excited about renaming `Instrument` to `Pipette`. I think I did it correctly and in a way that preserves user-code-level back-compat, but it would mess with #7630 and #7640, so let's **get those in first**. Marking this PR as a draft in the meantime.

Closes #7437

(If you're an Opentrons user stumbling upon this PR and see some references to Protocol API v3, don't be scared! We're a ways off from v3, v3 is intended to be as syntactically close to v2 as possible, and we have no plans to end-of-life v2 at this time.)

## Changelog

- Add `load_pipette` method to `protocol_api_experimental.ProtocolContext`
    - Added a `load_instrument` facade to `load_pipette`
- Renamed `InstrumentContext` to `PipetteContext`
    - Added an `InstrumentContext` alias
- Had my formatter turned on in my editor, so made a bunch of formatting changes! Sorry but not really sorry

## Review requests

- How do the actual wire-up and tests look?
- How do we feel about the various renamings and slight type duplications?

## Risk assessment

N/A at the moment, not wired to anything
