### PR TITLE
feat(labware-creator): Add new errors for too large/small footprint

### DIFF
--- a/labware-library/cypress/integration/labware-creator/reservoir.spec.js
+++ b/labware-library/cypress/integration/labware-creator/reservoir.spec.js
@@ -49,19 +49,19 @@ context('Reservoirs', () => {
     it('tests footprint', () => {
       cy.get("input[name='footprintXDimension']").type('150').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintXDimension']").clear().type('127').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('not.exist')
       cy.get("input[name='footprintYDimension']").type('150').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintYDimension']").clear().type('85').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('not.exist')
     })
 

--- a/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
+++ b/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
@@ -55,19 +55,19 @@ context('Well Plates', () => {
     it('tests footprint', () => {
       cy.get("input[name='footprintXDimension']").type('150').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintXDimension']").clear().type('127').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('not.exist')
       cy.get("input[name='footprintYDimension']").type('150').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('exist')
       cy.get("input[name='footprintYDimension']").clear().type('85').blur()
       cy.contains(
-        'Your labware is not compatible with the Labware Creator'
+        'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
       ).should('not.exist')
     })
 

--- a/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/FormAlerts.test.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react'
 import { render } from '@testing-library/react'
 import { getIsHidden } from '../../formSelectors'
-import { IRREGULAR_LABWARE_ERROR, LOOSE_TIP_FIT_ERROR } from '../../fields'
+import {
+  IRREGULAR_LABWARE_ERROR,
+  LOOSE_TIP_FIT_ERROR,
+  LABWARE_TOO_SMALL_ERROR,
+  LABWARE_TOO_LARGE_ERROR,
+} from '../../fields'
 import { FormAlerts, Props as FormAlertProps } from '../alerts/FormAlerts'
 import { when, resetAllWhenMocks } from 'jest-when'
 
@@ -58,7 +63,7 @@ describe('FormAlerts', () => {
     )
   })
 
-  it('should render an loose tip fit error when hand placed fit is loose', () => {
+  it('should render a loose tip fit error when hand placed fit is loose', () => {
     when(getIsHiddenMock)
       .calledWith('labwareType', {} as any)
       .mockReturnValue(false)
@@ -78,6 +83,52 @@ describe('FormAlerts', () => {
     const error = container.querySelector('[class="alert error"]')
     expect(error?.textContent).toBe(
       'If your tip does not fit when placed by hand then it is not a good candidate for this pipette on the OT-2.'
+    )
+  })
+
+  it('should render labware too small error when labware footprint is too small', () => {
+    when(getIsHiddenMock)
+      .calledWith('labwareType', {} as any)
+      .mockReturnValue(false)
+    when(getIsHiddenMock)
+      .calledWith('tubeRackInsertLoadName', {} as any)
+      .mockReturnValue(false)
+
+    const props: FormAlertProps = {
+      fieldList: ['labwareType', 'tubeRackInsertLoadName'],
+      touched: { labwareType: true, tubeRackInsertLoadName: true },
+      errors: {
+        labwareType: LABWARE_TOO_SMALL_ERROR,
+      },
+    }
+
+    const { container } = render(<FormAlerts {...props} />)
+    const error = container.querySelector('[class="alert error"]')
+    expect(error?.textContent).toBe(
+      'Your labware is too small to fit in a slot properly. Please fill out this form to request an adapter.'
+    )
+  })
+
+  it('should render labware too large error when labware footprint is too large', () => {
+    when(getIsHiddenMock)
+      .calledWith('labwareType', {} as any)
+      .mockReturnValue(false)
+    when(getIsHiddenMock)
+      .calledWith('tubeRackInsertLoadName', {} as any)
+      .mockReturnValue(false)
+
+    const props: FormAlertProps = {
+      fieldList: ['labwareType', 'tubeRackInsertLoadName'],
+      touched: { labwareType: true, tubeRackInsertLoadName: true },
+      errors: {
+        labwareType: LABWARE_TOO_LARGE_ERROR,
+      },
+    }
+
+    const { container } = render(<FormAlerts {...props} />)
+    const error = container.querySelector('[class="alert error"]')
+    expect(error?.textContent).toBe(
+      'Your labware is too large to fit in a single slot properly. Please fill out this form to request a custom labware definition.'
     )
   })
 })

--- a/labware-library/src/labware-creator/components/alerts/FormAlerts.tsx
+++ b/labware-library/src/labware-creator/components/alerts/FormAlerts.tsx
@@ -5,8 +5,11 @@ import { AlertItem } from '@opentrons/components'
 import {
   LabwareFields,
   IRREGULAR_LABWARE_ERROR,
+  LABWARE_TOO_SMALL_ERROR,
+  LABWARE_TOO_LARGE_ERROR,
   LOOSE_TIP_FIT_ERROR,
   LINK_CUSTOM_LABWARE_FORM,
+  LINK_REQUEST_ADAPTER_FORM,
 } from '../../fields'
 import { LinkOut } from '../LinkOut'
 
@@ -25,6 +28,32 @@ export const IrregularLabwareAlert = (): JSX.Element => (
         Your labware is not compatible with the Labware Creator. Please fill out{' '}
         <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut> to request
         a custom labware definition.
+      </>
+    }
+  />
+)
+
+export const LabwareTooSmallAlert = (): JSX.Element => (
+  <AlertItem
+    type="error"
+    title={
+      <>
+        Your labware is too small to fit in a slot properly. Please fill out{' '}
+        <LinkOut href={LINK_REQUEST_ADAPTER_FORM}>this form</LinkOut> to request
+        an adapter.
+      </>
+    }
+  />
+)
+
+export const LabwareTooLargeAlert = (): JSX.Element => (
+  <AlertItem
+    type="error"
+    title={
+      <>
+        Your labware is too large to fit in a single slot properly. Please fill
+        out <LinkOut href={LINK_CUSTOM_LABWARE_FORM}>this form</LinkOut> to
+        request a custom labware definition.
       </>
     }
   />
@@ -59,7 +88,13 @@ export const FormAlerts = (props: Props): JSX.Element | null => {
         if (error === IRREGULAR_LABWARE_ERROR) {
           return <IrregularLabwareAlert key={error} />
         }
-        return <AlertItem key={error} type="warning" title={error} />
+        if (error === LABWARE_TOO_SMALL_ERROR) {
+          return <LabwareTooSmallAlert key={error} />
+        }
+        if (error === LABWARE_TOO_LARGE_ERROR) {
+          return <LabwareTooLargeAlert key={error} />
+        }
+        if (error) return <AlertItem key={error} type="warning" title={error} />
       })}
     </>
   )

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -20,8 +20,14 @@ export const IRREGULAR_LABWARE_ERROR = 'IRREGULAR_LABWARE_ERROR'
 
 export const LOOSE_TIP_FIT_ERROR = 'LOOSE_TIP_FIT_ERROR'
 
+export const LABWARE_TOO_SMALL_ERROR = 'LABWARE_TOO_SMALL_ERROR'
+export const LABWARE_TOO_LARGE_ERROR = 'LABWARE_TOO_LARGE_ERROR'
+
 export const LINK_CUSTOM_LABWARE_FORM =
   'https://opentrons-ux.typeform.com/to/xi8h0W'
+
+export const LINK_REQUEST_ADAPTER_FORM =
+  'https://docs.google.com/forms/d/e/1FAIpQLScvsHlXQrtIhIQYO0zr6mYwmzOCGpYPqepeDIorFIyj2jT-UQ/viewform'
 
 export type ImportErrorKey =
   | 'INVALID_FILE_TYPE'

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -6,6 +6,8 @@ import {
   wellBottomShapeOptions,
   wellShapeOptions,
   IRREGULAR_LABWARE_ERROR,
+  LABWARE_TOO_SMALL_ERROR,
+  LABWARE_TOO_LARGE_ERROR,
   LABELS,
   LOOSE_TIP_FIT_ERROR,
   MAX_X_DIMENSION,
@@ -91,16 +93,16 @@ export const labwareFormSchemaBaseObject = Yup.object({
     .default(0)
     .label(LABELS.footprintXDimension)
     .typeError(MUST_BE_A_NUMBER)
-    .min(MIN_X_DIMENSION, IRREGULAR_LABWARE_ERROR)
-    .max(MAX_X_DIMENSION, IRREGULAR_LABWARE_ERROR)
+    .min(MIN_X_DIMENSION, LABWARE_TOO_SMALL_ERROR)
+    .max(MAX_X_DIMENSION, LABWARE_TOO_LARGE_ERROR)
     .nullable()
     .required(),
   footprintYDimension: Yup.number()
     .default(0)
     .label(LABELS.footprintYDimension)
     .typeError(MUST_BE_A_NUMBER)
-    .min(MIN_Y_DIMENSION, IRREGULAR_LABWARE_ERROR)
-    .max(MAX_Y_DIMENSION, IRREGULAR_LABWARE_ERROR)
+    .min(MIN_Y_DIMENSION, LABWARE_TOO_SMALL_ERROR)
+    .max(MAX_Y_DIMENSION, LABWARE_TOO_LARGE_ERROR)
     .nullable()
     .required(),
   labwareZDimension: requiredPositiveNumber(LABELS.labwareZDimension).max(


### PR DESCRIPTION
# Overview

closes #7163 closes #7792 by adding the too big and too small footprint errors 

# Changelog

- feat(labware-creator): Add new errors for too large/small footprint

# Review requests

- [ ] Labware too small error renders when footprint X or Y is below minimum
- [ ] Labware too large error renders when footprint X or Y is above max
- [ ] Links open the appropriate forms

FYI:
```
MAX_X_DIMENSION = 129
MIN_X_DIMENSION = 127

MAX_Y_DIMENSION = 87
MIN_Y_DIMENSION = 85
```
# Risk assessment
Low, new errors in LC
