### PR TITLE
feat(labware-creator): update spacing section for custom tube racks

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellSpacing.test.tsx
@@ -48,7 +48,7 @@ describe('WellSpacing', () => {
 
     render(wrapInFormik(<WellSpacing />, formikConfig))
 
-    screen.getByRole('heading', { name: /Well Spacing/i })
+    screen.getByRole('heading', { name: /FAKE LABWARE NAME SINGULAR Spacing/i })
 
     screen.getByText(
       nestedTextMatcher(
@@ -66,14 +66,6 @@ describe('WellSpacing', () => {
     screen.getByRole('textbox', { name: /Y Spacing \(Ys\)/i })
   })
 
-  it('should render "Tip Spacing" instead of "Well Spacing" when tipRack is selected', () => {
-    formikConfig.initialValues.labwareType = 'tipRack'
-
-    render(wrapInFormik(<WellSpacing />, formikConfig))
-
-    screen.getByRole('heading', { name: /Tip Spacing/i })
-  })
-
   it('should NOT render when the labware type is aluminumBlock', () => {
     const { container } = render(
       wrapInFormik(<WellSpacing />, {
@@ -81,19 +73,6 @@ describe('WellSpacing', () => {
         initialValues: {
           ...formikConfig.initialValues,
           labwareType: 'aluminumBlock',
-        },
-      })
-    )
-    expect(container.firstChild).toBe(null)
-  })
-
-  it('should NOT render when the labware type is tubeRack', () => {
-    const { container } = render(
-      wrapInFormik(<WellSpacing />, {
-        ...formikConfig,
-        initialValues: {
-          ...formikConfig.initialValues,
-          labwareType: 'tubeRack',
         },
       })
     )

--- a/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellSpacing.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
+import capitalize from 'lodash/capitalize'
 import { makeMaskToDecimal } from '../../fieldMasks'
 import { isEveryFieldHidden, getLabwareName } from '../../utils'
 import { LabwareFields } from '../../fields'
@@ -71,14 +72,12 @@ export const WellSpacing = (): JSX.Element | null => {
   const { values, errors, touched } = useFormikContext<LabwareFields>()
   if (
     isEveryFieldHidden(fieldList, values) ||
-    (values.labwareType != null &&
-      ['aluminumBlock', 'tubeRack'].includes(values.labwareType))
+    values.labwareType === 'aluminumBlock'
   ) {
     return null
   }
-  // TODO (ka 2021-6-10): This will need getLabwareName once we introduce custom tuberacks
-  const label =
-    values.labwareType === 'tipRack' ? 'Tip Spacing' : 'Well Spacing'
+
+  const label = `${capitalize(getLabwareName(values, false))} Spacing`
   return (
     <div className={styles.new_definition_section}>
       <SectionBody label={label} id="WellSpacing">


### PR DESCRIPTION
# Overview

Closes #7983

# Changelog


# Review requests

- When a non-custom tube rack is selected, the Spacing section should be hidden, as in production
- When a custom tube rack is selected, the Spacing section should be visible with copy matching #7983 
- Spacing section should use correct wording (wells/tubes/tips) when different labwareTypes are selected
- Unit tests should cover all this

# Risk assessment

Low, LC only