### PR TITLE
feat(labware-creator): show whole labware in preview svg

### DIFF
--- a/components/src/deck/LabwareRender.tsx
+++ b/components/src/deck/LabwareRender.tsx
@@ -29,14 +29,18 @@ export interface LabwareRenderProps {
   /** Special class which, together with 'data-wellname' on the well elements,
     allows drag-to-select behavior */
   selectableWellClass?: string
+  gRef?: React.RefObject<SVGGElement>
 }
 
-export function LabwareRender(props: LabwareRenderProps): JSX.Element {
+export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
+  const { gRef } = props
   const cornerOffsetFromSlot = props.definition.cornerOffsetFromSlot
+
   return (
     <g
       /* eslint-disable-next-line @typescript-eslint/restrict-template-expressions */
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}
+      ref={gRef}
     >
       <StaticLabware
         definition={props.definition}

--- a/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
+++ b/labware-library/src/labware-creator/components/ConditionalLabwareRender.tsx
@@ -20,6 +20,22 @@ interface Props {
 }
 
 export const ConditionalLabwareRender = (props: Props): JSX.Element => {
+  const gRef = React.useRef<SVGGElement>(null)
+  const [bBox, updateBBox] = React.useState<DOMRect>()
+
+  // In order to implement "zoom to fit", we're calculating the desired viewBox based on getBBox of the child.
+  // So we have to actually render the child to get its bounding box. After that, we re-calculate the viewBox.
+  // Once the viewBox is re-calculated, we use setState to force a re-render.
+  React.useLayoutEffect((): void => {
+    const nextBBox = gRef.current?.getBBox()
+    if (
+      nextBBox != null &&
+      (nextBBox.width !== bBox?.width || nextBBox.height !== bBox?.height)
+    ) {
+      updateBBox(nextBBox)
+    }
+  })
+
   const definition = React.useMemo(() => {
     const values = cloneDeep(props.values)
 
@@ -65,18 +81,27 @@ export const ConditionalLabwareRender = (props: Props): JSX.Element => {
     return def
   }, [props.values])
 
-  const xDim = definition
-    ? definition.dimensions.xDimension
-    : DEFAULT_X_DIMENSION
-  const yDim = definition
-    ? definition.dimensions.yDimension
-    : DEFAULT_Y_DIMENSION
+  const xDim =
+    definition != null
+      ? bBox?.width ?? definition.dimensions.xDimension
+      : DEFAULT_X_DIMENSION
+  const yDim =
+    definition != null
+      ? bBox?.height ?? definition.dimensions.yDimension
+      : DEFAULT_Y_DIMENSION
+
+  // by-eye margin to make sure there is no visual clipping
+  const MARGIN = 5
 
   return (
-    <RobotWorkSpace viewBox={`0 0 ${xDim} ${yDim}`}>
+    <RobotWorkSpace
+      viewBox={`${(bBox?.x ?? 0) - MARGIN} ${(bBox?.y ?? 0) - MARGIN} ${
+        xDim + MARGIN * 2
+      } ${yDim + MARGIN * 2}`}
+    >
       {() =>
-        definition ? (
-          <LabwareRender definition={definition} />
+        definition != null ? (
+          <LabwareRender definition={definition} gRef={gRef} />
         ) : (
           <>
             <LabwareOutline />


### PR DESCRIPTION
# Overview

Closes #7164

I wanted to leverage what was already available in SVG land instead of working up from the labware definition data, and found [getBBox](https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement/getBBox). This fn requires that the element you're getting the bounding box of is rendered. Once we have the bounding box, we can apply those numbers (plus a margin) to the `viewPort` of the parent `<svg>`. 

Since we're rendering something in order to measure it, then re-rendering it correctly, there's a messy amount of re-rendering going on. But I can't think of another way to do it, besides re-constructing the render as data (each well has its relative X/Y, but all the offsets applied to them would need to be applied just the same as they are to the SVG).

# Changelog


# Review requests

- Is there a cleaner way to do this?
- Should not be able to trigger infinite re-render loop (we're doing `setState` inside `useLayoutEffect`, so that is a risk if I didn't guard against that correctly)
- Should not cause lag with eg a 384 well, no lag as you type in an input field


# Risk assessment

Medium, but LC-only. Added an optional prop to the `LabwareRender` component, but that shouldn't hurt anything