### PR TITLE
refactor(step-generation): point types and main to correct files

### DIFF
--- a/step-generation/package.json
+++ b/step-generation/package.json
@@ -12,8 +12,8 @@
   "private": true,
   "version": "4.3.1",
   "description": "Step generation",
-  "main": "lib/main.js",
-  "types": "lib/main.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "flow:main": "flow-types/index.js.flow",
   "bugs": {
     "url": "https://github.com/Opentrons/opentrons/issues"


### PR DESCRIPTION
# Overview

SG was pointing its `main` and `types` to files that never get generated (should be `index` not `main`). 

This is not a refactor but I don't want it showing up as a new feature or a bug fix in the changelog because it's technically neither of those two.

# Risk assessment

Low