### PR TITLE
fix(api): tolerate bad json in calibration defs

### DIFF
--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -74,7 +74,8 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
             try:
                 cal_blob = io.read_cal_file(str(cal_path))
             except json.JSONDecodeError:
-                log.error(f"Corrupt calibration file (bad JSON): {str(cal_path)}")
+                log.error(
+                    f"Skipping corrupt calibration file (bad JSON): {str(cal_path)}")
                 continue
             calibration = _format_calibration_type(cal_blob)  # type: ignore
             try:
@@ -85,7 +86,8 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
                         labware_id=key,
                         uri=data['uri']))
             except (KeyError, ValueError):
-                log.exception("Corrupt calibration file (bad data)")
+                log.exception(
+                    f"Skipping corrupt calibration file (bad data) {str(cal_path)}")
                 continue
     return all_calibrations
 
@@ -182,7 +184,8 @@ def get_all_tip_length_calibrations() \
             try:
                 data = io.read_cal_file(str(cal_path))
             except json.JSONDecodeError:
-                log.error(f"corrupt calibration file (bad json): {str(cal_path)}")
+                log.error(
+                    f"Skipping corrupt calibration file (bad json): {str(cal_path)}")
                 continue
             for tiprack, info in data.items():
                 all_calibrations.append(
@@ -229,7 +232,8 @@ def get_robot_deck_attitude() \
         try:
             data = io.read_cal_file(gantry_path)
         except json.JSONDecodeError:
-            log.error(f"corrupt calibration file (bad json): {str(gantry_path)}")
+            log.error(
+                f"Skipping corrupt calibration file (bad json): {str(gantry_path)}")
             return None
         try:
             return local_types.DeckCalibration(
@@ -255,7 +259,8 @@ def get_pipette_offset(
         try:
             data = io.read_cal_file(offset_path)
         except json.JSONDecodeError:
-            log.error(f"corrupt calibration file (bad json): {str(offset_path)}")
+            log.error(
+                f"Skipping corrupt calibration file (bad json): {str(offset_path)}")
             return None
         assert 'offset' in data.keys(), 'Not valid pipette calibration data'
         return local_types.PipetteOffsetByPipetteMount(
@@ -292,7 +297,9 @@ def get_all_pipette_offset_calibrations() \
                 try:
                     data = io.read_cal_file(str(cal_path))
                 except json.JSONDecodeError:
-                    log.error(f"corrupt calibration file (bad json): {str(cal_path)}")
+                    log.error(
+                        "Skipping corrupt calibration file (bad json): "
+                        + f"{str(cal_path)}")
                     continue
                 try:
                     all_calibrations.append(
@@ -306,7 +313,9 @@ def get_all_pipette_offset_calibrations() \
                             source=_get_calibration_source(data),
                             status=_get_calibration_status(data)))
                 except (KeyError, ValueError):
-                    log.exception("corrupt calibration file (bad data)")
+                    log.exception(
+                        "Skipping corrupt calibration file (bad data): "
+                        + f"{str(cal_path)}")
                     continue
     return all_calibrations
 

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -20,7 +20,9 @@ if typing.TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import LabwareUri
     from .dev_types import CalibrationIndexDict, CalibrationDict
 
+
 log = logging.getLogger(__name__)
+
 
 def _format_calibration_type(
         data: 'CalibrationDict') -> local_types.LabwareCalibrationTypes:

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -72,6 +72,13 @@ def test_load_malformed_calibration(ot_config_tempdir):
     assert np.allclose(obj.attitude, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
 
+def test_load_json(ot_config_tempdir):
+    path = config.get_opentrons_path('robot_calibration_dir')/'deck_calibration.json'
+    path.write('{')
+    obj = robot_calibration.load_attitude_matrix()
+    assert obj is None
+
+
 def test_load_pipette_offset(ot_config_tempdir):
     pip_id = 'fakePip'
     mount = Mount.LEFT
@@ -89,3 +96,12 @@ def test_load_pipette_offset(ot_config_tempdir):
     obj = robot_calibration.load_pipette_offset(pip_id, mount)
     offset = [1, 2, 3]
     assert np.allclose(obj.offset, offset)
+
+
+def test_load_bad_pipette_offset(ot_config_tempdir):
+    path = config.get_opentrons_path('pipette_calibration_dir')/'left'
+    path.mkdir(parents=True, exist_ok=True)
+    calpath = path / 'fakePip.json'
+    calpath.write('{')
+    obj = robot_calibration.load_pipette_offset('fakePip', Mount.LEFT)
+    assert obj is None

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -76,7 +76,7 @@ def test_load_json(ot_config_tempdir):
     path = config.get_opentrons_path('robot_calibration_dir')/'deck_calibration.json'
     path.write_text('{')
     obj = robot_calibration.load_attitude_matrix()
-    assert obj == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    assert obj.attitude == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
 
 def test_load_pipette_offset(ot_config_tempdir):
@@ -104,4 +104,4 @@ def test_load_bad_pipette_offset(ot_config_tempdir):
     calpath = path / 'fakePip.json'
     calpath.write_text('{')
     obj = robot_calibration.load_pipette_offset('fakePip', Mount.LEFT)
-    assert obj == [0, 0, 0]
+    assert obj.offset == [0, 0, 0]

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -74,7 +74,7 @@ def test_load_malformed_calibration(ot_config_tempdir):
 
 def test_load_json(ot_config_tempdir):
     path = config.get_opentrons_path('robot_calibration_dir')/'deck_calibration.json'
-    path.write('{')
+    path.write_text('{')
     obj = robot_calibration.load_attitude_matrix()
     assert obj is None
 
@@ -102,6 +102,6 @@ def test_load_bad_pipette_offset(ot_config_tempdir):
     path = config.get_opentrons_path('pipette_calibration_dir')/'left'
     path.mkdir(parents=True, exist_ok=True)
     calpath = path / 'fakePip.json'
-    calpath.write('{')
+    calpath.write_text('{')
     obj = robot_calibration.load_pipette_offset('fakePip', Mount.LEFT)
     assert obj is None

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -76,7 +76,7 @@ def test_load_json(ot_config_tempdir):
     path = config.get_opentrons_path('robot_calibration_dir')/'deck_calibration.json'
     path.write_text('{')
     obj = robot_calibration.load_attitude_matrix()
-    assert obj is None
+    assert obj == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
 
 def test_load_pipette_offset(ot_config_tempdir):
@@ -104,4 +104,4 @@ def test_load_bad_pipette_offset(ot_config_tempdir):
     calpath = path / 'fakePip.json'
     calpath.write_text('{')
     obj = robot_calibration.load_pipette_offset('fakePip', Mount.LEFT)
-    assert obj is None
+    assert obj == [0, 0, 0]


### PR DESCRIPTION
If a calibration file contains bad json data, we should ignore it rather
than crashing.
