### PR TITLE
feat(labware-library): change default display name for tube racks

### DIFF
--- a/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
+++ b/labware-library/cypress/integration/labware-creator/tubesRack.spec.js
@@ -149,9 +149,9 @@ context('Tubes and Rack', () => {
         cy.contains('Brand is required').should('not.exist')
 
         // File info
-        cy.get("input[placeholder='Opentrons 6 Tube Rack 10 µL']").should(
-          'exist'
-        )
+        cy.get(
+          "input[placeholder='Opentrons 6 Tube Rack with Generic 0.01 mL']"
+        ).should('exist')
         cy.get("input[placeholder='opentrons_6_tuberack_10ul']").should('exist')
 
         // Test pipette
@@ -323,9 +323,9 @@ context('Tubes and Rack', () => {
         cy.contains('Brand is required').should('not.exist')
 
         // File info
-        cy.get("input[placeholder='Opentrons 15 Tube Rack 10 µL']").should(
-          'exist'
-        )
+        cy.get(
+          "input[placeholder='Opentrons 15 Tube Rack with Generic 0.01 mL']"
+        ).should('exist')
         cy.get("input[placeholder='opentrons_15_tuberack_10ul']").should(
           'exist'
         )
@@ -499,9 +499,9 @@ context('Tubes and Rack', () => {
         cy.contains('Brand is required').should('not.exist')
 
         // File info
-        cy.get("input[placeholder='Opentrons 24 Tube Rack 10 µL']").should(
-          'exist'
-        )
+        cy.get(
+          "input[placeholder='Opentrons 24 Tube Rack with Generic 0.01 mL']"
+        ).should('exist')
         cy.get("input[placeholder='opentrons_24_tuberack_10ul']").should(
           'exist'
         )

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -228,7 +228,7 @@ export const tubeRackInsertOptions: Options = [
   },
 ]
 
-export const DEFAULT_TUBE_BRAND = 'Opentrons'
+export const DEFAULT_RACK_BRAND = 'Opentrons'
 
 // fields that get auto-filled when tubeRackInsertLoadName is selected
 // NOTE: these are duplicate data derived from tube rack defs, but

--- a/labware-library/src/labware-creator/formSelectors.ts
+++ b/labware-library/src/labware-creator/formSelectors.ts
@@ -1,3 +1,4 @@
+import round from 'lodash/round'
 import {
   createRegularLoadName,
   createDefaultDisplayName,
@@ -8,10 +9,11 @@ import {
   DISPLAY_VOLUME_UNITS,
   tubeRackAutofills,
   labwareTypeAutofills,
-  DEFAULT_TUBE_BRAND,
+  DEFAULT_RACK_BRAND,
 } from './fields'
 import type { LabwareFields } from './fields'
-import { getIsOpentronsTubeRack } from './utils'
+import { getIsOpentronsTubeRack } from './utils/getIsOpentronsTubeRack'
+import { getIsCustomTubeRack } from './utils/getIsCustomTubeRack'
 // TODO(Ian, 2019-07-24): consolidate `tubeRackAutofills/aluminumBlockAutofills`-getting logic btw here and makeAutofillOnChange
 export const _getIsAutofilled = (
   name: keyof LabwareFields,
@@ -83,10 +85,6 @@ const _valuesToCreateNameArgs = (values: LabwareFields): any => {
   const brand = (values.brand || '').trim()
 
   let brandDefault: string | undefined
-  // Opentrons tube racks need to default their brand
-  if (getIsOpentronsTubeRack(values)) {
-    brandDefault = DEFAULT_TUBE_BRAND
-  }
 
   return {
     gridColumns,
@@ -97,9 +95,32 @@ const _valuesToCreateNameArgs = (values: LabwareFields): any => {
     totalLiquidVolume: Number(values.wellVolume) || 0,
   }
 }
+const _getTubeRackDisplayName = (values: LabwareFields): string => {
+  const rows = Number(values.gridRows) || 1
+  const columns = Number(values.gridColumns) || 1
+  const volume = Number(values.wellVolume) || 0
+  const wellCount = rows * columns
 
-export const getDefaultLoadName = (values: LabwareFields): string =>
-  createRegularLoadName(_valuesToCreateNameArgs(values))
+  return `${values.brand || 'Generic'} ${wellCount} Tube Rack with ${
+    values.groupBrand || 'Generic'
+  } ${round(volume / 1000, 2)} mL`
+}
+export const getDefaultLoadName = (values: LabwareFields): string => {
+  let args
+  if (getIsOpentronsTubeRack(values)) {
+    args = _valuesToCreateNameArgs({ ...values, brand: DEFAULT_RACK_BRAND })
+  } else {
+    args = _valuesToCreateNameArgs(values)
+  }
+  return createRegularLoadName(args)
+}
 
-export const getDefaultDisplayName = (values: LabwareFields): string =>
-  createDefaultDisplayName(_valuesToCreateNameArgs(values))
+export const getDefaultDisplayName = (values: LabwareFields): string => {
+  if (getIsOpentronsTubeRack(values)) {
+    return _getTubeRackDisplayName({ ...values, brand: DEFAULT_RACK_BRAND })
+  } else if (getIsCustomTubeRack(values)) {
+    return _getTubeRackDisplayName(values)
+  }
+
+  return createDefaultDisplayName(_valuesToCreateNameArgs(values))
+}

--- a/labware-library/src/labware-creator/labwareFormSchema.ts
+++ b/labware-library/src/labware-creator/labwareFormSchema.ts
@@ -5,7 +5,7 @@ import {
   labwareTypeOptions,
   wellBottomShapeOptions,
   wellShapeOptions,
-  DEFAULT_TUBE_BRAND,
+  DEFAULT_RACK_BRAND,
   IRREGULAR_LABWARE_ERROR,
   LABWARE_TOO_SMALL_ERROR,
   LABWARE_TOO_LARGE_ERROR,
@@ -221,7 +221,7 @@ export const labwareFormSchemaBaseObject = Yup.object({
   // and user cannot see or override brand (aka "rack brand")
   brand: Yup.mixed().when(['labwareType', 'tubeRackInsertLoadName'], {
     is: matchOpentronsTubeRack,
-    then: Yup.mixed().nullable(), // defaulted to DEFAULT_TUBE_BRAND in form-level transform below
+    then: Yup.mixed().nullable(), // defaulted to DEFAULT_RACK_BRAND in form-level transform below
     otherwise: requiredString(LABELS.brand),
   }),
   // TODO(mc, 2020-06-02): should this be Yup.array() instead of mixed?
@@ -301,7 +301,7 @@ export const labwareFormSchema: Yup.Schema<ProcessedLabwareFields> = labwareForm
       currentValue.labwareType,
       currentValue.tubeRackInsertLoadName
     )
-      ? DEFAULT_TUBE_BRAND
+      ? DEFAULT_RACK_BRAND
       : currentValue.brand
 
     const nextValues = { ...currentValue, brand }


### PR DESCRIPTION
# Overview

Closes #7987

# Changelog


# Review requests

Default display name for tube racks (both Opentrons and custom) should match #7987 

# Risk assessment

Low, LC only