### PR TITLE
Translating references to `React.Node` to `JSX.Element` for functional components and `React.ReactNode` for class components.

### DIFF
--- a/protocol-designer/src/components/App.tsx
+++ b/protocol-designer/src/components/App.tsx
@@ -4,7 +4,7 @@ import { ProtocolEditor } from './ProtocolEditor'
 
 import '../css/reset.css'
 
-export function App(): React.Node {
+export function App(): JSX.Element {
   return (
     <div className="container">
       <ProtocolEditor />

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
@@ -36,7 +36,7 @@ type BatchEditMixProps = {
   handleCancel: () => mixed
   handleSave: () => mixed
 }
-export const BatchEditMix = (props: BatchEditMixProps): React.Node => {
+export const BatchEditMix = (props: BatchEditMixProps): JSX.Element => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -34,7 +34,7 @@ import buttonStyles from '../StepEditForm/ButtonRow/styles.css'
 const SourceDestBatchEditMoveLiquidFields = (props: {
   prefix: 'aspirate' | 'dispense'
   propsForFields: FieldPropsByName
-}): React.Node => {
+}): React.ReactNode => {
   const { prefix, propsForFields } = props
   const addFieldNamePrefix = name => `${prefix}_${name}`
 
@@ -159,7 +159,7 @@ type BatchEditMoveLiquidProps = {
 }
 export const BatchEditMoveLiquid = (
   props: BatchEditMoveLiquidProps
-): React.Node => {
+): React.ReactNode => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -34,7 +34,7 @@ import buttonStyles from '../StepEditForm/ButtonRow/styles.css'
 const SourceDestBatchEditMoveLiquidFields = (props: {
   prefix: 'aspirate' | 'dispense'
   propsForFields: FieldPropsByName
-}): React.ReactNode => {
+}): JSX.Element => {
   const { prefix, propsForFields } = props
   const addFieldNamePrefix = name => `${prefix}_${name}`
 
@@ -159,7 +159,7 @@ type BatchEditMoveLiquidProps = {
 }
 export const BatchEditMoveLiquid = (
   props: BatchEditMoveLiquidProps
-): React.ReactNode => {
+): JSX.Element => {
   const { propsForFields, handleCancel, handleSave } = props
   const [cancelButtonTargetProps, cancelButtonTooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,

--- a/protocol-designer/src/components/BatchEditForm/FormColumn.tsx
+++ b/protocol-designer/src/components/BatchEditForm/FormColumn.tsx
@@ -5,10 +5,10 @@ import { Box } from '@opentrons/components'
 import styles from '../StepEditForm/StepEditForm.css'
 
 export type FormColumnProps = {
-  children?: React.Node
-  sectionHeader?: React.Node
+  children?: React.ReactNode
+  sectionHeader?: React.ReactNode
 }
-export const FormColumn = (props: FormColumnProps): React.Node => {
+export const FormColumn = (props: FormColumnProps): JSX.Element => {
   return (
     <Box className={styles.section_column}>
       <Box className={styles.section_header}>

--- a/protocol-designer/src/components/BatchEditForm/NoBatchEditSharedSettings.tsx
+++ b/protocol-designer/src/components/BatchEditForm/NoBatchEditSharedSettings.tsx
@@ -10,7 +10,7 @@ import {
 } from '@opentrons/components'
 import { i18n } from '../../localization'
 
-export const NoBatchEditSharedSettings = (): React.Node => {
+export const NoBatchEditSharedSettings = (): JSX.Element => {
   return (
     <Flex
       justifyContent={JUSTIFY_CENTER}

--- a/protocol-designer/src/components/BatchEditForm/index.tsx
+++ b/protocol-designer/src/components/BatchEditForm/index.tsx
@@ -21,7 +21,7 @@ import { BatchEditMix } from './BatchEditMix'
 
 export type BatchEditFormProps = {}
 
-export const BatchEditForm = (props: BatchEditFormProps): React.Node => {
+export const BatchEditForm = (props: BatchEditFormProps): JSX.Element => {
   const dispatch = useDispatch()
   const fieldValues = useSelector(getMultiSelectFieldValues)
   const stepTypes = useSelector(getBatchEditSelectedStepTypes)

--- a/protocol-designer/src/components/ComputingSpinner.tsx
+++ b/protocol-designer/src/components/ComputingSpinner.tsx
@@ -9,7 +9,7 @@ const waitCursorStyle = css`
   cursor: wait;
 `
 
-export const ComputingSpinner = (): React.Node => {
+export const ComputingSpinner = (): JSX.Element  => {
   const showSpinner = useSelector(fileDataSelectors.getTimelineIsBeingComputed)
 
   return (

--- a/protocol-designer/src/components/ComputingSpinner.tsx
+++ b/protocol-designer/src/components/ComputingSpinner.tsx
@@ -9,7 +9,7 @@ const waitCursorStyle = css`
   cursor: wait;
 `
 
-export const ComputingSpinner = (): JSX.Element  => {
+export const ComputingSpinner = (): JSX.Element | boolean => {
   const showSpinner = useSelector(fileDataSelectors.getTimelineIsBeingComputed)
 
   return (

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
@@ -160,7 +160,7 @@ export const getSwapBlocked = (args: {
 
 // TODO IL 2020-01-12: to support dynamic labware/module movement during a protocol,
 // don't use initialDeckSetup here. Use some version of timelineFrameForActiveItem
-export const DeckSetupContents = (props: ContentsProps): React.Node => {
+export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
   const {
     initialDeckSetup,
     deckSlotsById,
@@ -354,7 +354,7 @@ const getHasGen1MultiChannelPipette = (
   )
 }
 
-export const DeckSetup = (props: Props): React.Node => {
+export const DeckSetup = (props: Props): JSX.Element => {
   const _disableCollisionWarnings = useSelector(
     featureFlagSelectors.getDisableModuleRestrictions
   )
@@ -401,7 +401,7 @@ export const DeckSetup = (props: Props): React.Node => {
   )
 }
 
-export const NullDeckState = (): React.Node => {
+export const NullDeckState = (): JSX.Element => {
   const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
 
   return (

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/BlockedSlot.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/BlockedSlot.tsx
@@ -16,7 +16,7 @@ type Props = {
   message: BlockedSlotMessage
 }
 
-export const BlockedSlot = (props: Props): React.Node => {
+export const BlockedSlot = (props: Props): JSX.Element => {
   const { x, y, width, height, message } = props
   return (
     <g>

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
@@ -38,8 +38,8 @@ type DP = {
 type DNDP = {
   draggedLabware: LabwareOnDeck | null | undefined
   isOver: boolean
-  connectDragSource: (val: React.Node) => React.Node
-  connectDropTarget: (val: React.Node) => React.Node
+  connectDragSource: (val: React.ReactNode) => React.ReactNode
+  connectDropTarget: (val: React.ReactNode) => React.ReactNode
 }
 
 type Props = OP & SP & DP & DNDP
@@ -69,7 +69,7 @@ const EditLabwareComponent = (props: Props) => {
   } else {
     const isBeingDragged = draggedLabware?.slot === labwareOnDeck.slot
 
-    let contents: React.Node = null
+    let contents: React.ReactNode = null
 
     if (swapBlocked) {
       contents = null

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/EditLabware.tsx
@@ -69,7 +69,7 @@ const EditLabwareComponent = (props: Props) => {
   } else {
     const isBeingDragged = draggedLabware?.slot === labwareOnDeck.slot
 
-    let contents: React.ReactNode = null
+    let contents: React.ReactNode | null = null
 
     if (swapBlocked) {
       contents = null

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareControls.tsx
@@ -22,7 +22,7 @@ type LabwareControlsProps = {
   swapBlocked: boolean
 }
 
-export const LabwareControls = (props: LabwareControlsProps): React.Node => {
+export const LabwareControls = (props: LabwareControlsProps): JSX.Element => {
   const {
     labwareOnDeck,
     slot,

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
@@ -14,7 +14,7 @@ type LabwareHighlightProps = {
   labwareOnDeck: LabwareOnDeck
 }
 
-export const LabwareHighlight = (props: LabwareHighlightProps): React.Node => {
+export const LabwareHighlight = (props: LabwareHighlightProps): JSX.Element => {
   const { labwareOnDeck } = props
   const highlighted = useSelector(getHoveredStepLabware).includes(
     labwareOnDeck.id

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -31,7 +31,7 @@ import styles from './LabwareOverlays.css'
 
 type DNDP = {
   isOver: boolean
-  connectDropTarget: (val: React.Node) => React.Node
+  connectDropTarget: (val: React.ReactNode) => React.ReactNode
   draggedItem: ?{ labwareOnDeck: LabwareOnDeck }
   itemType: string
 }
@@ -50,7 +50,7 @@ type SP = {
 }
 type Props = OP & DP & DNDP & SP
 
-export const SlotControlsComponent = (props: Props): React.Node => {
+export const SlotControlsComponent = (props: Props): JSX.Element => {
   const {
     slot,
     addLabware,

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
@@ -68,7 +68,7 @@ export const ModuleStatus = ({
   moduleState,
 }: {
   moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>
-}): React.Node => {
+}): React.ReactNode => {
   switch (moduleState.type) {
     case MAGNETIC_MODULE_TYPE:
       return (

--- a/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleTag.tsx
@@ -68,7 +68,7 @@ export const ModuleStatus = ({
   moduleState,
 }: {
   moduleState: $PropertyType<ModuleTemporalProperties, 'moduleState'>
-}): React.ReactNode => {
+}): JSX.Element | null => {
   switch (moduleState.type) {
     case MAGNETIC_MODULE_TYPE:
       return (

--- a/protocol-designer/src/components/DeckSetup/ModuleViz.tsx
+++ b/protocol-designer/src/components/DeckSetup/ModuleViz.tsx
@@ -13,7 +13,7 @@ type Props = {
   slotName: string
 }
 
-export const ModuleViz = (props: Props): React.Node => {
+export const ModuleViz = (props: Props): JSX.Element => {
   const moduleType = props.module.type
   const {
     xOffset,

--- a/protocol-designer/src/components/DeckSetup/SlotWarning.tsx
+++ b/protocol-designer/src/components/DeckSetup/SlotWarning.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 const OVERHANG = 60
 
-export const SlotWarning = (props: Props): React.Node => {
+export const SlotWarning = (props: Props): JSX.Element => {
   const { x, y, xDimension, yDimension, orientation, warningType } = props
   const rectXOffset = orientation === 'left' ? -OVERHANG : 0
   const textXOffset = orientation === 'left' ? -1 * OVERHANG : xDimension

--- a/protocol-designer/src/components/DeckSetupManager.tsx
+++ b/protocol-designer/src/components/DeckSetupManager.tsx
@@ -8,7 +8,7 @@ import {
 import { DeckSetup } from './DeckSetup'
 import { NullDeckState } from './DeckSetup/DeckSetup'
 
-export const DeckSetupManager = (): React.Node => {
+export const DeckSetupManager = (): JSX.Element => {
   const batchEditSelectedStepTypes = useSelector(getBatchEditSelectedStepTypes)
   const hoveredItem = useSelector(getHoveredItem)
 

--- a/protocol-designer/src/components/EditModules.tsx
+++ b/protocol-designer/src/components/EditModules.tsx
@@ -24,7 +24,7 @@ export type ModelModuleInfo = {
   slot: string
 }
 
-export const EditModules = (props: EditModulesProps): React.Node => {
+export const EditModules = (props: EditModulesProps): JSX.Element => {
   const { onCloseClick, moduleToEdit } = props
   const { moduleId, moduleType } = moduleToEdit
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)

--- a/protocol-designer/src/components/EditableTextField.tsx
+++ b/protocol-designer/src/components/EditableTextField.tsx
@@ -55,7 +55,7 @@ export class EditableTextField extends React.Component<Props, State> {
     this.setState({ transientValue: e.currentTarget.value })
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const { className, value } = this.props
     if (this.state.editing) {
       return (

--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -78,7 +78,7 @@ export class FilePage extends React.Component<Props, State> {
     })
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const {
       formValues,
       instruments,

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -38,7 +38,7 @@ type Props = {
 }
 
 type WarningContent = {
-  content: React.Node
+  content: React.ReactNode
   heading: string
 }
 
@@ -134,7 +134,7 @@ function getWarningContent({
   return null
 }
 
-export const v4WarningContent: React.Node = (
+export const v4WarningContent: JSX.Element = (
   <div>
     <p>
       {i18n.t(`alert.hint.export_v4_protocol_3_18.body1`)}{' '}
@@ -144,7 +144,7 @@ export const v4WarningContent: React.Node = (
   </div>
 )
 
-export const v5WarningContent: React.Node = (
+export const v5WarningContent: JSX.Element = (
   <div>
     <p>
       {i18n.t(`alert.hint.export_v5_protocol_3_20.body1`)}{' '}
@@ -154,7 +154,7 @@ export const v5WarningContent: React.Node = (
   </div>
 )
 
-export function FileSidebar(props: Props): React.Node {
+export function FileSidebar(props: Props): JSX.Element {
   const {
     canDownload,
     fileData,
@@ -200,7 +200,7 @@ export function FileSidebar(props: Props): React.Node {
 
   const getExportHintContent = (): {
     hintKey: HintKey
-    content: React.Node
+    content: React.ReactNode
   } => {
     return {
       hintKey:

--- a/protocol-designer/src/components/FormManager/index.tsx
+++ b/protocol-designer/src/components/FormManager/index.tsx
@@ -7,7 +7,7 @@ import { BatchEditForm } from '../BatchEditForm'
 import { StepSelectionBanner } from '../StepSelectionBanner'
 import { getIsMultiSelectMode } from '../../ui/steps/selectors'
 
-export const FormManager = (): React.Node => {
+export const FormManager = (): JSX.Element => {
   const isMultiSelectMode = useSelector(getIsMultiSelectMode)
 
   if (isMultiSelectMode) {

--- a/protocol-designer/src/components/Hints/useBlockingHint.tsx
+++ b/protocol-designer/src/components/Hints/useBlockingHint.tsx
@@ -15,11 +15,11 @@ export type HintProps = {
   hintKey: HintKey
   handleCancel: () => mixed
   handleContinue: () => mixed
-  content: React.Node
+  content: React.ReactNode
 }
 
 // This component handles the checkbox and dispatching `removeHint` action on continue/cancel
-export const BlockingHint = (props: HintProps): React.Node => {
+export const BlockingHint = (props: HintProps): JSX.Element => {
   const { hintKey, handleCancel, handleContinue } = props
   const dispatch = useDispatch()
 
@@ -69,12 +69,12 @@ export type HintArgs = {
    * useBlockingHint expects the parent to disable the hint on cancel/continue */
   enabled: boolean
   hintKey: HintKey
-  content: React.Node
+  content: React.ReactNode
   handleCancel: () => mixed
   handleContinue: () => mixed
 }
 
-export const useBlockingHint = (args: HintArgs): React.Node => {
+export const useBlockingHint = (args: HintArgs): JSX.Element => {
   const { enabled, hintKey, handleCancel, handleContinue, content } = args
   const isDismissed = useSelector(selectors.getDismissedHints).includes(hintKey)
 

--- a/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/LabwareDetailsCard.tsx
+++ b/protocol-designer/src/components/IngredientsList/LabwareDetailsCard/LabwareDetailsCard.tsx
@@ -12,7 +12,7 @@ type Props = {
   renameLabware: (name: string) => mixed
 }
 
-export function LabwareDetailsCard(props: Props): React.Node {
+export function LabwareDetailsCard(props: Props): JSX.Element {
   return (
     <PDTitledList title="labware details" iconName="flask-outline">
       <PDListItem>

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -30,7 +30,7 @@ type LiquidGroupCardProps = CommonProps & {
   labwareWellContents: SingleLabwareLiquidState
 }
 
-const LiquidGroupCard = (props: LiquidGroupCardProps): React.Node => {
+const LiquidGroupCard = (props: LiquidGroupCardProps): React.ReactNode => {
   const {
     ingredGroup,
     removeWellsContents,
@@ -149,7 +149,7 @@ type Props = CommonProps & {
   selectedIngredientGroupId: string | null | undefined
 }
 
-export function IngredientsList(props: Props): React.Node {
+export function IngredientsList(props: Props): JSX.Element {
   const {
     labwareWellContents,
     liquidGroupsById,

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -30,7 +30,7 @@ type LiquidGroupCardProps = CommonProps & {
   labwareWellContents: SingleLabwareLiquidState
 }
 
-const LiquidGroupCard = (props: LiquidGroupCardProps): React.ReactNode => {
+const LiquidGroupCard = (props: LiquidGroupCardProps): JSX.Element => {
   const {
     ingredGroup,
     removeWellsContents,

--- a/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
@@ -22,12 +22,12 @@ type Link = $Keys<typeof links>
 
 type Props = {
   to: Link
-  children: React.Node
+  children: React.ReactNode
   className: string | null | undefined
 }
 
 /** Link which opens a page on the knowledge base to a new tab/window */
-export function KnowledgeBaseLink(props: Props): React.Node {
+export function KnowledgeBaseLink(props: Props): JSX.Element {
   return (
     <a
       target="_blank"

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareItem.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareItem.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 const LABWARE_LIBRARY_PAGE_PATH = 'https://labware.opentrons.com'
 
-export function LabwareItem(props: Props): React.Node {
+export function LabwareItem(props: Props): JSX.Element {
   const {
     disabled,
     icon,

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwarePreview.tsx
@@ -24,7 +24,7 @@ type Props = {
     | null
 }
 
-export const LabwarePreview = (props: Props): React.Node => {
+export const LabwarePreview = (props: Props): JSX.Element => {
   const { labwareDef, moduleCompatibility } = props
   if (!labwareDef) return null
   const maxVolumes = reduce(

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -84,7 +84,7 @@ export const getLabwareIsRecommended = (
       )
     : false
 
-export const LabwareSelectionModal = (props: Props): React.Node => {
+export const LabwareSelectionModal = (props: Props): JSX.Element => {
   const {
     customLabwareDefs,
     permittedTipracks,

--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
@@ -105,7 +105,7 @@ export class LiquidPlacementForm extends React.Component<Props> {
     this.props.saveForm(values)
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const { liquidSelectionOptions, showForm } = this.props
     if (!showForm) return null
     return (

--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
@@ -105,7 +105,7 @@ export class LiquidPlacementForm extends React.Component<Props> {
     this.props.saveForm(values)
   }
 
-  render(): React.ReactNode {
+  render(): React.ReactNode | null {
     const { liquidSelectionOptions, showForm } = this.props
     if (!showForm) return null
     return (

--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -44,7 +44,7 @@ export const liquidEditFormSchema: Yup.Schema<
   serialize: Yup.boolean(),
 })
 
-export function LiquidEditForm(props: Props): React.Node {
+export function LiquidEditForm(props: Props): JSX.Element {
   const { deleteLiquidGroup, cancelForm, canDelete, saveForm } = props
 
   const initialValues: LiquidEditFormValues = {

--- a/protocol-designer/src/components/LiquidsPage/LiquidsPageInfo.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidsPageInfo.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Icon } from '@opentrons/components'
 import styles from './LiquidsPageInfo.css'
 
-export function LiquidsPageInfo(): React.Node {
+export function LiquidsPageInfo(): JSX.Element {
   return (
     <div className={styles.info_wrapper}>
       <h2 className={styles.header}>Define your liquids</h2>

--- a/protocol-designer/src/components/PrereleaseModeIndicator.tsx
+++ b/protocol-designer/src/components/PrereleaseModeIndicator.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { Icon } from '@opentrons/components'
 import { selectors as featureFlagSelectors } from '../feature-flags'
 
-export const PrereleaseModeIndicator = (): React.Node => {
+export const PrereleaseModeIndicator = (): JSX.Element => {
   const prereleaseModeEnabled = useSelector(
     featureFlagSelectors.getEnabledPrereleaseMode
   )

--- a/protocol-designer/src/components/SelectionRect.tsx
+++ b/protocol-designer/src/components/SelectionRect.tsx
@@ -8,7 +8,7 @@ type Props = {
   onSelectionMove?: (e: MouseEvent, GenericRect) => mixed
   onSelectionDone?: (e: MouseEvent, GenericRect) => mixed
   svg?: boolean // set true if this is an embedded SVG
-  children?: React.Node
+  children?: React.ReactNode
   originXOffset?: number
   originYOffset?: number
 }
@@ -27,7 +27,7 @@ export class SelectionRect extends React.Component<Props, State> {
     this.state = { positions: null }
   }
 
-  renderRect(args: DragRect): React.Node {
+  renderRect(args: DragRect): React.ReactNode {
     const { xStart, yStart, xDynamic, yDynamic } = args
     const left = Math.min(xStart, xDynamic)
     const top = Math.min(yStart, yDynamic)
@@ -136,7 +136,7 @@ export class SelectionRect extends React.Component<Props, State> {
       this.props.onSelectionDone(e, finalRect)
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const { svg, children } = this.props
 
     return svg ? (

--- a/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.tsx
+++ b/protocol-designer/src/components/SettingsPage/FeatureFlagCard/FeatureFlagCard.tsx
@@ -18,7 +18,7 @@ type Props = {
   setFeatureFlags: (flags: Flags) => mixed,
 }
 
-export const FeatureFlagCard = (props: Props): React.Node => {
+export const FeatureFlagCard = (props: Props): JSX.Element => {
   const [modalFlagName, setModalFlagName] = React.useState<FlagTypes | null>(
     null
   )
@@ -35,8 +35,8 @@ export const FeatureFlagCard = (props: Props): React.Node => {
     flagName => !userFacingFlags.includes(flagName)
   )
 
-  const getDescription = (flag: FlagTypes): React.Node => {
-    const RICH_DESCRIPTIONS: { [FlagTypes]: React.Node } = {
+  const getDescription = (flag: FlagTypes): JSX.Element => {
+    const RICH_DESCRIPTIONS: { [FlagTypes]: JSX.Element } = {
       OT_PD_DISABLE_MODULE_RESTRICTIONS: (
         <>
           <p>{i18n.t(`feature_flags.${flag}.description_1`)} </p>

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -48,7 +48,7 @@ const getSupportedSteps = () => [
 
 export const StepCreationButtonComponent = (
   props: StepButtonComponentProps
-): React.ReactNode => {
+): JSX.Element => {
   const { children, expanded, setExpanded, disabled } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,

--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -30,7 +30,7 @@ import { stepIconsByType, StepType } from '../form-types'
 import styles from './listButtons.css'
 
 type StepButtonComponentProps = {
-  children: React.Node,
+  children: React.ReactNode,
   expanded: boolean,
   disabled: boolean,
   setExpanded: (expanded: boolean) => unknown,
@@ -48,7 +48,7 @@ const getSupportedSteps = () => [
 
 export const StepCreationButtonComponent = (
   props: StepButtonComponentProps
-): React.Node => {
+): React.ReactNode => {
   const { children, expanded, setExpanded, disabled } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,
@@ -84,7 +84,7 @@ export type StepButtonItemProps = {
   stepType: StepType,
 }
 
-export function StepButtonItem(props: StepButtonItemProps): React.Node {
+export function StepButtonItem(props: StepButtonItemProps): JSX.Element {
   const { onClick, disabled, stepType } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_RIGHT,
@@ -110,7 +110,7 @@ export function StepButtonItem(props: StepButtonItemProps): React.Node {
   )
 }
 
-export const StepCreationButton = (): React.Node => {
+export const StepCreationButton = (): JSX.Element => {
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
   )

--- a/protocol-designer/src/components/StepEditForm/ButtonRow/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/ButtonRow/index.tsx
@@ -15,7 +15,7 @@ type ButtonRowProps = {
   canSave: boolean
 }
 
-export const ButtonRow = (props: ButtonRowProps): React.Node => {
+export const ButtonRow = (props: ButtonRowProps): JSX.Element => {
   const {
     handleDelete,
     handleClickMoreOptions,

--- a/protocol-designer/src/components/StepEditForm/StepEditFormComponent.tsx
+++ b/protocol-designer/src/components/StepEditForm/StepEditFormComponent.tsx
@@ -43,7 +43,7 @@ type Props = {
   toggleMoreOptionsModal: () => mixed
 }
 
-export const StepEditFormComponent = (props: Props): React.Node => {
+export const StepEditFormComponent = (props: Props): JSX.Element => {
   const {
     formData,
     focusHandlers,

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
@@ -14,7 +14,7 @@ type BlowoutLocationDropdownProps = FieldProps & {
 
 export const BlowoutLocationField = (
   props: BlowoutLocationDropdownProps
-): React.Node => {
+): React.ReactNode => {
   const {
     className,
     disabled,

--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutLocationField.tsx
@@ -14,7 +14,7 @@ type BlowoutLocationDropdownProps = FieldProps & {
 
 export const BlowoutLocationField = (
   props: BlowoutLocationDropdownProps
-): React.ReactNode => {
+): JSX.Element => {
   const {
     className,
     disabled,

--- a/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/index.tsx
@@ -25,7 +25,7 @@ const ALL_CHANGE_TIP_VALUES: ChangeTipOptions[] = [
 ]
 type Props = FieldProps & DisabledChangeTipArgs
 
-export const ChangeTipField = (props: Props): React.Node => {
+export const ChangeTipField = (props: Props): JSX.Element => {
   const {
     aspirateWells,
     dispenseWells,

--- a/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/CheckboxRowField.tsx
@@ -11,13 +11,13 @@ import styles from '../StepEditForm.css'
 import { FieldProps } from '../types'
 
 type CheckboxRowProps = FieldProps & {
-  children?: React.Node,
+  children?: React.ReactNode,
   className?: string,
   label?: string,
-  tooltipContent?: React.Node,
+  tooltipContent?: React.ReactNode,
 }
 
-export const CheckboxRowField = (props: CheckboxRowProps): React.Node => {
+export const CheckboxRowField = (props: CheckboxRowProps): JSX.Element => {
   const {
     children,
     className,

--- a/protocol-designer/src/components/StepEditForm/fields/DelayFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DelayFields.tsx
@@ -16,7 +16,7 @@ export type DelayFieldProps = {
   tipPositionFieldName?: StepFieldName // TODO(IL, 2021-03-03): strictly, could be TipOffsetFields!
 }
 
-export const DelayFields = (props: DelayFieldProps): React.Node => {
+export const DelayFields = (props: DelayFieldProps): JSX.Element => {
   const {
     checkboxFieldName,
     secondsFieldName,

--- a/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/FlowRateField/FlowRateInput.tsx
@@ -35,7 +35,7 @@ type State = {
   showModal: boolean
 }
 
-export const FlowRateInput = (props: FlowRateInputProps): React.Node => {
+export const FlowRateInput = (props: FlowRateInputProps): JSX.Element => {
   const {
     className,
     defaultFlowRate,

--- a/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
@@ -10,7 +10,7 @@ export const MixFields = (props: {
   checkboxFieldName: string
   volumeFieldName: string
   timesFieldName: string
-}): React.Node => {
+}): React.ReactNode => {
   const {
     propsForFields,
     checkboxFieldName,

--- a/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/MixFields.tsx
@@ -10,7 +10,7 @@ export const MixFields = (props: {
   checkboxFieldName: string
   volumeFieldName: string
   timesFieldName: string
-}): React.ReactNode => {
+}): JSX.Element => {
   const {
     propsForFields,
     checkboxFieldName,

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/Path.tsx
@@ -38,7 +38,7 @@ type PathFieldProps = FieldProps &
   }
 
 type ButtonProps = {
-  children?: React.Node
+  children?: React.ReactNode
   disabled: boolean
   id?: string
   selected: boolean
@@ -103,7 +103,7 @@ const getSubtitle = (
   return reasonForDisabled || ''
 }
 
-export const Path = (props: PathFieldProps): React.Node => {
+export const Path = (props: PathFieldProps): JSX.Element => {
   const { disabledPathMap, value, updateValue } = props
   return (
     <FormGroup label="Path">

--- a/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ProfileItemRows.tsx
@@ -48,7 +48,7 @@ type ProfileCycleRowProps = {
   focusHandlers: FocusHandlers
   stepOffset: number
 }
-export const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
+export const ProfileCycleRow = (props: ProfileCycleRowProps): JSX.Element => {
   const { cycleItem, focusHandlers, stepOffset } = props
   const dispatch = useDispatch()
 
@@ -147,7 +147,7 @@ export type ProfileItemRowsProps = {
   }
 }
 
-export const ProfileItemRows = (props: ProfileItemRowsProps): React.Node => {
+export const ProfileItemRows = (props: ProfileItemRowsProps): JSX.Element => {
   const { orderedProfileItems, profileItemsById } = props
 
   const dispatch = useDispatch()
@@ -233,7 +233,7 @@ type ProfileFieldProps = {
   name: string
   focusHandlers: FocusHandlers
   profileItem: ProfileItem
-  units?: React.Node
+  units?: React.ReactNode
   className?: string
   updateValue: (name: string, value: mixed) => mixed
 }

--- a/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/RadioGroupField.tsx
@@ -10,7 +10,7 @@ type RadioGroupFieldProps = FieldProps & {
   className?: string
 }
 
-export const RadioGroupField = (props: RadioGroupFieldProps): React.Node => {
+export const RadioGroupField = (props: RadioGroupFieldProps): JSX.Element => {
   const {
     className,
     disabled, // NOTE: not used

--- a/protocol-designer/src/components/StepEditForm/fields/StepFormDropdownField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/StepFormDropdownField.tsx
@@ -12,7 +12,7 @@ export type StepFormDropdownProps = FieldProps & {
   className?: string
 }
 
-export const StepFormDropdown = (props: StepFormDropdownProps): React.Node => {
+export const StepFormDropdown = (props: StepFormDropdownProps): JSX.Element => {
   const {
     options,
     name,

--- a/protocol-designer/src/components/StepEditForm/fields/TextField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TextField.tsx
@@ -9,7 +9,7 @@ type TextFieldProps = FieldProps & {
   units: string | null | undefined
 }
 
-export const TextField = (props: TextFieldProps): React.Node => {
+export const TextField = (props: TextFieldProps): JSX.Element => {
   const {
     errorToShow,
     onFieldBlur,

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -88,7 +88,7 @@ const getErrors = (args: {
   return errors
 }
 
-export const TipPositionModal = (props: Props): React.Node => {
+export const TipPositionModal = (props: Props): JSX.Element => {
   const { isIndeterminate, name, wellDepthMm } = props
 
   const defaultMmFromBottom = utils.getDefaultMmFromBottom({

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
@@ -14,7 +14,7 @@ type Props = {
   wellDepthMm: number
 }
 
-export const TipPositionZAxisViz = (props: Props): React.Node => {
+export const TipPositionZAxisViz = (props: Props): JSX.Element => {
   const fractionOfWellHeight = props.mmFromBottom / props.wellDepthMm
   const pixelsFromBottom =
     Number(fractionOfWellHeight) * WELL_HEIGHT_PIXELS - WELL_HEIGHT_PIXELS

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
@@ -107,7 +107,7 @@ function TipPositionInput(props: Props) {
 type WrapperProps = {
   isTouchTipField: boolean,
   isDelayPositionField: boolean,
-  children: React.Node,
+  children: React.ReactNode,
   disabled: boolean,
   targetProps: $ElementType<UseHoverTooltipResult, 0>,
 }

--- a/protocol-designer/src/components/StepEditForm/fields/ToggleRowField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/ToggleRowField.tsx
@@ -13,7 +13,7 @@ type ToggleRowProps = FieldProps & {
   onLabel?: string,
   className?: string,
 }
-export const ToggleRowField = (props: ToggleRowProps): React.Node => {
+export const ToggleRowField = (props: ToggleRowProps): JSX.Element => {
   const {
     updateValue,
     value,

--- a/protocol-designer/src/components/StepEditForm/fields/VolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/VolumeField.tsx
@@ -19,7 +19,7 @@ type Props = FieldProps & {
   label: string,
   className: string,
 }
-export const VolumeField = (props: Props): React.Node => {
+export const VolumeField = (props: Props): JSX.Element => {
   const { stepType, label, className, ...propsForVolumeField } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: TOOLTIP_TOP,

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
@@ -44,13 +44,13 @@ type State = {
   secondValue: WellOrderOption,
 }
 
-export const ResetButton = (props: { onClick: () => void }): React.Node => (
+export const ResetButton = (props: { onClick: () => void }): JSX.Element => (
   <OutlineButton className={modalStyles.button_medium} onClick={props.onClick}>
     {i18n.t('button.reset')}
   </OutlineButton>
 )
 
-export const CancelButton = (props: { onClick: () => void }): React.Node => (
+export const CancelButton = (props: { onClick: () => void }): JSX.Element => (
   <PrimaryButton
     className={cx(modalStyles.button_medium, modalStyles.button_right_of_break)}
     onClick={props.onClick}
@@ -59,7 +59,7 @@ export const CancelButton = (props: { onClick: () => void }): React.Node => (
   </PrimaryButton>
 )
 
-export const DoneButton = (props: { onClick: () => void }): React.Node => (
+export const DoneButton = (props: { onClick: () => void }): JSX.Element => (
   <PrimaryButton className={modalStyles.button_medium} onClick={props.onClick}>
     {i18n.t('button.done')}
   </PrimaryButton>
@@ -159,7 +159,7 @@ export class WellOrderModal extends React.Component<Props, State> {
     }
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     if (!this.props.isOpen) return null
 
     const { firstValue, secondValue } = this.state

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderModal.tsx
@@ -159,7 +159,7 @@ export class WellOrderModal extends React.Component<Props, State> {
     }
   }
 
-  render(): React.ReactNode {
+  render(): React.ReactNode | null {
     if (!this.props.isOpen) return null
 
     const { firstValue, secondValue } = this.state

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/WellOrderViz.tsx
@@ -14,7 +14,7 @@ type Props = {
   secondValue: WellOrderOption
 }
 
-export const WellOrderViz = (props: Props): React.Node => {
+export const WellOrderViz = (props: Props): JSX.Element => {
   const { firstValue, secondValue } = props
 
   return (

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
@@ -31,7 +31,7 @@ type Props = {
   updateSecondWellOrder: $PropertyType<FieldProps, 'updateValue'>
 }
 
-export const WellOrderField = (props: Props): React.Node => {
+export const WellOrderField = (props: Props): JSX.Element => {
   const {
     firstValue,
     secondValue,

--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionModal.tsx
@@ -109,7 +109,7 @@ const WellSelectionModalComponent = (
 
 export const WellSelectionModal = (
   props: WellSelectionModalProps
-): React.Node => {
+): React.ReactNode => {
   const { isOpen, labwareId, onCloseClick, pipetteId } = props
   const wellFieldData = props.value
 

--- a/protocol-designer/src/components/StepEditForm/forms/AspDispSection.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/AspDispSection.tsx
@@ -9,10 +9,10 @@ type Props = {
   collapsed: boolean | null | undefined
   toggleCollapsed: () => void
   prefix: 'aspirate' | 'dispense'
-  children?: React.Node
+  children?: React.ReactNode
 }
 
-export const AspDispSection = (props: Props): React.Node => {
+export const AspDispSection = (props: Props): JSX.Element => {
   const { children, className, collapsed, toggleCollapsed, prefix } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
   return (

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.tsx
@@ -13,7 +13,7 @@ import styles from '../StepEditForm.css'
 
 import { StepFormProps } from '../types'
 
-export const MagnetForm = (props: StepFormProps): React.Node => {
+export const MagnetForm = (props: StepFormProps): JSX.Element => {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getMagneticLabwareOptions
   )

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
@@ -27,7 +27,7 @@ import { StepFormProps } from '../types'
 
 import styles from '../StepEditForm.css'
 
-export const MixForm = (props: StepFormProps): React.Node => {
+export const MixForm = (props: StepFormProps): JSX.Element => {
   const [collapsed, setCollapsed] = React.useState(true)
 
   const { propsForFields, formData } = props

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -33,7 +33,7 @@ const makeAddFieldNamePrefix = (prefix: string) => (
   fieldName: string
 ): StepFieldName => `${prefix}_${fieldName}`
 
-export const SourceDestFields = (props: Props): React.Node => {
+export const SourceDestFields = (props: Props): JSX.Element => {
   const { className, formData, prefix, propsForFields } = props
 
   const addFieldNamePrefix = makeAddFieldNamePrefix(prefix)

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
@@ -23,7 +23,7 @@ const makeAddFieldNamePrefix = (prefix: string) => (
   fieldName: string
 ): StepFieldName => `${prefix}_${fieldName}`
 
-export const SourceDestHeaders = (props: Props): React.Node => {
+export const SourceDestHeaders = (props: Props): JSX.Element => {
   const {
     className,
     collapsed,

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
@@ -17,7 +17,7 @@ import { SourceDestHeaders } from './SourceDestHeaders'
 // TODO: BC 2019-01-25 instead of passing path from here, put it in connect fields where needed
 // or question if it even needs path
 
-export const MoveLiquidForm = (props: StepFormProps): React.Node => {
+export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
   const [collapsed, _setCollapsed] = React.useState<boolean>(true)
 
   const toggleCollapsed = () => _setCollapsed(!collapsed)

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
@@ -23,7 +23,7 @@ import styles from '../StepEditForm.css'
 
 import { StepFormProps } from '../types'
 
-export const PauseForm = (props: StepFormProps): React.Node => {
+export const PauseForm = (props: StepFormProps): JSX.Element => {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
@@ -9,7 +9,7 @@ import { StepFormDropdown, RadioGroupField, TextField } from '../fields'
 import styles from '../StepEditForm.css'
 import { StepFormProps } from '../types'
 
-export const TemperatureForm = (props: StepFormProps): React.Node => {
+export const TemperatureForm = (props: StepFormProps): JSX.Element => {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
@@ -11,7 +11,7 @@ import { FieldPropsByName } from '../../types'
 
 type Props = { propsForFields: FieldPropsByName }
 
-export const ProfileSettings = (props: Props): React.Node => {
+export const ProfileSettings = (props: Props): JSX.Element => {
   const { propsForFields } = props
 
   return (

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/StateFields.tsx
@@ -16,7 +16,7 @@ type Props = {
   formData: FormData
 }
 
-export const StateFields = (props: Props): React.Node => {
+export const StateFields = (props: Props): JSX.Element => {
   const { isEndingHold, propsForFields, formData } = props
 
   // Append 'Hold' to field names if component is used for an ending hold in a TC profile

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.tsx
@@ -13,7 +13,7 @@ import { ProfileSettings } from './ProfileSettings'
 import styles from '../../StepEditForm.css'
 import { StepFormProps } from '../../types'
 
-export const ThermocyclerForm = (props: StepFormProps): React.Node => {
+export const ThermocyclerForm = (props: StepFormProps): JSX.Element => {
   const { focusHandlers, propsForFields, formData } = props
 
   return (

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
@@ -46,7 +46,7 @@ const stepPillStyles = css`
   }
 `
 
-const StepPill = (props: StepPillProps): React.ReactNode => {
+const StepPill = (props: StepPillProps): JSX.Element => {
   const { count, stepType } = props
   const label = `${startCase(
     i18n.t(`application.stepType.${stepType}`)
@@ -63,7 +63,7 @@ export const ExitBatchEditButton = (props: {
     StepSelectionBannerProps,
     'handleExitBatchEdit'
   >
-}): React.ReactNode => (
+}): JSX.Element => (
   <Box flex="0 1 auto">
     <SecondaryBtn
       color={C_WHITE}
@@ -82,7 +82,7 @@ export type StepSelectionBannerProps = {
 
 export const StepSelectionBannerComponent = (
   props: StepSelectionBannerProps
-): React.ReactNode => {
+): JSX.Element => {
   const { countPerStepType, handleExitBatchEdit } = props
   const numSteps = Object.keys(countPerStepType).reduce<number>(
     (acc, stepType) => acc + countPerStepType[stepType],

--- a/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
+++ b/protocol-designer/src/components/StepSelectionBanner/StepSelectionBannerComponent.tsx
@@ -46,7 +46,7 @@ const stepPillStyles = css`
   }
 `
 
-const StepPill = (props: StepPillProps): React.Node => {
+const StepPill = (props: StepPillProps): React.ReactNode => {
   const { count, stepType } = props
   const label = `${startCase(
     i18n.t(`application.stepType.${stepType}`)
@@ -63,7 +63,7 @@ export const ExitBatchEditButton = (props: {
     StepSelectionBannerProps,
     'handleExitBatchEdit'
   >
-}): React.Node => (
+}): React.ReactNode => (
   <Box flex="0 1 auto">
     <SecondaryBtn
       color={C_WHITE}
@@ -82,7 +82,7 @@ export type StepSelectionBannerProps = {
 
 export const StepSelectionBannerComponent = (
   props: StepSelectionBannerProps
-): React.Node => {
+): React.ReactNode => {
   const { countPerStepType, handleExitBatchEdit } = props
   const numSteps = Object.keys(countPerStepType).reduce<number>(
     (acc, stepType) => acc + countPerStepType[stepType],

--- a/protocol-designer/src/components/StepSelectionBanner/index.tsx
+++ b/protocol-designer/src/components/StepSelectionBanner/index.tsx
@@ -15,7 +15,7 @@ const MemoizedStepSelectionBannerComponent = React.memo(
   StepSelectionBannerComponent
 )
 
-export const StepSelectionBanner = (): React.Node => {
+export const StepSelectionBanner = (): JSX.Element => {
   const countPerStepType = useSelector(getCountPerStepType)
   const batchEditFormHasUnsavedChanges = useSelector(
     stepFormSelectors.getBatchEditFormHasUnsavedChanges

--- a/protocol-designer/src/components/TitledListNotes.tsx
+++ b/protocol-designer/src/components/TitledListNotes.tsx
@@ -7,7 +7,7 @@ type Props = {
   notes: string | null | undefined
 }
 
-export function TitledListNotes(props: Props): React.Node {
+export function TitledListNotes(props: Props): JSX.Element | null {
   return props.notes ? (
     <div className={styles.notes}>
       <header>{i18n.t('card.notes')}</header>

--- a/protocol-designer/src/components/WellSelectionInstructions.tsx
+++ b/protocol-designer/src/components/WellSelectionInstructions.tsx
@@ -5,7 +5,7 @@ import { Icon } from '@opentrons/components'
 import { i18n } from '../localization'
 import styles from './WellSelectionInstructions.css'
 
-export function WellSelectionInstructions(): React.Node {
+export function WellSelectionInstructions(): JSX.Element {
   return (
     <div className={styles.wrapper}>
       <Icon className={styles.click_drag_icon} name="ot-click-and-drag" />

--- a/protocol-designer/src/components/alerts/ErrorContents.tsx
+++ b/protocol-designer/src/components/alerts/ErrorContents.tsx
@@ -10,7 +10,7 @@ type ErrorContentsProps = {
   errorType: string
   level: AlertLevel
 }
-export const ErrorContents = (props: ErrorContentsProps): React.Node => {
+export const ErrorContents = (props: ErrorContentsProps): JSX.Element => {
   if (props.level === 'timeline') {
     const bodyText = i18n.t(`alert.timeline.error.${props.errorType}.body`, {
       defaultValue: '',

--- a/protocol-designer/src/components/alerts/PDAlert.tsx
+++ b/protocol-designer/src/components/alerts/PDAlert.tsx
@@ -10,11 +10,11 @@ import { AlertType } from './types'
 type PDAlertProps = {
   alertType: AlertType
   title: string
-  description: React.Node
+  description: React.ReactNode
   onDismiss: (() => mixed) | null | undefined
 }
 
-export const PDAlert = (props: PDAlertProps): React.Node => {
+export const PDAlert = (props: PDAlertProps): JSX.Element => {
   const { alertType, title, description, onDismiss } = props
   return (
     <AlertItem

--- a/protocol-designer/src/components/alerts/WarningContents.tsx
+++ b/protocol-designer/src/components/alerts/WarningContents.tsx
@@ -9,7 +9,7 @@ type WarningContentsProps = {
   warningType: string
   level: AlertLevel
 }
-export const WarningContents = (props: WarningContentsProps): React.Node => {
+export const WarningContents = (props: WarningContentsProps): JSX.Element => {
   if (props.level === 'timeline') {
     switch (props.warningType) {
       case 'ASPIRATE_FROM_PRISTINE_WELL':

--- a/protocol-designer/src/components/labware/BrowsableLabware.tsx
+++ b/protocol-designer/src/components/labware/BrowsableLabware.tsx
@@ -18,7 +18,7 @@ type Props = {
   wellContents: ContentsByWell
 }
 
-export function BrowsableLabware(props: Props): React.Node {
+export function BrowsableLabware(props: Props): JSX.Element {
   const { definition, ingredNames, wellContents } = props
   if (!definition) {
     assert(definition, 'BrowseLabwareModal expected definition')

--- a/protocol-designer/src/components/labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/labware/SelectableLabware.tsx
@@ -117,7 +117,7 @@ export class SelectableLabware extends React.Component<Props> {
     this.props.updateHighlightedWells({})
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const {
       labwareProps,
       ingredNames,

--- a/protocol-designer/src/components/labware/SingleLabware.tsx
+++ b/protocol-designer/src/components/labware/SingleLabware.tsx
@@ -5,7 +5,7 @@ import { LabwareRender, RobotWorkSpace } from '@opentrons/components'
 type Props = React.ElementProps<typeof LabwareRender>
 
 /** Avoid boilerplate for viewbox-based-on-labware-dimensions */
-export function SingleLabware(props: Props): React.Node {
+export function SingleLabware(props: Props): JSX.Element {
   return (
     <RobotWorkSpace
       viewBox={`0 0 ${props.definition.dimensions.xDimension} ${props.definition.dimensions.yDimension}`}

--- a/protocol-designer/src/components/labware/WellTooltip.tsx
+++ b/protocol-designer/src/components/labware/WellTooltip.tsx
@@ -22,7 +22,7 @@ type WellTooltipParams = {
 }
 
 type Props = {
-  children: (wellTooltipParams: WellTooltipParams) => React.Node,
+  children: (wellTooltipParams: WellTooltipParams) => React.ReactNode,
   ingredNames: WellIngredientNames,
 }
 
@@ -68,7 +68,7 @@ export class WellTooltip extends React.Component<Props, State> {
     this.setState(initialState)
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const { tooltipX, tooltipY, tooltipOffset } = this.state
 
     return (

--- a/protocol-designer/src/components/lists/PDListItem.tsx
+++ b/protocol-designer/src/components/lists/PDListItem.tsx
@@ -12,7 +12,7 @@ type Props = {
 }
 
 /** Light wrapper around li for PD-specific styles */
-export function PDListItem(props: Props): React.Node {
+export function PDListItem(props: Props): JSX.Element {
   const { className, border, hoverable, ...passThruProps } = props
   const _className = cx(
     {

--- a/protocol-designer/src/components/lists/PDTitledList.tsx
+++ b/protocol-designer/src/components/lists/PDTitledList.tsx
@@ -7,7 +7,7 @@ import styles from './styles.css'
 type Props = React.ElementProps<typeof TitledList>
 
 /** Light wrapper around TitledList for PD-specific styles */
-export function PDTitledList(props: Props): React.Node {
+export function PDTitledList(props: Props): JSX.Element {
   return (
     <TitledList
       {...props}

--- a/protocol-designer/src/components/lists/TitledStepList.tsx
+++ b/protocol-designer/src/components/lists/TitledStepList.tsx
@@ -16,11 +16,11 @@ export type Props = {
   /** optional data test id for the container */
   'data-test'?: string
   /** children must all be `<li>` */
-  children?: React.Node
+  children?: React.ReactNode
   /** additional classnames */
   className?: string
   /** component with descriptive text about the list */
-  description?: React.Node
+  description?: React.ReactNode
   /** optional click action (on title div, not children) */
   onClick?: (event: SyntheticMouseEvent<>) => mixed
   /** optional right click action (on wrapping div) */
@@ -43,7 +43,7 @@ export type Props = {
   isLastSelected?: boolean
 }
 
-export function TitledStepList(props: Props): React.Node {
+export function TitledStepList(props: Props): JSX.Element {
   const {
     iconName,
     'data-test': dataTest,

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -7,9 +7,9 @@ import styles from './AnnouncementModal.css'
 
 export type Announcement = {
   announcementKey: string
-  image: React.Node | null
+  image: React.ReactNode | null
   heading: string
-  message: React.Node
+  message: React.ReactNode
 }
 
 const batchEditStyles = css`

--- a/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
@@ -13,7 +13,7 @@ import modalStyles from '../modal.css'
 import { announcements } from './announcements'
 import styles from './AnnouncementModal.css'
 
-export const AnnouncementModal = (): React.Node => {
+export const AnnouncementModal = (): JSX.Element => {
   const { announcementKey, message, heading, image } = announcements[
     announcements.length - 1
   ]

--- a/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.tsx
+++ b/protocol-designer/src/components/modals/AutoAddPauseUntilTempStepModal.tsx
@@ -11,7 +11,7 @@ type Props = {
   handleContinueClick: () => mixed
 }
 
-export const AutoAddPauseUntilTempStepModal = (props: Props): React.Node => (
+export const AutoAddPauseUntilTempStepModal = (props: Props): JSX.Element => (
   <AlertModal
     alertOverlay
     className={modalStyles.modal}

--- a/protocol-designer/src/components/modals/ConfirmDeleteModal.tsx
+++ b/protocol-designer/src/components/modals/ConfirmDeleteModal.tsx
@@ -29,7 +29,7 @@ type Props = {
   onContinueClick: (event: SyntheticMouseEvent<>) => mixed
 }
 
-export function ConfirmDeleteModal(props: Props): React.Node {
+export function ConfirmDeleteModal(props: Props): JSX.Element {
   const { modalType, onCancelClick, onContinueClick } = props
   const cancelCopy = i18n.t('button.cancel')
   const continueCopy = i18n.t(

--- a/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ConnectedSlotMap.tsx
@@ -8,7 +8,7 @@ type ConnectedSlotMapProps = {
   fieldName: string
 }
 
-export const ConnectedSlotMap = (props: ConnectedSlotMapProps): React.Node => {
+export const ConnectedSlotMap = (props: ConnectedSlotMapProps): JSX.Element => {
   const { fieldName } = props
   const [field, meta] = useField(fieldName)
   return field.value ? (

--- a/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/MagneticModuleWarningModalContent.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import styles from './MagneticModuleWarningModalContent.css'
 import { KnowledgeBaseLink } from '../../KnowledgeBaseLink'
 
-export const MagneticModuleWarningModalContent = (): React.Node => (
+export const MagneticModuleWarningModalContent = (): JSX.Element => (
   <div className={styles.content}>
     <p>
       Switching between GEN1 and GEN2 Magnetic Modules{' '}

--- a/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/ModelDropdown.tsx
@@ -12,7 +12,7 @@ type ModelDropdownProps = {
     disabled?: boolean
   }>
 }
-export const ModelDropdown = (props: ModelDropdownProps): React.Node => {
+export const ModelDropdown = (props: ModelDropdownProps): JSX.Element => {
   const { fieldName, options, tabIndex } = props
   const [field, meta] = useField(fieldName)
   return (

--- a/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/SlotDropdown.tsx
@@ -14,7 +14,7 @@ type ModelDropdownProps = {
   }>
 }
 
-export const SlotDropdown = (props: ModelDropdownProps): React.Node => {
+export const SlotDropdown = (props: ModelDropdownProps): JSX.Element => {
   const { fieldName, options, disabled, tabIndex } = props
   const [field, meta] = useField(props.fieldName)
   return (

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -64,7 +64,7 @@ export type EditModulesFormValues = {
   selectedSlot: string,
 }
 
-export const EditModulesModal = (props: EditModulesModalProps): React.Node => {
+export const EditModulesModal = (props: EditModulesModalProps): JSX.Element => {
   const {
     moduleType,
     displayModuleWarning,

--- a/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.tsx
+++ b/protocol-designer/src/components/modals/EditPipettesModal/StepChangesConfirmModal.tsx
@@ -9,7 +9,7 @@ import modalStyles from '../modal.css'
 
 type Props = { onCancel: () => void; onConfirm: () => void }
 
-export const StepChangesConfirmModal = (props: Props): React.Node => {
+export const StepChangesConfirmModal = (props: Props): JSX.Element => {
   const { onCancel, onConfirm } = props
 
   return (

--- a/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/ModuleFields.tsx
@@ -52,7 +52,7 @@ type Props = {
   onBlur: (event: SyntheticFocusEvent<HTMLSelectElement>) => mixed
 }
 
-export function ModuleFields(props: Props): React.Node {
+export function ModuleFields(props: Props): JSX.Element {
   const {
     onFieldChange,
     onSetFieldValue,

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
@@ -10,7 +10,7 @@ type Props = {
   leftPipette: string | null | undefined
   rightPipette: string | null | undefined
 }
-export function PipetteDiagram(props: Props): React.Node {
+export function PipetteDiagram(props: Props): JSX.Element {
   const { leftPipette, rightPipette } = props
 
   // TODO (ka 2020-4-16): This is temporaray until FF is removed.

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -56,7 +56,7 @@ export type Props = {
 // TODO(mc, 2019-10-14): delete this typedef when gen2 ff is removed
 type PipetteSelectProps = { mount: Mount; tabIndex: number }
 
-export function PipetteFields(props: Props): React.Node {
+export function PipetteFields(props: Props): JSX.Element {
   const {
     values,
     onFieldChange,

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -245,7 +245,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
     }
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     if (this.props.hideModal) return null
     const { showProtocolFields, moduleRestrictionsDisabled } = this.props
 

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -245,7 +245,7 @@ export class FilePipettesModal extends React.Component<Props, State> {
     }
   }
 
-  render(): React.ReactNode {
+  render(): React.ReactNode | null {
     if (this.props.hideModal) return null
     const { showProtocolFields, moduleRestrictionsDisabled } = this.props
 

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
@@ -13,7 +13,7 @@ type Props = {
   dismissModal: (event: SyntheticEvent) => unknown,
 }
 
-export function FileUploadMessageModal(props: Props): React.Node {
+export function FileUploadMessageModal(props: Props): JSX.Element {
   const { message, cancelProtocolMigration, dismissModal } = props
 
   if (!message) return null

--- a/protocol-designer/src/components/modals/GateModal/SignUpForm.tsx
+++ b/protocol-designer/src/components/modals/GateModal/SignUpForm.tsx
@@ -26,7 +26,7 @@ export class SignUpForm extends React.Component<{}> {
       hideScrollbars: true,
     })
   }
-  render(): React.Node {
+  render(): React.ReactNode {
     return (
       <div ref={this.embedElement} className={styles.sign_up_form_wrapper} />
     )

--- a/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/LabwareUploadMessageModal/LabwareUploadMessageModal.tsx
@@ -91,7 +91,7 @@ type Props = {
   overwriteLabwareDef?: () => mixed
 }
 
-export const LabwareUploadMessageModal = (props: Props): React.Node => {
+export const LabwareUploadMessageModal = (props: Props): JSX.Element => {
   const { message, dismissModal, overwriteLabwareDef } = props
   if (!message) return null
 

--- a/protocol-designer/src/components/modules/CrashInfoBox.tsx
+++ b/protocol-designer/src/components/modules/CrashInfoBox.tsx
@@ -10,7 +10,7 @@ type Props = {
   temperatureOnDeck: boolean | null | undefined
 }
 
-export function CrashInfoBox(props: Props): React.Node {
+export function CrashInfoBox(props: Props): JSX.Element {
   const moduleMessage = getCrashableModulesCopy(props) || ''
   return (
     <div className={styles.crash_info_container}>

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -24,7 +24,7 @@ type Props = {
   openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed
 }
 
-export function EditModulesCard(props: Props): React.Node {
+export function EditModulesCard(props: Props): JSX.Element {
   const { modules, openEditModuleModal } = props
 
   const pipettesByMount = useSelector(

--- a/protocol-designer/src/components/modules/ModuleDiagram.tsx
+++ b/protocol-designer/src/components/modules/ModuleDiagram.tsx
@@ -39,7 +39,7 @@ const MODULE_IMG_BY_TYPE: ModuleImg = {
   },
 }
 
-export function ModuleDiagram(props: Props): React.Node {
+export function ModuleDiagram(props: Props): JSX.Element {
   const model = MODULE_IMG_BY_TYPE[props.type][props.model]
   return <img className={styles.module_diagram} src={model} alt={props.type} />
 }

--- a/protocol-designer/src/components/modules/ModuleRow.tsx
+++ b/protocol-designer/src/components/modules/ModuleRow.tsx
@@ -29,7 +29,7 @@ type Props = {
   openEditModuleModal: (moduleType: ModuleRealType, moduleId?: string) => mixed
 }
 
-export function ModuleRow(props: Props): React.Node {
+export function ModuleRow(props: Props): JSX.Element {
   const { moduleOnDeck, openEditModuleModal, showCollisionWarnings } = props
   const type: ModuleRealType = moduleOnDeck?.type || props.type
 

--- a/protocol-designer/src/components/portals/MainPageModalPortal.tsx
+++ b/protocol-designer/src/components/portals/MainPageModalPortal.tsx
@@ -4,7 +4,7 @@ import ReactDom from 'react-dom'
 
 const PORTAL_ROOT_ID = 'main-page-modal-portal-root'
 
-export function PortalRoot(): React.Node {
+export function PortalRoot(): JSX.Element {
   return <div id={PORTAL_ROOT_ID} />
 }
 
@@ -12,11 +12,11 @@ export function getPortalElem(): HTMLElement | null {
   return document.getElementById(PORTAL_ROOT_ID)
 }
 
-type Props = { children: React.Node }
+type Props = { children: React.ReactNode }
 
 /** The children of Portal are rendered into the
  * PortalRoot, if the PortalRoot exists in the DOM */
-export function Portal(props: Props): React.Node {
+export function Portal(props: Props): JSX.Element {
   const modalRootElem = getPortalElem()
 
   if (!modalRootElem) {

--- a/protocol-designer/src/components/portals/TopPortal.tsx
+++ b/protocol-designer/src/components/portals/TopPortal.tsx
@@ -4,7 +4,7 @@ import ReactDom from 'react-dom'
 
 const PORTAL_ROOT_ID = 'top-portal-root'
 
-export function PortalRoot(): React.Node {
+export function PortalRoot(): JSX.Element {
   return <div id={PORTAL_ROOT_ID} />
 }
 
@@ -12,11 +12,11 @@ export function getPortalElem(): HTMLElement | null {
   return document.getElementById(PORTAL_ROOT_ID)
 }
 
-type Props = { children: React.Node }
+type Props = { children: React.ReactNode }
 
 /** The children of Portal are rendered into the
  * PortalRoot, if the PortalRoot exists in the DOM */
-export function Portal(props: Props): React.Node {
+export function Portal(props: Props): JSX.Element {
   const modalRootElem = getPortalElem()
 
   if (!modalRootElem) {

--- a/protocol-designer/src/components/portals/__mocks__/MainPageModalPortal.tsx
+++ b/protocol-designer/src/components/portals/__mocks__/MainPageModalPortal.tsx
@@ -4,4 +4,4 @@ type Props = {
   children: React.ReactNode
 }
 // replace Portal with a pass-through React.Fragment
-export const Portal = ({ children }: Props): React.ReactNode => <>{children}</>
+export const Portal = ({ children }: Props): JSX.Element => <>{children}</>

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
@@ -18,7 +18,7 @@ type AspirateDispenseHeaderProps = {
 
 export function AspirateDispenseHeader(
   props: AspirateDispenseHeaderProps
-): React.ReactNode {
+): JSX.Element {
   const { sourceLabwareNickname, destLabwareNickname } = props
 
   const [sourceTargetProps, sourceTooltipProps] = useHoverTooltip({

--- a/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
+++ b/protocol-designer/src/components/steplist/AspirateDispenseHeader.tsx
@@ -18,7 +18,7 @@ type AspirateDispenseHeaderProps = {
 
 export function AspirateDispenseHeader(
   props: AspirateDispenseHeaderProps
-): React.Node {
+): React.ReactNode {
   const { sourceLabwareNickname, destLabwareNickname } = props
 
   const [sourceTargetProps, sourceTooltipProps] = useHoverTooltip({

--- a/protocol-designer/src/components/steplist/ContextMenu.tsx
+++ b/protocol-designer/src/components/steplist/ContextMenu.tsx
@@ -20,12 +20,12 @@ type Props = {
     makeStepOnContextMenu: (stepIdType: StepIdType) => (
       event: SyntheticMouseEvent<>
     ) => unknown,
-  }) => React.Node,
+  }) => React.ReactNode,
 }
 
 type Position = { left: number | null, top: number | null }
 
-export const ContextMenu = (props: Props): React.Node => {
+export const ContextMenu = (props: Props): JSX.Element => {
   const dispatch = useDispatch()
   const deleteStep = (stepId: StepIdType) =>
     dispatch(steplistActions.deleteStep(stepId))

--- a/protocol-designer/src/components/steplist/IngredPill.tsx
+++ b/protocol-designer/src/components/steplist/IngredPill.tsx
@@ -12,7 +12,7 @@ type Props = {
   targetProps: $ElementType<UseHoverTooltipResult, 0> | null | undefined
 }
 
-export function IngredPill(props: Props): React.Node {
+export function IngredPill(props: Props): JSX.Element {
   const { ingredNames, targetProps } = props
   const ingredIds: string[] = Object.keys(props.ingreds)
 

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
@@ -7,7 +7,7 @@ type LabwareTooltipContentsProps = {
 }
 export const LabwareTooltipContents = (
   props: LabwareTooltipContentsProps
-): React.Node => {
+): React.ReactNode => {
   const { labwareNickname } = props
   return (
     <div className={styles.labware_tooltip_contents}>

--- a/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
+++ b/protocol-designer/src/components/steplist/LabwareTooltipContents.tsx
@@ -7,7 +7,7 @@ type LabwareTooltipContentsProps = {
 }
 export const LabwareTooltipContents = (
   props: LabwareTooltipContentsProps
-): React.ReactNode => {
+): JSX.Element => {
   const { labwareNickname } = props
   return (
     <div className={styles.labware_tooltip_contents}>

--- a/protocol-designer/src/components/steplist/MixHeader.tsx
+++ b/protocol-designer/src/components/steplist/MixHeader.tsx
@@ -12,7 +12,7 @@ type Props = {
   labwareNickname: string | null | undefined
 }
 
-export function MixHeader(props: Props): React.Node {
+export function MixHeader(props: Props): JSX.Element {
   const { volume, times, labwareNickname } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -21,7 +21,7 @@ export type ModuleStepItemRowProps = {
 
 export const ModuleStepItemRow = (
   props: ModuleStepItemRowProps
-): React.Node => (
+): React.ReactNode => (
   <PDListItem
     className={cx(styles.step_subitem_column_header, styles.substep_content)}
   >
@@ -38,11 +38,11 @@ type Props = {
   actionText: string
   labwareNickname: string | null | undefined
   message: string | null | undefined
-  children?: React.Node
+  children?: React.ReactNode
   hideHeader?: boolean
 }
 
-export const ModuleStepItems = (props: Props): React.Node => {
+export const ModuleStepItems = (props: Props): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',
     strategy: TOOLTIP_FIXED,

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -21,7 +21,7 @@ export type ModuleStepItemRowProps = {
 
 export const ModuleStepItemRow = (
   props: ModuleStepItemRowProps
-): React.ReactNode => (
+): JSX.Element => (
   <PDListItem
     className={cx(styles.step_subitem_column_header, styles.substep_content)}
   >

--- a/protocol-designer/src/components/steplist/MultiChannelSubstep.tsx
+++ b/protocol-designer/src/components/steplist/MultiChannelSubstep.tsx
@@ -39,7 +39,7 @@ export class MultiChannelSubstep extends React.PureComponent<
     this.setState({ collapsed: !this.state.collapsed })
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     const {
       rowGroup,
       highlighted,

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
@@ -55,7 +55,7 @@ const iconBoxStyles = css`
   }
 `
 
-export const ClickableIcon = (props: ClickableIconProps): React.Node => {
+export const ClickableIcon = (props: ClickableIconProps): JSX.Element => {
   const { id, iconName, onClick, tooltipText, width } = props
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'top',
@@ -83,10 +83,10 @@ type Props = {
 
 type AccordionProps = {
   expanded: boolean
-  children: React.Node
+  children: React.ReactNode
 }
 
-export const Accordion = (props: AccordionProps): React.Node => {
+export const Accordion = (props: AccordionProps): JSX.Element => {
   return (
     <Box
       height={props.expanded ? SIZE_2 : 0}
@@ -103,7 +103,7 @@ export const Accordion = (props: AccordionProps): React.Node => {
   )
 }
 
-export const MultiSelectToolbar = (props: Props): React.Node => {
+export const MultiSelectToolbar = (props: Props): JSX.Element => {
   const dispatch = useDispatch()
   const [isExpandState, setIsExpandState] = React.useState<boolean>(true)
   const stepCount = useSelector(stepFormSelectors.getOrderedStepIds).length

--- a/protocol-designer/src/components/steplist/PauseStepItems.tsx
+++ b/protocol-designer/src/components/steplist/PauseStepItems.tsx
@@ -7,7 +7,7 @@ type Props = {
   pauseArgs: PauseArgs
 }
 
-export function PauseStepItems(props: Props): React.Node {
+export function PauseStepItems(props: Props): JSX.Element {
   const { pauseArgs } = props
   if (!pauseArgs.meta) {
     // No message or time, show nothing

--- a/protocol-designer/src/components/steplist/PresavedStepItem.tsx
+++ b/protocol-designer/src/components/steplist/PresavedStepItem.tsx
@@ -10,7 +10,7 @@ import {
   actions as stepsActions,
 } from '../../ui/steps'
 
-export const PresavedStepItem = (): React.Node => {
+export const PresavedStepItem = (): JSX.Element => {
   const presavedStepForm = useSelector(stepFormSelectors.getPresavedStepForm)
   const stepNumber = useSelector(stepFormSelectors.getOrderedStepIds).length + 1
   const hovered = useSelector(getHoveredTerminalItemId) === PRESAVED_STEP_ID

--- a/protocol-designer/src/components/steplist/SourceDestSubstep.tsx
+++ b/protocol-designer/src/components/steplist/SourceDestSubstep.tsx
@@ -22,7 +22,7 @@ type SourceDestSubstepProps = StepSubItemProps & {
   hoveredSubstep: SubstepIdentifier | null | undefined,
 }
 
-export function SourceDestSubstep(props: SourceDestSubstepProps): React.Node {
+export function SourceDestSubstep(props: SourceDestSubstepProps): JSX.Element {
   const { substeps, selectSubstep, hoveredSubstep } = props
   if (substeps.multichannel) {
     // multi-channel row item (collapsible)
@@ -48,7 +48,7 @@ export function SourceDestSubstep(props: SourceDestSubstepProps): React.Node {
   }
 
   // single-channel row item
-  return substeps.rows.map<React.Node>((row, substepIndex) => (
+  return substeps.rows.map<React.ReactNode>((row, substepIndex) => (
     <SubstepRow
       key={substepIndex}
       className={cx(styles.step_subitem, {

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -54,10 +54,10 @@ export type StepItemProps = {
   handleClick?: (event: SyntheticMouseEvent<>) => mixed,
   toggleStepCollapsed: () => mixed,
   unhighlightStep: (event?: SyntheticEvent<>) => mixed,
-  children?: React.Node,
+  children?: React.ReactNode,
 }
 
-export const StepItem = (props: StepItemProps): React.Node => {
+export const StepItem = (props: StepItemProps): JSX.Element => {
   const {
     stepType,
     stepNumber,
@@ -137,7 +137,7 @@ type ProfileStepSubstepRowProps = {
 }
 export const ProfileStepSubstepRow = (
   props: ProfileStepSubstepRowProps
-): React.Node => {
+): React.ReactNode => {
   const { repetitionsDisplay, stepNumber } = props
   const { temperature, durationMinutes, durationSeconds } = props.step
   return (
@@ -177,7 +177,7 @@ export const ProfileStepSubstepRow = (
 
 // this is a row under a cycle under a substep
 type ProfileCycleRowProps = { step: ProfileStepItem, stepNumber: number }
-const ProfileCycleRow = (props: ProfileCycleRowProps): React.Node => {
+const ProfileCycleRow = (props: ProfileCycleRowProps): React.ReactNode => {
   const { step, stepNumber } = props
   return (
     <div className={styles.cycle_step_row}>
@@ -198,7 +198,7 @@ type ProfileCycleSubstepGroupProps = {
 }
 export const ProfileCycleSubstepGroup = (
   props: ProfileCycleSubstepGroupProps
-): React.Node => {
+): React.ReactNode => {
   const { steps, repetitions } = props.cycle
   return (
     <div className={styles.profile_substep_cycle}>
@@ -217,8 +217,8 @@ export const ProfileCycleSubstepGroup = (
 }
 
 type CollapsibleSubstepProps = {
-  children: React.Node,
-  headerContent: React.Node,
+  children: React.ReactNode,
+  headerContent: React.ReactNode,
 }
 const CollapsibleSubstep = (props: CollapsibleSubstepProps) => {
   const [contentCollapsed, setContentCollapsed] = React.useState<boolean>(true)
@@ -273,7 +273,7 @@ const renderSubstepInfo = (substeps: ThermocyclerProfileSubstepItem) => {
   return substepInfo
 }
 
-export const StepItemContents = (props: StepItemContentsProps): React.Node => {
+export const StepItemContents = (props: StepItemContentsProps): JSX.Element => {
   const {
     rawForm,
     stepType,

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -137,7 +137,7 @@ type ProfileStepSubstepRowProps = {
 }
 export const ProfileStepSubstepRow = (
   props: ProfileStepSubstepRowProps
-): React.ReactNode => {
+): JSX.Element => {
   const { repetitionsDisplay, stepNumber } = props
   const { temperature, durationMinutes, durationSeconds } = props.step
   return (
@@ -177,7 +177,7 @@ export const ProfileStepSubstepRow = (
 
 // this is a row under a cycle under a substep
 type ProfileCycleRowProps = { step: ProfileStepItem, stepNumber: number }
-const ProfileCycleRow = (props: ProfileCycleRowProps): React.ReactNode => {
+const ProfileCycleRow = (props: ProfileCycleRowProps): JSX.Element => {
   const { step, stepNumber } = props
   return (
     <div className={styles.cycle_step_row}>
@@ -198,7 +198,7 @@ type ProfileCycleSubstepGroupProps = {
 }
 export const ProfileCycleSubstepGroup = (
   props: ProfileCycleSubstepGroupProps
-): React.ReactNode => {
+): JSX.Element => {
   const { steps, repetitions } = props.cycle
   return (
     <div className={styles.profile_substep_cycle}>

--- a/protocol-designer/src/components/steplist/StepList.tsx
+++ b/protocol-designer/src/components/steplist/StepList.tsx
@@ -47,7 +47,7 @@ export class StepList extends React.Component<Props> {
     global.removeEventListener('keydown', this.handleKeyDown, false)
   }
 
-  render(): React.Node {
+  render(): React.ReactNode {
     return (
       <React.Fragment>
         <SidePanel title="Protocol Timeline">

--- a/protocol-designer/src/components/steplist/SubstepRow.tsx
+++ b/protocol-designer/src/components/steplist/SubstepRow.tsx
@@ -36,7 +36,7 @@ type PillTooltipContentsProps = {
 }
 export const PillTooltipContents = (
   props: PillTooltipContentsProps
-): React.ReactNode => {
+): JSX.Element => {
   const totalLiquidVolume = reduce(
     props.ingreds,
     (acc, ingred) => acc + ingred.volume,

--- a/protocol-designer/src/components/steplist/SubstepRow.tsx
+++ b/protocol-designer/src/components/steplist/SubstepRow.tsx
@@ -36,7 +36,7 @@ type PillTooltipContentsProps = {
 }
 export const PillTooltipContents = (
   props: PillTooltipContentsProps
-): React.Node => {
+): React.ReactNode => {
   const totalLiquidVolume = reduce(
     props.ingreds,
     (acc, ingred) => acc + ingred.volume,

--- a/protocol-designer/src/components/steplist/TerminalItem/index.tsx
+++ b/protocol-designer/src/components/steplist/TerminalItem/index.tsx
@@ -23,12 +23,12 @@ import { TerminalItemId } from '../../../steplist'
 export { TerminalItemLink } from './TerminalItemLink'
 
 type Props = {
-  children?: React.Node
+  children?: React.ReactNode
   id: TerminalItemId
   title: string
 }
 
-export const TerminalItem = (props: Props): React.Node => {
+export const TerminalItem = (props: Props): JSX.Element => {
   const { id, title, children } = props
   // const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false)
 


### PR DESCRIPTION
# Overview
Translating references to `React.Node` to `JSX.Element` for functional components and `React.ReactNode` for class components.  I see a couple of issues (such as with `ComputingSpinner`) where we return a boolean if spinner is not to be show.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
