### PR TITLE
fix(app): add missing border to thermocycler live status card

### DIFF
--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/styles.css
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/styles.css
@@ -29,8 +29,7 @@ updated component library cards after redesign/refactor
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-top: var(--bd-light);
-  border-top-width: 1px;
+  border-top: var(--bd-light) 1px solid;
 }
 
 .card_row:not(:last-child) {

--- a/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/styles.css
+++ b/app/src/pages/Run/RunPanel/ModuleLiveStatusCards/styles.css
@@ -29,6 +29,8 @@ updated component library cards after redesign/refactor
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-top: var(--bd-light);
+  border-top-width: 1px;
 }
 
 .card_row:not(:last-child) {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Adds a missing border on the thermocycler info card on the Run Panel.

<p align="center">
  Before & After
  <p align="center">
    <img width="213" alt="Screen Shot 2021-04-19 at 12 15 05 PM" src="https://user-images.githubusercontent.com/20424172/115269060-ee9cdd00-a108-11eb-927e-773e9be40a04.png">
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
    <img width="220" alt="Screen Shot 2021-04-19 at 12 14 33 PM" src="https://user-images.githubusercontent.com/20424172/115269034-e80e6580-a108-11eb-88a0-ab272b2f2408.png">
</p>
  <p>

