### PR TITLE
refactor(labware-creator): make constants readonly

### DIFF
--- a/labware-library/src/labware-creator/__tests__/formLevelValidation.test.ts
+++ b/labware-library/src/labware-creator/__tests__/formLevelValidation.test.ts
@@ -5,7 +5,7 @@ import {
   WELLS_OUT_OF_BOUNDS_X,
   WELLS_OUT_OF_BOUNDS_Y,
 } from '../formLevelValidation'
-import { getDefaultFormState } from '../fields'
+import { DEFAULT_FORM_STATE } from '../fields'
 // NOTE(IL, 2021-05-18): eventual dependency on definitions.tsx which uses require.context
 // would break this test (though it's not directly used)
 jest.mock('../../definitions')
@@ -92,13 +92,13 @@ describe('getWellGridBoundingBox', () => {
 
 describe('formLevelValidation', () => {
   it('should return no errors with the initial values of the form', () => {
-    const errors = formLevelValidation({ ...getDefaultFormState() })
+    const errors = formLevelValidation({ ...DEFAULT_FORM_STATE })
     expect(errors).toEqual({})
   })
 
   it('should return errors when well outside bounding box', () => {
     const errors = formLevelValidation({
-      ...getDefaultFormState(),
+      ...DEFAULT_FORM_STATE,
       footprintXDimension: '86',
       footprintYDimension: '128',
       gridColumns: '2',

--- a/labware-library/src/labware-creator/components/__tests__/sections/CreateNewDefinition.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/CreateNewDefinition.test.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { FormikConfig } from 'formik'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { wrapInFormik } from '../../utils/wrapInFormik'
 import { CreateNewDefinition } from '../../sections/CreateNewDefinition'
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormikConfig } from 'formik'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 
 import { CustomTiprackWarning } from '../../sections/CustomTiprackWarning'
 
@@ -12,7 +12,7 @@ let formikConfig: FormikConfig<LabwareFields>
 describe('CustomTiprackWarning', () => {
   beforeEach(() => {
     formikConfig = {
-      initialValues: getDefaultFormState(),
+      initialValues: DEFAULT_FORM_STATE,
       onSubmit: jest.fn(),
     }
   })

--- a/labware-library/src/labware-creator/components/__tests__/sections/Footprint.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Footprint.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import isEqual from 'lodash/isEqual'
 import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { Footprint } from '../../sections/Footprint'
 import { FormAlerts } from '../../alerts/FormAlerts'
 import { XYDimensionAlerts } from '../../alerts/XYDimensionAlerts'
@@ -28,7 +28,7 @@ const XYDimensionAlertsMock = XYDimensionAlerts as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual'
 import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import {
-  getDefaultFormState,
+  DEFAULT_FORM_STATE,
   LabwareFields,
   yesNoOptions,
 } from '../../../fields'
@@ -31,7 +31,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/GridOffset.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/GridOffset.test.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual'
 import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import { nestedTextMatcher } from '../../__testUtils__/nestedTextMatcher'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { isEveryFieldHidden } from '../../../utils'
 import { GridOffset } from '../../sections/GridOffset'
 import { FormAlerts } from '../../alerts/FormAlerts'
@@ -23,7 +23,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import isEqual from 'lodash/isEqual'
 import { render, screen } from '@testing-library/react'
 import {
-  getDefaultFormState,
+  DEFAULT_FORM_STATE,
   LabwareFields,
   snugLooseOptions,
 } from '../../../fields'
@@ -29,7 +29,7 @@ let formikConfig: FormikConfig<LabwareFields>
 describe('HandPlacedTipFit', () => {
   beforeEach(() => {
     formikConfig = {
-      initialValues: getDefaultFormState(),
+      initialValues: DEFAULT_FORM_STATE,
       onSubmit: jest.fn(),
     }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/Height.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Height.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import isEqual from 'lodash/isEqual'
 import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { isEveryFieldHidden } from '../../../utils'
 import { Height } from '../../sections/Height'
 import { FormAlerts } from '../../alerts/FormAlerts'
@@ -28,7 +28,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/Regularity.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Regularity.test.tsx
@@ -4,7 +4,7 @@ import { when } from 'jest-when'
 import { FormikConfig } from 'formik'
 import { render, screen } from '@testing-library/react'
 import {
-  getDefaultFormState,
+  DEFAULT_FORM_STATE,
   LabwareFields,
   yesNoOptions,
 } from '../../../fields'
@@ -25,7 +25,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/Volume.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Volume.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import { when } from 'jest-when'
 import isEqual from 'lodash/isEqual'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { isEveryFieldHidden } from '../../../utils'
 import { Volume } from '../../sections/Volume'
 import { FormAlerts } from '../../alerts/FormAlerts'
@@ -21,7 +21,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import { when } from 'jest-when'
 import isEqual from 'lodash/isEqual'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { wellBottomShapeOptionsWithIcons } from '../../optionsWithImages'
 import { displayAsTube } from '../../../utils'
 import { WellBottomAndDepth } from '../../sections/WellBottomAndDepth'
@@ -25,7 +25,7 @@ const displayAsTubeMock = displayAsTube as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import { when } from 'jest-when'
 import isEqual from 'lodash/isEqual'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { wellShapeOptionsWithIcons } from '../../optionsWithImages'
 import { displayAsTube } from '../../../utils'
 import { WellShapeAndSides } from '../../sections/WellShapeAndSides'
@@ -25,7 +25,7 @@ const displayAsTubeMock = displayAsTube as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
@@ -3,7 +3,7 @@ import { FormikConfig } from 'formik'
 import isEqual from 'lodash/isEqual'
 import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import { DEFAULT_FORM_STATE, LabwareFields } from '../../../fields'
 import { isEveryFieldHidden } from '../../../utils'
 import { WellSpacing } from '../../sections/WellSpacing'
 import { FormAlerts } from '../../alerts/FormAlerts'
@@ -23,7 +23,7 @@ const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
+  initialValues: DEFAULT_FORM_STATE,
   onSubmit: jest.fn(),
 }
 

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -285,18 +285,15 @@ export const aluminumBlockAutofills = {
   },
 }
 
-export const labwareTypeAutofills: Record<
-  LabwareType,
-  Partial<LabwareFields>
-> = {
+export const labwareTypeAutofills = {
   tipRack: {
-    homogeneousWells: 'true' as const,
+    homogeneousWells: 'true',
   },
   tubeRack: {},
   wellPlate: {},
   reservoir: {},
   aluminumBlock: {},
-}
+} as const
 
 export const aluminumBlockChildTypeOptions: Options = [
   {

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -39,7 +39,7 @@ export interface Option {
   disabled?: boolean
   imgSrc?: string
 }
-export type Options = Option[]
+export type Options = readonly Option[]
 
 export type LabwareType =
   | 'wellPlate'
@@ -283,7 +283,7 @@ export const aluminumBlockAutofills = {
     gridOffsetX: '14.38',
     gridOffsetY: '11.25',
   },
-}
+} as const
 
 export const labwareTypeAutofills = {
   tipRack: {
@@ -295,7 +295,7 @@ export const labwareTypeAutofills = {
   aluminumBlock: {},
 } as const
 
-export const aluminumBlockChildTypeOptions: Options = [
+export const aluminumBlockChildTypeOptions = [
   {
     name: 'Tubes',
     value: 'tubes',
@@ -308,7 +308,7 @@ export const aluminumBlockChildTypeOptions: Options = [
     name: 'PCR Plate',
     value: 'pcrPlate',
   },
-]
+] as const
 
 // For DRYness, these values aren't explicitly included in the autofill objects (eg tubeRackAutofills),
 // but should be included in the autofill spread
@@ -325,7 +325,7 @@ export const getImplicitAutofillValues = (
   return result
 }
 
-export const getDefaultFormState = (): LabwareFields => ({
+export const DEFAULT_FORM_STATE: Readonly<LabwareFields> = {
   labwareType: null,
   tubeRackInsertLoadName: null,
   aluminumBlockType: null,
@@ -368,9 +368,9 @@ export const getDefaultFormState = (): LabwareFields => ({
 
   // fields for test protocol
   pipetteName: null,
-})
+}
 
-export const LABELS: Record<keyof LabwareFields, string> = {
+export const LABELS: Readonly<Record<keyof LabwareFields, string>> = {
   labwareType: 'What type of labware are you creating?',
   tubeRackInsertLoadName: 'Which tube rack insert?',
   aluminumBlockType: 'Which aluminum block?',

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -15,7 +15,7 @@ import {
   aluminumBlockAutofills,
   aluminumBlockChildTypeOptions,
   aluminumBlockTypeOptions,
-  getDefaultFormState,
+  DEFAULT_FORM_STATE,
   tubeRackAutofills,
   tubeRackInsertOptions,
 } from './fields'
@@ -284,7 +284,7 @@ export const LabwareCreator = (): JSX.Element => {
         </AlertModal>
       )}
       <Formik
-        initialValues={lastUploaded || getDefaultFormState()}
+        initialValues={lastUploaded || DEFAULT_FORM_STATE}
         enableReinitialize
         validationSchema={labwareFormSchema}
         validate={formLevelValidation}


### PR DESCRIPTION
# Overview

Just going nuts having fun with using TS to ensure constants don't get mutated.

Before, `getDefaultFormState` was a fn to ensure the default form state didn't get mutated (which would be a hot mess) but if it's deep read-only, we should be safe just having it be a constant.

Based on #7806 so that needs to merge first then I can change the target branch of this PR

# Changelog


# Review requests

- Good idea? Executed correctly? Should we trust the type system and use constant dictionary-like objects like this, or should we ensure no mutation by keeping the getter (eg `getDefaultFormState`)? Probably the place it's most likely to go wrong is tests, I'm guessing.

# Risk assessment

Should be low!