### PR TITLE
chore(build): Build docs on tags and release

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -14,7 +14,6 @@ on:
       - '.github/actions/webstack/deploy-to-sandbox/**'
       - '.github/workflows/utils.js'
     tags:
-      - 'v*'
       - 'docs@*'
   workflow_dispatch:
 

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -13,11 +13,9 @@ on:
       - '.github/actions/python/**'
       - '.github/actions/webstack/deploy-to-sandbox/**'
       - '.github/workflows/utils.js'
-    branches-ignore: # ignore any release-related thing (handled elsewhere)
-      - 'release'
-      - 'chore_release-**'
-    tags-ignore:
-      - '*'
+    tags:
+      - 'v*'
+      - 'docs@*'
   workflow_dispatch:
 
 


### PR DESCRIPTION
For some reason the docs workflow just wasn't running on tag push or on
pushes to release branches. I don't know why, it says it was handled
elsewhere, but it's not. So let's fix that.
