### PR TITLE
feat(labware-creator): show Grid section for custom tube racks

### DIFF
--- a/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Grid.test.tsx
@@ -130,18 +130,6 @@ describe('Grid', () => {
     )
     expect(container.firstChild).toBe(null)
   })
-  it('should NOT render when the labware type is tubeRack', () => {
-    const { container } = render(
-      wrapInFormik(<Grid />, {
-        ...formikConfig,
-        initialValues: {
-          ...formikConfig.initialValues,
-          labwareType: 'tubeRack',
-        },
-      })
-    )
-    expect(container.firstChild).toBe(null)
-  })
 
   it('should not render when all fields are hidden', () => {
     when(isEveryFieldHiddenMock)

--- a/labware-library/src/labware-creator/components/sections/Grid.tsx
+++ b/labware-library/src/labware-creator/components/sections/Grid.tsx
@@ -48,8 +48,7 @@ export const Grid = (): JSX.Element | null => {
   const { values, errors, touched } = useFormikContext<LabwareFields>()
   if (
     isEveryFieldHidden(fieldList, values) ||
-    (values.labwareType != null &&
-      ['aluminumBlock', 'tubeRack'].includes(values.labwareType))
+    (values.labwareType != null && values.labwareType === 'aluminumBlock')
   ) {
     return null
   }


### PR DESCRIPTION
# Overview

Closes #7979

# Changelog


# Review requests

- Custom tube rack should show Grid section
- Should say "tubes" not "wells" etc
- Non-custom tube rack should still hide Grid section

# Risk assessment

Low, LC-only