### PR TITLE
feat(api): allow labware calibration on non liquid handling events

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -255,3 +255,18 @@ def drop_tip(
             'text': text
         }
     }
+
+
+def move_to(
+        instrument: InstrumentContext,
+        location: Union[Location, Well]) -> command_types.MoveToCommand:
+    location_text = stringify_location(location)
+    text = 'Moving to {location}'.format(location=location_text)
+    return {
+        'name': command_types.MOVE_TO,
+        'payload': {
+            'instrument': instrument,
+            'location': location,
+            'text': text
+        }
+    }

--- a/api/src/opentrons/commands/paired_commands.py
+++ b/api/src/opentrons/commands/paired_commands.py
@@ -178,3 +178,18 @@ def paired_drop_tip(
             'text': text
         }
     }
+
+
+def paired_move_to(
+        instruments: Apiv2Instruments,
+        locations: Apiv2Locations, pub_type: str) -> command_types.MoveToCommand:
+    location_text = combine_locations(locations)
+    text = f'{pub_type}: Moving to {location_text}'
+    return {
+        'name': command_types.MOVE_TO,
+        'payload': {
+            'instruments': instruments,
+            'locations': locations,
+            'text': text
+        }
+    }

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -36,6 +36,7 @@ BLOW_OUT: Final = 'command.BLOW_OUT'
 AIR_GAP: Final = 'command.AIR_GAP'
 TOUCH_TIP: Final = 'command.TOUCH_TIP'
 RETURN_TIP: Final = 'command.RETURN_TIP'
+MOVE_TO: Final = 'command.MOVE_TO'
 
 # Modules #
 
@@ -450,6 +451,21 @@ class DropTipCommand(TypedDict):
     payload: Union[DropTipCommandPayload, PairedDropTipCommandPayload]
 
 
+class MoveToCommand(TypedDict):
+    name: Literal['command.MOVE_TO']
+    payload: Union[MoveToCommandPayload, PairedMoveToCommandPayload]
+
+
+class MoveToCommandPayload(
+        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    pass
+
+
+class PairedMoveToCommandPayload(
+        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    pass
+
+
 Command = Union[
     DropTipCommand, PickUpTipCommand, ReturnTipCommand, AirGapCommand,
     TouchTipCommand, BlowOutCommand, MixCommand, TransferCommand,
@@ -463,7 +479,7 @@ Command = Union[
     TempdeckDeactivateCommand, TempdeckAwaitTempCommand,
     TempdeckSetTempCommand, MagdeckCalibrateCommand, MagdeckDisengageCommand,
     MagdeckEngageCommand, ResumeCommand, PauseCommand, DelayCommand,
-    CommentCommand]
+    CommentCommand, MoveToCommand]
 
 
 CommandPayload = Union[
@@ -492,7 +508,8 @@ CommandPayload = Union[
     ThermocyclerSetBlockTempCommandPayload,
     TempdeckAwaitTempCommandPayload,
     TempdeckSetTempCommandPayload,
-    PauseCommandPayload, DelayCommandPayload
+    PauseCommandPayload, DelayCommandPayload,
+    MoveToCommandPayload, PairedMoveToCommandPayload
 ]
 
 
@@ -507,6 +524,10 @@ CommandMessageMeta = TypedDict('CommandMessageMeta',
 
 
 class CommandMessageFields(CommandMessageMeta, CommandMessageSequence):
+    pass
+
+
+class MoveToMessage(CommandMessageFields, MoveToCommand):
     pass
 
 
@@ -673,4 +694,4 @@ CommandMessage = Union[
     ThermocyclerExecuteProfileMessage, ThermocyclerSetBlockTempMessage,
     ThermocyclerOpenMessage, TempdeckSetTempMessage, TempdeckDeactivateMessage,
     MagdeckEngageMessage, MagdeckDisengageMessage, MagdeckCalibrateMessage,
-    CommentMessage, DelayMessage, PauseMessage, ResumeMessage]
+    CommentMessage, DelayMessage, PauseMessage, ResumeMessage, MoveToMessage]

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1110,12 +1110,16 @@ class InstrumentContext(CommandPublisher):
             if isinstance(mod, ThermocyclerContext):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
+        do_publish(self.broker, cmds.move_to, self.move_to, 'before',
+                   None, None, self, location or self._ctx.location_cache)
         self._implementation.move_to(
             location=location,
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
             speed=speed
         )
+        do_publish(self.broker, cmds.move_to, self.move_to, 'after',
+                   None, None, self, location or self._ctx.location_cache)
         return self
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -191,7 +191,8 @@ class InstrumentContext(CommandPublisher):
             if self.api_version < APIVersion(2, 3) or \
                     not self._implementation.is_ready_to_aspirate():
                 if dest.labware.is_well:
-                    self.move_to(dest.labware.as_well().top())
+                    self.move_to(dest.labware.as_well().top(),
+                                 publish=False)
                 else:
                     # TODO(seth,2019/7/29): This should be a warning exposed
                     #  via rpc to the runapp
@@ -202,9 +203,9 @@ class InstrumentContext(CommandPublisher):
                         "cause over aspiration if the previous command is a "
                         "blow_out.")
                 self._implementation.prepare_for_aspirate()
-            self.move_to(dest)
+            self.move_to(dest, publish=False)
         elif dest != self._ctx.location_cache:
-            self.move_to(dest)
+            self.move_to(dest, publish=False)
 
         c_vol = self._implementation.get_available_volume() \
             if not volume else volume
@@ -271,10 +272,10 @@ class InstrumentContext(CommandPublisher):
             else:
                 loc = location.bottom().move(
                     types.Point(0, 0, self.well_bottom_clearance.dispense))
-            self.move_to(loc)
+            self.move_to(loc, publish=False)
         elif isinstance(location, types.Location):
             loc = location
-            self.move_to(location)
+            self.move_to(location, publish=False)
         elif location is not None:
             raise TypeError(
                 f'location should be a Well or Location, but it is {location}')
@@ -393,10 +394,10 @@ class InstrumentContext(CommandPublisher):
                 self._log.warning('Blow_out being performed on a tiprack. '
                                   'Please re-check your code')
             loc = location.top()
-            self.move_to(loc)
+            self.move_to(loc, publish=False)
         elif isinstance(location, types.Location):
             loc = location
-            self.move_to(loc)
+            self.move_to(loc, publish=False)
         elif location is not None:
             raise TypeError(
                 'location should be a Well or Location, but it is {}'
@@ -496,7 +497,7 @@ class InstrumentContext(CommandPublisher):
                 move_with_z_offset =\
                     well.as_well().top().point + types.Point(0, 0, v_offset)
                 to_loc = types.Location(move_with_z_offset, well)
-            self.move_to(to_loc)
+            self.move_to(to_loc, publish=False)
         else:
             raise TypeError(
                 'location should be a Well, but it is {}'.format(location))
@@ -554,7 +555,7 @@ class InstrumentContext(CommandPublisher):
         if not loc or not loc.labware.is_well:
             raise RuntimeError('No previous Well cached to perform air gap')
         target = loc.labware.as_well().top(height)
-        self.move_to(target)
+        self.move_to(target, publish=False)
         self.aspirate(volume)
         return self
 
@@ -660,7 +661,7 @@ class InstrumentContext(CommandPublisher):
         do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
                    'before', None, None, self, location=target)
 
-        self.move_to(target.top())
+        self.move_to(target.top(), publish=False)
 
         self._implementation.pick_up_tip(
             well=target._impl,
@@ -780,7 +781,7 @@ class InstrumentContext(CommandPublisher):
                 " However, it is a {}".format(location))
         do_publish(self.broker, cmds.drop_tip, self.drop_tip,
                    'before', None, None, self, location=target)
-        self.move_to(target)
+        self.move_to(target, publish=False)
 
         self._implementation.drop_tip(home_after=home_after)
         do_publish(self.broker, cmds.drop_tip, self.drop_tip,
@@ -1086,7 +1087,8 @@ class InstrumentContext(CommandPublisher):
                 location: types.Location,
                 force_direct: bool = False,
                 minimum_z_height: Optional[float] = None,
-                speed: Optional[float] = None
+                speed: Optional[float] = None,
+                publish: bool = True
                 ) -> InstrumentContext:
         """ Move the instrument.
 
@@ -1101,6 +1103,8 @@ class InstrumentContext(CommandPublisher):
                       the straight linear speed of the motion; to limit
                       individual axis speeds, you can use
                       :py:attr:`.ProtocolContext.max_speeds`.
+        :param publish: Whether a call to this function should publish to the
+        runlog or not.
         """
         from_loc = self._ctx.location_cache
         if not from_loc:
@@ -1110,16 +1114,18 @@ class InstrumentContext(CommandPublisher):
             if isinstance(mod, ThermocyclerContext):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
-        do_publish(self.broker, cmds.move_to, self.move_to, 'before',
-                   None, None, self, location or self._ctx.location_cache)
+        if publish:
+            do_publish(self.broker, cmds.move_to, self.move_to, 'before',
+                       None, None, self, location or self._ctx.location_cache)
         self._implementation.move_to(
             location=location,
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
             speed=speed
         )
-        do_publish(self.broker, cmds.move_to, self.move_to, 'after',
-                   None, None, self, location or self._ctx.location_cache)
+        if publish:
+            do_publish(self.broker, cmds.move_to, self.move_to, 'after',
+                       None, None, self, location or self._ctx.location_cache)
         return self
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -808,8 +808,16 @@ class PairedInstrumentContext(CommandPublisher):
                       to limit individual axis speeds, you can use
                       :py:attr:`.ProtocolContext.max_speeds`.
         """
+        instruments = list(self._instruments.values())
+        locations: Optional[List] = None
+        if location:
+            locations = self._get_locations(location)
+        publish_paired(self.broker, cmds.paired_move_to,
+                       'before', None, instruments, locations)
         self.paired_instrument_obj.move_to(
             location, force_direct, minimum_z_height, speed)
+        publish_paired(self.broker, cmds.paired_move_to,
+                       'after', None, instruments, locations)
         return self
 
     def _next_available_tip(self) -> Tuple[Labware, Well]:

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -812,6 +812,7 @@ class PairedInstrumentContext(CommandPublisher):
         locations: Optional[List] = None
         if location:
             locations = self._get_locations(location)
+
         publish_paired(self.broker, cmds.paired_move_to,
                        'before', None, instruments, locations)
         self.paired_instrument_obj.move_to(

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -286,9 +286,6 @@ def model(request, hardware, loop):
     # Use with pytest.mark.parametrize(’labware’, [some-labware-name])
     # to have a different labware loaded as .container. If not passed,
     # defaults to the version-appropriate way to do 96 flat
-    if request.node.get_closest_marker('api2_only')\
-       and request.param != build_v2_model:
-        pytest.skip('only works with hardware controller')
     try:
         lw_name = request.getfixturevalue('labware_name')
     except Exception:

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -703,7 +703,7 @@ def test_blow_out(ctx, monkeypatch):
     instr.pick_up_tip()
     instr.aspirate(10, lw.wells()[0])
 
-    def fake_move(loc):
+    def fake_move(loc, publish):
         nonlocal move_location
         move_location = loc
 

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -80,6 +80,7 @@ def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
+        'Moving to 5',
         'Dropping tip into A1 of Trash on 12'
     ]
 
@@ -106,6 +107,7 @@ def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
+        'Moving to 5',
         'Dropping tip into A1 of Trash on 12'
     ]
 
@@ -132,6 +134,9 @@ def test_execute_function_json_v5_apiv2(get_json_protocol_fixture,
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
+        'Moving to 5',
+        'Moving to B2 of Dest Plate on 3',
+        'Moving to B2 of Dest Plate on 3',
         'Dropping tip into A1 of Trash on 12'
     ]
 

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -41,6 +41,7 @@ def test_simulate_function_json_apiv2(get_json_protocol_fixture):
         'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
         'Touching tip',
         'Blowing out at B1 of Dest Plate on 3',
+        'Moving to 5',
         'Dropping tip into A1 of Trash on 12'
     ]
 


### PR DESCRIPTION
# Overview.
Closes #7800. In certain applications, a user may want to simply move to a labware with their pipette. In our current system, this means they cannot calibrate that labware until they either add a liquid handling command _or_ they create a whole separate 'calibration' protocol.

# Changelog

- Add a run log for `move_to` in both a regular instrument context and a paired instrument context
- Add a test to check that the session does indeed save that labware
- Update relevant types

# Review requests
Test on a robot. Have a robot move to a labware only, and you should be able to calibrate that labware now

# Risk assessment

Low. Simply adding the ability to calibrate extra labware in a protocol. Right now, users have to create a separate protocol or do fake aspirate/dispenses in order to calibrate labware that is only moved to.
