### PR TITLE
feat(labware-creator): add custom copy for tip rack volume section

### DIFF
--- a/labware-library/cypress/integration/labware-creator/reservoir.spec.js
+++ b/labware-library/cypress/integration/labware-creator/reservoir.spec.js
@@ -118,9 +118,9 @@ context('Reservoirs', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Max volume per well must be a number').should('exist')
+      cy.contains('Volume must be a number').should('exist')
       cy.get("input[name='wellVolume']").type('250').blur()
-      cy.contains('Max volume per well must be a number').should('not.exist')
+      cy.contains('Volume must be a number').should('not.exist')
     })
 
     describe('Well shape tests', () => {

--- a/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
@@ -82,9 +82,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Max volume per well must be a number').should('exist')
+        cy.contains('Volume must be a number').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Max volume per well must be a number').should('not.exist')
+        cy.contains('Volume must be a number').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -271,9 +271,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Max volume per well must be a number').should('exist')
+        cy.contains('Volume must be a number').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Max volume per well must be a number').should('not.exist')
+        cy.contains('Volume must be a number').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -460,9 +460,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Max volume per well must be a number').should('exist')
+        cy.contains('Volume must be a number').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Max volume per well must be a number').should('not.exist')
+        cy.contains('Volume must be a number').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -645,9 +645,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Max volume per well must be a number').should('exist')
+        cy.contains('Volume must be a number').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Max volume per well must be a number').should('not.exist')
+        cy.contains('Volume must be a number').should('not.exist')
       })
 
       describe('Well shape tests', () => {

--- a/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
@@ -70,9 +70,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Max volume per well must be a number').should('exist')
+      cy.contains('Volume must be a number').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Max volume per well must be a number').should('not.exist')
+      cy.contains('Volume must be a number').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -245,9 +245,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Max volume per well must be a number').should('exist')
+      cy.contains('Volume must be a number').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Max volume per well must be a number').should('not.exist')
+      cy.contains('Volume must be a number').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -424,9 +424,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Max volume per well must be a number').should('exist')
+      cy.contains('Volume must be a number').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Max volume per well must be a number').should('not.exist')
+      cy.contains('Volume must be a number').should('not.exist')
     })
 
     describe('Well shape tests', () => {

--- a/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
+++ b/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
@@ -130,9 +130,9 @@ context('Well Plates', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Max volume per well must be a number').should('exist')
+      cy.contains('Volume must be a number').should('exist')
       cy.get("input[name='wellVolume']").type('100').blur()
-      cy.contains('Max volume per well must be a number').should('not.exist')
+      cy.contains('Volume must be a number').should('not.exist')
     })
 
     describe('Well shape tests', () => {

--- a/labware-library/src/labware-creator/__tests__/utils/getLabwareName.test.ts
+++ b/labware-library/src/labware-creator/__tests__/utils/getLabwareName.test.ts
@@ -5,14 +5,76 @@ describe('getLabwareName', () => {
     { values: { labwareType: 'tipRack' }, plural: false, expected: 'tip' },
     { values: { labwareType: 'tipRack' }, plural: true, expected: 'tips' },
     {
-      values: { labwareType: 'aluminumBlock' },
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '24well',
+        aluminumBlockChildType: 'tubes', // user can select this if switching from 96 well to 24 well
+      },
+      plural: true,
+      expected: 'wells',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '24well',
+        aluminumBlockChildType: 'tubes', // user can select this if switching from 96 well to 24 well
+      },
+      plural: false,
+      expected: 'well',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'tubes',
+      },
+      plural: true,
+      expected: 'tubes',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'tubes',
+      },
       plural: false,
       expected: 'tube',
     },
     {
-      values: { labwareType: 'aluminumBlock' },
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'pcrTubeStrip',
+      },
+      plural: false,
+      expected: 'tube',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'pcrTubeStrip',
+      },
       plural: true,
       expected: 'tubes',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'pcrPlate',
+      },
+      plural: false,
+      expected: 'well',
+    },
+    {
+      values: {
+        labwareType: 'aluminumBlock',
+        aluminumBlockType: '96well',
+        aluminumBlockChildType: 'pcrPlate',
+      },
+      plural: true,
+      expected: 'wells',
     },
     { values: { labwareType: 'tubeRack' }, plural: false, expected: 'tube' },
     { values: { labwareType: 'tubeRack' }, plural: true, expected: 'tubes' },

--- a/labware-library/src/labware-creator/__tests__/utils/getLabwareName.test.ts
+++ b/labware-library/src/labware-creator/__tests__/utils/getLabwareName.test.ts
@@ -1,0 +1,32 @@
+import { getLabwareName } from '../../utils'
+
+describe('getLabwareName', () => {
+  const testCases: Array<{ values: any; plural: boolean; expected: String }> = [
+    { values: { labwareType: 'tipRack' }, plural: false, expected: 'tip' },
+    { values: { labwareType: 'tipRack' }, plural: true, expected: 'tips' },
+    {
+      values: { labwareType: 'aluminumBlock' },
+      plural: false,
+      expected: 'tube',
+    },
+    {
+      values: { labwareType: 'aluminumBlock' },
+      plural: true,
+      expected: 'tubes',
+    },
+    { values: { labwareType: 'tubeRack' }, plural: false, expected: 'tube' },
+    { values: { labwareType: 'tubeRack' }, plural: true, expected: 'tubes' },
+    { values: { labwareType: 'wellPlate' }, plural: false, expected: 'well' },
+    { values: { labwareType: 'wellPlate' }, plural: true, expected: 'wells' },
+    { values: { labwareType: 'reservoir' }, plural: false, expected: 'well' },
+    { values: { labwareType: 'reservoir' }, plural: true, expected: 'wells' },
+  ]
+
+  testCases.forEach(({ values, plural, expected }) => {
+    it(`should return ${expected} for values=${JSON.stringify(
+      values
+    )} and plural=${String(plural)}`, () => {
+      expect(getLabwareName(values, plural)).toEqual(expected)
+    })
+  })
+})

--- a/labware-library/src/labware-creator/components/__tests__/sections/Volume.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Volume.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import { getDefaultFormState, LabwareFields } from '../../../fields'
-import { isEveryFieldHidden } from '../../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../../utils'
 import { Volume } from '../../sections/Volume'
 import { wrapInFormik } from '../../utils/wrapInFormik'
 
@@ -12,6 +12,9 @@ jest.mock('../../../utils')
 
 const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
   typeof isEveryFieldHidden
+>
+const getLabwareNameMock = getLabwareName as jest.MockedFunction<
+  typeof getLabwareName
 >
 
 let formikConfig: FormikConfig<LabwareFields>
@@ -30,16 +33,22 @@ describe('Volume', () => {
   })
 
   it('should render with the correct information', () => {
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('well')
     render(wrapInFormik(<Volume />, formikConfig))
     expect(screen.getByRole('heading')).toHaveTextContent(/Volume/i)
 
     screen.getByText('Total maximum volume of each well.')
 
-    screen.getByRole('textbox', { name: /max volume per well/i })
+    screen.getByRole('textbox', { name: /Volume/i })
   })
 
   it('should render tubes when tubeRack is selected', () => {
     formikConfig.initialValues.labwareType = 'tubeRack'
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('tube')
     render(wrapInFormik(<Volume />, formikConfig))
 
     screen.getByText('Total maximum volume of each tube.')
@@ -47,6 +56,9 @@ describe('Volume', () => {
 
   it('should render tubes when aluminumBlock is selected', () => {
     formikConfig.initialValues.labwareType = 'aluminumBlock'
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('tube')
     render(wrapInFormik(<Volume />, formikConfig))
 
     screen.getByText('Total maximum volume of each tube.')
@@ -54,9 +66,22 @@ describe('Volume', () => {
 
   it('should render wells when wellPlate is selected', () => {
     formikConfig.initialValues.labwareType = 'wellPlate'
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('well')
     render(wrapInFormik(<Volume />, formikConfig))
 
     screen.getByText('Total maximum volume of each well.')
+  })
+
+  it('should render tips when tipRack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('tip')
+    render(wrapInFormik(<Volume />, formikConfig))
+
+    screen.getByText('Total maximum volume of each tip.')
   })
 
   it('should render alert when error is present', () => {

--- a/labware-library/src/labware-creator/components/sections/Volume.tsx
+++ b/labware-library/src/labware-creator/components/sections/Volume.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
-import { isEveryFieldHidden } from '../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../utils'
 import { makeMaskToDecimal } from '../../fieldMasks'
 import { LabwareFields } from '../../fields'
 import { FormAlerts } from '../alerts/FormAlerts'
@@ -16,15 +16,11 @@ interface ContentProps {
 }
 const Content = (props: ContentProps): JSX.Element => {
   const { values } = props
-  const wellLabel =
-    values.labwareType != null &&
-    ['aluminumBlock', 'tubeRack'].includes(values.labwareType)
-      ? 'tube'
-      : 'well'
+  const labwareName = getLabwareName(values, false)
   return (
     <div className={styles.flex_row}>
       <div className={styles.volume_instructions_column}>
-        <p>Total maximum volume of each {wellLabel}.</p>
+        <p>Total maximum volume of each {labwareName}.</p>
       </div>
 
       <div className={styles.form_fields_column}>

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -394,7 +394,7 @@ export const LABELS: Record<keyof LabwareFields, string> = {
   gridColumns: 'Number of columns',
   regularRowSpacing: 'Are all of your rows evenly spaced?',
   regularColumnSpacing: 'Are all of your columns evenly spaced?',
-  wellVolume: 'Max volume per well',
+  wellVolume: 'Volume',
   wellShape: 'Well shape',
   wellDiameter: 'Diameter',
   wellXDimension: 'Well X',

--- a/labware-library/src/labware-creator/formLevelValidation.ts
+++ b/labware-library/src/labware-creator/formLevelValidation.ts
@@ -1,6 +1,7 @@
 import { FormikErrors } from 'formik'
 import { labwareFormSchemaBaseObject } from './labwareFormSchema'
 import type { LabwareFields } from './fields'
+import { getLabwareName } from './utils'
 
 export const FORM_LEVEL_ERRORS = 'FORM_LEVEL_ERRORS'
 export const WELLS_OUT_OF_BOUNDS_X = 'WELLS_OUT_OF_BOUNDS_X'
@@ -73,21 +74,6 @@ export const getWellGridBoundingBox = (
       bottomRightCornerX,
       bottomRightCornerY,
     }
-  }
-}
-
-const getLabwareName = (values: LabwareFields): string => {
-  const { labwareType } = values
-  switch (labwareType) {
-    case 'tipRack':
-      return 'tips'
-    case 'tubeRack':
-      return 'tubes'
-    case 'wellPlate':
-    case 'aluminumBlock':
-    case 'reservoir':
-    default:
-      return 'wells'
   }
 }
 
@@ -225,7 +211,7 @@ export const formLevelValidation = (
   const wellBoundsInsideFootprintY =
     topLeftCornerY > 0 && bottomRightCornerY < footprintYDimension
 
-  const labwareName = getLabwareName(values)
+  const labwareName = getLabwareName(values, true)
 
   if (!wellBoundsInsideFootprintX) {
     formLevelErrors[WELLS_OUT_OF_BOUNDS_X] =

--- a/labware-library/src/labware-creator/utils/getLabwareName.ts
+++ b/labware-library/src/labware-creator/utils/getLabwareName.ts
@@ -8,10 +8,10 @@ export const getLabwareName = (
   switch (labwareType) {
     case 'tipRack':
       return `tip${plural ? 's' : ''}`
+    case 'aluminumBlock':
     case 'tubeRack':
       return `tube${plural ? 's' : ''}`
     case 'wellPlate':
-    case 'aluminumBlock':
     case 'reservoir':
     default:
       return `well${plural ? 's' : ''}`

--- a/labware-library/src/labware-creator/utils/getLabwareName.ts
+++ b/labware-library/src/labware-creator/utils/getLabwareName.ts
@@ -1,0 +1,19 @@
+import { LabwareFields } from '../fields'
+
+export const getLabwareName = (
+  values: LabwareFields,
+  plural: boolean
+): string => {
+  const { labwareType } = values
+  switch (labwareType) {
+    case 'tipRack':
+      return `tip${plural ? 's' : ''}`
+    case 'tubeRack':
+      return `tube${plural ? 's' : ''}`
+    case 'wellPlate':
+    case 'aluminumBlock':
+    case 'reservoir':
+    default:
+      return `well${plural ? 's' : ''}`
+  }
+}

--- a/labware-library/src/labware-creator/utils/getLabwareName.ts
+++ b/labware-library/src/labware-creator/utils/getLabwareName.ts
@@ -1,4 +1,5 @@
 import { LabwareFields } from '../fields'
+import { displayAsTube } from './displayAsTube'
 
 export const getLabwareName = (
   values: LabwareFields,
@@ -9,6 +10,9 @@ export const getLabwareName = (
     case 'tipRack':
       return `tip${plural ? 's' : ''}`
     case 'aluminumBlock':
+      return displayAsTube(values)
+        ? `tube${plural ? 's' : ''}`
+        : `well${plural ? 's' : ''}`
     case 'tubeRack':
       return `tube${plural ? 's' : ''}`
     case 'wellPlate':

--- a/labware-library/src/labware-creator/utils/index.ts
+++ b/labware-library/src/labware-creator/utils/index.ts
@@ -1,3 +1,4 @@
 export { displayAsTube } from './displayAsTube'
 export { isEveryFieldHidden } from './isEveryFieldHidden'
 export { makeAutofillOnChange } from './makeAutofillOnChange'
+export { getLabwareName } from './getLabwareName'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Closes #7717 by adding dynamic Volume copy when tip racks are selected

Will need to add a test case
# Changelog
- Create util `getLabwareName` to get "well" or "tip" depending on labware type
- Use util to display tip or well in volume section and error copy in `formLevelValidation`
- Add test coverage for displaying tip copy

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->
- [ ] Use "Volume" as title for all labware types
- [ ] Change "well" to "tip" in description when tip rack is selected

# Risk assessment
Low risk - will only impact dynamic copy in volume section and error messages
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
