### PR TITLE
chore(python): upgrade decoy for pytest plugin, `signature` support

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -32,7 +32,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.5.0"
+decoy = "~=1.6.1"
 
 [packages]
 aionotify = "==0.2.0"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -32,7 +32,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.6.1"
+decoy = "~=1.6.2"
 
 [packages]
 aionotify = "==0.2.0"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c144019e96c5ae96889ad59f16807b4e1c4cedf89acfc081d13096aa2072f4a9"
+            "sha256": "7290d9516778cc532375a96226f4d5212024488ac274e6262fa8c6f6e2f231f0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -298,6 +298,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
+                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.1"
+        },
         "clint": {
             "hashes": [
                 "sha256:05224c32b1075563d0b16d0015faaf9da43aa214e4a2140e51f08789e7a4c5aa"
@@ -352,11 +360,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:949e769cca522aefd6ed2759b5b174fff26341c01e8cd660bc6b9c55e7188b9a",
-                "sha256:c4ef05af5a5cc0193f27159d8eb8678a8b20f58e3de0683042a3aadc1e0c627f"
+                "sha256:524789c7fb3c39905d2c24b33412dbf9a9c0e1d3a4b4aa79e40cf2cdcc6e2c65",
+                "sha256:f0c39d2b9fbfb44b46fd1dffd8b8275b7b9b2e9f280b7925a77ef9a66734ac4c"
             ],
             "index": "pypi",
-            "version": "==1.5.0"
+            "version": "==1.6.1"
         },
         "dill": {
             "hashes": [
@@ -418,11 +426,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.10"
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
         },
         "imagesize": {
             "hashes": [
@@ -835,11 +843,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.25.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
         },
         "requests-toolbelt": {
             "hashes": [

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7290d9516778cc532375a96226f4d5212024488ac274e6262fa8c6f6e2f231f0"
+            "sha256": "a00b9ace936b97e7f3e2ddf7d111d2550c0ad38750c225b26d9019d64e7c30cf"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,9 +26,9 @@
         },
         "apply-defaults": {
             "hashes": [
-                "sha256:1ce26326a61d8773d38a9726a345c6525a91a6120d7333af79ad792dacb6246c"
+                "sha256:3773de3491b94c0fe44310f1a85888389cdc71e1544b343bce0d2bd6991acea5"
             ],
-            "version": "==0.1.4"
+            "version": "==0.1.6"
         },
         "attrs": {
             "hashes": [
@@ -273,11 +273,11 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:6123ddc1052673e52bab52cdc955bcb57a015264a1c57d37bea2f6b817af0125",
-                "sha256:98b3170739e5e83dd9dc19633f074727ad848cbedb6026708c8ac2d3b697a433"
+                "sha256:306483a5a9795474160ad57fce3ddd1b50551e981eed8e15a582d34cef28aafa",
+                "sha256:ae976d7174bba988c0b632def82fdc94235756edfb14e6558a9c5be555c9fb78"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "c445fee": {
             "editable": true,
@@ -300,11 +300,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
-                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
+                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
+                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.1"
+            "version": "==2.0.3"
         },
         "clint": {
             "hashes": [
@@ -360,11 +360,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:524789c7fb3c39905d2c24b33412dbf9a9c0e1d3a4b4aa79e40cf2cdcc6e2c65",
-                "sha256:f0c39d2b9fbfb44b46fd1dffd8b8275b7b9b2e9f280b7925a77ef9a66734ac4c"
+                "sha256:b8ae8b707169824af59b04215615a4b0fa0bff4dccc6dde053c2b18824a6271e",
+                "sha256:c605822c4d867acb5d950ce98b51727705ff55ecc7bad544f2b4face3ee69ae0"
             ],
             "index": "pypi",
-            "version": "==1.6.1"
+            "version": "==1.6.2"
         },
         "dill": {
             "hashes": [

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -23,7 +23,6 @@ from functools import partial
 import zipfile
 
 import pytest
-from decoy import Decoy
 
 from opentrons.api.routers import MainRouter
 from opentrons.api import models
@@ -50,12 +49,6 @@ def asyncio_loop_exception_handler(loop):
     loop.set_exception_handler(exception_handler)
     yield
     loop.set_exception_handler(None)
-
-
-@pytest.fixture
-def decoy() -> Decoy:
-    """Get a Decoy state container to clean up stubs after tests."""
-    return Decoy()
 
 
 def state(topic, state):

--- a/api/tests/opentrons/file_runner/test_command_queue_worker.py
+++ b/api/tests/opentrons/file_runner/test_command_queue_worker.py
@@ -22,7 +22,7 @@ from opentrons.file_runner.command_queue_worker import CommandQueueWorker
 @pytest.fixture
 def engine(decoy: Decoy) -> ProtocolEngine:
     """Get a mock ProtocolEngine."""
-    return decoy.create_decoy(spec=ProtocolEngine)
+    return decoy.mock(cls=ProtocolEngine)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/file_runner/test_json_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_json_file_runner.py
@@ -14,27 +14,21 @@ from opentrons.protocols.runner.json_proto.command_translator import CommandTran
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Create a Decoy state container for this test suite."""
-    return Decoy()
-
-
-@pytest.fixture
 def protocol_engine(decoy: Decoy) -> ProtocolEngine:
     """Create a protocol engine fixture."""
-    return decoy.create_decoy(spec=ProtocolEngine)
+    return decoy.mock(cls=ProtocolEngine)
 
 
 @pytest.fixture
 def command_translator(decoy: Decoy) -> CommandTranslator:
     """Create a stubbed command translator fixture."""
-    return decoy.create_decoy(spec=CommandTranslator)
+    return decoy.mock(cls=CommandTranslator)
 
 
 @pytest.fixture
 def command_queue_worker(decoy: Decoy) -> CommandQueueWorker:
     """Create a stubbed command queue worker fixture."""
-    return decoy.create_decoy(spec=CommandQueueWorker)
+    return decoy.mock(cls=CommandQueueWorker)
 
 
 @pytest.fixture
@@ -44,7 +38,7 @@ def file_reader(
     json_protocol: JsonProtocol,
 ) -> JsonFileReader:
     """Create a stubbed JsonFileReader interface."""
-    reader = decoy.create_decoy(spec=JsonFileReader)
+    reader = decoy.mock(cls=JsonFileReader)
 
     decoy.when(reader.read(protocol_file)).then_return(json_protocol)
 

--- a/api/tests/opentrons/file_runner/test_python_file_runner.py
+++ b/api/tests/opentrons/file_runner/test_python_file_runner.py
@@ -19,31 +19,31 @@ def protocol_file(decoy: Decoy) -> ProtocolFile:
 @pytest.fixture
 def python_protocol(decoy: Decoy) -> PythonProtocol:
     """Get a mock PythonProtocol object."""
-    return decoy.create_decoy(spec=PythonProtocol)
+    return decoy.mock(cls=PythonProtocol)
 
 
 @pytest.fixture
 def protocol_context(decoy: Decoy) -> ProtocolContext:
     """Get a mock ProtocolContext API interface."""
-    return decoy.create_decoy(spec=ProtocolContext)
+    return decoy.mock(cls=ProtocolContext)
 
 
 @pytest.fixture
 def file_reader(decoy: Decoy) -> PythonFileReader:
     """Get a mock FileReader."""
-    return decoy.create_decoy(spec=PythonFileReader)
+    return decoy.mock(cls=PythonFileReader)
 
 
 @pytest.fixture
 def context_creator(decoy: Decoy) -> ContextCreator:
     """Get a mock ContextCreator."""
-    return decoy.create_decoy(spec=ContextCreator)
+    return decoy.mock(cls=ContextCreator)
 
 
 @pytest.fixture
 def executor(decoy: Decoy) -> PythonExecutor:
     """Get a mock PythonExecutor."""
-    return decoy.create_decoy(spec=PythonExecutor)
+    return decoy.mock(cls=PythonExecutor)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api_experimental/test_labware.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_labware.py
@@ -10,15 +10,9 @@ from opentrons_shared_data.labware import dev_types
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Get a Decoy test double container."""
-    return Decoy()
-
-
-@pytest.fixture
 def engine_client(decoy: Decoy) -> ProtocolEngineClient:
     """Get a mock instance of a ProtocolEngineClient."""
-    return decoy.create_decoy(spec=ProtocolEngineClient)
+    return decoy.mock(cls=ProtocolEngineClient)
 
 
 @pytest.fixture
@@ -29,7 +23,7 @@ def subject(decoy: Decoy, engine_client: ProtocolEngineClient) -> Labware:
 
 @pytest.fixture
 def labware_definition(
-        minimal_labware_def: dev_types.LabwareDefinition
+    minimal_labware_def: dev_types.LabwareDefinition,
 ) -> LabwareDefinition:
     """Create a labware definition fixture."""
     return LabwareDefinition.parse_obj(minimal_labware_def)

--- a/api/tests/opentrons/protocol_api_experimental/test_pipette_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_pipette_context.py
@@ -8,15 +8,9 @@ from opentrons.protocol_api_experimental import PipetteContext, Labware, Well
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Decoy fixture."""
-    return Decoy()
-
-
-@pytest.fixture
 def engine_client(decoy: Decoy) -> EngineClient:
     """Mock sync client."""
-    return decoy.create_decoy(spec=EngineClient)
+    return decoy.mock(cls=EngineClient)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -25,15 +25,9 @@ from opentrons.protocol_api_experimental import (
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Get a Decoy test-double container fixture."""
-    return Decoy()
-
-
-@pytest.fixture
 def engine_client(decoy: Decoy) -> SyncClient:
     """Get a fake ProtocolEngine client."""
-    return decoy.create_decoy(spec=SyncClient)
+    return decoy.mock(cls=SyncClient)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -15,7 +15,7 @@ from opentrons.protocol_engine.clients.transports import ChildThreadTransport
 @pytest.fixture
 async def engine(decoy: Decoy) -> ProtocolEngine:
     """Get a stubbed out ProtocolEngine."""
-    return decoy.create_decoy(spec=ProtocolEngine)
+    return decoy.mock(cls=ProtocolEngine)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -24,15 +24,9 @@ UUID_MATCHER = matchers.StringMatching(
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Create a Decoy state container for this test suite."""
-    return Decoy()
-
-
-@pytest.fixture
 def transport(decoy: Decoy) -> AbstractSyncTransport:
     """Get a stubbed out AbstractSyncTransport."""
-    return decoy.create_decoy(spec=AbstractSyncTransport)
+    return decoy.mock(cls=AbstractSyncTransport)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/commands/conftest.py
+++ b/api/tests/opentrons/protocol_engine/commands/conftest.py
@@ -12,16 +12,16 @@ from opentrons.protocol_engine.execution import (
 @pytest.fixture
 def equipment(decoy: Decoy) -> EquipmentHandler:
     """Get a mocked out EquipmentHandler."""
-    return decoy.create_decoy(spec=EquipmentHandler)
+    return decoy.mock(cls=EquipmentHandler)
 
 
 @pytest.fixture
 def movement(decoy: Decoy) -> MovementHandler:
     """Get a mocked out MovementHandler."""
-    return decoy.create_decoy(spec=MovementHandler)
+    return decoy.mock(cls=MovementHandler)
 
 
 @pytest.fixture
 def pipetting(decoy: Decoy) -> PipettingHandler:
     """Get a mocked out PipettingHandler."""
-    return decoy.create_decoy(spec=PipettingHandler)
+    return decoy.mock(cls=PipettingHandler)

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -27,31 +27,31 @@ from opentrons.protocol_engine.execution import (
 @pytest.fixture
 def equipment(decoy: Decoy) -> EquipmentHandler:
     """Get a mocked out EquipmentHandler."""
-    return decoy.create_decoy(spec=EquipmentHandler)
+    return decoy.mock(cls=EquipmentHandler)
 
 
 @pytest.fixture
 def movement(decoy: Decoy) -> MovementHandler:
     """Get a mocked out MovementHandler."""
-    return decoy.create_decoy(spec=MovementHandler)
+    return decoy.mock(cls=MovementHandler)
 
 
 @pytest.fixture
 def pipetting(decoy: Decoy) -> PipettingHandler:
     """Get a mocked out PipettingHandler."""
-    return decoy.create_decoy(spec=PipettingHandler)
+    return decoy.mock(cls=PipettingHandler)
 
 
 @pytest.fixture
 def resources(decoy: Decoy) -> ResourceProviders:
     """Get a mocked out ResourceProviders."""
-    return decoy.create_decoy(spec=ResourceProviders)
+    return decoy.mock(cls=ResourceProviders)
 
 
 @pytest.fixture
 def command_mapper(decoy: Decoy) -> CommandMapper:
     """Get a mocked out CommandMapper."""
-    return decoy.create_decoy(spec=CommandMapper)
+    return decoy.mock(cls=CommandMapper)
 
 
 @pytest.fixture
@@ -95,8 +95,8 @@ async def test_execute(
     subject: CommandExecutor,
 ) -> None:
     """It should be able execute a command."""
-    TestCommandImplCls = decoy.create_decoy_func(spec=_TestCommandImpl)
-    command_impl = decoy.create_decoy(spec=_TestCommandImpl)
+    TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
+    command_impl = decoy.mock(cls=_TestCommandImpl)
 
     class _TestCommand(BaseCommand[_TestCommandData, _TestCommandResult]):
         commandType: str = "testCommand"
@@ -175,8 +175,8 @@ async def test_execute_raises_protocol_engine_error(
     subject: CommandExecutor,
 ) -> None:
     """It should be able execute a command."""
-    TestCommandImplCls = decoy.create_decoy_func(spec=_TestCommandImpl)
-    command_impl = decoy.create_decoy(spec=_TestCommandImpl)
+    TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
+    command_impl = decoy.mock(cls=_TestCommandImpl)
 
     class _TestCommand(BaseCommand[_TestCommandData, _TestCommandResult]):
         commandType: str = "testCommand"

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -15,13 +15,13 @@ from opentrons.protocol_engine.execution.movement import MovementHandler
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareAPI:
     """Get a mock in the shape of a HardwareAPI."""
-    return decoy.create_decoy(spec=HardwareAPI)
+    return decoy.mock(cls=HardwareAPI)
 
 
 @pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mock in the shape of a StateStore."""
-    return decoy.create_decoy(spec=StateStore)
+    return decoy.mock(cls=StateStore)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -34,19 +34,19 @@ class MockPipettes:
 @pytest.fixture
 def hardware_api(decoy: Decoy) -> HardwareAPI:
     """Get a mock in the shape of a HardwareAPI."""
-    return decoy.create_decoy(spec=HardwareAPI)
+    return decoy.mock(cls=HardwareAPI)
 
 
 @pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mock in the shape of a StateStore."""
-    return decoy.create_decoy(spec=StateStore)
+    return decoy.mock(cls=StateStore)
 
 
 @pytest.fixture
 def movement_handler(decoy: Decoy) -> MovementHandler:
     """Get a mock in the shape of a MovementHandler."""
-    return decoy.create_decoy(spec=MovementHandler)
+    return decoy.mock(cls=MovementHandler)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/state/conftest.py
+++ b/api/tests/opentrons/protocol_engine/state/conftest.py
@@ -10,16 +10,16 @@ from opentrons.protocol_engine.state.geometry import GeometryView
 @pytest.fixture
 def labware_view(decoy: Decoy) -> LabwareView:
     """Get a mock in the shape of a LabwareView."""
-    return decoy.create_decoy(spec=LabwareView)
+    return decoy.mock(cls=LabwareView)
 
 
 @pytest.fixture
 def pipette_view(decoy: Decoy) -> PipetteView:
     """Get a mock in the shape of a PipetteView."""
-    return decoy.create_decoy(spec=PipetteView)
+    return decoy.mock(cls=PipetteView)
 
 
 @pytest.fixture
 def geometry_view(decoy: Decoy) -> GeometryView:
     """Get a mock in the shape of a GeometryView."""
-    return decoy.create_decoy(spec=GeometryView)
+    return decoy.mock(cls=GeometryView)

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -16,12 +16,6 @@ from opentrons.protocol_engine.state.geometry import GeometryView
 
 
 @pytest.fixture
-def decoy() -> Decoy:
-    """Decoy fixture."""
-    return Decoy()
-
-
-@pytest.fixture
 def subject(labware_view: LabwareView) -> GeometryView:
     """Get a GeometryView with its store dependencies mocked out."""
     return GeometryView(labware_view=labware_view)

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -15,25 +15,25 @@ from opentrons.protocol_engine.state import StateStore
 @pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mock StateStore."""
-    return decoy.create_decoy(spec=StateStore)
+    return decoy.mock(cls=StateStore)
 
 
 @pytest.fixture
 def command_executor(decoy: Decoy) -> CommandExecutor:
     """Get a mock CommandExecutor."""
-    return decoy.create_decoy(spec=CommandExecutor)
+    return decoy.mock(cls=CommandExecutor)
 
 
 @pytest.fixture
 def command_mapper(decoy: Decoy) -> CommandMapper:
     """Get a mock CommandMapper."""
-    return decoy.create_decoy(spec=CommandMapper)
+    return decoy.mock(cls=CommandMapper)
 
 
 @pytest.fixture
 def resources(decoy: Decoy) -> ResourceProviders:
     """Get mock ResourceProviders."""
-    return decoy.create_decoy(spec=ResourceProviders)
+    return decoy.mock(cls=ResourceProviders)
 
 
 @pytest.fixture

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -23,7 +23,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.5.0"
+decoy = "~=1.6.1"
 httpx = "==0.18.*"
 
 [packages]

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -23,7 +23,7 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.6.1"
+decoy = "~=1.6.2"
 httpx = "==0.18.*"
 
 [packages]

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00373dc455aa0a5330bb2e1d0e2ec89c00b1e467f008cd18249c4e3e88d2e2d9"
+            "sha256": "cf0902d1c733e9e34a0d7dbdabdbf89723a1ae64c4be0137fd9728d344d21f1c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -172,19 +172,19 @@
         },
         "uvloop": {
             "hashes": [
-                "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc",
-                "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69",
-                "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01",
-                "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d",
-                "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760",
-                "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c",
-                "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47",
-                "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c",
-                "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c",
-                "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"
+                "sha256:0de811931e90ae2da9e19ce70ffad73047ab0c1dba7c6e74f9ae1a3aabeb89bd",
+                "sha256:1ff05116ede1ebdd81802df339e5b1d4cab1dfbd99295bf27e90b4cec64d70e9",
+                "sha256:2d8ffe44ae709f839c54bacf14ed283f41bee90430c3b398e521e10f8d117b3a",
+                "sha256:5cda65fc60a645470b8525ce014516b120b7057b576fa876cdfdd5e60ab1efbb",
+                "sha256:63a3288abbc9c8ee979d7e34c34e780b2fbab3e7e53d00b6c80271119f277399",
+                "sha256:7522df4e45e4f25b50adbbbeb5bb9847495c438a628177099d2721f2751ff825",
+                "sha256:7f4b8a905df909a407c5791fb582f6c03b0d3b491ecdc1cdceaefbc9bf9e08f6",
+                "sha256:905f0adb0c09c9f44222ee02f6b96fd88b493478fffb7a345287f9444e926030",
+                "sha256:ae2b325c0f6d748027f7463077e457006b4fdb35a8788f01754aadba825285ee",
+                "sha256:e71fb9038bfcd7646ca126c5ef19b17e48d4af9e838b2bcfda7a9f55a6552a32"
             ],
             "markers": "sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
-            "version": "==0.15.2"
+            "version": "==0.15.3"
         },
         "websockets": {
             "hashes": [
@@ -329,6 +329,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
+                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.1"
+        },
         "coverage": {
             "hashes": [
                 "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
@@ -389,11 +397,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:949e769cca522aefd6ed2759b5b174fff26341c01e8cd660bc6b9c55e7188b9a",
-                "sha256:c4ef05af5a5cc0193f27159d8eb8678a8b20f58e3de0683042a3aadc1e0c627f"
+                "sha256:524789c7fb3c39905d2c24b33412dbf9a9c0e1d3a4b4aa79e40cf2cdcc6e2c65",
+                "sha256:f0c39d2b9fbfb44b46fd1dffd8b8275b7b9b2e9f280b7925a77ef9a66734ac4c"
             ],
             "index": "pypi",
-            "version": "==1.5.0"
+            "version": "==1.6.1"
         },
         "docopt": {
             "hashes": [
@@ -442,11 +450,11 @@
         },
         "graphviz": {
             "hashes": [
-                "sha256:3cad5517c961090dfc679df6402a57de62d97703e2880a1a46147bb0dc1639eb",
-                "sha256:d2d25af1c199cad567ce4806f0449cb74eb30cf451fd7597251e1da099ac6e57"
+                "sha256:5dadec94046d82adaae6019311a30e0487536d9d5a60d85451f0ba32f9fc6559",
+                "sha256:ef6e2c5deb9cdcc0c7eece1d89625fd07b0f2208ea2bcb483520907ddf8b4e12"
             ],
             "index": "pypi",
-            "version": "==0.16"
+            "version": "==0.17"
         },
         "h11": {
             "hashes": [
@@ -473,10 +481,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
-            "version": "==2.10"
+            "version": "==3.2"
         },
         "importlib-metadata": {
             "hashes": [
@@ -831,11 +839,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.8.1"
+            "version": "==2.8.2"
         },
         "pyyaml": {
             "hashes": [
@@ -874,11 +882,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
             "index": "pypi",
-            "version": "==2.25.1"
+            "version": "==2.26.0"
         },
         "rfc3986": {
             "extras": [

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cf0902d1c733e9e34a0d7dbdabdbf89723a1ae64c4be0137fd9728d344d21f1c"
+            "sha256": "43dc27fd8fea8b90b4c2f16d45876a67990cd613a9ca2dfe55697d0353f4da86"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -331,11 +331,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:ad0da505736fc7e716a8da15bf19a985db21ac6415c26b34d2fafd3beb3d927e",
-                "sha256:b68b38179052975093d71c1b5361bf64afd80484697c1f27056e50593e695ceb"
+                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
+                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.1"
+            "version": "==2.0.3"
         },
         "coverage": {
             "hashes": [
@@ -397,11 +397,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:524789c7fb3c39905d2c24b33412dbf9a9c0e1d3a4b4aa79e40cf2cdcc6e2c65",
-                "sha256:f0c39d2b9fbfb44b46fd1dffd8b8275b7b9b2e9f280b7925a77ef9a66734ac4c"
+                "sha256:b8ae8b707169824af59b04215615a4b0fa0bff4dccc6dde053c2b18824a6271e",
+                "sha256:c605822c4d867acb5d950ce98b51727705ff55ecc7bad544f2b4face3ee69ae0"
             ],
             "index": "pypi",
-            "version": "==1.6.1"
+            "version": "==1.6.2"
         },
         "docopt": {
             "hashes": [
@@ -611,37 +611,37 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e",
-                "sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e",
-                "sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717",
-                "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461",
-                "sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d",
-                "sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f",
-                "sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99",
-                "sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513",
-                "sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2",
-                "sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6",
-                "sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38",
-                "sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d",
-                "sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e",
-                "sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914",
-                "sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54",
-                "sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef",
-                "sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54",
-                "sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883",
-                "sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491",
-                "sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3",
-                "sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8",
-                "sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63",
-                "sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a",
-                "sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f",
-                "sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c",
-                "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce",
-                "sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd",
-                "sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9"
+                "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33",
+                "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5",
+                "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1",
+                "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1",
+                "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac",
+                "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4",
+                "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50",
+                "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6",
+                "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267",
+                "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172",
+                "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af",
+                "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8",
+                "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2",
+                "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63",
+                "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1",
+                "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8",
+                "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16",
+                "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214",
+                "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd",
+                "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68",
+                "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062",
+                "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e",
+                "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f",
+                "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b",
+                "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd",
+                "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671",
+                "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a",
+                "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.21.0"
+            "version": "==1.21.1"
         },
         "opentrons": {
             "editable": true,

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -11,7 +11,6 @@ import requests
 import pytest
 
 from datetime import datetime, timezone
-from decoy import Decoy
 from fastapi import routing
 from mock import MagicMock
 from typing import Any, Dict
@@ -41,12 +40,6 @@ async def always_raise():
     raise RuntimeError
 
 app.include_router(test_router)
-
-
-@pytest.fixture
-def decoy() -> Decoy:
-    """Get a Decoy state container to clean up stubs after tests."""
-    return Decoy()
 
 
 @pytest.fixture

--- a/robot-server/tests/protocols/conftest.py
+++ b/robot-server/tests/protocols/conftest.py
@@ -9,10 +9,10 @@ from robot_server.protocols.response_builder import ResponseBuilder
 @pytest.fixture
 def protocol_store(decoy: Decoy) -> ProtocolStore:
     """Get a fake ProtocolStore interface."""
-    return decoy.create_decoy(spec=ProtocolStore)
+    return decoy.mock(cls=ProtocolStore)
 
 
 @pytest.fixture
 def response_builder(decoy: Decoy) -> ResponseBuilder:
     """Get a fake ResponseBuilder interface."""
-    return decoy.create_decoy(spec=ResponseBuilder)
+    return decoy.mock(cls=ResponseBuilder)

--- a/robot-server/tests/sessions/router/conftest.py
+++ b/robot-server/tests/sessions/router/conftest.py
@@ -21,31 +21,31 @@ from robot_server.sessions.dependencies import get_session_store, get_engine_sto
 @pytest.fixture
 def task_runner(decoy: Decoy) -> TaskRunner:
     """Get a mock background TaskRunner."""
-    return decoy.create_decoy(spec=TaskRunner)
+    return decoy.mock(cls=TaskRunner)
 
 
 @pytest.fixture
 def protocol_store(decoy: Decoy) -> ProtocolStore:
     """Get a mock ProtocolStore interface."""
-    return decoy.create_decoy(spec=ProtocolStore)
+    return decoy.mock(cls=ProtocolStore)
 
 
 @pytest.fixture
 def session_store(decoy: Decoy) -> SessionStore:
     """Get a mock SessionStore interface."""
-    return decoy.create_decoy(spec=SessionStore)
+    return decoy.mock(cls=SessionStore)
 
 
 @pytest.fixture
 def session_view(decoy: Decoy) -> SessionView:
     """Get a mock SessionView interface."""
-    return decoy.create_decoy(spec=SessionView)
+    return decoy.mock(cls=SessionView)
 
 
 @pytest.fixture
 def engine_store(decoy: Decoy) -> EngineStore:
     """Get a mock EngineStore interface."""
-    return decoy.create_decoy(spec=EngineStore)
+    return decoy.mock(cls=EngineStore)
 
 
 @pytest.fixture

--- a/robot-server/tests/sessions/router/test_commands_router.py
+++ b/robot-server/tests/sessions/router/test_commands_router.py
@@ -1,6 +1,5 @@
 """Tests for the /sessions/.../commands routes."""
 import pytest
-import inspect
 
 from datetime import datetime
 from decoy import Decoy, matchers
@@ -30,14 +29,7 @@ from robot_server.sessions.router.commands_router import (
 @pytest.fixture
 def get_session(decoy: Decoy) -> Callable[..., Awaitable[ResponseModel]]:
     """Get a mock version of the get_session route handler."""
-    get_session: Callable[..., Awaitable[ResponseModel]] = decoy.create_decoy_func(
-        spec=real_get_session,
-    )
-    # TODO(mc, 2021-07-06): add signature support in decoy
-    get_session.__signature__ = inspect.signature(  # type: ignore[attr-defined]
-        real_get_session
-    )
-    return get_session
+    return decoy.mock(func=real_get_session)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Overview

Easing back into work after a few days sick with an upgrade to [Decoy](https://pypi.org/project/decoy/) to incorporate some work I put into it over the weekend:

- Built-in [pytest plugin](https://mike.cousins.io/decoy/#pytest-setup) to automatically add the `decoy` pytest fixture
    - The built in fixture allows Decoy itself to handle cleanup, resulting in a much better [warnings checker](https://github.com/mcous/decoy/blob/main/decoy/warning_checker.py)
- [Support for `inspect.signature`](https://github.com/mcous/decoy/pull/35), which is important when injecting mocks via FastAPI's DI system
- A [more terse mock creation API](https://mike.cousins.io/decoy/usage/create/)
    - This is subjective, but I was bothered by the conflation between Decoy the library and "decoy" as a term for a test double
    - Now, you use `decoy.mock` to create a "mock", which may not be pedantically "correct" but certainly fits better with colloquial use, which I think makes the library easier to use
    - It also makes it easier for Decoy to expand into mocking things that aren't functions or class definitions, like object instances
- A new [`Stub.then_do` API](https://mike.cousins.io/decoy/usage/when/#performing-an-action) to trigger a callback when a stub is called
    - This is an advanced feature that should be used with caution, but may be helpful as we continue to test some more complex interactions involving async. and concurrency

## Changelog

- Upgrade [Decoy](https://pypi.org/project/decoy/) to the v1.6 line
- Replace deprecated `decoy.create_decoy` and decoy.create_decoy_func` with `decoy.mock`

## Review requests

- [x] You agree with my points in the overview
- [x] Tests and lints are passing

## Risk assessment

Very low if tests are passing