### PR TITLE
docs(api): Update return_tip to drop_tip

### DIFF
--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -46,7 +46,7 @@ This accomplishes the same thing as the following basic commands:
         p300.pick_up_tip()
         p300.aspirate(100, plate.wells('A1'))
         p300.dispense(100, plate.wells('B1'))
-        p300.return_tip()
+        p300.drop_tip()
 
 ******************************
 


### PR DESCRIPTION
Comments said that the two code snippet accomplished the same thing. The first (p300.transfer(100, plate['A1'], plate['B1'])) would drop the tip in the trash while the second:

p300.pick_up_tip()
p300.aspirate(100, plate.wells('A1'))
p300.dispense(100, plate.wells('B1'))
p300.return_tip()

would return the tip to the tiprack. I changed return_tip in the second example to drop_tip so the two commands would perform identical actions.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
