### PR TITLE
docs: Remove obsolete Travis badges from readme files, and fix code formatting

### DIFF
--- a/api/README.rst
+++ b/api/README.rst
@@ -2,10 +2,6 @@
 Opentrons
 =============
 
-.. image:: https://badgen.net/travis/Opentrons/opentrons/edge
-   :target: https://travis-ci.org/Opentrons/opentrons
-   :alt: Build Status
-
 .. image:: https://badgen.net/codecov/c/github/Opentrons/opentrons
    :target: https://codecov.io/gh/Opentrons/opentrons
    :alt: Coverage Status

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -63,7 +63,7 @@ Simulators
 ***************
 Simulation mode will run the robot-server with simple software simulations of the Smoothie and magnetic, temperature, and thermocycler modules. This mode is ideal for rapid testing as the GCODE communication layer is bypassed.
 
-- `make -C robot-server dev`
+- ``make -C robot-server dev``
 
 ***************
 Emulators
@@ -72,7 +72,7 @@ Using the emulation mode will have the robot server send GCODE commands to a run
 
 This requires two steps. Enter these commands from the opentrons directory:
 
-- `make -C api emulator`
-- `make -C robot-server dev-with-emulator`
+- ``make -C api emulator``
+- ``make -C robot-server dev-with-emulator``
 
-By default a `p20_multi_v2.0` is on the left mount and `p20_single_v2.0` is on the right. These can be changed by modifying the `OT_EMULATOR_smoothie` environment variable which contains a stringified JSON object with a `model` and `id` field for the `left` and `right`. All fields are optional. For example to use a `p300_multi` on the right use  `export OT_EMULATOR_smoothie='{"right": {"model": "p300_multi"}}' && make -C api emulator`
+By default a ``p20_multi_v2.0`` is on the left mount and ``p20_single_v2.0`` is on the right. These can be changed by modifying the ``OT_EMULATOR_smoothie`` environment variable which contains a stringified JSON object with a ``model`` and ``id`` field for the ``left`` and ``right``. All fields are optional. For example to use a ``p300_multi`` on the right use  ``export OT_EMULATOR_smoothie='{"right": {"model": "p300_multi"}}' && make -C api emulator``

--- a/robot-server/README.rst
+++ b/robot-server/README.rst
@@ -2,10 +2,6 @@
 Opentrons OT-2 HTTP API
 =======================
 
-.. image:: https://badgen.net/travis/Opentrons/opentrons/edge
-   :target: https://travis-ci.org/Opentrons/opentrons
-   :alt: Build Status
-
 .. image:: https://badgen.net/codecov/c/github/Opentrons/opentrons
    :target: https://codecov.io/gh/Opentrons/opentrons
    :alt: Coverage Status


### PR DESCRIPTION
# Changelog

* In the project readmes for `api` and `robot-server`, remove Travis CI badge images. The images were showing that CI was failing, but that's just because we don't use Travis anymore.
* In the `robot-server` readme, fix code formatting syntax errors. Unlike Markdown, reStructuredText uses ``` ``double backticks`` ``` for code, not `` `single backticks` ``.


# Risk assessment

None. Changes are to readmes only.
