### PR TITLE
chore(robot-server): make dev loads simulators.

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -44,6 +44,9 @@ ot_sources := $(ot_py_sources)
 # depend on a PHONY target
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'robot_server/**/.mypy_cache'
 
+# Uvicorn command to run the robot server in dev mode.
+run_dev ?= uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --reload
+
 .PHONY: all
 all: clean wheel
 
@@ -80,7 +83,7 @@ lint: $(ot_py_sources)
 .PHONY: dev
 dev: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev.env
 dev:
-	$(pipenv) run uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --reload
+	$(pipenv) run $(run_dev)
 
 .PHONY: local-shell
 local-shell:

--- a/robot-server/dev.env
+++ b/robot-server/dev.env
@@ -1,3 +1,4 @@
 # Environment for development
 OT_ROBOT_SERVER_ws_domain_socket=
 ENABLE_VIRTUAL_SMOOTHIE=true
+OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test.json

--- a/robot-server/test.env
+++ b/robot-server/test.env
@@ -1,4 +1,0 @@
-# Environment for running tests.
-OT_ROBOT_SERVER_ws_domain_socket=
-ENABLE_VIRTUAL_SMOOTHIE=true
-OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test.json

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -102,7 +102,7 @@ def run_server(request_session, server_temp_directory):
                            "--source", "robot_server",
                            "-m", "uvicorn", "robot_server:app",
                            "--host", "localhost", "--port", "31950"],
-                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': "test.env",
+                          env={'OT_ROBOT_SERVER_DOT_ENV_PATH': "dev.env",
                                'OT_API_CONFIG_DIR': server_temp_directory},
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE) as proc:


### PR DESCRIPTION
# Overview

Have `make dev` load simulating pipettes and modules. There was never much value in `make dev` if there are no pipettes and modules.

# Changelog

- delete test.env
- have dev.env load simulation file
- use dev.env in tavern test fixture

# Review requests


# Risk assessment

None