### PR TITLE
spike: TDD through fresh /protocols and /sessions routers to prep for protocol runner

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -6,6 +6,7 @@ protocol state and side-effects like robot movements.
 """
 
 from .protocol_engine import ProtocolEngine
+from .commands import CommandRequestType, CommandResultType
 from .state import StateStore, StateView, LabwareData
 from .execution import CommandHandlers
 from .resources import ResourceProviders
@@ -21,6 +22,9 @@ from .types import (
 __all__ = [
     # main export
     "ProtocolEngine",
+    # command types
+    "CommandRequestType",
+    "CommandResultType",
     # state interfaces and models
     "StateStore",
     "StateView",

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -18,6 +18,10 @@ class CommandState:
         """Get a command by its unique identifier."""
         return self._commands_by_id.get(uid)
 
+    def get_all_command_ids(self) -> List[str]:
+        """Get a list of all command IDs in state."""
+        raise NotImplementedError()
+
     def get_all_commands(self) -> List[Tuple[str, CommandType]]:
         """Get a list of all command entries in state."""
         return [entry for entry in self._commands_by_id.items()]

--- a/robot-server/robot_server/protocols/__init__.py
+++ b/robot-server/robot_server/protocols/__init__.py
@@ -1,0 +1,5 @@
+"""Protocol file upload and management."""
+
+from .router import protocols_router
+
+__all__ = ["protocols_router"]

--- a/robot-server/robot_server/protocols/models.py
+++ b/robot-server/robot_server/protocols/models.py
@@ -1,0 +1,15 @@
+"""Protocol file models."""
+from pydantic import Field
+from opentrons.file_runner import ProtocolFileType
+from robot_server.service.json_api import ResponseDataModel
+
+
+class ProtocolResource(ResponseDataModel):
+    """A model representing an uploaded protocol resource."""
+
+    id: str = Field(..., description="A unique identifier for this protocol.")
+    fileName: str = Field(..., description="The base name of the protocol file.")
+    fileType: ProtocolFileType = Field(
+        ...,
+        description="The type of protocol file (JSON or Python).",
+    )

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -1,0 +1,94 @@
+"""Router for /protocols endpoints."""
+from fastapi import APIRouter, Depends, File, UploadFile, status
+from typing import List
+from typing_extensions import Literal
+
+from robot_server.errors import ErrorDetails, ErrorResponse
+from robot_server.service.json_api import ResponseModel, MultiResponseModel
+
+from .models import ProtocolResource
+from .store import ProtocolStore, ProtocolStoreKeyError
+
+
+class ProtocolNotFound(ErrorDetails):
+    """An error returned when a given protocol cannot be found."""
+
+    id: Literal["ProtocolNotFound"] = "ProtocolNotFound"
+    title: str = "Protocol Not Found"
+
+
+protocols_router = APIRouter()
+
+
+@protocols_router.get(
+    path="/protocols",
+    summary="Get uploaded protocols",
+    status_code=status.HTTP_200_OK,
+    response_model=MultiResponseModel[ProtocolResource],
+)
+async def get_protocols(
+    protocol_store: ProtocolStore = Depends(ProtocolStore),
+) -> MultiResponseModel[ProtocolResource]:
+    """Get a list of all currently uploaded protocols."""
+    return MultiResponseModel(data=protocol_store.get_all_protocols())
+
+
+@protocols_router.post(
+    path="/protocols",
+    summary="Uploaded protocol",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ResponseModel[ProtocolResource],
+)
+async def create_protocol(
+    files: List[UploadFile] = File(...),
+    protocol_store: ProtocolStore = Depends(ProtocolStore),
+) -> ResponseModel[ProtocolResource]:
+    """Create a new protocol by uploading its files."""
+    data = protocol_store.add_protocol(files=files)
+    return ResponseModel(data=data)
+
+
+@protocols_router.get(
+    path="/protocols/{protocol_id}",
+    summary="Get an uploaded protocol",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[ProtocolResource],
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[ProtocolNotFound]},
+    },
+)
+async def get_protocol_by_id(
+    protocol_id: str,
+    protocol_store: ProtocolStore = Depends(ProtocolStore),
+) -> ResponseModel[ProtocolResource]:
+    """Get an uploaded protocol by ID."""
+    try:
+        data = protocol_store.get_protocol(id=protocol_id)
+
+    except ProtocolStoreKeyError as e:
+        raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=data)
+
+
+@protocols_router.delete(
+    path="/protocols/{protocol_id}",
+    summary="Delete an uploaded protocol",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[ProtocolResource],
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[ProtocolNotFound]},
+    },
+)
+async def delete_protocol_by_id(
+    protocol_id: str,
+    protocol_store: ProtocolStore = Depends(ProtocolStore),
+) -> ResponseModel[ProtocolResource]:
+    """Delete an uploaded protocol by ID."""
+    try:
+        data = protocol_store.remove_protocol(id=protocol_id)
+
+    except ProtocolStoreKeyError as e:
+        raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=data)

--- a/robot-server/robot_server/protocols/store.py
+++ b/robot-server/robot_server/protocols/store.py
@@ -1,0 +1,35 @@
+"""Methods for saving and retrieving protocol files."""
+from fastapi import UploadFile
+from typing import List, Sequence
+
+from .models import ProtocolResource
+
+
+class ProtocolStoreKeyError(RuntimeError):
+    """The referenced protocol ID was not found in the store."""
+
+    pass
+
+
+class ProtocolStore:
+    """Methods for storing and retrieving protocol files."""
+
+    @staticmethod
+    def get_all_protocols() -> List[ProtocolResource]:
+        """Get all protocols currently saved in the system."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_protocol(id: str) -> ProtocolResource:
+        """Get a single protocol by ID."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def add_protocol(files: Sequence[UploadFile]) -> ProtocolResource:
+        """Add a protocol to the store."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def remove_protocol(id: str) -> ProtocolResource:
+        """Remove a protocol from the store."""
+        raise NotImplementedError()

--- a/robot-server/robot_server/sessions/__init__.py
+++ b/robot-server/robot_server/sessions/__init__.py
@@ -1,0 +1,16 @@
+"""Session creation and management.
+
+A "session" is a logical container for a user's interaction with a robot,
+usually (but not always) with a well-defined start point and end point.
+Examples of "sessions" include:
+
+- A session to run a specific protocol
+- A session to complete a specific calibration procedure
+- A long running, "default" session to perform one-off actions, like toggling
+  the frame lights on
+"""
+from .router import sessions_router
+
+__all__ = [
+    "sessions_router",
+]

--- a/robot-server/robot_server/sessions/basic_session.py
+++ b/robot-server/robot_server/sessions/basic_session.py
@@ -1,0 +1,21 @@
+"""Basic session type.
+
+Can be used to execute commands, but provides no additional state
+management or logic. Useful for basic, one-off commands or live
+protocol execution via individual HTTP commands.
+"""
+from pydantic import Field
+from typing_extensions import Literal
+
+from .session_type import SessionType
+from .session_models import Session
+
+
+class BasicSession(Session):
+    """Basic session resource model."""
+
+    id: str = Field(..., description="Unique session identifier.")
+    sessionType: Literal[SessionType.BASIC] = Field(
+        SessionType.BASIC,
+        description="Session type identifier.",
+    )

--- a/robot-server/robot_server/sessions/command_models.py
+++ b/robot-server/robot_server/sessions/command_models.py
@@ -1,0 +1,21 @@
+"""Request models for the /sessions API."""
+from enum import Enum
+from pydantic import Field
+
+from robot_server.service.json_api import ResponseDataModel
+
+
+class CommandType(str, Enum):
+    """All available session types."""
+
+    NOOP = "noop"
+
+
+class SessionCommand(ResponseDataModel):
+    """A command to execute during the session."""
+
+    id: str = Field(..., description="Unique command identifier.")
+    commandType: CommandType = Field(
+        CommandType.NOOP,
+        description="Specific command type.",
+    )

--- a/robot-server/robot_server/sessions/dependencies.py
+++ b/robot-server/robot_server/sessions/dependencies.py
@@ -1,0 +1,40 @@
+"""Session router dependency wire-up."""
+from fastapi import Depends, Request
+
+from .engine_store import EngineStore
+from .session_store import SessionStore
+
+ENGINE_STORE_STATE_KEY = "sessions.engine_store"
+SESSION_STORE_STATE_KEY = "sessions.session_store"
+
+
+def get_engine_store(request: Request) -> EngineStore:
+    """Get the EngineStore dependency."""
+    app_state = request.app.state
+    engine_store = getattr(app_state, ENGINE_STORE_STATE_KEY, None)
+
+    if engine_store is None:
+        engine_store = EngineStore()
+        setattr(app_state, ENGINE_STORE_STATE_KEY, engine_store)
+
+    return engine_store
+
+
+def get_session_store(
+    request: Request,
+    engine_store: EngineStore = Depends(get_engine_store),
+) -> SessionStore:
+    """Get a SessionStore interface."""
+    app_state = request.app.state
+    session_store = getattr(app_state, SESSION_STORE_STATE_KEY, None)
+
+    if session_store is None:
+        session_store = SessionStore(engine_store=engine_store)
+        setattr(app_state, SESSION_STORE_STATE_KEY, session_store)
+
+    return session_store
+
+
+def get_unique_id() -> str:
+    """Generate a unique identifier string."""
+    raise NotImplementedError()

--- a/robot-server/robot_server/sessions/engine_store.py
+++ b/robot-server/robot_server/sessions/engine_store.py
@@ -1,0 +1,28 @@
+"""Management interface for ProtocolEngine instances."""
+from opentrons.protocol_engine import StateView
+
+
+class EngineNotFoundError(ValueError):
+    """Error raised when a engine cannot be found."""
+
+    def __init__(self, session_id: str) -> None:
+        """Initialize the error message from the session ID."""
+        super().__init__(f"No engine found for {session_id}.")
+
+
+class EngineStore:
+    """Manage the ProtocolEngine used in sessions."""
+
+    def get_state(self, session_id: str) -> StateView:
+        """Get the engine state for a given session ID.
+
+        Arguments:
+            session_id: Unique identifier of the engine's associated Session
+
+        Returns:
+            The ProtocolEngine state.
+
+        Raises:
+            EngineNotFound: No ProtocolEngine exists for the given session ID.
+        """
+        raise NotImplementedError()

--- a/robot-server/robot_server/sessions/router.py
+++ b/robot-server/robot_server/sessions/router.py
@@ -1,0 +1,119 @@
+"""Router for /sessions endpoints."""
+from fastapi import APIRouter, Depends, Request, status
+from typing import Optional
+from typing_extensions import Literal
+
+from robot_server.errors import ErrorDetails, ErrorResponse
+from robot_server.service.json_api import ResponseModel, MultiResponseModel
+
+from .dependencies import get_session_store, get_unique_id
+from .session_store import SessionStore, SessionNotFoundError
+from .session_type import SessionType
+from .session_models import Session, CreateSessionData
+from .command_models import SessionCommand
+
+
+sessions_router = APIRouter()
+
+
+class SessionNotFound(ErrorDetails):
+    """An error response for when a given session is not found."""
+
+    id: Literal["SessionNotFound"] = "SessionNotFound"
+    title: str = "Session Not Found"
+
+
+@sessions_router.post(
+    path="/sessions",
+    summary="Create a session",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ResponseModel[Session],
+)
+def create_session(
+    session_data: Optional[CreateSessionData] = None,
+    session_store: SessionStore = Depends(get_session_store),
+    session_id: str = Depends(get_unique_id),
+) -> ResponseModel[Session]:
+    """Create a new session."""
+    session_data = session_data or CreateSessionData(sessionType=SessionType.BASIC)
+    session = session_store.create_session(
+        session_data=session_data,
+        session_id=session_id,
+    )
+
+    return ResponseModel(data=session)
+
+
+@sessions_router.get(
+    path="/sessions",
+    summary="Get all sessions",
+    status_code=status.HTTP_200_OK,
+    response_model=MultiResponseModel[Session],
+)
+def get_sessions(
+    session_store: SessionStore = Depends(get_session_store),
+) -> MultiResponseModel[Session]:
+    """Get a list of all active and inactive sessions."""
+    sessions = session_store.get_all_sessions()
+    return MultiResponseModel(data=sessions)
+
+
+@sessions_router.get(
+    path="/sessions/{sessionId}",
+    summary="Get a session",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[Session],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+def get_session(
+    sessionId: str,
+    session_store: SessionStore = Depends(get_session_store),
+) -> ResponseModel[Session]:
+    """Get a specific session by its unique identifier."""
+    try:
+        session = session_store.get_session(session_id=sessionId)
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=session)
+
+
+@sessions_router.get(
+    path="/sessions/{sessionId}/commands",
+    summary="Get a session's commands",
+    status_code=status.HTTP_200_OK,
+    response_model=MultiResponseModel[SessionCommand],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+def get_session_commands(
+    sessionId: str,
+    request: Request,
+    session_store: SessionStore = Depends(get_session_store),
+) -> MultiResponseModel[SessionCommand]:
+    """Get the state of the sessions commands."""
+    try:
+        commands = session_store.get_session_commands(session_id=sessionId)
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return MultiResponseModel(data=commands)
+
+
+@sessions_router.delete(
+    path="/sessions/{sessionId}",
+    summary="Delete a session",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[Session],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+def remove_session_by_id(
+    sessionId: str,
+    session_store: SessionStore = Depends(get_session_store),
+) -> ResponseModel[Session]:
+    """Delete a specific session by its unique identifier."""
+    try:
+        session = session_store.remove_session_by_id(session_id=sessionId)
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=session)

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -1,0 +1,27 @@
+"""Request models for the /sessions API."""
+
+from pydantic import BaseModel, Field
+from typing import List
+
+from robot_server.service.json_api import ResponseDataModel
+from .session_type import SessionType
+
+
+class CreateSessionData(BaseModel):
+    """Request data sent when creating a session."""
+
+    sessionType: SessionType = Field(
+        SessionType.BASIC,
+        description="The session type to create.",
+    )
+
+
+class Session(ResponseDataModel):
+    """Basic session resource model."""
+
+    id: str = Field(..., description="Unique session identifier.")
+    sessionType: SessionType = Field(
+        SessionType.BASIC,
+        description="Specific session type.",
+    )
+    commands: List[str] = Field(..., description="List of associated command IDs")

--- a/robot-server/robot_server/sessions/session_store.py
+++ b/robot-server/robot_server/sessions/session_store.py
@@ -1,0 +1,107 @@
+"""Sessions in-memory store."""
+from typing import Dict, List
+
+from .engine_store import EngineStore, EngineNotFoundError
+from .command_models import SessionCommand
+from .session_models import Session, CreateSessionData
+from .session_type import SessionType
+
+
+class SessionNotFoundError(ValueError):
+    """Error raised when a given session ID is not found in the store."""
+
+    def __init__(self, session_id: str) -> None:
+        """Intialize the error message from the missing ID."""
+        super().__init__(f"Session {session_id} was not found.")
+
+
+class SessionStore:
+    """Methods for storing and retrieving session resources."""
+
+    def __init__(self, engine_store: EngineStore) -> None:
+        """Initialize the SessionStore with its dependencies."""
+        self._engine_store = engine_store
+        self._session_type_by_id: Dict[str, SessionType] = {}
+
+    def create_session(
+        self,
+        session_data: CreateSessionData,
+        session_id: str,
+    ) -> Session:
+        """Create and store a new session resource.
+
+        Arguments:
+            session: Input data to create session from.
+            session_id: Unique identifier.
+
+        Returns:
+            The created session.
+        """
+        session_type = session_data.sessionType
+        self._session_type_by_id[session_id] = session_type
+        return Session(id=session_id, sessionType=session_type, commands=[])
+
+    def get_all_sessions(self) -> List[Session]:
+        """Get all known session resources.
+
+        Returns:
+            All known sessions.
+        """
+        return [
+            self.get_session(session_id)
+            for session_id in self._session_type_by_id.keys()
+        ]
+
+    def get_session(self, session_id: str) -> Session:
+        """Get a session by its unique identifier.
+
+        Arguments:
+            session_id: The session's unique identifier.
+
+        Returns:
+            The session resource.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        try:
+            session_type = self._session_type_by_id[session_id]
+        except KeyError as e:
+            raise SessionNotFoundError(session_id) from e
+
+        try:
+            commands = self._engine_store.get_state(
+                session_id
+            ).commands.get_all_command_ids()
+        except EngineNotFoundError:
+            commands = []
+
+        return Session(id=session_id, sessionType=session_type, commands=commands)
+
+    def get_session_commands(self, session_id: str) -> List[SessionCommand]:
+        """Get a session's commands by the session's unique identifier.
+
+        Arguments:
+            session_id: The session's unique identifier.
+
+        Returns:
+            The command resources.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        raise NotImplementedError()
+
+    def remove_session_by_id(self, session_id: str) -> Session:
+        """Remove a session by its unique identifier.
+
+        Arguments:
+            session_id: The session's unique identifier.
+
+        Returns:
+            The session resource that was deleted.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        raise NotImplementedError()

--- a/robot-server/robot_server/sessions/session_type.py
+++ b/robot-server/robot_server/sessions/session_type.py
@@ -1,0 +1,8 @@
+"""Session type identifiers."""
+from enum import Enum
+
+
+class SessionType(str, Enum):
+    """All available session types."""
+
+    BASIC = "basic"

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -1,0 +1,222 @@
+"""Tests for the /protocols router."""
+import pytest
+from dataclasses import dataclass
+from decoy import Decoy
+from fastapi import FastAPI, UploadFile
+from fastapi.testclient import TestClient
+from typing import cast
+
+from robot_server.errors import exception_handlers
+from robot_server.protocols import protocols_router
+from robot_server.protocols.models import ProtocolResource, ProtocolFileType
+from robot_server.protocols.store import ProtocolStore, ProtocolStoreKeyError
+
+
+@dataclass(frozen=True)
+class UploadFileMatcher:
+    """Matcher class for a fastapi.UploadFile."""
+
+    filename: str
+    content_type: str
+
+    @classmethod
+    def create(cls, filename: str, content_type: str) -> UploadFile:
+        """Create an UploadFileMatcher cast as an UploadFile."""
+        return cast(UploadFile, cls(filename, content_type))
+
+    def __eq__(self, target: object) -> bool:
+        """Return true if target is a matching UploadFile."""
+        target_filename = getattr(target, "filename", None)
+        target_content_type = getattr(target, "content_type", None)
+
+        return (
+            self.filename == target_filename
+            and self.content_type == target_content_type
+        )
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container."""
+    return Decoy()
+
+
+@pytest.fixture
+def protocol_store(decoy: Decoy) -> ProtocolStore:
+    """Get a fake ProtocolStore interface."""
+    return decoy.create_decoy(spec=ProtocolStore)
+
+
+@pytest.fixture
+def client(protocol_store: ProtocolStore) -> TestClient:
+    """Get an TestClient for /protocols routes with dependencies mocked out."""
+    app = FastAPI(exception_handlers=exception_handlers)
+    app.dependency_overrides[ProtocolStore] = lambda: protocol_store
+    app.include_router(protocols_router)
+
+    return TestClient(app)
+
+
+def test_get_protocols_no_protocols(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no protocols loaded."""
+    decoy.when(protocol_store.get_all_protocols()).then_return([])
+
+    response = client.get("/protocols")
+
+    assert response.status_code == 200
+    assert response.json() == {"data": [], "links": None}
+
+
+def test_get_protocols(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return stored protocols."""
+    decoy.when(protocol_store.get_all_protocols()).then_return(
+        [
+            ProtocolResource(
+                id="foo", fileName="foo.py", fileType=ProtocolFileType.PYTHON
+            ),
+            ProtocolResource(
+                id="bar", fileName="bar.json", fileType=ProtocolFileType.JSON
+            ),
+        ]
+    )
+
+    response = client.get("/protocols")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": [
+            {"id": "foo", "fileName": "foo.py", "fileType": "python"},
+            {"id": "bar", "fileName": "bar.json", "fileType": "json"},
+        ],
+        "links": None,
+    }
+
+
+def test_get_protocol_by_id(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return a single protocol file."""
+    decoy.when(protocol_store.get_protocol(id="foo")).then_return(
+        ProtocolResource(id="foo", fileName="foo.py", fileType=ProtocolFileType.PYTHON)
+    )
+
+    response = client.get("/protocols/foo")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "id": "foo",
+            "fileName": "foo.py",
+            "fileType": "python",
+        },
+        "links": None,
+    }
+
+
+def test_get_protocol_not_found(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return a single protocol file."""
+    decoy.when(protocol_store.get_protocol(id="bar")).then_raise(
+        ProtocolStoreKeyError('Protocol with ID "bar" not found.')
+    )
+
+    response = client.get("/protocols/bar")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "errors": [
+            {
+                "id": "ProtocolNotFound",
+                "title": "Protocol Not Found",
+                "detail": 'Protocol with ID "bar" not found.',
+            },
+        ]
+    }
+
+
+def test_create_protocol(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should store a single protocol file."""
+    expected_file = UploadFileMatcher.create(
+        filename="foo.py", content_type="text/x-python"
+    )
+
+    decoy.when(protocol_store.add_protocol(files=[expected_file])).then_return(
+        ProtocolResource(id="foo", fileName="foo.py", fileType=ProtocolFileType.PYTHON)
+    )
+
+    files = [("files", ("foo.py", bytes("# my protocol", "utf-8"), "text/x-python"))]
+    response = client.post("/protocols", files=files)
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "data": {
+            "id": "foo",
+            "fileName": "foo.py",
+            "fileType": "python",
+        },
+        "links": None,
+    }
+
+
+def test_delete_protocol_by_id(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should store a single protocol file."""
+    decoy.when(protocol_store.remove_protocol(id="foo")).then_return(
+        ProtocolResource(id="foo", fileName="foo.py", fileType=ProtocolFileType.PYTHON)
+    )
+
+    response = client.delete("/protocols/foo")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "id": "foo",
+            "fileName": "foo.py",
+            "fileType": "python",
+        },
+        "links": None,
+    }
+
+
+def test_delete_protocol_not_found(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the protocol to delete is not found."""
+    decoy.when(protocol_store.remove_protocol(id="bar")).then_raise(
+        ProtocolStoreKeyError('Protocol with ID "bar" not found.')
+    )
+
+    response = client.delete("/protocols/bar")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "errors": [
+            {
+                "id": "ProtocolNotFound",
+                "title": "Protocol Not Found",
+                "detail": 'Protocol with ID "bar" not found.',
+            },
+        ]
+    }

--- a/robot-server/tests/sessions/__init__.py
+++ b/robot-server/tests/sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the robot_server.sessions module."""

--- a/robot-server/tests/sessions/test_session_store.py
+++ b/robot-server/tests/sessions/test_session_store.py
@@ -1,0 +1,133 @@
+"""Tests for robot_server.sessions.session_store."""
+import pytest
+from decoy import Decoy
+
+from opentrons.protocol_engine import StateView as EngineState
+from robot_server.sessions.engine_store import EngineStore, EngineNotFoundError
+from robot_server.sessions.session_type import SessionType
+from robot_server.sessions.session_models import Session, CreateSessionData
+from robot_server.sessions.session_store import SessionStore, SessionNotFoundError
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container."""
+    return Decoy()
+
+
+@pytest.fixture
+def engine_state(decoy: Decoy) -> EngineState:
+    """Get a fake ProtocolEngine state view."""
+    return decoy.create_decoy(spec=EngineState)
+
+
+@pytest.fixture
+def engine_store(decoy: Decoy) -> EngineStore:
+    """Get a fake EngineStore interface."""
+    return decoy.create_decoy(spec=EngineStore)
+
+
+@pytest.fixture
+def subject(engine_store: EngineStore) -> SessionStore:
+    """Get a SessionStore test subject with its dependencies mocked out."""
+    return SessionStore(engine_store=engine_store)
+
+
+def test_create_specific_session(subject: SessionStore) -> None:
+    """It should be able to create a specific type of session."""
+    session_data = CreateSessionData(sessionType=SessionType.BASIC)
+    result = subject.create_session(session_data=session_data, session_id="session-id")
+
+    assert result == Session(
+        id="session-id",
+        sessionType=SessionType.BASIC,
+        commands=[],
+    )
+
+
+def test_get_session(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    engine_state: EngineState,
+    subject: SessionStore,
+) -> None:
+    """It can get a created session."""
+    decoy.when(engine_store.get_state("session-id")).then_return(engine_state)
+    decoy.when(engine_state.commands.get_all_command_ids()).then_return(["foo", "bar"])
+
+    session_data = CreateSessionData(sessionType=SessionType.BASIC)
+    subject.create_session(session_data=session_data, session_id="session-id")
+    result = subject.get_session(session_id="session-id")
+
+    assert result == Session(
+        id="session-id",
+        sessionType=SessionType.BASIC,
+        commands=["foo", "bar"],
+    )
+
+
+def test_get_session_missing(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    engine_state: EngineState,
+    subject: SessionStore,
+) -> None:
+    """It raises if the session does not exist."""
+    with pytest.raises(SessionNotFoundError, match="session-id"):
+        subject.get_session(session_id="session-id")
+
+
+def test_get_session_no_engine(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    engine_state: EngineState,
+    subject: SessionStore,
+) -> None:
+    """It can get a created session even if no engine has been created yet."""
+    decoy.when(engine_store.get_state("session-id")).then_raise(
+        EngineNotFoundError("session-id")
+    )
+
+    session_data = CreateSessionData(sessionType=SessionType.BASIC)
+    subject.create_session(session_data=session_data, session_id="session-id")
+    result = subject.get_session(session_id="session-id")
+
+    assert result == Session(
+        id="session-id",
+        sessionType=SessionType.BASIC,
+        commands=[],
+    )
+
+
+def test_get_all_sessions(
+    decoy: Decoy,
+    engine_store: EngineStore,
+    engine_state: EngineState,
+    subject: SessionStore,
+) -> None:
+    """It can get all created sessions."""
+    decoy.when(engine_store.get_state("session-id-1")).then_return(engine_state)
+    decoy.when(engine_store.get_state("session-id-2")).then_raise(
+        EngineNotFoundError("session-id-2")
+    )
+
+    decoy.when(engine_state.commands.get_all_command_ids()).then_return(["foo", "bar"])
+
+    session_data = CreateSessionData(sessionType=SessionType.BASIC)
+    subject.create_session(session_data=session_data, session_id="session-id-1")
+    subject.create_session(session_data=session_data, session_id="session-id-2")
+
+    result = subject.get_all_sessions()
+
+    assert result == [
+        Session(
+            id="session-id-1",
+            sessionType=SessionType.BASIC,
+            commands=["foo", "bar"],
+        ),
+        Session(
+            id="session-id-2",
+            sessionType=SessionType.BASIC,
+            commands=[],
+        ),
+    ]

--- a/robot-server/tests/sessions/test_sessions_router.py
+++ b/robot-server/tests/sessions/test_sessions_router.py
@@ -1,0 +1,231 @@
+"""Tests for the /sessions router."""
+import pytest
+from decoy import Decoy
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from robot_server.errors import exception_handlers
+from robot_server.sessions.router import sessions_router, SessionNotFound
+from robot_server.sessions.dependencies import get_session_store, get_unique_id
+from robot_server.sessions.session_type import SessionType
+from robot_server.sessions.session_models import CreateSessionData
+from robot_server.sessions.command_models import SessionCommand
+from robot_server.sessions.basic_session import BasicSession
+from robot_server.sessions.session_store import SessionStore, SessionNotFoundError
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container."""
+    return Decoy()
+
+
+@pytest.fixture
+def session_store(decoy: Decoy) -> SessionStore:
+    """Get a fake SessionStore interface."""
+    return decoy.create_decoy(spec=SessionStore)
+
+
+@pytest.fixture
+def unique_id() -> str:
+    """Get a fake unique-id."""
+    return "session-id"
+
+
+@pytest.fixture
+def client(session_store: SessionStore, unique_id: str) -> TestClient:
+    """Get an TestClient for /protocols routes with dependencies mocked out."""
+    app = FastAPI(exception_handlers=exception_handlers)
+    app.dependency_overrides[get_session_store] = lambda: session_store
+    app.dependency_overrides[get_unique_id] = lambda: unique_id
+    app.include_router(sessions_router)
+
+    return TestClient(app)
+
+
+def test_get_sessions_empty(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    decoy.when(session_store.get_all_sessions()).then_return([])
+
+    response = client.get("/sessions")
+
+    assert response.status_code == 200
+    assert response.json() == {"data": [], "links": None}
+
+
+def test_get_sessions_not_empty(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    session1 = BasicSession(id="unique-id-1", commands=[])
+    session2 = BasicSession(id="unique-id-2", commands=[])
+
+    decoy.when(session_store.get_all_sessions()).then_return([session1, session2])
+
+    response = client.get("/sessions")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": [
+            session1.dict(),
+            session2.dict(),
+        ],
+        "links": None,
+    }
+
+
+def test_create_basic_session_implicitely(
+    decoy: Decoy,
+    session_store: SessionStore,
+    unique_id: str,
+    client: TestClient,
+) -> None:
+    """It should be able to create a basic session from an empty POST request."""
+    session = BasicSession(id=unique_id, commands=[])
+
+    decoy.when(
+        session_store.create_session(
+            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+            session_id=unique_id,
+        )
+    ).then_return(session)
+
+    response = client.post("/sessions")
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "data": session.dict(),
+        "links": None,
+    }
+
+
+def test_create_session_explicitely(
+    decoy: Decoy,
+    session_store: SessionStore,
+    unique_id: str,
+    client: TestClient,
+) -> None:
+    """It should be able to create a basic session from an empty POST request."""
+    session = BasicSession(id=unique_id, commands=[])
+
+    decoy.when(
+        session_store.create_session(
+            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+            session_id=unique_id,
+        )
+    ).then_return(session)
+
+    response = client.post("/sessions", json={"data": {"sessionType": "basic"}})
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "data": session.dict(),
+        "links": None,
+    }
+
+
+def test_get_session(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should be able to get a session by ID."""
+    session = BasicSession(id="unique-id", commands=[])
+
+    decoy.when(session_store.get_session(session_id="unique-id")).then_return(session)
+
+    response = client.get("/sessions/unique-id")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": session.dict(),
+        "links": None,
+    }
+
+
+def test_get_session_with_missing_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the session ID does not exist."""
+    key_error = SessionNotFoundError(session_id="unique-id")
+
+    decoy.when(session_store.get_session(session_id="unique-id")).then_raise(key_error)
+
+    response = client.get("/sessions/unique-id")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "errors": [SessionNotFound(detail=str(key_error)).dict(exclude_none=True)],
+    }
+
+
+def test_delete_session_by_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should be able to remove a session by ID."""
+    session = BasicSession(id="unique-id", commands=[])
+
+    decoy.when(session_store.remove_session_by_id(session_id="unique-id")).then_return(
+        session
+    )
+
+    response = client.delete("/sessions/unique-id")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": session.dict(),
+        "links": None,
+    }
+
+
+def test_delete_session_by_id_with_missing_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the session ID does not exist."""
+    key_error = SessionNotFoundError(session_id="unique-id")
+
+    decoy.when(session_store.remove_session_by_id(session_id="unique-id")).then_raise(
+        key_error
+    )
+
+    response = client.delete("/sessions/unique-id")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "errors": [SessionNotFound(detail=str(key_error)).dict(exclude_none=True)],
+    }
+
+
+def test_get_session_commands(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should be able to get a session's full command list."""
+    command = SessionCommand(id="command-id")
+
+    decoy.when(session_store.get_session_commands(session_id="session-id")).then_return(
+        [command]
+    )
+
+    response = client.get("/sessions/session-id/commands")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": [
+            command.dict(),
+        ],
+        "links": None,
+    }


### PR DESCRIPTION
## Overview

**Prototyping / research branch; not for merging**

I've been spending the past couple days TDD'ing my way through the HTTP interfaces for uploading and then running a protocol file. This is intended to map out the work to connect #7548 to the HTTP API. Any code from this branch that may be incorporated into `edge` will be done so through smaller future PRs.

I wanted to share this diff before I got way to deep, because I think I've hit on some stuff so far:

- I think to start off, we can keep one ProtocolEngine (lazily) around for session purposes
    - Any time the active session changes, get a new ProtocolEngine
    - Later, we can think about memoizing and restoring ProtocolEngine state if we have an actual use case
- I think we should rework the `Command` models in `opentrons.protocol_engine` quite heavily in the immediate term for OpenAPI spec purposes:
    - Include `commandType` disambiguation literal somewhere
    - Maybe ditch the whole `PendingCommand` / `RunningCommand` / etc. situation as a little too heavy-weight for what we truly need
    - Synchronize what we call command request data and command execution result data across the engine and the HAPI

## Changelog

- Add new top-level routers to `robot_server` -> `protocols` and `sessions`
- Add a series of incomplete interfaces one level below the routers that are really only present as test decoys
- Create some really minimal request/response models not tethered to our existing models

## Review requests

I'm not really sure. This is very in-progress, and is not wired up in any way. I think there are two places to start on this:

- The routers: do these basic CRUD interactions make sense?
- The router tests: do these system components behind the routers make sense?

Stuff that is decidedly not present in this prototype so far:

- A session for running a protocol file
    - e.g. accessing a protocol file during session creation
- Any sort of actual session or command state

Overall, I'm hoping this can start as a jumping off point for tickets and system architecture. Going to keep noodling on this and maybe even start breaking off actual PRs that potentially put new route(s) behind the Protocol Engine feature flag.

## Risk assessment

N/A, not for merging
