### PR TITLE
feat(labware-creator): update bottom & depth section for tubes

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { FormikConfig } from 'formik'
 import { when, resetAllWhenMocks } from 'jest-when'
-import { getDefaultFormState, LabwareFields } from '../../../fields'
+import {
+  getDefaultFormState,
+  LabwareFields,
+  LabwareType,
+} from '../../../fields'
 import { getLabwareName } from '../../../utils'
 import { WellBottomAndDepth } from '../../sections/WellBottomAndDepth'
 
@@ -30,30 +34,39 @@ describe('WellBottomAndDepth', () => {
     resetAllWhenMocks()
   })
 
-  it('should render with the correct information', () => {
-    when(getLabwareNameMock)
-      .calledWith(formikConfig.initialValues, false)
-      .mockReturnValue('FAKE LABWARE NAME SINGULAR')
-    when(getLabwareNameMock)
-      .calledWith(formikConfig.initialValues, true)
-      .mockReturnValue('FAKE LABWARE NAME PLURAL')
+  const labwareTypes: LabwareType[] = [
+    'tubeRack',
+    'wellPlate',
+    'reservoir',
+    'aluminumBlock',
+  ]
+  labwareTypes.forEach(labwareType => {
+    it(`should render with the correct information ${labwareType}`, () => {
+      formikConfig.initialValues.labwareType = labwareType
+      when(getLabwareNameMock)
+        .calledWith(formikConfig.initialValues, false)
+        .mockReturnValue('FAKE LABWARE NAME SINGULAR')
+      when(getLabwareNameMock)
+        .calledWith(formikConfig.initialValues, true)
+        .mockReturnValue('FAKE LABWARE NAME PLURAL')
 
-    render(wrapInFormik(<WellBottomAndDepth />, formikConfig))
+      render(wrapInFormik(<WellBottomAndDepth />, formikConfig))
 
-    expect(screen.getByRole('heading')).toHaveTextContent(
-      /FAKE LABWARE NAME SINGULAR Bottom & Depth/i
-    )
+      expect(screen.getByRole('heading')).toHaveTextContent(
+        /FAKE LABWARE NAME SINGULAR Bottom & Depth/i
+      )
 
-    screen.getByText(
-      'Depth informs the robot how far down it can go inside a FAKE LABWARE NAME SINGULAR.'
-    )
-    const radioElements = screen.getAllByRole('radio')
-    expect(radioElements).toHaveLength(3)
-    screen.getAllByRole('radio', { name: /flat/i })
-    screen.getAllByRole('radio', { name: /round/i })
-    screen.getAllByRole('radio', { name: /v-bottom/i })
+      screen.getByText(
+        'Depth informs the robot how far down it can go inside a FAKE LABWARE NAME SINGULAR.'
+      )
+      const radioElements = screen.getAllByRole('radio')
+      expect(radioElements).toHaveLength(3)
+      screen.getAllByRole('radio', { name: /flat/i })
+      screen.getAllByRole('radio', { name: /round/i })
+      screen.getAllByRole('radio', { name: /v-bottom/i })
 
-    screen.getByRole('textbox', { name: /depth/i })
+      screen.getByRole('textbox', { name: /depth/i })
+    })
   })
 
   it('should render tip length when tipRack is selected and hide the well bottom shape radioFields', () => {

--- a/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellBottomAndDepth.test.tsx
@@ -4,15 +4,15 @@ import '@testing-library/jest-dom'
 import { FormikConfig } from 'formik'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { getDefaultFormState, LabwareFields } from '../../../fields'
-import { displayAsTube } from '../../../utils'
+import { getLabwareName } from '../../../utils'
 import { WellBottomAndDepth } from '../../sections/WellBottomAndDepth'
 
 import { wrapInFormik } from '../../utils/wrapInFormik'
 
-jest.mock('../../../utils/displayAsTube')
+jest.mock('../../../utils')
 
-const displayAsTubeMock = displayAsTube as jest.MockedFunction<
-  typeof displayAsTube
+const getLabwareNameMock = getLabwareName as jest.MockedFunction<
+  typeof getLabwareName
 >
 
 let formikConfig: FormikConfig<LabwareFields>
@@ -23,10 +23,6 @@ describe('WellBottomAndDepth', () => {
       initialValues: getDefaultFormState(),
       onSubmit: jest.fn(),
     }
-
-    when(displayAsTubeMock)
-      .calledWith(expect.any(Object))
-      .mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -35,14 +31,21 @@ describe('WellBottomAndDepth', () => {
   })
 
   it('should render with the correct information', () => {
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, false)
+      .mockReturnValue('FAKE LABWARE NAME SINGULAR')
+    when(getLabwareNameMock)
+      .calledWith(formikConfig.initialValues, true)
+      .mockReturnValue('FAKE LABWARE NAME PLURAL')
+
     render(wrapInFormik(<WellBottomAndDepth />, formikConfig))
 
     expect(screen.getByRole('heading')).toHaveTextContent(
-      /Well Bottom & Depth/i
+      /FAKE LABWARE NAME SINGULAR Bottom & Depth/i
     )
 
     screen.getByText(
-      'Depth informs the robot how far down it can go inside a well.'
+      'Depth informs the robot how far down it can go inside a FAKE LABWARE NAME SINGULAR.'
     )
     const radioElements = screen.getAllByRole('radio')
     expect(radioElements).toHaveLength(3)
@@ -64,30 +67,6 @@ describe('WellBottomAndDepth', () => {
     expect(screen.queryByRole('radio', { name: /flat/i })).toBeNull()
     expect(screen.queryByRole('radio', { name: /u/i })).toBeNull()
     expect(screen.queryByRole('radio', { name: /v/i })).toBeNull()
-  })
-
-  it('should render tubes when labware that should displayAsTube is selected', () => {
-    when(displayAsTubeMock)
-      .expectCalledWith(formikConfig.initialValues)
-      .mockReturnValue(true)
-
-    render(wrapInFormik(<WellBottomAndDepth />, formikConfig))
-
-    screen.getByText(
-      'Depth informs the robot how far down it can go inside a tube.'
-    )
-  })
-
-  it('should render wells when labware that should NOT displayAsTube is selected', () => {
-    when(displayAsTubeMock)
-      .expectCalledWith(formikConfig.initialValues)
-      .mockReturnValue(false)
-
-    render(wrapInFormik(<WellBottomAndDepth />, formikConfig))
-
-    screen.getByText(
-      'Depth informs the robot how far down it can go inside a well.'
-    )
   })
 
   it('should render alert when error is present', () => {

--- a/labware-library/src/labware-creator/components/sections/WellBottomAndDepth.tsx
+++ b/labware-library/src/labware-creator/components/sections/WellBottomAndDepth.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
+import capitalize from 'lodash/capitalize'
 import { useFormikContext } from 'formik'
 import { makeMaskToDecimal } from '../../fieldMasks'
-import { displayAsTube } from '../../utils'
 import { LabwareFields } from '../../fields'
 import { FormAlerts } from '../alerts/FormAlerts'
 import { TextField } from '../TextField'
@@ -11,6 +11,7 @@ import { SectionBody } from './SectionBody'
 import { wellBottomShapeOptionsWithIcons } from '../optionsWithImages'
 
 import styles from '../../styles.css'
+import { getLabwareName } from '../../utils'
 
 const maskTo2Decimal = makeMaskToDecimal(2)
 
@@ -24,18 +25,18 @@ const Instructions = (props: Props): JSX.Element => {
   if (values.labwareType === 'tipRack') {
     return <p>Reference the top of the tip to the bottom of the tip.</p>
   }
+
+  const labwareName = getLabwareName(values, false)
   return (
     <>
       <p>
-        Reference the measurement from the top of the{' '}
-        {displayAsTube(values) ? 'tube' : 'well'} (include any lip but exclude
-        any cap) to the bottom of the <strong>inside</strong> of the{' '}
-        {displayAsTube(values) ? 'tube' : 'well'}.
+        Reference the measurement from the top of the {labwareName} (include any
+        lip but exclude any cap) to the bottom of the <strong>inside</strong> of
+        the {labwareName}.
       </p>
 
       <p>
-        Depth informs the robot how far down it can go inside a{' '}
-        {displayAsTube(values) ? 'tube' : 'well'}.
+        Depth informs the robot how far down it can go inside a {labwareName}.
       </p>
     </>
   )
@@ -75,7 +76,9 @@ export const WellBottomAndDepth = (): JSX.Element | null => {
   const fieldList: Array<keyof LabwareFields> = ['wellBottomShape', 'wellDepth']
   const { values, errors, touched } = useFormikContext<LabwareFields>()
   const label =
-    values.labwareType === 'tipRack' ? 'Tip Length' : 'Well Bottom & Depth'
+    values.labwareType === 'tipRack'
+      ? 'Tip Length'
+      : `${capitalize(getLabwareName(values, false))} Bottom & Depth`
   return (
     <div className={styles.new_definition_section}>
       <SectionBody label={label} id="WellBottomAndDepth">


### PR DESCRIPTION
# Overview

Closes #7982

# Changelog


# Review requests

- Should work correctly for custom tubes, tip racks, well plates, etc
- ~Should still be hidden for non-custom tubes (aka Opentrons tube racks)~ NOPE should still be **shown**. So, shown for Opentrons tube racks, shown for custom tube racks.

# Risk assessment

low, lc only