### PR TITLE
feat(labware-creator): change preview text to reflect labware type

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
@@ -3,11 +3,7 @@ import { FormikConfig } from 'formik'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import {
-  getDefaultFormState,
-  LabwareFields,
-  LabwareType,
-} from '../../../fields'
+import { getDefaultFormState, LabwareFields } from '../../../fields'
 import { getLabwareName } from '../../../utils'
 import { Preview } from '../../sections/Preview'
 import { wrapInFormik } from '../../utils/wrapInFormik'

--- a/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
@@ -47,7 +47,7 @@ describe('Preview', () => {
     )
     screen.getByText('Add missing info to see labware preview')
   })
-  
+
   const wellLabwareTypes: LabwareType[] = [
     'aluminumBlock',
     'reservoir',

--- a/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Preview.test.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import { FormikConfig } from 'formik'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import {
+  getDefaultFormState,
+  LabwareFields,
+  LabwareType,
+} from '../../../fields'
 import { Preview } from '../../sections/Preview'
 import { wrapInFormik } from '../../utils/wrapInFormik'
 import { FORM_LEVEL_ERRORS } from '../../../formLevelValidation'
@@ -25,22 +29,49 @@ describe('Preview', () => {
     jest.restoreAllMocks()
   })
 
-  it('should render the preview section', () => {
+  it('should render the preview section telling user to check their tips when labware is a tiprack', () => {
+    formikConfig.initialValues.labwareType = 'tipRack'
     render(wrapInFormik(<Preview />, formikConfig))
     expect(screen.getByRole('heading')).toHaveTextContent(/check your work/i)
     screen.getByText(
-      'Check that the size, spacing, and shape of your wells looks correct.'
+      'Check that the size, spacing, and shape of your tips looks correct.'
     )
     screen.getByText('Add missing info to see labware preview')
   })
-
-  it('should render form-level alerts when form-level errors are present', () => {
-    const FAKE_ERROR = 'ahh'
-    // @ts-expect-error: fake form-level error
-    formikConfig.initialErrors = { [FORM_LEVEL_ERRORS]: { FAKE_ERROR } }
+  it('should render the preview section telling user to check their tubes when labware is a tube rack', () => {
+    formikConfig.initialValues.labwareType = 'tubeRack'
     render(wrapInFormik(<Preview />, formikConfig))
-
-    // TODO(IL, 2021-05-26): AlertItem should have role="alert", then we can `getByRole('alert', {name: FAKE_ERROR})`
-    screen.getByText(FAKE_ERROR)
+    expect(screen.getByRole('heading')).toHaveTextContent(/check your work/i)
+    screen.getByText(
+      'Check that the size, spacing, and shape of your tubes looks correct.'
+    )
+    screen.getByText('Add missing info to see labware preview')
   })
+  
+  const wellLabwareTypes: LabwareType[] = [
+    'aluminumBlock',
+    'reservoir',
+    'wellPlate',
+  ]
+  wellLabwareTypes.forEach(labwareType => {
+    it(`should render the preview section telling user to check their wells when the labware type is ${labwareType}`, () => {
+      formikConfig.initialValues.labwareType = labwareType
+      render(wrapInFormik(<Preview />, formikConfig))
+      expect(screen.getByRole('heading')).toHaveTextContent(/check your work/i)
+      screen.getByText(
+        'Check that the size, spacing, and shape of your wells looks correct.'
+      )
+      screen.getByText('Add missing info to see labware preview')
+    })
+  })
+})
+
+it('should render form-level alerts when form-level errors are present', () => {
+  const FAKE_ERROR = 'ahh'
+  // @ts-expect-error: fake form-level error
+  formikConfig.initialErrors = { [FORM_LEVEL_ERRORS]: { FAKE_ERROR } }
+  render(wrapInFormik(<Preview />, formikConfig))
+
+  // TODO(IL, 2021-05-26): AlertItem should have role="alert", then we can `getByRole('alert', {name: FAKE_ERROR})`
+  screen.getByText(FAKE_ERROR)
 })

--- a/labware-library/src/labware-creator/components/sections/Preview.tsx
+++ b/labware-library/src/labware-creator/components/sections/Preview.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
-import { LabwareFields, LabwareType } from '../../fields'
+import { LabwareFields } from '../../fields'
+import { getLabwareName } from '../../utils'
 import { ConditionalLabwareRender } from '../ConditionalLabwareRender'
 import { FormLevelErrorAlerts } from '../FormLevelErrorAlerts'
 
@@ -9,24 +10,13 @@ import { SectionBody } from './SectionBody'
 import styles from '../../styles.css'
 
 export const PreviewInstructions = (props: {
-  labwareType: LabwareType | null | undefined
+  values: LabwareFields
 }): JSX.Element => {
-  const { labwareType } = props
-  let labwarePreviewType = ''
-  switch (labwareType) {
-    case 'tipRack':
-      labwarePreviewType = 'tips'
-      break
-    case 'tubeRack':
-      labwarePreviewType = 'tubes'
-      break
-    default:
-      labwarePreviewType = 'wells'
-  }
+  const { values } = props
   return (
     <p className={styles.preview_instructions}>
-      Check that the size, spacing, and shape of your {labwarePreviewType} looks
-      correct.
+      Check that the size, spacing, and shape of your{' '}
+      {getLabwareName(values, true)} looks correct.
     </p>
   )
 }
@@ -39,7 +29,7 @@ export const Preview = (): JSX.Element => {
       <FormLevelErrorAlerts errors={errors} />
       <div className={styles.preview_labware}>
         <ConditionalLabwareRender values={values} />
-        <PreviewInstructions labwareType={values.labwareType} />
+        <PreviewInstructions values={values} />
       </div>
     </SectionBody>
   )

--- a/labware-library/src/labware-creator/components/sections/Preview.tsx
+++ b/labware-library/src/labware-creator/components/sections/Preview.tsx
@@ -1,12 +1,35 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
-import { LabwareFields } from '../../fields'
+import { LabwareFields, LabwareType } from '../../fields'
 import { ConditionalLabwareRender } from '../ConditionalLabwareRender'
 import { FormLevelErrorAlerts } from '../FormLevelErrorAlerts'
 
 import { SectionBody } from './SectionBody'
 
 import styles from '../../styles.css'
+
+export const PreviewInstructions = (props: {
+  labwareType: LabwareType | null | undefined
+}): JSX.Element => {
+  const { labwareType } = props
+  let labwarePreviewType = ''
+  switch (labwareType) {
+    case 'tipRack':
+      labwarePreviewType = 'tips'
+      break
+    case 'tubeRack':
+      labwarePreviewType = 'tubes'
+      break
+    default:
+      labwarePreviewType = 'wells'
+  }
+  return (
+    <p className={styles.preview_instructions}>
+      Check that the size, spacing, and shape of your {labwarePreviewType} looks
+      correct.
+    </p>
+  )
+}
 
 export const Preview = (): JSX.Element => {
   const { values, errors } = useFormikContext<LabwareFields>()
@@ -16,9 +39,7 @@ export const Preview = (): JSX.Element => {
       <FormLevelErrorAlerts errors={errors} />
       <div className={styles.preview_labware}>
         <ConditionalLabwareRender values={values} />
-        <p className={styles.preview_instructions}>
-          Check that the size, spacing, and shape of your wells looks correct.
-        </p>
+        <PreviewInstructions labwareType={values.labwareType} />
       </div>
     </SectionBody>
   )


### PR DESCRIPTION
# Overview

closes #8028

# Review requests
Code review

Create a tiprack, tuberack, and anything with wells. Check the preview section at the end to make sure the text dynamically reflects the labware type as per the ticket. 

# Risk assessment
Low
