### PR TITLE
fix(api): add pause manager to separate pause and delay

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -36,7 +36,8 @@ from opentrons.hardware_control import (API, ThreadManager,
                                         SynchronousAdapter,
                                         ExecutionCancelledError,
                                         ThreadedAsyncLock)
-from opentrons.hardware_control.types import (HardwareEventType, HardwareEvent)
+from opentrons.hardware_control.types import (HardwareEventType, HardwareEvent,
+                                              PauseType)
 from .models import Container, Instrument, Module
 from .dev_types import State, StateInfo, Message, LastCommand, Error, CommandShortId
 
@@ -468,14 +469,14 @@ class Session(RobotBusy):
               reason: str = None,
               user_message: str = None,
               duration: float = None) -> None:
-        self._hardware.pause()
+        self._hardware.pause(PauseType.PAUSE)
         self.set_state(
             'paused', reason=reason,
             user_message=user_message, duration=duration)
 
     def resume(self) -> None:
         if not self.blocked:
-            self._hardware.resume()
+            self._hardware.resume(PauseType.PAUSE)
             self.set_state('running')
 
     def _start_hardware_event_watcher(self) -> None:

--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -37,7 +37,7 @@ from opentrons.hardware_control import (API, ThreadManager,
                                         ExecutionCancelledError,
                                         ThreadedAsyncLock)
 from opentrons.hardware_control.types import (DoorState, HardwareEventType,
-                                              HardwareEvent)
+                                              HardwareEvent, PauseType)
 from .models import Container, Instrument, Module
 from .dev_types import State, StateInfo, Message, LastCommand, Error, CommandShortId
 
@@ -469,6 +469,7 @@ class Session(RobotBusy):
               reason: str = None,
               user_message: str = None,
               duration: float = None) -> None:
+        self._hardware.pause_manager_pause(PauseType.PAUSE)
         self._hardware.pause()
         self.set_state(
             'paused', reason=reason,
@@ -476,6 +477,7 @@ class Session(RobotBusy):
 
     def resume(self) -> None:
         if not self.blocked:
+            self._hardware.pause_manager_resume(PauseType.PAUSE)
             self._hardware.resume()
             self.set_state('running')
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -11,7 +11,7 @@ functions are available elsewhere.
 """
 
 from .adapters import SynchronousAdapter
-from .api import API
+from .api import API, PauseManager
 from .controller import Controller
 from .simulator import Simulator
 from .pipette import Pipette
@@ -24,7 +24,7 @@ from .execution_manager import ExecutionManager
 from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
 
 __all__ = [
-    'API', 'Controller', 'Simulator', 'Pipette',
+    'API', 'Controller', 'Simulator', 'Pipette', 'PauseManager',
     'SynchronousAdapter', 'HardwareAPILike', 'CriticalPoint',
     'NoTipAttachedError', 'TipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
     'ThreadManager', 'ExecutionManager', 'ExecutionState',

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -374,12 +374,14 @@ class API(HardwareAPILike):
         """
         await self._wait_for_is_running()
         self.pause(PauseType.DELAY)
-        if not self.is_simulator:
-            async def sleep_for_seconds(seconds: float):
-                await asyncio.sleep(seconds)
-            delay_task = self._loop.create_task(sleep_for_seconds(duration_s))
-            await self._execution_manager.register_cancellable_task(delay_task)
-        self.resume(PauseType.DELAY)
+        try:
+            if not self.is_simulator:
+                async def sleep_for_seconds(seconds: float):
+                    await asyncio.sleep(seconds)
+                delay_task = self._loop.create_task(sleep_for_seconds(duration_s))
+                await self._execution_manager.register_cancellable_task(delay_task)
+        finally:
+            self.resume(PauseType.DELAY)
 
     def reset_instrument(self, mount: top_types.Mount = None):
         """

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -560,7 +560,7 @@ class API(HardwareAPILike):
         """
         self._pause_manager.resume(pause_type)
 
-        if self._pause_manager.queue:
+        if self._pause_manager.should_pause:
             return
 
         # Resume must be called immediately to awaken thread running hardware

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -47,7 +47,7 @@ PipetteHandlingData = Tuple[Pipette, top_types.Mount]
 
 class PauseManager:
     """ This class determines whether or not the hardware controller should
-    pause or resume by evaluating the pause and resume targets. The use of two
+    pause or resume by evaluating the pause and resume types. The use of two
     pause types are used to separate the delay resume (triggered when the delay
     timer runs out) and the pause resume (trigged by user via the app).
     """
@@ -68,9 +68,6 @@ class PauseManager:
     def set_door(self, door_state):
         mod_log.info(f'setting door: {door_state}')
         self._is_door_blocking = self._evaluate_door_state(door_state)
-        if self._is_door_blocking:
-            # add a pause to the queue as it requies manual resume
-            self.pause(PauseType.PAUSE)
 
     def resume(self, pause_type: PauseType):
         # door should be closed before a resume from the app can be received

--- a/api/src/opentrons/hardware_control/pause_manager.py
+++ b/api/src/opentrons/hardware_control/pause_manager.py
@@ -17,6 +17,10 @@ class PauseManager:
         self._blocked_by_door = self._evaluate_door_state(door_state)
 
     @property
+    def should_pause(self) -> bool:
+        return bool(self.queue)
+
+    @property
     def blocked_by_door(self) -> bool:
         return self._blocked_by_door
 

--- a/api/src/opentrons/hardware_control/pause_manager.py
+++ b/api/src/opentrons/hardware_control/pause_manager.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from opentrons.config import feature_flags as ff
+
+from .types import DoorState, PauseType, PauseResumeError
+
+
+class PauseManager:
+    """ This class determines whether or not the hardware controller should
+    pause or resume by evaluating the pause and resume types. The use of two
+    pause types are used to separate the delay resume (triggered when the delay
+    timer runs out) and the pause resume (trigged by user via the app).
+    """
+
+    def __init__(self, door_state: DoorState) -> None:
+        self.queue: List[PauseType] = []
+        self._blocked_by_door = self._evaluate_door_state(door_state)
+
+    @property
+    def blocked_by_door(self) -> bool:
+        return self._blocked_by_door
+
+    def _evaluate_door_state(self, door_state: DoorState) -> bool:
+        if ff.enable_door_safety_switch():
+            return door_state is DoorState.OPEN
+        return False
+
+    def set_door(self, door_state: DoorState):
+        self._blocked_by_door = self._evaluate_door_state(door_state)
+
+    def resume(self, pause_type: PauseType):
+        # door should be closed before a resume from the app can be received
+        if self._blocked_by_door and pause_type is PauseType.PAUSE:
+            raise PauseResumeError
+        if pause_type in self.queue:
+            self.queue.remove(pause_type)
+
+    def pause(self, pause_type: PauseType):
+        if pause_type not in self.queue:
+            self.queue.append(pause_type)
+
+    def reset(self):
+        self.queue = []

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -235,6 +235,15 @@ class HardwareAction(enum.Enum):
         return self.name
 
 
+class PauseType(enum.Enum):
+    PAUSE = 0
+    DELAY = 1
+
+
+class PauseResumeError(RuntimeError):
+    pass
+
+
 class ExecutionCancelledError(RuntimeError):
     pass
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -89,6 +89,7 @@ class DoorStateNotification:
     event: 'DoorStateNotificationType' = \
         HardwareEventType.DOOR_SWITCH_CHANGE
     new_state: DoorState = DoorState.CLOSED
+    blocking: bool = False
 
 
 # new event types get new dataclasses

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Set, TYPE_CHECKING
 from opentrons import types, API
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.config import feature_flags as fflags
-from opentrons.hardware_control.types import DoorState
+from opentrons.hardware_control.types import DoorState, PauseType
 from opentrons.hardware_control import SynchronousAdapter
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry.deck import Deck
@@ -258,11 +258,11 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def pause(self, msg: Optional[str]) -> None:
         """Pause the protocol."""
-        self._hw_manager.hardware.pause()
+        self._hw_manager.hardware.pause(PauseType.PAUSE)
 
     def resume(self) -> None:
         """Result the protocol."""
-        self._hw_manager.hardware.resume()
+        self._hw_manager.hardware.resume(PauseType.PAUSE)
 
     def comment(self, msg: str) -> None:
         """Add comment to run log."""

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -139,6 +139,15 @@ async def old_aspiration(monkeypatch):
 
 
 @pytest.fixture
+async def enable_door_safety_switch():
+    await config.advanced_settings.set_adv_setting(
+        'enableDoorSafetySwitch', True)
+    yield
+    await config.advanced_settings.set_adv_setting(
+        'enableDoorSafetySwitch', False)
+
+
+@pytest.fixture
 async def use_new_calibration(monkeypatch):
     await config.advanced_settings.set_adv_setting(
         'enableTipLengthCalibration', True)

--- a/api/tests/opentrons/hardware_control/test_pause_manager.py
+++ b/api/tests/opentrons/hardware_control/test_pause_manager.py
@@ -36,14 +36,15 @@ def test_pause_and_delay_separation():
 
 def test_door_pause_protocol(enable_door_safety_switch):
     """
-    Test that when the door safety switch is enabled, door state OPEN
-    adds a pause to the queue, and does not resume until the door is closed
+    Test that when the door safety switch is enabled, pause cannot
+    be resumed until the door is closed
     """
     pause_mgr = PauseManager(door_state=DoorState.CLOSED)
     assert pause_mgr.queue == []
     assert not pause_mgr.should_pause
 
     pause_mgr.set_door(door_state=DoorState.OPEN)
+    pause_mgr.pause(PauseType.PAUSE)
     assert pause_mgr.queue == [PauseType.PAUSE]
     assert pause_mgr.should_pause
 

--- a/api/tests/opentrons/hardware_control/test_pause_manager.py
+++ b/api/tests/opentrons/hardware_control/test_pause_manager.py
@@ -1,0 +1,61 @@
+import pytest
+from opentrons.hardware_control import PauseManager
+from opentrons.hardware_control.types import (DoorState, PauseType,
+                                              PauseResumeError)
+
+
+def test_pause_and_delay_separation():
+    """
+    Test that pause and delay rely on two separate pause types, and
+    do not resume each other
+    """
+    pause_mgr = PauseManager(door_state=DoorState.CLOSED)
+    assert pause_mgr.queue == []
+    assert not pause_mgr.should_pause
+
+    pause_mgr.pause(PauseType.PAUSE)
+    assert pause_mgr.queue == [PauseType.PAUSE]
+    assert pause_mgr.should_pause
+
+    pause_mgr.pause(PauseType.DELAY)
+    assert pause_mgr.queue == [PauseType.PAUSE, PauseType.DELAY]
+    assert pause_mgr.should_pause
+
+    pause_mgr.resume(PauseType.PAUSE)
+    assert pause_mgr.queue == [PauseType.DELAY]
+    assert pause_mgr.should_pause
+
+    pause_mgr.resume(PauseType.PAUSE)
+    assert pause_mgr.queue == [PauseType.DELAY]
+    assert pause_mgr.should_pause
+
+    pause_mgr.resume(PauseType.DELAY)
+    assert pause_mgr.queue == []
+    assert not pause_mgr.should_pause
+
+
+def test_door_pause_protocol(enable_door_safety_switch):
+    """
+    Test that when the door safety switch is enabled, door state OPEN
+    adds a pause to the queue, and does not resume until the door is closed
+    """
+    pause_mgr = PauseManager(door_state=DoorState.CLOSED)
+    assert pause_mgr.queue == []
+    assert not pause_mgr.should_pause
+
+    pause_mgr.set_door(door_state=DoorState.OPEN)
+    assert pause_mgr.queue == [PauseType.PAUSE]
+    assert pause_mgr.should_pause
+
+    with pytest.raises(PauseResumeError):
+        pause_mgr.resume(PauseType.PAUSE)
+        assert pause_mgr.queue == [PauseType.PAUSE]
+        assert pause_mgr.should_pause
+
+    pause_mgr.set_door(door_state=DoorState.CLOSED)
+    assert pause_mgr.queue == [PauseType.PAUSE]
+    assert pause_mgr.should_pause
+
+    pause_mgr.resume(PauseType.PAUSE)
+    assert pause_mgr.queue == []
+    assert not pause_mgr.should_pause

--- a/api/tests/opentrons/hardware_control/test_pause_manager.py
+++ b/api/tests/opentrons/hardware_control/test_pause_manager.py
@@ -11,27 +11,21 @@ def test_pause_and_delay_separation():
     """
     pause_mgr = PauseManager(door_state=DoorState.CLOSED)
     assert pause_mgr.queue == []
-    assert not pause_mgr.should_pause
 
     pause_mgr.pause(PauseType.PAUSE)
     assert pause_mgr.queue == [PauseType.PAUSE]
-    assert pause_mgr.should_pause
 
     pause_mgr.pause(PauseType.DELAY)
     assert pause_mgr.queue == [PauseType.PAUSE, PauseType.DELAY]
-    assert pause_mgr.should_pause
 
     pause_mgr.resume(PauseType.PAUSE)
     assert pause_mgr.queue == [PauseType.DELAY]
-    assert pause_mgr.should_pause
 
     pause_mgr.resume(PauseType.PAUSE)
     assert pause_mgr.queue == [PauseType.DELAY]
-    assert pause_mgr.should_pause
 
     pause_mgr.resume(PauseType.DELAY)
     assert pause_mgr.queue == []
-    assert not pause_mgr.should_pause
 
 
 def test_door_pause_protocol(enable_door_safety_switch):
@@ -41,22 +35,17 @@ def test_door_pause_protocol(enable_door_safety_switch):
     """
     pause_mgr = PauseManager(door_state=DoorState.CLOSED)
     assert pause_mgr.queue == []
-    assert not pause_mgr.should_pause
 
     pause_mgr.set_door(door_state=DoorState.OPEN)
     pause_mgr.pause(PauseType.PAUSE)
     assert pause_mgr.queue == [PauseType.PAUSE]
-    assert pause_mgr.should_pause
 
     with pytest.raises(PauseResumeError):
         pause_mgr.resume(PauseType.PAUSE)
         assert pause_mgr.queue == [PauseType.PAUSE]
-        assert pause_mgr.should_pause
 
     pause_mgr.set_door(door_state=DoorState.CLOSED)
     assert pause_mgr.queue == [PauseType.PAUSE]
-    assert pause_mgr.should_pause
 
     pause_mgr.resume(PauseType.PAUSE)
     assert pause_mgr.queue == []
-    assert not pause_mgr.should_pause


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Introducing pause manager - this class helps keep track of the pauses and delays during a protocol. We now save a list of pause reasons (pause from the protocol / app / door opening or delay) and only allow the protocol to actually resume when the entire list is resolved. By treating pauses and delay differently, we can make sure that a resume from a delay would not accidentally resume a pause that is triggered by the app or through opening the safety door. Closes #6898, closes #7272

Previously, session monitors the door state and blocks the protocol when the door is closed. Now this is also being handled by pause manager. When hardware controller detects a door switch state change, it tells the pause manager to figure out whether or not the protocol should be blocked. This info is then sent to session, so it can notify the app that the protocol is paused. 


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Review requests
Try the following:
1. Pause a protocol from the app during a delay
  protocol should stay paused when the delay timer runs out
2. Open the door during a delay or pause
  protocol should stay paused until the door is closed and after you manually resume from the app
 

<!--
Describe any requests for your reviewers here.
-->

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
