### PR TITLE
chore(build): run js checks on typescript files

### DIFF
--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -8,6 +8,8 @@ on:
     paths:
       - '**/*.js'
       - './.*.js'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '**/*.json'
       - '**/*.css'
       - '**/*.md'
@@ -15,6 +17,8 @@ on:
     paths:
       - '**/*.js'
       - './.*.js'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '**/*.json'
       - '**/*.md'
       - '.github/workflows/js-check.yaml'


### PR DESCRIPTION
# Overview

JS Checks are getting missed now that we have `ts` + `tsx` files in the monorepo

# Changelog

- Run js checks on typescript files


# Risk assessment
Low
