### PR TITLE
feat(protocol-engine): Support loading pipettes and labware from JSON protocols

### DIFF
--- a/api/src/opentrons/file_runner/json_file_runner.py
+++ b/api/src/opentrons/file_runner/json_file_runner.py
@@ -37,11 +37,9 @@ class JsonFileRunner(AbstractFileRunner):
     def load(self) -> None:
         """Translate JSON commands and send them to protocol engine."""
         protocol = self._file_reader.read(self._file)
-
-        for json_cmd in protocol.commands:
-            translated_items = self._command_translator.translate(json_cmd)
-            for cmd in translated_items:
-                self._protocol_engine.add_command(cmd)
+        translated_items = self._command_translator.translate(protocol)
+        for cmd in translated_items:
+            self._protocol_engine.add_command(cmd)
 
     def play(self) -> None:
         """Start (or un-pause) running the JSON protocol file."""

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -16,7 +16,7 @@ class LoadPipetteRequest(BaseModel):
 
     pipetteName: PipetteName = Field(
         ...,
-        description="The name of the pipette to be required.",
+        description="The load name of the pipette to be required.",
     )
     mount: MountType = Field(
         ...,

--- a/api/src/opentrons/protocols/models/__init__.py
+++ b/api/src/opentrons/protocols/models/__init__.py
@@ -1,18 +1,19 @@
+# Convenience re-exports of models that are especially common or important.
+# More detailed sub-models are always available through the underlying
+# submodules.
+#
+# If re-exporting something, its name should still make sense when it's separatred
+# from the name of its parent submodule. e.g. re-exporting models.json_protocol.Labware
+# as models.Labware could be confusing.
+
 from .labware_definition import (
     LabwareDefinition,
     WellDefinition
 )
-from .json_protocol import (
-    Labware,
-    Model as JsonProtocol,
-)
+from .json_protocol import Model as JsonProtocol
 
 __all__ = [
-    # Models for labware definitions:
     "LabwareDefinition",
     "WellDefinition",
-    # Models for JSON protocols:
-    "AllCommands",  # Fix before merge: Why doesn't the linter catch this?
-    "Labware",
     "JsonProtocol",
 ]

--- a/api/src/opentrons/protocols/models/__init__.py
+++ b/api/src/opentrons/protocols/models/__init__.py
@@ -2,11 +2,17 @@ from .labware_definition import (
     LabwareDefinition,
     WellDefinition
 )
-from .json_protocol import Model as JsonProtocol, Labware
+from .json_protocol import (
+    Labware,
+    Model as JsonProtocol,
+)
 
 __all__ = [
-    "Labware",
+    # Models for labware definitions:
     "LabwareDefinition",
     "WellDefinition",
+    # Models for JSON protocols:
+    "AllCommands",  # Fix before merge: Why doesn't the linter catch this?
+    "Labware",
     "JsonProtocol",
 ]

--- a/api/src/opentrons/protocols/models/__init__.py
+++ b/api/src/opentrons/protocols/models/__init__.py
@@ -2,9 +2,10 @@ from .labware_definition import (
     LabwareDefinition,
     WellDefinition
 )
-from .json_protocol import Model as JsonProtocol
+from .json_protocol import Model as JsonProtocol, Labware
 
 __all__ = [
+    "Labware",
     "LabwareDefinition",
     "WellDefinition",
     "JsonProtocol",

--- a/api/src/opentrons/protocols/runner/json_proto/command_translator.py
+++ b/api/src/opentrons/protocols/runner/json_proto/command_translator.py
@@ -2,7 +2,7 @@ from typing import Dict, Iterable, List
 
 import opentrons.types
 
-from opentrons import protocol_engine
+from opentrons import protocol_engine as pe
 from opentrons.protocols import models
 
 
@@ -10,7 +10,7 @@ class CommandTranslatorError(Exception):
     pass
 
 
-PECommands = Iterable[protocol_engine.commands.CommandRequestType]
+PECommands = Iterable[pe.commands.CommandRequestType]
 
 
 class CommandTranslator:
@@ -22,7 +22,7 @@ class CommandTranslator:
 
     def translate(self, protocol: models.JsonProtocol) -> PECommands:
         """Return all Protocol Engine commands required to run the given protocol."""
-        result: List[protocol_engine.commands.CommandRequestType] = []
+        result: List[pe.commands.CommandRequestType] = []
 
         for pipette_id, pipette in protocol.pipettes.items():
             result += [self._translate_load_pipette(pipette_id, pipette)]
@@ -65,14 +65,16 @@ class CommandTranslator:
 
     def _translate_add_labware_definition(
             self,
-            labware_definition: models.LabwareDefinition) -> protocol_engine.commands.AddLabwareDefinitionRequest:
-        return protocol_engine.commands.AddLabwareDefinitionRequest(definition=labware_definition)
+            labware_definition: models.LabwareDefinition
+            ) -> pe.commands.AddLabwareDefinitionRequest:
+        return pe.commands.AddLabwareDefinitionRequest(definition=labware_definition)
 
     def _translate_load_labware(
             self,
             labware_id: str,
             labware: models.json_protocol.Labware,
-            labware_definitions: Dict[str, models.LabwareDefinition]) -> protocol_engine.commands.LoadLabwareRequest:
+            labware_definitions: Dict[str, models.LabwareDefinition]
+            ) -> pe.commands.LoadLabwareRequest:
         """
         Args:
             labware_id:
@@ -85,8 +87,8 @@ class CommandTranslator:
                 The JSON protocol's collection of labware definitions.
         """
         definition = labware_definitions[labware.definitionId]
-        return protocol_engine.commands.LoadLabwareRequest(
-            location=protocol_engine.DeckSlotLocation(
+        return pe.commands.LoadLabwareRequest(
+            location=pe.DeckSlotLocation(
                 slot=opentrons.types.DeckSlotName.from_primitive(labware.slot)
             ),
             loadName=definition.parameters.loadName,
@@ -98,10 +100,9 @@ class CommandTranslator:
     def _translate_load_pipette(
             self,
             pipette_id: str,
-            pipette: models.json_protocol.Pipettes) -> protocol_engine.commands.LoadPipetteRequest:
-        return protocol_engine.commands.LoadPipetteRequest(
-            pipetteName=protocol_engine.PipetteName(pipette.name),
-            # todo(mm, 2021-06-16): Should protocol_engine re-export MountType?
+            pipette: models.json_protocol.Pipettes) -> pe.commands.LoadPipetteRequest:
+        return pe.commands.LoadPipetteRequest(
+            pipetteName=pe.PipetteName(pipette.name),
             mount=opentrons.types.MountType(pipette.mount),
             pipetteId=pipette_id
         )
@@ -121,13 +122,13 @@ class CommandTranslator:
         # TODO (al, 2021-04-26): incoming pipette and labware ids are
         #  assigned by PD. Are they the same as Protocol Engine's?
         return [
-            protocol_engine.commands.AspirateRequest(
+            pe.commands.AspirateRequest(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
                 volume=command.params.volume,
-                wellLocation=protocol_engine.WellLocation(
-                    origin=protocol_engine.WellOrigin.BOTTOM,
+                wellLocation=pe.WellLocation(
+                    origin=pe.WellOrigin.BOTTOM,
                     offset=(0, 0, command.params.offsetFromBottomMm)
                 )
             )
@@ -145,13 +146,13 @@ class CommandTranslator:
         Returns: DispenseRequest
         """
         return [
-            protocol_engine.commands.DispenseRequest(
+            pe.commands.DispenseRequest(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well,
                 volume=command.params.volume,
-                wellLocation=protocol_engine.WellLocation(
-                    origin=protocol_engine.WellOrigin.BOTTOM,
+                wellLocation=pe.WellLocation(
+                    origin=pe.WellOrigin.BOTTOM,
                     offset=(0, 0, command.params.offsetFromBottomMm)
                 )
             )
@@ -184,7 +185,7 @@ class CommandTranslator:
         Returns: PickUpTipRequest
         """
         return [
-            protocol_engine.commands.PickUpTipRequest(
+            pe.commands.PickUpTipRequest(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well
@@ -204,7 +205,7 @@ class CommandTranslator:
 
         """
         return [
-            protocol_engine.commands.DropTipRequest(
+            pe.commands.DropTipRequest(
                 pipetteId=command.params.pipette,
                 labwareId=command.params.labware,
                 wellName=command.params.well

--- a/api/src/opentrons/protocols/runner/json_proto/command_translator.py
+++ b/api/src/opentrons/protocols/runner/json_proto/command_translator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, List
+from typing import Dict, List
 
 import opentrons.types
 
@@ -10,7 +10,7 @@ class CommandTranslatorError(Exception):
     pass
 
 
-PECommands = Iterable[pe.commands.CommandRequestType]
+PECommands = List[pe.commands.CommandRequestType]
 
 
 class CommandTranslator:

--- a/api/src/opentrons/protocols/runner/json_proto/command_translator.py
+++ b/api/src/opentrons/protocols/runner/json_proto/command_translator.py
@@ -119,8 +119,6 @@ class CommandTranslator:
         Returns: AspirateRequest
 
         """
-        # TODO (al, 2021-04-26): incoming pipette and labware ids are
-        #  assigned by PD. Are they the same as Protocol Engine's?
         return [
             pe.commands.AspirateRequest(
                 pipetteId=command.params.pipette,

--- a/api/src/opentrons/protocols/runner/json_proto/command_translator.py
+++ b/api/src/opentrons/protocols/runner/json_proto/command_translator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, cast
+from typing import Dict, Iterable
 
 import opentrons.types
 
@@ -102,10 +102,9 @@ class CommandTranslator:
         pipette_id: str
     ):  # To do: Type.
         return LoadPipetteRequest(
-            # Rely on Pydantic to validate these casts at runtime.
-            pipetteName=cast(pe.PipetteName, pipette.name),
+            pipetteName=pe.PipetteName(pipette.name),
             # todo(mm, 2021-06-16): Should protocol_engine re-export MountType?
-            mount=cast(opentrons.types.MountType, pipette.mount),
+            mount=opentrons.types.MountType(pipette.mount),
             pipetteId=pipette_id
         )
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -506,7 +506,7 @@ def get_bundle_fixture():
 
 
 @pytest.fixture
-def minimal_labware_def():
+def minimal_labware_def() -> dict:
     return {
         "metadata": {
             "displayName": "minimal labware",
@@ -565,7 +565,9 @@ def minimal_labware_def():
 def minimal_labware_def2():
     return {
         "metadata": {
-            "displayName": "other test labware"
+            "displayName": "other test labware",
+            "displayCategory": "other",
+            "displayVolumeUnits": "mL",
         },
         "cornerOffsetFromSlot": {
                 "x": 10,
@@ -574,7 +576,9 @@ def minimal_labware_def2():
         },
         "parameters": {
             "isTiprack": False,
-            "loadName": "minimal_labware_def"
+            "loadName": "minimal_labware_def",
+            "isMagneticModuleCompatible": True,
+            "format": "irregular"
         },
         "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
         "wells": {
@@ -633,11 +637,18 @@ def minimal_labware_def2():
               "shape": "circular"
             }
         },
+        "groups": [],
         "dimensions": {
             "xDimension": 1.0,
             "yDimension": 2.0,
             "zDimension": 3.0
-        }
+        },
+        "schemaVersion": 2,
+        "version": 1,
+        "namespace": "dummy_namespace",
+        "brand": {
+            "brand": "opentrons"
+        },
     }
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -562,7 +562,7 @@ def minimal_labware_def() -> dict:
 
 
 @pytest.fixture
-def minimal_labware_def2():
+def minimal_labware_def2() -> dict:
     return {
         "metadata": {
             "displayName": "other test labware",

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -135,14 +135,9 @@ def test_json_runner_load_commands_to_engine(
         labwareId="xyz",
         wellName="def",
     )
-    decoy.when(command_translator.translate(json_protocol.commands[0])).then_return(
-        [mock_cmd1]
-    )
-    decoy.when(command_translator.translate(json_protocol.commands[1])).then_return(
-        [mock_cmd2]
-    )
-    decoy.when(command_translator.translate(json_protocol.commands[2])).then_return(
-        [mock_cmd3]
+
+    decoy.when(command_translator.translate(json_protocol)).then_return(
+        [mock_cmd1, mock_cmd2, mock_cmd3]
     )
 
     subject.load()

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -8,11 +8,23 @@ from opentrons.protocols import models
 from opentrons.protocols.runner.json_proto.command_translator import CommandTranslator
 
 
-# todo(mm, 2021-06-17):
+# todo(mc & mm, 2021-06-17):
 #
-# This JSON protocol fixture is copy-pasted from an opentrons.file_runner fixture.
-# Either lift the fixture somewhere common to both of these modules, or move one of
-# the modules next to the other so they can benefit from the same fixtures.
+# There are two big problems with these tests:
+#
+# 1. I copy-pasted the big JSON protocol fixture from opentrons.file_runner tests.
+# 2. The command translation tests use the internal implementation detail
+#    _translate_command().
+#
+# We should fix both of these by:
+#
+# * Writing a helper function, possibly specific to this test file, to return a minimal
+#   JSON protocol with some given commands, given labware, etc., filling in boring
+#   stuff like metadata.
+# * Making every test here use that helper function with its own hard-coded choice of
+#   commands. (So we don't have to pull expected details out of a fixture to assert
+#   against.)
+# * Consistently testing CommandTranslator as a black box here.
 
 
 @pytest.fixture
@@ -163,18 +175,6 @@ def test_pipettes(
     )
 
     assert expected_request in result
-
-
-# todo(mm, 2021-06-17):
-#
-# These tests use the internal implementation detail _translate_command.
-#
-# Maybe _translate_command(), _translate_add_labware_definition(), and
-# _translate_load_labware() should be static methods in classes (or a single class)
-# separate from CommandTranslator. Then these methods could be public again.
-#
-# Otherwise, we should delete these tests in favor of treating CommandTranslator
-# as a black box.
 
 
 def test_aspirate(

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -87,10 +87,6 @@ def json_protocol_dict(
     }
 
 
-# Fix before merge: Fix subject._translate_command to use a fixture
-# and go through top-level translate(), or something like that
-
-
 @pytest.fixture
 def subject() -> CommandTranslator:
     return CommandTranslator()
@@ -173,6 +169,18 @@ def test_pipettes(
     )
 
     assert expected_request in result
+
+
+# todo(mm, 2021-06-17):
+#
+# These tests use the internal implementation detail _translate_command.
+#
+# Maybe _translate_command(), _translate_add_labware_definition(), and
+# _translate_load_labware() should be static methods in classes (or a single class)
+# separate from CommandTranslator. Then these methods could be public again.
+#
+# Otherwise, we should delete these tests in favor of treating CommandTranslator
+# as a black box.
 
 
 def test_aspirate(

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -6,6 +6,7 @@ from opentrons.protocol_engine import WellLocation, WellOrigin
 from opentrons.protocol_engine.commands import (
     AddLabwareDefinitionRequest,
     LoadLabwareRequest,
+    LoadPipetteRequest,
     AspirateRequest,
     DispenseRequest,
     PickUpTipRequest,
@@ -136,7 +137,7 @@ def _assert_appear_in_order(
     assert sorted(element_indexes) == element_indexes
 
 
-def test_translates_labware_commands(
+def test_labware(
     subject: CommandTranslator,
     json_protocol: JsonProtocol,
     minimal_labware_def: dict,  # To do: Uhhh something
@@ -175,6 +176,21 @@ def test_translates_labware_commands(
         elements=[expected_add_definition_request_2, expected_load_request_2],
         source=result
     )
+
+
+def test_pipettes(
+    subject: CommandTranslator,
+    json_protocol: JsonProtocol,
+) -> None:
+    result = subject.translate(json_protocol)
+
+    expected_request = LoadPipetteRequest(
+        pipetteName="p300_single",
+        mount="left",
+        pipetteId="leftPipetteId"
+    )
+
+    assert expected_request in result
 
 
 def test_aspirate(

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -114,7 +114,7 @@ def _assert_appear_in_order(elements: typing.Iterable, source: typing.Iterable) 
 def test_labware(
     subject: CommandTranslator,
     json_protocol: models.JsonProtocol,
-    minimal_labware_def: dict,  # To do: Uhhh something
+    minimal_labware_def: dict,
     minimal_labware_def2: dict,
 ) -> None:
     result = subject.translate(json_protocol)

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -5,9 +5,7 @@ import pytest
 from opentrons import protocol_engine as pe
 from opentrons.protocols import models
 
-from opentrons.protocols.runner.json_proto.command_translator import (
-    CommandTranslator
-)
+from opentrons.protocols.runner.json_proto.command_translator import CommandTranslator
 
 
 # Fix before merge: This gross-ass copy-paste
@@ -20,10 +18,7 @@ def json_protocol(json_protocol_dict: dict) -> models.JsonProtocol:
 
 
 @pytest.fixture
-def json_protocol_dict(
-    minimal_labware_def: dict,
-    minimal_labware_def2: dict
-) -> dict:
+def json_protocol_dict(minimal_labware_def: dict, minimal_labware_def2: dict) -> dict:
     """Get a JSON protocol dictionary fixture."""
     return {
         "schemaVersion": 3,
@@ -92,10 +87,7 @@ def subject() -> CommandTranslator:
     return CommandTranslator()
 
 
-def _assert_appear_in_order(
-    elements: typing.Iterable,
-    source: typing.Iterable
-) -> None:
+def _assert_appear_in_order(elements: typing.Iterable, source: typing.Iterable) -> None:
     """
     Make sure all elements appear in source, in the given relative order.
 
@@ -131,7 +123,7 @@ def test_labware(
         loadName=minimal_labware_def["parameters"]["loadName"],
         namespace=minimal_labware_def["namespace"],
         version=minimal_labware_def["version"],
-        labwareId="tiprack1Id"
+        labwareId="tiprack1Id",
     )
 
     expected_add_definition_request_2 = pe.commands.AddLabwareDefinitionRequest(
@@ -142,17 +134,17 @@ def test_labware(
         loadName=minimal_labware_def2["parameters"]["loadName"],
         namespace=minimal_labware_def2["namespace"],
         version=minimal_labware_def2["version"],
-        labwareId="wellplate1Id"
+        labwareId="wellplate1Id",
     )
 
     _assert_appear_in_order(
         elements=[expected_add_definition_request_1, expected_load_request_1],
-        source=result
+        source=result,
     )
 
     _assert_appear_in_order(
         elements=[expected_add_definition_request_2, expected_load_request_2],
-        source=result
+        source=result,
     )
 
 
@@ -163,9 +155,7 @@ def test_pipettes(
     result = subject.translate(json_protocol)
 
     expected_request = pe.commands.LoadPipetteRequest(
-        pipetteName="p300_single",
-        mount="left",
-        pipetteId="leftPipetteId"
+        pipetteName="p300_single", mount="left", pipetteId="leftPipetteId"
     )
 
     assert expected_request in result
@@ -184,10 +174,10 @@ def test_pipettes(
 
 
 def test_aspirate(
-        subject: CommandTranslator, aspirate_command: models.json_protocol.LiquidCommand
+    subject: CommandTranslator, aspirate_command: models.json_protocol.LiquidCommand
 ) -> None:
     """It should translate a JSON aspirate command to a Protocol Engine
-     aspirate request."""
+    aspirate request."""
     request = subject._translate_command(aspirate_command)
 
     assert request == [
@@ -198,18 +188,17 @@ def test_aspirate(
             volume=aspirate_command.params.volume,
             wellLocation=pe.WellLocation(
                 origin=pe.WellOrigin.BOTTOM,
-                offset=(0, 0, aspirate_command.params.offsetFromBottomMm)
-            )
+                offset=(0, 0, aspirate_command.params.offsetFromBottomMm),
+            ),
         )
     ]
 
 
 def test_dispense(
-        subject: CommandTranslator,
-        dispense_command: models.json_protocol.LiquidCommand
+    subject: CommandTranslator, dispense_command: models.json_protocol.LiquidCommand
 ) -> None:
     """It should translate a JSON dispense command to a Protocol Engine
-     dispense request."""
+    dispense request."""
     request = subject._translate_command(dispense_command)
 
     assert request == [
@@ -220,30 +209,32 @@ def test_dispense(
             volume=dispense_command.params.volume,
             wellLocation=pe.WellLocation(
                 origin=pe.WellOrigin.BOTTOM,
-                offset=(0, 0, dispense_command.params.offsetFromBottomMm)
-            )
+                offset=(0, 0, dispense_command.params.offsetFromBottomMm),
+            ),
         )
     ]
 
 
 def test_drop_tip(
-        subject: CommandTranslator,
-        drop_tip_command: models.json_protocol.PickUpDropTipCommand
+    subject: CommandTranslator,
+    drop_tip_command: models.json_protocol.PickUpDropTipCommand,
 ) -> None:
     """It should translate a JSON drop tip command to a Protocol Engine
-     drop tip request."""
+    drop tip request."""
     request = subject._translate_command(drop_tip_command)
 
     assert request == [
         pe.commands.DropTipRequest(
             pipetteId=drop_tip_command.params.pipette,
             labwareId=drop_tip_command.params.labware,
-            wellName=drop_tip_command.params.well
+            wellName=drop_tip_command.params.well,
         )
     ]
 
 
-def test_pick_up_tip(subject, pick_up_command: models.json_protocol.PickUpDropTipCommand) -> None:
+def test_pick_up_tip(
+    subject, pick_up_command: models.json_protocol.PickUpDropTipCommand
+) -> None:
     """
     It should translate a JSON pick up tip command to a Protocol Engine
     PickUpTip request.
@@ -255,6 +246,5 @@ def test_pick_up_tip(subject, pick_up_command: models.json_protocol.PickUpDropTi
             pipetteId=pick_up_command.params.pipette,
             labwareId=pick_up_command.params.labware,
             wellName=pick_up_command.params.well,
-
         )
     ]

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -1,13 +1,113 @@
+import decoy
 import pytest
+
+
+from opentrons import protocol_engine
+
 from opentrons.protocol_engine import WellLocation, WellOrigin
 from opentrons.protocol_engine.commands import (
-    AspirateRequest, DispenseRequest, PickUpTipRequest, DropTipRequest
+    AddLabwareDefinitionRequest,
+    LoadLabwareRequest,
+    AspirateRequest,
+    DispenseRequest,
+    PickUpTipRequest,
+    DropTipRequest,
 )
+
+import opentrons.protocols.models
+
+# To do: Redundant imports
 from opentrons.protocols.models import json_protocol as models
+from opentrons.protocols.models import LabwareDefinition
+
 
 from opentrons.protocols.runner.json_proto.command_translator import (
     CommandTranslator
 )
+
+
+# Fix before merge: This gross-ass copy-paste
+
+
+from opentrons.protocols.models import JsonProtocol
+
+
+@pytest.fixture
+def json_protocol(json_protocol_dict: dict) -> JsonProtocol:
+    """Get a parsed JSON protocol model fixture."""
+    return JsonProtocol.parse_obj(json_protocol_dict)
+
+
+@pytest.fixture
+def json_protocol_dict(
+    minimal_labware_def: dict,
+    minimal_labware_def2: dict
+) -> dict:
+    """Get a JSON protocol dictionary fixture."""
+    return {
+        "schemaVersion": 3,
+        "metadata": {},
+        "robot": {"model": "OT-2 Standard"},
+        "pipettes": {"leftPipetteId": {"mount": "left", "name": "p300_single"}},
+        "labware": {
+            "trashId": {
+                "slot": "12",
+                "displayName": "Trash",
+                "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1",
+            },
+            "tiprack1Id": {
+                "slot": "1",
+                "displayName": "Opentrons 96 Tip Rack 300 µL",
+                "definitionId": "opentrons/opentrons_96_tiprack_300ul/1",
+            },
+            "wellplate1Id": {
+                "slot": "10",
+                "displayName": "Corning 96 Well Plate 360 µL Flat",
+                "definitionId": "opentrons/corning_96_wellplate_360ul_flat/1",
+            },
+        },
+        "labwareDefinitions": {
+            "opentrons/opentrons_1_trash_1100ml_fixed/1": minimal_labware_def,
+            "opentrons/opentrons_96_tiprack_300ul/1": minimal_labware_def,
+            "opentrons/corning_96_wellplate_360ul_flat/1": minimal_labware_def2,
+        },
+        "commands": [
+            {
+                "command": "pickUpTip",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "labware": "tiprack1Id",
+                    "well": "A1",
+                },
+            },
+            {
+                "command": "aspirate",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "volume": 51,
+                    "labware": "wellplate1Id",
+                    "well": "B1",
+                    "offsetFromBottomMm": 10,
+                    "flowRate": 10,
+                },
+            },
+            {
+                "command": "dispense",
+                "params": {
+                    "pipette": "leftPipetteId",
+                    "volume": 50,
+                    "labware": "wellplate1Id",
+                    "well": "H1",
+                    "offsetFromBottomMm": 1,
+                    "flowRate": 50,
+                },
+            },
+        ],
+    }
+
+
+# Fix before merge: Fix subject._translate_command to use a fixture
+# and go through top-level translate(), or something like that
 
 
 @pytest.fixture
@@ -15,12 +115,45 @@ def subject() -> CommandTranslator:
     return CommandTranslator()
 
 
+def test_translates_labware_commands(
+    subject: CommandTranslator, 
+    json_protocol: JsonProtocol,
+    minimal_labware_def: dict,  # To do: Uhhh something
+    minimal_labware_def2: dict,
+) -> None:
+    result = subject.translate(json_protocol)
+    
+    # To do: More correct ordering constraints
+    assert AddLabwareDefinitionRequest(
+        definition=LabwareDefinition.parse_obj(minimal_labware_def)
+    ) in result
+    assert AddLabwareDefinitionRequest(
+        definition=LabwareDefinition.parse_obj(minimal_labware_def2)
+    ) in result
+    
+    assert LoadLabwareRequest(
+        location=protocol_engine.DeckSlotLocation(slot=1),
+        loadName=minimal_labware_def["parameters"]["loadName"],
+        namespace=minimal_labware_def["namespace"],
+        version=minimal_labware_def["version"],
+        labwareId="tiprack1Id"
+    ) in result
+
+    assert LoadLabwareRequest(
+        location=protocol_engine.DeckSlotLocation(slot=10),
+        loadName=minimal_labware_def2["parameters"]["loadName"],
+        namespace=minimal_labware_def2["namespace"],
+        version=minimal_labware_def2["version"],
+        labwareId="wellplate1Id"
+    ) in result
+
+
 def test_aspirate(
         subject: CommandTranslator, aspirate_command: models.LiquidCommand
 ) -> None:
     """It should translate a JSON aspirate command to a Protocol Engine
      aspirate request."""
-    request = subject.translate(aspirate_command)
+    request = subject._translate_command(aspirate_command)
 
     assert request == [
         AspirateRequest(
@@ -42,7 +175,7 @@ def test_dispense(
 ) -> None:
     """It should translate a JSON dispense command to a Protocol Engine
      dispense request."""
-    request = subject.translate(dispense_command)
+    request = subject._translate_command(dispense_command)
 
     assert request == [
         DispenseRequest(
@@ -64,7 +197,7 @@ def test_drop_tip(
 ) -> None:
     """It should translate a JSON drop tip command to a Protocol Engine
      drop tip request."""
-    request = subject.translate(drop_tip_command)
+    request = subject._translate_command(drop_tip_command)
 
     assert request == [
         DropTipRequest(
@@ -80,7 +213,7 @@ def test_pick_up_tip(subject, pick_up_command: models.PickUpDropTipCommand) -> N
     It should translate a JSON pick up tip command to a Protocol Engine
     PickUpTip request.
     """
-    request = subject.translate(pick_up_command)
+    request = subject._translate_command(pick_up_command)
 
     assert request == [
         PickUpTipRequest(

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -1,6 +1,4 @@
-import decoy
 import pytest
-
 
 from opentrons import protocol_engine
 
@@ -13,8 +11,6 @@ from opentrons.protocol_engine.commands import (
     PickUpTipRequest,
     DropTipRequest,
 )
-
-import opentrons.protocols.models
 
 # To do: Redundant imports
 from opentrons.protocols.models import json_protocol as models

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -134,7 +134,7 @@ def _assert_appear_in_order(
     """
     element_indexes = [source.index(element) for element in elements]
     assert sorted(element_indexes) == element_indexes
-    
+
 
 def test_translates_labware_commands(
     subject: CommandTranslator,
@@ -143,7 +143,7 @@ def test_translates_labware_commands(
     minimal_labware_def2: dict,
 ) -> None:
     result = subject.translate(json_protocol)
-    
+
     expected_add_definition_request_1 = AddLabwareDefinitionRequest(
         definition=LabwareDefinition.parse_obj(minimal_labware_def)
     )
@@ -154,7 +154,7 @@ def test_translates_labware_commands(
         version=minimal_labware_def["version"],
         labwareId="tiprack1Id"
     )
-    
+
     expected_add_definition_request_2 = AddLabwareDefinitionRequest(
         definition=LabwareDefinition.parse_obj(minimal_labware_def2)
     )

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -116,13 +116,13 @@ def subject() -> CommandTranslator:
 
 
 def test_translates_labware_commands(
-    subject: CommandTranslator, 
+    subject: CommandTranslator,
     json_protocol: JsonProtocol,
     minimal_labware_def: dict,  # To do: Uhhh something
     minimal_labware_def2: dict,
 ) -> None:
     result = subject.translate(json_protocol)
-    
+
     # To do: More correct ordering constraints
     assert AddLabwareDefinitionRequest(
         definition=LabwareDefinition.parse_obj(minimal_labware_def)
@@ -130,7 +130,7 @@ def test_translates_labware_commands(
     assert AddLabwareDefinitionRequest(
         definition=LabwareDefinition.parse_obj(minimal_labware_def2)
     ) in result
-    
+
     assert LoadLabwareRequest(
         location=protocol_engine.DeckSlotLocation(slot=1),
         loadName=minimal_labware_def["parameters"]["loadName"],

--- a/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
+++ b/api/tests/opentrons/protocols/runnner/json_proto/test_command_translator.py
@@ -8,7 +8,11 @@ from opentrons.protocols import models
 from opentrons.protocols.runner.json_proto.command_translator import CommandTranslator
 
 
-# Fix before merge: This gross-ass copy-paste
+# todo(mm, 2021-06-17):
+#
+# This JSON protocol fixture is copy-pasted from an opentrons.file_runner fixture.
+# Either lift the fixture somewhere common to both of these modules, or move one of
+# the modules next to the other so they can benefit from the same fixtures.
 
 
 @pytest.fixture
@@ -89,7 +93,7 @@ def subject() -> CommandTranslator:
 
 def _assert_appear_in_order(elements: typing.Iterable, source: typing.Iterable) -> None:
     """
-    Make sure all elements appear in source, in the given relative order.
+    Assert all elements appear in source, in the given order relative to each other.
 
     Example:
 


### PR DESCRIPTION
# Overview

When a JSON protocol is uploaded through the experimental HTTP API, to be run through protocol engine, implement the missing parts of loading the pipettes and labware that the JSON protocol uses. Closes #7946.

# Changelog

Main changes:

* Changed `CommandTranslator` to take in an entire protocol at once, instead of going command-by-command.
  * Changed calling code and its tests accordingly.
* Gave `CommandTranslator` the ability to translate a JSON protocol's choices of pipettes and labware into Protocol Engine `LoadPipetteRequest`s, `AddLabwareDefinitionRequest`s, and `LoadLabwareRequest`s.

Also:

* Clarified that `LoadPipetteRequest.pipetteName` is the pipette *load* name, as opposed to the model name or something.
* Left a maybe unnecessary comment in `opentrons/protocols/models/__init.py__` describing when (I think) it should re-export things from its child submodules. I had gone down an unproductive path adding re-exports for everything I could possibly need from that tree.

# Deferred work

* I made a mess of the tests, which I will clean up in a follow-up PR. See the `todo` comment at the top of `test_command_translator.py` for the fix approach that @mcous and I agreed on.
  * For alternative approaches considered, see these todo comments from an earlier version of this PR, which I've since removed: https://github.com/Opentrons/opentrons/pull/7950#discussion_r653875070, https://github.com/Opentrons/opentrons/pull/7950#discussion_r653879429.
  * Ticket for follow-up: #7958
* There's some confusing "id"/"URI"/"UUID" terminology between PD and PE that we should reconcile at some pont.

# Other stuff discussed in in-person reviews

* @sanni-t and I considered renaming `CommandTranslator` to `ProtocolTranslator`, since it now takes in and translates an entire JSON protocol at once, rather than going command-by-command. This could have been necessary if we chose a testing approach where command translation is a separate class from protocol translation, but we didn't, so this renaming doesn't feel worthwhile to me anymore.

# Review requests

I would focus on the production code, since we know the tests to be messy and we already have a good path in mind to fix them.

# Risk assessment

Low. Only used in our experimental Protocol Engine work, behind a feature flag.
