### PR TITLE
refactor(labware-creator): Add section IDs and alt img text

### DIFF
--- a/labware-library/src/labware-creator/components/diagrams/index.tsx
+++ b/labware-library/src/labware-creator/components/diagrams/index.tsx
@@ -11,22 +11,26 @@ interface HeightImgProps {
 export const HeightImg = (props: HeightImgProps): JSX.Element => {
   const { labwareType, aluminumBlockChildType } = props
   let src = require('../../images/height_plate-and-reservoir.svg')
+  let alt = 'plate or reservoir height'
   if (labwareType === 'tubeRack') {
     src = require('../../images/height_tubeRack.svg')
+    alt = 'tube rack height'
   } else if (labwareType === 'aluminumBlock') {
     // @ts-expect-error(IL, 2021-03-24): `includes` doesn't want to take null/undefined
     if (['tubes', 'pcrTubeStrip'].includes(aluminumBlockChildType)) {
       src = require('../../images/height_aluminumBlock_tubes.svg')
+      alt = 'alumninum block with tubes height'
     } else {
       src = require('../../images/height_aluminumBlock_plate.svg')
+      alt = 'alumninum block with plate height'
     }
   }
-  return <img src={src} />
+  return <img src={src} alt={alt} />
 }
 
 export const GridImg = (): JSX.Element => {
   const src = require('../../images/grid_row_column.svg')
-  return <img src={src} />
+  return <img src={src} alt="grid rows and columns" />
 }
 
 export const WellXYImg = (props: {
@@ -38,8 +42,15 @@ export const WellXYImg = (props: {
     rectangular: require('../../images/wellXY_rectangular.svg'),
   }
 
+  const wellShapeToAlt: Record<WellShape, string> = {
+    circular: 'circular well diameter',
+    rectangular: 'rectangluar well XY',
+  }
+
   if (wellShape != null && wellShape in wellShapeToImg) {
-    return <img src={wellShapeToImg[wellShape]} />
+    return (
+      <img src={wellShapeToImg[wellShape]} alt={wellShapeToAlt[wellShape]} />
+    )
   }
 
   return null
@@ -54,19 +65,22 @@ export const XYSpacingImg = (props: {
   const gridRows = Number(props.gridRows)
   // default to this
   let src = require('../../images/spacing_plate_circular.svg')
-
+  let alt = 'circular well spacing'
   if (labwareType === 'reservoir') {
     if (gridRows > 1) {
       src = require('../../images/spacing_reservoir_multirow.svg')
+      alt = 'multi row reservoir spacing'
     } else {
       src = require('../../images/spacing_reservoir_1row.svg')
+      alt = 'singular row reservoir spacing'
     }
   } else {
     if (wellShape === 'rectangular') {
       src = require('../../images/spacing_plate_rectangular.svg')
+      alt = 'rectangular well spacing'
     }
   }
-  return <img src={src} />
+  return <img src={src} alt={alt} />
 }
 
 interface DepthImgProps {
@@ -77,6 +91,7 @@ interface DepthImgProps {
 export const DepthImg = (props: DepthImgProps): JSX.Element | null => {
   const { labwareType, wellBottomShape } = props
   let src
+  let alt
 
   if (!wellBottomShape) return null
 
@@ -86,17 +101,29 @@ export const DepthImg = (props: DepthImgProps): JSX.Element | null => {
       flat: require('../../images/depth_reservoir-and-tubes_flat.svg'),
       u: require('../../images/depth_reservoir-and-tubes_round.svg'),
     }
+    const altMap = {
+      v: 'v shaped reservoir or tube rack depth',
+      flat: 'flat bottom reservoir or tube rack depth',
+      u: 'u shaped reservoir or tube rack depth',
+    }
     src = imgMap[wellBottomShape]
+    alt = altMap[wellBottomShape]
   } else {
     const imgMap = {
       v: require('../../images/depth_plate_v.svg'),
       flat: require('../../images/depth_plate_flat.svg'),
       u: require('../../images/depth_plate_round.svg'),
     }
+    const altMap = {
+      v: 'v shaped well depth',
+      flat: 'flat bottom well depth',
+      u: 'u shaped well depth',
+    }
     src = imgMap[wellBottomShape]
+    alt = altMap[wellBottomShape]
   }
 
-  return <img src={src} />
+  return <img src={src} alt={alt} />
 }
 
 export const XYOffsetImg = (props: {
@@ -105,10 +132,13 @@ export const XYOffsetImg = (props: {
 }): JSX.Element => {
   const { labwareType, wellShape } = props
   let src = require('../../images/offset_plate_circular.svg')
+  let alt = 'circular well offset'
   if (labwareType === 'reservoir') {
     src = require('../../images/offset_reservoir.svg')
+    alt = 'reservoir well offset'
   } else if (wellShape === 'rectangular') {
     src = require('../../images/offset_plate_rectangular.svg')
+    alt = 'rectangular well offset'
   }
-  return <img src={src} />
+  return <img src={src} alt={alt} />
 }

--- a/labware-library/src/labware-creator/components/sections/CustomTiprackWarning.tsx
+++ b/labware-library/src/labware-creator/components/sections/CustomTiprackWarning.tsx
@@ -11,7 +11,10 @@ export const CustomTiprackWarning = (): JSX.Element | null => {
   if (values.labwareType === 'tipRack') {
     return (
       <div className={styles.new_definition_section}>
-        <SectionBody label="Custom Tip Racks Are Not Recommended">
+        <SectionBody
+          label="Custom Tip Racks Are Not Recommended"
+          id="CustomTiprackWarning"
+        >
           <div className={styles.flex_row}>
             <p className={styles.instructions_text}>
               Opentrons tip racks are recommended for use with the OT-2. You are

--- a/labware-library/src/labware-creator/components/sections/Footprint.tsx
+++ b/labware-library/src/labware-creator/components/sections/Footprint.tsx
@@ -25,7 +25,10 @@ const Content = (): JSX.Element => (
       </p>
     </div>
     <div className={styles.diagram_column}>
-      <img src={require('../../images/footprint.svg')} />
+      <img
+        src={require('../../images/footprint.svg')}
+        alt="labware footprint"
+      />
     </div>
     <div className={styles.form_fields_column}>
       <TextField
@@ -55,7 +58,7 @@ export const Footprint = (): JSX.Element | null => {
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Footprint">
+      <SectionBody label="Footprint" id="Footprint">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <XYDimensionAlerts values={values} touched={touched} />

--- a/labware-library/src/labware-creator/components/sections/Grid.tsx
+++ b/labware-library/src/labware-creator/components/sections/Grid.tsx
@@ -51,7 +51,7 @@ export const Grid = (): JSX.Element | null => {
   }
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Grid">
+      <SectionBody label="Grid" id="Grid">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content />

--- a/labware-library/src/labware-creator/components/sections/GridOffset.tsx
+++ b/labware-library/src/labware-creator/components/sections/GridOffset.tsx
@@ -82,7 +82,7 @@ export const GridOffset = (): JSX.Element | null => {
   }
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Grid Offset">
+      <SectionBody label="Grid Offset" id="GridOffset">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
+++ b/labware-library/src/labware-creator/components/sections/HandPlacedTipFit.tsx
@@ -36,7 +36,7 @@ export const HandPlacedTipFit = (): JSX.Element | null => {
   if (values.labwareType === 'tipRack') {
     return (
       <div className={styles.new_definition_section}>
-        <SectionBody label="Hand-Placed Tip Fit">
+        <SectionBody label="Hand-Placed Tip Fit" id="HandPlacedTipFit">
           <>
             <FormAlerts
               touched={touched}

--- a/labware-library/src/labware-creator/components/sections/Height.tsx
+++ b/labware-library/src/labware-creator/components/sections/Height.tsx
@@ -62,6 +62,7 @@ export const Height = (): JSX.Element | null => {
             ? 'Total Height'
             : 'Height'
         }
+        id="Height"
       >
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />

--- a/labware-library/src/labware-creator/components/sections/Regularity.tsx
+++ b/labware-library/src/labware-creator/components/sections/Regularity.tsx
@@ -18,7 +18,7 @@ export const Regularity = (): JSX.Element | null => {
   }
 
   return (
-    <SectionBody label="Regularity">
+    <SectionBody label="Regularity" id="Regularity">
       <>
         <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
         <div className={styles.flex_row}>

--- a/labware-library/src/labware-creator/components/sections/SectionBody.tsx
+++ b/labware-library/src/labware-creator/components/sections/SectionBody.tsx
@@ -5,10 +5,11 @@ interface Props {
   children: JSX.Element
   headingClassName?: string
   label: string
+  id?: string
 }
 
 export const SectionBody = (props: Props): JSX.Element => (
-  <div className={styles.section_wrapper}>
+  <div className={styles.section_wrapper} id={props.id}>
     <h2 className={props.headingClassName || styles.section_header}>
       {props.label}
     </h2>

--- a/labware-library/src/labware-creator/components/sections/Volume.tsx
+++ b/labware-library/src/labware-creator/components/sections/Volume.tsx
@@ -44,7 +44,7 @@ export const Volume = (): JSX.Element | null => {
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Volume">
+      <SectionBody label="Volume" id="Volume">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/components/sections/WellBottomAndDepth.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellBottomAndDepth.tsx
@@ -69,7 +69,7 @@ export const WellBottomAndDepth = (): JSX.Element | null => {
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Well Bottom & Depth">
+      <SectionBody label="Well Bottom & Depth" id="WellBottomAndDepth">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
@@ -97,7 +97,7 @@ export const WellShapeAndSides = (): JSX.Element | null => {
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Well Shape & Sides">
+      <SectionBody label="Well Shape & Sides" id="WellShapeAndSides">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
@@ -73,7 +73,7 @@ export const WellSpacing = (): JSX.Element | null => {
   }
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Well Spacing">
+      <SectionBody label="Well Spacing" id="WellSpacing">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. 
- Add ids to each section of the form in labware creator
- Add alt text to dynamic images

# Changelog

- refactor(labware-creator): Add section IDs and alt img text

# Review requests

- [ ] Each section of the form should have an inspectable ID
- [ ] Each diagram should have inspectable alt text

NOTE: IDs have not been added to the check your work, file, and description sections since these sections have not been broken out with the new `SectionBody` component yet!

# Risk assessment

Low, ids and alt text in LC
