### PR TITLE
refactor(robot-server): add experimental protocol router

### DIFF
--- a/robot-server/robot_server/protocols/__init__.py
+++ b/robot-server/robot_server/protocols/__init__.py
@@ -4,7 +4,7 @@ from opentrons.file_runner import ProtocolFileType
 
 from .router import protocols_router
 from .dependencies import get_protocol_store
-from .protocol_store import ProtocolStore, ProtocolStoreEntry
+from .protocol_store import ProtocolStore, ProtocolResource
 
 __all__ = [
     # main protocols router
@@ -12,7 +12,7 @@ __all__ = [
     # protocol state management
     "get_protocol_store",
     "ProtocolStore",
-    "ProtocolStoreEntry",
+    "ProtocolResource",
     # convenience re-exports from opentrons
     "ProtocolFileType",
 ]

--- a/robot-server/robot_server/protocols/__init__.py
+++ b/robot-server/robot_server/protocols/__init__.py
@@ -1,0 +1,18 @@
+"""Protocol file upload and management."""
+
+from opentrons.file_runner import ProtocolFileType
+
+from .router import protocols_router
+from .dependencies import get_protocol_store
+from .protocol_store import ProtocolStore, ProtocolStoreEntry
+
+__all__ = [
+    # main protocols router
+    "protocols_router",
+    # protocol state management
+    "get_protocol_store",
+    "ProtocolStore",
+    "ProtocolStoreEntry",
+    # convenience re-exports from opentrons
+    "ProtocolFileType",
+]

--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -1,0 +1,23 @@
+"""Protocol router dependency wire-up."""
+from fastapi import Request
+from logging import getLogger
+from pathlib import Path
+from tempfile import gettempdir
+from .protocol_store import ProtocolStore
+
+log = getLogger(__name__)
+
+PROTOCOL_STORE_KEY = "protocol_store"
+PROTOCOL_STORE_DIRECTORY = Path(gettempdir()) / "protocols"
+
+
+def get_protocol_store(request: Request) -> ProtocolStore:
+    """Get a singleton ProtocolStore to keep track of created protocols."""
+    protocol_store = getattr(request.app.state, PROTOCOL_STORE_KEY, None)
+
+    if protocol_store is None:
+        log.info(f"Storing protocols in {PROTOCOL_STORE_DIRECTORY}")
+        protocol_store = ProtocolStore(directory=PROTOCOL_STORE_DIRECTORY)
+        setattr(request.app.state, PROTOCOL_STORE_KEY, protocol_store)
+
+    return protocol_store

--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -8,7 +8,7 @@ from .protocol_store import ProtocolStore
 log = getLogger(__name__)
 
 PROTOCOL_STORE_KEY = "protocol_store"
-PROTOCOL_STORE_DIRECTORY = Path(gettempdir()) / "protocols"
+PROTOCOL_STORE_DIRECTORY = Path(gettempdir()) / "opentrons-protocols"
 
 
 def get_protocol_store(request: Request) -> ProtocolStore:

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -1,0 +1,17 @@
+"""Protocol file models."""
+from __future__ import annotations
+from datetime import datetime
+from pydantic import Field
+from opentrons.file_runner import ProtocolFileType
+from robot_server.service.json_api import ResourceModel
+
+
+class Protocol(ResourceModel):
+    """A model representing an uploaded protocol resource."""
+
+    id: str = Field(..., description="A unique identifier for this protocol.")
+    createdAt: datetime = Field(..., description="When this protocol was uploaded.")
+    protocolType: ProtocolFileType = Field(
+        ...,
+        description="The type of protocol file (JSON or Python).",
+    )

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -12,7 +12,7 @@ log = getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ProtocolStoreEntry:
+class ProtocolResource:
     """An entry in the session store, used to construct response models."""
 
     protocol_id: str
@@ -39,14 +39,14 @@ class ProtocolStore:
             directory: Directory in which to place created files.
         """
         self._directory = directory
-        self._protocols_by_id: Dict[str, ProtocolStoreEntry] = {}
+        self._protocols_by_id: Dict[str, ProtocolResource] = {}
 
     async def create(
         self,
         protocol_id: str,
         created_at: datetime,
         files: Sequence[UploadFile],
-    ) -> ProtocolStoreEntry:
+    ) -> ProtocolResource:
         """Add a protocol to the store."""
         protocol_dir = self._get_protocol_dir(protocol_id)
         protocol_dir.mkdir(parents=True, exist_ok=True)
@@ -65,7 +65,7 @@ class ProtocolStore:
 
                 saved_files.append(file_path)
 
-        entry = ProtocolStoreEntry(
+        entry = ProtocolResource(
             protocol_id=protocol_id,
             protocol_type=self._get_protocol_type(saved_files),
             created_at=created_at,
@@ -76,18 +76,18 @@ class ProtocolStore:
 
         return entry
 
-    def get(self, protocol_id: str) -> ProtocolStoreEntry:
+    def get(self, protocol_id: str) -> ProtocolResource:
         """Get a single protocol by ID."""
         try:
             return self._protocols_by_id[protocol_id]
         except KeyError as e:
             raise ProtocolNotFoundError(protocol_id) from e
 
-    def get_all(self) -> List[ProtocolStoreEntry]:
+    def get_all(self) -> List[ProtocolResource]:
         """Get all protocols currently saved in this store."""
         return list(self._protocols_by_id.values())
 
-    def remove(self, protocol_id: str) -> ProtocolStoreEntry:
+    def remove(self, protocol_id: str) -> ProtocolResource:
         """Remove a protocol from the store."""
         try:
             entry = self._protocols_by_id.pop(protocol_id)

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -58,7 +58,8 @@ class ProtocolStore:
     ) -> ProtocolResource:
         """Add a protocol to the store."""
         protocol_dir = self._get_protocol_dir(protocol_id)
-        protocol_dir.mkdir(parents=True, exist_ok=True)
+        # TODO(mc, 2021-06-02): check for protocol collision
+        protocol_dir.mkdir(parents=True)
         saved_files = []
 
         for index, upload_file in enumerate(files):

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -53,15 +53,17 @@ class ProtocolStore:
         saved_files = []
 
         for upload_file in files:
-            contents = await upload_file.read()
-            file_path = protocol_dir / upload_file.filename
+            # TODO(mc, 2021-06-01): raise error for empty file
+            if upload_file.filename != "":
+                contents = await upload_file.read()
+                file_path = protocol_dir / upload_file.filename
 
-            if isinstance(contents, str):
-                file_path.write_text(contents, "utf-8")
-            else:
-                file_path.write_bytes(contents)
+                if isinstance(contents, str):
+                    file_path.write_text(contents, "utf-8")
+                else:
+                    file_path.write_bytes(contents)
 
-            saved_files.append(file_path)
+                saved_files.append(file_path)
 
         entry = ProtocolStoreEntry(
             protocol_id=protocol_id,

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -1,0 +1,117 @@
+"""Methods for saving and retrieving protocol files."""
+from dataclasses import dataclass
+from datetime import datetime
+from fastapi import UploadFile
+from logging import getLogger
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from opentrons.file_runner import ProtocolFileType
+
+log = getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProtocolStoreEntry:
+    """An entry in the session store, used to construct response models."""
+
+    protocol_id: str
+    protocol_type: ProtocolFileType
+    created_at: datetime
+    files: List[Path]
+
+
+class ProtocolNotFoundError(ValueError):
+    """Error raised when a protocol ID was not found in the store."""
+
+    def __init__(self, protocol_id: str) -> None:
+        """Initialize the error message from the missing ID."""
+        super().__init__(f"Protocol {protocol_id} was not found.")
+
+
+class ProtocolStore:
+    """Methods for storing and retrieving protocol files."""
+
+    def __init__(self, directory: Path) -> None:
+        """Initialize the ProtocolStore.
+
+        Arguments:
+            directory: Directory in which to place created files.
+        """
+        self._directory = directory
+        self._protocols_by_id: Dict[str, ProtocolStoreEntry] = {}
+
+    async def create(
+        self,
+        protocol_id: str,
+        created_at: datetime,
+        files: Sequence[UploadFile],
+    ) -> ProtocolStoreEntry:
+        """Add a protocol to the store."""
+        protocol_dir = self._get_protocol_dir(protocol_id)
+        protocol_dir.mkdir(parents=True, exist_ok=True)
+        saved_files = []
+
+        for upload_file in files:
+            contents = await upload_file.read()
+            file_path = protocol_dir / upload_file.filename
+
+            if isinstance(contents, str):
+                file_path.write_text(contents, "utf-8")
+            else:
+                file_path.write_bytes(contents)
+
+            saved_files.append(file_path)
+
+        entry = ProtocolStoreEntry(
+            protocol_id=protocol_id,
+            protocol_type=self._get_protocol_type(saved_files),
+            created_at=created_at,
+            files=saved_files,
+        )
+
+        self._protocols_by_id[protocol_id] = entry
+
+        return entry
+
+    def get(self, protocol_id: str) -> ProtocolStoreEntry:
+        """Get a single protocol by ID."""
+        try:
+            return self._protocols_by_id[protocol_id]
+        except KeyError as e:
+            raise ProtocolNotFoundError(protocol_id) from e
+
+    def get_all(self) -> List[ProtocolStoreEntry]:
+        """Get all protocols currently saved in the system."""
+        return list(self._protocols_by_id.values())
+
+    def remove(self, protocol_id: str) -> ProtocolStoreEntry:
+        """Remove a protocol from the store."""
+        try:
+            entry = self._protocols_by_id.pop(protocol_id)
+        except KeyError as e:
+            raise ProtocolNotFoundError(protocol_id) from e
+
+        try:
+            for file_path in entry.files:
+                file_path.unlink()
+            self._get_protocol_dir(protocol_id).rmdir()
+        except Exception as e:
+            log.warn(f"Unable to delete all files for protocol {protocol_id}: {str(e)}")
+
+        return entry
+
+    def _get_protocol_dir(self, protocol_id: str) -> Path:
+        return self._directory / protocol_id
+
+    # TODO(mc, 2021-05-29): add python support
+    # TODO(mc, 2021-05-29): add multi-file support
+    @staticmethod
+    def _get_protocol_type(files: List[Path]) -> ProtocolFileType:
+        """Naively get file type based on Path extension."""
+        file_path = files[0]
+
+        if file_path.suffix == ".json":
+            return ProtocolFileType.JSON
+        else:
+            raise NotImplementedError()

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -21,7 +21,7 @@ class ProtocolStoreEntry:
     files: List[Path]
 
 
-class ProtocolNotFoundError(ValueError):
+class ProtocolNotFoundError(KeyError):
     """Error raised when a protocol ID was not found in the store."""
 
     def __init__(self, protocol_id: str) -> None:
@@ -84,7 +84,7 @@ class ProtocolStore:
             raise ProtocolNotFoundError(protocol_id) from e
 
     def get_all(self) -> List[ProtocolStoreEntry]:
-        """Get all protocols currently saved in the system."""
+        """Get all protocols currently saved in this store."""
         return list(self._protocols_by_id.values())
 
     def remove(self, protocol_id: str) -> ProtocolStoreEntry:

--- a/robot-server/robot_server/protocols/response_builder.py
+++ b/robot-server/robot_server/protocols/response_builder.py
@@ -1,0 +1,23 @@
+"""Protocol response model factory."""
+from .protocol_store import ProtocolStoreEntry
+from .protocol_models import Protocol
+
+
+class ResponseBuilder:
+    """Interface to construct protocol resource models from data."""
+
+    @staticmethod
+    def build(protocol_entry: ProtocolStoreEntry) -> Protocol:
+        """Build a protocol resource model.
+
+        Arguments:
+            entry: Protocol data from the ProtocolStore.
+
+        Returns:
+            Protocol model representing the resource.
+        """
+        return Protocol(
+            id=protocol_entry.protocol_id,
+            protocolType=protocol_entry.protocol_type,
+            createdAt=protocol_entry.created_at,
+        )

--- a/robot-server/robot_server/protocols/response_builder.py
+++ b/robot-server/robot_server/protocols/response_builder.py
@@ -1,5 +1,5 @@
 """Protocol response model factory."""
-from .protocol_store import ProtocolStoreEntry
+from .protocol_store import ProtocolResource
 from .protocol_models import Protocol
 
 
@@ -7,7 +7,7 @@ class ResponseBuilder:
     """Interface to construct protocol resource models from data."""
 
     @staticmethod
-    def build(protocol_entry: ProtocolStoreEntry) -> Protocol:
+    def build(protocol_entry: ProtocolResource) -> Protocol:
         """Build a protocol resource model.
 
         Arguments:

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -47,7 +47,7 @@ async def get_protocols(
 
 @protocols_router.post(
     path="/protocols",
-    summary="Uploaded protocol",
+    summary="Upload a protocol",
     status_code=status.HTTP_201_CREATED,
     response_model=ResponseModel[Protocol],
 )

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -1,0 +1,123 @@
+"""Router for /protocols endpoints."""
+from datetime import datetime
+from fastapi import APIRouter, Depends, File, UploadFile, status
+from typing import List
+from typing_extensions import Literal
+
+from robot_server.errors import ErrorDetails, ErrorResponse
+from robot_server.service.dependencies import get_unique_id, get_current_time
+from robot_server.service.json_api import (
+    ResponseModel,
+    MultiResponseModel,
+    EmptyResponseModel,
+)
+
+from .dependencies import get_protocol_store
+from .protocol_models import Protocol
+from .protocol_store import ProtocolStore, ProtocolNotFoundError
+from .response_builder import ResponseBuilder
+
+
+class ProtocolNotFound(ErrorDetails):
+    """An error returned when a given protocol cannot be found."""
+
+    id: Literal["ProtocolNotFound"] = "ProtocolNotFound"
+    title: str = "Protocol Not Found"
+
+
+protocols_router = APIRouter()
+
+
+@protocols_router.get(
+    path="/protocols",
+    summary="Get uploaded protocols",
+    status_code=status.HTTP_200_OK,
+    response_model=MultiResponseModel[Protocol],
+)
+async def get_protocols(
+    response_builder: ResponseBuilder = Depends(ResponseBuilder),
+    protocol_store: ProtocolStore = Depends(get_protocol_store),
+) -> MultiResponseModel[Protocol]:
+    """Get a list of all currently uploaded protocols."""
+    protocol_entries = protocol_store.get_all()
+    data = [response_builder.build(e) for e in protocol_entries]
+
+    return MultiResponseModel(data=data)
+
+
+@protocols_router.post(
+    path="/protocols",
+    summary="Uploaded protocol",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ResponseModel[Protocol],
+)
+async def create_protocol(
+    files: List[UploadFile] = File(...),
+    response_builder: ResponseBuilder = Depends(ResponseBuilder),
+    protocol_store: ProtocolStore = Depends(get_protocol_store),
+    protocol_id: str = Depends(get_unique_id),
+    created_at: datetime = Depends(get_current_time),
+) -> ResponseModel[Protocol]:
+    """Create a new protocol by uploading its files."""
+    if len(files) > 1:
+        raise NotImplementedError("Multi-file protocols not yet supported.")
+    elif files[0].filename.endswith(".py"):
+        raise NotImplementedError("Python protocols not yet supported")
+
+    protocol_entry = await protocol_store.create(
+        protocol_id=protocol_id,
+        created_at=created_at,
+        files=files,
+    )
+    data = response_builder.build(protocol_entry)
+
+    return ResponseModel(data=data)
+
+
+@protocols_router.get(
+    path="/protocols/{protocol_id}",
+    summary="Get an uploaded protocol",
+    status_code=status.HTTP_200_OK,
+    response_model=ResponseModel[Protocol],
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[ProtocolNotFound]},
+    },
+)
+async def get_protocol_by_id(
+    protocol_id: str,
+    response_builder: ResponseBuilder = Depends(ResponseBuilder),
+    protocol_store: ProtocolStore = Depends(get_protocol_store),
+) -> ResponseModel[Protocol]:
+    """Get an uploaded protocol by ID."""
+    try:
+        protocol_entry = protocol_store.get(protocol_id=protocol_id)
+
+    except ProtocolNotFoundError as e:
+        raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    data = response_builder.build(protocol_entry)
+
+    return ResponseModel(data=data)
+
+
+@protocols_router.delete(
+    path="/protocols/{protocol_id}",
+    summary="Delete an uploaded protocol",
+    status_code=status.HTTP_200_OK,
+    response_model=EmptyResponseModel,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"model": ErrorResponse[ProtocolNotFound]},
+    },
+)
+async def delete_protocol_by_id(
+    protocol_id: str,
+    protocol_store: ProtocolStore = Depends(get_protocol_store),
+) -> EmptyResponseModel:
+    """Delete an uploaded protocol by ID."""
+    try:
+        protocol_store.remove(protocol_id=protocol_id)
+
+    except ProtocolNotFoundError as e:
+        raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
+
+    return EmptyResponseModel()

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -6,13 +6,14 @@ from opentrons.config.feature_flags import enable_protocol_engine
 from .constants import V1_TAG
 from .errors import LegacyErrorResponse
 from .health import health_router
+from .protocols import protocols_router
 from .sessions import sessions_router
 from .system import system_router
 from .service.legacy.routers import legacy_routes
 from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
 from .service.labware.router import router as labware_router
-from .service.protocol.router import router as protocol_router
+from .service.protocol.router import router as deprecated_protocol_router
 from .service.tip_length.router import router as tl_router
 from .service.notifications.router import router as notifications_router
 
@@ -40,19 +41,32 @@ router.include_router(
 )
 
 
-router.include_router(
-    router=sessions_router if enable_protocol_engine() else deprecated_session_router,
-    tags=["Session Management"],
-)
+if enable_protocol_engine():
+    router.include_router(
+        router=sessions_router,
+        tags=["Session Management"],
+    )
+
+    router.include_router(
+        router=protocols_router,
+        tags=["Protocol Management"],
+    )
+
+else:
+    router.include_router(
+        router=deprecated_session_router,
+        tags=["Session Management"],
+    )
+
+    router.include_router(
+        router=deprecated_protocol_router,
+        tags=["Protocol Management"],
+    )
+
 
 router.include_router(
     router=labware_router,
     tags=["Labware Calibration Management"],
-)
-
-router.include_router(
-    router=protocol_router,
-    tags=["Protocol Management"],
 )
 
 router.include_router(

--- a/robot-server/robot_server/service/dependencies.py
+++ b/robot-server/robot_server/service/dependencies.py
@@ -1,5 +1,7 @@
 import typing
+from datetime import datetime, timezone
 from typing_extensions import Literal
+from uuid import uuid4
 
 from starlette import status
 from fastapi import Depends, HTTPException, Header
@@ -126,3 +128,13 @@ async def check_version_header(
     else:
         # Attach the api version to request's state dict
         request.state.api_version = min(requested_version, constants.API_VERSION)
+
+
+def get_unique_id() -> str:
+    """Get a unique ID string to use as a resource identifier."""
+    return str(uuid4())
+
+
+def get_current_time() -> datetime:
+    """Get the current time in UTC to use as a resource timestamp."""
+    return datetime.now(tz=timezone.utc)

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -10,9 +10,10 @@ import pathlib
 import requests
 import pytest
 
-from mock import MagicMock
-from datetime import datetime
+from datetime import datetime, timezone
+from decoy import Decoy
 from fastapi import routing
+from mock import MagicMock
 from typing import Any, Dict
 
 from opentrons.protocols.context.protocol_api.labware import \
@@ -40,6 +41,30 @@ async def always_raise():
     raise RuntimeError
 
 app.include_router(test_router)
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container to clean up stubs after tests."""
+    return Decoy()
+
+
+@pytest.fixture
+def unique_id() -> str:
+    """Get a fake unique identifier.
+
+    Override robot_server.service.dependencies.get_unique_id
+    """
+    return "unique-id"
+
+
+@pytest.fixture
+def current_time() -> datetime:
+    """Get a fake current time.
+
+    Override robot_server.service.dependencies.get_current_time
+    """
+    return datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
 
 
 @pytest.fixture

--- a/robot-server/tests/helpers.py
+++ b/robot-server/tests/helpers.py
@@ -1,13 +1,14 @@
 """Server test helpers."""
 import json
 from pydantic import BaseModel
-from requests import Response
+from requests import Response as TestClientResponse
+from httpx import Response as HttpxResponse
 from typing import Optional, Sequence, Union
 
 
 # TODO(mc, 2021-05-24): add links checking
 def verify_response(
-    response: Response,
+    response: Union[TestClientResponse, HttpxResponse],
     *,
     expected_data: Optional[Union[BaseModel, Sequence[BaseModel]]] = None,
     expected_errors: Optional[Union[BaseModel, Sequence[BaseModel]]] = None,

--- a/robot-server/tests/protocols/__init__.py
+++ b/robot-server/tests/protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the robot_server.protocols module."""

--- a/robot-server/tests/protocols/conftest.py
+++ b/robot-server/tests/protocols/conftest.py
@@ -1,0 +1,18 @@
+"""Common test fixtures for protocols route tests."""
+import pytest
+from decoy import Decoy
+
+from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.protocols.response_builder import ResponseBuilder
+
+
+@pytest.fixture
+def protocol_store(decoy: Decoy) -> ProtocolStore:
+    """Get a fake ProtocolStore interface."""
+    return decoy.create_decoy(spec=ProtocolStore)
+
+
+@pytest.fixture
+def response_builder(decoy: Decoy) -> ResponseBuilder:
+    """Get a fake ResponseBuilder interface."""
+    return decoy.create_decoy(spec=ResponseBuilder)

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -120,7 +120,7 @@ async def test_get_all_protocols(
     json_upload_file: UploadFile,
     subject: ProtocolStore,
 ) -> None:
-    """It should get a single protocol from the store."""
+    """It should get all protocols existing in the store."""
     created_at_1 = datetime.now()
     created_at_2 = datetime.now()
 
@@ -159,7 +159,7 @@ async def test_remove_protocol(
     json_upload_file: UploadFile,
     subject: ProtocolStore,
 ) -> None:
-    """It should save a single protocol to disk."""
+    """It should remove specified protocol's files from store."""
     created_at = datetime.now()
 
     expected_result = await subject.create(
@@ -182,6 +182,6 @@ async def test_remove_missing_protocol_raises(
     json_upload_file: UploadFile,
     subject: ProtocolStore,
 ) -> None:
-    """It should get a single protocol from the store."""
+    """It should raise an error when trying to remove non-existent protocol."""
     with pytest.raises(ProtocolNotFoundError, match="protocol-id"):
         subject.remove("protocol-id")

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -12,6 +12,7 @@ from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
     ProtocolNotFoundError,
+    ProtocolFileInvalidError,
 )
 
 
@@ -59,6 +60,22 @@ async def test_create_protocol(
     file_path = result.files[0]
     assert file_path.read_text("utf-8") == "{}\n"
     assert str(file_path).startswith(str(tmp_path))
+
+
+async def test_create_protocol_raises_for_missing_filename(
+    tmp_path: Path,
+    subject: ProtocolStore,
+) -> None:
+    """It should raise an error if an input file is missing a filename."""
+    created_at = datetime.now()
+    invalid_file = UploadFile(filename="")
+
+    with pytest.raises(ProtocolFileInvalidError):
+        await subject.create(
+            protocol_id="protocol-id",
+            created_at=created_at,
+            files=[invalid_file],
+        )
 
 
 async def test_get_protocol(

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -1,0 +1,174 @@
+"""Tests for the ProtocolStore interface."""
+import pytest
+from datetime import datetime
+from pathlib import Path
+from fastapi import UploadFile
+from typing import Iterator
+
+from opentrons.file_runner import ProtocolFileType
+
+from robot_server.protocols.protocol_store import (
+    ProtocolStore,
+    ProtocolStoreEntry,
+    ProtocolNotFoundError,
+)
+
+
+@pytest.fixture
+def json_upload_file(tmp_path: Path) -> Iterator[UploadFile]:
+    """Get an UploadFile with contents."""
+    file_path = tmp_path / "protocol.json"
+    file_path.write_text("{}\n", encoding="utf-8")
+
+    with file_path.open() as json_file:
+        yield UploadFile(
+            filename="protocol.json",
+            file=json_file,
+            content_type="application/json",
+        )
+
+
+@pytest.fixture
+def subject(tmp_path: Path) -> ProtocolStore:
+    """Get a ProtocolStore test subject."""
+    return ProtocolStore(directory=tmp_path)
+
+
+async def test_create_protocol(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should save a single protocol to disk."""
+    created_at = datetime.now()
+
+    result = await subject.create(
+        protocol_id="protocol-id",
+        created_at=created_at,
+        files=[json_upload_file],
+    )
+
+    expected_file_path = tmp_path / "protocol-id" / "protocol.json"
+
+    assert result == ProtocolStoreEntry(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.JSON,
+        created_at=created_at,
+        files=[expected_file_path],
+    )
+
+    assert expected_file_path.read_text("utf-8") == "{}\n"
+
+
+async def test_get_protocol(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should get a single protocol from the store."""
+    created_at = datetime.now()
+
+    await subject.create(
+        protocol_id="protocol-id",
+        created_at=created_at,
+        files=[json_upload_file],
+    )
+
+    expected_file_path = tmp_path / "protocol-id" / "protocol.json"
+
+    result = subject.get("protocol-id")
+
+    assert result == ProtocolStoreEntry(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.JSON,
+        created_at=created_at,
+        files=[expected_file_path],
+    )
+
+
+async def test_get_missing_protocol_raises(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should get a single protocol from the store."""
+    with pytest.raises(ProtocolNotFoundError, match="protocol-id"):
+        subject.get("protocol-id")
+
+
+async def test_get_all_protocols(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should get a single protocol from the store."""
+    created_at_1 = datetime.now()
+    created_at_2 = datetime.now()
+
+    await subject.create(
+        protocol_id="protocol-id-1",
+        created_at=created_at_1,
+        files=[json_upload_file],
+    )
+
+    await subject.create(
+        protocol_id="protocol-id-2",
+        created_at=created_at_2,
+        files=[json_upload_file],
+    )
+
+    expected_file_path_1 = tmp_path / "protocol-id-1" / "protocol.json"
+    expected_file_path_2 = tmp_path / "protocol-id-2" / "protocol.json"
+
+    result = subject.get_all()
+
+    assert result == [
+        ProtocolStoreEntry(
+            protocol_id="protocol-id-1",
+            protocol_type=ProtocolFileType.JSON,
+            created_at=created_at_1,
+            files=[expected_file_path_1],
+        ),
+        ProtocolStoreEntry(
+            protocol_id="protocol-id-2",
+            protocol_type=ProtocolFileType.JSON,
+            created_at=created_at_2,
+            files=[expected_file_path_2],
+        ),
+    ]
+
+
+async def test_remove_protocol(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should save a single protocol to disk."""
+    created_at = datetime.now()
+
+    await subject.create(
+        protocol_id="protocol-id",
+        created_at=created_at,
+        files=[json_upload_file],
+    )
+
+    expected_dir_path = tmp_path / "protocol-id"
+    expected_file_path = tmp_path / "protocol-id" / "protocol.json"
+
+    subject.remove("protocol-id")
+
+    assert expected_dir_path.exists() is False
+    assert expected_file_path.exists() is False
+
+    with pytest.raises(ProtocolNotFoundError, match="protocol-id"):
+        subject.get("protocol-id")
+
+
+async def test_remove_missing_protocol_raises(
+    tmp_path: Path,
+    json_upload_file: UploadFile,
+    subject: ProtocolStore,
+) -> None:
+    """It should get a single protocol from the store."""
+    with pytest.raises(ProtocolNotFoundError, match="protocol-id"):
+        subject.remove("protocol-id")

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -110,7 +110,7 @@ async def test_get_missing_protocol_raises(
     json_upload_file: UploadFile,
     subject: ProtocolStore,
 ) -> None:
-    """It should get a single protocol from the store."""
+    """It should raise an error when protocol not found."""
     with pytest.raises(ProtocolNotFoundError, match="protocol-id"):
         subject.get("protocol-id")
 

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -38,7 +38,7 @@ def app(
     protocol_store: ProtocolStore,
     response_builder: ResponseBuilder,
 ) -> FastAPI:
-    """Get an TestClient for /protocols routes with dependencies mocked out."""
+    """Get an app instance for /protocols routes with dependencies mocked out."""
     app = FastAPI(exception_handlers=exception_handlers)
     app.dependency_overrides[get_unique_id] = lambda: unique_id
     app.dependency_overrides[get_current_time] = lambda: current_time
@@ -162,7 +162,7 @@ def test_get_protocol_not_found(
     protocol_store: ProtocolStore,
     client: TestClient,
 ) -> None:
-    """It should return a single protocol file."""
+    """It should return a 404 error when requesting a non-existent protocol."""
     not_found_error = ProtocolNotFoundError("protocol-id")
 
     decoy.when(protocol_store.get(protocol_id="protocol-id")).then_raise(

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -14,7 +14,7 @@ from robot_server.protocols.protocol_models import Protocol, ProtocolFileType
 from robot_server.protocols.response_builder import ResponseBuilder
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
-    ProtocolStoreEntry,
+    ProtocolResource,
     ProtocolNotFoundError,
 )
 
@@ -86,13 +86,13 @@ def test_get_protocols(
     created_at_1 = datetime.now()
     created_at_2 = datetime.now()
 
-    entry_1 = ProtocolStoreEntry(
+    entry_1 = ProtocolResource(
         protocol_id="abc",
         protocol_type=ProtocolFileType.PYTHON,
         created_at=created_at_1,
         files=[],
     )
-    entry_2 = ProtocolStoreEntry(
+    entry_2 = ProtocolResource(
         protocol_id="123",
         protocol_type=ProtocolFileType.JSON,
         created_at=created_at_2,
@@ -131,7 +131,7 @@ def test_get_protocol_by_id(
 ) -> None:
     """It should return a single protocol file."""
     created_at = datetime.now()
-    entry = ProtocolStoreEntry(
+    entry = ProtocolResource(
         protocol_id="protocol-id",
         protocol_type=ProtocolFileType.PYTHON,
         created_at=created_at,
@@ -185,7 +185,7 @@ async def test_create_protocol(
     async_client: AsyncClient,
 ) -> None:
     """It should store a single protocol file."""
-    entry = ProtocolStoreEntry(
+    entry = ProtocolResource(
         protocol_id=unique_id,
         protocol_type=ProtocolFileType.JSON,
         created_at=current_time,

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -1,0 +1,292 @@
+"""Tests for the /protocols router."""
+import pytest
+from asyncio import AbstractEventLoop
+from datetime import datetime
+from decoy import Decoy, matchers
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.datastructures import UploadFile
+from httpx import AsyncClient
+from typing import AsyncIterator
+
+from robot_server.errors import exception_handlers
+from robot_server.protocols.protocol_models import Protocol, ProtocolFileType
+from robot_server.protocols.response_builder import ResponseBuilder
+from robot_server.protocols.protocol_store import (
+    ProtocolStore,
+    ProtocolStoreEntry,
+    ProtocolNotFoundError,
+)
+
+from robot_server.protocols.router import (
+    protocols_router,
+    ProtocolNotFound,
+    get_unique_id,
+    get_current_time,
+    get_protocol_store,
+)
+
+from ..helpers import verify_response
+
+
+@pytest.fixture
+def app(
+    unique_id: str,
+    current_time: datetime,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+) -> FastAPI:
+    """Get an TestClient for /protocols routes with dependencies mocked out."""
+    app = FastAPI(exception_handlers=exception_handlers)
+    app.dependency_overrides[get_unique_id] = lambda: unique_id
+    app.dependency_overrides[get_current_time] = lambda: current_time
+    app.dependency_overrides[get_protocol_store] = lambda: protocol_store
+    app.dependency_overrides[ResponseBuilder] = lambda: response_builder
+    app.include_router(protocols_router)
+
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """Get an TestClient for /protocols route testing."""
+    return TestClient(app)
+
+
+@pytest.fixture
+async def async_client(
+    loop: AbstractEventLoop,
+    app: FastAPI,
+) -> AsyncIterator[AsyncClient]:
+    """Get an asynchronous client for /protocols route testing."""
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        yield client
+
+
+def test_get_protocols_no_protocols(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return an empty collection response with no protocols loaded."""
+    decoy.when(protocol_store.get_all()).then_return([])
+
+    response = client.get("/protocols")
+
+    verify_response(response, expected_status=200, expected_data=[])
+
+
+def test_get_protocols(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+    client: TestClient,
+) -> None:
+    """It should return stored protocols."""
+    created_at_1 = datetime.now()
+    created_at_2 = datetime.now()
+
+    entry_1 = ProtocolStoreEntry(
+        protocol_id="abc",
+        protocol_type=ProtocolFileType.PYTHON,
+        created_at=created_at_1,
+        files=[],
+    )
+    entry_2 = ProtocolStoreEntry(
+        protocol_id="123",
+        protocol_type=ProtocolFileType.JSON,
+        created_at=created_at_2,
+        files=[],
+    )
+
+    protocol_1 = Protocol(
+        id="abc",
+        createdAt=created_at_1,
+        protocolType=ProtocolFileType.PYTHON,
+    )
+    protocol_2 = Protocol(
+        id="123",
+        createdAt=created_at_2,
+        protocolType=ProtocolFileType.JSON,
+    )
+
+    decoy.when(protocol_store.get_all()).then_return([entry_1, entry_2])
+    decoy.when(response_builder.build(entry_1)).then_return(protocol_1)
+    decoy.when(response_builder.build(entry_2)).then_return(protocol_2)
+
+    response = client.get("/protocols")
+
+    verify_response(
+        response,
+        expected_status=200,
+        expected_data=[protocol_1, protocol_2],
+    )
+
+
+def test_get_protocol_by_id(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+    client: TestClient,
+) -> None:
+    """It should return a single protocol file."""
+    created_at = datetime.now()
+    entry = ProtocolStoreEntry(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.PYTHON,
+        created_at=created_at,
+        files=[],
+    )
+    protocol = Protocol(
+        id="protocol-id",
+        createdAt=created_at,
+        protocolType=ProtocolFileType.PYTHON,
+    )
+
+    decoy.when(protocol_store.get(protocol_id="protocol-id")).then_return(entry)
+    decoy.when(response_builder.build(entry)).then_return(protocol)
+
+    response = client.get("/protocols/protocol-id")
+
+    verify_response(
+        response,
+        expected_status=200,
+        expected_data=protocol,
+    )
+
+
+def test_get_protocol_not_found(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should return a single protocol file."""
+    not_found_error = ProtocolNotFoundError("protocol-id")
+
+    decoy.when(protocol_store.get(protocol_id="protocol-id")).then_raise(
+        not_found_error
+    )
+
+    response = client.get("/protocols/protocol-id")
+
+    verify_response(
+        response,
+        expected_status=404,
+        expected_errors=ProtocolNotFound(detail=str(not_found_error)),
+    )
+
+
+async def test_create_protocol(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+    unique_id: str,
+    current_time: datetime,
+    async_client: AsyncClient,
+) -> None:
+    """It should store a single protocol file."""
+    entry = ProtocolStoreEntry(
+        protocol_id=unique_id,
+        protocol_type=ProtocolFileType.JSON,
+        created_at=current_time,
+        files=[],
+    )
+    protocol = Protocol(
+        id=unique_id,
+        createdAt=current_time,
+        protocolType=ProtocolFileType.JSON,
+    )
+
+    decoy.when(
+        await protocol_store.create(
+            protocol_id=unique_id,
+            created_at=current_time,
+            files=[
+                matchers.IsA(
+                    UploadFile,
+                    {"filename": "foo.json", "content_type": "application/json"},
+                )
+            ],
+        )
+    ).then_return(entry)
+
+    decoy.when(response_builder.build(entry)).then_return(protocol)
+
+    files = [("files", ("foo.json", bytes("{}\n", "utf-8"), "application/json"))]
+    response = await async_client.post("/protocols", files=files)
+
+    verify_response(
+        response,
+        expected_status=201,
+        expected_data=protocol,
+    )
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+async def test_create_python_protocol(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+    unique_id: str,
+    current_time: datetime,
+    async_client: AsyncClient,
+) -> None:
+    """It should store a Python protocol file."""
+    files = [
+        ("files", ("foo.py", bytes("# my protocol", "utf-8"), "text/x-python")),
+    ]
+
+    await async_client.post("/protocols", files=files)
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+async def test_create_multifile_protocol(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    response_builder: ResponseBuilder,
+    unique_id: str,
+    current_time: datetime,
+    async_client: AsyncClient,
+) -> None:
+    """It should store multiple protocol files."""
+    files = [
+        ("files", ("foo.py", bytes("# my protocol", "utf-8"), "text/x-python")),
+        ("files", ("bar.py", bytes("# support file", "utf-8"), "text/x-python")),
+    ]
+
+    await async_client.post("/protocols", files=files)
+
+
+def test_delete_protocol_by_id(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should remove a single protocol file."""
+    response = client.delete("/protocols/protocol-id")
+
+    decoy.verify(protocol_store.remove(protocol_id="protocol-id"))
+
+    assert response.status_code == 200
+    assert response.json()["data"] is None
+
+
+def test_delete_protocol_not_found(
+    decoy: Decoy,
+    protocol_store: ProtocolStore,
+    client: TestClient,
+) -> None:
+    """It should 404 if the protocol to delete is not found."""
+    not_found_error = ProtocolNotFoundError("protocol-id")
+
+    decoy.when(protocol_store.remove(protocol_id="protocol-id")).then_raise(
+        not_found_error
+    )
+
+    response = client.delete("/protocols/protocol-id")
+
+    verify_response(
+        response,
+        expected_status=404,
+        expected_errors=ProtocolNotFound(detail=str(not_found_error)),
+    )

--- a/robot-server/tests/protocols/test_response_builder.py
+++ b/robot-server/tests/protocols/test_response_builder.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 from opentrons.file_runner import ProtocolFileType
-from robot_server.protocols.protocol_store import ProtocolStoreEntry
+from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.protocols.protocol_models import Protocol
 from robot_server.protocols.response_builder import ResponseBuilder
 
@@ -20,7 +20,7 @@ def test_create_single_json_file_response(
     subject: ResponseBuilder,
 ) -> None:
     """It should create a BasicSession if session_data is None."""
-    protocol_entry = ProtocolStoreEntry(
+    protocol_entry = ProtocolResource(
         protocol_id="protocol-id",
         protocol_type=ProtocolFileType.JSON,
         created_at=current_time,

--- a/robot-server/tests/protocols/test_response_builder.py
+++ b/robot-server/tests/protocols/test_response_builder.py
@@ -1,0 +1,36 @@
+"""Tests for the protocol response model builder."""
+import pytest
+from datetime import datetime
+from pathlib import Path
+
+from opentrons.file_runner import ProtocolFileType
+from robot_server.protocols.protocol_store import ProtocolStoreEntry
+from robot_server.protocols.protocol_models import Protocol
+from robot_server.protocols.response_builder import ResponseBuilder
+
+
+@pytest.fixture
+def subject() -> ResponseBuilder:
+    """Get an instance of the ResponseBuilder test subject."""
+    return ResponseBuilder()
+
+
+def test_create_single_json_file_response(
+    current_time: datetime,
+    subject: ResponseBuilder,
+) -> None:
+    """It should create a BasicSession if session_data is None."""
+    protocol_entry = ProtocolStoreEntry(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.JSON,
+        created_at=current_time,
+        files=[Path("/tmp/protocol.json")],
+    )
+
+    result = subject.build(protocol_entry)
+
+    assert result == Protocol(
+        id="protocol-id",
+        protocolType=ProtocolFileType.JSON,
+        createdAt=current_time,
+    )

--- a/robot-server/tests/sessions/test_sessions_router.py
+++ b/robot-server/tests/sessions/test_sessions_router.py
@@ -1,6 +1,6 @@
 """Tests for the /sessions router."""
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime
 from decoy import Decoy
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -34,12 +34,6 @@ from ..helpers import verify_response
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Get a Decoy state container."""
-    return Decoy()
-
-
-@pytest.fixture
 def session_store(decoy: Decoy) -> SessionStore:
     """Get a fake SessionStore interface."""
     return decoy.create_decoy(spec=SessionStore)
@@ -55,18 +49,6 @@ def session_builder(decoy: Decoy) -> SessionBuilder:
 def session_runner(decoy: Decoy) -> SessionRunner:
     """Get a fake SessionRunner interface."""
     return decoy.create_decoy(spec=SessionRunner)
-
-
-@pytest.fixture
-def unique_id() -> str:
-    """Get a fake unique identifier."""
-    return "unique-id"
-
-
-@pytest.fixture
-def current_time() -> datetime:
-    """Get a fake current time."""
-    return datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview

This PR is 2 of 4 working towards #7808 and #7816. Closes #7816.

1. ~chore(api,robot-server): update testing dev deps #7855~ Merged
2. **refactor(robot-server): add experimental protocol router #7856**
3. refactor(api): add create_file_runner factory #7857
4. refactor(robot-server): start wiring /sessions into runner and engine #7858

This PR adds an experimental `/protocols` router when the `enableProtocolEngine` feature flag is on. It's goal is to tackle the following checkbox from #7816:

- [ ] a /protocol_upload http POST endpoint that is able to fetch the protocol file as form data

Blocked by #7855, will require sync after merge

## Changelog

This PR re-adds functionality already covered by the HTTP Protocol Upload Beta program. I went with a feature flagged separate router for two reasons:

- To avoid breaking the working HTTP protocol upload, which is in use by various people
- To give us space to complete ignore large chunks of functionality until we have concrete uses for them
    - (At which point we would pull them in from the previous protocols router or write new stuff, as needed)

## Review requests

You should be able to run these endpoints yourself:

```shell
make -C robot-server dev OT_API_FF_enableProtocolEngine=1
```

- [ ] `GET /protocols`
    - Retrieve all uploaded protocols
- [ ] `POST /protocols files=<file_list>`
    - Upload files under the `files` key via a `form-data` body
- [ ] `GET /protocols/:protocol_id`
- [ ] `DELETE /protocols/:protocol_id`  

I've also made [a Postman collection](https://gist.github.com/mcous/7dde93b6ea83753b86b0d84b40ba07f6) to make testing this endpoints easier:

- `{{hostname}}` is set to `localhost` by default
- `{{protocol_id}}` is set to the ID of the latest `POST`'d protocol

### Known deviations / not implemented for this PR

- Has a single `files` list for protocol creation, per discussions in Slack, for simplicity at this point, if nothing else
    - Will not work if you pass more that one file, though
    - It will also fail if you pass 0 files!
- Only understands JSON files
    - However, does not yet attempt any validation of those files
- Does not attempt to limit how many protocols get uploaded
- Does not run any simulation or analysis on the files, just assigns an ID and stores them

## Risk assessment

Very low! Completely isolated from production via feature flag
