### PR TITLE
feat(emulator): allow overriding pipettes used by smoothie emulator

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,4 +1,3 @@
-
 Docker Guide  
 =======================  
 Included in this repo are the tools to run a containerized Opentrons robot stack in docker.
@@ -26,16 +25,17 @@ Start a terminal and change directory to the root of this repo.
 ## Configuration
 
 ### Pipettes
-By default a `p20_multi_v2.0` is on the left mount and `p20_single_v2.0` is on the right. These can be changed by modifying environment variables in the `docker-compose.yml`  file.
+
+By default a `p20_multi_v2.0` is on the left mount and `p20_single_v2.0` is on the right. These can be changed by modifying environment variables in the `docker-compose.yml` file.
 
 Under the `emulator` section add an `environment` section with a variable called `OT_EMULATOR_smoothie`. A stringified JSON object with `model` and `id` field for the `left` and `right` mounts is defined by `OT_EMULATOR_smoothie`. All fields are optional.
 
 For example to use a `p300_multi` on the right add:
+
 ```
   environment:
     OT_EMULATOR_smoothie: '{"right": {"model": "p300_multi"}}'
 ```
-
 
 ## Known Issues
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,3 +1,4 @@
+
 Docker Guide  
 =======================  
 Included in this repo are the tools to run a containerized Opentrons robot stack in docker.
@@ -6,7 +7,7 @@ This includes the `robot-server` connected to the hardware emulation application
 
 ## Requirements
 
-- A clone of this repo.
+- A clone of [this](https://github.com/Opentrons/opentrons) repo.
 - An installation [docker](https://docs.docker.com/get-docker/)
 - An installation of [docker-compose](https://docs.docker.com/compose/install/)
 
@@ -22,7 +23,20 @@ Start a terminal and change directory to the root of this repo.
 
 3. Start the Opentrons application. The docker container will appear as `dev`. Connect and run just as you would on a robot.
 
+## Configuration
+
+### Pipettes
+By default a `p20_multi_v2.0` is on the left mount and `p20_single_v2.0` is on the right. These can be changed by modifying environment variables in the `docker-compose.yml`  file.
+
+Under the `emulator` section add an `environment` section with a variable called `OT_EMULATOR_smoothie`. A stringified JSON object with `model` and `id` field for the `left` and `right` mounts is defined by `OT_EMULATOR_smoothie`. All fields are optional.
+
+For example to use a `p300_multi` on the right add:
+```
+  environment:
+    OT_EMULATOR_smoothie: '{"right": {"model": "p300_multi"}}'
+```
+
+
 ## Known Issues
 
 - Pipettes cannot be changed at run time.
-- Pipettes are fixed as `p20_multi_v2.0` on the left mount and `p20_single_v2.0` on the right.

--- a/api/src/opentrons/hardware_control/emulation/app.py
+++ b/api/src/opentrons/hardware_control/emulation/app.py
@@ -5,6 +5,7 @@ from opentrons.hardware_control.emulation.connection_handler import \
     ConnectionHandler
 from opentrons.hardware_control.emulation.magdeck import MagDeckEmulator
 from opentrons.hardware_control.emulation.parser import Parser
+from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.emulation.tempdeck import TempDeckEmulator
 from opentrons.hardware_control.emulation.thermocycler import ThermocyclerEmulator
 from opentrons.hardware_control.emulation.smoothie import SmoothieEmulator
@@ -28,7 +29,8 @@ async def run_server(host: str, port: int, handler: ConnectionHandler) -> None:
 
 async def run() -> None:
     """Run the module emulators."""
-    host = "0.0.0.0"
+    settings = Settings()
+    host = settings.host
 
     await asyncio.gather(
         run_server(host=host,
@@ -42,7 +44,9 @@ async def run() -> None:
                    handler=ConnectionHandler(ThermocyclerEmulator(parser=Parser()))),
         run_server(host=host,
                    port=SMOOTHIE_PORT,
-                   handler=ConnectionHandler(SmoothieEmulator(parser=Parser()))),
+                   handler=ConnectionHandler(
+                       SmoothieEmulator(parser=Parser(), settings=settings.smoothie))
+                   ),
     )
 
 

--- a/api/src/opentrons/hardware_control/emulation/settings.py
+++ b/api/src/opentrons/hardware_control/emulation/settings.py
@@ -1,0 +1,24 @@
+from pydantic import BaseSettings, Field, BaseModel
+
+
+class PipetteSettings(BaseModel):
+    model: str = "p20_single_v2.0"
+    id: str = "P20SV202020070101"
+
+
+class SmoothieSettings(BaseModel):
+    left: PipetteSettings = PipetteSettings(
+        model="p20_multi_v2.0", id="P3HMV202020041605"
+    )
+    right: PipetteSettings = PipetteSettings(
+        model="p20_single_v2.0", id="P20SV202020070101"
+    )
+
+
+class Settings(BaseSettings):
+    smoothie: SmoothieSettings = SmoothieSettings()
+
+    host: str = "0.0.0.0"
+
+    class Config:
+        env_prefix = "OT_EMULATOR_"

--- a/api/src/opentrons/hardware_control/emulation/settings.py
+++ b/api/src/opentrons/hardware_control/emulation/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings, Field, BaseModel
+from pydantic import BaseSettings, BaseModel
 
 
 class PipetteSettings(BaseModel):

--- a/api/src/opentrons/hardware_control/emulation/smoothie.py
+++ b/api/src/opentrons/hardware_control/emulation/smoothie.py
@@ -14,6 +14,7 @@ from opentrons.drivers.smoothie_drivers.driver_3_0 import GCODE
 from opentrons.hardware_control.emulation.parser import Command, Parser
 
 from .abstract_emulator import AbstractEmulator
+from .settings import SmoothieSettings
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class SmoothieEmulator(AbstractEmulator):
 
     WRITE_INSTRUMENT_RE = re.compile(r"(?P<mount>[LR])\s*(?P<value>[a-f0-9]+)")
 
-    def __init__(self, parser: Parser) -> None:
+    def __init__(self, parser: Parser, settings: SmoothieSettings) -> None:
         """Constructor"""
         _, fw_version = _find_smoothie_file()
         self._version_string = \
@@ -41,12 +42,12 @@ class SmoothieEmulator(AbstractEmulator):
         }
         self._speed = 0.0
         self._pipette_model = {
-            "L": utils.string_to_hex("p20_multi_v2.0", 64),
-            "R": utils.string_to_hex("p20_single_v2.0", 64)
+            "L": utils.string_to_hex(settings.left.model, 64),
+            "R": utils.string_to_hex(settings.right.model, 64)
         }
         self._pipette_id = {
-            "L": utils.string_to_hex("P3HMV202020041605", 64),
-            "R": utils.string_to_hex("P20SV202020070101", 64),
+            "L": utils.string_to_hex(settings.left.id, 64),
+            "R": utils.string_to_hex(settings.right.id, 64),
         }
         self._parser = parser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - '9997:9997'
       - '9998:9998'
       - '9999:9999'
+    # Uncomment lines below to override the pipette(s) loaded by emulator
+    #environment:
+    #  OT_EMULATOR_smoothie: '{"right": {"model": "p300_multi"}, "left": {"model": "p20_single_v2.0"}}'
   robot-server:
     build: .
     command: uvicorn "robot_server:app" --host 0.0.0.0 --port 31950 --ws wsproto --reload

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -78,3 +78,5 @@ This requires two steps. Enter these commands from the opentrons directory:
 
 - `make -C api emulator`
 - `make -C robot-server dev-with-emulator`
+
+By default a `p20_multi_v2.0` is on the left mount and `p20_single_v2.0` is on the right. These can be changed by modifying the `OT_EMULATOR_smoothie` environment variable which contains a stringified JSON object with a `model` and `id` field for the `left` and `right`. All fields are optional. For example to use a `p300_multi` on the right use  `export OT_EMULATOR_smoothie='{"right": {"model": "p300_multi"}}' && make -C api emulator`


### PR DESCRIPTION
# Overview

Users can define which pipettes are loaded by smoothie emulator

# Changelog

- Added Settings object to emulator app
- Documented how to override in `DOCKER.md`
- Document how to override in `README.rst`
- added commented about override in `docker-compose.yml`

# Review requests


# Risk assessment

None