### PR TITLE
fix(api): fix module path for jupyter notebook

### DIFF
--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -208,7 +208,7 @@ class AttachedModulesControl:
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None
-            return modules.ModuleAtPort(port=f'dev/{port}', name=name)
+            return modules.ModuleAtPort(port=f'/dev/{port}', name=name)
         return None
 
     async def handle_module_appearance(self, event: AionotifyEvent):


### PR DESCRIPTION
# Overview

Closes #7959. We should use the absolute path for modules, otherwise jupyter notebook will not be able to find the correct port to connect to the module.

# Changelog
- Change port path from `dev/ot_module*` to `/dev/ot_module*`

# Review requests
Pls make sure this didn't break anything. Run module protocol in the app and also in jupyter notebook. Disconnect/Reconnect modules a few times.

# Risk assessment
Medium.
