### PR TITLE
style(api,robot-server): start using black to format some modules

### DIFF
--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -74,5 +74,3 @@ jobs:
         run: make lint-json
       - name: 'lint css'
         run: make lint-css
-      - name: 'stylecheck js'
-        run: make format

--- a/Makefile
+++ b/Makefile
@@ -179,14 +179,6 @@ test-js:
 .PHONY: lint
 lint: lint-py lint-js lint-json lint-css check-js circular-dependencies-js
 
-.PHONY: format
-format:
-ifeq ($(watch),true)
-	onchange $(FORMAT_FILE_GLOB) -- prettier --ignore-path .eslintignore --write {{changed}}
-else
-	prettier --ignore-path .eslintignore --write $(FORMAT_FILE_GLOB)
-endif
-
 .PHONY: lint-py
 lint-py:
 	$(MAKE) -C $(API_DIR) lint
@@ -207,6 +199,18 @@ lint-json:
 .PHONY: lint-css
 lint-css:
 	stylelint "**/*.css" "**/*.js"
+
+.PHONY: format
+format: format-js format-py
+
+.PHONY: format-py
+format-py:
+	$(MAKE) -C $(API_DIR) format
+	$(MAKE) -C $(ROBOT_SERVER_DIR) format
+
+.PHONY: format-js
+format-js:
+	prettier --ignore-path .eslintignore --write $(FORMAT_FILE_GLOB)
 
 .PHONY: check-js
 check-js: build-ts

--- a/api/Makefile
+++ b/api/Makefile
@@ -3,13 +3,6 @@
 include ../scripts/push.mk
 include ../scripts/python.mk
 
-# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
-SHELL := bash
-
-# add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
-# and also make an explicit version for shx for use in the shell function,
-# where PATH won’t be propagated
-PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx
 
 # make push wheel file (= rather than := to expand at every use)
@@ -57,12 +50,18 @@ ot_shared_data_sources := $(filter %.json,$(shell $(SHX) find ../shared-data/))
 ot_resources := $(filter %,$(shell $(SHX) find src/opentrons/resources))
 ot_sources := $(ot_py_sources) $(ot_shared_data_sources) $(ot_resources)
 
+# test modules to typecheck
+# TODO(mc, 2021-07-23): expand this to all tests
 ot_tests_to_typecheck := \
 	tests/opentrons/protocol_api_experimental \
 	tests/opentrons/protocol_engine \
 	tests/opentrons/motion_planning \
 	tests/opentrons/file_runner \
 	tests/opentrons/protocols/runner
+
+# files and modules to format
+# TODO(mc, 2021-07-23): expand this to all files, replace this variable with `.`
+ot_files_to_format :=
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
@@ -99,9 +98,13 @@ test:
 	$(pytest) $(tests) $(test_opts)
 
 .PHONY: lint
-lint: $(ot_py_sources)
+lint:
 	$(python) -m mypy src/opentrons $(ot_tests_to_typecheck)
 	$(python) -m flake8 setup.py src/opentrons tests
+
+.PHONY: format
+format:
+	$(python) -m black $(ot_files_to_format)
 
 docs/build/html/v%: docs/v%
 	$(sphinx_build) -b html -d docs/build/doctrees -n $< $@

--- a/api/Makefile
+++ b/api/Makefile
@@ -60,8 +60,16 @@ ot_tests_to_typecheck := \
 	tests/opentrons/protocols/runner
 
 # files and modules to format
-# TODO(mc, 2021-07-23): expand this to all files, replace this variable with `.`
-ot_files_to_format :=
+# TODO(mc, 2021-07-23): expand this to all files until we can format `.`
+ot_files_to_format := \
+	src/opentrons/file_runner \
+	src/opentrons/motion_planning \
+	src/opentrons/protocol_api_experimental \
+	src/opentrons/protocol_engine \
+	tests/opentrons/file_runner \
+	tests/opentrons/motion_planning  \
+	tests/opentrons/protocol_api_experimental \
+	tests/opentrons/protocol_engine
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target

--- a/api/Makefile
+++ b/api/Makefile
@@ -108,6 +108,7 @@ test:
 .PHONY: lint
 lint:
 	$(python) -m mypy src/opentrons $(ot_tests_to_typecheck)
+	$(python) -m black --check $(ot_files_to_format)
 	$(python) -m flake8 setup.py src/opentrons tests
 
 .PHONY: format

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -33,7 +33,8 @@ flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
 diff-match-patch = "*"
-decoy = "~=1.6.2"
+decoy = "~=1.6.4"
+black = "==21.7b0"
 
 [packages]
 aionotify = "==0.2.0"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a00b9ace936b97e7f3e2ddf7d111d2550c0ad38750c225b26d9019d64e7c30cf"
+            "sha256": "8a027db01b30d59bc90e2753d26e5dc9910ac7c8c1b2112c3dd9c685a2d5fcf8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -233,6 +233,13 @@
             ],
             "version": "==0.7.12"
         },
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
         "args": {
             "hashes": [
                 "sha256:a785b8d837625e9b61c39108532d95b85274acd679693b71ebb5156848fcf814"
@@ -271,6 +278,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.1"
         },
+        "black": {
+            "hashes": [
+                "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116",
+                "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"
+            ],
+            "index": "pypi",
+            "version": "==21.7b0"
+        },
         "bleach": {
             "hashes": [
                 "sha256:306483a5a9795474160ad57fce3ddd1b50551e981eed8e15a582d34cef28aafa",
@@ -305,6 +320,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==2.0.3"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
         },
         "clint": {
             "hashes": [
@@ -360,11 +383,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:b8ae8b707169824af59b04215615a4b0fa0bff4dccc6dde053c2b18824a6271e",
-                "sha256:c605822c4d867acb5d950ce98b51727705ff55ecc7bad544f2b4face3ee69ae0"
+                "sha256:450f0c53e1f2b901a1e40ab013020d3a24894c5f823d6c3e393d937d4e8fce07",
+                "sha256:55b03ce61903b6442e88e5c542e416da9b0b341234a35ff7169db23bc8145ed3"
             ],
             "index": "pypi",
-            "version": "==1.6.2"
+            "version": "==1.6.4"
         },
         "diff-match-patch": {
             "hashes": [
@@ -669,6 +692,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==21.0"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
         "pkginfo": {
             "hashes": [
                 "sha256:37ecd857b47e5f55949c41ed061eb51a0bee97a87c969219d144c0e023982779",
@@ -849,6 +879,52 @@
             ],
             "version": "==29.0"
         },
+        "regex": {
+            "hashes": [
+                "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f",
+                "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad",
+                "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a",
+                "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf",
+                "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59",
+                "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d",
+                "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895",
+                "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4",
+                "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3",
+                "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222",
+                "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0",
+                "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c",
+                "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417",
+                "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d",
+                "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d",
+                "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761",
+                "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0",
+                "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026",
+                "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854",
+                "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb",
+                "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d",
+                "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068",
+                "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde",
+                "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d",
+                "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec",
+                "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa",
+                "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd",
+                "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b",
+                "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26",
+                "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2",
+                "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f",
+                "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694",
+                "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0",
+                "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407",
+                "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874",
+                "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035",
+                "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d",
+                "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c",
+                "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5",
+                "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985",
+                "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"
+            ],
+            "version": "==2021.7.6"
+        },
         "requests": {
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
@@ -958,6 +1034,14 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
+        "tomli": {
+            "hashes": [
+                "sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5",
+                "sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.0"
+        },
         "tqdm": {
             "hashes": [
                 "sha256:5aa445ea0ad8b16d82b15ab342de6b195a722d75fc1ef9934a46bba6feafbc64",
@@ -1007,7 +1091,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==1.4.3"
         },
         "typeguard": {

--- a/api/src/opentrons/motion_planning/__init__.py
+++ b/api/src/opentrons/motion_planning/__init__.py
@@ -4,7 +4,7 @@ from .waypoints import (
     DEFAULT_GENERAL_ARC_Z_MARGIN,
     DEFAULT_IN_LABWARE_ARC_Z_MARGIN,
     MINIMUM_Z_MARGIN,
-    get_waypoints
+    get_waypoints,
 )
 
 from .types import Waypoint, MoveType

--- a/api/src/opentrons/motion_planning/errors.py
+++ b/api/src/opentrons/motion_planning/errors.py
@@ -12,7 +12,7 @@ class MotionPlanningError(Exception):
         clearance: float,
         min_travel_z: float,
         max_travel_z: float,
-        message: str
+        message: str,
     ) -> None:
         """Initialize an error with properties of the planned motion."""
         super().__init__(message)

--- a/api/src/opentrons/motion_planning/waypoints.py
+++ b/api/src/opentrons/motion_planning/waypoints.py
@@ -62,7 +62,7 @@ def get_waypoints(
             clearance=MINIMUM_Z_MARGIN,
             min_travel_z=min_travel_z,
             max_travel_z=max_travel_z,
-            message="Destination out of bounds in the Z-axis"
+            message="Destination out of bounds in the Z-axis",
         )
 
     # ensure that the passed in min_travel_z and max_travel_z are compatible
@@ -73,7 +73,7 @@ def get_waypoints(
             clearance=MINIMUM_Z_MARGIN,
             min_travel_z=min_travel_z,
             max_travel_z=max_travel_z,
-            message="Arc out of bounds in the Z-axis"
+            message="Arc out of bounds in the Z-axis",
         )
 
     # set the z clearance according to the arc type
@@ -88,10 +88,7 @@ def get_waypoints(
     # if any of those exceed max_travel_z, just use max_travel_z
     # if max_travel_z does not provide enough clearance, check above would
     # raise an ArcOutOfBoundsError
-    travel_z = min(
-        max_travel_z,
-        max(min_travel_z + travel_z_margin, origin.z, dest.z)
-    )
+    travel_z = min(max_travel_z, max(min_travel_z + travel_z_margin, origin.z, dest.z))
 
     # if origin.z isn't the travel height: add waypoint to move to origin.z
     if travel_z > origin.z:

--- a/api/src/opentrons/protocol_api_experimental/labware.py
+++ b/api/src/opentrons/protocol_api_experimental/labware.py
@@ -108,7 +108,7 @@ class Labware:  # noqa: D101
     # operational logic, and its presence in this interface is no longer
     # necessary with Protocol Engine controlling execution. Can we get rid of it?
     @property
-    def magdeck_engage_height(self) -> Optional[float]:    # noqa: D102
+    def magdeck_engage_height(self) -> Optional[float]:  # noqa: D102
         definition = self._engine_client.state.labware.get_labware_definition(
             labware_id=self._labware_id
         )

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -45,7 +45,7 @@ class DeckDataProvider:
 
     async def get_deck_fixed_labware(
         self,
-        deck_definition: DeckDefinitionV2
+        deck_definition: DeckDefinitionV2,
     ) -> List[DeckFixedLabware]:
         """Get a list of all labware fixtures from a given deck definition."""
         labware = []

--- a/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/labware_data_provider.py
@@ -36,11 +36,11 @@ class LabwareDataProvider:
         # TODO(mc, 2020-10-18): Fetching labware calibration data is a little
         #  convoluted and could use some clean up
         as_type_dict = cast(dev_types.LabwareDefinition, definition.dict())
-        labware_path = f'{hash_labware_def(as_type_dict)}.json'
+        labware_path = f"{hash_labware_def(as_type_dict)}.json"
         cal_point = get_labware_calibration(
             labware_path,
             as_type_dict,
             # TODO(mc, 2020-10-18): Support labware on modules
-            parent='',
+            parent="",
         )
         return (cal_point.x, cal_point.y, cal_point.z)

--- a/api/tests/opentrons/motion_planning/test_waypoints.py
+++ b/api/tests/opentrons/motion_planning/test_waypoints.py
@@ -21,9 +21,7 @@ def test_get_waypoints_direct() -> None:
         max_travel_z=100,
     )
 
-    assert result == [
-        Waypoint(Point(1, 2, 4))
-    ]
+    assert result == [Waypoint(Point(1, 2, 4))]
 
 
 def test_get_waypoints_in_labware_arc() -> None:
@@ -239,6 +237,4 @@ def test_get_waypoints_direct_moves_ignore_clearance_requirements() -> None:
         max_travel_z=5.9,
     )
 
-    assert result == [
-        Waypoint(Point(1, 1, 5.5))
-    ]
+    assert result == [Waypoint(Point(1, 1, 5.5))]

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -59,7 +59,7 @@ async def test_get_deck_labware_fixtures(
         DeckFixedLabware(
             labware_id="fixedTrash",
             location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
-            definition=fixed_trash_def
+            definition=fixed_trash_def,
         )
     ]
     mock_labware_data.get_labware_definition.assert_called_with(
@@ -84,7 +84,7 @@ async def test_get_deck_labware_fixtures_short_trash(
         DeckFixedLabware(
             labware_id="fixedTrash",
             location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
-            definition=short_fixed_trash_def
+            definition=short_fixed_trash_def,
         )
     ]
     mock_labware_data.get_labware_definition.assert_called_with(

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
@@ -19,12 +19,12 @@ async def test_labware_data_gets_standard_definition() -> None:
     expected = get_labware_definition(
         load_name="opentrons_96_tiprack_300ul",
         namespace="opentrons",
-        version=1
+        version=1,
     )
     result = await LabwareDataProvider().get_labware_definition(
         load_name="opentrons_96_tiprack_300ul",
         namespace="opentrons",
-        version=1
+        version=1,
     )
 
     assert result == LabwareDefinition.parse_obj(expected)
@@ -37,7 +37,7 @@ async def test_labware_data_gets_calibration(
     # TODO(mc, 2020-10-18): this mock is a kinda code-smelly. Fetching labware
     #  calibration data is a little convoluted and could use some clean up
     with patch(
-        'opentrons.protocol_engine.resources.labware_data_provider.get_labware_calibration'  # noqa: E501
+        "opentrons.protocol_engine.resources.labware_data_provider.get_labware_calibration"  # noqa: E501
     ) as mock_get_lw_calibration:
         mock_get_lw_calibration.return_value = Point(1, 2, 3)
 
@@ -50,7 +50,7 @@ async def test_labware_data_gets_calibration(
 
         assert result == (1, 2, 3)
         mock_get_lw_calibration.assert_called_with(
-            f'{hash_labware_def(as_type_dict)}.json',
+            f"{hash_labware_def(as_type_dict)}.json",
             as_type_dict,
-            parent='',
+            parent="",
         )

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "multer": "^1.4.2",
     "nanobench": "^2.1.1",
     "ntee": "^2.0.0",
-    "onchange": "^6.1.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "portfinder": "^1.0.13",
     "postcss": "^7.0.18",

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -101,6 +101,7 @@ test:
 .PHONY: lint
 lint:
 	$(python) -m mypy $(SRC_PATH) $(tests)
+	$(python) -m black --check $(ot_files_to_format)
 	$(python) -m flake8 $(SRC_PATH) $(tests) setup.py
 
 .PHONY: format

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -3,13 +3,6 @@
 include ../scripts/push.mk
 include ../scripts/python.mk
 
-# using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
-SHELL := bash
-
-# add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)
-# and also make an explicit version for shx for use in the shell function,
-# where PATH won’t be propagated
-PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx
 
 # Path of source package
@@ -39,6 +32,10 @@ ssh_opts ?= $(default_ssh_opts)
 # For the python sources
 ot_py_sources := $(filter %.py,$(shell $(SHX) find $(SRC_PATH)))
 ot_sources := $(ot_py_sources)
+
+# files and modules to format
+# TODO(mc, 2021-07-23): expand this to all files, replace this variable with `.`
+ot_files_to_format :=
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
@@ -90,9 +87,13 @@ test:
 	$(pytest) $(tests) $(test_opts)
 
 .PHONY: lint
-lint: $(ot_py_sources)
+lint:
 	$(python) -m mypy $(SRC_PATH) $(tests)
 	$(python) -m flake8 $(SRC_PATH) $(tests) setup.py
+
+.PHONY: format
+format:
+	$(python) -m black $(ot_files_to_format)
 
 .PHONY: dev
 dev: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev.env

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -34,8 +34,20 @@ ot_py_sources := $(filter %.py,$(shell $(SHX) find $(SRC_PATH)))
 ot_sources := $(ot_py_sources)
 
 # files and modules to format
-# TODO(mc, 2021-07-23): expand this to all files, replace this variable with `.`
-ot_files_to_format :=
+# TODO(mc, 2021-07-23): expand this to all files until we can format `.`
+ot_files_to_format := \
+	robot_server/errors \
+	robot_server/health \
+	robot_server/protocols \
+	robot_server/sessions \
+	robot_server/app.py \
+	robot_server/util.py \
+	tests/errors \
+	tests/health \
+	tests/protocols \
+	tests/sessions \
+	tests/test_app.py \
+	tests/test_util.py
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target

--- a/robot-server/Pipfile
+++ b/robot-server/Pipfile
@@ -23,8 +23,9 @@ flake8 = "~=3.9.0"
 flake8-annotations = "~=2.6.2"
 flake8-docstrings = "~=1.6.0"
 flake8-noqa = "~=1.1.0"
-decoy = "~=1.6.2"
+decoy = "~=1.6.4"
 httpx = "==0.18.*"
+black = "==21.7b0"
 
 [packages]
 uvicorn = "==0.11.3"

--- a/robot-server/Pipfile.lock
+++ b/robot-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "43dc27fd8fea8b90b4c2f16d45876a67990cd613a9ca2dfe55697d0353f4da86"
+            "sha256": "bcd3ddea34eba7412eb87e9c6a2e43da1dc2b514dbb02a4c5f3aa89e23011dfc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -280,11 +280,18 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:07968db9fa7c1ca5435a133dc62f988d84ef78e1d9b22814a59d1c62618afbc5",
-                "sha256:442678a3c7e1cdcdbc37dcfe4527aa851b1b0c9162653b516e9f509821691d50"
+                "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0",
+                "sha256:ae57a67583e5ff8b4af47666ff5651c3732d45fd26c929253748e796af860374"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.2.1"
+            "version": "==3.3.0"
+        },
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
         },
         "async-timeout": {
             "hashes": [
@@ -309,6 +316,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116",
+                "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"
+            ],
+            "index": "pypi",
+            "version": "==21.7b0"
         },
         "c445fee": {
             "editable": true,
@@ -336,6 +351,14 @@
             ],
             "markers": "python_version >= '3'",
             "version": "==2.0.3"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
         },
         "coverage": {
             "hashes": [
@@ -397,11 +420,11 @@
         },
         "decoy": {
             "hashes": [
-                "sha256:b8ae8b707169824af59b04215615a4b0fa0bff4dccc6dde053c2b18824a6271e",
-                "sha256:c605822c4d867acb5d950ce98b51727705ff55ecc7bad544f2b4face3ee69ae0"
+                "sha256:450f0c53e1f2b901a1e40ab013020d3a24894c5f823d6c3e393d937d4e8fce07",
+                "sha256:55b03ce61903b6442e88e5c542e416da9b0b341234a35ff7169db23bc8145ed3"
             ],
             "index": "pypi",
-            "version": "==1.6.2"
+            "version": "==1.6.4"
         },
         "docopt": {
             "hashes": [
@@ -665,6 +688,13 @@
             ],
             "version": "==1.5.1"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
         "pbr": {
             "hashes": [
                 "sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd",
@@ -880,6 +910,52 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==5.4.1"
         },
+        "regex": {
+            "hashes": [
+                "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f",
+                "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad",
+                "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a",
+                "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf",
+                "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59",
+                "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d",
+                "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895",
+                "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4",
+                "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3",
+                "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222",
+                "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0",
+                "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c",
+                "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417",
+                "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d",
+                "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d",
+                "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761",
+                "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0",
+                "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026",
+                "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854",
+                "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb",
+                "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d",
+                "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068",
+                "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde",
+                "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d",
+                "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec",
+                "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa",
+                "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd",
+                "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b",
+                "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26",
+                "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2",
+                "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f",
+                "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694",
+                "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0",
+                "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407",
+                "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874",
+                "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035",
+                "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d",
+                "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c",
+                "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5",
+                "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985",
+                "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"
+            ],
+            "version": "==2021.7.6"
+        },
         "requests": {
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
@@ -979,6 +1055,14 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
+        "tomli": {
+            "hashes": [
+                "sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5",
+                "sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.0"
+        },
         "typed-ast": {
             "hashes": [
                 "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace",
@@ -1012,7 +1096,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==1.4.3"
         },
         "typing-extensions": {

--- a/robot-server/robot_server/util.py
+++ b/robot-server/robot_server/util.py
@@ -33,7 +33,7 @@ def save_upload(directory: Path, upload_file: UploadFile) -> FileMeta:
     content_hash = hashlib.sha256(contents).hexdigest()
 
     # write contents to file
-    with path.open('wb') as p:
+    with path.open("wb") as p:
         p.write(contents)
 
     return FileMeta(path=path, content_hash=content_hash)
@@ -51,6 +51,7 @@ def call_once(fn):
 
     :param fn: a coroutine
     """
+
     @wraps(fn)
     async def wrapped(*args, **kwargs):
         if not hasattr(wrapped, CALL_ONCE_RESULT_ATTR):

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -3,8 +3,7 @@ from mock import MagicMock
 from starlette.testclient import TestClient
 
 from opentrons import __version__
-from opentrons.protocol_api import (
-    MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION)
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
 
 
 def test_get_health(api_client: TestClient, hardware: MagicMock) -> None:
@@ -13,24 +12,24 @@ def test_get_health(api_client: TestClient, hardware: MagicMock) -> None:
     hardware.board_revision = "BR2.1"
 
     expected = {
-        'name': 'opentrons-dev',
-        'api_version': __version__,
-        'fw_version': 'FW111',
-        'board_revision': 'BR2.1',
-        'logs': ['/logs/serial.log', '/logs/api.log', '/logs/server.log'],
-        'system_version': '0.0.0',
-        'minimum_protocol_api_version': list(MIN_SUPPORTED_VERSION),
-        'maximum_protocol_api_version': list(MAX_SUPPORTED_VERSION),
+        "name": "opentrons-dev",
+        "api_version": __version__,
+        "fw_version": "FW111",
+        "board_revision": "BR2.1",
+        "logs": ["/logs/serial.log", "/logs/api.log", "/logs/server.log"],
+        "system_version": "0.0.0",
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
         "links": {
             "apiLog": "/logs/api.log",
             "serialLog": "/logs/serial.log",
             "serverLog": "/logs/server.log",
             "apiSpec": "/openapi.json",
-            "systemTime": "/system/time"
-        }
+            "systemTime": "/system/time",
+        },
     }
 
-    resp = api_client.get('/health')
+    resp = api_client.get("/health")
     text = resp.json()
     assert resp.status_code == 200
     assert text == expected

--- a/robot-server/tests/test_app.py
+++ b/robot-server/tests/test_app.py
@@ -26,9 +26,10 @@ from robot_server.constants import (
             {API_VERSION_HEADER: str(API_VERSION_LATEST)},
             API_VERSION,
         ],
-    ])
+    ],
+)
 def test_api_versioning(api_client, headers, expected_version):
-    resp = api_client.get('/settings', headers=headers)
+    resp = api_client.get("/settings", headers=headers)
     assert resp.headers.get(API_VERSION_HEADER) == str(expected_version)
     assert resp.headers.get(MIN_API_VERSION_HEADER) == str(MIN_API_VERSION)
 
@@ -50,9 +51,9 @@ def mock_log_control():
         "/logs/api.log",
         "/logs/some-random-journald-thing",
         "/",
-    ])
-def test_api_versioning_non_versions_endpoints(
-        api_client, path, mock_log_control):
+    ],
+)
+def test_api_versioning_non_versions_endpoints(api_client, path, mock_log_control):
     del api_client.headers["Opentrons-Version"]
     resp = api_client.get(path)
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)
@@ -61,7 +62,7 @@ def test_api_versioning_non_versions_endpoints(
 
 def test_api_version_too_low(api_client):
     """It should reject any API version lower than 2."""
-    resp = api_client.get('/settings', headers={API_VERSION_HEADER: "1"})
+    resp = api_client.get("/settings", headers={API_VERSION_HEADER: "1"})
 
     assert resp.status_code == HTTPStatus.BAD_REQUEST
     assert resp.headers.get(API_VERSION_HEADER) == str(API_VERSION)
@@ -72,7 +73,7 @@ def test_api_version_too_low(api_client):
             "detail": (
                 "HTTP API version 1 is no longer supported. Please upgrade "
                 "your Opentrons App or other HTTP API client."
-            )
+            ),
         }
     ]
 
@@ -85,7 +86,8 @@ def test_api_version_too_low(api_client):
         "/system/time",
         "/calibration/pipette_offset",
         "/calibration/tip_length",
-    ])
+    ],
+)
 def test_api_version_missing(api_client, path):
     """It should reject any request without an version header."""
     del api_client.headers["Opentrons-Version"]

--- a/robot-server/tests/test_util.py
+++ b/robot-server/tests/test_util.py
@@ -18,6 +18,7 @@ def mock_utc_now(mock_start_time):
 
     First call will be mock_start_time. Subsequent calls will increment by
     1 day."""
+
     class _TimeIncrementer:
         def __init__(self, t):
             self._time = t
@@ -27,7 +28,7 @@ def mock_utc_now(mock_start_time):
             self._time += timedelta(days=1)
             return ret
 
-    with patch.object(util, 'utc_now') as p:
+    with patch.object(util, "utc_now") as p:
         p.side_effect = _TimeIncrementer(mock_start_time)
         yield p
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,11 +1148,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blakeembrey/deque@^1.0.3":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@blakeembrey/deque/-/deque-1.0.5.tgz#f4fa17fc5ee18317ec01a763d355782c7b395eaf"
-  integrity sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -5120,7 +5115,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-arrify@^2.0.0, arrify@^2.0.1:
+arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
@@ -6449,7 +6444,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.0.0, chokidar@^3.4.1, chokidar@^3.4.2:
+chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
   integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
@@ -7327,7 +7322,7 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -15295,20 +15290,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onchange@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/onchange/-/onchange-6.1.1.tgz#8e23e5c696df1b8eae4efec2b49ea24847980cf3"
-  integrity sha512-G60OULp9Hi2dixPKYn/lfs7C8oDgFcneAhZ/4nPnvzd+Ar94q3FN0UG/t1zqXI15StSLvt7NlRqylamTSGhc4A==
-  dependencies:
-    "@blakeembrey/deque" "^1.0.3"
-    arrify "^2.0.0"
-    chokidar "^3.0.0"
-    cross-spawn "^7.0.1"
-    ignore "^5.1.4"
-    minimist "^1.2.3"
-    supports-color "^7.0.0"
-    tree-kill "^1.2.2"
-
 one-time@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
@@ -20732,7 +20713,7 @@ traverse-chain@~0.1.0:
   resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
   integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
 
-tree-kill@^1.2.1, tree-kill@^1.2.2:
+tree-kill@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==


### PR DESCRIPTION
## Overview

As part of #7629, this PR introduces [black](https://github.com/psf/black) to the monorepo. It takes a low-churn approach to this addition by limiting formatting / associated `make` tasks to files that were already broadly adhering to `black` style.

## Changelog

- Bring in black
- Introduce `format` targets in Makefiles
- Format some code that was already close

## Review requests

- [ ] Low churn approach seems good?
- [ ] Ok with using a beta version of black?
    - Anecdotally, I have yet to encounter a single issue after having black set in my editor for various projects for several months now
- [ ] Any other files we want to pull into formatting right now? 

## Risk assessment

Low, but not zero, as source code is technically being changed
