### PR TITLE
fix(labware-creator): reduce spacing btw tube brand + rack brand

### DIFF
--- a/labware-library/src/labware-creator/components/sections/Description.tsx
+++ b/labware-library/src/labware-creator/components/sections/Description.tsx
@@ -8,6 +8,7 @@ import { TextField } from '../TextField'
 import { SectionBody } from './SectionBody'
 
 import styles from '../../styles.css'
+import { Flex } from '@opentrons/components'
 
 interface Props {
   values: LabwareFields
@@ -20,17 +21,17 @@ const Content = (props: Props): JSX.Element => {
   return (
     <>
       {showBrand && (
-        <div className={styles.flex_row}>
+        <Flex>
           <div className={styles.brand_column}>
             <TextField name="brand" />
           </div>
           <div className={styles.brand_id_column}>
             <TextField name="brandId" caption="Separate multiple by comma" />
           </div>
-        </div>
+        </Flex>
       )}
       {showGroupBrand && (
-        <div className={styles.flex_row}>
+        <Flex>
           <div className={styles.brand_column}>
             <TextField name="groupBrand" />
           </div>
@@ -40,7 +41,7 @@ const Content = (props: Props): JSX.Element => {
               caption="Separate multiple by comma"
             />
           </div>
-        </div>
+        </Flex>
       )}
     </>
   )


### PR DESCRIPTION
# Overview

Closes #8140

# Changelog


# Review requests

- Spacing btw Rack Brand and Tube Brand looks reasonable (you see these fields with custom tube rack)
- When it's just Brand (eg choose Well Plate), no weird spacing in the Description section there

# Risk assessment

Low, LC only