### PR TITLE
fix(robot-server): exempt /logs and RPC from version header requirement

### DIFF
--- a/robot-server/robot_server/app.py
+++ b/robot-server/robot_server/app.py
@@ -2,14 +2,13 @@
 import logging
 
 from opentrons import __version__
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 from starlette.requests import Request
 from starlette.middleware.base import RequestResponseEndpoint
 
 from .service.dependencies import (
-    check_version_header,
     get_rpc_server,
     get_protocol_manager,
     get_hardware_wrapper,
@@ -53,10 +52,7 @@ app.add_middleware(
 )
 
 # main router
-app.include_router(
-    router=router,
-    dependencies=[Depends(check_version_header)],
-)
+app.include_router(router=router)
 
 
 @app.on_event("startup")

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -1,5 +1,5 @@
 """Application routes."""
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, status
 
 from opentrons.config.feature_flags import enable_protocol_engine
 
@@ -9,6 +9,7 @@ from .health import health_router
 from .protocols import protocols_router
 from .sessions import sessions_router
 from .system import system_router
+from .service.dependencies import check_version_header
 from .service.legacy.routers import legacy_routes
 from .service.session.router import router as deprecated_session_router
 from .service.pipette_offset.router import router as pip_os_router
@@ -33,6 +34,7 @@ router.include_router(
 router.include_router(
     router=health_router,
     tags=["Health", V1_TAG],
+    dependencies=[Depends(check_version_header)],
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
             "model": LegacyErrorResponse,
@@ -45,46 +47,55 @@ if enable_protocol_engine():
     router.include_router(
         router=sessions_router,
         tags=["Session Management"],
+        dependencies=[Depends(check_version_header)],
     )
 
     router.include_router(
         router=protocols_router,
         tags=["Protocol Management"],
+        dependencies=[Depends(check_version_header)],
     )
 
 else:
     router.include_router(
         router=deprecated_session_router,
         tags=["Session Management"],
+        dependencies=[Depends(check_version_header)],
     )
 
     router.include_router(
         router=deprecated_protocol_router,
         tags=["Protocol Management"],
+        dependencies=[Depends(check_version_header)],
     )
 
 
 router.include_router(
     router=labware_router,
     tags=["Labware Calibration Management"],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=pip_os_router,
     tags=["Pipette Offset Calibration Management"],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=tl_router,
     tags=["Tip Length Calibration Management"],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=notifications_router,
     tags=["Notification Server Management"],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(
     router=system_router,
     tags=["System Control"],
+    dependencies=[Depends(check_version_header)],
 )

--- a/robot-server/robot_server/service/legacy/routers/__init__.py
+++ b/robot-server/robot_server/service/legacy/routers/__init__.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from robot_server.service.dependencies import check_version_header
 
 from . import (
     networking,
@@ -10,29 +12,69 @@ from . import (
     motors,
     camera,
     logs,
-    rpc
+    rpc,
 )
 
 legacy_routes = APIRouter()
 
-legacy_routes.include_router(router=networking.router, tags=["Networking"])
+legacy_routes.include_router(
+    router=networking.router,
+    tags=["Networking"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=control.router, tags=["Control"])
+legacy_routes.include_router(
+    router=control.router,
+    tags=["Control"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=settings.router, tags=["Settings"])
+legacy_routes.include_router(
+    router=settings.router,
+    tags=["Settings"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=deck_calibration.router, tags=["Deck Calibration"])
+legacy_routes.include_router(
+    router=deck_calibration.router,
+    tags=["Deck Calibration"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=modules.router, tags=["Modules"])
+legacy_routes.include_router(
+    router=modules.router,
+    tags=["Modules"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=pipettes.router, tags=["Pipettes"])
+legacy_routes.include_router(
+    router=pipettes.router,
+    tags=["Pipettes"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=motors.router, tags=["Motors"])
+legacy_routes.include_router(
+    router=motors.router,
+    tags=["Motors"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=camera.router, tags=["Camera"])
+legacy_routes.include_router(
+    router=camera.router,
+    tags=["Camera"],
+    dependencies=[Depends(check_version_header)],
+)
 
-legacy_routes.include_router(router=logs.router, tags=["Logs"])
+# logs routes are exempt from version header requirements
+legacy_routes.include_router(
+    router=logs.router,
+    tags=["Logs"],
+)
 
-legacy_routes.include_router(router=rpc.router, tags=["RPC"])
+# RPC websocket route is exempt from version header requirements
+legacy_routes.include_router(
+    router=rpc.router,
+    tags=["RPC"],
+)
 
 __all__ = ["legacy_routes"]


### PR DESCRIPTION
## Overview

This PR fixes an unreleased bug with robot logs downloads caused by #7632. It exempts certain endpoints (`/logs` included) to fix robot logs downloading.

Closes #7924.

## Changelog

- fix(robot-server): exempt /logs and RPC from version header requirement

## Review requests

- [ ] Can download logs with this build installed on a robot

## Risk assessment

Low. Revert of bad change