### PR TITLE
fix(labware-creator): simplify autofill and fix bugs

### DIFF
--- a/labware-library/src/labware-creator/Autofilling.md
+++ b/labware-library/src/labware-creator/Autofilling.md
@@ -1,0 +1,38 @@
+# AUTOFILL
+
+"Autofill" is what LC uses to automatically fill in fields when the user has selected certain values for other fields. For example, if you choose an Opentrons Tube Rack with the 6-tube insert, then the dimensions having to do with that insert automatically get filled in. Currently in LC, only a few fields can cause autofill to happen (listed below).
+
+## Autofills and hiding fields
+
+In LC, fields that have been autofilled shouldn't be shown to the user. Also, we don't want to user to edit autofilled fields, because eg if you're selected a tip rack then the "well shape" should always be "circular", and if you choose a particular 6-tube tuberack insert the well grid should always be 3 x 2, and so on. So you can think of autofilled fields as not as "filled in with a default via other fields" but actually "determined by other fields and locked".
+
+### `getIsHidden`
+
+A field is hidden when it's autofilled or defaulted.
+
+- We know it's autofilled if there is some defined value for the field in the corresponding autofill data object (listed out below). For example, if labwareType is tubeRack, we see if there's a value for our field in `tubeRackAutofills[values.tubeRckInsertLoadName`.
+- Some fields are defaulted by the Yup schema. These are handled case-by-case in `_getIsDefaulted`. For example, if your labware has one column, `gridSpacingX` gets a default value from the Yup schema and so that field does not need to be displayed. Whereas "autofilled" has more to do with labwareType and secondary type, "defaulted" has to do with other fields besides those having an effect on other fields, in a way that doesn't have anything to do with labwareType.
+
+TODO: do we really need both "autofill" AND "default"? Can they both use the same mechanism instead of having 2 different ways this is accomplished?
+
+When the form is missing info (for example, no labwareType chosen yet, or chose aluminumBlock but no aluminumBlockType, etc), the default is "not hidden" bc we don't have enough info to hide it. (However, Labware Creator only shows most of the form after the user has clicked "Start Creating Labware" which can only happen after a user has chosen labwareType and if applicable a secondary type. So this is kind of a technicality.)
+
+Each field component (eg `RadioField`, `TextField`) calls `getIsHidden` to determine whether to render itself.
+
+Also, `isEveryFieldHidden` runs through all the fields of a `Section`, calling `getIsHidden` on each, to determine if a `Section` should overall be hidden bc all its constituent fields are hidden.
+
+## Data
+
+The data behind the autofills is from several types of objects listed below. These objects map some kind of key to a set of `field:value` pairs that will be spread into the form values to effect the autofill. They generally look like `{[someKindOfKey]: {gridRows: '8', gridColumns: '12'}}`.
+
+- `tubeRackAutofills` is a map of `tubeRackInsertLoadName` to fields
+- `aluminumBlockAutofills` maps aluminumBlockType to fields
+- `labwareTypeAutofills` maps labwareType to fields, but only has content for `tipRack`
+
+## `makeAutofillOnChange`
+
+This fn is hooked into the `onValueChange` of three Dropdown fields, `labwareType`, `tubeRackInsertLoadName`, and `aluminumBlockType`, so every change to those particular fields triggers this autofill process.
+
+Here, when one of these fields is updated, `setValues` is called to not only update the field itself, but all the fields that have their values autofilled as a result. Also, `setTouched` is called to make those autofilled fields non-pristine.
+
+NOTE: Right now, if you choose a tube rack insert and then switch to a well plate, the autofilled values carry over. Ideally the autofill wouldn't modify `values` state, but rather autofill could one day be more like a lens or selector on top of `values`. It's hard to do this in Formik though bc there's not good ways to get "in between" the steps of the data flow :(

--- a/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/Description.test.tsx
@@ -86,7 +86,10 @@ describe('Description', () => {
 
   it('should not render when all of the fields are hidden', () => {
     when(isEveryFieldHiddenMock)
-      .calledWith(['brand', 'brandId'], formikConfig.initialValues)
+      .calledWith(
+        ['brand', 'brandId', 'groupBrand', 'groupBrandId'],
+        formikConfig.initialValues
+      )
       .mockReturnValue(true)
 
     const { container } = render(wrapInFormik(<Description />, formikConfig))

--- a/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
+++ b/labware-library/src/labware-creator/components/__tests__/sections/WellShapeAndSides.test.tsx
@@ -80,7 +80,7 @@ describe('WellShapeAndSides', () => {
     )
   })
 
-  it('should render diameter field when tipRack is selected (and hide the well shape radio group),(and should not render x/y fields)', () => {
+  it('should render diameter field when tipRack is selected (and hide the well shape radio group ,and should not render x/y fields)', () => {
     formikConfig.initialValues.labwareType = 'tipRack'
     render(wrapInFormik(<WellShapeAndSides />, formikConfig))
 

--- a/labware-library/src/labware-creator/components/getPipetteOptions.tsx
+++ b/labware-library/src/labware-creator/components/getPipetteOptions.tsx
@@ -113,8 +113,6 @@ const _getPipetteNameOptions = (allowMultiChannel: boolean): RichOptions =>
 
     const disabled = pipette.isMultiChannel ? !allowMultiChannel : false
 
-    console.log('_getPipetteNameOptions', { allowMultiChannel })
-
     return {
       name: (
         <PipetteOptionRow

--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { useFormikContext } from 'formik'
 import { LabwareFields } from '../../fields'
-import { getIsOpentronsTubeRack, isEveryFieldHidden } from '../../utils'
+import { isEveryFieldHidden } from '../../utils'
+import { getIsOpentronsTubeRack } from '../../utils/getIsOpentronsTubeRack'
 import { FormAlerts } from '../alerts/FormAlerts'
 import { TextField } from '../TextField'
 import { SectionBody } from './SectionBody'
@@ -46,7 +47,12 @@ const Content = (props: Props): JSX.Element => {
 }
 
 export const Description = (): JSX.Element | null => {
-  const fieldList: Array<keyof LabwareFields> = ['brand', 'brandId']
+  const fieldList: Array<keyof LabwareFields> = [
+    'brand',
+    'brandId',
+    'groupBrand',
+    'groupBrandId',
+  ]
   const { values, errors, touched } = useFormikContext<LabwareFields>()
 
   if (isEveryFieldHidden(fieldList, values)) {

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -247,6 +247,8 @@ export const tubeRackAutofills: {
     gridSpacingY: '35.0',
     gridOffsetX: '35.50',
     gridOffsetY: '25.24',
+    regularRowSpacing: 'true',
+    regularColumnSpacing: 'true',
   },
   '24tubesSnapCap': {
     // NOTE: based on opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap
@@ -258,6 +260,8 @@ export const tubeRackAutofills: {
     gridSpacingY: '19.28',
     gridOffsetX: '18.21',
     gridOffsetY: '10.07',
+    regularRowSpacing: 'true',
+    regularColumnSpacing: 'true',
   },
   '15tubes': {
     // NOTE: based on opentrons_15_tuberack_falcon_15ml_conical
@@ -269,6 +273,8 @@ export const tubeRackAutofills: {
     gridSpacingY: '25.00',
     gridOffsetX: '13.88',
     gridOffsetY: '17.74',
+    regularRowSpacing: 'true',
+    regularColumnSpacing: 'true',
   },
   customTubeRack: {}, // not an insert, no autofills
 }
@@ -304,6 +310,8 @@ export const aluminumBlockAutofills = {
     gridSpacingY: '17.25',
     gridOffsetX: '20.75',
     gridOffsetY: '16.87',
+    regularRowSpacing: 'true',
+    regularColumnSpacing: 'true',
   },
   '96well': {
     // NOTE: based on opentrons_96_aluminumblock_generic_pcr_strip_200ul
@@ -315,8 +323,10 @@ export const aluminumBlockAutofills = {
     gridSpacingY: '9.00',
     gridOffsetX: '14.38',
     gridOffsetY: '11.25',
+    regularRowSpacing: 'true',
+    regularColumnSpacing: 'true',
   },
-}
+} as const
 
 export const labwareTypeAutofills: Record<
   LabwareType,
@@ -347,21 +357,6 @@ export const aluminumBlockChildTypeOptions: Options = [
     value: 'pcrPlate',
   },
 ]
-
-// For DRYness, these values aren't explicitly included in the autofill objects (eg tubeRackAutofills),
-// but should be included in the autofill spread
-export const getImplicitAutofillValues = (
-  preAutofilledValues: Partial<LabwareFields>
-): Partial<LabwareFields> => {
-  const result: Partial<LabwareFields> = {}
-  if ('gridRows' in preAutofilledValues) {
-    result.regularRowSpacing = 'true'
-  }
-  if ('gridColumns' in preAutofilledValues) {
-    result.regularColumnSpacing = 'true'
-  }
-  return result
-}
 
 export const getInitialStatus = (): FormStatus => ({
   defaultedDef: null,

--- a/labware-library/src/labware-creator/getDefaultedDef.ts
+++ b/labware-library/src/labware-creator/getDefaultedDef.ts
@@ -28,6 +28,7 @@ export const DEFAULTED_DEF_PATCH: Readonly<Partial<LabwareFields>> = {
   displayName: 'Some Labware',
   loadName: 'some_labware',
   brand: 'somebrand',
+  groupBrand: 'somebrand',
   // A few other fields don't even go into the definition (eg "is row spacing uniform" etc).
   homogeneousWells: 'true',
   regularRowSpacing: 'true',
@@ -55,7 +56,9 @@ export const getDefaultedDef = (
     // TODO(IL, 2021-06-01): if we stick with this instead of single value casting, sniff this error to make sure it's
     // really a Yup validation error (see how Formik does it in `Formik.tsx`).
     // See #7824 and see pattern in formLevelValidation fn
-  } catch (error) {}
+  } catch (error) {
+    console.log('getDefaultedDef casting error', error)
+  }
 
   if (castValues === null) {
     return null

--- a/labware-library/src/labware-creator/utils/determineMultiChannelSupport.ts
+++ b/labware-library/src/labware-creator/utils/determineMultiChannelSupport.ts
@@ -17,7 +17,7 @@ export const determineMultiChannelSupport = (
   // all 8 channels fit into the first column correctly
   const multiChannelTipsFirstColumn =
     def !== null ? getWellNamePerMultiTip(def, 'A1') : null
-  console.log({ multiChannelTipsFirstColumn })
+
   const allowMultiChannel =
     multiChannelTipsFirstColumn !== null &&
     multiChannelTipsFirstColumn.length === 8

--- a/labware-library/src/labware-creator/utils/makeAutofillOnChange.ts
+++ b/labware-library/src/labware-creator/utils/makeAutofillOnChange.ts
@@ -1,5 +1,5 @@
 import mapValues from 'lodash/mapValues'
-import { getImplicitAutofillValues, LabwareFields } from '../fields'
+import { LabwareFields } from '../fields'
 import type { FormikTouched } from 'formik'
 
 interface MakeAutofillOnChangeArgs {
@@ -26,10 +26,9 @@ export const makeAutofillOnChange = ({
     return
   }
   const _autofillValues = autofills[value]
-  if (_autofillValues) {
+  if (_autofillValues !== undefined) {
     const autofillValues = {
       ..._autofillValues,
-      ...getImplicitAutofillValues(_autofillValues),
     }
 
     const namesToTrue = mapValues(autofillValues, () => true)


### PR DESCRIPTION
# Overview

Documented how autofilling works and simplified it a bit

# Changelog

- No more getImplicitAutofillValues
- Document autofill process in a .md file
- Show labware render even if group brand isn't filled out
- Show regularity fields for custom tube rack

# Review requests

- Test LC with different labware, the expected fields should show up
- For custom tip racks (or well plates etc), adding a number of rows/columns shouldn't make the "...evenly spaced?" radio button disappear!

# Risk assessment

Med, LC only, should be just fixes