### PR TITLE
docs(api): Publicly document the deprecation of some long-deprecated APIv2 methods

### DIFF
--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -399,9 +399,12 @@ class Labware(DeckItem):
 
     @requires_version(2, 0)
     def wells_by_index(self) -> Dict[str, Well]:
+        """
+        .. deprecated:: 2.0
+            Use :py:meth:`wells_by_name` or dict access instead.
+        """
         MODULE_LOG.warning(
-            'wells_by_index is deprecated and will be deleted in version '
-            '3.12.0. please wells_by_name or dict access')
+            'wells_by_index is deprecated. Use wells_by_name or dict access instead.')
         return self.wells_by_name()
 
     @requires_version(2, 0)
@@ -452,9 +455,12 @@ class Labware(DeckItem):
 
     @requires_version(2, 0)
     def rows_by_index(self) -> Dict[str, List[Well]]:
+        """
+        .. deprecated:: 2.0
+            Use :py:meth:`rows_by_name` instead.
+        """
         MODULE_LOG.warning(
-            'rows_by_index is deprecated and will be deleted in version '
-            '3.12.0. please use rows_by_name')
+            'rows_by_index is deprecated. Use rows_by_name instead.')
         return self.rows_by_name()
 
     @requires_version(2, 0)
@@ -507,9 +513,12 @@ class Labware(DeckItem):
 
     @requires_version(2, 0)
     def columns_by_index(self) -> Dict[str, List[Well]]:
+        """
+        .. deprecated:: 2.0
+            Use :py:meth:`columns_by_name` instead.
+        """
         MODULE_LOG.warning(
-            'columns_by_index is deprecated and will be deleted in version '
-            '3.12.0. please use columns_by_name')
+            'columns_by_index is deprecated. Use columns_by_name instead.')
         return self.columns_by_name()
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -144,7 +144,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
                              namespace: Optional[str] = None,
                              version: int = 1,) -> Labware:
         """
-        .. deprecated:: 2.1
+        .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
         MODULE_LOG.warning(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -143,9 +143,12 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
                              label: Optional[str] = None,
                              namespace: Optional[str] = None,
                              version: int = 1,) -> Labware:
+        """
+        .. deprecated:: 2.1
+            Use :py:meth:`load_labware` instead.
+        """
         MODULE_LOG.warning(
-            'load_labware_by_name is deprecated and will be removed in '
-            'version 3.12.0. please use load_labware')
+            'load_labware_by_name is deprecated. Use load_labware instead.')
         return self.load_labware(name, label, namespace, version)
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -374,9 +374,12 @@ class ProtocolContext(CommandPublisher):
             namespace: Optional[str] = None,
             version: int = 1
     ) -> Labware:
+        """
+        .. deprecated:: 2.0
+            Use :py:meth:`load_labware` instead.
+        """
         MODULE_LOG.warning(
-            'load_labware_by_name is deprecated and will be removed in '
-            'version 3.12.0. please use load_labware')
+            'load_labware_by_name is deprecated. Use load_labware instead.')
         return self.load_labware(
             load_name, location, label, namespace, version)
 


### PR DESCRIPTION
# Overview

These methods have been deprecated since the initial publication of APIv2 (see #3806), but the only indications of this were internal `LOG.warning()` messages.

* `Labware.wells_by_index()`
* `Labware.rows_by_index()`
* `Labware.columns_by_index()`
* `ProtocolContext.load_labware_by_name()`
* `ModuleContext.load_labware_by_name()`

This PR adds public-facing deprecation warnings for these methods on docs.opentrons.com. Closes #7682.

# Changelog

* For the above methods, add public-facing deprecation warnings on docs.opentrons.com saying that they were deprecated in the same version they were added. (Which sounds weird, but it's technically true!)
   ![Screen Shot 2021-04-23 at 11 42 37 AM](https://user-images.githubusercontent.com/3236864/115896620-99730b00-a429-11eb-96a9-d8c5ce647053.png)
* Also change the `LOG.warning()` statements to not say that these functions "will be removed in version 3.12.0."

# Review requests

Does the new copy look good?

# Risk assessment

None. This changes docs and log messages only.