### PR TITLE
chore(docs): add docs for api v2.10

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -206,4 +206,4 @@ Version 2.9
 
 Version 2.10
 ++++++++++++
-- In Python protocols requesting API version 2.10, moving to the same well with two pipettes no longer results in strange diagonal movements.
+- In Python protocols requesting API version 2.10, moving to the same well twice in a row with different pipettes no longer results in strange diagonal movements.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -112,6 +112,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+-----------------------------+
 |     2.9     |          4.1.0              |
 +-------------+-----------------------------+
+|     2.10    |          4.3.0              |
++-------------+-----------------------------+
 
 
 Changes in API Versions
@@ -201,3 +203,7 @@ Version 2.8
 Version 2.9
 +++++++++++
 - You can now access certain geometry data regarding a labware's well via a Well Object. See :ref:`new-labware-well-properties` for more information.
+
+Version 2.10
+++++++++++++
+- In Python protocols requesting API version 2.10, moving to the same well with two pipettes no longer results in strange diagonal movements.


### PR DESCRIPTION
There was a motion-affecting bugfix that needed (and got) an API version
bump but it didn't have a corresponding entry in the versioning file.
