### PR TITLE
refactor(protocol-designer): migrate PD file-data, labware-defs, and labware-ingred to TS

### DIFF
--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -1,8 +1,9 @@
 // Named arguments to createFile selector. This data would be the result of several selectors.
 import { fixtureP10Single } from '@opentrons/shared-data/pipette/fixtures/name'
-import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
-import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
-import fixture_trash from '@opentrons/shared-data/labware/fixtures/2/fixture_trash.json'
+import _fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
+import _fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import _fixture_trash from '@opentrons/shared-data/labware/fixtures/2/fixture_trash.json'
+import { LabwareDefinition2 } from '@opentrons/shared-data'
 import {
   LabwareLiquidState,
   LabwareEntities,
@@ -12,6 +13,10 @@ import { DismissedWarningState } from '../../../dismiss/reducers'
 import { IngredientsState } from '../../../labware-ingred/reducers'
 import { LabwareDefByDefURI } from '../../../labware-defs'
 import { FileMetadataFields } from '../../types'
+
+const fixture96Plate = _fixture_96_plate as LabwareDefinition2
+const fixtureTiprack10ul = _fixture_tiprack_10_ul as LabwareDefinition2
+const fixtureTrash = _fixture_trash as LabwareDefinition2
 export const fileMetadata: FileMetadataFields = {
   protocolName: 'Test Protocol',
   author: 'The Author',
@@ -28,17 +33,17 @@ export const labwareEntities: LabwareEntities = {
   trashId: {
     labwareDefURI: 'opentrons/opentrons_1_trash_1100ml_fixed/1',
     id: 'trashId',
-    def: fixture_trash,
+    def: fixtureTrash,
   },
   tiprackId: {
     labwareDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
     id: 'tiprackId',
-    def: fixture_tiprack_10_ul,
+    def: fixtureTiprack10ul,
   },
   plateId: {
     labwareDefURI: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
     id: 'plateId',
-    def: fixture_96_plate,
+    def: fixture96Plate,
   },
 }
 export const pipetteEntities: PipetteEntities = {
@@ -47,7 +52,7 @@ export const pipetteEntities: PipetteEntities = {
     name: 'p10_single',
     spec: fixtureP10Single,
     tiprackDefURI: 'opentrons/opentrons_96_tiprack_10ul/1',
-    tiprackLabwareDef: fixture_tiprack_10_ul,
+    tiprackLabwareDef: fixtureTiprack10ul,
   },
 }
 export const labwareNicknamesById: Record<string, string> = {
@@ -56,7 +61,7 @@ export const labwareNicknamesById: Record<string, string> = {
   plateId: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
 }
 export const labwareDefsByURI: LabwareDefByDefURI = {
-  'opentrons/opentrons_96_tiprack_10ul/1': fixture_tiprack_10_ul,
-  'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': fixture_96_plate,
-  'opentrons/opentrons_1_trash_1100ml_fixed/1': fixture_trash,
+  'opentrons/opentrons_96_tiprack_10ul/1': fixtureTiprack10ul,
+  'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1': fixture96Plate,
+  'opentrons/opentrons_1_trash_1100ml_fixed/1': fixtureTrash,
 }

--- a/protocol-designer/src/file-data/__tests__/commandsSelectors.test.ts
+++ b/protocol-designer/src/file-data/__tests__/commandsSelectors.test.ts
@@ -6,8 +6,8 @@ import { getLabwareLiquidState } from '../selectors'
 
 jest.mock('../../labware-defs/utils')
 
-let labwareEntities
-let ingredLocs
+let labwareEntities: any
+let ingredLocs: any
 
 beforeEach(() => {
   labwareEntities = {
@@ -36,7 +36,7 @@ beforeEach(() => {
   }
 })
 
-function hasAllWellKeys(result) {
+function hasAllWellKeys(result: { wellPlateId: {}; troughId: {}; FIXED_TRASH_ID: {} }) {
   // make sure each labware has keys for all wells added in
   expect(Object.keys(result.wellPlateId).length).toBe(96)
   expect(Object.keys(result.troughId).length).toBe(12)
@@ -45,16 +45,19 @@ function hasAllWellKeys(result) {
 
 describe('getLabwareLiquidState', () => {
   it('no labware + no ingreds', () => {
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getLabwareLiquidState.resultFunc({}, {})).toEqual({})
   })
 
   it('labware + no ingreds: generate empty well keys', () => {
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = getLabwareLiquidState.resultFunc({}, labwareEntities)
 
     hasAllWellKeys(result)
   })
 
   it('selects liquids with multiple ingredient groups & multiple labware: generate all well keys', () => {
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = getLabwareLiquidState.resultFunc(ingredLocs, labwareEntities)
 
     expect(result).toMatchObject(ingredLocs)

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -12,6 +12,7 @@ import {
   fixtureP10Single,
   fixtureP300Single,
 } from '@opentrons/shared-data/pipette/fixtures/name'
+import { LabwareDefinition2 } from '@opentrons/shared-data';
 import {
   createFile,
   getRequiresAtLeastV5,
@@ -30,8 +31,10 @@ import {
 import * as engageMagnet from '../__fixtures__/createFile/engageMagnet'
 import * as noModules from '../__fixtures__/createFile/noModules'
 import * as v5Fixture from '../__fixtures__/createFile/v5Fixture'
+import { LabwareEntities, PipetteEntities } from '../../../../step-generation/src/types';
+import { LabwareDefByDefURI } from '../../labware-defs'
 
-const getAjvValidator = _protocolSchema => {
+const getAjvValidator = (_protocolSchema: Record<string, any>) => {
   const ajv = new Ajv({
     allErrors: true,
     jsonPointers: true,
@@ -42,7 +45,7 @@ const getAjvValidator = _protocolSchema => {
   return validateProtocol
 }
 
-const expectResultToMatchSchema = (result, _protocolSchema): void => {
+const expectResultToMatchSchema = (result: any, _protocolSchema:Record<string, any>): void => {
   const validate = getAjvValidator(_protocolSchema)
   const valid = validate(result)
   const validationErrors = validate.errors
@@ -57,7 +60,7 @@ const expectResultToMatchSchema = (result, _protocolSchema): void => {
 
 describe('createFile selector', () => {
   it('should return a schema-valid JSON V3 protocol, if the protocol has NO modules', () => {
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = createFile.resultFunc(
       fileMetadata,
       noModules.initialRobotState,
@@ -82,7 +85,7 @@ describe('createFile selector', () => {
     expect(!isEmpty(result.pipettes)).toBe(true)
   })
   it('should return a schema-valid JSON V4 protocol, if the protocol does have modules', () => {
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = createFile.resultFunc(
       fileMetadata,
       engageMagnet.initialRobotState,
@@ -108,7 +111,7 @@ describe('createFile selector', () => {
     expect(!isEmpty(result.pipettes)).toBe(true)
   })
   it('should return a schema-valid JSON V5 protocol, if getRequiresAtLeastV5 returns true', () => {
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     const result = createFile.resultFunc(
       fileMetadata,
       v5Fixture.initialRobotState,
@@ -154,7 +157,7 @@ describe('getRequiresAtLeastV5', () => {
         },
       ],
     }
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getRequiresAtLeastV5.resultFunc(airGapTimeline)).toBe(true)
   })
   it('should return true if protocol has moveToWell', () => {
@@ -179,16 +182,16 @@ describe('getRequiresAtLeastV5', () => {
         },
       ],
     }
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getRequiresAtLeastV5.resultFunc(moveToWellTimeline)).toBe(true)
   })
   it('should return false if protocol has no airGap and no moveToWell', () => {
-    // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getRequiresAtLeastV5.resultFunc(noModules.robotStateTimeline)).toBe(
       false
     )
     expect(
-      // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+      // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
       getRequiresAtLeastV5.resultFunc(engageMagnet.robotStateTimeline)
     ).toBe(false)
   })
@@ -201,37 +204,39 @@ describe('getLabwareDefinitionsInUse util', () => {
     const nonTiprackLabwareNotOnDeckDef = fixture_96_plate
     // NOTE that assignedTiprackNotOnDeckDef and nonTiprackLabwareNotOnDeckDef are
     // missing from LabwareEntities bc they're not on the deck
-    const labwareEntities = {
+    const labwareEntities: LabwareEntities = {
       someLabwareId: {
         id: 'someLabwareId',
-        def: assignedTiprackOnDeckDef,
+        def: assignedTiprackOnDeckDef as LabwareDefinition2,
         labwareDefURI: 'assignedTiprackOnDeckURI',
       },
       otherLabwareId: {
         id: 'otherLabwareId',
-        def: nonTiprackLabwareOnDeckDef,
+        def: nonTiprackLabwareOnDeckDef as LabwareDefinition2,
         labwareDefURI: 'nonTiprackLabwareOnDeckURI',
       },
     }
-    const allLabwareDefsByURI = {
-      assignedTiprackOnDeckURI: assignedTiprackOnDeckDef,
-      assignedTiprackNotOnDeckURI: assignedTiprackNotOnDeckDef,
-      nonTiprackLabwareOnDeckURI: nonTiprackLabwareOnDeckDef,
-      nonTiprackLabwareNotOnDeckURI: nonTiprackLabwareNotOnDeckDef,
+    const allLabwareDefsByURI: LabwareDefByDefURI = {
+      assignedTiprackOnDeckURI: assignedTiprackOnDeckDef as LabwareDefinition2,
+      assignedTiprackNotOnDeckURI: assignedTiprackNotOnDeckDef as LabwareDefinition2,
+      nonTiprackLabwareOnDeckURI: nonTiprackLabwareOnDeckDef as LabwareDefinition2,
+      nonTiprackLabwareNotOnDeckURI: nonTiprackLabwareNotOnDeckDef as LabwareDefinition2,
     }
-    const pipetteEntities = {
+    const pipetteEntities: PipetteEntities = {
       somePipetteId: {
         id: 'somePipetteId',
+        // @ts-expect-error(sa, 2021-6-18): not a valid pipette name
         name: 'foo',
         spec: fixtureP10Single,
-        tiprackLabwareDef: assignedTiprackOnDeckDef,
+        tiprackLabwareDef: assignedTiprackOnDeckDef as LabwareDefinition2,
         tiprackDefURI: 'assignedTiprackOnDeckURI',
       },
       otherPipetteId: {
         id: 'otherPipetteId',
+        // @ts-expect-error(sa, 2021-6-18): not a valid pipette name
         name: 'foo',
         spec: fixtureP300Single,
-        tiprackLabwareDef: assignedTiprackNotOnDeckDef,
+        tiprackLabwareDef: assignedTiprackNotOnDeckDef as LabwareDefinition2,
         tiprackDefURI: 'assignedTiprackNotOnDeckURI',
       },
     }

--- a/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.ts
+++ b/protocol-designer/src/file-data/__tests__/getExportedFileSchemaVersion.test.ts
@@ -1,17 +1,17 @@
 import { getExportedFileSchemaVersion } from '../selectors/fileCreator'
 describe('getExportedFileSchemaVersion selector', () => {
   it('should return 5 when getRequiresAtLeastV5 is true', () => {
-    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getExportedFileSchemaVersion.resultFunc(false, true)).toBe(5)
-    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getExportedFileSchemaVersion.resultFunc(true, true)).toBe(5)
   })
   it('should return 4 when getRequiresAtLeastV4 is true and getRequiresAtLeastV5 is false', () => {
-    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getExportedFileSchemaVersion.resultFunc(true, false)).toBe(4)
   })
   it('should return 3 when neither is true', () => {
-    // $FlowFixMe TODO(SA, 2020-08-26): Flow doesn't have type for resultFunc
+    // @ts-expect-error(sa, 2021-6-15): resultFunc not part of Selector type
     expect(getExportedFileSchemaVersion.resultFunc(false, false)).toBe(3)
   })
 })

--- a/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.ts
+++ b/protocol-designer/src/file-data/__tests__/getIsV4Protocol.test.ts
@@ -47,7 +47,7 @@ describe('getRequiresAtLeastV4 selector', () => {
   testCases.forEach(
     ({ testName, robotStateTimeline, moduleEntities, expected }) => {
       it(testName, () => {
-        // $FlowFixMe TODO(IL, 2020-02-25): Flow doesn't have type for resultFunc
+        // @ts-expect-error(sa, 2021-6-18): resultFunc not part of Selector type
         const result = getRequiresAtLeastV4.resultFunc(
           robotStateTimeline,
           moduleEntities

--- a/protocol-designer/src/file-data/__tests__/getRobotStateTimelineWithoutAirGapDispenseCommand.test.ts
+++ b/protocol-designer/src/file-data/__tests__/getRobotStateTimelineWithoutAirGapDispenseCommand.test.ts
@@ -26,6 +26,7 @@ describe('getRobotStateTimelineWithoutAirGapDispenseCommand', () => {
       ],
     }
     expect(
+      // @ts-expect-error(sa, 2021-6-18): resultFunc not part of Selector type
       getRobotStateTimelineWithoutAirGapDispenseCommand.resultFunc(
         robotStateTimeline
       )

--- a/protocol-designer/src/file-data/reducers/index.ts
+++ b/protocol-designer/src/file-data/reducers/index.ts
@@ -14,8 +14,11 @@ export const timelineIsBeingComputed: Reducer<boolean, any> = handleActions(
   },
   false
 )
+// @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 export const computedRobotStateTimeline: Reducer<Timeline, any> = handleActions(
   {
+    // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
     COMPUTE_ROBOT_STATE_TIMELINE_SUCCESS: (
       state,
       action: ComputeRobotStateTimelineSuccessAction
@@ -27,6 +30,8 @@ export const computedRobotStateTimeline: Reducer<Timeline, any> = handleActions(
 )
 export const computedSubsteps: Reducer<Substeps, any> = handleActions(
   {
+    // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
+    // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
     COMPUTE_ROBOT_STATE_TIMELINE_SUCCESS: (
       state,
       action: ComputeRobotStateTimelineSuccessAction
@@ -70,7 +75,8 @@ function newProtocolMetadata(
     lastModified: null,
   }
 }
-
+// @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const fileMetadata = handleActions(
   {
     LOAD_FILE: updateMetadataFields,
@@ -86,7 +92,7 @@ const fileMetadata = handleActions(
   },
   defaultFields
 )
-export type RootState = {
+export interface RootState {
   computedRobotStateTimeline: Timeline
   computedSubsteps: Substeps
   currentProtocolExists: boolean

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -148,7 +148,7 @@ export const commandCreatorFromStepArgs = (
         args
       )
   }
-
+  // @ts-expect-error(sa, 2021-6-18): this is technically unreachable since we've covered all of the command creators in the switch
   console.warn(`unhandled commandCreatorFnName: ${args.commandCreatorFnName}`)
   return null
 }
@@ -161,7 +161,7 @@ export const getSubsteps: Selector<Substeps> = state =>
   state.fileData.computedSubsteps
 type WarningsPerStep = {
   [stepId in number | string]?:
-    | Array<StepGeneration.CommandCreatorWarning>
+    | StepGeneration.CommandCreatorWarning[]
     | null
     | undefined
 }

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -6,7 +6,10 @@ import uniq from 'lodash/uniq'
 import { getFileMetadata } from './fileFields'
 import { getInitialRobotState, getRobotStateTimeline } from './commands'
 import { selectors as dismissSelectors } from '../../dismiss'
-import { selectors as labwareDefSelectors } from '../../labware-defs'
+import {
+  selectors as labwareDefSelectors,
+  LabwareDefByDefURI,
+} from '../../labware-defs'
 import { selectors as ingredSelectors } from '../../labware-ingred/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { selectors as uiLabwareSelectors } from '../../ui/labware'
@@ -27,9 +30,8 @@ import {
   FilePipette,
   FileLabware,
   FileModule,
-} from '@opentrons/shared-data/protocol/flowTypes/schemaV4'
-import { Command } from '@opentrons/shared-data/protocol/flowTypes/schemaV6'
-import { LabwareDefByDefURI } from '../../labware-defs'
+} from '@opentrons/shared-data/protocol/types/schemaV4'
+import { Command } from '@opentrons/shared-data/protocol/types/schemaV6'
 import { Selector } from '../../types'
 import { PDProtocolFile } from '../../file-types'
 // TODO: BC: 2018-02-21 uncomment this assert, causes test failures

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -94,7 +94,8 @@ export const getRobotStateTimelineWithoutAirGapDispenseCommand: Selector<Timelin
       ...frame,
       commands: frame.commands.map(command => {
         if (command.command === 'dispenseAirGap') {
-          return { ...command, command: 'dispense' }
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          return { ...command, command: 'dispense' } as Command
         }
 
         return command

--- a/protocol-designer/src/file-data/types.ts
+++ b/protocol-designer/src/file-data/types.ts
@@ -1,7 +1,7 @@
-import { ProtocolFile } from '@opentrons/shared-data/protocol/flowTypes/schemaV5'
+import { ProtocolFile } from '@opentrons/shared-data/protocol/types/schemaV5'
 export type FileMetadataFields = ProtocolFile<{}>['metadata']
 export type FileMetadataFieldAccessors = keyof FileMetadataFields
-export type SaveFileMetadataAction = {
+export interface SaveFileMetadataAction {
   type: 'SAVE_FILE_METADATA'
   payload: FileMetadataFields
 }

--- a/protocol-designer/src/labware-defs/__mocks__/utils.ts
+++ b/protocol-designer/src/labware-defs/__mocks__/utils.ts
@@ -11,7 +11,9 @@ const LABWARE_FIXTURE_PATTERN = path.join(
 const allLabware: LabwareDefByDefURI = glob
   .sync(LABWARE_FIXTURE_PATTERN)
   .map(require)
+  // @ts-expect-error(sa, 2021-6-20): not sure why TS thinks d is void
   .filter(d => d.metadata.displayCategory !== 'trash')
+  // @ts-expect-error(sa, 2021-6-20): not sure why TS thinks d is void
   .reduce((acc, d) => ({ ...acc, [getLabwareDefURI(d)]: d }), {})
 assert(
   Object.keys(allLabware).length > 0,

--- a/protocol-designer/src/labware-defs/reducers.ts
+++ b/protocol-designer/src/labware-defs/reducers.ts
@@ -1,12 +1,11 @@
 import omit from 'lodash/omit'
-import { combineReducers } from 'redux'
+import { Reducer, combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import pickBy from 'lodash/pickBy'
 import {
   getLabwareDefURI,
   getLabwareDefIsStandard,
 } from '@opentrons/shared-data'
-import { Reducer } from 'redux'
 import { Action } from '../types'
 import { LabwareUploadMessage, LabwareDefByDefURI } from './types'
 import {
@@ -15,7 +14,9 @@ import {
   ReplaceCustomLabwareDef,
 } from './actions'
 import { LoadFileAction } from '../load-file'
-const customDefs = handleActions(
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
+const customDefs: Reducer<LabwareDefByDefURI, Action> = handleActions(
   {
     CREATE_CUSTOM_LABWARE_DEF: (
       state: LabwareDefByDefURI,
@@ -46,6 +47,8 @@ const labwareUploadMessage = handleActions<
   any
 >(
   {
+    // @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+    // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
     LABWARE_UPLOAD_MESSAGE: (
       state,
       action: LabwareUploadMessageAction
@@ -56,7 +59,7 @@ const labwareUploadMessage = handleActions<
   },
   null
 )
-export type RootState = {
+export interface RootState {
   customDefs: LabwareDefByDefURI
   labwareUploadMessage: LabwareUploadMessage | null | undefined
 }

--- a/protocol-designer/src/labware-defs/utils.ts
+++ b/protocol-designer/src/labware-defs/utils.ts
@@ -6,7 +6,6 @@ import { LabwareDefByDefURI } from './types'
 // TODO: Ian 2019-04-11 getAllDefinitions also exists (differently) in labware-library,
 // should reconcile differences & make a general util fn imported from shared-data
 // require all definitions in the labware/definitions/2 directory
-// @ts-expect-error: require.context is webpack-specific method
 const definitionsContext = require.context(
   '@opentrons/shared-data/labware/definitions/2',
   true, // traverse subdirectories
@@ -14,7 +13,7 @@ const definitionsContext = require.context(
   'sync' // load every definition into one synchronous chunk
 )
 
-let _definitions = null
+let _definitions: LabwareDefByDefURI | null = null
 export function getAllDefinitions(): LabwareDefByDefURI {
   // NOTE: unlike labware-library, no filtering out trashes here (we need 'em)
   // also, more convenient & performant to make a map {labwareDefURI: def} not an array
@@ -33,7 +32,7 @@ export function getAllDefinitions(): LabwareDefByDefURI {
 // filter out all but the latest version of each labware
 // NOTE: this is similar to labware-library's getOnlyLatestDefs, but this one
 // has the {labwareDefURI: def} shape, instead of an array of labware defs
-let _latestDefs = null
+let _latestDefs: LabwareDefByDefURI | null = null
 export function getOnlyLatestDefs(): LabwareDefByDefURI {
   if (!_latestDefs) {
     const allDefs = getAllDefinitions()

--- a/protocol-designer/src/labware-ingred/__tests__/actions.test.ts
+++ b/protocol-designer/src/labware-ingred/__tests__/actions.test.ts
@@ -3,13 +3,14 @@ import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import fixture_tiprack_10_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_10_ul.json'
+import { LabwareDefinition2 } from '@opentrons/shared-data'
 import { getLabwareDefsByURI } from '../../labware-defs/selectors'
 import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import { uuid } from '../../utils'
 import { renameLabware, createContainer } from '../actions'
 import { getNextAvailableDeckSlot, getNextNickname } from '../utils'
-import { InitialDeckSetup } from '../../step-forms'
+
 jest.mock('../../labware-defs/selectors')
 jest.mock('../../step-forms/selectors')
 jest.mock('../../ui/labware/selectors')
@@ -20,7 +21,9 @@ const mockGetLabwareDefsByURI = getLabwareDefsByURI as jest.MockedFunction<
   typeof getLabwareDefsByURI
 >
 
-const mockGetLabwareNicknamesById = getLabwareNicknamesById as jest.MockedFunction<getLabwareNicknamesById>
+const mockGetLabwareNicknamesById = getLabwareNicknamesById as jest.MockedFunction<
+  typeof getLabwareNicknamesById
+>
 
 const mockUuid = uuid as jest.MockedFunction<typeof uuid>
 
@@ -45,7 +48,7 @@ afterEach(() => {
 
 describe('renameLabware thunk', () => {
   it('should dispatch RENAME_LABWARE with a nickname from getNextNickname if `name` arg is unspecified', () => {
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     mockGetLabwareNicknamesById.mockImplementation(state => {
       expect(state).toBe(store.getState())
@@ -65,13 +68,12 @@ describe('renameLabware thunk', () => {
         payload: { labwareId: 'someLabwareId', name: 'Mock Next Nickname' },
       },
     ]
-    // $FlowFixMe(IL. 2020-11-13): flow hates thunks
     store.dispatch(renameLabware({ labwareId: 'someLabwareId' }))
     expect(store.getActions()).toEqual(expectedActions)
   })
 
   it('should dispatch RENAME_LABWARE with a nickname from getNextNickname, with the nickname specified in the `name` arg', () => {
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     mockGetLabwareNicknamesById.mockImplementation(state => {
       expect(state).toBe(store.getState())
@@ -96,7 +98,6 @@ describe('renameLabware thunk', () => {
     ]
 
     store.dispatch(
-      // $FlowFixMe(IL. 2020-11-13): flow hates thunks
       renameLabware({ labwareId: 'someLabwareId', name: 'Specified Name' })
     )
     expect(store.getActions()).toEqual(expectedActions)
@@ -105,7 +106,7 @@ describe('renameLabware thunk', () => {
 
 describe('createContainer', () => {
   it('should dispatch CREATE_CONTAINER with the specified slot', () => {
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     mockGetInitialDeckSetup.mockImplementation(state => {
       expect(state).toBe(store.getState())
@@ -114,7 +115,7 @@ describe('createContainer', () => {
 
     mockGetLabwareDefsByURI.mockImplementation(state => {
       expect(state).toBe(store.getState())
-      return { someLabwareDefURI: fixture_96_plate }
+      return { someLabwareDefURI: fixture_96_plate as LabwareDefinition2 }
     })
 
     mockUuid.mockImplementation(() => 'fakeUuid')
@@ -131,14 +132,13 @@ describe('createContainer', () => {
     ]
 
     store.dispatch(
-      // $FlowFixMe(IL. 2020-11-13): flow hates thunks
       createContainer({ labwareDefURI: 'someLabwareDefURI', slot: '4' })
     )
     expect(store.getActions()).toEqual(expectedActions)
   })
 
   it('should dispatch CREATE_CONTAINER with slot from getNextAvailableDeckSlot if no slot is specified', () => {
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     const initialDeckSetup = { labware: {}, pipettes: {}, modules: {} }
     mockGetInitialDeckSetup.mockImplementation(state => {
@@ -148,7 +148,7 @@ describe('createContainer', () => {
 
     mockGetLabwareDefsByURI.mockImplementation(state => {
       expect(state).toBe(store.getState())
-      return { someLabwareDefURI: fixture_96_plate }
+      return { someLabwareDefURI: fixture_96_plate as LabwareDefinition2 }
     })
 
     mockUuid.mockImplementation(() => 'fakeUuid')
@@ -177,7 +177,7 @@ describe('createContainer', () => {
   })
 
   it('should do nothing if no slot is specified and getNextAvailableDeckSlot returns falsey', () => {
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     const initialDeckSetup = { labware: {}, pipettes: {}, modules: {} }
     mockGetInitialDeckSetup.mockImplementation(state => {
@@ -187,7 +187,7 @@ describe('createContainer', () => {
 
     mockGetLabwareDefsByURI.mockImplementation(state => {
       expect(state).toBe(store.getState())
-      return { someLabwareDefURI: fixture_96_plate }
+      return { someLabwareDefURI: fixture_96_plate as LabwareDefinition2 }
     })
 
     mockGetNextAvailableDeckSlot.mockImplementation(_initialDeckSetup => {
@@ -196,7 +196,7 @@ describe('createContainer', () => {
       return null
     })
 
-    const expectedActions = []
+    const expectedActions: any[] = []
 
     store.dispatch(
       // $FlowFixMe(IL. 2020-11-13): flow hates thunks
@@ -209,7 +209,7 @@ describe('createContainer', () => {
     // NOTE: this is because we don't show the NameThisLabwareOverlay for tipracks,
     // so for the auto-incrementing My Tiprack (1), My Tiprack (2) mechanism to work
     // we must dispatch RENAME_LABWARE here instead of having that overlay dispatch it.
-    const store = mockStore({})
+    const store: any = mockStore({})
 
     mockGetLabwareNicknamesById.mockImplementation(state => {
       expect(state).toBe(store.getState())
@@ -236,7 +236,7 @@ describe('createContainer', () => {
 
     mockGetLabwareDefsByURI.mockImplementation(state => {
       expect(state).toBe(store.getState())
-      return { someLabwareDefURI: fixture_tiprack_10_ul }
+      return { someLabwareDefURI: fixture_tiprack_10_ul as LabwareDefinition2 }
     })
 
     mockUuid.mockImplementation(() => 'fakeUuid')
@@ -260,7 +260,6 @@ describe('createContainer', () => {
     ]
 
     store.dispatch(
-      // $FlowFixMe(IL. 2020-11-13): flow hates thunks
       createContainer({ labwareDefURI: 'someLabwareDefURI', slot: '4' })
     )
     expect(store.getActions()).toEqual(expectedActions)

--- a/protocol-designer/src/labware-ingred/__tests__/containers.test.ts
+++ b/protocol-designer/src/labware-ingred/__tests__/containers.test.ts
@@ -16,6 +16,7 @@ describe('DELETE_CONTAINER action', () => {
   it('no-op with nonexistent labwareId', () => {
     expect(
       containers(
+        // @ts-expect-error(sa, 2021-6-20): not a valid ContainersState
         {
           1: 'blah',
           999: 'blaaah',
@@ -34,6 +35,7 @@ describe('DELETE_CONTAINER action', () => {
   it('delete given labwareId', () => {
     expect(
       containers(
+        // @ts-expect-error(sa, 2021-6-20): not a valid ContainersState
         {
           1: 'blah',
           123: 'delete this',

--- a/protocol-designer/src/labware-ingred/__tests__/selectors.test.ts
+++ b/protocol-designer/src/labware-ingred/__tests__/selectors.test.ts
@@ -13,6 +13,7 @@ const allIngredientsXXSingleIngred = {
 describe('allIngredientNamesIds selector', () => {
   it('selects names & ids from allIngredients selector result', () => {
     expect(
+      // @ts-expect-error(sa, 2021-6-20): resultFunc not part of Selector type
       selectors.allIngredientNamesIds.resultFunc(
         // flow def for resultFunc is wrong and/or resultFun isn't typeable
         allIngredientsXXSingleIngred as any
@@ -27,13 +28,13 @@ describe('allIngredientNamesIds selector', () => {
 })
 describe('allIngredientGroupFields', () => {
   it('no ingreds - return empty obj', () => {
-    // flow def for resultFunc is wrong and/or resultFun isn't typeable
+    // @ts-expect-error(sa, 2021-6-20): resultFunc not part of Selector type
     expect(selectors.allIngredientGroupFields.resultFunc({} as any)).toEqual({})
   })
   it('select fields from all ingred groups', () => {
     expect(
+      // @ts-expect-error(sa, 2021-6-20): resultFunc not part of Selector type
       selectors.allIngredientGroupFields.resultFunc(
-        // flow def for resultFunc is wrong and/or resultFun isn't typeable
         allIngredientsXXSingleIngred as any
       )
     ).toEqual({

--- a/protocol-designer/src/labware-ingred/actions/actions.ts
+++ b/protocol-designer/src/labware-ingred/actions/actions.ts
@@ -9,8 +9,9 @@ export interface OpenAddLabwareModalAction {
     slot: DeckSlot
   }
 }
+// @ts-expect-error(sa, 2021-6-20): creatActions doesn't return exact actions
 export const openAddLabwareModal: (payload: {
-  slot: DeckSlot // $FlowFixMe(mc, 2020-06-04): creatActions doesn't return exact actions
+  slot: DeckSlot
 }) => OpenAddLabwareModalAction = createAction('OPEN_ADD_LABWARE_MODAL')
 export interface CloseLabwareSelectorAction {
   type: 'CLOSE_LABWARE_SELECTOR'
@@ -24,9 +25,9 @@ export interface OpenIngredientSelectorAction {
   type: 'OPEN_INGREDIENT_SELECTOR'
   payload: string
 }
+// @ts-expect-error(sa, 2021-6-20): creatActions doesn't return exact actions
 export const openIngredientSelector: (
-  payload: // $FlowFixMe(mc, 2020-06-04): creatActions doesn't return exact actions
-  string
+  payload: string
 ) => OpenIngredientSelectorAction = createAction('OPEN_INGREDIENT_SELECTOR')
 export interface CloseIngredientSelectorAction {
   type: 'CLOSE_INGREDIENT_SELECTOR'
@@ -40,9 +41,9 @@ export interface DrillDownOnLabwareAction {
   type: 'DRILL_DOWN_ON_LABWARE'
   payload: string
 }
+// @ts-expect-error(sa, 2021-6-20): creatActions doesn't return exact actions
 export const drillDownOnLabware: (
-  payload: // $FlowFixMe(mc, 2020-06-04): creatActions doesn't return exact actions
-  string
+  payload: string
 ) => DrillDownOnLabwareAction = createAction('DRILL_DOWN_ON_LABWARE')
 export interface DrillUpFromLabwareAction {
   type: 'DRILL_UP_FROM_LABWARE'
@@ -70,8 +71,9 @@ export interface DeleteContainerAction {
     labwareId: string
   }
 }
+// @ts-expect-error(sa, 2021-6-20): creatActions doesn't return exact actions
 export const deleteContainer: (payload: {
-  labwareId: string // $FlowFixMe(mc, 2020-06-04): creatActions doesn't return exact actions
+  labwareId: string
 }) => DeleteContainerAction = createAction('DELETE_CONTAINER')
 // ===========
 export interface SwapSlotContentsAction {

--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -1,11 +1,10 @@
-import { combineReducers } from 'redux'
+import { Reducer, combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
 import omit from 'lodash/omit'
 import mapValues from 'lodash/mapValues'
 import pickBy from 'lodash/pickBy'
 import { FIXED_TRASH_ID } from '../../constants'
 import { getPDMetadata } from '../../file-types'
-import { Reducer } from 'redux'
 import {
   SingleLabwareLiquidState,
   LocationLiquidState,
@@ -33,9 +32,12 @@ import {
 // REDUCERS
 // modeLabwareSelection: boolean. If true, we're selecting labware to add to a slot
 // (this state just toggles a modal)
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const modeLabwareSelection: Reducer<DeckSlot | false, any> = handleActions(
   {
+    // @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
     OPEN_ADD_LABWARE_MODAL: (state, action: OpenAddLabwareModalAction) =>
       action.payload.slot,
     CLOSE_LABWARE_SELECTOR: () => false,
@@ -44,7 +46,8 @@ const modeLabwareSelection: Reducer<DeckSlot | false, any> = handleActions(
   false
 )
 export type SelectedContainerId = string | null | undefined
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const selectedContainerId: Reducer<SelectedContainerId, any> = handleActions(
   {
     OPEN_INGREDIENT_SELECTOR: (
@@ -59,7 +62,8 @@ const selectedContainerId: Reducer<SelectedContainerId, any> = handleActions(
   null
 )
 export type DrillDownLabwareId = string | null | undefined
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const drillDownLabwareId: Reducer<DrillDownLabwareId, any> = handleActions(
   {
     DRILL_DOWN_ON_LABWARE: (
@@ -74,7 +78,7 @@ const drillDownLabwareId: Reducer<DrillDownLabwareId, any> = handleActions(
   null
 )
 export type ContainersState = Record<string, DisplayLabware | null | undefined>
-export type SelectedLiquidGroupState = {
+export interface SelectedLiquidGroupState {
   liquidGroupId: string | null | undefined
   newLiquidGroup?: true
 }
@@ -85,6 +89,8 @@ const unselectedLiquidGroupState = {
 // null = nothing selected, newLiquidGroup: true means user is creating new liquid
 const selectedLiquidGroup = handleActions(
   {
+    // @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+    // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
     SELECT_LIQUID_GROUP: (
       state: SelectedLiquidGroupState,
       action: SelectLiquidAction
@@ -106,7 +112,8 @@ const initialLabwareState: ContainersState = {
     nickname: 'Trash',
   },
 }
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 export const containers: Reducer<ContainersState, any> = handleActions(
   {
     CREATE_CONTAINER: (
@@ -127,6 +134,7 @@ export const containers: Reducer<ContainersState, any> = handleActions(
     ): ContainersState =>
       pickBy(
         state,
+        // @ts-expect-error(sa, 2021-6-20): pickBy might return null or undefined
         (value: DisplayLabware, key: string) => key !== action.payload.labwareId
       ),
     RENAME_LABWARE: (
@@ -187,7 +195,8 @@ export const containers: Reducer<ContainersState, any> = handleActions(
 type SavedLabwareState = Record<string, boolean>
 
 /** Keeps track of which labware have saved nicknames */
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 export const savedLabware: Reducer<SavedLabwareState, any> = handleActions(
   {
     DELETE_CONTAINER: (
@@ -210,7 +219,8 @@ export const savedLabware: Reducer<SavedLabwareState, any> = handleActions(
   {}
 )
 export type IngredientsState = LiquidGroupsById
-// NOTE(mc, 2020-06-04): `handleActions` cannot be strictly typed
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 export const ingredients: Reducer<IngredientsState, any> = handleActions(
   {
     EDIT_LIQUID_GROUP: (
@@ -238,6 +248,8 @@ export const ingredients: Reducer<IngredientsState, any> = handleActions(
   {}
 )
 type LocationsState = LabwareLiquidState
+// @ts-expect-error(sa, 2021-6-20): cannot use string literals as action type
+// TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 export const ingredLocations: Reducer<LocationsState, any> = handleActions(
   {
     SET_WELL_CONTENTS: (
@@ -290,7 +302,7 @@ export const ingredLocations: Reducer<LocationsState, any> = handleActions(
   },
   {}
 )
-export type RootState = {
+export interface RootState {
   modeLabwareSelection: DeckSlot | false
   selectedContainerId: SelectedContainerId
   drillDownLabwareId: DrillDownLabwareId

--- a/protocol-designer/src/labware-ingred/selectors.ts
+++ b/protocol-designer/src/labware-ingred/selectors.ts
@@ -21,7 +21,7 @@ import {
   LiquidGroup,
   OrderedLiquids,
 } from './types'
-import { BaseState, MemoizedSelector, DeckSlot } from './../types'
+import { BaseState, DeckSlot } from './../types'
 // TODO: Ian 2019-02-15 no RootSlice, use BaseState
 interface RootSlice {
   labwareIngred: RootState
@@ -50,8 +50,13 @@ const getNextLiquidGroupId: Selector<RootSlice, string> = createSelector(
 const getLiquidNamesById: Selector<
   RootSlice,
   Record<string, string>
-> = createSelector(getLiquidGroupsById, ingredGroups =>
-  mapValues(ingredGroups, (ingred: LiquidGroup) => ingred.name)
+> = createSelector(
+  getLiquidGroupsById,
+  ingredGroups =>
+    mapValues(ingredGroups, (ingred: LiquidGroup) => ingred.name) as Record<
+      string,
+      string
+    >
 )
 const getLiquidSelectionOptions: Selector<RootSlice, Options> = createSelector(
   getLiquidGroupsById,
@@ -131,7 +136,7 @@ const getLiquidGroupsOnDeck: Selector<RootSlice, string[]> = createSelector(
               groupId: keyof typeof groupContents
             ) => {
               if (contents.volume > 0) {
-                liquidGroups.add(groupId)
+                liquidGroups.add(groupId as string)
               }
             }
           )

--- a/protocol-designer/src/labware-ingred/types.ts
+++ b/protocol-designer/src/labware-ingred/types.ts
@@ -1,8 +1,9 @@
 import { LocationLiquidState } from '@opentrons/step-generation'
 // TODO Ian 2018-02-19 make these shared in component library, standardize with Run App
 //  ===== LABWARE ===========
-export type DisplayLabware = {
+export interface DisplayLabware {
   nickname: string | null | undefined
+  disambiguationNumber?: number
 }
 export type LabwareTypeById = Record<string, string | null | undefined>
 // ==== WELLS ==========

--- a/protocol-designer/typings/reselect.d.ts
+++ b/protocol-designer/typings/reselect.d.ts
@@ -1,5 +1,24 @@
-// declare module "reselect" { 
-//     interface App {
-//         additional: string;
-//     }
-// }
+import { OutputSelector, Selector } from 'reselect';
+declare module 'reselect' {
+  // declaring type for createSelector with 15 selectors because the reselect types only support up to 12 selectors
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, T>(
+    selector1: Selector<S, R1>,
+    selector2: Selector<S, R2>,
+    selector3: Selector<S, R3>,
+    selector4: Selector<S, R4>,
+    selector5: Selector<S, R5>,
+    selector6: Selector<S, R6>,
+    selector7: Selector<S, R7>,
+    selector8: Selector<S, R8>,
+    selector9: Selector<S, R9>,
+    selector10: Selector<S, R10>,
+    selector11: Selector<S, R11>,
+    selector12: Selector<S, R12>,
+    selector13: Selector<S, R13>,
+    selector14: Selector<S, R14>,
+    selector15: Selector<S, R15>,
+    combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+              res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12, res13: R13, res14: R14, res15: R15) => T,
+  ): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+    res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12, res13: R13, res14: R14, res15: R15) => T>;
+} 

--- a/protocol-designer/typings/reselect.d.ts
+++ b/protocol-designer/typings/reselect.d.ts
@@ -1,0 +1,5 @@
+// declare module "reselect" { 
+//     interface App {
+//         additional: string;
+//     }
+// }


### PR DESCRIPTION
# Overview

migrate `protocol-designer/src/file-data`, `protocol-designer/src/ labware-defs` and `protocol-designer/src/ labware-ingred`  to TS

closes #7891 