### PR TITLE
feat(api): implement JsonFileRunner

### DIFF
--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = pydantic.mypy
+plugins = pydantic.mypy, decoy.mypy
 ignore_missing_imports = False
 check_untyped_defs = True
 show_error_codes = True

--- a/api/src/opentrons/file_runner/command_queue_worker.py
+++ b/api/src/opentrons/file_runner/command_queue_worker.py
@@ -1,13 +1,17 @@
+"""CommandQueueWorker definition. Implements JSON protocol flow control."""
 
 
 class CommandQueueWorker:
     """A class that executes the queued commands in a ProtocolEngine."""
 
-    def play(self):
+    def play(self) -> None:
+        """Start/resume queued command execution."""
         raise NotImplementedError()
 
-    def pause(self):
+    def pause(self) -> None:
+        """Pause queued command execution."""
         raise NotImplementedError()
 
-    def stop(self):
+    def stop(self) -> None:
+        """Stop queued command execution."""
         raise NotImplementedError()

--- a/api/src/opentrons/file_runner/command_queue_worker.py
+++ b/api/src/opentrons/file_runner/command_queue_worker.py
@@ -1,0 +1,13 @@
+
+
+class CommandQueueWorker:
+    """A class that executes the queued commands in a ProtocolEngine."""
+
+    def play(self):
+        raise NotImplementedError()
+
+    def pause(self):
+        raise NotImplementedError()
+
+    def stop(self):
+        raise NotImplementedError()

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -1,18 +1,43 @@
 """File runner interfaces for JSON protocols."""
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocols.models import JsonProtocol
+from opentrons.protocols.runner import CommandTranslator
+
 from .abstract_file_runner import AbstractFileRunner
+from .command_queue_worker import CommandQueueWorker
 
 
 class JsonFileRunner(AbstractFileRunner):
     """JSON protocol file runner."""
 
+    def __init__(
+            self,
+            protocol: JsonProtocol,
+            protocol_engine: ProtocolEngine,
+            command_translator: CommandTranslator,
+            command_queue_worker: CommandQueueWorker):
+        """
+        Constructor.
+
+        Args:
+            protocol:
+            protocol_engine:
+            command_translator:
+            command_queue_worker:
+        """
+        self._protocol = protocol
+        self._protocol_engine = protocol_engine
+        self._command_translator = command_translator
+        self._command_queue_worker = command_queue_worker
+
     def play(self) -> None:
         """Start (or un-pause) running the JSON protocol file."""
-        raise NotImplementedError()
+        self._command_queue_worker.play()
 
     def pause(self) -> None:
         """Pause the running JSON protocol file's execution."""
-        raise NotImplementedError()
+        self._command_queue_worker.pause()
 
     def stop(self) -> None:
         """Cancel the running JSON protocol file."""
-        raise NotImplementedError()
+        self._command_queue_worker.stop()

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -30,6 +30,13 @@ class JsonFileRunner(AbstractFileRunner):
         self._command_translator = command_translator
         self._command_queue_worker = command_queue_worker
 
+    def load(self):
+        """Translate JSON commands and send them to protocol engine."""
+        for json_cmd in self._protocol.commands:
+            translated_items = self._command_translator.translate(json_cmd)
+            for cmd in translated_items:
+                self._protocol_engine.add_command(cmd)
+
     def play(self) -> None:
         """Start (or un-pause) running the JSON protocol file."""
         self._command_queue_worker.play()

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -16,7 +16,7 @@ class JsonFileRunner(AbstractFileRunner):
             protocol_engine: ProtocolEngine,
             command_translator: CommandTranslator,
             command_queue_worker: CommandQueueWorker) -> None:
-        """JsonFileRunner constructor.
+        """JSON file runner constructor.
 
         Args:
             protocol: a JSON protocol

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -15,22 +15,21 @@ class JsonFileRunner(AbstractFileRunner):
             protocol: JsonProtocol,
             protocol_engine: ProtocolEngine,
             command_translator: CommandTranslator,
-            command_queue_worker: CommandQueueWorker):
-        """
-        Constructor.
+            command_queue_worker: CommandQueueWorker) -> None:
+        """ JsonFileRunner constructor.
 
         Args:
-            protocol:
-            protocol_engine:
-            command_translator:
-            command_queue_worker:
+            protocol: a JSON protocol
+            protocol_engine: instance of the Protocol Engine
+            command_translator: the JSON command translator
+            command_queue_worker: Command Queue worker
         """
         self._protocol = protocol
         self._protocol_engine = protocol_engine
         self._command_translator = command_translator
         self._command_queue_worker = command_queue_worker
 
-    def load(self):
+    def load(self) -> None:
         """Translate JSON commands and send them to protocol engine."""
         for json_cmd in self._protocol.commands:
             translated_items = self._command_translator.translate(json_cmd)

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -16,7 +16,7 @@ class JsonFileRunner(AbstractFileRunner):
             protocol_engine: ProtocolEngine,
             command_translator: CommandTranslator,
             command_queue_worker: CommandQueueWorker) -> None:
-        """ JsonFileRunner constructor.
+        """JsonFileRunner constructor.
 
         Args:
             protocol: a JSON protocol

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -94,6 +94,6 @@ class ProtocolEngine:
 
         return done_cmd
 
-    def add_command(self, request: CommandRequestType):
+    def add_command(self, request: CommandRequestType) -> None:
         """Add a command to ProtocolEngine."""
         raise NotImplementedError

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -93,3 +93,7 @@ class ProtocolEngine:
         self.state_store.handle_command(done_cmd, command_id=command_id)
 
         return done_cmd
+
+    def add_command(self, request: CommandRequestType):
+        """Add a command to ProtocolEngine."""
+        raise NotImplementedError

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -96,4 +96,6 @@ class ProtocolEngine:
 
     def add_command(self, request: CommandRequestType) -> None:
         """Add a command to ProtocolEngine."""
+        # TODO(spp, 2020-05-13):
+        #   Generate a UUID to be used as command_id for each command added.
         raise NotImplementedError

--- a/api/src/opentrons/protocols/runner/__init__.py
+++ b/api/src/opentrons/protocols/runner/__init__.py
@@ -1,0 +1,5 @@
+from .json_proto.command_translator import CommandTranslator
+
+__all__ = [
+    "CommandTranslator",
+]

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -6,7 +6,6 @@ from decoy import Decoy
 from opentrons.file_runner import JsonFileRunner
 from opentrons.file_runner.command_queue_worker import CommandQueueWorker
 from opentrons.protocol_engine import ProtocolEngine, WellLocation
-# from opentrons.protocol_engine.commands import (PickUpTipReq
 from opentrons.protocol_engine.commands import CommandRequestType, PickUpTipRequest, \
     AspirateRequest, DispenseRequest
 from opentrons.protocols import models
@@ -16,29 +15,31 @@ from opentrons.protocols.runner.json_proto.command_translator import \
 
 @pytest.fixture
 def decoy() -> Decoy:
+    """Create a Decoy state container for this test suite."""
     return Decoy()
 
 
 @pytest.fixture
 def protocol_engine(decoy: Decoy) -> ProtocolEngine:
-    """Create a protocol engine fixture"""
+    """Create a protocol engine fixture."""
     return decoy.create_decoy(spec=ProtocolEngine)
 
 
 @pytest.fixture
 def command_translator(decoy: Decoy) -> CommandTranslator:
-    """Create a command translator fixture"""
+    """Create a stubbed command translator fixture."""
     return decoy.create_decoy(spec=CommandTranslator)
 
 
 @pytest.fixture
 def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
-    """Create a command translator fixture"""
+    """Create a stubbed command translator fixture."""
     return decoy.create_decoy(spec=CommandQueueWorker)
 
 
 @pytest.fixture
-def sample_json_proto(minimal_labware_def) -> dict:
+def sample_json_proto(minimal_labware_def: dict) -> dict:
+    """JSON protocol fixture."""
     return {
         "schemaVersion": 3,
         "metadata": {},
@@ -109,8 +110,8 @@ def sample_json_proto(minimal_labware_def) -> dict:
 
 
 @pytest.fixture
-def protocol(sample_json_proto) -> models.JsonProtocol:
-    """Create a json protocol fixture."""
+def protocol(sample_json_proto: dict) -> models.JsonProtocol:
+    """Create a JSON protocol fixture."""
     return models.JsonProtocol.parse_obj(sample_json_proto)
 
 
@@ -161,7 +162,7 @@ def test_json_runner_load_translation(
         decoy: Decoy,
         subject: JsonFileRunner,
         protocol: models.JsonProtocol,
-        protocol_engine,
+        protocol_engine: ProtocolEngine,
         command_translator: CommandTranslator
 ) -> None:
     """It should create a list of translated commands."""
@@ -180,11 +181,10 @@ def test_json_runner_load_commands_to_engine(
         decoy: Decoy,
         protocol: models.JsonProtocol,
         subject: JsonFileRunner,
-        command_translator,
-        protocol_engine
+        command_translator: CommandTranslator,
+        protocol_engine: ProtocolEngine
 ) -> None:
     """It should send translated commands to protocol engine."""
-
     mock_cmd1 = cast(CommandRequestType,
                      PickUpTipRequest(pipetteId="123", labwareId="abc", wellName="def"))
     mock_cmd2 = cast(CommandRequestType,

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -1,13 +1,12 @@
 """Tests for a JsonFileRunner interface."""
 import pytest
-from typing import cast
 from decoy import Decoy
 
 from opentrons.file_runner import JsonFileRunner
 from opentrons.file_runner.command_queue_worker import CommandQueueWorker
 from opentrons.protocol_engine import ProtocolEngine, WellLocation
-from opentrons.protocol_engine.commands import CommandRequestType, PickUpTipRequest, \
-    AspirateRequest, DispenseRequest
+from opentrons.protocol_engine.commands import (PickUpTipRequest, AspirateRequest,
+                                                DispenseRequest)
 from opentrons.protocols import models
 from opentrons.protocols.runner.json_proto.command_translator import \
     CommandTranslator
@@ -158,25 +157,6 @@ def test_json_runner_stop(
     decoy.verify(command_queue_worker.stop())
 
 
-def test_json_runner_load_translation(
-        decoy: Decoy,
-        subject: JsonFileRunner,
-        protocol: models.JsonProtocol,
-        protocol_engine: ProtocolEngine,
-        command_translator: CommandTranslator
-) -> None:
-    """It should create a list of translated commands."""
-    decoy.when(command_translator.translate(protocol.commands[0])).then_return([])
-    decoy.when(command_translator.translate(protocol.commands[1])).then_return([])
-    decoy.when(command_translator.translate(protocol.commands[2])).then_return([])
-
-    subject.load()
-
-    decoy.verify(command_translator.translate(protocol.commands[0]),
-                 command_translator.translate(protocol.commands[1]),
-                 command_translator.translate(protocol.commands[2]))
-
-
 def test_json_runner_load_commands_to_engine(
         decoy: Decoy,
         protocol: models.JsonProtocol,
@@ -185,14 +165,11 @@ def test_json_runner_load_commands_to_engine(
         protocol_engine: ProtocolEngine
 ) -> None:
     """It should send translated commands to protocol engine."""
-    mock_cmd1 = cast(CommandRequestType,
-                     PickUpTipRequest(pipetteId="123", labwareId="abc", wellName="def"))
-    mock_cmd2 = cast(CommandRequestType,
-                     AspirateRequest(volume=321, wellLocation=WellLocation(),
-                                     pipetteId="123", labwareId="xyz", wellName="def"))
-    mock_cmd3 = cast(CommandRequestType,
-                     DispenseRequest(volume=321, wellLocation=WellLocation(),
-                                     pipetteId="123", labwareId="xyz", wellName="def"))
+    mock_cmd1 = PickUpTipRequest(pipetteId="123", labwareId="abc", wellName="def")
+    mock_cmd2 = AspirateRequest(volume=321, wellLocation=WellLocation(),
+                                pipetteId="123", labwareId="xyz", wellName="def")
+    mock_cmd3 = DispenseRequest(volume=321, wellLocation=WellLocation(),
+                                pipetteId="123", labwareId="xyz", wellName="def")
     decoy.when(
         command_translator.translate(protocol.commands[0])).then_return([mock_cmd1])
     decoy.when(

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -32,7 +32,7 @@ def command_translator(decoy: Decoy) -> CommandTranslator:
 
 @pytest.fixture
 def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
-    """Create a stubbed command translator fixture."""
+    """Create a stubbed command queue worker fixture."""
     return decoy.create_decoy(spec=CommandQueueWorker)
 
 

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -1,10 +1,14 @@
 """Tests for a JsonFileRunner interface."""
 import pytest
+from typing import cast
 from decoy import Decoy
 
 from opentrons.file_runner import JsonFileRunner
 from opentrons.file_runner.command_queue_worker import CommandQueueWorker
-from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocol_engine import ProtocolEngine, WellLocation
+# from opentrons.protocol_engine.commands import (PickUpTipReq
+from opentrons.protocol_engine.commands import CommandRequestType, PickUpTipRequest, \
+    AspirateRequest, DispenseRequest
 from opentrons.protocols import models
 from opentrons.protocols.runner.json_proto.command_translator import \
     CommandTranslator
@@ -34,12 +38,80 @@ def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
 
 
 @pytest.fixture
-def protocol(get_json_protocol_fixture) -> models.JsonProtocol:
+def sample_json_proto(minimal_labware_def) -> dict:
+    return {
+        "schemaVersion": 3,
+        "metadata": {},
+        "robot": {
+            "model": "OT-2 Standard"
+        },
+        "pipettes": {
+            "leftPipetteId": {
+                "mount": "left",
+                "name": "p300_single"
+            }
+        },
+        "labware": {
+            "trashId": {
+                "slot": "12",
+                "displayName": "Trash",
+                "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
+            },
+            "tiprack1Id": {
+                "slot": "1",
+                "displayName": "Opentrons 96 Tip Rack 300 µL",
+                "definitionId": "opentrons/opentrons_96_tiprack_300ul/1"
+            },
+            "wellplate1Id": {
+                "slot": "10",
+                "displayName": "Corning 96 Well Plate 360 µL Flat",
+                "definitionId": "opentrons/corning_96_wellplate_360ul_flat/1"
+            }
+        },
+        "labwareDefinitions": {
+            "opentrons/opentrons_1_trash_1100ml_fixed/1": minimal_labware_def,
+            "opentrons/opentrons_96_tiprack_300ul/1": minimal_labware_def,
+            "opentrons/corning_96_wellplate_360ul_flat/1": minimal_labware_def
+        },
+        "commands": [
+           {
+               "command": "pickUpTip",
+               "params": {
+                   "pipette": "leftPipetteId",
+                   "labware": "tiprack1Id",
+                   "well": "A1"
+               }
+           },
+           {
+               "command": "aspirate",
+               "params": {
+                   "pipette": "leftPipetteId",
+                   "volume": 51,
+                   "labware": "wellplate1Id",
+                   "well": "B1",
+                   "offsetFromBottomMm": 10,
+                   "flowRate": 10
+               }
+           },
+           {
+               "command": "dispense",
+               "params": {
+                   "pipette": "leftPipetteId",
+                   "volume": 50,
+                   "labware": "wellplate1Id",
+                   "well": "H1",
+                   "offsetFromBottomMm": 1,
+                   "flowRate": 50
+               }
+           },
+        ]
+    }
+
+
+@pytest.fixture
+def protocol(sample_json_proto) -> models.JsonProtocol:
     """Create a json protocol fixture."""
-    fx = get_json_protocol_fixture(
-        fixture_version="3", fixture_name="testAllAtomicSingleV3", decode=True
-    )
-    return models.JsonProtocol.parse_obj(fx)
+    return models.JsonProtocol.parse_obj(sample_json_proto)
 
 
 @pytest.fixture
@@ -83,3 +155,53 @@ def test_json_runner_stop(
     subject.stop()
 
     decoy.verify(command_queue_worker.stop())
+
+
+def test_json_runner_load_translation(
+        decoy: Decoy,
+        subject: JsonFileRunner,
+        protocol: models.JsonProtocol,
+        protocol_engine,
+        command_translator: CommandTranslator
+) -> None:
+    """It should create a list of translated commands."""
+    decoy.when(command_translator.translate(protocol.commands[0])).then_return([])
+    decoy.when(command_translator.translate(protocol.commands[1])).then_return([])
+    decoy.when(command_translator.translate(protocol.commands[2])).then_return([])
+
+    subject.load()
+
+    decoy.verify(command_translator.translate(protocol.commands[0]),
+                 command_translator.translate(protocol.commands[1]),
+                 command_translator.translate(protocol.commands[2]))
+
+
+def test_json_runner_load_commands_to_engine(
+        decoy: Decoy,
+        protocol: models.JsonProtocol,
+        subject: JsonFileRunner,
+        command_translator,
+        protocol_engine
+) -> None:
+    """It should send translated commands to protocol engine."""
+
+    mock_cmd1 = cast(CommandRequestType,
+                     PickUpTipRequest(pipetteId="123", labwareId="abc", wellName="def"))
+    mock_cmd2 = cast(CommandRequestType,
+                     AspirateRequest(volume=321, wellLocation=WellLocation(),
+                                     pipetteId="123", labwareId="xyz", wellName="def"))
+    mock_cmd3 = cast(CommandRequestType,
+                     DispenseRequest(volume=321, wellLocation=WellLocation(),
+                                     pipetteId="123", labwareId="xyz", wellName="def"))
+    decoy.when(
+        command_translator.translate(protocol.commands[0])).then_return([mock_cmd1])
+    decoy.when(
+        command_translator.translate(protocol.commands[1])).then_return([mock_cmd2])
+    decoy.when(
+        command_translator.translate(protocol.commands[2])).then_return([mock_cmd3])
+
+    subject.load()
+
+    decoy.verify(protocol_engine.add_command(mock_cmd1),
+                 protocol_engine.add_command(mock_cmd2),
+                 protocol_engine.add_command(mock_cmd3))

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -1,28 +1,85 @@
 """Tests for a JsonFileRunner interface."""
 import pytest
+from decoy import Decoy
 
 from opentrons.file_runner import JsonFileRunner
+from opentrons.file_runner.command_queue_worker import CommandQueueWorker
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocols import models
+from opentrons.protocols.runner.json_proto.command_translator import \
+    CommandTranslator
 
 
 @pytest.fixture
-def subject() -> JsonFileRunner:
+def decoy() -> Decoy:
+    return Decoy()
+
+
+@pytest.fixture
+def protocol_engine(decoy: Decoy) -> ProtocolEngine:
+    """Create a protocol engine fixture"""
+    return decoy.create_decoy(spec=ProtocolEngine)
+
+
+@pytest.fixture
+def command_translator(decoy: Decoy) -> CommandTranslator:
+    """Create a command translator fixture"""
+    return decoy.create_decoy(spec=CommandTranslator)
+
+
+@pytest.fixture
+def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
+    """Create a command translator fixture"""
+    return decoy.create_decoy(spec=CommandQueueWorker)
+
+
+@pytest.fixture
+def protocol(get_json_protocol_fixture) -> models.JsonProtocol:
+    """Create a json protocol fixture."""
+    fx = get_json_protocol_fixture(
+        fixture_version="3", fixture_name="testAllAtomicSingleV3", decode=True
+    )
+    return models.JsonProtocol.parse_obj(fx)
+
+
+@pytest.fixture
+def subject(
+        protocol: models.JsonProtocol,
+        protocol_engine: ProtocolEngine,
+        command_translator: CommandTranslator,
+        command_queue_worker: CommandQueueWorker
+) -> JsonFileRunner:
     """Get a JsonFileRunner test subject."""
-    return JsonFileRunner()
+    return JsonFileRunner(
+        protocol=protocol,
+        protocol_engine=protocol_engine,
+        command_translator=command_translator,
+        command_queue_worker=command_queue_worker,
+    )
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
-def test_python_runner_play(subject: JsonFileRunner) -> None:
+def test_json_runner_play(
+        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+) -> None:
     """It should be able to start the run."""
     subject.play()
 
+    decoy.verify(command_queue_worker.play())
 
-@pytest.mark.xfail(raises=NotImplementedError)
-def test_python_runner_pause(subject: JsonFileRunner) -> None:
+
+def test_json_runner_pause(
+        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+) -> None:
     """It should be able to pause the run."""
     subject.pause()
 
+    decoy.verify(command_queue_worker.pause())
 
-@pytest.mark.xfail(raises=NotImplementedError)
-def test_python_runner_stop(subject: JsonFileRunner) -> None:
+
+def test_json_runner_stop(
+        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+) -> None:
     """It should be able to stop the run."""
     subject.stop()
+
+    decoy.verify(command_queue_worker.stop())


### PR DESCRIPTION
Closes #7645 

# Overview

Implements the `JsonFileRunner` class. .

# Changelog

- implemented `load`, `play`, `pause`, `stop` for `JsonFileRunner`
- created a `CommandQueueWorker` skeleton to delegate flow control to
- added `ProtocolEngine` `add_command` stub
- tests

# Review requests

- tests make sense?
- thoughts about `add_command` being sync/ async?
- anything missing in the implementation?

# Risk assessment

None
