### PR TITLE
feat(labware-creator): add dynamic height copy for tip racks

### DIFF
--- a/labware-library/src/labware-creator/components/HeightGuidingText.tsx
+++ b/labware-library/src/labware-creator/components/HeightGuidingText.tsx
@@ -39,6 +39,16 @@ export const HeightGuidingText = (props: {
       </>
     )
   }
+  if (labwareType === 'tipRack') {
+    return (
+      <>
+        <p>
+          Include the adapter and tops of the pipette tips in the measurement.
+        </p>
+        {footer}
+      </>
+    )
+  }
   return (
     <>
       <p>Include any well lip in the measurement. Exclude any cover or cap.</p>

--- a/labware-library/src/labware-creator/components/__tests__/sections/Height.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Height.test.tsx
@@ -1,27 +1,14 @@
 import React from 'react'
+import '@testing-library/jest-dom'
 import { FormikConfig } from 'formik'
-import isEqual from 'lodash/isEqual'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import { getDefaultFormState, LabwareFields } from '../../../fields'
 import { isEveryFieldHidden } from '../../../utils'
 import { Height } from '../../sections/Height'
-import { FormAlerts } from '../../alerts/FormAlerts'
-import { HeightAlerts } from '../../alerts/HeightAlerts'
-import { TextField } from '../../TextField'
 import { wrapInFormik } from '../../utils/wrapInFormik'
 
 jest.mock('../../../utils')
-jest.mock('../../TextField')
-jest.mock('../../alerts/FormAlerts')
-jest.mock('../../alerts/HeightAlerts')
-
-const FormAlertsMock = FormAlerts as jest.MockedFunction<typeof FormAlerts>
-const textFieldMock = TextField as jest.MockedFunction<typeof TextField>
-
-const HeightAlertsMock = HeightAlerts as jest.MockedFunction<
-  typeof HeightAlerts
->
 
 const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
   typeof isEveryFieldHidden
@@ -32,39 +19,8 @@ const formikConfig: FormikConfig<LabwareFields> = {
   onSubmit: jest.fn(),
 }
 
-describe('Height Section with Alerts', () => {
+describe('Height Section', () => {
   beforeEach(() => {
-    textFieldMock.mockImplementation(args => {
-      return <div>labwareZDimension text field</div>
-    })
-
-    FormAlertsMock.mockImplementation(args => {
-      if (
-        isEqual(args, {
-          touched: {},
-          errors: {},
-          fieldList: ['labwareType', 'labwareZDimension'],
-        })
-      ) {
-        return <div>mock alerts</div>
-      } else {
-        return <div></div>
-      }
-    })
-
-    HeightAlertsMock.mockImplementation(args => {
-      if (
-        isEqual(args, {
-          values: formikConfig.initialValues,
-          touched: {},
-        })
-      ) {
-        return <div>mock heightAlertsMock alerts</div>
-      } else {
-        return <div></div>
-      }
-    })
-
     when(isEveryFieldHiddenMock)
       .calledWith(
         ['labwareType', 'labwareZDimension'],
@@ -78,31 +34,55 @@ describe('Height Section with Alerts', () => {
     resetAllWhenMocks()
   })
 
-  it('should render text fields and alerts when fields are visible', () => {
+  it('should render text fields when fields are visible', () => {
     render(wrapInFormik(<Height />, formikConfig))
-    expect(screen.getByText('Height'))
+    expect(screen.getByRole('heading')).toHaveTextContent(/total height/i)
     expect(
       screen.getByText(
         'The height measurement informs the robot of the top and bottom of your labware.'
       )
     )
-    expect(screen.getByText('mock alerts'))
-    expect(screen.getByText('labwareZDimension text field'))
-    expect(screen.getByText('mock heightAlertsMock alerts'))
+    screen.getByRole('textbox', { name: /Height/i })
   })
 
-  it('should update title and instructions when tubeRack is selected', () => {
+  it('should update instructions when tubeRack is selected', () => {
     formikConfig.initialValues.labwareType = 'tubeRack'
     render(wrapInFormik(<Height />, formikConfig))
-    expect(screen.getByText('Total Height'))
     expect(screen.getByText('Place your tubes inside the rack.'))
   })
 
-  it('should update title and instructions when aluminumBlock is selected', () => {
+  it('should update instructions when aluminumBlock is selected', () => {
     formikConfig.initialValues.labwareType = 'aluminumBlock'
     render(wrapInFormik(<Height />, formikConfig))
-    expect(screen.getByText('Total Height'))
     expect(screen.getByText('Put your labware on top of the aluminum block.'))
+  })
+
+  it('should update instructions when tipRack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    render(wrapInFormik(<Height />, formikConfig))
+    expect(
+      screen.getByText(
+        'Include the adapter and tops of the pipette tips in the measurement.'
+      )
+    )
+  })
+
+  it('should render form alert when error is present', () => {
+    const FAKE_ERROR = 'ahh'
+    formikConfig.initialErrors = { labwareZDimension: FAKE_ERROR }
+    formikConfig.initialTouched = { labwareZDimension: true }
+    render(wrapInFormik(<Height />, formikConfig))
+    screen.getByText(FAKE_ERROR)
+  })
+
+  it('should render height alert when error is present', () => {
+    formikConfig.initialValues.labwareZDimension = '130'
+    formikConfig.initialTouched = { labwareZDimension: true }
+    const { container } = render(wrapInFormik(<Height />, formikConfig))
+    const error = container.querySelector('[class="alert info"]')
+    expect(error?.textContent).toBe(
+      'This labware may be too tall to work with some pipette + tip combinations. Please test on robot.'
+    )
   })
 
   it('should not render when all fields are hidden', () => {

--- a/labware-library/src/labware-creator/components/sections/Height.tsx
+++ b/labware-library/src/labware-creator/components/sections/Height.tsx
@@ -55,15 +55,7 @@ export const Height = (): JSX.Element | null => {
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody
-        label={
-          // @ts-expect-error(IL, 2021-03-24): `includes` doesn't want to take null/undefined
-          ['aluminumBlock', 'tubeRack'].includes(values.labwareType)
-            ? 'Total Height'
-            : 'Height'
-        }
-        id="Height"
-      >
+      <SectionBody label="Total Height" id="Height">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <HeightAlerts values={values} touched={touched} />


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Closes #7716 by adding dynamic height copy for tip racks


# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
- Added dynamic copy to height section for tip racks
- Use "Total Height" as title for all labware types
- Converted height test to `react-testing-library`
- Added test coverage for dynamic tip rack copy

# Review requests

- [ ]  Use "Total Height" as the title. This will apply to all labware types
- [ ] New conditional copy in description, based on tip rack selection

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

Low risk - dynamic copy in labware creator only