### PR TITLE
feat(labware_creator): add tiprack test file to export section

### DIFF
--- a/labware-library/cypress/integration/labware-creator/fileImport.spec.js
+++ b/labware-library/cypress/integration/labware-creator/fileImport.spec.js
@@ -27,7 +27,7 @@ context('File Import', () => {
   })
 
   it('contains a button to the testing guide', () => {
-    cy.contains('view test guide')
+    cy.contains('labware test guide')
       .should('have.prop', 'href')
       .and('to.have.string', 'labwareDefinition_testGuide')
   })

--- a/labware-library/cypress/integration/labware-creator/reservoir.spec.js
+++ b/labware-library/cypress/integration/labware-creator/reservoir.spec.js
@@ -22,7 +22,7 @@ context('Reservoirs', () => {
     })
 
     it('contains a button to the testing guide', () => {
-      cy.contains('view test guide')
+      cy.contains('labware test guide')
         .should('have.prop', 'href')
         .and('to.have.string', 'labwareDefinition_testGuide')
     })

--- a/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
@@ -42,7 +42,7 @@ context('Tubes and Block', () => {
       })
 
       it('contains a button to the testing guide', () => {
-        cy.contains('view test guide')
+        cy.contains('labware test guide')
           .should('have.prop', 'href')
           .and('to.have.string', 'labwareDefinition_testGuide')
       })
@@ -231,7 +231,7 @@ context('Tubes and Block', () => {
       })
 
       it('contains a button to the testing guide', () => {
-        cy.contains('view test guide')
+        cy.contains('labware test guide')
           .should('have.prop', 'href')
           .and('to.have.string', 'labwareDefinition_testGuide')
       })
@@ -420,7 +420,7 @@ context('Tubes and Block', () => {
       })
 
       it('contains a button to the testing guide', () => {
-        cy.contains('view test guide')
+        cy.contains('labware test guide')
           .should('have.prop', 'href')
           .and('to.have.string', 'labwareDefinition_testGuide')
       })
@@ -605,7 +605,7 @@ context('Tubes and Block', () => {
       })
 
       it('contains a button to the testing guide', () => {
-        cy.contains('view test guide')
+        cy.contains('labware test guide')
           .should('have.prop', 'href')
           .and('to.have.string', 'labwareDefinition_testGuide')
       })

--- a/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
@@ -30,7 +30,7 @@ context('Tubes and Rack', () => {
     })
 
     it('contains a button to the testing guide', () => {
-      cy.contains('view test guide')
+      cy.contains('labware test guide')
         .should('have.prop', 'href')
         .and('to.have.string', 'labwareDefinition_testGuide')
     })
@@ -205,7 +205,7 @@ context('Tubes and Rack', () => {
     })
 
     it('contains a button to the testing guide', () => {
-      cy.contains('view test guide')
+      cy.contains('labware test guide')
         .should('have.prop', 'href')
         .and('to.have.string', 'labwareDefinition_testGuide')
     })
@@ -384,7 +384,7 @@ context('Tubes and Rack', () => {
     })
 
     it('contains a button to the testing guide', () => {
-      cy.contains('view test guide')
+      cy.contains('labware test guide')
         .should('have.prop', 'href')
         .and('to.have.string', 'labwareDefinition_testGuide')
     })

--- a/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
+++ b/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
@@ -28,7 +28,7 @@ context('Well Plates', () => {
     })
 
     it('contains a button to the testing guide', () => {
-      cy.contains('view test guide')
+      cy.contains('labware test guide')
         .should('have.prop', 'href')
         .and('to.have.string', 'labwareDefinition_testGuide')
     })

--- a/labware-library/src/labware-creator/components/LinkOut.tsx
+++ b/labware-library/src/labware-creator/components/LinkOut.tsx
@@ -14,6 +14,7 @@ export const LinkOut = (props: Props): JSX.Element => (
     href={props.href}
     target="_blank"
     rel="noopener noreferrer"
+    role="button"
   >
     {props.children}
   </a>

--- a/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Export.test.tsx
@@ -62,6 +62,20 @@ describe('Export', () => {
     screen.getByText(FAKE_ERROR)
   })
 
+  it('should render the tip rack button when tip rack is selected', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
+    render(wrapInFormik(<Export onExportClick={onExportClick} />, formikConfig))
+
+    screen.getByRole('button', { name: /tip rack test guide/i })
+  })
+
+  it('should render the labware button when tip rack is not selected', () => {
+    formikConfig.initialValues.labwareType = 'wellPlate'
+    render(wrapInFormik(<Export onExportClick={onExportClick} />, formikConfig))
+
+    screen.getByRole('button', { name: /labware test guide/i })
+  })
+
   it('should not render when all of the fields are hidden', () => {
     when(isEveryFieldHiddenMock)
       .calledWith(['pipetteName'], formikConfig.initialValues)

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -25,6 +25,13 @@ export const Export = (props: ExportProps): JSX.Element | null => {
   const fieldList: Array<keyof LabwareFields> = ['pipetteName']
   const { values, errors, touched } = useFormikContext<LabwareFields>()
 
+  const exportUrl =
+    values.labwareType === 'tipRack' ? TIPRACK_PDF_URL : LABWARE_PDF_URL
+  const exportLabel =
+    values.labwareType === 'tipRack'
+      ? 'tip rack test guide'
+      : 'labware test guide'
+
   if (isEveryFieldHidden(fieldList, values)) {
     return null
   }
@@ -61,30 +68,17 @@ export const Export = (props: ExportProps): JSX.Element | null => {
             Use the Tip Rack guide to troubleshoot Tip Rack definitions. Use the
             Labware guide for all other labware types.
           </p>
-          <div className={styles.test_guide_container}>
-            <LinkOut
-              onClick={() =>
-                reportEvent({
-                  name: 'labwareCreatorClickTestLabware',
-                })
-              }
-              href={LABWARE_PDF_URL}
-              className={styles.test_guide_button}
-            >
-              labware test guide
-            </LinkOut>
-            <LinkOut
-              onClick={() =>
-                reportEvent({
-                  name: 'labwareCreatorClickTestLabware',
-                })
-              }
-              href={TIPRACK_PDF_URL}
-              className={styles.test_guide_button}
-            >
-              tip rack test guide
-            </LinkOut>
-          </div>
+          <LinkOut
+            onClick={() =>
+              reportEvent({
+                name: 'labwareCreatorClickTestLabware',
+              })
+            }
+            href={exportUrl}
+            className={styles.test_guide_button}
+          >
+            {exportLabel}
+          </LinkOut>
         </div>
         <PrimaryBtn
           className={styles.export_button}

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -12,8 +12,10 @@ import { LinkOut } from '../LinkOut'
 import { SectionBody } from './SectionBody'
 import styles from '../../styles.css'
 
-const PDF_URL =
+const LABWARE_PDF_URL =
   'https://opentrons-publications.s3.us-east-2.amazonaws.com/labwareDefinition_testGuide.pdf'
+const TIPRACK_PDF_URL =
+  'https://zh-file.s3.amazonaws.com/38644841/f4df21db-26be-4a04-ae6a-58d32e70bddc?Expires=1624630757&AWSAccessKeyId=AKIAI5X57DET3FHKSALA&Signature=KQc%2F8fBo817c3uvlRcfovJxm7MQ%3D'
 
 interface ExportProps {
   onExportClick: (e: React.MouseEvent) => unknown
@@ -55,18 +57,34 @@ export const Export = (props: ExportProps): JSX.Element | null => {
             definitions that are precise and do not rely on excessive
             calibration prior to each run to achieve accuracy.
           </p>
-          <p>Use the test guide to troubleshoot your definition.</p>
-          <LinkOut
-            onClick={() =>
-              reportEvent({
-                name: 'labwareCreatorClickTestLabware',
-              })
-            }
-            href={PDF_URL}
-            className={styles.test_guide_button}
-          >
-            view test guide
-          </LinkOut>
+          <p>
+            Use the Tip Rack guide to troubleshoot Tip Rack definitions. Use the
+            Labware guide for all other labware types.
+          </p>
+          <div className={styles.test_guide_container}>
+            <LinkOut
+              onClick={() =>
+                reportEvent({
+                  name: 'labwareCreatorClickTestLabware',
+                })
+              }
+              href={LABWARE_PDF_URL}
+              className={styles.test_guide_button}
+            >
+              labware test guide
+            </LinkOut>
+            <LinkOut
+              onClick={() =>
+                reportEvent({
+                  name: 'labwareCreatorClickTestLabware',
+                })
+              }
+              href={TIPRACK_PDF_URL}
+              className={styles.test_guide_button}
+            >
+              tip rack test guide
+            </LinkOut>
+          </div>
         </div>
         <PrimaryBtn
           className={styles.export_button}

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -25,9 +25,9 @@ export const Export = (props: ExportProps): JSX.Element | null => {
   const fieldList: Array<keyof LabwareFields> = ['pipetteName']
   const { values, errors, touched } = useFormikContext<LabwareFields>()
 
-  const exportUrl =
+  const testGuideUrl =
     values.labwareType === 'tipRack' ? TIPRACK_PDF_URL : LABWARE_PDF_URL
-  const exportLabel =
+  const testGuideLabel =
     values.labwareType === 'tipRack'
       ? 'tip rack test guide'
       : 'labware test guide'
@@ -74,10 +74,10 @@ export const Export = (props: ExportProps): JSX.Element | null => {
                 name: 'labwareCreatorClickTestLabware',
               })
             }
-            href={exportUrl}
+            href={testGuideUrl}
             className={styles.test_guide_button}
           >
-            {exportLabel}
+            {testGuideLabel}
           </LinkOut>
         </div>
         <PrimaryBtn

--- a/labware-library/src/labware-creator/components/sections/Export.tsx
+++ b/labware-library/src/labware-creator/components/sections/Export.tsx
@@ -15,7 +15,7 @@ import styles from '../../styles.css'
 const LABWARE_PDF_URL =
   'https://opentrons-publications.s3.us-east-2.amazonaws.com/labwareDefinition_testGuide.pdf'
 const TIPRACK_PDF_URL =
-  'https://zh-file.s3.amazonaws.com/38644841/f4df21db-26be-4a04-ae6a-58d32e70bddc?Expires=1624630757&AWSAccessKeyId=AKIAI5X57DET3FHKSALA&Signature=KQc%2F8fBo817c3uvlRcfovJxm7MQ%3D'
+  'https://opentrons-publications.s3.us-east-2.amazonaws.com/labwareDefinition_tipRack_testGuide.pdf'
 
 interface ExportProps {
   onExportClick: (e: React.MouseEvent) => unknown

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -254,6 +254,11 @@
   font-size: var(--fs-body-2);
 }
 
+.test_guide_container {
+  display: flex;
+  justify-content: space-evenly;
+}
+
 .test_guide_button {
   @apply --link-btn-blue;
 

--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -254,11 +254,6 @@
   font-size: var(--fs-body-2);
 }
 
-.test_guide_container {
-  display: flex;
-  justify-content: space-evenly;
-}
-
 .test_guide_button {
   @apply --link-btn-blue;
 


### PR DESCRIPTION
fix #7166 

# Overview
Add Tip Rack test guide variation to Export section of labware creator


# Changelog
1. Updated copy of second paragraph in export section
2. Added new PDF for tip rack test
3. Swap title and url of test guide button if tip rack is selected
4. Added test cases for variable button text

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

- [ ] There is a new test file for tip racks that get exported along with the definition
- [ ]  Add a new button to the section above the export button that lets the user get the Tip rack guide
- [ ]  The tip rack test guide button should show when the tip rack form is showing, the regular labware definition test button should show when other labware type forms are showing
- [ ]  Change the copy of the existing button
- [ ]  Change second paragraph copy to reference both the tiprack and labware test guides

# Risk assessment
Low risk - swapping the test guide in labware creator only
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
