### PR TITLE
refactor(api): move module commands out of the hardware controller

### DIFF
--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -319,9 +319,7 @@ class MagDeck:
 
     def _connect_to_port(self, port=None):
         try:
-            mag_deck = environ.get('OT_MAG_DECK_ID')
             self._connection = serial_communication.connect(
-                device_name=mag_deck,
                 port=port,
                 baudrate=MAG_DECK_BAUDRATE
             )

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -274,9 +274,7 @@ class TempDeck:
 
     def _connect_to_port(self, port=None):
         try:
-            temp_deck = environ.get('OT_TEMP_DECK_ID', None)
             self._connection = serial_communication.connect(
-                device_name=temp_deck,
                 port=port,
                 baudrate=TEMP_DECK_BAUDRATE
             )

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -155,10 +155,6 @@ class API(HardwareAPILike):
         """
         checked_loop = use_or_initialize_loop(loop)
         checked_config = config or robot_configs.load()
-        # TODO (lc 05-12-2021) give responsibility of the the
-        # execution manager to the hardware controller in a follow-up.
-        # That means both execution manager and pause with message callback
-        # not need to be passed in to the builder any longer.
         backend = await Controller.build(checked_config)
         backend.set_lights(button=None, rails=False)
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -75,8 +75,7 @@ class API(HardwareAPILike):
         self._config = config
         self._backend = backend
         self._loop = loop
-        # TODO (lc 05-12-2021) give responsibility of the the
-        # execution manager to the hardware controller in a follow-up.
+
         self._execution_manager = ExecutionManager(loop=loop)
         self._callbacks: set = set()
         # {'X': 0.0, 'Y': 0.0, 'Z': 0.0, 'A': 0.0, 'B': 0.0, 'C': 0.0}

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -18,7 +18,7 @@ from opentrons.config.types import RobotConfig
 from opentrons.types import Mount
 
 from .module_control import AttachedModulesControl
-from .types import BoardRevision, Axis
+from .types import AionotifyEvent, BoardRevision, Axis
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
@@ -222,7 +222,10 @@ class Controller:
             return
         if event is not None:
             if 'ot_module' in event.name:
-                await self.module_controls.handle_module_appearance(event)
+                event_name = event.name
+                flags = aionotify.Flags.parse(event.flags)
+                event_description = AionotifyEvent.build(event_name, flags)
+                await self.module_controls.handle_module_appearance(event_description)
 
     async def watch(self, loop: asyncio.AbstractEventLoop):
         can_watch = aionotify is not None

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager, ExitStack
 import logging
-from typing import (Any, Dict, List, Optional,
-                    Tuple, TYPE_CHECKING, Union, Sequence)
+from typing import (Any, Dict, List, Optional, Tuple,
+                    TYPE_CHECKING, Union, Sequence)
 from typing_extensions import Final
 try:
     import aionotify  # type: ignore
@@ -11,14 +11,13 @@ except OSError:
     aionotify = None  # type: ignore
 
 from opentrons.drivers.smoothie_drivers import driver_3_0
-from opentrons.drivers.rpi_drivers import build_gpio_chardev, types, usb
+from opentrons.drivers.rpi_drivers import build_gpio_chardev, usb
 import opentrons.config
 from opentrons.config import pipette_config
 from opentrons.config.types import RobotConfig
 from opentrons.types import Mount
 
-from . import modules
-from .execution_manager import ExecutionManager
+from .module_control import AttachedModulesControl
 from .types import BoardRevision, Axis
 
 if TYPE_CHECKING:
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
         PipetteModel, PipetteName
     )
     from .dev_types import (
-        RegisterModules, AttachedInstrument, AttachedInstruments,
+        AttachedInstrument, AttachedInstruments,
         InstrumentHardwareConfigs)
     from opentrons.drivers.rpi_drivers.dev_types\
         import GPIODriverLike
@@ -40,7 +39,8 @@ class Controller:
     """
 
     @classmethod
-    async def build(cls, config: RobotConfig) -> Controller:
+    async def build(
+            cls, config: RobotConfig) -> Controller:
         """ Build a Controller instance.
 
         Use this factory method rather than the initializer to handle proper
@@ -79,16 +79,22 @@ class Controller:
             handle_locks=False)
         self._cached_fw_version: Optional[str] = None
         self._usb = usb.USBBus(self._board_revision)
+        self._module_controls: Optional[AttachedModulesControl] = None
         try:
-            self._module_watcher = aionotify.Watcher()
-            self._module_watcher.watch(
-                alias='modules',
-                path='/dev',
-                flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE))
+            self._event_watcher = self._build_event_watcher()
         except AttributeError:
             MODULE_LOG.warning(
                 'Failed to initiate aionotify, cannot watch modules '
                 'or door, likely because not running on linux')
+
+    @staticmethod
+    def _build_event_watcher():
+        watcher = aionotify.Watcher()
+        watcher.watch(
+            alias='modules',
+            path='/dev',
+            flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE))
+        return watcher
 
     @property
     def gpio_chardev(self) -> GPIODriverLike:
@@ -97,6 +103,16 @@ class Controller:
     @property
     def board_revision(self) -> BoardRevision:
         return self._board_revision
+
+    @property
+    def module_controls(self) -> AttachedModulesControl:
+        if not self._module_controls:
+            raise AttributeError('Module controls not found.')
+        return self._module_controls
+
+    @module_controls.setter
+    def module_controls(self, module_controls: AttachedModulesControl):
+        self._module_controls = module_controls
 
     def start_gpio_door_watcher(self, **kargs):
         self.gpio_chardev.start_door_switch_watcher(**kargs)
@@ -198,65 +214,23 @@ class Controller:
         finally:
             self._smoothie_driver.pop_active_current()
 
-    async def _handle_watch_event(self, register_modules: RegisterModules):
+    async def _handle_watch_event(self):
         try:
-            event = await self._module_watcher.get_event()
+            event = await self._event_watcher.get_event()
         except asyncio.IncompleteReadError:
             MODULE_LOG.debug("incomplete read error when quitting watcher")
             return
-        flags = aionotify.Flags.parse(event.flags)
-        if event is not None and 'ot_module' in event.name:
-            maybe_module_at_port = modules.get_module_at_port(event.name)
-            new_modules = None
-            removed_modules = None
-            if maybe_module_at_port is not None:
-                if aionotify.Flags.DELETE in flags:
-                    removed_modules = [maybe_module_at_port]
-                    MODULE_LOG.info(
-                        f'Module Removed: {maybe_module_at_port}')
-                elif aionotify.Flags.CREATE in flags:
-                    new_modules = [maybe_module_at_port]
-                    MODULE_LOG.info(
-                        f'Module Added: {maybe_module_at_port}')
-                try:
-                    await register_modules(
-                        removed_mods_at_ports=removed_modules,
-                        new_mods_at_ports=new_modules,
-                    )
-                except Exception:
-                    MODULE_LOG.exception(
-                        'Exception in Module registration')
+        if event is not None:
+            if 'ot_module' in event.name:
+                await self.module_controls.handle_module_appearance(event)
 
-    async def watch_modules(self, loop: asyncio.AbstractEventLoop,
-                            register_modules: RegisterModules):
+    async def watch(self, loop: asyncio.AbstractEventLoop):
         can_watch = aionotify is not None
         if can_watch:
-            await self._module_watcher.setup(loop)
+            await self._event_watcher.setup(loop)
 
-        initial_modules = modules.discover()
-        try:
-            await register_modules(new_mods_at_ports=initial_modules)
-        except Exception:
-            MODULE_LOG.exception('Exception in Module registration')
-        while can_watch and (not self._module_watcher.closed):
-            await self._handle_watch_event(register_modules)
-
-    async def build_module(
-            self,
-            port: str,
-            usb_port: types.USBPort,
-            model: str,
-            interrupt_callback: modules.InterruptCallback,
-            loop: asyncio.AbstractEventLoop,
-            execution_manager: ExecutionManager) -> modules.AbstractModule:
-        return await modules.build(
-            port=port,
-            usb_port=usb_port,
-            which=model,
-            simulating=False,
-            interrupt_callback=interrupt_callback,
-            loop=loop,
-            execution_manager=execution_manager)
+        while can_watch and (not self._event_watcher.closed):
+            await self._handle_watch_event()
 
     async def connect(self, port: str = None):
         self._smoothie_driver.connect(port)
@@ -326,9 +300,9 @@ class Controller:
             loop = asyncio.get_event_loop()
         except RuntimeError:
             return
-        if hasattr(self, '_module_watcher'):
-            if loop.is_running() and self._module_watcher:
-                self._module_watcher.close()
+        if hasattr(self, '_event_watcher'):
+            if loop.is_running() and self._event_watcher:
+                self._event_watcher.close()
         if hasattr(self, 'gpio_chardev'):
             try:
                 if not loop.is_closed():

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # and are only relevant for static typechecking. this file should only
 # be imported if typing.TYPE_CHECKING is True
 import asyncio
-from typing import List, Optional, Dict, Union
+from typing import Optional, Dict, Union
 
 from typing_extensions import Protocol, TypedDict, Literal
 
@@ -12,19 +12,10 @@ from opentrons_shared_data.pipette.dev_types import (
 )
 
 from opentrons.drivers.types import MoveSplit
-from .modules import ModuleAtPort
 from .types import HardwareEventType
 
 from opentrons.types import Mount
 from opentrons.config.pipette_config import PipetteConfig
-
-
-class RegisterModules(Protocol):
-    async def __call__(
-        self,
-        new_mods_at_ports: List[ModuleAtPort] = None,
-        removed_mods_at_ports: List[ModuleAtPort] = None
-    ) -> None: ...
 
 
 class HasLoop(Protocol):

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -1,0 +1,225 @@
+import logging
+import asyncio
+import re
+from typing import List, Tuple, Optional, TYPE_CHECKING
+from glob import glob
+
+from opentrons.config import IS_ROBOT, IS_LINUX
+from opentrons.drivers.rpi_drivers import types
+from opentrons.hardware_control.modules.types import ModuleAtPort
+
+from .execution_manager import ExecutionManager
+from . import modules
+
+try:
+    import aionotify  # type: ignore
+except OSError:
+    aionotify = None  # type: ignore
+
+
+log = logging.getLogger(__name__)
+
+MODULE_PORT_REGEX = re.compile('|'.join(modules.MODULE_HW_BY_NAME.keys()), re.I)
+
+
+class AttachedModulesControl:
+    """
+    A class to handle monitoring module attachment, capturing the physical
+    USB port information and finally building a module object.
+    """
+
+    def __init__(self, api):
+        self._available_modules: List[modules.AbstractModule] = []
+        self._api = api
+
+    @classmethod
+    async def build(cls, api_instance):
+        mc_instance = cls(api_instance)
+        if not api_instance.is_simulator:
+            await mc_instance.register_modules(mc_instance.scan())
+        return mc_instance
+
+    @property
+    def available_modules(self) -> List[modules.AbstractModule]:
+        return self._available_modules
+
+    @property
+    def api(self):
+        return self._api
+
+    async def build_module(
+            self,
+            port: str,
+            usb_port: types.USBPort,
+            model: str,
+            loop: asyncio.AbstractEventLoop,
+            sim_model: str = None
+            ) -> modules.AbstractModule:
+        return await modules.build(
+            port=port,
+            usb_port=usb_port,
+            which=model,
+            simulating=self.api.is_simulator,
+            interrupt_callback=self.api.pause_with_message,
+            loop=loop,
+            execution_manager=self.api._execution_manager,
+            sim_model=sim_model)
+
+    def unregister_modules(self,
+                           mods_at_ports: List[modules.ModuleAtPort]) -> None:
+        """
+        De-register Modules.
+
+        Remove any modules that are no longer found by aionotify.
+        """
+        removed_modules = []
+        for mod in mods_at_ports:
+            for attached_mod in self.available_modules:
+                if attached_mod.port == mod.port:
+                    removed_modules.append(attached_mod)
+        for removed_mod in removed_modules:
+            try:
+                self._available_modules.remove(removed_mod)
+            except ValueError:
+                log.exception(f"Removed Module {removed_mod} not"
+                              " found in attached modules")
+        for removed_mod in removed_modules:
+            log.info(f"Module {removed_mod.name()} detached"
+                     f" from port {removed_mod.port}")
+            del removed_mod
+
+    async def register_modules(
+            self,
+            new_mods_at_ports: List[modules.ModuleAtPort] = None,
+            removed_mods_at_ports: List[modules.ModuleAtPort] = None
+            ) -> None:
+        """
+        Register Modules.
+
+        Upon system recognition of a module being plugged in, we should
+        register that module and de-register any modules that are
+        no longer found on the system.
+        """
+        if new_mods_at_ports is None:
+            new_mods_at_ports = []
+        if removed_mods_at_ports is None:
+            removed_mods_at_ports = []
+
+        # destroy removed mods
+        self.unregister_modules(removed_mods_at_ports)
+        sorted_mods_at_port =\
+            self.api._backend._usb.match_virtual_ports(new_mods_at_ports)
+
+        # build new mods
+        for mod in sorted_mods_at_port:
+            new_instance = await self.build_module(
+                    port=mod.port,
+                    usb_port=mod.usb_port,
+                    model=mod.name,
+                    loop=self.api.loop)
+            self._available_modules.append(new_instance)
+            log.info(f"Module {mod.name} discovered and attached"
+                     f" at port {mod.port}, new_instance: {new_instance}")
+
+    async def parse_modules(
+                self, by_model: modules.types.ModuleModel,
+                resolved_type: modules.types.ModuleType
+    ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
+        """
+        Parse Modules.
+        Given a module model and type, find all attached
+        modules that fit this criteria. If there are no
+        modules attached, but the module is being loaded
+        in simulation, then it should return a simulating
+        module of the same type.
+        """
+        matching_modules = []
+        simulated_module = None
+        mod_type = {
+            modules.types.ModuleType.MAGNETIC: 'magdeck',
+            modules.types.ModuleType.TEMPERATURE: 'tempdeck',
+            modules.types.ModuleType.THERMOCYCLER: 'thermocycler'
+        }[resolved_type]
+        for module in self.available_modules:
+            if mod_type == module.name():
+                matching_modules.append(module)
+        if self.api.is_simulator:
+            mod_class = {
+                'magdeck': modules.MagDeck,
+                'tempdeck': modules.TempDeck,
+                'thermocycler': modules.Thermocycler
+            }[mod_type]
+            simulating_module = mod_class(
+                port='',
+                usb_port=self.api._backend._usb.find_port(''),
+                simulating=True,
+                loop=self.api.loop,
+                execution_manager=ExecutionManager(
+                    loop=self.api.loop),
+                sim_model=by_model.value)
+            await simulating_module._connect()
+            simulated_module = simulating_module
+        return matching_modules, simulated_module
+
+    def scan(self) -> List[ModuleAtPort]:
+        """ Scan for connected modules and return list of
+            tuples of serial ports and device names
+        """
+        if IS_ROBOT and IS_LINUX:
+            devices = glob('/dev/ot_module*')
+        else:
+            devices = []
+
+        discovered_modules = []
+
+        for port in devices:
+            module_at_port = self.get_module_at_port(port)
+            if module_at_port:
+                discovered_modules.append(module_at_port)
+        log.debug('Discovered modules: {}'.format(discovered_modules))
+        return discovered_modules
+
+    @staticmethod
+    def get_module_at_port(port: str) -> Optional[ModuleAtPort]:
+        """ Given a port, returns either a ModuleAtPort
+            if it is a recognized module, or None if not recognized.
+        """
+        match = MODULE_PORT_REGEX.search(port)
+        if match:
+            name = match.group().lower()
+            if name not in modules.MODULE_HW_BY_NAME:
+                log.warning(f"Unexpected module connected: {name} on {port}")
+                return None
+            return ModuleAtPort(port=f'/dev/{port}', name=name)
+        return None
+
+    async def handle_module_appearance(self, event):
+        """ Only called upon availability of aionotify. Check that
+        the file system has changed and either remove or add modules
+        depending on the result.
+
+        :param event: Aionotify event. Note that since aionotify is
+        only supported on a linux system, we cannot properly type
+        this parameter.
+        """
+        maybe_module_at_port = self.get_module_at_port(event.name)
+        new_modules = None
+        removed_modules = None
+        flags = aionotify.Flags.parse(event.flags)
+        if maybe_module_at_port is not None:
+            if aionotify.Flags.DELETE in flags:
+                removed_modules = [maybe_module_at_port]
+                log.info(
+                    f'Module Removed: {maybe_module_at_port}')
+            elif aionotify.Flags.CREATE in flags:
+                new_modules = [maybe_module_at_port]
+                log.info(
+                    f'Module Added: {maybe_module_at_port}')
+            try:
+                await self.register_modules(
+                    removed_mods_at_ports=removed_modules,
+                    new_mods_at_ports=new_modules,
+                )
+            except Exception:
+                log.exception(
+                    'Exception in Module registration')

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -169,7 +169,8 @@ class AttachedModulesControl:
         discovered_modules = []
 
         for port in devices:
-            module_at_port = self.get_module_at_port(port)
+            symlink_port = port.split('dev/')[1]
+            module_at_port = self.get_module_at_port(symlink_port)
             if module_at_port:
                 discovered_modules.append(module_at_port)
         log.debug('Discovered modules: {}'.format(discovered_modules))
@@ -186,7 +187,7 @@ class AttachedModulesControl:
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None
-            return modules.ModuleAtPort(port=f'{port}', name=name)
+            return modules.ModuleAtPort(port=f'dev/{port}', name=name)
         return None
 
     async def handle_module_appearance(self, event: AionotifyEvent):

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 import re
-from typing import List, Tuple, Optional, TYPE_CHECKING
+from typing import List, Tuple, Optional
 from glob import glob
 
 from opentrons.config import IS_ROBOT, IS_LINUX

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -3,15 +3,15 @@ from .tempdeck import TempDeck
 from .magdeck import MagDeck
 from .thermocycler import Thermocycler
 from .update import update_firmware
-from .utils import MODULE_HW_BY_NAME, build, get_module_at_port, discover
+from .utils import MODULE_HW_BY_NAME, build
 from .types import (ThermocyclerStep, InterruptCallback, UploadFunction,
                     BundledFirmware, UpdateError, UnsupportedModuleError,
                     AbsentModuleError, ModuleAtPort)
 
 __all__ = [
-    'MODULE_HW_BY_NAME', 'build', 'get_module_at_port', 'discover',
-    'update_firmware', 'ThermocyclerStep', 'AbstractModule',
-    'TempDeck', 'MagDeck', 'Thermocycler', 'InterruptCallback',
+    'MODULE_HW_BY_NAME', 'build', 'update_firmware',
+    'ThermocyclerStep', 'AbstractModule', 'TempDeck',
+    'MagDeck', 'Thermocycler', 'InterruptCallback',
     'UploadFunction', 'BundledFirmware', 'UpdateError',
     'UnsupportedModuleError', 'AbsentModuleError', 'ModuleAtPort'
 ]

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -1,30 +1,21 @@
 import asyncio
 import logging
-import re
-from glob import glob
-from typing import List, Optional
 
-from opentrons.config import IS_ROBOT, IS_LINUX
 from opentrons.drivers.rpi_drivers.types import USBPort
 # NOTE: Must import all modules so they actually create the subclasses
 from . import update, tempdeck, magdeck, thermocycler, types  # noqa: F401
 from .mod_abc import AbstractModule
 from ..execution_manager import ExecutionManager
-from .types import InterruptCallback, ModuleAtPort
+from .types import InterruptCallback
 
 
 log = logging.getLogger(__name__)
 
-
-# mypy isn’t quite expressive enough to handle what we’re doing here, which
-# is get all the class objects that are subclasses of an abstract module
-# (strike 1) and call a classmethod on them (strike 2) and actually store
-# the class objects (strike 3). So, type: ignore
+# TODO (lc 05-12-2021) This is pretty gross. We should think
+# of a better way to do this.
 MODULE_HW_BY_NAME = {
-    cls.name(): cls for cls in AbstractModule.__subclasses__()  # type: ignore
+    cls.name(): cls for cls in AbstractModule.__subclasses__()
 }
-
-MODULE_PORT_REGEX = re.compile('|'.join(MODULE_HW_BY_NAME.keys()), re.I)
 
 
 async def build(
@@ -45,42 +36,3 @@ async def build(
         execution_manager=execution_manager,
         sim_model=sim_model
     )
-
-
-def get_module_at_port(port: str) -> Optional[ModuleAtPort]:
-    """ Given a port, returns either a ModuleAtPort
-        if it is a recognized module, or None if not recognized.
-    """
-    match = MODULE_PORT_REGEX.search(port)
-    if match:
-        name = match.group().lower()
-        return ModuleAtPort(port=f'/dev/{port}', name=name)
-    return None
-
-
-# TODO: BC 2020-02-13 consolidate this functionality with
-# hardware_controller.controller.Controller::_handle_watch_event
-# as they do nearly the same thing
-def discover() -> List[ModuleAtPort]:
-    """ Scan for connected modules and return list of
-        tuples of serial ports and device names
-    """
-    if IS_ROBOT and IS_LINUX:
-        devices = glob('/dev/ot_module*')
-    else:
-        devices = []
-
-    discovered_modules = []
-
-    for port in devices:
-        match = MODULE_PORT_REGEX.search(port)
-        if match:
-            name = match.group().lower()
-            if name not in MODULE_HW_BY_NAME:
-                log.warning("Unexpected module connected: {} on {}"
-                            .format(name, port))
-                continue
-            discovered_modules.append(ModuleAtPort(port=port, name=name))
-    log.debug('Discovered modules: {}'.format(discovered_modules))
-
-    return discovered_modules

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -3,7 +3,7 @@ import asyncio
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, TYPE_CHECKING
+from typing import cast, Tuple, Union, List, Dict, TYPE_CHECKING
 from typing_extensions import Literal
 from opentrons import types as top_types
 
@@ -239,6 +239,24 @@ class HardwareAction(enum.Enum):
 class PauseType(enum.Enum):
     PAUSE = 0
     DELAY = 1
+
+
+@dataclass
+class AionotifyEvent:
+    flags: enum.EnumMeta
+    name: str
+
+    @classmethod
+    def build(cls, name: str, flags: List[enum.Enum]):
+        # See https://github.com/python/mypy/issues/5317
+        # as to why mypy cannot detect that list
+        # comprehension or variables cannot be dynamically
+        # determined to meet the argument criteria for
+        # enums. Hence, the type ignore below.
+        flag_list = [f.name for f in flags]
+        Flag = enum.Enum('Flag',  # type: ignore
+                         flag_list)
+        cls(flags=Flag, name=name)
 
 
 class PauseResumeError(RuntimeError):

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -3,7 +3,7 @@ import asyncio
 import enum
 import logging
 from dataclasses import dataclass
-from typing import cast, Tuple, Union, List, Dict, TYPE_CHECKING
+from typing import cast, Tuple, Union, List, TYPE_CHECKING
 from typing_extensions import Literal
 from opentrons import types as top_types
 
@@ -247,7 +247,7 @@ class AionotifyEvent:
     name: str
 
     @classmethod
-    def build(cls, name: str, flags: List[enum.Enum]):
+    def build(cls, name: str, flags: List[enum.Enum]) -> 'AionotifyEvent':
         # See https://github.com/python/mypy/issues/5317
         # as to why mypy cannot detect that list
         # comprehension or variables cannot be dynamically
@@ -256,7 +256,7 @@ class AionotifyEvent:
         flag_list = [f.name for f in flags]
         Flag = enum.Enum('Flag',  # type: ignore
                          flag_list)
-        cls(flags=Flag, name=name)
+        return cls(flags=Flag, name=name)
 
 
 class PauseResumeError(RuntimeError):

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -34,14 +34,14 @@ async def test_module_caching():
     # Check that we can add and remove modules and the caching keeps up
     found_mods = api.attached_modules
     assert found_mods[0].name() == 'tempdeck'
-    await api.register_modules(
+    await api._backend.module_controls.register_modules(
         new_mods_at_ports=[ModuleAtPort(port='/dev/ot_module_sim_magdeck1',
                                         name='magdeck')
                            ])
     with_magdeck = api.attached_modules.copy()
     assert len(with_magdeck) == 2
     assert with_magdeck[0] is found_mods[0]
-    await api.register_modules(
+    await api._backend.module_controls.register_modules(
         removed_mods_at_ports=[
             ModuleAtPort(port='/dev/ot_module_sim_tempdeck0',
                          name='tempdeck')
@@ -51,7 +51,7 @@ async def test_module_caching():
 
     # Check that two modules of the same kind on different ports are
     # distinct
-    await api.register_modules(
+    await api._backend.module_controls.register_modules(
         new_mods_at_ports=[ModuleAtPort(port='/dev/ot_module_sim_magdeck2',
                                         name='magdeck')
                            ])
@@ -68,7 +68,7 @@ async def test_filtering_modules():
         'magdeck', 'thermocycler']
     api = await hardware_control.API.build_hardware_simulator(
                         attached_modules=mods)
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(0.05)
 
     filtered_modules, _ = await api.find_modules(
         MagneticModuleModel.MAGNETIC_V1, ModuleType.MAGNETIC)

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -47,7 +47,7 @@ async def test_module_cache_remove_entry():
     mods_before = thread_manager.attached_modules
     assert len(mods_before) == 2
 
-    await thread_manager.register_modules(
+    await thread_manager._backend.module_controls.register_modules(
         removed_mods_at_ports=[
             ModuleAtPort(port='/dev/ot_module_sim_tempdeck0',
                          name='tempdeck')

--- a/api/tests/opentrons/hardware_control/test_types.py
+++ b/api/tests/opentrons/hardware_control/test_types.py
@@ -1,0 +1,24 @@
+import enum
+from opentrons.hardware_control import types
+
+
+def test_create_aionotify_event():
+
+    class FakeEnum(enum.Enum):
+        CREATE = enum.auto()
+        DELETE = enum.auto()
+        MODIFY = enum.auto()
+
+    enum_list = [
+        FakeEnum.CREATE,
+        FakeEnum.DELETE,
+        FakeEnum.MODIFY]
+
+    new_event =\
+        types.AionotifyEvent.build('fake event', enum_list)
+
+    assert new_event.flags.CREATE
+    assert new_event.flags.DELETE
+    assert new_event.flags.MODIFY
+
+    assert new_event.name == 'fake event'


### PR DESCRIPTION
# Overview
There were a couple of goals with this refactor. First, we wanted to pull out all of the functionality around registering modules/finding registered modules. Second, I wanted to clean up the watch function for aionotify (maybe we can find a better library for this use-case that is cross-platform compatible, can get a bit annoying for typing purposes). Third, I wanted to make the initial discovery part of modules a little cleaner. Closes #7799.

# Changelog
- Clean up watch functionality in the controllers
- Created a new class to hold module registration/deregistration/finding control

# Future Considerations
1. I would love to combine all of the system 'watches' together/give full control to the controller for this. In a follow-up PR, we should refactor how the door file change is watched.
2. I feel like the execution manager should also be handled by the controller, but I'm open to other opinions on keeping it in the api file.

# Review requests
Please thoroughly test on a robot/review the code. Let me know if things don't make sense or you'd like me to change how something is implemented. Also let me know if naming of things is confusing.

# Risk assessment

High! Pulled out all the module code, deleted/refactored how modules are initially scanned. We should:
1. Run protocols with multiple modules
2. Check modules of the same type functionality still works
3. Plug/unplug modules a bunch of times, check that the app updates in a reasonable time.
4. Control modules in the app, check that that still works.