### PR TITLE
feat(labware-creator): make error copy "is required" not "must be a number"

### DIFF
--- a/labware-library/cypress/integration/labware-creator/reservoir.spec.js
+++ b/labware-library/cypress/integration/labware-creator/reservoir.spec.js
@@ -82,9 +82,9 @@ context('Reservoirs', () => {
     describe('Grid tests', () => {
       it('tests number of rows', () => {
         cy.get("input[name='gridRows']").focus().blur()
-        cy.contains('Number of rows must be a number').should('exist')
+        cy.contains('Number of rows is a required field').should('exist')
         cy.get("input[name='gridRows']").type('1').blur()
-        cy.contains('Number of rows must be a number').should('not.exist')
+        cy.contains('Number of rows is a required field').should('not.exist')
       })
 
       it('should not ask if all of your rows evenly spaced, since we only have one row', () => {
@@ -95,9 +95,9 @@ context('Reservoirs', () => {
 
       it('tests number of columns', () => {
         cy.get("input[name='gridColumns']").focus().blur()
-        cy.contains('Number of columns must be a number').should('exist')
+        cy.contains('Number of columns is a required field').should('exist')
         cy.get("input[name='gridColumns']").type('10').blur()
-        cy.contains('Number of columns must be a number').should('not.exist')
+        cy.contains('Number of columns is a required field').should('not.exist')
       })
 
       it('tests are all of your columns evenly spaced', () => {
@@ -118,9 +118,9 @@ context('Reservoirs', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Volume must be a number').should('exist')
+      cy.contains('Volume is a required field').should('exist')
       cy.get("input[name='wellVolume']").type('250').blur()
-      cy.contains('Volume must be a number').should('not.exist')
+      cy.contains('Volume is a required field').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -132,9 +132,9 @@ context('Reservoirs', () => {
         cy.get("input[name='wellXDimension']").should('not.exist')
         cy.get("input[name='wellYDimension']").should('not.exist')
         cy.get("input[name='wellDiameter']").focus().blur()
-        cy.contains('Diameter must be a number').should('exist')
+        cy.contains('Diameter is a required field').should('exist')
         cy.get("input[name='wellDiameter']").type('10').blur()
-        cy.contains('Diameter must be a number').should('not.exist')
+        cy.contains('Diameter is a required field').should('not.exist')
       })
 
       it('tests rectangular wells', () => {
@@ -145,13 +145,13 @@ context('Reservoirs', () => {
         cy.get("input[name='wellXDimension']").should('exist')
         cy.get("input[name='wellYDimension']").should('exist')
         cy.get("input[name='wellXDimension']").focus().blur()
-        cy.contains('Well X must be a number').should('exist')
+        cy.contains('Well X is a required field').should('exist')
         cy.get("input[name='wellXDimension']").type('8').blur()
-        cy.contains('Well X must be a number').should('not.exist')
+        cy.contains('Well X is a required field').should('not.exist')
         cy.get("input[name='wellYDimension']").focus().blur()
-        cy.contains('Well Y must be a number').should('exist')
+        cy.contains('Well Y is a required field').should('exist')
         cy.get("input[name='wellYDimension']").type('60').blur()
-        cy.contains('Well Y must be a number').should('not.exist')
+        cy.contains('Well Y is a required field').should('not.exist')
       })
 
       it('tests well bottom shape and depth', () => {
@@ -174,27 +174,27 @@ context('Reservoirs', () => {
         cy.get("img[src*='_round.']").should('not.exist')
         cy.get("img[src*='_v.']").should('exist')
         cy.get("input[name='wellDepth']").focus().blur()
-        cy.contains('Depth must be a number').should('exist')
+        cy.contains('Depth is a required field').should('exist')
         cy.get("input[name='wellDepth']").type('70').blur()
-        cy.contains('Depth must be a number').should('not.exist')
+        cy.contains('Depth is a required field').should('not.exist')
       })
 
       it('tests well spacing', () => {
         cy.get("input[name='gridSpacingX']").focus().blur()
-        cy.contains('X Spacing (Xs) must be a number').should('exist')
+        cy.contains('X Spacing (Xs) is a required field').should('exist')
         cy.get("input[name='gridSpacingX']").type('12').blur()
-        cy.contains('X Spacing (Xs) must be a number').should('not.exist')
+        cy.contains('X Spacing (Xs) is a required field').should('not.exist')
       })
 
       it('tests grid offset', () => {
         cy.get("input[name='gridOffsetX']").focus().blur()
-        cy.contains('X Offset (Xo) must be a number').should('exist')
+        cy.contains('X Offset (Xo) is a required field').should('exist')
         cy.get("input[name='gridOffsetX']").type('10').blur()
-        cy.contains('X Offset (Xo) must be a number').should('not.exist')
+        cy.contains('X Offset (Xo) is a required field').should('not.exist')
         cy.get("input[name='gridOffsetY']").focus().blur()
-        cy.contains('Y Offset (Yo) must be a number').should('exist')
+        cy.contains('Y Offset (Yo) is a required field').should('exist')
         cy.get("input[name='gridOffsetY']").type('45').blur()
-        cy.contains('Y Offset (Yo) must be a number').should('not.exist')
+        cy.contains('Y Offset (Yo) is a required field').should('not.exist')
       })
 
       it('does has a preview image', () => {

--- a/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesBlock.spec.js
@@ -82,9 +82,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Volume must be a number').should('exist')
+        cy.contains('Volume is a required field').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Volume must be a number').should('not.exist')
+        cy.contains('Volume is a required field').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -96,9 +96,9 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('not.exist')
           cy.get("input[name='wellYDimension']").should('not.exist')
           cy.get("input[name='wellDiameter']").focus().blur()
-          cy.contains('Diameter must be a number').should('exist')
+          cy.contains('Diameter is a required field').should('exist')
           cy.get("input[name='wellDiameter']").type('10').blur()
-          cy.contains('Diameter must be a number').should('not.exist')
+          cy.contains('Diameter is a required field').should('not.exist')
         })
 
         it('tests rectangular wells', () => {
@@ -109,13 +109,13 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('exist')
           cy.get("input[name='wellYDimension']").should('exist')
           cy.get("input[name='wellXDimension']").focus().blur()
-          cy.contains('Well X must be a number').should('exist')
+          cy.contains('Well X is a required field').should('exist')
           cy.get("input[name='wellXDimension']").type('10').blur()
-          cy.contains('Well X must be a number').should('not.exist')
+          cy.contains('Well X is a required field').should('not.exist')
           cy.get("input[name='wellYDimension']").focus().blur()
-          cy.contains('Well Y must be a number').should('exist')
+          cy.contains('Well Y is a required field').should('exist')
           cy.get("input[name='wellYDimension']").type('10').blur()
-          cy.contains('Well Y must be a number').should('not.exist')
+          cy.contains('Well Y is a required field').should('not.exist')
         })
 
         it('tests well bottom shape and depth', () => {
@@ -138,9 +138,9 @@ context('Tubes and Block', () => {
           cy.get("img[src*='_round.']").should('not.exist')
           cy.get("img[src*='_v.']").should('exist')
           cy.get("input[name='wellDepth']").focus().blur()
-          cy.contains('Depth must be a number').should('exist')
+          cy.contains('Depth is a required field').should('exist')
           cy.get("input[name='wellDepth']").type('10').blur()
-          cy.contains('Depth must be a number').should('not.exist')
+          cy.contains('Depth is a required field').should('not.exist')
         })
 
         it('does has a preview image', () => {
@@ -271,9 +271,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Volume must be a number').should('exist')
+        cy.contains('Volume is a required field').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Volume must be a number').should('not.exist')
+        cy.contains('Volume is a required field').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -285,9 +285,9 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('not.exist')
           cy.get("input[name='wellYDimension']").should('not.exist')
           cy.get("input[name='wellDiameter']").focus().blur()
-          cy.contains('Diameter must be a number').should('exist')
+          cy.contains('Diameter is a required field').should('exist')
           cy.get("input[name='wellDiameter']").type('10').blur()
-          cy.contains('Diameter must be a number').should('not.exist')
+          cy.contains('Diameter is a required field').should('not.exist')
         })
 
         it('tests rectangular wells', () => {
@@ -298,13 +298,13 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('exist')
           cy.get("input[name='wellYDimension']").should('exist')
           cy.get("input[name='wellXDimension']").focus().blur()
-          cy.contains('Well X must be a number').should('exist')
+          cy.contains('Well X is a required field').should('exist')
           cy.get("input[name='wellXDimension']").type('10').blur()
-          cy.contains('Well X must be a number').should('not.exist')
+          cy.contains('Well X is a required field').should('not.exist')
           cy.get("input[name='wellYDimension']").focus().blur()
-          cy.contains('Well Y must be a number').should('exist')
+          cy.contains('Well Y is a required field').should('exist')
           cy.get("input[name='wellYDimension']").type('10').blur()
-          cy.contains('Well Y must be a number').should('not.exist')
+          cy.contains('Well Y is a required field').should('not.exist')
         })
 
         it('tests well bottom shape and depth', () => {
@@ -327,9 +327,9 @@ context('Tubes and Block', () => {
           cy.get("img[src*='_round.']").should('not.exist')
           cy.get("img[src*='_v.']").should('exist')
           cy.get("input[name='wellDepth']").focus().blur()
-          cy.contains('Depth must be a number').should('exist')
+          cy.contains('Depth is a required field').should('exist')
           cy.get("input[name='wellDepth']").type('10').blur()
-          cy.contains('Depth must be a number').should('not.exist')
+          cy.contains('Depth is a required field').should('not.exist')
         })
 
         it('does has a preview image', () => {
@@ -460,9 +460,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Volume must be a number').should('exist')
+        cy.contains('Volume is a required field').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Volume must be a number').should('not.exist')
+        cy.contains('Volume is a required field').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -474,9 +474,9 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('not.exist')
           cy.get("input[name='wellYDimension']").should('not.exist')
           cy.get("input[name='wellDiameter']").focus().blur()
-          cy.contains('Diameter must be a number').should('exist')
+          cy.contains('Diameter is a required field').should('exist')
           cy.get("input[name='wellDiameter']").type('10').blur()
-          cy.contains('Diameter must be a number').should('not.exist')
+          cy.contains('Diameter is a required field').should('not.exist')
         })
 
         it('tests rectangular wells', () => {
@@ -487,13 +487,13 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('exist')
           cy.get("input[name='wellYDimension']").should('exist')
           cy.get("input[name='wellXDimension']").focus().blur()
-          cy.contains('Well X must be a number').should('exist')
+          cy.contains('Well X is a required field').should('exist')
           cy.get("input[name='wellXDimension']").type('10').blur()
-          cy.contains('Well X must be a number').should('not.exist')
+          cy.contains('Well X is a required field').should('not.exist')
           cy.get("input[name='wellYDimension']").focus().blur()
-          cy.contains('Well Y must be a number').should('exist')
+          cy.contains('Well Y is a required field').should('exist')
           cy.get("input[name='wellYDimension']").type('10').blur()
-          cy.contains('Well Y must be a number').should('not.exist')
+          cy.contains('Well Y is a required field').should('not.exist')
         })
 
         it('tests well bottom shape and depth', () => {
@@ -516,9 +516,9 @@ context('Tubes and Block', () => {
           cy.get("img[src*='_round.']").should('not.exist')
           cy.get("img[src*='_v.']").should('exist')
           cy.get("input[name='wellDepth']").focus().blur()
-          cy.contains('Depth must be a number').should('exist')
+          cy.contains('Depth is a required field').should('exist')
           cy.get("input[name='wellDepth']").type('10').blur()
-          cy.contains('Depth must be a number').should('not.exist')
+          cy.contains('Depth is a required field').should('not.exist')
         })
 
         it('does has a preview image', () => {
@@ -645,9 +645,9 @@ context('Tubes and Block', () => {
 
       it('tests volume', () => {
         cy.get("input[name='wellVolume']").focus().blur()
-        cy.contains('Volume must be a number').should('exist')
+        cy.contains('Volume is a required field').should('exist')
         cy.get("input[name='wellVolume']").type('10').blur()
-        cy.contains('Volume must be a number').should('not.exist')
+        cy.contains('Volume is a required field').should('not.exist')
       })
 
       describe('Well shape tests', () => {
@@ -659,9 +659,9 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('not.exist')
           cy.get("input[name='wellYDimension']").should('not.exist')
           cy.get("input[name='wellDiameter']").focus().blur()
-          cy.contains('Diameter must be a number').should('exist')
+          cy.contains('Diameter is a required field').should('exist')
           cy.get("input[name='wellDiameter']").type('10').blur()
-          cy.contains('Diameter must be a number').should('not.exist')
+          cy.contains('Diameter is a required field').should('not.exist')
         })
 
         it('tests rectangular wells', () => {
@@ -672,13 +672,13 @@ context('Tubes and Block', () => {
           cy.get("input[name='wellXDimension']").should('exist')
           cy.get("input[name='wellYDimension']").should('exist')
           cy.get("input[name='wellXDimension']").focus().blur()
-          cy.contains('Well X must be a number').should('exist')
+          cy.contains('Well X is a required field').should('exist')
           cy.get("input[name='wellXDimension']").type('10').blur()
-          cy.contains('Well X must be a number').should('not.exist')
+          cy.contains('Well X is a required field').should('not.exist')
           cy.get("input[name='wellYDimension']").focus().blur()
-          cy.contains('Well Y must be a number').should('exist')
+          cy.contains('Well Y is a required field').should('exist')
           cy.get("input[name='wellYDimension']").type('10').blur()
-          cy.contains('Well Y must be a number').should('not.exist')
+          cy.contains('Well Y is a required field').should('not.exist')
         })
 
         it('tests well bottom shape and depth', () => {
@@ -701,9 +701,9 @@ context('Tubes and Block', () => {
           cy.get("img[src*='_round.']").should('not.exist')
           cy.get("img[src*='_v.']").should('exist')
           cy.get("input[name='wellDepth']").focus().blur()
-          cy.contains('Depth must be a number').should('exist')
+          cy.contains('Depth is a required field').should('exist')
           cy.get("input[name='wellDepth']").type('10').blur()
-          cy.contains('Depth must be a number').should('not.exist')
+          cy.contains('Depth is a required field').should('not.exist')
         })
 
         it('does has a preview image', () => {

--- a/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
@@ -70,9 +70,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Volume must be a number').should('exist')
+      cy.contains('Volume is a required field').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Volume must be a number').should('not.exist')
+      cy.contains('Volume is a required field').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -84,9 +84,9 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('not.exist')
         cy.get("input[name='wellYDimension']").should('not.exist')
         cy.get("input[name='wellDiameter']").focus().blur()
-        cy.contains('Diameter must be a number').should('exist')
+        cy.contains('Diameter is a required field').should('exist')
         cy.get("input[name='wellDiameter']").type('10').blur()
-        cy.contains('Diameter must be a number').should('not.exist')
+        cy.contains('Diameter is a required field').should('not.exist')
       })
 
       it('tests rectangular wells', () => {
@@ -97,13 +97,13 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('exist')
         cy.get("input[name='wellYDimension']").should('exist')
         cy.get("input[name='wellXDimension']").focus().blur()
-        cy.contains('Well X must be a number').should('exist')
+        cy.contains('Well X is a required field').should('exist')
         cy.get("input[name='wellXDimension']").type('10').blur()
-        cy.contains('Well X must be a number').should('not.exist')
+        cy.contains('Well X is a required field').should('not.exist')
         cy.get("input[name='wellYDimension']").focus().blur()
-        cy.contains('Well Y must be a number').should('exist')
+        cy.contains('Well Y is a required field').should('exist')
         cy.get("input[name='wellYDimension']").type('10').blur()
-        cy.contains('Well Y must be a number').should('not.exist')
+        cy.contains('Well Y is a required field').should('not.exist')
       })
 
       it('tests well bottom shape and depth', () => {
@@ -126,9 +126,9 @@ context('Tubes and Rack', () => {
         cy.get("img[src*='_round.']").should('not.exist')
         cy.get("img[src*='_v.']").should('exist')
         cy.get("input[name='wellDepth']").focus().blur()
-        cy.contains('Depth must be a number').should('exist')
+        cy.contains('Depth is a required field').should('exist')
         cy.get("input[name='wellDepth']").type('10').blur()
-        cy.contains('Depth must be a number').should('not.exist')
+        cy.contains('Depth is a required field').should('not.exist')
       })
 
       it('does has a preview image', () => {
@@ -245,9 +245,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Volume must be a number').should('exist')
+      cy.contains('Volume is a required field').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Volume must be a number').should('not.exist')
+      cy.contains('Volume is a required field').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -259,9 +259,9 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('not.exist')
         cy.get("input[name='wellYDimension']").should('not.exist')
         cy.get("input[name='wellDiameter']").focus().blur()
-        cy.contains('Diameter must be a number').should('exist')
+        cy.contains('Diameter is a required field').should('exist')
         cy.get("input[name='wellDiameter']").type('10').blur()
-        cy.contains('Diameter must be a number').should('not.exist')
+        cy.contains('Diameter is a required field').should('not.exist')
       })
 
       it('tests rectangular wells', () => {
@@ -272,13 +272,13 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('exist')
         cy.get("input[name='wellYDimension']").should('exist')
         cy.get("input[name='wellXDimension']").focus().blur()
-        cy.contains('Well X must be a number').should('exist')
+        cy.contains('Well X is a required field').should('exist')
         cy.get("input[name='wellXDimension']").type('10').blur()
-        cy.contains('Well X must be a number').should('not.exist')
+        cy.contains('Well X is a required field').should('not.exist')
         cy.get("input[name='wellYDimension']").focus().blur()
-        cy.contains('Well Y must be a number').should('exist')
+        cy.contains('Well Y is a required field').should('exist')
         cy.get("input[name='wellYDimension']").type('10').blur()
-        cy.contains('Well Y must be a number').should('not.exist')
+        cy.contains('Well Y is a required field').should('not.exist')
       })
 
       it('tests well bottom shape and depth', () => {
@@ -301,9 +301,9 @@ context('Tubes and Rack', () => {
         cy.get("img[src*='_round.']").should('not.exist')
         cy.get("img[src*='_v.']").should('exist')
         cy.get("input[name='wellDepth']").focus().blur()
-        cy.contains('Depth must be a number').should('exist')
+        cy.contains('Depth is a required field').should('exist')
         cy.get("input[name='wellDepth']").type('10').blur()
-        cy.contains('Depth must be a number').should('not.exist')
+        cy.contains('Depth is a required field').should('not.exist')
       })
 
       it('does has a preview image', () => {
@@ -424,9 +424,9 @@ context('Tubes and Rack', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Volume must be a number').should('exist')
+      cy.contains('Volume is a required field').should('exist')
       cy.get("input[name='wellVolume']").type('10').blur()
-      cy.contains('Volume must be a number').should('not.exist')
+      cy.contains('Volume is a required field').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -438,9 +438,9 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('not.exist')
         cy.get("input[name='wellYDimension']").should('not.exist')
         cy.get("input[name='wellDiameter']").focus().blur()
-        cy.contains('Diameter must be a number').should('exist')
+        cy.contains('Diameter is a required field').should('exist')
         cy.get("input[name='wellDiameter']").type('10').blur()
-        cy.contains('Diameter must be a number').should('not.exist')
+        cy.contains('Diameter is a required field').should('not.exist')
       })
 
       it('tests rectangular wells', () => {
@@ -451,13 +451,13 @@ context('Tubes and Rack', () => {
         cy.get("input[name='wellXDimension']").should('exist')
         cy.get("input[name='wellYDimension']").should('exist')
         cy.get("input[name='wellXDimension']").focus().blur()
-        cy.contains('Well X must be a number').should('exist')
+        cy.contains('Well X is a required field').should('exist')
         cy.get("input[name='wellXDimension']").type('10').blur()
-        cy.contains('Well X must be a number').should('not.exist')
+        cy.contains('Well X is a required field').should('not.exist')
         cy.get("input[name='wellYDimension']").focus().blur()
-        cy.contains('Well Y must be a number').should('exist')
+        cy.contains('Well Y is a required field').should('exist')
         cy.get("input[name='wellYDimension']").type('10').blur()
-        cy.contains('Well Y must be a number').should('not.exist')
+        cy.contains('Well Y is a required field').should('not.exist')
       })
 
       it('tests well bottom shape and depth', () => {
@@ -480,9 +480,9 @@ context('Tubes and Rack', () => {
         cy.get("img[src*='_round.']").should('not.exist')
         cy.get("img[src*='_v.']").should('exist')
         cy.get("input[name='wellDepth']").focus().blur()
-        cy.contains('Depth must be a number').should('exist')
+        cy.contains('Depth is a required field').should('exist')
         cy.get("input[name='wellDepth']").type('10').blur()
-        cy.contains('Depth must be a number').should('not.exist')
+        cy.contains('Depth is a required field').should('not.exist')
       })
 
       it('does has a preview image', () => {

--- a/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
+++ b/labware-library/cypress/integration/labware-creator/wellPlate.spec.js
@@ -88,9 +88,9 @@ context('Well Plates', () => {
     describe('Grid tests', () => {
       it('tests number of rows', () => {
         cy.get("input[name='gridRows']").focus().blur()
-        cy.contains('Number of rows must be a number').should('exist')
+        cy.contains('Number of rows is a required field').should('exist')
         cy.get("input[name='gridRows']").type('8').blur()
-        cy.contains('Number of rows must be a number').should('not.exist')
+        cy.contains('Number of rows is a required field').should('not.exist')
       })
 
       it('tests are all of your rows evenly spaced', () => {
@@ -107,9 +107,9 @@ context('Well Plates', () => {
 
       it('tests number of columns', () => {
         cy.get("input[name='gridColumns']").focus().blur()
-        cy.contains('Number of columns must be a number').should('exist')
+        cy.contains('Number of columns is a required field').should('exist')
         cy.get("input[name='gridColumns']").type('10').blur()
-        cy.contains('Number of columns must be a number').should('not.exist')
+        cy.contains('Number of columns is a required field').should('not.exist')
       })
 
       it('tests are all of your columns evenly spaced', () => {
@@ -130,9 +130,9 @@ context('Well Plates', () => {
 
     it('tests volume', () => {
       cy.get("input[name='wellVolume']").focus().blur()
-      cy.contains('Volume must be a number').should('exist')
+      cy.contains('Volume is a required field').should('exist')
       cy.get("input[name='wellVolume']").type('100').blur()
-      cy.contains('Volume must be a number').should('not.exist')
+      cy.contains('Volume is a required field').should('not.exist')
     })
 
     describe('Well shape tests', () => {
@@ -144,9 +144,9 @@ context('Well Plates', () => {
         cy.get("input[name='wellXDimension']").should('not.exist')
         cy.get("input[name='wellYDimension']").should('not.exist')
         cy.get("input[name='wellDiameter']").focus().blur()
-        cy.contains('Diameter must be a number').should('exist')
+        cy.contains('Diameter is a required field').should('exist')
         cy.get("input[name='wellDiameter']").type('10').blur()
-        cy.contains('Diameter must be a number').should('not.exist')
+        cy.contains('Diameter is a required field').should('not.exist')
       })
 
       it('tests rectangular wells', () => {
@@ -157,13 +157,13 @@ context('Well Plates', () => {
         cy.get("input[name='wellXDimension']").should('exist')
         cy.get("input[name='wellYDimension']").should('exist')
         cy.get("input[name='wellXDimension']").focus().blur()
-        cy.contains('Well X must be a number').should('exist')
+        cy.contains('Well X is a required field').should('exist')
         cy.get("input[name='wellXDimension']").type('8').blur()
-        cy.contains('Well X must be a number').should('not.exist')
+        cy.contains('Well X is a required field').should('not.exist')
         cy.get("input[name='wellYDimension']").focus().blur()
-        cy.contains('Well Y must be a number').should('exist')
+        cy.contains('Well Y is a required field').should('exist')
         cy.get("input[name='wellYDimension']").type('8').blur()
-        cy.contains('Well Y must be a number').should('not.exist')
+        cy.contains('Well Y is a required field').should('not.exist')
       })
 
       it('tests well bottom shape and depth', () => {
@@ -186,31 +186,31 @@ context('Well Plates', () => {
         cy.get("img[src*='_round.']").should('not.exist')
         cy.get("img[src*='_v.']").should('exist')
         cy.get("input[name='wellDepth']").focus().blur()
-        cy.contains('Depth must be a number').should('exist')
+        cy.contains('Depth is a required field').should('exist')
         cy.get("input[name='wellDepth']").type('10').blur()
-        cy.contains('Depth must be a number').should('not.exist')
+        cy.contains('Depth is a required field').should('not.exist')
       })
 
       it('tests well spacing', () => {
         cy.get("input[name='gridSpacingX']").focus().blur()
-        cy.contains('X Spacing (Xs) must be a number').should('exist')
+        cy.contains('X Spacing (Xs) is a required field').should('exist')
         cy.get("input[name='gridSpacingX']").type('12').blur()
-        cy.contains('X Spacing (Xs) must be a number').should('not.exist')
+        cy.contains('X Spacing (Xs) is a required field').should('not.exist')
         cy.get("input[name='gridSpacingY']").focus().blur()
-        cy.contains('Y Spacing (Ys) must be a number').should('exist')
+        cy.contains('Y Spacing (Ys) is a required field').should('exist')
         cy.get("input[name='gridSpacingY']").type('10').blur()
-        cy.contains('Y Spacing (Ys) must be a number').should('not.exist')
+        cy.contains('Y Spacing (Ys) is a required field').should('not.exist')
       })
 
       it('tests grid offset', () => {
         cy.get("input[name='gridOffsetX']").focus().blur()
-        cy.contains('X Offset (Xo) must be a number').should('exist')
+        cy.contains('X Offset (Xo) is a required field').should('exist')
         cy.get("input[name='gridOffsetX']").type('10').blur()
-        cy.contains('X Offset (Xo) must be a number').should('not.exist')
+        cy.contains('X Offset (Xo) is a required field').should('not.exist')
         cy.get("input[name='gridOffsetY']").focus().blur()
-        cy.contains('Y Offset (Yo) must be a number').should('exist')
+        cy.contains('Y Offset (Yo) is a required field').should('exist')
         cy.get("input[name='gridOffsetY']").type('8').blur()
-        cy.contains('Y Offset (Yo) must be a number').should('not.exist')
+        cy.contains('Y Offset (Yo) is a required field').should('not.exist')
       })
 
       it('should have a preview image and no footprint errors', () => {

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -27,12 +27,22 @@ const requiredString = (label: string): Yup.StringSchema =>
   Yup.string().label(label).typeError(REQUIRED_FIELD).required()
 const MUST_BE_A_NUMBER = '${label} must be a number' // eslint-disable-line no-template-curly-in-string
 
+// put this in a transform to make Yup to show "this field is required"
+// instead of "must be a number". See https://github.com/jquense/yup/issues/971
+const nanToUndefined = (value: number): number | undefined =>
+  isNaN(value) ? undefined : value
+
 const requiredPositiveNumber = (label: string): Yup.NumberSchema =>
-  Yup.number().label(label).typeError(MUST_BE_A_NUMBER).moreThan(0).required()
+  Yup.number()
+    .label(label)
+    .transform(nanToUndefined)
+    .typeError(MUST_BE_A_NUMBER)
+    .moreThan(0)
+    .required()
 
 const requiredPositiveInteger = (label: string): Yup.NumberSchema =>
   Yup.number()
-    .default(0)
+    .transform(nanToUndefined)
     .label(label)
     .typeError(MUST_BE_A_NUMBER)
     .moreThan(0)
@@ -90,7 +100,7 @@ export const labwareFormSchemaBaseObject = Yup.object({
 
   // tubeRackSides: Array<string>
   footprintXDimension: Yup.number()
-    .default(0)
+    .transform(nanToUndefined)
     .label(LABELS.footprintXDimension)
     .typeError(MUST_BE_A_NUMBER)
     .min(MIN_X_DIMENSION, LABWARE_TOO_SMALL_ERROR)
@@ -98,7 +108,7 @@ export const labwareFormSchemaBaseObject = Yup.object({
     .nullable()
     .required(),
   footprintYDimension: Yup.number()
-    .default(0)
+    .transform(nanToUndefined)
     .label(LABELS.footprintYDimension)
     .typeError(MUST_BE_A_NUMBER)
     .min(MIN_Y_DIMENSION, LABWARE_TOO_SMALL_ERROR)
@@ -149,7 +159,7 @@ export const labwareFormSchemaBaseObject = Yup.object({
   wellDepth: Yup.number().when('labwareType', {
     is: 'tipRack',
     then: Yup.number()
-      .default(0)
+      .transform(nanToUndefined)
       .label('Length')
       .typeError(MUST_BE_A_NUMBER)
       .moreThan(0)
@@ -159,7 +169,7 @@ export const labwareFormSchemaBaseObject = Yup.object({
       )
       .required(),
     otherwise: Yup.number()
-      .default(0)
+      .transform(nanToUndefined)
       .label(LABELS.wellDepth)
       .typeError(MUST_BE_A_NUMBER)
       .moreThan(0)


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Closes #8026

# Changelog

- change all numerical fields so they don't surface type errors, but instead surface "required" errors
- update many e2e tests re that error copy change

# Review requests

- code review, manually test. This is a little dangerous bc it messes with the Yup schema

# Risk assessment

Medium, LC only