### PR TITLE
refactor(step-generation): avoid "as" casting in tests

### DIFF
--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -49,7 +49,7 @@ export const ASPIRATE_OFFSET_FROM_BOTTOM_MM = 3.1
 export const DISPENSE_OFFSET_FROM_BOTTOM_MM = 3.2
 export const BLOWOUT_OFFSET_FROM_TOP_MM = 3.3
 const TOUCH_TIP_OFFSET_FROM_BOTTOM_MM = 3.4
-interface FlowRateAndOffsetParamsTransferlike {
+export interface FlowRateAndOffsetParamsTransferlike {
   aspirateFlowRateUlSec: number
   dispenseFlowRateUlSec: number
   blowoutFlowRateUlSec: number


### PR DESCRIPTION
# Overview

This is just a draft to serve as both an example and a reminder. After the TS conversion, all the command creator tests have type-unsafe casting going on with lots of `} as FooArgs`. This is scary because the command creators have many many arguments and they're very easy to lose track of!

This draft PR only updates `transfer.test.ts`, but as-is sets up a pattern we can follow for the rest. Note the use of `Omit` for all the partial-args objects that get spread in. `Partial` isn't specific enough, because TS has no way to know `Partial<FooArgs> + Partial<FooArgs> = FooArgs`.

There was a pattern of mutating `mixinArgs` etc variables, which makes it hard to TS to follow. The mutation pattern isn't necessary, it's just as easy to spread, so I switched to that.

I changed some variable naming too, eg `advArgs` is just "all args except 'volume'" so I renamed it `noVolumeArgs` 🤷 

Also `as const` is helpful in some places, eg `['always', 'never'] as const` allows TS to infer that the type of all elements in that array is `'always' | 'never'` instead of `string`.


# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
