### PR TITLE
fix(api): ignore missing aionotify more properly

### DIFF
--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -7,7 +7,7 @@ from typing import (Any, Dict, List, Optional, Tuple,
 from typing_extensions import Final
 try:
     import aionotify  # type: ignore
-except OSError:
+except (OSError, ModuleNotFoundError):
     aionotify = None  # type: ignore
 
 from opentrons.drivers.smoothie_drivers import driver_3_0

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -9,7 +9,7 @@ from opentrons.protocols.context.protocol_api.protocol_context import \
 
 try:
     import aionotify
-except OSError:
+except (OSError, ModuleNotFoundError):
     aionotify = None  # type: ignore
 import asyncio
 import os

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -2,7 +2,7 @@ import asyncio
 from unittest import mock
 try:
     import aionotify
-except OSError:
+except (OSError, ModuleNotFoundError):
     aionotify = None  # type: ignore
 import pytest
 import typeguard

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -2,10 +2,6 @@ import asyncio
 from pathlib import Path
 from unittest import mock
 import pytest
-try:
-    import aionotify
-except (OSError, ModuleNotFoundError):
-    aionotify = None  # type: ignore
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import ModuleAtPort
 from opentrons.hardware_control.modules.types import (

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 try:
     import aionotify
-except OSError:
+except (OSError, ModuleNotFoundError):
     aionotify = None  # type: ignore
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import ModuleAtPort


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The `aionotify` is supposed to work only under Linux (that's why the corresponding [conda-forge package](https://anaconda.org/conda-forge/aionotify/files) exists for Linux only). The failure with the other platforms was observed during the work on https://github.com/conda-forge/staged-recipes/pull/15705 (failed build log for OSX can be found [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=355110&view=logs&j=e35d4f76-8ff2-5536-d795-df91e63eb9f7&t=fa7b4b17-b6ff-5c9c-8cfc-15f888c92310&l=3005)).
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog
Added an additional `ModuleNotFoundError` exception to catch the missing package for OSX and Windows platforms properly. Thanks to https://stackoverflow.com/a/6470452 for the hints.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Please review and accept the addition as it fixes the missing import.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
The risk is minimal in my opinion.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
