### PR TITLE
feat(labware-library): fix mixpanel id bug

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -85,6 +85,9 @@ jobs:
           yarn config set cache-folder ./.yarn-cache
           make setup-js
       - name: 'test-e2e'
+        env:
+          OT_LL_MIXPANEL_ID: ${{ secrets.OT_LL_MIXPANEL_ID }}
+          OT_LL_MIXPANEL_DEV_ID: ${{ secrets.OT_LL_MIXPANEL_DEV_ID }}
         run: make -C labware-library test-e2e
   build-ll:
     name: 'build labware library artifact'
@@ -110,6 +113,9 @@ jobs:
           yarn config set cache-folder ./.yarn-cache
           make setup-js
       - name: 'build LL'
+        env:
+          OT_LL_MIXPANEL_ID: ${{ secrets.OT_LL_MIXPANEL_ID }}
+          OT_LL_MIXPANEL_DEV_ID: ${{ secrets.OT_LL_MIXPANEL_DEV_ID }}
         run: |
           make -C labware-library
       - name: 'upload github artifact'

--- a/labware-library/README.md
+++ b/labware-library/README.md
@@ -77,10 +77,11 @@ This project (along with our other front-end projects) uses [webpack][] to gener
 
 Certain environment variables, when set, will affect the artifact output.
 
-| variable            | value                                | description                                               |
-| ------------------- | ------------------------------------ | --------------------------------------------------------- |
-| NODE_ENV            | production, development, test        | Optimizes output for a specific environment               |
-| OT_LL_FULLSTORY_ORG | some string ID                       | Fullstory organization ID.                                |
-| OT_LL_MIXPANEL_ID   | some string ID                       | Mixpanel token.                                           |
-| OT_LL_VERSION       | semver string eg "1.2.3"             | reported to analytics. Read from package.json by default. |
-| OT_LL_BUILD_DATE    | result of `new Date().toUTCString()` | reported to analytics. Uses current date-time by default. |
+| variable              | value                                | description                                               |
+| --------------------- | ------------------------------------ | --------------------------------------------------------- |
+| NODE_ENV              | production, development, test        | Optimizes output for a specific environment               |
+| OT_LL_FULLSTORY_ORG   | some string ID                       | Fullstory organization ID.                                |
+| OT_LL_MIXPANEL_ID     | some string ID                       | Mixpanel token for prod environment.                      |
+| OT_LL_MIXPANEL_DEV_ID | some string ID                       | Mixpanel token for dev environment.                       |
+| OT_LL_VERSION         | semver string eg "1.2.3"             | reported to analytics. Read from package.json by default. |
+| OT_LL_BUILD_DATE      | result of `new Date().toUTCString()` | reported to analytics. Uses current date-time by default. |

--- a/labware-library/src/analytics/mixpanel.ts
+++ b/labware-library/src/analytics/mixpanel.ts
@@ -4,7 +4,7 @@ import mixpanel from 'mixpanel-browser'
 
 // pulled in from environment at build time
 export const getIsProduction = (): boolean =>
-  global.location.host === 'labware.opentrons.com'
+  window.location.host === 'labware.opentrons.com'
 
 const MIXPANEL_ID = getIsProduction()
   ? process.env.OT_LL_MIXPANEL_ID

--- a/labware-library/src/analytics/mixpanel.ts
+++ b/labware-library/src/analytics/mixpanel.ts
@@ -3,7 +3,12 @@
 import mixpanel from 'mixpanel-browser'
 
 // pulled in from environment at build time
-const MIXPANEL_ID = process.env.OT_LL_MIXPANEL_ID
+export const getIsProduction = (): boolean =>
+  global.location.host === 'labware.opentrons.com'
+
+const MIXPANEL_ID = getIsProduction()
+  ? process.env.OT_LL_MIXPANEL_ID
+  : process.env.OT_LL_MIXPANEL_DEV_ID
 
 const MIXPANEL_OPTS = {
   // opt out by default
@@ -31,6 +36,7 @@ export function initializeMixpanel(): void {
     mixpanel.init(MIXPANEL_ID, MIXPANEL_OPTS)
   } else {
     console.warn('MIXPANEL_ID not found; this is a bug if build is production')
+    mixpanel.init('FAKE_MIXPANEL_DEV_ID', MIXPANEL_OPTS)
   }
 }
 

--- a/protocol-designer/README.md
+++ b/protocol-designer/README.md
@@ -59,7 +59,11 @@ Used for FullStory. Should be provided in the Travis build.
 
 ### `OT_PD_MIXPANEL_ID`
 
-Used for Mixpanel. Should be provided in the Travis build.
+Used for Mixpanel in prod. Should be provided in the CI build.
+
+### `OT_PD_MIXPANEL_DEV_ID`
+
+Used for Mixpanel in dev (eg via a sandbox URL). Should be provided in the CI build.
 
 ### `OT_PD_SHOW_GATE`
 


### PR DESCRIPTION
# Overview

Closes #7536 and moves LC toward the Mixpanel patten in PD/App

The difference is that PD and App have a general "has user opted in?" boolean somewhere in Redux state, while LL/LC uses a cookie.

One move here is that the sandbox builds for LC should now report Mixpanel events to the DEV Mixpanel project (yikes, before it was prod!!).

# Changelog


# Review requests

- On localhost with `make -C labware-library dev`, should not be able to reproduce #7536 (make sure to delete your cookie `ot_ll_analytics`, refresh, and choose "yes" for the opt-in)
- On sandbox build of this branch, should not be able to reproduce #7536 
- On sandbox build of this branch
- The only way to check is to mess with a local webserver and spoof a url 😞 or wait until release -- LL/LC should, on the production URL, use the production mixpanel ID. (Similar to PD, it should check if it's sandbox or not to detemine which Mixpanel ID to use)
- CI passes (I added the 2 new LL secrets in to GH Actions before this build began)

# Risk assessment

Medium. Might mess up LL/LC's analytics, and might mess it up in a way we don't see until it's in prod.