### PR TITLE
fix(app): fix calibrate page redirect url

### DIFF
--- a/app/src/pages/Calibrate/index.js
+++ b/app/src/pages/Calibrate/index.js
@@ -81,7 +81,7 @@ function getRedirectUrl(props: Props): string {
     return `/calibrate/pipettes/${nextPipetteTiprack.mount}/${nextPipetteTiprack.tiprack.definitionHash}`
   }
 
-  if (modules) {
+  if (modules.length) {
     return `calibrate/modules`
   }
   if (nextLabware) return `/calibrate/labware/${nextLabware.slot}`


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
This PR fixes the issue where the app shows an empty calibrate page when no module is needed in a protocol.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
