### PR TITLE
feat(api): expand emulators and integration tests.

### DIFF
--- a/api/src/opentrons/drivers/command_builder.py
+++ b/api/src/opentrons/drivers/command_builder.py
@@ -27,7 +27,7 @@ class CommandBuilder:
 
         Returns: self
         """
-        value = round(value, precision) if precision else value
+        value = round(value, precision) if precision is not None else value
         return self.add_element(f"{prefix}{value}")
 
     def add_int(self, prefix: str, value: int) -> 'CommandBuilder':

--- a/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/driver_3_0.py
@@ -17,7 +17,8 @@ from opentrons.config.robot_configs import current_for_revision
 from opentrons.drivers import serial_communication
 from opentrons.drivers.types import MoveSplits
 from opentrons.drivers.utils import (
-    AxisMoveTimestamp, parse_key_values, parse_number, parse_optional_number
+    AxisMoveTimestamp, parse_key_values, parse_number, parse_optional_number,
+    string_to_hex
 )
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
@@ -213,19 +214,6 @@ def _byte_array_to_ascii_string(byte_array):
         log.exception('Unexpected argument to _byte_array_to_ascii_string:')
         raise ParseError(
             f'Unexpected argument to _byte_array_to_ascii_string: {byte_array}'
-        )
-    return res
-
-
-def _byte_array_to_hex_string(byte_array):
-    # data must be sent as stringified HEX values
-    # because of how Smoothieware parses GCODE messages
-    try:
-        res = ''.join('%02x' % b for b in byte_array)
-    except TypeError:
-        log.exception('Unexpected argument to _byte_array_to_hex_string:')
-        raise ParseError(
-            f'Unexpected argument to _byte_array_to_hex_string: {byte_array}'
         )
     return res
 
@@ -1400,8 +1388,7 @@ class SmoothieDriver_3_0_0:
         self.delay(CURRENT_CHANGE_DELAY)
         # data is read/written as strings of HEX characters
         # to avoid firmware weirdness in how it parses GCode arguments
-        byte_string = _byte_array_to_hex_string(
-            bytearray(data_string.encode()))
+        byte_string = string_to_hex(data_string)
         command = _command_builder().add_gcode(
             gcode=gcode
         ).add_element(

--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -29,6 +29,10 @@ class PlateTemperature(Temperature):
     hold: Optional[float]
 
 
-class LidStatus(str, Enum):
-    OPEN = "open"
-    CLOSED = "closed"
+class ThermocyclerLidStatus(str, Enum):
+    """Thermocycler lid status."""
+    UNKNOWN = 'unknown'
+    CLOSED = 'closed'
+    IN_BETWEEN = 'in_between'
+    OPEN = 'open'
+    MAX = 'max'

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -150,8 +150,8 @@ class AxisMoveTimestamp:
 
 def string_to_hex(val: str, min_length: int = 0) -> str:
     """
-    Create a hex representation of val. Will be padded with "0"
-    until min_length is reached.
+    Create a hex representation of val. The end of the result will be padded
+    with "0" until min_length is reached.
 
     Args:
         val: The string to convert.

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -1,3 +1,4 @@
+import binascii
 import logging
 import time
 from typing import Dict, Optional, Mapping, Iterable, Sequence
@@ -145,3 +146,23 @@ class AxisMoveTimestamp:
     def reset_moved(self, axis_iter: Iterable[str]):
         """ Reset the clocks for a set of axes """
         self._moved_at.update({ax: None for ax in axis_iter})
+
+
+def string_to_hex(val: str, min_length: int = 0) -> str:
+    """
+    Create a hex representation of val. Will be padded with "0"
+    until min_length is reached.
+
+    Args:
+        val: The string to convert.
+        min_length: The minimum length of result. "0" will be used as
+            padding. Default is no minimum length and no padding.
+
+    Returns:
+        Hex string
+    """
+    hex_string = binascii.hexlify(val.encode()).decode()
+    hex_string_length = len(hex_string)
+    if hex_string_length < min_length:
+        return hex_string + "0" * (min_length - hex_string_length)
+    return hex_string

--- a/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
+++ b/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional
 
 
 class AbstractEmulator(ABC):
     """Interface of gcode line processing hardware emulator."""
 
     @abstractmethod
-    def handle(self, words: List[str]) -> Optional[str]:
+    def handle(self, line: str) -> Optional[str]:
         """Handle a command and return a response."""
         ...
 

--- a/api/src/opentrons/hardware_control/emulation/app.py
+++ b/api/src/opentrons/hardware_control/emulation/app.py
@@ -4,6 +4,7 @@ import logging
 from opentrons.hardware_control.emulation.connection_handler import \
     ConnectionHandler
 from opentrons.hardware_control.emulation.magdeck import MagDeckEmulator
+from opentrons.hardware_control.emulation.parser import Parser
 from opentrons.hardware_control.emulation.tempdeck import TempDeckEmulator
 from opentrons.hardware_control.emulation.thermocycler import ThermocyclerEmulator
 from opentrons.hardware_control.emulation.smoothie import SmoothieEmulator
@@ -32,16 +33,16 @@ async def run() -> None:
     await asyncio.gather(
         run_server(host=host,
                    port=MAGDECK_PORT,
-                   handler=ConnectionHandler(MagDeckEmulator())),
+                   handler=ConnectionHandler(MagDeckEmulator(parser=Parser()))),
         run_server(host=host,
                    port=TEMPDECK_PORT,
-                   handler=ConnectionHandler(TempDeckEmulator())),
+                   handler=ConnectionHandler(TempDeckEmulator(parser=Parser()))),
         run_server(host=host,
                    port=THERMOCYCLER_PORT,
-                   handler=ConnectionHandler(ThermocyclerEmulator())),
+                   handler=ConnectionHandler(ThermocyclerEmulator(parser=Parser()))),
         run_server(host=host,
                    port=SMOOTHIE_PORT,
-                   handler=ConnectionHandler(SmoothieEmulator())),
+                   handler=ConnectionHandler(SmoothieEmulator(parser=Parser()))),
     )
 
 

--- a/api/src/opentrons/hardware_control/emulation/connection_handler.py
+++ b/api/src/opentrons/hardware_control/emulation/connection_handler.py
@@ -18,18 +18,15 @@ class ConnectionHandler:
         while True:
             line = await reader.readuntil(self._emulator.get_terminator())
             logger.debug("Received: %s", line)
-
-            words = line.decode().strip().split(' ')
-            if words:
-                try:
-                    response = self._emulator.handle(words)
-                    if response:
-                        response = f'{response}\r\n'
-                        logger.debug("Sending: %s", response)
-                        writer.write(response.encode())
-                except (IndexError, StopIteration) as e:
-                    logger.exception("exception")
-                    writer.write(f'Error: {str(e)}\r\n'.encode())
+            try:
+                response = self._emulator.handle(line.decode().strip())
+                if response:
+                    response = f'{response}\r\n'
+                    logger.debug("Sending: %s", response)
+                    writer.write(response.encode())
+            except Exception as e:
+                logger.exception("exception")
+                writer.write(f'Error: {str(e)}\r\n'.encode())
 
             writer.write(self._emulator.get_ack())
             await writer.drain()

--- a/api/src/opentrons/hardware_control/emulation/connection_handler.py
+++ b/api/src/opentrons/hardware_control/emulation/connection_handler.py
@@ -1,3 +1,5 @@
+"""The handler of a driver client connection."""
+
 import asyncio
 import logging
 
@@ -7,8 +9,10 @@ logger = logging.getLogger(__name__)
 
 
 class ConnectionHandler:
+    """Responsible for reading data and routing it to an emulator."""
+
     def __init__(self, emulator: AbstractEmulator):
-        """Construct"""
+        """Construct with an emulator."""
         self._emulator = emulator
 
     async def __call__(self, reader: asyncio.StreamReader,

--- a/api/src/opentrons/hardware_control/emulation/magdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/magdeck.py
@@ -27,10 +27,10 @@ VERSION = 1
 class MagDeckEmulator(AbstractEmulator):
     """Magdeck emulator"""
 
-    def __init__(self) -> None:
+    def __init__(self, parser: Parser) -> None:
         self.height: float = 0
         self.position: float = 0
-        self._parser = Parser()
+        self._parser = parser
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/magdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/magdeck.py
@@ -1,17 +1,18 @@
 import logging
-from typing import Optional, List
+from typing import Optional
 from opentrons.drivers.mag_deck.driver import GCODES
+from opentrons.hardware_control.emulation.parser import Parser, Command
 from .abstract_emulator import AbstractEmulator
 
 logger = logging.getLogger(__name__)
 
 GCODE_HOME = GCODES['HOME']
 GCODE_MOVE = GCODES['MOVE']
-GCODE_PROBE = GCODES['PROBE_PLATE']
-GCODE_GET_PROBED_DISTANCE = GCODES['GET_PLATE_HEIGHT']
-GCODE_GET_POSITION = GCODES['GET_CURRENT_POSITION']
+GCODE_PROBE_PLATE = GCODES['PROBE_PLATE']
+GCODE_GET_PLATE_HEIGHT = GCODES['GET_PLATE_HEIGHT']
+GCODE_GET_CURRENT_POSITION = GCODES['GET_CURRENT_POSITION']
 GCODE_DEVICE_INFO = GCODES['DEVICE_INFO']
-GCODE_DFU = GCODES['PROGRAMMING_MODE']
+GCODE_PROGRAMMING_MODE = GCODES['PROGRAMMING_MODE']
 
 SERIAL = "fake_serial"
 MODEL = "magdeck_emulator"
@@ -22,25 +23,33 @@ class MagDeckEmulator(AbstractEmulator):
     """Magdeck emulator"""
 
     def __init__(self) -> None:
-        self.height = 0
-        self.position = 0
+        self.height: float = 0
+        self.position: float = 0
+        self._parser = Parser(gcodes=list(GCODES.values()))
 
-    def handle(self, words: List[str]) -> Optional[str]:
+    def handle(self, line: str) -> Optional[str]:
+        """Handle a line"""
+        results = (self._handle(c) for c in self._parser.parse(line))
+        joined = ' '.join(r for r in results if r)
+        return None if not joined else joined
+
+    def _handle(self, command: Command) -> Optional[str]:
         """Handle a command."""
-        cmd = words[0]
-        logger.info(f"Got command {cmd}")
-        if cmd == GCODE_HOME:
-            pass
-        elif cmd == GCODE_MOVE:
-            pass
-        elif cmd == GCODE_PROBE:
-            pass
-        elif cmd == GCODE_GET_PROBED_DISTANCE:
+        logger.info(f"Got command {command}")
+        if command.gcode == GCODE_HOME:
+            self.height = 0
+        elif command.gcode == GCODE_MOVE:
+            position = command.params['Z']
+            assert isinstance(position, float), f"invalid position '{position}'"
+            self.position = position
+        elif command.gcode == GCODE_PROBE_PLATE:
+            self.height = 45
+        elif command.gcode == GCODE_GET_PLATE_HEIGHT:
             return f"height:{self.height}"
-        elif cmd == GCODE_GET_POSITION:
+        elif command.gcode == GCODE_GET_CURRENT_POSITION:
             return f"Z:{self.position}"
-        elif cmd == GCODE_DEVICE_INFO:
+        elif command.gcode == GCODE_DEVICE_INFO:
             return f"serial:{SERIAL} model:{MODEL} version:{VERSION}"
-        elif cmd == GCODE_DFU:
+        elif command.gcode == GCODE_PROGRAMMING_MODE:
             pass
         return None

--- a/api/src/opentrons/hardware_control/emulation/magdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/magdeck.py
@@ -1,3 +1,8 @@
+"""An emulation of the opentrons magnetic module.
+
+The purpose is to provide a fake backend that responds to GCODE commands.
+"""
+
 import logging
 from typing import Optional
 from opentrons.drivers.mag_deck.driver import GCODES
@@ -25,7 +30,7 @@ class MagDeckEmulator(AbstractEmulator):
     def __init__(self) -> None:
         self.height: float = 0
         self.position: float = 0
-        self._parser = Parser(gcodes=list(GCODES.values()))
+        self._parser = Parser()
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/parser.py
+++ b/api/src/opentrons/hardware_control/emulation/parser.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Sequence, Dict, Generator, Optional
+from typing import Dict, Generator, Optional
 
 
 @dataclass
@@ -13,22 +13,10 @@ class Command:
 class Parser:
     """Gcode line parser."""
 
+    GCODE_RE = re.compile(r"(?:(?:[MG]\d+\.*\d*)|dfu|version)")
+    """A gcode is either M or G followed by decimal. Or 'dfu' or 'version'."""
     PREFIX_NUMBER_RE = re.compile(r"(?P<prefix>[A-Z])(?P<value>-?\d*\.?\d*)")
-
-    def __init__(self, gcodes: Sequence[str]) -> None:
-        """
-        Construct a parser.
-
-        Args:
-            gcodes: a sequence of gcodes this parser supports.
-        """
-        # Sort in reversed size order to find most specific first.
-        ordered = reversed(sorted(gcodes, key=lambda x: len(x)))
-        # Create a regular expression that looks like this
-        #  For valid gcodes: G1, G123, G123.2 ->
-        #       (G123.2|G123|G1)(?!\d)
-        #  Match any of the gcodes not followed by a digit.
-        self._re = re.compile(r'({})(?!\d)'.format('|'.join(ordered)))
+    """All parameters are a capital letter followed by a decimal value."""
 
     def parse(self, line: str) -> Generator[Command, None, None]:
         """
@@ -40,19 +28,29 @@ class Parser:
         Returns:
             Command object
         """
+        line = line.strip()
         previous = None
-        for i in self._re.finditer(line):
+        for i in self.GCODE_RE.finditer(line):
             if previous:
                 yield self._create_command(
                     line[previous.start(): previous.end()],
                     line[previous.end(): i.start()]
                 )
+            else:
+                # This is the first match. It better bet at the beginning or
+                # there's junk in the beginning.
+                if i.start() != 0:
+                    raise ValueError(f"Invalid content: {line}")
             previous = i
         if previous:
+            # Create command from final GCODE and remainder of the line.
             yield self._create_command(
                 line[previous.start(): previous.end()],
                 line[previous.end():]
             )
+        elif line:
+            # There are no GCODEs and it's a non-empty line.
+            raise ValueError(f"Invalid content: {line}")
 
     @staticmethod
     def _create_command(gcode: str, body: str) -> Command:

--- a/api/src/opentrons/hardware_control/emulation/parser.py
+++ b/api/src/opentrons/hardware_control/emulation/parser.py
@@ -13,9 +13,9 @@ class Command:
 class Parser:
     """Gcode line parser."""
 
-    GCODE_RE = re.compile(r"(?:(?:[MG]\d+\.*\d*)|dfu|version)")
+    GCODE_RE = re.compile(r"(?:(?:[MG]\d+\.?\d*)|dfu|version)")
     """A gcode is either M or G followed by decimal. Or 'dfu' or 'version'."""
-    PREFIX_NUMBER_RE = re.compile(r"(?P<prefix>[A-Z])(?P<value>-?\d*\.?\d*)")
+    ALPHA_PREFIXED_NUMBER_RE = re.compile(r"(?P<prefix>[A-Z])(?P<number>-?\d*\.?\d*)")
     """All parameters are a capital letter followed by a decimal value."""
 
     def parse(self, line: str) -> Generator[Command, None, None]:
@@ -37,7 +37,7 @@ class Parser:
                     line[previous.end(): i.start()]
                 )
             else:
-                # This is the first match. It better bet at the beginning or
+                # This is the first match. It better be at the beginning or
                 # there's junk in the beginning.
                 if i.start() != 0:
                     raise ValueError(f"Invalid content: {line}")
@@ -63,11 +63,11 @@ class Parser:
 
         Returns: a Command object
         """
-        pars = (i.groupdict() for i in Parser.PREFIX_NUMBER_RE.finditer(body))
+        pars = (i.groupdict() for i in Parser.ALPHA_PREFIXED_NUMBER_RE.finditer(body))
         return Command(
             gcode=gcode,
             body=body.strip(),
             params={
-                p['prefix']: float(p['value']) if p['value'] else None for p in pars
+                p['prefix']: float(p['number']) if p['number'] else None for p in pars
             }
         )

--- a/api/src/opentrons/hardware_control/emulation/parser.py
+++ b/api/src/opentrons/hardware_control/emulation/parser.py
@@ -1,0 +1,75 @@
+import re
+from dataclasses import dataclass
+from typing import Sequence, Dict, Generator, Optional
+
+
+@dataclass
+class Command:
+    gcode: str
+    body: str
+    params: Dict[str, Optional[float]]
+
+
+class Parser:
+    """Gcode line parser."""
+
+    PREFIX_NUMBER_RE = re.compile(r"(?P<prefix>[A-Z])(?P<value>-?\d*\.?\d*)")
+
+    def __init__(self, gcodes: Sequence[str]) -> None:
+        """
+        Construct a parser.
+
+        Args:
+            gcodes: a sequence of gcodes this parser supports.
+        """
+        # Sort in reversed size order to find most specific first.
+        ordered = reversed(sorted(gcodes, key=lambda x: len(x)))
+        # Create a regular expression that looks like this
+        #  For valid gcodes: G1, G123, G123.2 ->
+        #       (G123.2|G123|G1)(?!\d)
+        #  Match any of the gcodes not followed by a digit.
+        self._re = re.compile(r'({})(?!\d)'.format('|'.join(ordered)))
+
+    def parse(self, line: str) -> Generator[Command, None, None]:
+        """
+        Parse a line to extract commands.
+
+        Args:
+            line: a line containing gcodes and their values. spaces are optional.
+
+        Returns:
+            Command object
+        """
+        previous = None
+        for i in self._re.finditer(line):
+            if previous:
+                yield self._create_command(
+                    line[previous.start(): previous.end()],
+                    line[previous.end(): i.start()]
+                )
+            previous = i
+        if previous:
+            yield self._create_command(
+                line[previous.start(): previous.end()],
+                line[previous.end():]
+            )
+
+    @staticmethod
+    def _create_command(gcode: str, body: str) -> Command:
+        """
+        Create a Command.
+
+        Args:
+            gcode: the gcode
+            body: the parameter string
+
+        Returns: a Command object
+        """
+        pars = (i.groupdict() for i in Parser.PREFIX_NUMBER_RE.finditer(body))
+        return Command(
+            gcode=gcode,
+            body=body.strip(),
+            params={
+                p['prefix']: float(p['value']) if p['value'] else None for p in pars
+            }
+        )

--- a/api/src/opentrons/hardware_control/emulation/parser.py
+++ b/api/src/opentrons/hardware_control/emulation/parser.py
@@ -13,6 +13,8 @@ class Command:
 class Parser:
     """Gcode line parser."""
 
+    # TODO (al, 2021-05-11): Should G01 and G1 be treated differently? Currently
+    #  they are two different Gcodes.
     GCODE_RE = re.compile(r"(?:(?:[MG]\d+\.?\d*)|dfu|version)")
     """A gcode is either M or G followed by decimal. Or 'dfu' or 'version'."""
     ALPHA_PREFIXED_NUMBER_RE = re.compile(r"(?P<prefix>[A-Z])(?P<number>-?\d*\.?\d*)")

--- a/api/src/opentrons/hardware_control/emulation/smoothie.py
+++ b/api/src/opentrons/hardware_control/emulation/smoothie.py
@@ -1,3 +1,9 @@
+"""An emulation of the Smoothie.
+
+The purpose is to provide a fake backend that responds to the GCODE sent by the
+Opentrons smoothie driver.
+"""
+
 import logging
 import re
 from typing import Optional, Dict
@@ -42,7 +48,7 @@ class SmoothieEmulator(AbstractEmulator):
             # P20SV202020070101
             "R": "5032305356323032303230303730313031000000000000000000000000000000"
         }
-        self._parser = Parser(gcodes=list(GCODE))
+        self._parser = Parser()
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/smoothie.py
+++ b/api/src/opentrons/hardware_control/emulation/smoothie.py
@@ -25,7 +25,7 @@ class SmoothieEmulator(AbstractEmulator):
 
     WRITE_INSTRUMENT_RE = re.compile(r"(?P<mount>[LR])\s*(?P<value>[a-f0-9]+)")
 
-    def __init__(self) -> None:
+    def __init__(self, parser: Parser) -> None:
         self._pos = {'A': 0.0, 'B': 0.0, 'C': 0.0, 'X': 0.0, 'Y': 0.0, 'Z': 0.0}
         self._home_status: Dict[str, bool] = {
             'X': False,
@@ -44,7 +44,7 @@ class SmoothieEmulator(AbstractEmulator):
             "L": utils.string_to_hex("P3HMV202020041605", 64),
             "R": utils.string_to_hex("P20SV202020070101", 64),
         }
-        self._parser = Parser()
+        self._parser = parser
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/tempdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/tempdeck.py
@@ -29,10 +29,10 @@ VERSION = 1
 class TempDeckEmulator(AbstractEmulator):
     """TempDeck emulator"""
 
-    def __init__(self) -> None:
+    def __init__(self, parser: Parser) -> None:
         self.target_temp = util.OptionalValue[float]()
         self.current_temp = 0.0
-        self._parser = Parser()
+        self._parser = parser
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/tempdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/tempdeck.py
@@ -1,3 +1,8 @@
+"""An emulation of the opentrons temperature module.
+
+The purpose is to provide a fake backend that responds to GCODE commands.
+"""
+
 import logging
 from typing import Optional
 
@@ -27,7 +32,7 @@ class TempDeckEmulator(AbstractEmulator):
     def __init__(self) -> None:
         self.target_temp = util.OptionalValue[float]()
         self.current_temp = 0.0
-        self._parser = Parser(gcodes=list(GCODES.values()))
+        self._parser = Parser()
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/tempdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/tempdeck.py
@@ -1,9 +1,12 @@
 import logging
-from typing import Optional, List
+from typing import Optional
 
 from opentrons.drivers.temp_deck.driver import GCODES
+from opentrons.hardware_control.emulation import util
+from opentrons.hardware_control.emulation.parser import Parser, Command
 
 from .abstract_emulator import AbstractEmulator
+
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +14,7 @@ GCODE_GET_TEMP = GCODES['GET_TEMP']
 GCODE_SET_TEMP = GCODES['SET_TEMP']
 GCODE_DEVICE_INFO = GCODES['DEVICE_INFO']
 GCODE_DISENGAGE = GCODES['DISENGAGE']
-GCODE_DFU = GCODES['PROGRAMMING_MODE']
+GCODE_PROGRAMMING_MODE = GCODES['PROGRAMMING_MODE']
 
 SERIAL = "fake_serial"
 MODEL = "temp_emulator"
@@ -22,21 +25,34 @@ class TempDeckEmulator(AbstractEmulator):
     """TempDeck emulator"""
 
     def __init__(self) -> None:
-        self.target_temp = 0
-        self.current_temp = 0
+        self.target_temp = util.OptionalValue[float]()
+        self.current_temp = 0.0
+        self._parser = Parser(gcodes=list(GCODES.values()))
 
-    def handle(self, words: List[str]) -> Optional[str]:
+    def handle(self, line: str) -> Optional[str]:
+        """Handle a line"""
+        results = (self._handle(c) for c in self._parser.parse(line))
+        joined = ' '.join(r for r in results if r)
+        return None if not joined else joined
+
+    def _handle(self, command: Command) -> Optional[str]:
         """Handle a command."""
-        cmd = words[0]
-        logger.info(f"Got command {cmd}")
-        if cmd == GCODE_GET_TEMP:
+        logger.info(f"Got command {command}")
+        if command.gcode == GCODE_GET_TEMP:
             return f"T:{self.target_temp} C:{self.current_temp}"
-        elif cmd == GCODE_SET_TEMP:
-            pass
-        elif cmd == GCODE_DISENGAGE:
-            pass
-        elif cmd == GCODE_DEVICE_INFO:
+        elif command.gcode == GCODE_SET_TEMP:
+            temperature = command.params['S']
+            assert isinstance(temperature, float),\
+                f"invalid temperature '{temperature}'"
+            self._set_target(temperature)
+        elif command.gcode == GCODE_DISENGAGE:
+            self._set_target(util.TEMPERATURE_ROOM)
+        elif command.gcode == GCODE_DEVICE_INFO:
             return f"serial:{SERIAL} model:{MODEL} version:{VERSION}"
-        elif cmd == GCODE_DFU:
+        elif command.gcode == GCODE_PROGRAMMING_MODE:
             pass
         return None
+
+    def _set_target(self, target_temp: float) -> None:
+        self.target_temp.val = target_temp
+        self.current_temp = self.target_temp.val

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -1,8 +1,11 @@
 import logging
-from typing import Optional, List
-import enum
+from typing import Optional
 from opentrons.drivers.thermocycler.driver import GCODES
+from opentrons.drivers.types import ThermocyclerLidStatus
+from opentrons.hardware_control.emulation.parser import Parser, Command
+
 from .abstract_emulator import AbstractEmulator
+from . import util
 
 logger = logging.getLogger(__name__)
 
@@ -25,61 +28,79 @@ MODEL = "thermocycler_emulator"
 VERSION = 1
 
 
-class LidStatus(str, enum.Enum):
-    IN_BETWEEN = 'in_between'
-    CLOSED = 'closed'
-    OPEN = 'open'
-    UNKNOWN = 'unknown'
-    MAX = 'max'
-
-
 class ThermocyclerEmulator(AbstractEmulator):
     """Thermocycler emulator"""
 
     def __init__(self) -> None:
-        self.target_temp = 0
-        self.current_temp = 0
-        self.lid_status = LidStatus.CLOSED
-        self.at_target = None
-        self.total_hold_time = None
-        self.time_remaining = None
+        self.lid_target_temp = util.OptionalValue[float]()
+        self.lid_current_temp: float = util.TEMPERATURE_ROOM
+        self.lid_status = ThermocyclerLidStatus.CLOSED
+        self.lid_at_target: Optional[bool] = None
+        self.plate_total_hold_time = util.OptionalValue[float]()
+        self.plate_time_remaining = util.OptionalValue[float]()
+        self.plate_target_temp = util.OptionalValue[float]()
+        self.plate_current_temp: float = util.TEMPERATURE_ROOM
+        self.plate_volume = util.OptionalValue[float]()
+        self.plate_at_target = util.OptionalValue[float]()
+        self.plate_ramp_rate = util.OptionalValue[float]()
+        self._parser = Parser(gcodes=list(GCODES.values()))
 
-    def handle(self, words: List[str]) -> Optional[str]:  # noqa: C901
+    def handle(self, line: str) -> Optional[str]:
+        """Handle a line"""
+        results = (self._handle(c) for c in self._parser.parse(line))
+        joined = ' '.join(r for r in results if r)
+        return None if not joined else joined
+
+    def _handle(self, command: Command) -> Optional[str]:  # noqa: C901
         """
         Handle a command.
 
         TODO: AL 20210218 create dispatch map and remove 'noqa(C901)'
         """
-        cmd = words[0]
-        logger.info(f"Got command {cmd}")
-        if cmd == GCODE_OPEN_LID:
-            pass
-        elif cmd == GCODE_CLOSE_LID:
-            pass
-        elif cmd == GCODE_GET_LID_STATUS:
+        logger.info(f"Got command {command}")
+        if command.gcode == GCODE_OPEN_LID:
+            self.lid_status = ThermocyclerLidStatus.OPEN
+        elif command.gcode == GCODE_CLOSE_LID:
+            self.lid_status = ThermocyclerLidStatus.CLOSED
+        elif command.gcode == GCODE_GET_LID_STATUS:
             return f"Lid:{self.lid_status}"
-        elif cmd == GCODE_SET_LID_TEMP:
-            pass
-        elif cmd == GCODE_GET_LID_TEMP:
-            return f"T:{self.target_temp} C:{self.current_temp} " \
+        elif command.gcode == GCODE_SET_LID_TEMP:
+            temperature = command.params['S']
+            assert isinstance(temperature, float),\
+                f"invalid temperature '{temperature}'"
+            self.lid_target_temp.val = temperature
+            self.lid_current_temp = self.lid_target_temp.val
+        elif command.gcode == GCODE_GET_LID_TEMP:
+            return f"T:{self.lid_target_temp} C:{self.lid_current_temp} " \
                    f"H:none Total_H:none At_target?:0"
-        elif cmd == GCODE_EDIT_PID_PARAMS:
+        elif command.gcode == GCODE_EDIT_PID_PARAMS:
             pass
-        elif cmd == GCODE_SET_PLATE_TEMP:
+        elif command.gcode == GCODE_SET_PLATE_TEMP:
+            for prefix, value in command.params.items():
+                assert isinstance(value, float), f"invalid value '{value}'"
+                if prefix == 'S':
+                    self.plate_target_temp.val = value
+                    self.plate_current_temp = self.plate_target_temp.val
+                elif prefix == 'V':
+                    self.plate_volume.val = value
+                elif prefix == 'H':
+                    self.plate_total_hold_time.val = value
+                    self.plate_time_remaining.val = value
+        elif command.gcode == GCODE_GET_PLATE_TEMP:
+            return f"T:{self.plate_target_temp} " \
+                   f"C:{self.plate_current_temp} " \
+                   f"H:{self.plate_time_remaining} " \
+                   f"Total_H:{self.plate_total_hold_time} " \
+                   f"At_target?:{self.plate_at_target}"
+        elif command.gcode == GCODE_SET_RAMP_RATE:
+            self.plate_ramp_rate.val = command.params['S']
+        elif command.gcode == GCODE_DEACTIVATE_ALL:
             pass
-        elif cmd == GCODE_GET_PLATE_TEMP:
-            return f"T:{self.target_temp} C:{self.current_temp} " \
-                   f"H:{self.time_remaining} Total_H:{self.total_hold_time} " \
-                   f"At_target?:{self.at_target}"
-        elif cmd == GCODE_SET_RAMP_RATE:
+        elif command.gcode == GCODE_DEACTIVATE_LID:
             pass
-        elif cmd == GCODE_DEACTIVATE_ALL:
+        elif command.gcode == GCODE_DEACTIVATE_BLOCK:
             pass
-        elif cmd == GCODE_DEACTIVATE_LID:
-            pass
-        elif cmd == GCODE_DEACTIVATE_BLOCK:
-            pass
-        elif cmd == GCODE_DEVICE_INFO:
+        elif command.gcode == GCODE_DEVICE_INFO:
             return f"serial:{SERIAL} model:{MODEL} version:{VERSION}"
         return None
 

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -36,7 +36,7 @@ VERSION = 1
 class ThermocyclerEmulator(AbstractEmulator):
     """Thermocycler emulator"""
 
-    def __init__(self) -> None:
+    def __init__(self, parser: Parser) -> None:
         self.lid_target_temp = util.OptionalValue[float]()
         self.lid_current_temp: float = util.TEMPERATURE_ROOM
         self.lid_status = ThermocyclerLidStatus.CLOSED
@@ -48,7 +48,7 @@ class ThermocyclerEmulator(AbstractEmulator):
         self.plate_volume = util.OptionalValue[float]()
         self.plate_at_target = util.OptionalValue[float]()
         self.plate_ramp_rate = util.OptionalValue[float]()
-        self._parser = Parser()
+        self._parser = parser
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -1,3 +1,8 @@
+"""An emulation of the opentrons thermocycler module.
+
+The purpose is to provide a fake backend that responds to GCODE commands.
+"""
+
 import logging
 from typing import Optional
 from opentrons.drivers.thermocycler.driver import GCODES
@@ -43,7 +48,7 @@ class ThermocyclerEmulator(AbstractEmulator):
         self.plate_volume = util.OptionalValue[float]()
         self.plate_at_target = util.OptionalValue[float]()
         self.plate_ramp_rate = util.OptionalValue[float]()
-        self._parser = Parser(gcodes=list(GCODES.values()))
+        self._parser = Parser()
 
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""

--- a/api/src/opentrons/hardware_control/emulation/util.py
+++ b/api/src/opentrons/hardware_control/emulation/util.py
@@ -7,6 +7,13 @@ ValueType = TypeVar('ValueType')
 
 
 class OptionalValue(Generic[ValueType]):
+    """
+    A class that serializes optional values.
+
+    Modules represent a null value as 'none'. For example this response from
+    the thermocycler means the hold time is not set:
+        H:none T:1.23
+    """
     _value: Optional[ValueType]
 
     def __init__(self, value: Optional[ValueType] = None):
@@ -22,3 +29,9 @@ class OptionalValue(Generic[ValueType]):
 
     def __repr__(self) -> str:
         return "none" if self._value is None else str(self._value)
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, OptionalValue):
+            return False
+
+        return other.val == self.val

--- a/api/src/opentrons/hardware_control/emulation/util.py
+++ b/api/src/opentrons/hardware_control/emulation/util.py
@@ -1,0 +1,24 @@
+from typing import Optional, Generic, TypeVar
+
+TEMPERATURE_ROOM = 23
+
+
+ValueType = TypeVar('ValueType')
+
+
+class OptionalValue(Generic[ValueType]):
+    _value: Optional[ValueType]
+
+    def __init__(self, value: Optional[ValueType] = None):
+        self._value = value
+
+    @property
+    def val(self) -> Optional[ValueType]:
+        return self._value
+
+    @val.setter
+    def val(self, value: Optional[ValueType]) -> None:
+        self._value = value
+
+    def __repr__(self) -> str:
+        return "none" if self._value is None else str(self._value)

--- a/api/tests/opentrons/drivers/test_command_builder.py
+++ b/api/tests/opentrons/drivers/test_command_builder.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+import pytest
 from opentrons.drivers.command_builder import CommandBuilder
 
 
@@ -8,23 +11,22 @@ def test_builder_create_command_with_terminator() -> None:
     assert builder.build() == "terminator"
 
 
-def test_builder_create_command_with_float() -> None:
+@pytest.mark.parametrize(
+    argnames=["value", "precision", "expected_float"],
+    argvalues=[
+        [1.2342, 3, 1.234],
+        [1.2342, None, 1.2342],
+        [1.2342, 0, 1.0],
+    ]
+)
+def test_builder_create_command_add_float(
+        value: float, precision: Optional[int], expected_float: float) -> None:
     """It should create a command with a floating point value."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
     assert builder.add_float(
-        prefix='Z', value=1.2342, precision=3
-    ).build() == f"Z1.234 {terminator}"
-
-
-def test_builder_create_command_with_float_no_round() -> None:
-    """It should create a command with a floating point value that is
-    not rounded."""
-    terminator = "terminator"
-    builder = CommandBuilder(terminator=terminator)
-    assert builder.add_float(
-        prefix='Z', value=1.23442, precision=None
-    ).build() == f"Z1.23442 {terminator}"
+        prefix='Z', value=value, precision=precision
+    ).build() == f"Z{expected_float} terminator"
 
 
 def test_builder_create_command_add_int() -> None:

--- a/api/tests/opentrons/drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/test_driver.py
@@ -6,7 +6,7 @@ from opentrons.drivers.types import MoveSplit
 from tests.opentrons.conftest import fuzzy_assert
 from opentrons.config.robot_configs import (
     DEFAULT_GANTRY_STEPS_PER_MM, DEFAULT_PIPETTE_CONFIGS)
-from opentrons.drivers import serial_communication
+from opentrons.drivers import serial_communication, utils
 from opentrons.drivers.smoothie_drivers import driver_3_0
 
 
@@ -502,8 +502,7 @@ def test_functional(smoothie):
 def test_parse_pipette_data():
     msg = 'TestsRule!!'
     mount = 'L'
-    good_data = mount + ': ' \
-        + driver_3_0._byte_array_to_hex_string(msg.encode())
+    good_data = f"{mount}:{utils.string_to_hex(msg)}"
     parsed = driver_3_0._parse_instrument_data(good_data).get(mount)
     assert parsed.decode() == msg
 
@@ -552,7 +551,7 @@ def test_read_pipette_v13(smoothie, monkeypatch):
 
     def _new_send_message(
             command, timeout=None, suppress_error_msg=True):
-        return 'L:' + driver_3_0._byte_array_to_hex_string(b'p300_single_v13')
+        return 'L:' + utils.string_to_hex('p300_single_v13')
 
     monkeypatch.setattr(driver, '_send_command', _new_send_message)
 

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -106,3 +106,17 @@ def test_parse_plate_temperature_response_failure(input_str: str) -> None:
     """It should fail to parse plate temperature response"""
     with pytest.raises(utils.ParseError):
         utils.parse_plate_temperature_response(input_str, 2)
+
+
+@pytest.mark.parametrize(
+    argnames=['input_str', 'min_length', "expected"],
+    argvalues=[
+        ["", 0, ""],
+        ["", 1, "0"],
+        ["abcd", 12, "616263640000"],
+        ["abcd", 5, "61626364"],
+    ]
+)
+def test_string_to_hex(input_str: str, min_length: int, expected: str) -> None:
+    """It should convert string to hex with padding to reach min_length."""
+    assert expected == utils.string_to_hex(val=input_str, min_length=min_length)

--- a/api/tests/opentrons/hardware_control/emulation/test_parser.py
+++ b/api/tests/opentrons/hardware_control/emulation/test_parser.py
@@ -1,0 +1,58 @@
+from typing import Sequence
+
+import pytest
+from opentrons.hardware_control.emulation.parser import Parser, Command
+
+
+@pytest.fixture
+def gcodes() -> Sequence[str]:
+    return ["G123", "G123.2", "G1", "M123.2"]
+
+
+@pytest.fixture
+def parser(gcodes: Sequence[str]) -> Parser:
+    return Parser(gcodes)
+
+
+@pytest.mark.parametrize(
+    argnames=["line", "expected"],
+    argvalues=[
+        ["", []],
+        ["G2", []],
+        ["G13", []],
+        ["M123", []],
+        ["G123 V2 X0", [
+            Command(
+                gcode="G123",
+                body="V2 X0",
+                params={"V": 2.0, "X": 0.0})
+        ]],
+        # Substring check. Don't confuse G1 with G123 or G123 with G123.2
+        ["G123G123.2G1", [
+            Command(gcode="G123", body="", params={}),
+            Command(gcode="G123.2", body="", params={}),
+            Command(gcode="G1", body="", params={}),
+        ]],
+        # Negative numbers, no spaces.
+        ["M123.2 B132C-1D321.2", [
+            Command(
+                gcode="M123.2",
+                body="B132C-1D321.2",
+                params={"B": 132, "C": -1, "D": 321.2}
+            )
+        ]],
+        # Just key, no value.
+        ["M123.2 LX R", [
+            Command(
+                gcode="M123.2",
+                body="LX R",
+                params={"L": None, "X": None, "R": None}
+            )
+        ]]
+    ]
+)
+def test_parse_command(parser: Parser, line: str, expected: Sequence[Command]) -> None:
+    """It should parse the commands and parameters."""
+    result = list(parser.parse(line))
+
+    assert result == expected

--- a/api/tests/opentrons/hardware_control/integration/test_controller.py
+++ b/api/tests/opentrons/hardware_control/integration/test_controller.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import pytest
+from opentrons.config.robot_configs import build_config
+from opentrons.hardware_control import Controller
+from opentrons.hardware_control.emulation.app import SMOOTHIE_PORT
+from opentrons.types import Mount
+
+
+@pytest.fixture
+async def smoothie(loop: asyncio.BaseEventLoop, emulation_app) -> Controller:
+    conf = build_config({})
+    hc = await Controller.build(config=conf)
+    await hc.connect(f"socket://127.0.0.1:{SMOOTHIE_PORT}")
+    yield hc
+
+
+def test_get_fw_version(smoothie: Controller):
+    """It should be set."""
+    assert smoothie._cached_fw_version == 'EMULATOR'
+
+
+def test_get_attached_instruments(smoothie: Controller):
+    """It should get the attached instruments."""
+    instruments = smoothie.get_attached_instruments({})
+    assert instruments[Mount.RIGHT]['id'] == "P20SV202020070101"
+    assert instruments[Mount.RIGHT]['config'].name == "p20_single_gen2"
+    assert instruments[Mount.LEFT]['id'] == "P3HMV202020041605"
+    assert instruments[Mount.LEFT]['config'].name == "p20_multi_gen2"
+
+
+def test_move(smoothie: Controller):
+    """It should move."""
+    new_position = {
+        "X": 1.0, "Z": 2.0, "Y": 3.0, "A": 4.0, "B": 5.0, "C": 6.0
+    }
+
+    smoothie.move(target_position=new_position)
+
+    updated_position = smoothie.update_position()
+
+    assert updated_position == {
+        "X": 1, "Z": 2, "Y": 3, "A": 4, "B": 5, "C": 6
+    }

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -9,15 +9,38 @@ from opentrons.hardware_control.modules import MagDeck
 
 @pytest.fixture
 async def magdeck(loop: asyncio.BaseEventLoop, emulation_app) -> MagDeck:
-    td = await MagDeck.build(
+    module = await MagDeck.build(
         port=f"socket://127.0.0.1:{MAGDECK_PORT}",
         execution_manager=AsyncMock(),
         usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="", hub=1),
         loop=loop
     )
-    yield td
+    yield module
+    module.cleanup()
 
 
-def test_device_info(magdeck):
-    assert {'model': 'magdeck_emulator', 'serial': 'fake_serial',
-            'version': '1'} == magdeck.device_info
+def test_device_info(magdeck: MagDeck):
+    assert magdeck.device_info == {
+        'model': 'magdeck_emulator', 'serial': 'fake_serial', 'version': '1'
+    }
+
+
+async def test_engage_cycle(magdeck: MagDeck):
+    """It should cycle engage and disengage"""
+    await magdeck.engage(1)
+    assert magdeck.current_height == 1
+    assert magdeck.live_data == {
+        'data': {
+            'engaged': True, 'height': 1.0
+        },
+        'status': 'engaged'
+    }
+
+    await magdeck.deactivate()
+    assert magdeck.current_height == 0
+    assert magdeck.live_data == {
+        'data': {
+            'engaged': False, 'height': 0.0
+        },
+        'status': 'disengaged'
+    }

--- a/api/tests/opentrons/hardware_control/integration/test_smoothie.py
+++ b/api/tests/opentrons/hardware_control/integration/test_smoothie.py
@@ -359,35 +359,13 @@ def test_fast_home(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
     ]
 
 
-def test_homing_flags(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
-    smoothie.move(target={
-        'X': 0,
-        'Y': 0,
-        'Z': 0,
-        'A': 0,
-        'B': 0,
-        'C': 0
-    })
+def test_update_homing_flags(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
     smoothie.update_homed_flags()
-    assert smoothie.homed_flags == {
-        'X': False,
-        'Y': False,
-        'Z': False,
-        'A': False,
-        'B': False,
-        'C': False
-    }
-
-    smoothie.home("abcZ")
-    smoothie.update_homed_flags()
-    assert smoothie.homed_flags == {
-        'X': False,
-        'Y': False,
-        'Z': True,
-        'A': True,
-        'B': True,
-        'C': True
-    }
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == [
+        'G28.6',
+        'M400'
+    ]
 
 
 def test_update_pipette_config(

--- a/api/tests/opentrons/hardware_control/integration/test_smoothie.py
+++ b/api/tests/opentrons/hardware_control/integration/test_smoothie.py
@@ -1,19 +1,441 @@
-import asyncio
-
 import pytest
-from opentrons.config.robot_configs import build_config
-from opentrons.drivers.smoothie_drivers.driver_3_0 import SmoothieDriver_3_0_0
+from mock import MagicMock
+from opentrons.drivers.types import MoveSplit
 from opentrons.hardware_control.emulation.app import SMOOTHIE_PORT
+
+from tests.opentrons.conftest import fuzzy_assert
+from opentrons.config.robot_configs import (
+    DEFAULT_GANTRY_STEPS_PER_MM, DEFAULT_PIPETTE_CONFIGS, build_config)
+from opentrons.drivers.smoothie_drivers import driver_3_0
 
 
 @pytest.fixture
-def smoothie(loop: asyncio.BaseEventLoop, emulation_app) -> SmoothieDriver_3_0_0:
-    conf = build_config({})
-    s = SmoothieDriver_3_0_0(config=conf)
-    s.connect(f"socket://127.0.0.1:{SMOOTHIE_PORT}")
-    yield s
-    s.disconnect()
+def smoothie(emulation_app) -> driver_3_0.SmoothieDriver_3_0_0:
+    """Smoothie driver connected to emulator."""
+    d = driver_3_0.SmoothieDriver_3_0_0(config=build_config({}), handle_locks=False)
+    d.connect(f"socket://127.0.0.1:{SMOOTHIE_PORT}")
+    yield d
+    d.disconnect()
 
 
-def test_get_fw_version(smoothie: SmoothieDriver_3_0_0):
-    assert smoothie.get_fw_version() == 'EMULATOR'
+@pytest.fixture
+def spy() -> MagicMock:
+    """Attach a spy to gcode sender."""
+    spy = MagicMock(wraps=driver_3_0.serial_communication.write_and_return)
+    driver_3_0.serial_communication.write_and_return = spy
+    return spy
+
+
+def test_dwell_and_activate_axes(
+        smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock
+):
+    smoothie.activate_axes('X')
+    smoothie._set_saved_current()
+    smoothie.dwell_axes('X')
+    smoothie._set_saved_current()
+    smoothie.activate_axes('XYBC')
+    smoothie._set_saved_current()
+    smoothie.dwell_axes('XC')
+    smoothie._set_saved_current()
+    smoothie.dwell_axes('BCY')
+    smoothie._set_saved_current()
+    expected = [
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_disable_motor(
+        smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock
+):
+    smoothie.disengage_axis('X')
+    smoothie.disengage_axis('XYZ')
+    smoothie.disengage_axis('ABCD')
+    expected = [
+        ['M18 X'],
+        ['M400'],
+        ['M18 [XYZ]+'],
+        ['M400'],
+        ['M18 [ABC]+'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_plunger_commands(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie.home()
+    expected = [
+        ['M907 A0.8 B0.05 C0.05 X0.3 Y0.3 Z0.8 G4 P0.005 G28.2.+[ABCZ].+'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M203.1 Y50'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90'],
+        ['M400'],
+        ['M203.1 X80'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X'],
+        ['M400'],
+        ['M203.1 A125 B40 C40 X600 Y400 Z125'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M203.1 Y80'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005 G28.2 Y'],
+        ['M400'],
+        ['M203.1 Y8'],
+        ['M400'],
+        ['G91 G0 Y-3 G90'],
+        ['M400'],
+        ['G28.2 Y'],
+        ['M400'],
+        ['G91 G0 Y-3 G90'],
+        ['M400'],
+        ['M203.1 A125 B40 C40 X600 Y400 Z125'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['M114.2'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+    spy.reset_mock()
+
+    smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
+    expected = [
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0.+'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+    spy.reset_mock()
+
+    smoothie.move({'B': 2})
+    expected = [
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+    spy.reset_mock()
+
+    smoothie.move({
+        'X': 10.987654321,
+        'Y': 2.12345678,
+        'Z': 2.5,
+        'A': 3.5,
+        'B': 4.25,
+        'C': 5.55})
+    expected = [
+        # Set active axes high
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0.+[BC].+'],
+        ['M400'],
+        # Set plunger current low
+        ['M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_move_with_split(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie._setup()
+    smoothie.home()
+    spy.reset_mock()
+
+    smoothie.configure_splits_for(
+        {
+            "B": MoveSplit(
+                split_distance=1,
+                split_current=1.75,
+                split_speed=1,
+                after_time=1800,
+                fullstep=True),
+            "C": MoveSplit(
+                split_distance=1,
+                split_current=1.75,
+                split_speed=1,
+                after_time=1800,
+                fullstep=True)
+        }
+    )
+    smoothie._steps_per_mm = {"B": 1.0, "C": 1.0}
+
+    smoothie.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'C': 3})
+    expected = [
+        ['M55 M92 C0.03125 G4 P0.01 G0 F60 M907 A0.1 B0.05 C1.75 X1.25 Y1.25 '
+         'Z0.8 G4 P0.005'],
+        ['M400'],
+        ['G0 C18.0'],
+        ['M400'],
+        ['M54 M92 C1.0 G4 P0.01'],
+        ['M400'],
+        ['G0 F24000 M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0.+'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+    spy.reset_mock()
+
+    smoothie.move({'B': 2})
+    expected = [
+        ['M53 M92 B0.03125 G4 P0.01 G0 F60 M907 A0.1 B1.75 C0.05 '
+         'X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+        ['G0 B18.0'],
+        ['M400'],
+        ['M52 M92 B1.0 G4 P0.01'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2'],
+        ['M400'],
+        ['M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_set_active_current(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie._setup()
+    smoothie.home()
+
+    spy.reset_mock()
+
+    smoothie.set_active_current(
+        {'X': 2, 'Y': 2, 'Z': 2, 'A': 2, 'B': 2, 'C': 2})
+    smoothie.set_dwelling_current(
+        {'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
+
+    smoothie.move({'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
+    smoothie.move({'B': 1, 'C': 1})
+    smoothie.set_active_current({'B': 0.42, 'C': 0.42})
+    smoothie.home('BC')
+    expected = [
+        # move all
+        ['M907 A2 B2 C2 X2 Y2 Z2 G4 P0.005 G0 A0 B0 C0 X0 Y0 Z0'],
+        ['M400'],
+        ['M907 A2 B0 C0 X2 Y2 Z2 G4 P0.005'],  # disable BC axes
+        ['M400'],
+        # move BC
+        ['M907 A0 B2 C2 X0 Y0 Z0 G4 P0.005 G0 B1.3 C1.3 G0 B1 C1'],
+        ['M400'],
+        ['M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005'],  # disable BC axes
+        ['M400'],
+        ['M907 A0 B0.42 C0.42 X0 Y0 Z0 G4 P0.005 G28.2 BC'],  # home BC
+        ['M400'],
+        ['M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005'],  # dwell all axes after home
+        ['M400'],
+        ['M114.2'],  # update the position
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_steps_per_mm(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    expected = {
+        **DEFAULT_GANTRY_STEPS_PER_MM,
+        'B': DEFAULT_PIPETTE_CONFIGS['stepsPerMM'],
+        'C': DEFAULT_PIPETTE_CONFIGS['stepsPerMM'],
+    }
+    assert smoothie.steps_per_mm == expected
+    smoothie.update_steps_per_mm({'Z': 450})
+    expected['Z'] = 450
+    assert smoothie.steps_per_mm == expected
+
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == ['M92 Z450', 'M400']
+
+
+def test_pipette_configs(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    res = smoothie.update_pipette_config(
+        'Z',
+        {'home': 175, 'debounce': 12, 'max_travel': 13, 'retract': 14}
+    )
+    expected_return = {
+        'Z': {
+            'home': 175, 'debounce': 12, 'max_travel': 13, 'retract': 14
+        }
+    }
+    assert res == expected_return
+
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == [
+        'M365.0 Z175',
+        'M400',
+        'M365.2 O12',
+        'M400',
+        'M365.1 Z13',
+        'M400',
+        'M365.3 Z14',
+        'M400'
+    ]
+
+
+def test_set_acceleration(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie.set_acceleration(
+        {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6})
+    smoothie.push_acceleration()
+    smoothie.pop_acceleration()
+    smoothie.set_acceleration(
+        {'X': 10, 'Y': 20, 'Z': 30, 'A': 40, 'B': 50, 'C': 60})
+    smoothie.pop_acceleration()
+
+    expected = [
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
+        ['M204 S10000 A40 B50 C60 X10 Y20 Z30'],
+        ['M400'],
+        ['M204 S10000 A4 B5 C6 X1 Y2 Z3'],
+        ['M400'],
+    ]
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    fuzzy_assert(result=command_log, expected=expected)
+
+
+def test_read_and_write_pipettes(
+        smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock
+):
+    test_id = 'TestsRock!!'
+    test_model = 'TestPipette'
+    smoothie.write_pipette_id('left', test_id)
+    read_id = smoothie.read_pipette_id('left')
+    assert read_id == test_id
+
+    smoothie.write_pipette_model('left', test_model)
+    read_model = smoothie.read_pipette_model('left')
+    assert read_model == test_model + '_v1'
+
+
+def test_fast_home(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie.home()
+    spy.reset_mock()
+
+    smoothie.fast_home(axis='X', safety_margin=12)
+
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == [
+        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G0 X406.0',
+        'M400',
+        'M203.1 Y50',
+        'M400',
+        'M907 A0.1 B0.05 C0.05 X1.25 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90',
+        'M400',
+        'M203.1 X80',
+        'M400',
+        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X',
+        'M400',
+        'M203.1 A125 B40 C40 X600 Y400 Z125',
+        'M400',
+        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
+        'M400',
+        'M114.2',
+        'M400'
+    ]
+
+
+def test_homing_flags(smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock):
+    smoothie.move(target={
+        'X': 0,
+        'Y': 0,
+        'Z': 0,
+        'A': 0,
+        'B': 0,
+        'C': 0
+    })
+    smoothie.update_homed_flags()
+    assert smoothie.homed_flags == {
+        'X': False,
+        'Y': False,
+        'Z': False,
+        'A': False,
+        'B': False,
+        'C': False
+    }
+
+    smoothie.home("abcZ")
+    smoothie.update_homed_flags()
+    assert smoothie.homed_flags == {
+        'X': False,
+        'Y': False,
+        'Z': True,
+        'A': True,
+        'B': True,
+        'C': True
+    }
+
+
+def test_update_pipette_config(
+        smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock
+):
+    smoothie.update_pipette_config("X", {
+        'retract': 2,
+        'debounce': 3,
+        'max_travel': 4,
+        'home': 5
+    })
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == [
+        "M365.3 X2",
+        "M400",
+        "M365.2 O3",
+        "M400",
+        "M365.1 X4",
+        "M400",
+        "M365.0 X5",
+        "M400",
+    ]
+
+
+def test_do_relative_splits_during_home_for(
+        smoothie: driver_3_0.SmoothieDriver_3_0_0, spy: MagicMock
+):
+    """Test command structure when a split configuration is present."""
+    smoothie.configure_splits_for(
+        {
+            "B": MoveSplit(
+                split_distance=1,
+                split_current=1.75,
+                split_speed=1,
+                after_time=1800,
+                fullstep=True)
+        }
+    )
+    smoothie._steps_per_mm = {"B": 1.0, "C": 1.0}
+
+    smoothie._do_relative_splits_during_home_for("BC")
+
+    command_log = [x[0][0].strip() for x in spy.call_args_list]
+    assert command_log == [
+        'M53 M55 M92 B0.03125 C0.03125 G4 P0.01 M907 B1.75 G4 P0.005 G0 F60 G91',
+        'M400',
+        'G0 B-1',
+        'M400',
+        'G90 M52 M54 M92 B1.0 C1.0 G4 P0.01 G0 F24000',
+        'M400',
+    ]

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -27,6 +27,7 @@ def test_device_info(tempdeck) -> None:
             'version': '1'} == tempdeck.device_info
 
 
+@pytest.mark.xfail(reason="This test an its sleeps will be deprecated soon.")
 async def test_cycle(tempdeck) -> None:
     assert tempdeck.live_data == {
         'status': "idle",

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -1,24 +1,59 @@
 import asyncio
 
 import pytest
-from mock import AsyncMock
 from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.app import TEMPDECK_PORT
 from opentrons.hardware_control.modules import TempDeck
 
 
 @pytest.fixture
 async def tempdeck(loop: asyncio.BaseEventLoop, emulation_app) -> TempDeck:
-    td = await TempDeck.build(
+    execution_manager = ExecutionManager(loop)
+    module = await TempDeck.build(
         port=f"socket://127.0.0.1:{TEMPDECK_PORT}",
-        execution_manager=AsyncMock(),
+        execution_manager=execution_manager,
         usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="",
                          hub=1),
         loop=loop
     )
-    yield td
+    yield module
+    await execution_manager.cancel()
+    module.cleanup()
 
 
-def test_device_info(tempdeck):
+def test_device_info(tempdeck) -> None:
     assert {'model': 'temp_emulator', 'serial': 'fake_serial',
             'version': '1'} == tempdeck.device_info
+
+
+async def test_cycle(tempdeck) -> None:
+    assert tempdeck.live_data == {
+        'status': "idle",
+        'data': {
+            'currentTemp': 25,
+            'targetTemp': None
+        }
+    }
+
+    await tempdeck.set_temperature(10)
+    # Wait for poll
+    await asyncio.sleep(1)
+    assert tempdeck.live_data == {
+            'status': "holding at target",
+            'data': {
+                'currentTemp': 10,
+                'targetTemp': 10
+            }
+        }
+
+    await tempdeck.deactivate()
+    # Wait for poll
+    await asyncio.sleep(1)
+    assert tempdeck.live_data == {
+        'status': "holding at target",
+        'data': {
+            'currentTemp': 23,
+            'targetTemp': 23
+        }
+    }

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -5,6 +5,7 @@ from mock import AsyncMock, patch
 from opentrons.config import IS_WIN
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler.driver import TCPoller
+from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.emulation.app import THERMOCYCLER_PORT
 from opentrons.hardware_control.modules import Thermocycler
 
@@ -23,20 +24,21 @@ async def thermocycler(
         patch_fd_path,
         emulation_app) -> Thermocycler:
     """Thermocycler fixture."""
-    td = await Thermocycler.build(
+    execution_manager = ExecutionManager(loop)
+    module = await Thermocycler.build(
         port=f"socket://127.0.0.1:{THERMOCYCLER_PORT}",
         execution_manager=AsyncMock(),
         usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="",
                          hub=1),
         loop=loop
     )
-    yield td
-    # Thermocycler class does not have a public interface to disconnect
-    td._driver.disconnect()
+    yield module
+    module.cleanup()
+    await execution_manager.cancel()
 
 
 @pytest.mark.skipif(IS_WIN, reason="Cannot be run on Windows")
 def test_device_info(thermocycler: Thermocycler):
-    """"""
+    """It should have device info."""
     assert {'model': 'thermocycler_emulator', 'serial': 'fake_serial',
             'version': '1'} == thermocycler.device_info


### PR DESCRIPTION
# Overview

As I work on the asyncio driver refactor I've found the emulators to be extremely useful. Especially for the smoothie driver which is so complex.

A big motivator for this PR is to have some incremental PRs from the massive incoming asyncio port PRs.

This PR expands the emulator functionality. 
- The parser can handle long GCODE command strings.
- Most set commands are handles in the modules and smoothie.
- Most importantly the integration tests are expanded.

# Changelog

- Created `Parser` that splits a GCODE line into `Command` objects. 
- Smoothie and module emulators filled out to handle more commands.
- Add `hardware_control.emulation.test_controller` to use emulation for basic testing of HC to smoothie interaction.
- Add `hardware_control.emulation.test_smoothie`. This is a porting of 'drivers.test_driver' to use the smoothie emulator.

# Review requests

I'll try to add comments and questions in PR.

# Risk assessment

No impact except for making tests taking longer to complete. Will be remedied when asyncio drivers are done.
