### PR TITLE
fix(robot-server): Don't hide exceptions in startup/shutdown handlers

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -48,6 +48,17 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 #
 # "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
 # See github.com/encode/starlette/issues/1138.
+#
+# todo(mm, 2021-07-08): Figure out how to run the server with Python development
+# mode enabled, to expose more errors and warnings.
+#   * Using a Makefile target-specific variable to set PYTHONDEVMODE=1
+#     doesn't work because it applies the variable to the whole `pipenv run`
+#     command, and we only want our inner server process running under dev mode,
+#     not the outer pipenv process.
+#   * Adding PYTHONDEVMODE=1 to the .env file specified by
+#     OT_ROBOT_SERVER_DOT_ENV_PATH doesn't work because that's read too late.
+#   * Doing `pipenv run env PYTHONDEVMODE=1 uvicorn ...` works, except it's
+#     probably POSIX-only.
 run_dev ?= uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --lifespan on --reload
 
 .PHONY: all

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -45,7 +45,10 @@ ot_sources := $(ot_py_sources)
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'robot_server/**/.mypy_cache'
 
 # Uvicorn command to run the robot server in dev mode.
-run_dev ?= uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --reload
+#
+# "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
+# See github.com/encode/starlette/issues/1138.
+run_dev ?= uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --lifespan on --reload
 
 .PHONY: all
 all: clean wheel

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -47,7 +47,7 @@ clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__p
 # Uvicorn command to run the robot server in dev mode.
 #
 # "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
-# See github.com/encode/starlette/issues/1138.
+# See github.com/encode/starlette/issues/1138, fixed in Starlette v0.16.0?
 #
 # todo(mm, 2021-07-08): Figure out how to run the server with Python development
 # mode enabled, to expose more errors and warnings.

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -6,7 +6,9 @@ After=opentrons-status-leds.service
 
 [Service]
 Type=notify
-ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto
+# "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
+# See github.com/encode/starlette/issues/1138.
+ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto --lifespan on
 # Stop the button blinking
 ExecStartPost=systemctl stop opentrons-gpio-setup.service
 Environment=OT_SMOOTHIE_ID=AMA RUNNING_ON_PI=true

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -7,7 +7,7 @@ After=opentrons-status-leds.service
 [Service]
 Type=notify
 # "--lifespan on" ensures errors in startup and shutdown handlers won't be hidden.
-# See github.com/encode/starlette/issues/1138.
+# See github.com/encode/starlette/issues/1138, fixed in Starlette v0.16.0?
 ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto --lifespan on
 # Stop the button blinking
 ExecStartPost=systemctl stop opentrons-gpio-setup.service


### PR DESCRIPTION
# Overview

This PR is a first step to resolving #8051. It fixes one of several reasons why errors in startup and shutdown handlers are being hidden from view. It doesn't fix the underlying errors.

# Changelog

* Work around a Starlette bug that was hiding exceptions in startup and shutdown handlers.
    * The workaround is to run Uvicorn with `--lifespan on`, overriding the default of `--lifespan auto`.
    * For details on why this is necessary, see encode/starlette#1138.
    * If you run `make dev` and then exit with `^C`, you should now see an exception in our shutdown handler: `AttributeError: 'Depends' object has no attribute 'sync'`.
    * This exception existed before, but was being hidden. With this PR, it's exposed.
* Record a todo for `make dev` to run the server with [Python development mode](https://docs.python.org/3/library/devmode.html) enabled.
    * I think this is a good idea because it exposes other problems. For example, if you manually try it with `pipenv run env PYTHONDEVMODE=1 uvicorn "robot_server:app" --host localhost --port 31950 --ws wsproto --lifespan on`, you can see an additional `IndexError` that's otherwise hidden.
    * (A lot of potential problems are also revealed when we run the *test suite* in dev mode. See #8079.)
    * However, I couldn't figure out how to integrate this into the Makefile, so I left it as a todo. See the comment for details.

# Review requests

* Please test this on a real robot. Make sure robot-server still comes up and serves basic requests like toggling the deck lights.
* Any ideas for resolving the Python development mode todo comment?

# Risk assessment

Despite the small diff, this is relatively risky. Whereas exceptions raised from our startup handlers used to be ignored, they will now prevent robot-server from starting.

This feels a little precarious because there currently *are* errors in our startup handlers—which are only not raising exceptions because of unrelated error propagation problems, described in #8051.

IMO, this risk is acceptable because:

* Failures will be obvious.
* The alternative, continuing to run the server despite startup errors, is not really any less precarious.