### PR TITLE
refactor(api): Refactor Supported Text Modes

### DIFF
--- a/api/src/opentrons/hardware_control/g_code_parsing/errors.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/errors.py
@@ -12,8 +12,11 @@ class UnparsableGCodeError(ValueError):
 class InvalidTextModeError(ValueError):
     """Error raised if passed text mode is not a valid mode"""
     def __init__(self, invalid_mode: str, valid_modes: List[str]) -> None:
-        valid_modes = ', '.join(valid_modes)
+        joined_valid_modes = ', '.join(valid_modes)
+
         super().__init__(
-            f'Mode named "{invalid_mode}" not found. Valid modes are: {valid_modes}')
+            f'Mode named "{invalid_mode}" not found. '
+            f'Valid modes are: {joined_valid_modes}'
+        )
         self.invalid_mode = invalid_mode
-        self.valid_modes = valid_modes
+        self.joined_valid_modes = joined_valid_modes

--- a/api/src/opentrons/hardware_control/g_code_parsing/errors.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/errors.py
@@ -1,6 +1,19 @@
+from typing import List
+
+
 class UnparsableGCodeError(ValueError):
     """Error raised if G-Code was unable to be successfully parsed"""
 
     def __init__(self, invalid_g_code_line: str) -> None:
         super().__init__(f"{invalid_g_code_line} was unable to be parsed")
         self.invalid_g_code_line = invalid_g_code_line
+
+
+class InvalidTextModeError(ValueError):
+    """Error raised if passed text mode is not a valid mode"""
+    def __init__(self, invalid_mode: str, valid_modes: List[str]) -> None:
+        valid_modes = ', '.join(valid_modes)
+        super().__init__(
+            f'Mode named "{invalid_mode}" not found. Valid modes are: {valid_modes}')
+        self.invalid_mode = invalid_mode
+        self.valid_modes = valid_modes

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/g_code_program.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/g_code_program.py
@@ -3,7 +3,7 @@ import os
 import json
 from opentrons.hardware_control.emulation.app import \
     TEMPDECK_PORT, THERMOCYCLER_PORT, SMOOTHIE_PORT, MAGDECK_PORT
-from typing import List
+from typing import List, Union
 from opentrons.hardware_control.g_code_parsing.g_code_watcher import GCodeWatcher
 from opentrons.hardware_control.g_code_parsing.g_code import GCode
 from .supported_text_modes import SupportedTextModes
@@ -82,22 +82,20 @@ class GCodeProgram:
             indent=4
         )
 
-    def get_text_explanation(self, mode=SupportedTextModes.DEFAULT) -> str:
+    def get_text_explanation(self, mode: Union[SupportedTextModes, str]) -> str:
         """
         Returns a textual explanation of all the G-Codes in the GCodeProgram
         :param mode: Mode to output text in. See SupportedTextModes for more info
         :return: Textual description of all GCodes
         """
-        if mode not in SupportedTextModes.__members__:
-            supported_modes = ', '.join(SupportedTextModes.__members__.keys())
-            raise ValueError(f'Text Mode "{mode}" is not supported. Supported modes'
-                             f'are: {supported_modes}')
 
-        selected_mode = SupportedTextModes[mode].value
-
+        if isinstance(mode, SupportedTextModes):
+            text_mode = SupportedTextModes.get_text_mode_by_enum_value(mode)
+        else:
+            text_mode = SupportedTextModes.get_text_mode(mode)
         return '\n'.join(
             [
-                selected_mode.builder(code)
+                text_mode.builder(code)
                 for code in self._g_codes
             ]
         )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
@@ -100,7 +100,6 @@ class SupportedTextModes(Enum):
         a single line
     """
     DEFAULT = 'Default'
-    EXPLANATION_ONLY = 'Explanation Only'
     CONCISE = 'Concise'
 
     @classmethod

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
@@ -53,7 +53,7 @@ def default_builder(code: GCode):
            f'Response: {code.response}'
 
 
-def explanation_only(code: GCode):
+def explanation_only_builder(code: GCode):
     """
     Function to build string that contains only the explanation. In the form of:
 
@@ -76,7 +76,7 @@ def explanation_only(code: GCode):
     return code.get_explanation().command_explanation
 
 
-def concise(code: GCode):
+def concise_builder(code: GCode):
     """
     Function to build concise string. Removes all newlines and tabs In the form of:
 
@@ -110,15 +110,27 @@ class SupportedTextModes(Enum):
     Concise: Same as Default but with all newlines and tabs removed to fit everything on
         a single line
     """
-    DEFAULT = TextMode(
-        'Default',
-        default_builder
-    )
-    EXPLANATION_ONLY = TextMode(
-        'Explanation Only',
-        explanation_only
-    )
-    CONCISE = TextMode(
-        'Concise',
-        concise
-    )
+    DEFAULT = 'Default'
+    EXPLANATION_ONLY = 'Explanation Only'
+    CONCISE = 'Concise'
+
+    @classmethod
+    def get_text_mode(cls, key: str):
+        # Defining this inside of the function so that it does not show up
+        # when using the __members__ attribute
+        _internal_mapping = {
+            cls.DEFAULT.value: TextMode(cls.DEFAULT.value, default_builder),
+            cls.EXPLANATION_ONLY.value: TextMode(
+                cls.EXPLANATION_ONLY.value, explanation_only_builder
+            ),
+            cls.CONCISE.value: TextMode(cls.CONCISE.value, concise_builder)
+        }
+        members = [member.value for member in list(cls.__members__.values())]
+        if key not in members:
+            raise ValueError(f'Mode named "{key}" not found. Valid modes are: {members}')
+
+        return _internal_mapping[key]
+
+    @classmethod
+    def get_text_mode_by_enum_value(cls, enum_value):
+        return cls.get_text_mode(enum_value.value)

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
@@ -59,8 +59,8 @@ def default_builder(code: GCode):
     :return: Textual description
     """
     message = f'Code: {code.g_code} {code.g_code_body}\n' \
-           f'Explanation: {code.get_explanation().command_explanation}\n' \
-           f'Response: {code.get_explanation().response}'
+              f'Explanation: {code.get_explanation().command_explanation}\n' \
+              f'Response: {code.get_explanation().response}'
     return MULTIPLE_SPACE_REGEX.sub(' ', message).strip()
 
 
@@ -78,8 +78,8 @@ def concise_builder(code: GCode):
     :return: Textual description
     """
     message = f'{code.g_code} {code.g_code_body} -> ' \
-           f'{code.get_explanation().command_explanation} -> ' \
-           f'{code.get_explanation().response}'\
+              f'{code.get_explanation().command_explanation} -> ' \
+              f'{code.get_explanation().response}'\
         .replace('\n', ' ')\
         .replace('\t', '')
     return MULTIPLE_SPACE_REGEX.sub(' ', message).strip()

--- a/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
@@ -1,0 +1,41 @@
+import pytest
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
+    import SupportedTextModes,\
+    default_builder,\
+    concise_builder,\
+    explanation_only_builder
+
+
+@pytest.mark.parametrize(
+    'input_mode,name,builder_function',
+    [
+        [SupportedTextModes.CONCISE.value, 'Concise', concise_builder],
+        [SupportedTextModes.DEFAULT.value, 'Default', default_builder],
+        [
+            SupportedTextModes.EXPLANATION_ONLY.value,
+            'Explanation Only',
+            explanation_only_builder
+        ],
+    ]
+)
+def test_mode_lookup(input_mode, name, builder_function):
+    assert SupportedTextModes.get_text_mode(input_mode).name == name
+    assert SupportedTextModes.get_text_mode(input_mode).builder == builder_function
+
+
+@pytest.mark.parametrize(
+    'input_mode,name,builder_function',
+    [
+        [SupportedTextModes.CONCISE, 'Concise', concise_builder],
+        [SupportedTextModes.DEFAULT, 'Default', default_builder],
+        [
+            SupportedTextModes.EXPLANATION_ONLY,
+            'Explanation Only',
+            explanation_only_builder
+        ],
+    ]
+)
+def test_mode_lookup_by_enum(input_mode, name, builder_function):
+    assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).name == name
+    assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).builder\
+           == builder_function

--- a/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
@@ -1,21 +1,38 @@
 import pytest
+
+from opentrons.hardware_control.g_code_parsing.errors import InvalidTextModeError
+from opentrons.hardware_control.g_code_parsing.g_code import GCode
 from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
     import SupportedTextModes,\
+    TextMode,\
     default_builder,\
-    concise_builder,\
-    explanation_only_builder
+    concise_builder
+
+@pytest.fixture
+def concise_mode() -> TextMode:
+    return SupportedTextModes.get_text_mode('Concise')
+
+
+@pytest.fixture
+def default_mode() -> TextMode:
+    return SupportedTextModes.get_text_mode('Default')
+
+
+@pytest.fixture
+def g_code() -> GCode:
+    return GCode.from_raw_code(
+        'M92 X80.0 Y80.0 Z400 A400',
+        'smoothie',
+        'X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:955.000000 '
+        'C:768.000000 \r\nok\r\nok\r\n'
+    )[0]
 
 
 @pytest.mark.parametrize(
     'input_mode,name,builder_function',
     [
         [SupportedTextModes.CONCISE.value, 'Concise', concise_builder],
-        [SupportedTextModes.DEFAULT.value, 'Default', default_builder],
-        [
-            SupportedTextModes.EXPLANATION_ONLY.value,
-            'Explanation Only',
-            explanation_only_builder
-        ],
+        [SupportedTextModes.DEFAULT.value, 'Default', default_builder]
     ]
 )
 def test_mode_lookup(input_mode, name, builder_function):
@@ -27,15 +44,52 @@ def test_mode_lookup(input_mode, name, builder_function):
     'input_mode,name,builder_function',
     [
         [SupportedTextModes.CONCISE, 'Concise', concise_builder],
-        [SupportedTextModes.DEFAULT, 'Default', default_builder],
-        [
-            SupportedTextModes.EXPLANATION_ONLY,
-            'Explanation Only',
-            explanation_only_builder
-        ],
+        [SupportedTextModes.DEFAULT, 'Default', default_builder]
     ]
 )
 def test_mode_lookup_by_enum(input_mode, name, builder_function):
     assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).name == name
     assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).builder\
            == builder_function
+
+
+def test_invalid_mode_name():
+    with pytest.raises(InvalidTextModeError):
+        SupportedTextModes.get_text_mode('INVALID MODE')
+
+
+def test_concise_mode(concise_mode, g_code):
+    expected = 'M92 X80.0 Y80.0 Z400.0 A400.0 -> ' \
+               'Setting the following axes steps per mm: ' \
+               'X-Axis: 80.0 steps per mm ' \
+               'Y-Axis: 80.0 steps per mm ' \
+               'Z-Axis: 400.0 steps per mm ' \
+               'A-Axis: 400.0 steps per mm -> ' \
+               'Current set steps per mm: ' \
+               'X Axis: 80.000000 ' \
+               'Y Axis: 80.000000 ' \
+               'Z Axis: 400.000000 ' \
+               'A Axis: 400.000000 ' \
+               'B Axis: 955.000000 ' \
+               'C Axis: 768.000000' \
+
+
+    assert concise_mode.builder(g_code) == expected
+
+
+def test_default_mode(default_mode, g_code):
+    expected = 'Code: M92 X80.0 Y80.0 Z400.0 A400.0' \
+               '\nExplanation: Setting the following axes steps per mm:' \
+               '\n\tX-Axis: 80.0 steps per mm' \
+               '\n\tY-Axis: 80.0 steps per mm' \
+               '\n\tZ-Axis: 400.0 steps per mm' \
+               '\n\tA-Axis: 400.0 steps per mm' \
+               '\nResponse: Current set steps per mm:'\
+               '\n\tX Axis: 80.000000' \
+               '\n\tY Axis: 80.000000' \
+               '\n\tZ Axis: 400.000000' \
+               '\n\tA Axis: 400.000000' \
+               '\n\tB Axis: 955.000000' \
+               '\n\tC Axis: 768.000000'
+
+    assert default_mode.builder(g_code) == expected

--- a/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
@@ -8,6 +8,7 @@ from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_mod
     default_builder,\
     concise_builder
 
+
 @pytest.fixture
 def concise_mode() -> TextMode:
     return SupportedTextModes.get_text_mode('Concise')


### PR DESCRIPTION
# Overview

Refactored supported text modes to support using both enum and nice text value. Expanded test coverage to 100% 

# Changelog

* Changed SupportedTextModes enum mappings to string values instead of tuples
* Added `get_text_mode` and `get_text_mode_by_enum_value` method to SupportedTextModes. This replaces the functionality of the above mentioned tuples
* Added removal of multiple spaces inside of returned text strings
* Replaced ValueError with  InvalidTextModeError
* Refactored get_text_explanation method on g_code_program.py to use newly refactored SupportedTextModes. Made it cleaner and easier to understand
* Added test coverage for 100% of supported_text_modes.py

# Review requests

None

# Risk assessment

None
