### PR TITLE
test(labware-creator): Update ID when TipDiameter instead of WellShapeAndSides

### DIFF
--- a/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellShapeAndSides.tsx
@@ -102,10 +102,12 @@ export const WellShapeAndSides = (): JSX.Element | null => {
   const { values, errors, touched } = useFormikContext<LabwareFields>()
   const label =
     values.labwareType === 'tipRack' ? 'Tip Diameter' : 'Well Shape & Sides'
+  const id =
+    values.labwareType === 'tipRack' ? 'TipDiameter' : 'WellShapeAndSides'
 
   return (
     <div className={styles.new_definition_section}>
-      <SectionBody label={label} id="WellShapeAndSides">
+      <SectionBody label={label} id={id}>
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
           <Content values={values} />


### PR DESCRIPTION
# Overview

This PR serves as its own ticket. It updates the ID for the Tip Diameter section to be `TipDiameter` instead of `WellShapeAndSides` when a tipRack is selected fo e2e tests.

# Changelog

- test(labware-creator): Update ID when TipDiameter instead of WellShapeAndSides

# Review requests

- [ ] ID is `TipDiameter` for tipRacks
- [ ] ID is `WellShapeAndSides` for all other labware types

# Risk assessment

low. selector in LC only
