### PR TITLE
feat(labware-library): use correct type import

### DIFF
--- a/labware-library/src/labware-creator/components/diagrams/index.tsx
+++ b/labware-library/src/labware-creator/components/diagrams/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import * as React from 'react'
 import type { WellBottomShape } from '@opentrons/shared-data'
-import type { LabwareType, WellShape } from './fields'
+import type { LabwareType, WellShape } from '../../fields'
 
 interface HeightImgProps {
   labwareType: LabwareType | null | undefined


### PR DESCRIPTION
# Overview

This got missed when moving labware diagrams (https://github.com/Opentrons/opentrons/pull/7709) because JS checks never ran


# Risk assessment
Low