### PR TITLE
feat(robot-server): Clarify "local connection only" error message

### DIFF
--- a/update-server/otupdate/buildroot/ssh_key_management.py
+++ b/update-server/otupdate/buildroot/ssh_key_management.py
@@ -25,8 +25,13 @@ def require_linklocal(handler):
         ipaddr_str = request.headers.get('x-host-ip')
         invalid_req_data = {
             'error': 'bad-interface',
-            'message': f'The endpoint {request.url} can only be used from '
-            'local connections'
+            'message': (
+                f"The endpoint {request.rel_url}"
+                f" can only be used from link-local connections."
+                f" Make sure you're connected to this robot directly by cable"
+                f" and using this robot's wired IP address"
+                f" (not its wireless IP address)."
+            )
         }
         if not ipaddr_str:
             return web.json_response(


### PR DESCRIPTION
# Overview

When you add an SSH key, it needs to be over a link-local connection for security reasons. We mention this in [Setting up SSH access to your OT-2](https://support.opentrons.com/en/articles/3203681-setting-up-ssh-access-to-your-ot-2), but the error message that the OT-2 itself gives you is a little opaque, as shown in #7533. This PR tries to clear it up a little.

Closes #7538.

# Changelog

* Use `request.rel_url` instead of `request.url`. This changes the message from "The endpoint http://127.0.0.1:34000/server/ssh_keys..." to "The endpoint /server/ssh_keys...".
* Say "link-local connection" instead of "local connection," since I think that's the more pedantically correct term?
* Explicitly suggest connecting to the robot directly by cable and making sure you're using its wired IP.

# Review requests

Does the new copy make sense?

# Risk assessment

Low.