### PR TITLE
refactor(api): add create_file_runner factory

### DIFF
--- a/api/src/opentrons/file_runner/__init__.py
+++ b/api/src/opentrons/file_runner/__init__.py
@@ -13,12 +13,7 @@ from .create_file_runner import create_file_runner
 from .abstract_file_runner import AbstractFileRunner
 from .json_file_runner import JsonFileRunner
 from .python_file_runner import PythonFileRunner
-from .protocol_file import (
-    ProtocolFileType,
-    ProtocolFile,
-    JsonProtocolFile,
-    PythonProtocolFile,
-)
+from .protocol_file import ProtocolFileType, ProtocolFile
 
 __all__ = [
     # runner factory
@@ -30,6 +25,4 @@ __all__ = [
     # value objects
     "ProtocolFileType",
     "ProtocolFile",
-    "JsonProtocolFile",
-    "PythonProtocolFile",
 ]

--- a/api/src/opentrons/file_runner/__init__.py
+++ b/api/src/opentrons/file_runner/__init__.py
@@ -9,17 +9,27 @@ responsibilities of this module are:
 - Dispatch ProtocolEngine commands to an engine instance
 """
 
+from .create_file_runner import create_file_runner
 from .abstract_file_runner import AbstractFileRunner
 from .json_file_runner import JsonFileRunner
 from .python_file_runner import PythonFileRunner
-from .protocol_file import ProtocolFile, ProtocolFileType
+from .protocol_file import (
+    ProtocolFileType,
+    ProtocolFile,
+    JsonProtocolFile,
+    PythonProtocolFile,
+)
 
 __all__ = [
+    # runner factory
+    "create_file_runner",
     # runner interfaces
     "AbstractFileRunner",
     "JsonFileRunner",
     "PythonFileRunner",
     # value objects
-    "ProtocolFile",
     "ProtocolFileType",
+    "ProtocolFile",
+    "JsonProtocolFile",
+    "PythonProtocolFile",
 ]

--- a/api/src/opentrons/file_runner/abstract_file_runner.py
+++ b/api/src/opentrons/file_runner/abstract_file_runner.py
@@ -6,6 +6,11 @@ class AbstractFileRunner(ABC):
     """Abstract interface for an object that can run protocol files."""
 
     @abstractmethod
+    def load(self) -> None:
+        """Prepare runner and engine state prior to starting the run."""
+        ...
+
+    @abstractmethod
     def play(self) -> None:
         """Start (or un-pause) running the protocol file."""
         ...

--- a/api/src/opentrons/file_runner/create_file_runner.py
+++ b/api/src/opentrons/file_runner/create_file_runner.py
@@ -18,8 +18,8 @@ def create_file_runner(
     """Construct a wired-up protocol runner instance.
 
     Arguments:
-        file: Protocol file the runner will be using. If `None`, returns
-            a basic runner for ProtocolEngine usage without a file.
+        protocol_file: Protocol file the runner will be using. If `None`,
+            returns a basic runner for ProtocolEngine usage without a file.
         engine: The protocol engine interface the runner will use.
 
     Returns:

--- a/api/src/opentrons/file_runner/create_file_runner.py
+++ b/api/src/opentrons/file_runner/create_file_runner.py
@@ -1,5 +1,4 @@
 """Protocol runner factory."""
-from pathlib import Path
 from typing import Optional
 
 from opentrons.protocol_engine import ProtocolEngine
@@ -9,12 +8,11 @@ from .abstract_file_runner import AbstractFileRunner
 from .json_file_runner import JsonFileRunner
 from .json_file_reader import JsonFileReader
 from .command_queue_worker import CommandQueueWorker
-from .protocol_file import ProtocolFileType, JsonProtocolFile
+from .protocol_file import ProtocolFileType, ProtocolFile
 
 
 def create_file_runner(
-    file_type: Optional[ProtocolFileType],
-    file_path: Optional[Path],
+    protocol_file: Optional[ProtocolFile],
     engine: ProtocolEngine,
 ) -> AbstractFileRunner:
     """Construct a wired-up protocol runner instance.
@@ -27,14 +25,9 @@ def create_file_runner(
     Returns:
         A runner appropriate for the requested protocol type.
     """
-    file = None
-
-    if file_path is not None and file_type == ProtocolFileType.JSON:
-        file = JsonProtocolFile(file_path=file_path)
-
-    if isinstance(file, JsonProtocolFile):
+    if protocol_file is not None and protocol_file.file_type == ProtocolFileType.JSON:
         return JsonFileRunner(
-            file=file,
+            file=protocol_file,
             protocol_engine=engine,
             file_reader=JsonFileReader(),
             command_translator=CommandTranslator(),

--- a/api/src/opentrons/file_runner/create_file_runner.py
+++ b/api/src/opentrons/file_runner/create_file_runner.py
@@ -1,0 +1,44 @@
+"""Protocol runner factory."""
+from pathlib import Path
+from typing import Optional
+
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocols.runner import CommandTranslator
+
+from .abstract_file_runner import AbstractFileRunner
+from .json_file_runner import JsonFileRunner
+from .json_file_reader import JsonFileReader
+from .command_queue_worker import CommandQueueWorker
+from .protocol_file import ProtocolFileType, JsonProtocolFile
+
+
+def create_file_runner(
+    file_type: Optional[ProtocolFileType],
+    file_path: Optional[Path],
+    engine: ProtocolEngine,
+) -> AbstractFileRunner:
+    """Construct a wired-up protocol runner instance.
+
+    Arguments:
+        file: Protocol file the runner will be using. If `None`, returns
+            a basic runner for ProtocolEngine usage without a file.
+        engine: The protocol engine interface the runner will use.
+
+    Returns:
+        A runner appropriate for the requested protocol type.
+    """
+    file = None
+
+    if file_path is not None and file_type == ProtocolFileType.JSON:
+        file = JsonProtocolFile(file_path=file_path)
+
+    if isinstance(file, JsonProtocolFile):
+        return JsonFileRunner(
+            file=file,
+            protocol_engine=engine,
+            file_reader=JsonFileReader(),
+            command_translator=CommandTranslator(),
+            command_queue_worker=CommandQueueWorker(),
+        )
+
+    raise NotImplementedError("Other runner types not yet supported")

--- a/api/src/opentrons/file_runner/json_file_reader.py
+++ b/api/src/opentrons/file_runner/json_file_reader.py
@@ -1,0 +1,14 @@
+"""JSON file reading."""
+
+from opentrons.protocols.models import JsonProtocol
+from .protocol_file import JsonProtocolFile
+
+
+class JsonFileReader:
+    """Reads and parses JSON protocol files."""
+
+    @staticmethod
+    def read(file: JsonProtocolFile) -> JsonProtocol:
+        """Read and parse file into a JsonProtocol model."""
+        contents = file.file_path.read_text(encoding="utf-8")
+        return JsonProtocol.parse_raw(contents)

--- a/api/src/opentrons/file_runner/json_file_reader.py
+++ b/api/src/opentrons/file_runner/json_file_reader.py
@@ -1,14 +1,14 @@
 """JSON file reading."""
 
 from opentrons.protocols.models import JsonProtocol
-from .protocol_file import JsonProtocolFile
+from .protocol_file import ProtocolFile
 
 
 class JsonFileReader:
     """Reads and parses JSON protocol files."""
 
     @staticmethod
-    def read(file: JsonProtocolFile) -> JsonProtocol:
+    def read(file: ProtocolFile) -> JsonProtocol:
         """Read and parse file into a JsonProtocol model."""
         contents = file.file_path.read_text(encoding="utf-8")
         return JsonProtocol.parse_raw(contents)

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -5,7 +5,7 @@ from opentrons.protocols.runner import CommandTranslator
 from .abstract_file_runner import AbstractFileRunner
 from .json_file_reader import JsonFileReader
 from .command_queue_worker import CommandQueueWorker
-from .protocol_file import JsonProtocolFile
+from .protocol_file import ProtocolFile
 
 
 class JsonFileRunner(AbstractFileRunner):
@@ -13,7 +13,7 @@ class JsonFileRunner(AbstractFileRunner):
 
     def __init__(
         self,
-        file: JsonProtocolFile,
+        file: ProtocolFile,
         file_reader: JsonFileReader,
         protocol_engine: ProtocolEngine,
         command_translator: CommandTranslator,

--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -1,37 +1,44 @@
 """File runner interfaces for JSON protocols."""
 from opentrons.protocol_engine import ProtocolEngine
-from opentrons.protocols.models import JsonProtocol
 from opentrons.protocols.runner import CommandTranslator
 
 from .abstract_file_runner import AbstractFileRunner
+from .json_file_reader import JsonFileReader
 from .command_queue_worker import CommandQueueWorker
+from .protocol_file import JsonProtocolFile
 
 
 class JsonFileRunner(AbstractFileRunner):
     """JSON protocol file runner."""
 
     def __init__(
-            self,
-            protocol: JsonProtocol,
-            protocol_engine: ProtocolEngine,
-            command_translator: CommandTranslator,
-            command_queue_worker: CommandQueueWorker) -> None:
+        self,
+        file: JsonProtocolFile,
+        file_reader: JsonFileReader,
+        protocol_engine: ProtocolEngine,
+        command_translator: CommandTranslator,
+        command_queue_worker: CommandQueueWorker,
+    ) -> None:
         """JSON file runner constructor.
 
         Args:
-            protocol: a JSON protocol
+            file: a JSON protocol file
+            file_reader: an interface to read the file into a data model.
             protocol_engine: instance of the Protocol Engine
             command_translator: the JSON command translator
             command_queue_worker: Command Queue worker
         """
-        self._protocol = protocol
+        self._file = file
+        self._file_reader = file_reader
         self._protocol_engine = protocol_engine
         self._command_translator = command_translator
         self._command_queue_worker = command_queue_worker
 
     def load(self) -> None:
         """Translate JSON commands and send them to protocol engine."""
-        for json_cmd in self._protocol.commands:
+        protocol = self._file_reader.read(self._file)
+
+        for json_cmd in protocol.commands:
             translated_items = self._command_translator.translate(json_cmd)
             for cmd in translated_items:
                 self._protocol_engine.add_command(cmd)

--- a/api/src/opentrons/file_runner/protocol_file.py
+++ b/api/src/opentrons/file_runner/protocol_file.py
@@ -3,8 +3,12 @@
 # existing logic and models from:
 #   - api/src/opentrons/protocols/types.py
 #   - robot-server/robot_server/service/protocol/models.py
+from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
+from typing import Union
+from typing_extensions import Literal
 
 
 class ProtocolFileType(str, Enum):
@@ -20,11 +24,29 @@ class ProtocolFileType(str, Enum):
 
 
 @dataclass(frozen=True)
-class ProtocolFile:
+class AbstractProtocolFile:
     """A value object representing a protocol file on disk.
 
     Attributes:
         file_type: Whether the file is a JSON protocol or Python protocol
     """
 
+    file_path: Path
     file_type: ProtocolFileType
+
+
+@dataclass(frozen=True)
+class JsonProtocolFile(AbstractProtocolFile):
+    """A value object representing a JSON protocol file."""
+
+    file_type: Literal[ProtocolFileType.JSON] = ProtocolFileType.JSON
+
+
+@dataclass(frozen=True)
+class PythonProtocolFile(AbstractProtocolFile):
+    """A value object representing a Python protocol file."""
+
+    file_type: Literal[ProtocolFileType.PYTHON] = ProtocolFileType.PYTHON
+
+
+ProtocolFile = Union[JsonProtocolFile, PythonProtocolFile]

--- a/api/src/opentrons/file_runner/protocol_file.py
+++ b/api/src/opentrons/file_runner/protocol_file.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Union
-from typing_extensions import Literal
 
 
 class ProtocolFileType(str, Enum):
@@ -24,7 +22,7 @@ class ProtocolFileType(str, Enum):
 
 
 @dataclass(frozen=True)
-class AbstractProtocolFile:
+class ProtocolFile:
     """A value object representing a protocol file on disk.
 
     Attributes:
@@ -33,20 +31,3 @@ class AbstractProtocolFile:
 
     file_path: Path
     file_type: ProtocolFileType
-
-
-@dataclass(frozen=True)
-class JsonProtocolFile(AbstractProtocolFile):
-    """A value object representing a JSON protocol file."""
-
-    file_type: Literal[ProtocolFileType.JSON] = ProtocolFileType.JSON
-
-
-@dataclass(frozen=True)
-class PythonProtocolFile(AbstractProtocolFile):
-    """A value object representing a Python protocol file."""
-
-    file_type: Literal[ProtocolFileType.PYTHON] = ProtocolFileType.PYTHON
-
-
-ProtocolFile = Union[JsonProtocolFile, PythonProtocolFile]

--- a/api/src/opentrons/file_runner/python_file_runner.py
+++ b/api/src/opentrons/file_runner/python_file_runner.py
@@ -7,7 +7,7 @@ class PythonFileRunner(AbstractFileRunner):
 
     def load(self) -> None:
         """Prepare to run the Python protocol file."""
-        raise NotImplementedError()
+        raise NotImplementedError("Python protocol loading not implemented")
 
     def play(self) -> None:
         """Start (or un-pause) running the Python protocol file."""

--- a/api/src/opentrons/file_runner/python_file_runner.py
+++ b/api/src/opentrons/file_runner/python_file_runner.py
@@ -5,6 +5,10 @@ from .abstract_file_runner import AbstractFileRunner
 class PythonFileRunner(AbstractFileRunner):
     """Python protocol file runner."""
 
+    def load(self) -> None:
+        """Prepare to run the Python protocol file."""
+        raise NotImplementedError()
+
     def play(self) -> None:
         """Start (or un-pause) running the Python protocol file."""
         raise NotImplementedError()

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -23,6 +23,7 @@ from functools import partial
 import zipfile
 
 import pytest
+from decoy import Decoy
 
 from opentrons.api.routers import MainRouter
 from opentrons.api import models
@@ -49,6 +50,12 @@ def asyncio_loop_exception_handler(loop):
     loop.set_exception_handler(exception_handler)
     yield
     loop.set_exception_handler(None)
+
+
+@pytest.fixture
+def decoy() -> Decoy:
+    """Get a Decoy state container to clean up stubs after tests."""
+    return Decoy()
 
 
 def state(topic, state):

--- a/api/tests/opentrons/file_runner/conftest.py
+++ b/api/tests/opentrons/file_runner/conftest.py
@@ -1,0 +1,75 @@
+"""Test fixtures for opentrons.file_runner tests."""
+import pytest
+
+from opentrons.protocols.models import JsonProtocol
+
+
+@pytest.fixture
+def json_protocol(json_protocol_dict: dict) -> JsonProtocol:
+    """Get a parsed JSON protocol model fixture."""
+    return JsonProtocol.parse_obj(json_protocol_dict)
+
+
+@pytest.fixture
+def json_protocol_dict(minimal_labware_def: dict) -> dict:
+    """Get a JSON protocol dictionary fixture."""
+    return {
+        "schemaVersion": 3,
+        "metadata": {},
+        "robot": {"model": "OT-2 Standard"},
+        "pipettes": {"leftPipetteId": {"mount": "left", "name": "p300_single"}},
+        "labware": {
+            "trashId": {
+                "slot": "12",
+                "displayName": "Trash",
+                "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1",
+            },
+            "tiprack1Id": {
+                "slot": "1",
+                "displayName": "Opentrons 96 Tip Rack 300 µL",
+                "definitionId": "opentrons/opentrons_96_tiprack_300ul/1",
+            },
+            "wellplate1Id": {
+                "slot": "10",
+                "displayName": "Corning 96 Well Plate 360 µL Flat",
+                "definitionId": "opentrons/corning_96_wellplate_360ul_flat/1",
+            },
+        },
+        "labwareDefinitions": {
+            "opentrons/opentrons_1_trash_1100ml_fixed/1": minimal_labware_def,
+            "opentrons/opentrons_96_tiprack_300ul/1": minimal_labware_def,
+            "opentrons/corning_96_wellplate_360ul_flat/1": minimal_labware_def,
+        },
+        "commands": [
+            {
+                "command": "pickUpTip",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "labware": "tiprack1Id",
+                    "well": "A1",
+                },
+            },
+            {
+                "command": "aspirate",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "volume": 51,
+                    "labware": "wellplate1Id",
+                    "well": "B1",
+                    "offsetFromBottomMm": 10,
+                    "flowRate": 10,
+                },
+            },
+            {
+                "command": "dispense",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "volume": 50,
+                    "labware": "wellplate1Id",
+                    "well": "H1",
+                    "offsetFromBottomMm": 1,
+                    "flowRate": 50,
+                },
+            },
+        ],
+    }

--- a/api/tests/opentrons/file_runner/test_create_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_create_file_runner.py
@@ -1,4 +1,6 @@
 """Tests for the create_protocol_runner factory."""
+# TODO(mc, 2021-06-03): turn these into actual integration tests
+# that uses real protocol files
 from mock import MagicMock
 from pathlib import Path
 

--- a/api/tests/opentrons/file_runner/test_create_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_create_file_runner.py
@@ -1,0 +1,19 @@
+"""Tests for the create_protocol_runner factory."""
+from mock import MagicMock
+from pathlib import Path
+
+from opentrons.file_runner import ProtocolFileType, JsonFileRunner, create_file_runner
+
+
+def test_create_json_runner() -> None:
+    """It should be able to create a JSON file runner."""
+    file_type = ProtocolFileType.JSON
+    file_path = Path("/dev/null")
+
+    result = create_file_runner(
+        file_type=file_type,
+        file_path=file_path,
+        engine=MagicMock(),
+    )
+
+    assert isinstance(result, JsonFileRunner)

--- a/api/tests/opentrons/file_runner/test_create_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_create_file_runner.py
@@ -2,17 +2,23 @@
 from mock import MagicMock
 from pathlib import Path
 
-from opentrons.file_runner import ProtocolFileType, JsonFileRunner, create_file_runner
+from opentrons.file_runner import (
+    ProtocolFileType,
+    ProtocolFile,
+    JsonFileRunner,
+    create_file_runner,
+)
 
 
 def test_create_json_runner() -> None:
     """It should be able to create a JSON file runner."""
-    file_type = ProtocolFileType.JSON
-    file_path = Path("/dev/null")
+    protocol_file = ProtocolFile(
+        file_type=ProtocolFileType.JSON,
+        file_path=Path("/dev/null"),
+    )
 
     result = create_file_runner(
-        file_type=file_type,
-        file_path=file_path,
+        protocol_file=protocol_file,
         engine=MagicMock(),
     )
 

--- a/api/tests/opentrons/file_runner/test_json_file_reader.py
+++ b/api/tests/opentrons/file_runner/test_json_file_reader.py
@@ -1,0 +1,37 @@
+"""Integration tests for the JsonFileReader interface."""
+import pytest
+import json
+from pathlib import Path
+
+from opentrons.protocols.models import JsonProtocol
+from opentrons.file_runner import JsonProtocolFile
+from opentrons.file_runner.json_file_reader import JsonFileReader
+
+
+@pytest.fixture
+def json_protocol_file(
+    tmpdir: Path,
+    json_protocol_dict: dict,
+) -> JsonProtocolFile:
+    """Get a JsonProtocolFile with JSON on-disk."""
+    file_path = tmpdir / "protocol.json"
+    file_path.write_text(json.dumps(json_protocol_dict), encoding="utf-8")
+
+    return JsonProtocolFile(file_path=file_path)
+
+
+@pytest.fixture
+def subject() -> JsonFileReader:
+    """Get a JsonFileReader test subject."""
+    return JsonFileReader()
+
+
+def test_reads_file(
+    json_protocol_dict: dict,
+    json_protocol_file: JsonProtocolFile,
+    subject: JsonFileReader,
+) -> None:
+    """It should read a JSON file into a JsonProtocol model."""
+    result = subject.read(json_protocol_file)
+
+    assert result == JsonProtocol.parse_obj(json_protocol_dict)

--- a/api/tests/opentrons/file_runner/test_json_file_reader.py
+++ b/api/tests/opentrons/file_runner/test_json_file_reader.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from opentrons.protocols.models import JsonProtocol
-from opentrons.file_runner import JsonProtocolFile
+from opentrons.file_runner import ProtocolFile, ProtocolFileType
 from opentrons.file_runner.json_file_reader import JsonFileReader
 
 
@@ -12,12 +12,12 @@ from opentrons.file_runner.json_file_reader import JsonFileReader
 def json_protocol_file(
     tmpdir: Path,
     json_protocol_dict: dict,
-) -> JsonProtocolFile:
-    """Get a JsonProtocolFile with JSON on-disk."""
+) -> ProtocolFile:
+    """Get a ProtocolFile with JSON on-disk."""
     file_path = tmpdir / "protocol.json"
     file_path.write_text(json.dumps(json_protocol_dict), encoding="utf-8")
 
-    return JsonProtocolFile(file_path=file_path)
+    return ProtocolFile(file_type=ProtocolFileType.JSON, file_path=file_path)
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def subject() -> JsonFileReader:
 
 def test_reads_file(
     json_protocol_dict: dict,
-    json_protocol_file: JsonProtocolFile,
+    json_protocol_file: ProtocolFile,
     subject: JsonFileReader,
 ) -> None:
     """It should read a JSON file into a JsonProtocol model."""

--- a/api/tests/opentrons/file_runner/test_json_file_reader.py
+++ b/api/tests/opentrons/file_runner/test_json_file_reader.py
@@ -34,4 +34,6 @@ def test_reads_file(
     """It should read a JSON file into a JsonProtocol model."""
     result = subject.read(json_protocol_file)
 
+    # TODO(mc, 2021-06-03): this `parse_obj` is sort of mirroring
+    # the implementation exactly; rethink and revisit
     assert result == JsonProtocol.parse_obj(json_protocol_dict)

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -1,15 +1,20 @@
 """Tests for a JsonFileRunner interface."""
 import pytest
 from decoy import Decoy
+from pathlib import Path
 
-from opentrons.file_runner import JsonFileRunner
+from opentrons.file_runner import JsonFileRunner, JsonProtocolFile
+from opentrons.file_runner.json_file_reader import JsonFileReader
 from opentrons.file_runner.command_queue_worker import CommandQueueWorker
+
 from opentrons.protocol_engine import ProtocolEngine, WellLocation
-from opentrons.protocol_engine.commands import (PickUpTipRequest, AspirateRequest,
-                                                DispenseRequest)
-from opentrons.protocols import models
-from opentrons.protocols.runner.json_proto.command_translator import \
-    CommandTranslator
+from opentrons.protocol_engine.commands import (
+    PickUpTipRequest,
+    AspirateRequest,
+    DispenseRequest,
+)
+from opentrons.protocols.models import JsonProtocol
+from opentrons.protocols.runner.json_proto.command_translator import CommandTranslator
 
 
 @pytest.fixture
@@ -37,93 +42,37 @@ def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
 
 
 @pytest.fixture
-def sample_json_proto(minimal_labware_def: dict) -> dict:
-    """JSON protocol fixture."""
-    return {
-        "schemaVersion": 3,
-        "metadata": {},
-        "robot": {
-            "model": "OT-2 Standard"
-        },
-        "pipettes": {
-            "leftPipetteId": {
-                "mount": "left",
-                "name": "p300_single"
-            }
-        },
-        "labware": {
-            "trashId": {
-                "slot": "12",
-                "displayName": "Trash",
-                "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
-            },
-            "tiprack1Id": {
-                "slot": "1",
-                "displayName": "Opentrons 96 Tip Rack 300 µL",
-                "definitionId": "opentrons/opentrons_96_tiprack_300ul/1"
-            },
-            "wellplate1Id": {
-                "slot": "10",
-                "displayName": "Corning 96 Well Plate 360 µL Flat",
-                "definitionId": "opentrons/corning_96_wellplate_360ul_flat/1"
-            }
-        },
-        "labwareDefinitions": {
-            "opentrons/opentrons_1_trash_1100ml_fixed/1": minimal_labware_def,
-            "opentrons/opentrons_96_tiprack_300ul/1": minimal_labware_def,
-            "opentrons/corning_96_wellplate_360ul_flat/1": minimal_labware_def
-        },
-        "commands": [
-           {
-               "command": "pickUpTip",
-               "params": {
-                   "pipette": "leftPipetteId",
-                   "labware": "tiprack1Id",
-                   "well": "A1"
-               }
-           },
-           {
-               "command": "aspirate",
-               "params": {
-                   "pipette": "leftPipetteId",
-                   "volume": 51,
-                   "labware": "wellplate1Id",
-                   "well": "B1",
-                   "offsetFromBottomMm": 10,
-                   "flowRate": 10
-               }
-           },
-           {
-               "command": "dispense",
-               "params": {
-                   "pipette": "leftPipetteId",
-                   "volume": 50,
-                   "labware": "wellplate1Id",
-                   "well": "H1",
-                   "offsetFromBottomMm": 1,
-                   "flowRate": 50
-               }
-           },
-        ]
-    }
+def file_reader(
+    decoy: Decoy,
+    protocol_file: JsonProtocolFile,
+    json_protocol: JsonProtocol,
+) -> JsonFileReader:
+    """Create a stubbed JsonFileReader interface."""
+    reader = decoy.create_decoy(spec=JsonFileReader)
+
+    decoy.when(reader.read(protocol_file)).then_return(json_protocol)
+
+    return reader
 
 
 @pytest.fixture
-def protocol(sample_json_proto: dict) -> models.JsonProtocol:
-    """Create a JSON protocol fixture."""
-    return models.JsonProtocol.parse_obj(sample_json_proto)
+def protocol_file(decoy: Decoy) -> JsonProtocolFile:
+    """Get a JsonProtocolFile value fixture."""
+    return JsonProtocolFile(file_path=Path("/dev/null"))
 
 
 @pytest.fixture
 def subject(
-        protocol: models.JsonProtocol,
-        protocol_engine: ProtocolEngine,
-        command_translator: CommandTranslator,
-        command_queue_worker: CommandQueueWorker
+    protocol_file: JsonProtocolFile,
+    protocol_engine: ProtocolEngine,
+    file_reader: JsonFileReader,
+    command_translator: CommandTranslator,
+    command_queue_worker: CommandQueueWorker,
 ) -> JsonFileRunner:
     """Get a JsonFileRunner test subject."""
     return JsonFileRunner(
-        protocol=protocol,
+        file=protocol_file,
+        file_reader=file_reader,
         protocol_engine=protocol_engine,
         command_translator=command_translator,
         command_queue_worker=command_queue_worker,
@@ -131,7 +80,9 @@ def subject(
 
 
 def test_json_runner_play(
-        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+    decoy: Decoy,
+    subject: JsonFileRunner,
+    command_queue_worker: CommandQueueWorker,
 ) -> None:
     """It should be able to start the run."""
     subject.play()
@@ -140,7 +91,9 @@ def test_json_runner_play(
 
 
 def test_json_runner_pause(
-        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+    decoy: Decoy,
+    subject: JsonFileRunner,
+    command_queue_worker: CommandQueueWorker,
 ) -> None:
     """It should be able to pause the run."""
     subject.pause()
@@ -149,7 +102,9 @@ def test_json_runner_pause(
 
 
 def test_json_runner_stop(
-        decoy: Decoy, subject: JsonFileRunner, command_queue_worker: CommandQueueWorker
+    decoy: Decoy,
+    subject: JsonFileRunner,
+    command_queue_worker: CommandQueueWorker,
 ) -> None:
     """It should be able to stop the run."""
     subject.stop()
@@ -158,27 +113,42 @@ def test_json_runner_stop(
 
 
 def test_json_runner_load_commands_to_engine(
-        decoy: Decoy,
-        protocol: models.JsonProtocol,
-        subject: JsonFileRunner,
-        command_translator: CommandTranslator,
-        protocol_engine: ProtocolEngine
+    decoy: Decoy,
+    json_protocol: JsonProtocol,
+    subject: JsonFileRunner,
+    command_translator: CommandTranslator,
+    protocol_engine: ProtocolEngine,
 ) -> None:
     """It should send translated commands to protocol engine."""
     mock_cmd1 = PickUpTipRequest(pipetteId="123", labwareId="abc", wellName="def")
-    mock_cmd2 = AspirateRequest(volume=321, wellLocation=WellLocation(),
-                                pipetteId="123", labwareId="xyz", wellName="def")
-    mock_cmd3 = DispenseRequest(volume=321, wellLocation=WellLocation(),
-                                pipetteId="123", labwareId="xyz", wellName="def")
-    decoy.when(
-        command_translator.translate(protocol.commands[0])).then_return([mock_cmd1])
-    decoy.when(
-        command_translator.translate(protocol.commands[1])).then_return([mock_cmd2])
-    decoy.when(
-        command_translator.translate(protocol.commands[2])).then_return([mock_cmd3])
+    mock_cmd2 = AspirateRequest(
+        volume=321,
+        wellLocation=WellLocation(),
+        pipetteId="123",
+        labwareId="xyz",
+        wellName="def",
+    )
+    mock_cmd3 = DispenseRequest(
+        volume=321,
+        wellLocation=WellLocation(),
+        pipetteId="123",
+        labwareId="xyz",
+        wellName="def",
+    )
+    decoy.when(command_translator.translate(json_protocol.commands[0])).then_return(
+        [mock_cmd1]
+    )
+    decoy.when(command_translator.translate(json_protocol.commands[1])).then_return(
+        [mock_cmd2]
+    )
+    decoy.when(command_translator.translate(json_protocol.commands[2])).then_return(
+        [mock_cmd3]
+    )
 
     subject.load()
 
-    decoy.verify(protocol_engine.add_command(mock_cmd1),
-                 protocol_engine.add_command(mock_cmd2),
-                 protocol_engine.add_command(mock_cmd3))
+    decoy.verify(
+        protocol_engine.add_command(mock_cmd1),
+        protocol_engine.add_command(mock_cmd2),
+        protocol_engine.add_command(mock_cmd3),
+    )

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -3,7 +3,7 @@ import pytest
 from decoy import Decoy
 from pathlib import Path
 
-from opentrons.file_runner import JsonFileRunner, JsonProtocolFile
+from opentrons.file_runner import JsonFileRunner, ProtocolFile, ProtocolFileType
 from opentrons.file_runner.json_file_reader import JsonFileReader
 from opentrons.file_runner.command_queue_worker import CommandQueueWorker
 
@@ -44,7 +44,7 @@ def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
 @pytest.fixture
 def file_reader(
     decoy: Decoy,
-    protocol_file: JsonProtocolFile,
+    protocol_file: ProtocolFile,
     json_protocol: JsonProtocol,
 ) -> JsonFileReader:
     """Create a stubbed JsonFileReader interface."""
@@ -56,14 +56,14 @@ def file_reader(
 
 
 @pytest.fixture
-def protocol_file(decoy: Decoy) -> JsonProtocolFile:
+def protocol_file(decoy: Decoy) -> ProtocolFile:
     """Get a JsonProtocolFile value fixture."""
-    return JsonProtocolFile(file_path=Path("/dev/null"))
+    return ProtocolFile(file_type=ProtocolFileType.JSON, file_path=Path("/dev/null"))
 
 
 @pytest.fixture
 def subject(
-    protocol_file: JsonProtocolFile,
+    protocol_file: ProtocolFile,
     protocol_engine: ProtocolEngine,
     file_reader: JsonFileReader,
     command_translator: CommandTranslator,


### PR DESCRIPTION
## Overview

This PR is 3 of 4 working towards #7816.

1. ~chore(api,robot-server): update testing dev deps #7855~ Merged
2. ~refactor(robot-server): add experimental protocol router #7856~ Merged
3. **refactor(api): add create_file_runner factory #7857**
4. refactor(robot-server): start wiring /sessions into runner and engine #7858

This PR prepares for session wireup to the `JsonFileRunner` by adding a factory function to set up a JsonFileRunner.

~Blocked by #7856, will require sync after merge~

## Changelog

- Addded `create_file_runner` factory to create a file runner instance given:
    - `file_type`: Python or JSON (Python and others left unimplemented)
    - `file_path`: path on the filesystem to the file
    - `engine`: ProtocolEngine instance

## Review requests

- [ ] Code and tests look good
- [ ] Wire-up makes sense in followup PR #7858

## Risk assessment

Low, not hooked to production code