### PR TITLE
refactor(components): regenerate flow-types

### DIFF
--- a/components/flow-types/buttons/Button.js.flow
+++ b/components/flow-types/buttons/Button.js.flow
@@ -22,7 +22,7 @@ export type ButtonProps = {|
   /**
    * click handler
    */
-  onClick?: (event: React.MouseEvent<>) => mixed,
+  onClick?: React.MouseEventHandler<>,
 
   /**
    * name attribute

--- a/components/flow-types/deck/types.js.flow
+++ b/components/flow-types/deck/types.js.flow
@@ -7,7 +7,9 @@
 
 import type { DeckSlot } from "@opentrons/shared-data";
 export type RobotWorkSpaceRenderProps = {|
-  deckSlotsById: { [key: string]: DeckSlot },
+  deckSlotsById: {
+    [slotId: string]: DeckSlot,
+  },
   getRobotCoordsFromDOMCoords: (
     domX: number,
     domY: number

--- a/components/flow-types/forms/CheckboxField.js.flow
+++ b/components/flow-types/forms/CheckboxField.js.flow
@@ -6,6 +6,10 @@
  */
 
 import * as React from "react";
+
+/**
+ * Checkbox Field Properties.
+ */
 export type CheckboxFieldProps = {|
   /**
    * change handler
@@ -62,4 +66,8 @@ export type CheckboxFieldProps = {|
    */
   isIndeterminate?: boolean,
 |};
+
+/**
+ * Checkbox Form Field
+ */
 declare export function CheckboxField(props: CheckboxFieldProps): React$Node;

--- a/components/flow-types/forms/InputField.js.flow
+++ b/components/flow-types/forms/InputField.js.flow
@@ -17,7 +17,7 @@ export type InputFieldProps = {|
   /**
    * change handler
    */
-  onChange?: (event: React.SyntheticEvent<HTMLInputElement>) => mixed,
+  onChange?: React.ChangeEventHandler<HTMLInputElement>,
 
   /**
    * classes to apply to outer element

--- a/components/flow-types/instrument/InstrumentInfo.js.flow
+++ b/components/flow-types/instrument/InstrumentInfo.js.flow
@@ -17,7 +17,7 @@ export type InstrumentInfoProps = {|
   /**
    * if true, show labels 'LEFT PIPETTE' / 'RIGHT PIPETTE'
    */
-  showMountLabel?: boolean | null | void,
+  showMountLabel?: boolean | null,
 
   /**
    * human-readable description, eg 'p300 Single-channel'
@@ -37,10 +37,7 @@ export type InstrumentInfoProps = {|
   /**
    * specs of mounted pipette
    */
-  pipetteSpecs?: $PropertyType<
-    InstrumentDiagramProps,
-    "pipetteSpecs"
-  > | null | void,
+  pipetteSpecs?: $PropertyType<InstrumentDiagramProps, "pipetteSpecs"> | null,
 
   /**
    * classes to apply

--- a/components/flow-types/primitives/Box.js.flow
+++ b/components/flow-types/primitives/Box.js.flow
@@ -8,7 +8,7 @@
 import type { PrimitiveComponent } from "./types";
 
 /**
- * Box primitive
+ * Simple Box atom. Renders a `div` by default and accepts all primitive styling props.
  * @component
  */
 declare export var Box: PrimitiveComponent<"div">;


### PR DESCRIPTION
# Overview

Somehow, these got behind. This PR is just the result of running:

```
rm -rf components/flow-type/*
make -C components flow-types
```

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

- Seems more correct than before?
- CI still passing?

# Risk assessment

Low