### PR TITLE
test(labware-creator): Add missing e2e selectors for sections

### DIFF
--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -28,7 +28,7 @@ export const Description = (): JSX.Element | null => {
   }
 
   return (
-    <SectionBody label="Description">
+    <SectionBody label="Description" id="Description">
       <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
       <Content />
     </SectionBody>

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -28,7 +28,7 @@ export const Export = (props: ExportProps): JSX.Element | null => {
   }
 
   return (
-    <SectionBody label="Labware Test Protocol">
+    <SectionBody label="Labware Test Protocol" id="Export">
       <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
 
       <div className={cx(styles.flex_row, styles.flex_row_start)}>
@@ -43,7 +43,7 @@ export const Export = (props: ExportProps): JSX.Element | null => {
           <Dropdown name="pipetteName" options={pipetteNameOptions} />
         </div>
       </div>
-      <div className={styles.export_section}>
+      <div className={styles.export_section} id="DefinitionTest">
         <div className={cx(styles.callout, styles.export_callout)}>
           <h4 className={styles.test_labware_heading}>
             Please test your definition file!

--- a/labware-library/src/labware-creator/components/sections/File.tsx
+++ b/labware-library/src/labware-creator/components/sections/File.tsx
@@ -36,7 +36,7 @@ export const File = (): JSX.Element | null => {
   }
 
   return (
-    <SectionBody label="File">
+    <SectionBody label="File" id="File">
       <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
       <Content values={values} />
     </SectionBody>

--- a/labware-library/src/labware-creator/components/sections/Preview.tsx
+++ b/labware-library/src/labware-creator/components/sections/Preview.tsx
@@ -12,7 +12,7 @@ export const Preview = (): JSX.Element => {
   const { values, errors } = useFormikContext<LabwareFields>()
 
   return (
-    <SectionBody label="Check your work">
+    <SectionBody label="Check your work" id="CheckYourWork">
       <FormLevelErrorAlerts errors={errors} />
       <div className={styles.preview_labware}>
         <ConditionalLabwareRender values={values} />


### PR DESCRIPTION

# Overview

This PR serves as its own ticket. Some sections were missing IDs for e2e tests. This PR adds them.

```
id="Description"
id="CheckYourWork"
id="File"
id="Export"
id="DefinitionTest"
```

# Changelog

- test(labware-creator): Add missing e2e selectors for sections

# Review requests

- [ ] Ids listed above can be found and inspected on this branch

# Risk assessment

low. IDs in LC only
