### PR TITLE
fix(labware-creator): show regularity fields

### DIFF
--- a/labware-library/src/labware-creator/components/getPipetteOptions.tsx
+++ b/labware-library/src/labware-creator/components/getPipetteOptions.tsx
@@ -113,8 +113,6 @@ const _getPipetteNameOptions = (allowMultiChannel: boolean): RichOptions =>
 
     const disabled = pipette.isMultiChannel ? !allowMultiChannel : false
 
-    console.log('_getPipetteNameOptions', { allowMultiChannel })
-
     return {
       name: (
         <PipetteOptionRow

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -354,10 +354,10 @@ export const getImplicitAutofillValues = (
   preAutofilledValues: Partial<LabwareFields>
 ): Partial<LabwareFields> => {
   const result: Partial<LabwareFields> = {}
-  if ('gridRows' in preAutofilledValues) {
+  if (Number(preAutofilledValues.gridRows) > 0) {
     result.regularRowSpacing = 'true'
   }
-  if ('gridColumns' in preAutofilledValues) {
+  if (Number(preAutofilledValues.gridColumns) > 0) {
     result.regularColumnSpacing = 'true'
   }
   return result

--- a/labware-library/src/labware-creator/utils/determineMultiChannelSupport.ts
+++ b/labware-library/src/labware-creator/utils/determineMultiChannelSupport.ts
@@ -17,7 +17,7 @@ export const determineMultiChannelSupport = (
   // all 8 channels fit into the first column correctly
   const multiChannelTipsFirstColumn =
     def !== null ? getWellNamePerMultiTip(def, 'A1') : null
-  console.log({ multiChannelTipsFirstColumn })
+
   const allowMultiChannel =
     multiChannelTipsFirstColumn !== null &&
     multiChannelTipsFirstColumn.length === 8


### PR DESCRIPTION
# Overview

Regularity fields were accidentally hidden when they shouldn't have been, bc a fn was using 'field in obj' instead of "is value of field truthy"

# Changelog


# Review requests

- Should be able to make custom tube rack without getting the error

# Risk assessment

Low, fix for LC