### PR TITLE
Bulk replace flow's `|` property sytax whatever it is called delimiter

### DIFF
--- a/protocol-designer/src/analytics/mixpanel.ts
+++ b/protocol-designer/src/analytics/mixpanel.ts
@@ -7,12 +7,12 @@ import type { BaseState } from '../types'
 
 // TODO(IL, 2020-09-09): AnalyticsEvent type copied from app/src/analytics/types.js, consider merging
 export type AnalyticsEvent =
-  | {|
+  | {
       name: string,
       properties: { ... },
       superProperties?: { ... },
-    |}
-  | {| superProperties: { ... } |}
+    }
+  | { superProperties: { ... } }
 
 // pulled in from environment at build time
 const MIXPANEL_ID = getIsProduction()

--- a/protocol-designer/src/collision-types.ts
+++ b/protocol-designer/src/collision-types.ts
@@ -1,24 +1,24 @@
 // @flow
 
-export type DragRect = {|
-  xStart: number,
-  yStart: number,
-  xDynamic: number,
-  yDynamic: number,
-|}
+export type DragRect = {
+  xStart: number
+  yStart: number
+  xDynamic: number
+  yDynamic: number
+}
 
-export type GenericRect = {|
-  x0: number,
-  x1: number,
-  y0: number,
-  y1: number,
-|}
+export type GenericRect = {
+  x0: number
+  x1: number
+  y0: number
+  y1: number
+}
 
-export type BoundingRect = {|
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-|}
+export type BoundingRect = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
 
 export type RectEvent = (MouseEvent, GenericRect) => mixed

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
@@ -30,12 +30,12 @@ import formStyles from '../forms/forms.css'
 import styles from '../StepEditForm/StepEditForm.css'
 import buttonStyles from '../StepEditForm/ButtonRow/styles.css'
 
-type BatchEditMixProps = {|
-  batchEditFormHasChanges: boolean,
-  propsForFields: FieldPropsByName,
-  handleCancel: () => mixed,
-  handleSave: () => mixed,
-|}
+type BatchEditMixProps = {
+  batchEditFormHasChanges: boolean
+  propsForFields: FieldPropsByName
+  handleCancel: () => mixed
+  handleSave: () => mixed
+}
 export const BatchEditMix = (props: BatchEditMixProps): React.Node => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -31,10 +31,10 @@ import formStyles from '../forms/forms.css'
 import styles from '../StepEditForm/StepEditForm.css'
 import buttonStyles from '../StepEditForm/ButtonRow/styles.css'
 
-const SourceDestBatchEditMoveLiquidFields = (props: {|
+const SourceDestBatchEditMoveLiquidFields = (props: {
   prefix: 'aspirate' | 'dispense',
   propsForFields: FieldPropsByName,
-|}): React.Node => {
+}): React.Node => {
   const { prefix, propsForFields } = props
   const addFieldNamePrefix = name => `${prefix}_${name}`
 
@@ -149,12 +149,12 @@ const SourceDestBatchEditMoveLiquidFields = (props: {|
   )
 }
 
-type BatchEditMoveLiquidProps = {|
+type BatchEditMoveLiquidProps = {
   batchEditFormHasChanges: boolean,
   propsForFields: FieldPropsByName,
   handleCancel: () => mixed,
   handleSave: () => mixed,
-|}
+}
 export const BatchEditMoveLiquid = (
   props: BatchEditMoveLiquidProps
 ): React.Node => {

--- a/protocol-designer/src/components/BatchEditForm/FormColumn.tsx
+++ b/protocol-designer/src/components/BatchEditForm/FormColumn.tsx
@@ -4,10 +4,10 @@ import { Box } from '@opentrons/components'
 // TODO(IL, 2021-03-01): refactor these fragmented style rules (see #7402)
 import styles from '../StepEditForm/StepEditForm.css'
 
-export type FormColumnProps = {|
-  children?: React.Node,
-  sectionHeader?: React.Node,
-|}
+export type FormColumnProps = {
+  children?: React.Node
+  sectionHeader?: React.Node
+}
 export const FormColumn = (props: FormColumnProps): React.Node => {
   return (
     <Box className={styles.section_column}>

--- a/protocol-designer/src/components/BatchEditForm/index.tsx
+++ b/protocol-designer/src/components/BatchEditForm/index.tsx
@@ -19,7 +19,7 @@ import { maskField } from '../../steplist/fieldLevel'
 import { BatchEditMoveLiquid } from './BatchEditMoveLiquid'
 import { BatchEditMix } from './BatchEditMix'
 
-export type BatchEditFormProps = {||}
+export type BatchEditFormProps = {}
 
 export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
   const dispatch = useDispatch()

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
@@ -62,19 +62,19 @@ export const DECK_LAYER_BLOCKLIST = [
   'screwHoles',
 ]
 
-type Props = {|
+type Props = {
   selectedTerminalItemId: ?TerminalItemId,
   handleClickOutside?: () => mixed,
   drilledDown: boolean,
   initialDeckSetup: InitialDeckSetup,
-|}
+}
 
-type ContentsProps = {|
+type ContentsProps = {
   ...RobotWorkSpaceRenderProps,
   selectedTerminalItemId: ?TerminalItemId,
   initialDeckSetup: InitialDeckSetup,
   showGen1MultichannelCollisionWarnings: boolean,
-|}
+}
 
 export const VIEWBOX_MIN_X = -64
 export const VIEWBOX_MIN_Y = -10

--- a/protocol-designer/src/components/DeckSetup/LabwareOnDeck.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOnDeck.tsx
@@ -11,18 +11,18 @@ import type { ContentsByWell } from '../../labware-ingred/types'
 import type { BaseState } from '../../types'
 import { wellFillFromWellContents } from '../labware/utils'
 
-type OP = {|
+type OP = {
   className?: string,
   labwareOnDeck: LabwareOnDeckType,
   x: number,
   y: number,
-|}
+}
 
-type SP = {|
+type SP = {
   wellContents: ContentsByWell,
   missingTips: ?WellGroup,
   highlightedWells: ?WellGroup,
-|}
+}
 
 type Props = { ...OP, ...SP }
 
@@ -68,7 +68,7 @@ export const LabwareOnDeck: React.AbstractComponent<OP> = connect<
   Props,
   OP,
   SP,
-  {||},
+  {},
   _,
   _
 >(mapStateToProps)(LabwareOnDeckComponent)

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/BlockedSlot.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/BlockedSlot.tsx
@@ -8,13 +8,13 @@ type BlockedSlotMessage =
   | 'MODULE_INCOMPATIBLE_SINGLE_LABWARE'
   | 'MODULE_INCOMPATIBLE_LABWARE_SWAP'
 
-type Props = {|
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  message: BlockedSlotMessage,
-|}
+type Props = {
+  x: number
+  y: number
+  width: number
+  height: number
+  message: BlockedSlotMessage
+}
 
 export const BlockedSlot = (props: Props): React.Node => {
   const { x, y, width, height, message } = props

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/BrowseLabware.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/BrowseLabware.tsx
@@ -10,15 +10,15 @@ import { drillDownOnLabware } from '../../../labware-ingred/actions'
 import { resetScrollElements } from '../../../ui/steps/utils'
 import styles from './LabwareOverlays.css'
 
-type OP = {|
+type OP = {
   labwareOnDeck: LabwareOnDeck,
-|}
+}
 
-type DP = {|
+type DP = {
   drillDown: () => mixed,
-|}
+}
 
-type Props = {| ...OP, ...DP |}
+type Props = { ...OP, ...DP }
 
 function BrowseLabwareOverlay(props: Props) {
   if (props.labwareOnDeck.def.parameters.isTiprack) return null

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/DragPreview.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/DragPreview.tsx
@@ -8,14 +8,14 @@ import type { RobotWorkSpaceRenderProps } from '@opentrons/components'
 import styles from './DragPreview.css'
 
 type DragPreviewProps = {
-  isDragging: boolean,
-  currentOffset?: { x: number, y: number },
-  item: { labwareOnDeck: LabwareOnDeckType },
-  itemType: string,
+  isDragging: boolean
+  currentOffset?: { x: number; y: number }
+  item: { labwareOnDeck: LabwareOnDeckType }
+  itemType: string
   getRobotCoordsFromDOMCoords: $PropertyType<
     RobotWorkSpaceRenderProps,
     'getRobotCoordsFromDOMCoords'
-  >,
+  >
 }
 
 const LabwareDragPreview = (props: DragPreviewProps) => {
@@ -45,7 +45,7 @@ const LabwareDragPreview = (props: DragPreviewProps) => {
 export const DragPreview: React.AbstractComponent<
   $Diff<
     DragPreviewProps,
-    {| currentOffset: mixed, isDragging: mixed, itemType: mixed, item: mixed |}
+    { currentOffset: mixed; isDragging: mixed; itemType: mixed; item: mixed }
   >
 > = DragLayer(monitor => ({
   currentOffset: monitor.getSourceClientOffset(),

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
@@ -19,30 +19,30 @@ import type { BaseState, ThunkDispatch, DeckSlot } from '../../../types'
 import type { LabwareOnDeck } from '../../../step-forms'
 import styles from './LabwareOverlays.css'
 
-type OP = {|
+type OP = {
   labwareOnDeck: LabwareOnDeck,
   setHoveredLabware: (?LabwareOnDeck) => mixed,
   setDraggedLabware: (?LabwareOnDeck) => mixed,
   swapBlocked: boolean,
-|}
-type SP = {|
+}
+type SP = {
   isYetUnnamed: boolean,
-|}
-type DP = {|
+}
+type DP = {
   editLiquids: () => mixed,
   duplicateLabware: () => mixed,
   deleteLabware: () => mixed,
   moveDeckItem: (DeckSlot, DeckSlot) => mixed,
-|}
+}
 
-type DNDP = {|
+type DNDP = {
   draggedLabware: ?LabwareOnDeck,
   isOver: boolean,
   connectDragSource: React.Node => React.Node,
   connectDropTarget: React.Node => React.Node,
-|}
+}
 
-type Props = {| ...OP, ...SP, ...DP, ...DNDP |}
+type Props = { ...OP, ...SP, ...DP, ...DNDP }
 
 const EditLabwareComponent = (props: Props) => {
   const {
@@ -206,7 +206,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>, ownProps: OP): DP => ({
 })
 
 export const EditLabware: React.AbstractComponent<OP> = connect<
-  {| ...OP, ...SP, ...DP |},
+  { ...OP, ...SP, ...DP },
   OP,
   SP,
   DP,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.tsx
@@ -13,14 +13,14 @@ import { LabwareName } from './LabwareName'
 import { LabwareHighlight } from './LabwareHighlight'
 import styles from './LabwareOverlays.css'
 
-type LabwareControlsProps = {|
+type LabwareControlsProps = {
   labwareOnDeck: LabwareOnDeck,
   selectedTerminalItemId: ?TerminalItemId,
   slot: DeckSlot,
   setHoveredLabware: (?LabwareOnDeck) => mixed,
   setDraggedLabware: (?LabwareOnDeck) => mixed,
   swapBlocked: boolean,
-|}
+}
 
 export const LabwareControls = (props: LabwareControlsProps): React.Node => {
   const {

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
@@ -10,9 +10,9 @@ import { THERMOCYCLER_PROFILE } from '../../../constants'
 import styles from './LabwareOverlays.css'
 import type { LabwareOnDeck } from '../../../step-forms'
 
-type LabwareHighlightProps = {|
-  labwareOnDeck: LabwareOnDeck,
-|}
+type LabwareHighlightProps = {
+  labwareOnDeck: LabwareOnDeck
+}
 
 export const LabwareHighlight = (props: LabwareHighlightProps): React.Node => {
   const { labwareOnDeck } = props

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareName.tsx
@@ -6,13 +6,13 @@ import { getLabwareDisplayName } from '@opentrons/shared-data'
 import type { BaseState, ThunkDispatch } from '../../../types'
 import { selectors as uiLabwareSelectors } from '../../../ui/labware'
 import type { LabwareOnDeck } from '../../../step-forms'
-type OP = {|
+type OP = {
   labwareOnDeck: LabwareOnDeck,
-|}
+}
 
-type SP = {|
+type SP = {
   nickname: ?string,
-|}
+}
 
 type Props = { ...OP, ...SP }
 

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/NameThisLabware.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/NameThisLabware.tsx
@@ -9,15 +9,15 @@ import { i18n } from '../../../localization'
 import type { LabwareOnDeck } from '../../../step-forms'
 import styles from './LabwareOverlays.css'
 
-type OP = {|
+type OP = {
   labwareOnDeck: LabwareOnDeck,
   editLiquids: () => mixed,
-|}
+}
 
-type DP = {|
+type DP = {
   // TODO Ian 2018-02-16 type these fns elsewhere and import the type
   setLabwareName: (name: ?string) => mixed,
-|}
+}
 
 type Props = { ...OP, ...DP }
 

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -29,26 +29,26 @@ import type {
 } from '@opentrons/shared-data'
 import styles from './LabwareOverlays.css'
 
-type DNDP = {|
+type DNDP = {
   isOver: boolean,
   connectDropTarget: React.Node => React.Node,
   draggedItem: ?{ labwareOnDeck: LabwareOnDeck },
   itemType: string,
-|}
-type OP = {|
-  slot: {| ...DeckSlotDefinition, id: DeckSlot |}, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
+}
+type OP = {
+  slot: {| ...DeckSlotDefinition, id: DeckSlot }, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
   moduleType: ModuleRealType | null,
   selectedTerminalItemId: ?TerminalItemId,
   handleDragHover?: () => mixed,
 |}
-type DP = {|
+type DP = {
   addLabware: (e: SyntheticEvent<*>) => mixed,
   moveDeckItem: (DeckSlot, DeckSlot) => mixed,
-|}
-type SP = {|
+}
+type SP = {
   customLabwareDefs: LabwareDefByDefURI,
-|}
-type Props = {| ...OP, ...DP, ...DNDP, ...SP |}
+}
+type Props = { ...OP, ...DP, ...DNDP, ...SP }
 
 export const SlotControlsComponent = (props: Props): React.Node => {
   const {
@@ -169,7 +169,7 @@ const collectSlotTarget = (connect, monitor) => ({
 })
 
 export const SlotControls: React.AbstractComponent<OP> = connect<
-  {| ...OP, ...DP, ...SP |},
+  { ...OP, ...DP, ...SP },
   OP,
   _,
   DP,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -36,11 +36,11 @@ type DNDP = {
   itemType: string,
 }
 type OP = {
-  slot: {| ...DeckSlotDefinition, id: DeckSlot }, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
+  slot: { ...DeckSlotDefinition, id: DeckSlot }, // NOTE: Ian 2019-10-22 make slot `id` more restrictive when used in PD
   moduleType: ModuleRealType | null,
   selectedTerminalItemId: ?TerminalItemId,
   handleDragHover?: () => mixed,
-|}
+}
 type DP = {
   addLabware: (e: SyntheticEvent<*>) => mixed,
   moveDeckItem: (DeckSlot, DeckSlot) => mixed,

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
@@ -29,12 +29,12 @@ import type {
   TemperatureModuleState,
 } from '../../step-forms'
 
-type Props = {|
+type Props = {
   x: number,
   y: number,
   orientation: ModuleOrientation,
   id: string,
-|}
+}
 
 // eyeballed width/height to match designs
 const STANDARD_TAG_HEIGHT = 50
@@ -66,9 +66,9 @@ function getTempStatus(temperatureModuleState: TemperatureModuleState): string {
 
 export const ModuleStatus = ({
   moduleState,
-}: {|
+}: {
   moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>,
-|}): React.Node => {
+}): React.Node => {
   switch (moduleState.type) {
     case MAGNETIC_MODULE_TYPE:
       return (

--- a/protocol-designer/src/components/DeckSetup/ModuleViz.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleViz.tsx
@@ -5,13 +5,13 @@ import styles from './ModuleViz.css'
 import type { ModuleOnDeck } from '../../step-forms'
 import type { ModuleOrientation } from '../../types'
 
-type Props = {|
-  x: number,
-  y: number,
-  orientation: ModuleOrientation,
-  module: ModuleOnDeck,
-  slotName: string,
-|}
+type Props = {
+  x: number
+  y: number
+  orientation: ModuleOrientation
+  module: ModuleOnDeck
+  slotName: string
+}
 
 export const ModuleViz = (props: Props): React.Node => {
   const moduleType = props.module.type

--- a/protocol-designer/src/components/DeckSetup/SlotWarning.tsx
+++ b/protocol-designer/src/components/DeckSetup/SlotWarning.tsx
@@ -5,14 +5,14 @@ import { RobotCoordsForeignDiv } from '@opentrons/components'
 import styles from './SlotWarning.css'
 import type { ModuleOrientation } from '../../types'
 
-type Props = {|
-  x: number,
-  y: number,
-  xDimension: number,
-  yDimension: number,
-  orientation: ModuleOrientation,
-  warningType: 'gen1multichannel', // NOTE: Ian 2019-10-31 if we want more on-deck warnings, expand the type here
-|}
+type Props = {
+  x: number
+  y: number
+  xDimension: number
+  yDimension: number
+  orientation: ModuleOrientation
+  warningType: 'gen1multichannel' // NOTE: Ian 2019-10-31 if we want more on-deck warnings, expand the type here
+}
 
 const OVERHANG = 60
 

--- a/protocol-designer/src/components/EditModules.tsx
+++ b/protocol-designer/src/components/EditModules.tsx
@@ -11,18 +11,18 @@ import { MagneticModuleWarningModalContent } from './modals/EditModulesModal/Mag
 import { EditModulesModal } from './modals/EditModulesModal'
 import type { ModuleModel, ModuleRealType } from '@opentrons/shared-data'
 
-type EditModulesProps = {|
+type EditModulesProps = {
   moduleToEdit: {|
     moduleId: ?string,
     moduleType: ModuleRealType,
-  |},
+  },
   onCloseClick: () => mixed,
 |}
 
-export type ModelModuleInfo = {|
+export type ModelModuleInfo = {
   model: ModuleModel,
   slot: string,
-|}
+}
 
 export const EditModules = (props: EditModulesProps): React.Node => {
   const { onCloseClick, moduleToEdit } = props

--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -37,11 +37,11 @@ export type Props = {
 
 type State = {
   isEditPipetteModalOpen: boolean,
-  moduleToEdit: {|
+  moduleToEdit: {
     moduleType: ModuleRealType,
     moduleId: ?string,
   } | null,
-|}
+}
 
 // TODO(mc, 2020-02-28): explore l10n for these dates
 const DATE_ONLY_FORMAT = 'MMM dd, yyyy'

--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -26,21 +26,21 @@ import type { ModuleRealType } from '@opentrons/shared-data'
 import type { FileMetadataFields } from '../file-data'
 import type { ModulesForEditModulesCard } from '../step-forms'
 
-export type Props = {|
+export type Props = {
   formValues: FileMetadataFields,
   instruments: React.ElementProps<typeof InstrumentGroup>,
   goToNextPage: () => mixed,
   saveFileMetadata: FileMetadataFields => mixed,
   swapPipettes: () => mixed,
   modules: ModulesForEditModulesCard,
-|}
+}
 
-type State = {|
+type State = {
   isEditPipetteModalOpen: boolean,
   moduleToEdit: {|
     moduleType: ModuleRealType,
     moduleId: ?string,
-  |} | null,
+  } | null,
 |}
 
 // TODO(mc, 2020-02-28): explore l10n for these dates

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -25,28 +25,28 @@ import type {
   PipetteOnDeck,
 } from '../../step-forms'
 
-type Props = {|
-  loadFile: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
-  createNewFile?: () => mixed,
-  canDownload: boolean,
-  onDownload: () => mixed,
-  fileData: ?PDProtocolFile,
-  pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>,
-  modulesOnDeck: $PropertyType<InitialDeckSetup, 'modules'>,
-  savedStepForms: SavedStepFormState,
-  schemaVersion: number,
-|}
+type Props = {
+  loadFile: (event: SyntheticInputEvent<HTMLInputElement>) => mixed
+  createNewFile?: () => mixed
+  canDownload: boolean
+  onDownload: () => mixed
+  fileData: ?PDProtocolFile
+  pipettesOnDeck: $PropertyType<InitialDeckSetup, 'pipettes'>
+  modulesOnDeck: $PropertyType<InitialDeckSetup, 'modules'>
+  savedStepForms: SavedStepFormState
+  schemaVersion: number
+}
 
-type WarningContent = {|
-  content: React.Node,
-  heading: string,
-|}
+type WarningContent = {
+  content: React.Node
+  heading: string
+}
 
-type MissingContent = {|
-  noCommands: boolean,
-  pipettesWithoutStep: Array<PipetteOnDeck>,
-  modulesWithoutStep: Array<ModuleOnDeck>,
-|}
+type MissingContent = {
+  noCommands: boolean
+  pipettesWithoutStep: Array<PipetteOnDeck>
+  modulesWithoutStep: Array<ModuleOnDeck>
+}
 
 function getWarningContent({
   noCommands,
@@ -198,10 +198,10 @@ export function FileSidebar(props: Props): React.Node {
       modulesWithoutStep,
     })
 
-  const getExportHintContent = (): {|
-    hintKey: HintKey,
-    content: React.Node,
-  |} => {
+  const getExportHintContent = (): {
+    hintKey: HintKey
+    content: React.Node
+  } => {
     return {
       hintKey:
         schemaVersion === 5

--- a/protocol-designer/src/components/Hints/index.tsx
+++ b/protocol-designer/src/components/Hints/index.tsx
@@ -14,12 +14,12 @@ import EXAMPLE_BATCH_EDIT_IMAGE from '../../images/announcements/multi_select.gi
 import type { HintKey } from '../../tutorial'
 import type { BaseState, ThunkDispatch } from '../../types'
 
-type SP = {| hintKey: ?HintKey |}
-type DP = {|
+type SP = { hintKey: ?HintKey }
+type DP = {
   removeHint: (HintKey, boolean) => mixed,
   selectTerminalItem: TerminalItemId => mixed,
-|}
-type Props = {| ...SP, ...DP |}
+}
+type Props = { ...SP, ...DP }
 
 type State = { rememberDismissal: boolean }
 
@@ -196,9 +196,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
     dispatch(stepsActions.selectTerminalItem(terminalId)),
 })
 
-export const Hints: React.AbstractComponent<{||}> = connect<
+export const Hints: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/components/Hints/useBlockingHint.tsx
+++ b/protocol-designer/src/components/Hints/useBlockingHint.tsx
@@ -11,12 +11,12 @@ import { i18n } from '../../localization'
 import styles from './hints.css'
 import type { HintKey } from '../../tutorial'
 
-export type HintProps = {|
-  hintKey: HintKey,
-  handleCancel: () => mixed,
-  handleContinue: () => mixed,
-  content: React.Node,
-|}
+export type HintProps = {
+  hintKey: HintKey
+  handleCancel: () => mixed
+  handleContinue: () => mixed
+  content: React.Node
+}
 
 // This component handles the checkbox and dispatching `removeHint` action on continue/cancel
 export const BlockingHint = (props: HintProps): React.Node => {
@@ -63,16 +63,16 @@ export const BlockingHint = (props: HintProps): React.Node => {
   )
 }
 
-export type HintArgs = {|
+export type HintArgs = {
   /** `enabled` should be a condition that the parent uses to toggle whether the hint should be active or not.
    * If the hint is enabled but has been dismissed, it will automatically call `handleContinue` when enabled.
    * useBlockingHint expects the parent to disable the hint on cancel/continue */
-  enabled: boolean,
-  hintKey: HintKey,
-  content: React.Node,
-  handleCancel: () => mixed,
-  handleContinue: () => mixed,
-|}
+  enabled: boolean
+  hintKey: HintKey
+  content: React.Node
+  handleCancel: () => mixed
+  handleContinue: () => mixed
+}
 
 export const useBlockingHint = (args: HintArgs): React.Node => {
   const { enabled, hintKey, handleCancel, handleContinue, content } = args

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -13,23 +13,23 @@ import styles from './IngredientsList.css'
 import type { LiquidGroupsById, LiquidGroup } from '../../labware-ingred/types'
 import type { SingleLabwareLiquidState } from '@opentrons/step-generation'
 
-type RemoveWellsContents = (args: {|
+type RemoveWellsContents = (args: {
   liquidGroupId: string,
   wells: Array<string>,
-|}) => mixed
+}) => mixed
 
 // Props used by both IngredientsList and LiquidGroupCard
-type CommonProps = {|
+type CommonProps = {
   removeWellsContents: RemoveWellsContents,
   selected?: boolean,
-|}
+}
 
-type LiquidGroupCardProps = {|
+type LiquidGroupCardProps = {
   groupId: string,
   ingredGroup: LiquidGroup,
   labwareWellContents: SingleLabwareLiquidState,
   ...CommonProps,
-|}
+}
 
 const LiquidGroupCard = (props: LiquidGroupCardProps): React.Node => {
   const {
@@ -100,7 +100,7 @@ const LiquidGroupCard = (props: LiquidGroupCardProps): React.Node => {
   )
 }
 
-type IndividProps = {|
+type IndividProps = {
   name: ?string,
   wellName: string,
   volume: number,
@@ -108,7 +108,7 @@ type IndividProps = {|
   canDelete: boolean,
   groupId: string,
   removeWellsContents: RemoveWellsContents,
-|}
+}
 
 function IngredIndividual(props: IndividProps) {
   const {

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
@@ -20,11 +20,11 @@ export const links = {
 
 type Link = $Keys<typeof links>
 
-type Props = {|
-  to: Link,
-  children: React.Node,
-  className?: ?string,
-|}
+type Props = {
+  to: Link
+  children: React.Node
+  className?: ?string
+}
 
 /** Link which opens a page on the knowledge base to a new tab/window */
 export function KnowledgeBaseLink(props: Props): React.Node {

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareItem.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareItem.tsx
@@ -12,14 +12,14 @@ import {
   type LabwareDefinition2,
 } from '@opentrons/shared-data'
 
-type Props = {|
+type Props = {
   disabled?: ?boolean,
   icon?: ?IconName,
   labwareDef: LabwareDefinition2,
   onMouseEnter: () => any,
   onMouseLeave: () => any,
   selectLabware: (labwareLoadName: string) => mixed,
-|}
+}
 
 const LABWARE_LIBRARY_PAGE_PATH = 'https://labware.opentrons.com'
 

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -31,7 +31,7 @@ import styles from './styles.css'
 import type { DeckSlot } from '../../types'
 import type { LabwareDefByDefURI } from '../../labware-defs'
 
-type Props = {|
+type Props = {
   onClose: (e?: any) => mixed,
   onUploadLabware: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
   selectLabware: (containerType: string) => mixed,
@@ -44,7 +44,7 @@ type Props = {|
   moduleType: ?ModuleRealType,
   /** tipracks that may be added to deck (depends on pipette<>tiprack assignment) */
   permittedTipracks: Array<string>,
-|}
+}
 
 const LABWARE_CREATOR_URL = 'https://labware.opentrons.com/create'
 const CUSTOM_CATEGORY = 'custom'

--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
@@ -19,17 +19,17 @@ import stepEditFormStyles from '../StepEditForm/StepEditForm.css'
 import type { Options } from '@opentrons/components'
 import type { FormikProps } from 'formik/@flow-typed'
 
-type ValidFormValues = {|
+type ValidFormValues = {
   selectedLiquidId: string,
   volume: string,
-|}
+}
 
-export type LiquidPlacementFormValues = {|
+export type LiquidPlacementFormValues = {
   selectedLiquidId: ?string,
   volume: ?string,
-|}
+}
 
-type Props = {|
+type Props = {
   commonSelectedLiquidId: ?string,
   commonSelectedVolume: ?number,
   liquidSelectionOptions: Options,
@@ -39,7 +39,7 @@ type Props = {|
   cancelForm: () => mixed,
   clearWells: ?() => mixed,
   saveForm: LiquidPlacementFormValues => mixed,
-|}
+}
 
 export class LiquidPlacementForm extends React.Component<Props> {
   getInitialValues: () => ValidFormValues = () => {
@@ -51,10 +51,10 @@ export class LiquidPlacementForm extends React.Component<Props> {
   }
 
   getValidationSchema: () => Yup.Schema<
-    {|
+    {
       selectedLiquidId: string,
       volume: number,
-    |},
+    },
     any
   > = () => {
     const { selectedWellsMaxVolume } = this.props

--- a/protocol-designer/src/components/LiquidPlacementModal.tsx
+++ b/protocol-designer/src/components/LiquidPlacementModal.tsx
@@ -27,17 +27,17 @@ import type { BaseState } from '../types'
 import type { ContentsByWell } from '../labware-ingred/types'
 import type { WellIngredientNames } from '../steplist'
 
-type SP = {|
+type SP = {
   selectedWells: WellGroup,
   wellContents: ContentsByWell,
   labwareDef: ?LabwareDefinition2,
   liquidNamesById: WellIngredientNames,
-|}
+}
 
-type DP = {|
+type DP = {
   selectWells: WellGroup => mixed,
   deselectWells: WellGroup => mixed,
-|}
+}
 
 type Props = { ...SP, ...DP }
 
@@ -127,9 +127,9 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): DP => ({
   selectWells: wells => dispatch(selectWells(wells)),
 })
 
-export const LiquidPlacementModal: React.AbstractComponent<{||}> = connect<
+export const LiquidPlacementModal: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   _,
   _,
   _,

--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -33,7 +33,7 @@ type LiquidEditFormValues = {
 }
 
 export const liquidEditFormSchema: Yup.Schema<
-  {| name: string, description: string, serialize: boolean |},
+  { name: string, description: string, serialize: boolean },
   any
 > = Yup.object().shape({
   name: Yup.string().required(

--- a/protocol-designer/src/components/LiquidsPage/index.tsx
+++ b/protocol-designer/src/components/LiquidsPage/index.tsx
@@ -14,12 +14,12 @@ import type { BaseState, ThunkDispatch } from '../../types'
 type Props = React.ElementProps<typeof LiquidEditForm>
 type WrapperProps = { showForm: boolean, formKey: string, formProps: Props }
 
-type SP = {|
+type SP = {
   ...$Exact<LiquidGroup>,
   _liquidGroupId: ?string,
   showForm: boolean,
   canDelete: $ElementType<Props, 'canDelete'>,
-|}
+}
 
 function LiquidEditFormWrapper(props: WrapperProps) {
   const { showForm, formKey, formProps } = props
@@ -90,11 +90,11 @@ function mergeProps(
   }
 }
 
-export const LiquidsPage: React.AbstractComponent<{||}> = connect<
+export const LiquidsPage: React.AbstractComponent<{}> = connect<
   WrapperProps,
-  {||},
+  {},
   SP,
-  {||},
+  {},
   _,
   _
 >(

--- a/protocol-designer/src/components/LiquidsSidebar/index.tsx
+++ b/protocol-designer/src/components/LiquidsSidebar/index.tsx
@@ -12,17 +12,17 @@ import type { OrderedLiquids } from '../../labware-ingred/types'
 import * as labwareIngredActions from '../../labware-ingred/actions'
 import type { BaseState, ThunkDispatch } from '../../types'
 
-type SP = {|
+type SP = {
   liquids: OrderedLiquids,
   selectedLiquid: ?string,
-|}
+}
 
-type DP = {|
+type DP = {
   createNewLiquid: () => mixed,
   selectLiquid: (liquidId: string) => mixed,
-|}
+}
 
-type Props = {| ...SP, ...DP |}
+type Props = { ...SP, ...DP }
 
 function LiquidsSidebarComponent(props: Props) {
   const { liquids, selectedLiquid, createNewLiquid, selectLiquid } = props
@@ -66,9 +66,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export const LiquidsSidebar: React.AbstractComponent<{||}> = connect<
+export const LiquidsSidebar: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/components/ProtocolEditor.tsx
+++ b/protocol-designer/src/components/ProtocolEditor.tsx
@@ -56,6 +56,6 @@ function ProtocolEditorComponent() {
   )
 }
 
-export const ProtocolEditor: React.AbstractComponent<{||}> = DragDropContext(
+export const ProtocolEditor: React.AbstractComponent<{}> = DragDropContext(
   MouseBackEnd
 )(ProtocolEditorComponent)

--- a/protocol-designer/src/components/SelectionRect.tsx
+++ b/protocol-designer/src/components/SelectionRect.tsx
@@ -4,18 +4,18 @@ import * as React from 'react'
 import styles from './SelectionRect.css'
 import type { DragRect, GenericRect } from '../collision-types'
 
-type Props = {|
-  onSelectionMove?: (e: MouseEvent, GenericRect) => mixed,
-  onSelectionDone?: (e: MouseEvent, GenericRect) => mixed,
-  svg?: boolean, // set true if this is an embedded SVG
-  children?: React.Node,
-  originXOffset?: number,
-  originYOffset?: number,
-|}
+type Props = {
+  onSelectionMove?: (e: MouseEvent, GenericRect) => mixed
+  onSelectionDone?: (e: MouseEvent, GenericRect) => mixed
+  svg?: boolean // set true if this is an embedded SVG
+  children?: React.Node
+  originXOffset?: number
+  originYOffset?: number
+}
 
-type State = {|
-  positions: DragRect | null,
-|}
+type State = {
+  positions: DragRect | null
+}
 
 export class SelectionRect extends React.Component<Props, State> {
   // TODO Ian 2018-02-22 No support in Flow for SVGElement yet: https://github.com/facebook/flow/issues/2332
@@ -43,12 +43,12 @@ export class SelectionRect extends React.Component<Props, State> {
       }
 
       const clientRect: {
-        width: number,
-        height: number,
-        left: number,
-        top: number,
+        width: number
+        height: number
+        left: number
+        top: number
       } = parentRef.getBoundingClientRect()
-      const viewBox: { width: number, height: number } = parentRef.closest(
+      const viewBox: { width: number; height: number } = parentRef.closest(
         'svg'
       ).viewBox.baseVal // WARNING: elem.closest() is experiemental
 

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.tsx
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.tsx
@@ -13,10 +13,10 @@ import {
   type FlagTypes,
 } from '../../../feature-flags'
 
-type Props = {|
+type Props = {
   flags: Flags,
   setFeatureFlags: (flags: Flags) => mixed,
-|}
+}
 
 export const FeatureFlagCard = (props: Props): React.Node => {
   const [modalFlagName, setModalFlagName] = React.useState<FlagTypes | null>(

--- a/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsApp.tsx
@@ -22,16 +22,16 @@ import styles from './SettingsPage.css'
 import type { BaseState, ThunkDispatch } from '../../types'
 
 type Props = {
-  canClearHintDismissals: boolean,
-  hasOptedIn: boolean | null,
-  restoreHints: () => mixed,
-  toggleOptedIn: () => mixed,
+  canClearHintDismissals: boolean
+  hasOptedIn: boolean | null
+  restoreHints: () => mixed
+  toggleOptedIn: () => mixed
 }
 
-type SP = {|
-  canClearHintDismissals: $PropertyType<Props, 'canClearHintDismissals'>,
-  hasOptedIn: $PropertyType<Props, 'hasOptedIn'>,
-|}
+type SP = {
+  canClearHintDismissals: $PropertyType<Props, 'canClearHintDismissals'>
+  hasOptedIn: $PropertyType<Props, 'hasOptedIn'>
+}
 
 function SettingsAppComponent(props: Props) {
   const {
@@ -130,11 +130,11 @@ function mergeProps(
   }
 }
 
-export const SettingsApp: React.AbstractComponent<{||}> = connect<
+export const SettingsApp: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
-  {||},
+  {},
   BaseState,
   _
 >(

--- a/protocol-designer/src/components/SettingsPage/SettingsSidebar.tsx
+++ b/protocol-designer/src/components/SettingsPage/SettingsSidebar.tsx
@@ -9,8 +9,8 @@ import { i18n } from '../../localization'
 import { PDTitledList } from '../lists'
 import styles from './SettingsPage.css'
 
-type SP = {| currentPage: Page |}
-type DP = {| makeNavigateToPage: Page => () => mixed |}
+type SP = { currentPage: Page }
+type DP = { makeNavigateToPage: Page => () => mixed }
 type Props = { ...SP, ...DP }
 
 const SettingsSidebarComponent = (props: Props) => (
@@ -38,9 +38,9 @@ const DTP = (dispatch: ThunkDispatch<*>): DP => ({
     dispatch(actions.navigateToPage(pageName)),
 })
 
-export const SettingsSidebar: React.AbstractComponent<{||}> = connect<
+export const SettingsSidebar: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/components/SettingsPage/index.tsx
+++ b/protocol-designer/src/components/SettingsPage/index.tsx
@@ -23,9 +23,9 @@ const STP = (state: BaseState): $Exact<Props> => ({
   currentPage: selectors.getCurrentPage(state),
 })
 
-export const SettingsPage: React.AbstractComponent<{||}> = connect<
+export const SettingsPage: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   $Exact<Props>,
   _,
   _,

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -29,12 +29,12 @@ import { Portal } from './portals/MainPageModalPortal'
 import { stepIconsByType, type StepType } from '../form-types'
 import styles from './listButtons.css'
 
-type StepButtonComponentProps = {|
+type StepButtonComponentProps = {
   children: React.Node,
   expanded: boolean,
   disabled: boolean,
   setExpanded: boolean => mixed,
-|}
+}
 
 // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
 const getSupportedSteps = () => [
@@ -78,11 +78,11 @@ export const StepCreationButtonComponent = (
   )
 }
 
-export type StepButtonItemProps = {|
+export type StepButtonItemProps = {
   onClick: () => mixed,
   disabled: boolean,
   stepType: StepType,
-|}
+}
 
 export function StepButtonItem(props: StepButtonItemProps): React.Node {
   const { onClick, disabled, stepType } = props

--- a/protocol-designer/src/components/StepEditForm/ButtonRow/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow/index.tsx
@@ -7,13 +7,13 @@ import { i18n } from '../../../localization'
 import modalStyles from '../../modals/modal.css'
 import styles from './styles.css'
 
-type ButtonRowProps = {|
-  handleClickMoreOptions: () => mixed,
-  handleClose: () => mixed,
-  handleSave: () => mixed,
-  handleDelete: () => mixed,
-  canSave: boolean,
-|}
+type ButtonRowProps = {
+  handleClickMoreOptions: () => mixed
+  handleClose: () => mixed
+  handleSave: () => mixed
+  handleDelete: () => mixed
+  canSave: boolean
+}
 
 export const ButtonRow = (props: ButtonRowProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/StepEditFormComponent.tsx
+++ b/protocol-designer/src/components/StepEditForm/StepEditFormComponent.tsx
@@ -27,19 +27,19 @@ const STEP_FORM_MAP: { [StepType]: ?React.ComponentType<StepFormProps> } = {
   thermocycler: ThermocyclerForm,
 }
 
-type Props = {|
-  canSave: boolean,
-  dirtyFields: Array<string>,
-  focusHandlers: FocusHandlers,
-  focusedField: string | null,
-  formData: FormData,
-  propsForFields: FieldPropsByName,
-  handleClose: () => mixed,
-  handleDelete: () => mixed,
-  handleSave: () => mixed,
-  showMoreOptionsModal: boolean,
-  toggleMoreOptionsModal: () => mixed,
-|}
+type Props = {
+  canSave: boolean
+  dirtyFields: Array<string>
+  focusHandlers: FocusHandlers
+  focusedField: string | null
+  formData: FormData
+  propsForFields: FieldPropsByName
+  handleClose: () => mixed
+  handleDelete: () => mixed
+  handleSave: () => mixed
+  showMoreOptionsModal: boolean
+  toggleMoreOptionsModal: () => mixed
+}
 
 export const StepEditFormComponent = (props: Props): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
@@ -7,11 +7,11 @@ import { selectors as uiLabwareSelectors } from '../../../ui/labware'
 import styles from '../StepEditForm.css'
 import type { FieldProps } from '../types'
 
-type BlowoutLocationDropdownProps = {|
+type BlowoutLocationDropdownProps = {
   ...FieldProps,
   className?: string,
   options: Options,
-|}
+}
 
 export const BlowoutLocationField = (
   props: BlowoutLocationDropdownProps

--- a/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/index.tsx
@@ -23,10 +23,10 @@ const ALL_CHANGE_TIP_VALUES: Array<ChangeTipOptions> = [
   'perDest',
   'never',
 ]
-type Props = {|
+type Props = {
   ...FieldProps,
   ...DisabledChangeTipArgs,
-|}
+}
 
 export const ChangeTipField = (props: Props): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -10,13 +10,13 @@ import cx from 'classnames'
 import styles from '../StepEditForm.css'
 import type { FieldProps } from '../types'
 
-type CheckboxRowProps = {|
+type CheckboxRowProps = {
   ...FieldProps,
   children?: React.Node,
   className?: string,
   label?: string,
   tooltipContent?: React.Node,
-|}
+}
 
 export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/DelayFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DelayFields.tsx
@@ -8,13 +8,13 @@ import styles from '../StepEditForm.css'
 import type { FieldPropsByName } from '../types'
 import type { StepFieldName } from '../../../form-types'
 
-export type DelayFieldProps = {|
-  checkboxFieldName: StepFieldName, // TODO(IL, 2021-03-03): strictly, could be DelayCheckboxFields!
-  labwareId: ?string,
-  propsForFields: FieldPropsByName,
-  secondsFieldName: StepFieldName, // TODO(IL, 2021-03-03): strictly, could be DelaySecondFields!
-  tipPositionFieldName?: StepFieldName, // TODO(IL, 2021-03-03): strictly, could be TipOffsetFields!
-|}
+export type DelayFieldProps = {
+  checkboxFieldName: StepFieldName // TODO(IL, 2021-03-03): strictly, could be DelayCheckboxFields!
+  labwareId: ?string
+  propsForFields: FieldPropsByName
+  secondsFieldName: StepFieldName // TODO(IL, 2021-03-03): strictly, could be DelaySecondFields!
+  tipPositionFieldName?: StepFieldName // TODO(IL, 2021-03-03): strictly, could be TipOffsetFields!
+}
 
 export const DelayFields = (props: DelayFieldProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
@@ -22,11 +22,11 @@ import type { BaseState } from '../../../types'
 
 import styles from '../StepEditForm.css'
 
-type DropdownFormFieldProps = {|
+type DropdownFormFieldProps = {
   ...FieldProps,
   className?: string,
   options: Options,
-|}
+}
 const DropdownFormField = (props: DropdownFormFieldProps) => {
   return (
     <DropdownField
@@ -40,11 +40,11 @@ const DropdownFormField = (props: DropdownFormFieldProps) => {
   )
 }
 
-type SP = {|
+type SP = {
   disposalDestinationOptions: Options,
   maxDisposalVolume: ?number,
-|}
-type OP = {|
+}
+type OP = {
   aspirate_airGap_checkbox?: boolean | null,
   aspirate_airGap_volume?: string | null,
   path: PathOption,
@@ -52,7 +52,7 @@ type OP = {|
   propsForFields: FieldPropsByName,
   stepType: StepType,
   volume: string | null,
-|}
+}
 type Props = { ...SP, ...OP }
 
 const DisposalVolumeFieldComponent = (props: Props) => {

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.tsx
@@ -18,7 +18,7 @@ const DEFAULT_LABEL = i18n.t('form.step_edit_form.field.flow_rate.label')
 const DECIMALS_ALLOWED = 1
 
 /** When flow rate is falsey (including 0), it means 'use default' */
-export type FlowRateInputProps = {|
+export type FlowRateInputProps = {
   ...FieldProps,
   defaultFlowRate: ?number,
   flowRateType: 'aspirate' | 'dispense',
@@ -27,14 +27,14 @@ export type FlowRateInputProps = {|
   maxFlowRate: number,
   pipetteDisplayName: ?string,
   className?: string,
-|}
+}
 
-type State = {|
+type State = {
   isPristine: boolean,
   modalFlowRate: ?string,
   modalUseDefault: boolean,
   showModal: boolean,
-|}
+}
 
 export const FlowRateInput = (props: FlowRateInputProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/index.tsx
@@ -6,26 +6,26 @@ import { selectors as stepFormSelectors } from '../../../../step-forms'
 import type { FieldProps } from '../../types'
 import type { BaseState } from '../../../../types'
 
-type OP = {|
+type OP = {
   ...FieldProps,
   pipetteId: ?string,
   className?: $PropertyType<FlowRateInputProps, 'className'>,
   flowRateType: $PropertyType<FlowRateInputProps, 'flowRateType'>,
   label?: $PropertyType<FlowRateInputProps, 'label'>,
-|}
+}
 
-type SP = {|
+type SP = {
   innerKey: string,
   defaultFlowRate: ?number,
   minFlowRate: number,
   maxFlowRate: number,
   pipetteDisplayName: string,
-|}
+}
 
-type Props = {|
+type Props = {
   ...FlowRateInputProps,
   innerKey: string,
-|}
+}
 
 // Add a key to force re-constructing component when values change
 function FlowRateInputWithKey(props: Props) {
@@ -73,7 +73,7 @@ export const FlowRateField: React.AbstractComponent<OP> = connect<
   Props,
   OP,
   SP,
-  {||},
+  {},
   _,
   _
 >(

--- a/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
@@ -5,12 +5,12 @@ import { CheckboxRowField, TextField } from './'
 import type { FieldPropsByName } from '../types'
 import styles from '../StepEditForm.css'
 
-export const MixFields = (props: {|
-  propsForFields: FieldPropsByName,
-  checkboxFieldName: string,
-  volumeFieldName: string,
-  timesFieldName: string,
-|}): React.Node => {
+export const MixFields = (props: {
+  propsForFields: FieldPropsByName
+  checkboxFieldName: string
+  volumeFieldName: string
+  timesFieldName: string
+}): React.Node => {
   const {
     propsForFields,
     checkboxFieldName,

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
@@ -32,11 +32,11 @@ const ALL_PATH_OPTIONS = [
   },
 ]
 
-type PathFieldProps = {|
+type PathFieldProps = {
   ...FieldProps,
   ...ValuesForPath,
   disabledPathMap: DisabledPathMap,
-|}
+}
 
 type ButtonProps = {
   children?: React.Node,

--- a/protocol-designer/src/components/StepEditForm/fields/PipetteField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PipetteField.tsx
@@ -8,11 +8,11 @@ import type { BaseState } from '../../../types'
 import styles from '../StepEditForm.css'
 import type { FieldProps } from '../types'
 
-type OP = {|
+type OP = {
   ...FieldProps,
-|}
+}
 
-type SP = {| pipetteOptions: Options |}
+type SP = { pipetteOptions: Options }
 
 type Props = { ...OP, ...SP }
 

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.tsx
@@ -36,18 +36,18 @@ export const showProfileFieldErrors = ({
   fieldId,
   focusedField,
   dirtyFields,
-}: {|
+}: {
   fieldId: string,
   focusedField: ?string,
   dirtyFields: Array<string>,
-|}): boolean =>
+}): boolean =>
   !(fieldId === focusedField) && dirtyFields && dirtyFields.includes(fieldId)
 
-type ProfileCycleRowProps = {|
+type ProfileCycleRowProps = {
   cycleItem: ProfileCycleItem,
   focusHandlers: FocusHandlers,
   stepOffset: number,
-|}
+}
 export const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   const { cycleItem, focusHandlers, stepOffset } = props
   const dispatch = useDispatch()
@@ -139,14 +139,14 @@ export const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   )
 }
 
-export type ProfileItemRowsProps = {|
+export type ProfileItemRowsProps = {
   focusHandlers: FocusHandlers,
   orderedProfileItems: Array<string>,
   profileItemsById: {
     [string]: ProfileItem,
     ...
   },
-|}
+}
 
 export const ProfileItemRows = (props: ProfileItemRowsProps): React.Node => {
   const { orderedProfileItems, profileItemsById } = props
@@ -230,14 +230,14 @@ export const ProfileItemRows = (props: ProfileItemRowsProps): React.Node => {
   )
 }
 
-type ProfileFieldProps = {|
+type ProfileFieldProps = {
   name: string,
   focusHandlers: FocusHandlers,
   profileItem: ProfileItem,
   units?: React.Node,
   className?: string,
   updateValue: (name: string, value: mixed) => mixed,
-|}
+}
 const ProfileField = (props: ProfileFieldProps) => {
   const {
     focusHandlers,
@@ -289,12 +289,12 @@ const ProfileField = (props: ProfileFieldProps) => {
   )
 }
 
-type ProfileStepRowProps = {|
+type ProfileStepRowProps = {
   focusHandlers: FocusHandlers,
   profileStepItem: ProfileStepItem,
   stepNumber: number,
   isCycle?: ?boolean,
-|}
+}
 
 const ProfileStepRow = (props: ProfileStepRowProps) => {
   const { focusHandlers, profileStepItem, isCycle } = props

--- a/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.tsx
@@ -4,12 +4,12 @@ import { RadioGroup } from '@opentrons/components'
 import type { StepFieldName } from '../../../steplist/fieldLevel'
 import type { FieldProps } from '../types'
 
-type RadioGroupFieldProps = {|
+type RadioGroupFieldProps = {
   ...FieldProps,
   name: StepFieldName,
   options: $PropertyType<React.ElementProps<typeof RadioGroup>, 'options'>,
   className?: string,
-|}
+}
 
 export const RadioGroupField = (props: RadioGroupFieldProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/TextField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TextField.tsx
@@ -3,12 +3,12 @@ import * as React from 'react'
 import { InputField } from '@opentrons/components'
 import type { FieldProps } from '../types'
 
-type TextFieldProps = {|
+type TextFieldProps = {
   ...FieldProps,
   className?: string,
   caption?: ?string,
   units?: ?string,
-|}
+}
 
 export const TextField = (props: TextFieldProps): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -24,14 +24,14 @@ const SMALL_STEP_MM = 1
 const LARGE_STEP_MM = 10
 const DECIMALS_ALLOWED = 1
 
-type Props = {|
+type Props = {
   closeModal: () => mixed,
   isIndeterminate?: boolean,
   mmFromBottom: number | null,
   name: StepFieldName,
   updateValue: (?number) => mixed,
   wellDepthMm: number,
-|}
+}
 
 const roundValue = (value: number | string | null): number => {
   return round(Number(value), DECIMALS_ALLOWED)
@@ -41,12 +41,12 @@ const TOO_MANY_DECIMALS: 'TOO_MANY_DECIMALS' = 'TOO_MANY_DECIMALS'
 const OUT_OF_BOUNDS: 'OUT_OF_BOUNDS' = 'OUT_OF_BOUNDS'
 type Error = typeof TOO_MANY_DECIMALS | typeof OUT_OF_BOUNDS
 
-const getErrorText = (args: {|
+const getErrorText = (args: {
   errors: Array<Error>,
   maxMmFromBottom: number,
   minMmFromBottom: number,
   isPristine: boolean,
-|}): string | null => {
+}): string | null => {
   const { errors, minMmFromBottom, maxMmFromBottom, isPristine } = args
 
   if (errors.includes(TOO_MANY_DECIMALS)) {
@@ -61,12 +61,12 @@ const getErrorText = (args: {|
   }
 }
 
-const getErrors = (args: {|
+const getErrors = (args: {
   isDefault: boolean,
   value: string | null,
   maxMmFromBottom: number,
   minMmFromBottom: number,
-|}): Array<Error> => {
+}): Array<Error> => {
   const { isDefault, value, maxMmFromBottom, minMmFromBottom } = args
   const errors = []
   if (isDefault) return errors
@@ -105,10 +105,10 @@ export const TipPositionModal = (props: Props): React.Node => {
   // in this modal, pristinity hides the OUT_OF_BOUNDS error only.
   const [isPristine, setPristine] = React.useState<boolean>(true)
 
-  const getMinMaxMmFromBottom = (): {|
+  const getMinMaxMmFromBottom = (): {
     maxMmFromBottom: number,
     minMmFromBottom: number,
-  |} => {
+  } => {
     if (getIsTouchTipField(name)) {
       return {
         maxMmFromBottom: roundValue(wellDepthMm),

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
@@ -23,18 +23,18 @@ import { getDefaultMmFromBottom } from './utils'
 import type { BaseState } from '../../../../types'
 import type { FieldProps } from '../../types'
 
-type OP = {|
+type OP = {
   ...FieldProps,
   labwareId: ?string,
   className?: string,
-|}
+}
 
-type SP = {|
+type SP = {
   mmFromBottom: number | null,
   wellDepthMm: number,
-|}
+}
 
-type Props = {| ...OP, ...SP |}
+type Props = { ...OP, ...SP }
 
 function TipPositionInput(props: Props) {
   const [isModalOpen, setModalOpen] = React.useState(false)
@@ -105,13 +105,13 @@ function TipPositionInput(props: Props) {
   )
 }
 
-type WrapperProps = {|
+type WrapperProps = {
   isTouchTipField: boolean,
   isDelayPositionField: boolean,
   children: React.Node,
   disabled: boolean,
   targetProps: $ElementType<UseHoverTooltipResult, 0>,
-|}
+}
 
 const Wrapper = (props: WrapperProps) =>
   props.isTouchTipField || props.isDelayPositionField ? (

--- a/protocol-designer/src/components/StepEditForm/fields/ToggleRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ToggleRowField.tsx
@@ -8,12 +8,12 @@ import styles from '../StepEditForm.css'
 
 import type { FieldProps } from '../types'
 
-type ToggleRowProps = {|
+type ToggleRowProps = {
   ...FieldProps,
   offLabel?: string,
   onLabel?: string,
   className?: string,
-|}
+}
 export const ToggleRowField = (props: ToggleRowProps): React.Node => {
   const {
     updateValue,

--- a/protocol-designer/src/components/StepEditForm/fields/VolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/VolumeField.tsx
@@ -14,12 +14,12 @@ import type { StepType } from '../../../form-types'
 import type { FieldProps } from '../types'
 import styles from '../StepEditForm.css'
 
-type Props = {|
+type Props = {
   ...FieldProps,
   stepType: StepType,
   label: string,
   className: string,
-|}
+}
 export const VolumeField = (props: Props): React.Node => {
   const { stepType, label, className, ...propsForVolumeField } = props
   const [targetProps, tooltipProps] = useHoverTooltip({

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
@@ -25,7 +25,7 @@ const WELL_ORDER_VALUES: Array<WellOrderOption> = [
   ...VERTICAL_VALUES,
   ...HORIZONTAL_VALUES,
 ]
-type Props = {|
+type Props = {
   isOpen: boolean,
   closeModal: () => mixed,
   prefix: 'aspirate' | 'dispense' | 'mix',
@@ -37,20 +37,20 @@ type Props = {|
     firstValue: ?WellOrderOption,
     secondValue: ?WellOrderOption
   ) => void,
-|}
+}
 
-type State = {|
+type State = {
   firstValue: WellOrderOption,
   secondValue: WellOrderOption,
-|}
+}
 
-export const ResetButton = (props: {| onClick: () => void |}): React.Node => (
+export const ResetButton = (props: { onClick: () => void }): React.Node => (
   <OutlineButton className={modalStyles.button_medium} onClick={props.onClick}>
     {i18n.t('button.reset')}
   </OutlineButton>
 )
 
-export const CancelButton = (props: {| onClick: () => void |}): React.Node => (
+export const CancelButton = (props: { onClick: () => void }): React.Node => (
   <PrimaryButton
     className={cx(modalStyles.button_medium, modalStyles.button_right_of_break)}
     onClick={props.onClick}
@@ -59,7 +59,7 @@ export const CancelButton = (props: {| onClick: () => void |}): React.Node => (
   </PrimaryButton>
 )
 
-export const DoneButton = (props: {| onClick: () => void |}): React.Node => (
+export const DoneButton = (props: { onClick: () => void }): React.Node => (
   <PrimaryButton className={modalStyles.button_medium} onClick={props.onClick}>
     {i18n.t('button.done')}
   </PrimaryButton>
@@ -78,10 +78,10 @@ export class WellOrderModal extends React.Component<Props, State> {
     }
   }
 
-  getInitialFirstValues: () => {|
+  getInitialFirstValues: () => {
     initialFirstValue: WellOrderOption,
     initialSecondValue: WellOrderOption,
-  |} = () => {
+  } = () => {
     const { firstValue, secondValue } = this.props
     if (firstValue == null || secondValue == null) {
       return {

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.tsx
@@ -9,10 +9,10 @@ import type { WellOrderOption } from '../../../../form-types'
 
 import styles from './WellOrderInput.css'
 
-type Props = {|
-  firstValue: WellOrderOption,
-  secondValue: WellOrderOption,
-|}
+type Props = {
+  firstValue: WellOrderOption
+  secondValue: WellOrderOption
+}
 
 export const WellOrderViz = (props: Props): React.Node => {
   const { firstValue, secondValue } = props

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
@@ -19,17 +19,17 @@ import styles from './WellOrderInput.css'
 import type { FieldProps } from '../../types'
 import type { WellOrderOption } from '../../../../form-types'
 
-type Props = {|
-  className?: ?string,
-  label?: string,
-  prefix: 'aspirate' | 'dispense' | 'mix',
-  firstValue: ?WellOrderOption,
-  secondValue: ?WellOrderOption,
-  firstName: string,
-  secondName: string,
-  updateFirstWellOrder: $PropertyType<FieldProps, 'updateValue'>,
-  updateSecondWellOrder: $PropertyType<FieldProps, 'updateValue'>,
-|}
+type Props = {
+  className?: ?string
+  label?: string
+  prefix: 'aspirate' | 'dispense' | 'mix'
+  firstValue: ?WellOrderOption
+  secondValue: ?WellOrderOption
+  firstName: string
+  secondName: string
+  updateFirstWellOrder: $PropertyType<FieldProps, 'updateValue'>
+  updateSecondWellOrder: $PropertyType<FieldProps, 'updateValue'>
+}
 
 export const WellOrderField = (props: Props): React.Node => {
   const {

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionInput.tsx
@@ -17,25 +17,25 @@ import type { StepIdType } from '../../../../form-types'
 import type { BaseState } from '../../../../types'
 import type { FieldProps } from '../../types'
 
-type SP = {|
+type SP = {
   stepId: ?StepIdType,
   wellSelectionLabwareKey: ?string,
-|}
+}
 
-type DP = {|
+type DP = {
   onOpen: string => mixed,
   onClose: () => mixed,
-|}
+}
 
-type OP = {|
+type OP = {
   ...FieldProps,
   primaryWellCount?: number,
   isMulti: ?boolean,
   pipetteId: ?string,
   labwareId: ?string,
-|}
+}
 
-type Props = {| ...OP, ...SP, ...DP |}
+type Props = { ...OP, ...SP, ...DP }
 
 class WellSelectionInputComponent extends React.Component<Props> {
   handleOpen = () => {

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
@@ -26,7 +26,7 @@ import type { StepFieldName } from '../../../../form-types'
 import styles from './WellSelectionModal.css'
 import modalStyles from '../../../modals/modal.css'
 
-type WellSelectionModalProps = {|
+type WellSelectionModalProps = {
   isOpen: boolean,
   labwareId: ?string,
   name: StepFieldName,
@@ -34,9 +34,9 @@ type WellSelectionModalProps = {|
   pipetteId: ?string,
   value: mixed,
   updateValue: (?mixed) => void,
-|}
+}
 
-type WellSelectionModalComponentProps = {|
+type WellSelectionModalComponentProps = {
   deselectWells: WellGroup => mixed,
   handleSave: () => mixed,
   highlightedWells: WellGroup,
@@ -48,7 +48,7 @@ type WellSelectionModalComponentProps = {|
   selectWells: WellGroup => mixed,
   updateHighlightedWells: WellGroup => mixed,
   wellContents: ContentsByWell,
-|}
+}
 
 const WellSelectionModalComponent = (
   props: WellSelectionModalComponentProps

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -22,12 +22,12 @@ import type { StepFieldName } from '../../../../steplist/fieldLevel'
 import type { FieldPropsByName } from '../../types'
 import styles from '../../StepEditForm.css'
 
-type Props = {|
-  className?: ?string,
-  prefix: 'aspirate' | 'dispense',
-  propsForFields: FieldPropsByName,
-  formData: FormData,
-|}
+type Props = {
+  className?: ?string
+  prefix: 'aspirate' | 'dispense'
+  propsForFields: FieldPropsByName
+  formData: FormData
+}
 
 const makeAddFieldNamePrefix = (prefix: string) => (
   fieldName: string

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
@@ -10,14 +10,14 @@ import type { FieldPropsByName } from '../../types'
 
 import styles from '../../StepEditForm.css'
 
-type Props = {|
-  className?: ?string,
-  collapsed?: ?boolean,
-  formData: FormData,
-  prefix: 'aspirate' | 'dispense',
-  propsForFields: FieldPropsByName,
-  toggleCollapsed: () => void,
-|}
+type Props = {
+  className?: ?string
+  collapsed?: ?boolean
+  formData: FormData
+  prefix: 'aspirate' | 'dispense'
+  propsForFields: FieldPropsByName
+  toggleCollapsed: () => void
+}
 
 const makeAddFieldNamePrefix = (prefix: string) => (
   fieldName: string

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
@@ -9,7 +9,7 @@ import styles from '../../StepEditForm.css'
 
 import type { FieldPropsByName } from '../../types'
 
-type Props = {| propsForFields: FieldPropsByName |}
+type Props = { propsForFields: FieldPropsByName }
 
 export const ProfileSettings = (props: Props): React.Node => {
   const { propsForFields } = props

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.tsx
@@ -10,11 +10,11 @@ import styles from '../../StepEditForm.css'
 import type { FieldPropsByName } from '../../types'
 import type { FormData } from '../../../../form-types'
 
-type Props = {|
-  propsForFields: FieldPropsByName,
-  isEndingHold?: boolean,
-  formData: FormData,
-|}
+type Props = {
+  propsForFields: FieldPropsByName
+  isEndingHold?: boolean
+  formData: FormData
+}
 
 export const StateFields = (props: Props): React.Node => {
   const { isEndingHold, propsForFields, formData } = props

--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -20,24 +20,24 @@ import { getDirtyFields } from './utils'
 import type { BaseState, ThunkDispatch } from '../../types'
 import type { FormData, StepFieldName } from '../../form-types'
 
-type SP = {|
+type SP = {
   canSave: boolean,
   formData: ?FormData,
   formHasChanges: boolean,
   isNewStep: boolean,
   isPristineSetTempForm: boolean,
-|}
-type DP = {|
+}
+type DP = {
   deleteStep: (stepId: string) => mixed,
   handleClose: () => mixed,
   saveSetTempFormWithAddedPauseUntilTemp: () => mixed,
   saveStepForm: () => mixed,
   handleChangeFormInput: (name: string, value: mixed) => void,
-|}
-type StepEditFormManagerProps = {|
+}
+type StepEditFormManagerProps = {
   ...SP,
   ...DP,
-|}
+}
 
 const StepEditFormManager = (props: StepEditFormManagerProps) => {
   const {
@@ -213,9 +213,9 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => {
 // It doesn't matter if the children are using connect or useSelector,
 // only the parent matters.)
 // https://react-redux.js.org/api/hooks#stale-props-and-zombie-children
-export const StepEditForm: React.AbstractComponent<{||}> = connect<
+export const StepEditForm: React.AbstractComponent<{}> = connect<
   StepEditFormManagerProps,
-  {||},
+  {},
   _,
   _,
   _,

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
@@ -28,7 +28,7 @@ import {
 import { i18n } from '../../localization'
 import type { CountPerStepType, StepType } from '../../form-types'
 
-type StepPillProps = {| stepType: StepType, count: number |}
+type StepPillProps = { stepType: StepType; count: number }
 
 const stepPillStyles = css`
   align-items: ${ALIGN_CENTER};
@@ -62,7 +62,7 @@ export const ExitBatchEditButton = (props: {
   handleExitBatchEdit: $PropertyType<
     StepSelectionBannerProps,
     'handleExitBatchEdit'
-  >,
+  >
 }): React.Node => (
   <Box flex="0 1 auto">
     <SecondaryBtn
@@ -75,10 +75,10 @@ export const ExitBatchEditButton = (props: {
   </Box>
 )
 
-export type StepSelectionBannerProps = {|
-  countPerStepType: CountPerStepType,
-  handleExitBatchEdit: () => mixed,
-|}
+export type StepSelectionBannerProps = {
+  countPerStepType: CountPerStepType
+  handleExitBatchEdit: () => mixed
+}
 
 export const StepSelectionBannerComponent = (
   props: StepSelectionBannerProps

--- a/protocol-designer/src/components/TitledListNotes.tsx
+++ b/protocol-designer/src/components/TitledListNotes.tsx
@@ -3,9 +3,9 @@ import { i18n } from '../localization'
 import * as React from 'react'
 import styles from './TitledListNotes.css'
 
-type Props = {|
-  notes: ?string,
-|}
+type Props = {
+  notes: ?string
+}
 
 export function TitledListNotes(props: Props): React.Node {
   return props.notes ? (

--- a/protocol-designer/src/components/alerts/PDAlert.tsx
+++ b/protocol-designer/src/components/alerts/PDAlert.tsx
@@ -7,12 +7,12 @@ import { i18n } from '../../localization'
 import styles from './alerts.css'
 import type { AlertType } from './types'
 
-type PDAlertProps = {|
-  alertType: AlertType,
-  title: string,
-  description: React.Node,
-  onDismiss?: ?() => mixed,
-|}
+type PDAlertProps = {
+  alertType: AlertType
+  title: string
+  description: React.Node
+  onDismiss?: ?(() => mixed)
+}
 
 export const PDAlert = (props: PDAlertProps): React.Node => {
   const { alertType, title, description, onDismiss } = props

--- a/protocol-designer/src/components/alerts/TimelineAlerts.tsx
+++ b/protocol-designer/src/components/alerts/TimelineAlerts.tsx
@@ -13,11 +13,11 @@ import { Alerts, type Props } from './Alerts'
 import type { CommandCreatorError } from '@opentrons/step-generation'
 import type { BaseState } from '../../types'
 
-type SP = {|
+type SP = {
   errors: $PropertyType<Props, 'errors'>,
   warnings: $PropertyType<Props, 'warnings'>,
   _stepId: ?string,
-|}
+}
 
 /** Errors and Warnings from step-generation are written for developers
  * who are using step-generation as an API for writing Opentrons protocols.
@@ -75,11 +75,11 @@ function mergeProps(
   }
 }
 
-export const TimelineAlerts: React.AbstractComponent<{||}> = connect<
+export const TimelineAlerts: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
-  {||},
+  {},
   _,
   _
 >(

--- a/protocol-designer/src/components/labware/BrowsableLabware.tsx
+++ b/protocol-designer/src/components/labware/BrowsableLabware.tsx
@@ -12,11 +12,11 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 import { WellTooltip } from './WellTooltip'
 
-type Props = {|
-  definition: ?LabwareDefinition2,
-  ingredNames: WellIngredientNames,
-  wellContents: ContentsByWell,
-|}
+type Props = {
+  definition: ?LabwareDefinition2
+  ingredNames: WellIngredientNames
+  wellContents: ContentsByWell
+}
 
 export function BrowsableLabware(props: Props): React.Node {
   const { definition, ingredNames, wellContents } = props

--- a/protocol-designer/src/components/labware/BrowseLabwareModal.tsx
+++ b/protocol-designer/src/components/labware/BrowseLabwareModal.tsx
@@ -21,17 +21,17 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import modalStyles from '../modals/modal.css'
 import styles from './labware.css'
 
-type SP = {|
+type SP = {
   definition: ?LabwareDefinition2,
   wellContents: ContentsByWell,
   ingredNames: WellIngredientNames,
-|}
+}
 
-type DP = {|
+type DP = {
   drillUp: () => mixed,
-|}
+}
 
-type Props = {| ...SP, ...DP |}
+type Props = { ...SP, ...DP }
 
 const BrowseLabwareModalComponent = (props: Props) => {
   const { drillUp, definition, ingredNames, wellContents } = props
@@ -86,9 +86,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   return { drillUp: () => dispatch(labwareIngredsActions.drillUpFromLabware()) }
 }
 
-export const BrowseLabwareModal: React.AbstractComponent<{||}> = connect<
+export const BrowseLabwareModal: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -17,7 +17,7 @@ import type { ContentsByWell } from '../../labware-ingred/types'
 import type { WellIngredientNames } from '../../steplist/types'
 import type { GenericRect } from '../../collision-types'
 
-export type Props = {|
+export type Props = {
   labwareProps: $Diff<
     React.ElementProps<typeof SingleLabware>,
     { selectedWells: * }
@@ -30,7 +30,7 @@ export type Props = {|
   pipetteChannels?: ?Channels,
   ingredNames: WellIngredientNames,
   wellContents: ContentsByWell,
-|}
+}
 
 export class SelectableLabware extends React.Component<Props> {
   _getWellsFromRect: (rect: GenericRect) => WellGroup = rect => {

--- a/protocol-designer/src/components/lists/TitledStepList.tsx
+++ b/protocol-designer/src/components/lists/TitledStepList.tsx
@@ -6,42 +6,42 @@ import { Icon } from '@opentrons/components'
 import styles from './styles.css'
 import type { IconName } from '@opentrons/components'
 
-export type Props = {|
+export type Props = {
   /** text of title */
-  title: string,
+  title: string
   /** icon left of the step */
-  iconName: IconName,
+  iconName: IconName
   /** props passed down to icon (`className` and `name` are ignored) */
-  iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>,
+  iconProps?: $Diff<React.ElementProps<typeof Icon>, { name: mixed }>
   /** optional data test id for the container */
-  'data-test'?: string,
+  'data-test'?: string
   /** children must all be `<li>` */
-  children?: React.Node,
+  children?: React.Node
   /** additional classnames */
-  className?: string,
+  className?: string
   /** component with descriptive text about the list */
-  description?: React.Node,
+  description?: React.Node
   /** optional click action (on title div, not children) */
-  onClick?: (event: SyntheticMouseEvent<>) => mixed,
+  onClick?: (event: SyntheticMouseEvent<>) => mixed
   /** optional right click action (on wrapping div) */
-  onContextMenu?: (event: SyntheticMouseEvent<>) => mixed,
+  onContextMenu?: (event: SyntheticMouseEvent<>) => mixed
   /** optional mouseEnter action */
-  onMouseEnter?: (event: SyntheticMouseEvent<>) => mixed,
+  onMouseEnter?: (event: SyntheticMouseEvent<>) => mixed
   /** optional mouseLeave action */
-  onMouseLeave?: (event: SyntheticMouseEvent<>) => mixed,
+  onMouseLeave?: (event: SyntheticMouseEvent<>) => mixed
   /** caret click action; if defined, list is expandable and carat is visible */
-  onCollapseToggle?: (event: SyntheticMouseEvent<>) => mixed,
+  onCollapseToggle?: (event: SyntheticMouseEvent<>) => mixed
   /** collapse the list if true (false by default) */
-  collapsed?: boolean,
+  collapsed?: boolean
   /** set to true when Step is selected (eg, user clicked it) */
-  selected?: boolean,
+  selected?: boolean
   /** set to true when Step is hovered (but not when its contents are hovered) */
-  hovered?: boolean,
+  hovered?: boolean
   /** show checkbox icons if true */
-  isMultiSelectMode?: boolean,
+  isMultiSelectMode?: boolean
   /** set to true when Step is the last selected in multi select mode */
-  isLastSelected?: boolean,
-|}
+  isLastSelected?: boolean
+}
 
 export function TitledStepList(props: Props): React.Node {
   const {

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -5,12 +5,12 @@ import { css } from 'styled-components'
 import { Flex, JUSTIFY_SPACE_AROUND, SPACING_3 } from '@opentrons/components'
 import styles from './AnnouncementModal.css'
 
-export type Announcement = {|
-  announcementKey: string,
-  image: React.Node | null,
-  heading: string,
-  message: React.Node,
-|}
+export type Announcement = {
+  announcementKey: string
+  image: React.Node | null
+  heading: string
+  message: React.Node
+}
 
 const batchEditStyles = css`
   justify-content: ${JUSTIFY_SPACE_AROUND};

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.tsx
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.tsx
@@ -5,11 +5,11 @@ import { i18n } from '../../localization'
 import modalStyles from './modal.css'
 import styles from './AutoAddPauseUntilTempStepModal.css'
 
-type Props = {|
-  displayTemperature: string,
-  handleCancelClick: () => mixed,
-  handleContinueClick: () => mixed,
-|}
+type Props = {
+  displayTemperature: string
+  handleCancelClick: () => mixed
+  handleContinueClick: () => mixed
+}
 
 export const AutoAddPauseUntilTempStepModal = (props: Props): React.Node => (
   <AlertModal

--- a/protocol-designer/src/components/modals/ConfirmDeleteModal.tsx
+++ b/protocol-designer/src/components/modals/ConfirmDeleteModal.tsx
@@ -23,11 +23,11 @@ export type DeleteModalType =
   | typeof CLOSE_BATCH_EDIT_FORM
   | typeof DELETE_MULTIPLE_STEP_FORMS
 
-type Props = {|
-  modalType: DeleteModalType,
-  onCancelClick: (event: ?SyntheticMouseEvent<>) => mixed,
-  onContinueClick: (event: SyntheticMouseEvent<>) => mixed,
-|}
+type Props = {
+  modalType: DeleteModalType
+  onCancelClick: (event: ?SyntheticMouseEvent<>) => mixed
+  onContinueClick: (event: SyntheticMouseEvent<>) => mixed
+}
 
 export function ConfirmDeleteModal(props: Props): React.Node {
   const { modalType, onCancelClick, onContinueClick } = props

--- a/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
@@ -4,9 +4,9 @@ import { useField } from 'formik'
 import { SlotMap } from '@opentrons/components'
 import styles from './EditModules.css'
 
-type ConnectedSlotMapProps = {|
-  fieldName: string,
-|}
+type ConnectedSlotMapProps = {
+  fieldName: string
+}
 
 export const ConnectedSlotMap = (props: ConnectedSlotMapProps): React.Node => {
   const { fieldName } = props

--- a/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
@@ -3,14 +3,14 @@ import * as React from 'react'
 import { useField } from 'formik'
 import { DropdownField } from '@opentrons/components'
 
-type ModelDropdownProps = {|
+type ModelDropdownProps = {
   fieldName: string,
   tabIndex: number,
   options: Array<{|
     name: string,
     value: string,
     disabled?: boolean,
-  |}>,
+  }>,
 |}
 export const ModelDropdown = (props: ModelDropdownProps): React.Node => {
   const { fieldName, options, tabIndex } = props

--- a/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
@@ -6,12 +6,12 @@ import { DropdownField } from '@opentrons/components'
 type ModelDropdownProps = {
   fieldName: string,
   tabIndex: number,
-  options: Array<{|
+  options: Array<{
     name: string,
     value: string,
     disabled?: boolean,
   }>,
-|}
+}
 export const ModelDropdown = (props: ModelDropdownProps): React.Node => {
   const { fieldName, options, tabIndex } = props
   const [field, meta] = useField(fieldName)

--- a/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useField } from 'formik'
 import { DropdownField } from '@opentrons/components'
 
-type ModelDropdownProps = {|
+type ModelDropdownProps = {
   fieldName: string,
   disabled: boolean,
   tabIndex: number,
@@ -11,7 +11,7 @@ type ModelDropdownProps = {|
     name: string,
     value: string,
     disabled?: boolean,
-  |}>,
+  }>,
 |}
 
 export const SlotDropdown = (props: ModelDropdownProps): React.Node => {

--- a/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
@@ -7,12 +7,12 @@ type ModelDropdownProps = {
   fieldName: string,
   disabled: boolean,
   tabIndex: number,
-  options: Array<{|
+  options: Array<{
     name: string,
     value: string,
     disabled?: boolean,
   }>,
-|}
+}
 
 export const SlotDropdown = (props: ModelDropdownProps): React.Node => {
   const { fieldName, options, disabled, tabIndex } = props

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -46,24 +46,24 @@ import type { ModuleRealType, ModuleModel } from '@opentrons/shared-data'
 import type { ModuleOnDeck } from '../../../step-forms/types'
 import type { ModelModuleInfo } from '../../EditModules'
 
-type EditModulesModalProps = {|
+type EditModulesModalProps = {
   moduleType: ModuleRealType,
   moduleOnDeck: ModuleOnDeck | null,
   onCloseClick: () => mixed,
   editModuleModel: (model: ModuleModel) => mixed,
   editModuleSlot: (slot: string) => mixed,
   displayModuleWarning: (module: ModelModuleInfo) => mixed,
-|}
+}
 
-type EditModulesModalComponentProps = {|
+type EditModulesModalComponentProps = {
   ...EditModulesModalProps,
   supportedModuleSlot: string,
-|}
+}
 
-export type EditModulesFormValues = {|
+export type EditModulesFormValues = {
   selectedModel: ModuleModel | null,
   selectedSlot: string,
-|}
+}
 
 export const EditModulesModal = (props: EditModulesModalProps): React.Node => {
   const {

--- a/protocol-designer/src/components/modals/EditPipettesModal/index.ts
+++ b/protocol-designer/src/components/modals/EditPipettesModal/index.ts
@@ -22,16 +22,16 @@ import type { StepIdType } from '../../../form-types'
 
 type Props = React.ElementProps<typeof FilePipettesModal>
 
-type SP = {|
-  initialPipetteValues: FormPipettesByMount,
-  _prevPipettes: { [pipetteId: string]: PipetteOnDeck },
-  _orderedStepIds: Array<StepIdType>,
-  moduleRestrictionsDisabled: ?boolean,
-|}
+type SP = {
+  initialPipetteValues: FormPipettesByMount
+  _prevPipettes: { [pipetteId: string]: PipetteOnDeck }
+  _orderedStepIds: Array<StepIdType>
+  moduleRestrictionsDisabled: ?boolean
+}
 
-type OP = {|
-  closeModal: () => mixed,
-|}
+type OP = {
+  closeModal: () => mixed
+}
 
 const mapSTP = (state: BaseState): SP => {
   const initialPipettes = stepFormSelectors.getPipettesForEditPipetteForm(state)
@@ -68,11 +68,11 @@ const makeUpdatePipettes = (
   const usedPrevPipettes: Array<string> = [] // IDs of pipettes in prevPipettes that were already put into nextPipettes
   const nextPipettes: {
     [pipetteId: string]: {
-      mount: string,
-      name: string,
-      tiprackDefURI: string,
-      id: string,
-    },
+      mount: string
+      name: string
+      tiprackDefURI: string
+      id: string
+    }
   } = {}
 
   // from array of pipettes from Edit Pipette form (with no IDs),
@@ -195,7 +195,7 @@ const makeUpdatePipettes = (
 
 const mergeProps = (
   stateProps: SP,
-  dispatchProps: {| dispatch: ThunkDispatch<*> |},
+  dispatchProps: { dispatch: ThunkDispatch<*> },
   ownProps: OP
 ): Props => {
   const { _prevPipettes, _orderedStepIds, ...passThruStateProps } = stateProps
@@ -221,7 +221,7 @@ export const EditPipettesModal: React.AbstractComponent<OP> = connect<
   Props,
   OP,
   SP,
-  {||},
+  {},
   _,
   _
 >(

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -13,7 +13,7 @@ import styles from './FilePipettesModal.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
 import type { FormModulesByType } from '../../../step-forms'
 
-type Props = {|
+type Props = {
   // TODO 2020-3-20 use formik typing here after we update the def in flow-typed
   errors:
     | null
@@ -28,7 +28,7 @@ type Props = {|
         thermocyclerModuleType?: {
           model: string,
         },
-      |},
+      },
   touched:
     | null
     | boolean

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -18,7 +18,7 @@ type Props = {
   errors:
     | null
     | string
-    | {|
+    | {
         magneticModuleType?: {
           model: string,
         },
@@ -50,7 +50,7 @@ type Props = {
   onSetFieldValue: (field: string, value: string | null) => void,
   onSetFieldTouched: (field: string, touched: boolean) => void,
   onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed,
-|}
+}
 
 export function ModuleFields(props: Props): React.Node {
   const {

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -21,7 +21,7 @@ import formStyles from '../../forms/forms.css'
 
 import type { FormPipettesByMount } from '../../../step-forms'
 
-export type Props = {|
+export type Props = {
   initialTabIndex?: number,
   values: FormPipettesByMount,
   // TODO 2020-3-20 use formik typing here after we update the def in flow-typed
@@ -51,10 +51,10 @@ export type Props = {|
   onSetFieldValue: (field: string, value: string | null) => void,
   onSetFieldTouched: (field: string, touched: boolean) => void,
   onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed,
-|}
+}
 
 // TODO(mc, 2019-10-14): delete this typedef when gen2 ff is removed
-type PipetteSelectProps = {| mount: Mount, tabIndex: number |}
+type PipetteSelectProps = { mount: Mount, tabIndex: number }
 
 export function PipetteFields(props: Props): React.Node {
   const {

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -40,26 +40,26 @@ import type { FormikProps } from 'formik/@flow-typed'
 
 export type PipetteFieldsData = $Diff<
   PipetteOnDeck,
-  {| id: mixed, spec: mixed, tiprackLabwareDef: mixed |}
+  { id: mixed, spec: mixed, tiprackLabwareDef: mixed }
 >
 
-export type ModuleCreationArgs = {|
+export type ModuleCreationArgs = {
   type: ModuleRealType,
   model: string,
   slot: DeckSlot,
-|}
+}
 
-type FormState = {|
+type FormState = {
   fields: NewProtocolFields,
   pipettesByMount: FormPipettesByMount,
   modulesByType: FormModulesByType,
-|}
+}
 
-type State = {|
+type State = {
   showEditPipetteConfirmation: boolean,
-|}
+}
 
-export type Props = {|
+export type Props = {
   showProtocolFields?: ?boolean,
   showModulesFields?: ?boolean,
   hideModal?: boolean,
@@ -70,7 +70,7 @@ export type Props = {|
     newProtocolFields: NewProtocolFields,
     pipettes: Array<PipetteFieldsData>,
     modules: Array<ModuleCreationArgs>,
-  |}) => mixed,
+  }) => mixed,
   moduleRestrictionsDisabled: ?boolean,
 |}
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -66,13 +66,13 @@ export type Props = {
   onCancel: () => mixed,
   initialPipetteValues?: $PropertyType<FormState, 'pipettesByMount'>,
   initialModuleValues?: $PropertyType<FormState, 'modulesByType'>,
-  onSave: ({|
+  onSave: ({
     newProtocolFields: NewProtocolFields,
     pipettes: Array<PipetteFieldsData>,
     modules: Array<ModuleCreationArgs>,
   }) => mixed,
   moduleRestrictionsDisabled: ?boolean,
-|}
+}
 
 const initialFormState: FormState = {
   fields: { name: '' },

--- a/protocol-designer/src/components/modals/GateModal/index.tsx
+++ b/protocol-designer/src/components/modals/GateModal/index.tsx
@@ -22,9 +22,9 @@ type Props = {
   optOut: () => mixed,
 }
 
-type SP = {|
+type SP = {
   hasOptedIn: $PropertyType<Props, 'hasOptedIn'>,
-|}
+}
 
 type DP = $Rest<$Exact<Props>, SP>
 
@@ -177,9 +177,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export const GateModal: React.AbstractComponent<{||}> = connect<
+export const GateModal: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.tsx
@@ -11,7 +11,7 @@ import { i18n } from '../../../localization'
 import modalStyles from '../modal.css'
 import type { LabwareUploadMessage } from '../../../labware-defs'
 
-const MessageBody = (props: {| message: LabwareUploadMessage |}) => {
+const MessageBody = (props: { message: LabwareUploadMessage }) => {
   const { message } = props
 
   if (
@@ -89,11 +89,11 @@ const MessageBody = (props: {| message: LabwareUploadMessage |}) => {
   return null
 }
 
-type Props = {|
+type Props = {
   message: ?LabwareUploadMessage,
   dismissModal: () => mixed,
   overwriteLabwareDef?: () => mixed,
-|}
+}
 
 export const LabwareUploadMessageModal = (props: Props): React.Node => {
   const { message, dismissModal, overwriteLabwareDef } = props

--- a/protocol-designer/src/components/modals/MoreOptionsModal.tsx
+++ b/protocol-designer/src/components/modals/MoreOptionsModal.tsx
@@ -16,16 +16,16 @@ import type { ThunkDispatch } from '../../types'
 import modalStyles from './modal.css'
 import styles from './MoreOptionsModal.css'
 
-type OP = {|
+type OP = {
   close: (event: ?SyntheticEvent<>) => mixed,
   formData: FormData,
-|}
+}
 
-type DP = {|
+type DP = {
   saveValuesToForm: ({ [StepFieldName]: ?mixed }) => mixed,
-|}
+}
 
-type Props = {| ...OP, ...DP |}
+type Props = { ...OP, ...DP }
 type State = { [StepFieldName]: ?mixed }
 
 class MoreOptionsModalComponent extends React.Component<Props, State> {
@@ -99,7 +99,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<*>): DP => ({
 export const MoreOptionsModal: React.AbstractComponent<OP> = connect<
   Props,
   OP,
-  {||},
+  {},
   DP,
   _,
   _

--- a/protocol-designer/src/components/modules/CrashInfoBox.tsx
+++ b/protocol-designer/src/components/modules/CrashInfoBox.tsx
@@ -4,11 +4,11 @@ import { Icon } from '@opentrons/components'
 import { KnowledgeBaseLink } from '../KnowledgeBaseLink'
 import styles from './styles.css'
 
-type Props = {|
-  showDiagram?: boolean,
-  magnetOnDeck: ?boolean,
-  temperatureOnDeck: ?boolean,
-|}
+type Props = {
+  showDiagram?: boolean
+  magnetOnDeck: ?boolean
+  temperatureOnDeck: ?boolean
+}
 
 export function CrashInfoBox(props: Props): React.Node {
   const moduleMessage = getCrashableModulesCopy(props) || ''

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -22,12 +22,12 @@ import styles from './styles.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
 import type { ModuleOnDeck } from '../../step-forms'
 
-type Props = {|
-  moduleOnDeck?: ModuleOnDeck,
-  showCollisionWarnings?: boolean,
-  type: ModuleRealType,
-  openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed,
-|}
+type Props = {
+  moduleOnDeck?: ModuleOnDeck
+  showCollisionWarnings?: boolean
+  type: ModuleRealType
+  openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed
+}
 
 export function ModuleRow(props: Props): React.Node {
   const { moduleOnDeck, openEditModuleModal, showCollisionWarnings } = props

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
@@ -11,10 +11,10 @@ import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 
-type AspirateDispenseHeaderProps = {|
-  sourceLabwareNickname: ?string,
-  destLabwareNickname: ?string,
-|}
+type AspirateDispenseHeaderProps = {
+  sourceLabwareNickname: ?string
+  destLabwareNickname: ?string
+}
 
 export function AspirateDispenseHeader(
   props: AspirateDispenseHeaderProps

--- a/protocol-designer/src/components/steplist/ContextMenu.tsx
+++ b/protocol-designer/src/components/steplist/ContextMenu.tsx
@@ -15,15 +15,15 @@ import type { StepIdType } from '../../form-types'
 
 const MENU_OFFSET_PX = 5
 
-type Props = {|
+type Props = {
   children: ({
     makeStepOnContextMenu: StepIdType => (
       event: SyntheticMouseEvent<>
     ) => mixed,
   }) => React.Node,
-|}
+}
 
-type Position = {| left: number | null, top: number | null |}
+type Position = { left: number | null, top: number | null }
 
 export const ContextMenu = (props: Props): React.Node => {
   const dispatch = useDispatch()

--- a/protocol-designer/src/components/steplist/DraggableStepItems.tsx
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.tsx
@@ -17,7 +17,7 @@ import type { BaseState } from '../../types'
 import { ContextMenu } from './ContextMenu'
 import styles from './StepItem.css'
 
-type DragDropStepItemProps = {|
+type DragDropStepItemProps = {
   ...$Exact<React.ElementProps<typeof ConnectedStepItem>>,
   connectDragSource: mixed => React.Element<any>,
   connectDropTarget: mixed => React.Element<any>,
@@ -27,7 +27,7 @@ type DragDropStepItemProps = {|
   findStepIndex: StepIdType => number,
   onDrag: () => void,
   moveStep: (StepIdType, number) => void,
-|}
+}
 
 const DragSourceStepItem = (props: DragDropStepItemProps) =>
   props.connectDragSource(
@@ -78,13 +78,13 @@ const DragDropStepItem = DropTarget(
   collectStepTarget
 )(DraggableStepItem)
 
-type StepItemsProps = {|
+type StepItemsProps = {
   orderedStepIds: Array<StepIdType>,
   reorderSteps: (Array<StepIdType>) => mixed,
   isOver: boolean,
   connectDropTarget: mixed => React.Element<any>,
-|}
-type StepItemsState = {| stepIds: Array<StepIdType> |}
+}
+type StepItemsState = { stepIds: Array<StepIdType> }
 class StepItems extends React.Component<StepItemsProps, StepItemsState> {
   constructor(props) {
     super(props)
@@ -152,16 +152,16 @@ class StepItems extends React.Component<StepItemsProps, StepItemsState> {
 
 const NAV_OFFSET = 64
 
-type StepDragPreviewSP = {| stepType: ?StepType, stepName: ?string |}
+type StepDragPreviewSP = { stepType: ?StepType, stepName: ?string }
 
-type StepDragPreviewOP = {|
+type StepDragPreviewOP = {
   currentOffset?: { y: number, x: number },
   itemType: string,
   isDragging: boolean,
   item: { stepId: StepIdType },
-|}
+}
 
-type StepDragPreviewProps = {| ...StepDragPreviewOP, ...StepDragPreviewSP |}
+type StepDragPreviewProps = { ...StepDragPreviewOP, ...StepDragPreviewSP }
 
 const StepDragPreview = (props: StepDragPreviewProps) => {
   const { itemType, isDragging, currentOffset, stepType, stepName } = props
@@ -198,7 +198,7 @@ const mapSTPForPreview = (
   return { stepType, stepName }
 }
 
-export const StepDragPreviewLayer: React.AbstractComponent<{||}> = DragLayer(
+export const StepDragPreviewLayer: React.AbstractComponent<{}> = DragLayer(
   monitor => ({
     currentOffset: monitor.getSourceClientOffset(),
     isDragging: monitor.isDragging(),
@@ -220,5 +220,5 @@ const collectListTarget = (connect, monitor) => ({
 })
 
 export const DraggableStepItems: React.AbstractComponent<
-  $Diff<StepItemsProps, {| isOver: mixed, connectDropTarget: mixed |}>
+  $Diff<StepItemsProps, { isOver: mixed, connectDropTarget: mixed }>
 > = DropTarget(DND_TYPES.STEP_ITEM, listTarget, collectListTarget)(StepItems)

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
@@ -2,9 +2,9 @@
 import * as React from 'react'
 import styles from './StepItem.css'
 
-type LabwareTooltipContentsProps = {|
-  labwareNickname: ?string,
-|}
+type LabwareTooltipContentsProps = {
+  labwareNickname: ?string
+}
 export const LabwareTooltipContents = (
   props: LabwareTooltipContentsProps
 ): React.Node => {

--- a/protocol-designer/src/components/steplist/MixHeader.tsx
+++ b/protocol-designer/src/components/steplist/MixHeader.tsx
@@ -6,11 +6,11 @@ import { PDListItem } from '../lists'
 import styles from './StepItem.css'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
 
-type Props = {|
-  volume: ?string,
-  times: ?string,
-  labwareNickname: ?string,
-|}
+type Props = {
+  volume: ?string
+  times: ?string
+  labwareNickname: ?string
+}
 
 export function MixHeader(props: Props): React.Node {
   const { volume, times, labwareNickname } = props

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -13,11 +13,11 @@ import { LabwareTooltipContents } from './LabwareTooltipContents'
 import styles from './StepItem.css'
 import type { ModuleRealType } from '@opentrons/shared-data'
 
-export type ModuleStepItemRowProps = {|
+export type ModuleStepItemRowProps = {
   label?: ?string,
   value?: ?string,
   targetProps?: UseHoverTooltipTargetProps,
-|}
+}
 
 export const ModuleStepItemRow = (
   props: ModuleStepItemRowProps
@@ -32,7 +32,7 @@ export const ModuleStepItemRow = (
   </PDListItem>
 )
 
-type Props = {|
+type Props = {
   action?: string,
   moduleType: ModuleRealType,
   actionText: string,
@@ -40,7 +40,7 @@ type Props = {|
   message?: ?string,
   children?: React.Node,
   hideHeader?: boolean,
-|}
+}
 
 export const ModuleStepItems = (props: Props): React.Node => {
   const [targetProps, tooltipProps] = useHoverTooltip({

--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.tsx
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.tsx
@@ -16,18 +16,18 @@ import type {
 
 const DEFAULT_COLLAPSED_STATE = true
 
-type MultiChannelSubstepProps = {|
+type MultiChannelSubstepProps = {
   rowGroup: Array<StepItemSourceDestRow>,
   ingredNames: WellIngredientNames,
   highlighted?: boolean,
   stepId: string,
   substepIndex: number,
   selectSubstep: SubstepIdentifier => mixed,
-|}
+}
 
-type MultiChannelSubstepState = {|
+type MultiChannelSubstepState = {
   collapsed: boolean,
-|}
+}
 
 export class MultiChannelSubstep extends React.PureComponent<
   MultiChannelSubstepProps,

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
@@ -35,15 +35,15 @@ import {
 
 import type { IconName } from '@opentrons/components'
 
-type ClickableIconProps = {|
-  id?: string,
-  iconName: IconName,
-  tooltipText: string,
-  width?: string,
-  alignRight?: boolean,
-  isLast?: boolean,
-  onClick?: (event: SyntheticMouseEvent<>) => mixed,
-|}
+type ClickableIconProps = {
+  id?: string
+  iconName: IconName
+  tooltipText: string
+  width?: string
+  alignRight?: boolean
+  isLast?: boolean
+  onClick?: (event: SyntheticMouseEvent<>) => mixed
+}
 
 const iconBoxStyles = css`
   align-self: stretch;
@@ -77,14 +77,14 @@ export const ClickableIcon = (props: ClickableIconProps): React.Node => {
   )
 }
 
-type Props = {|
-  isMultiSelectMode: boolean,
-|}
+type Props = {
+  isMultiSelectMode: boolean
+}
 
-type AccordionProps = {|
-  expanded: boolean,
-  children: React.Node,
-|}
+type AccordionProps = {
+  expanded: boolean
+  children: React.Node
+}
 
 export const Accordion = (props: AccordionProps): React.Node => {
   return (

--- a/protocol-designer/src/components/steplist/SourceDestSubstep.tsx
+++ b/protocol-designer/src/components/steplist/SourceDestSubstep.tsx
@@ -12,16 +12,16 @@ import type {
   WellIngredientNames,
 } from '../../steplist/types'
 
-export type StepSubItemProps = {|
+export type StepSubItemProps = {
   substeps: SourceDestSubstepItem,
-|}
+}
 
-type SourceDestSubstepProps = {|
+type SourceDestSubstepProps = {
   ...StepSubItemProps,
   ingredNames: WellIngredientNames,
   selectSubstep: SubstepIdentifier => mixed,
   hoveredSubstep: ?SubstepIdentifier,
-|}
+}
 
 export function SourceDestSubstep(props: SourceDestSubstepProps): React.Node {
   const { substeps, selectSubstep, hoveredSubstep } = props

--- a/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.tsx
+++ b/protocol-designer/src/components/steplist/StartingDeckStateTerminalItem.tsx
@@ -9,7 +9,7 @@ import { START_TERMINAL_ITEM_ID } from '../../steplist'
 import { selectors as stepFormSelectors } from '../../step-forms'
 
 type Props = {
-  showHint: boolean,
+  showHint: boolean
 }
 
 type SP = $Exact<Props>
@@ -36,9 +36,9 @@ function mapStateToProps(state: BaseState): SP {
   return { showHint: noLabware }
 }
 
-export const StartingDeckStateTerminalItem: React.AbstractComponent<{||}> = connect<
+export const StartingDeckStateTerminalItem: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   _,
   _,

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -34,7 +34,7 @@ import type {
   WellIngredientNames,
 } from '../../steplist/types'
 
-export type StepItemProps = {|
+export type StepItemProps = {
   description?: ?string,
   rawForm: ?FormData,
   stepNumber: number,
@@ -55,7 +55,7 @@ export type StepItemProps = {|
   toggleStepCollapsed: () => mixed,
   unhighlightStep: (event?: SyntheticEvent<>) => mixed,
   children?: React.Node,
-|}
+}
 
 export const StepItem = (props: StepItemProps): React.Node => {
   const {
@@ -110,7 +110,7 @@ export const StepItem = (props: StepItemProps): React.Node => {
   )
 }
 
-export type StepItemContentsProps = {|
+export type StepItemContentsProps = {
   rawForm: ?FormData,
   stepType: StepType,
   substeps: ?SubstepItemData,
@@ -120,7 +120,7 @@ export type StepItemContentsProps = {|
 
   highlightSubstep: SubstepIdentifier => mixed,
   hoveredSubstep: ?SubstepIdentifier,
-|}
+}
 
 const makeDurationText = (
   durationMinutes: string,
@@ -130,11 +130,11 @@ const makeDurationText = (
   return `${minutesText}${durationSeconds || 0}s`
 }
 
-type ProfileStepSubstepRowProps = {|
+type ProfileStepSubstepRowProps = {
   step: ProfileStepItem,
   stepNumber: number,
   repetitionsDisplay: ?string,
-|}
+}
 export const ProfileStepSubstepRow = (
   props: ProfileStepSubstepRowProps
 ): React.Node => {
@@ -176,7 +176,7 @@ export const ProfileStepSubstepRow = (
 }
 
 // this is a row under a cycle under a substep
-type ProfileCycleRowProps = {| step: ProfileStepItem, stepNumber: number |}
+type ProfileCycleRowProps = { step: ProfileStepItem, stepNumber: number }
 const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   const { step, stepNumber } = props
   return (
@@ -192,10 +192,10 @@ const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
   )
 }
 
-type ProfileCycleSubstepGroupProps = {|
+type ProfileCycleSubstepGroupProps = {
   cycle: ProfileCycleItem,
   stepNumber: number,
-|}
+}
 export const ProfileCycleSubstepGroup = (
   props: ProfileCycleSubstepGroupProps
 ): React.Node => {
@@ -216,10 +216,10 @@ export const ProfileCycleSubstepGroup = (
   )
 }
 
-type CollapsibleSubstepProps = {|
+type CollapsibleSubstepProps = {
   children: React.Node,
   headerContent: React.Node,
-|}
+}
 const CollapsibleSubstep = (props: CollapsibleSubstepProps) => {
   const [contentCollapsed, setContentCollapsed] = React.useState<boolean>(true)
   return (

--- a/protocol-designer/src/components/steplist/StepList.tsx
+++ b/protocol-designer/src/components/steplist/StepList.tsx
@@ -14,12 +14,12 @@ import { MultiSelectToolbar } from './MultiSelectToolbar'
 
 import type { StepIdType } from '../../form-types'
 
-type Props = {|
+type Props = {
   isMultiSelectMode: ?boolean,
   orderedStepIds: Array<StepIdType>,
   reorderSelectedStep: (delta: number) => mixed,
   reorderSteps: (Array<StepIdType>) => mixed,
-|}
+}
 
 export class StepList extends React.Component<Props> {
   handleKeyDown: (e: SyntheticKeyboardEvent<>) => void = e => {

--- a/protocol-designer/src/components/steplist/SubstepRow.tsx
+++ b/protocol-designer/src/components/steplist/SubstepRow.tsx
@@ -18,7 +18,7 @@ import type {
 } from '../../steplist/types'
 import styles from './StepItem.css'
 
-type SubstepRowProps = {|
+type SubstepRowProps = {
   volume?: ?number | ?string,
   source?: SubstepWellData,
   dest?: SubstepWellData,
@@ -27,7 +27,7 @@ type SubstepRowProps = {|
   stepId: string,
   substepIndex: number,
   selectSubstep?: SubstepIdentifier => mixed,
-|}
+}
 
 type PillTooltipContentsProps = {
   ingreds: WellIngredientVolumeData | LocationLiquidState,

--- a/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.tsx
+++ b/protocol-designer/src/components/steplist/TerminalItem/TerminalItemLink.tsx
@@ -8,9 +8,9 @@ import { type TerminalItemId } from '../../../steplist'
 import { i18n } from '../../../localization'
 import styles from './styles.css'
 
-type OP = {| terminalId: TerminalItemId |}
-type DP = {| selectTerminalItem: TerminalItemId => mixed |}
-type Props = {| ...OP, ...DP |}
+type OP = { terminalId: TerminalItemId }
+type DP = { selectTerminalItem: TerminalItemId => mixed }
+type Props = { ...OP, ...DP }
 
 class TerminalItemLinkComponent extends React.Component<Props> {
   handleClick = () => {
@@ -34,7 +34,7 @@ const mapDTP = (dispatch: ThunkDispatch<*>): DP => ({
 export const TerminalItemLink: React.AbstractComponent<OP> = connect<
   Props,
   OP,
-  {||},
+  {},
   DP,
   _,
   _

--- a/protocol-designer/src/components/steplist/TerminalItem/index.tsx
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.tsx
@@ -22,11 +22,11 @@ import type { TerminalItemId } from '../../../steplist'
 
 export { TerminalItemLink } from './TerminalItemLink'
 
-type Props = {|
-  children?: React.Node,
-  id: TerminalItemId,
-  title: string,
-|}
+type Props = {
+  children?: React.Node
+  id: TerminalItemId
+  title: string
+}
 
 export const TerminalItem = (props: Props): React.Node => {
   const { id, title, children } = props

--- a/protocol-designer/src/containers/ConnectedMainPanel.tsx
+++ b/protocol-designer/src/containers/ConnectedMainPanel.tsx
@@ -66,9 +66,9 @@ function mapStateToProps(state: BaseState): $Exact<Props> {
   }
 }
 
-export const ConnectedMainPanel: React.AbstractComponent<{||}> = connect<
+export const ConnectedMainPanel: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   _,
   _,
   _,

--- a/protocol-designer/src/containers/ConnectedNav.tsx
+++ b/protocol-designer/src/containers/ConnectedNav.tsx
@@ -9,14 +9,14 @@ import { i18n } from '../localization'
 import { type Page, actions, selectors } from '../navigation'
 import { selectors as fileSelectors } from '../file-data'
 
-type SP = {|
+type SP = {
   currentPage: Page,
   currentProtocolExists: boolean,
-|}
+}
 
-type DP = {| handleClick: Page => (e: ?SyntheticEvent<>) => void |}
+type DP = { handleClick: Page => (e: ?SyntheticEvent<>) => void }
 
-type Props = {| ...SP, ...DP |}
+type Props = { ...SP, ...DP }
 
 function Nav(props: Props) {
   const noCurrentProtocol = !props.currentProtocolExists
@@ -88,9 +88,9 @@ function mapDispatchToProps(dispatch: ThunkDispatch<*>): DP {
   }
 }
 
-export const ConnectedNav: React.AbstractComponent<{||}> = connect<
+export const ConnectedNav: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
   DP,
   _,

--- a/protocol-designer/src/containers/ConnectedSidebar.tsx
+++ b/protocol-designer/src/containers/ConnectedSidebar.tsx
@@ -14,8 +14,8 @@ import type { BaseState } from '../types'
 import type { Page } from '../navigation'
 
 type Props = {
-  page: Page,
-  liquidPlacementMode: boolean,
+  page: Page
+  liquidPlacementMode: boolean
 }
 
 function Sidebar(props: Props) {
@@ -49,9 +49,9 @@ function mapStateToProps(state: BaseState): $Exact<Props> {
   }
 }
 
-export const ConnectedSidebar: React.AbstractComponent<{||}> = connect<
+export const ConnectedSidebar: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   _,
   _,
   _,

--- a/protocol-designer/src/containers/ConnectedStepItem.tsx
+++ b/protocol-designer/src/containers/ConnectedStepItem.tsx
@@ -34,11 +34,11 @@ import {
 import type { SubstepIdentifier } from '../steplist/types'
 import type { StepIdType } from '../form-types'
 
-type Props = {|
+type Props = {
   stepId: StepIdType,
   stepNumber: number,
   onStepContextMenu?: () => mixed,
-|}
+}
 
 const nonePressed = (keysPressed: Array<boolean>): boolean =>
   keysPressed.every(keyPress => keyPress === false)
@@ -47,7 +47,7 @@ const getUserOS = () => new UAParser().getOS().name
 
 const getMouseClickKeyInfo = (
   event: SyntheticMouseEvent<>
-): {| isShiftKeyPressed: boolean, isMetaKeyPressed: boolean |} => {
+): { isShiftKeyPressed: boolean, isMetaKeyPressed: boolean } => {
   const isMac: boolean = getUserOS() === 'Mac OS'
   const isShiftKeyPressed: boolean = event.shiftKey
   const isMetaKeyPressed: boolean =

--- a/protocol-designer/src/containers/ConnectedTitleBar.tsx
+++ b/protocol-designer/src/containers/ConnectedTitleBar.tsx
@@ -28,14 +28,14 @@ import type { BaseState } from '../types'
 
 type Props = React.ElementProps<typeof TitleBar>
 
-type DP = {| onBackClick: $PropertyType<Props, 'onBackClick'> |}
+type DP = { onBackClick: $PropertyType<Props, 'onBackClick'> }
 
-type SP = {|
+type SP = {
   ...$Diff<$Exact<Props>, DP>,
   _page: Page,
   _liquidPlacementMode?: boolean,
   _wellSelectionMode?: boolean,
-|}
+}
 
 type TitleWithIconProps = {
   iconName?: ?IconName,
@@ -207,11 +207,11 @@ const StickyTitleBar = (props: TitleBarProps) => (
   <TitleBar id="TitleBar_main" {...props} className={styles.sticky_bar} />
 )
 
-export const ConnectedTitleBar: React.AbstractComponent<{||}> = connect<
+export const ConnectedTitleBar: React.AbstractComponent<{}> = connect<
   Props,
-  {||},
+  {},
   SP,
-  {||},
+  {},
   _,
   _
 >(

--- a/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.ts
+++ b/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.ts
@@ -7,15 +7,15 @@ import {
 import type { ModuleEntities } from '../../step-forms'
 
 describe('getRequiresAtLeastV4 selector', () => {
-  const testCases: Array<{|
-    testName: string,
+  const testCases: Array<{
+    testName: string
     robotStateTimeline: {
       // NOTE: this is a simplified version of Timeline type so we don't need a huge fixture
-      timeline: Array<{ commands: Array<{ command: string }> }>,
-    },
-    moduleEntities: ModuleEntities,
-    expected: boolean,
-  |}> = [
+      timeline: Array<{ commands: Array<{ command: string }> }>
+    }
+    moduleEntities: ModuleEntities
+    expected: boolean
+  }> = [
     {
       testName: 'should return true if there are modules',
       expected: true,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/thermocyclerFormToArgs.test.ts
@@ -8,11 +8,11 @@ import type { ThermocyclerStateStepArgs } from '../../../../step-generation/type
 const tcModuleId = 'tcModuleId'
 
 describe('thermocyclerFormToArgs', () => {
-  const testCases: Array<{|
-    formData: FormData,
-    expected: ThermocyclerStateStepArgs,
-    testName: string,
-  |}> = [
+  const testCases: Array<{
+    formData: FormData
+    expected: ThermocyclerStateStepArgs
+    testName: string
+  }> = [
     {
       testName: 'all active temps',
       formData: {

--- a/protocol-designer/src/steplist/test/mergeSubstepsFns.test.ts
+++ b/protocol-designer/src/steplist/test/mergeSubstepsFns.test.ts
@@ -23,7 +23,7 @@ const repeatIngreds = (
     : ingreds
 }
 
-const getFixtures = ({ isMulti }: {| isMulti: boolean |}) => {
+const getFixtures = ({ isMulti }: { isMulti: boolean }) => {
   const makeIngreds = (volume: number | null, colNum: string) =>
     repeatIngreds(isMulti, colNum, volume ? { [ingred1Id]: volume } : null)
   // NOTE: these cases do not cover dynamic behavior of `activeTips` key

--- a/protocol-designer/src/ui/steps/test/reducers.test.ts
+++ b/protocol-designer/src/ui/steps/test/reducers.test.ts
@@ -204,12 +204,12 @@ describe('selectedItem reducer', () => {
       type: 'SELECT_MULTIPLE_STEPS',
       payload: { stepIds, lastSelected },
     }
-    const multiTestCases: {|
+    const multiTestCases: {
       title: string,
       prev: SelectableItem | null,
       action: SelectMultipleStepsAction,
       expected: SelectableItem | null,
-    |} = [
+    } = [
       {
         title: 'should enter multi-select mode from null',
         prev: null,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
