### PR TITLE
fix(api) Fix Read Instrument ID and Model G-Code Parsing error

### DIFF
--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
@@ -17,6 +17,6 @@ class ReadInstrumentIDGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        hex_string = response.split(' ')[-1]
+        hex_string = response.split(':')[-1].strip()
         instrument_id = _byte_array_to_ascii_string(bytearray.fromhex(hex_string))
         return f'Read Instrument ID: {instrument_id}'

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
@@ -18,6 +18,6 @@ class ReadInstrumentModelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        hex_string = response.split(' ')[-1]
+        hex_string = response.split(':')[-1].strip()
         instrument_model = _byte_array_to_ascii_string(bytearray.fromhex(hex_string))
         return f'Read Instrument Model: {instrument_model}'

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code.py
@@ -178,6 +178,19 @@ def g_codes() -> List[GCode]:
             ''
         ],
 
+        # Read Instrument ID no space
+        [  # Test 40
+            'M369 L',
+            'M369 L\r\n\r\nL:5032305356323032303230303730313031'
+            '000000000000000000000000000000 \r\nok\r\nok\r\n'
+        ],
+
+        # Read Instrument Model no space
+        [  # Test 41
+            'M371 L',
+            'M371 L\r\n\r\nL:7032305f6d756c74695f76322e3'
+            '0000000000000000000000000000000000000 \r\nok\r\nok\r\n'
+        ],
     ]
     g_code_list = [
         GCode.from_raw_code(code, 'smoothie', response)
@@ -235,6 +248,8 @@ def expected_function_name_values() -> List[str]:
         'MICROSTEPPING_B_DISABLE',  # Test 37
         'MICROSTEPPING_C_ENABLE',  # Test 38
         'MICROSTEPPING_C_DISABLE',  # Test 39
+        'READ_INSTRUMENT_ID',  # Test 40
+        'READ_INSTRUMENT_MODEL',  # Test 41
 
     ]
 
@@ -378,6 +393,12 @@ def expected_arg_values() -> List[Dict[str, int]]:
 
         # Test 39
         {},
+
+        # Test 40
+        {'L': None},
+
+        # Test 41
+        {'L': None},
     ]
 
 
@@ -763,7 +784,23 @@ def explanations() -> List[Explanation]:
             response='',
             provided_args={},
             command_explanation='Disabling microstepping on C-Axis'
-        )
+        ),
+        # Test 40
+        Explanation(
+            code='M369',
+            command_name='READ_INSTRUMENT_ID',
+            response='Read Instrument ID: P20SV202020070101',
+            provided_args={'L': None},
+            command_explanation='Reading instrument ID for Left pipette'
+        ),
+        # Test 41
+        Explanation(
+            code='M371',
+            command_name='READ_INSTRUMENT_MODEL',
+            response='Read Instrument Model: p20_multi_v2.0',
+            provided_args={'L': None},
+            command_explanation='Reading instrument model for Left pipette'
+        ),
     ]
 
 


### PR DESCRIPTION
# Overview

Fix bug where the response from a read instrument id or model command is incorrectly parsed, causing exception.

# Changelog

* Instead of splitting on a space, which is not guaranteed to be there, split on colon which is guaranteed to be there
* Add tests for above case

# Review requests

None

# Risk assessment

None