### PR TITLE
fix(app): add USB hub port number

### DIFF
--- a/app/src/molecules/DeckMap/index.js
+++ b/app/src/molecules/DeckMap/index.js
@@ -137,11 +137,13 @@ function mapStateToProps(state: State, ownProps: OP): SP {
       module => {
         const matchedMod =
           matchedModules.find(mm => mm.slot === module.slot) ?? null
-        const usbInfo = matchedMod?.module?.usbPort?.hub
-          ? `USB Port ${matchedMod.module.usbPort.hub} via Hub`
-          : matchedMod?.module?.usbPort?.port
-          ? `USB Port ${matchedMod.module.usbPort.port}`
-          : 'USB Info N/A'
+        const usbPort = matchedMod?.module?.usbPort
+        const usbInfo =
+          usbPort?.hub && usbPort?.port
+            ? `USB Port ${usbPort.hub} - Hub Port ${usbPort.port}`
+            : usbPort?.port
+            ? `USB Port ${usbPort.port}`
+            : 'USB Info N/A'
         return {
           ...module,
           mode: matchedMod !== null ? 'present' : 'missing',

--- a/app/src/organisms/ProtocolModuleList/__tests__/ProtocolModuleList.test.js
+++ b/app/src/organisms/ProtocolModuleList/__tests__/ProtocolModuleList.test.js
@@ -67,7 +67,7 @@ const mockMatchedModule1 = {
 const mockMatchedModule2 = {
   module: {
     ...mockMagneticModule,
-    usbPort: { hub: 2, port: null },
+    usbPort: { hub: 2, port: 3 },
   },
   slot: '3',
 }
@@ -155,7 +155,7 @@ describe('ModuleList', () => {
         expect(allText).not.toContain('N/A')
         expect(toolTip.exists()).toBe(false)
       } else {
-        expect(allText).toContain('Port 2 via Hub')
+        expect(allText).toContain('USB Port 2 Hub Port 3')
         expect(toolTip.exists()).toBe(false)
       }
     })

--- a/app/src/organisms/ProtocolModuleList/index.js
+++ b/app/src/organisms/ProtocolModuleList/index.js
@@ -30,10 +30,10 @@ import styles from './styles.css'
 import type { MatchedModule } from '../../redux/modules/types'
 import type { State } from '../../redux/types'
 
-const MODULE_STYLE = { width: '37%' }
-const USB_ORDER_STYLE = { width: '27%', paddingRight: '0.75rem' }
-const USB_PORT_STYLE = { width: '23%', paddingRight: '0.75rem' }
-const DECK_SLOT_STYLE = { width: '13%' }
+const MODULE_STYLE = { width: '33%' }
+const USB_ORDER_STYLE = { width: '25%', paddingRight: '0.4rem' }
+const USB_PORT_STYLE = { width: '27%', paddingRight: '0.75rem' }
+const DECK_SLOT_STYLE = { width: '15%' }
 
 export function ProtocolModuleList(): React.Node {
   const { t } = useTranslation('protocol_calibration')
@@ -121,11 +121,12 @@ function UsbPortInfo(props: UsbPortInfoProps): React.Node {
   // return nothing if module is missing
   if (props.matchedModule === null) return null
   const portInfo = props.matchedModule.module.usbPort
-  const portText = portInfo?.hub
-    ? `Port ${portInfo.hub} via Hub`
-    : portInfo?.port
-    ? `Port ${portInfo.port}`
-    : 'N/A'
+  const portText =
+    portInfo?.hub && portInfo?.port
+      ? `USB Port ${portInfo.hub} Hub Port ${portInfo.port}`
+      : portInfo?.port
+      ? `USB Port ${portInfo.port}`
+      : 'N/A'
   return (
     <>
       <Text>{portText}</Text>

--- a/app/src/pages/Robots/ModuleSettings/ModuleItem/index.js
+++ b/app/src/pages/Robots/ModuleSettings/ModuleItem/index.js
@@ -24,16 +24,20 @@ type Props = {|
   module: AttachedModule,
   controlDisabledReason: string | null,
   usbPort?: ?string,
+  hubPort?: ?string,
 |}
 
 export function ModuleItem(props: Props): React.Node {
-  const { module, controlDisabledReason, usbPort } = props
+  const { module, controlDisabledReason, usbPort, hubPort } = props
 
   return (
     <>
       <Flex marginBottom={SPACING_1} fontWeight={FONT_WEIGHT_SEMIBOLD}>
         {usbPort && (
           <Text marginRight={SPACING_2}>{`USB Port ${usbPort}:`}</Text>
+        )}
+        {hubPort && (
+          <Text marginRight={SPACING_2}>{`Hub Port ${hubPort}:`}</Text>
         )}
         <Text>{getModuleDisplayName(module.model)}</Text>
       </Flex>

--- a/app/src/pages/Robots/ModuleSettings/UsbHubItem.js
+++ b/app/src/pages/Robots/ModuleSettings/UsbHubItem.js
@@ -52,6 +52,7 @@ export function UsbHubItem(props: Props): React.Node {
             key={mod.serial}
             module={mod}
             controlDisabledReason={controlDisabledReason}
+            hubPort={String(mod.usbPort.port)}
           />
         </Box>
       ))}

--- a/components/src/deck/Module.css
+++ b/components/src/deck/Module.css
@@ -50,7 +50,7 @@
 .module_port_text {
   fill: currentColor;
   color: var(--c-white);
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
 }
@@ -58,7 +58,7 @@
 .module_port_text_na {
   fill: currentColor;
   color: var(--c-med-gray);
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds the USB hub port info to the module card on the calibrate page.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
