### PR TITLE
refactor(robot-server): start sessions router for HTTP-based runs

### DIFF
--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -6,10 +6,10 @@ from opentrons.config.feature_flags import enable_protocol_engine
 from .constants import V1_TAG
 from .errors import LegacyErrorResponse
 from .health import health_router
-from .sessions import sessions_router as experimental_sessions_router
+from .sessions import sessions_router
 from .system import system_router
 from .service.legacy.routers import legacy_routes
-from .service.session.router import router as session_router
+from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
 from .service.labware.router import router as labware_router
 from .service.protocol.router import router as protocol_router
@@ -39,16 +39,11 @@ router.include_router(
     },
 )
 
-if enable_protocol_engine():
-    router.include_router(
-        router=experimental_sessions_router,
-        tags=["Session Management"],
-    )
-else:
-    router.include_router(
-        router=session_router,
-        tags=["Session Management"],
-    )
+
+router.include_router(
+    router=sessions_router if enable_protocol_engine() else deprecated_session_router,
+    tags=["Session Management"],
+)
 
 router.include_router(
     router=labware_router,

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -1,9 +1,12 @@
 """Application routes."""
 from fastapi import APIRouter, status
 
+from opentrons.config.feature_flags import enable_protocol_engine
+
 from .constants import V1_TAG
 from .errors import LegacyErrorResponse
 from .health import health_router
+from .sessions import sessions_router as experimental_sessions_router
 from .system import system_router
 from .service.legacy.routers import legacy_routes
 from .service.session.router import router as session_router
@@ -36,11 +39,16 @@ router.include_router(
     },
 )
 
-# New v2 routes
-router.include_router(
-    router=session_router,
-    tags=["Session Management"],
-)
+if enable_protocol_engine():
+    router.include_router(
+        router=experimental_sessions_router,
+        tags=["Session Management"],
+    )
+else:
+    router.include_router(
+        router=session_router,
+        tags=["Session Management"],
+    )
 
 router.include_router(
     router=labware_router,

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -1,10 +1,19 @@
 from .request import RequestModel
-from .response import ResponseModel, MultiResponseModel, ResponseDataModel
 from .resource_links import ResourceLink, ResourceLinks, ResourceLinkKey
+from .response import (
+    ResourceModel,
+    ResponseModel,
+    EmptyResponseModel,
+    MultiResponseModel,
+    ResponseDataModel,
+)
+
 
 __all__ = [
     "RequestModel",
+    "ResourceModel",
     "ResponseModel",
+    "EmptyResponseModel",
     "MultiResponseModel",
     "ResponseDataModel",
     "ResourceLink",

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -1,4 +1,5 @@
-from typing import Generic, TypeVar, Optional, List
+from typing import Generic, Optional, List, TypeVar
+from typing_extensions import Literal
 from pydantic import Field, BaseModel
 from pydantic.generics import GenericModel
 
@@ -6,39 +7,47 @@ from .resource_links import ResourceLinks
 
 
 class ResponseDataModel(BaseModel):
+    """A model representing an identifiable resource of the server.
+
+    .. deprecated::
+        Prefer ResourceModel, which requires ID to be specified
     """
-    """
-    id: str = \
-        Field(None,
-              description="id member represents a resource object.")
+
+    id: str = Field(None, description="Unique identifier for the resource object.")
 
 
-ResponseDataT = TypeVar('ResponseDataT', bound=ResponseDataModel)
+class ResourceModel(ResponseDataModel):
+    """A model representing an identifiable resource of the server."""
+
+    id: str = Field(..., description="Unique identifier of the resource.")
 
 
-DESCRIPTION_DATA = "the document’s 'primary data'"
+ResponseDataT = TypeVar("ResponseDataT", bound=ResponseDataModel)
+
+
+DESCRIPTION_DATA = "the document’s primary data"
 
 DESCRIPTION_LINKS = "a links object related to the primary data."
 
-DESCRIPTION_META = "a meta object that contains non-standard" \
-                             " meta-information."
+DESCRIPTION_META = "a meta object that contains non-standard meta-information."
 
 
 class ResponseModel(GenericModel, Generic[ResponseDataT]):
-    """A response that returns a single resource"""
+    """A response that returns a single resource."""
 
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: ResponseDataT = Field(
-        ...,
-        description=DESCRIPTION_DATA
-    )
+    data: ResponseDataT = Field(..., description=DESCRIPTION_DATA)
+
+
+class EmptyResponseModel(BaseModel):
+    """A response that returns no data."""
+
+    links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
+    data: Literal[None] = Field(None, description=DESCRIPTION_DATA)
 
 
 class MultiResponseModel(GenericModel, Generic[ResponseDataT]):
-    """A response that returns multiple resources"""
+    """A response that returns multiple resources."""
 
     links: Optional[ResourceLinks] = Field(None, description=DESCRIPTION_LINKS)
-    data: List[ResponseDataT] = Field(
-        ...,
-        description=DESCRIPTION_DATA
-    )
+    data: List[ResponseDataT] = Field(..., description=DESCRIPTION_DATA)

--- a/robot-server/robot_server/sessions/__init__.py
+++ b/robot-server/robot_server/sessions/__init__.py
@@ -1,0 +1,16 @@
+"""Session creation and management.
+
+A "session" is a logical container for a user's interaction with a robot,
+usually (but not always) with a well-defined start point and end point.
+Examples of "sessions" include:
+
+- A session to run a specific protocol
+- A session to complete a specific calibration procedure
+- A long running, "default" session to perform one-off actions, like toggling
+  the frame lights on
+"""
+from .router import sessions_router
+
+__all__ = [
+    "sessions_router",
+]

--- a/robot-server/robot_server/sessions/dependencies.py
+++ b/robot-server/robot_server/sessions/dependencies.py
@@ -1,8 +1,14 @@
 """Session router dependency wire-up."""
 from datetime import datetime
 
+from .session_builder import SessionBuilder
 from .session_store import SessionStore
 from .session_runner import SessionRunner
+
+
+def get_session_builder() -> SessionBuilder:
+    """Get an interface to build session resource models."""
+    raise NotImplementedError()
 
 
 def get_session_store() -> SessionStore:

--- a/robot-server/robot_server/sessions/dependencies.py
+++ b/robot-server/robot_server/sessions/dependencies.py
@@ -1,0 +1,25 @@
+"""Session router dependency wire-up."""
+from datetime import datetime
+
+from .session_store import SessionStore
+from .session_runner import SessionRunner
+
+
+def get_session_store() -> SessionStore:
+    """Get an interface to retrieve session data."""
+    raise NotImplementedError()
+
+
+def get_session_runner() -> SessionRunner:
+    """Get an interface to control the session's run lifecycle."""
+    raise NotImplementedError()
+
+
+def get_unique_id() -> str:
+    """Generate a unique identifier string."""
+    raise NotImplementedError()
+
+
+def get_current_time() -> datetime:
+    """Get the current system time."""
+    raise NotImplementedError()

--- a/robot-server/robot_server/sessions/router.py
+++ b/robot-server/robot_server/sessions/router.py
@@ -1,0 +1,179 @@
+"""Router for /sessions endpoints."""
+from fastapi import APIRouter, Depends, status
+from datetime import datetime
+from typing import Optional
+from typing_extensions import Literal
+
+from robot_server.errors import ErrorDetails, ErrorResponse
+from robot_server.service.json_api import (
+    RequestModel,
+    ResponseModel,
+    MultiResponseModel,
+)
+
+from .session_store import SessionStore, SessionNotFoundError
+from .session_runner import SessionRunner
+from .session_models import Session, CreateSessionData, SessionType
+from .session_inputs import SessionInput, CreateSessionInputData
+
+from .dependencies import (
+    get_session_store,
+    get_session_runner,
+    get_unique_id,
+    get_current_time,
+)
+
+sessions_router = APIRouter()
+
+
+class SessionNotFound(ErrorDetails):
+    """An error response for when a given session is not found."""
+
+    id: Literal["SessionNotFound"] = "SessionNotFound"
+    title: str = "Session Not Found"
+
+
+@sessions_router.post(
+    path="/sessions",
+    summary="Create a session",
+    description="Create a new session to track robot interaction.",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ResponseModel[Session],
+)
+async def create_session(
+    request_body: Optional[RequestModel[CreateSessionData]] = None,
+    session_store: SessionStore = Depends(get_session_store),
+    session_id: str = Depends(get_unique_id),
+    created_at: datetime = Depends(get_current_time),
+) -> ResponseModel[Session]:
+    """Create a new session.
+
+    Args:
+        request_body: Optional request body with session creation data.
+        session_store: Session storage interface.
+        session_id: Generated ID to assign to the session.
+        created_at: Timestamp to attach to created session
+    """
+    session_data = (
+        request_body.data
+        if request_body is not None
+        else CreateSessionData(sessionType=SessionType.BASIC)
+    )
+    session = session_store.create_session(
+        session_data=session_data,
+        session_id=session_id,
+        created_at=created_at,
+    )
+
+    return ResponseModel(data=session)
+
+
+@sessions_router.get(
+    path="/sessions",
+    summary="Get all sessions",
+    description="Get a list of all active and inactive sessions.",
+    status_code=status.HTTP_200_OK,
+    response_model=MultiResponseModel[Session],
+)
+async def get_sessions(
+    session_store: SessionStore = Depends(get_session_store),
+) -> MultiResponseModel[Session]:
+    """Get all sessions.
+
+    Args:
+        session_store: Session storage interface
+    """
+    sessions = session_store.get_all_sessions()
+    return MultiResponseModel(data=sessions)
+
+
+@sessions_router.get(
+    path="/sessions/{sessionId}",
+    summary="Get a session",
+    description="Get a specific session by its unique identifier.",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[Session],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+async def get_session(
+    sessionId: str,
+    session_store: SessionStore = Depends(get_session_store),
+) -> ResponseModel[Session]:
+    """Get a session by its ID.
+
+    Args:
+        sessionId: Session ID pulled from URL
+        session_store: Session storage interface
+    """
+    try:
+        session = session_store.get_session(session_id=sessionId)
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=session)
+
+
+@sessions_router.delete(
+    path="/sessions/{sessionId}",
+    summary="Delete a session",
+    description="Delete a specific session by its unique identifier.",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[Session],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+async def remove_session_by_id(
+    sessionId: str,
+    session_store: SessionStore = Depends(get_session_store),
+) -> ResponseModel[Session]:
+    """Delete a session by its ID.
+
+    Args:
+        sessionId: Session ID pulled from URL
+        session_store: Session storage interface
+    """
+    try:
+        session = session_store.remove_session_by_id(session_id=sessionId)
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=session)
+
+
+@sessions_router.post(
+    path="/sessions/{sessionId}/inputs",
+    summary="Create a session control input.",
+    description=(
+        "Provide input data to the session in order to control the"
+        "execution of the run."
+    ),
+    status_code=status.HTTP_201_CREATED,
+    response_model=ResponseModel[SessionInput],
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
+)
+async def create_session_input(
+    sessionId: str,
+    request_body: RequestModel[CreateSessionInputData],
+    session_runner: SessionRunner = Depends(get_session_runner),
+    input_id: str = Depends(get_unique_id),
+    created_at: datetime = Depends(get_current_time),
+) -> ResponseModel[SessionInput]:
+    """Create a session input.
+
+    Args:
+        sessionId: Session ID pulled from the URL.
+        request_body: Input payload from the request body.
+        session_runner: Session control interface.
+        input_id: Generated ID to assign to the input data.
+        created_at: Timestamp to attach to the input data.
+    """
+    try:
+        data = session_runner.handle_input(
+            session_id=sessionId,
+            input_data=request_body.data,
+            input_id=input_id,
+            created_at=created_at,
+        )
+    except SessionNotFoundError as e:
+        raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return ResponseModel(data=data)

--- a/robot-server/robot_server/sessions/router.py
+++ b/robot-server/robot_server/sessions/router.py
@@ -8,15 +8,18 @@ from robot_server.errors import ErrorDetails, ErrorResponse
 from robot_server.service.json_api import (
     RequestModel,
     ResponseModel,
+    EmptyResponseModel,
     MultiResponseModel,
 )
 
 from .session_store import SessionStore, SessionNotFoundError
+from .session_builder import SessionBuilder, CreateSessionData
 from .session_runner import SessionRunner
-from .session_models import Session, CreateSessionData, SessionType
+from .session_models import Session
 from .session_inputs import SessionInput, CreateSessionInputData
 
 from .dependencies import (
+    get_session_builder,
     get_session_store,
     get_session_runner,
     get_unique_id,
@@ -42,30 +45,36 @@ class SessionNotFound(ErrorDetails):
 )
 async def create_session(
     request_body: Optional[RequestModel[CreateSessionData]] = None,
+    session_builder: SessionBuilder = Depends(get_session_builder),
     session_store: SessionStore = Depends(get_session_store),
     session_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),
 ) -> ResponseModel[Session]:
     """Create a new session.
 
-    Args:
+    Arguments:
         request_body: Optional request body with session creation data.
+        session_builder: Session model construction interface.
         session_store: Session storage interface.
         session_id: Generated ID to assign to the session.
         created_at: Timestamp to attach to created session
     """
-    session_data = (
-        request_body.data
-        if request_body is not None
-        else CreateSessionData(sessionType=SessionType.BASIC)
-    )
-    session = session_store.create_session(
-        session_data=session_data,
+    session_data = request_body.data if request_body is not None else None
+
+    entry = session_store.create(
         session_id=session_id,
+        session_data=session_data,
         created_at=created_at,
     )
 
-    return ResponseModel(data=session)
+    data = session_builder.build(
+        session_id=entry.session_id,
+        session_data=entry.session_data,
+        created_at=entry.created_at,
+        inputs=entry.inputs,
+    )
+
+    return ResponseModel(data=data)
 
 
 @sessions_router.get(
@@ -76,15 +85,26 @@ async def create_session(
     response_model=MultiResponseModel[Session],
 )
 async def get_sessions(
+    session_builder: SessionBuilder = Depends(get_session_builder),
     session_store: SessionStore = Depends(get_session_store),
 ) -> MultiResponseModel[Session]:
     """Get all sessions.
 
     Args:
+        session_builder: Session model construction interface.
         session_store: Session storage interface
     """
-    sessions = session_store.get_all_sessions()
-    return MultiResponseModel(data=sessions)
+    data = [
+        session_builder.build(
+            session_id=entry.session_id,
+            session_data=entry.session_data,
+            created_at=entry.created_at,
+            inputs=entry.inputs,
+        )
+        for entry in session_store.get_all()
+    ]
+
+    return MultiResponseModel(data=data)
 
 
 @sessions_router.get(
@@ -97,20 +117,29 @@ async def get_sessions(
 )
 async def get_session(
     sessionId: str,
+    session_builder: SessionBuilder = Depends(get_session_builder),
     session_store: SessionStore = Depends(get_session_store),
 ) -> ResponseModel[Session]:
     """Get a session by its ID.
 
     Args:
         sessionId: Session ID pulled from URL
+        session_builder: Session model construction interface.
         session_store: Session storage interface
     """
     try:
-        session = session_store.get_session(session_id=sessionId)
+        entry = session_store.get(session_id=sessionId)
     except SessionNotFoundError as e:
         raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    return ResponseModel(data=session)
+    data = session_builder.build(
+        session_id=entry.session_id,
+        session_data=entry.session_data,
+        created_at=entry.created_at,
+        inputs=entry.inputs,
+    )
+
+    return ResponseModel(data=data)
 
 
 @sessions_router.delete(
@@ -118,32 +147,32 @@ async def get_session(
     summary="Delete a session",
     description="Delete a specific session by its unique identifier.",
     status_code=status.HTTP_200_OK,
-    response_model=ResponseModel[Session],
+    response_model=EmptyResponseModel,
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[SessionNotFound]}},
 )
 async def remove_session_by_id(
     sessionId: str,
     session_store: SessionStore = Depends(get_session_store),
-) -> ResponseModel[Session]:
+) -> EmptyResponseModel:
     """Delete a session by its ID.
 
-    Args:
-        sessionId: Session ID pulled from URL
-        session_store: Session storage interface
+    Arguments:
+        sessionId: Session ID pulled from URL.
+        session_store: Session storage interface.
     """
     try:
-        session = session_store.remove_session_by_id(session_id=sessionId)
+        session_store.remove(session_id=sessionId)
     except SessionNotFoundError as e:
         raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    return ResponseModel(data=session)
+    return EmptyResponseModel()
 
 
 @sessions_router.post(
     path="/sessions/{sessionId}/inputs",
     summary="Create a session control input.",
     description=(
-        "Provide input data to the session in order to control the"
+        "Provide input data to the session in order to control the "
         "execution of the run."
     ),
     status_code=status.HTTP_201_CREATED,
@@ -153,21 +182,23 @@ async def remove_session_by_id(
 async def create_session_input(
     sessionId: str,
     request_body: RequestModel[CreateSessionInputData],
+    session_store: SessionStore = Depends(get_session_store),
     session_runner: SessionRunner = Depends(get_session_runner),
     input_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),
 ) -> ResponseModel[SessionInput]:
     """Create a session input.
 
-    Args:
+    Arguments:
         sessionId: Session ID pulled from the URL.
         request_body: Input payload from the request body.
+        session_store: Session storage interface.
         session_runner: Session control interface.
         input_id: Generated ID to assign to the input data.
         created_at: Timestamp to attach to the input data.
     """
     try:
-        data = session_runner.handle_input(
+        data = session_store.create_input(
             session_id=sessionId,
             input_data=request_body.data,
             input_id=input_id,
@@ -175,5 +206,7 @@ async def create_session_input(
         )
     except SessionNotFoundError as e:
         raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    session_runner.trigger_input_effects(input=data)
 
     return ResponseModel(data=data)

--- a/robot-server/robot_server/sessions/session_builder.py
+++ b/robot-server/robot_server/sessions/session_builder.py
@@ -1,0 +1,53 @@
+"""Session model factory interface and types."""
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import List, Optional, Union
+from typing_extensions import Literal
+
+from .session_inputs import SessionInput
+from .session_models import SessionType, Session
+
+
+class AbstractCreateSessionData(BaseModel):
+    """Request data sent when creating a session."""
+
+    sessionType: SessionType = Field(
+        ...,
+        description="The session type to create.",
+    )
+    createParams: Optional[BaseModel] = Field(
+        None,
+        description="Parameters to set session behaviors at creation time.",
+    )
+
+
+class CreateBasicSessionData(AbstractCreateSessionData):
+    """Creation request data for a basic session."""
+
+    sessionType: Literal[SessionType.BASIC] = SessionType.BASIC
+
+
+CreateSessionData = Union[CreateBasicSessionData]
+
+
+class SessionBuilder:
+    """Interface to construct session resources."""
+
+    @staticmethod
+    def build(
+        session_id: str,
+        session_data: Optional[CreateSessionData],
+        created_at: datetime,
+        inputs: List[SessionInput],
+    ) -> Session:
+        """Build a session resource model.
+
+        Arguments:
+            session_id: Unique identifier of the session resource.
+            session_data: Data used to when the resource was created.
+            created_at: Resource creation timestamp.
+
+        Returns:
+            Session model representing the resource.
+        """
+        raise NotImplementedError()

--- a/robot-server/robot_server/sessions/session_inputs.py
+++ b/robot-server/robot_server/sessions/session_inputs.py
@@ -1,0 +1,36 @@
+"""Request and response models for session input resources."""
+from datetime import datetime
+from enum import Enum
+from pydantic import BaseModel, Field
+
+from robot_server.service.json_api import ResponseDataModel
+
+
+class SessionInputType(str, Enum):
+    """Input model types."""
+
+    START = "start"
+
+
+class CreateSessionInputData(BaseModel):
+    """Request model for new input creation."""
+
+    inputType: SessionInputType
+
+
+class SessionInput(ResponseDataModel):
+    """Session input model.
+
+    A SessionInput resource represents a client-provided input into the
+    session in order to control the execution of the session itself.
+
+    This is different than a protocol command, which represents an individual
+    action to execute on the robot as part of a protocol.
+    """
+
+    id: str = Field(..., description="A unique identifier to reference this input.")
+    createdAt: datetime = Field(..., description="When this input was created.")
+    inputType: SessionInputType = Field(
+        ...,
+        description="Specific type of input, which determines how to handle the input.",
+    )

--- a/robot-server/robot_server/sessions/session_inputs.py
+++ b/robot-server/robot_server/sessions/session_inputs.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import Enum
 from pydantic import BaseModel, Field
 
-from robot_server.service.json_api import ResponseDataModel
+from robot_server.service.json_api import ResourceModel
 
 
 class SessionInputType(str, Enum):
@@ -18,7 +18,7 @@ class CreateSessionInputData(BaseModel):
     inputType: SessionInputType
 
 
-class SessionInput(ResponseDataModel):
+class SessionInput(ResourceModel):
     """Session input model.
 
     A SessionInput resource represents a client-provided input into the

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -2,8 +2,11 @@
 from enum import Enum
 from datetime import datetime
 from pydantic import BaseModel, Field
+from typing import List, Optional, Union
+from typing_extensions import Literal
 
-from robot_server.service.json_api import ResponseDataModel
+from robot_server.service.json_api import ResourceModel
+from .session_inputs import SessionInput
 
 
 class SessionType(str, Enum):
@@ -12,21 +15,27 @@ class SessionType(str, Enum):
     BASIC = "basic"
 
 
-class CreateSessionData(BaseModel):
-    """Request data sent when creating a session."""
-
-    sessionType: SessionType = Field(
-        SessionType.BASIC,
-        description="The session type to create.",
-    )
-
-
-class Session(ResponseDataModel):
-    """Basic session resource model."""
+class AbstractSession(ResourceModel):
+    """Base session resource model."""
 
     id: str = Field(..., description="Unique session identifier.")
-    sessionType: SessionType = Field(
-        SessionType.BASIC,
-        description="Specific session type.",
-    )
+    sessionType: SessionType = Field(..., description="Specific session type.")
     createdAt: datetime = Field(..., description="When the session was created")
+    # TODO(mc, 2021-05-25): how hard would it be to rename this field to `config`?
+    createParams: Optional[BaseModel] = Field(
+        None,
+        description="Configuration parameters for the session.",
+    )
+    inputs: List[SessionInput] = Field(
+        ...,
+        description="Client-initiated events for session control input.",
+    )
+
+
+class BasicSession(AbstractSession):
+    """A session to execute commands without a previously loaded protocol file."""
+
+    sessionType: Literal[SessionType.BASIC] = SessionType.BASIC
+
+
+Session = Union[BasicSession]

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -1,0 +1,32 @@
+"""Request and response models for session resources."""
+from enum import Enum
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+from robot_server.service.json_api import ResponseDataModel
+
+
+class SessionType(str, Enum):
+    """All available session types."""
+
+    BASIC = "basic"
+
+
+class CreateSessionData(BaseModel):
+    """Request data sent when creating a session."""
+
+    sessionType: SessionType = Field(
+        SessionType.BASIC,
+        description="The session type to create.",
+    )
+
+
+class Session(ResponseDataModel):
+    """Basic session resource model."""
+
+    id: str = Field(..., description="Unique session identifier.")
+    sessionType: SessionType = Field(
+        SessionType.BASIC,
+        description="Specific session type.",
+    )
+    createdAt: datetime = Field(..., description="When the session was created")

--- a/robot-server/robot_server/sessions/session_runner.py
+++ b/robot-server/robot_server/sessions/session_runner.py
@@ -1,28 +1,15 @@
 """Session run input and controls."""
-from datetime import datetime
 
-from .session_inputs import SessionInput, CreateSessionInputData
+from .session_inputs import SessionInput
 
 
 class SessionRunner:
     """Methods for managing the lifecycle of a session."""
 
-    def handle_input(
-        self,
-        session_id: str,
-        input_id: str,
-        created_at: datetime,
-        input_data: CreateSessionInputData,
-    ) -> SessionInput:
-        """Handle an input event.
+    def trigger_input_effects(self, input: SessionInput) -> None:
+        """Trigger side-effects for an incoming input resource.
 
         Arguments:
-            session_id: Session the input is targeting.
-            input_id: ID to assign to the input event resource.
-            created_at: Timestamp to assign to the input event resource.
-            input_data: Input event payload
-
-        Returns:
-            A resource model representing the input event.
+            input: The session input resource to react to.
         """
         raise NotImplementedError()

--- a/robot-server/robot_server/sessions/session_runner.py
+++ b/robot-server/robot_server/sessions/session_runner.py
@@ -1,0 +1,17 @@
+"""Session run input and controls."""
+from datetime import datetime
+
+from .session_inputs import SessionInput, CreateSessionInputData
+
+
+class SessionRunner:
+    """Methods for managing the lifecycle of a session."""
+
+    def handle_input(
+        self,
+        session_id: str,
+        input_id: str,
+        created_at: datetime,
+        input_data: CreateSessionInputData,
+    ) -> SessionInput:
+        raise NotImplementedError()

--- a/robot-server/robot_server/sessions/session_runner.py
+++ b/robot-server/robot_server/sessions/session_runner.py
@@ -14,4 +14,15 @@ class SessionRunner:
         created_at: datetime,
         input_data: CreateSessionInputData,
     ) -> SessionInput:
+        """Handle an input event.
+
+        Arguments:
+            session_id: Session the input is targeting.
+            input_id: ID to assign to the input event resource.
+            created_at: Timestamp to assign to the input event resource.
+            input_data: Input event payload
+
+        Returns:
+            A resource model representing the input event.
+        """
         raise NotImplementedError()

--- a/robot-server/robot_server/sessions/session_store.py
+++ b/robot-server/robot_server/sessions/session_store.py
@@ -1,8 +1,20 @@
 """Sessions in-memory store."""
+from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
-from .session_models import Session, CreateSessionData
+from .session_builder import CreateSessionData
+from .session_inputs import SessionInput, CreateSessionInputData
+
+
+@dataclass(frozen=True)
+class SessionStoreEntry:
+    """An entry in the session store, used to construct response models."""
+
+    session_id: str
+    session_data: Optional[CreateSessionData]
+    created_at: datetime
+    inputs: List[SessionInput]
 
 
 class SessionNotFoundError(ValueError):
@@ -16,53 +28,74 @@ class SessionNotFoundError(ValueError):
 class SessionStore:
     """Methods for storing and retrieving session resources."""
 
-    def create_session(
+    def create(
         self,
-        session_data: CreateSessionData,
         session_id: str,
+        session_data: Optional[CreateSessionData],
         created_at: datetime,
-    ) -> Session:
+    ) -> SessionStoreEntry:
         """Create and store a new session resource.
 
         Arguments:
-            session: Input data to create session from.
             session_id: Unique identifier.
+            session_data: Data used to create the session.
+            created_at: Resource creation timestampe
 
         Returns:
-            The created session.
+            The created session entry in the store.
         """
         raise NotImplementedError()
 
-    def get_all_sessions(self) -> List[Session]:
+    def get(self, session_id: str) -> SessionStoreEntry:
+        """Get a specific session entry by its identifier.
+
+        Arguments:
+            session_id: Unique identifier of session entry to retrieve.
+
+        Returns:
+            The retrieved session entry from the store.
+        """
+        raise NotImplementedError()
+
+    def get_all(self) -> List[SessionStoreEntry]:
         """Get all known session resources.
 
         Returns:
-            All known sessions.
+            All stored session entries.
         """
         raise NotImplementedError()
 
-    def get_session(self, session_id: str) -> Session:
-        """Get a session by its unique identifier.
-
-        Arguments:
-            session_id: The session's unique identifier.
-
-        Returns:
-            The session resource.
-
-        Raises:
-            SessionNotFoundError: The specified session ID was not found.
-        """
-        raise NotImplementedError()
-
-    def remove_session_by_id(self, session_id: str) -> Session:
+    def remove(self, session_id: str) -> SessionStoreEntry:
         """Remove a session by its unique identifier.
 
         Arguments:
             session_id: The session's unique identifier.
 
         Returns:
-            The session resource that was deleted.
+            The session entry that was deleted.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        raise NotImplementedError()
+
+    def create_input(
+        self,
+        session_id: str,
+        input_id: str,
+        input_data: CreateSessionInputData,
+        created_at: datetime,
+    ) -> SessionInput:
+        """Create a session input resource and add it to the store.
+
+        Arguments:
+            session_id: The session to add the input to.
+            input_id: Unique ID to assign to the input resource.
+            input_data: Data used to create the input resource.
+            created_at: Resource creation timestamp.
+
+        Returns:
+            The created input resource.
 
         Raises:
             SessionNotFoundError: The specified session ID was not found.

--- a/robot-server/robot_server/sessions/session_store.py
+++ b/robot-server/robot_server/sessions/session_store.py
@@ -1,0 +1,70 @@
+"""Sessions in-memory store."""
+from datetime import datetime
+from typing import List
+
+from .session_models import Session, CreateSessionData
+
+
+class SessionNotFoundError(ValueError):
+    """Error raised when a given session ID is not found in the store."""
+
+    def __init__(self, session_id: str) -> None:
+        """Intialize the error message from the missing ID."""
+        super().__init__(f"Session {session_id} was not found.")
+
+
+class SessionStore:
+    """Methods for storing and retrieving session resources."""
+
+    def create_session(
+        self,
+        session_data: CreateSessionData,
+        session_id: str,
+        created_at: datetime,
+    ) -> Session:
+        """Create and store a new session resource.
+
+        Arguments:
+            session: Input data to create session from.
+            session_id: Unique identifier.
+
+        Returns:
+            The created session.
+        """
+        raise NotImplementedError()
+
+    def get_all_sessions(self) -> List[Session]:
+        """Get all known session resources.
+
+        Returns:
+            All known sessions.
+        """
+        raise NotImplementedError()
+
+    def get_session(self, session_id: str) -> Session:
+        """Get a session by its unique identifier.
+
+        Arguments:
+            session_id: The session's unique identifier.
+
+        Returns:
+            The session resource.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        raise NotImplementedError()
+
+    def remove_session_by_id(self, session_id: str) -> Session:
+        """Remove a session by its unique identifier.
+
+        Arguments:
+            session_id: The session's unique identifier.
+
+        Returns:
+            The session resource that was deleted.
+
+        Raises:
+            SessionNotFoundError: The specified session ID was not found.
+        """
+        raise NotImplementedError()

--- a/robot-server/tests/helpers.py
+++ b/robot-server/tests/helpers.py
@@ -1,0 +1,47 @@
+"""Server test helpers."""
+import json
+from pydantic import BaseModel
+from requests import Response
+from typing import Optional, Sequence, Union
+
+
+# TODO(mc, 2021-05-24): add links checking
+def verify_response(
+    response: Response,
+    *,
+    expected_data: Optional[Union[BaseModel, Sequence[BaseModel]]] = None,
+    expected_errors: Optional[Union[BaseModel, Sequence[BaseModel]]] = None,
+    expected_status: int,
+) -> None:
+    """Check that response's "data" field matches an expected model.
+
+    Serializes to JSON via Pydantic and deserializes via json.loads so that router
+    tests can assert using models directly, which allows the tests to concentrate
+    on data flows.
+    """
+    if expected_data is not None and expected_errors is not None:
+        raise ValueError(
+            "Needed one of `expected_data` or `expected_errors`, but received both."
+        )
+    elif expected_data is None and expected_errors is None:
+        raise ValueError(
+            "Needed `expected_data` or `expected_errors`, but received neither."
+        )
+
+    if isinstance(expected_data, BaseModel):
+        body_key = "data"
+        expected_json = expected_data.json()
+    elif expected_data is not None:
+        body_key = "data"
+        expected_json = f"[{','.join(item.json() for item in expected_data)}]"
+    elif isinstance(expected_errors, BaseModel):
+        body_key = "errors"
+        expected_json = f"[{expected_errors.json(exclude_none=True)}]"
+    elif expected_errors is not None:
+        body_key = "errors"
+        expected_json = (
+            f"[{','.join(item.json(exclude_none=True) for item in expected_errors)}]"
+        )
+
+    assert response.json()[body_key] == json.loads(expected_json)
+    assert response.status_code == expected_status

--- a/robot-server/tests/sessions/__init__.py
+++ b/robot-server/tests/sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the robot_server.sessions module."""

--- a/robot-server/tests/sessions/test_sessions_router.py
+++ b/robot-server/tests/sessions/test_sessions_router.py
@@ -7,9 +7,14 @@ from fastapi.testclient import TestClient
 
 from robot_server.errors import exception_handlers
 from robot_server.sessions.router import sessions_router, SessionNotFound
-from robot_server.sessions.session_models import Session, CreateSessionData, SessionType
-from robot_server.sessions.session_store import SessionStore, SessionNotFoundError
+from robot_server.sessions.session_builder import SessionBuilder, CreateBasicSessionData
+from robot_server.sessions.session_models import BasicSession
 from robot_server.sessions.session_runner import SessionRunner
+from robot_server.sessions.session_store import (
+    SessionStore,
+    SessionNotFoundError,
+    SessionStoreEntry,
+)
 
 from robot_server.sessions.session_inputs import (
     SessionInput,
@@ -18,6 +23,7 @@ from robot_server.sessions.session_inputs import (
 )
 
 from robot_server.sessions.dependencies import (
+    get_session_builder,
     get_session_store,
     get_session_runner,
     get_unique_id,
@@ -37,6 +43,12 @@ def decoy() -> Decoy:
 def session_store(decoy: Decoy) -> SessionStore:
     """Get a fake SessionStore interface."""
     return decoy.create_decoy(spec=SessionStore)
+
+
+@pytest.fixture
+def session_builder(decoy: Decoy) -> SessionBuilder:
+    """Get a fake SessionBuilder interface."""
+    return decoy.create_decoy(spec=SessionBuilder)
 
 
 @pytest.fixture
@@ -60,12 +72,14 @@ def current_time() -> datetime:
 @pytest.fixture
 def client(
     session_store: SessionStore,
+    session_builder: SessionBuilder,
     session_runner: SessionRunner,
     unique_id: str,
     current_time: datetime,
 ) -> TestClient:
     """Get an TestClient for /protocols routes with dependencies mocked out."""
     app = FastAPI(exception_handlers=exception_handlers)
+    app.dependency_overrides[get_session_builder] = lambda: session_builder
     app.dependency_overrides[get_session_store] = lambda: session_store
     app.dependency_overrides[get_session_runner] = lambda: session_runner
     app.dependency_overrides[get_unique_id] = lambda: unique_id
@@ -75,73 +89,38 @@ def client(
     return TestClient(app)
 
 
-def test_get_sessions_empty(
+def test_create_session(
     decoy: Decoy,
-    session_store: SessionStore,
-    client: TestClient,
-) -> None:
-    """It should return an empty collection response with no sessions exist."""
-    decoy.when(session_store.get_all_sessions()).then_return([])
-
-    response = client.get("/sessions")
-
-    verify_response(response, expected_status=200, expected_data=[])
-
-
-def test_get_sessions_not_empty(
-    decoy: Decoy,
-    session_store: SessionStore,
-    client: TestClient,
-) -> None:
-    """It should return an empty collection response with no sessions exist."""
-    session1 = Session(id="unique-id-1", createdAt=datetime.now())
-    session2 = Session(id="unique-id-2", createdAt=datetime.now())
-
-    decoy.when(session_store.get_all_sessions()).then_return([session1, session2])
-
-    response = client.get("/sessions")
-
-    verify_response(response, expected_status=200, expected_data=[session1, session2])
-
-
-def test_create_basic_session_implicitely(
-    decoy: Decoy,
+    session_builder: SessionBuilder,
     session_store: SessionStore,
     unique_id: str,
     current_time: datetime,
     client: TestClient,
 ) -> None:
     """It should be able to create a basic session from an empty POST request."""
-    expected_session = Session(id=unique_id, createdAt=current_time)
+    session_data = CreateBasicSessionData()
+    session_entry = SessionStoreEntry(
+        session_id=unique_id,
+        session_data=session_data,
+        created_at=current_time,
+        inputs=[],
+    )
+    expected_session = BasicSession(id=unique_id, createdAt=current_time, inputs=[])
 
     decoy.when(
-        session_store.create_session(
-            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+        session_store.create(
+            session_data=session_data,
             session_id=unique_id,
             created_at=current_time,
         )
-    ).then_return(expected_session)
-
-    response = client.post("/sessions")
-
-    verify_response(response, expected_status=201, expected_data=expected_session)
-
-
-def test_create_session_explicitely(
-    decoy: Decoy,
-    session_store: SessionStore,
-    unique_id: str,
-    current_time: datetime,
-    client: TestClient,
-) -> None:
-    """It should be able to create a basic session from an empty POST request."""
-    expected_session = Session(id=unique_id, createdAt=current_time)
+    ).then_return(session_entry)
 
     decoy.when(
-        session_store.create_session(
-            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+        session_builder.build(
+            session_data=session_data,
             session_id=unique_id,
             created_at=current_time,
+            inputs=[],
         )
     ).then_return(expected_session)
 
@@ -152,15 +131,31 @@ def test_create_session_explicitely(
 
 def test_get_session(
     decoy: Decoy,
+    session_builder: SessionBuilder,
     session_store: SessionStore,
     client: TestClient,
 ) -> None:
     """It should be able to get a session by ID."""
-    expected_session = Session(id="session-id", createdAt=datetime.now())
-
-    decoy.when(session_store.get_session(session_id="session-id")).then_return(
-        expected_session
+    created_at = datetime.now()
+    session_data = CreateBasicSessionData()
+    session_entry = SessionStoreEntry(
+        session_id="session-id",
+        session_data=session_data,
+        created_at=created_at,
+        inputs=[],
     )
+    expected_session = BasicSession(id="session-id", createdAt=created_at, inputs=[])
+
+    decoy.when(session_store.get(session_id="session-id")).then_return(session_entry)
+
+    decoy.when(
+        session_builder.build(
+            session_id="session-id",
+            session_data=session_data,
+            created_at=created_at,
+            inputs=[],
+        )
+    ).then_return(expected_session)
 
     response = client.get("/sessions/session-id")
 
@@ -173,17 +168,75 @@ def test_get_session_with_missing_id(
     client: TestClient,
 ) -> None:
     """It should 404 if the session ID does not exist."""
-    key_error = SessionNotFoundError(session_id="session-id")
+    not_found_error = SessionNotFoundError(session_id="session-id")
 
-    decoy.when(session_store.get_session(session_id="session-id")).then_raise(key_error)
+    decoy.when(session_store.get(session_id="session-id")).then_raise(not_found_error)
 
     response = client.get("/sessions/session-id")
 
     verify_response(
         response,
         expected_status=404,
-        expected_errors=SessionNotFound(detail=str(key_error)),
+        expected_errors=SessionNotFound(detail=str(not_found_error)),
     )
+
+
+def test_get_sessions_empty(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    decoy.when(session_store.get_all()).then_return([])
+
+    response = client.get("/sessions")
+
+    verify_response(response, expected_status=200, expected_data=[])
+
+
+def test_get_sessions_not_empty(
+    decoy: Decoy,
+    session_builder: SessionBuilder,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    created_at_1 = datetime.now()
+    created_at_2 = datetime.now()
+
+    entry_1 = SessionStoreEntry(
+        session_id="unique-id-1", session_data=None, created_at=created_at_1, inputs=[]
+    )
+    entry_2 = SessionStoreEntry(
+        session_id="unique-id-2", session_data=None, created_at=created_at_2, inputs=[]
+    )
+
+    session_1 = BasicSession(id="unique-id-1", createdAt=created_at_1, inputs=[])
+    session_2 = BasicSession(id="unique-id-2", createdAt=created_at_2, inputs=[])
+
+    decoy.when(session_store.get_all()).then_return([entry_1, entry_2])
+
+    decoy.when(
+        session_builder.build(
+            session_id="unique-id-1",
+            session_data=None,
+            created_at=created_at_1,
+            inputs=[],
+        )
+    ).then_return(session_1)
+
+    decoy.when(
+        session_builder.build(
+            session_id="unique-id-2",
+            session_data=None,
+            created_at=created_at_2,
+            inputs=[],
+        )
+    ).then_return(session_2)
+
+    response = client.get("/sessions")
+
+    verify_response(response, expected_status=200, expected_data=[session_1, session_2])
 
 
 def test_delete_session_by_id(
@@ -192,18 +245,15 @@ def test_delete_session_by_id(
     client: TestClient,
 ) -> None:
     """It should be able to remove a session by ID."""
-    expected_session = Session(id="session-id", createdAt=datetime.now())
-
-    decoy.when(session_store.remove_session_by_id(session_id="unique-id")).then_return(
-        expected_session
-    )
-
     response = client.delete("/sessions/unique-id")
 
-    verify_response(response, expected_status=200, expected_data=expected_session)
+    decoy.verify(session_store.remove(session_id="unique-id"))
+
+    assert response.status_code == 200
+    assert response.json()["data"] is None
 
 
-def test_delete_session_by_id_with_missing_id(
+def test_delete_session_with_bad_id(
     decoy: Decoy,
     session_store: SessionStore,
     client: TestClient,
@@ -211,9 +261,7 @@ def test_delete_session_by_id_with_missing_id(
     """It should 404 if the session ID does not exist."""
     key_error = SessionNotFoundError(session_id="session-id")
 
-    decoy.when(session_store.remove_session_by_id(session_id="session-id")).then_raise(
-        key_error
-    )
+    decoy.when(session_store.remove(session_id="session-id")).then_raise(key_error)
 
     response = client.delete("/sessions/session-id")
 
@@ -226,6 +274,7 @@ def test_delete_session_by_id_with_missing_id(
 
 def test_create_session_input(
     decoy: Decoy,
+    session_store: SessionStore,
     session_runner: SessionRunner,
     unique_id: str,
     current_time: datetime,
@@ -239,12 +288,12 @@ def test_create_session_input(
     )
 
     decoy.when(
-        session_runner.handle_input(
+        session_store.create_input(
             session_id="session-id",
             input_id=unique_id,
             input_data=CreateSessionInputData(inputType=SessionInputType.START),
             created_at=current_time,
-        )
+        ),
     ).then_return(expected_input)
 
     response = client.post(
@@ -252,27 +301,29 @@ def test_create_session_input(
         json={"data": {"inputType": "start"}},
     )
 
+    decoy.verify(session_runner.trigger_input_effects(input=expected_input))
+
     verify_response(response, expected_status=201, expected_data=expected_input)
 
 
 def test_create_session_input_with_missing_id(
     decoy: Decoy,
-    session_runner: SessionRunner,
+    session_store: SessionStore,
     unique_id: str,
     current_time: datetime,
     client: TestClient,
 ) -> None:
     """It should 404 if the session ID does not exist."""
-    key_error = SessionNotFoundError(session_id="session-id")
+    not_found_error = SessionNotFoundError(session_id="session-id")
 
     decoy.when(
-        session_runner.handle_input(
+        session_store.create_input(
             session_id="session-id",
             input_id=unique_id,
             input_data=CreateSessionInputData(inputType=SessionInputType.START),
             created_at=current_time,
-        )
-    ).then_raise(key_error)
+        ),
+    ).then_raise(not_found_error)
 
     response = client.post(
         "/sessions/session-id/inputs",
@@ -282,5 +333,5 @@ def test_create_session_input_with_missing_id(
     verify_response(
         response,
         expected_status=404,
-        expected_errors=SessionNotFound(detail=str(key_error)),
+        expected_errors=SessionNotFound(detail=str(not_found_error)),
     )

--- a/robot-server/tests/sessions/test_sessions_router.py
+++ b/robot-server/tests/sessions/test_sessions_router.py
@@ -280,7 +280,7 @@ def test_create_session_input(
     current_time: datetime,
     client: TestClient,
 ) -> None:
-    """It should handle a pause input."""
+    """It should handle a start input."""
     expected_input = SessionInput(
         inputType=SessionInputType.START,
         createdAt=current_time,

--- a/robot-server/tests/sessions/test_sessions_router.py
+++ b/robot-server/tests/sessions/test_sessions_router.py
@@ -1,0 +1,286 @@
+"""Tests for the /sessions router."""
+import pytest
+from datetime import datetime, timezone
+from decoy import Decoy
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from robot_server.errors import exception_handlers
+from robot_server.sessions.router import sessions_router, SessionNotFound
+from robot_server.sessions.session_models import Session, CreateSessionData, SessionType
+from robot_server.sessions.session_store import SessionStore, SessionNotFoundError
+from robot_server.sessions.session_runner import SessionRunner
+
+from robot_server.sessions.session_inputs import (
+    SessionInput,
+    SessionInputType,
+    CreateSessionInputData,
+)
+
+from robot_server.sessions.dependencies import (
+    get_session_store,
+    get_session_runner,
+    get_unique_id,
+    get_current_time,
+)
+
+from ..helpers import verify_response
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container."""
+    return Decoy()
+
+
+@pytest.fixture
+def session_store(decoy: Decoy) -> SessionStore:
+    """Get a fake SessionStore interface."""
+    return decoy.create_decoy(spec=SessionStore)
+
+
+@pytest.fixture
+def session_runner(decoy: Decoy) -> SessionRunner:
+    """Get a fake SessionRunner interface."""
+    return decoy.create_decoy(spec=SessionRunner)
+
+
+@pytest.fixture
+def unique_id() -> str:
+    """Get a fake unique identifier."""
+    return "unique-id"
+
+
+@pytest.fixture
+def current_time() -> datetime:
+    """Get a fake current time."""
+    return datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def client(
+    session_store: SessionStore,
+    session_runner: SessionRunner,
+    unique_id: str,
+    current_time: datetime,
+) -> TestClient:
+    """Get an TestClient for /protocols routes with dependencies mocked out."""
+    app = FastAPI(exception_handlers=exception_handlers)
+    app.dependency_overrides[get_session_store] = lambda: session_store
+    app.dependency_overrides[get_session_runner] = lambda: session_runner
+    app.dependency_overrides[get_unique_id] = lambda: unique_id
+    app.dependency_overrides[get_current_time] = lambda: current_time
+    app.include_router(sessions_router)
+
+    return TestClient(app)
+
+
+def test_get_sessions_empty(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    decoy.when(session_store.get_all_sessions()).then_return([])
+
+    response = client.get("/sessions")
+
+    verify_response(response, expected_status=200, expected_data=[])
+
+
+def test_get_sessions_not_empty(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no sessions exist."""
+    session1 = Session(id="unique-id-1", createdAt=datetime.now())
+    session2 = Session(id="unique-id-2", createdAt=datetime.now())
+
+    decoy.when(session_store.get_all_sessions()).then_return([session1, session2])
+
+    response = client.get("/sessions")
+
+    verify_response(response, expected_status=200, expected_data=[session1, session2])
+
+
+def test_create_basic_session_implicitely(
+    decoy: Decoy,
+    session_store: SessionStore,
+    unique_id: str,
+    current_time: datetime,
+    client: TestClient,
+) -> None:
+    """It should be able to create a basic session from an empty POST request."""
+    expected_session = Session(id=unique_id, createdAt=current_time)
+
+    decoy.when(
+        session_store.create_session(
+            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+            session_id=unique_id,
+            created_at=current_time,
+        )
+    ).then_return(expected_session)
+
+    response = client.post("/sessions")
+
+    verify_response(response, expected_status=201, expected_data=expected_session)
+
+
+def test_create_session_explicitely(
+    decoy: Decoy,
+    session_store: SessionStore,
+    unique_id: str,
+    current_time: datetime,
+    client: TestClient,
+) -> None:
+    """It should be able to create a basic session from an empty POST request."""
+    expected_session = Session(id=unique_id, createdAt=current_time)
+
+    decoy.when(
+        session_store.create_session(
+            session_data=CreateSessionData(sessionType=SessionType.BASIC),
+            session_id=unique_id,
+            created_at=current_time,
+        )
+    ).then_return(expected_session)
+
+    response = client.post("/sessions", json={"data": {"sessionType": "basic"}})
+
+    verify_response(response, expected_status=201, expected_data=expected_session)
+
+
+def test_get_session(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should be able to get a session by ID."""
+    expected_session = Session(id="session-id", createdAt=datetime.now())
+
+    decoy.when(session_store.get_session(session_id="session-id")).then_return(
+        expected_session
+    )
+
+    response = client.get("/sessions/session-id")
+
+    verify_response(response, expected_status=200, expected_data=expected_session)
+
+
+def test_get_session_with_missing_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the session ID does not exist."""
+    key_error = SessionNotFoundError(session_id="session-id")
+
+    decoy.when(session_store.get_session(session_id="session-id")).then_raise(key_error)
+
+    response = client.get("/sessions/session-id")
+
+    verify_response(
+        response,
+        expected_status=404,
+        expected_errors=SessionNotFound(detail=str(key_error)),
+    )
+
+
+def test_delete_session_by_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should be able to remove a session by ID."""
+    expected_session = Session(id="session-id", createdAt=datetime.now())
+
+    decoy.when(session_store.remove_session_by_id(session_id="unique-id")).then_return(
+        expected_session
+    )
+
+    response = client.delete("/sessions/unique-id")
+
+    verify_response(response, expected_status=200, expected_data=expected_session)
+
+
+def test_delete_session_by_id_with_missing_id(
+    decoy: Decoy,
+    session_store: SessionStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the session ID does not exist."""
+    key_error = SessionNotFoundError(session_id="session-id")
+
+    decoy.when(session_store.remove_session_by_id(session_id="session-id")).then_raise(
+        key_error
+    )
+
+    response = client.delete("/sessions/session-id")
+
+    verify_response(
+        response,
+        expected_status=404,
+        expected_errors=SessionNotFound(detail=str(key_error)),
+    )
+
+
+def test_create_session_input(
+    decoy: Decoy,
+    session_runner: SessionRunner,
+    unique_id: str,
+    current_time: datetime,
+    client: TestClient,
+) -> None:
+    """It should handle a pause input."""
+    expected_input = SessionInput(
+        inputType=SessionInputType.START,
+        createdAt=current_time,
+        id=unique_id,
+    )
+
+    decoy.when(
+        session_runner.handle_input(
+            session_id="session-id",
+            input_id=unique_id,
+            input_data=CreateSessionInputData(inputType=SessionInputType.START),
+            created_at=current_time,
+        )
+    ).then_return(expected_input)
+
+    response = client.post(
+        "/sessions/session-id/inputs",
+        json={"data": {"inputType": "start"}},
+    )
+
+    verify_response(response, expected_status=201, expected_data=expected_input)
+
+
+def test_create_session_input_with_missing_id(
+    decoy: Decoy,
+    session_runner: SessionRunner,
+    unique_id: str,
+    current_time: datetime,
+    client: TestClient,
+) -> None:
+    """It should 404 if the session ID does not exist."""
+    key_error = SessionNotFoundError(session_id="session-id")
+
+    decoy.when(
+        session_runner.handle_input(
+            session_id="session-id",
+            input_id=unique_id,
+            input_data=CreateSessionInputData(inputType=SessionInputType.START),
+            created_at=current_time,
+        )
+    ).then_raise(key_error)
+
+    response = client.post(
+        "/sessions/session-id/inputs",
+        json={"data": {"inputType": "start"}},
+    )
+
+    verify_response(
+        response,
+        expected_status=404,
+        expected_errors=SessionNotFound(detail=str(key_error)),
+    )


### PR DESCRIPTION
## Overview

This PR builds of the #7804 research spike to add a new `/sessions` router that will execute protocols runs using a `ProtocolEngine`, `AbstractFileRunner`, and other associated interfaces.

Specifically, this starts building out stubs for the following robot-server interfaces and value objects:

- `SessionStore`, where session resource data can be kept in memory
- `SessionRunner`, where `ProtocolEngine` and `FileRunner` instances can be managed
- `Session` models, to be replaced / merged with pre-existing session models
- `SessionInput` models, to provide an interface for controlling the lifecycle of a session (aka play/pause)

This takes out a chunk of #7808 by providing the beginnings of HTTP routes to:

- Create a session from a protocol resource
- Tell the session to start executing

## Changelog

- refactor(robot-server): start sessions router for HTTP-based runs

## Review requests

Two main requests on this one:

- I'm interested in feedback from a standpoint of data encapsulation and interface / responsibility design
    - e.g. "SessionInput is a weird name, what about XYZ" is helpful, because the name of the value object affects perceived responsibilities
    - e.g. "We need other session types" is not helpful, because having more subclasses of Session in this PR wouldn't change how data flows through the routes and dependencies
- Tests in this PR are for interface design of the router, so please approach them from that standpoint
    - Do they communicate the intent of the test subject's dependency orchestration well?
    - Is the test subject doing a good job of not mixing logic with delegation?

This new sessions router is placed behind the `enableProtocolEngine` feature flag, but all routes will raise a `NotImplementedError` right now. If you'd like to see for yourself, go ahead and run the dev server with the feature flag enabled:

```shell
make dev OT_API_FF_enableProtocolEngine=true
```

## Risk assessment

No risk for production code. The risk here is mostly in strategy and approach. Eventually, this sessions router and models will need to account for existing flows, like deck calibration and tip length check. The trick will be to pay down tech debt while keeping that stuff operational.