### PR TITLE
feat(api): CommandTranslator._aspirate implemented.

### DIFF
--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -1,6 +1,8 @@
 import pytest
-from opentrons.protocol_engine import StateView
 from mock import MagicMock
+from opentrons.protocol_engine import StateView, WellLocation, WellOrigin
+from opentrons.protocol_engine.commands import AspirateRequest
+from opentrons.protocols.runner.json_proto.models import json_protocol as models
 
 from opentrons.protocols.runner.json_proto.command_translator import (
     CommandTranslator
@@ -13,5 +15,24 @@ def mock_state_view() -> MagicMock:
 
 
 @pytest.fixture
-def translator(mock_state_view) -> CommandTranslator:
+def subject(mock_state_view) -> CommandTranslator:
     return CommandTranslator(state_view=mock_state_view)
+
+
+def test_aspirate(subject, aspirate_command: models.LiquidCommand) -> None:
+    """It should translate a JSON aspirate command to a Protocol Engine
+     aspirate request."""
+    request = subject.translate(aspirate_command)
+
+    assert request == [
+        AspirateRequest(
+            pipetteId=aspirate_command.params.pipette,
+            labwareId=aspirate_command.params.labware,
+            wellName=aspirate_command.params.well,
+            volume=aspirate_command.params.volume,
+            wellLocation=WellLocation(
+                origin=WellOrigin.BOTTOM,
+                offset=(0, 0, aspirate_command.params.offsetFromBottomMm)
+            )
+        )
+    ]


### PR DESCRIPTION
# Overview

CommandTranslator can convert a PD/JSON aspirate to a Protocol Engine AspirateRequest.

closes #7434 

# Changelog

- implement `CommandTranslator._aspirate`
- tests

# Review requests

- Is the WellLocation translated correctly?
- See TODO. What do we do about PD resource ids vs PE resource ids? Seems to me that is for a future ticket.

# Risk assessment

None