### PR TITLE
feat(labware-creator): allow dynamic field labels via getLabel

### DIFF
--- a/labware-library/src/labware-creator/components/Dropdown.tsx
+++ b/labware-library/src/labware-creator/components/Dropdown.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 import { SelectField } from '@opentrons/components'
 import { Field } from 'formik'
 import { reportFieldEdit } from '../analyticsUtils'
-import { LABELS } from '../fields'
+import { getLabel, LabwareFields } from '../fields'
 import type { Option, Options } from '../fields'
 import fieldStyles from './fieldStyles.css'
 import styles from './Dropdown.css'
 
 export interface DropdownProps {
-  name: keyof typeof LABELS
+  name: keyof LabwareFields
   options: Options
   caption?: string
   /** optionally override the default onValueChange */
@@ -17,7 +17,9 @@ export interface DropdownProps {
 
 export const OptionLabel = (props: Option): JSX.Element => (
   <div className={styles.option_row}>
-    {props.imgSrc && <img className={styles.option_image} src={props.imgSrc} />}
+    {props.imgSrc != null && (
+      <img className={styles.option_image} src={props.imgSrc} />
+    )}
     <div className={styles.option_label}>{props.name}</div>
   </div>
 )
@@ -35,28 +37,30 @@ export const Dropdown = (props: DropdownProps): JSX.Element => {
   return (
     <div className={fieldStyles.field_wrapper}>
       <label className={fieldStyles.field_label}>
-        {LABELS[props.name]}
         <Field name={props.name}>
           {/* @ts-expect-error(IL, 2021-03-24): formik types need cleanup w LabwareFields */}
           {({ field, form }) => (
-            <SelectField
-              name={field.name}
-              caption={props.caption}
-              value={field.value}
-              options={options}
-              onLoseFocus={name => {
-                reportFieldEdit({ value: field.value, name })
-                form.setFieldTouched(name)
-              }}
-              onValueChange={
-                props.onValueChange ||
-                ((name, value) => form.setFieldValue(name, value))
-              }
-              formatOptionLabel={({ value, label }) => {
-                const option = props.options.find(opt => opt.value === value)
-                return option ? <OptionLabel {...option} /> : null
-              }}
-            />
+            <>
+              {getLabel(field.name, form.values)}
+              <SelectField
+                name={field.name}
+                caption={props.caption}
+                value={field.value}
+                options={options}
+                onLoseFocus={name => {
+                  reportFieldEdit({ value: field.value, name })
+                  form.setFieldTouched(name)
+                }}
+                onValueChange={
+                  props.onValueChange ||
+                  ((name, value) => form.setFieldValue(name, value))
+                }
+                formatOptionLabel={({ value, label }) => {
+                  const option = props.options.find(opt => opt.value === value)
+                  return option ? <OptionLabel {...option} /> : null
+                }}
+              />
+            </>
           )}
         </Field>
       </label>

--- a/labware-library/src/labware-creator/components/RadioField.tsx
+++ b/labware-library/src/labware-creator/components/RadioField.tsx
@@ -3,7 +3,7 @@ import { Field } from 'formik'
 import { RadioGroup } from '@opentrons/components'
 import { reportFieldEdit } from '../analyticsUtils'
 import { getIsHidden } from '../formSelectors'
-import { LABELS } from '../fields'
+import { getLabel } from '../fields'
 import type { LabwareFields } from '../fields'
 import type { RadioGroupProps } from '@opentrons/components'
 import fieldStyles from './fieldStyles.css'
@@ -20,7 +20,9 @@ export const RadioField = (props: Props): JSX.Element => (
     {({ form, field }) =>
       getIsHidden(props.name, form.values) ? null : (
         <div className={fieldStyles.field_wrapper}>
-          <div className={fieldStyles.field_label}>{LABELS[props.name]}</div>
+          <div className={fieldStyles.field_label}>
+            {getLabel(props.name, form.values)}
+          </div>
           <RadioGroup
             name={field.name}
             value={field.value}

--- a/labware-library/src/labware-creator/components/TextField.tsx
+++ b/labware-library/src/labware-creator/components/TextField.tsx
@@ -3,7 +3,7 @@ import { Field } from 'formik'
 import { InputField } from '@opentrons/components'
 import { reportFieldEdit } from '../analyticsUtils'
 import { getIsHidden } from '../formSelectors'
-import { LABELS } from '../fields'
+import { getLabel } from '../fields'
 import type { InputFieldProps } from '@opentrons/components'
 import type { LabwareFields } from '../fields'
 import type { FieldProps } from 'formik'
@@ -22,7 +22,7 @@ interface Props {
 // because sections are laid out to contain groups of autofilled fields.
 // This functionality in TextField may be removed if we clearly don't need it.
 export const TextField = (props: Props): JSX.Element => {
-  const { label, caption, name, placeholder, units } = props
+  const { label, caption, placeholder, units } = props
   const inputMasks = props.inputMasks || []
   // @ts-expect-error(IL, 2021-03-24): formik types need cleanup w LabwareFields
   const makeHandleChange = ({ field, form }) => (
@@ -36,7 +36,6 @@ export const TextField = (props: Props): JSX.Element => {
     )
     form.setFieldValue(props.name, nextValue)
   }
-  const fieldLabel = label !== undefined ? label : LABELS[name]
 
   return (
     <Field name={props.name}>
@@ -44,7 +43,7 @@ export const TextField = (props: Props): JSX.Element => {
         getIsHidden(props.name, form.values) ? null : (
           <div className={fieldStyles.field_wrapper}>
             <label className={fieldStyles.field_label}>
-              {fieldLabel}
+              {label !== undefined ? label : getLabel(props.name, form.values)}
               <InputField
                 name={field.name}
                 value={field.value}

--- a/labware-library/src/labware-creator/components/__tests__/sections/Regularity.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Regularity.test.tsx
@@ -4,7 +4,7 @@ import { FormikConfig } from 'formik'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { getDefaultFormState, LabwareFields } from '../../../fields'
-import { isEveryFieldHidden } from '../../../utils'
+import { isEveryFieldHidden, getLabwareName } from '../../../utils'
 import { Regularity } from '../../sections/Regularity'
 import { wrapInFormik } from '../../utils/wrapInFormik'
 
@@ -12,6 +12,10 @@ jest.mock('../../../utils')
 
 const isEveryFieldHiddenMock = isEveryFieldHidden as jest.MockedFunction<
   typeof isEveryFieldHidden
+>
+
+const getLabwareNameMock = getLabwareName as jest.MockedFunction<
+  typeof getLabwareName
 >
 
 let formikConfig: FormikConfig<LabwareFields>
@@ -34,10 +38,16 @@ describe('Regularity', () => {
   })
 
   it('should render radio fields when fields are visible', () => {
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, true)
+      .mockReturnValue('FAKE LABWARE NAME PLURAL')
+
     render(wrapInFormik(<Regularity />, formikConfig))
     expect(screen.getByRole('heading')).toHaveTextContent(/regularity/i)
     // TODO(IL, 2021-05-26): this should be a semantic label, but is just a div
-    screen.getByText('Are all your wells the same shape and size?')
+    screen.getByText(
+      'Are all your FAKE LABWARE NAME PLURAL the same shape and size?'
+    )
 
     const radioElements = screen.getAllByRole('radio')
     expect(radioElements).toHaveLength(2)

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -1,4 +1,5 @@
 import type { WellBottomShape } from '@opentrons/shared-data'
+import { getLabwareName } from './utils'
 
 export const MAX_X_DIMENSION = 129
 export const MIN_X_DIMENSION = 127
@@ -411,4 +412,17 @@ export const LABELS: Record<keyof LabwareFields, string> = {
   displayName: 'Display Name',
   loadName: 'API Load Name',
   pipetteName: 'Test Pipette',
+}
+
+export const getLabel = (
+  name: keyof LabwareFields,
+  values: LabwareFields
+): string => {
+  if (name === 'homogeneousWells') {
+    return `Are all your ${getLabwareName(
+      values,
+      true
+    )} the same shape and size?`
+  }
+  return LABELS[name]
 }


### PR DESCRIPTION
# Overview

Closes #7974 and should make it so we can add similar exceptions to field labels in the future if we need to

# Changelog


# Review requests

- Visually check all field types (text, radio, dropdown) to make sure there's no regressions about label copy & positioning (check with **well plate** selected so that all the fields are revealed to see & check!)
- "Regularity" section should switch btw tubes / wells according to selected `labwareType` as in #7974 .

# Risk assessment

Medium, LC only