### PR TITLE
feat(labware-creator): add "Tip Racks" to labwareType dropdown

### DIFF
--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -44,11 +44,13 @@ export type LabwareType =
   | 'reservoir'
   | 'tubeRack'
   | 'aluminumBlock'
+  | 'tiprack'
 export const labwareTypeOptions: Options = [
   { name: 'Well Plate', value: 'wellPlate' },
   { name: 'Reservoir', value: 'reservoir' },
   { name: 'Tubes + Opentrons Tube Rack', value: 'tubeRack' },
   { name: 'Tubes / Plates + Opentrons Aluminum Block', value: 'aluminumBlock' },
+  { name: 'Tip Rack', value: 'tiprack' },
 ]
 
 export type WellShape = 'circular' | 'rectangular'

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -44,13 +44,13 @@ export type LabwareType =
   | 'reservoir'
   | 'tubeRack'
   | 'aluminumBlock'
-  | 'tiprack'
+  | 'tipRack'
 export const labwareTypeOptions: Options = [
   { name: 'Well Plate', value: 'wellPlate' },
   { name: 'Reservoir', value: 'reservoir' },
   { name: 'Tubes + Opentrons Tube Rack', value: 'tubeRack' },
   { name: 'Tubes / Plates + Opentrons Aluminum Block', value: 'aluminumBlock' },
-  { name: 'Tip Rack', value: 'tiprack' },
+  { name: 'Tip Rack', value: 'tipRack' },
 ]
 
 export type WellShape = 'circular' | 'rectangular'

--- a/labware-library/src/labware-creator/fieldsToLabware.ts
+++ b/labware-library/src/labware-creator/fieldsToLabware.ts
@@ -102,9 +102,7 @@ export function fieldsToLabware(
       parameters: {
         format,
         quirks,
-
-        // @ts-expect-error(IL, 2021-03-18): see note below
-        isTiprack: fields.labwareType === 'tiprack', // NOTE: 'tiprack' is not a possible labwareType now anyway
+        isTiprack: fields.labwareType === 'tipRack',
         //   tipLength?: number,
         // Currently, assume labware is not magnetic module compatible. We don't have the information here.
         isMagneticModuleCompatible: false,

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -394,7 +394,7 @@ export const LabwareCreator = (): JSX.Element => {
           const canProceedToForm = Boolean(
             values.labwareType === 'wellPlate' ||
               values.labwareType === 'reservoir' ||
-              values.labwareType === 'tiprack' ||
+              values.labwareType === 'tipRack' ||
               (values.labwareType === 'tubeRack' &&
                 values.tubeRackInsertLoadName) ||
               (values.labwareType === 'aluminumBlock' &&

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -394,6 +394,7 @@ export const LabwareCreator = (): JSX.Element => {
           const canProceedToForm = Boolean(
             values.labwareType === 'wellPlate' ||
               values.labwareType === 'reservoir' ||
+              values.labwareType === 'tiprack' ||
               (values.labwareType === 'tubeRack' &&
                 values.tubeRackInsertLoadName) ||
               (values.labwareType === 'aluminumBlock' &&


### PR DESCRIPTION
# Overview

Closes #7160

# Changelog


# Review requests

Not much to review -- sanity check?

E2E selector already available: `input[name=labwareType]`

# Risk assessment

Low, but we def shouldn't release LC any more and this isn't under a FF!!