### PR TITLE
 fix(api): do not cache removed modules in thread_manager

### DIFF
--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -222,13 +222,6 @@ class TempDeck:
             self._update_thread.start()
         return ''
 
-    def _update_temperature(self):
-        self._update_thread = Thread(
-            target=self._recursive_update_temperature,
-            args=[DEFAULT_COMMAND_RETRIES],
-            name='Tempdeck recursive update temperature')
-        self._update_thread.start()
-
     @property
     def target(self) -> Optional[int]:
         return self._temperature.get('target')

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -214,7 +214,7 @@ class TempDeck:
                 try:
                     self._recursive_update_temperature(retries=DEFAULT_COMMAND_RETRIES)
                 except (OSError, TempDeckError, SerialException, SerialNoResponse):
-                    log.exception("UPDATE FAILED")
+                    log.exception("Failed to execute _recursive_update_temperature.")
 
             self._update_thread = Thread(
                 target=_update(),

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -331,12 +331,12 @@ class TCPoller(threading.Thread):
             self._send_write_fd.write(b'c')
 
     def close(self):
-        log.info("===== Halting TCPoller")
+        log.debug("Halting TCPoller")
         self._halt_write_fd.write(b'q')
 
     def __del__(self):
         """ Clean up thread fifos"""
-        log.info("===== Cleaning up thread fifos in TCPoller.")
+        log.debug("Cleaning up thread fifos in TCPoller.")
         try:
             os.unlink(self._send_path)
         except NameError:
@@ -381,7 +381,7 @@ class Thermocycler:
         if self.is_connected() or self._poller:
             self._poller.close()  # type: ignore
             self._poller.join()  # type: ignore
-            log.info("===== TC poller stopped.")
+            log.debug("TC poller stopped.")
         self._poller = None
         return self
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -627,10 +627,3 @@ class Thermocycler:
         await asyncio.sleep(0.05)
         trigger_connection.close()
         self.disconnect()
-
-    def __del__(self):
-        try:
-            if self._poller:
-                self._poller.close()  # type: ignore
-        except Exception:
-            log.exception('Exception while cleaning up Thermocycler')

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -331,12 +331,12 @@ class TCPoller(threading.Thread):
             self._send_write_fd.write(b'c')
 
     def close(self):
-        log.debug("Halting TCPoller")
+        log.info("===== Halting TCPoller")
         self._halt_write_fd.write(b'q')
 
     def __del__(self):
         """ Clean up thread fifos"""
-        log.debug("Cleaning up thread fifos in TCPoller.")
+        log.info("===== Cleaning up thread fifos in TCPoller.")
         try:
             os.unlink(self._send_path)
         except NameError:
@@ -381,7 +381,7 @@ class Thermocycler:
         if self.is_connected() or self._poller:
             self._poller.close()  # type: ignore
             self._poller.join()  # type: ignore
-            log.debug("TC poller stopped.")
+            log.info("===== TC poller stopped.")
         self._poller = None
         return self
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -331,10 +331,12 @@ class TCPoller(threading.Thread):
             self._send_write_fd.write(b'c')
 
     def close(self):
+        log.debug("Halting TCPoller")
         self._halt_write_fd.write(b'q')
 
     def __del__(self):
         """ Clean up thread fifos"""
+        log.debug("Cleaning up thread fifos in TCPoller.")
         try:
             os.unlink(self._send_path)
         except NameError:
@@ -376,9 +378,10 @@ class Thermocycler:
         return self
 
     def disconnect(self) -> 'Thermocycler':
-        if self.is_connected():
+        if self.is_connected() or self._poller:
             self._poller.close()  # type: ignore
             self._poller.join()  # type: ignore
+            log.debug("TC poller stopped.")
         self._poller = None
         return self
 
@@ -627,6 +630,7 @@ class Thermocycler:
 
     def __del__(self):
         try:
-            self._poller.close()  # type: ignore
+            if self._poller:
+                self._poller.close()  # type: ignore
         except Exception:
-            log.exception('Exception while cleaning up Thermocycler:')
+            log.exception('Exception while cleaning up Thermocycler')

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1733,7 +1733,7 @@ class API(HardwareAPILike):
         for removed_mod in removed_modules:
             self._log.info(f"Module {removed_mod.name()} detached"
                            f" from port {removed_mod.port}")
-            del removed_mod
+            removed_mod.cleanup()
 
     async def register_modules(
             self,

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -209,7 +209,7 @@ class MagDeck(mod_abc.AbstractModule):
         if self._driver:
             self._driver.disconnect(port=self._port)
 
-    def __del__(self):
+    def cleanup(self) -> None:
         self._disconnect()
 
     async def prep_for_update(self) -> str:

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -212,6 +212,9 @@ class MagDeck(mod_abc.AbstractModule):
     def cleanup(self) -> None:
         self._disconnect()
 
+    def __del__(self):
+        self.cleanup()
+
     async def prep_for_update(self) -> str:
         self._driver.enter_programming_mode()
         new_port = await update.find_bootloader_port()

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -162,3 +162,11 @@ class AbstractModule(abc.ABC):
     def bootloader(cls) -> UploadFunction:
         """ Method used to upload file to this module's bootloader. """
         pass
+
+    def cleanup(self) -> None:
+        """ Clean up the module instance.
+
+        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
+        object destruction.
+        """
+        pass

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -242,8 +242,9 @@ class TempDeck(mod_abc.AbstractModule):
         self._poller = Poller(self._driver)
         self._poller.start()
 
-    def __del__(self):
-        if hasattr(self, '_poller') and self._poller:
+    def cleanup(self) -> None:
+        if self._poller:
+            log.debug("Stopping tempdeck poller.")
             self._poller.stop()
 
     async def prep_for_update(self) -> str:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -244,8 +244,11 @@ class TempDeck(mod_abc.AbstractModule):
 
     def cleanup(self) -> None:
         if hasattr(self, '_poller') and self._poller:
-            log.info("===== Stopping tempdeck poller.")
+            log.debug("Stopping tempdeck poller.")
             self._poller.stop()
+
+    def __del__(self):
+        self.cleanup()
 
     async def prep_for_update(self) -> str:
         model = self._device_info and self._device_info.get('model')

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -243,8 +243,8 @@ class TempDeck(mod_abc.AbstractModule):
         self._poller.start()
 
     def cleanup(self) -> None:
-        if self._poller:
-            log.debug("Stopping tempdeck poller.")
+        if hasattr(self, '_poller') and self._poller:
+            log.info("===== Stopping tempdeck poller.")
             self._poller.stop()
 
     async def prep_for_update(self) -> str:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -353,3 +353,6 @@ class Thermocycler(mod_abc.AbstractModule):
             self._driver.disconnect()
         except Exception:
             MODULE_LOG.exception('Exception while cleaning up Thermocycler')
+
+    def __del__(self):
+        self.cleanup()

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -349,4 +349,7 @@ class Thermocycler(mod_abc.AbstractModule):
         return new_port or self.port
 
     def cleanup(self) -> None:
-        self._driver.disconnect()
+        try:
+            self._driver.disconnect()
+        except Exception:
+            MODULE_LOG.exception('Exception while cleaning up Thermocycler')

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -347,3 +347,6 @@ class Thermocycler(mod_abc.AbstractModule):
         new_port = await update.find_bootloader_port()
 
         return new_port or self.port
+
+    def cleanup(self) -> None:
+        self._driver.disconnect()

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -175,7 +175,7 @@ class ThreadManager:
             loop.call_soon_threadsafe(loop.stop)
         except Exception:
             pass
-        self._cached_modules = {}
+        object.__setattr__(self, '_cached_modules', {})
         object.__getattribute__(self, '_thread').join()
 
     def wrap_module(
@@ -199,7 +199,7 @@ class ThreadManager:
             # is necessary in order to allow the garbage collector to delete
             # those objects from memory and cleanly stop all associated threads.
             cached_mods = {
-                    module: cached_mods.get(module, wrap(module)) for module in attr}
+                    module: cached_mods.get(module) or wrap(module) for module in attr}
             object.__setattr__(self, '_cached_modules', cached_mods)
             return cached_mods.values()
         elif attr_name == 'clean_up':

--- a/api/src/opentrons/hardware_control/thread_manager.py
+++ b/api/src/opentrons/hardware_control/thread_manager.py
@@ -196,8 +196,8 @@ class ThreadManager:
 
             # Update self._cached_modules to delete all removed modules' entries and add
             # newly attached modules. Removing references to stale instances
-            # is necessary to allow the garbage collector to delete those objects from
-            # memory and cleanly stop all the threads associated with them.
+            # is necessary in order to allow the garbage collector to delete
+            # those objects from memory and cleanly stop all associated threads.
             cached_mods = {
                     module: cached_mods.get(module, wrap(module)) for module in attr}
             object.__setattr__(self, '_cached_modules', cached_mods)

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -14,7 +14,6 @@ from opentrons.hardware_control.modules import tempdeck, magdeck
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
-# Freezes
 async def test_get_modules_simulating():
     import opentrons.hardware_control as hardware_control
     mods = ['tempdeck', 'magdeck', 'thermocycler']
@@ -62,7 +61,6 @@ async def test_module_caching():
     assert two_magdecks[1] is not two_magdecks[0]
 
 
-# freezes
 async def test_filtering_modules():
     import opentrons.hardware_control as hardware_control
     mods = [
@@ -180,7 +178,6 @@ async def test_module_update_integration(monkeypatch, loop):
     )
 
 
-# freezes
 async def test_get_bundled_fw(monkeypatch, tmpdir):
     from opentrons.hardware_control import modules
 

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -14,6 +14,7 @@ from opentrons.hardware_control.modules import tempdeck, magdeck
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
+# Freezes
 async def test_get_modules_simulating():
     import opentrons.hardware_control as hardware_control
     mods = ['tempdeck', 'magdeck', 'thermocycler']
@@ -61,6 +62,7 @@ async def test_module_caching():
     assert two_magdecks[1] is not two_magdecks[0]
 
 
+# freezes
 async def test_filtering_modules():
     import opentrons.hardware_control as hardware_control
     mods = [
@@ -178,6 +180,7 @@ async def test_module_update_integration(monkeypatch, loop):
     )
 
 
+# freezes
 async def test_get_bundled_fw(monkeypatch, tmpdir):
     from opentrons.hardware_control import modules
 

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -1,6 +1,9 @@
 import pytest
+import weakref
+from opentrons.hardware_control.modules import ModuleAtPort
 from opentrons.hardware_control.thread_manager import ThreadManagerException,\
     ThreadManager
+from opentrons.hardware_control.api import API
 
 
 def test_build_fail_raises_exception():
@@ -12,3 +15,42 @@ def test_build_fail_raises_exception():
         raise Exception()
     with pytest.raises(ThreadManagerException):
         ThreadManager(f)
+
+
+def test_module_cache_add_entry():
+    """ Test that _cached_modules updates correctly."""
+
+    mod_names = ['tempdeck']
+    thread_manager = ThreadManager(API.build_hardware_simulator,
+                                   attached_modules=mod_names)
+
+    # Test that module gets added to the cache
+    mods = thread_manager.attached_modules
+    wrapper_cache = thread_manager._cached_modules.copy()
+    assert isinstance(wrapper_cache, weakref.WeakKeyDictionary)
+    assert len(wrapper_cache) == 1
+    assert mods[0] in wrapper_cache.values()
+
+    # Test that calling attached modules doesn't add duplicate entries to cache
+    mods2 = thread_manager.attached_modules
+    wrapper_cache2 = thread_manager._cached_modules.copy()
+    assert len(wrapper_cache2) == 1
+    assert mods == mods2
+
+
+async def test_module_cache_remove_entry():
+    """Test that module entry gets removed from cache when module detaches. """
+    mod_names = ['tempdeck', 'magdeck']
+    thread_manager = ThreadManager(API.build_hardware_simulator,
+                                   attached_modules=mod_names)
+
+    mods_before = thread_manager.attached_modules
+    assert len(mods_before) == 2
+
+    await thread_manager.register_modules(
+        removed_mods_at_ports=[
+            ModuleAtPort(port='/dev/ot_module_sim_tempdeck0',
+                         name='tempdeck')
+        ])
+    mods_after = thread_manager.attached_modules
+    assert len(mods_after) == 1


### PR DESCRIPTION
Closes #5359

# Overview

Currently, when we unplug an OT module, a series of events ultimately leads to `API._unregister_modules` being called. This function then calls the `__delete__` function on the `AbstractModule` instances, which is supposed to stop the associated module's pollers and disconnect cleanly. But the python garbage collector does not execute the object's destructor (`__delete__`), unless all references to that object are removed. 

This is where the issue in #5359 comes into picture. The behavior we notice is that if a module is unplugged when the app has polled the `/modules` endpoint, the temperature polling thread doesn't stop. This happens because the module endpoints in robot server talk to the modules via the `ThreadManager`. The thread manager wraps every instance of the attached modules in a `CallBridger` and *caches* it using `lru_cache`. This cached instance doesn't leave the cache unless it's removed to make space for a new instance; which happens very rarely given the size of the cache. Which means that the ThreadManager keeps holding onto the `AbstractModule` instance, which prevents the module from being garbage-collected, resulting in the polling threads staying alive even when the module is unplugged.

To fix this behavior, we decided to implement our own caching of wrapped modules such that stale instances are removed timely. Additionally, we will explicitly call a `cleanup` function on all modules to stop any threads spawned by them instead of relying on the garbage collector.

# Changelog

- replaced the `lru_cache` with a `WeakKeyDictionary` that doesn't prevent objects from being garbage collected.
- Added a `cleanup` method to all modules, which gets called in `API._unregister_modules`.
- refactored tempdeck driver's `update_temperature` in order to catch exceptions better.

# Review requests

- If you have a tempdeck, test that the behavior described in #5359 doesn't show up
- Am I missing any cases where the threads will still not stop? Or behave unexpectedly?

# Risk assessment

Medium. Could affect communication with modules if implemented poorly. 
