### PR TITLE
refactor(robot-server,api): wire up JSON protocol runner to /sessions

### DIFF
--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -99,6 +99,9 @@ class ProtocolEngine:
 
     def add_command(self, request: CommandRequestType) -> PendingCommandType:
         """Add a command to ProtocolEngine."""
+        # TODO(mc, 2021-06-14): ID generation and timestamp generation need to
+        # be redone / reconsidered. Too much about command execution has leaked
+        # into the root ProtocolEngine class, so we should delegate downwards.
         command_id = self._resources.id_generator.generate_id()
         created_at = utc_now()
         command_impl = request.get_implementation()

--- a/api/tests/opentrons/file_runner/test_python_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_python_file_runner.py
@@ -10,19 +10,19 @@ def subject() -> PythonFileRunner:
     return PythonFileRunner()
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_python_runner_play(subject: PythonFileRunner) -> None:
     """It should be able to start the run."""
     subject.play()
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_python_runner_pause(subject: PythonFileRunner) -> None:
     """It should be able to pause the run."""
     subject.pause()
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_python_runner_stop(subject: PythonFileRunner) -> None:
     """It should be able to stop the run."""
     subject.stop()

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -114,7 +114,7 @@ def test_load_pipette_with_bad_args(
         subject.load_pipette(pipette_name="p300_single", mount="west")
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_load_pipette_with_tipracks_list(subject: ProtocolContext) -> None:
     """TODO: it should do something with the `tip_racks` parameter to load_pipette."""
     subject.load_pipette(
@@ -124,7 +124,7 @@ def test_load_pipette_with_tipracks_list(subject: ProtocolContext) -> None:
     )
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_load_pipette_with_replace(subject: ProtocolContext) -> None:
     """TODO: it should do something with the `replace` parameter to load_pipette."""
     subject.load_pipette(pipette_name="p300_single", mount="left", replace=True)
@@ -189,7 +189,7 @@ def test_load_labware_default_namespace_and_version(
     assert result == Labware(labware_id="abc123", engine_client=engine_client)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
 def test_load_labware_with_label(subject: ProtocolContext) -> None:
     """TODO: it should do something with the `label` parameter to load_labware."""
     subject.load_labware(load_name="some_labware", location=5, label="some_label")

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -152,17 +152,13 @@ def well_plate_def() -> LabwareDefinition:
 @pytest.fixture(scope="session")
 def reservoir_def() -> LabwareDefinition:
     """Get the definition of single-row reservoir."""
-    return LabwareDefinition.parse_obj(
-        load_definition("nest_12_reservoir_15ml", 1)
-    )
+    return LabwareDefinition.parse_obj(load_definition("nest_12_reservoir_15ml", 1))
 
 
 @pytest.fixture(scope="session")
 def tip_rack_def() -> LabwareDefinition:
     """Get the definition of Opentrons 300 uL tip rack."""
-    return LabwareDefinition.parse_obj(
-        load_definition("opentrons_96_tiprack_300ul", 1)
-    )
+    return LabwareDefinition.parse_obj(load_definition("opentrons_96_tiprack_300ul", 1))
 
 
 @pytest.fixture
@@ -177,10 +173,12 @@ def store(standard_deck_def: DeckDefinitionV2) -> StateStore:
 @pytest.fixture
 def engine(
     mock_state_store: MagicMock,
-    mock_handlers: AsyncMock
+    mock_handlers: AsyncMock,
+    mock_resources: AsyncMock,
 ) -> ProtocolEngine:
     """Get a ProtocolEngine with its dependencies mocked out."""
     return ProtocolEngine(
         state_store=mock_state_store,
         handlers=mock_handlers,
+        resources=mock_resources,
     )

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -64,7 +64,8 @@ async def test_create_engine_initializes_state_with_deck_geometry(
 
 
 async def test_execute_command_creates_command(
-    engine: ProtocolEngine, mock_state_store: MagicMock
+    engine: ProtocolEngine,
+    mock_state_store: MagicMock,
 ) -> None:
     """It should create a command in the state store when executing."""
     req = MoveToWellRequest(pipetteId="123", labwareId="abc", wellName="A1")
@@ -108,7 +109,8 @@ async def test_execute_command_adds_result_to_state(
 
     mock_req.get_implementation.return_value = mock_impl
     mock_impl.create_command.return_value = PendingCommand(
-        request=mock_req, created_at=now
+        request=mock_req,
+        created_at=now,
     )
     mock_impl.execute.return_value = result
 
@@ -141,7 +143,8 @@ async def test_execute_command_adds_error_to_state(
 
     mock_req.get_implementation.return_value = mock_impl
     mock_impl.create_command.return_value = PendingCommand(
-        request=mock_req, created_at=now
+        request=mock_req,
+        created_at=now,
     )
     mock_impl.execute.side_effect = error
 

--- a/robot-server/robot_server/protocols/__init__.py
+++ b/robot-server/robot_server/protocols/__init__.py
@@ -2,17 +2,20 @@
 
 from opentrons.file_runner import ProtocolFileType
 
-from .router import protocols_router
+from .router import protocols_router, ProtocolNotFound
 from .dependencies import get_protocol_store
-from .protocol_store import ProtocolStore, ProtocolResource
+from .protocol_store import ProtocolStore, ProtocolResource, ProtocolNotFoundError
 
 __all__ = [
     # main protocols router
     "protocols_router",
+    # common error response details
+    "ProtocolNotFound",
     # protocol state management
     "get_protocol_store",
     "ProtocolStore",
     "ProtocolResource",
+    "ProtocolNotFoundError",
     # convenience re-exports from opentrons
     "ProtocolFileType",
 ]

--- a/robot-server/robot_server/sessions/action_models.py
+++ b/robot-server/robot_server/sessions/action_models.py
@@ -15,7 +15,7 @@ class SessionActionType(str, Enum):
 class SessionActionCreateData(BaseModel):
     """Request model for new control action creation."""
 
-    controlType: SessionActionType
+    actionType: SessionActionType
 
 
 class SessionAction(ResourceModel):
@@ -30,7 +30,7 @@ class SessionAction(ResourceModel):
 
     id: str = Field(..., description="A unique identifier to reference the command.")
     createdAt: datetime = Field(..., description="When the command was created.")
-    controlType: SessionActionType = Field(
+    actionType: SessionActionType = Field(
         ...,
         description="Specific type of action, which determines behavior.",
     )

--- a/robot-server/robot_server/sessions/engine_store.py
+++ b/robot-server/robot_server/sessions/engine_store.py
@@ -2,7 +2,9 @@
 from typing import Optional
 
 from opentrons.hardware_control import API as HardwareAPI
+from opentrons.file_runner import AbstractFileRunner, ProtocolFile, create_file_runner
 from opentrons.protocol_engine import ProtocolEngine
+from robot_server.protocols import ProtocolResource
 
 
 class EngineConflictError(RuntimeError):
@@ -33,6 +35,7 @@ class EngineStore:
         """
         self._hardware_api = hardware_api
         self._engine: Optional[ProtocolEngine] = None
+        self._runner: Optional[AbstractFileRunner] = None
 
     @property
     def engine(self) -> ProtocolEngine:
@@ -46,7 +49,19 @@ class EngineStore:
 
         return self._engine
 
-    async def create(self) -> ProtocolEngine:
+    @property
+    def runner(self) -> AbstractFileRunner:
+        """Get the persisted AbstractFileRunner.
+
+        Raises:
+            EngineMissingError: Runner has not yet been created and persisted.
+        """
+        if self._runner is None:
+            raise EngineMissingError("Runner not yet created.")
+
+        return self._runner
+
+    async def create(self, protocol: Optional[ProtocolResource]) -> ProtocolEngine:
         """Create and store a ProtocolEngine.
 
         Returns:
@@ -56,15 +71,35 @@ class EngineStore:
             EngineConflictError: a ProtocolEngine is already present.
         """
         # NOTE: this async. creation happens before the `self._engine`
-        # check intentially to avoid a race condition where `self._engine` is
+        # check intentionally to avoid a race condition where `self._engine` is
         # set after the check but before the engine has finished getting created,
         # at the expense of having to potentially throw away an engine instance
         engine = await ProtocolEngine.create(hardware=self._hardware_api)
+        runner = None
 
         if self._engine is not None:
             raise EngineConflictError("Cannot load multiple sessions simultaneously.")
 
+        if protocol is not None:
+            # TODO(mc, 2021-06-11): add multi-file support. As written, other
+            # parts of the API will make sure len(files) == 0, but this will
+            # not remain true as engine sessions are built out
+            protocol_file = ProtocolFile(
+                file_path=protocol.files[0],
+                file_type=protocol.protocol_type,
+            )
+            runner = create_file_runner(
+                protocol_file=protocol_file,
+                engine=engine,
+            )
+
+            # TODO(mc, 2021-06-11): serparating load from creation is a potentially
+            # two-phase initialization. Revisit this, but for now keep the weirdness
+            # contained here in this factory method
+            runner.load()
+
         self._engine = engine
+        self._runner = runner
 
         return engine
 

--- a/robot-server/robot_server/sessions/router.py
+++ b/robot-server/robot_server/sessions/router.py
@@ -42,7 +42,7 @@ class SessionAlreadyActive(ErrorDetails):
 class SessionActionNotAllowed(ErrorDetails):
     """An error if one tries to issue an unsupported session action."""
 
-    id: Literal["SessionActionNotAllow"] = "SessionActionNotAllow"
+    id: Literal["SessionActionNotAllowed"] = "SessionActionNotAllowed"
     title: str = "Session Action Not Allowed"
 
 

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -13,6 +13,7 @@ class SessionType(str, Enum):
     """All available session types."""
 
     BASIC = "basic"
+    PROTOCOL = "protocol"
 
 
 class AbstractSessionCreateData(BaseModel):
@@ -39,7 +40,7 @@ class AbstractSession(ResourceModel):
         None,
         description="Configuration parameters for the session.",
     )
-    controlCommands: List[SessionAction] = Field(
+    actions: List[SessionAction] = Field(
         ...,
         description="Client-initiated commands for session control.",
     )
@@ -57,10 +58,35 @@ class BasicSession(AbstractSession):
     sessionType: Literal[SessionType.BASIC] = SessionType.BASIC
 
 
+class ProtocolSessionCreateParams(BaseModel):
+    """Creation parameters for a protocol session."""
+
+    protocolId: str = Field(
+        ...,
+        description="Unique identifier of the protocol this session will run.",
+    )
+
+
+class ProtocolSessionCreateData(AbstractSessionCreateData):
+    """Creation request data for a basic session."""
+
+    sessionType: Literal[SessionType.PROTOCOL] = SessionType.PROTOCOL
+    createParams: ProtocolSessionCreateParams
+
+
+class ProtocolSession(AbstractSession):
+    """A session to execute commands without a previously loaded protocol file."""
+
+    sessionType: Literal[SessionType.PROTOCOL] = SessionType.PROTOCOL
+    createParams: ProtocolSessionCreateParams
+
+
 SessionCreateData = Union[
     BasicSessionCreateData,
+    ProtocolSessionCreateData,
 ]
 
 Session = Union[
     BasicSession,
+    ProtocolSession,
 ]

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -68,14 +68,14 @@ class ProtocolSessionCreateParams(BaseModel):
 
 
 class ProtocolSessionCreateData(AbstractSessionCreateData):
-    """Creation request data for a basic session."""
+    """Creation request data for a protocol session."""
 
     sessionType: Literal[SessionType.PROTOCOL] = SessionType.PROTOCOL
     createParams: ProtocolSessionCreateParams
 
 
 class ProtocolSession(AbstractSession):
-    """A session to execute commands without a previously loaded protocol file."""
+    """A session to execute commands with a previously loaded protocol file."""
 
     sessionType: Literal[SessionType.PROTOCOL] = SessionType.PROTOCOL
     createParams: ProtocolSessionCreateParams

--- a/robot-server/robot_server/sessions/session_view.py
+++ b/robot-server/robot_server/sessions/session_view.py
@@ -7,9 +7,11 @@ from .session_store import SessionResource
 from .action_models import SessionAction, SessionActionCreateData
 from .session_models import (
     Session,
-    BasicSession,
     SessionCreateData,
+    BasicSession,
     BasicSessionCreateData,
+    ProtocolSession,
+    ProtocolSessionCreateData,
 )
 
 
@@ -67,7 +69,7 @@ class SessionView:
         actions = SessionAction(
             id=action_id,
             createdAt=created_at,
-            controlType=action_data.controlType,
+            actionType=action_data.actionType,
         )
 
         updated_session = replace(
@@ -93,7 +95,14 @@ class SessionView:
             return BasicSession.construct(
                 id=session.session_id,
                 createdAt=session.created_at,
-                controlCommands=session.actions,
+                actions=session.actions,
+            )
+        if isinstance(create_data, ProtocolSessionCreateData):
+            return ProtocolSession.construct(
+                id=session.session_id,
+                createdAt=session.created_at,
+                createParams=create_data.createParams,
+                actions=session.actions,
             )
 
-        raise ValueError(f"Invalid session store entry {session}")
+        raise ValueError(f"Invalid session resource {session}")

--- a/robot-server/tests/sessions/conftest.py
+++ b/robot-server/tests/sessions/conftest.py
@@ -1,10 +1,19 @@
 """Common test fixtures for sessions route tests."""
 import pytest
+import json
+from pathlib import Path
 from decoy import Decoy
 
+from robot_server.protocols import ProtocolStore
 from robot_server.sessions.session_view import SessionView
 from robot_server.sessions.session_store import SessionStore
 from robot_server.sessions.engine_store import EngineStore
+
+
+@pytest.fixture
+def protocol_store(decoy: Decoy) -> ProtocolStore:
+    """Get a mock ProtocolStore interface."""
+    return decoy.create_decoy(spec=ProtocolStore)
 
 
 @pytest.fixture
@@ -23,3 +32,80 @@ def session_view(decoy: Decoy) -> SessionView:
 def engine_store(decoy: Decoy) -> EngineStore:
     """Get a mock EngineStore interface."""
     return decoy.create_decoy(spec=EngineStore)
+
+
+@pytest.fixture
+def json_protocol_file(
+    tmp_path: Path,
+    minimal_labware_def: dict,
+) -> Path:
+    """Get an on-disk, minimal JSON protocol fixture."""
+    file_path = tmp_path / "protocol-name.json"
+
+    file_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 3,
+                "metadata": {},
+                "robot": {"model": "OT-2 Standard"},
+                "pipettes": {"leftPipetteId": {"mount": "left", "name": "p300_single"}},
+                "labware": {
+                    "trashId": {
+                        "slot": "12",
+                        "displayName": "Trash",
+                        "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1",
+                    },
+                    "tiprack1Id": {
+                        "slot": "1",
+                        "displayName": "Opentrons 96 Tip Rack 300 µL",
+                        "definitionId": "opentrons/opentrons_96_tiprack_300ul/1",
+                    },
+                    "wellplate1Id": {
+                        "slot": "10",
+                        "displayName": "Corning 96 Well Plate 360 µL Flat",
+                        "definitionId": "opentrons/corning_96_wellplate_360ul_flat/1",
+                    },
+                },
+                "labwareDefinitions": {
+                    "opentrons/opentrons_1_trash_1100ml_fixed/1": minimal_labware_def,
+                    "opentrons/opentrons_96_tiprack_300ul/1": minimal_labware_def,
+                    "opentrons/corning_96_wellplate_360ul_flat/1": minimal_labware_def,
+                },
+                "commands": [
+                    {
+                        "command": "pickUpTip",
+                        "params": {
+                            "pipette": "leftPipetteId",
+                            "labware": "tiprack1Id",
+                            "well": "A1",
+                        },
+                    },
+                    {
+                        "command": "aspirate",
+                        "params": {
+                            "pipette": "leftPipetteId",
+                            "volume": 51,
+                            "labware": "wellplate1Id",
+                            "well": "B1",
+                            "offsetFromBottomMm": 10,
+                            "flowRate": 10,
+                        },
+                    },
+                    {
+                        "command": "dispense",
+                        "params": {
+                            "pipette": "leftPipetteId",
+                            "volume": 50,
+                            "labware": "wellplate1Id",
+                            "well": "H1",
+                            "offsetFromBottomMm": 1,
+                            "flowRate": 50,
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    return file_path

--- a/robot-server/tests/sessions/test_engine_store.py
+++ b/robot-server/tests/sessions/test_engine_store.py
@@ -64,6 +64,14 @@ async def test_raise_if_engine_already_exists(subject: EngineStore) -> None:
         await subject.create(protocol=None)
 
 
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_cannot_persist_multiple_engines(subject: EngineStore) -> None:
+    """It should protect against engine creation race conditions."""
+    # TODO(mc, 2021-06-14): figure out how to write a test that actually
+    # fails in practice when race condition is able to be hit
+    raise NotImplementedError("Test not yet implemented")
+
+
 def test_raise_if_engine_does_not_exist(subject: EngineStore) -> None:
     """It should raise if no engine exists when requested."""
     with pytest.raises(EngineMissingError):

--- a/robot-server/tests/sessions/test_engine_store.py
+++ b/robot-server/tests/sessions/test_engine_store.py
@@ -1,8 +1,12 @@
 """Tests for the EngineStore interface."""
 import pytest
+from datetime import datetime
 from mock import MagicMock
+from pathlib import Path
 
 from opentrons.protocol_engine import ProtocolEngine
+from opentrons.file_runner import JsonFileRunner
+from robot_server.protocols import ProtocolResource, ProtocolFileType
 from robot_server.sessions.engine_store import (
     EngineStore,
     EngineConflictError,
@@ -20,19 +24,44 @@ def subject() -> EngineStore:
 
 async def test_create_engine(subject: EngineStore) -> None:
     """It should create an engine."""
-    result = await subject.create()
+    result = await subject.create(protocol=None)
 
     assert result == subject.engine
     assert isinstance(result, ProtocolEngine)
     assert isinstance(subject.engine, ProtocolEngine)
 
 
+async def test_create_engine_for_json_protocol(
+    subject: EngineStore,
+    json_protocol_file: Path,
+) -> None:
+    """It should create a protocol runner.
+
+    This test is functioning as an integration / smoke test. Ensuring that
+    the protocol was loaded correctly is / should be covered in unit tests
+    elsewhere.
+    """
+    protocol = ProtocolResource(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.JSON,
+        created_at=datetime.now(),
+        files=[json_protocol_file],
+    )
+
+    result = await subject.create(protocol=protocol)
+
+    assert result == subject.engine
+    assert isinstance(result, ProtocolEngine)
+    assert isinstance(subject.engine, ProtocolEngine)
+    assert isinstance(subject.runner, JsonFileRunner)
+
+
 async def test_raise_if_engine_already_exists(subject: EngineStore) -> None:
     """It should not create more than one engine / runner pair."""
-    await subject.create()
+    await subject.create(protocol=None)
 
     with pytest.raises(EngineConflictError):
-        await subject.create()
+        await subject.create(protocol=None)
 
 
 def test_raise_if_engine_does_not_exist(subject: EngineStore) -> None:
@@ -43,7 +72,7 @@ def test_raise_if_engine_does_not_exist(subject: EngineStore) -> None:
 
 async def test_clear_engine(subject: EngineStore) -> None:
     """It should clear a stored engine entry."""
-    await subject.create()
+    await subject.create(protocol=None)
     subject.clear()
 
     with pytest.raises(EngineMissingError):

--- a/robot-server/tests/sessions/test_session_view.py
+++ b/robot-server/tests/sessions/test_session_view.py
@@ -8,6 +8,9 @@ from robot_server.sessions.session_models import (
     Session,
     BasicSession,
     BasicSessionCreateData,
+    ProtocolSession,
+    ProtocolSessionCreateData,
+    ProtocolSessionCreateParams,
 )
 
 from robot_server.sessions.action_models import (
@@ -57,6 +60,28 @@ def test_create_session_resource() -> None:
     )
 
 
+def test_create_protocol_session_resource() -> None:
+    """It should create a protocol session resource view."""
+    created_at = datetime.now()
+    create_data = ProtocolSessionCreateData(
+        createParams=ProtocolSessionCreateParams(protocolId="protocol-id")
+    )
+
+    subject = SessionView()
+    result = subject.as_resource(
+        session_id="session-id",
+        create_data=create_data,
+        created_at=created_at,
+    )
+
+    assert result == SessionResource(
+        session_id="session-id",
+        create_data=create_data,
+        created_at=created_at,
+        actions=[],
+    )
+
+
 current_time = datetime.now()
 
 
@@ -73,7 +98,23 @@ current_time = datetime.now()
             BasicSession(
                 id="session-id",
                 createdAt=current_time,
-                controlCommands=[],
+                actions=[],
+            ),
+        ),
+        (
+            SessionResource(
+                session_id="session-id",
+                create_data=ProtocolSessionCreateData(
+                    createParams=ProtocolSessionCreateParams(protocolId="protocol-id")
+                ),
+                created_at=current_time,
+                actions=[],
+            ),
+            ProtocolSession(
+                id="session-id",
+                createdAt=current_time,
+                createParams=ProtocolSessionCreateParams(protocolId="protocol-id"),
+                actions=[],
             ),
         ),
     ),
@@ -99,7 +140,7 @@ def test_create_action(current_time: datetime) -> None:
     )
 
     command_data = SessionActionCreateData(
-        controlType=SessionActionType.START,
+        actionType=SessionActionType.START,
     )
 
     subject = SessionView()
@@ -113,7 +154,7 @@ def test_create_action(current_time: datetime) -> None:
     assert action_result == SessionAction(
         id="control-command-id",
         createdAt=current_time,
-        controlType=SessionActionType.START,
+        actionType=SessionActionType.START,
     )
 
     assert session_result == SessionResource(


### PR DESCRIPTION
## Overview

This PR gets us pretty close to #7808.

- You can create a protocol session from an uploaded JSON protocol file
- On session creation, a JSON protocol runner is created and loads the protocol state into a Protocol Engine
- You can issue a `start` action to kick off the run

There's still a few items to address before I think 7808 can be considered complete, but we're almost there!

- Pipette and labware loading into the Engine from the JSON protocol data (I think?)
- Get next command from the queue (#7936)
- Translation of all JSON protocol commands that we could support in the `CommandTranslator`

## Changelog

- Implement a basic version of `ProtocolEngine::add_command`
- Create `ProtocolSession` response model type(s)
- Allow the `EngineStore` to create and load an `AbtractFileRunner` if needed

## Review requests

- I have no idea what will happen if this gets run on a robot
- This is pretty hard to smoke test without #7871
- Do the changes / TODOs all make sense?

[Postman testing collections here](https://gist.github.com/mcous/7dde93b6ea83753b86b0d84b40ba07f6)

1. `POST /protocols` with a JSON protocol
    - I took the protocol at `shared-data/protocol/fixtures/5/simpleV5.json` and stripped out all the commands that `CommandTranslator` doesn't know about
2. `POST /sessions` with `sessionType: "protocol"` and `createParams: { protocolId: "{{ protocol_id }}" }`
3. `POST /sessions/{{ session_id }}/actions` with `actionType: "start"`

## Risk assessment

Low. Feature-flagged endpoints.
