### PR TITLE
feat(labware-creator): Update well shape and size section when tipRack is selected

### DIFF
--- a/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
@@ -18,8 +18,14 @@ interface Props {
   values: LabwareFields
 }
 
-// TODO (ka 2021-5-7): Broke this out here since we will need to have more conditions for tips
 const Instructions = (props: Props): JSX.Element => {
+  if (props.values.labwareType === 'tipRack') {
+    return (
+      <p>
+        Reference the <strong>inside</strong> of the tip.
+      </p>
+    )
+  }
   return (
     <>
       {displayAsTube(props.values) ? (
@@ -94,10 +100,12 @@ export const WellShapeAndSides = (): JSX.Element | null => {
     'wellYDimension',
   ]
   const { values, errors, touched } = useFormikContext<LabwareFields>()
+  const label =
+    values.labwareType === 'tipRack' ? 'Tip Diameter' : 'Well Shape & Sides'
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Well Shape & Sides" id="WellShapeAndSides">
+      <SectionBody label={label} id="WellShapeAndSides">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -291,6 +291,7 @@ export const labwareTypeAutofills: Record<
 > = {
   tipRack: {
     homogeneousWells: 'true' as const,
+    wellShape: 'circular' as const,
   },
   tubeRack: {},
   wellPlate: {},


### PR DESCRIPTION
# Overview

closes #7723 by updating the WellShapeAndSides section to Tip Diameter etc... when tip rack is selected.

Just a draft for now. Will need to rebase and add a test case soon.


# Changelog

- feat(labware-creator): Update well shape and size section when tipRack is selected
- NOT IN THIS PR -  Add test coverage after #7853 is merged 

# Review requests

- [ ] Title is now `Tip Diameter` when tipRack is selected
- [ ] Description references `tips` when tipRack is selected
- [ ] Well shape radio group is autofilled and hidden when tipRack is selected

# Risk assessment

Low. LC dynamic text updates.
