### PR TITLE
feat(api): promote fast protocol analysis to default behavior

### DIFF
--- a/api/src/opentrons/api/session.py
+++ b/api/src/opentrons/api/session.py
@@ -399,7 +399,7 @@ class Session(RobotBusy):
             # Use feature flag to determine ProtocolContext implementation
             # class: real or simulating.
             impl_class = ProtocolContextImplementation \
-                if not ff.enable_fast_protocol_upload() \
+                if ff.disable_fast_protocol_upload() \
                 else ProtocolContextSimulation
 
             ctx_impl = impl_class.build_using(

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -149,18 +149,20 @@ settings = [
                     "current motion."
     ),
     SettingDefinition(
-        _id='disableFastProtocolUpload',
-        title='Disable Fast Protocol Upload',
+        _id="disableFastProtocolUpload",
+        title="Use older protocol analysis method",
         description=(
-            "By default, the OT-2 will perform a fast protocol analysis when you "
-            "upload a protocol file. This setting will disable fast analysis in "
-            "favor of slower, legacy simulation logic."
+            "Use an older, slower method of analyzing uploaded protocols. "
+            "This changes how the OT-2 validates your protocol during the upload "
+            "step, but does not affect how your protocol actually runs. "
+            "Opentrons Support might ask you to change this setting if you encounter "
+            "problems with the newer, faster protocol analysis method."
         ),
         restart_required=False,
     ),
     SettingDefinition(
         _id='enableHttpProtocolSessions',
-        title='Enable Experimental HTTP Protocol Sessions',
+        title='Enable experimental HTTP protocol sessions',
         description='Do not activate this unless you are a developer. '
                     'Activating this will disable protocol running from the '
                     'Opentrons application.',
@@ -168,7 +170,7 @@ settings = [
     ),
     SettingDefinition(
         _id="enableProtocolEngine",
-        title="Enable Experimental Protocol Engine",
+        title="Enable experimental protocol engine",
         description=(
             "Do not enable. This is an Opentrons-internal setting to test "
             "new protocol execution logic. This feature is not yet complete; "

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -127,11 +127,6 @@ settings = [
                     ' robots that do not have crosses etched on the deck'
     ),
     SettingDefinition(
-        _id='useProtocolApi2',
-        title='Use Protocol API version 2',
-        description='Deprecated feature flag'
-    ),
-    SettingDefinition(
         _id='disableHomeOnBoot',
         old_id='disable-home-on-boot',
         title='Disable home on boot',
@@ -154,11 +149,14 @@ settings = [
                     "current motion."
     ),
     SettingDefinition(
-        _id='enableTipLengthCalibration',
-        title='Enable Under-Development Calibration Flows',
-        description='Do not activate this unless you are a developer. '
-                    'Enables the in-progress robot calibration flows '
-                    'for tip length, deck, and instrument calibration.'
+        _id='disableFastProtocolUpload',
+        title='Disable Fast Protocol Upload',
+        description=(
+            "By default, the OT-2 will perform a fast protocol analysis when you "
+            "upload a protocol file. This setting will disable fast analysis in "
+            "favor of slower, legacy simulation logic."
+        ),
+        restart_required=False,
     ),
     SettingDefinition(
         _id='enableHttpProtocolSessions',
@@ -169,16 +167,6 @@ settings = [
         restart_required=True,
     ),
     SettingDefinition(
-        _id='enableFastProtocolUpload',
-        title='Enable Experimental Fast Protocol Upload',
-        description='Enabling this flag will skip simulation for a faster '
-                    'upload. The protocol will be analyzed for syntax errors, '
-                    'run steps, and equipment requirements. This feature '
-                    'should only be used if a protocol has been simulated '
-                    'before.',
-        restart_required=False,
-    ),
-    SettingDefinition(
         _id="enableProtocolEngine",
         title="Enable Experimental Protocol Engine",
         description=(
@@ -186,8 +174,8 @@ settings = [
             "new protocol execution logic. This feature is not yet complete; "
             "your protocols will break if you enable this setting."
         ),
-        restart_required=False,
-    )
+        restart_required=True,
+    ),
 ]
 
 if ARCHITECTURE == SystemArchitecture.BUILDROOT:
@@ -384,18 +372,35 @@ def _migrate7to8(previous: SettingsMap) -> SettingsMap:
 
 
 def _migrate8to9(previous: SettingsMap) -> SettingsMap:
-    """
-    Migration to version 8 of the feature flags file. Adds the
-    enableFastProtocolUpload config element.
+    """Migrate to version 9 of the feature flags file.
+
+    - Adds the enableProtocolEngine config element.
     """
     newmap = {k: v for k, v in previous.items()}
     newmap["enableProtocolEngine"] = None
     return newmap
 
 
+def _migrate9to10(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 10 of the feature flags file.
+
+    - Removes deprecated useProtocolApi2 option
+    - Removes deprecated enableApi1BackCompat option
+    - Removed deprecated useV1HttpApi option
+    - Removes deprecated enableTipLengthCalibration option
+    - Removes deprecated enableFastProtocolUpload option
+    - Adds disableFastProtocolUpload option
+    """
+    removals = ['useProtocolApi2', 'enableApi1BackCompat', 'useV1HttpApi',
+                'enableTipLengthCalibration', 'enableFastProtocolUpload']
+    newmap = {k: v for k, v in previous.items() if k not in removals}
+    newmap["disableFastProtocolUpload"] = None
+    return newmap
+
+
 _MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4,
                _migrate4to5, _migrate5to6, _migrate6to7, _migrate7to8,
-               _migrate8to9]
+               _migrate8to9, _migrate9to10]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should
@@ -426,9 +431,11 @@ def _migrate(data: Mapping[str, Any]) -> SettingsData:
 
 
 def _ensure(data: Mapping[str, Any]) -> SettingsMap:
-    """
+    """Ensure config data is valid, regardless of version.
+
     Even after migration, we may have an invalid file. For instance,
-    we may have _downgraded_. Make sure all required keys are present.
+    the user may have _downgraded_. Make sure all required keys are present,
+    regardless of config version.
     """
     newdata = {k: v for k, v in data.items()}
     for s in settings:

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -17,10 +17,6 @@ def disable_home_on_boot() -> bool:
     return advs.get_setting_with_env_overload('disableHomeOnBoot')
 
 
-def use_protocol_api_v2() -> bool:
-    return not advs.get_setting_with_env_overload('useLegacyInternals')
-
-
 def use_old_aspiration_functions() -> bool:
     return advs.get_setting_with_env_overload('useOldAspirationFunctions')
 
@@ -33,11 +29,11 @@ def enable_http_protocol_sessions() -> bool:
     return advs.get_setting_with_env_overload('enableHttpProtocolSessions')
 
 
-def enable_fast_protocol_upload() -> bool:
-    return advs.get_setting_with_env_overload('enableFastProtocolUpload')
-
-
 def enable_protocol_engine() -> bool:
     """Get if the ProtocolEngine should be used to run protocol files."""
 
     return advs.get_setting_with_env_overload("enableProtocolEngine")
+
+
+def disable_fast_protocol_upload() -> bool:
+    return advs.get_setting_with_env_overload('disableFastProtocolUpload')

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Optional, Union, Tuple, TYPE_CHECKING
 
 import jsonschema  # type: ignore
 
-from opentrons.config import feature_flags as ff
 from opentrons_shared_data import load_shared_data, protocol
 from .api_support.types import APIVersion
 from .types import (Protocol, PythonProtocol, JsonProtocol,
@@ -128,12 +127,6 @@ def _parse_python(
 
 def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:
     """ Parse a bundled Python protocol """
-    if not ff.use_protocol_api_v2():
-        raise RuntimeError(
-            'Uploading a bundled protocol requires the robot to be set to '
-            'Protocol API V2. Enable the \'Use Protocol API version 2\' '
-            'toggle in the robot\'s Advanced Settings and restart the robot')
-
     contents = extract_bundle(bundle)
 
     result = _parse_python(

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -17,8 +17,8 @@ def mock_settings_version():
 @pytest.fixture
 def mock_settings(mock_settings_values, mock_settings_version):
     return advanced_settings.SettingsData(
-                settings_map=mock_settings_values,
-                version=mock_settings_version)
+        settings_map=mock_settings_values,
+        version=mock_settings_version)
 
 
 @pytest.fixture
@@ -118,7 +118,7 @@ async def test_get_all_adv_settings_lru_cache(loop,
     mock_read_settings_file.assert_not_called()
     mock_read_settings_file.reset_mock()
     # Updating will invalidate cache
-    await advanced_settings.set_adv_setting('useProtocolApi2', True)
+    await advanced_settings.set_adv_setting('calibrateToBottom', True)
     mock_read_settings_file.reset_mock()
     # Cache should not be used
     advanced_settings.get_all_adv_settings()
@@ -134,7 +134,7 @@ async def test_on_change_called(loop,
                                 mock_settings_values,
                                 mock_write_settings_file,
                                 restore_restart_required):
-    _id = 'useProtocolApi2'
+    _id = 'calibrateToBottom'
     with patch(
         "opentrons.config.advanced_settings.SettingDefinition.on_change"
     ) as m:
@@ -178,25 +178,25 @@ def test_get_setting_use_env_overload(mock_read_settings_file,
                                       mock_settings_values):
     with patch("os.environ",
                new={
-                   "OT_API_FF_useProtocolApi2": "TRUE"
+                   "OT_API_FF_calibrateToBottom": "TRUE"
                }):
-        v = advanced_settings.get_setting_with_env_overload("useProtocolApi2")
-        assert v is not mock_settings_values['useProtocolApi2']
+        v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
+        assert v is not mock_settings_values['calibrateToBottom']
 
 
 def test_get_setting_with_env_overload(mock_read_settings_file,
                                        mock_settings_values):
     with patch("os.environ",
                new={}):
-        v = advanced_settings.get_setting_with_env_overload("useProtocolApi2")
-        assert v is mock_settings_values['useProtocolApi2']
+        v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
+        assert v is mock_settings_values['calibrateToBottom']
 
 
 @pytest.mark.parametrize(argnames=["v", "expected_level"],
                          argvalues=[
                              [True, "emerg"],
                              [False, "info"],
-                         ])
+])
 async def test_disable_log_integration_side_effect(loop,
                                                    v,
                                                    expected_level):

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -7,7 +7,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 9
+    return 10
 
 
 @pytest.fixture
@@ -19,14 +19,10 @@ def default_file_settings() -> Dict[str, Optional[bool]]:
         'disableHomeOnBoot': None,
         'useOldAspirationFunctions': None,
         'disableLogAggregation': None,
-        'enableApi1BackCompat': None,
-        'useProtocolApi2': None,
-        'useV1HttpApi': None,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None,
         'enableHttpProtocolSessions': None,
-        'enableFastProtocolUpload': None,
         'enableProtocolEngine': None,
+        'disableFastProtocolUpload': None,
     }
 
 
@@ -61,7 +57,7 @@ def v1_config():
 
 @pytest.fixture
 def v2_config(v1_config):
-    r = v1_config
+    r = v1_config.copy()
     r.update({
         '_version': 2,
         'disableLogAggregation': True,
@@ -71,7 +67,7 @@ def v2_config(v1_config):
 
 @pytest.fixture
 def v3_config(v2_config):
-    r = v2_config
+    r = v2_config.copy()
     r.update({
         '_version': 3,
         'enableApi1BackCompat': False
@@ -81,7 +77,7 @@ def v3_config(v2_config):
 
 @pytest.fixture
 def v4_config(v3_config):
-    r = v3_config
+    r = v3_config.copy()
     r.update({
         '_version': 4,
         'useV1HttpApi': False
@@ -91,7 +87,7 @@ def v4_config(v3_config):
 
 @pytest.fixture
 def v5_config(v4_config):
-    r = v4_config
+    r = v4_config.copy()
     r.update({
         '_version': 5,
         'enableDoorSafetySwitch': True,
@@ -101,7 +97,7 @@ def v5_config(v4_config):
 
 @pytest.fixture
 def v6_config(v5_config):
-    r = v5_config
+    r = v5_config.copy()
     r.update({
         '_version': 6,
         'enableTipLengthCalibration': True,
@@ -111,7 +107,7 @@ def v6_config(v5_config):
 
 @pytest.fixture
 def v7_config(v6_config):
-    r = v6_config
+    r = v6_config.copy()
     r.update({
         '_version': 7,
         'enableHttpProtocolSessions': True,
@@ -121,7 +117,7 @@ def v7_config(v6_config):
 
 @pytest.fixture
 def v8_config(v7_config):
-    r = v7_config
+    r = v7_config.copy()
     r.update({
         '_version': 8,
         'enableFastProtocolUpload': True,
@@ -131,10 +127,25 @@ def v8_config(v7_config):
 
 @pytest.fixture
 def v9_config(v8_config):
-    r = v8_config
+    r = v8_config.copy()
     r.update({
         '_version': 9,
         'enableProtocolEngine': True,
+    })
+    return r
+
+
+@pytest.fixture
+def v10_config(v9_config):
+    r = v9_config.copy()
+    r.pop("useProtocolApi2")
+    r.pop("enableApi1BackCompat")
+    r.pop("useV1HttpApi")
+    r.pop("enableTipLengthCalibration")
+    r.pop("enableFastProtocolUpload")
+    r.update({
+        '_version': 10,
+        'disableFastProtocolUpload': True,
     })
     return r
 
@@ -153,6 +164,7 @@ def v9_config(v8_config):
         lazy_fixture("v7_config"),
         lazy_fixture("v8_config"),
         lazy_fixture("v9_config"),
+        lazy_fixture("v10_config"),
     ]
 )
 def old_settings(request):
@@ -163,9 +175,11 @@ def test_migrations(
         old_settings, migrated_file_version, default_file_settings):
     settings, version = _migrate(old_settings)
 
-    expected = default_file_settings
+    expected = default_file_settings.copy()
     expected.update({
-        k: v for k, v in old_settings.items() if k != '_version'
+        k: v
+        for k, v in old_settings.items()
+        if k != '_version' and k in default_file_settings
     })
 
     assert version == migrated_file_version
@@ -181,7 +195,7 @@ def test_migrates_versionless_old_config(
         'disable-home-on-boot': False,
     })
 
-    expected = default_file_settings
+    expected = default_file_settings.copy()
     expected.update({
         'shortFixedTrash': None,
         'calibrateToBottom': None,
@@ -203,7 +217,7 @@ def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
     assert settings == default_file_settings
 
 
-def test_ensures_config(default_file_settings):
+def test_ensures_config():
     assert _ensure({
         '_version': 3,
         'shortFixedTrash': False,
@@ -216,10 +230,8 @@ def test_ensures_config(default_file_settings):
         'disableHomeOnBoot': None,
         'useOldAspirationFunctions': None,
         'disableLogAggregation': True,
-        'useProtocolApi2': None,
         'enableDoorSafetySwitch': None,
-        'enableTipLengthCalibration': None,
         'enableHttpProtocolSessions': None,
-        'enableFastProtocolUpload': None,
         'enableProtocolEngine': None,
+        'disableFastProtocolUpload': None,
     }

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -286,7 +286,7 @@ def model(request, hardware, loop):
 @pytest.fixture
 def smoothie(monkeypatch):
     from opentrons.drivers.smoothie_drivers.driver_3_0 import \
-        SmoothieDriver_3_0_0 as SmoothieDriver
+         SmoothieDriver_3_0_0 as SmoothieDriver
     from opentrons.config import robot_configs
 
     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
@@ -306,7 +306,7 @@ def hardware_controller_lockfile():
     old_lockfile = config.CONFIG['hardware_controller_lockfile']
     with tempfile.TemporaryDirectory() as td:
         config.CONFIG['hardware_controller_lockfile']\
-            = pathlib.Path(td) / 'hardware.lock'
+            = pathlib.Path(td)/'hardware.lock'
         yield td
         config.CONFIG['hardware_controller_lockfile'] = old_lockfile
 
@@ -339,8 +339,8 @@ async def hardware_api(loop, is_robot):
 @pytest.fixture
 def get_labware_fixture():
     def _get_labware_fixture(fixture_name):
-        with open((pathlib.Path(__file__).parent / '..' / '..' / '..' / 'shared-data' /
-                   'labware' / 'fixtures' / '2' / f'{fixture_name}.json'), 'rb'
+        with open((pathlib.Path(__file__).parent/'..'/'..'/'..'/'shared-data' /
+                   'labware' / 'fixtures'/'2'/f'{fixture_name}.json'), 'rb'
                   ) as f:
             return json.loads(f.read().decode('utf-8'))
 
@@ -351,8 +351,8 @@ def get_labware_fixture():
 def get_json_protocol_fixture():
     def _get_json_protocol_fixture(fixture_version, fixture_name, decode=True):
         with open(pathlib.Path(__file__).parent /
-                  '..' / '..' / '..' / 'shared-data' / 'protocol' / 'fixtures' /
-                  fixture_version / f'{fixture_name}.json', 'rb') as f:
+                  '..'/'..'/'..'/'shared-data'/'protocol'/'fixtures' /
+                  fixture_version/f'{fixture_name}.json', 'rb') as f:
             contents = f.read().decode('utf-8')
             if decode:
                 return json.loads(contents)
@@ -508,22 +508,22 @@ def minimal_labware_def() -> dict:
         "ordering": [["A1"], ["A2"]],
         "wells": {
             "A1": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 0,
-                "y": 0,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 0,
+              "y": 0,
+              "z": 0,
+              "shape": "circular"
             },
             "A2": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 10,
-                "y": 0,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 10,
+              "y": 0,
+              "z": 0,
+              "shape": "circular"
             }
         },
         "dimensions": {
@@ -550,9 +550,9 @@ def minimal_labware_def2() -> dict:
             "displayVolumeUnits": "mL",
         },
         "cornerOffsetFromSlot": {
-            "x": 10,
-            "y": 10,
-            "z": 5
+                "x": 10,
+                "y": 10,
+                "z": 5
         },
         "parameters": {
             "isTiprack": False,
@@ -563,58 +563,58 @@ def minimal_labware_def2() -> dict:
         "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
         "wells": {
             "A1": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 0,
-                "y": 18,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 0,
+              "y": 18,
+              "z": 0,
+              "shape": "circular"
             },
             "B1": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 0,
-                "y": 9,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 0,
+              "y": 9,
+              "z": 0,
+              "shape": "circular"
             },
             "C1": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 0,
-                "y": 0,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 0,
+              "y": 0,
+              "z": 0,
+              "shape": "circular"
             },
             "A2": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 9,
-                "y": 18,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 9,
+              "y": 18,
+              "z": 0,
+              "shape": "circular"
             },
             "B2": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 9,
-                "y": 9,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 9,
+              "y": 9,
+              "z": 0,
+              "shape": "circular"
             },
             "C2": {
-                "depth": 40,
-                "totalLiquidVolume": 100,
-                "diameter": 30,
-                "x": 9,
-                "y": 0,
-                "z": 0,
-                "shape": "circular"
+              "depth": 40,
+              "totalLiquidVolume": 100,
+              "diameter": 30,
+              "x": 9,
+              "y": 0,
+              "z": 0,
+              "shape": "circular"
             }
         },
         "groups": [],
@@ -635,8 +635,8 @@ def minimal_labware_def2() -> dict:
 @pytest.fixture
 def min_lw_impl(minimal_labware_def) -> LabwareImplementation:
     return LabwareImplementation(
-        definition=minimal_labware_def,
-        parent=Location(Point(0, 0, 0), 'deck')
+            definition=minimal_labware_def,
+            parent=Location(Point(0, 0, 0), 'deck')
     )
 
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -153,27 +153,7 @@ async def enable_door_safety_switch():
     await config.advanced_settings.set_adv_setting(
         'enableDoorSafetySwitch', False)
 
-
-@pytest.fixture
-async def use_new_calibration(monkeypatch):
-    await config.advanced_settings.set_adv_setting(
-        'enableTipLengthCalibration', True)
-    yield
-    await config.advanced_settings.set_adv_setting(
-        'enableTipLengthCalibration', False)
 # -----end feature flag fixtures-----------
-
-
-@pytest.fixture(params=[False, True])
-async def toggle_new_calibration(request):
-    if request.param:
-        await config.advanced_settings.set_adv_setting(
-            'enableTipLengthCalibration', True)
-        yield
-        await config.advanced_settings.set_adv_setting(
-            'enableTipLengthCalibration', False)
-    else:
-        yield
 
 
 @pytest.fixture(params=["testosaur_v2.py"])
@@ -306,7 +286,7 @@ def model(request, hardware, loop):
 @pytest.fixture
 def smoothie(monkeypatch):
     from opentrons.drivers.smoothie_drivers.driver_3_0 import \
-         SmoothieDriver_3_0_0 as SmoothieDriver
+        SmoothieDriver_3_0_0 as SmoothieDriver
     from opentrons.config import robot_configs
 
     monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
@@ -326,7 +306,7 @@ def hardware_controller_lockfile():
     old_lockfile = config.CONFIG['hardware_controller_lockfile']
     with tempfile.TemporaryDirectory() as td:
         config.CONFIG['hardware_controller_lockfile']\
-            = pathlib.Path(td)/'hardware.lock'
+            = pathlib.Path(td) / 'hardware.lock'
         yield td
         config.CONFIG['hardware_controller_lockfile'] = old_lockfile
 
@@ -359,8 +339,8 @@ async def hardware_api(loop, is_robot):
 @pytest.fixture
 def get_labware_fixture():
     def _get_labware_fixture(fixture_name):
-        with open((pathlib.Path(__file__).parent/'..'/'..'/'..'/'shared-data' /
-                   'labware' / 'fixtures'/'2'/f'{fixture_name}.json'), 'rb'
+        with open((pathlib.Path(__file__).parent / '..' / '..' / '..' / 'shared-data' /
+                   'labware' / 'fixtures' / '2' / f'{fixture_name}.json'), 'rb'
                   ) as f:
             return json.loads(f.read().decode('utf-8'))
 
@@ -371,8 +351,8 @@ def get_labware_fixture():
 def get_json_protocol_fixture():
     def _get_json_protocol_fixture(fixture_version, fixture_name, decode=True):
         with open(pathlib.Path(__file__).parent /
-                  '..'/'..'/'..'/'shared-data'/'protocol'/'fixtures' /
-                  fixture_version/f'{fixture_name}.json', 'rb') as f:
+                  '..' / '..' / '..' / 'shared-data' / 'protocol' / 'fixtures' /
+                  fixture_version / f'{fixture_name}.json', 'rb') as f:
             contents = f.read().decode('utf-8')
             if decode:
                 return json.loads(contents)
@@ -528,22 +508,22 @@ def minimal_labware_def() -> dict:
         "ordering": [["A1"], ["A2"]],
         "wells": {
             "A1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
             },
             "A2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 10,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 10,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
             }
         },
         "dimensions": {
@@ -570,9 +550,9 @@ def minimal_labware_def2() -> dict:
             "displayVolumeUnits": "mL",
         },
         "cornerOffsetFromSlot": {
-                "x": 10,
-                "y": 10,
-                "z": 5
+            "x": 10,
+            "y": 10,
+            "z": 5
         },
         "parameters": {
             "isTiprack": False,
@@ -583,58 +563,58 @@ def minimal_labware_def2() -> dict:
         "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
         "wells": {
             "A1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 18,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 18,
+                "z": 0,
+                "shape": "circular"
             },
             "B1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 9,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 9,
+                "z": 0,
+                "shape": "circular"
             },
             "C1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
             },
             "A2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 18,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 18,
+                "z": 0,
+                "shape": "circular"
             },
             "B2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 9,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 9,
+                "z": 0,
+                "shape": "circular"
             },
             "C2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 0,
+                "z": 0,
+                "shape": "circular"
             }
         },
         "groups": [],
@@ -655,8 +635,8 @@ def minimal_labware_def2() -> dict:
 @pytest.fixture
 def min_lw_impl(minimal_labware_def) -> LabwareImplementation:
     return LabwareImplementation(
-            definition=minimal_labware_def,
-            parent=Location(Point(0, 0, 0), 'deck')
+        definition=minimal_labware_def,
+        parent=Location(Point(0, 0, 0), 'deck')
     )
 
 

--- a/api/tests/opentrons/hardware_control/test_api_helpers.py
+++ b/api/tests/opentrons/hardware_control/test_api_helpers.py
@@ -4,7 +4,7 @@ from opentrons.hardware_control.util import DeckTransformState
 from opentrons.hardware_control.robot_calibration import RobotCalibration
 
 
-async def test_validating_attitude(hardware, use_new_calibration):
+async def test_validating_attitude(hardware):
 
     inrange_matrix = [[1, 0, 1], [0, 1, 2], [0, 0, 1]]
     deck_cal = DeckCalibration(

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -33,7 +33,7 @@ async def test_home_specific_sim(hardware_api, monkeypatch, is_robot):
                                               Axis.C: 19}
 
 
-async def test_retract(hardware_api, toggle_new_calibration):
+async def test_retract(hardware_api):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 10, 20))
     await hardware_api.retract(types.Mount.RIGHT, 10)
@@ -45,7 +45,7 @@ async def test_retract(hardware_api, toggle_new_calibration):
                                               Axis.C: 19}
 
 
-async def test_move(hardware_api, is_robot, toggle_new_calibration):
+async def test_move(hardware_api, is_robot):
     abs_position = types.Point(30, 20, 10)
     mount = types.Mount.RIGHT
     target_position1 = {Axis.X: 30,
@@ -98,7 +98,7 @@ async def test_move_extras_passed_through(hardware_api, monkeypatch):
 
 
 async def test_mount_offset_applied(
-        hardware_api, is_robot, toggle_new_calibration):
+        hardware_api, is_robot):
     await hardware_api.home()
     abs_position = types.Point(30, 20, 10)
     mount = types.Mount.LEFT
@@ -179,7 +179,7 @@ async def test_critical_point_applied(hardware_api, monkeypatch, is_robot):
 
 
 async def test_new_critical_point_applied(
-        hardware_api, monkeypatch, is_robot, use_new_calibration):
+        hardware_api, monkeypatch, is_robot):
     await hardware_api.home()
     hardware_api._backend._attached_instruments\
         = {types.Mount.LEFT: {'model': None, 'id': None},
@@ -245,7 +245,7 @@ async def test_new_critical_point_applied(
 
 
 async def test_attitude_deck_cal_applied(
-        monkeypatch, loop, use_new_calibration):
+        monkeypatch, loop):
     new_gantry_cal = [
         [1.0047, -0.0046, 0.0],
         [0.0011, 1.0038, 0.0],
@@ -278,7 +278,7 @@ async def test_attitude_deck_cal_applied(
 
 
 async def test_other_mount_retracted(
-        hardware_api, is_robot, toggle_new_calibration):
+        hardware_api, is_robot):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
     assert await hardware_api.gantry_position(types.Mount.RIGHT)\
@@ -289,7 +289,7 @@ async def test_other_mount_retracted(
 
 
 async def test_shake_during_pick_up(
-        hardware_api, monkeypatch, toggle_new_calibration):
+        hardware_api, monkeypatch):
     await hardware_api.home()
     hardware_api._backend._attached_instruments\
         = {types.Mount.LEFT: {'model': None, 'id': None},
@@ -326,7 +326,7 @@ async def test_shake_during_pick_up(
 
 
 async def test_shake_during_drop(
-        hardware_api, monkeypatch, toggle_new_calibration):
+        hardware_api, monkeypatch):
     await hardware_api.home()
     hardware_api._backend._attached_instruments\
         = {types.Mount.LEFT: {'model': None, 'id': None},
@@ -351,7 +351,7 @@ async def test_shake_during_drop(
     # Test drop tip shake with 25% of tiprack well diameter
     # between upper (2.25 mm) and lower limit (1.0 mm)
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 2.0*4)
+    await shake_tips_drop(types.Mount.RIGHT, 2.0 * 4)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-2, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4, 0, 0), speed=50),
@@ -362,7 +362,7 @@ async def test_shake_during_drop(
     # Test drop tip shake with 25% of tiprack well diameter
     # over upper (2.25 mm) limit
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 2.3*4)
+    await shake_tips_drop(types.Mount.RIGHT, 2.3 * 4)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4.5, 0, 0), speed=50),
@@ -373,7 +373,7 @@ async def test_shake_during_drop(
     # Test drop tip shake with 25% of tiprack well diameter
     # below lower (1.0 mm) limit
     shake_tips_drop.reset_mock()
-    await shake_tips_drop(types.Mount.RIGHT, 0.9*4)
+    await shake_tips_drop(types.Mount.RIGHT, 0.9 * 4)
     move_rel_calls = [
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(2, 0, 0), speed=50),
@@ -383,7 +383,7 @@ async def test_shake_during_drop(
 
 
 async def test_move_rel_bounds(
-        hardware_api, toggle_new_calibration):
+        hardware_api):
     with pytest.raises(OutOfBoundsMove):
         await hardware_api.move_rel(
             types.Mount.RIGHT, types.Point(0, 0, 2000),

--- a/api/tests/opentrons/hardware_control/test_paired_pipettes.py
+++ b/api/tests/opentrons/hardware_control/test_paired_pipettes.py
@@ -43,7 +43,7 @@ async def test_move_z_axis(hardware_api, monkeypatch):
     assert mock_be_move.call_args_list[0][0][0] == expected
 
 
-async def test_move_gantry(hardware_api, is_robot, toggle_new_calibration):
+async def test_move_gantry(hardware_api, is_robot):
     abs_position = types.Point(30, 20, 10)
     mount = PipettePair.PRIMARY_RIGHT
     target_position1 = {Axis.X: 30,
@@ -89,7 +89,7 @@ async def test_move_currents(smoothie, monkeypatch, loop):
 
 
 async def test_pick_up_tip(
-        dummy_instruments, loop, is_robot, toggle_new_calibration):
+        dummy_instruments, loop, is_robot):
     hw_api = await hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments, loop=loop)
     mount = PipettePair.PRIMARY_RIGHT
@@ -118,7 +118,7 @@ async def test_pick_up_tip(
 
 
 async def test_drop_tip(
-        dummy_instruments, loop, is_robot, toggle_new_calibration):
+        dummy_instruments, loop, is_robot):
     hw_api = await hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments, loop=loop)
     mount = PipettePair.PRIMARY_RIGHT
@@ -138,7 +138,7 @@ async def test_drop_tip(
 
 
 async def test_prep_aspirate(
-        dummy_instruments, loop, toggle_new_calibration):
+        dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments, loop=loop)
     await hw_api.home()

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -29,7 +29,7 @@ def test_tip_tracking():
 
 
 @pytest.mark.parametrize('model', pipette_config.config_models)
-def test_critical_points_nozzle_offset(model, use_new_calibration):
+def test_critical_points_nozzle_offset(model):
     loaded = pipette_config.load(model)
     pip = pipette.Pipette(loaded,
                           PIP_CAL,
@@ -54,7 +54,7 @@ def test_critical_points_nozzle_offset(model, use_new_calibration):
 
 
 @pytest.mark.parametrize('model', pipette_config.config_models)
-def test_critical_points_pipette_offset(model, use_new_calibration):
+def test_critical_points_pipette_offset(model):
     loaded = pipette_config.load(model)
     # set pipette offset calibration
     pip_cal = cal_types.PipetteOffsetByPipetteMount(

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -944,7 +944,7 @@ def test_tip_length_for(ctx, monkeypatch):
             ['opentrons/geb_96_tiprack_10ul/1'])
 
 
-def test_tip_length_for_caldata(ctx, monkeypatch, use_new_calibration):
+def test_tip_length_for_caldata(ctx, monkeypatch):
     instr = ctx.load_instrument('p20_single_gen2', 'left')
     tiprack = ctx.load_labware('geb_96_tiprack_10ul', '1')
     mock_tip_length = mock.Mock()

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -56,13 +56,13 @@ stages:
             value: !anything
           - id: enableHttpProtocolSessions
             old_id: Null
-            title: Enable Experimental HTTP Protocol Sessions
+            title: Enable experimental HTTP protocol sessions
             description: !re_search 'Activating this will disable protocol running from the Opentrons application'
             restart_required: true
             value: !anything
           - id: enableProtocolEngine
             old_id: Null
-            title: Enable Experimental Protocol Engine
+            title: Enable experimental protocol engine
             description: !re_search 'Opentrons-internal setting to test new protocol execution logic'
             restart_required: true
             value: !anything

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -50,8 +50,8 @@ stages:
             value: !anything
           - id: disableFastProtocolUpload
             old_id: Null
-            title: Disable Fast Protocol Upload
-            description: !re_search 'This setting will disable fast analysis'
+            title: Use older protocol analysis method
+            description: !re_search 'Use an older, slower method of analyzing uploaded protocols'
             restart_required: false
             value: !anything
           - id: enableHttpProtocolSessions

--- a/robot-server/tests/integration/test_settings.tavern.yaml
+++ b/robot-server/tests/integration/test_settings.tavern.yaml
@@ -30,12 +30,6 @@ stages:
             description: !re_search 'Perform deck calibration to dots'
             restart_required: false
             value: !anything
-          - id: useProtocolApi2
-            old_id: Null
-            title: Use Protocol API version 2
-            description: Deprecated feature flag
-            restart_required: false
-            value: !anything
           - id: disableHomeOnBoot
             old_id: disable-home-on-boot
             title: Disable home on boot
@@ -54,10 +48,10 @@ stages:
             description: !re_search 'Automatically pause protocols when robot door opens'
             restart_required: false
             value: !anything
-          - id: enableTipLengthCalibration
+          - id: disableFastProtocolUpload
             old_id: Null
-            title: Enable Under-Development Calibration Flows
-            description: !re_search 'Enables the in-progress robot calibration flows'
+            title: Disable Fast Protocol Upload
+            description: !re_search 'This setting will disable fast analysis'
             restart_required: false
             value: !anything
           - id: enableHttpProtocolSessions
@@ -66,17 +60,11 @@ stages:
             description: !re_search 'Activating this will disable protocol running from the Opentrons application'
             restart_required: true
             value: !anything
-          - id: enableFastProtocolUpload
-            old_id: Null
-            title: Enable Experimental Fast Protocol Upload
-            description: !re_search 'Enabling this flag will skip simulation for a faster'
-            restart_required: false
-            value: !anything
           - id: enableProtocolEngine
             old_id: Null
             title: Enable Experimental Protocol Engine
             description: !re_search 'Opentrons-internal setting to test new protocol execution logic'
-            restart_required: false
+            restart_required: true
             value: !anything
         links: !anydict
 
@@ -92,12 +80,12 @@ marks:
         - shortFixedTrash
         - calibrateToBottom
         - deckCalibrationDots
-        - useProtocolApi2
         - disableHomeOnBoot
         - useOldAspirationFunctions
         - enableDoorSafetySwitch
-        - enableTipLengthCalibration
+        - disableFastProtocolUpload
         - enableHttpProtocolSessions
+        - enableProtocolEngine
   - parametrize:
       key: value
       vals:
@@ -131,11 +119,10 @@ marks:
         - shortFixedTrash
         - calibrateToBottom
         - deckCalibrationDots
-        - useProtocolApi2
         - disableHomeOnBoot
         - useOldAspirationFunctions
         - enableDoorSafetySwitch
-        - enableTipLengthCalibration
+        - disableFastProtocolUpload
         - enableHttpProtocolSessions
 stages:
   - name: Set each setting to acceptable values


### PR DESCRIPTION
## Overview

This PR promotes "fast simulation" to the default protocol analysis behavior on upload and adds an advanced setting to disable the default in favor of the slower, legacy simulation.

Closes #7835

## Changelog

- Remove a handful of deprecated advanced settings / feature flags:
    -  `useProtocolApi2`
    - `enableApi1BackCompat`
    - `useV1HttpApi`
    - `enableTipLengthCalibration`
    - `enableFastProtocolUpload`
- Add `disableFastProtocolUpload` advanced setting

## Review requests

- [ ] Fast analysis is the default behavior on this branch
- [ ] Changing the `disableFastProtocolUpload` setting drops back to slow uploads
- [ ] Nothing blows up if you downgrade your OT-2 after running this version
    - This PR **removes** config keys as part of its migration
    - Our code is _supposed_ to account for this, but removals have [bitten us in the past](https://github.com/Opentrons/opentrons/pull/4665)

## Risk assessment

Risk from this PR comes from settings removals. As mitigation, downgrade is part of the test plan and I'm adding QA as a required reviewer for this PR.