### PR TITLE
fix(labware-creator): add margin to bottom of LC

### DIFF
--- a/labware-library/src/labware-creator/styles.css
+++ b/labware-library/src/labware-creator/styles.css
@@ -31,6 +31,7 @@
   max-width: 50rem;
   margin: 1rem auto;
   padding: 1rem;
+  padding-bottom: 10rem;
 
   & p {
     margin: 1rem 0;


### PR DESCRIPTION
# Overview

Closes #8027

# Changelog

add margin to bottom of Labware Creator main section

# Review requests

- you should now be able to scroll down past the bottom of the expanded labware type dropdown (before, the dropdown extended past the bottom of the screen)

# Risk assessment

low, LC only