### PR TITLE
test(labware-creator): Add test case for tip diameter in WellShapesAndSides

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
@@ -67,6 +67,20 @@ describe('WellShapeAndSides', () => {
     screen.getByText('Diameter helps the robot locate the sides of the wells.')
   })
 
+  it('should render diameter field when tipRack is selected (and hide the well shape radio group),(and should not render x/y fields)', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    render(wrapInFormik(<WellShapeAndSides />, formikConfig))
+
+    expect(screen.getByRole('heading')).toHaveTextContent(/Tip Diameter/i)
+
+    expect(screen.queryByRole('textbox', { name: /Well X/i })).toBeNull()
+    expect(screen.queryByRole('textbox', { name: /Well Y/i })).toBeNull()
+    expect(screen.queryByRole('radio', { name: /circular/i })).toBeNull()
+    expect(screen.queryByRole('radio', { name: /rectangular/i })).toBeNull()
+
+    screen.getByRole('textbox', { name: /Diameter/i })
+  })
+
   it('should render diameter field when circular is selected (and should not render x/y fields)', () => {
     formikConfig.initialValues.wellShape = 'circular'
     render(wrapInFormik(<WellShapeAndSides />, formikConfig))


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. Updates to Tip Diameter aka Well Shapes and Sides component needed test coverage. Missing test added here checks for 
- Title Update
- Hiding of well shape section (we know its circular and autofill and hide)
- Presence of diameter field

# Changelog

- test(labware-creator): Add test case for tip diameter in WellShapesAndSides

# Review requests

- [ ] Code review

# Risk assessment

Low. Adds a test in LC only
