### PR TITLE
chore(makefile): fix pipenv invocation in update-server

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -23,7 +23,7 @@ br_ssh_opts ?= $(default_ssh_opts)
 
 .PHONY: setup
 setup:
-	$(pipenv_envvars) $(pipenv) sync $(pipenv_opts)
+	$(pipenv) sync $(pipenv_opts)
 
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -23,7 +23,7 @@ br_ssh_opts ?= $(default_ssh_opts)
 
 .PHONY: setup
 setup:
-	$(pipenv_envvars) pipenv sync $(pipenv_opts)
+	$(pipenv_envvars) $(pipenv) sync $(pipenv_opts)
 
 .PHONY: dev
 dev: export ENABLE_VIRTUAL_SMOOTHIE := true


### PR DESCRIPTION
Pipenv was being invoked using an implicit local install, changed it to use the environment variable
$PIPENV instead.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
