### PR TITLE
feat(labware-creator): Add custom tiprack not recommended section

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { FormikConfig } from 'formik'
+import { render, screen } from '@testing-library/react'
+import { getDefaultFormState, LabwareFields } from '../../../fields'
+
+import { CustomTiprackWarning } from '../../sections/CustomTiprackWarning'
+
+import { wrapInFormik } from '../../utils/wrapInFormik'
+
+const formikConfig: FormikConfig<LabwareFields> = {
+  initialValues: getDefaultFormState(),
+  onSubmit: jest.fn(),
+}
+
+describe('CustomTiprackWarning', () => {
+  it('should not render when no labware type selecred', () => {
+    const { container } = render(
+      wrapInFormik(<CustomTiprackWarning />, formikConfig)
+    )
+    expect(container.firstChild).toBe(null)
+  })
+
+  it('should render when tiprack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    render(wrapInFormik(<CustomTiprackWarning />, formikConfig))
+    expect(screen.getByText('Custom Tip Racks Are Not Recommended'))
+  })
+
+  it('should not render when non tiprack labware selected', () => {
+    formikConfig.initialValues.labwareType = 'tubeRack'
+    const { container } = render(
+      wrapInFormik(<CustomTiprackWarning />, formikConfig)
+    )
+    expect(container.firstChild).toBe(null)
+  })
+})

--- a/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/CustomTiprackWarning.test.tsx
@@ -7,13 +7,20 @@ import { CustomTiprackWarning } from '../../sections/CustomTiprackWarning'
 
 import { wrapInFormik } from '../../utils/wrapInFormik'
 
-const formikConfig: FormikConfig<LabwareFields> = {
-  initialValues: getDefaultFormState(),
-  onSubmit: jest.fn(),
-}
+let formikConfig: FormikConfig<LabwareFields>
 
 describe('CustomTiprackWarning', () => {
-  it('should not render when no labware type selecred', () => {
+  beforeEach(() => {
+    formikConfig = {
+      initialValues: getDefaultFormState(),
+      onSubmit: jest.fn(),
+    }
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+  it('should not render when no labware type selected', () => {
     const { container } = render(
       wrapInFormik(<CustomTiprackWarning />, formikConfig)
     )

--- a/labware-library/src/labware-creator/components/sections/CustomTiprackWarning.tsx
+++ b/labware-library/src/labware-creator/components/sections/CustomTiprackWarning.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { useFormikContext } from 'formik'
+import { SectionBody } from './SectionBody'
+import styles from '../../styles.css'
+
+import type { LabwareFields } from '../../fields'
+
+export const CustomTiprackWarning = (): JSX.Element | null => {
+  const { values } = useFormikContext<LabwareFields>()
+
+  if (values.labwareType === 'tipRack') {
+    return (
+      <div className={styles.new_definition_section}>
+        <SectionBody label="Custom Tip Racks Are Not Recommended">
+          <div className={styles.flex_row}>
+            <p className={styles.instructions_text}>
+              Opentrons tip racks are recommended for use with the OT-2. You are
+              welcome to try to use third party tip racks but accuracy is not
+              guaranteed.
+            </p>
+          </div>
+        </SectionBody>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -37,8 +37,9 @@ import { TextField } from './components/TextField'
 import { ImportErrorModal } from './components/ImportErrorModal'
 import { CreateNewDefinition } from './components/sections/CreateNewDefinition'
 import { UploadExisting } from './components/sections/UploadExisting'
-import { Regularity } from './components/sections/Regularity'
 
+import { CustomTiprackWarning } from './components/sections/CustomTiprackWarning'
+import { Regularity } from './components/sections/Regularity'
 import { Footprint } from './components/sections/Footprint'
 import { Height } from './components/sections/Height'
 import { Grid } from './components/sections/Grid'
@@ -406,6 +407,7 @@ export const LabwareCreator = (): JSX.Element => {
               {showCreatorForm && (
                 <>
                   {/* PAGE 1 - Labware */}
+                  <CustomTiprackWarning />
                   <Regularity />
                   <Footprint />
                   <Height />

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -133,7 +133,8 @@
 .preview_instructions,
 .brand_column,
 .brand_id_column,
-.volume_instructions_column {
+.volume_instructions_column,
+.instructions_text {
   flex-basis: 100%;
   flex-shrink: 0;
   font-size: var(--fs-body-1);


### PR DESCRIPTION
# Overview

closes #7712 by conditionally rendering custom tip racks not recommended section when tip racks are selected

# Changelog

- feat(labware-creator): Add custom tiprack not recommended section
- add tests

# Review requests

- [ ] custom tiprack not recommended section does not render for any non tiprack type labware
- [ ] custom tiprack not recommended section renders when tip rack is selected


# Risk assessment

Low this is a pretty dumb conditionally rendered presentational component
