### PR TITLE
feat(labware-creator): make dynamic wells/tips copy in Grid section

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
@@ -8,7 +8,7 @@ import {
   LabwareFields,
   yesNoOptions,
 } from '../../../fields'
-import { isEveryFieldHidden } from '../../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../../utils'
 import { Grid } from '../../sections/Grid'
 import { FormAlerts } from '../../alerts/FormAlerts'
 import { TextField } from '../../TextField'
@@ -28,6 +28,10 @@ const radioFieldMock = RadioField as jest.MockedFunction<typeof RadioField>
 
 const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
   typeof isEveryFieldHidden
+>
+
+const getLabwareNameMock = getLabwareName as jest.MockedFunction<
+  typeof getLabwareName
 >
 
 const formikConfig: FormikConfig<LabwareFields> = {
@@ -94,12 +98,18 @@ describe('Grid', () => {
     resetAllWhenMocks()
   })
   it('should render when fields are visible', () => {
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, true)
+      .mockReturnValue('FAKE LABWARE NAME PLURAL')
+    when(getLabwareNameMock)
+
     render(wrapInFormik(<Grid />, formikConfig))
     expect(screen.getByText('Grid'))
     expect(screen.getByText('mock alerts'))
     expect(
       screen.getByText(
-        'The grid of wells on your labware is arranged via rows and columns. Rows run horizontally across your labware (left to right). Columns run top to bottom.'
+        'The grid of FAKE LABWARE NAME PLURAL on your labware is arranged via rows and columns. ' +
+          'Rows run horizontally across your labware (left to right). Columns run top to bottom.'
       )
     )
     expect(screen.getByText('gridRows text field'))

--- a/labware-library/src/labware-creator/components/sections/Grid.tsx
+++ b/labware-library/src/labware-creator/components/sections/Grid.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
 import { maskToInteger } from '../../fieldMasks'
-import { isEveryFieldHidden } from '../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../utils'
 import { LabwareFields, yesNoOptions } from '../../fields'
 import { FormAlerts } from '../alerts/FormAlerts'
 import { TextField } from '../TextField'
@@ -11,14 +11,18 @@ import { SectionBody } from './SectionBody'
 
 import styles from '../../styles.css'
 
-const Content = (): JSX.Element => {
+interface Props {
+  values: LabwareFields
+}
+
+const Content = (props: Props): JSX.Element => {
   return (
     <div className={styles.flex_row}>
       <div className={styles.instructions_column}>
         <p>
-          The grid of wells on your labware is arranged via rows and columns.
-          Rows run horizontally across your labware (left to right). Columns run
-          top to bottom.
+          The grid of {getLabwareName(props.values, true)} on your labware is
+          arranged via rows and columns. Rows run horizontally across your
+          labware (left to right). Columns run top to bottom.
         </p>
       </div>
       <div className={styles.diagram_column}>
@@ -54,7 +58,7 @@ export const Grid = (): JSX.Element | null => {
       <SectionBody label="Grid" id="Grid">
         <>
           <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
-          <Content />
+          <Content values={values} />
         </>
       </SectionBody>
     </div>


### PR DESCRIPTION
# Overview

I thought this was working, but maybe somehow we reverted it? Anyway, with this PR the Grid section's copy should match the Figma. All that changes is "wells" vs "tips" in the text depending on whether a tip rack is selected or not.

# Changelog


# Review requests

- Tests good
- Matches figma

# Risk assessment

Low, LC only