### PR TITLE
fix(api): do not cache tip lengths because it breaks calibration

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1420,7 +1420,6 @@ class InstrumentContext(CommandPublisher):
             log_parent=self._log
         )
 
-    @lru_cache(maxsize=12)
     def _tip_length_for(self, tiprack: Labware) -> float:
         """ Get the tip length, including overlap, for a tip from this rack """
         return tip_length_for(self.hw_pipette, tiprack)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
 from typing import (
     List, Optional, Sequence, TYPE_CHECKING, Union)
 from opentrons.broker import Broker

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -938,7 +938,6 @@ def test_order_of_module_load(loop):
 def test_tip_length_for(ctx, monkeypatch):
     instr = ctx.load_instrument('p20_single_gen2', 'left')
     tiprack = ctx.load_labware('geb_96_tiprack_10ul', '1')
-    instr._tip_length_for.cache_clear()
     assert instr._tip_length_for(tiprack)\
         == (tiprack._implementation.get_definition()['parameters']['tipLength']
             - instr.hw_pipette['tip_overlap']
@@ -959,9 +958,7 @@ def test_tip_length_for_caldata(ctx, monkeypatch, use_new_calibration):
             status=cs_types.CalibrationStatus(markedBad=False),
             uri='opentrons/geb_96_tiprack_10ul/1')
     monkeypatch.setattr(get, 'load_tip_length_calibration', mock_tip_length)
-    instr._tip_length_for.cache_clear()
     assert instr._tip_length_for(tiprack) == 2
-    instr._tip_length_for.cache_clear()
     mock_tip_length.side_effect = cs_types.TipLengthCalNotFound
     assert instr._tip_length_for(tiprack) == (
         tiprack._implementation.get_definition()['parameters']['tipLength']


### PR DESCRIPTION
Because of this cache, tip lengths wouldn't properly be applied during labware calibration but would be during run.