### PR TITLE
refactor(api): add load_labware implementation to engine-based ProtocolContext

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/__init__.py
+++ b/api/src/opentrons/protocol_api_experimental/__init__.py
@@ -20,6 +20,8 @@ This code is totally unsupported. To do science on a robot, use the stable
 from .protocol_context import ProtocolContext
 from .pipette_context import PipetteContext
 from .instrument_context import InstrumentContext
+from .labware import Labware
+from .well import Well
 from .errors import InvalidPipetteNameError, InvalidMountError
 from .types import PipetteName, Mount, DeprecatedMount
 
@@ -28,6 +30,8 @@ __all__ = [
     "ProtocolContext",
     "PipetteContext",
     "InstrumentContext",
+    "Labware",
+    "Well",
     # Protocol API errors
     "InvalidPipetteNameError",
     "InvalidMountError",

--- a/api/src/opentrons/protocol_api_experimental/errors.py
+++ b/api/src/opentrons/protocol_api_experimental/errors.py
@@ -1,4 +1,5 @@
 """Python Protocol API v3 errors."""
+# TODO(mc, 2021-04-22): assign unique codes to all these errors
 
 
 class InvalidPipetteNameError(ValueError):

--- a/api/src/opentrons/protocol_api_experimental/pipette_context.py
+++ b/api/src/opentrons/protocol_api_experimental/pipette_context.py
@@ -26,7 +26,7 @@ class PipetteContext:  # noqa: D101
     def __init__(
         self,
         engine_client: ProtocolEngineClient,
-        resource_id: str,
+        pipette_id: str,
     ) -> None:
         """Initialize a PipetteContext API provider.
 
@@ -34,21 +34,26 @@ class PipetteContext:  # noqa: D101
         create a PipetteContext for you when you call :py:meth:`load_pipette`.
 
         Args:
-            engine_client: A client to a ProtocolEngine to execute commands.
-            resource_id: The pipette's identifier inside the ProtocolEngine.
+            engine_client: A client to access protocol state and execute commands.
+            pipette_id: The pipette's identifier in commands and protocol state.
         """
         self._engine_client = engine_client
-        self._resource_id = resource_id
+        self._pipette_id = pipette_id
 
     def __hash__(self) -> int:
-        """Get resource identity for hash equality."""
-        return hash(self._resource_id)
+        """Get hash.
+
+        Uses the pipette instance's unique identifier in protocol state.
+        """
+        return hash(self._pipette_id)
 
     def __eq__(self, other: object) -> bool:
-        """Compare to another object by matching resource identifier."""
+        """Compare for object equality.
+
+        Checks that other object is a `PipetteContext` and has the same identifier.
+        """
         return (
-            isinstance(other, PipetteContext)
-            and self._resource_id == other._resource_id
+            isinstance(other, PipetteContext) and self._pipette_id == other._pipette_id
         )
 
     def __repr__(self) -> str:  # noqa: D105
@@ -98,8 +103,8 @@ class PipetteContext:  # noqa: D101
 
         if isinstance(location, Well):
             self._engine_client.aspirate(
-                pipette_id=self._resource_id,
-                labware_id=location.parent.resource_id,
+                pipette_id=self._pipette_id,
+                labware_id=location.parent.labware_id,
                 well_name=location.well_name,
                 well_location=WellLocation(
                     origin=WellOrigin.BOTTOM,
@@ -140,8 +145,8 @@ class PipetteContext:  # noqa: D101
         #  - Use well_bottom_clearance as offset for well_location(?)
         if isinstance(location, Well):
             self._engine_client.dispense(
-                pipette_id=self._resource_id,
-                labware_id=location.parent.resource_id,
+                pipette_id=self._pipette_id,
+                labware_id=location.parent.labware_id,
                 well_name=location.well_name,
                 well_location=WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1)),
                 volume=volume,
@@ -199,8 +204,8 @@ class PipetteContext:  # noqa: D101
             raise NotImplementedError()
         if isinstance(location, Well):
             self._engine_client.pick_up_tip(
-                pipette_id=self._resource_id,
-                labware_id=location.parent.resource_id,
+                pipette_id=self._pipette_id,
+                labware_id=location.parent.labware_id,
                 well_name=location.well_name,
             )
         else:
@@ -220,8 +225,8 @@ class PipetteContext:  # noqa: D101
             raise NotImplementedError()
         if isinstance(location, Well):
             self._engine_client.drop_tip(
-                pipette_id=self._resource_id,
-                labware_id=location.parent.resource_id,
+                pipette_id=self._pipette_id,
+                labware_id=location.parent.labware_id,
                 well_name=location.well_name,
             )
         else:

--- a/api/src/opentrons/protocol_api_experimental/types.py
+++ b/api/src/opentrons/protocol_api_experimental/types.py
@@ -1,5 +1,22 @@
 """Python Protocol API v3 type definitions and value classes."""
-from opentrons.types import MountType as Mount, Mount as DeprecatedMount
-from opentrons.protocol_engine import PipetteName
+from opentrons.types import (
+    DeckSlotName,
+    Location,
+    MountType as Mount,
+    Mount as DeprecatedMount,
+    Point,
+)
 
-__all__ = ["PipetteName", "Mount", "DeprecatedMount"]
+from opentrons.protocol_engine import DeckSlotLocation, PipetteName
+
+__all__ = [
+    # re-exports from opentrons.types
+    "DeckSlotName",
+    "Location",
+    "Mount",
+    "DeprecatedMount",
+    "Point",
+    # re-exports from opentrons.protocol_engine
+    "DeckSlotLocation",
+    "PipetteName",
+]

--- a/api/src/opentrons/protocol_api_experimental/well.py
+++ b/api/src/opentrons/protocol_api_experimental/well.py
@@ -1,0 +1,110 @@
+# noqa: D100
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any, Optional
+
+from opentrons.protocols.geometry.well_geometry import WellGeometry
+from opentrons.protocol_engine.clients import SyncClient as ProtocolEngineClient
+
+from .types import Location, Point
+
+if TYPE_CHECKING:
+    from .labware import Labware
+
+
+class Well:  # noqa: D101
+    def __init__(
+        self,
+        engine_client: ProtocolEngineClient,
+        labware: Labware,
+        well_name: str,
+    ) -> None:
+        """Initialize a Well API provider.
+
+        You should not need to call this constructor yourself. The system will
+        create `Well`s for you when you call :py:meth:`load_labware`.
+
+        Args:
+            engine_client: A client to access protocol state.
+            labware: The well's parent Labware instance.
+            well_name: The unique name of the well inside its parent labware.
+        """
+        self._engine_client = engine_client
+        self._labware = labware
+        self._well_name = well_name
+
+    # TODO(mc, 2021-04-22): remove this property; it's redundant and
+    # unlikely to be used by PAPI users
+    @property
+    def api_version(self) -> Any:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def parent(self) -> Labware:  # noqa: D102
+        return self._labware
+
+    @property
+    def has_tip(self) -> bool:  # noqa: D102
+        raise NotImplementedError()
+
+    @has_tip.setter
+    def has_tip(self, value: bool) -> None:
+        raise NotImplementedError()
+
+    @property
+    def max_volume(self) -> float:  # noqa: D102
+        raise NotImplementedError()
+
+    # TODO(mc, 2021-04-22): explore collapsing WellGeometry into Well
+    @property
+    def geometry(self) -> WellGeometry:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def diameter(self) -> Optional[float]:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def length(self) -> Optional[float]:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def width(self) -> Optional[float]:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def depth(self) -> float:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def display_name(self) -> str:  # noqa: D102
+        raise NotImplementedError()
+
+    @property
+    def well_name(self) -> str:  # noqa: D102
+        return self._well_name
+
+    def top(self, z: float = 0.0) -> Location:  # noqa: D102
+        raise NotImplementedError()
+
+    def bottom(self, z: float = 0.0) -> Location:  # noqa: D102
+        raise NotImplementedError()
+
+    def center(self) -> Location:  # noqa: D102
+        raise NotImplementedError()
+
+    def from_center_cartesian(  # noqa: D102
+        self,
+        x: float,
+        y: float,
+        z: float,
+    ) -> Point:
+        raise NotImplementedError()
+
+    def __repr__(self) -> str:  # noqa: D105
+        raise NotImplementedError()
+
+    def __eq__(self, other: object) -> bool:  # noqa: D105
+        raise NotImplementedError()
+
+    def __hash__(self) -> int:  # noqa: D105
+        raise NotImplementedError()


### PR DESCRIPTION
## Overview

This PR takes the work done in #7398 and puts it in the new(er) `opentrons.protocol_api_experimental` module.

## Changelog

- refactor(api): add load_labware implementation to engine-based ProtocolContext

## Review requests

A selection of choices I made to look out for:

- Split `labware.py` into `labware.py` for `class Labware` and `well.py` for `class Well`
    - Still need to figure out what we're doing with `Context` vs non-`Context` class naming
- Replaced `resource_id` with `pipette_id` and `labware_id`, respectively, for more obvious naming
- Defaulted `namespace` and `version` to `opentrons` and `1` at the Protocol API level, which is a good deal higher than this behavior in PAPIv2
    - This will have implications for custom labware, when we get to implementing it
    - I added a TODO comment to that effect
- Skipped dealing with the `label` argument for now
- Decided to remove usage of a few type aliases in `Labware` and `Well`:
    - `ApiVersion` - These properties feel really redundant given its existence on `ProtocolContext`, so I'd like to remove the properties entirely at some point. For now, marked them as `Any`
    - `DeckLocation` - I think the Protocol API is / will be the only place where this is used, so removed the alias and used `Union[str, int]` directly
    - `LabwareLocation` - This is a big union representing the "parent" of a labware. Given that a labware can be in a deck slot or in a module, went with a two-member union to that effect instead

## Risk assessment

N/A for now, as it's not hooked up and we'll have a lot of time with it before it is
