### PR TITLE
fix(api): opentrons_simulate ignores the apiLevel specified in the protocol, uses the highest apiLevel it supports instead

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -202,7 +202,10 @@ def _build_protocol_context(
         extra_labware=extra_labware,
         hardware=hardware_simulator
     )
-    context = protocol_api.contexts.ProtocolContext(implementation=ctx_impl)
+    context = protocol_api.contexts.ProtocolContext(
+        implementation=ctx_impl,
+        api_version=version
+    )
     context.home()
     return context
 

--- a/api/tests/opentrons/data/test_simulate.py
+++ b/api/tests/opentrons/data/test_simulate.py
@@ -1,0 +1,21 @@
+from opentrons import types
+
+metadata = {
+    'protocolName': 'Test Simulate',
+    'author': 'Opentrons <engineering@opentrons.com>',
+    'description': 'Testing "simulate"',
+    'source': 'Opentrons Repository',
+    'apiLevel': '2.0',
+}
+
+
+def run(ctx):
+    ctx.comment(str(ctx.api_version))
+    ctx.home()
+    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    right = ctx.load_instrument('p300_single', types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    right.pick_up_tip()
+    right.aspirate(10, lw.wells()[0].bottom())
+    right.dispense(10, lw.wells()[1].bottom())
+    right.drop_tip(tr.wells()[-1].top())

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -12,15 +12,16 @@ from opentrons.protocols.execution.errors import ExceptionInProtocolError
 HERE = Path(__file__).parent
 
 
-@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+@pytest.mark.parametrize('protocol_file', ['test_simulate.py'])
 def test_simulate_function_apiv2(protocol,
                                  protocol_file,
                                  monkeypatch):
     monkeypatch.setenv('OT_API_FF_allowBundleCreation', '1')
     runlog, bundle = simulate.simulate(
-        protocol.filelike, 'testosaur_v2.py')
+        protocol.filelike, 'test_simulate.py')
     assert isinstance(bundle, protocols.types.BundleContents)
     assert [item['payload']['text'] for item in runlog] == [
+        '2.0',
         'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
         'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa: E501,
         'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa: E501,


### PR DESCRIPTION
# Overview
Change as per bug reported as follows:
_When you simulate a protocol on the command line with opentrons_simulate, it appears to ignore the apiLevel that you set in the protocol's metadata block. Instead, the command uses the highest apiLevel that it supports.
This potentially changes the behavior of the simulated protocol._

# Changelog
- include the version when instantiating a `ProtocolContext`
- revise unit test to test api-version. To prevent changes to existing tests, I've created a protocol dedicated to simulate.

# Review requests
Any test data cares? Was not sure about the testosaur theme nonetheless violated it.

# Risk assessment
Any simulations depending on the bug?