### PR TITLE
refactor(api): Fix deprecated use of `asyncio.Task.current_task()`

### DIFF
--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -62,7 +62,7 @@ class _Internal:
 
     async def __aenter__(self):
         pref = f"[ThreadedAsyncLock tid {threading.get_ident()} "\
-            f"task {asyncio.Task.current_task()}] "
+            f"task {asyncio.current_task()}] "
         log.debug(pref + 'will acquire')
         then = time.perf_counter()
         while not self._thread_lock.acquire(blocking=False):
@@ -75,7 +75,7 @@ class _Internal:
 
     async def __aexit__(self, exc_type, exc, tb):
         log.debug(f"[ThreadedAsyncLock tid {threading.get_ident()} "
-                  f"task {asyncio.Task.current_task()}] will release")
+                  f"task {asyncio.current_task()}] will release")
         self._thread_lock.release()
 
     def __enter__(self):


### PR DESCRIPTION
# Overview

Fix some usage of `asyncio.Task.current_task()`, which [has been deprecated since Python 3.7](https://docs.python.org/3.7/library/asyncio-task.html#asyncio.Task.current_task) in favor of `asyncio.current_task()`.

Although this is an `api` change, it resolves the following warnings in the `robot-server` tests:

```
tests/service/legacy/routers/test_control.py::test_home_pipette[left-LEFT]
tests/service/legacy/routers/test_control.py::test_home_pipette[right-RIGHT]
tests/service/legacy/routers/test_control.py::test_home_robot
tests/service/legacy/routers/test_control.py::test_move_mount
tests/service/legacy/routers/test_control.py::test_move_pipette
  /Users/maxpm/Code/Opentrons/opentrons/api/src/opentrons/hardware_control/threaded_async_lock.py:64: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    pref = f"[ThreadedAsyncLock tid {threading.get_ident()} "\

tests/service/legacy/routers/test_control.py::test_home_pipette[left-LEFT]
tests/service/legacy/routers/test_control.py::test_home_pipette[right-RIGHT]
tests/service/legacy/routers/test_control.py::test_home_robot
tests/service/legacy/routers/test_control.py::test_move_mount
tests/service/legacy/routers/test_control.py::test_move_pipette
  /Users/maxpm/Code/Opentrons/opentrons/api/src/opentrons/hardware_control/threaded_async_lock.py:77: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    log.debug(f"[ThreadedAsyncLock tid {threading.get_ident()} "
```

# Review requests

None in particular.

# Risk assessment

Very low. The change is tiny, and the tests pass.
