### PR TITLE
fix(api): ensure loaded modules is returned in order

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -2,7 +2,8 @@ import asyncio
 import contextlib
 import logging
 from typing import (Dict, Iterator, List, Callable,
-                    Optional, Set, Tuple, Union, TYPE_CHECKING, cast)
+                    Optional, Tuple, Union, TYPE_CHECKING, cast)
+from collections import OrderedDict
 
 from opentrons.hardware_control import (SynchronousAdapter, ThreadManager)
 from opentrons import types
@@ -87,7 +88,7 @@ class ProtocolContext(CommandPublisher):
         self._loop = loop or asyncio.get_event_loop()
         self._instruments: Dict[types.Mount, Optional[InstrumentContext]]\
             = {mount: None for mount in types.Mount}
-        self._modules: Set[ModuleContext] = set()
+        self._modules: List[ModuleContext] = []
 
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
         self._commands: List[str] = []
@@ -469,7 +470,7 @@ class ProtocolContext(CommandPublisher):
         module_context = mod_class(
             self, module.module, module.geometry, self.api_version, self._loop
         )
-        self._modules.add(module_context)
+        self._modules.append(module_context)
         return module_context
 
     @property  # type: ignore
@@ -492,7 +493,7 @@ class ProtocolContext(CommandPublisher):
             for module in self._modules:
                 yield int(str(module.geometry.parent)), module
 
-        return dict(_modules())
+        return OrderedDict(_modules())
 
     @requires_version(2, 0)
     def load_instrument(

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Optional, Set, TYPE_CHECKING
+from typing import Dict, Optional, Set, List, TYPE_CHECKING
+from collections import OrderedDict
 
 from opentrons import types, API
 from opentrons.protocols.api_support.types import APIVersion
@@ -75,7 +76,7 @@ class ProtocolContextImplementation(AbstractProtocol):
         self._instruments: InstrumentDict = {
             mount: None for mount in types.Mount
         }
-        self._modules: Set[LoadModuleResult] = set()
+        self._modules: List[LoadModuleResult] = []
 
         self._hw_manager = HardwareManager(hardware)
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
@@ -213,14 +214,14 @@ class ProtocolContextImplementation(AbstractProtocol):
                                   geometry=geometry,
                                   module=hc_mod_instance)
 
-        self._modules.add(result)
+        self._modules.append(result)
         self._deck_layout[resolved_location] = geometry
         return result
 
     def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
         """Get a mapping of deck location to loaded module."""
-        return {int(str(module.geometry.parent)): module
-                for module in self._modules}
+        return OrderedDict({int(str(module.geometry.parent)): module
+                            for module in self._modules})
 
     def load_instrument(self,
                         instrument_name: str,

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -872,11 +872,22 @@ def test_loaded_labwares(ctx):
 
 def test_loaded_modules(ctx, monkeypatch):
     assert ctx.loaded_modules == {}
-    mod1 = ctx.load_module('tempdeck', 4)
-    mod1.load_labware('biorad_96_wellplate_200ul_pcr')
-    mod2 = ctx.load_module('thermocycler')
-    assert ctx.loaded_modules[4] == mod1
-    assert ctx.loaded_modules[7] == mod2
+    from collections import OrderedDict
+
+    mag1 = ctx.load_module('magnetic module gen2', 1)
+    mag2 = ctx.load_module('magnetic module', 2)
+    temp1 = ctx.load_module('temperature module', 3)
+    temp2 = ctx.load_module('temperature module', 4)
+
+    expected_load_order = OrderedDict(
+        {int(mod.geometry.parent): mod
+         for mod in [mag1, mag2, temp1, temp2]})
+
+    assert ctx.loaded_modules == expected_load_order
+    assert ctx.loaded_modules[1] == mag1
+    assert ctx.loaded_modules[2] == mag2
+    assert ctx.loaded_modules[3] == temp1
+    assert ctx.loaded_modules[4] == temp2
 
 
 def test_order_of_module_load(loop):


### PR DESCRIPTION
# Overview
We were using sets to keep track of the order modules were loaded in the protocol. When we didn't care about order, that was OK. Now that we care which order modules were loaded in, we need to change the set to a list since sets are unordered.

# Changelog
- Change module sets to lists, and loaded modules to ordered dictionaries.
-
# Review requests

Please test on a robot with a 4.3.0 app. The mapping to the port should now match the order loaded in.

# Risk assessment

Low