### PR TITLE
ci(LL + PD): enable manual workflow runs

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -23,6 +23,7 @@ on:
       - '*'
     tags:
       - 'labware-library*'
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -25,6 +25,7 @@ on:
       - '*'
     tags:
       - 'protocol-designer*'
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
# Overview

Forgot to allow manual workflow runs using [workflow_dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) when migrating PD + LL builds from travis to gh actions.
# Changelog

- Enable manual workflow runs for LL and PD


# Risk assessment
Low
