### PR TITLE
refactor(robot-server): support Python protocols in experimental `/protocols`, `/sessions`

### DIFF
--- a/api/src/opentrons/file_runner/create_file_runner.py
+++ b/api/src/opentrons/file_runner/create_file_runner.py
@@ -8,6 +8,7 @@ from .abstract_file_runner import AbstractFileRunner
 from .json_file_runner import JsonFileRunner
 from .json_file_reader import JsonFileReader
 from .command_queue_worker import CommandQueueWorker
+from .python_file_runner import PythonFileRunner
 from .protocol_file import ProtocolFileType, ProtocolFile
 
 
@@ -25,13 +26,16 @@ def create_file_runner(
     Returns:
         A runner appropriate for the requested protocol type.
     """
-    if protocol_file is not None and protocol_file.file_type == ProtocolFileType.JSON:
-        return JsonFileRunner(
-            file=protocol_file,
-            protocol_engine=engine,
-            file_reader=JsonFileReader(),
-            command_translator=CommandTranslator(),
-            command_queue_worker=CommandQueueWorker(engine),
-        )
+    if protocol_file is not None:
+        if protocol_file.file_type == ProtocolFileType.JSON:
+            return JsonFileRunner(
+                file=protocol_file,
+                protocol_engine=engine,
+                file_reader=JsonFileReader(),
+                command_translator=CommandTranslator(),
+                command_queue_worker=CommandQueueWorker(engine),
+            )
+        elif protocol_file.file_type == ProtocolFileType.PYTHON:
+            return PythonFileRunner()
 
     raise NotImplementedError("Other runner types not yet supported")

--- a/api/tests/opentrons/file_runner/conftest.py
+++ b/api/tests/opentrons/file_runner/conftest.py
@@ -100,7 +100,7 @@ def python_protocol_file(tmp_path: Path) -> Path:
             """
             # my protocol
             metadata = {
-                "apiVersion": 3.0
+                "apiVersion": "3.0",
             }
             def run(ctx):
                 pass

--- a/api/tests/opentrons/file_runner/conftest.py
+++ b/api/tests/opentrons/file_runner/conftest.py
@@ -1,6 +1,8 @@
 """Test fixtures for opentrons.file_runner tests."""
 import pytest
-
+import json
+import textwrap
+from pathlib import Path
 from opentrons.protocols.models import JsonProtocol
 
 
@@ -73,3 +75,38 @@ def json_protocol_dict(minimal_labware_def: dict) -> dict:
             },
         ],
     }
+
+
+@pytest.fixture
+def json_protocol_file(
+    tmp_path: Path,
+    json_protocol_dict: dict,
+) -> Path:
+    """Get an on-disk, minimal JSON protocol fixture."""
+    file_path = tmp_path / "protocol-name.json"
+
+    file_path.write_text(json.dumps(json_protocol_dict), encoding="utf-8")
+
+    return file_path
+
+
+@pytest.fixture
+def python_protocol_file(tmp_path: Path) -> Path:
+    """Get an on-disk, minimal Python protocol fixture."""
+    file_path = tmp_path / "protocol-name.py"
+
+    file_path.write_text(
+        textwrap.dedent(
+            """
+            # my protocol
+            metadata = {
+                "apiVersion": 3.0
+            }
+            def run(ctx):
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    return file_path

--- a/api/tests/opentrons/file_runner/test_create_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_create_file_runner.py
@@ -1,27 +1,55 @@
 """Tests for the create_protocol_runner factory."""
-# TODO(mc, 2021-06-03): turn these into actual integration tests
-# that uses real protocol files
-from mock import MagicMock
+import pytest
 from pathlib import Path
 
+from opentrons.hardware_control import API as HardwareAPI
+from opentrons.protocol_engine import ProtocolEngine, create_protocol_engine
 from opentrons.file_runner import (
     ProtocolFileType,
     ProtocolFile,
     JsonFileRunner,
+    PythonFileRunner,
     create_file_runner,
 )
 
 
-def test_create_json_runner() -> None:
+@pytest.fixture
+async def protocol_engine(hardware: HardwareAPI) -> ProtocolEngine:
+    """Get an actual ProtocolEngine for smoke-test purposes."""
+    return await create_protocol_engine(hardware=hardware)
+
+
+def test_create_json_runner(
+    protocol_engine: ProtocolEngine,
+    json_protocol_file: Path,
+) -> None:
     """It should be able to create a JSON file runner."""
     protocol_file = ProtocolFile(
         file_type=ProtocolFileType.JSON,
-        file_path=Path("/dev/null"),
+        file_path=json_protocol_file,
     )
 
     result = create_file_runner(
         protocol_file=protocol_file,
-        engine=MagicMock(),
+        engine=protocol_engine,
     )
 
     assert isinstance(result, JsonFileRunner)
+
+
+def test_create_python_runner(
+    protocol_engine: ProtocolEngine,
+    python_protocol_file: Path,
+) -> None:
+    """It should be able to create a JSON file runner."""
+    protocol_file = ProtocolFile(
+        file_type=ProtocolFileType.PYTHON,
+        file_path=python_protocol_file,
+    )
+
+    result = create_file_runner(
+        protocol_file=protocol_file,
+        engine=protocol_engine,
+    )
+
+    assert isinstance(result, PythonFileRunner)

--- a/api/tests/opentrons/file_runner/test_create_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_create_file_runner.py
@@ -41,7 +41,7 @@ def test_create_python_runner(
     protocol_engine: ProtocolEngine,
     python_protocol_file: Path,
 ) -> None:
-    """It should be able to create a JSON file runner."""
+    """It should be able to create a Python file runner."""
     protocol_file = ProtocolFile(
         file_type=ProtocolFileType.PYTHON,
         file_path=python_protocol_file,

--- a/robot-server/robot_server/protocols/protocol_store.py
+++ b/robot-server/robot_server/protocols/protocol_store.py
@@ -120,14 +120,15 @@ class ProtocolStore:
     def _get_protocol_dir(self, protocol_id: str) -> Path:
         return self._directory / protocol_id
 
-    # TODO(mc, 2021-06-01): add python support, add multi-file support, and
-    # honestly, probably ditch all of this logic in favor of whatever
-    # `ProtocolAnalyzer` situation we come up with
+    # TODO(mc, 2021-06-01): add multi-file support and ditch all of this
+    # logic in favor of whatever protocol analyzer we come up with
     @staticmethod
     def _get_protocol_type(files: List[Path]) -> ProtocolFileType:
         file_path = files[0]
 
         if file_path.suffix == ".json":
             return ProtocolFileType.JSON
+        elif file_path.suffix == ".py":
+            return ProtocolFileType.PYTHON
         else:
-            raise NotImplementedError()
+            raise NotImplementedError("Protocol type not yet supported")

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -66,8 +66,6 @@ async def create_protocol(
     """
     if len(files) > 1:
         raise NotImplementedError("Multi-file protocols not yet supported.")
-    elif files[0].filename.endswith(".py"):
-        raise NotImplementedError("Python protocols not yet supported")
 
     try:
         protocol_entry = await protocol_store.create(

--- a/robot-server/tests/sessions/conftest.py
+++ b/robot-server/tests/sessions/conftest.py
@@ -1,6 +1,7 @@
 """Common test fixtures for sessions route tests."""
 import pytest
 import json
+import textwrap
 from pathlib import Path
 from decoy import Decoy
 
@@ -34,6 +35,8 @@ def engine_store(decoy: Decoy) -> EngineStore:
     return decoy.create_decoy(spec=EngineStore)
 
 
+# TODO(mc, 2021-06-28): these fixtures are duplicated with fixtures in
+# tests/opentrons/file_runner/conftest.py
 @pytest.fixture
 def json_protocol_file(
     tmp_path: Path,
@@ -104,6 +107,28 @@ def json_protocol_file(
                     },
                 ],
             }
+        ),
+        encoding="utf-8",
+    )
+
+    return file_path
+
+
+@pytest.fixture
+def python_protocol_file(tmp_path: Path) -> Path:
+    """Get an on-disk, minimal Python protocol fixture."""
+    file_path = tmp_path / "protocol-name.py"
+
+    file_path.write_text(
+        textwrap.dedent(
+            """
+            # my protocol
+            metadata = {
+                "apiVersion": 3.0
+            }
+            def run(ctx):
+                pass
+            """
         ),
         encoding="utf-8",
     )

--- a/robot-server/tests/sessions/conftest.py
+++ b/robot-server/tests/sessions/conftest.py
@@ -124,7 +124,7 @@ def python_protocol_file(tmp_path: Path) -> Path:
             """
             # my protocol
             metadata = {
-                "apiVersion": 3.0
+                "apiVersion": "3.0"
             }
             def run(ctx):
                 pass

--- a/robot-server/tests/sessions/test_engine_store.py
+++ b/robot-server/tests/sessions/test_engine_store.py
@@ -1,11 +1,14 @@
 """Tests for the EngineStore interface."""
+# TODO(mc, 2021-06-28): these factory smoke tests are becoming duplicated
+# with test logic in `api`. Try to rework the EngineStore / tests into more
+# of a collaborator
 import pytest
 from datetime import datetime
 from mock import MagicMock
 from pathlib import Path
 
 from opentrons.protocol_engine import ProtocolEngine
-from opentrons.file_runner import JsonFileRunner
+from opentrons.file_runner import JsonFileRunner, PythonFileRunner
 from robot_server.protocols import ProtocolResource, ProtocolFileType
 from robot_server.sessions.engine_store import (
     EngineStore,
@@ -35,7 +38,7 @@ async def test_create_engine_for_json_protocol(
     subject: EngineStore,
     json_protocol_file: Path,
 ) -> None:
-    """It should create a protocol runner.
+    """It should create a JSON protocol runner.
 
     This test is functioning as an integration / smoke test. Ensuring that
     the protocol was loaded correctly is / should be covered in unit tests
@@ -54,6 +57,32 @@ async def test_create_engine_for_json_protocol(
     assert isinstance(result, ProtocolEngine)
     assert isinstance(subject.engine, ProtocolEngine)
     assert isinstance(subject.runner, JsonFileRunner)
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True)
+async def test_create_engine_for_python_protocol(
+    subject: EngineStore,
+    python_protocol_file: Path,
+) -> None:
+    """It should create a Python protocol runner.
+
+    This test is functioning as an integration / smoke test. Ensuring that
+    the protocol was loaded correctly is / should be covered in unit tests
+    elsewhere.
+    """
+    protocol = ProtocolResource(
+        protocol_id="protocol-id",
+        protocol_type=ProtocolFileType.PYTHON,
+        created_at=datetime.now(),
+        files=[python_protocol_file],
+    )
+
+    result = await subject.create(protocol=protocol)
+
+    assert result == subject.engine
+    assert isinstance(result, ProtocolEngine)
+    assert isinstance(subject.engine, ProtocolEngine)
+    assert isinstance(subject.runner, PythonFileRunner)
 
 
 async def test_raise_if_engine_already_exists(subject: EngineStore) -> None:


### PR DESCRIPTION
## Overview

This is a little PR to wire the experimental, ProtocolEngine-based `/protocols` and `/sessions` endpoints up to the (not yet implemented) `PythonFileRunner` class in the API.

This PR is a start to #7844.

## Changelog

- Allow `opentrons.file_runner.create_file_runner` to create `PythonFileRunner`s
- Do not block the upload of Python protocols in `/protocols` nor the creation of Python protocol sessions in `/sessions`

## Review requests

Given that the `PythonFileRunner` is not yet implemented, you will still hit `NotImplementedError`s if you try to exercise these endpoints with a Python protocol file. That `NotImplementedError` will, however, now be lower down in the stack: at `PythonFileRunner.load`.

This review should therefore be focused on clarity of code and tests.

## Risk assessment

N/A, fully feature flagged development with high test coverage.
