### PR TITLE
chore: ignore TS generated JSON files for linting and formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@ shared-data/flow-types/**
 app-shell/lib/**
 discovery-client/lib/**
 **/lib/**/*.d.ts
+**/lib/**/*.json
 
 # prettier
 **/package.json


### PR DESCRIPTION
## Overview

#7731 added JSON file "generation" to the TS build to allow stuff from our shared-data JSON blobs to be used in type definitions. Unfortunately, I forgot to add those JSON files to the lint ignore. This PR fixes that oversight.

## Changelog

- chore: ignore TS generated JSON files for linting and formatting

## Review requests

- [ ] `make build-ts lint-js lint-json` does not result in any lint errors

## Risk assessment

N/A
