### PR TITLE
ci: fix app builds on Linux due to typo in makefile

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -110,7 +110,7 @@ dist-macos-latest: dist-osx
 dist-ubuntu-latest: dist-linux
 
 .PHONY: dist-ubuntu-18.04
-dist-ubuntu-latest: dist-linux
+dist-ubuntu-18.04: dist-linux
 
 .PHONY: dist-windows-latest
 dist-windows-latest: dist-win


### PR DESCRIPTION
## Overview

We missed a `s/ubuntu-latest/ubuntu-18.04/` in #7475, breaking Linux app artifact uploads in CI. This PR fixes that target name to get app builds on Linux working again

## Changelog

- ci: fix app builds on Linux due to typo in makefile

## Review requests

- [ ] You see Linux builds for this branch in the #builds channel

## Risk assessment

N/A
