### PR TITLE
feat(components, protocol-library): pass thru semantic 'disabled' attr to InputField elem

### DIFF
--- a/components/src/forms/InputField.tsx
+++ b/components/src/forms/InputField.tsx
@@ -93,6 +93,7 @@ function Input(props: InputFieldProps): JSX.Element {
     <div className={styles.input_field_container}>
       <div className={styles.input_field}>
         <input
+          disabled={props.disabled}
           id={props.id}
           type={props.type ?? INPUT_TYPE_TEXT}
           value={value}

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.js
@@ -136,6 +136,7 @@ export const FlowRateInput = (props: FlowRateInputProps): React.Node => {
 
   const FlowRateInputField = (
     <InputField
+      disabled={disabled}
       caption={rangeDescription}
       error={errorMessage}
       isIndeterminate={isIndeterminate && modalFlowRate === null}

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.js
@@ -91,6 +91,7 @@ function TipPositionInput(props: Props) {
         isDelayPositionField={isDelayPositionField}
       >
         <InputField
+          disabled={disabled}
           className={props.className || stepFormStyles.small_field}
           readOnly
           onClick={handleOpen}


### PR DESCRIPTION
# Overview

`InputField` wasn't passing `disabled` attr down to the actual `<input>` elem, so in E2E tests we couldn't semantically determine that input fields are disabled/enabled.

Closes #7758 

# Changelog


# Review requests

- [ ] This is a change to `InputField`, which is used in several JS projects. Sanity check, make sure this doesn't mess up anything it's not supposed to affect.
- [ ] Should meet conditions of #7758 -- in Transfer multi-select mode, inspect the `input` elems and make sure they have the `disabled` attr when they are disabled. (reminder: to make fields disabled, see https://docs.google.com/spreadsheets/d/1dbEeeFj3Bdi9IsRQUl_N-xUr3XnERoJkL2BhEuWO9gw/edit#gid=0 ) 

# Risk assessment

Medium since it affects a frequently-used component