### PR TITLE
chore: Add notify-server to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 api/**
 update-server/**
 robot-server/**
+notify-server/**
 shared-data/python/**
 **/node_modules/**
 **/coverage/**
@@ -32,4 +33,6 @@ lerna.json
 storybook-static
 
 # mypy
+# todo(mm, 2021-07-01): Is this necessary, given that we already ignore whole
+# Python project directories?
 **/.mypy_cache/**


### PR DESCRIPTION
This makes `make js-lint` ignore the `notify-server` directory.

Without this, if you do a top-level `make test` followed by a top-level `make lint`, you get this error:

```
prettier --ignore-path .eslintignore --check ".*.@(js|ts|tsx|yml)" "**/*.@(ts|tsx|js|json|md|yml)"
Checking formatting...
[warn] notify-server/.pytest_cache/README.md
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
```

Because `pytest` autogenerates a `README.md` that doesn't match Prettier's style.
