### PR TITLE
feat(labware-creator): Add hand placed tip fit section and alerts

### DIFF
--- a/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
+++ b/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
@@ -15,6 +15,7 @@ Object {
   "gridRows": "1",
   "gridSpacingX": "9.09",
   "gridSpacingY": null,
+  "handPlacedTipFit": null,
   "homogeneousWells": "true",
   "labwareType": "reservoir",
   "labwareZDimension": "44.45",

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.ts
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.ts
@@ -19,6 +19,7 @@ describe('labwareDefToFields', () => {
       tubeRackInsertLoadName: null,
       aluminumBlockType: null,
       aluminumBlockChildType: null,
+      handPlacedTipFit: null,
 
       footprintXDimension: String(def.dimensions.xDimension),
       footprintYDimension: String(def.dimensions.yDimension),

--- a/labware-library/src/labware-creator/components/FormAlerts.tsx
+++ b/labware-library/src/labware-creator/components/FormAlerts.tsx
@@ -5,6 +5,7 @@ import { AlertItem } from '@opentrons/components'
 import {
   LabwareFields,
   IRREGULAR_LABWARE_ERROR,
+  LOOSE_TIP_FIT_ERROR,
   LINK_CUSTOM_LABWARE_FORM,
 } from '../fields'
 import { LinkOut } from './LinkOut'
@@ -30,6 +31,20 @@ export const IrregularLabwareAlert = (): JSX.Element => (
   />
 )
 
+// make LOOSE_TIP_FIT_ERROR alert here
+export const LooseTipFitAlert = (): JSX.Element => (
+  <AlertItem
+    key={LOOSE_TIP_FIT_ERROR}
+    type="error"
+    title={
+      <>
+        If your tip does not fit when placed by hand then it is not a good
+        candidate for this pipette on the OT-2.
+      </>
+    }
+  />
+)
+
 export const FormAlerts = (props: Props): JSX.Element | null => {
   const { fieldList, touched, errors } = props
 
@@ -41,11 +56,14 @@ export const FormAlerts = (props: Props): JSX.Element | null => {
   return (
     <>
       {allErrors.map(error => {
+        if (error === LOOSE_TIP_FIT_ERROR) {
+          return <LooseTipFitAlert key={error} />
+        }
         if (error === IRREGULAR_LABWARE_ERROR) {
           return <IrregularLabwareAlert key={error} />
         }
         return <AlertItem key={error} type="warning" title={error} />
-      })}{' '}
+      })}
     </>
   )
 }

--- a/labware-library/src/labware-creator/components/FormAlerts.tsx
+++ b/labware-library/src/labware-creator/components/FormAlerts.tsx
@@ -19,7 +19,6 @@ export interface Props {
 
 export const IrregularLabwareAlert = (): JSX.Element => (
   <AlertItem
-    key={IRREGULAR_LABWARE_ERROR}
     type="error"
     title={
       <>
@@ -33,7 +32,6 @@ export const IrregularLabwareAlert = (): JSX.Element => (
 
 export const LooseTipFitAlert = (): JSX.Element => (
   <AlertItem
-    key={LOOSE_TIP_FIT_ERROR}
     type="error"
     title={
       <>

--- a/labware-library/src/labware-creator/components/FormAlerts.tsx
+++ b/labware-library/src/labware-creator/components/FormAlerts.tsx
@@ -31,7 +31,6 @@ export const IrregularLabwareAlert = (): JSX.Element => (
   />
 )
 
-// make LOOSE_TIP_FIT_ERROR alert here
 export const LooseTipFitAlert = (): JSX.Element => (
   <AlertItem
     key={LOOSE_TIP_FIT_ERROR}

--- a/labware-library/src/labware-creator/components/TipFitAlerts.tsx
+++ b/labware-library/src/labware-creator/components/TipFitAlerts.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react'
 import { FormikTouched } from 'formik'
-import { LabwareFields } from '../../fields'
+import { LabwareFields } from '../fields'
 import { AlertItem } from '@opentrons/components'
 
-export const getTipFitAlerts = (
-  values: LabwareFields,
+export interface Props {
+  values: LabwareFields
   touched: FormikTouched<LabwareFields>
-): JSX.Element | null => {
-  const { handPlacedTipFit } = values
-  if (touched.handPlacedTipFit && handPlacedTipFit === 'snug') {
+}
+
+// TODO: (ka 2021-5-25): Move this along with other form/section alerts to alerts/ as components
+export const TipFitAlerts = (props: Props): JSX.Element | null => {
+  const { values, touched } = props
+  if (touched.handPlacedTipFit && values.handPlacedTipFit === 'snug') {
     return (
       <AlertItem
         type="info"

--- a/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { render } from '@testing-library/react'
 import { getIsHidden } from '../../formSelectors'
-import { IRREGULAR_LABWARE_ERROR } from '../../fields'
+import { IRREGULAR_LABWARE_ERROR, LOOSE_TIP_FIT_ERROR } from '../../fields'
 import { FormAlerts, Props as FormAlertProps } from '../FormAlerts'
 import { when, resetAllWhenMocks } from 'jest-when'
 
@@ -55,6 +55,29 @@ describe('FormAlerts', () => {
     const error = container.querySelector('[class="alert error"]')
     expect(error?.textContent).toBe(
       'Your labware is not compatible with the Labware Creator. Please fill out this form to request a custom labware definition.'
+    )
+  })
+
+  it('should render an loose tip fit error when hand placed fit is loose', () => {
+    when(getIsHiddenMock)
+      .calledWith('labwareType', {} as any)
+      .mockReturnValue(false)
+    when(getIsHiddenMock)
+      .calledWith('tubeRackInsertLoadName', {} as any)
+      .mockReturnValue(false)
+
+    const props: FormAlertProps = {
+      fieldList: ['labwareType', 'tubeRackInsertLoadName'],
+      touched: { labwareType: true, tubeRackInsertLoadName: true },
+      errors: {
+        labwareType: LOOSE_TIP_FIT_ERROR,
+      },
+    }
+
+    const { container } = render(<FormAlerts {...props} />)
+    const error = container.querySelector('[class="alert error"]')
+    expect(error?.textContent).toBe(
+      'If your tip does not fit when placed by hand then it is not a good candidate for this pipette on the OT-2.'
     )
   })
 })

--- a/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { FormikConfig } from 'formik'
+import isEqual from 'lodash/isEqual'
+import { when } from 'jest-when'
+import { render, screen } from '@testing-library/react'
+import {
+  getDefaultFormState,
+  LabwareFields,
+  snugLooseOptions,
+} from '../../../fields'
+import { HandPlacedTipFit } from '../../sections/HandPlacedTipFit'
+import { FormAlerts } from '../../FormAlerts'
+import { Dropdown } from '../../Dropdown'
+import { wrapInFormik } from '../../utils/wrapInFormik'
+import { getTipFitAlerts } from '../../utils/getTipFitAlerts'
+
+jest.mock('../../Dropdown')
+jest.mock('../../FormAlerts')
+jest.mock('../../utils/getTipFitAlerts')
+
+const FormAlertsMock = FormAlerts as jest.MockedFunction<typeof FormAlerts>
+const dropdownMock = Dropdown as jest.MockedFunction<typeof Dropdown>
+
+const getTipFitAlertsMock = getTipFitAlerts as jest.MockedFunction<
+  typeof getTipFitAlerts
+>
+
+let formikConfig: FormikConfig<LabwareFields>
+
+describe('HandPlacedTipFit', () => {
+  beforeEach(() => {
+    formikConfig = {
+      initialValues: getDefaultFormState(),
+      onSubmit: jest.fn(),
+    }
+
+    dropdownMock.mockImplementation(args => {
+      if (
+        isEqual(args, { name: 'handPlacedTipFit', options: snugLooseOptions })
+      ) {
+        return <div>handPlacedTipFit dropdown field</div>
+      } else {
+        return <div></div>
+      }
+    })
+
+    FormAlertsMock.mockImplementation(args => {
+      if (
+        isEqual(args, {
+          touched: {},
+          errors: {},
+          fieldList: ['handPlacedTipFit'],
+        })
+      ) {
+        return <div>mock alerts</div>
+      } else {
+        return <div></div>
+      }
+    })
+
+    when(getTipFitAlertsMock)
+      .expectCalledWith(formikConfig.initialValues, {})
+      .mockReturnValue(<div>mock getTipFitAlertsMock alerts</div>)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should not render when no labware type selected', () => {
+    const { container } = render(
+      wrapInFormik(<HandPlacedTipFit />, formikConfig)
+    )
+    expect(container.firstChild).toBe(null)
+  })
+
+  it('should render alerts and dropdown when tiprack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    render(wrapInFormik(<HandPlacedTipFit />, formikConfig))
+    expect(screen.getByText('Hand-Placed Tip Fit'))
+    expect(
+      screen.getByText(
+        'Place the tip you wish to use on the pipette you wish to use it on. Give the tip a wiggle to check the fit.'
+      )
+    )
+    expect(screen.getByText('mock alerts'))
+    expect(screen.getByText('handPlacedTipFit dropdown field'))
+    expect(screen.getByText('mock getTipFitAlertsMock alerts'))
+  })
+
+  it('should not render when non tiprack labware selected', () => {
+    formikConfig.initialValues.labwareType = 'wellPlate'
+    const { container } = render(
+      wrapInFormik(<HandPlacedTipFit />, formikConfig)
+    )
+    expect(container.firstChild).toBe(null)
+  })
+})

--- a/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
@@ -85,15 +85,15 @@ describe('HandPlacedTipFit', () => {
   it('should render alerts and dropdown when tiprack is selected', () => {
     formikConfig.initialValues.labwareType = 'tipRack'
     render(wrapInFormik(<HandPlacedTipFit />, formikConfig))
-    expect(screen.getByText('Hand-Placed Tip Fit'))
+    expect(screen.getByText('Hand-Placed Tip Fit')).toBeTruthy()
     expect(
       screen.getByText(
         'Place the tip you wish to use on the pipette you wish to use it on. Give the tip a wiggle to check the fit.'
       )
-    )
-    expect(screen.getByText('mock alerts'))
-    expect(screen.getByText('handPlacedTipFit dropdown field'))
-    expect(screen.getByText('mock getTipFitAlertsMock alerts'))
+    ).toBeTruthy()
+    expect(screen.getByText('mock alerts')).toBeTruthy()
+    expect(screen.getByText('handPlacedTipFit dropdown field')).toBeTruthy()
+    expect(screen.getByText('mock getTipFitAlertsMock alerts')).toBeTruthy()
   })
 
   it('should not render when non tiprack labware selected', () => {

--- a/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/HandPlacedTipFit.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { FormikConfig } from 'formik'
 import isEqual from 'lodash/isEqual'
-import { when } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import {
   getDefaultFormState,
@@ -12,17 +11,17 @@ import { HandPlacedTipFit } from '../../sections/HandPlacedTipFit'
 import { FormAlerts } from '../../FormAlerts'
 import { Dropdown } from '../../Dropdown'
 import { wrapInFormik } from '../../utils/wrapInFormik'
-import { getTipFitAlerts } from '../../utils/getTipFitAlerts'
+import { TipFitAlerts } from '../../TipFitAlerts'
 
 jest.mock('../../Dropdown')
 jest.mock('../../FormAlerts')
-jest.mock('../../utils/getTipFitAlerts')
+jest.mock('../../TipFitAlerts')
 
 const FormAlertsMock = FormAlerts as jest.MockedFunction<typeof FormAlerts>
 const dropdownMock = Dropdown as jest.MockedFunction<typeof Dropdown>
 
-const getTipFitAlertsMock = getTipFitAlerts as jest.MockedFunction<
-  typeof getTipFitAlerts
+const tipFitAlertsMock = TipFitAlerts as jest.MockedFunction<
+  typeof TipFitAlerts
 >
 
 let formikConfig: FormikConfig<LabwareFields>
@@ -58,9 +57,18 @@ describe('HandPlacedTipFit', () => {
       }
     })
 
-    when(getTipFitAlertsMock)
-      .expectCalledWith(formikConfig.initialValues, {})
-      .mockReturnValue(<div>mock getTipFitAlertsMock alerts</div>)
+    tipFitAlertsMock.mockImplementation(args => {
+      if (
+        isEqual(args, {
+          values: formikConfig.initialValues,
+          touched: {},
+        })
+      ) {
+        return <div>mock getTipFitAlertsMock alerts</div>
+      } else {
+        return <div></div>
+      }
+    })
   })
 
   afterEach(() => {

--- a/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
+++ b/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { useFormikContext } from 'formik'
+import { snugLooseOptions } from '../../fields'
+import { getTipFitAlerts } from '../utils/getTipFitAlerts'
+import { FormAlerts } from '../FormAlerts'
+import { Dropdown } from '../Dropdown'
+import { SectionBody } from './SectionBody'
+
+import styles from '../../styles.css'
+
+import type { LabwareFields } from '../../fields'
+
+const Content = (): JSX.Element => (
+  <div className={styles.flex_row}>
+    <div className={styles.tip_fit_column}>
+      <p>
+        Place the tip you wish to use on the pipette you wish to use it on. Give
+        the tip a wiggle to check the fit.
+      </p>
+
+      <p>
+        Note that fit may vary between Single and 8 Channel pipettes, as well as
+        between generations of the same pipette.
+      </p>
+    </div>
+    <div className={styles.form_fields_column}>
+      <Dropdown name="handPlacedTipFit" options={snugLooseOptions} />
+    </div>
+  </div>
+)
+
+export const HandPlacedTipFit = (): JSX.Element | null => {
+  const fieldList: Array<keyof LabwareFields> = ['handPlacedTipFit']
+  const { values, errors, touched } = useFormikContext<LabwareFields>()
+
+  if (values.labwareType === 'tipRack') {
+    return (
+      <div className={styles.new_definition_section}>
+        <SectionBody label="Hand-Placed Tip Fit">
+          <>
+            <FormAlerts
+              touched={touched}
+              errors={errors}
+              fieldList={fieldList}
+            />
+            {getTipFitAlerts(values, touched)}
+            <Content />
+          </>
+        </SectionBody>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
+++ b/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
 import { snugLooseOptions } from '../../fields'
-import { getTipFitAlerts } from '../utils/getTipFitAlerts'
 import { FormAlerts } from '../FormAlerts'
+import { TipFitAlerts } from '../TipFitAlerts'
 import { Dropdown } from '../Dropdown'
 import { SectionBody } from './SectionBody'
 
@@ -43,7 +43,7 @@ export const HandPlacedTipFit = (): JSX.Element | null => {
               errors={errors}
               fieldList={fieldList}
             />
-            {getTipFitAlerts(values, touched)}
+            <TipFitAlerts values={values} touched={touched} />
             <Content />
           </>
         </SectionBody>

--- a/labware-library/src/labware-creator/components/utils/getTipFitAlerts.tsx
+++ b/labware-library/src/labware-creator/components/utils/getTipFitAlerts.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { FormikTouched } from 'formik'
+import { LabwareFields } from '../../fields'
+import { AlertItem } from '@opentrons/components'
+
+export const getTipFitAlerts = (
+  values: LabwareFields,
+  touched: FormikTouched<LabwareFields>
+): JSX.Element | null => {
+  const { handPlacedTipFit } = values
+  if (touched.handPlacedTipFit && handPlacedTipFit === 'snug') {
+    return (
+      <AlertItem
+        type="info"
+        title="If your tip seems to fit when placed by hand it may work on the OT-2.  Proceed through the form to generate a definition. Once you have a definition you can check performance on the robot. "
+      />
+    )
+  }
+  return null
+}

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -85,6 +85,7 @@ export interface LabwareFields {
   aluminumBlockType: string | null | undefined // eg, '24well' or '96well'
   aluminumBlockChildType: string | null | undefined
 
+  handPlacedTipFit: string | null | undefined
   // tubeRackSides: string[], // eg, []
   footprintXDimension: string | null | undefined
   footprintYDimension: string | null | undefined
@@ -132,6 +133,7 @@ export interface ProcessedLabwareFields {
   tubeRackInsertLoadName: string
   aluminumBlockType: string
   aluminumBlockChildType: string | null
+  handPlacedTipFit: string | null
 
   // tubeRackSides: string[], // eg, []
   footprintXDimension: number
@@ -332,6 +334,7 @@ export const getDefaultFormState = (): LabwareFields => ({
   aluminumBlockType: null,
   aluminumBlockChildType: null,
 
+  handPlacedTipFit: null,
   // tubeRackSides: [],
   footprintXDimension: null,
   footprintYDimension: null,

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -18,6 +18,8 @@ export const DISPLAY_VOLUME_UNITS = 'µL'
 // magic string for all validation errors that direct user away to the labware request form
 export const IRREGULAR_LABWARE_ERROR = 'IRREGULAR_LABWARE_ERROR'
 
+export const LOOSE_TIP_FIT_ERROR = 'LOOSE_TIP_FIT_ERROR'
+
 export const LINK_CUSTOM_LABWARE_FORM =
   'https://opentrons-ux.typeform.com/to/xi8h0W'
 
@@ -70,6 +72,11 @@ export type BooleanString = 'true' | 'false' // TODO IMMEDIATELY revisit
 export const yesNoOptions = [
   { name: 'Yes', value: 'true' },
   { name: 'No', value: 'false' },
+]
+
+export const snugLooseOptions = [
+  { name: 'Snug', value: 'snug' },
+  { name: 'Loose', value: 'loose' },
 ]
 
 export interface LabwareFields {
@@ -368,6 +375,7 @@ export const LABELS: Record<keyof LabwareFields, string> = {
   tubeRackInsertLoadName: 'Which tube rack insert?',
   aluminumBlockType: 'Which aluminum block?',
   aluminumBlockChildType: 'What labware is on top of your aluminum block?',
+  handPlacedTipFit: 'Fit',
   homogeneousWells: 'Are all your wells the same shape and size?',
   footprintXDimension: 'Length',
   footprintYDimension: 'Width',

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -39,6 +39,7 @@ import { CreateNewDefinition } from './components/sections/CreateNewDefinition'
 import { UploadExisting } from './components/sections/UploadExisting'
 
 import { CustomTiprackWarning } from './components/sections/CustomTiprackWarning'
+import { HandPlacedTipFit } from './components/sections/HandPlacedTipFit'
 import { Regularity } from './components/sections/Regularity'
 import { Footprint } from './components/sections/Footprint'
 import { Height } from './components/sections/Height'
@@ -408,6 +409,7 @@ export const LabwareCreator = (): JSX.Element => {
                 <>
                   {/* PAGE 1 - Labware */}
                   <CustomTiprackWarning />
+                  <HandPlacedTipFit />
                   <Regularity />
                   <Footprint />
                   <Height />

--- a/labware-library/src/labware-creator/labwareDefToFields.ts
+++ b/labware-library/src/labware-creator/labwareDefToFields.ts
@@ -79,6 +79,7 @@ export function labwareDefToFields(
     tubeRackInsertLoadName: null,
     aluminumBlockType: null,
     aluminumBlockChildType: null,
+    handPlacedTipFit: null,
 
     labwareType,
     footprintXDimension: String(def.dimensions.xDimension),

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -54,13 +54,13 @@ export const labwareFormSchema: Yup.Schema<ProcessedLabwareFields> = Yup.object(
     labwareType: requiredString(LABELS.labwareType).oneOf(
       labwareTypeOptions.map(o => o.value)
     ),
-    handPlacedTipFit: Yup.mixed().when('labwareType', {
+    handPlacedTipFit: Yup.string().when('labwareType', {
       is: 'tipRack',
       then: requiredString(LABELS.handPlacedTipFit).oneOf(
         ['snug'],
         LOOSE_TIP_FIT_ERROR
       ),
-      otherwise: Yup.mixed().nullable(),
+      otherwise: Yup.string().nullable(),
     }),
     tubeRackInsertLoadName: Yup.mixed().when('labwareType', {
       is: 'tubeRack',

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -6,6 +6,7 @@ import {
   wellBottomShapeOptions,
   wellShapeOptions,
   IRREGULAR_LABWARE_ERROR,
+  LOOSE_TIP_FIT_ERROR,
   LABELS,
   MAX_X_DIMENSION,
   MIN_X_DIMENSION,
@@ -53,6 +54,14 @@ export const labwareFormSchema: Yup.Schema<ProcessedLabwareFields> = Yup.object(
     labwareType: requiredString(LABELS.labwareType).oneOf(
       labwareTypeOptions.map(o => o.value)
     ),
+    handPlacedTipFit: Yup.mixed().when('labwareType', {
+      is: 'tipRack',
+      then: requiredString(LABELS.handPlacedTipFit).oneOf(
+        ['snug'],
+        LOOSE_TIP_FIT_ERROR
+      ),
+      otherwise: Yup.mixed().nullable(),
+    }),
     tubeRackInsertLoadName: Yup.mixed().when('labwareType', {
       is: 'tubeRack',
       then: requiredString(LABELS.tubeRackInsertLoadName),

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -134,7 +134,8 @@
 .brand_column,
 .brand_id_column,
 .volume_instructions_column,
-.instructions_text {
+.instructions_text,
+.tip_fit_column {
   flex-basis: 100%;
   flex-shrink: 0;
   font-size: var(--fs-body-1);
@@ -176,7 +177,7 @@
   .brand_id_column,
   .help_text,
   .export_form_fields,
-  .volume_instructions_column {
+  .volume_instructions_column .tip_fit_column {
     flex-basis: var(--size-50p);
     flex-shrink: 1;
   }
@@ -208,7 +209,8 @@
   .instructions_column,
   .diagram_column,
   .form_fields_column,
-  .brand_column {
+  .brand_column,
+  .tip_fit_column {
     flex-basis: var(--size-third);
     flex-shrink: 1;
   }


### PR DESCRIPTION
# Overview

closes #7713

# Changelog

- feat(labware-creator): Add hand placed tip fit section and alerts
- add tests

# Review requests

- [ ] Hand-Fit section only renders when tipRack is selected
- [ ] Hand fit dropdown is required when visible (orange) (don't select an option and blur the field)
- [ ] Selecting `loose` renders error (red)
- [ ] Selecting `snug` renders info to proceed (blue)
- [ ] Code/tests are sane?

NOTE: Re Ians comment about `TipFitAlerts` vs `getTipFitAlerts` - we have a bunch of components in utils that do similar things for height and xy alerts. Will address these in a follow up PR where I move FormAlerts, TipFitAlerts, HeightAlerts etc... into an `alerts/` folder in components. 

# Risk assessment

Med. Had to touch `labwareDefToFields` to add the new field `handPlacedTipFit` so please sanity check!
