### PR TITLE
feat(labware-creator): remove text saying tipracks not supported in LC

### DIFF
--- a/labware-library/src/labware-creator/components/ImportErrorModal.tsx
+++ b/labware-library/src/labware-creator/components/ImportErrorModal.tsx
@@ -15,7 +15,7 @@ const ERROR_MAP: Record<ImportErrorKey, React.ReactNode> = {
       </p>
       <p>
         Labware Creator currently only supports labware with a single regular
-        grid. Also, it does not support tipracks or trash boxes.
+        grid. Also, it does not support trash boxes.
       </p>
     </>
   ),


### PR DESCRIPTION
# Overview

Closes #7988

Importing an unsupported labware (anything with an irregular grid, eg the 15+50 tube rack standard def) should no longer say that tipracks are unsupported in LC.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

- Copy change is correct

# Risk assessment

Low