### PR TITLE
feat(labware-creator): Update grid spacing when tiprack is selected

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
@@ -41,7 +41,10 @@ describe('WellSpacing', () => {
     formikConfig.initialValues.labwareType = 'wellPlate'
     when(getLabwareNameMock)
       .calledWith(formikConfig.initialValues, false)
-      .mockReturnValue('well')
+      .mockReturnValue('FAKE LABWARE NAME SINGULAR')
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, true)
+      .mockReturnValue('FAKE LABWARE NAME PLURAL')
 
     render(wrapInFormik(<WellSpacing />, formikConfig))
 
@@ -49,12 +52,26 @@ describe('WellSpacing', () => {
 
     screen.getByText(
       nestedTextMatcher(
-        'well spacing measurements inform the robot how far away rows and columns are from each other.'
+        'Spacing is between the center of FAKE LABWARE NAME PLURAL.'
+      )
+    )
+
+    screen.getByText(
+      nestedTextMatcher(
+        'FAKE LABWARE NAME SINGULAR spacing measurements inform the robot how far away rows and columns are from each other.'
       )
     )
 
     screen.getByRole('textbox', { name: /X Spacing \(Xs\)/i })
     screen.getByRole('textbox', { name: /Y Spacing \(Ys\)/i })
+  })
+
+  it('should render "Tip Spacing" instead of "Well Spacing" when tipRack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+
+    render(wrapInFormik(<WellSpacing />, formikConfig))
+
+    screen.getByRole('heading', { name: /Tip Spacing/i })
   })
 
   it('should NOT render when the labware type is aluminumBlock', () => {
@@ -68,22 +85,6 @@ describe('WellSpacing', () => {
       })
     )
     expect(container.firstChild).toBe(null)
-  })
-
-  it('should render tips instead of wells when tipRack is selected', () => {
-    formikConfig.initialValues.labwareType = 'tipRack'
-    when(getLabwareNameMock)
-      .calledWith(formikConfig.initialValues, false)
-      .mockReturnValue('tip')
-
-    render(wrapInFormik(<WellSpacing />, formikConfig))
-
-    screen.getByRole('heading', { name: /Tip Spacing/i })
-    screen.getByText(
-      nestedTextMatcher(
-        'tip spacing measurements inform the robot how far away rows and columns are from each other.'
-      )
-    )
   })
 
   it('should NOT render when the labware type is tubeRack', () => {

--- a/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
 import { makeMaskToDecimal } from '../../fieldMasks'
-import { isEveryFieldHidden } from '../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../utils'
 import { LabwareFields } from '../../fields'
 import { FormAlerts } from '../alerts/FormAlerts'
 import { TextField } from '../TextField'
@@ -16,16 +16,21 @@ interface Props {
   values: LabwareFields
 }
 
-// TODO (ka 2021-5-11): Broke this out here since we will need to have more conditions for tips
-const Instructions = (): JSX.Element => {
+const Instructions = (props: Props): JSX.Element => {
+  const { values } = props
+
   return (
     <>
       <p>
-        Spacing is between the <strong>center</strong> of wells.
+        Spacing is between the <strong>center</strong> of{' '}
+        {getLabwareName(values, false)}.
       </p>
       <p>
-        Well spacing measurements inform the robot how far away rows and columns
-        are from each other.
+        <span className={styles.capitalize}>
+          {getLabwareName(values, false)}
+        </span>{' '}
+        spacing measurements inform the robot how far away rows and columns are
+        from each other.
       </p>
     </>
   )
@@ -36,7 +41,7 @@ const Content = (props: Props): JSX.Element => {
   return (
     <div className={styles.flex_row}>
       <div className={styles.instructions_column}>
-        <Instructions />
+        <Instructions values={values} />
       </div>
       <div className={styles.diagram_column}>
         <XYSpacingImg
@@ -71,9 +76,12 @@ export const WellSpacing = (): JSX.Element | null => {
   ) {
     return null
   }
+  // TODO (ka 2021-6-10): This will need getLabwareName once we introduce custom tuberacks
+  const label =
+    values.labwareType === 'tipRack' ? 'Tip Spacing' : 'Well Spacing'
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label="Well Spacing" id="WellSpacing">
+      <SectionBody label={label} id="WellSpacing">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />

--- a/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
@@ -23,7 +23,7 @@ const Instructions = (props: Props): JSX.Element => {
     <>
       <p>
         Spacing is between the <strong>center</strong> of{' '}
-        {getLabwareName(values, false)}.
+        {getLabwareName(values, true)}.
       </p>
       <p>
         <span className={styles.capitalize}>

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -260,3 +260,7 @@
   margin-top: 0;
   padding: 1rem 4rem;
 }
+
+.capitalize {
+  text-transform: capitalize;
+}


### PR DESCRIPTION
# Overview

closes #7725 by updating title and instructions to grid spacing section when tiprack is selected . Shout out to @smb2268 for the dope new util function!

# Changelog

- feat(labware-creator): Update grid spacing when tiprack is selected

# Review requests

- [ ] title reads tip spacing when tiprack selected
- [ ] description references tips when triprack selected

# Risk assessment

Low copy changes in LC only
