### PR TITLE
feat(labware-creator): added tube brand and rack brand

### DIFF
--- a/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
@@ -145,15 +145,14 @@ context('Tubes and Rack', () => {
         ).should('exist')
         cy.contains('close').click({ force: true })
 
-        // Brand info
-        cy.contains('Brand is required').should('exist')
-        cy.get("input[name='brand']").type('TestPro')
+        // Brand field should not be shown for Opentrons tube rack (aka non-custom)
         cy.contains('Brand is required').should('not.exist')
-        cy.get("input[name='brandId']").type('001')
 
         // File info
-        cy.get("input[placeholder='TestPro 6 Tube Rack 10 µL']").should('exist')
-        cy.get("input[placeholder='testpro_6_tuberack_10ul']").should('exist')
+        cy.get("input[placeholder='Opentrons 6 Tube Rack 10 µL']").should(
+          'exist'
+        )
+        cy.get("input[placeholder='opentrons_6_tuberack_10ul']").should('exist')
 
         // Test pipette
         cy.contains('Test Pipette is required').should('exist')
@@ -320,17 +319,16 @@ context('Tubes and Rack', () => {
         ).should('exist')
         cy.contains('close').click({ force: true })
 
-        // Brand info
-        cy.contains('Brand is required').should('exist')
-        cy.get("input[name='brand']").type('TestPro')
+        // Brand field should not be shown for Opentrons tube rack (aka non-custom)
         cy.contains('Brand is required').should('not.exist')
-        cy.get("input[name='brandId']").type('001')
 
         // File info
-        cy.get("input[placeholder='TestPro 15 Tube Rack 10 µL']").should(
+        cy.get("input[placeholder='Opentrons 15 Tube Rack 10 µL']").should(
           'exist'
         )
-        cy.get("input[placeholder='testpro_15_tuberack_10ul']").should('exist')
+        cy.get("input[placeholder='opentrons_15_tuberack_10ul']").should(
+          'exist'
+        )
 
         // Test pipette
         cy.contains('Test Pipette is required').should('exist')
@@ -497,17 +495,16 @@ context('Tubes and Rack', () => {
         ).should('exist')
         cy.contains('close').click({ force: true })
 
-        // Brand info
-        cy.contains('Brand is required').should('exist')
-        cy.get("input[name='brand']").type('TestPro')
+        // Brand field should not be shown for Opentrons tube rack (aka non-custom)
         cy.contains('Brand is required').should('not.exist')
-        cy.get("input[name='brandId']").type('001')
 
         // File info
-        cy.get("input[placeholder='TestPro 24 Tube Rack 10 µL']").should(
+        cy.get("input[placeholder='Opentrons 24 Tube Rack 10 µL']").should(
           'exist'
         )
-        cy.get("input[placeholder='testpro_24_tuberack_10ul']").should('exist')
+        cy.get("input[placeholder='opentrons_24_tuberack_10ul']").should(
+          'exist'
+        )
 
         // Test pipette
         cy.contains('Test Pipette is required').should('exist')

--- a/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.tsx.snap
+++ b/labware-library/src/components/LabwareList/__tests__/__snapshots__/LabwareList.test.tsx.snap
@@ -469,6 +469,16 @@ exports[`LabwareList component renders 1`] = `
         },
         "groups": Array [
           Object {
+            "brand": Object {
+              "brand": "tube brand here",
+              "brandId": Array [
+                "tube123",
+                "other123",
+              ],
+              "links": Array [
+                "http://www.example.com/tube123",
+              ],
+            },
             "metadata": Object {},
             "wells": Array [
               "A1",

--- a/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
+++ b/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
@@ -35,3 +35,39 @@ Object {
   "wellYDimension": "71.88",
 }
 `;
+
+exports[`labwareDefToFields fixture_24_tuberack should match snapshot 1`] = `
+Object {
+  "aluminumBlockChildType": null,
+  "aluminumBlockType": null,
+  "brand": "Opentrons",
+  "brandId": "649020",
+  "displayName": null,
+  "footprintXDimension": "127.75",
+  "footprintYDimension": "85.5",
+  "gridColumns": "6",
+  "gridOffsetX": "18.21",
+  "gridOffsetY": "10.07",
+  "gridRows": "4",
+  "gridSpacingX": "19.89",
+  "gridSpacingY": "19.28",
+  "groupBrand": "tube brand here",
+  "groupBrandId": "tube123,other123",
+  "handPlacedTipFit": null,
+  "homogeneousWells": "true",
+  "labwareType": "tubeRack",
+  "labwareZDimension": "84",
+  "loadName": null,
+  "pipetteName": null,
+  "regularColumnSpacing": "true",
+  "regularRowSpacing": "true",
+  "tubeRackInsertLoadName": null,
+  "wellBottomShape": null,
+  "wellDepth": "42",
+  "wellDiameter": "8.5",
+  "wellShape": "circular",
+  "wellVolume": "2000",
+  "wellXDimension": null,
+  "wellYDimension": null,
+}
+`;

--- a/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
+++ b/labware-library/src/labware-creator/__tests__/__snapshots__/labwareDefToFields.test.ts.snap
@@ -15,6 +15,8 @@ Object {
   "gridRows": "1",
   "gridSpacingX": "9.09",
   "gridSpacingY": null,
+  "groupBrand": undefined,
+  "groupBrandId": undefined,
   "handPlacedTipFit": null,
   "homogeneousWells": "true",
   "labwareType": "reservoir",

--- a/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.ts
+++ b/labware-library/src/labware-creator/__tests__/labwareDefToFields.test.ts
@@ -1,12 +1,15 @@
 import { labwareDefToFields } from '../labwareDefToFields'
-import _fixture96Plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _fixture12Trough from '@opentrons/shared-data/labware/fixtures/2/fixture_12_trough.json'
+import _fixture24Tuberack from '@opentrons/shared-data/labware/fixtures/2/fixture_24_tuberack.json'
+import _fixture96Plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import _fixtureIrregularExample1 from '@opentrons/shared-data/labware/fixtures/2/fixture_irregular_example_1.json'
+
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 const fixture96Plate = _fixture96Plate as LabwareDefinition2
 const fixture12Trough = _fixture12Trough as LabwareDefinition2
 const fixtureIrregularExample1 = _fixtureIrregularExample1 as LabwareDefinition2
+const fixture24Tuberack = _fixture24Tuberack as LabwareDefinition2
 
 jest.mock('../../definitions')
 
@@ -72,5 +75,18 @@ describe('labwareDefToFields', () => {
     const def = fixtureIrregularExample1
     const result = labwareDefToFields(def)
     expect(result).toEqual(null)
+  })
+
+  it('fixture_24_tuberack should match snapshot', () => {
+    const def = fixture24Tuberack
+    const result = labwareDefToFields(def)
+
+    expect(result?.labwareType).toEqual('tubeRack')
+    expect(result?.brand).toBe('Opentrons')
+    expect(result?.brandId).toBe('649020')
+    expect(result?.groupBrand).toBe('tube brand here')
+    expect(result?.groupBrandId).toBe('tube123,other123')
+
+    expect(result).toMatchSnapshot()
   })
 })

--- a/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
@@ -24,7 +24,10 @@ describe('Description', () => {
     }
 
     when(isEveryFieldHiddenMock)
-      .calledWith(['brand', 'brandId', 'groupBrand', 'groupBrandId'], formikConfig.initialValues)
+      .calledWith(
+        ['brand', 'brandId', 'groupBrand', 'groupBrandId'],
+        formikConfig.initialValues
+      )
       .mockReturnValue(false)
   })
 
@@ -43,8 +46,8 @@ describe('Description', () => {
   })
 
   it('should show tube brand when an Opentrons Tube rack is selected', () => {
-    formikConfig.initialValues.labwareType='tubeRack'
-    formikConfig.initialValues.tubeRackInsertLoadName='6tubes'
+    formikConfig.initialValues.labwareType = 'tubeRack'
+    formikConfig.initialValues.tubeRackInsertLoadName = '6tubes'
     render(wrapInFormik(<Description />, formikConfig))
     expect(screen.getByRole('heading')).toHaveTextContent(/description/i)
 
@@ -54,13 +57,15 @@ describe('Description', () => {
   })
 
   it('should show tube brand and rack brand when Custom Tube rack is selected', () => {
-    formikConfig.initialValues.labwareType='tubeRack'
-    formikConfig.initialValues.tubeRackInsertLoadName='customTubeRack'
+    formikConfig.initialValues.labwareType = 'tubeRack'
+    formikConfig.initialValues.tubeRackInsertLoadName = 'customTubeRack'
     render(wrapInFormik(<Description />, formikConfig))
     expect(screen.getByRole('heading')).toHaveTextContent(/description/i)
 
     screen.getByRole('textbox', { name: /^tube brand$/i })
-    expect(screen.getAllByRole('textbox', { name: /manufacturer\/catalog #/i })).toHaveLength(2)
+    expect(
+      screen.getAllByRole('textbox', { name: /manufacturer\/catalog #/i })
+    ).toHaveLength(2)
     screen.getByRole('textbox', { name: /^rack brand$/i })
   })
 

--- a/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { when } from 'jest-when'
+import { resetAllWhenMocks, when } from 'jest-when'
 import { FormikConfig } from 'formik'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
@@ -24,12 +24,13 @@ describe('Description', () => {
     }
 
     when(isEveryFieldHiddenMock)
-      .calledWith(['brand', 'brandId'], formikConfig.initialValues)
+      .calledWith(['brand', 'brandId', 'groupBrand', 'groupBrandId'], formikConfig.initialValues)
       .mockReturnValue(false)
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+    resetAllWhenMocks()
   })
 
   it('should render fields when fields are visible', () => {
@@ -39,6 +40,28 @@ describe('Description', () => {
     // TODO IMMEDIATELY: changes from 7715 ???
     screen.getByRole('textbox', { name: /^brand$/i })
     screen.getByRole('textbox', { name: /manufacturer\/catalog #/i })
+  })
+
+  it('should show tube brand when an Opentrons Tube rack is selected', () => {
+    formikConfig.initialValues.labwareType='tubeRack'
+    formikConfig.initialValues.tubeRackInsertLoadName='6tubes'
+    render(wrapInFormik(<Description />, formikConfig))
+    expect(screen.getByRole('heading')).toHaveTextContent(/description/i)
+
+    screen.getByRole('textbox', { name: /^tube brand$/i })
+    screen.getByRole('textbox', { name: /manufacturer\/catalog #/i })
+    expect(screen.queryByRole('textbox', { name: /^rack brand$/i })).toBeNull()
+  })
+
+  it('should show tube brand and rack brand when Custom Tube rack is selected', () => {
+    formikConfig.initialValues.labwareType='tubeRack'
+    formikConfig.initialValues.tubeRackInsertLoadName='customTubeRack'
+    render(wrapInFormik(<Description />, formikConfig))
+    expect(screen.getByRole('heading')).toHaveTextContent(/description/i)
+
+    screen.getByRole('textbox', { name: /^tube brand$/i })
+    expect(screen.getAllByRole('textbox', { name: /manufacturer\/catalog #/i })).toHaveLength(2)
+    screen.getByRole('textbox', { name: /^rack brand$/i })
   })
 
   it('should render alert when error is present', () => {

--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -8,16 +8,43 @@ import { SectionBody } from './SectionBody'
 
 import styles from '../../styles.css'
 
-const Content = (): JSX.Element => (
-  <div className={styles.flex_row}>
-    <div className={styles.brand_column}>
-      <TextField name="brand" />
-    </div>
-    <div className={styles.brand_id_column}>
-      <TextField name="brandId" caption="Separate multiple by comma" />
-    </div>
-  </div>
-)
+interface Props {
+  values: LabwareFields
+}
+const Content = (props: Props): JSX.Element => {
+//  if (props.values.labwareType === 'tipRack') {
+  const labwareType = props.values.labwareType
+  const isOpentronsTubeRack = labwareType === 'tubeRack' && props.values.tubeRackInsertLoadName !== 'customTubeRack'
+  const showBrand = !isOpentronsTubeRack
+  const showGroupBrand = labwareType === 'tubeRack'
+    return (
+      <>
+
+      {
+          showBrand &&
+          <div className={styles.flex_row}>
+            <div className={styles.brand_column}>
+              <TextField name="brand" />
+            </div>
+            <div className={styles.brand_id_column}>
+              <TextField name="brandId" caption="Separate multiple by comma" />
+            </div>
+          </div>
+          }
+        {
+        showGroupBrand &&
+        <div className={styles.flex_row}>
+          <div className={styles.brand_column}>
+            <TextField name="groupBrand" />
+          </div>
+          <div className={styles.brand_id_column}>
+            <TextField name="groupBrandId" caption="Separate multiple by comma" />
+          </div>
+        </div>
+        }
+      </>
+    )
+}
 
 export const Description = (): JSX.Element | null => {
   const fieldList: Array<keyof LabwareFields> = ['brand', 'brandId']
@@ -30,7 +57,7 @@ export const Description = (): JSX.Element | null => {
   return (
     <SectionBody label="Description" id="Description">
       <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
-      <Content />
+      <Content values={values}/>
     </SectionBody>
   )
 }

--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -13,36 +13,38 @@ interface Props {
 }
 const Content = (props: Props): JSX.Element => {
   const labwareType = props.values.labwareType
-  const isOpentronsTubeRack = labwareType === 'tubeRack' && props.values.tubeRackInsertLoadName !== 'customTubeRack'
+  const isOpentronsTubeRack =
+    labwareType === 'tubeRack' &&
+    props.values.tubeRackInsertLoadName !== 'customTubeRack'
   const showBrand = !isOpentronsTubeRack
   const showGroupBrand = labwareType === 'tubeRack'
-    return (
-      <>
-
-      {
-          showBrand &&
-          <div className={styles.flex_row}>
-            <div className={styles.brand_column}>
-              <TextField name="brand" />
-            </div>
-            <div className={styles.brand_id_column}>
-              <TextField name="brandId" caption="Separate multiple by comma" />
-            </div>
+  return (
+    <>
+      {showBrand && (
+        <div className={styles.flex_row}>
+          <div className={styles.brand_column}>
+            <TextField name="brand" />
           </div>
-          }
-        {
-        showGroupBrand &&
+          <div className={styles.brand_id_column}>
+            <TextField name="brandId" caption="Separate multiple by comma" />
+          </div>
+        </div>
+      )}
+      {showGroupBrand && (
         <div className={styles.flex_row}>
           <div className={styles.brand_column}>
             <TextField name="groupBrand" />
           </div>
           <div className={styles.brand_id_column}>
-            <TextField name="groupBrandId" caption="Separate multiple by comma" />
+            <TextField
+              name="groupBrandId"
+              caption="Separate multiple by comma"
+            />
           </div>
         </div>
-        }
-      </>
-    )
+      )}
+    </>
+  )
 }
 
 export const Description = (): JSX.Element | null => {
@@ -56,7 +58,7 @@ export const Description = (): JSX.Element | null => {
   return (
     <SectionBody label="Description" id="Description">
       <FormAlerts touched={touched} errors={errors} fieldList={fieldList} />
-      <Content values={values}/>
+      <Content values={values} />
     </SectionBody>
   )
 }

--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -12,7 +12,6 @@ interface Props {
   values: LabwareFields
 }
 const Content = (props: Props): JSX.Element => {
-//  if (props.values.labwareType === 'tipRack') {
   const labwareType = props.values.labwareType
   const isOpentronsTubeRack = labwareType === 'tubeRack' && props.values.tubeRackInsertLoadName !== 'customTubeRack'
   const showBrand = !isOpentronsTubeRack

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -214,6 +214,8 @@ export const tubeRackInsertOptions: Options = [
   },
 ]
 
+export const DEFAULT_TUBE_BRAND = 'Opentrons'
+
 // fields that get auto-filled when tubeRackInsertLoadName is selected
 // NOTE: these are duplicate data derived from tube rack defs, but
 // are intentionally duplicated to be the source of truth about the

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -123,6 +123,8 @@ export interface LabwareFields {
 
   brand: string | null | undefined
   brandId: string | null | undefined // comma-separated values
+  groupBrand: string | null | undefined
+  groupBrandId: string | null | undefined
 
   loadName: string | null | undefined
   displayName: string | null | undefined
@@ -141,6 +143,7 @@ export interface ProcessedLabwareFields {
   aluminumBlockType: string
   aluminumBlockChildType: string | null
   handPlacedTipFit: string | null
+
 
   // tubeRackSides: string[], // eg, []
   footprintXDimension: number
@@ -172,6 +175,8 @@ export interface ProcessedLabwareFields {
 
   brand: string
   brandId: string[]
+  groupBrand: string
+  groupBrandId: string[]
 
   // if loadName or displayName are left blank, Yup schema generates them
   loadName: string
@@ -380,6 +385,8 @@ export const getDefaultFormState = (): LabwareFields => ({
 
   brand: null,
   brandId: null,
+  groupBrand: null,
+  groupBrandId: null,
 
   loadName: null,
   displayName: null,
@@ -415,6 +422,8 @@ export const LABELS: Record<keyof LabwareFields, string> = {
   gridOffsetY: 'Y Offset (Yo)',
   brand: 'Brand',
   brandId: 'Manufacturer/Catalog #',
+  groupBrand: 'Tube Brand',
+  groupBrandId: 'Manufacturer/Catalog #',
   displayName: 'Display Name',
   loadName: 'API Load Name',
   pipetteName: 'Test Pipette',
@@ -428,7 +437,9 @@ export const getLabel = (
     return `Are all your ${getLabwareName(
       values,
       true
-    )} the same shape and size?`
+    )} the same shape and size?`}
+  else if (name === 'brand' && values.labwareType==='tubeRack'){
+    return 'Rack Brand'
   }
   return LABELS[name]
 }

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -144,7 +144,6 @@ export interface ProcessedLabwareFields {
   aluminumBlockChildType: string | null
   handPlacedTipFit: string | null
 
-
   // tubeRackSides: string[], // eg, []
   footprintXDimension: number
   footprintYDimension: number
@@ -437,8 +436,8 @@ export const getLabel = (
     return `Are all your ${getLabwareName(
       values,
       true
-    )} the same shape and size?`}
-  else if (name === 'brand' && values.labwareType==='tubeRack'){
+    )} the same shape and size?`
+  } else if (name === 'brand' && values.labwareType === 'tubeRack') {
     return 'Rack Brand'
   }
   return LABELS[name]

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -124,7 +124,7 @@ export interface LabwareFields {
   brand: string | null | undefined
   brandId: string | null | undefined // comma-separated values
   groupBrand: string | null | undefined
-  groupBrandId: string | null | undefined
+  groupBrandId: string | null | undefined // comma-separated values
 
   loadName: string | null | undefined
   displayName: string | null | undefined

--- a/labware-library/src/labware-creator/formSelectors.ts
+++ b/labware-library/src/labware-creator/formSelectors.ts
@@ -8,6 +8,7 @@ import {
   DISPLAY_VOLUME_UNITS,
   tubeRackAutofills,
   labwareTypeAutofills,
+  DEFAULT_TUBE_BRAND,
 } from './fields'
 import type { LabwareFields } from './fields'
 // TODO(Ian, 2019-07-24): consolidate `tubeRackAutofills/aluminumBlockAutofills`-getting logic btw here and makeAutofillOnChange
@@ -80,12 +81,21 @@ const _valuesToCreateNameArgs = (values: LabwareFields): any => {
   const gridColumns = Number(values.gridColumns) || 1
   const brand = (values.brand || '').trim()
 
+  let brandDefault: string | undefined
+  // Opentrons tube racks need to default their brand
+  if (
+    values.labwareType === 'tubeRack' &&
+    values.tubeRackInsertLoadName !== 'customTubeRack'
+  ) {
+    brandDefault = DEFAULT_TUBE_BRAND
+  }
+
   return {
     gridColumns,
     gridRows,
     displayCategory: values.labwareType || '',
     displayVolumeUnits: DISPLAY_VOLUME_UNITS,
-    brandName: brand === '' ? undefined : brand,
+    brandName: brand === '' ? brandDefault : brand,
     totalLiquidVolume: Number(values.wellVolume) || 0,
   }
 }

--- a/labware-library/src/labware-creator/labwareDefToFields.ts
+++ b/labware-library/src/labware-creator/labwareDefToFields.ts
@@ -1,5 +1,8 @@
 import { getUniqueWellProperties } from '../labwareInference'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  LabwareWellGroup,
+} from '@opentrons/shared-data'
 import type { LabwareFields, BooleanString } from './fields'
 
 // NOTE: this is just String() with some typing for flow
@@ -75,6 +78,9 @@ export function labwareDefToFields(
     return null
   }
 
+  const firstGroup: LabwareWellGroup | undefined = def.groups[0]
+  const firstGroupBrand = firstGroup?.brand ?? null
+
   return {
     // NOTE: Ian 2019-08-26 these LC-specific fields cannot easily/reliably be inferred
     tubeRackInsertLoadName: null,
@@ -118,6 +124,8 @@ export function labwareDefToFields(
 
     brand: def.brand.brand,
     brandId: def.brand.brandId != null ? def.brand.brandId.join(',') : null, // comma-separated values
+    groupBrand: firstGroupBrand?.brand ?? undefined,
+    groupBrandId: firstGroupBrand?.brandId?.join(',') ?? undefined,
 
     // NOTE: intentionally null these fields, do not import them
     loadName: null,

--- a/labware-library/src/labware-creator/labwareDefToFields.ts
+++ b/labware-library/src/labware-creator/labwareDefToFields.ts
@@ -79,7 +79,7 @@ export function labwareDefToFields(
   }
 
   const firstGroup: LabwareWellGroup | undefined = def.groups[0]
-  const firstGroupBrand = firstGroup?.brand ?? null
+  const firstGroupBrand = firstGroup?.brand
 
   return {
     // NOTE: Ian 2019-08-26 these LC-specific fields cannot easily/reliably be inferred
@@ -124,7 +124,7 @@ export function labwareDefToFields(
 
     brand: def.brand.brand,
     brandId: def.brand.brandId != null ? def.brand.brandId.join(',') : null, // comma-separated values
-    groupBrand: firstGroupBrand?.brand ?? undefined,
+    groupBrand: firstGroupBrand?.brand,
     groupBrandId: firstGroupBrand?.brandId?.join(',') ?? undefined,
 
     // NOTE: intentionally null these fields, do not import them

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -5,6 +5,7 @@ import {
   labwareTypeOptions,
   wellBottomShapeOptions,
   wellShapeOptions,
+  DEFAULT_TUBE_BRAND,
   IRREGULAR_LABWARE_ERROR,
   LABWARE_TOO_SMALL_ERROR,
   LABWARE_TOO_LARGE_ERROR,
@@ -15,6 +16,7 @@ import {
   MAX_Z_DIMENSION,
   MIN_X_DIMENSION,
   MIN_Y_DIMENSION,
+  LabwareFields,
 } from './fields'
 import type { ProcessedLabwareFields } from './fields'
 
@@ -61,6 +63,18 @@ const nameExistsError = (nameName: string): string =>
   `This ${nameName} already exists in the Opentrons default labware library. Please edit the ${nameName} to make it unique.`
 
 // NOTE: all IRREGULAR_LABWARE_ERROR messages will be converted to a special 'error' Alert
+
+const matchCustomTubeRack = (
+  labwareType: LabwareFields['labwareType'],
+  tubeRackInsertLoadName: LabwareFields['tubeRackInsertLoadName']
+): boolean =>
+  labwareType === 'tubeRack' && tubeRackInsertLoadName === 'customTubeRack'
+
+const matchNonCustomTubeRack = (
+  labwareType: LabwareFields['labwareType'],
+  tubeRackInsertLoadName: LabwareFields['tubeRackInsertLoadName']
+): boolean =>
+  labwareType === 'tubeRack' && tubeRackInsertLoadName !== 'customTubeRack'
 
 export const labwareFormSchemaBaseObject = Yup.object({
   labwareType: requiredString(LABELS.labwareType).oneOf(
@@ -201,8 +215,13 @@ export const labwareFormSchemaBaseObject = Yup.object({
     then: requiredPositiveNumber(LABELS.wellYDimension),
     otherwise: Yup.mixed().nullable(),
   }),
-
-  brand: requiredString(LABELS.brand),
+  // non-custom tuberacks (aka Opentrons tube racks) default to "Opentrons" brand,
+  // and user cannot see or override brand (aka "rack brand")
+  brand: Yup.mixed().when(['labwareType', 'tubeRackInsertLoadName'], {
+    is: matchNonCustomTubeRack,
+    then: Yup.mixed().nullable(), // defaulted to DEFAULT_TUBE_BRAND in form-level transform below
+    otherwise: requiredString(LABELS.brand),
+  }),
   // TODO(mc, 2020-06-02): should this be Yup.array() instead of mixed?
   brandId: Yup.mixed()
     .nullable()
@@ -217,8 +236,12 @@ export const labwareFormSchemaBaseObject = Yup.object({
           .map(s => s.trim())
           .filter(Boolean)
     ),
-
-  groupBrand: requiredString(LABELS.groupBrand),
+  // group brand (aka "tube brand") is only required for custom tube racks
+  groupBrand: Yup.mixed().when(['labwareType', 'tubeRackInsertLoadName'], {
+    is: matchCustomTubeRack,
+    then: requiredString(LABELS.groupBrand),
+    otherwise: Yup.mixed().nullable(),
+  }),
   // TODO(mc, 2020-06-02): should this be Yup.array() instead of mixed?
   groupBrandId: Yup.mixed()
     .nullable()
@@ -267,14 +290,26 @@ export const labwareFormSchemaBaseObject = Yup.object({
 export const labwareFormSchema: Yup.Schema<ProcessedLabwareFields> = labwareFormSchemaBaseObject.transform(
   (currentValue, originalValue) => {
     // "form-level" transforms
-    // NOTE: the currentValue does NOT have transforms applied :(
+    // NOTE: the currentValue does NOT have field-level transforms applied :(
     // TODO: these results are not validated, ideally I could do these transforms in the fields
+
+    // Yup runs transforms before defaults. In order for brand defaulting to work for displayName/loadName
+    // creation, we can't do .default() to the brand field, but need to default it here.
+    const brand = matchNonCustomTubeRack(
+      currentValue.labwareType,
+      currentValue.tubeRackInsertLoadName
+    )
+      ? DEFAULT_TUBE_BRAND
+      : currentValue.brand
+
+    const nextValues = { ...currentValue, brand }
+
     const displayName =
       currentValue.displayName == null || currentValue.displayName.trim() === ''
-        ? getDefaultDisplayName(currentValue)
+        ? getDefaultDisplayName(nextValues)
         : currentValue.displayName
 
-    const loadName = currentValue.loadName || getDefaultLoadName(currentValue)
+    const loadName = currentValue.loadName || getDefaultLoadName(nextValues)
 
     return {
       ...currentValue,

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -218,6 +218,22 @@ export const labwareFormSchemaBaseObject = Yup.object({
           .filter(Boolean)
     ),
 
+  groupBrand: requiredString(LABELS.groupBrand),
+  // TODO(mc, 2020-06-02): should this be Yup.array() instead of mixed?
+  groupBrandId: Yup.mixed()
+    .nullable()
+    .transform(
+      (
+        currentValue: string | null | undefined,
+        originalValue: string | null | undefined
+      ): ProcessedLabwareFields['groupBrandId'] =>
+        (currentValue || '')
+          .trim()
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+    ),
+
   loadName: Yup.string()
     .nullable()
     .label(LABELS.loadName)

--- a/shared-data/labware/fixtures/2/fixture_24_tuberack.json
+++ b/shared-data/labware/fixtures/2/fixture_24_tuberack.json
@@ -277,6 +277,11 @@
         "C6",
         "D6"
       ],
+      "brand": {
+        "brand": "tube brand here",
+        "brandId": ["tube123", "other123"],
+        "links": ["http://www.example.com/tube123"]
+      },
       "metadata": {}
     }
   ],


### PR DESCRIPTION

# Overview

Adds tube rack and brand rack to LC, closes #7986 

# Changelog

-added groupBrandId and groupBrand

# Review requests

- `brand` and `brandId` continue to work the same as for any other labware, but when Tube Rack is selected, the label is `Rack Brand` not just `Brand`
- Add new fields `groupBrand` and `groupBrandId`. They are required for tubeRack labware type, but should be null for all other labware types
- Wire up `groupBrand` and `groupBrandId` into `fieldsToLabware` and `labwareDefToFields`
- For non-custom tube racks, only "Tube Brand" field (+ corresponding brand id) should be visible, and "Rack Brand" (with its own corresponding brand id) should not be shown.
- In contrast, for custom tube racks, both Rack Branch and Tube Brand should be shown (plus both fields' corresponding brand ID field)
- e2e selectors added as needed

# Risk assessment

medium, LC only