### PR TITLE
docs(api): Fix `move()` example

### DIFF
--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -125,8 +125,7 @@ class Location:
 
             >>> loc = Location(Point(1, 1, 1), None)
             >>> new_loc = loc.move(Point(1, 1, 1))
-            >>> assert loc_2.point == Point(2, 2, 2)  # True
-            >>> assert loc.point == Point(1, 1, 1)  # True
+            >>> assert new_loc.point == Point(2, 2, 2)  # True
 
         """
         return Location(point=self.point + point,

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -125,7 +125,12 @@ class Location:
 
             >>> loc = Location(Point(1, 1, 1), None)
             >>> new_loc = loc.move(Point(1, 1, 1))
+            >>>
+            >>> # The new point is the old one plus the given offset.
             >>> assert new_loc.point == Point(2, 2, 2)  # True
+            >>>
+            >>> # The old point hasn't changed.
+            >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
         return Location(point=self.point + point,


### PR DESCRIPTION
# Overview and changelog

This is a small fix to the `location.move(x, y, z)` example code.

* Fix an inconsistent variable name.
* ~~Remove an `assert` that I think was more noise than it was signal, given that this example code is specifically in the `move()` reference documentation.~~
  * Never mind, I see now why this was added. It's to show how it doesn't modify the original location in-place. Putting this assertion back in.

# Risk analysis

None. Changes are to docs only.