### PR TITLE
feat(protocol-engine): Implement `CommandState.get_next_request()`

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -1,5 +1,7 @@
 """Protocol engine commands sub-state."""
-from typing import Dict, List, Optional, Tuple
+import typing
+from typing import List, Optional, Tuple
+import collections
 
 from ..commands import CommandType, CommandRequestType
 from .substore import Substore
@@ -8,18 +10,23 @@ from .substore import Substore
 class CommandState:
     """Command state and getters."""
 
-    _commands_by_id: Dict[str, CommandType]
+    _commands_by_id: typing.OrderedDict[str, CommandType]
 
     def __init__(self) -> None:
         """Initialize a CommandState instance."""
-        self._commands_by_id = {}
+        self._commands_by_id = collections.OrderedDict()
 
     def get_command_by_id(self, uid: str) -> Optional[CommandType]:
         """Get a command by its unique identifier."""
         return self._commands_by_id.get(uid)
 
     def get_all_commands(self) -> List[Tuple[str, CommandType]]:
-        """Get a list of all command entries in state."""
+        """Get a list of all command entries in state.
+        
+        Entries are returned in the order of first-added command to last-added command.
+        Replacing a command (to change its status, for example) keeps its place in the
+        ordering.
+        """
         return [entry for entry in self._commands_by_id.items()]
 
     def get_next_request(self) -> Optional[Tuple[str, CommandRequestType]]:

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -69,4 +69,4 @@ def run_python(
         except KeyError:
             # No pretty names, just raise it
             raise e
-        raise ExceptionInProtocolError(e, tb, str(e), frame.lineno)
+        raise ExceptionInProtocolError(e, tb, str(e), frame.lineno) from e

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -96,7 +96,7 @@ def test_state_store_handles_command(
     assert store.commands.get_command_by_id("unique-id") == pending_command
 
 
-def test_command_state_preserves_handle_order(  # noqa:D103
+def test_command_state_preserves_handle_order(
     store: StateStore, now: datetime
 ) -> None:
     unique_commands = [
@@ -107,6 +107,7 @@ def test_command_state_preserves_handle_order(  # noqa:D103
         for r in _make_unique_requests(3)
     ]
     command_a, command_b, command_c = unique_commands
+    """It should return commands in the order they are first added."""
 
     store.handle_command(command_a, "command-id-1")
     store.handle_command(command_b, "command-id-2")
@@ -120,12 +121,13 @@ def test_command_state_preserves_handle_order(  # noqa:D103
     ]
 
 
-def test_get_next_request_returns_first_pending(  # noqa: D103
+def test_get_next_request_returns_first_pending(
     pending_command: PendingCommand,
     running_command: RunningCommand,
     completed_command: CompletedCommand,
     failed_command: FailedCommand,
 ) -> None:
+    """It should return the first command that's pending."""
     subject = CommandState()
 
     subject._commands_by_id["command-id-1"] = running_command
@@ -138,11 +140,12 @@ def test_get_next_request_returns_first_pending(  # noqa: D103
     )
 
 
-def test_get_next_request_returns_none_when_no_pending(  # noqa: D103
+def test_get_next_request_returns_none_when_no_pending(
     running_command: RunningCommand,
     completed_command: CompletedCommand,
     failed_command: FailedCommand
 ) -> None:
+    """It should return None if there are no pending commands to return."""
     subject = CommandState()
 
     assert subject.get_next_request() is None
@@ -154,10 +157,11 @@ def test_get_next_request_returns_none_when_no_pending(  # noqa: D103
     assert subject.get_next_request() is None
 
 
-def test_get_next_request_returns_none_when_earlier_command_failed(  # noqa: D103
+def test_get_next_request_returns_none_when_earlier_command_failed(
     pending_command: PendingCommand,
     failed_command: FailedCommand
 ) -> None:
+    """It should return None if any prior-added command is failed."""
     subject = CommandState()
 
     subject._commands_by_id["command-id-1"] = failed_command

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -27,3 +27,50 @@ def test_state_store_handles_command(store: StateStore, now: datetime) -> None:
     store.handle_command(cmd, command_id="unique-id")
 
     assert store.commands.get_command_by_id("unique-id") == cmd
+
+
+def test_command_state_ordering(store: StateStore, now: datetime) -> None:
+    # Fx before merge: Fixturize? Or maybe turn into a private util function?
+    cmd1 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+        created_at=now,
+        request=LoadLabwareRequest(
+            loadName="load-name",
+            namespace="opentrons-test",
+            version=1,
+            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+            labwareId=None
+        )
+    )
+    cmd2 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+        created_at=now,
+        request=LoadLabwareRequest(
+            loadName="load-name",
+            namespace="opentrons-test",
+            version=1,
+            location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
+            labwareId=None
+        )
+    )
+    cmd3 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+        created_at=now,
+        request=LoadLabwareRequest(
+            loadName="load-name",
+            namespace="opentrons-test",
+            version=1,
+            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
+            labwareId=None
+        )
+    )
+    
+    # Testing the test: check that all 3 cmds compare non-equal to each other, so we
+    # know the rest of the asserts in this test are meaningful.
+    assert cmd1 != cmd2
+    assert cmd1 != cmd3
+    assert cmd2 != cmd3
+    
+    store.handle_command(cmd1, "id-1")
+    store.handle_command(cmd2, "id-2")
+    assert store.commands.get_all_commands() == [("id-1", cmd1), ("id-2", cmd2)]
+    
+    store.handle_command(cmd3, "id-1")
+    assert store.commands.get_all_commands() == [("id-1", cmd3), ("id-2", cmd2)]

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -1,14 +1,41 @@
 """Tests for the command lifecycle state."""
 from datetime import datetime
+from typing import List
+import itertools
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import StateStore
 from opentrons.protocol_engine.types import DeckSlotLocation
 from opentrons.protocol_engine.commands import (
+    CommandRequestType,
     PendingCommand,
+    RunningCommand,
+    FailedCommand,
     LoadLabwareRequest,
-    LoadLabwareResult
+    LoadLabwareResult,
 )
+
+
+def _make_unique_requests(n: int) -> List[LoadLabwareRequest]:
+    """Return n dummy requests that are non-equal (!=) to each other."""
+    def request(i: int) -> LoadLabwareRequest:
+        return LoadLabwareRequest(
+            loadName=f"load-name-{i}",
+            namespace="opentrons-test",
+            version=1,
+            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+            labwareId=None
+        )
+    requests = [request(i) for i in range(n)]
+    for a, b in itertools.combinations(requests, 2):
+        # Testing the test. If these accidentally compare equal real assertions in this
+        # module (e.g. to compare iteration order) could trivially succeed.
+        assert a != b
+    return requests
+
+
+def _make_request() -> LoadLabwareRequest:
+    return _make_unique_requests(1)[0]
 
 
 def test_state_store_handles_command(store: StateStore, now: datetime) -> None:
@@ -29,48 +56,84 @@ def test_state_store_handles_command(store: StateStore, now: datetime) -> None:
     assert store.commands.get_command_by_id("unique-id") == cmd
 
 
-def test_command_state_ordering(store: StateStore, now: datetime) -> None:
-    # Fx before merge: Fixturize? Or maybe turn into a private util function?
-    cmd1 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
-        created_at=now,
-        request=LoadLabwareRequest(
-            loadName="load-name",
-            namespace="opentrons-test",
-            version=1,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-            labwareId=None
+def test_command_state_preserves_handle_order(store: StateStore, now: datetime) -> None:
+    unique_commands = [
+        PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+            created_at=now,
+            request=r
         )
-    )
-    cmd2 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+        for r in _make_unique_requests(3)
+    ]
+    command_a, command_b, command_c = unique_commands
+
+    store.handle_command(command_a, "first-handled-id")
+    store.handle_command(command_b, "second-handled-id")
+    assert store.commands.get_all_commands() == [
+        ("first-handled-id", command_a), ("second-handled-id", command_b)
+    ]
+
+    store.handle_command(command_c, "first-handled-id")
+    assert store.commands.get_all_commands() == [
+        ("first-handled-id", command_c), ("second-handled-id", command_b)
+    ]
+
+
+# todo(mm, 2021-06-10): Not sure if this is the right way to initialize the queue
+# of commands for the purposes of this test.
+#
+# Options:
+#
+# * Manually initalize ._commands_by_id? ._commands_by_id is private (sort of), and
+#   touching private attributes in a test seems Bad.
+# * Add the commands through store.handle_command()? That would make this
+#   test partially redundant with test_state_store_handles_command(), which seems
+#   Bad.
+# * Mock out CommandState.get_all_commands() and avoid the need to initialize the
+#   queue of commands at all? That would mean CommandState is partially mocked out,
+#   which seems Bad.
+def test_get_next_request_returns_first_pending(
+    store: StateStore, now: datetime
+) -> None:
+    running_command = RunningCommand[LoadLabwareRequest, LoadLabwareResult](
         created_at=now,
-        request=LoadLabwareRequest(
-            loadName="load-name",
-            namespace="opentrons-test",
-            version=1,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-            labwareId=None
-        )
+        started_at=now,
+        request=_make_request()
     )
-    cmd3 = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
+    pending_command = PendingCommand[LoadLabwareRequest, LoadLabwareResult](
         created_at=now,
-        request=LoadLabwareRequest(
-            loadName="load-name",
-            namespace="opentrons-test",
-            version=1,
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-            labwareId=None
-        )
+        request=_make_request()
     )
-    
-    # Testing the test: check that all 3 cmds compare non-equal to each other, so we
-    # know the rest of the asserts in this test are meaningful.
-    assert cmd1 != cmd2
-    assert cmd1 != cmd3
-    assert cmd2 != cmd3
-    
-    store.handle_command(cmd1, "id-1")
-    store.handle_command(cmd2, "id-2")
-    assert store.commands.get_all_commands() == [("id-1", cmd1), ("id-2", cmd2)]
-    
-    store.handle_command(cmd3, "id-1")
-    assert store.commands.get_all_commands() == [("id-1", cmd3), ("id-2", cmd2)]
+    # Testing the test: the next assert is only meaningful if these compare nonequal.
+    assert running_command != pending_command
+
+    store.handle_command(running_command, "id-1")
+    store.handle_command(pending_command, "id-2")
+    # Skips running_command even though it came first.
+    assert store.commands.get_next_request() == pending_command
+
+
+def test_get_next_request_returns_none_when_no_pending(
+    store: StateStore, now: datetime
+) -> None:
+    assert store.commands.get_next_request() is None
+
+    store.handle_command(
+        RunningCommand[LoadLabwareRequest, LoadLabwareResult](
+            created_at=now,
+            started_at=now,
+            request=_make_request()
+        ),
+        "command-id"
+    )
+
+    # todo(mm, 2021-06-11): We should throw a completed command and failed command
+    # in here too, but I'm skipping it because they're a pain to construct.
+
+    assert store.commands.get_next_request() is None
+
+
+def test_get_next_request_returns_none_when_any_failed(
+    store: StateStore, now: datetime
+) -> None:
+    # Fix before merge.
+    raise NotImplementedError()

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -56,7 +56,9 @@ def test_state_store_handles_command(store: StateStore, now: datetime) -> None:
     assert store.commands.get_command_by_id("unique-id") == cmd
 
 
-def test_command_state_preserves_handle_order(store: StateStore, now: datetime) -> None:
+def test_command_state_preserves_handle_order(  # noqa:D103
+    store: StateStore, now: datetime
+) -> None:
     unique_commands = [
         PendingCommand[LoadLabwareRequest, LoadLabwareResult](
             created_at=now,
@@ -91,7 +93,7 @@ def test_command_state_preserves_handle_order(store: StateStore, now: datetime) 
 # * Mock out CommandState.get_all_commands() and avoid the need to initialize the
 #   queue of commands at all? That would mean CommandState is partially mocked out,
 #   which seems Bad.
-def test_get_next_request_returns_first_pending(
+def test_get_next_request_returns_first_pending(  # noqa: D103
     store: StateStore, now: datetime
 ) -> None:
     running_command = RunningCommand[LoadLabwareRequest, LoadLabwareResult](
@@ -109,10 +111,10 @@ def test_get_next_request_returns_first_pending(
     store.handle_command(running_command, "id-1")
     store.handle_command(pending_command, "id-2")
     # Skips running_command even though it came first.
-    assert store.commands.get_next_request() == pending_command
+    assert store.commands.get_next_request() == ("id-2", pending_command.request)
 
 
-def test_get_next_request_returns_none_when_no_pending(
+def test_get_next_request_returns_none_when_no_pending(  # noqa: D103
     store: StateStore, now: datetime
 ) -> None:
     assert store.commands.get_next_request() is None
@@ -132,7 +134,7 @@ def test_get_next_request_returns_none_when_no_pending(
     assert store.commands.get_next_request() is None
 
 
-def test_get_next_request_returns_none_when_any_failed(
+def test_get_next_request_returns_none_when_earlier_command_failed(  # noqa: D103
     store: StateStore, now: datetime
 ) -> None:
     # Fix before merge.

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -122,30 +122,33 @@ def test_command_state_preserves_handle_order(  # noqa:D103
 
 def test_get_next_request_returns_first_pending(  # noqa: D103
     pending_command: PendingCommand,
-    running_command: RunningCommand
+    running_command: RunningCommand,
+    completed_command: CompletedCommand,
+    failed_command: FailedCommand,
 ) -> None:
     subject = CommandState()
 
-    # todo(mm, 2021-06-14): Add completed and failed, for thoroughness.
     subject._commands_by_id["command-id-1"] = running_command
-    subject._commands_by_id["command-id-2"] = pending_command
+    subject._commands_by_id["command-id-2"] = completed_command
+    subject._commands_by_id["command-id-3"] = pending_command
+    subject._commands_by_id["command-id-4"] = pending_command
 
-    # running_command should be skipped even though it came first.
     assert subject.get_next_request() == (
-        "command-id-2", pending_command.request
+        "command-id-3", pending_command.request
     )
 
 
 def test_get_next_request_returns_none_when_no_pending(  # noqa: D103
     running_command: RunningCommand,
+    completed_command: CompletedCommand,
     failed_command: FailedCommand
 ) -> None:
     subject = CommandState()
 
     assert subject.get_next_request() is None
 
-    # todo(mm, 2021-06-11): We should throw a completed command in here too.
     subject._commands_by_id["running-command-id"] = running_command
+    subject._commands_by_id["completed-command-id"] = completed_command
     subject._commands_by_id["failed-command-id"] = failed_command
 
     assert subject.get_next_request() is None

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -1,23 +1,18 @@
 """Tests for the command lifecycle state."""
-import pytest
 
 from datetime import datetime
-from typing import List
 
+import pytest
 from pydantic import BaseModel
 
-from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import StateStore
-from opentrons.protocol_engine.types import DeckSlotLocation
-from opentrons.protocol_engine.errors import ProtocolEngineError
 from opentrons.protocol_engine.commands import (
     PendingCommand,
     RunningCommand,
     CompletedCommand,
     FailedCommand,
-    LoadLabwareRequest,
-    LoadLabwareResult,
 )
+from opentrons.protocol_engine.errors import ProtocolEngineError
 from opentrons.protocol_engine.state.commands import CommandState
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -40,10 +40,6 @@ def _make_unique_requests(n: int) -> List[LoadLabwareRequest]:
     return requests
 
 
-def _make_request() -> LoadLabwareRequest:
-    return _make_unique_requests(1)[0]
-
-
 @pytest.fixture
 def pending_command(now: datetime) -> PendingCommand:
     """Fixture for an arbitrary `PendingCommand`."""

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -135,12 +135,16 @@ def test_get_next_request_returns_none_when_no_pending(
 
 def test_get_next_request_returns_none_when_earlier_command_failed(
     pending_command: PendingCommand,
+    running_command: RunningCommand,
+    completed_command: CompletedCommand,
     failed_command: FailedCommand
 ) -> None:
     """It should return None if any prior-added command is failed."""
     subject = CommandState()
 
-    subject._commands_by_id["command-id-1"] = failed_command
-    subject._commands_by_id["command-id-2"] = pending_command
+    subject._commands_by_id["command-id-1"] = completed_command
+    subject._commands_by_id["command-id-2"] = failed_command
+    subject._commands_by_id["command-id-3"] = running_command
+    subject._commands_by_id["command-id-4"] = pending_command
 
     assert subject.get_next_request() is None


### PR DESCRIPTION
# Overview

Document, test, and implement `opentrons.protocol_engine.state.commands.get_next_request()`, which was formerly a `NotImplementedError`, in service towards #7808.

# Review requests

Mostly on testing.

# Risk assessment

None. Not production code, and this wasn't implemented before.