### PR TITLE
style(robot-server): apply black format to all robot-server code

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -33,22 +33,6 @@ ssh_opts ?= $(default_ssh_opts)
 ot_py_sources := $(filter %.py,$(shell $(SHX) find $(SRC_PATH)))
 ot_sources := $(ot_py_sources)
 
-# files and modules to format
-# TODO(mc, 2021-07-23): expand this to all files until we can format `.`
-ot_files_to_format := \
-	robot_server/errors \
-	robot_server/health \
-	robot_server/protocols \
-	robot_server/sessions \
-	robot_server/app.py \
-	robot_server/util.py \
-	tests/errors \
-	tests/health \
-	tests/protocols \
-	tests/sessions \
-	tests/test_app.py \
-	tests/test_util.py
-
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'robot_server/**/.mypy_cache'
@@ -101,12 +85,12 @@ test:
 .PHONY: lint
 lint:
 	$(python) -m mypy $(SRC_PATH) $(tests)
-	$(python) -m black --check $(ot_files_to_format)
+	$(python) -m black --check .
 	$(python) -m flake8 $(SRC_PATH) $(tests) setup.py
 
 .PHONY: format
 format:
-	$(python) -m black $(ot_files_to_format)
+	$(python) -m black .
 
 .PHONY: dev
 dev: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev.env

--- a/robot-server/robot_server/hardware_wrapper.py
+++ b/robot-server/robot_server/hardware_wrapper.py
@@ -31,12 +31,14 @@ class HardwareWrapper:
         """Initialize the API."""
         app_settings = get_settings()
         if app_settings.simulator_configuration_file_path:
-            log.info(f"Loading simulator from "
-                     f"{app_settings.simulator_configuration_file_path}")
+            log.info(
+                f"Loading simulator from "
+                f"{app_settings.simulator_configuration_file_path}"
+            )
             # A path to a simulation configuration is defined. Let's use it.
             self._tm = ThreadManager(
-                load_simulator,
-                Path(app_settings.simulator_configuration_file_path))
+                load_simulator, Path(app_settings.simulator_configuration_file_path)
+            )
         else:
             # Create the hardware
             self._tm = await initialize_api()
@@ -47,17 +49,21 @@ class HardwareWrapper:
     async def init_event_watchers(self) -> None:
         """Register the publisher callbacks with the hw thread manager."""
         if self._tm is None:
-            log.error("HW Thread Manager not initialized. "
-                      "Cannot initialize robot event watchers.")
+            log.error(
+                "HW Thread Manager not initialized. "
+                "Cannot initialize robot event watchers."
+            )
             return
 
         if self._hardware_event_watcher is None:
             log.info("Starting hardware-event-notify publisher")
             self._hardware_event_watcher = await self._tm.register_callback(
-                self._publish_hardware_event)
+                self._publish_hardware_event
+            )
         else:
-            log.warning("Cannot start new hardware event watcher "
-                        "when one already exists")
+            log.warning(
+                "Cannot start new hardware event watcher " "when one already exists"
+            )
 
     def _publish_hardware_event(self, hw_event: HardwareEvent) -> None:
         if hw_event.event == HardwareEventType.DOOR_SWITCH_CHANGE:
@@ -68,11 +74,8 @@ class HardwareWrapper:
         topic = topics.RobotEventTopics.HARDWARE_EVENTS
         publisher = self._publish_hardware_event.__qualname__
         self._event_publisher.send_nowait(
-            topic,
-            event.Event(
-                createdOn=utc_now(),
-                publisher=publisher,
-                data=payload))
+            topic, event.Event(createdOn=utc_now(), publisher=publisher, data=payload)
+        )
 
     def async_initialize(self) -> None:
         """Create task to initialize hardware."""

--- a/robot-server/robot_server/robot/calibration/check/constants.py
+++ b/robot-server/robot_server/robot/calibration/check/constants.py
@@ -5,7 +5,11 @@ from enum import Enum
 from opentrons.types import Point
 
 from robot_server.robot.calibration.constants import (
-    STATE_WILDCARD, POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID)
+    STATE_WILDCARD,
+    POINT_ONE_ID,
+    POINT_TWO_ID,
+    POINT_THREE_ID,
+)
 
 
 class CalibrationCheckState(str, Enum):
@@ -32,23 +36,22 @@ class CalibrationCheckState(str, Enum):
 # tip length. Please review the Motion research for
 # further information.
 PIPETTE_TOLERANCES = {
-    'p1000_crosses': Point(2.7, 2.7, 0.0),
-    'p1000_height': Point(0.0, 0.0, 1.0),
-    'p300_crosses': Point(1.8, 1.8, 0.0),
-    'p20_crosses': Point(1.4, 1.4, 0.0),
-    'other_height': Point(0.0, 0.0, 0.8),
-    'p20_tip': Point(0.0, 0.0, 0.50),
-    'p300_tip': Point(0.0, 0.0, 1.0),
-    'p1000_tip': Point(0.0, 0.0, 1.0)
+    "p1000_crosses": Point(2.7, 2.7, 0.0),
+    "p1000_height": Point(0.0, 0.0, 1.0),
+    "p300_crosses": Point(1.8, 1.8, 0.0),
+    "p20_crosses": Point(1.4, 1.4, 0.0),
+    "other_height": Point(0.0, 0.0, 0.8),
+    "p20_tip": Point(0.0, 0.0, 0.50),
+    "p300_tip": Point(0.0, 0.0, 1.0),
+    "p1000_tip": Point(0.0, 0.0, 1.0),
 }
 
-TIPRACK_SLOT = '8'
+TIPRACK_SLOT = "8"
 
-StatePointMap = Dict[
-    CalibrationCheckState, Union[Literal['1BLC', '3BRC', '7TLC']]]
+StatePointMap = Dict[CalibrationCheckState, Union[Literal["1BLC", "3BRC", "7TLC"]]]
 
 MOVE_POINT_STATE_MAP: StatePointMap = {
     CalibrationCheckState.comparingHeight: POINT_ONE_ID,
     CalibrationCheckState.comparingPointOne: POINT_TWO_ID,
-    CalibrationCheckState.comparingPointTwo: POINT_THREE_ID
+    CalibrationCheckState.comparingPointTwo: POINT_THREE_ID,
 }

--- a/robot-server/robot_server/robot/calibration/check/models.py
+++ b/robot-server/robot_server/robot/calibration/check/models.py
@@ -7,54 +7,64 @@ from ..helper_classes import RequiredLabware, AttachedPipette
 
 OffsetVector = Tuple[float, float, float]
 
-OffsetVectorField = partial(Field, ...,
-                            description="An offset vector in deck "
-                                        "coordinates (x, y, z)")
+OffsetVectorField = partial(
+    Field, ..., description="An offset vector in deck " "coordinates (x, y, z)"
+)
 
 
 class ComparisonStatus(BaseModel):
     """
     A model describing the comparison of a checked point to calibrated value
     """
+
     differenceVector: OffsetVector = OffsetVectorField()
-    thresholdVector:  OffsetVector = OffsetVectorField()
+    thresholdVector: OffsetVector = OffsetVectorField()
     exceedsThreshold: bool
 
 
 class DeckComparisonMap(BaseModel):
-    status: Literal['IN_THRESHOLD', 'OUTSIDE_THRESHOLD'] =\
-        Field(...,
-              description="The status of this calibration type,"
-                          "dependent on the calibration being"
-                          "inside or outside of the threshold")
-    comparingPointOne: Optional[ComparisonStatus] =\
-        Field(None, description="point 1 validation step")
-    comparingPointTwo: Optional[ComparisonStatus] =\
-        Field(None, description="point 2 validation step")
-    comparingPointThree: Optional[ComparisonStatus] =\
-        Field(None, description="point 3 validation step")
+    status: Literal["IN_THRESHOLD", "OUTSIDE_THRESHOLD"] = Field(
+        ...,
+        description="The status of this calibration type,"
+        "dependent on the calibration being"
+        "inside or outside of the threshold",
+    )
+    comparingPointOne: Optional[ComparisonStatus] = Field(
+        None, description="point 1 validation step"
+    )
+    comparingPointTwo: Optional[ComparisonStatus] = Field(
+        None, description="point 2 validation step"
+    )
+    comparingPointThree: Optional[ComparisonStatus] = Field(
+        None, description="point 3 validation step"
+    )
 
 
 class PipetteOffsetComparisonMap(BaseModel):
-    status: Literal['IN_THRESHOLD', 'OUTSIDE_THRESHOLD'] =\
-        Field(...,
-              description="The status of this calibration type,"
-                          "dependent on the calibration being"
-                          "inside or outside of the threshold")
-    comparingHeight: Optional[ComparisonStatus] =\
-        Field(None, description="height validation step")
-    comparingPointOne: Optional[ComparisonStatus] =\
-        Field(None, description="point 1 validation step")
+    status: Literal["IN_THRESHOLD", "OUTSIDE_THRESHOLD"] = Field(
+        ...,
+        description="The status of this calibration type,"
+        "dependent on the calibration being"
+        "inside or outside of the threshold",
+    )
+    comparingHeight: Optional[ComparisonStatus] = Field(
+        None, description="height validation step"
+    )
+    comparingPointOne: Optional[ComparisonStatus] = Field(
+        None, description="point 1 validation step"
+    )
 
 
 class TipComparisonMap(BaseModel):
-    status: Literal['IN_THRESHOLD', 'OUTSIDE_THRESHOLD'] =\
-        Field(...,
-              description="The status of this calibration type,"
-                          "dependent on the calibration being"
-                          "inside or outside of the threshold")
-    comparingTip: Optional[ComparisonStatus] =\
-        Field(None, description="tip validation step")
+    status: Literal["IN_THRESHOLD", "OUTSIDE_THRESHOLD"] = Field(
+        ...,
+        description="The status of this calibration type,"
+        "dependent on the calibration being"
+        "inside or outside of the threshold",
+    )
+    comparingTip: Optional[ComparisonStatus] = Field(
+        None, description="tip validation step"
+    )
 
 
 class ComparisonStatePerCalibration(BaseModel):
@@ -69,32 +79,34 @@ class ComparisonStatePerPipette(BaseModel):
 
 
 class CheckAttachedPipette(AttachedPipette):
-    rank: Literal['first', 'second'] =\
-        Field(..., description="The order of a given pipette")
-    tipRackLoadName: str =\
-        Field(..., description="The load name of the tiprack")
-    tipRackDisplay: str =\
-        Field(..., description="The display name of the tiprack")
-    tipRackUri: str =\
-        Field(..., description="The uri of the tiprack")
+    rank: Literal["first", "second"] = Field(
+        ..., description="The order of a given pipette"
+    )
+    tipRackLoadName: str = Field(..., description="The load name of the tiprack")
+    tipRackDisplay: str = Field(..., description="The display name of the tiprack")
+    tipRackUri: str = Field(..., description="The uri of the tiprack")
 
 
 class SessionCreateParams(BaseModel):
     """
     Calibration Health Check create params
     """
+
     hasCalibrationBlock: bool = Field(
         False,
-        description='Whether to use a calibration block in the'
-                    'calibration health check flow.')
+        description="Whether to use a calibration block in the"
+        "calibration health check flow.",
+    )
     tipRacks: List[dict] = Field(
         [],
-        description='A list of labware definitions to use in'
-                    'calibration health check')
+        description="A list of labware definitions to use in"
+        "calibration health check",
+    )
 
 
 class CalibrationCheckSessionStatus(BaseModel):
     """The current status of a given session."""
+
     instruments: List[CheckAttachedPipette]
     activePipette: CheckAttachedPipette
     currentStep: str = Field(..., description="Current step of session")
@@ -102,7 +114,8 @@ class CalibrationCheckSessionStatus(BaseModel):
     labware: List[RequiredLabware]
     activeTipRack: RequiredLabware
     supportedCommands: List[Optional[str]] = Field(
-        ..., description="A list of supported commands for this user flow")
+        ..., description="A list of supported commands for this user flow"
+    )
 
     class Config:
         arbitrary_types_allowed = True
@@ -115,23 +128,23 @@ class CalibrationCheckSessionStatus(BaseModel):
                             "name": "p300_single",
                             "tip_length": 51.7,
                             "mount": "left",
-                            "id": "P3HS12123041"
+                            "id": "P3HS12123041",
                         },
                         {
                             "model": None,
                             "name": None,
                             "tip_length": None,
                             "mount": "right",
-                            "id": None
-                        }
+                            "id": None,
+                        },
                     ],
                     "currentStep": "sessionStarted",
                     "comparisonsByPipette": {
                         "comparingFirstPipetteHeight": {
                             "differenceVector": [1, 0, 0],
-                            "exceedsThreshold": False
+                            "exceedsThreshold": False,
                         }
-                    }
+                    },
                 }
             ]
         }

--- a/robot-server/robot_server/robot/calibration/check/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/check/state_machine.py
@@ -1,25 +1,25 @@
 from typing import Dict
 
-from robot_server.service.session.models.command_definitions import \
-    CommandDefinition, CalibrationCommand, DeckCalibrationCommand, \
-    CheckCalibrationCommand
-from robot_server.robot.calibration.util import (
-    SimpleStateMachine, StateTransitionError)
+from robot_server.service.session.models.command_definitions import (
+    CommandDefinition,
+    CalibrationCommand,
+    DeckCalibrationCommand,
+    CheckCalibrationCommand,
+)
+from robot_server.robot.calibration.util import SimpleStateMachine, StateTransitionError
 
 from .constants import CalibrationCheckState as State
 
 
 CALIBRATION_CHECK_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
-    State.sessionStarted: {
-        CalibrationCommand.load_labware: State.labwareLoaded
-    },
+    State.sessionStarted: {CalibrationCommand.load_labware: State.labwareLoaded},
     State.labwareLoaded: {
         CalibrationCommand.move_to_reference_point: State.comparingNozzle
     },
     State.comparingNozzle: {
         CalibrationCommand.jog: State.comparingNozzle,
         CalibrationCommand.move_to_tip_rack: State.preparingPipette,
-        CalibrationCommand.invalidate_last_action: State.comparingNozzle
+        CalibrationCommand.invalidate_last_action: State.comparingNozzle,
     },
     State.preparingPipette: {
         CalibrationCommand.jog: State.preparingPipette,
@@ -28,55 +28,52 @@ CALIBRATION_CHECK_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
     },
     State.inspectingTip: {
         CalibrationCommand.invalidate_tip: State.preparingPipette,
-        CalibrationCommand.move_to_reference_point: State.comparingTip
+        CalibrationCommand.move_to_reference_point: State.comparingTip,
     },
     State.comparingTip: {
         CheckCalibrationCommand.compare_point: State.comparingTip,
         CalibrationCommand.jog: State.comparingTip,
         CalibrationCommand.move_to_deck: State.comparingHeight,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.comparingHeight: {
         CalibrationCommand.jog: State.comparingHeight,
         CheckCalibrationCommand.compare_point: State.comparingHeight,
         CalibrationCommand.move_to_point_one: State.comparingPointOne,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.comparingPointOne: {
         CalibrationCommand.jog: State.comparingPointOne,
         CheckCalibrationCommand.compare_point: State.comparingPointOne,
         DeckCalibrationCommand.move_to_point_two: State.comparingPointTwo,
         CalibrationCommand.move_to_tip_rack: State.returningTip,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.comparingPointTwo: {
         CalibrationCommand.jog: State.comparingPointTwo,
         CheckCalibrationCommand.compare_point: State.comparingPointTwo,
         DeckCalibrationCommand.move_to_point_three: State.comparingPointThree,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.comparingPointThree: {
         CalibrationCommand.jog: State.comparingPointThree,
         CheckCalibrationCommand.compare_point: State.comparingPointThree,
         CalibrationCommand.move_to_tip_rack: State.returningTip,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
     State.returningTip: {
         CheckCalibrationCommand.return_tip: State.returningTip,
         CheckCalibrationCommand.transition: State.resultsSummary,
-        CheckCalibrationCommand.switch_pipette: State.labwareLoaded
+        CheckCalibrationCommand.switch_pipette: State.labwareLoaded,
     },
-    State.WILDCARD: {
-        CalibrationCommand.exit: State.sessionExited
-    }
+    State.WILDCARD: {CalibrationCommand.exit: State.sessionExited},
 }
 
 
 class CalibrationCheckStateMachine:
     def __init__(self):
         self._state_machine = SimpleStateMachine(
-            states=set(s for s in State),
-            transitions=CALIBRATION_CHECK_TRANSITIONS
+            states=set(s for s in State), transitions=CALIBRATION_CHECK_TRANSITIONS
         )
 
     def get_next_state(self, from_state: State, command: CommandDefinition):

--- a/robot-server/robot_server/robot/calibration/check/util.py
+++ b/robot-server/robot_server/robot/calibration/check/util.py
@@ -3,11 +3,9 @@ from typing import Optional, Union
 
 from opentrons.types import Point
 
-from .models import (
-    TipComparisonMap, PipetteOffsetComparisonMap,
-    DeckComparisonMap)
+from .models import TipComparisonMap, PipetteOffsetComparisonMap, DeckComparisonMap
 
-WILDCARD = '*'
+WILDCARD = "*"
 
 
 @dataclass
@@ -32,9 +30,10 @@ class ComparisonStatePerCalibration:
     deck: Optional[DeckComparisonMap] = None
 
     def set_value(
-            self, name: str,
-            value: Union[TipComparisonMap, PipetteOffsetComparisonMap,
-                         DeckComparisonMap]):
+        self,
+        name: str,
+        value: Union[TipComparisonMap, PipetteOffsetComparisonMap, DeckComparisonMap],
+    ):
         setattr(self, name, value)
 
 
@@ -43,14 +42,8 @@ class ComparisonStatePerPipette:
     first: ComparisonStatePerCalibration
     second: ComparisonStatePerCalibration
 
-    def set_value(
-            self, name: str,
-            value: ComparisonStatePerCalibration):
+    def set_value(self, name: str, value: ComparisonStatePerCalibration):
         setattr(self, name, value)
 
 
-REFERENCE_POINT_MAP = {
-    '1BLC': 'one',
-    '3BRC': 'two',
-    '7TLC': 'three'
-}
+REFERENCE_POINT_MAP = {"1BLC": "one", "3BRC": "two", "7TLC": "three"}

--- a/robot-server/robot_server/robot/calibration/constants.py
+++ b/robot-server/robot_server/robot/calibration/constants.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from typing_extensions import Final
 
 
-STATE_WILDCARD = '*'
+STATE_WILDCARD = "*"
 
 _lw_fmt = "opentrons_96_{}_{}ul"
 _filtertiprack = "filtertiprack"
@@ -25,7 +25,7 @@ FILTERTIPRACK_300 = _lw_fmt.format(_filtertiprack, 300)
 FILTERTIPRACK_1000 = _lw_fmt.format(_filtertiprack, 1000)
 
 
-JOG_TO_DECK_SLOT: Final = '5'
+JOG_TO_DECK_SLOT: Final = "5"
 
 
 @dataclass
@@ -42,61 +42,48 @@ class LabwareLookUp:
 
 
 TIP_RACK_LOOKUP_BY_MAX_VOL: Dict[str, LabwareLookUp] = {
-    '10': LabwareLookUp(
+    "10": LabwareLookUp(
         load_name=TIPRACK_10,
-        alternatives={
-            TIPRACK_20,
-            FILTERTIPRACK_10,
-            FILTERTIPRACK_20}),
-    '20': LabwareLookUp(
+        alternatives={TIPRACK_20, FILTERTIPRACK_10, FILTERTIPRACK_20},
+    ),
+    "20": LabwareLookUp(
         load_name=TIPRACK_20,
-        alternatives={
-            TIPRACK_10,
-            FILTERTIPRACK_10,
-            FILTERTIPRACK_20}),
-    '50': LabwareLookUp(
-        load_name=TIPRACK_300,
-        alternatives={
-            TIPRACK_300,
-            FILTERTIPRACK_300}),
-    '300': LabwareLookUp(
-         load_name=TIPRACK_300,
-         alternatives={
-             TIPRACK_300,
-             FILTERTIPRACK_300}),
-    '1000': LabwareLookUp(
-          load_name=TIPRACK_1000,
-          alternatives={
-              TIPRACK_1000,
-              FILTERTIPRACK_1000})
+        alternatives={TIPRACK_10, FILTERTIPRACK_10, FILTERTIPRACK_20},
+    ),
+    "50": LabwareLookUp(
+        load_name=TIPRACK_300, alternatives={TIPRACK_300, FILTERTIPRACK_300}
+    ),
+    "300": LabwareLookUp(
+        load_name=TIPRACK_300, alternatives={TIPRACK_300, FILTERTIPRACK_300}
+    ),
+    "1000": LabwareLookUp(
+        load_name=TIPRACK_1000, alternatives={TIPRACK_1000, FILTERTIPRACK_1000}
+    ),
 }
 
-SHORT_TRASH_DECK = 'ot2_short_trash'
-STANDARD_DECK = 'ot2_standard'
+SHORT_TRASH_DECK = "ot2_short_trash"
+STANDARD_DECK = "ot2_standard"
 
-POINT_ONE_ID: Final = '1BLC'
-POINT_TWO_ID: Final = '3BRC'
-POINT_THREE_ID: Final = '7TLC'
+POINT_ONE_ID: Final = "1BLC"
+POINT_TWO_ID: Final = "3BRC"
+POINT_THREE_ID: Final = "7TLC"
 
 MOVE_TO_TIP_RACK_SAFETY_BUFFER = Point(0, 0, 10)
 MOVE_TO_POINT_SAFETY_BUFFER = Point(0, 0, 5)
 MOVE_TO_DECK_SAFETY_BUFFER = Point(0, 10, 5)
 MOVE_TO_REF_POINT_SAFETY_BUFFER = Point(0, 0, 5)
 
-TRASH_WELL = 'A1'
+TRASH_WELL = "A1"
 TRASH_REF_POINT_OFFSET = Point(-57.84, -55, 0)  # offset from center of trash
 
 CAL_BLOCK_SETUP_BY_MOUNT: Dict[Mount, LabwareInfo] = {
     Mount.LEFT: LabwareInfo(
-        load_name='opentrons_calibrationblock_short_side_right',
-        slot='3',
-        well='A1'),
+        load_name="opentrons_calibrationblock_short_side_right", slot="3", well="A1"
+    ),
     Mount.RIGHT: LabwareInfo(
-        load_name='opentrons_calibrationblock_short_side_left',
-        slot='1',
-        well='A2')}
+        load_name="opentrons_calibrationblock_short_side_left", slot="1", well="A2"
+    ),
+}
 CAL_BLOCK_SETUP_CAL_CHECK: LabwareInfo = LabwareInfo(
-    load_name='opentrons_calibrationblock_short_side_right',
-    slot='6',
-    well='A1'
+    load_name="opentrons_calibrationblock_short_side_right", slot="6", well="A1"
 )

--- a/robot-server/robot_server/robot/calibration/deck/constants.py
+++ b/robot-server/robot_server/robot/calibration/deck/constants.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 from robot_server.robot.calibration.constants import (
-    STATE_WILDCARD, POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID)
+    STATE_WILDCARD,
+    POINT_ONE_ID,
+    POINT_TWO_ID,
+    POINT_THREE_ID,
+)
 
 if TYPE_CHECKING:
     from .dev_types import StatePointMap
@@ -23,15 +27,15 @@ class DeckCalibrationState(str, Enum):
     WILDCARD = STATE_WILDCARD
 
 
-TIP_RACK_SLOT = '8'
+TIP_RACK_SLOT = "8"
 
 MOVE_POINT_STATE_MAP: StatePointMap = {
     DeckCalibrationState.joggingToDeck: POINT_ONE_ID,
     DeckCalibrationState.savingPointOne: POINT_TWO_ID,
-    DeckCalibrationState.savingPointTwo: POINT_THREE_ID
+    DeckCalibrationState.savingPointTwo: POINT_THREE_ID,
 }
 SAVE_POINT_STATE_MAP: StatePointMap = {
     DeckCalibrationState.savingPointOne: POINT_ONE_ID,
     DeckCalibrationState.savingPointTwo: POINT_TWO_ID,
-    DeckCalibrationState.savingPointThree: POINT_THREE_ID
+    DeckCalibrationState.savingPointThree: POINT_THREE_ID,
 }

--- a/robot-server/robot_server/robot/calibration/deck/dev_types.py
+++ b/robot-server/robot_server/robot/calibration/deck/dev_types.py
@@ -5,22 +5,22 @@ from opentrons.types import Point
 from .constants import DeckCalibrationState
 
 SavedPoints = TypedDict(
-    'SavedPoints',
+    "SavedPoints",
     {
-        '1BLC': Point,
-        '3BRC': Point,
-        '7TLC': Point,
+        "1BLC": Point,
+        "3BRC": Point,
+        "7TLC": Point,
     },
-    total=False
-    )
+    total=False,
+)
 
 ExpectedPoints = TypedDict(
-    'ExpectedPoints',
+    "ExpectedPoints",
     {
-        '1BLC': Point,
-        '3BRC': Point,
-        '7TLC': Point,
-    })
+        "1BLC": Point,
+        "3BRC": Point,
+        "7TLC": Point,
+    },
+)
 
-StatePointMap = Dict[
-    DeckCalibrationState, Union[Literal['1BLC', '3BRC', '7TLC']]]
+StatePointMap = Dict[DeckCalibrationState, Union[Literal["1BLC", "3BRC", "7TLC"]]]

--- a/robot-server/robot_server/robot/calibration/deck/models.py
+++ b/robot-server/robot_server/robot/calibration/deck/models.py
@@ -6,13 +6,15 @@ from ..helper_classes import AttachedPipette, RequiredLabware
 
 class DeckCalibrationSessionStatus(BaseModel):
     """The current status of a deck calibration session."""
+
     instrument: AttachedPipette
     currentStep: str = Field(
-        ...,
-        description="Current step of deck calibration user flow")
+        ..., description="Current step of deck calibration user flow"
+    )
     labware: List[RequiredLabware]
     supportedCommands: List[Optional[str]] = Field(
-        ..., description="A list of supported commands for this user flow")
+        ..., description="A list of supported commands for this user flow"
+    )
 
     class Config:
         schema_extra = {
@@ -33,11 +35,9 @@ class DeckCalibrationSessionStatus(BaseModel):
                             "namespace": "opentrons",
                             "version": 1,
                             "isTiprack": "true",
-                            "definition": {
-                                "ordering": "the ordering section..."
-                            }
+                            "definition": {"ordering": "the ordering section..."},
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/robot-server/robot_server/robot/calibration/deck/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/deck/state_machine.py
@@ -1,20 +1,17 @@
 from typing import Dict
 
-from robot_server.service.session.models.command_definitions import \
-    CommandDefinition, CalibrationCommand, \
-    DeckCalibrationCommand as DeckCalCommand
-from robot_server.robot.calibration.util import (
-    SimpleStateMachine, StateTransitionError)
+from robot_server.service.session.models.command_definitions import (
+    CommandDefinition,
+    CalibrationCommand,
+    DeckCalibrationCommand as DeckCalCommand,
+)
+from robot_server.robot.calibration.util import SimpleStateMachine, StateTransitionError
 from .constants import DeckCalibrationState as State
 
 
 DECK_CALIBRATION_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
-    State.sessionStarted: {
-        CalibrationCommand.load_labware: State.labwareLoaded
-    },
-    State.labwareLoaded: {
-        CalibrationCommand.move_to_tip_rack: State.preparingPipette
-    },
+    State.sessionStarted: {CalibrationCommand.load_labware: State.labwareLoaded},
+    State.labwareLoaded: {CalibrationCommand.move_to_tip_rack: State.preparingPipette},
     State.preparingPipette: {
         CalibrationCommand.jog: State.preparingPipette,
         CalibrationCommand.pick_up_tip: State.inspectingTip,
@@ -49,17 +46,14 @@ DECK_CALIBRATION_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
         CalibrationCommand.move_to_tip_rack: State.calibrationComplete,
         CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
-    State.WILDCARD: {
-        CalibrationCommand.exit: State.sessionExited
-    }
+    State.WILDCARD: {CalibrationCommand.exit: State.sessionExited},
 }
 
 
 class DeckCalibrationStateMachine:
     def __init__(self):
         self._state_machine = SimpleStateMachine(
-            states=set(s for s in State),
-            transitions=DECK_CALIBRATION_TRANSITIONS
+            states=set(s for s in State), transitions=DECK_CALIBRATION_TRANSITIONS
         )
 
     def get_next_state(self, from_state: State, command: CommandDefinition):

--- a/robot-server/robot_server/robot/calibration/errors.py
+++ b/robot-server/robot_server/robot/calibration/errors.py
@@ -6,40 +6,42 @@ from robot_server.service.errors import ErrorDef, ErrorCreateDef
 class CalibrationError(ErrorDef):
     NO_PIPETTE_ON_MOUNT = ErrorCreateDef(
         status_code=HTTPStatus.FORBIDDEN,
-        title='No Pipette Attached',
-        format_string='No pipette present on {mount} mount')
+        title="No Pipette Attached",
+        format_string="No pipette present on {mount} mount",
+    )
     NO_PIPETTE_ATTACHED = ErrorCreateDef(
         status_code=HTTPStatus.FORBIDDEN,
-        title='No Pipette Attached',
-        format_string='Cannot start {flow} with fewer than one pipette')
+        title="No Pipette Attached",
+        format_string="Cannot start {flow} with fewer than one pipette",
+    )
     BAD_LABWARE_DEF = ErrorCreateDef(
         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-        title='Bad Labware Definition',
-        format_string='Bad definition for tip rack under calibration')
+        title="Bad Labware Definition",
+        format_string="Bad definition for tip rack under calibration",
+    )
     BAD_STATE_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
-        title='Illegal State Transition',
-        format_string='The action {action} may not occur in the state {state}'
+        title="Illegal State Transition",
+        format_string="The action {action} may not occur in the state {state}",
     )
     NO_STATE_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
-        title='No State Transition',
-        format_string='No transition available for state {state}'
+        title="No State Transition",
+        format_string="No transition available for state {state}",
     )
     UNMET_STATE_TRANSITION_REQ = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
-        title='Unmet State Transition Requirement',
-        format_string='The command handler {handler} may not occur in the'
-                      ' state {state} when "{condition}" is not true'
+        title="Unmet State Transition Requirement",
+        format_string="The command handler {handler} may not occur in the"
+        ' state {state} when "{condition}" is not true',
     )
     UNCALIBRATED_ROBOT = ErrorCreateDef(
         status_code=HTTPStatus.CONFLICT,
-        title='No Calibration Data Found',
-        format_string='Cannot start {flow} without robot calibration'
+        title="No Calibration Data Found",
+        format_string="Cannot start {flow} without robot calibration",
     )
     ERROR_DURING_TRANSITION = ErrorCreateDef(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-        title='Error During State Transition',
-        format_string='Event {action} failed to transition '
-                      'from {state}: {error}'
+        title="Error During State Transition",
+        format_string="Event {action} failed to transition " "from {state}: {error}",
     )

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -14,16 +14,15 @@ if typing.TYPE_CHECKING:
 
 
 class RobotHealthCheck(Enum):
-    IN_THRESHOLD = 'IN_THRESHOLD'
-    OUTSIDE_THRESHOLD = 'OUTSIDE_THRESHOLD'
+    IN_THRESHOLD = "IN_THRESHOLD"
+    OUTSIDE_THRESHOLD = "OUTSIDE_THRESHOLD"
 
     def __str__(self):
         return self.name
 
     @classmethod
-    def status_from_string(
-            cls, status: str) -> 'RobotHealthCheck':
-        if status == 'IN_THRESHOLD':
+    def status_from_string(cls, status: str) -> "RobotHealthCheck":
+        if status == "IN_THRESHOLD":
             return cls.IN_THRESHOLD
         else:
             return cls.OUTSIDE_THRESHOLD
@@ -31,8 +30,9 @@ class RobotHealthCheck(Enum):
 
 class PipetteRank(str, Enum):
     """The rank in the order of pipettes to use within flow"""
-    first = 'first'
-    second = 'second'
+
+    first = "first"
+    second = "second"
 
     def __str__(self):
         return self.name
@@ -64,8 +64,8 @@ class PipetteInfo:
     mount: Mount
     max_volume: int
     channels: int
-    tip_rack: 'Labware'
-    default_tipracks: typing.List['LabwareDefinition']
+    tip_rack: "Labware"
+    default_tipracks: typing.List["LabwareDefinition"]
 
 
 @dataclass
@@ -74,6 +74,7 @@ class SupportedCommands:
     A class that allows you to set currently supported
     commands depending on the current state.
     """
+
     loadLabware: bool = False
 
     def __init__(self, namespace: str):
@@ -95,22 +96,24 @@ class SupportedCommands:
 # the middle ware before they are returned to the client
 class AttachedPipette(BaseModel):
     """Pipette (if any) attached to the mount"""
-    model: str =\
-        Field(None,
-              description="The model of the attached pipette. These are snake "
-                          "case as in the Protocol API. This includes the full"
-                          " version string")
-    name: str =\
-        Field(None, description="Short name of pipette model without"
-                                "generation version")
-    tipLength: float =\
-        Field(None, description="The default tip length for this pipette")
-    mount: str =\
-        Field(None, description="The mount this pipette attached to")
-    serial: str =\
-        Field(None, description="The serial number of the attached pipette")
-    defaultTipracks: typing.List[dict] =\
-        Field(None, description="A list of default tipracks for this pipette")
+
+    model: str = Field(
+        None,
+        description="The model of the attached pipette. These are snake "
+        "case as in the Protocol API. This includes the full"
+        " version string",
+    )
+    name: str = Field(
+        None, description="Short name of pipette model without" "generation version"
+    )
+    tipLength: float = Field(
+        None, description="The default tip length for this pipette"
+    )
+    mount: str = Field(None, description="The mount this pipette attached to")
+    serial: str = Field(None, description="The serial number of the attached pipette")
+    defaultTipracks: typing.List[dict] = Field(
+        None, description="A list of default tipracks for this pipette"
+    )
 
 
 class RequiredLabware(BaseModel):
@@ -118,6 +121,7 @@ class RequiredLabware(BaseModel):
     A model that describes a single labware required for performing a
     calibration action.
     """
+
     slot: DeckLocation
     loadName: str
     namespace: str
@@ -126,9 +130,7 @@ class RequiredLabware(BaseModel):
     definition: dict
 
     @classmethod
-    def from_lw(cls,
-                lw: labware.Labware,
-                slot: typing.Optional[DeckLocation] = None):
+    def from_lw(cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None):
         if not slot:
             slot = lw.parent  # type: ignore[assignment]
         lw_def = lw._implementation.get_definition()
@@ -137,12 +139,13 @@ class RequiredLabware(BaseModel):
             #  Union[int,str,None] expected by cls
             slot=slot,  # type: ignore[arg-type]
             loadName=lw.load_name,
-            namespace=lw_def['namespace'],
-            version=str(lw_def['version']),
+            namespace=lw_def["namespace"],
+            version=str(lw_def["version"]),
             isTiprack=lw.is_tiprack,
             # TODO(mc, 2020-09-17): LabwareDefinition does not match
             # Dict[any,any] expected by cls
-            definition=lw_def)  # type: ignore[arg-type]
+            definition=lw_def,  # type: ignore[arg-type]
+        )
 
 
 class NextStepLink(BaseModel):

--- a/robot-server/robot_server/robot/calibration/models.py
+++ b/robot-server/robot_server/robot/calibration/models.py
@@ -9,31 +9,31 @@ class SessionCreateParams(BaseModel):
     2. Pipette Offset Calibration
     3. Tip Length Calibration + Pipette Offset Calibration
     """
+
     mount: str = Field(
-        ...,
-        description='The mount on which the pipette is attached, left or right'
+        ..., description="The mount on which the pipette is attached, left or right"
     )
     hasCalibrationBlock: bool = Field(
         False,
-        description='Whether to use a calibration block in the'
-                    'instance of TLC + pipette offset flow. If no tip length '
-                    'is performed, this is ignored, but it should always be '
-                    'specified.'
+        description="Whether to use a calibration block in the"
+        "instance of TLC + pipette offset flow. If no tip length "
+        "is performed, this is ignored, but it should always be "
+        "specified.",
     )
     tipRackDefinition: Optional[dict] = Field(
         None,
-        description='The full labware definition of the tip rack to '
-                    'calibrate. If not specified, then a default will be '
-                    'used - either the same tiprack as in the current '
-                    'calibration, or, if there is no calibration, the '
-                    'default Opentrons tiprack for this pipette.'
+        description="The full labware definition of the tip rack to "
+        "calibrate. If not specified, then a default will be "
+        "used - either the same tiprack as in the current "
+        "calibration, or, if there is no calibration, the "
+        "default Opentrons tiprack for this pipette.",
     )
     shouldRecalibrateTipLength: bool = Field(
         True,
-        description='whether to perform TLC with the loaded tip rack, '
-                    'prior to recalibrating the pipette offset. If the '
-                    'tiprack used (either the one specified by '
-                    'tipRackDefinition or the default if not specified) '
-                    'does not have a tip length calibration, this will be '
-                    'forced to be true.'
+        description="whether to perform TLC with the loaded tip rack, "
+        "prior to recalibrating the pipette offset. If the "
+        "tiprack used (either the one specified by "
+        "tipRackDefinition or the default if not specified) "
+        "does not have a tip length calibration, this will be "
+        "forced to be true.",
     )

--- a/robot-server/robot_server/robot/calibration/pipette_offset/constants.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/constants.py
@@ -35,4 +35,4 @@ class PipetteOffsetWithTipLengthCalibrationState(str, Enum):
     WILDCARD = STATE_WILDCARD
 
 
-TIP_RACK_SLOT: Final = '8'
+TIP_RACK_SLOT: Final = "8"

--- a/robot-server/robot_server/robot/calibration/pipette_offset/models.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/models.py
@@ -6,18 +6,23 @@ from ..helper_classes import AttachedPipette, RequiredLabware, NextSteps
 
 class PipetteOffsetCalibrationSessionStatus(BaseModel):
     """The current status of a pipette offset calibration session."""
+
     instrument: AttachedPipette
     currentStep: str = Field(
-        ...,
-        description="Current step of pipette offset user flow")
+        ..., description="Current step of pipette offset user flow"
+    )
     labware: List[RequiredLabware]
-    shouldPerformTipLength: bool =\
-        Field(None, description="Does tip length calibration data exist for "
-                                "this pipette and tip rack combination")
+    shouldPerformTipLength: bool = Field(
+        None,
+        description="Does tip length calibration data exist for "
+        "this pipette and tip rack combination",
+    )
     supportedCommands: List[Optional[str]] = Field(
-        ..., description="A list of supported commands for this user flow")
-    nextSteps: Optional[NextSteps] =\
-        Field(None, description="Next Available Steps in Session")
+        ..., description="A list of supported commands for this user flow"
+    )
+    nextSteps: Optional[NextSteps] = Field(
+        None, description="Next Available Steps in Session"
+    )
 
     class Config:
         schema_extra = {
@@ -28,23 +33,19 @@ class PipetteOffsetCalibrationSessionStatus(BaseModel):
                         "name": "p300_single",
                         "tip_length": 51.7,
                         "mount": "left",
-                        "serial": "P3HS12123041"
+                        "serial": "P3HS12123041",
                     },
                     "currentStep": "sessionStarted",
-                    "nextSteps": {
-                        "links": {
-                            "loadLabware": {"url": "", "params": {}}
-                        }
-                    },
+                    "nextSteps": {"links": {"loadLabware": {"url": "", "params": {}}}},
                     "labware": [
-                      {
-                          "slot": "8",
-                          "loadName": "tiprack_loadname",
-                          "namespace": "opentrons",
-                          "version": "1",
-                          "isTiprack": "true",
-                          "definition": {"ordering": "the ordering section..."}
-                      },
+                        {
+                            "slot": "8",
+                            "loadName": "tiprack_loadname",
+                            "namespace": "opentrons",
+                            "version": "1",
+                            "isTiprack": "true",
+                            "definition": {"ordering": "the ordering section..."},
+                        },
                     ],
                     "shouldPerformTipLength": True,
                 }

--- a/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/state_machine.py
@@ -1,21 +1,19 @@
 from typing import Dict, Type
 
-from robot_server.service.session.models.command_definitions import \
-    CommandDefinition, CalibrationCommand
-from robot_server.robot.calibration.util import (
-    SimpleStateMachine, StateTransitionError)
+from robot_server.service.session.models.command_definitions import (
+    CommandDefinition,
+    CalibrationCommand,
+)
+from robot_server.robot.calibration.util import SimpleStateMachine, StateTransitionError
 from .constants import (
     PipetteOffsetCalibrationState as POCState,
-    PipetteOffsetWithTipLengthCalibrationState as POWTState)
+    PipetteOffsetWithTipLengthCalibrationState as POWTState,
+)
 
-PipetteOffsetTransitions =\
-    Dict[POCState, Dict[CommandDefinition, POCState]]
-PipetteOffsetWithTLTransitions =\
-    Dict[POWTState, Dict[CommandDefinition, POWTState]]
+PipetteOffsetTransitions = Dict[POCState, Dict[CommandDefinition, POCState]]
+PipetteOffsetWithTLTransitions = Dict[POWTState, Dict[CommandDefinition, POWTState]]
 PIP_OFFSET_CAL_TRANSITIONS: PipetteOffsetTransitions = {
-    POCState.sessionStarted: {
-        CalibrationCommand.load_labware: POCState.labwareLoaded
-    },
+    POCState.sessionStarted: {CalibrationCommand.load_labware: POCState.labwareLoaded},
     POCState.labwareLoaded: {
         CalibrationCommand.move_to_tip_rack: POCState.preparingPipette,
     },
@@ -42,9 +40,7 @@ PIP_OFFSET_CAL_TRANSITIONS: PipetteOffsetTransitions = {
     POCState.calibrationComplete: {
         CalibrationCommand.move_to_tip_rack: POCState.calibrationComplete,
     },
-    POCState.WILDCARD: {
-        CalibrationCommand.exit: POCState.sessionExited
-    }
+    POCState.WILDCARD: {CalibrationCommand.exit: POCState.sessionExited},
 }
 
 PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
@@ -52,15 +48,13 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
         CalibrationCommand.load_labware: POWTState.labwareLoaded
     },
     POWTState.labwareLoaded: {
-        CalibrationCommand.move_to_reference_point:
-            POWTState.measuringNozzleOffset
+        CalibrationCommand.move_to_reference_point: POWTState.measuringNozzleOffset
     },
     POWTState.measuringNozzleOffset: {
         CalibrationCommand.save_offset: POWTState.measuringNozzleOffset,
         CalibrationCommand.jog: POWTState.measuringNozzleOffset,
         CalibrationCommand.move_to_tip_rack: POWTState.preparingPipette,
-        CalibrationCommand.invalidate_last_action:
-            POWTState.measuringNozzleOffset,
+        CalibrationCommand.invalidate_last_action: POWTState.measuringNozzleOffset,
     },
     POWTState.preparingPipette: {
         CalibrationCommand.jog: POWTState.preparingPipette,
@@ -69,8 +63,7 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
     },
     POWTState.inspectingTip: {
         CalibrationCommand.invalidate_tip: POWTState.preparingPipette,
-        CalibrationCommand.move_to_reference_point:
-            POWTState.measuringTipOffset,
+        CalibrationCommand.move_to_reference_point: POWTState.measuringTipOffset,
     },
     POWTState.measuringTipOffset: {
         CalibrationCommand.jog: POWTState.measuringTipOffset,
@@ -78,8 +71,7 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
         CalibrationCommand.invalidate_last_action: POWTState.preparingPipette,
     },
     POWTState.tipLengthComplete: {
-        CalibrationCommand.set_has_calibration_block:
-            POWTState.tipLengthComplete,
+        CalibrationCommand.set_has_calibration_block: POWTState.tipLengthComplete,
         CalibrationCommand.move_to_deck: POWTState.joggingToDeck,
     },
     POWTState.joggingToDeck: {
@@ -96,17 +88,14 @@ PIP_OFFSET_WITH_TL_TRANSITIONS: PipetteOffsetWithTLTransitions = {
     POWTState.calibrationComplete: {
         CalibrationCommand.move_to_tip_rack: POWTState.calibrationComplete,
     },
-    POWTState.WILDCARD: {
-        CalibrationCommand.exit: POWTState.sessionExited
-    }
+    POWTState.WILDCARD: {CalibrationCommand.exit: POWTState.sessionExited},
 }
 
 
 class PipetteOffsetCalibrationStateMachine:
     def __init__(self):
         self._state_machine = SimpleStateMachine(
-            states=set(s for s in POCState),
-            transitions=PIP_OFFSET_CAL_TRANSITIONS
+            states=set(s for s in POCState), transitions=PIP_OFFSET_CAL_TRANSITIONS
         )
         self._state = POCState
         self._current_state = POCState.sessionStarted
@@ -150,8 +139,7 @@ class PipetteOffsetWithTipLengthStateMachine:
     def set_state(self, state: POWTState):
         self._current_state = state
 
-    def get_next_state(
-            self, from_state: POWTState, command: CommandDefinition):
+    def get_next_state(self, from_state: POWTState, command: CommandDefinition):
         next_state = self._state_machine.get_next_state(from_state, command)
         if next_state:
             return next_state

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -1,20 +1,33 @@
 import logging
 from typing import (
-    Any, Awaitable, Callable, Dict, List,
-    Optional, Union, TYPE_CHECKING, Tuple)
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+    Tuple,
+)
 
 from opentrons.calibration_storage import get, modify, helpers, delete
 from opentrons.calibration_storage.types import (
-    TipLengthCalNotFound, PipetteOffsetByPipetteMount)
+    TipLengthCalNotFound,
+    PipetteOffsetByPipetteMount,
+)
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import (
-    ThreadManager, CriticalPoint, Pipette, robot_calibration as robot_cal)
+    ThreadManager,
+    CriticalPoint,
+    Pipette,
+    robot_calibration as robot_cal,
+)
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Mount, Point, Location
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand
+from robot_server.service.session.models.command_definitions import CalibrationCommand
 from robot_server.robot.calibration import util
 from robot_server.robot.calibration.constants import (
     TIP_RACK_LOOKUP_BY_MAX_VOL,
@@ -24,17 +37,19 @@ from robot_server.robot.calibration.constants import (
     MOVE_TO_DECK_SAFETY_BUFFER,
     MOVE_TO_TIP_RACK_SAFETY_BUFFER,
     CAL_BLOCK_SETUP_BY_MOUNT,
-    JOG_TO_DECK_SLOT)
+    JOG_TO_DECK_SLOT,
+)
 from ..errors import CalibrationError
-from ..helper_classes import (
-    RequiredLabware, AttachedPipette, SupportedCommands)
+from ..helper_classes import RequiredLabware, AttachedPipette, SupportedCommands
 from .constants import (
     PipetteOffsetCalibrationState as POCState,
     PipetteOffsetWithTipLengthCalibrationState as POWTState,
-    TIP_RACK_SLOT)
+    TIP_RACK_SLOT,
+)
 from .state_machine import (
     PipetteOffsetCalibrationStateMachine,
-    PipetteOffsetWithTipLengthStateMachine)
+    PipetteOffsetWithTipLengthStateMachine,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware import LabwareDefinition
@@ -53,18 +68,20 @@ COMMAND_HANDLER = Callable[..., Awaitable]
 
 COMMAND_MAP = Dict[str, COMMAND_HANDLER]
 PipetteOffsetStateMachine = Union[
-    PipetteOffsetCalibrationStateMachine,
-    PipetteOffsetWithTipLengthStateMachine]
+    PipetteOffsetCalibrationStateMachine, PipetteOffsetWithTipLengthStateMachine
+]
 PipetteOffsetState = Union[POWTState, POCState]
 
 
 class PipetteOffsetCalibrationUserFlow:
-    def __init__(self,
-                 hardware: ThreadManager,
-                 mount: Mount = Mount.RIGHT,
-                 recalibrate_tip_length: bool = False,
-                 has_calibration_block: bool = False,
-                 tip_rack_def: Optional['LabwareDefinition'] = None):
+    def __init__(
+        self,
+        hardware: ThreadManager,
+        mount: Mount = Mount.RIGHT,
+        recalibrate_tip_length: bool = False,
+        has_calibration_block: bool = False,
+        tip_rack_def: Optional["LabwareDefinition"] = None,
+    ):
 
         self._hardware = hardware
         self._mount = mount
@@ -72,17 +89,15 @@ class PipetteOffsetCalibrationUserFlow:
         self._hw_pipette = self._hardware._attached_instruments[mount]
         if not self._hw_pipette:
             raise RobotServerError(
-                definition=CalibrationError.NO_PIPETTE_ON_MOUNT,
-                mount=mount)
+                definition=CalibrationError.NO_PIPETTE_ON_MOUNT, mount=mount
+            )
 
-        deck_load_name = SHORT_TRASH_DECK if ff.short_fixed_trash() \
-            else STANDARD_DECK
+        deck_load_name = SHORT_TRASH_DECK if ff.short_fixed_trash() else STANDARD_DECK
         self._deck = Deck(load_name=deck_load_name)
 
         self._saved_offset_this_session = False
 
-        point_one_pos = \
-            self._deck.get_calibration_position(POINT_ONE_ID).position
+        point_one_pos = self._deck.get_calibration_position(POINT_ONE_ID).position
         self._cal_ref_point = Point(*point_one_pos)
 
         self._tip_origin_pt: Optional[Point] = None
@@ -94,8 +109,9 @@ class PipetteOffsetCalibrationUserFlow:
         self._load_tip_rack(tip_rack_def, existing_offset_calibration)
 
         existing_tip_length_calibration = self._get_stored_tip_length_cal()
-        perform_tip_length = recalibrate_tip_length \
-            or not existing_tip_length_calibration
+        perform_tip_length = (
+            recalibrate_tip_length or not existing_tip_length_calibration
+        )
 
         if perform_tip_length and has_calibration_block:
             self._load_calibration_block()
@@ -103,12 +119,11 @@ class PipetteOffsetCalibrationUserFlow:
         else:
             self._has_calibration_block = False
 
-        self._has_calibrated_tip_length: bool =\
-            (self._get_stored_tip_length_cal() is not None
-             or self._using_default_tiprack)
+        self._has_calibrated_tip_length: bool = (
+            self._get_stored_tip_length_cal() is not None or self._using_default_tiprack
+        )
 
-        self._sm =\
-            self._determine_state_machine(perform_tip_length)
+        self._sm = self._determine_state_machine(perform_tip_length)
 
         self._current_state = self._sm.state.sessionStarted
 
@@ -116,8 +131,7 @@ class PipetteOffsetCalibrationUserFlow:
 
         self._command_map: COMMAND_MAP = {
             CalibrationCommand.load_labware: self.load_labware,
-            CalibrationCommand.move_to_reference_point:
-                self.move_to_reference_point,
+            CalibrationCommand.move_to_reference_point: self.move_to_reference_point,
             CalibrationCommand.jog: self.jog,
             CalibrationCommand.pick_up_tip: self.pick_up_tip,
             CalibrationCommand.invalidate_tip: self.invalidate_tip,
@@ -125,18 +139,18 @@ class PipetteOffsetCalibrationUserFlow:
             CalibrationCommand.move_to_tip_rack: self.move_to_tip_rack,
             CalibrationCommand.move_to_deck: self.move_to_deck,
             CalibrationCommand.move_to_point_one: self.move_to_point_one,
-            CalibrationCommand.set_has_calibration_block:
-                self.set_has_calibration_block,
+            CalibrationCommand.set_has_calibration_block: self.set_has_calibration_block,  # noqa: E501
             CalibrationCommand.exit: self.exit_session,
-            CalibrationCommand.invalidate_last_action:
-                self.invalidate_last_action,
+            CalibrationCommand.invalidate_last_action: self.invalidate_last_action,
         }
 
         self._hw_pipette.update_pipette_offset(
-            robot_cal.load_pipette_offset(pip_id=None, mount=self._mount))
-        self._default_tipracks =\
-            util.get_default_tipracks(self.hw_pipette.config.default_tipracks)
-        self._supported_commands = SupportedCommands(namespace='calibration')
+            robot_cal.load_pipette_offset(pip_id=None, mount=self._mount)
+        )
+        self._default_tipracks = util.get_default_tipracks(
+            self.hw_pipette.config.default_tipracks
+        )
+        self._supported_commands = SupportedCommands(namespace="calibration")
         self._supported_commands.loadLabware = True
 
     @property
@@ -184,15 +198,16 @@ class PipetteOffsetCalibrationUserFlow:
             tipLength=self._hw_pipette.config.tip_length,
             mount=str(self._mount),
             serial=self._hw_pipette.pipette_id,
-            defaultTipracks=self._default_tipracks  # type: ignore[arg-type]
-            )
+            defaultTipracks=self._default_tipracks,  # type: ignore[arg-type]
+        )
 
     def get_required_labware(self) -> List[RequiredLabware]:
         slots = self._deck.get_non_fixture_slots()
         lw_by_slot = {s: self._deck[s] for s in slots if self._deck[s]}
         return [
             RequiredLabware.from_lw(lw, s)  # type: ignore
-            for s, lw in lw_by_slot.items()]
+            for s, lw in lw_by_slot.items()
+        ]
 
     async def set_has_calibration_block(self, hasBlock: bool):
         if self._has_calibration_block and not hasBlock:
@@ -204,12 +219,9 @@ class PipetteOffsetCalibrationUserFlow:
     def _get_tip_rack_lw(self) -> labware.Labware:
         pip_vol = self._hw_pipette.config.max_volume
         lw_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(pip_vol)].load_name
-        return labware.load(lw_load_name,
-                            self._deck.position_for(TIP_RACK_SLOT))
+        return labware.load(lw_load_name, self._deck.position_for(TIP_RACK_SLOT))
 
-    async def handle_command(self,
-                             name: Any,
-                             data: Dict[Any, Any]):
+    async def handle_command(self, name: Any, data: Dict[Any, Any]):
         """
         Handle a client command
 
@@ -228,40 +240,39 @@ class PipetteOffsetCalibrationUserFlow:
             await handler(**data)
         self._sm.set_state(next_state)
         MODULE_LOG.debug(
-            f'PipetteOffsetCalUserFlow handled command {name}, transitioned'
-            f'from {self._sm.current_state} to {next_state}')
+            f"PipetteOffsetCalUserFlow handled command {name}, transitioned"
+            f"from {self._sm.current_state} to {next_state}"
+        )
 
     @property
     def critical_point_override(self) -> Optional[CriticalPoint]:
-        return (CriticalPoint.FRONT_NOZZLE if
-                self._hw_pipette.config.channels == 8 else None)
+        return (
+            CriticalPoint.FRONT_NOZZLE
+            if self._hw_pipette.config.channels == 8
+            else None
+        )
 
-    async def get_current_point(
-            self,
-            critical_point: Optional[CriticalPoint]) -> Point:
-        return await self._hardware.gantry_position(self._mount,
-                                                    critical_point)
+    async def get_current_point(self, critical_point: Optional[CriticalPoint]) -> Point:
+        return await self._hardware.gantry_position(self._mount, critical_point)
 
     async def load_labware(self, tiprackDefinition: Optional[dict] = None):
         self._supported_commands.loadLabware = False
         if tiprackDefinition:
             verified_definition = labware.verify_definition(tiprackDefinition)
             existing_offset_calibration = self._get_stored_pipette_offset_cal()
-            self._load_tip_rack(
-                verified_definition,
-                existing_offset_calibration)
+            self._load_tip_rack(verified_definition, existing_offset_calibration)
 
     async def jog(self, vector):
-        await self._hardware.move_rel(mount=self._mount,
-                                      delta=Point(*vector))
+        await self._hardware.move_rel(mount=self._mount, delta=Point(*vector))
 
     @property
     def tip_origin(self) -> Point:
         if self._tip_origin_pt:
             return self._tip_origin_pt
         else:
-            return self._tip_rack.wells()[0].top().point +\
-                MOVE_TO_TIP_RACK_SAFETY_BUFFER
+            return (
+                self._tip_rack.wells()[0].top().point + MOVE_TO_TIP_RACK_SAFETY_BUFFER
+            )
 
     @tip_origin.setter
     def tip_origin(self, new_val: Point):
@@ -275,17 +286,19 @@ class PipetteOffsetCalibrationUserFlow:
         return self._supported_commands.supported()
 
     async def move_to_tip_rack(self):
-        if self._sm.current_state == self._sm.state.labwareLoaded and \
-                not self.has_calibrated_tip_length and\
-                not self.should_perform_tip_length:
+        if (
+            self._sm.current_state == self._sm.state.labwareLoaded
+            and not self.has_calibrated_tip_length
+            and not self.should_perform_tip_length
+        ):
             self._flag_unmet_transition_req(
                 command_handler="move_to_tip_rack",
-                unmet_condition="not performing tip length calibration")
+                unmet_condition="not performing tip length calibration",
+            )
         await self._move(Location(self.tip_origin, None))
 
     @staticmethod
-    def _determine_state_machine(
-            perform_tip_length: bool) -> PipetteOffsetStateMachine:
+    def _determine_state_machine(perform_tip_length: bool) -> PipetteOffsetStateMachine:
         if perform_tip_length:
             return PipetteOffsetWithTipLengthStateMachine()
         else:
@@ -295,22 +308,18 @@ class PipetteOffsetCalibrationUserFlow:
         try:
             return get.load_tip_length_calibration(
                 self._hw_pipette.pipette_id,
-                self._tip_rack._implementation.get_definition()
-                ).tip_length
+                self._tip_rack._implementation.get_definition(),
+            ).tip_length
         except TipLengthCalNotFound:
             return None
 
-    def _get_stored_pipette_offset_cal(
-            self) -> Optional[PipetteOffsetByPipetteMount]:
-        return get.get_pipette_offset(
-            self._hw_pipette.pipette_id, self._mount
-        )
+    def _get_stored_pipette_offset_cal(self) -> Optional[PipetteOffsetByPipetteMount]:
+        return get.get_pipette_offset(self._hw_pipette.pipette_id, self._mount)
 
     def _get_tip_length(self) -> float:
         stored_tip_length_cal = self._get_stored_tip_length_cal()
         if stored_tip_length_cal is None or self._should_perform_tip_length:
-            tip_overlap = self._hw_pipette.config.tip_overlap.get(
-                self._tip_rack.uri, 0)
+            tip_overlap = self._hw_pipette.config.tip_overlap.get(self._tip_rack.uri, 0)
             tip_length = self._tip_rack.tip_length
             return tip_length - tip_overlap
         else:
@@ -319,94 +328,105 @@ class PipetteOffsetCalibrationUserFlow:
     def _load_calibration_block(self):
         cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
         self._deck[cb_setup.slot] = labware.load(
-            cb_setup.load_name,
-            self._deck.position_for(cb_setup.slot))
+            cb_setup.load_name, self._deck.position_for(cb_setup.slot)
+        )
 
     def _remove_calibration_block(self):
         cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
         del self._deck[cb_setup.slot]
 
     @staticmethod
-    def _get_tr_lw(tip_rack_def: Optional['LabwareDefinition'],
-                   existing_calibration: Optional[PipetteOffsetByPipetteMount],
-                   volume: float,
-                   position: Location) -> Tuple[bool, labware.Labware]:
-        """ Find the right tiprack to use. Specifically,
+    def _get_tr_lw(
+        tip_rack_def: Optional["LabwareDefinition"],
+        existing_calibration: Optional[PipetteOffsetByPipetteMount],
+        volume: float,
+        position: Location,
+    ) -> Tuple[bool, labware.Labware]:
+        """Find the right tiprack to use. Specifically,
 
         - If it's specified from above, use that
         - If it's not, and we have a calibration, use that
         - If we don't, use the default
         """
         if tip_rack_def:
-            return False, labware.load_from_definition(
-                tip_rack_def, position)
+            return False, labware.load_from_definition(tip_rack_def, position)
         if existing_calibration and existing_calibration.uri:
             try:
-                details \
-                     = helpers.details_from_uri(existing_calibration.uri)
-                return True, labware.load(load_name=details.load_name,
-                                          namespace=details.namespace,
-                                          version=details.version,
-                                          parent=position)
+                details = helpers.details_from_uri(existing_calibration.uri)
+                return True, labware.load(
+                    load_name=details.load_name,
+                    namespace=details.namespace,
+                    version=details.version,
+                    parent=position,
+                )
             except (IndexError, ValueError, FileNotFoundError):
                 pass
         tr_load_name = TIP_RACK_LOOKUP_BY_MAX_VOL[str(volume)].load_name
         return True, labware.load(tr_load_name, position)
 
     def _load_tip_rack(
-            self,
-            tip_rack_def: Optional['LabwareDefinition'],
-            existing_calibration: Optional[PipetteOffsetByPipetteMount]):
+        self,
+        tip_rack_def: Optional["LabwareDefinition"],
+        existing_calibration: Optional[PipetteOffsetByPipetteMount],
+    ):
         """
         load onto the deck the default opentrons tip rack labware for this
         pipette and return the tip rack labware. If tip_rack_def is supplied,
         load specific tip rack from def onto the deck and return the labware.
         """
         self._using_default_tiprack, self._tip_rack = self._get_tr_lw(
-            tip_rack_def, existing_calibration,
+            tip_rack_def,
+            existing_calibration,
             self._hw_pipette.config.max_volume,
-            self._deck.position_for(TIP_RACK_SLOT))
+            self._deck.position_for(TIP_RACK_SLOT),
+        )
         if self._deck[TIP_RACK_SLOT]:
             del self._deck[TIP_RACK_SLOT]
         self._deck[TIP_RACK_SLOT] = self._tip_rack
 
-    def _flag_unmet_transition_req(self, command_handler: str,
-                                   unmet_condition: str):
+    def _flag_unmet_transition_req(self, command_handler: str, unmet_condition: str):
         raise RobotServerError(
             definition=CalibrationError.UNMET_STATE_TRANSITION_REQ,
             handler=command_handler,
             state=self._sm.current_state,
-            condition=unmet_condition)
+            condition=unmet_condition,
+        )
 
     async def move_to_deck(self):
         current_state = self._sm.current_state
-        if not self.has_calibrated_tip_length and \
-                current_state == self._sm.state.inspectingTip:
+        if (
+            not self.has_calibrated_tip_length
+            and current_state == self._sm.state.inspectingTip
+        ):
             self._flag_unmet_transition_req(
                 command_handler="move_to_deck",
-                unmet_condition="tip length calibration data exists")
-        if self.should_perform_tip_length and \
-                isinstance(self._sm.state, POWTState) and \
-                current_state == self._sm.state.tipLengthComplete and \
-                self._saved_offset_this_session:
+                unmet_condition="tip length calibration data exists",
+            )
+        if (
+            self.should_perform_tip_length
+            and isinstance(self._sm.state, POWTState)
+            and current_state == self._sm.state.tipLengthComplete
+            and self._saved_offset_this_session
+        ):
             self._flag_unmet_transition_req(
                 command_handler="move_to_deck",
-                unmet_condition="offset not saved this session")
+                unmet_condition="offset not saved this session",
+            )
         deck_pt = self._deck.get_slot_center(JOG_TO_DECK_SLOT)
-        ydim = self._deck.get_slot_definition(
-            JOG_TO_DECK_SLOT)['boundingBox']['yDimension']
-        new_pt = deck_pt + Point(0, -1 * ydim/2, 0) + \
-            MOVE_TO_DECK_SAFETY_BUFFER
+        ydim = self._deck.get_slot_definition(JOG_TO_DECK_SLOT)["boundingBox"][
+            "yDimension"
+        ]
+        new_pt = deck_pt + Point(0, -1 * ydim / 2, 0) + MOVE_TO_DECK_SAFETY_BUFFER
         to_loc = Location(new_pt, None)
         await self._move(to_loc)
         self._should_perform_tip_length = False
 
     async def move_to_point_one(self):
-        assert self._z_height_reference is not None, \
-            "saveOffset has not been called yet"
+        assert (
+            self._z_height_reference is not None
+        ), "saveOffset has not been called yet"
         target_loc = Location(self._cal_ref_point, None)
-        target = target_loc.move(
-                point=Point(0, 0, self._z_height_reference))
+        target = target_loc.move(point=Point(0, 0, self._z_height_reference))
         await self._move(target)
 
     async def save_offset(self):
@@ -417,34 +437,40 @@ class PipetteOffsetCalibrationUserFlow:
         elif current_state == self._sm.state.savingPointOne:
             if self._hw_pipette.config.channels > 1:
                 cur_pt = await self.get_current_point(
-                    critical_point=CriticalPoint.FRONT_NOZZLE)
+                    critical_point=CriticalPoint.FRONT_NOZZLE
+                )
             tiprack_hash = helpers.hash_labware_def(
-                self._tip_rack._implementation.get_definition())
+                self._tip_rack._implementation.get_definition()
+            )
             offset = self._cal_ref_point - cur_pt
             modify.save_pipette_calibration(
                 offset=offset,
                 mount=self._mount,
                 pip_id=self._hw_pipette.pipette_id,
                 tiprack_hash=tiprack_hash,
-                tiprack_uri=self._tip_rack.uri)
+                tiprack_uri=self._tip_rack.uri,
+            )
             self._saved_offset_this_session = True
-        elif isinstance(current_state, POWTState)\
-                and current_state == POWTState.measuringNozzleOffset:
+        elif (
+            isinstance(current_state, POWTState)
+            and current_state == POWTState.measuringNozzleOffset
+        ):
             self._nozzle_height_at_reference = cur_pt.z
-        elif isinstance(current_state, POWTState)\
-                and current_state == POWTState.measuringTipOffset:
+        elif (
+            isinstance(current_state, POWTState)
+            and current_state == POWTState.measuringTipOffset
+        ):
             assert self._hw_pipette.has_tip
             assert self._nozzle_height_at_reference is not None
             # set critical point explicitly to nozzle
-            noz_pt = await self.get_current_point(
-                critical_point=CriticalPoint.NOZZLE)
+            noz_pt = await self.get_current_point(critical_point=CriticalPoint.NOZZLE)
 
             util.save_tip_length_calibration(
                 pipette_id=self._hw_pipette.pipette_id,
                 tip_length_offset=noz_pt.z - self._nozzle_height_at_reference,
-                tip_rack=self._tip_rack)
-            delete.delete_pipette_offset_file(
-                self._hw_pipette.pipette_id, self.mount)
+                tip_rack=self._tip_rack,
+            )
+            delete.delete_pipette_offset_file(self._hw_pipette.pipette_id, self.mount)
             new_tip_length = self._get_stored_tip_length_cal()
             self._has_calibrated_tip_length = new_tip_length is not None
             # load the new tip length for the rest of the session
@@ -452,22 +478,23 @@ class PipetteOffsetCalibrationUserFlow:
             await self.hardware.retract(self._mount, 20)
 
     async def move_to_reference_point(self):
-        if not self.should_perform_tip_length and \
-                self._sm.current_state in (self._sm.state.labwareLoaded,
-                                           self._sm.state.inspectingTip):
+        if not self.should_perform_tip_length and self._sm.current_state in (
+            self._sm.state.labwareLoaded,
+            self._sm.state.inspectingTip,
+        ):
             self._flag_unmet_transition_req(
                 command_handler="move_to_reference_point",
-                unmet_condition="performing additional tip length calibration")
+                unmet_condition="performing additional tip length calibration",
+            )
         if self._has_calibration_block:
             cb_setup = CAL_BLOCK_SETUP_BY_MOUNT[self._mount]
-            calblock: labware.Labware = \
-                self._deck[cb_setup.slot]  # type: ignore
+            calblock: labware.Labware = self._deck[cb_setup.slot]  # type: ignore
             cal_block_target_well = calblock.wells_by_name()[cb_setup.well]
         else:
             cal_block_target_well = None
         ref_loc = util.get_reference_location(
-            deck=self._deck,
-            cal_block_target_well=cal_block_target_well)
+            deck=self._deck, cal_block_target_well=cal_block_target_well
+        )
         await self._move(ref_loc)
 
     async def invalidate_last_action(self):
@@ -484,8 +511,8 @@ class PipetteOffsetCalibrationUserFlow:
             await self.hardware.home()
             await self._hardware.gantry_position(self.mount, refresh=True)
             trash = self._deck.get_fixed_trash()
-            assert trash, 'Bad deck setup'
-            await util.move(self, trash['A1'].top(), CriticalPoint.XY_CENTER)
+            assert trash, "Bad deck setup"
+            await util.move(self, trash["A1"].top(), CriticalPoint.XY_CENTER)
             await self.hardware.drop_tip(self.mount)
             await self.move_to_tip_rack()
 

--- a/robot-server/robot_server/robot/calibration/tip_length/constants.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/constants.py
@@ -14,4 +14,4 @@ class TipCalibrationState(str, Enum):
     WILDCARD = STATE_WILDCARD
 
 
-TIP_RACK_SLOT = '8'
+TIP_RACK_SLOT = "8"

--- a/robot-server/robot_server/robot/calibration/tip_length/models.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/models.py
@@ -6,15 +6,18 @@ from ..helper_classes import AttachedPipette, RequiredLabware, NextSteps
 
 class TipCalibrationSessionStatus(BaseModel):
     """The current status of a tip length calibration session."""
+
     instrument: AttachedPipette
     currentStep: str = Field(
-        ...,
-        description="Current step of tip calibration user flow")
-    nextSteps: Optional[NextSteps] =\
-        Field(None, description="Next Available Steps in Session")
+        ..., description="Current step of tip calibration user flow"
+    )
+    nextSteps: Optional[NextSteps] = Field(
+        None, description="Next Available Steps in Session"
+    )
     labware: List[RequiredLabware]
     supportedCommands: List[Optional[str]] = Field(
-        ..., description="A list of supported commands for this user flow")
+        ..., description="A list of supported commands for this user flow"
+    )
 
     class Config:
         schema_extra = {
@@ -25,32 +28,28 @@ class TipCalibrationSessionStatus(BaseModel):
                         "name": "p300_single",
                         "tip_length": 51.7,
                         "mount": "left",
-                        "serial": "P3HS12123041"
+                        "serial": "P3HS12123041",
                     },
                     "currentStep": "sessionStarted",
-                    "nextSteps": {
-                        "links": {
-                            "loadLabware": {"url": "", "params": {}}
-                        }
-                    },
+                    "nextSteps": {"links": {"loadLabware": {"url": "", "params": {}}}},
                     "labware": [
-                      {
-                          "slot": "8",
-                          "loadName": "tiprack_loadname",
-                          "namespace": "opentrons",
-                          "version": "1",
-                          "isTiprack": "true",
-                          "definition": {"ordering": "the ordering section..."}
-                      },
-                      {
-                          "slot": "3",
-                          "loadName": "cal_block_loadname",
-                          "namespace": "opentrons",
-                          "version": "1",
-                          "isTiprack": "false",
-                          "definition": {"ordering": "the ordering section..."}
-                      }
-                    ]
+                        {
+                            "slot": "8",
+                            "loadName": "tiprack_loadname",
+                            "namespace": "opentrons",
+                            "version": "1",
+                            "isTiprack": "true",
+                            "definition": {"ordering": "the ordering section..."},
+                        },
+                        {
+                            "slot": "3",
+                            "loadName": "cal_block_loadname",
+                            "namespace": "opentrons",
+                            "version": "1",
+                            "isTiprack": "false",
+                            "definition": {"ordering": "the ordering section..."},
+                        },
+                    ],
                 }
             ]
         }

--- a/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/state_machine.py
@@ -1,19 +1,16 @@
 from typing import Dict
-from robot_server.service.session.models.command_definitions import \
-    CommandDefinition, CalibrationCommand
-from robot_server.robot.calibration.util import (
-    SimpleStateMachine,
-    StateTransitionError
+from robot_server.service.session.models.command_definitions import (
+    CommandDefinition,
+    CalibrationCommand,
 )
+from robot_server.robot.calibration.util import SimpleStateMachine, StateTransitionError
 from robot_server.robot.calibration.tip_length.constants import (
     TipCalibrationState as State,
 )
 
 
 TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
-    State.sessionStarted: {
-        CalibrationCommand.load_labware: State.labwareLoaded
-    },
+    State.sessionStarted: {CalibrationCommand.load_labware: State.labwareLoaded},
     State.labwareLoaded: {
         CalibrationCommand.move_to_reference_point: State.measuringNozzleOffset
     },
@@ -36,19 +33,16 @@ TIP_LENGTH_TRANSITIONS: Dict[State, Dict[CommandDefinition, State]] = {
         CalibrationCommand.save_offset: State.measuringTipOffset,
         CalibrationCommand.jog: State.measuringTipOffset,
         CalibrationCommand.move_to_tip_rack: State.calibrationComplete,
-        CalibrationCommand.invalidate_last_action: State.preparingPipette
+        CalibrationCommand.invalidate_last_action: State.preparingPipette,
     },
-    State.WILDCARD: {
-        CalibrationCommand.exit: State.sessionExited
-    }
+    State.WILDCARD: {CalibrationCommand.exit: State.sessionExited},
 }
 
 
 class TipCalibrationStateMachine:
     def __init__(self):
         self._state_machine = SimpleStateMachine(
-            states=set(s for s in State),
-            transitions=TIP_LENGTH_TRANSITIONS
+            states=set(s for s in State), transitions=TIP_LENGTH_TRANSITIONS
         )
 
     def get_next_state(self, from_state: State, command: CommandDefinition):

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -14,12 +14,17 @@ from opentrons.types import Point, Location
 from robot_server.service.errors import RobotServerError
 from ...service.session.models.command_definitions import CommandDefinition
 from .constants import (
-    STATE_WILDCARD, MOVE_TO_REF_POINT_SAFETY_BUFFER,
-    TRASH_WELL, TRASH_REF_POINT_OFFSET)
+    STATE_WILDCARD,
+    MOVE_TO_REF_POINT_SAFETY_BUFFER,
+    TRASH_WELL,
+    TRASH_REF_POINT_OFFSET,
+)
 from .errors import CalibrationError
 from .tip_length.constants import TipCalibrationState
 from .pipette_offset.constants import (
-    PipetteOffsetCalibrationState, PipetteOffsetWithTipLengthCalibrationState)
+    PipetteOffsetCalibrationState,
+    PipetteOffsetWithTipLengthCalibrationState,
+)
 from .deck.constants import DeckCalibrationState
 from .check.constants import CalibrationCheckState
 
@@ -31,18 +36,22 @@ if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import LabwareUri
     from opentrons_shared_data.labware import LabwareDefinition
 
-ValidState = Union[TipCalibrationState, DeckCalibrationState,
-                   PipetteOffsetCalibrationState, CalibrationCheckState,
-                   PipetteOffsetWithTipLengthCalibrationState]
+ValidState = Union[
+    TipCalibrationState,
+    DeckCalibrationState,
+    PipetteOffsetCalibrationState,
+    CalibrationCheckState,
+    PipetteOffsetWithTipLengthCalibrationState,
+]
 
 
 class StateTransitionError(RobotServerError):
-    def __init__(self,
-                 action: CommandDefinition,
-                 state: ValidState):
-        super().__init__(definition=CalibrationError.BAD_STATE_TRANSITION,
-                         action=action,
-                         state=state.name)
+    def __init__(self, action: CommandDefinition, state: ValidState):
+        super().__init__(
+            definition=CalibrationError.BAD_STATE_TRANSITION,
+            action=action,
+            state=state.name,
+        )
 
 
 TransitionMap = Dict[Any, Dict[Any, Any]]
@@ -50,9 +59,7 @@ MODULE_LOG = logging.getLogger(__name__)
 
 
 class SimpleStateMachine:
-    def __init__(self,
-                 states: Set[Any],
-                 transitions: TransitionMap):
+    def __init__(self, states: Set[Any], transitions: TransitionMap):
         """
         Construct a simple state machine
 
@@ -88,10 +95,11 @@ class SimpleStateMachine:
 
 
 CalibrationUserFlow = Union[
-    'DeckCalibrationUserFlow',
-    'TipCalibrationUserFlow',
-    'PipetteOffsetCalibrationUserFlow',
-    'CheckCalibrationUserFlow']
+    "DeckCalibrationUserFlow",
+    "TipCalibrationUserFlow",
+    "PipetteOffsetCalibrationUserFlow",
+    "CheckCalibrationUserFlow",
+]
 
 
 async def invalidate_tip(user_flow: CalibrationUserFlow):
@@ -104,24 +112,24 @@ async def invalidate_tip(user_flow: CalibrationUserFlow):
 def save_default_pick_up_current(instr: Pipette):
     # reduce pick up current for multichannel pipette picking up 1 tip
     saved_default = instr.config.pick_up_current
-    instr.update_config_item('pick_up_current', 0.1)
+    instr.update_config_item("pick_up_current", 0.1)
 
     try:
         yield
     finally:
-        instr.update_config_item('pick_up_current', saved_default)
+        instr.update_config_item("pick_up_current", saved_default)
 
 
 async def pick_up_tip(user_flow: CalibrationUserFlow, tip_length: float):
     # grab position of active nozzle for ref when returning tip later
     cp = user_flow.critical_point_override
     user_flow.tip_origin = await user_flow.hardware.gantry_position(
-        user_flow.mount, critical_point=cp)
+        user_flow.mount, critical_point=cp
+    )
 
     with contextlib.ExitStack() as stack:
         if user_flow.hw_pipette.config.channels > 1:
-            stack.enter_context(
-                save_default_pick_up_current(user_flow.hw_pipette))
+            stack.enter_context(save_default_pick_up_current(user_flow.hw_pipette))
 
         await user_flow.hardware.pick_up_tip(user_flow.mount, tip_length)
 
@@ -138,37 +146,33 @@ async def return_tip(user_flow: CalibrationUserFlow, tip_length: float):
         coeff = user_flow.hw_pipette.config.return_tip_height
         to_pt = user_flow.tip_origin - Point(0, 0, tip_length * coeff)
         cp = user_flow.critical_point_override
-        await user_flow.hardware.move_to(mount=user_flow.mount,
-                                         abs_position=to_pt,
-                                         critical_point=cp)
+        await user_flow.hardware.move_to(
+            mount=user_flow.mount, abs_position=to_pt, critical_point=cp
+        )
         await user_flow.hardware.drop_tip(user_flow.mount)
         user_flow.reset_tip_origin()
 
 
-async def move(user_flow: CalibrationUserFlow,
-               to_loc: Location,
-               this_move_cp: CriticalPoint = None):
+async def move(
+    user_flow: CalibrationUserFlow, to_loc: Location, this_move_cp: CriticalPoint = None
+):
     from_pt = await user_flow.get_current_point(None)
     from_loc = Location(from_pt, None)
     cp = this_move_cp or user_flow.critical_point_override
 
-    max_height = user_flow.hardware.get_instrument_max_height(
-        user_flow.mount)
+    max_height = user_flow.hardware.get_instrument_max_height(user_flow.mount)
 
-    safe = planning.safe_height(
-        from_loc, to_loc, user_flow.deck, max_height)
-    moves = plan_arc(from_pt, to_loc.point, safe,
-                     origin_cp=None,
-                     dest_cp=cp)
+    safe = planning.safe_height(from_loc, to_loc, user_flow.deck, max_height)
+    moves = plan_arc(from_pt, to_loc.point, safe, origin_cp=None, dest_cp=cp)
     for move in moves:
-        await user_flow.hardware.move_to(mount=user_flow.mount,
-                                         abs_position=move[0],
-                                         critical_point=move[1])
+        await user_flow.hardware.move_to(
+            mount=user_flow.mount, abs_position=move[0], critical_point=move[1]
+        )
 
 
 def get_reference_location(
-        deck: Deck,
-        cal_block_target_well: labware.Well = None) -> Location:
+    deck: Deck, cal_block_target_well: labware.Well = None
+) -> Location:
     """
     Get location of static z reference point.
     Will be on Calibration Block if available, otherwise will be on
@@ -181,32 +185,30 @@ def get_reference_location(
         trash = deck.get_fixed_trash()
         assert trash
         trash_loc = trash.wells_by_name()[TRASH_WELL].top()
-        ref_loc = trash_loc.move(TRASH_REF_POINT_OFFSET +
-                                 MOVE_TO_REF_POINT_SAFETY_BUFFER)
+        ref_loc = trash_loc.move(
+            TRASH_REF_POINT_OFFSET + MOVE_TO_REF_POINT_SAFETY_BUFFER
+        )
     return ref_loc
 
 
-def save_tip_length_calibration(pipette_id: str,
-                                tip_length_offset: float,
-                                tip_rack: labware.Labware):
+def save_tip_length_calibration(
+    pipette_id: str, tip_length_offset: float, tip_rack: labware.Labware
+):
     # TODO: 07-22-2020 parent slot is not important when tracking
     # tip length data, hence the empty string, we should remove it
     # from create_tip_length_data in a refactor
     tip_length_data = modify.create_tip_length_data(
-        tip_rack._implementation.get_definition(),
-        tip_length_offset
+        tip_rack._implementation.get_definition(), tip_length_offset
     )
     modify.save_tip_length_calibration(pipette_id, tip_length_data)
 
 
-def get_default_tipracks(
-        default_uris: List['LabwareUri']) -> List['LabwareDefinition']:
+def get_default_tipracks(default_uris: List["LabwareUri"]) -> List["LabwareDefinition"]:
     definitions = []
     for rack in default_uris:
         details = helpers.details_from_uri(rack)
         rack_def = labware.get_labware_definition(
-            details.load_name,
-            details.namespace,
-            details.version)
+            details.load_name, details.namespace, details.version
+        )
         definitions.append(rack_def)
     return definitions

--- a/robot-server/robot_server/service/json_api/request.py
+++ b/robot-server/robot_server/service/json_api/request.py
@@ -3,12 +3,10 @@ from pydantic import Field
 from pydantic.generics import GenericModel
 
 
-RequestDataT = TypeVar('RequestDataT')
+RequestDataT = TypeVar("RequestDataT")
 
 
 class RequestModel(GenericModel, Generic[RequestDataT]):
-    """
-    """
-    data: RequestDataT = \
-        Field(...,
-              description="the document’s 'primary data'")
+    """ """
+
+    data: RequestDataT = Field(..., description="the document’s 'primary data'")

--- a/robot-server/robot_server/service/json_api/resource_links.py
+++ b/robot-server/robot_server/service/json_api/resource_links.py
@@ -5,11 +5,11 @@ from pydantic import BaseModel, Field
 
 class ResourceLink(BaseModel):
     """https://jsonapi.org/format/#document-links"""
-    href: str = \
-        Field(...,
-              description="The link’s URL")
-    meta: typing.Optional[typing.Dict[typing.Any, typing.Any]] = \
-        Field(None, description="Meta data about the link")
+
+    href: str = Field(..., description="The link’s URL")
+    meta: typing.Optional[typing.Dict[typing.Any, typing.Any]] = Field(
+        None, description="Meta data about the link"
+    )
 
 
 class ResourceLinkKey(str, Enum):

--- a/robot-server/robot_server/service/labware/models.py
+++ b/robot-server/robot_server/service/labware/models.py
@@ -5,62 +5,72 @@ from functools import partial
 from pydantic import BaseModel, Field
 
 from robot_server.service.json_api import (
-    ResponseModel, ResponseDataModel, MultiResponseModel)
+    ResponseModel,
+    ResponseDataModel,
+    MultiResponseModel,
+)
 
 OffsetVector = typing.Tuple[float, float, float]
 
-OffsetVectorField = partial(Field, ...,
-                            description="A labware offset vector in deck "
-                                        "coordinates (x, y, z)")
+OffsetVectorField = partial(
+    Field, ..., description="A labware offset vector in deck " "coordinates (x, y, z)"
+)
 
 
 class OffsetData(BaseModel):
     value: OffsetVector = OffsetVectorField()
-    lastModified: datetime =\
-        Field(..., description="When this calibration was last modified")
+    lastModified: datetime = Field(
+        ..., description="When this calibration was last modified"
+    )
 
 
 class TipData(BaseModel):
     """
     A model for tip length calibration data
     """
-    value: typing.Optional[float] =\
-        Field(..., description="The tip length of a labware")
-    lastModified: typing.Optional[datetime] =\
-        Field(..., description="When this calibration was last modified")
+
+    value: typing.Optional[float] = Field(
+        ..., description="The tip length of a labware"
+    )
+    lastModified: typing.Optional[datetime] = Field(
+        ..., description="When this calibration was last modified"
+    )
 
 
 class CalibrationData(BaseModel):
     """
     A model for labware calibration data
     """
+
     offset: OffsetData = Field(..., description="An array of XYZ offset data.")
-    tipLength: TipData =\
-        Field(..., description="The tip length of a labware, if relevant.")
+    tipLength: TipData = Field(
+        ..., description="The tip length of a labware, if relevant."
+    )
 
 
 class LabwareCalibration(ResponseDataModel):
     """
     A model describing labware calibrations (tiplength and offset)
     """
-    calibrationData: CalibrationData =\
-        Field(...,
-              description="A dictionary of calibration data"
-                          "including tip length and offsets")
-    loadName: str =\
-        Field(...,
-              description="The loadname of the labware definition.")
-    namespace: str =\
-        Field(...,
-              description="The namespace location of the labware definition")
+
+    calibrationData: CalibrationData = Field(
+        ...,
+        description="A dictionary of calibration data"
+        "including tip length and offsets",
+    )
+    loadName: str = Field(..., description="The loadname of the labware definition.")
+    namespace: str = Field(
+        ..., description="The namespace location of the labware definition"
+    )
     version: int = Field(..., description="The labware definition version")
-    parent: str =\
-        Field(...,
-              description="The module associated with this offset or an empty"
-                          " string if the offset is associated with a slot")
-    definitionHash: str =\
-        Field(...,
-              description="The sha256 hash of key labware definition details")
+    parent: str = Field(
+        ...,
+        description="The module associated with this offset or an empty"
+        " string if the offset is associated with a slot",
+    )
+    definitionHash: str = Field(
+        ..., description="The sha256 hash of key labware definition details"
+    )
 
     class Config:
         schema_extra = {
@@ -69,12 +79,12 @@ class LabwareCalibration(ResponseDataModel):
                     "calibrationData": {
                         "tipLength": {
                             "value": 10,
-                            "lastModified": "2020-07-10T12:50:47.156321"
-                            },
+                            "lastModified": "2020-07-10T12:50:47.156321",
+                        },
                         "offset": {
                             "value": [1, -2, 10],
-                            "lastModified": "2020-07-10T12:40:17.05"
-                        }
+                            "lastModified": "2020-07-10T12:40:17.05",
+                        },
                     },
                     "version": "1",
                     "parent": "",
@@ -85,26 +95,22 @@ class LabwareCalibration(ResponseDataModel):
                     "calibrationData": {
                         "tipLength": {
                             "value": 10,
-                            "lastModified": "2020-07-10T12:50:47.156321"
-                            },
+                            "lastModified": "2020-07-10T12:50:47.156321",
+                        },
                         "offset": {
                             "value": [1, -2, 10],
-                            "lastModified": "2020-07-10T12:40:17.05"
-                        }
+                            "lastModified": "2020-07-10T12:40:17.05",
+                        },
                     },
                     "version": "1",
                     "parent": "temperatureModuleV2",
                     "namespace": "opentrons",
                     "loadName": "corning_96_wellPlate_384ul",
-                }
+                },
             ]
         }
 
 
-MultipleCalibrationsResponse = MultiResponseModel[
-    LabwareCalibration
-]
+MultipleCalibrationsResponse = MultiResponseModel[LabwareCalibration]
 
-SingleCalibrationResponse = ResponseModel[
-    LabwareCalibration
-]
+SingleCalibrationResponse = ResponseModel[LabwareCalibration]

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -9,7 +9,8 @@ from opentrons.calibration_storage import (
     helpers,
     types as cal_types,
     get as get_cal,
-    delete)
+    delete,
+)
 
 from robot_server.errors import ErrorResponse
 from robot_server.service.labware import models as lw_models
@@ -25,8 +26,8 @@ These routes serve the current labware offsets on the robot to a client.
 
 
 def _format_calibrations(
-        calibrations: List[cal_types.CalibrationInformation])\
-        -> List[lw_models.LabwareCalibration]:
+    calibrations: List[cal_types.CalibrationInformation],
+) -> List[lw_models.LabwareCalibration]:
     formatted_calibrations = []
     for calInfo in calibrations:
         details = helpers.details_from_uri(calInfo.uri)
@@ -38,18 +39,18 @@ def _format_calibrations(
         # expected by OffsetData
         offset = lw_models.OffsetData(
             value=lw_offset.value,  # type: ignore[arg-type]
-            lastModified=lw_offset.last_modified)  # type: ignore[arg-type]
+            lastModified=lw_offset.last_modified,  # type: ignore[arg-type]
+        )
 
         tip_cal = calInfo.calibration.tip_length
         tip_length = lw_models.TipData(
-            value=tip_cal.value,
-            lastModified=tip_cal.last_modified)
+            value=tip_cal.value, lastModified=tip_cal.last_modified
+        )
         if calInfo.parent.module:
             parent_info = calInfo.parent.module
         else:
             parent_info = calInfo.parent.slot
-        cal_data = lw_models.CalibrationData(
-            offset=offset, tipLength=tip_length)
+        cal_data = lw_models.CalibrationData(offset=offset, tipLength=tip_length)
         formatted_cal = lw_models.LabwareCalibration(
             id=calInfo.labware_id,
             calibrationData=cal_data,
@@ -57,15 +58,17 @@ def _format_calibrations(
             namespace=details.namespace,
             version=details.version,
             parent=parent_info,
-            definitionHash=calInfo.labware_id)
+            definitionHash=calInfo.labware_id,
+        )
         formatted_calibrations.append(formatted_cal)
     return formatted_calibrations
 
 
 def _grab_value(
-        calibration: cal_types.CalibrationInformation,
-        filtering: str,
-        comparison: Union[str, int]) -> bool:
+    calibration: cal_types.CalibrationInformation,
+    filtering: str,
+    comparison: Union[str, int],
+) -> bool:
     """
     A filtering function to determine whether a particular
     calibration matches any of the following criteria:
@@ -78,18 +81,16 @@ def _grab_value(
     provided by the client.
     """
     details = helpers.details_from_uri(calibration.uri)
-    if filtering == 'namespace':
+    if filtering == "namespace":
         return details.namespace == comparison
-    if filtering == 'loadname':
+    if filtering == "loadname":
         return details.load_name == comparison
-    if filtering == 'version':
+    if filtering == "version":
         return details.version == comparison
     return False
 
 
-def _check_parent(
-        parentOpts: cal_types.ParentOptions,
-        parent: str) -> bool:
+def _check_parent(parentOpts: cal_types.ParentOptions, parent: str) -> bool:
     """
     A filtering function to check whether the parent provided
     by the client matches the parent provided by the client.
@@ -101,17 +102,17 @@ def _check_parent(
     return False
 
 
-@router.get("/labware/calibrations",
-            summary="Fetch all saved labware calibrations from the robot",
-            description="Search the robot for any saved labware offsets "
-                        "which allows you to check whether a particular "
-                        "labware has been calibrated or not.",
-            response_model=lw_models.MultipleCalibrationsResponse)
+@router.get(
+    "/labware/calibrations",
+    summary="Fetch all saved labware calibrations from the robot",
+    description="Search the robot for any saved labware offsets "
+    "which allows you to check whether a particular "
+    "labware has been calibrated or not.",
+    response_model=lw_models.MultipleCalibrationsResponse,
+)
 async def get_all_labware_calibrations(
-        loadName: str = None,
-        namespace: str = None,
-        version: int = None,
-        parent: str = None) -> lw_models.MultipleCalibrationsResponse:
+    loadName: str = None, namespace: str = None, version: int = None, parent: str = None
+) -> lw_models.MultipleCalibrationsResponse:
     all_calibrations = get_cal.get_all_calibrations()
 
     if not all_calibrations:
@@ -122,21 +123,30 @@ async def get_all_labware_calibrations(
         )
 
     if namespace:
-        all_calibrations = list(filter(
-            partial(_grab_value, filtering='namespace', comparison=namespace),
-            all_calibrations))
+        all_calibrations = list(
+            filter(
+                partial(_grab_value, filtering="namespace", comparison=namespace),
+                all_calibrations,
+            )
+        )
     if loadName:
-        all_calibrations = list(filter(
-          partial(_grab_value, filtering='loadname', comparison=loadName),
-          all_calibrations))
+        all_calibrations = list(
+            filter(
+                partial(_grab_value, filtering="loadname", comparison=loadName),
+                all_calibrations,
+            )
+        )
     if version:
-        all_calibrations = list(filter(
-          partial(_grab_value, filtering='version', comparison=version),
-          all_calibrations))
+        all_calibrations = list(
+            filter(
+                partial(_grab_value, filtering="version", comparison=version),
+                all_calibrations,
+            )
+        )
     if parent:
-        all_calibrations = list(filter(
-          partial(_check_parent, parent=parent),
-          all_calibrations))
+        all_calibrations = list(
+            filter(partial(_check_parent, parent=parent), all_calibrations)
+        )
     calibrations = _format_calibrations(all_calibrations)
 
     # TODO(mc, 2020-09-17): the type of all_calibrations does not match
@@ -146,38 +156,46 @@ async def get_all_labware_calibrations(
     )
 
 
-@router.get("/labware/calibrations/{calibrationId}",
-            description="Fetch one specific labware offset by ID",
-            response_model=lw_models.SingleCalibrationResponse,
-            responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}})
+@router.get(
+    "/labware/calibrations/{calibrationId}",
+    description="Fetch one specific labware offset by ID",
+    response_model=lw_models.SingleCalibrationResponse,
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}},
+)
 async def get_specific_labware_calibration(
-        calibrationId: str) -> lw_models.SingleCalibrationResponse:
+    calibrationId: str,
+) -> lw_models.SingleCalibrationResponse:
     calibration: Optional[cal_types.CalibrationInformation] = None
     for cal in get_cal.get_all_calibrations():
         if calibrationId == cal.labware_id:
             calibration = cal
             break
     if not calibration:
-        raise RobotServerError(definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-                               resource='calibration',
-                               id=calibrationId)
+        raise RobotServerError(
+            definition=CommonErrorDef.RESOURCE_NOT_FOUND,
+            resource="calibration",
+            id=calibrationId,
+        )
 
     formatted_calibrations = _format_calibrations([calibration])
     # TODO(mc, 2020-09-17): type of formatted_calibrations[0] does not match
     # what SingleCalibrationResponse expects for data
     return lw_models.SingleCalibrationResponse(
-        data=formatted_calibrations[0])  # type: ignore[arg-type]
+        data=formatted_calibrations[0]
+    )  # type: ignore[arg-type]
 
 
-@router.delete("/labware/calibrations/{calibrationId}",
-               description="Delete one specific labware offset by ID",
-               responses={
-                   status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}})
-async def delete_specific_labware_calibration(
-        calibrationId: cal_types.CalibrationID):
+@router.delete(
+    "/labware/calibrations/{calibrationId}",
+    description="Delete one specific labware offset by ID",
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}},
+)
+async def delete_specific_labware_calibration(calibrationId: cal_types.CalibrationID):
     try:
         delete.delete_offset_file(calibrationId)
     except (FileNotFoundError, KeyError):
-        raise RobotServerError(definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-                               resource='calibration',
-                               id=calibrationId)
+        raise RobotServerError(
+            definition=CommonErrorDef.RESOURCE_NOT_FOUND,
+            resource="calibration",
+            id=calibrationId,
+        )

--- a/robot-server/robot_server/service/legacy/models/__init__.py
+++ b/robot-server/robot_server/service/legacy/models/__init__.py
@@ -3,4 +3,5 @@ from pydantic import BaseModel, Field
 
 class V1BasicResponse(BaseModel):
     """A response with a human readable message"""
+
     message: str = Field(..., description="A human-readable message")

--- a/robot-server/robot_server/service/legacy/models/control.py
+++ b/robot-server/robot_server/service/legacy/models/control.py
@@ -11,6 +11,7 @@ class MotionTarget(str, Enum):
     What should be moved. If mount, move the nominal position of the mount;
     if pipette, move the nozzle of the pipette
     """
+
     pipette = "pipette"
     mount = "mount"
 
@@ -23,9 +24,13 @@ class HomeTarget(str, Enum):
 Point = typing.List[float]
 
 # Commonly used Point type description and constraints
-PointField = partial(Field, ...,
-                     description="A point in deck coordinates (x, y, z)",
-                     min_items=3, max_items=3)
+PointField = partial(
+    Field,
+    ...,
+    description="A point in deck coordinates (x, y, z)",
+    min_items=3,
+    max_items=3,
+)
 
 
 class ChangePipette(BaseModel):
@@ -48,19 +53,18 @@ class RobotPositionsResponse(BaseModel):
     positions: RobotPositions
 
     class Config:
-        schema_extra = {"example": {
-            "positions": {
-                "change_pipette": {
-                    "target": "mount",
-                    "left": [325, 40, 30],
-                    "right": [65, 40, 30]
-                },
-                "attach_tip": {
-                    "target": "pipette",
-                    "point": [200, 90, 150]
+        schema_extra = {
+            "example": {
+                "positions": {
+                    "change_pipette": {
+                        "target": "mount",
+                        "left": [325, 40, 30],
+                        "right": [65, 40, 30],
+                    },
+                    "attach_tip": {"target": "pipette", "point": [200, 90, 150]},
                 }
             }
-        }}
+        }
 
 
 class Mount(str, Enum):
@@ -73,7 +77,7 @@ class Mount(str, Enum):
         else:
             return types.Mount.LEFT
 
-    def other_mount(self) -> 'Mount':
+    def other_mount(self) -> "Mount":
         if self is Mount.right:
             return Mount.left
         else:
@@ -84,98 +88,102 @@ class RobotMoveTarget(BaseModel):
     target: MotionTarget
     point: Point = PointField()
     mount: Mount = Field(..., description="Which mount to move")
-    model: typing.Optional[str] = \
-        Field(None,
-              description="A pipette model that matches the pipette attached "
-                          "to the specified mount. Required "
-                          "if target is pipette")
+    model: typing.Optional[str] = Field(
+        None,
+        description="A pipette model that matches the pipette attached "
+        "to the specified mount. Required "
+        "if target is pipette",
+    )
 
     @root_validator(pre=True)
     def root_validator(cls, values):
         points = values.get("point", [])
         target = values.get("target")
-        if target == MotionTarget.mount and \
-                len(points) == 3 and points[2] < 30:
-            raise ValueError("Sending a mount to a z position lower than 30 "
-                             "can cause a collision with the deck or reach the"
-                             " end of the Z axis  movement screw. Z values for"
-                             " mount movement must be >= 30")
+        if target == MotionTarget.mount and len(points) == 3 and points[2] < 30:
+            raise ValueError(
+                "Sending a mount to a z position lower than 30 "
+                "can cause a collision with the deck or reach the"
+                " end of the Z axis  movement screw. Z values for"
+                " mount movement must be >= 30"
+            )
         return values
 
     class Config:
-        schema_extra = {"examples": {
-            "moveLeftMount": {
-                "description": "Move the left mount, regardless of what is "
-                               "attached to that mount, to a specific "
-                               "position. Since you move the mount, the end of"
-                               " the pipette will be in different places "
-                               "depending on what pipette is attached - but "
-                               "you don't have to know what's attached.",
-                "summary": "Move left mount",
-                "value": {
-                    "target": "mount",
-                    "point": [100, 100, 80],
-                    "mount": "left"
-                }
-            },
-            "moveRightP300Single": {
-                "summary": "Move P300 Single on right mount",
-                "description": "Move a P300 Single attached to the right mount"
-                               " to a specific position. You have to specify "
-                               "that it's a P300 Single that you're moving, "
-                               "but as long as you specify the correct model "
-                               "the end of the pipette will always be at the "
-                               "specified position.",
-                "value": {
-                    "target": "pipette",
-                    "mount": "right",
-                    "model": "p300_single",
-                    "point": [25, 25, 50]
-                }
+        schema_extra = {
+            "examples": {
+                "moveLeftMount": {
+                    "description": "Move the left mount, regardless of what is "
+                    "attached to that mount, to a specific "
+                    "position. Since you move the mount, the end of"
+                    " the pipette will be in different places "
+                    "depending on what pipette is attached - but "
+                    "you don't have to know what's attached.",
+                    "summary": "Move left mount",
+                    "value": {
+                        "target": "mount",
+                        "point": [100, 100, 80],
+                        "mount": "left",
+                    },
+                },
+                "moveRightP300Single": {
+                    "summary": "Move P300 Single on right mount",
+                    "description": "Move a P300 Single attached to the right mount"
+                    " to a specific position. You have to specify "
+                    "that it's a P300 Single that you're moving, "
+                    "but as long as you specify the correct model "
+                    "the end of the pipette will always be at the "
+                    "specified position.",
+                    "value": {
+                        "target": "pipette",
+                        "mount": "right",
+                        "model": "p300_single",
+                        "point": [25, 25, 50],
+                    },
+                },
             }
-        }}
+        }
 
 
 class RobotHomeTarget(BaseModel):
     """Parameters for the home"""
-    target: HomeTarget = \
-        Field(...,
-              description="What to home. Robot means to home all axes; "
-                          "pipette, only that pipette's carriage and pipette "
-                          "axes")
-    mount: typing.Optional[Mount] = \
-        Field(None,
-              description="Which mount to home, if target is pipette (required"
-                          " in that case)")
+
+    target: HomeTarget = Field(
+        ...,
+        description="What to home. Robot means to home all axes; "
+        "pipette, only that pipette's carriage and pipette "
+        "axes",
+    )
+    mount: typing.Optional[Mount] = Field(
+        None,
+        description="Which mount to home, if target is pipette (required"
+        " in that case)",
+    )
 
     @root_validator(pre=True)
     def root_validate(cls, values):
         # Make sure that mount is present if target is pipette
-        if values.get("target") == HomeTarget.pipette.value \
-                and not values.get("mount"):
+        if values.get("target") == HomeTarget.pipette.value and not values.get("mount"):
             raise ValueError("mount must be specified if target is pipette")
         return values
 
     class Config:
-        schema_extra = {"examples": {
-            "homeGantry": {
-                "summary": "Home Gantry",
-                "description": "Home the robot's gantry",
-                "value": {
-                    "target": "robot"
-                }
-            },
-            "homeRight": {
-                "summary": "Home right pipette",
-                "description": "Home only the right pipette",
-                "value": {
-                    "target": "pipette",
-                    "mount": "right"
-                }
+        schema_extra = {
+            "examples": {
+                "homeGantry": {
+                    "summary": "Home Gantry",
+                    "description": "Home the robot's gantry",
+                    "value": {"target": "robot"},
+                },
+                "homeRight": {
+                    "summary": "Home right pipette",
+                    "description": "Home only the right pipette",
+                    "value": {"target": "pipette", "mount": "right"},
+                },
             }
-        }}
+        }
 
 
 class RobotLightState(BaseModel):
     """Whether a light is (or should be turned) on or off"""
+
     on: bool = Field(..., description="The light state")

--- a/robot-server/robot_server/service/legacy/models/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/models/deck_calibration.py
@@ -11,15 +11,17 @@ from robot_server.service.shared_models import calibration as cal_model
 Offset = typing.Tuple[float, float, float]
 
 AffineMatrix = typing.Tuple[
-  typing.Tuple[float, float, float, float],
-  typing.Tuple[float, float, float, float],
-  typing.Tuple[float, float, float, float],
-  typing.Tuple[float, float, float, float]]
+    typing.Tuple[float, float, float, float],
+    typing.Tuple[float, float, float, float],
+    typing.Tuple[float, float, float, float],
+    typing.Tuple[float, float, float, float],
+]
 
 AttitudeMatrix = typing.Tuple[
-  typing.Tuple[float, float, float],
-  typing.Tuple[float, float, float],
-  typing.Tuple[float, float, float]]
+    typing.Tuple[float, float, float],
+    typing.Tuple[float, float, float],
+    typing.Tuple[float, float, float],
+]
 
 
 class InstrumentOffset(BaseModel):
@@ -34,48 +36,47 @@ class InstrumentCalibrationStatus(BaseModel):
 
 class MatrixType(str, Enum):
     """The deck calibration matrix type"""
-    affine = 'affine'
-    attitude = 'attitude'
+
+    affine = "affine"
+    attitude = "attitude"
 
 
 class DeckCalibrationData(BaseModel):
-    type: MatrixType = \
-        Field(...,
-              description="The type of deck calibration matrix:"
-                          "affine or attitude")
-    matrix: typing.Union[AffineMatrix, AttitudeMatrix] = \
-        Field(...,
-              description="The deck calibration transform matrix")
-    lastModified: typing.Optional[datetime] = \
-        Field(None,
-              description="When this calibration was last modified")
-    pipetteCalibratedWith: typing.Optional[str] = \
-        Field(None,
-              description="The ID of the pipette used in this calibration")
-    tiprack: typing.Optional[str] = \
-        Field(None,
-              description="The sha256 hash of the tiprack used in this"
-                          "calibration")
-    source: SourceType = \
-        Field(None,
-              description="The calibration source")
-    status: cal_model.CalibrationStatus = \
-        Field(None, description="The status of this calibration as determined"
-                                "by a user performing calibration check.")
+    type: MatrixType = Field(
+        ..., description="The type of deck calibration matrix:" "affine or attitude"
+    )
+    matrix: typing.Union[AffineMatrix, AttitudeMatrix] = Field(
+        ..., description="The deck calibration transform matrix"
+    )
+    lastModified: typing.Optional[datetime] = Field(
+        None, description="When this calibration was last modified"
+    )
+    pipetteCalibratedWith: typing.Optional[str] = Field(
+        None, description="The ID of the pipette used in this calibration"
+    )
+    tiprack: typing.Optional[str] = Field(
+        None, description="The sha256 hash of the tiprack used in this" "calibration"
+    )
+    source: SourceType = Field(None, description="The calibration source")
+    status: cal_model.CalibrationStatus = Field(
+        None,
+        description="The status of this calibration as determined"
+        "by a user performing calibration check.",
+    )
 
 
 class DeckCalibrationStatus(BaseModel):
-    status: DeckTransformState = \
-        Field(...,
-              description="An enum stating whether a user has a valid robot"
-                          "deck calibration. See DeckTransformState"
-                          "class for more information.")
-    data: DeckCalibrationData = \
-        Field(...,
-              description="Deck calibration data")
+    status: DeckTransformState = Field(
+        ...,
+        description="An enum stating whether a user has a valid robot"
+        "deck calibration. See DeckTransformState"
+        "class for more information.",
+    )
+    data: DeckCalibrationData = Field(..., description="Deck calibration data")
 
 
 class CalibrationStatus(BaseModel):
     """The calibration status"""
+
     deckCalibration: DeckCalibrationStatus
     instrumentCalibration: InstrumentCalibrationStatus

--- a/robot-server/robot_server/service/legacy/models/logs.py
+++ b/robot-server/robot_server/service/legacy/models/logs.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class LogIdentifier(str, Enum):
     """Identifier of the log"""
+
     api = "api.log"
     serial = "serial.log"
     server = "server.log"
@@ -10,5 +11,6 @@ class LogIdentifier(str, Enum):
 
 class LogFormat(str, Enum):
     """Format to use for log records"""
+
     text = "text"
     json = "json"

--- a/robot-server/robot_server/service/legacy/models/modules.py
+++ b/robot-server/robot_server/service/legacy/models/modules.py
@@ -5,64 +5,62 @@ from pydantic import BaseModel, Field
 
 class TemperatureModuleLiveData(BaseModel):
     """Temperature Module live data"""
-    currentTemp: float = \
-        Field(...,
-              description="The current temperature of the module")
-    targetTemp: typing.Optional[float] = \
-        Field(...,
-              description="The target temperature of the module if any")
+
+    currentTemp: float = Field(..., description="The current temperature of the module")
+    targetTemp: typing.Optional[float] = Field(
+        ..., description="The target temperature of the module if any"
+    )
 
 
 class MagneticModuleLiveData(BaseModel):
     """Magnetic Module live data"""
-    engaged: bool = \
-        Field(...,
-              description="Whether the magnets are raised or lowered")
-    height: float = \
-        Field(...,
-              description="The height of the top of the magnets relative to "
-                          "their home position, in mm")
+
+    engaged: bool = Field(..., description="Whether the magnets are raised or lowered")
+    height: float = Field(
+        ...,
+        description="The height of the top of the magnets relative to "
+        "their home position, in mm",
+    )
 
 
 class ThermocyclerModuleLiveData(BaseModel):
     """Thermocycler live data"""
+
     lid: str = Field(..., description="The current state of the lid")
-    lidTarget: typing.Optional[float] = \
-        Field(...,
-              description="The target temperature of the lid temperature "
-                          "controller")
-    lidTemp: float = \
-        Field(...,
-              description="The current temperature of the lid")
-    currentTemp: float = \
-        Field(...,
-              description="The current temperature of the thermocycler block")
-    targetTemp: typing.Optional[float] = \
-        Field(...,
-              description="The target temperature of the thermocycler block")
-    holdTime: typing.Optional[float] = \
-        Field(...,
-              description="The time left in the current hold step, if any (in "
-                          "seconds)")
-    rampRate: typing.Optional[float] = \
-        Field(...,
-              description="The current ramp rate (in degC/s) for the "
-                          "thermocycler block")
-    currentCycleIndex: typing.Optional[int] = \
-        Field(...,
-              description="The index of the current cycle within the current "
-                          "programmed sequence")
-    totalCycleCount: typing.Optional[int] = \
-        Field(...,
-              description="The total number of cycles within the current "
-                          "sequence")
-    currentStepIndex: typing.Optional[int] = \
-        Field(...,
-              description="The index of the current step within the current "
-                          "programmed cycle")
-    totalStepCount: typing.Optional[int] = \
-        Field(...,
-              description="The total number of steps within the current cycle")
+    lidTarget: typing.Optional[float] = Field(
+        ..., description="The target temperature of the lid temperature " "controller"
+    )
+    lidTemp: float = Field(..., description="The current temperature of the lid")
+    currentTemp: float = Field(
+        ..., description="The current temperature of the thermocycler block"
+    )
+    targetTemp: typing.Optional[float] = Field(
+        ..., description="The target temperature of the thermocycler block"
+    )
+    holdTime: typing.Optional[float] = Field(
+        ...,
+        description="The time left in the current hold step, if any (in " "seconds)",
+    )
+    rampRate: typing.Optional[float] = Field(
+        ...,
+        description="The current ramp rate (in degC/s) for the " "thermocycler block",
+    )
+    currentCycleIndex: typing.Optional[int] = Field(
+        ...,
+        description="The index of the current cycle within the current "
+        "programmed sequence",
+    )
+    totalCycleCount: typing.Optional[int] = Field(
+        ..., description="The total number of cycles within the current " "sequence"
+    )
+    currentStepIndex: typing.Optional[int] = Field(
+        ...,
+        description="The index of the current step within the current "
+        "programmed cycle",
+    )
+    totalStepCount: typing.Optional[int] = Field(
+        ..., description="The total number of steps within the current cycle"
+    )
 
 
 # ThermocyclerModuleLiveData must be first. The ordering in a Union has to go
@@ -75,194 +73,197 @@ ModuleLiveData = typing.Union[
 
 
 class PhysicalPort(BaseModel):
-    hub: typing.Optional[int] = \
-        Field(...,
-              description="A physical USB external hub that is"
-                          "connected to the raspberry pi")
-    port: typing.Optional[int] = \
-        Field(...,
-              description="The physical port that a module is"
-                          "connected to.")
+    hub: typing.Optional[int] = Field(
+        ...,
+        description="A physical USB external hub that is"
+        "connected to the raspberry pi",
+    )
+    port: typing.Optional[int] = Field(
+        ..., description="The physical port that a module is" "connected to."
+    )
 
 
 class Module(BaseModel):
     """An object identifying a module"""
-    name: str = \
-        Field(...,
-              description="A machine readable identifying name for a module. "
-                          "Deprecated. Prefer moduleModel", )
-    displayName: str = \
-        Field(...,
-              description="A human-presentable name of the module. Deprecated."
-                          " Prefer lookup in the def", )
-    moduleModel: str = \
-        Field(...,
-              description="The model of the module (e.g. magneticModuleV1)")
-    port: str = \
-        Field(...,
-              description="The virtual port to which the module is attached", )
-    usbPort: PhysicalPort = \
-        Field(...,
-              description="The physical port to which the module is attached")
-    serial: str = \
-        Field(...,
-              description="The unique serial number of the module", )
-    model: str = \
-        Field(...,
-              description="The model identifier (i.e. the part number). "
-                          "Deprecated. Prefer revision", )
-    revision: str = \
-        Field(...,
-              description="The hardware identifier (i.e. the part number)")
-    fwVersion: str = \
-        Field(..., description="The current firmware version", )
-    hasAvailableUpdate: bool = \
-        Field(..., description="If set, a module update is available")
-    status: str = \
-        Field(...,
-              description="A human-readable module-specific status", )
+
+    name: str = Field(
+        ...,
+        description="A machine readable identifying name for a module. "
+        "Deprecated. Prefer moduleModel",
+    )
+    displayName: str = Field(
+        ...,
+        description="A human-presentable name of the module. Deprecated."
+        " Prefer lookup in the def",
+    )
+    moduleModel: str = Field(
+        ..., description="The model of the module (e.g. magneticModuleV1)"
+    )
+    port: str = Field(
+        ...,
+        description="The virtual port to which the module is attached",
+    )
+    usbPort: PhysicalPort = Field(
+        ..., description="The physical port to which the module is attached"
+    )
+    serial: str = Field(
+        ...,
+        description="The unique serial number of the module",
+    )
+    model: str = Field(
+        ...,
+        description="The model identifier (i.e. the part number). "
+        "Deprecated. Prefer revision",
+    )
+    revision: str = Field(
+        ..., description="The hardware identifier (i.e. the part number)"
+    )
+    fwVersion: str = Field(
+        ...,
+        description="The current firmware version",
+    )
+    hasAvailableUpdate: bool = Field(
+        ..., description="If set, a module update is available"
+    )
+    status: str = Field(
+        ...,
+        description="A human-readable module-specific status",
+    )
     data: ModuleLiveData
 
 
 class Modules(BaseModel):
     """A list of all attached modules and the status of each one"""
+
     modules: typing.List[Module]
 
     class Config:
-        schema_extra = {"examples": {
-            "nothingAttached": {
-                "description": "With no modules present",
-                "value": {
-                    "modules": []
-                }
-            },
-            "magneticModuleAttached": {
-                "description": "With a Magnetic Module attached",
-                "value": {
-                    "modules": [
-                        {
-                            "name": "magdeck",
-                            "displayName": "Magnetic Module",
-                            "moduleModel": "magneticModuleV1",
-                            "port": "tty01_magdeck",
-                            "serial": "MDV2313121",
-                            "model": "mag_deck_v4.0",
-                            "revision": "mag_deck_v4.0",
-                            "fwVersion": "2.1.3",
-                            "status": "engaged",
-                            "hasAvailableUpdate": True,
-                            "data": {
-                                "engaged": True,
-                                "height": 10
+        schema_extra = {
+            "examples": {
+                "nothingAttached": {
+                    "description": "With no modules present",
+                    "value": {"modules": []},
+                },
+                "magneticModuleAttached": {
+                    "description": "With a Magnetic Module attached",
+                    "value": {
+                        "modules": [
+                            {
+                                "name": "magdeck",
+                                "displayName": "Magnetic Module",
+                                "moduleModel": "magneticModuleV1",
+                                "port": "tty01_magdeck",
+                                "serial": "MDV2313121",
+                                "model": "mag_deck_v4.0",
+                                "revision": "mag_deck_v4.0",
+                                "fwVersion": "2.1.3",
+                                "status": "engaged",
+                                "hasAvailableUpdate": True,
+                                "data": {"engaged": True, "height": 10},
                             }
-                        }
-                    ]
-                }
-            },
-            "tempDeckAttached": {
-                "description": "With a Temperature Module attached",
-                "value": {
-                    "modules": [
-                        {
-                            "name": "tempdeck",
-                            "displayName": "Temperature Module",
-                            "moduleModel": "temperatureModuleV1",
-                            "revision": "temp_deck_v10",
-                            "port": "tty2_tempdeck",
-                            "serial": "TDV10231231",
-                            "model": "temp_deck_v10",
-                            "hasAvailableUpdate": False,
-                            "fwVersion": "1.2.0",
-                            "status": "cooling",
-                            "data": {
-                                "currentTemp": 25,
-                                "targetTemp": 10
+                        ]
+                    },
+                },
+                "tempDeckAttached": {
+                    "description": "With a Temperature Module attached",
+                    "value": {
+                        "modules": [
+                            {
+                                "name": "tempdeck",
+                                "displayName": "Temperature Module",
+                                "moduleModel": "temperatureModuleV1",
+                                "revision": "temp_deck_v10",
+                                "port": "tty2_tempdeck",
+                                "serial": "TDV10231231",
+                                "model": "temp_deck_v10",
+                                "hasAvailableUpdate": False,
+                                "fwVersion": "1.2.0",
+                                "status": "cooling",
+                                "data": {"currentTemp": 25, "targetTemp": 10},
                             }
-                        }
-                    ]
-                }
-            },
-            "thermocyclerAttached": {
-                "description": "With a Thermocycler attached",
-                "value": {
-                    "modules": [
-                        {
-                            "name": "thermocycler",
-                            "displayName": "Thermocycler",
-                            "revision": "thermocycler_v10",
-                            "moduleModel": "thermocyclerModuleV1",
-                            "port": "tty3_thermocycler",
-                            "serial": "TCV1006052018",
-                            "model": "thermocycler_v10",
-                            "hasAvailableUpdate": True,
-                            "fwVersion": "1.0.0",
-                            "status": "cooling",
-                            "data": {
-                                "lid": "closed",
-                                "lidTarget": 10,
-                                "lidTemp": 15,
-                                "currentTemp": 20,
-                                "targetTemp": 10,
-                                "holdTime": None,
-                                "rampRate": 10,
-                                "currentCycleIndex": None,
-                                "totalCycleCount": None,
-                                "currentStepIndex": None,
-                                "totalStepCount": None
+                        ]
+                    },
+                },
+                "thermocyclerAttached": {
+                    "description": "With a Thermocycler attached",
+                    "value": {
+                        "modules": [
+                            {
+                                "name": "thermocycler",
+                                "displayName": "Thermocycler",
+                                "revision": "thermocycler_v10",
+                                "moduleModel": "thermocyclerModuleV1",
+                                "port": "tty3_thermocycler",
+                                "serial": "TCV1006052018",
+                                "model": "thermocycler_v10",
+                                "hasAvailableUpdate": True,
+                                "fwVersion": "1.0.0",
+                                "status": "cooling",
+                                "data": {
+                                    "lid": "closed",
+                                    "lidTarget": 10,
+                                    "lidTemp": 15,
+                                    "currentTemp": 20,
+                                    "targetTemp": 10,
+                                    "holdTime": None,
+                                    "rampRate": 10,
+                                    "currentCycleIndex": None,
+                                    "totalCycleCount": None,
+                                    "currentStepIndex": None,
+                                    "totalStepCount": None,
+                                },
                             }
-                        }
-                    ]
-                }
+                        ]
+                    },
+                },
             }
-        }
         }
 
 
 class ModuleSerial(BaseModel):
     """Data from the module"""
-    status: str = Field(...,
-                        description="A human-readable module-specific status")
+
+    status: str = Field(..., description="A human-readable module-specific status")
     data: ModuleLiveData
 
 
 class SerialCommand(BaseModel):
     """The serialized module call"""
-    command_type: str = \
-        Field(...,
-              description="The name of the module function to call")
-    args: typing.Optional[typing.List[typing.Any]] = \
-        Field(None,
-              description="The ordered args list for the call")
+
+    command_type: str = Field(
+        ..., description="The name of the module function to call"
+    )
+    args: typing.Optional[typing.List[typing.Any]] = Field(
+        None, description="The ordered args list for the call"
+    )
 
     class Config:
-        schema_extra = {"examples": {
-            "tempModSetTemp": {
-                "summary": "Set Temperature Module temperature",
-                "description": "Set the temperature of an attached "
-                               "Temperature Module",
-                "value": {
-                    "command_type": "set_temperature",
-                    "args": [60]
+        schema_extra = {
+            "examples": {
+                "tempModSetTemp": {
+                    "summary": "Set Temperature Module temperature",
+                    "description": "Set the temperature of an attached "
+                    "Temperature Module",
+                    "value": {"command_type": "set_temperature", "args": [60]},
                 }
             }
-        }}
+        }
 
 
 class SerialCommandResponse(BaseModel):
-    """"The result of a successful call"""
+    """ "The result of a successful call"""
+
     message: str = Field(..., description="A human readable string")
-    returnValue: str = Field(None,
-                             description="The return value from the call")
+    returnValue: str = Field(None, description="The return value from the call")
 
     class Config:
-        schema_extra = {"examples": {
-            "tempModSetTemperature": {
-                "summary": "Set temperature OK",
-                "description": "A successful call to set_temperature "
-                               "on a Temperature Module",
-                "value": {
-                    "message": "Success",
-                    "returnValue": None
+        schema_extra = {
+            "examples": {
+                "tempModSetTemperature": {
+                    "summary": "Set temperature OK",
+                    "description": "A successful call to set_temperature "
+                    "on a Temperature Module",
+                    "value": {"message": "Success", "returnValue": None},
                 }
             }
-        }}
+        }

--- a/robot-server/robot_server/service/legacy/models/motors.py
+++ b/robot-server/robot_server/service/legacy/models/motors.py
@@ -20,6 +20,7 @@ class MotorName(str, Enum):
 
 class EngagedMotor(BaseModel):
     """Engaged motor"""
+
     enabled: bool = Field(..., description="Is engine enabled")
 
 
@@ -30,17 +31,16 @@ EngagedMotors = create_model(
     __base__=None,
     __module__=None,
     __validators__=None,
-    **{
-        motor.value: (EngagedMotor, ...) for motor in MotorName
-    }
+    **{motor.value: (EngagedMotor, ...) for motor in MotorName}
 )
 EngagedMotors.__doc__ = "Which motors are engaged"
 
 
 class Axes(BaseModel):
     """A list of motor axes to disengage"""
+
     axes: typing.List[MotorName]
 
-    @validator('axes', pre=True)
+    @validator("axes", pre=True)
     def lower_case_motor_name(cls, v):
         return [m.lower() for m in v]

--- a/robot-server/robot_server/service/legacy/models/networking.py
+++ b/robot-server/robot_server/service/legacy/models/networking.py
@@ -20,36 +20,39 @@ class ConnectionType(str, Enum):
 
 class InterfaceStatus(BaseModel):
     """Status for an interface"""
-    ipAddress: str = \
-        Field(None,
-              description="The interface IP address with CIDR subnet appended "
-                          "(e.g. 10.0.0.1/24)")
-    macAddress: str = \
-        Field(None,
-              description="The MAC address of this interface (at least when "
-                          "connected to this network - it may change due to "
-                          "NetworkManager's privacy functionality when "
-                          "disconnected or connected to a different network)")
-    gatewayAddress: str = \
-        Field(None,
-              description="The address of the configured gateway")
-    state: str = \
-        Field(...,
-              description="The state of the connection. (i.e. connected, "
-                          "disconnected, connection failed)")
-    type: ConnectionType = \
-        Field(...,
-              description="What kind of interface this is")
+
+    ipAddress: str = Field(
+        None,
+        description="The interface IP address with CIDR subnet appended "
+        "(e.g. 10.0.0.1/24)",
+    )
+    macAddress: str = Field(
+        None,
+        description="The MAC address of this interface (at least when "
+        "connected to this network - it may change due to "
+        "NetworkManager's privacy functionality when "
+        "disconnected or connected to a different network)",
+    )
+    gatewayAddress: str = Field(
+        None, description="The address of the configured gateway"
+    )
+    state: str = Field(
+        ...,
+        description="The state of the connection. (i.e. connected, "
+        "disconnected, connection failed)",
+    )
+    type: ConnectionType = Field(..., description="What kind of interface this is")
 
 
 class NetworkingStatus(BaseModel):
-    status: ConnectivityStatus = \
-        Field(ConnectivityStatus.none,
-              description="Overall connectivity of the robot")
-    interfaces: typing.Dict[str, InterfaceStatus] = \
-        Field({},
-              description="Per-interface networking status. Properties are "
-                          "named for network interfaces")
+    status: ConnectivityStatus = Field(
+        ConnectivityStatus.none, description="Overall connectivity of the robot"
+    )
+    interfaces: typing.Dict[str, InterfaceStatus] = Field(
+        {},
+        description="Per-interface networking status. Properties are "
+        "named for network interfaces",
+    )
 
     class Config:
         schema_extra = {
@@ -61,22 +64,23 @@ class NetworkingStatus(BaseModel):
                         "macAddress": "B8:27:EB:6C:95:CF",
                         "gatewayAddress": "192.168.43.161",
                         "state": "connected",
-                        "type": "wifi"
+                        "type": "wifi",
                     },
                     "eth0": {
                         "ipAddress": "169.254.229.173/16",
                         "macAddress": "B8:27:EB:39:C0:9A",
                         "gatewayAddress": None,
                         "state": "connected",
-                        "type": "ethernet"
-                    }
-                }
+                        "type": "ethernet",
+                    },
+                },
             }
         }
 
 
 class NetworkingSecurityType(str, Enum):
     """Top-level type of network security"""
+
     wpa_eap = "wpa-eap"
     wpa_psk = "wpa-psk"
     none = "none"
@@ -85,74 +89,79 @@ class NetworkingSecurityType(str, Enum):
 
 class WifiNetwork(BaseModel):
     """Identifier of a wifi network"""
-    ssid: str = \
-        Field(...,
-              description="The network's SSID")
+
+    ssid: str = Field(..., description="The network's SSID")
 
 
 class WifiNetworkFull(WifiNetwork):
     """A visible Network"""
-    signal: int =\
-        Field(...,
-              description="A unitless signal strength; a higher number is a "
-                          "better signal")
-    active: bool = \
-        Field(...,
-              description="Whether there is a connection active")
-    security: str =\
-        Field(...,
-              description="The raw NetworkManager output about the wifi "
-                          "security")
+
+    signal: int = Field(
+        ...,
+        description="A unitless signal strength; a higher number is a " "better signal",
+    )
+    active: bool = Field(..., description="Whether there is a connection active")
+    security: str = Field(
+        ..., description="The raw NetworkManager output about the wifi " "security"
+    )
     securityType: NetworkingSecurityType
 
 
 class WifiNetworks(BaseModel):
     """The list of networks"""
+
     list: typing.List[WifiNetworkFull]
 
     class Config:
         schema_extra = {
             "example": {
-                "list": [{
-                    "ssid": "linksys",
-                    "signal": 50,
-                    "active": False,
-                    "security": "WPA2 802.1X",
-                    "securityType": "wpa-eap"}]
+                "list": [
+                    {
+                        "ssid": "linksys",
+                        "signal": 50,
+                        "active": False,
+                        "security": "WPA2 802.1X",
+                        "securityType": "wpa-eap",
+                    }
+                ]
             }
         }
 
 
 class WifiConfiguration(BaseModel):
-    ssid: str = \
-        Field(...,
-              description="The SSID to connect to. If this isn't an SSID that "
-                          "is being broadcast by a network, you "
-                          "should also set hidden to true.", )
-    hidden: typing.Optional[bool] = \
-        Field(False,
-              description="True if the network is hidden (not broadcasting an "
-                          "ssid). False (default if key is not "
-                          "present) otherwise")
+    ssid: str = Field(
+        ...,
+        description="The SSID to connect to. If this isn't an SSID that "
+        "is being broadcast by a network, you "
+        "should also set hidden to true.",
+    )
+    hidden: typing.Optional[bool] = Field(
+        False,
+        description="True if the network is hidden (not broadcasting an "
+        "ssid). False (default if key is not "
+        "present) otherwise",
+    )
     securityType: typing.Optional[NetworkingSecurityType]
 
-    psk: SecretStr = \
-        Field(None,
-              description="If this is a PSK-secured network (securityType is "
-                          "wpa-psk), the PSK")
-    eapConfig: typing.Optional[typing.Dict[str, str]] = \
-        Field(None,
-              description="All options required to configure EAP access to the"
-                          " wifi. All options should match one of the cases "
-                          "described in /wifi/eap-options; for instance, "
-                          "configuring for peap/mschapv2 should have "
-                          "\"peap/mschapv2\" as the eapType; it should have "
-                          "\"identity\" and \"password\" props, both of which "
-                          "are identified as mandatory in /wifi/eap-options; "
-                          "and it may also have \"anonymousIdentity\" and "
-                          "\"caCert\" properties, both of which are identified"
-                          " as present but not required.",
-              required=["eapType"])
+    psk: SecretStr = Field(
+        None,
+        description="If this is a PSK-secured network (securityType is "
+        "wpa-psk), the PSK",
+    )
+    eapConfig: typing.Optional[typing.Dict[str, str]] = Field(
+        None,
+        description="All options required to configure EAP access to the"
+        " wifi. All options should match one of the cases "
+        "described in /wifi/eap-options; for instance, "
+        "configuring for peap/mschapv2 should have "
+        '"peap/mschapv2" as the eapType; it should have '
+        '"identity" and "password" props, both of which '
+        "are identified as mandatory in /wifi/eap-options; "
+        'and it may also have "anonymousIdentity" and '
+        '"caCert" properties, both of which are identified'
+        " as present but not required.",
+        required=["eapType"],
+    )
 
     @validator("eapConfig")
     def eap_config_validate(cls, v):
@@ -170,85 +179,78 @@ class WifiConfiguration(BaseModel):
     @root_validator(pre=True)
     def validate_configuration(cls, values):
         """Validate the configuration"""
-        security_type = values.get('securityType')
-        psk = values.get('psk')
-        eapconfig = values.get('eapConfig')
+        security_type = values.get("securityType")
+        psk = values.get("psk")
+        eapconfig = values.get("eapConfig")
         if not security_type:
             # security type is not specified. Try to to deduce from the
             # remainder of the payload.
             if psk and eapconfig:
-                raise ValueError(
-                    'Cannot deduce security type: psk and eap both passed'
-                )
+                raise ValueError("Cannot deduce security type: psk and eap both passed")
             security_type = NetworkingSecurityType.none
             if psk:
                 security_type = NetworkingSecurityType.wpa_psk
             elif eapconfig:
                 security_type = NetworkingSecurityType.wpa_eap
-            values['securityType'] = security_type
+            values["securityType"] = security_type
         elif security_type == NetworkingSecurityType.wpa_psk and not psk:
-            raise ValueError(
-                'If securityType is wpa-psk, psk must be specified'
-            )
+            raise ValueError("If securityType is wpa-psk, psk must be specified")
         elif security_type == NetworkingSecurityType.wpa_eap and not eapconfig:
-            raise ValueError(
-                'If securityType is wpa-eap, eapConfig must be specified'
-            )
+            raise ValueError("If securityType is wpa-eap, eapConfig must be specified")
         return values
 
     class Config:
-        schema_extra = {"examples": {
-            "unsecuredNetwork": {
-                "summary": "Connect to an unsecured network",
-                "value": {
-                    "ssid": "linksys"
-                }
-            },
-            "pskNetwork": {
-                "summary": "Connect to a WPA2-PSK secured network",
-                "description": "This is the \"standard\" way to set up a WiFi "
-                               "router, and is where you provide a password",
-                "value": {
-                    "ssid": "linksys",
-                    "securityType": "wpa-psk",
-                    "psk": "psksrock"
-                }
-            },
-            "hiddenNetwork": {
-                "summary": "Connect to a network not broadcasting its SSID, "
-                           "with a PSK",
-                "value": {
-                    "ssid": "cantseeme",
-                    "securityType": "wpa-psk",
-                    "psk": "letmein",
-                    "hidden": True
-                }
-            },
-            "eapNetwork": {
-                "summary": "Connect to a network secured by WPA2-EAP using "
-                           "PEAP/MSCHAPv2",
-                "description": "WPA2 Enterprise network security is based "
-                               "around the EAP protocol, which is a very "
-                               " comple tunneled authentication protocol. It "
-                               "can be configured in many different ways. The "
-                               "OT-2 supports several but by no means all of "
-                               "these variants. The variants supported on a "
-                               "given OT-2 can be found by GET "
-                               "/wifi/eap-options. This example describes how "
-                               "to set up PEAP/MSCHAPv2, which is an older EAP"
-                               " variant that was at one time the mechanism "
-                               "securing Eduroam.",
-                "value": {
-                    "ssid": "Eduroam",
-                    "securityType": "wpa-eap",
-                    "eapConfig": {
-                        "eapType": "peap/mschapv2",
-                        "identity": "scientist@biology.org",
-                        "password": "leeuwenhoek"
-                    }
-                }
+        schema_extra = {
+            "examples": {
+                "unsecuredNetwork": {
+                    "summary": "Connect to an unsecured network",
+                    "value": {"ssid": "linksys"},
+                },
+                "pskNetwork": {
+                    "summary": "Connect to a WPA2-PSK secured network",
+                    "description": 'This is the "standard" way to set up a WiFi '
+                    "router, and is where you provide a password",
+                    "value": {
+                        "ssid": "linksys",
+                        "securityType": "wpa-psk",
+                        "psk": "psksrock",
+                    },
+                },
+                "hiddenNetwork": {
+                    "summary": "Connect to a network not broadcasting its SSID, "
+                    "with a PSK",
+                    "value": {
+                        "ssid": "cantseeme",
+                        "securityType": "wpa-psk",
+                        "psk": "letmein",
+                        "hidden": True,
+                    },
+                },
+                "eapNetwork": {
+                    "summary": "Connect to a network secured by WPA2-EAP using "
+                    "PEAP/MSCHAPv2",
+                    "description": "WPA2 Enterprise network security is based "
+                    "around the EAP protocol, which is a very "
+                    " comple tunneled authentication protocol. It "
+                    "can be configured in many different ways. The "
+                    "OT-2 supports several but by no means all of "
+                    "these variants. The variants supported on a "
+                    "given OT-2 can be found by GET "
+                    "/wifi/eap-options. This example describes how "
+                    "to set up PEAP/MSCHAPv2, which is an older EAP"
+                    " variant that was at one time the mechanism "
+                    "securing Eduroam.",
+                    "value": {
+                        "ssid": "Eduroam",
+                        "securityType": "wpa-eap",
+                        "eapConfig": {
+                            "eapType": "peap/mschapv2",
+                            "identity": "scientist@biology.org",
+                            "password": "leeuwenhoek",
+                        },
+                    },
+                },
             }
-        }
         }
 
 
@@ -257,45 +259,50 @@ class WifiConfigurationResponse(BaseModel):
     The OT-2 successfully connected to the specified network using the
     specified parameters
     """
+
     message: str = Field(..., description="A human-readable success message")
     ssid: str = Field(..., description="The SSID configured")
 
 
 class WifiKeyFile(BaseModel):
     """Wifi Key File"""
-    uri: str = \
-        Field(...,
-              description="A URI for the key (mostly for use with DELETE "
-                          "/wifi/keys/{key_id})")
-    id: str = \
-        Field(...,
-              description="A contents hash of the key used to specify the key "
-                          "in POST /wifi/configure (and also to determine the"
-                          " key URI)")
-    name: str = \
-        Field(...,
-              description="The original filename of the key")
+
+    uri: str = Field(
+        ...,
+        description="A URI for the key (mostly for use with DELETE "
+        "/wifi/keys/{key_id})",
+    )
+    id: str = Field(
+        ...,
+        description="A contents hash of the key used to specify the key "
+        "in POST /wifi/configure (and also to determine the"
+        " key URI)",
+    )
+    name: str = Field(..., description="The original filename of the key")
 
 
 class AddWifiKeyFileResponse(WifiKeyFile):
     """Response to add wifi key file"""
+
     message: typing.Optional[str]
 
 
 class WifiKeyFiles(BaseModel):
     """The list of key files"""
-    wifi_keys: typing.List[WifiKeyFile] =\
-        Field([],
-              alias="keys",
-              description="A list of keys in the system")
+
+    wifi_keys: typing.List[WifiKeyFile] = Field(
+        [], alias="keys", description="A list of keys in the system"
+    )
 
     class Config:
         schema_extra = {
             "example": {
                 "keys": [
-                    {"uri": "/wifi/keys/abda234a234",
-                     "id": "abda234a234",
-                     "name": "client.pem"}
+                    {
+                        "uri": "/wifi/keys/abda234a234",
+                        "id": "abda234a234",
+                        "name": "client.pem",
+                    }
                 ]
             }
         }
@@ -309,69 +316,79 @@ class EapConfigOptionType(str, Enum):
 
 class EapConfigOption(BaseModel):
     """An object describing the name and format of an EAP config option"""
-    name: str = \
-        Field(...,
-              description="The name of the config option")
-    displayName: str = \
-        Field(...,
-              description="A human-readable and nicely formatted name for "
-                          "the option")
-    required: bool =\
-        Field(...,
-              description="Whether the option is required for this EAP variant"
-                          " or optional")
-    type: EapConfigOptionType =\
-        Field(...,
-              description="The type of the value. If string, a non-sensitive "
-                          "string like a username. If password, a sensitive "
-                          "string like a passphrase for a keyfile or a "
-                          "password. If file, upload the file with POST "
-                          "/wifi/keys and pass the hash.")
+
+    name: str = Field(..., description="The name of the config option")
+    displayName: str = Field(
+        ..., description="A human-readable and nicely formatted name for " "the option"
+    )
+    required: bool = Field(
+        ...,
+        description="Whether the option is required for this EAP variant"
+        " or optional",
+    )
+    type: EapConfigOptionType = Field(
+        ...,
+        description="The type of the value. If string, a non-sensitive "
+        "string like a username. If password, a sensitive "
+        "string like a passphrase for a keyfile or a "
+        "password. If file, upload the file with POST "
+        "/wifi/keys and pass the hash.",
+    )
 
 
 class EapVariant(BaseModel):
     """An object describing an EAP variant"""
-    name: str = \
-        Field(...,
-              description="The identifier for the EAP variant")
-    displayName: str = \
-        Field(...,
-              description="A human-readable formatted name for the EAP "
-                          "variant")
-    options: typing.List[EapConfigOption] =\
-        Field(...,
-              description="A list of objects describing configuration options "
-                          "for the EAP variant")
+
+    name: str = Field(..., description="The identifier for the EAP variant")
+    displayName: str = Field(
+        ..., description="A human-readable formatted name for the EAP " "variant"
+    )
+    options: typing.List[EapConfigOption] = Field(
+        ...,
+        description="A list of objects describing configuration options "
+        "for the EAP variant",
+    )
 
 
 class EapOptions(BaseModel):
     """An object describing all supported EAP variants and their parameters"""
+
     options: typing.List[EapVariant]
 
     class Config:
-        schema_extra = {"example": {
-            "options": [
-                {"name": "peap/mschapv2",
-                 "displayName": "PEAP/MS-CHAP v2",
-                 "options": [
-                     {"name": "identity",
-                      "displayName": "Username",
-                      "required": True,
-                      "type": "string"
-                      },
-                     {"name": "anonymousIdentity",
-                      "displayName": "Anonymous Identity",
-                      "required": False,
-                      "type": "string"},
-                     {"name": "caCert",
-                      "displayName": "CA Certificate File",
-                      "required": False,
-                      "type": "file"},
-                     {"name": "password",
-                      "displayName": "password",
-                      "required": True,
-                      "type": "password"}
-                 ]}
-            ]
-        }
+        schema_extra = {
+            "example": {
+                "options": [
+                    {
+                        "name": "peap/mschapv2",
+                        "displayName": "PEAP/MS-CHAP v2",
+                        "options": [
+                            {
+                                "name": "identity",
+                                "displayName": "Username",
+                                "required": True,
+                                "type": "string",
+                            },
+                            {
+                                "name": "anonymousIdentity",
+                                "displayName": "Anonymous Identity",
+                                "required": False,
+                                "type": "string",
+                            },
+                            {
+                                "name": "caCert",
+                                "displayName": "CA Certificate File",
+                                "required": False,
+                                "type": "file",
+                            },
+                            {
+                                "name": "password",
+                                "displayName": "password",
+                                "required": True,
+                                "type": "password",
+                            },
+                        ],
+                    }
+                ]
+            }
         }

--- a/robot-server/robot_server/service/legacy/models/pipettes.py
+++ b/robot-server/robot_server/service/legacy/models/pipettes.py
@@ -5,51 +5,56 @@ from pydantic import BaseModel, Field
 
 class AttachedPipette(BaseModel):
     """Pipette (if any) attached to the mount"""
-    model: typing.Optional[str] = \
-        Field(...,
-              description="The model of the attached pipette. These are snake "
-                          "case as in the Protocol API. This includes the full"
-                          " version string")
-    name: typing.Optional[str] = \
-        Field(...,
-              description="The name of the attached pipette - the model "
-                          "without the version string")
-    tip_length: typing.Optional[float] = \
-        Field(...,
-              description="The default tip length for this pipette, if "
-                          "attached")
-    mount_axis: str = \
-        Field(...,
-              description="The axis that moves this pipette up and down")
-    plunger_axis: str = \
-        Field(...,
-              description="The axis that moves this pipette's plunger")
-    id: typing.Optional[str] = \
-        Field(...,
-              description="The serial number of the attached pipette")
+
+    model: typing.Optional[str] = Field(
+        ...,
+        description="The model of the attached pipette. These are snake "
+        "case as in the Protocol API. This includes the full"
+        " version string",
+    )
+    name: typing.Optional[str] = Field(
+        ...,
+        description="The name of the attached pipette - the model "
+        "without the version string",
+    )
+    tip_length: typing.Optional[float] = Field(
+        ..., description="The default tip length for this pipette, if " "attached"
+    )
+    mount_axis: str = Field(
+        ..., description="The axis that moves this pipette up and down"
+    )
+    plunger_axis: str = Field(
+        ..., description="The axis that moves this pipette's plunger"
+    )
+    id: typing.Optional[str] = Field(
+        ..., description="The serial number of the attached pipette"
+    )
 
 
 class PipettesByMount(BaseModel):
     """The attached pipettes by mount"""
+
     left: AttachedPipette
     right: AttachedPipette
 
     class Config:
-        schema_extra = {"example": {
-            "left": {
-                "model": "p300_single_v1.5",
-                "name": "p300_single",
-                "tip_length": 51.7,
-                "mount_axis": "z",
-                "plunger_axis": "b",
-                "id": "P3HS12123041"
-            },
-            "right": {
-                "model": None,
-                "name": None,
-                "tip_length": None,
-                "mount_axis": "a",
-                "plunger_axis": "c",
-                "id": None
+        schema_extra = {
+            "example": {
+                "left": {
+                    "model": "p300_single_v1.5",
+                    "name": "p300_single",
+                    "tip_length": 51.7,
+                    "mount_axis": "z",
+                    "plunger_axis": "b",
+                    "id": "P3HS12123041",
+                },
+                "right": {
+                    "model": None,
+                    "name": None,
+                    "tip_length": None,
+                    "mount_axis": "a",
+                    "plunger_axis": "c",
+                    "id": None,
+                },
             }
-        }}
+        }

--- a/robot-server/robot_server/service/legacy/models/settings.py
+++ b/robot-server/robot_server/service/legacy/models/settings.py
@@ -11,61 +11,70 @@ from opentrons.config.reset import ResetOptionId
 
 class AdvancedSetting(BaseModel):
     """An advanced setting (Feature Flag)"""
-    id: str = \
-        Field(...,
-              description="The machine-readable property ID")
-    old_id: Optional[str] = \
-        Field(...,
-              description="The ID by which the property used to be known; not"
-                          " useful now and may contain spaces or hyphens")
-    title: str = \
-        Field(...,
-              description="A human-readable short string suitable for display"
-                          " as the title of the setting")
-    description: str =\
-        Field(...,
-              description="A human-readable long string suitable for display "
-                          "as a paragraph or two explaining the setting")
-    restart_required: bool =\
-        Field(...,
-              description="Whether a robot restart is required to make this "
-                          "change take effect")
-    value: Optional[bool] =\
-        Field(...,
-              description="Whether the setting is off by previous user choice"
-                          " (false), true by user choice (true), or off and "
-                          "has never been altered (null)")
+
+    id: str = Field(..., description="The machine-readable property ID")
+    old_id: Optional[str] = Field(
+        ...,
+        description="The ID by which the property used to be known; not"
+        " useful now and may contain spaces or hyphens",
+    )
+    title: str = Field(
+        ...,
+        description="A human-readable short string suitable for display"
+        " as the title of the setting",
+    )
+    description: str = Field(
+        ...,
+        description="A human-readable long string suitable for display "
+        "as a paragraph or two explaining the setting",
+    )
+    restart_required: bool = Field(
+        ...,
+        description="Whether a robot restart is required to make this "
+        "change take effect",
+    )
+    value: Optional[bool] = Field(
+        ...,
+        description="Whether the setting is off by previous user choice"
+        " (false), true by user choice (true), or off and "
+        "has never been altered (null)",
+    )
 
 
 class Links(BaseModel):
     restart: Optional[str] = Field(
         None,
         description="A URI to POST to restart the robot. If this is present,"
-                    " it must be requested for any settings changes to take "
-                    "effect")
+        " it must be requested for any settings changes to take "
+        "effect",
+    )
 
 
 class AdvancedSettingsResponse(BaseModel):
     """A dump of advanced settings and suitable links for next action"""
+
     settings: List[AdvancedSetting]
     links: Links
 
 
 class AdvancedSettingRequest(BaseModel):
     """Configure the setting to change and the new value"""
+
     id: str = Field(
         ...,
         description="The ID of the setting to change (something returned by"
-                    " GET /settings)")
+        " GET /settings)",
+    )
     value: Optional[bool] = Field(
-        None,
-        description="The new value to set. If null, reset to default")
+        None, description="The new value to set. If null, reset to default"
+    )
 
 
 class LogLevels(str, Enum):
     _level_id: int
 
     """Valid log levels"""
+
     def __new__(cls, value, level):
         # https://docs.python.org/3/library/enum.html#when-to-use-new-vs-init
         obj = str.__new__(cls, value)
@@ -85,28 +94,28 @@ class LogLevels(str, Enum):
 
 
 class LogLevel(BaseModel):
-    log_level: LogLevels = \
-        Field(None,
-              description="The value to set (conforming to Python "
-                          "log levels)")
+    log_level: LogLevels = Field(
+        None, description="The value to set (conforming to Python " "log levels)"
+    )
 
-    @validator('log_level', pre=True)
+    @validator("log_level", pre=True)
     def lower_case_log_keys(cls, value):
         return value if value is None else LogLevels(value.lower(), None)
 
 
 class FactoryResetOption(BaseModel):
-    id: ResetOptionId = \
-        Field(..., description="A short machine-readable id for the setting")
-    name: str = \
-        Field(..., description="A short human-readable name for the setting")
-    description: str = \
-        Field(..., description="A longer human-readable description of the "
-                               "setting")
+    id: ResetOptionId = Field(
+        ..., description="A short machine-readable id for the setting"
+    )
+    name: str = Field(..., description="A short human-readable name for the setting")
+    description: str = Field(
+        ..., description="A longer human-readable description of the " "setting"
+    )
 
 
 class FactoryResetOptions(BaseModel):
     """Available values to reset as factory reset"""
+
     options: List[FactoryResetOption]
 
 
@@ -115,100 +124,96 @@ RobotConfigs = Dict[str, Any]
 
 class PipetteSettingsFieldType(str, Enum):
     """The type of the property"""
+
     float = "float"
     int = "int"
 
 
 class PipetteSettingsField(BaseModel):
     """A pipette config element identified by the property's name"""
-    units: str = \
-        Field(None,
-              description="The physical units this value is in (e.g. mm, uL)")
+
+    units: str = Field(
+        None, description="The physical units this value is in (e.g. mm, uL)"
+    )
     type: Optional[PipetteSettingsFieldType]
-    min: float = \
-        Field(...,
-              description="The minimum acceptable value of the property")
-    max: float = \
-        Field(...,
-              description="The maximum acceptable value of the property")
-    default: float = \
-        Field(...,
-              description="The default value of the property")
-    value: float =\
-        Field(...,
-              description="The current value of the property")
+    min: float = Field(..., description="The minimum acceptable value of the property")
+    max: float = Field(..., description="The maximum acceptable value of the property")
+    default: float = Field(..., description="The default value of the property")
+    value: float = Field(..., description="The current value of the property")
 
 
 class PipetteSettingsInfo(BaseModel):
     """Metadata about this pipette"""
-    name: str = \
-        Field(...,
-              description="A pipette name (e.g. \"p300_single\")")
-    model: str = \
-        Field(...,
-              description="The exact pipette model (e.g. \""
-                          "p300_single_v1.5\")")
+
+    name: str = Field(..., description='A pipette name (e.g. "p300_single")')
+    model: str = Field(
+        ..., description='The exact pipette model (e.g. "' 'p300_single_v1.5")'
+    )
 
 
 class BasePipetteSettingFields(BaseModel):
-    quirks: Dict[str, bool] = \
-        Field(None,
-              description="Quirks are behavioral changes associated with "
-                          "pipettes. For instance, some models of pipette "
-                          "might need to run their drop tip behavior twice. "
-                          "Specific pipettes have which can then be enabled "
-                          "or disabled; quirks that are not originally "
-                          "defined as compatible with a specific kind of "
-                          "pipette cannot be added to an incompatible "
-                          "pipette. Because quirks are only defined as "
-                          "compatible for a pipette if they should be on, "
-                          "the default value for all quirks is true.")
+    quirks: Dict[str, bool] = Field(
+        None,
+        description="Quirks are behavioral changes associated with "
+        "pipettes. For instance, some models of pipette "
+        "might need to run their drop tip behavior twice. "
+        "Specific pipettes have which can then be enabled "
+        "or disabled; quirks that are not originally "
+        "defined as compatible with a specific kind of "
+        "pipette cannot be added to an incompatible "
+        "pipette. Because quirks are only defined as "
+        "compatible for a pipette if they should be on, "
+        "the default value for all quirks is true.",
+    )
 
 
 # A dynamic model of the possible fields in pipette configuration. It's
 # generated from pipette_config module. It's derived from an object with the
 # 'quirks` member.
 PipetteSettingsFields = create_model(
-    'PipetteSettingsFields',
+    "PipetteSettingsFields",
     __base__=BasePipetteSettingFields,
     __config__=None,
     __module__=None,
     __validators__=None,
     **{
-        conf: (PipetteSettingsField, None) for conf in MUTABLE_CONFIGS
-        if conf != 'quirks'
-    }
+        conf: (PipetteSettingsField, None)
+        for conf in MUTABLE_CONFIGS
+        if conf != "quirks"
+    },
 )
 PipetteSettingsFields.__doc__ = "The fields of the pipette settings"
 
 
 class PipetteSettings(BaseModel):
     info: PipetteSettingsInfo
-    setting_fields: PipetteSettingsFields   # type: ignore
+    setting_fields: PipetteSettingsFields  # type: ignore
 
     class Config:
-        fields = {'setting_fields': 'fields'}
+        fields = {"setting_fields": "fields"}
 
 
 MultiPipetteSettings = Dict[str, PipetteSettings]
 
 
 class PipetteUpdateField(BaseModel):
-    value: Union[None, bool, float] = \
-        Field(...,
-              description="Must be a boolean if this is a quirk. The "
-                          "format if this is not a quirk. Must be between max "
-                          "and min for this property. Null means reset.")
+    value: Union[None, bool, float] = Field(
+        ...,
+        description="Must be a boolean if this is a quirk. The "
+        "format if this is not a quirk. Must be between max "
+        "and min for this property. Null means reset.",
+    )
 
 
 class PipetteSettingsUpdate(BaseModel):
-    setting_fields: Optional[Dict[str, Optional[PipetteUpdateField]]] = \
-        Field(None, alias="fields")
+    setting_fields: Optional[Dict[str, Optional[PipetteUpdateField]]] = Field(
+        None, alias="fields"
+    )
 
-    @validator('setting_fields')
+    @validator("setting_fields")
     def validate_fields(cls, v):
         """A validator to ensure that values for mutable configs are
-         floats and booleans for quirks."""
+        floats and booleans for quirks."""
         for key, value in v.items():
             if value is None:
                 pass
@@ -218,8 +223,9 @@ class PipetteSettingsUpdate(BaseModel):
                     value.value = float(value.value)
             elif key in VALID_QUIRKS:
                 if not isinstance(value.value, bool):
-                    raise ValueError(f"{key} quirk value must "
-                                     f"be a boolean. Got {value.value}")
+                    raise ValueError(
+                        f"{key} quirk value must " f"be a boolean. Got {value.value}"
+                    )
             else:
                 raise ValueError(f"{key} is not a valid field or quirk name")
         return v

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -18,15 +18,11 @@ router = APIRouter()
 JPG = "image/jpg"
 
 
-@router.post("/camera/picture",
-             description="Capture an image from the OT-2's on-board camera "
-                         "and return it",
-             responses={
-                 status.HTTP_200_OK: {
-                     "content": {JPG: {}},
-                     "description": "The image"
-                 }
-             })
+@router.post(
+    "/camera/picture",
+    description="Capture an image from the OT-2's on-board camera " "and return it",
+    responses={status.HTTP_200_OK: {"content": {JPG: {}}, "description": "The image"}},
+)
 async def post_picture_capture() -> StreamingResponse:
     """Take a picture"""
     filename = Path(tempfile.mktemp(suffix=".jpg"))
@@ -36,15 +32,16 @@ async def post_picture_capture() -> StreamingResponse:
         log.info(f"Image taken at {filename}")
         # Open the file. It will be closed and deleted when the response is
         # finished.
-        fd = filename.open('rb')
-        return StreamingResponse(fd,
-                                 media_type=JPG,
-                                 background=BackgroundTask(func=_cleanup,
-                                                           filename=filename,
-                                                           fd=fd))
+        fd = filename.open("rb")
+        return StreamingResponse(
+            fd,
+            media_type=JPG,
+            background=BackgroundTask(func=_cleanup, filename=filename, fd=fd),
+        )
     except camera.CameraException as e:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            detail=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
+        )
 
 
 def _cleanup(filename: Path, fd: io.IOBase) -> None:

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -3,8 +3,11 @@ import asyncio
 from fastapi import APIRouter, Query, Depends
 from starlette import status
 
-from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock, \
-    ThreadedAsyncForbidden
+from opentrons.hardware_control import (
+    ThreadManager,
+    ThreadedAsyncLock,
+    ThreadedAsyncForbidden,
+)
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 
@@ -16,22 +19,24 @@ from robot_server.service.legacy.models import control
 router = APIRouter()
 
 
-@router.post("/identify",
-             description="Blink the OT-2's gantry lights so you can pick it "
-                         "out of a crowd")
+@router.post(
+    "/identify",
+    description="Blink the OT-2's gantry lights so you can pick it " "out of a crowd",
+)
 async def post_identify(
-        seconds: int = Query(...,
-                             description="Time to blink the lights for"),
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> V1BasicResponse:
+    seconds: int = Query(..., description="Time to blink the lights for"),
+    hardware: ThreadManager = Depends(get_hardware),
+) -> V1BasicResponse:
     identify = hardware.identify  # type: ignore
     asyncio.ensure_future(identify(seconds))
     return V1BasicResponse(message="identifying")
 
 
-@router.get("/robot/positions",
-            description="Get a list of useful positions",
-            response_model=control.RobotPositionsResponse)
+@router.get(
+    "/robot/positions",
+    description="Get a list of useful positions",
+    response_model=control.RobotPositionsResponse,
+)
 async def get_robot_positions() -> control.RobotPositionsResponse:
     """
     Positions determined experimentally by issuing move commands. Change
@@ -40,11 +45,12 @@ async def get_robot_positions() -> control.RobotPositionsResponse:
     position places either pipette roughly in the front-center of the deck area
     """
     robot_positions = control.RobotPositions(
-        change_pipette=control.ChangePipette(target=control.MotionTarget.mount,
-                                             left=[300, 40, 30],
-                                             right=[95, 40, 30]),
-        attach_tip=control.AttachTip(target=control.MotionTarget.pipette,
-                                     point=[200, 90, 150])
+        change_pipette=control.ChangePipette(
+            target=control.MotionTarget.mount, left=[300, 40, 30], right=[95, 40, 30]
+        ),
+        attach_tip=control.AttachTip(
+            target=control.MotionTarget.pipette, point=[200, 90, 150]
+        ),
     )
     return control.RobotPositionsResponse(positions=robot_positions)
 
@@ -61,18 +67,15 @@ async def get_robot_positions() -> control.RobotPositionsResponse:
     },
 )
 async def post_move_robot(
-        robot_move_target: control.RobotMoveTarget,
-        hardware: ThreadManager = Depends(get_hardware),
-        motion_lock: ThreadedAsyncLock = Depends(get_motion_lock))\
-        -> V1BasicResponse:
+    robot_move_target: control.RobotMoveTarget,
+    hardware: ThreadManager = Depends(get_hardware),
+    motion_lock: ThreadedAsyncLock = Depends(get_motion_lock),
+) -> V1BasicResponse:
     """Move the robot"""
     try:
         async with motion_lock.forbid():
-            pos = await _do_move(hardware=hardware,
-                                 robot_move_target=robot_move_target)
-            return V1BasicResponse(
-                message=f"Move complete. New position: {pos}"
-            )
+            pos = await _do_move(hardware=hardware, robot_move_target=robot_move_target)
+            return V1BasicResponse(message=f"Move complete. New position: {pos}")
     except ThreadedAsyncForbidden as e:
         raise LegacyErrorResponse(message=str(e)).as_error(status.HTTP_403_FORBIDDEN)
 
@@ -87,10 +90,10 @@ async def post_move_robot(
     },
 )
 async def post_home_robot(
-        robot_home_target: control.RobotHomeTarget,
-        hardware: ThreadManager = Depends(get_hardware),
-        motion_lock: ThreadedAsyncLock = Depends(get_motion_lock)) \
-        -> V1BasicResponse:
+    robot_home_target: control.RobotHomeTarget,
+    hardware: ThreadManager = Depends(get_hardware),
+    motion_lock: ThreadedAsyncLock = Depends(get_motion_lock),
+) -> V1BasicResponse:
     """Home the robot or one of the pipettes"""
     try:
         async with motion_lock.forbid():
@@ -108,38 +111,41 @@ async def post_home_robot(
                 await home()
                 message = "Homing robot."
             else:
-                raise LegacyErrorResponse(
-                    message=f"{target} is invalid"
-                ).as_error(status.HTTP_400_BAD_REQUEST)
+                raise LegacyErrorResponse(message=f"{target} is invalid").as_error(
+                    status.HTTP_400_BAD_REQUEST
+                )
 
             return V1BasicResponse(message=message)
     except ThreadedAsyncForbidden as e:
         raise LegacyErrorResponse(message=str(e)).as_error(status.HTTP_403_FORBIDDEN)
 
 
-@router.get("/robot/lights",
-            description="Get the current status of the OT-2's rail lights",
-            response_model=control.RobotLightState,)
+@router.get(
+    "/robot/lights",
+    description="Get the current status of the OT-2's rail lights",
+    response_model=control.RobotLightState,
+)
 async def get_robot_light_state(
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> control.RobotLightState:
+    hardware: ThreadManager = Depends(get_hardware),
+) -> control.RobotLightState:
     light_state = hardware.get_lights()  # type: ignore
-    return control.RobotLightState(on=light_state.get('rails', False))
+    return control.RobotLightState(on=light_state.get("rails", False))
 
 
-@router.post("/robot/lights",
-             description="Turn the rail lights on or off",
-             response_model=control.RobotLightState)
+@router.post(
+    "/robot/lights",
+    description="Turn the rail lights on or off",
+    response_model=control.RobotLightState,
+)
 async def post_robot_light_state(
-        robot_light_state: control.RobotLightState,
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> control.RobotLightState:
+    robot_light_state: control.RobotLightState,
+    hardware: ThreadManager = Depends(get_hardware),
+) -> control.RobotLightState:
     await hardware.set_lights(rails=robot_light_state.on)  # type: ignore
     return robot_light_state
 
 
-async def _do_move(hardware: ThreadManager,
-                   robot_move_target: control.RobotMoveTarget):
+async def _do_move(hardware: ThreadManager, robot_move_target: control.RobotMoveTarget):
     """Perform the move"""
     await hardware.cache_instruments()  # type: ignore
 
@@ -158,8 +164,11 @@ async def _do_move(hardware: ThreadManager,
 
     pos = await gantry_position(mount, critical_point=critical_point)
     # Move to requested x, y and current z position
-    await move_to(mount, Point(x=target_pos.x, y=target_pos.y, z=pos.z),
-                  critical_point=critical_point)
+    await move_to(
+        mount,
+        Point(x=target_pos.x, y=target_pos.y, z=pos.z),
+        critical_point=critical_point,
+    )
     # Move to requested z position
     await move_to(mount, target_pos, critical_point=critical_point)
     return await gantry_position(mount)

--- a/robot-server/robot_server/service/legacy/routers/deck_calibration.py
+++ b/robot-server/robot_server/service/legacy/routers/deck_calibration.py
@@ -5,31 +5,36 @@ from opentrons.calibration_storage import helpers
 
 from robot_server.service.dependencies import get_hardware
 from robot_server.service.legacy.models.deck_calibration import (
-    CalibrationStatus, DeckCalibrationStatus, DeckCalibrationData, MatrixType,
-    InstrumentCalibrationStatus, InstrumentOffset)
+    CalibrationStatus,
+    DeckCalibrationStatus,
+    DeckCalibrationData,
+    MatrixType,
+    InstrumentCalibrationStatus,
+    InstrumentOffset,
+)
 from robot_server.service.shared_models import calibration as cal_model
 
 router = APIRouter()
 
-DEFAULT_INSTR_OFFSET = InstrumentOffset(
-    single=(0, 0, 0),
-    multi=(0, 0, 0))
+DEFAULT_INSTR_OFFSET = InstrumentOffset(single=(0, 0, 0), multi=(0, 0, 0))
 
 
-@router.get("/calibration/status",
-            description="Get the calibration status",
-            response_model=CalibrationStatus)
+@router.get(
+    "/calibration/status",
+    description="Get the calibration status",
+    response_model=CalibrationStatus,
+)
 async def get_calibration_status(
-        hardware: ThreadManager = Depends(get_hardware)) -> CalibrationStatus:
+    hardware: ThreadManager = Depends(get_hardware),
+) -> CalibrationStatus:
     # TODO: AA 12-01-2020 Instrument offset has been deprecated. We should
     # exclude instrument calibration in a future refactor
     instr_offset = InstrumentCalibrationStatus(  # always load default values
-        right=DEFAULT_INSTR_OFFSET,
-        left=DEFAULT_INSTR_OFFSET)
+        right=DEFAULT_INSTR_OFFSET, left=DEFAULT_INSTR_OFFSET
+    )
 
     deck_cal = hardware.robot_calibration.deck_calibration
-    status = cal_model.CalibrationStatus(
-        **helpers.convert_to_dict(deck_cal.status))
+    status = cal_model.CalibrationStatus(**helpers.convert_to_dict(deck_cal.status))
     deck_cal_data = DeckCalibrationData(
         type=MatrixType.attitude,
         matrix=deck_cal.attitude,
@@ -37,10 +42,12 @@ async def get_calibration_status(
         pipetteCalibratedWith=deck_cal.pipette_calibrated_with,
         tiprack=deck_cal.tiprack,
         source=deck_cal.source,
-        status=status)
+        status=status,
+    )
 
     return CalibrationStatus(
         deckCalibration=DeckCalibrationStatus(
-            status=hardware.validate_calibration(),
-            data=deck_cal_data),
-        instrumentCalibration=instr_offset)
+            status=hardware.validate_calibration(), data=deck_cal_data
+        ),
+        instrumentCalibration=instr_offset,
+    )

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -7,9 +7,9 @@ from robot_server.service.legacy.models.logs import LogIdentifier, LogFormat
 router = APIRouter()
 
 IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
-    LogIdentifier.api: 'opentrons-api',
-    LogIdentifier.serial: 'opentrons-api-serial',
-    LogIdentifier.server: 'uvicorn',
+    LogIdentifier.api: "opentrons-api",
+    LogIdentifier.serial: "opentrons-api-serial",
+    LogIdentifier.server: "uvicorn",
 }
 
 
@@ -18,16 +18,17 @@ async def get_logs(
     log_identifier: LogIdentifier,
     format: LogFormat = Query(LogFormat.text, title="Log format type"),
     records: int = Query(
-        log_control.DEFAULT_RECORDS, title="Number of records to retrieve",
-        gt=0, le=log_control.MAX_RECORDS
+        log_control.DEFAULT_RECORDS,
+        title="Number of records to retrieve",
+        gt=0,
+        le=log_control.MAX_RECORDS,
     ),
 ) -> Response:
     syslog_id = IDENTIFIER_TO_SYSLOG_ID[log_identifier]
-    modes = {LogFormat.json: ("json", "application/json"),
-             LogFormat.text: ("short", "text/plain")}
+    modes = {
+        LogFormat.json: ("json", "application/json"),
+        LogFormat.text: ("short", "text/plain"),
+    }
     format_type, media_type = modes[format]
-    output = await log_control.get_records_dumb(
-        syslog_id, records, format_type
-    )
-    return Response(
-        content=output.decode('utf-8'), media_type=media_type)
+    output = await log_control.get_records_dumb(syslog_id, records, format_type)
+    return Response(content=output.decode("utf-8"), media_type=media_type)

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -9,33 +9,39 @@ from opentrons.hardware_control.modules import AbstractModule
 from robot_server.errors import LegacyErrorResponse
 from robot_server.service.dependencies import get_hardware
 from robot_server.service.legacy.models import V1BasicResponse
-from robot_server.service.legacy.models.modules import Module, ModuleSerial,\
-    Modules, SerialCommandResponse, SerialCommand, PhysicalPort
+from robot_server.service.legacy.models.modules import (
+    Module,
+    ModuleSerial,
+    Modules,
+    SerialCommandResponse,
+    SerialCommand,
+    PhysicalPort,
+)
 
 router = APIRouter()
 
 
-@router.get("/modules",
-            description="Describe the modules attached to the OT-2",
-            response_model=Modules)
-async def get_modules(hardware: ThreadManager = Depends(get_hardware))\
-        -> Modules:
-    attached_modules = hardware.attached_modules   # type: ignore
+@router.get(
+    "/modules",
+    description="Describe the modules attached to the OT-2",
+    response_model=Modules,
+)
+async def get_modules(hardware: ThreadManager = Depends(get_hardware)) -> Modules:
+    attached_modules = hardware.attached_modules  # type: ignore
     module_data = [
         Module(
             name=mod.name(),  # TODO: legacy, remove
             displayName=mod.name(),  # TODO: legacy, remove
-            model=mod.device_info.get('model'),  # TODO legacy, remove
+            model=mod.device_info.get("model"),  # TODO legacy, remove
             moduleModel=mod.model(),
             port=mod.port,  # /dev/ttyS0
-            usbPort=PhysicalPort(
-                hub=mod.usb_port.hub, port=mod.usb_port.port_number),
-            serial=mod.device_info.get('serial'),
-            revision=mod.device_info.get('model'),
-            fwVersion=mod.device_info.get('version'),
+            usbPort=PhysicalPort(hub=mod.usb_port.hub, port=mod.usb_port.port_number),
+            serial=mod.device_info.get("serial"),
+            revision=mod.device_info.get("model"),
+            fwVersion=mod.device_info.get("version"),
             hasAvailableUpdate=mod.has_available_update(),
-            status=mod.live_data['status'],
-            data=mod.live_data['data']
+            status=mod.live_data["status"],
+            data=mod.live_data["data"],
         )
         for mod in attached_modules
     ]
@@ -55,27 +61,26 @@ async def get_modules(hardware: ThreadManager = Depends(get_hardware))\
     },
 )
 async def get_module_serial(
-        serial: str = Path(...,
-                           description="Serial number of the module"),
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> ModuleSerial:
+    serial: str = Path(..., description="Serial number of the module"),
+    hardware: ThreadManager = Depends(get_hardware),
+) -> ModuleSerial:
     res = None
 
-    attached_modules = hardware.attached_modules   # type: ignore
+    attached_modules = hardware.attached_modules  # type: ignore
     matching_module = find_matching_module(serial, attached_modules)
-    if matching_module and hasattr(matching_module, 'live_data'):
+    if matching_module and hasattr(matching_module, "live_data"):
         res = matching_module.live_data
 
     if not res:
-        raise LegacyErrorResponse(
-            message="Module not found"
-        ).as_error(status.HTTP_404_NOT_FOUND)
+        raise LegacyErrorResponse(message="Module not found").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
 
     # TODO(mc, 2020-09-17): types of res.get(...) do not match what
     # ModuleSerial expects
     return ModuleSerial(
-        status=res.get('status'),  # type: ignore[arg-type]
-        data=res.get('data')  # type: ignore[arg-type]
+        status=res.get("status"),  # type: ignore[arg-type]
+        data=res.get("data"),  # type: ignore[arg-type]
     )
 
 
@@ -95,25 +100,24 @@ async def get_module_serial(
     },
 )
 async def post_serial_command(
-        command: SerialCommand,
-        serial: str = Path(...,
-                           description="Serial number of the module"),
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> SerialCommandResponse:
+    command: SerialCommand,
+    serial: str = Path(..., description="Serial number of the module"),
+    hardware: ThreadManager = Depends(get_hardware),
+) -> SerialCommandResponse:
     """Send a command on device identified by serial"""
-    attached_modules = hardware.attached_modules     # type: ignore
+    attached_modules = hardware.attached_modules  # type: ignore
     if not attached_modules:
-        raise LegacyErrorResponse(
-            message="No connected modules"
-        ).as_error(status.HTTP_404_NOT_FOUND)
+        raise LegacyErrorResponse(message="No connected modules").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
 
     # Search for the module
     matching_mod = find_matching_module(serial, attached_modules)
 
     if not matching_mod:
-        raise LegacyErrorResponse(
-            message="Specified module not found"
-        ).as_error(status.HTTP_404_NOT_FOUND)
+        raise LegacyErrorResponse(message="Specified module not found").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
 
     if hasattr(matching_mod, command.command_type):
         clean_args = command.args or []
@@ -125,15 +129,15 @@ async def post_serial_command(
                 val = method(*clean_args)
         except TypeError as e:
             raise LegacyErrorResponse(
-                message=f'Server encountered a TypeError '
-                        f'while running {method} : {e}. '
-                        f'Possibly a type mismatch in args'
+                message=f"Server encountered a TypeError "
+                f"while running {method} : {e}. "
+                f"Possibly a type mismatch in args"
             ).as_error(status.HTTP_400_BAD_REQUEST)
         else:
-            return SerialCommandResponse(message='Success', returnValue=val)
+            return SerialCommandResponse(message="Success", returnValue=val)
     else:
         raise LegacyErrorResponse(
-            message=f'Module does not have command: {command.command_type}'
+            message=f"Module does not have command: {command.command_type}"
         ).as_error(status.HTTP_400_BAD_REQUEST)
 
 
@@ -151,18 +155,17 @@ async def post_serial_command(
     },
 )
 async def post_serial_update(
-        serial: str = Path(...,
-                           description="Serial number of the module"),
-        hardware: ThreadManager = Depends(get_hardware))\
-        -> V1BasicResponse:
+    serial: str = Path(..., description="Serial number of the module"),
+    hardware: ThreadManager = Depends(get_hardware),
+) -> V1BasicResponse:
     """Update module firmware"""
-    attached_modules = hardware.attached_modules     # type: ignore
+    attached_modules = hardware.attached_modules  # type: ignore
     matching_module = find_matching_module(serial, attached_modules)
 
     if not matching_module:
-        raise LegacyErrorResponse(
-            message=f'Module {serial} not found'
-        ).as_error(status.HTTP_404_NOT_FOUND)
+        raise LegacyErrorResponse(message=f"Module {serial} not found").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
 
     try:
         if matching_module.bundled_fw:
@@ -170,27 +173,29 @@ async def post_serial_update(
                 modules.update_firmware(
                     matching_module,
                     matching_module.bundled_fw.path,
-                    asyncio.get_event_loop()),
-                100)
-            return V1BasicResponse(
-                message=f'Successfully updated module {serial}'
+                    asyncio.get_event_loop(),
+                ),
+                100,
             )
+            return V1BasicResponse(message=f"Successfully updated module {serial}")
         else:
-            res = (f'Bundled fw file not found for module of '
-                   f'type: {matching_module.name()}')
+            res = (
+                f"Bundled fw file not found for module of "
+                f"type: {matching_module.name()}"
+            )
             status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     except modules.UpdateError as e:
-        res = f'Update error: {e}'
+        res = f"Update error: {e}"
         status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     except asyncio.TimeoutError:
-        res = 'Module not responding'
+        res = "Module not responding"
         status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     raise LegacyErrorResponse(message=res).as_error(status_code)
 
 
-def find_matching_module(serial: str,
-                         attached_modules: typing.List[AbstractModule]) -> \
-        typing.Optional[AbstractModule]:
+def find_matching_module(
+    serial: str, attached_modules: typing.List[AbstractModule]
+) -> typing.Optional[AbstractModule]:
     """
     Given a serial name try to find a matching attached instrument.
 
@@ -200,6 +205,6 @@ def find_matching_module(serial: str,
     """
     if attached_modules:
         for m in attached_modules:
-            if m.device_info.get('serial') == serial:
+            if m.device_info.get("serial") == serial:
                 return m
     return None

--- a/robot-server/robot_server/service/legacy/routers/motors.py
+++ b/robot-server/robot_server/service/legacy/routers/motors.py
@@ -21,29 +21,31 @@ router = APIRouter()
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
     },
 )
-async def get_engaged_motors(hardware: ThreadManager = Depends(get_hardware)
-                             ) -> model.EngagedMotors:  # type: ignore
+async def get_engaged_motors(
+    hardware: ThreadManager = Depends(get_hardware),
+) -> model.EngagedMotors:  # type: ignore
     try:
-        engaged_axes = hardware.engaged_axes    # type: ignore
-        axes_dict = {str(k).lower(): model.EngagedMotor(enabled=v)
-                     for k, v in engaged_axes.items()}
+        engaged_axes = hardware.engaged_axes  # type: ignore
+        axes_dict = {
+            str(k).lower(): model.EngagedMotor(enabled=v)
+            for k, v in engaged_axes.items()
+        }
         return model.EngagedMotors(**axes_dict)
     except ValidationError as e:
-        raise LegacyErrorResponse(
-            message=str(e)
-        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR)
+        raise LegacyErrorResponse(message=str(e)).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
 
-@router.post("/motors/disengage",
-             description="Disengage a motor or set of motors",
-             response_model=V1BasicResponse)
+@router.post(
+    "/motors/disengage",
+    description="Disengage a motor or set of motors",
+    response_model=V1BasicResponse,
+)
 async def post_disengage_motors(
-        axes: model.Axes,
-        hardware: ThreadManager = Depends(get_hardware)) \
-        -> V1BasicResponse:
+    axes: model.Axes, hardware: ThreadManager = Depends(get_hardware)
+) -> V1BasicResponse:
 
     input_axes = [Axis[ax.upper()] for ax in axes.axes]
-    await hardware.disengage_axes(input_axes)    # type: ignore
-    return V1BasicResponse(
-        message="Disengaged axes: {}".format(', '.join(axes.axes))
-    )
+    await hardware.disengage_axes(input_axes)  # type: ignore
+    return V1BasicResponse(message="Disengaged axes: {}".format(", ".join(axes.axes)))

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -9,11 +9,22 @@ from opentrons.system import nmcli, wifi
 
 from robot_server.errors import LegacyErrorResponse
 from robot_server.service.legacy.models import V1BasicResponse
-from robot_server.service.legacy.models.networking import NetworkingStatus, \
-    WifiNetworks, WifiNetwork, WifiConfiguration, WifiConfigurationResponse, \
-    WifiKeyFiles, WifiKeyFile, EapOptions, EapVariant, EapConfigOption, \
-    EapConfigOptionType, WifiNetworkFull, AddWifiKeyFileResponse, \
-    ConnectivityStatus
+from robot_server.service.legacy.models.networking import (
+    NetworkingStatus,
+    WifiNetworks,
+    WifiNetwork,
+    WifiConfiguration,
+    WifiConfigurationResponse,
+    WifiKeyFiles,
+    WifiKeyFile,
+    EapOptions,
+    EapVariant,
+    EapConfigOption,
+    EapConfigOptionType,
+    WifiNetworkFull,
+    AddWifiKeyFileResponse,
+    ConnectivityStatus,
+)
 
 log = logging.getLogger(__name__)
 
@@ -21,35 +32,38 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/networking/status",
-            summary="Query the current network connectivity state",
-            description="Gets information about the OT-2's network interfaces "
-                        "including their connectivity, their "
-                        "addresses, and their networking info",
-            response_model=NetworkingStatus)
+@router.get(
+    "/networking/status",
+    summary="Query the current network connectivity state",
+    description="Gets information about the OT-2's network interfaces "
+    "including their connectivity, their "
+    "addresses, and their networking info",
+    response_model=NetworkingStatus,
+)
 async def get_networking_status() -> NetworkingStatus:
     try:
         connectivity = await nmcli.is_connected()
         # TODO(mc, 2020-09-17): interfaces should be typed
-        interfaces = {i.value: await nmcli.iface_info(i)
-                      for i in nmcli.NETWORK_IFACES}
+        interfaces = {i.value: await nmcli.iface_info(i) for i in nmcli.NETWORK_IFACES}
         log.debug(f"Connectivity: {connectivity}")
         log.debug(f"Interfaces: {interfaces}")
         return NetworkingStatus(
             status=ConnectivityStatus(connectivity),
-            interfaces=interfaces  # type: ignore[arg-type]
+            interfaces=interfaces,  # type: ignore[arg-type]
         )
     except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
         log.exception("Failed calling nmcli")
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, str(e))
 
 
-@router.get("/wifi/list",
-            summary="Scan for visible Wi-Fi networks",
-            description="Scans for beaconing WiFi networks and returns the "
-                        "list of visible ones along with some data about "
-                        "their security and strength",
-            response_model=WifiNetworks)
+@router.get(
+    "/wifi/list",
+    summary="Scan for visible Wi-Fi networks",
+    description="Scans for beaconing WiFi networks and returns the "
+    "list of visible ones along with some data about "
+    "their security and strength",
+    response_model=WifiNetworks,
+)
 async def get_wifi_networks() -> WifiNetworks:
     networks = await nmcli.available_ssids()
     return WifiNetworks(list=[WifiNetworkFull(**n) for n in networks])
@@ -59,8 +73,7 @@ async def get_wifi_networks() -> WifiNetworks:
     path="/wifi/configure",
     summary="Configure the OT-2's Wi-Fi",
     description=(
-        "Configures the wireless network interface to "
-        "connect to a network"
+        "Configures the wireless network interface to " "connect to a network"
     ),
     status_code=status.HTTP_201_CREATED,
     response_model=WifiConfigurationResponse,
@@ -69,17 +82,17 @@ async def get_wifi_networks() -> WifiNetworks:
         status.HTTP_401_UNAUTHORIZED: {"model": LegacyErrorResponse},
     },
 )
-async def post_wifi_configure(configuration: WifiConfiguration)\
-        -> WifiConfigurationResponse:
+async def post_wifi_configure(
+    configuration: WifiConfiguration,
+) -> WifiConfigurationResponse:
     try:
-        psk = configuration.psk.get_secret_value() if \
-            configuration.psk else None
+        psk = configuration.psk.get_secret_value() if configuration.psk else None
         ok, message = await nmcli.configure(
             ssid=configuration.ssid,
             securityType=nmcli.SECURITY_TYPES(configuration.securityType),
             eapConfig=configuration.eapConfig,
             hidden=configuration.hidden is True,
-            psk=psk
+            psk=psk,
         )
         log.debug(f"Wifi configure result: {message}")
     except (ValueError, TypeError) as e:
@@ -88,23 +101,26 @@ async def post_wifi_configure(configuration: WifiConfiguration)\
         raise LegacyErrorResponse(message=str(e)).as_error(status.HTTP_400_BAD_REQUEST)
 
     if not ok:
-        raise LegacyErrorResponse(
-            message=message
-        ).as_error(status.HTTP_401_UNAUTHORIZED)
+        raise LegacyErrorResponse(message=message).as_error(
+            status.HTTP_401_UNAUTHORIZED
+        )
 
     return WifiConfigurationResponse(message=message, ssid=configuration.ssid)
 
 
-@router.get("/wifi/keys",
-            description="Get a list of key files known to the system",
-            response_model=WifiKeyFiles,
-            response_model_by_alias=True,
-            )
+@router.get(
+    "/wifi/keys",
+    description="Get a list of key files known to the system",
+    response_model=WifiKeyFiles,
+    response_model_by_alias=True,
+)
 async def get_wifi_keys():
     keys = [
-        WifiKeyFile(uri=f'/wifi/keys/{key.directory}',
-                    id=key.directory,
-                    name=os.path.basename(key.file))
+        WifiKeyFile(
+            uri=f"/wifi/keys/{key.directory}",
+            id=key.directory,
+            name=os.path.basename(key.file),
+        )
         for key in wifi.list_keys()
     ]
     # Why not create a WifiKeyFiles? Because validation fails when there's a
@@ -112,32 +128,30 @@ async def get_wifi_keys():
     # there's a call to `dict(model)` which raises an exception because `keys`
     # is not callable, like the `keys` member of dict.
     # A problem for another time.
-    return {
-        "keys": keys
-    }
+    return {"keys": keys}
 
 
-@router.post("/wifi/keys",
-             description="Send a new key file to the OT-2",
-             responses={
-                 status.HTTP_200_OK: {"model": AddWifiKeyFileResponse}
-             },
-             response_model=AddWifiKeyFileResponse,
-             status_code=status.HTTP_201_CREATED,
-             response_model_exclude_unset=True)
+@router.post(
+    "/wifi/keys",
+    description="Send a new key file to the OT-2",
+    responses={status.HTTP_200_OK: {"model": AddWifiKeyFileResponse}},
+    response_model=AddWifiKeyFileResponse,
+    status_code=status.HTTP_201_CREATED,
+    response_model_exclude_unset=True,
+)
 async def post_wifi_key(key: UploadFile = File(...)):
     add_key_result = wifi.add_key(key.filename, key.file.read())
 
     response = AddWifiKeyFileResponse(
-        uri=f'/wifi/keys/{add_key_result.key.directory}',
+        uri=f"/wifi/keys/{add_key_result.key.directory}",
         id=add_key_result.key.directory,
-        name=os.path.basename(add_key_result.key.file)
+        name=os.path.basename(add_key_result.key.file),
     )
     if add_key_result.created:
         return response
     else:
         # We return a JSONResponse because we want the 200 status code.
-        response.message = 'Key file already present'
+        response.message = "Key file already present"
         return JSONResponse(content=response.dict())
 
 
@@ -150,23 +164,26 @@ async def post_wifi_key(key: UploadFile = File(...)):
     },
 )
 async def delete_wifi_key(
-        key_uuid: str = Path(
-            ...,
-            description="The ID of key to delete, as determined by a previous"
-                        " call to GET /wifi/keys")) -> V1BasicResponse:
+    key_uuid: str = Path(
+        ...,
+        description="The ID of key to delete, as determined by a previous"
+        " call to GET /wifi/keys",
+    )
+) -> V1BasicResponse:
     """Delete wifi key handler"""
     deleted_file = wifi.remove_key(key_uuid)
     if not deleted_file:
-        raise LegacyErrorResponse(
-            message=f"No such key file {key_uuid}"
-        ).as_error(status.HTTP_404_NOT_FOUND)
-    return V1BasicResponse(message=f'Key file {deleted_file} deleted')
+        raise LegacyErrorResponse(message=f"No such key file {key_uuid}").as_error(
+            status.HTTP_404_NOT_FOUND
+        )
+    return V1BasicResponse(message=f"Key file {deleted_file} deleted")
 
 
-@router.get("/wifi/eap-options",
-            description="Get the supported EAP variants and their "
-                        "configuration parameters",
-            response_model=EapOptions)
+@router.get(
+    "/wifi/eap-options",
+    description="Get the supported EAP variants and their " "configuration parameters",
+    response_model=EapOptions,
+)
 async def get_eap_options() -> EapOptions:
     options = [
         EapVariant(
@@ -176,12 +193,13 @@ async def get_eap_options() -> EapOptions:
                 EapConfigOption(
                     # TODO(mc, 2020-09-17): dict.get returns Optional but
                     # EapConfigOption parameters are required
-                    name=o.get('name'),  # type: ignore[arg-type]
-                    displayName=o.get('displayName'),  # type: ignore[arg-type]
-                    required=o.get('required'),  # type: ignore[arg-type]
-                    type=EapConfigOptionType(o.get('type'))
-                ) for o in m.args()
-            ]
+                    name=o.get("name"),  # type: ignore[arg-type]
+                    displayName=o.get("displayName"),  # type: ignore[arg-type]
+                    required=o.get("required"),  # type: ignore[arg-type]
+                    type=EapConfigOptionType(o.get("type")),
+                )
+                for o in m.args()
+            ],
         )
         for m in nmcli.EAP_TYPES
     ]
@@ -189,13 +207,15 @@ async def get_eap_options() -> EapOptions:
     return result
 
 
-@router.post("/wifi/disconnect",
-             summary="Disconnect the OT-2 from Wi-Fi",
-             description="Deactivates the Wi-Fi connection and removes it "
-                         "from known connections",
-             response_model=V1BasicResponse,
-             responses={status.HTTP_200_OK: {"model": V1BasicResponse}},
-             status_code=status.HTTP_207_MULTI_STATUS)
+@router.post(
+    "/wifi/disconnect",
+    summary="Disconnect the OT-2 from Wi-Fi",
+    description="Deactivates the Wi-Fi connection and removes it "
+    "from known connections",
+    response_model=V1BasicResponse,
+    responses={status.HTTP_200_OK: {"model": V1BasicResponse}},
+    status_code=status.HTTP_207_MULTI_STATUS,
+)
 async def post_wifi_disconnect(wifi_ssid: WifiNetwork):
     ok, message = await nmcli.wifi_disconnect(wifi_ssid.ssid)
 
@@ -203,8 +223,11 @@ async def post_wifi_disconnect(wifi_ssid: WifiNetwork):
     if ok:
         # TODO have nmcli interpret error messages rather than exposing them
         #  all the way up here.
-        stat = status.HTTP_200_OK if 'successfully deleted' in message\
+        stat = (
+            status.HTTP_200_OK
+            if "successfully deleted" in message
             else status.HTTP_207_MULTI_STATUS
+        )
     else:
         stat = status.HTTP_500_INTERNAL_SERVER_ERROR
     return JSONResponse(status_code=stat, content=result.dict())

--- a/robot-server/robot_server/service/legacy/routers/pipettes.py
+++ b/robot-server/robot_server/service/legacy/routers/pipettes.py
@@ -10,26 +10,29 @@ from robot_server.service.legacy.models import pipettes
 router = APIRouter()
 
 
-@router.get("/pipettes",
-            summary="Get the pipettes currently attached",
-            description="This endpoint lists properties of the pipettes "
-                        "currently attached to the robot like name, model, "
-                        "and mount. It queries a cached value unless the "
-                        "refresh query parameter is set to true, in which "
-                        "case it will actively scan for pipettes. This "
-                        "requires disabling the pipette motors (which is done "
-                        "automatically) and therefore should only be done "
-                        "through user intent.",
-            response_model=pipettes.PipettesByMount)
+@router.get(
+    "/pipettes",
+    summary="Get the pipettes currently attached",
+    description="This endpoint lists properties of the pipettes "
+    "currently attached to the robot like name, model, "
+    "and mount. It queries a cached value unless the "
+    "refresh query parameter is set to true, in which "
+    "case it will actively scan for pipettes. This "
+    "requires disabling the pipette motors (which is done "
+    "automatically) and therefore should only be done "
+    "through user intent.",
+    response_model=pipettes.PipettesByMount,
+)
 async def get_pipettes(
-        refresh: typing.Optional[bool] = Query(
-            False,
-            description="If true, actively scan for attached pipettes. Note:"
-                        " this requires  disabling the pipette motors and"
-                        " should only be done when no  protocol is running "
-                        "and you know  it won't cause a problem"),
-        hardware: ThreadManager = Depends(get_hardware))\
-        -> pipettes.PipettesByMount:
+    refresh: typing.Optional[bool] = Query(
+        False,
+        description="If true, actively scan for attached pipettes. Note:"
+        " this requires  disabling the pipette motors and"
+        " should only be done when no  protocol is running "
+        "and you know  it won't cause a problem",
+    ),
+    hardware: ThreadManager = Depends(get_hardware),
+) -> pipettes.PipettesByMount:
     """
     Query robot for model strings on 'left' and 'right' mounts, and return a
     dict with the results keyed by mount. By default, this endpoint provides
@@ -43,21 +46,23 @@ async def get_pipettes(
     mount will report `'model': null`
     """
     if refresh is True:
-        await hardware.cache_instruments()     # type: ignore
+        await hardware.cache_instruments()  # type: ignore
 
-    attached = hardware.attached_instruments   # type: ignore
+    attached = hardware.attached_instruments  # type: ignore
 
     def make_pipette(mount, o):
         return pipettes.AttachedPipette(
-            model=o.get('model'),
-            name=o.get('name'),
-            id=o.get('pipette_id'),
+            model=o.get("model"),
+            name=o.get("name"),
+            id=o.get("pipette_id"),
             mount_axis=str(Axis.by_mount(mount)).lower(),
             plunger_axis=str(Axis.of_plunger(mount)).lower(),
-            tip_length=o.get('tip_length', 0) if o.get('model') else None
+            tip_length=o.get("tip_length", 0) if o.get("model") else None,
         )
 
-    e = {mount.name.lower(): make_pipette(mount, data)
-         for mount, data in attached.items()}
+    e = {
+        mount.name.lower(): make_pipette(mount, data)
+        for mount, data in attached.items()
+    }
 
     return pipettes.PipettesByMount(**e)

--- a/robot-server/robot_server/service/legacy/routers/rpc.py
+++ b/robot-server/robot_server/service/legacy/routers/rpc.py
@@ -9,7 +9,8 @@ router = APIRouter()
 
 
 @router.websocket("/")
-async def websocket_endpoint(websocket: WebSocket,
-                             rpc_server: RPCServer = Depends(get_rpc_server)):
+async def websocket_endpoint(
+    websocket: WebSocket, rpc_server: RPCServer = Depends(get_rpc_server)
+):
     await websocket.accept()
     await rpc_server.handle_new_connection(websocket)

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -7,17 +7,32 @@ from fastapi import APIRouter, Depends
 
 from opentrons.hardware_control import ThreadManager
 from opentrons.system import log_control
-from opentrons.config import pipette_config, reset as reset_util, \
-    robot_configs, advanced_settings
+from opentrons.config import (
+    pipette_config,
+    reset as reset_util,
+    robot_configs,
+    advanced_settings,
+)
 
 from robot_server.errors import LegacyErrorResponse
 from robot_server.service.dependencies import get_hardware
 from robot_server.service.legacy.models import V1BasicResponse
-from robot_server.service.legacy.models.settings import \
-    AdvancedSettingsResponse, LogLevel, LogLevels, FactoryResetOptions,\
-    PipetteSettings, PipetteSettingsUpdate, RobotConfigs, \
-    MultiPipetteSettings, PipetteSettingsInfo, PipetteSettingsFields, \
-    FactoryResetOption, AdvancedSettingRequest, Links, AdvancedSetting
+from robot_server.service.legacy.models.settings import (
+    AdvancedSettingsResponse,
+    LogLevel,
+    LogLevels,
+    FactoryResetOptions,
+    PipetteSettings,
+    PipetteSettingsUpdate,
+    RobotConfigs,
+    MultiPipetteSettings,
+    PipetteSettingsInfo,
+    PipetteSettingsFields,
+    FactoryResetOption,
+    AdvancedSettingRequest,
+    Links,
+    AdvancedSetting,
+)
 
 log = logging.getLogger(__name__)
 
@@ -32,10 +47,9 @@ router = APIRouter()
     responses={
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
-    }
+    },
 )
-async def post_settings(update: AdvancedSettingRequest)\
-        -> AdvancedSettingsResponse:
+async def post_settings(update: AdvancedSettingRequest) -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
     try:
         await advanced_settings.set_adv_setting(update.id, update.value)
@@ -43,17 +57,19 @@ async def post_settings(update: AdvancedSettingRequest)\
         raise LegacyErrorResponse(message=str(e)).as_error(status.HTTP_400_BAD_REQUEST)
     except advanced_settings.SettingException as e:
         # Severe internal error
-        raise LegacyErrorResponse(
-            message=str(e)
-        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR)
+        raise LegacyErrorResponse(message=str(e)).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
     return _create_settings_response()
 
 
-@router.get("/settings",
-            description="Get a list of available advanced settings (feature "
-                        "flags) and their values",
-            response_model=AdvancedSettingsResponse,
-            response_model_exclude_unset=True)
+@router.get(
+    "/settings",
+    description="Get a list of available advanced settings (feature "
+    "flags) and their values",
+    response_model=AdvancedSettingsResponse,
+    response_model_exclude_unset=True,
+)
 async def get_settings() -> AdvancedSettingsResponse:
     """Get advanced setting (feature flags)"""
     return _create_settings_response()
@@ -64,20 +80,23 @@ def _create_settings_response() -> AdvancedSettingsResponse:
     data = advanced_settings.get_all_adv_settings()
 
     if advanced_settings.is_restart_required():
-        links = Links(restart='/server/restart')
+        links = Links(restart="/server/restart")
     else:
         links = Links()
 
     return AdvancedSettingsResponse(
         links=links,
         settings=[
-            AdvancedSetting(id=s.definition.id,
-                            old_id=s.definition.old_id,
-                            title=s.definition.title,
-                            description=s.definition.description,
-                            restart_required=s.definition.restart_required,
-                            value=s.value
-                            ) for s in data.values()]
+            AdvancedSetting(
+                id=s.definition.id,
+                old_id=s.definition.old_id,
+                title=s.definition.title,
+                description=s.definition.description,
+                restart_required=s.definition.restart_required,
+                value=s.value,
+            )
+            for s in data.values()
+        ],
     )
 
 
@@ -87,27 +106,27 @@ def _create_settings_response() -> AdvancedSettingsResponse:
     response_model=V1BasicResponse,
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": LegacyErrorResponse},
-    }
+    },
 )
 async def post_log_level_local(
-        log_level: LogLevel,
-        hardware: ThreadManager = Depends(get_hardware)) -> V1BasicResponse:
+    log_level: LogLevel, hardware: ThreadManager = Depends(get_hardware)
+) -> V1BasicResponse:
     """Update local log level"""
     level = log_level.log_level
     if not level:
-        raise LegacyErrorResponse(
-            message="log_level must be set"
-        ).as_error(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
+        raise LegacyErrorResponse(message="log_level must be set").as_error(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+        )
     # Level name is upper case
     level_name = level.value.upper()
     # Set the log levels
-    for logger_name in ('opentrons', 'robot_server', 'uvicorn'):
+    for logger_name in ("opentrons", "robot_server", "uvicorn"):
         logging.getLogger(logger_name).setLevel(level.level_id)
     # Update and save settings
     await hardware.update_config(log_level=level_name)  # type: ignore
     robot_configs.save_robot_settings(hardware.config)  # type: ignore
 
-    return V1BasicResponse(message=f'log_level set to {level}')
+    return V1BasicResponse(message=f"log_level set to {level}")
 
 
 @router.post(
@@ -120,7 +139,7 @@ async def post_log_level_local(
     response_model=V1BasicResponse,
     responses={
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
-    }
+    },
 )
 async def post_log_level_upstream(log_level: LogLevel) -> V1BasicResponse:
     log_level_value = log_level.log_level
@@ -129,7 +148,7 @@ async def post_log_level_upstream(log_level: LogLevel) -> V1BasicResponse:
         LogLevels.error.name: "err",
         LogLevels.warning.name: "warning",
         LogLevels.info.name: "info",
-        LogLevels.debug.name: "debug"
+        LogLevels.debug.name: "debug",
     }
 
     syslog_level = "emerg"
@@ -141,9 +160,9 @@ async def post_log_level_upstream(log_level: LogLevel) -> V1BasicResponse:
     if code != 0:
         msg = f"Could not reload config: {stdout} {stderr}"
         log.error(msg)
-        raise LegacyErrorResponse(
-            message=msg
-        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR)
+        raise LegacyErrorResponse(message=msg).as_error(
+            status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
     if log_level_name:
         result = f"Upstreaming log level changed to {log_level_name}"
@@ -155,50 +174,56 @@ async def post_log_level_upstream(log_level: LogLevel) -> V1BasicResponse:
     return V1BasicResponse(message=result)
 
 
-@router.get("/settings/reset/options",
-            description="Get the settings that can be reset as part of "
-                        "factory reset",
-            response_model=FactoryResetOptions)
+@router.get(
+    "/settings/reset/options",
+    description="Get the settings that can be reset as part of " "factory reset",
+    response_model=FactoryResetOptions,
+)
 async def get_settings_reset_options() -> FactoryResetOptions:
     reset_options = reset_util.reset_options().items()
     return FactoryResetOptions(
         options=[
-            FactoryResetOption(
-                id=k,
-                name=v.name,
-                description=v.description)
+            FactoryResetOption(id=k, name=v.name, description=v.description)
             for k, v in reset_options
         ]
     )
 
 
-@router.post("/settings/reset",
-             description="Perform a factory reset of some robot data")
+@router.post(
+    "/settings/reset", description="Perform a factory reset of some robot data"
+)
 async def post_settings_reset_options(
-        factory_reset_commands: Dict[reset_util.ResetOptionId, bool]) \
-        -> V1BasicResponse:
+    factory_reset_commands: Dict[reset_util.ResetOptionId, bool]
+) -> V1BasicResponse:
     options = set(k for k, v in factory_reset_commands.items() if v)
     reset_util.reset(options)
 
-    message = "Options '{}' were reset".format(
-        ", ".join(o.name for o in options)) \
-        if options else "Nothing to do"
+    message = (
+        "Options '{}' were reset".format(", ".join(o.name for o in options))
+        if options
+        else "Nothing to do"
+    )
     return V1BasicResponse(message=message)
 
 
-@router.get("/settings/robot",
-            description="Get the current robot config",
-            response_model=RobotConfigs)
+@router.get(
+    "/settings/robot",
+    description="Get the current robot config",
+    response_model=RobotConfigs,
+)
 async def get_robot_settings(
-        hardware: ThreadManager = Depends(get_hardware)) -> RobotConfigs:
+    hardware: ThreadManager = Depends(get_hardware),
+) -> RobotConfigs:
     return asdict(hardware.config)
 
 
-@router.get("/settings/pipettes",
-            description="List all settings for all known pipettes by id",
-            response_model=MultiPipetteSettings,
-            response_model_by_alias=True,
-            response_model_exclude_unset=True)
+@router.get(
+    "/settings/pipettes",
+    description="List all settings for all known pipettes by id",
+    response_model=MultiPipetteSettings,
+    response_model_by_alias=True,
+    response_model_exclude_unset=True,
+)
 async def get_pipette_settings() -> MultiPipetteSettings:
     res = {}
     for pipette_id in pipette_config.known_pipettes():
@@ -223,11 +248,9 @@ async def get_pipette_settings() -> MultiPipetteSettings:
 async def get_pipette_setting(pipette_id: str) -> PipetteSettings:
     if pipette_id not in pipette_config.known_pipettes():
         raise LegacyErrorResponse(
-            message=f'{pipette_id} is not a valid pipette id'
+            message=f"{pipette_id} is not a valid pipette id"
         ).as_error(status.HTTP_404_NOT_FOUND)
-    r = _pipette_settings_from_config(
-        pipette_config, pipette_id
-    )
+    r = _pipette_settings_from_config(pipette_config, pipette_id)
     return r
 
 
@@ -242,24 +265,20 @@ async def get_pipette_setting(pipette_id: str) -> PipetteSettings:
     },
 )
 async def patch_pipette_setting(
-        pipette_id: str,
-        settings_update: PipetteSettingsUpdate) \
-        -> PipetteSettings:
+    pipette_id: str, settings_update: PipetteSettingsUpdate
+) -> PipetteSettings:
 
     # Convert fields to dict of field name to value
     fields = settings_update.setting_fields or {}
-    field_values = {k: None if v is None else v.value
-                    for k, v in fields.items()}
+    field_values = {k: None if v is None else v.value for k, v in fields.items()}
     if field_values:
         try:
             pipette_config.override(fields=field_values, pipette_id=pipette_id)
         except ValueError as e:
-            raise LegacyErrorResponse(
-                message=str(e)
-            ).as_error(status.HTTP_412_PRECONDITION_FAILED)
-    r = _pipette_settings_from_config(
-        pipette_config, pipette_id
-    )
+            raise LegacyErrorResponse(message=str(e)).as_error(
+                status.HTTP_412_PRECONDITION_FAILED
+            )
+    r = _pipette_settings_from_config(pipette_config, pipette_id)
     return r
 
 
@@ -272,13 +291,10 @@ def _pipette_settings_from_config(pc, pipette_id: str) -> PipetteSettings:
     :return: PipetteSettings object
     """
     mutuble_configs = pc.list_mutable_configs(pipette_id=pipette_id)
-    fields = PipetteSettingsFields(
-        **{k: v for k, v in mutuble_configs.items()}
-    )
+    fields = PipetteSettingsFields(**{k: v for k, v in mutuble_configs.items()})
     c, m = pc.load_config_dict(pipette_id)
 
     # TODO(mc, 2020-09-17): s/fields/setting_fields (?)
     return PipetteSettings(  # type: ignore[call-arg]
-        info=PipetteSettingsInfo(name=c.get('name'), model=m),
-        fields=fields
+        info=PipetteSettingsInfo(name=c.get("name"), model=m), fields=fields
     )

--- a/robot-server/robot_server/service/legacy/rpc/serialize.py
+++ b/robot-server/robot_server/service/legacy/rpc/serialize.py
@@ -3,14 +3,13 @@ from typing import Any, List, Dict
 
 
 def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa: C901
-
     def object_container(value):
         # Save id of instance of object's type as a reference too
         # We will need it to keep track of types the same we are
         # tracking objects
         t = type(obj)
         refs[id(t)] = t
-        return {'i': id(obj), 't': id(t), 'v': value}
+        return {"i": id(obj), "t": id(t), "v": value}
 
     # TODO: what's the better way to detect primitive types?
     if isinstance(obj, (str, int, bool, float, complex)) or obj is None:
@@ -18,12 +17,11 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa: C901
 
     # If we have ourself in path, it's a circular reference
     # we are terminating it with a valid id but a value of None
-    if hasattr(obj, '__dict__') and id(obj) in path:
+    if hasattr(obj, "__dict__") and id(obj) in path:
         return object_container(None)
 
     # Shorthand for calling ourselves recursively
-    object_tree = functools.partial(
-        _get_object_tree, max_depth, path, refs, depth + 1)
+    object_tree = functools.partial(_get_object_tree, max_depth, path, refs, depth + 1)
 
     path += [id(obj)]
 
@@ -40,7 +38,7 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa: C901
 
     if isinstance(obj, dict):
         return object_container(iterate(obj))
-    elif hasattr(obj, '__dict__'):
+    elif hasattr(obj, "__dict__"):
         refs[id(obj)] = obj
         items: List[Any] = []
         # If Type is iterable we will iterate generating numeric keys and
@@ -52,9 +50,7 @@ def _get_object_tree(max_depth, path, refs, depth, obj):  # noqa: C901
         tail = {i: v for i, v in enumerate(items)}
 
         # Filter out private attributes
-        attributes = {
-            k: v for k, v in obj.__dict__.items()
-            if not k.startswith('_')}
+        attributes = {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
         return object_container({**iterate(attributes), **tail})
     else:
         return object_container({})

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -8,8 +8,7 @@ def initialize_logging():
     # TODO Amit 2019/04/08 Move the logging level from robot configs to
     #  robot server mutable configs.
     robot_conf = robot_configs.load()
-    level = logging._nameToLevel.get(robot_conf.log_level.upper(),
-                                     logging.INFO)
+    level = logging._nameToLevel.get(robot_conf.log_level.upper(), logging.INFO)
     if IS_ROBOT:
         c = _robot_log_config(level)
     else:
@@ -20,73 +19,71 @@ def initialize_logging():
 def _robot_log_config(log_level: int):
     """Logging configuration for robot deployment"""
     return {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'message_only': {
-                'format': '%(message)s'
-            },
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "message_only": {"format": "%(message)s"},
         },
-        'handlers': {
-            'robot_server': {
-                'class': 'systemd.journal.JournalHandler',
-                'level': logging.DEBUG,
-                'formatter': 'message_only',
-                'SYSLOG_IDENTIFIER': 'opentrons-api',
+        "handlers": {
+            "robot_server": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api",
             }
         },
-        'loggers': {
-            'robot_server': {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False
+        "loggers": {
+            "robot_server": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
             },
-            'uvicorn.error': {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False
+            "uvicorn.error": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
             },
-            'fastapi': {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False
+            "fastapi": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
             },
-            'starlette':  {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False,
-            }
-        }
+            "starlette": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
+            },
+        },
     }
 
 
 def _dev_log_config(log_level: int):
     """Logging configuration for local dev deployment"""
     return {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'basic': {
-                'format': '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'  # noqa: E501
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "basic": {
+                "format": "%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s"  # noqa: E501
             },
         },
-        'handlers': {
-            'robot_server': {
-                'class': 'logging.StreamHandler',
-                'level': logging.DEBUG,
-                'formatter': 'basic',
+        "handlers": {
+            "robot_server": {
+                "class": "logging.StreamHandler",
+                "level": logging.DEBUG,
+                "formatter": "basic",
             }
         },
-        'loggers': {
-            'robot_server': {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False
+        "loggers": {
+            "robot_server": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
             },
-            'uvicorn': {
-                'handlers': ['robot_server'],
-                'level': log_level,
-                'propagate': False
+            "uvicorn": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
             },
-        }
+        },
     }

--- a/robot-server/robot_server/service/notifications/handle_subscriber.py
+++ b/robot-server/robot_server/service/notifications/handle_subscriber.py
@@ -14,17 +14,11 @@ from robot_server.settings import get_settings
 log = logging.getLogger(__name__)
 
 
-async def handle_socket(
-        websocket: WebSocket,
-        topics: List[str]) -> None:
+async def handle_socket(websocket: WebSocket, topics: List[str]) -> None:
     """Handle a websocket connection."""
-    subscriber = create(
-        get_settings().notification_server_subscriber_address,
-        topics
-    )
+    subscriber = create(get_settings().notification_server_subscriber_address, topics)
     await asyncio.gather(
-        receive(websocket, subscriber),
-        route_events(websocket, subscriber)
+        receive(websocket, subscriber), route_events(websocket, subscriber)
     )
 
 

--- a/robot-server/robot_server/service/notifications/router.py
+++ b/robot-server/robot_server/service/notifications/router.py
@@ -8,9 +8,7 @@ router = APIRouter()
 
 
 @router.websocket("/notifications/subscribe")
-async def handle_subscribe(
-        websocket: WebSocket,
-        topic: List[str] = Query(...)):
+async def handle_subscribe(websocket: WebSocket, topic: List[str] = Query(...)):
     """Accept a websocket connection."""
     await websocket.accept()
     await handle_subscriber.handle_socket(websocket, topic)

--- a/robot-server/robot_server/service/pipette_offset/models.py
+++ b/robot-server/robot_server/service/pipette_offset/models.py
@@ -6,7 +6,10 @@ from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
 from robot_server.service.json_api import (
-    ResponseModel, MultiResponseModel, ResponseDataModel)
+    ResponseModel,
+    MultiResponseModel,
+    ResponseDataModel,
+)
 from robot_server.service.shared_models import calibration as cal_model
 
 OffsetVector = typing.Tuple[float, float, float]
@@ -14,6 +17,7 @@ OffsetVector = typing.Tuple[float, float, float]
 
 class MountType(str, Enum):
     """Pipette mount type"""
+
     left = "left"
     right = "right"
 
@@ -23,37 +27,30 @@ class PipetteOffsetCalibration(ResponseDataModel):
     A model describing pipette calibration based on the mount and
     the pipette's serial number
     """
-    pipette: str = \
-        Field(..., description="The pipette ID")
-    mount: str = \
-        Field(..., description="The pipette mount")
-    offset: typing.List[float] = \
-        Field(...,
-              description="The pipette offset vector",
-              max_items=3,
-              min_items=3)
-    tiprack: str = \
-        Field(...,
-              description="The sha256 hash of the tiprack used "
-                          "in this calibration")
-    tiprackUri: str = \
-        Field(...,
-              description="The standard labware uri of the tiprack "
-                          "used in this calibration")
-    lastModified: datetime = \
-        Field(...,
-              description="When this calibration was last modified")
-    source: SourceType = \
-        Field(..., description="The calibration source")
-    status: cal_model.CalibrationStatus = \
-        Field(..., description="The status of this calibration")
+
+    pipette: str = Field(..., description="The pipette ID")
+    mount: str = Field(..., description="The pipette mount")
+    offset: typing.List[float] = Field(
+        ..., description="The pipette offset vector", max_items=3, min_items=3
+    )
+    tiprack: str = Field(
+        ..., description="The sha256 hash of the tiprack used " "in this calibration"
+    )
+    tiprackUri: str = Field(
+        ...,
+        description="The standard labware uri of the tiprack "
+        "used in this calibration",
+    )
+    lastModified: datetime = Field(
+        ..., description="When this calibration was last modified"
+    )
+    source: SourceType = Field(..., description="The calibration source")
+    status: cal_model.CalibrationStatus = Field(
+        ..., description="The status of this calibration"
+    )
 
 
-MultipleCalibrationsResponse = MultiResponseModel[
-    PipetteOffsetCalibration
-]
+MultipleCalibrationsResponse = MultiResponseModel[PipetteOffsetCalibration]
 
 
-SingleCalibrationResponse = ResponseModel[
-    PipetteOffsetCalibration
-]
+SingleCalibrationResponse = ResponseModel[PipetteOffsetCalibration]

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -6,7 +6,8 @@ from opentrons.calibration_storage import (
     types as cal_types,
     get as get_cal,
     helpers,
-    delete)
+    delete,
+)
 
 from robot_server.errors import ErrorResponse
 from robot_server.service.pipette_offset import models as pip_models
@@ -17,12 +18,11 @@ router = APIRouter()
 
 
 def _format_calibration(
-    calibration: cal_types.PipetteOffsetCalibration
+    calibration: cal_types.PipetteOffsetCalibration,
 ) -> pip_models.PipetteOffsetCalibration:
-    status = cal_model.CalibrationStatus(
-        **helpers.convert_to_dict(calibration.status))
+    status = cal_model.CalibrationStatus(**helpers.convert_to_dict(calibration.status))
     formatted_cal = pip_models.PipetteOffsetCalibration(
-        id=f'{calibration.pipette}&{calibration.mount}',
+        id=f"{calibration.pipette}&{calibration.mount}",
         pipette=calibration.pipette,
         mount=calibration.mount,
         offset=calibration.offset,
@@ -30,7 +30,8 @@ def _format_calibration(
         tiprackUri=calibration.uri,
         lastModified=calibration.last_modified,
         source=calibration.source,
-        status=status)
+        status=status,
+    )
 
     return formatted_cal
 
@@ -39,10 +40,10 @@ def _format_calibration(
     "/calibration/pipette_offset",
     description="Fetch all saved pipette offset calibrations from the robot",
     summary="Search the robot for any saved pipette offsets",
-    response_model=pip_models.MultipleCalibrationsResponse)
+    response_model=pip_models.MultipleCalibrationsResponse,
+)
 async def get_all_pipette_offset_calibrations(
-        pipette_id: str = None,
-        mount: pip_models.MountType = None
+    pipette_id: str = None, mount: pip_models.MountType = None
 ) -> pip_models.MultipleCalibrationsResponse:
     all_calibrations = get_cal.get_all_pipette_offset_calibrations()
 
@@ -52,11 +53,13 @@ async def get_all_pipette_offset_calibrations(
         )
 
     if pipette_id:
-        all_calibrations = list(filter(
-            lambda cal: cal.pipette == pipette_id, all_calibrations))
+        all_calibrations = list(
+            filter(lambda cal: cal.pipette == pipette_id, all_calibrations)
+        )
     if mount:
-        all_calibrations = list(filter(
-            lambda cal: cal.mount == mount, all_calibrations))
+        all_calibrations = list(
+            filter(lambda cal: cal.mount == mount, all_calibrations)
+        )
 
     calibrations = [_format_calibration(cal) for cal in all_calibrations]
     return pip_models.MultipleCalibrationsResponse(data=calibrations)
@@ -65,14 +68,17 @@ async def get_all_pipette_offset_calibrations(
 @router.delete(
     "/calibration/pipette_offset",
     description="Delete one specific pipette calibration "
-                "by pipette serial and mount",
-    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}})
+    "by pipette serial and mount",
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}},
+)
 async def get_specific_pipette_offset_calibration(
-        pipette_id: str, mount: pip_models.MountType):
+    pipette_id: str, mount: pip_models.MountType
+):
     try:
-        delete.delete_pipette_offset_file(pipette_id,
-                                          ot_types.Mount[mount.upper()])
+        delete.delete_pipette_offset_file(pipette_id, ot_types.Mount[mount.upper()])
     except FileNotFoundError:
-        raise RobotServerError(definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-                               resource='PipetteOffsetCalibration',
-                               id=f"{pipette_id}&{mount}")
+        raise RobotServerError(
+            definition=CommonErrorDef.RESOURCE_NOT_FOUND,
+            resource="PipetteOffsetCalibration",
+            id=f"{pipette_id}&{mount}",
+        )

--- a/robot-server/robot_server/service/protocol/contents.py
+++ b/robot-server/robot_server/service/protocol/contents.py
@@ -16,8 +16,8 @@ from robot_server.util import FileMeta, save_upload
 log = logging.getLogger(__name__)
 
 
-DIR_PREFIX = 'opentrons_'
-DIR_SUFFIX = '._proto_dir'
+DIR_PREFIX = "opentrons_"
+DIR_SUFFIX = "._proto_dir"
 
 
 @dataclass
@@ -28,8 +28,8 @@ class Contents:
 
 
 def create(
-        protocol_file: UploadFile,
-        support_files: typing.List[UploadFile]) -> Contents:
+    protocol_file: UploadFile, support_files: typing.List[UploadFile]
+) -> Contents:
     """
     Create the temporary directory.
 
@@ -38,14 +38,12 @@ def create(
     :raise ProtocolIOException:
     """
     try:
-        temp_dir = TemporaryDirectory(suffix=DIR_SUFFIX,
-                                      prefix=DIR_PREFIX)
+        temp_dir = TemporaryDirectory(suffix=DIR_SUFFIX, prefix=DIR_PREFIX)
 
         try:
             temp_dir_path = Path(temp_dir.name)
             protocol_file_meta = save_upload(temp_dir_path, protocol_file)
-            support_files_meta = [save_upload(temp_dir_path, s)
-                                  for s in support_files]
+            support_files_meta = [save_upload(temp_dir_path, s) for s in support_files]
         except IOError:
             # File saving failed. Remove the temporary directory and reraise.
             temp_dir.cleanup()
@@ -61,9 +59,7 @@ def create(
     )
 
 
-def update(
-        contents: Contents,
-        upload_file: UploadFile) -> Contents:
+def update(contents: Contents, upload_file: UploadFile) -> Contents:
     """
     Update the contents of the protocol temp directory.
 
@@ -80,14 +76,11 @@ def update(
 
     if file_meta.path == contents.protocol_file.path:
         # The protocol file has been replaced
-        return replace(
-            contents,
-            protocol_file=file_meta)
+        return replace(contents, protocol_file=file_meta)
     else:
         # A support file has been added or replaces.
         # Omit the file being replaced from existing support files (if found).
-        filtered_files = [f for f in contents.support_files
-                          if f.path != file_meta.path]
+        filtered_files = [f for f in contents.support_files if f.path != file_meta.path]
         return replace(
             contents,
             support_files=filtered_files + [file_meta],

--- a/robot-server/robot_server/service/protocol/errors.py
+++ b/robot-server/robot_server/service/protocol/errors.py
@@ -3,34 +3,41 @@ from robot_server.service.errors import RobotServerError, CommonErrorDef
 
 class ProtocolException(RobotServerError):
     """Base of all protocol exceptions"""
+
     pass
 
 
 class ProtocolNotFoundException(ProtocolException):
     """Protocol is not found"""
+
     def __init__(self, identifier: str):
-        super().__init__(definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-                         resource='protocol',
-                         id=identifier)
+        super().__init__(
+            definition=CommonErrorDef.RESOURCE_NOT_FOUND,
+            resource="protocol",
+            id=identifier,
+        )
 
 
 class ProtocolAlreadyExistsException(ProtocolException):
     """Attempting to overwrite an existing resource"""
+
     def __init__(self, identifier: str):
-        super().__init__(definition=CommonErrorDef.RESOURCE_ALREADY_EXISTS,
-                         resource="protocol",
-                         id=identifier)
+        super().__init__(
+            definition=CommonErrorDef.RESOURCE_ALREADY_EXISTS,
+            resource="protocol",
+            id=identifier,
+        )
 
 
 class ProtocolIOException(ProtocolException):
     """IO Failure"""
+
     def __init__(self, msg: str):
-        super().__init__(definition=CommonErrorDef.INTERNAL_SERVER_ERROR,
-                         error=msg)
+        super().__init__(definition=CommonErrorDef.INTERNAL_SERVER_ERROR, error=msg)
 
 
 class ProtocolUploadCountLimitReached(ProtocolException):
     """Maximum protocol upload count reached"""
+
     def __init__(self, msg: str):
-        super().__init__(definition=CommonErrorDef.ACTION_FORBIDDEN,
-                         reason=msg)
+        super().__init__(definition=CommonErrorDef.ACTION_FORBIDDEN, reason=msg)

--- a/robot-server/robot_server/service/protocol/manager.py
+++ b/robot-server/robot_server/service/protocol/manager.py
@@ -17,10 +17,11 @@ class ProtocolManager:
     def __init__(self):
         self._protocols: typing.Dict[str, UploadedProtocol] = {}
 
-    def create(self,
-               protocol_file: UploadFile,
-               support_files: typing.List[UploadFile],
-               ) -> UploadedProtocol:
+    def create(
+        self,
+        protocol_file: UploadFile,
+        support_files: typing.List[UploadFile],
+    ) -> UploadedProtocol:
         """Create a protocol object from upload"""
         protocol_id = Path(protocol_file.filename).stem
         if protocol_id in self._protocols:
@@ -30,13 +31,13 @@ class ProtocolManager:
 
         if len(self._protocols) >= ProtocolManager.MAX_COUNT:
             raise errors.ProtocolUploadCountLimitReached(
-                f"Upload limit of {ProtocolManager.MAX_COUNT} has "
-                f"been reached.")
+                f"Upload limit of {ProtocolManager.MAX_COUNT} has " f"been reached."
+            )
 
         new_protocol = UploadedProtocol.create(
             protocol_id=protocol_id,
             protocol_file=protocol_file,
-            support_files=support_files
+            support_files=support_files,
         )
         log.debug(f"Created new protocol: {new_protocol.data}")
 

--- a/robot-server/robot_server/service/protocol/models.py
+++ b/robot-server/robot_server/service/protocol/models.py
@@ -8,44 +8,44 @@ from pydantic import BaseModel, Field
 
 from opentrons.hardware_control.dev_types import ONE_CHANNEL, EIGHT_CHANNELS
 from robot_server.service.json_api import (
-    ResponseModel, ResponseDataModel, MultiResponseModel)
+    ResponseModel,
+    ResponseDataModel,
+    MultiResponseModel,
+)
 
 from robot_server.service.legacy.models.control import Mount
 
 
 class LoadedPipette(BaseModel):
     """Model of a pipette required by protocol."""
-    mount: Mount = \
-        Field(..., description="The mount to which this pipette is attached.")
-    requestedAs: str = \
-        Field(..., description="The user supplied name.")
-    pipetteName: PipetteName = \
-        Field(..., description="The pipette name.")
+
+    mount: Mount = Field(
+        ..., description="The mount to which this pipette is attached."
+    )
+    requestedAs: str = Field(..., description="The user supplied name.")
+    pipetteName: PipetteName = Field(..., description="The pipette name.")
     channels: typing.Union[ONE_CHANNEL, EIGHT_CHANNELS]
 
 
 class LoadedLabware(BaseModel):
     """Model of labware loaded by protocol."""
-    label: str = \
-        Field(..., description="The display name of the labware.")
-    uri: str = \
-        Field(..., description="The uri (namespace/loadname/version).")
-    location: int = \
-        Field(..., description="The slot in which this labware is located.")
+
+    label: str = Field(..., description="The display name of the labware.")
+    uri: str = Field(..., description="The uri (namespace/loadname/version).")
+    location: int = Field(..., description="The slot in which this labware is located.")
 
 
 class LoadedModule(BaseModel):
     """Model of module loaded by protocol."""
-    type: ModuleType = \
-        Field(..., description="The name of the module.")
-    model: ModuleModel = \
-        Field(..., description="The module model.")
-    location: int = \
-        Field(..., description="The slot in which this module is located.")
+
+    type: ModuleType = Field(..., description="The name of the module.")
+    model: ModuleModel = Field(..., description="The module model.")
+    location: int = Field(..., description="The slot in which this module is located.")
 
 
 class Meta(BaseModel):
     """Metadata extracted from the protocol."""
+
     name: typing.Optional[str]
     author: typing.Optional[str]
     apiLevel: typing.Optional[str]
@@ -53,16 +53,21 @@ class Meta(BaseModel):
 
 class RequiredEquipment(BaseModel):
     """Results of analysis of protocol."""
-    pipettes: typing.List[LoadedPipette] = \
-        Field(..., description="The pipettes required by the protocol.")
-    labware: typing.List[LoadedLabware] = \
-        Field(..., description="The labware required by the protocol.")
-    modules: typing.List[LoadedModule] = \
-        Field(..., description="The modules required by the protocol.")
+
+    pipettes: typing.List[LoadedPipette] = Field(
+        ..., description="The pipettes required by the protocol."
+    )
+    labware: typing.List[LoadedLabware] = Field(
+        ..., description="The labware required by the protocol."
+    )
+    modules: typing.List[LoadedModule] = Field(
+        ..., description="The modules required by the protocol."
+    )
 
 
 class ProtocolError(BaseModel):
     """An error created during analysis of the uploaded protocol."""
+
     type: str
     description: str
     lineNumber: typing.Optional[int] = None
@@ -76,22 +81,20 @@ class FileAttributes(BaseModel):
 class ProtocolResponseAttributes(ResponseDataModel):
     protocolFile: FileAttributes
     supportFiles: typing.List[FileAttributes]
-    lastModifiedAt: datetime =\
-        Field(...,
-              description="When the protocol was last modified.")
-    createdAt: datetime =\
-        Field(...,
-              description="When the protocol was uploaded.")
-    requiredEquipment: RequiredEquipment =\
-        Field(...,
-              description="The equipment required by the protocol.")
-    metadata: Meta =\
-        Field(...,
-              description="Metadata extracted from the protocol file.")
-    errors: typing.List[ProtocolError] = \
-        Field([],
-              description="Errors that must be addressed before the protocol "
-                          "can be run.")
+    lastModifiedAt: datetime = Field(
+        ..., description="When the protocol was last modified."
+    )
+    createdAt: datetime = Field(..., description="When the protocol was uploaded.")
+    requiredEquipment: RequiredEquipment = Field(
+        ..., description="The equipment required by the protocol."
+    )
+    metadata: Meta = Field(
+        ..., description="Metadata extracted from the protocol file."
+    )
+    errors: typing.List[ProtocolError] = Field(
+        [],
+        description="Errors that must be addressed before the protocol " "can be run.",
+    )
 
 
 ProtocolResponse = ResponseModel[ProtocolResponseAttributes]

--- a/robot-server/robot_server/service/protocol/protocol.py
+++ b/robot-server/robot_server/service/protocol/protocol.py
@@ -25,17 +25,17 @@ class UploadedProtocolData:
 
 class UploadedProtocol:
     # TODO AL 20201219 - make the methods of this class async
-    def __init__(self,
-                 data: UploadedProtocolData):
+    def __init__(self, data: UploadedProtocolData):
         """Constructor"""
         self._data = data
 
     @classmethod
     def create(
-            cls,
-            protocol_id: str,
-            protocol_file: UploadFile,
-            support_files: typing.List[UploadFile]) -> 'UploadedProtocol':
+        cls,
+        protocol_id: str,
+        protocol_file: UploadFile,
+        support_files: typing.List[UploadFile],
+    ) -> "UploadedProtocol":
         """
         Create the UploadedProtocol object. The protocol is analyzed after the
          files are saved.
@@ -57,7 +57,7 @@ class UploadedProtocol:
             UploadedProtocolData(
                 identifier=protocol_id,
                 analysis_result=analysis_results,
-                contents=protocol_contents
+                contents=protocol_contents,
             )
         )
 

--- a/robot-server/robot_server/service/protocol/router.py
+++ b/robot-server/robot_server/service/protocol/router.py
@@ -6,8 +6,7 @@ from fastapi import APIRouter, UploadFile, File, Depends, Body
 
 from robot_server.service.dependencies import get_protocol_manager
 from robot_server.service.json_api import ResourceLink
-from robot_server.service.json_api.resource_links import ResourceLinkKey, \
-    ResourceLinks
+from robot_server.service.json_api.resource_links import ResourceLinkKey, ResourceLinks
 from robot_server.service.protocol import models as route_models
 from robot_server.service.protocol.manager import ProtocolManager
 from robot_server.service.protocol.protocol import UploadedProtocol
@@ -20,36 +19,45 @@ PATH_ROOT = "/protocols"
 PATH_PROTOCOL_ID = PATH_ROOT + "/{protocolId}"
 
 
-@router.post(PATH_ROOT,
-             description="Create a protocol",
-             response_model_exclude_unset=True,
-             response_model=route_models.ProtocolResponse,
-             status_code=http_status_codes.HTTP_201_CREATED)
+@router.post(
+    PATH_ROOT,
+    description="Create a protocol",
+    response_model_exclude_unset=True,
+    response_model=route_models.ProtocolResponse,
+    status_code=http_status_codes.HTTP_201_CREATED,
+)
 async def create_protocol(
-        protocolFile: UploadFile = File(..., description="The protocol file"),
-        supportFiles: typing.List[UploadFile] = Body(
-            default=list(),
-            description="Any support files needed by the protocol (ie data "
-                        "files, additional python files)"),
-        protocol_manager=Depends(get_protocol_manager)):
+    protocolFile: UploadFile = File(..., description="The protocol file"),
+    supportFiles: typing.List[UploadFile] = Body(
+        default=list(),
+        description="Any support files needed by the protocol (ie data "
+        "files, additional python files)",
+    ),
+    protocol_manager=Depends(get_protocol_manager),
+):
     """Create protocol from proto file plus optional support files"""
-    new_proto = protocol_manager.create(protocol_file=protocolFile,
-                                        support_files=supportFiles,)
+    new_proto = protocol_manager.create(
+        protocol_file=protocolFile,
+        support_files=supportFiles,
+    )
     return route_models.ProtocolResponse(
         data=_to_response(new_proto),
-        links=get_protocol_links(router, new_proto.data.identifier)
+        links=get_protocol_links(router, new_proto.data.identifier),
     )
 
 
-@router.get(PATH_ROOT,
-            description="Get all protocols",
-            response_model_exclude_unset=True,
-            response_model=route_models.MultiProtocolResponse)
+@router.get(
+    PATH_ROOT,
+    description="Get all protocols",
+    response_model_exclude_unset=True,
+    response_model=route_models.MultiProtocolResponse,
+)
 async def get_protocols(
-        protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
+    protocol_manager: ProtocolManager = Depends(get_protocol_manager),
+):
     return route_models.MultiProtocolResponse(
         data=[_to_response(u) for u in protocol_manager.get_all()],
-        links=get_root_links(router)
+        links=get_root_links(router),
     )
 
 
@@ -57,14 +65,15 @@ async def get_protocols(
     PATH_PROTOCOL_ID,
     description="Get a protocol",
     response_model_exclude_unset=True,
-    response_model=route_models.ProtocolResponse)
+    response_model=route_models.ProtocolResponse,
+)
 async def get_protocol(
-        protocolId: str,
-        protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
+    protocolId: str, protocol_manager: ProtocolManager = Depends(get_protocol_manager)
+):
     proto = protocol_manager.get(protocolId)
     return route_models.ProtocolResponse(
         data=_to_response(proto),
-        links=get_protocol_links(router, proto.data.identifier)
+        links=get_protocol_links(router, proto.data.identifier),
     )
 
 
@@ -72,10 +81,11 @@ async def get_protocol(
     PATH_PROTOCOL_ID,
     description="Delete a protocol",
     response_model_exclude_unset=True,
-    response_model=route_models.ProtocolResponse)
+    response_model=route_models.ProtocolResponse,
+)
 async def delete_protocol(
-        protocolId: str,
-        protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
+    protocolId: str, protocol_manager: ProtocolManager = Depends(get_protocol_manager)
+):
     proto = protocol_manager.remove(protocolId)
     return route_models.ProtocolResponse(
         data=_to_response(proto),
@@ -88,11 +98,13 @@ async def delete_protocol(
     description="Add a new file or replace an existing file in the protocol.",
     response_model_exclude_unset=True,
     response_model=route_models.ProtocolResponse,
-    status_code=http_status_codes.HTTP_200_OK)
+    status_code=http_status_codes.HTTP_200_OK,
+)
 async def upload_file(
-        protocolId: str,
-        file: UploadFile = File(...),
-        protocol_manager: ProtocolManager = Depends(get_protocol_manager)):
+    protocolId: str,
+    file: UploadFile = File(...),
+    protocol_manager: ProtocolManager = Depends(get_protocol_manager),
+):
     proto = protocol_manager.get(protocolId)
     proto.update(file)
     return route_models.ProtocolResponse(
@@ -101,8 +113,9 @@ async def upload_file(
     )
 
 
-def _to_response(uploaded_protocol: UploadedProtocol) \
-        -> route_models.ProtocolResponseAttributes:
+def _to_response(
+    uploaded_protocol: UploadedProtocol,
+) -> route_models.ProtocolResponseAttributes:
     """Create ProtocolResponse from an UploadedProtocol"""
     meta = uploaded_protocol.data
     analysis_result = uploaded_protocol.data.analysis_result
@@ -111,14 +124,15 @@ def _to_response(uploaded_protocol: UploadedProtocol) \
         protocolFile=route_models.FileAttributes(
             basename=meta.contents.protocol_file.path.name
         ),
-        supportFiles=[route_models.FileAttributes(
-            basename=s.path.name
-        ) for s in meta.contents.support_files],
+        supportFiles=[
+            route_models.FileAttributes(basename=s.path.name)
+            for s in meta.contents.support_files
+        ],
         lastModifiedAt=meta.last_modified_at,
         createdAt=meta.created_at,
         metadata=analysis_result.meta,
         requiredEquipment=analysis_result.required_equipment,
-        errors=analysis_result.errors
+        errors=analysis_result.errors,
     )
 
 
@@ -134,13 +148,12 @@ def get_root_links(api_router: APIRouter) -> ResourceLinks:
     }
 
 
-def get_protocol_links(api_router: APIRouter, protocol_id: str) \
-        -> ResourceLinks:
+def get_protocol_links(api_router: APIRouter, protocol_id: str) -> ResourceLinks:
     """Get resource links for specific resource path handlers"""
     return {
         ResourceLinkKey.self: ResourceLink(
-            href=api_router.url_path_for(get_protocol.__name__,
-                                         protocolId=protocol_id)),
+            href=api_router.url_path_for(get_protocol.__name__, protocolId=protocol_id)
+        ),
         ResourceLinkKey.protocols: ROOT_RESOURCE,
-        ResourceLinkKey.protocol_by_id: PROTOCOL_BY_ID_RESOURCE
+        ResourceLinkKey.protocol_by_id: PROTOCOL_BY_ID_RESOURCE,
     }

--- a/robot-server/robot_server/service/session/command_execution/__init__.py
+++ b/robot-server/robot_server/service/session/command_execution/__init__.py
@@ -1,4 +1,9 @@
 from .base_command_queue import CommandQueue  # noqa: F401
 from .base_executor import CommandExecutor  # noqa: F401
-from .command import Command, CompletedCommand, create_command, CommandResult  # noqa: F401, E501
+from .command import (  # noqa: F401
+    Command,
+    CompletedCommand,
+    create_command,
+    CommandResult,
+)
 from .callable_executor import CallableExecutor  # noqa: F401

--- a/robot-server/robot_server/service/session/command_execution/base_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/base_executor.py
@@ -5,8 +5,7 @@ from ..errors import UnsupportedCommandException
 class CommandExecutor:
     """Interface for command executors"""
 
-    async def execute(self, command: Command) \
-            -> CompletedCommand:
+    async def execute(self, command: Command) -> CompletedCommand:
         """
         Execute a command
 

--- a/robot-server/robot_server/service/session/command_execution/callable_executor.py
+++ b/robot-server/robot_server/service/session/command_execution/callable_executor.py
@@ -6,8 +6,8 @@ from .command import Command, CompletedCommand, CommandResult
 
 
 CommandHandler = typing.Callable[
-    [str, typing.Dict[typing.Any, typing.Any]],
-    typing.Coroutine]
+    [str, typing.Dict[typing.Any, typing.Any]], typing.Coroutine
+]
 
 
 class CallableExecutor(CommandExecutor):
@@ -33,6 +33,5 @@ class CallableExecutor(CommandExecutor):
         return CompletedCommand(
             request=command.request,
             meta=command.meta,
-            result=CommandResult(started_at=time_it.start,
-                                 completed_at=time_it.end)
+            result=CommandResult(started_at=time_it.start, completed_at=time_it.end),
         )

--- a/robot-server/robot_server/service/session/command_execution/command.py
+++ b/robot-server/robot_server/service/session/command_execution/command.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Optional, Generic, TypeVar
 
-from robot_server.service.session.models.command import (
-    CommandStatus, RequestTypes)
-from robot_server.service.session.models.common import (
-    IdentifierType, create_identifier)
+from robot_server.service.session.models.command import CommandStatus, RequestTypes
+from robot_server.service.session.models.common import IdentifierType, create_identifier
 from opentrons.util.helpers import utc_now
 
 
@@ -41,6 +39,4 @@ class CompletedCommand:
 
 def create_command(request: RequestTypes) -> Command:
     """Create a command object"""
-    return Command(
-        request=request
-    )
+    return Command(request=request)

--- a/robot-server/robot_server/service/session/configuration.py
+++ b/robot-server/robot_server/service/session/configuration.py
@@ -8,13 +8,15 @@ from robot_server.service.session.models.common import IdentifierType
 
 class SessionConfiguration:
     """Data and utilities common to all session types
-     provided by session manager"""
+    provided by session manager"""
 
-    def __init__(self,
-                 hardware: ThreadManager,
-                 is_active: Callable[[IdentifierType], bool],
-                 motion_lock: ThreadedAsyncLock,
-                 protocol_manager: ProtocolManager):
+    def __init__(
+        self,
+        hardware: ThreadManager,
+        is_active: Callable[[IdentifierType], bool],
+        motion_lock: ThreadedAsyncLock,
+        protocol_manager: ProtocolManager,
+    ):
         self._hardware = hardware
         self._is_active = is_active
         self._motion_lock = motion_lock

--- a/robot-server/robot_server/service/session/errors.py
+++ b/robot-server/robot_server/service/session/errors.py
@@ -3,32 +3,37 @@ from robot_server.service.errors import RobotServerError, CommonErrorDef
 
 class SessionException(RobotServerError):
     """Base of all session exceptions"""
+
     def __init__(self, reason: str):
-        super().__init__(definition=CommonErrorDef.ACTION_FORBIDDEN,
-                         reason=reason)
+        super().__init__(definition=CommonErrorDef.ACTION_FORBIDDEN, reason=reason)
 
 
 class SessionCommandException(SessionException):
     """Base of all command exceptions"""
+
     pass
 
 
 class SessionCreationException(SessionException):
     """A session cannot be created"""
+
     pass
 
 
 class UnsupportedFeature(SessionException):
     """A feature is not supported"""
+
     def __init__(self):
         super().__init__(reason="This feature is not supported")
 
 
 class UnsupportedCommandException(SessionCommandException):
     """A command is not supported by the session"""
+
     pass
 
 
 class CommandExecutionException(SessionCommandException):
     """An error occurred during command execution"""
+
     pass

--- a/robot-server/robot_server/service/session/models/command.py
+++ b/robot-server/robot_server/service/session/models/command.py
@@ -28,60 +28,60 @@ from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import commands
 
 from robot_server.service.session.models.command_definitions import (
-    ProtocolCommand, EquipmentCommand, PipetteCommand, CalibrationCommand,
-    DeckCalibrationCommand, CheckCalibrationCommand, CommandDefinitionType)
-from robot_server.service.session.models.common import (
-    EmptyModel, JogPosition)
-from robot_server.service.json_api import (
-    ResponseModel, RequestModel, ResponseDataModel)
+    ProtocolCommand,
+    EquipmentCommand,
+    PipetteCommand,
+    CalibrationCommand,
+    DeckCalibrationCommand,
+    CheckCalibrationCommand,
+    CommandDefinitionType,
+)
+from robot_server.service.session.models.common import EmptyModel, JogPosition
+from robot_server.service.json_api import ResponseModel, RequestModel, ResponseDataModel
 
 
 class LoadLabwareByDefinitionRequestData(BaseModel):
     tiprackDefinition: typing.Optional[dict] = Field(
-        None,
-        description="The tiprack definition to load into a user flow")
+        None, description="The tiprack definition to load into a user flow"
+    )
 
 
 class SetHasCalibrationBlockRequestData(BaseModel):
     hasBlock: bool = Field(
-        ...,
-        description="whether or not there is a calibration block present")
+        ..., description="whether or not there is a calibration block present"
+    )
 
 
 class CommandStatus(str, Enum):
     """The command status."""
+
     executed = "executed"
     queued = "queued"
     failed = "failed"
 
 
-CommandT = typing.TypeVar('CommandT', bound=CommandDefinitionType)
-RequestDataT = typing.TypeVar('RequestDataT', bound=BaseModel)
-ResponseDataT = typing.TypeVar('ResponseDataT')
+CommandT = typing.TypeVar("CommandT", bound=CommandDefinitionType)
+RequestDataT = typing.TypeVar("RequestDataT", bound=BaseModel)
+ResponseDataT = typing.TypeVar("ResponseDataT")
 
 
 class SessionCommandRequest(
-    GenericModel,
-    typing.Generic[CommandT, RequestDataT, ResponseDataT]
+    GenericModel, typing.Generic[CommandT, RequestDataT, ResponseDataT]
 ):
     """A session command request."""
-    command: CommandT = Field(
-        ...,
-        description="The command description")
-    data: RequestDataT = Field(
-        ...,
-        description="The command data"
-    )
+
+    command: CommandT = Field(..., description="The command description")
+    data: RequestDataT = Field(..., description="The command data")
 
     def make_response(
-            self,
-            identifier: str,
-            status: CommandStatus,
-            created_at: datetime,
-            started_at: typing.Optional[datetime],
-            completed_at: typing.Optional[datetime],
-            result: typing.Optional[ResponseDataT]
-    ) -> 'SessionCommandResponse[CommandT, RequestDataT, ResponseDataT]':
+        self,
+        identifier: str,
+        status: CommandStatus,
+        created_at: datetime,
+        started_at: typing.Optional[datetime],
+        completed_at: typing.Optional[datetime],
+        result: typing.Optional[ResponseDataT],
+    ) -> "SessionCommandResponse[CommandT, RequestDataT, ResponseDataT]":
         """Create a SessionCommandResponse object."""
         return SessionCommandResponse(
             command=self.command,
@@ -91,15 +91,17 @@ class SessionCommandRequest(
             createdAt=created_at,
             startedAt=started_at,
             completedAt=completed_at,
-            result=result)
+            result=result,
+        )
 
 
 class SessionCommandResponse(
     ResponseDataModel,
     GenericModel,
-    typing.Generic[CommandT, RequestDataT, ResponseDataT]
+    typing.Generic[CommandT, RequestDataT, ResponseDataT],
 ):
     """A session command response."""
+
     command: CommandT
     data: RequestDataT
     status: CommandStatus
@@ -130,22 +132,17 @@ CommandsEmptyData = Literal[
     CheckCalibrationCommand.compare_point,
     CheckCalibrationCommand.switch_pipette,
     CheckCalibrationCommand.return_tip,
-    CheckCalibrationCommand.transition
+    CheckCalibrationCommand.transition,
 ]
 """The command definitions requiring no data and result types."""
 
 
-SimpleCommandRequest = SessionCommandRequest[
-    CommandsEmptyData,
-    EmptyModel,
-    EmptyModel]
+SimpleCommandRequest = SessionCommandRequest[CommandsEmptyData, EmptyModel, EmptyModel]
 """A command request containing no data and result type."""
 
 
 SimpleCommandResponse = SessionCommandResponse[
-    CommandsEmptyData,
-    EmptyModel,
-    EmptyModel
+    CommandsEmptyData, EmptyModel, EmptyModel
 ]
 """Response to :class:`~SimpleCommandRequest`"""
 
@@ -153,126 +150,111 @@ SimpleCommandResponse = SessionCommandResponse[
 LoadLabwareRequest = SessionCommandRequest[
     Literal[EquipmentCommand.load_labware],
     commands.LoadLabwareRequest,
-    commands.LoadLabwareResult
+    commands.LoadLabwareResult,
 ]
 
 
 LoadLabwareResponse = SessionCommandResponse[
     Literal[EquipmentCommand.load_labware],
     commands.LoadLabwareRequest,
-    commands.LoadLabwareResult
+    commands.LoadLabwareResult,
 ]
 
 
 LoadInstrumentRequest = SessionCommandRequest[
     Literal[EquipmentCommand.load_pipette],
     commands.LoadPipetteRequest,
-    commands.LoadPipetteResult
+    commands.LoadPipetteResult,
 ]
 
 
 LoadInstrumentResponse = SessionCommandResponse[
     Literal[EquipmentCommand.load_pipette],
     commands.LoadPipetteRequest,
-    commands.LoadPipetteResult
+    commands.LoadPipetteResult,
 ]
 
 
 AspirateRequest = SessionCommandRequest[
-    Literal[PipetteCommand.aspirate],
-    commands.AspirateRequest,
-    commands.AspirateResult
+    Literal[PipetteCommand.aspirate], commands.AspirateRequest, commands.AspirateResult
 ]
 
 
 AspirateResponse = SessionCommandResponse[
-    Literal[PipetteCommand.aspirate],
-    commands.AspirateRequest,
-    commands.AspirateResult
+    Literal[PipetteCommand.aspirate], commands.AspirateRequest, commands.AspirateResult
 ]
 
 
 DispenseRequest = SessionCommandRequest[
-    Literal[PipetteCommand.dispense],
-    commands.DispenseRequest,
-    commands.DispenseResult
+    Literal[PipetteCommand.dispense], commands.DispenseRequest, commands.DispenseResult
 ]
 
 
 DispenseResponse = SessionCommandResponse[
-    Literal[PipetteCommand.dispense],
-    commands.DispenseRequest,
-    commands.DispenseResult
+    Literal[PipetteCommand.dispense], commands.DispenseRequest, commands.DispenseResult
 ]
 
 
 PickUpTipRequest = SessionCommandRequest[
     Literal[PipetteCommand.pick_up_tip],
     commands.PickUpTipRequest,
-    commands.PickUpTipResult
+    commands.PickUpTipResult,
 ]
 
 
 PickUpTipResponse = SessionCommandResponse[
     Literal[PipetteCommand.pick_up_tip],
     commands.PickUpTipRequest,
-    commands.PickUpTipResult
+    commands.PickUpTipResult,
 ]
 
 
 DropTipRequest = SessionCommandRequest[
-    Literal[PipetteCommand.drop_tip],
-    commands.DropTipRequest,
-    commands.DropTipResult
+    Literal[PipetteCommand.drop_tip], commands.DropTipRequest, commands.DropTipResult
 ]
 
 
 DropTipResponse = SessionCommandResponse[
-    Literal[PipetteCommand.drop_tip],
-    commands.DropTipRequest,
-    commands.DropTipResult
+    Literal[PipetteCommand.drop_tip], commands.DropTipRequest, commands.DropTipResult
 ]
 
 
 JogRequest = SessionCommandRequest[
-    Literal[CalibrationCommand.jog],
-    JogPosition,
-    EmptyModel
+    Literal[CalibrationCommand.jog], JogPosition, EmptyModel
 ]
 
 
 JogResponse = SessionCommandResponse[
-    Literal[CalibrationCommand.jog],
-    JogPosition,
-    EmptyModel
+    Literal[CalibrationCommand.jog], JogPosition, EmptyModel
 ]
 
 
 LabwareByDefinitionRequest = SessionCommandRequest[
     Literal[CalibrationCommand.load_labware],
     LoadLabwareByDefinitionRequestData,
-    EmptyModel
+    EmptyModel,
 ]
 
 
 LabwareByDefinitionResponse = SessionCommandResponse[
     Literal[CalibrationCommand.load_labware],
     LoadLabwareByDefinitionRequestData,
-    EmptyModel
+    EmptyModel,
 ]
 
 
 SetHasCalibrationBlockRequest = SessionCommandRequest[
     Literal[CalibrationCommand.set_has_calibration_block],
     SetHasCalibrationBlockRequestData,
-    EmptyModel
+    EmptyModel,
 ]
 
 
 SetHasCalibrationBlockResponse = SessionCommandResponse[
     Literal[CalibrationCommand.set_has_calibration_block],
     SetHasCalibrationBlockRequestData,
-    EmptyModel]
+    EmptyModel,
+]
 
 
 RequestTypes = typing.Union[
@@ -285,7 +267,7 @@ RequestTypes = typing.Union[
     DropTipRequest,
     JogRequest,
     SetHasCalibrationBlockRequest,
-    LabwareByDefinitionRequest
+    LabwareByDefinitionRequest,
 ]
 """Union of all request types"""
 
@@ -299,17 +281,13 @@ ResponseTypes = typing.Union[
     DropTipResponse,
     JogResponse,
     SetHasCalibrationBlockResponse,
-    LabwareByDefinitionResponse
+    LabwareByDefinitionResponse,
 ]
 """Union of all response types"""
 
 
-CommandRequest = RequestModel[
-    RequestTypes
-]
+CommandRequest = RequestModel[RequestTypes]
 """The command request model."""
 
-CommandResponse = ResponseModel[
-    ResponseTypes
-]
+CommandResponse = ResponseModel[ResponseTypes]
 """The command response model."""

--- a/robot-server/robot_server/service/session/models/command_definitions.py
+++ b/robot-server/robot_server/service/session/models/command_definitions.py
@@ -11,6 +11,7 @@ class CommandDefinition(str, Enum):
     _localname: str
 
     """The base of command definition enumerations."""
+
     def __new__(cls, value):
         """Create a string enum."""
         # https://docs.python.org/3/library/enum.html#when-to-use-new-vs-init
@@ -38,6 +39,7 @@ class CommandDefinition(str, Enum):
 
 class RobotCommand(CommandDefinition):
     """Robot commands"""
+
     home_all_motors = "homeAllMotors"
     home_pipette = "homePipette"
     toggle_lights = "toggleLights"
@@ -49,6 +51,7 @@ class RobotCommand(CommandDefinition):
 
 class ProtocolCommand(CommandDefinition):
     """Protocol commands"""
+
     start_run = "startRun"
     start_simulate = "startSimulate"
     cancel = "cancel"
@@ -82,6 +85,7 @@ class PipetteCommand(CommandDefinition):
 
 class CalibrationCommand(CommandDefinition):
     """Shared Between Calibration Flows"""
+
     load_labware = "loadLabware"
     jog = "jog"
     set_has_calibration_block = "setHasCalibrationBlock"
@@ -103,6 +107,7 @@ class CalibrationCommand(CommandDefinition):
 
 class DeckCalibrationCommand(CommandDefinition):
     """Deck Calibration Specific"""
+
     move_to_point_two = "moveToPointTwo"
     move_to_point_three = "moveToPointThree"
 
@@ -113,6 +118,7 @@ class DeckCalibrationCommand(CommandDefinition):
 
 class CheckCalibrationCommand(CommandDefinition):
     """Check Calibration Health Specific"""
+
     compare_point = "comparePoint"
     switch_pipette = "switchPipette"
     return_tip = "returnTip"

--- a/robot-server/robot_server/service/session/models/common.py
+++ b/robot-server/robot_server/service/session/models/common.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-IdentifierType = typing.NewType('IdentifierType', str)
+IdentifierType = typing.NewType("IdentifierType", str)
 
 
 def create_identifier() -> IdentifierType:

--- a/robot-server/robot_server/service/session/models/session.py
+++ b/robot-server/robot_server/service/session/models/session.py
@@ -8,29 +8,36 @@ from typing_extensions import Literal
 
 from robot_server.robot.calibration.check.models import (
     CalibrationCheckSessionStatus,
-    SessionCreateParams as CalCheckCreateParams)
-from robot_server.robot.calibration.deck.models import \
-    DeckCalibrationSessionStatus
+    SessionCreateParams as CalCheckCreateParams,
+)
+from robot_server.robot.calibration.deck.models import DeckCalibrationSessionStatus
 from robot_server.robot.calibration.models import SessionCreateParams
-from robot_server.robot.calibration.pipette_offset.models import\
-    PipetteOffsetCalibrationSessionStatus
-from robot_server.robot.calibration.tip_length.models import\
-    TipCalibrationSessionStatus
+from robot_server.robot.calibration.pipette_offset.models import (
+    PipetteOffsetCalibrationSessionStatus,
+)
+from robot_server.robot.calibration.tip_length.models import TipCalibrationSessionStatus
 from robot_server.service.json_api import (
-    RequestModel, ResponseModel, ResponseDataModel, MultiResponseModel)
+    RequestModel,
+    ResponseModel,
+    ResponseDataModel,
+    MultiResponseModel,
+)
 from robot_server.service.session.models.common import EmptyModel
-from robot_server.service.session.session_types.protocol.models import \
-    ProtocolCreateParams, ProtocolSessionDetails
+from robot_server.service.session.session_types.protocol.models import (
+    ProtocolCreateParams,
+    ProtocolSessionDetails,
+)
 
 
 class SessionType(str, Enum):
     """The available session types"""
-    calibration_check = 'calibrationCheck'
-    tip_length_calibration = 'tipLengthCalibration'
-    deck_calibration = 'deckCalibration'
-    pipette_offset_calibration = 'pipetteOffsetCalibration'
-    protocol = 'protocol'
-    live_protocol = 'liveProtocol'
+
+    calibration_check = "calibrationCheck"
+    tip_length_calibration = "tipLengthCalibration"
+    deck_calibration = "deckCalibration"
+    pipette_offset_calibration = "pipetteOffsetCalibration"
+    protocol = "protocol"
+    live_protocol = "liveProtocol"
 
 
 """
@@ -52,76 +59,80 @@ SessionDetails = typing.Union[
     TipCalibrationSessionStatus,
     DeckCalibrationSessionStatus,
     ProtocolSessionDetails,
-    EmptyModel
+    EmptyModel,
 ]
 
 
 class SessionCreateAttributes(BaseModel):
     """Attributes required for creating a session"""
-    sessionType: SessionType =\
-        Field(...,
-              description="The type of the session")
+
+    sessionType: SessionType = Field(..., description="The type of the session")
 
 
 class SessionCreateAttributesNoParams(SessionCreateAttributes):
     """The base model of request that has no createParams."""
+
     createParams: typing.Optional[BaseModel]
 
 
 class CalibrationCheckCreateAttributes(SessionCreateAttributesNoParams):
     """The calibration check create request."""
-    sessionType: Literal[SessionType.calibration_check] =\
-        SessionType.calibration_check
+
+    sessionType: Literal[SessionType.calibration_check] = SessionType.calibration_check
     createParams: CalCheckCreateParams
 
 
 class TipLengthCalibrationCreateAttributes(SessionCreateAttributes):
     """The tip length calibration create request."""
-    sessionType: Literal[SessionType.tip_length_calibration] =\
+
+    sessionType: Literal[
         SessionType.tip_length_calibration
+    ] = SessionType.tip_length_calibration
     createParams: SessionCreateParams
 
 
 class DeckCalibrationCreateAttributes(SessionCreateAttributesNoParams):
     """The deck calibration create request."""
-    sessionType: Literal[SessionType.deck_calibration] =\
-        SessionType.deck_calibration
+
+    sessionType: Literal[SessionType.deck_calibration] = SessionType.deck_calibration
 
 
 class PipetteOffsetCalibrationCreateAttributes(SessionCreateAttributes):
     """Pipette offset calibration create request."""
-    sessionType: Literal[SessionType.pipette_offset_calibration] =\
+
+    sessionType: Literal[
         SessionType.pipette_offset_calibration
+    ] = SessionType.pipette_offset_calibration
     createParams: SessionCreateParams
 
 
 class ProtocolCreateAttributes(SessionCreateAttributes):
     """Protocol session create request."""
-    sessionType: Literal[SessionType.protocol] =\
-        SessionType.protocol
+
+    sessionType: Literal[SessionType.protocol] = SessionType.protocol
     createParams: ProtocolCreateParams
 
 
 class LiveProtocolCreateAttributes(SessionCreateAttributesNoParams):
     """Live protocol session create request."""
-    sessionType: Literal[SessionType.live_protocol] =\
-        SessionType.live_protocol
+
+    sessionType: Literal[SessionType.live_protocol] = SessionType.live_protocol
 
 
 class SessionResponseAttributes(ResponseDataModel):
     """Common session response attributes."""
-    createdAt: datetime = \
-        Field(...,
-              description="Date and time that this session was created")
-    details: BaseModel =\
-        Field(...,
-              description="Detailed session specific status")
+
+    createdAt: datetime = Field(
+        ..., description="Date and time that this session was created"
+    )
+    details: BaseModel = Field(..., description="Detailed session specific status")
 
 
 class CalibrationCheckResponseAttributes(
     CalibrationCheckCreateAttributes, SessionResponseAttributes
 ):
     """Response attributes of cal check session."""
+
     details: CalibrationCheckSessionStatus
 
 
@@ -129,6 +140,7 @@ class TipLengthCalibrationResponseAttributes(
     TipLengthCalibrationCreateAttributes, SessionResponseAttributes
 ):
     """Response attributes of tip length calibration session."""
+
     details: TipCalibrationSessionStatus
 
 
@@ -136,6 +148,7 @@ class DeckCalibrationResponseAttributes(
     DeckCalibrationCreateAttributes, SessionResponseAttributes
 ):
     """Response attributes of deck calibration session."""
+
     details: DeckCalibrationSessionStatus
 
 
@@ -143,13 +156,13 @@ class PipetteOffsetCalibrationResponseAttributes(
     PipetteOffsetCalibrationCreateAttributes, SessionResponseAttributes
 ):
     """Response attributes of pipette offset calibration session."""
+
     details: PipetteOffsetCalibrationSessionStatus
 
 
-class ProtocolResponseAttributes(
-    ProtocolCreateAttributes, SessionResponseAttributes
-):
+class ProtocolResponseAttributes(ProtocolCreateAttributes, SessionResponseAttributes):
     """Response attributes of protocol session."""
+
     details: ProtocolSessionDetails
 
 
@@ -157,6 +170,7 @@ class LiveProtocolResponseAttributes(
     LiveProtocolCreateAttributes, SessionResponseAttributes
 ):
     """Response attributes of live protocol session."""
+
     pass
 
 
@@ -166,7 +180,7 @@ RequestTypes = typing.Union[
     DeckCalibrationCreateAttributes,
     PipetteOffsetCalibrationCreateAttributes,
     ProtocolCreateAttributes,
-    LiveProtocolCreateAttributes
+    LiveProtocolCreateAttributes,
 ]
 
 
@@ -176,17 +190,11 @@ ResponseTypes = typing.Union[
     DeckCalibrationResponseAttributes,
     PipetteOffsetCalibrationResponseAttributes,
     ProtocolResponseAttributes,
-    LiveProtocolResponseAttributes
+    LiveProtocolResponseAttributes,
 ]
 
 
 # Session create and query requests/responses
-SessionCreateRequest = RequestModel[
-    RequestTypes
-]
-SessionResponse = ResponseModel[
-    ResponseTypes
-]
-MultiSessionResponse = MultiResponseModel[
-    ResponseTypes
-]
+SessionCreateRequest = RequestModel[RequestTypes]
+SessionResponse = ResponseModel[ResponseTypes]
+MultiSessionResponse = MultiResponseModel[ResponseTypes]

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -7,14 +7,16 @@ from robot_server.service.session.models.common import IdentifierType
 from robot_server.service.dependencies import get_session_manager
 from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.json_api import ResourceLink
-from robot_server.service.json_api.resource_links import ResourceLinkKey, \
-    ResourceLinks
+from robot_server.service.json_api.resource_links import ResourceLinkKey, ResourceLinks
 from robot_server.service.session.errors import CommandExecutionException
 from robot_server.service.session.manager import SessionManager, BaseSession
-from robot_server.service.session.models.command import CommandResponse,\
-    CommandRequest
-from robot_server.service.session.models.session import SessionResponse, \
-    SessionCreateRequest, MultiSessionResponse, SessionType
+from robot_server.service.session.models.command import CommandResponse, CommandRequest
+from robot_server.service.session.models.session import (
+    SessionResponse,
+    SessionCreateRequest,
+    MultiSessionResponse,
+    SessionType,
+)
 from robot_server.service.session.session_types import SessionMetaData
 
 
@@ -26,8 +28,7 @@ log = logging.getLogger(__name__)
 PATH_SESSION_BY_ID = "/sessions/{sessionId}"
 
 
-def get_session(manager: SessionManager,
-                session_id: IdentifierType) -> BaseSession:
+def get_session(manager: SessionManager, session_id: IdentifierType) -> BaseSession:
     """Get the session or raise a RobotServerError"""
     found_session = manager.get_by_id(session_id)
     if not found_session:
@@ -35,44 +36,46 @@ def get_session(manager: SessionManager,
         raise RobotServerError(
             definition=CommonErrorDef.RESOURCE_NOT_FOUND,
             links=get_sessions_links(),
-            resource='session',
-            id=session_id
+            resource="session",
+            id=session_id,
         )
     return found_session
 
 
-@router.post("/sessions",
-             description="Create a session",
-             response_model=SessionResponse,
-             status_code=http_status_codes.HTTP_201_CREATED)
+@router.post(
+    "/sessions",
+    description="Create a session",
+    response_model=SessionResponse,
+    status_code=http_status_codes.HTTP_201_CREATED,
+)
 async def create_session_handler(
-        create_request: SessionCreateRequest,
-        session_manager: SessionManager = Depends(get_session_manager)) \
-        -> SessionResponse:
+    create_request: SessionCreateRequest,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> SessionResponse:
     """Create a session"""
     session_type = create_request.data.sessionType
     create_params = create_request.data.createParams
 
     new_session = await session_manager.add(
         session_type=session_type,
-        session_meta_data=SessionMetaData(create_params=create_params))
+        session_meta_data=SessionMetaData(create_params=create_params),
+    )
 
     return SessionResponse(
         data=new_session.get_response_model(),
-        links=get_valid_session_links(new_session.meta.identifier, router)
+        links=get_valid_session_links(new_session.meta.identifier, router),
     )
 
 
-@router.delete(PATH_SESSION_BY_ID,
-               description="Delete a session",
-               response_model=SessionResponse)
+@router.delete(
+    PATH_SESSION_BY_ID, description="Delete a session", response_model=SessionResponse
+)
 async def delete_session_handler(
-        sessionId: IdentifierType,
-        session_manager: SessionManager = Depends(get_session_manager)) \
-        -> SessionResponse:
+    sessionId: IdentifierType,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> SessionResponse:
     """Delete a session"""
-    session_obj = get_session(manager=session_manager,
-                              session_id=sessionId)
+    session_obj = get_session(manager=session_manager, session_id=sessionId)
     await session_manager.remove(session_obj.meta.identifier)
 
     return SessionResponse(
@@ -81,31 +84,30 @@ async def delete_session_handler(
     )
 
 
-@router.get(PATH_SESSION_BY_ID,
-            description="Get session",
-            response_model=SessionResponse)
+@router.get(
+    PATH_SESSION_BY_ID, description="Get session", response_model=SessionResponse
+)
 async def get_session_handler(
-        sessionId: IdentifierType,
-        session_manager: SessionManager = Depends(get_session_manager))\
-        -> SessionResponse:
-    session_obj = get_session(manager=session_manager,
-                              session_id=sessionId)
+    sessionId: IdentifierType,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> SessionResponse:
+    session_obj = get_session(manager=session_manager, session_id=sessionId)
 
     return SessionResponse(
         data=session_obj.get_response_model(),
-        links=get_valid_session_links(sessionId, router)
+        links=get_valid_session_links(sessionId, router),
     )
 
 
-@router.get("/sessions",
-            description="Get all the sessions",
-            response_model=MultiSessionResponse)
+@router.get(
+    "/sessions", description="Get all the sessions", response_model=MultiSessionResponse
+)
 async def get_sessions_handler(
-        session_type: SessionType = Query(
-            None,
-            description="Will limit the results to only this session type"),
-        session_manager: SessionManager = Depends(get_session_manager)) \
-        -> MultiSessionResponse:
+    session_type: SessionType = Query(
+        None, description="Will limit the results to only this session type"
+    ),
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> MultiSessionResponse:
     """Get multiple sessions"""
     sessions = session_manager.get(session_type=session_type)
     return MultiSessionResponse(
@@ -113,52 +115,53 @@ async def get_sessions_handler(
     )
 
 
-@router.post(f"{PATH_SESSION_BY_ID}/commands/execute",
-             description="Create and execute a command immediately",
-             response_model=CommandResponse)
+@router.post(
+    f"{PATH_SESSION_BY_ID}/commands/execute",
+    description="Create and execute a command immediately",
+    response_model=CommandResponse,
+)
 async def session_command_execute_handler(
-        sessionId: IdentifierType,
-        command_request: CommandRequest,
-        session_manager: SessionManager = Depends(get_session_manager),
+    sessionId: IdentifierType,
+    command_request: CommandRequest,
+    session_manager: SessionManager = Depends(get_session_manager),
 ) -> CommandResponse:
     """
     Execute a session command
     """
-    session_obj = get_session(manager=session_manager,
-                              session_id=sessionId)
+    session_obj = get_session(manager=session_manager, session_id=sessionId)
     if not session_manager.is_active(session_obj.meta.identifier):
         raise CommandExecutionException(
             reason=f"Session '{sessionId}' is not active. "
-                   "Only the active session can execute commands")
+            "Only the active session can execute commands"
+        )
 
     command_result = await session_obj.execute_command(command_request.data)
 
     log.debug(f"Command result: {command_result}")
 
     return CommandResponse(
-        data=command_result,
-        links=get_valid_session_links(sessionId, router)
+        data=command_result, links=get_valid_session_links(sessionId, router)
     )
 
 
-ROOT_RESOURCE = ResourceLink(
-    href=router.url_path_for(get_sessions_handler.__name__)
-)
+ROOT_RESOURCE = ResourceLink(href=router.url_path_for(get_sessions_handler.__name__))
 SESSIONS_BY_ID_RESOURCE = ResourceLink(href=PATH_SESSION_BY_ID)
 
 
-def get_valid_session_links(session_id: IdentifierType,
-                            api_router: APIRouter) \
-        -> ResourceLinks:
+def get_valid_session_links(
+    session_id: IdentifierType, api_router: APIRouter
+) -> ResourceLinks:
     """Get the valid links for a session"""
     return {
-        ResourceLinkKey.self: ResourceLink(href=api_router.url_path_for(
-            get_session_handler.__name__,
-            sessionId=session_id)),
+        ResourceLinkKey.self: ResourceLink(
+            href=api_router.url_path_for(
+                get_session_handler.__name__, sessionId=session_id
+            )
+        ),
         ResourceLinkKey.session_command_execute: ResourceLink(
             href=api_router.url_path_for(
-                session_command_execute_handler.__name__,
-                sessionId=session_id)
+                session_command_execute_handler.__name__, sessionId=session_id
+            )
         ),
         ResourceLinkKey.sessions: ROOT_RESOURCE,
         ResourceLinkKey.session_by_id: SESSIONS_BY_ID_RESOURCE,

--- a/robot-server/robot_server/service/session/session_types/base_session.py
+++ b/robot-server/robot_server/service/session/session_types/base_session.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 
-from robot_server.service.session.models.common import (
-    IdentifierType, create_identifier)
-from robot_server.service.session.command_execution import CommandQueue, \
-    CommandExecutor, create_command
+from robot_server.service.session.models.common import IdentifierType, create_identifier
+from robot_server.service.session.command_execution import (
+    CommandQueue,
+    CommandExecutor,
+    create_command,
+)
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session.models import session as models
 from robot_server.service.session.models import command as command_models
@@ -18,18 +20,16 @@ class SessionMetaData:
     name: Optional[str] = None
     description: Optional[str] = None
     create_params: Optional[models.SessionCreateParamType] = None
-    identifier: IdentifierType = field(
-        default_factory=create_identifier
-    )
+    identifier: IdentifierType = field(default_factory=create_identifier)
     created_at: datetime = field(default_factory=utc_now)
 
 
 class BaseSession(ABC):
     """Base class of all sessions"""
 
-    def __init__(self,
-                 configuration: SessionConfiguration,
-                 instance_meta: SessionMetaData):
+    def __init__(
+        self, configuration: SessionConfiguration, instance_meta: SessionMetaData
+    ):
         """
         Constructor
 
@@ -40,9 +40,9 @@ class BaseSession(ABC):
         self._instance_meta = instance_meta
 
     @classmethod
-    async def create(cls,
-                     configuration: SessionConfiguration,
-                     instance_meta: SessionMetaData) -> 'BaseSession':
+    async def create(
+        cls, configuration: SessionConfiguration, instance_meta: SessionMetaData
+    ) -> "BaseSession":
         """
         Create a session object
 
@@ -51,8 +51,7 @@ class BaseSession(ABC):
         :return: A new session
         :raise SessionCreationException:
         """
-        return cls(configuration=configuration,
-                   instance_meta=instance_meta)
+        return cls(configuration=configuration, instance_meta=instance_meta)
 
     @abstractmethod
     def get_response_model(self) -> models.ResponseTypes:
@@ -63,8 +62,9 @@ class BaseSession(ABC):
         """Called before session is deleted"""
         pass
 
-    async def execute_command(self, command: command_models.RequestTypes) -> \
-            command_models.ResponseTypes:
+    async def execute_command(
+        self, command: command_models.RequestTypes
+    ) -> command_models.ResponseTypes:
         """Execute a command."""
         command_obj = create_command(command)
         command_result = await self.command_executor.execute(command_obj)
@@ -99,7 +99,6 @@ class BaseSession(ABC):
         pass
 
     def __str__(self) -> str:
-        return f"Session(" \
-               f"session_type={self.session_type}," \
-               f"meta={self.meta}," \
-               f")"
+        return (
+            f"Session(" f"session_type={self.session_type}," f"meta={self.meta}," f")"
+        )

--- a/robot-server/robot_server/service/session/session_types/check_session.py
+++ b/robot-server/robot_server/service/session/session_types/check_session.py
@@ -1,28 +1,40 @@
 from typing import Awaitable, cast, TYPE_CHECKING
 
-from robot_server.robot.calibration.check.user_flow import\
-    CheckCalibrationUserFlow
+from robot_server.robot.calibration.check.user_flow import CheckCalibrationUserFlow
 from robot_server.robot.calibration.check.models import (
-    ComparisonStatePerCalibration, ComparisonStatePerPipette,
-    CalibrationCheckSessionStatus, SessionCreateParams)
+    ComparisonStatePerCalibration,
+    ComparisonStatePerPipette,
+    CalibrationCheckSessionStatus,
+    SessionCreateParams,
+)
 from robot_server.robot.calibration.check import util
 
-from robot_server.service.session.command_execution import \
-    CommandQueue, CallableExecutor, Command, CompletedCommand
+from robot_server.service.session.command_execution import (
+    CommandQueue,
+    CallableExecutor,
+    Command,
+    CompletedCommand,
+)
 from robot_server.service.session.configuration import SessionConfiguration
-from robot_server.service.session.models.session import SessionType, \
-    CalibrationCheckResponseAttributes
-from robot_server.service.session.session_types.base_session \
-    import BaseSession, SessionMetaData
-from robot_server.service.session.errors import SessionCreationException, \
-    CommandExecutionException, UnsupportedFeature
+from robot_server.service.session.models.session import (
+    SessionType,
+    CalibrationCheckResponseAttributes,
+)
+from robot_server.service.session.session_types.base_session import (
+    BaseSession,
+    SessionMetaData,
+)
+from robot_server.service.session.errors import (
+    SessionCreationException,
+    CommandExecutionException,
+    UnsupportedFeature,
+)
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware import LabwareDefinition
 
 
 class CheckSessionCommandExecutor(CallableExecutor):
-
     async def execute(self, command: Command) -> CompletedCommand:
         try:
             return await super().execute(command)
@@ -31,12 +43,13 @@ class CheckSessionCommandExecutor(CallableExecutor):
 
 
 class CheckSession(BaseSession):
-
-    def __init__(self,
-                 configuration: SessionConfiguration,
-                 instance_meta: SessionMetaData,
-                 calibration_check: CheckCalibrationUserFlow,
-                 shutdown_handler: Awaitable[None] = None):
+    def __init__(
+        self,
+        configuration: SessionConfiguration,
+        instance_meta: SessionMetaData,
+        calibration_check: CheckCalibrationUserFlow,
+        shutdown_handler: Awaitable[None] = None,
+    ):
         super().__init__(configuration, instance_meta)
         self._calibration_check = calibration_check
         self._command_executor = CheckSessionCommandExecutor(
@@ -45,9 +58,9 @@ class CheckSession(BaseSession):
         self._shutdown_coroutine = shutdown_handler
 
     @classmethod
-    async def create(cls,
-                     configuration: SessionConfiguration,
-                     instance_meta: SessionMetaData) -> BaseSession:
+    async def create(
+        cls, configuration: SessionConfiguration, instance_meta: SessionMetaData
+    ) -> BaseSession:
         """Create an instance"""
         assert isinstance(instance_meta.create_params, SessionCreateParams)
         tip_racks = instance_meta.create_params.tipRacks
@@ -55,16 +68,15 @@ class CheckSession(BaseSession):
         # if lights are on already it's because the user clicked the button,
         # so a) we don't need to turn them on now and b) we shouldn't turn them
         # off after
-        session_controls_lights =\
-            not configuration.hardware.get_lights()['rails']
+        session_controls_lights = not configuration.hardware.get_lights()["rails"]
         await configuration.hardware.cache_instruments()
         await configuration.hardware.home()
         try:
             calibration_check = CheckCalibrationUserFlow(
                 configuration.hardware,
                 has_calibration_block=has_calibration_block,
-                tip_rack_defs=[
-                    cast('LabwareDefinition', rack) for rack in tip_racks])
+                tip_rack_defs=[cast("LabwareDefinition", rack) for rack in tip_racks],
+            )
         except AssertionError as e:
             raise SessionCreationException(str(e))
 
@@ -78,36 +90,38 @@ class CheckSession(BaseSession):
             configuration=configuration,
             instance_meta=instance_meta,
             calibration_check=calibration_check,
-            shutdown_handler=shutdown_handler)
+            shutdown_handler=shutdown_handler,
+        )
 
     def _map_to_pydantic_model(
-            self, comparison_map: util.ComparisonStatePerPipette
-            ) -> ComparisonStatePerPipette:
+        self, comparison_map: util.ComparisonStatePerPipette
+    ) -> ComparisonStatePerPipette:
         first = comparison_map.first
         second = comparison_map.second
         first_compmap = ComparisonStatePerCalibration(
             tipLength=first.tipLength,
             pipetteOffset=first.pipetteOffset,
-            deck=first.deck)
+            deck=first.deck,
+        )
         second_compmap = ComparisonStatePerCalibration(
             tipLength=second.tipLength,
             pipetteOffset=second.pipetteOffset,
-            deck=second.deck)
-        return ComparisonStatePerPipette(
-            first=first_compmap, second=second_compmap)
+            deck=second.deck,
+        )
+        return ComparisonStatePerPipette(first=first_compmap, second=second_compmap)
 
     def get_response_model(self) -> CalibrationCheckResponseAttributes:
         return CalibrationCheckResponseAttributes(
             id=self.meta.identifier,
-            createParams=cast(SessionCreateParams,
-                              self.meta.create_params),
+            createParams=cast(SessionCreateParams, self.meta.create_params),
             createdAt=self.meta.created_at,
-            details=self._get_response_details()
+            details=self._get_response_details(),
         )
 
     def _get_response_details(self) -> CalibrationCheckSessionStatus:
-        comparison_map =\
-            self._map_to_pydantic_model(self._calibration_check.comparison_map)
+        comparison_map = self._map_to_pydantic_model(
+            self._calibration_check.comparison_map
+        )
         return CalibrationCheckSessionStatus(
             instruments=self._calibration_check.get_instruments(),
             currentStep=self._calibration_check.current_state,
@@ -115,7 +129,7 @@ class CheckSession(BaseSession):
             labware=self._calibration_check.get_required_labware(),
             activePipette=self._calibration_check.get_active_pipette(),
             activeTipRack=self._calibration_check.get_active_tiprack(),
-            supportedCommands=self._calibration_check.supported_commands
+            supportedCommands=self._calibration_check.supported_commands,
         )
 
     @property

--- a/robot-server/robot_server/service/session/session_types/live_protocol/command_executor.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/command_executor.py
@@ -3,16 +3,16 @@ import logging
 from opentrons.protocol_engine import ProtocolEngine
 
 from robot_server.service.session.command_execution import (
-    CommandExecutor, Command, CompletedCommand)
+    CommandExecutor,
+    Command,
+    CompletedCommand,
+)
 
 log = logging.getLogger(__name__)
 
 
 class LiveProtocolCommandExecutor(CommandExecutor):
-
-    def __init__(
-            self,
-            protocol_engine: ProtocolEngine):
+    def __init__(self, protocol_engine: ProtocolEngine):
         self._protocol_engine = protocol_engine
 
     async def execute(self, command: Command) -> CompletedCommand:

--- a/robot-server/robot_server/service/session/session_types/live_protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/live_protocol/session.py
@@ -4,39 +4,38 @@ from opentrons import API
 from opentrons.protocol_engine import ProtocolEngine, create_protocol_engine
 
 from robot_server.service.session.models import session as models
-from robot_server.service.session.command_execution import CommandQueue, \
-    CommandExecutor
+from robot_server.service.session.command_execution import CommandQueue, CommandExecutor
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.session.models.common import EmptyModel
-from robot_server.service.session.session_types import BaseSession, \
-    SessionMetaData
-from robot_server.service.session.session_types.live_protocol.command_executor import LiveProtocolCommandExecutor    # noqa: E501
+from robot_server.service.session.session_types import BaseSession, SessionMetaData
+from robot_server.service.session.session_types.live_protocol.command_executor import (
+    LiveProtocolCommandExecutor,
+)
 
 
 class LiveProtocolSession(BaseSession):
-
-    def __init__(self,
-                 configuration: SessionConfiguration,
-                 instance_meta: SessionMetaData,
-                 protocol_engine: ProtocolEngine):
+    def __init__(
+        self,
+        configuration: SessionConfiguration,
+        instance_meta: SessionMetaData,
+        protocol_engine: ProtocolEngine,
+    ):
         """Constructor"""
         super(self.__class__, self).__init__(configuration, instance_meta)
 
-        self._executor = LiveProtocolCommandExecutor(
-            protocol_engine=protocol_engine
-        )
+        self._executor = LiveProtocolCommandExecutor(protocol_engine=protocol_engine)
 
     @classmethod
-    async def create(cls,
-                     configuration: SessionConfiguration,
-                     instance_meta: SessionMetaData) -> 'LiveProtocolSession':
+    async def create(
+        cls, configuration: SessionConfiguration, instance_meta: SessionMetaData
+    ) -> "LiveProtocolSession":
         return LiveProtocolSession(
             configuration=configuration,
             instance_meta=instance_meta,
             protocol_engine=await create_protocol_engine(
                 # Cast the ThreadManager to the wrapped API object.
                 cast(API, configuration.hardware)
-            )
+            ),
         )
 
     @property
@@ -56,5 +55,5 @@ class LiveProtocolSession(BaseSession):
             id=self.meta.identifier,
             createdAt=self.meta.created_at,
             createParams=self.meta.create_params,
-            details=EmptyModel()
+            details=EmptyModel(),
         )

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/protocol_runner.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class CancelledException(Exception):
     """Exception raised when a simulation or run is cancelled"""
+
     pass
 
 
@@ -31,12 +32,13 @@ class ProtocolRunner:
     Protocols are run and simulated synchronously. A listener callback can
     be provided for inspecting and control flow of the protocol execution."""
 
-    def __init__(self,
-                 protocol: UploadedProtocol,
-                 loop: asyncio.AbstractEventLoop,
-                 hardware: ThreadManager,
-                 motion_lock: ThreadedAsyncLock,
-                 ):
+    def __init__(
+        self,
+        protocol: UploadedProtocol,
+        loop: asyncio.AbstractEventLoop,
+        hardware: ThreadManager,
+        motion_lock: ThreadedAsyncLock,
+    ):
         """Constructor"""
         self._protocol = protocol
         self._loop = loop
@@ -66,7 +68,8 @@ class ProtocolRunner:
                 loop=self._loop,
                 broker=self._broker,
                 motion_lock=self._motion_lock,
-                extra_labware=list(self._protocol.get_custom_labware().values()))
+                extra_labware=list(self._protocol.get_custom_labware().values()),
+            )
 
     def run(self):
         """Run the protocol"""

--- a/robot-server/robot_server/service/session/session_types/protocol/execution/worker.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/execution/worker.py
@@ -3,14 +3,16 @@ import logging
 import typing
 from enum import Enum, auto
 
-from robot_server.service.session.session_types.protocol.\
-    execution.protocol_runner import ProtocolRunner
+from robot_server.service.session.session_types.protocol.execution.protocol_runner import (  # noqa: E501
+    ProtocolRunner,
+)
 
 log = logging.getLogger(__name__)
 
 
 class WorkerDirective(int, Enum):
     """Direction for the worker task"""
+
     none = auto()
     # End the task. This is used for cleanup.
     terminate = auto()
@@ -25,10 +27,13 @@ class _Worker:
     A private class used by ProtocolCommandExecutor to handle protocol session
      commands. It manages a ProtocolRunner's behavior in an asyncio task.
     """
-    def __init__(self,
-                 protocol_runner: ProtocolRunner,
-                 listener: 'WorkerListener',
-                 loop: asyncio.AbstractEventLoop):
+
+    def __init__(
+        self,
+        protocol_runner: ProtocolRunner,
+        listener: "WorkerListener",
+        loop: asyncio.AbstractEventLoop,
+    ):
         """Constructor the command handling worker"""
         self._protocol_runner = protocol_runner
         self._protocol_runner.add_listener(self._on_command)
@@ -117,13 +122,12 @@ class _Worker:
         """ProtocolRunner command listener"""
         # Notify command on main thread
         asyncio.run_coroutine_threadsafe(
-            self._listener.on_protocol_event(msg),
-            self._loop
+            self._listener.on_protocol_event(msg), self._loop
         )
 
 
 class WorkerListener:
-    async def on_directive(self, directive: 'WorkerDirective'):
+    async def on_directive(self, directive: "WorkerDirective"):
         """Called when worker has a new directive"""
         pass
 

--- a/robot-server/robot_server/service/session/session_types/protocol/models.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/models.py
@@ -12,10 +12,9 @@ class EventSource(str, Enum):
 
 class ProtocolSessionEvent(BaseModel):
     """An event occurring during a protocol session"""
-    source: EventSource = \
-        Field(..., description="Initiator of this event")
-    event: str = \
-        Field(..., description="The event that occurred")
+
+    source: EventSource = Field(..., description="Initiator of this event")
+    event: str = Field(..., description="The event that occurred")
     timestamp: datetime
     commandId: typing.Optional[str] = None
     params: typing.Optional[typing.Dict[str, typing.Any]] = None
@@ -23,13 +22,11 @@ class ProtocolSessionEvent(BaseModel):
 
 
 class ProtocolSessionDetails(BaseModel):
-    protocolId: str = \
-        Field(...,
-              description="The protocol used by this session")
+    protocolId: str = Field(..., description="The protocol used by this session")
     currentState: typing.Optional[str]
-    events: typing.List[ProtocolSessionEvent] =\
-        Field(...,
-              description="The events that have occurred thus far")
+    events: typing.List[ProtocolSessionEvent] = Field(
+        ..., description="The events that have occurred thus far"
+    )
 
 
 class ProtocolCreateParams(BaseModel):

--- a/robot-server/robot_server/service/session/session_types/protocol/session.py
+++ b/robot-server/robot_server/service/session/session_types/protocol/session.py
@@ -3,50 +3,53 @@ from typing import cast
 
 from opentrons.config.feature_flags import enable_http_protocol_sessions
 
-from robot_server.service.session.errors import UnsupportedFeature, \
-    SessionCreationException
-from robot_server.service.session.models.session import SessionType, \
-    ProtocolResponseAttributes
-from robot_server.service.session.session_types import BaseSession, \
-    SessionMetaData
-from robot_server.service.session.command_execution import CommandQueue,\
-    CommandExecutor
+from robot_server.service.session.errors import (
+    UnsupportedFeature,
+    SessionCreationException,
+)
+from robot_server.service.session.models.session import (
+    SessionType,
+    ProtocolResponseAttributes,
+)
+from robot_server.service.session.session_types import BaseSession, SessionMetaData
+from robot_server.service.session.command_execution import CommandQueue, CommandExecutor
 from robot_server.service.session.configuration import SessionConfiguration
 from robot_server.service.protocol.protocol import UploadedProtocol
-from robot_server.service.session.session_types.protocol.execution.\
-    command_executor import ProtocolCommandExecutor
-from robot_server.service.session.session_types.protocol.models import \
-    ProtocolSessionDetails, ProtocolCreateParams
+from robot_server.service.session.session_types.protocol.execution.command_executor import (  # noqa: E501
+    ProtocolCommandExecutor,
+)
+from robot_server.service.session.session_types.protocol.models import (
+    ProtocolSessionDetails,
+    ProtocolCreateParams,
+)
 
 log = logging.getLogger(__name__)
 
 
 class ProtocolSession(BaseSession):
-
-    def __init__(self,
-                 configuration: SessionConfiguration,
-                 instance_meta: SessionMetaData,
-                 protocol: UploadedProtocol):
+    def __init__(
+        self,
+        configuration: SessionConfiguration,
+        instance_meta: SessionMetaData,
+        protocol: UploadedProtocol,
+    ):
         """Constructor"""
         super().__init__(configuration, instance_meta)
         self._uploaded_protocol = protocol
         self._command_executor = ProtocolCommandExecutor(
-            protocol=self._uploaded_protocol,
-            configuration=configuration
+            protocol=self._uploaded_protocol, configuration=configuration
         )
 
     @classmethod
-    async def create(cls, configuration: SessionConfiguration,
-                     instance_meta: SessionMetaData) -> 'BaseSession':
+    async def create(
+        cls, configuration: SessionConfiguration, instance_meta: SessionMetaData
+    ) -> "BaseSession":
         """Try to create the protocol session"""
         if not enable_http_protocol_sessions():
-            raise SessionCreationException(
-                "HTTP Protocol Session feature is disabled")
+            raise SessionCreationException("HTTP Protocol Session feature is disabled")
 
         protocol = configuration.protocol_manager.get(
-            cast(
-                ProtocolCreateParams,
-                instance_meta.create_params).protocolId
+            cast(ProtocolCreateParams, instance_meta.create_params).protocolId
         )
         return cls(configuration, instance_meta, protocol)
 
@@ -58,8 +61,8 @@ class ProtocolSession(BaseSession):
             details=ProtocolSessionDetails(
                 protocolId=self._uploaded_protocol.data.identifier,
                 currentState=self._command_executor.current_state,
-                events=self._command_executor.events
-            )
+                events=self._command_executor.events,
+            ),
         )
 
     @property

--- a/robot-server/robot_server/service/shared_models/calibration.py
+++ b/robot-server/robot_server/service/shared_models/calibration.py
@@ -10,9 +10,11 @@ class CalibrationStatus(BaseModel):
     A model describing whether a calibration on the robot is valid
     or not. This should be used for all calibration data models.
     """
-    markedBad: bool = \
-        Field(..., description="Whether a calibration is invalid or not")
-    source: typing.Optional[SourceType] = \
-        Field(None, description="The source that marked the calibration bad.")
-    markedAt: typing.Optional[datetime] = \
-        Field(None, description="The time the calibration was marked bad.")
+
+    markedBad: bool = Field(..., description="Whether a calibration is invalid or not")
+    source: typing.Optional[SourceType] = Field(
+        None, description="The source that marked the calibration bad."
+    )
+    markedAt: typing.Optional[datetime] = Field(
+        None, description="The time the calibration was marked bad."
+    )

--- a/robot-server/robot_server/service/tip_length/models.py
+++ b/robot-server/robot_server/service/tip_length/models.py
@@ -4,7 +4,10 @@ from pydantic import Field
 
 from opentrons.calibration_storage.types import SourceType
 from robot_server.service.json_api import (
-    ResponseModel, MultiResponseModel, ResponseDataModel)
+    ResponseModel,
+    MultiResponseModel,
+    ResponseDataModel,
+)
 from robot_server.service.shared_models import calibration as cal_model
 
 
@@ -12,26 +15,20 @@ class TipLengthCalibration(ResponseDataModel):
     """
     A model describing tip length calibration
     """
-    tipLength: float = \
-        Field(..., description="The tip length value in mm")
-    tiprack: str = \
-        Field(..., description="The sha256 hash of the tiprack")
-    pipette: str = \
-        Field(..., description="The pipette ID")
-    lastModified: datetime = \
-        Field(..., description="When this calibration was last modified")
-    source: SourceType = \
-        Field(..., description="The calibration source")
-    status: cal_model.CalibrationStatus = \
-        Field(..., description="The status of this calibration")
-    uri: str = \
-        Field(..., description="The uri of the tiprack")
+
+    tipLength: float = Field(..., description="The tip length value in mm")
+    tiprack: str = Field(..., description="The sha256 hash of the tiprack")
+    pipette: str = Field(..., description="The pipette ID")
+    lastModified: datetime = Field(
+        ..., description="When this calibration was last modified"
+    )
+    source: SourceType = Field(..., description="The calibration source")
+    status: cal_model.CalibrationStatus = Field(
+        ..., description="The status of this calibration"
+    )
+    uri: str = Field(..., description="The uri of the tiprack")
 
 
-MultipleCalibrationsResponse = MultiResponseModel[
-    TipLengthCalibration
-]
+MultipleCalibrationsResponse = MultiResponseModel[TipLengthCalibration]
 
-SingleCalibrationResponse = ResponseModel[
-    TipLengthCalibration
-]
+SingleCalibrationResponse = ResponseModel[TipLengthCalibration]

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -5,7 +5,8 @@ from opentrons.calibration_storage import (
     types as cal_types,
     get as get_cal,
     helpers,
-    delete)
+    delete,
+)
 
 from robot_server.errors import ErrorResponse
 from robot_server.service.tip_length import models as tl_models
@@ -17,19 +18,19 @@ router = APIRouter()
 
 
 def _format_calibration(
-    calibration: cal_types.TipLengthCalibration
+    calibration: cal_types.TipLengthCalibration,
 ) -> tl_models.TipLengthCalibration:
-    status = cal_model.CalibrationStatus(
-        **helpers.convert_to_dict(calibration.status))
+    status = cal_model.CalibrationStatus(**helpers.convert_to_dict(calibration.status))
     formatted_cal = tl_models.TipLengthCalibration(
-        id=f'{calibration.tiprack}&{calibration.pipette}',
+        id=f"{calibration.tiprack}&{calibration.pipette}",
         tipLength=calibration.tip_length,
         tiprack=calibration.tiprack,
         pipette=calibration.pipette,
         lastModified=calibration.last_modified,
         source=calibration.source,
         status=status,
-        uri=calibration.uri)
+        uri=calibration.uri,
+    )
 
     return formatted_cal
 
@@ -38,11 +39,10 @@ def _format_calibration(
     "/calibration/tip_length",
     description="Fetch all saved tip length calibrations from the robot",
     summary="Search the robot for any saved tip length calibration",
-    response_model=tl_models.MultipleCalibrationsResponse)
+    response_model=tl_models.MultipleCalibrationsResponse,
+)
 async def get_all_tip_length_calibrations(
-    tiprack_hash: str = None,
-    pipette_id: str = None,
-    tiprack_uri: str = None
+    tiprack_hash: str = None, pipette_id: str = None, tiprack_uri: str = None
 ) -> tl_models.MultipleCalibrationsResponse:
     all_calibrations = get_cal.get_all_tip_length_calibrations()
 
@@ -52,14 +52,17 @@ async def get_all_tip_length_calibrations(
         )
 
     if tiprack_hash:
-        all_calibrations = list(filter(
-            lambda cal: cal.tiprack == tiprack_hash, all_calibrations))
+        all_calibrations = list(
+            filter(lambda cal: cal.tiprack == tiprack_hash, all_calibrations)
+        )
     if pipette_id:
-        all_calibrations = list(filter(
-            lambda cal: cal.pipette == pipette_id, all_calibrations))
+        all_calibrations = list(
+            filter(lambda cal: cal.pipette == pipette_id, all_calibrations)
+        )
     if tiprack_uri:
-        all_calibrations = list(filter(
-            lambda cal: cal.uri == tiprack_uri, all_calibrations))
+        all_calibrations = list(
+            filter(lambda cal: cal.uri == tiprack_uri, all_calibrations)
+        )
 
     calibrations = [_format_calibration(cal) for cal in all_calibrations]
     return tl_models.MultipleCalibrationsResponse(data=calibrations)
@@ -68,13 +71,15 @@ async def get_all_tip_length_calibrations(
 @router.delete(
     "/calibration/tip_length",
     description="Delete one specific tip length calibration by pipette "
-                "serial and tiprack hash",
-    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}})
-async def delete_specific_tip_length_calibration(
-        tiprack_hash: str, pipette_id: str):
+    "serial and tiprack hash",
+    responses={status.HTTP_404_NOT_FOUND: {"model": ErrorResponse}},
+)
+async def delete_specific_tip_length_calibration(tiprack_hash: str, pipette_id: str):
     try:
         delete.delete_tip_length_calibration(tiprack_hash, pipette_id)
     except FileNotFoundError:
-        raise RobotServerError(definition=CommonErrorDef.RESOURCE_NOT_FOUND,
-                               resource='TipLengthCalibration',
-                               id=f"{tiprack_hash}&{pipette_id}")
+        raise RobotServerError(
+            definition=CommonErrorDef.RESOURCE_NOT_FOUND,
+            resource="TipLengthCalibration",
+            id=f"{tiprack_hash}&{pipette_id}",
+        )

--- a/robot-server/robot_server/settings.py
+++ b/robot-server/robot_server/settings.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
-def get_settings() -> 'RobotServerSettings':
+def get_settings() -> "RobotServerSettings":
     """Get the settings"""
     load_dotenv(get_dotenv_path())
     return RobotServerSettings()
@@ -25,7 +25,8 @@ def get_dotenv_path() -> Path:
 
 class Environment(BaseSettings):
     """Environment related settings"""
-    dot_env_path: Path = infer_config_base_dir() / 'robot.env'
+
+    dot_env_path: Path = infer_config_base_dir() / "robot.env"
 
     class Config:
         env_prefix = "OT_ROBOT_SERVER_"
@@ -38,33 +39,34 @@ class RobotServerSettings(BaseSettings):
     To override any of these create an environment variable with prefix
     OT_ROBOT_SERVER_.
     """
+
     ws_host_name: str = Field(
         "localhost",
         description="TCP/IP hostname to serve on. Will be ignored if domain "
-                    "socket is defined.")
+        "socket is defined.",
+    )
     ws_port: int = Field(
         31950,
         description="TCP/IP port to serve on. Will be ignored if domain socket"
-                    " is defined.")
+        " is defined.",
+    )
     ws_domain_socket: typing.Optional[str] = Field(
         "/run/aiohttp.sock",
         description="Unix file system path to serve on. This value supersedes"
-                    " the port and host name settings."
+        " the port and host name settings.",
     )
     simulator_configuration_file_path: str = Field(
         None,
-        description="Path to a json file that describes the hardware"
-                    " simulator."
+        description="Path to a json file that describes the hardware" " simulator.",
     )
 
     protocol_manager_max_protocols: int = Field(
-        1,
-        description="The maximum number of protocols allowed for upload"
+        1, description="The maximum number of protocols allowed for upload"
     )
 
     notification_server_subscriber_address: str = Field(
         "tcp://localhost:5555",
-        description="The endpoint to subscribe to notification server topics."
+        description="The endpoint to subscribe to notification server topics.",
     )
 
     class Config:

--- a/robot-server/robot_server/system/errors.py
+++ b/robot-server/robot_server/system/errors.py
@@ -8,6 +8,7 @@ from robot_server.service.errors import (
 
 class SystemException(RobotServerError):
     """Base of all system exceptions."""
+
     pass
 
 

--- a/robot-server/robot_server/system/models.py
+++ b/robot-server/robot_server/system/models.py
@@ -2,15 +2,12 @@
 from datetime import datetime
 from pydantic import BaseModel
 
-from robot_server.service.json_api import (
-    ResponseModel,
-    ResponseDataModel,
-    RequestModel
-)
+from robot_server.service.json_api import ResponseModel, ResponseDataModel, RequestModel
 
 
 class SystemTimeAttributes(BaseModel):
     """System time attributes common to requests and responses."""
+
     systemTime: datetime
 
 

--- a/robot-server/robot_server/system/router.py
+++ b/robot-server/robot_server/system/router.py
@@ -21,7 +21,7 @@ def _create_time_response(dt: datetime) -> SystemTimeResponse:
     """Create a SystemTimeResponse from a datetime."""
     return SystemTimeResponse(
         data=SystemTimeResponseAttributes(id="time", systemTime=dt),
-        links={ResourceLinkKey.self: ResourceLink(href='/system/time')}
+        links={ResourceLinkKey.self: ResourceLink(href="/system/time")},
     )
 
 
@@ -33,7 +33,7 @@ def _create_time_response(dt: datetime) -> SystemTimeResponse:
         "date & time, local timezone, whether robot time is "
         "synced with an NTP server &/or it has an active RTC."
     ),
-    response_model=SystemTimeResponse
+    response_model=SystemTimeResponse,
 )
 async def get_time() -> SystemTimeResponse:
     """Get the robot's system time."""
@@ -45,7 +45,7 @@ async def get_time() -> SystemTimeResponse:
     "/system/time",
     description="Update system time",
     summary="Set robot time",
-    response_model=SystemTimeResponse
+    response_model=SystemTimeResponse,
 )
 async def set_time(new_time: SystemTimeRequest) -> SystemTimeResponse:
     """Set the robot's system time."""

--- a/robot-server/scripts/plot_session.py
+++ b/robot-server/scripts/plot_session.py
@@ -5,50 +5,53 @@ import graphviz as gv
 import robot_server.service.session.session_types
 from robot_server.robot.calibration.check.session import (
     CalibrationCheckState,
-    CHECK_TRANSITIONS
+    CHECK_TRANSITIONS,
 )
-from robot_server.robot.calibration.tip_length.constants import (
-    TipCalibrationState)
+from robot_server.robot.calibration.tip_length.constants import TipCalibrationState
 from robot_server.robot.calibration.tip_length.state_machine import (
-    TipCalibrationStateMachine)
-from robot_server.robot.calibration.deck.constants import (
-    DeckCalibrationState)
+    TipCalibrationStateMachine,
+)
+from robot_server.robot.calibration.deck.constants import DeckCalibrationState
 from robot_server.robot.calibration.deck.state_machine import (
-    DeckCalibrationStateMachine)
+    DeckCalibrationStateMachine,
+)
 from robot_server.robot.calibration.pipette_offset.constants import (
-    PipetteOffsetCalibrationState)
+    PipetteOffsetCalibrationState,
+)
 from robot_server.robot.calibration.pipette_offset.state_machine import (
-    PipetteOffsetCalibrationStateMachine)
+    PipetteOffsetCalibrationStateMachine,
+)
 
 
 def build_calibration_check_plot(
-        wildcard_separate: bool,
-        plot_actions: bool) -> gv.Digraph:
-    d = gv.Digraph('Calibration Check Session')
+    wildcard_separate: bool, plot_actions: bool
+) -> gv.Digraph:
+    d = gv.Digraph("Calibration Check Session")
     for state in CalibrationCheckState:
         d.node(state.name, state.value)
     all_states = [s.name for s in CalibrationCheckState]
     if wildcard_separate:
-        d.node('*', 'wildcard')
+        d.node("*", "wildcard")
     for edgespec in CHECK_TRANSITIONS:
-        fs = edgespec['from_state']
+        fs = edgespec["from_state"]
         if isinstance(fs, CalibrationCheckState):
             fs_s = [fs.name]
         elif wildcard_separate:
             fs_s = [fs]
         else:
             fs_s = all_states
-        ts = edgespec['to_state']
+        ts = edgespec["to_state"]
 
         kws: Dict[str, str] = {}
         if plot_actions:
-            if edgespec.get('before'):
-                kws['before'] = edgespec['before']
-            if edgespec.get('after'):
-                kws['after'] = edgespec['after']
-        label = r'\n'.join([edgespec['trigger'].name]
-                           + [rf'{k}: {v}' for k, v in kws.items()])
-        if edgespec.get('condition'):
+            if edgespec.get("before"):
+                kws["before"] = edgespec["before"]
+            if edgespec.get("after"):
+                kws["after"] = edgespec["after"]
+        label = r"\n".join(
+            [edgespec["trigger"].name] + [rf"{k}: {v}" for k, v in kws.items()]
+        )
+        if edgespec.get("condition"):
             label += rf'\ncondition: {edgespec["condition"]}'
         for f in fs_s:
             d.edge(f, ts, label=label)
@@ -56,34 +59,32 @@ def build_calibration_check_plot(
 
 
 def build_tip_length_calibration_plot(
-        wildcard_separate: bool,
-        plot_actions: bool) -> gv.Digraph:
-    d = gv.Digraph('Tip Length Calibration Session')
+    wildcard_separate: bool, plot_actions: bool
+) -> gv.Digraph:
+    d = gv.Digraph("Tip Length Calibration Session")
 
     tip_cal = TipCalibrationStateMachine()
     for state in tip_cal._state_machine._states:
-        d.node(state.name,  state.value)
+        d.node(state.name, state.value)
 
     uniq_edge_map = {}
-    for from_state, to_states_by_command in \
-            tip_cal._state_machine._transitions.items():
-        if from_state == TipCalibrationState.WILDCARD and \
-                not wildcard_separate:
+    for from_state, to_states_by_command in tip_cal._state_machine._transitions.items():
+        if from_state == TipCalibrationState.WILDCARD and not wildcard_separate:
             all_states = (s.name for s in TipCalibrationState)
             for s in all_states:
                 d.edge(from_state.name, s.name)
         else:
             for command, ts in to_states_by_command.items():
-                edge_key = f'{from_state.name}->{ts.name}'
-                existing_edge = uniq_edge_map.get(
-                        f'{from_state.name}->{ts.name}', None)
+                edge_key = f"{from_state.name}->{ts.name}"
+                existing_edge = uniq_edge_map.get(f"{from_state.name}->{ts.name}", None)
                 if existing_edge:
-                    uniq_edge_map[edge_key] = \
-                        (existing_edge[0], existing_edge[1],
-                         f'{existing_edge[2]} | {command.name}')
+                    uniq_edge_map[edge_key] = (
+                        existing_edge[0],
+                        existing_edge[1],
+                        f"{existing_edge[2]} | {command.name}",
+                    )
                 else:
-                    uniq_edge_map[edge_key] = (from_state.name, ts.name,
-                                               command.name)
+                    uniq_edge_map[edge_key] = (from_state.name, ts.name, command.name)
     for k, v in uniq_edge_map.items():
         fs, ts, c = v
         d.edge(fs, ts, label=c)
@@ -91,34 +92,35 @@ def build_tip_length_calibration_plot(
 
 
 def build_deck_calibration_plot(
-        wildcard_separate: bool,
-        plot_actions: bool) -> gv.Digraph:
-    d = gv.Digraph('Deck Calibration Session')
+    wildcard_separate: bool, plot_actions: bool
+) -> gv.Digraph:
+    d = gv.Digraph("Deck Calibration Session")
 
     deck_cal = DeckCalibrationStateMachine()
     for state in deck_cal._state_machine._states:
-        d.node(state.name,  state.value)
+        d.node(state.name, state.value)
 
     uniq_edge_map = {}
-    for from_state, to_states_by_command in \
-            deck_cal._state_machine._transitions.items():
-        if from_state == DeckCalibrationState.WILDCARD and \
-                not wildcard_separate:
+    for (
+        from_state,
+        to_states_by_command,
+    ) in deck_cal._state_machine._transitions.items():
+        if from_state == DeckCalibrationState.WILDCARD and not wildcard_separate:
             all_states = (s.name for s in DeckCalibrationState)
             for s in all_states:
                 d.edge(from_state.name, s.name)
         else:
             for command, ts in to_states_by_command.items():
-                edge_key = f'{from_state.name}->{ts.name}'
-                existing_edge = uniq_edge_map.get(
-                        f'{from_state.name}->{ts.name}', None)
+                edge_key = f"{from_state.name}->{ts.name}"
+                existing_edge = uniq_edge_map.get(f"{from_state.name}->{ts.name}", None)
                 if existing_edge:
-                    uniq_edge_map[edge_key] = \
-                        (existing_edge[0], existing_edge[1],
-                         f'{existing_edge[2]} | {command.name}')
+                    uniq_edge_map[edge_key] = (
+                        existing_edge[0],
+                        existing_edge[1],
+                        f"{existing_edge[2]} | {command.name}",
+                    )
                 else:
-                    uniq_edge_map[edge_key] = (from_state.name, ts.name,
-                                               command.name)
+                    uniq_edge_map[edge_key] = (from_state.name, ts.name, command.name)
     for k, v in uniq_edge_map.items():
         fs, ts, c = v
         d.edge(fs, ts, label=c)
@@ -126,92 +128,102 @@ def build_deck_calibration_plot(
 
 
 def build_pipette_offset_calibration_plot(
-        wildcard_separate: bool,
-        plot_actions: bool) -> gv.Digraph:
-    d = gv.Digraph('Pipette Offset Calibration Session')
+    wildcard_separate: bool, plot_actions: bool
+) -> gv.Digraph:
+    d = gv.Digraph("Pipette Offset Calibration Session")
 
     pip_offset_cal = PipetteOffsetCalibrationStateMachine()
     for state in pip_offset_cal._state_machine._states:
-        d.node(state.name,  state.value)
+        d.node(state.name, state.value)
 
     uniq_edge_map = {}
-    for from_state, to_states_by_command in \
-            pip_offset_cal._state_machine._transitions.items():
-        if from_state == PipetteOffsetCalibrationState.WILDCARD and \
-                not wildcard_separate:
+    for (
+        from_state,
+        to_states_by_command,
+    ) in pip_offset_cal._state_machine._transitions.items():
+        if (
+            from_state == PipetteOffsetCalibrationState.WILDCARD
+            and not wildcard_separate
+        ):
             all_states = (s.name for s in PipetteOffsetCalibrationState)
             for s in all_states:
                 d.edge(from_state.name, s.name)
         else:
             for command, ts in to_states_by_command.items():
-                edge_key = f'{from_state.name}->{ts.name}'
-                existing_edge = uniq_edge_map.get(
-                        f'{from_state.name}->{ts.name}', None)
+                edge_key = f"{from_state.name}->{ts.name}"
+                existing_edge = uniq_edge_map.get(f"{from_state.name}->{ts.name}", None)
                 if existing_edge:
-                    uniq_edge_map[edge_key] = \
-                        (existing_edge[0], existing_edge[1],
-                         f'{existing_edge[2]} | {command.name}')
+                    uniq_edge_map[edge_key] = (
+                        existing_edge[0],
+                        existing_edge[1],
+                        f"{existing_edge[2]} | {command.name}",
+                    )
                 else:
-                    uniq_edge_map[edge_key] = (from_state.name, ts.name,
-                                               command.name)
+                    uniq_edge_map[edge_key] = (from_state.name, ts.name, command.name)
     for k, v in uniq_edge_map.items():
         fs, ts, c = v
         d.edge(fs, ts, label=c)
     return d
 
 
-def build_argparser(
-        parent: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
+def build_argparser(parent: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
     if not parent:
-        parent = argparse.ArgumentParser(
-            description='Build plots of sessions')
-    parent.add_argument('session', metavar='SESSION',
-                        choices=['calibration_check',
-                                 'tip_length_calibration'
-                                 'deck_calibration',
-                                 'pipette_offset_calibration'],
-                        help='The session to check')
-    parent.add_argument('output', metavar='OUTFILE',
-                        type=argparse.FileType('wb'),
-                        default='session.pdf',
-                        nargs='?',
-                        help='Where to store the file')
+        parent = argparse.ArgumentParser(description="Build plots of sessions")
     parent.add_argument(
-        '-w', '--wildcard-integrated',
-        action='store_true',
-        help='Integrate wildcard-based edges into the graph. This will give '
-             'a better idea of the true shape but can be very hard to read.')
-    parent.add_argument(
-        '-a', '--actions',
-        action='store_true',
-        help='Add labels for before/after actions to edges'
+        "session",
+        metavar="SESSION",
+        choices=[
+            "calibration_check",
+            "tip_length_calibration" "deck_calibration",
+            "pipette_offset_calibration",
+        ],
+        help="The session to check",
     )
     parent.add_argument(
-        '-f', '--format',
+        "output",
+        metavar="OUTFILE",
+        type=argparse.FileType("wb"),
+        default="session.pdf",
+        nargs="?",
+        help="Where to store the file",
+    )
+    parent.add_argument(
+        "-w",
+        "--wildcard-integrated",
+        action="store_true",
+        help="Integrate wildcard-based edges into the graph. This will give "
+        "a better idea of the true shape but can be very hard to read.",
+    )
+    parent.add_argument(
+        "-a",
+        "--actions",
+        action="store_true",
+        help="Add labels for before/after actions to edges",
+    )
+    parent.add_argument(
+        "-f",
+        "--format",
         type=str,
-        default='pdf',
-        help='Select output format (one of https://www.graphviz.org/doc/info/output.html)')
+        default="pdf",
+        help="Select output format (one of https://www.graphviz.org/doc/info/output.html)",
+    )
     return parent
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = build_argparser()
     args = parser.parse_args()
-    if args.session == 'calibration_check':
-        graph = build_calibration_check_plot(
-            not args.wildcard_integrated,
-            args.actions)
-    elif args.session == 'tip_length_calibration':
+    if args.session == "calibration_check":
+        graph = build_calibration_check_plot(not args.wildcard_integrated, args.actions)
+    elif args.session == "tip_length_calibration":
         graph = build_tip_length_calibration_plot(
-            not args.wildcard_integrated,
-            args.actions)
-    elif args.session == 'deck_calibration':
-        graph = build_deck_calibration_plot(
-            not args.wildcard_integrated,
-            args.actions)
-    elif args.session == 'pipette_offset_calibration':
+            not args.wildcard_integrated, args.actions
+        )
+    elif args.session == "deck_calibration":
+        graph = build_deck_calibration_plot(not args.wildcard_integrated, args.actions)
+    elif args.session == "pipette_offset_calibration":
         graph = build_pipette_offset_calibration_plot(
-            not args.wildcard_integrated,
-            args.actions)
+            not args.wildcard_integrated, args.actions
+        )
     graph.format = args.format
     args.output.write(graph.pipe())

--- a/robot-server/scripts/settings_schema.py
+++ b/robot-server/scripts/settings_schema.py
@@ -3,6 +3,6 @@
 from sys import argv
 from robot_server.settings import RobotServerSettings
 
-if __name__ == '__main__':
-    with open(argv[1], 'w') as f:
+if __name__ == "__main__":
+    with open(argv[1], "w") as f:
         f.write(RobotServerSettings.schema_json(indent=2))

--- a/robot-server/setup.py
+++ b/robot-server/setup.py
@@ -7,56 +7,56 @@ import os.path
 from setuptools import setup, find_packages
 
 # make stdout blocking since Travis sets it to nonblocking
-if os.name == 'posix':
+if os.name == "posix":
     import fcntl
+
     flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL)
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(os.path.join(HERE, '..', 'scripts'))
+sys.path.append(os.path.join(HERE, "..", "scripts"))
 
 from python_build_utils import normalize_version  # noqa: E402
 
 
 def get_version():
-    buildno = os.getenv('BUILD_NUMBER')
+    buildno = os.getenv("BUILD_NUMBER")
     if buildno:
-        normalize_opts = {'extra_tag': buildno}
+        normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version('robot-server', **normalize_opts)
+    return normalize_version("robot-server", **normalize_opts)
 
 
 VERSION = get_version()
 
-DISTNAME = 'robotserver'
-LICENSE = 'Apache 2.0'
+DISTNAME = "robotserver"
+LICENSE = "Apache 2.0"
 AUTHOR = "Opentrons"
 EMAIL = "engineering@opentrons.com"
 URL = "https://github.com/Opentrons/opentrons"
-DOWNLOAD_URL = ''
+DOWNLOAD_URL = ""
 CLASSIFIERS = [
-    'Development Status :: 5 - Production/Stable',
-    'Environment :: Console',
-    'Operating System :: OS Independent',
-    'Intended Audience :: Science/Research',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Topic :: Scientific/Engineering',
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Scientific/Engineering",
 ]
 KEYWORDS = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
-DESCRIPTION = (
-    "A server providing access to the Opentrons API")
-PACKAGES = find_packages(where='.', exclude=["tests.*", "tests"])
+DESCRIPTION = "A server providing access to the Opentrons API"
+PACKAGES = find_packages(where=".", exclude=["tests.*", "tests"])
 INSTALL_REQUIRES = [
-    'fastapi==0.54.1',
-    'python-multipart==0.0.5',
-    'uvicorn==0.11.3',
-    'python-dotenv',
-    'opentrons',
-    'wsproto==0.15.0',
-    'typing-extensions>=3.7.4.3',
+    "fastapi==0.54.1",
+    "python-multipart==0.0.5",
+    "uvicorn==0.11.3",
+    "python-dotenv",
+    "opentrons",
+    "wsproto==0.15.0",
+    "typing-extensions>=3.7.4.3",
 ]
 
 
@@ -71,7 +71,7 @@ def read(*parts):
 
 if __name__ == "__main__":
     setup(
-        python_requires='>=3.7',
+        python_requires=">=3.7",
         name=DISTNAME,
         description=DESCRIPTION,
         license=LICENSE,
@@ -87,5 +87,5 @@ if __name__ == "__main__":
         zip_safe=False,
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
-        include_package_data=True
+        include_package_data=True,
     )

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -1,5 +1,4 @@
-from opentrons.protocol_api import (
-    MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION)
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION
 from opentrons import __version__, config
 
 minimum_version = list(MIN_SUPPORTED_VERSION)
@@ -8,21 +7,21 @@ maximum_version = list(MAX_SUPPORTED_VERSION)
 
 def check_health_response(response):
     expected = {
-      'name': 'opentrons-dev',
-      'api_version': __version__,
-      'fw_version': 'Virtual Smoothie',
-      'board_revision': "2.1",
-      'logs': ['/logs/serial.log', '/logs/api.log', '/logs/server.log'],
-      'system_version': config.OT_SYSTEM_VERSION,
-      'minimum_protocol_api_version': minimum_version,
-      'maximum_protocol_api_version': maximum_version,
-      'links': {
-          'apiLog': '/logs/api.log',
-          'serialLog': '/logs/serial.log',
-          'apiSpec': '/openapi.json',
-          'systemTime': '/system/time',
-          'serverLog': '/logs/server.log'
-      }
+        "name": "opentrons-dev",
+        "api_version": __version__,
+        "fw_version": "Virtual Smoothie",
+        "board_revision": "2.1",
+        "logs": ["/logs/serial.log", "/logs/api.log", "/logs/server.log"],
+        "system_version": config.OT_SYSTEM_VERSION,
+        "minimum_protocol_api_version": minimum_version,
+        "maximum_protocol_api_version": maximum_version,
+        "links": {
+            "apiLog": "/logs/api.log",
+            "serialLog": "/logs/serial.log",
+            "apiSpec": "/openapi.json",
+            "systemTime": "/system/time",
+            "serverLog": "/logs/server.log",
+        },
     }
 
     assert response.json() == expected

--- a/robot-server/tests/integration/protocols/basic_transfer_standalone.py
+++ b/robot-server/tests/integration/protocols/basic_transfer_standalone.py
@@ -1,17 +1,18 @@
 from opentrons import protocol_api
 
-metadata = {'apiLevel': '2.6',
-            'author': 'engineer@opentrons.com',
-            'protocolName': 'basic_transfer_standalone'}
+metadata = {
+    "apiLevel": "2.6",
+    "author": "engineer@opentrons.com",
+    "protocolName": "basic_transfer_standalone",
+}
 
 
 def run(protocol: protocol_api.ProtocolContext):
-    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 1)
-    tiprack_1 = protocol.load_labware('opentrons_96_tiprack_300ul', 2)
-    p300 = protocol.load_instrument('p300_single', 'right',
-                                    tip_racks=[tiprack_1])
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", 1)
+    tiprack_1 = protocol.load_labware("opentrons_96_tiprack_300ul", 2)
+    p300 = protocol.load_instrument("p300_single", "right", tip_racks=[tiprack_1])
 
     p300.pick_up_tip()
-    p300.aspirate(100, plate['A1'])
-    p300.dispense(100, plate['B1'])
+    p300.aspirate(100, plate["A1"])
+    p300.dispense(100, plate["B1"])
     p300.return_tip()

--- a/robot-server/tests/integration/protocols/basic_transfer_with_config.py
+++ b/robot-server/tests/integration/protocols/basic_transfer_with_config.py
@@ -1,21 +1,23 @@
 from opentrons import protocol_api
 from helpers import load_config, pick_up_then_drop
 
-metadata = {'apiLevel': '2.6'}
+metadata = {"apiLevel": "2.6"}
 
 
 def run(protocol: protocol_api.ProtocolContext):
     configuration = load_config("basic_transfer_config.json")
 
-    plate = protocol.load_labware(configuration['plate'], 1)
-    tiprack_1 = protocol.load_labware(configuration['tiprack'], 2)
-    instrument = protocol.load_instrument(configuration['instrument']['model'],
-                                          configuration['instrument']['mount'],
-                                          tip_racks=[tiprack_1])
+    plate = protocol.load_labware(configuration["plate"], 1)
+    tiprack_1 = protocol.load_labware(configuration["tiprack"], 2)
+    instrument = protocol.load_instrument(
+        configuration["instrument"]["model"],
+        configuration["instrument"]["mount"],
+        tip_racks=[tiprack_1],
+    )
 
-    transfers = configuration['transfers']
+    transfers = configuration["transfers"]
     for transfer in transfers:
         with pick_up_then_drop(instrument):
-            ml = transfer['ml']
-            instrument.aspirate(ml, plate[transfer['source_well']])
-            instrument.dispense(ml, plate[transfer['target_well']])
+            ml = transfer["ml"]
+            instrument.aspirate(ml, plate[transfer["source_well"]])
+            instrument.dispense(ml, plate[transfer["target_well"]])

--- a/robot-server/tests/integration/protocols/helpers.py
+++ b/robot-server/tests/integration/protocols/helpers.py
@@ -4,7 +4,7 @@ import json
 
 def load_config(name: str):
     """Load a configuration file"""
-    with open(name, 'rb') as f:
+    with open(name, "rb") as f:
         return json.load(f)
 
 

--- a/robot-server/tests/integration/protocols/labware_pipettes_modules.py
+++ b/robot-server/tests/integration/protocols/labware_pipettes_modules.py
@@ -1,24 +1,24 @@
 metadata = {
-    'protocolName': 'Extraction',
-    'author': 'Opentrons <protocols@opentrons.com>',
-    'apiLevel': '2.4'
+    "protocolName": "Extraction",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "apiLevel": "2.4",
 }
 
 
 def run(ctx):
-    magdeck = ctx.load_module('magnetic module gen2', '6')
-    magdeck.load_labware('nest_96_wellplate_2ml_deep',
-                         'deepwell plate')
-    tempdeck = ctx.load_module('Temperature Module Gen2', '1')
+    magdeck = ctx.load_module("magnetic module gen2", "6")
+    magdeck.load_labware("nest_96_wellplate_2ml_deep", "deepwell plate")
+    tempdeck = ctx.load_module("Temperature Module Gen2", "1")
     tempdeck.load_labware(
-        'opentrons_96_aluminumblock_nest_wellplate_100ul',
-        'elution plate')
-    ctx.load_labware('nest_1_reservoir_195ml', '9', 'Liquid Waste')
-    ctx.load_labware('nest_12_reservoir_15ml', '3', 'reagent reservoir 2')
-    ctx.load_labware('nest_12_reservoir_15ml', '2', 'reagent reservoir 1')
-    [ctx.load_labware('opentrons_96_tiprack_300ul',
-                      slot, '200µl filtertiprack') for slot in
-     ['4', '7', '8', '10', '11']]
-    ctx.load_labware('opentrons_96_tiprack_300ul', '5', 'tiprack for parking')
-    ctx.load_instrument('p300_multi_gen2', 'left')
-    ctx.load_instrument('p20_single_gen2', 'right')
+        "opentrons_96_aluminumblock_nest_wellplate_100ul", "elution plate"
+    )
+    ctx.load_labware("nest_1_reservoir_195ml", "9", "Liquid Waste")
+    ctx.load_labware("nest_12_reservoir_15ml", "3", "reagent reservoir 2")
+    ctx.load_labware("nest_12_reservoir_15ml", "2", "reagent reservoir 1")
+    [
+        ctx.load_labware("opentrons_96_tiprack_300ul", slot, "200µl filtertiprack")
+        for slot in ["4", "7", "8", "10", "11"]
+    ]
+    ctx.load_labware("opentrons_96_tiprack_300ul", "5", "tiprack for parking")
+    ctx.load_instrument("p300_multi_gen2", "left")
+    ctx.load_instrument("p20_single_gen2", "right")

--- a/robot-server/tests/integration/protocols/load_custom_labware.py
+++ b/robot-server/tests/integration/protocols/load_custom_labware.py
@@ -1,15 +1,15 @@
 metadata = {
-    'protocolName': 'custom',
-    'author': 'Opentrons <protocols@opentrons.com>',
-    'apiLevel': '2.4'
+    "protocolName": "custom",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "apiLevel": "2.4",
 }
 
 
 def run(ctx):
     ctx.load_labware(
-        load_name='test_1_reservoir_5ul',
+        load_name="test_1_reservoir_5ul",
         location=1,
         namespace="custom_beta",
         label="custom1",
-        version=1
+        version=1,
     )

--- a/robot-server/tests/integration/protocols/load_unknown_module.py
+++ b/robot-server/tests/integration/protocols/load_unknown_module.py
@@ -1,9 +1,9 @@
 metadata = {
-    'protocolName': 'Extraction',
-    'author': 'Opentrons <protocols@opentrons.com>',
-    'apiLevel': '2.4'
+    "protocolName": "Extraction",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "apiLevel": "2.4",
 }
 
 
 def run(ctx):
-    ctx.load_module('pickle maker', '6')
+    ctx.load_module("pickle maker", "6")

--- a/robot-server/tests/integration/protocols/runtime_error.py
+++ b/robot-server/tests/integration/protocols/runtime_error.py
@@ -1,4 +1,4 @@
-metadata = {'apiLevel': '2.6'}
+metadata = {"apiLevel": "2.6"}
 
 
 def run(ctx):

--- a/robot-server/tests/integration/protocols/thermocycler.py
+++ b/robot-server/tests/integration/protocols/thermocycler.py
@@ -1,10 +1,10 @@
 metadata = {
-    'protocolName': 'Thermocycler test',
-    'author': 'Opentrons <protocols@opentrons.com>',
-    'apiLevel': '2.4'
+    "protocolName": "Thermocycler test",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "apiLevel": "2.4",
 }
 
 
 def run(ctx):
-    thermocycler = ctx.load_module('thermocycler module', '7')
-    thermocycler.load_labware('nest_96_wellplate_2ml_deep', 'deepwell plate')
+    thermocycler = ctx.load_module("thermocycler module", "7")
+    thermocycler.load_labware("nest_96_wellplate_2ml_deep", "deepwell plate")

--- a/robot-server/tests/integration/utils.py
+++ b/robot-server/tests/integration/utils.py
@@ -1,7 +1,7 @@
 def verify_settings_value(response, id: str, value: str):
-    """ Verify settings are updated as expectted """
-    for setting in response.json().get('settings'):
-        if setting.get('id') == id:
-            assert str(setting.get('value')) == str(value)
+    """Verify settings are updated as expectted"""
+    for setting in response.json().get("settings"):
+        if setting.get("id") == id:
+            assert str(setting.get("value")) == str(value)
             return
     assert False

--- a/robot-server/tests/robot/calibration/check/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/check/test_state_machine.py
@@ -1,44 +1,46 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand as CalCommand, DeckCalibrationCommand as DeckCommand, \
-    CheckCalibrationCommand as CheckCommand
-from robot_server.robot.calibration.check.state_machine import \
-    CalibrationCheckStateMachine
+from robot_server.service.session.models.command_definitions import (
+    CalibrationCommand as CalCommand,
+    DeckCalibrationCommand as DeckCommand,
+    CheckCalibrationCommand as CheckCommand,
+)
+from robot_server.robot.calibration.check.state_machine import (
+    CalibrationCheckStateMachine,
+)
 
 valid_commands: List[Tuple[str, str, str]] = [
-    (CalCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-    (CalCommand.move_to_reference_point, 'labwareLoaded', 'comparingNozzle'),
-    (CalCommand.jog, 'comparingNozzle', 'comparingNozzle'),
-    (CalCommand.move_to_tip_rack, 'comparingNozzle', 'preparingPipette'),
-    (CalCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-    (CalCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-    (CalCommand.move_to_reference_point, 'inspectingTip', 'comparingTip'),
-    (CheckCommand.compare_point, 'comparingTip', 'comparingTip'),
-    (CalCommand.move_to_deck, 'comparingTip', 'comparingHeight'),
-    (CalCommand.jog, 'comparingHeight', 'comparingHeight'),
-    (CheckCommand.compare_point, 'comparingHeight', 'comparingHeight'),
-    (CalCommand.move_to_point_one, 'comparingHeight', 'comparingPointOne'),
-    (CalCommand.jog, 'comparingPointOne', 'comparingPointOne'),
-    (CheckCommand.compare_point, 'comparingPointOne', 'comparingPointOne'),
-    (DeckCommand.move_to_point_two, 'comparingPointOne', 'comparingPointTwo'),
-    (CalCommand.jog, 'comparingPointTwo', 'comparingPointTwo'),
-    (CheckCommand.compare_point, 'comparingPointTwo', 'comparingPointTwo'),
-    (DeckCommand.move_to_point_three,
-        'comparingPointTwo', 'comparingPointThree'),
-    (CalCommand.jog, 'comparingPointThree', 'comparingPointThree'),
-    (CheckCommand.compare_point, 'comparingPointThree', 'comparingPointThree'),
-    (CalCommand.move_to_tip_rack, 'comparingPointThree', 'returningTip'),
-    (CheckCommand.return_tip, 'returningTip', 'returningTip'),
-    (CheckCommand.transition, 'returningTip', 'resultsSummary'),
-    (CalCommand.exit, 'calibrationComplete', 'sessionExited'),
-    (CalCommand.exit, 'sessionStarted', 'sessionExited'),
-    (CalCommand.exit, 'labwareLoaded', 'sessionExited'),
-    (CalCommand.exit, 'preparingPipette', 'sessionExited'),
-    (CalCommand.exit, 'comparingPointOne', 'sessionExited'),
-    (CalCommand.exit, 'comparingPointTwo', 'sessionExited'),
-    (CalCommand.exit, 'comparingPointThree', 'sessionExited'),
+    (CalCommand.load_labware, "sessionStarted", "labwareLoaded"),
+    (CalCommand.move_to_reference_point, "labwareLoaded", "comparingNozzle"),
+    (CalCommand.jog, "comparingNozzle", "comparingNozzle"),
+    (CalCommand.move_to_tip_rack, "comparingNozzle", "preparingPipette"),
+    (CalCommand.pick_up_tip, "preparingPipette", "inspectingTip"),
+    (CalCommand.invalidate_tip, "inspectingTip", "preparingPipette"),
+    (CalCommand.move_to_reference_point, "inspectingTip", "comparingTip"),
+    (CheckCommand.compare_point, "comparingTip", "comparingTip"),
+    (CalCommand.move_to_deck, "comparingTip", "comparingHeight"),
+    (CalCommand.jog, "comparingHeight", "comparingHeight"),
+    (CheckCommand.compare_point, "comparingHeight", "comparingHeight"),
+    (CalCommand.move_to_point_one, "comparingHeight", "comparingPointOne"),
+    (CalCommand.jog, "comparingPointOne", "comparingPointOne"),
+    (CheckCommand.compare_point, "comparingPointOne", "comparingPointOne"),
+    (DeckCommand.move_to_point_two, "comparingPointOne", "comparingPointTwo"),
+    (CalCommand.jog, "comparingPointTwo", "comparingPointTwo"),
+    (CheckCommand.compare_point, "comparingPointTwo", "comparingPointTwo"),
+    (DeckCommand.move_to_point_three, "comparingPointTwo", "comparingPointThree"),
+    (CalCommand.jog, "comparingPointThree", "comparingPointThree"),
+    (CheckCommand.compare_point, "comparingPointThree", "comparingPointThree"),
+    (CalCommand.move_to_tip_rack, "comparingPointThree", "returningTip"),
+    (CheckCommand.return_tip, "returningTip", "returningTip"),
+    (CheckCommand.transition, "returningTip", "resultsSummary"),
+    (CalCommand.exit, "calibrationComplete", "sessionExited"),
+    (CalCommand.exit, "sessionStarted", "sessionExited"),
+    (CalCommand.exit, "labwareLoaded", "sessionExited"),
+    (CalCommand.exit, "preparingPipette", "sessionExited"),
+    (CalCommand.exit, "comparingPointOne", "sessionExited"),
+    (CalCommand.exit, "comparingPointTwo", "sessionExited"),
+    (CalCommand.exit, "comparingPointThree", "sessionExited"),
 ]
 
 
@@ -47,7 +49,7 @@ def state_machine():
     return CalibrationCheckStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', valid_commands)
+@pytest.mark.parametrize("command,from_state,to_state", valid_commands)
 async def test_valid_commands(command, from_state, to_state, state_machine):
     next_state = state_machine.get_next_state(from_state, command)
     assert next_state == to_state

--- a/robot-server/tests/robot/calibration/check/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/check/test_user_flow.py
@@ -8,38 +8,41 @@ from opentrons.calibration_storage import get, modify, types as CSTypes
 from opentrons.config import robot_configs
 from opentrons.config.pipette_config import load
 
-from robot_server.robot.calibration.check.user_flow import\
-    CheckCalibrationUserFlow
-from robot_server.robot.calibration.check.constants import\
-    CalibrationCheckState
+from robot_server.robot.calibration.check.user_flow import CheckCalibrationUserFlow
+from robot_server.robot.calibration.check.constants import CalibrationCheckState
 from robot_server.robot.calibration.check.models import (
-    ComparisonStatus, PipetteOffsetComparisonMap,
-    DeckComparisonMap, TipComparisonMap)
+    ComparisonStatus,
+    PipetteOffsetComparisonMap,
+    DeckComparisonMap,
+    TipComparisonMap,
+)
 from robot_server.service.errors import RobotServerError
 from robot_server.robot.calibration.constants import (
-    POINT_ONE_ID, POINT_TWO_ID, POINT_THREE_ID)
+    POINT_ONE_ID,
+    POINT_TWO_ID,
+    POINT_THREE_ID,
+)
 
 
 PIP_OFFSET = CSTypes.PipetteOffsetByPipetteMount(
-        offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
-        source=CSTypes.SourceType.user,
-        status=CSTypes.CalibrationStatus())
+    offset=robot_configs.DEFAULT_PIPETTE_OFFSET,
+    source=CSTypes.SourceType.user,
+    status=CSTypes.CalibrationStatus(),
+)
 
 
 @pytest.fixture
 def mock_hw(hardware):
-    pip = pipette.Pipette(load("p300_single_v2.1", 'testiId'),
-                          PIP_OFFSET,
-                          'testId')
+    pip = pipette.Pipette(load("p300_single_v2.1", "testiId"), PIP_OFFSET, "testId")
     hardware._attached_instruments = {Mount.RIGHT: pip, Mount.LEFT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
     async def async_mock_move_rel(*args, **kwargs):
-        delta = kwargs.get('delta', Point(0, 0, 0))
+        delta = kwargs.get("delta", Point(0, 0, 0))
         hardware._current_pos += delta
 
     async def async_mock_move_to(*args, **kwargs):
-        to_pt = kwargs.get('abs_position', Point(0, 0, 0))
+        to_pt = kwargs.get("abs_position", Point(0, 0, 0))
         hardware._current_pos = to_pt
 
     async def gantry_pos_mock(*args, **kwargs):
@@ -53,68 +56,51 @@ def mock_hw(hardware):
 
 
 pipette_combos: List[Tuple[List[str], Mount]] = [
-    (['p20_multi_v2.1', 'p20_multi_v2.1'], Mount.RIGHT),
-    (['p20_single_v2.1', 'p20_multi_v2.1'], Mount.LEFT),
-    (['p20_multi_v2.1', 'p300_single_v2.1'], Mount.RIGHT),
-    (['p300_multi_v2.1', 'p1000_single_v2.1'], Mount.RIGHT),
-    (['p1000_single_v2.1', ''], Mount.LEFT),
-    (['', 'p300_multi_v2.1'], Mount.RIGHT)
+    (["p20_multi_v2.1", "p20_multi_v2.1"], Mount.RIGHT),
+    (["p20_single_v2.1", "p20_multi_v2.1"], Mount.LEFT),
+    (["p20_multi_v2.1", "p300_single_v2.1"], Mount.RIGHT),
+    (["p300_multi_v2.1", "p1000_single_v2.1"], Mount.RIGHT),
+    (["p1000_single_v2.1", ""], Mount.LEFT),
+    (["", "p300_multi_v2.1"], Mount.RIGHT),
 ]
 
 
-@pytest.mark.parametrize('pipettes,target_mount', pipette_combos)
+@pytest.mark.parametrize("pipettes,target_mount", pipette_combos)
 def test_user_flow_select_pipette(pipettes, target_mount, hardware):
     pip, pip2 = None, None
     if pipettes[0]:
-        pip = pipette.Pipette(load(pipettes[0], 'testId'),
-                              PIP_OFFSET,
-                              'testId')
+        pip = pipette.Pipette(load(pipettes[0], "testId"), PIP_OFFSET, "testId")
     if pipettes[1]:
-        pip2 = pipette.Pipette(load(pipettes[1], 'testId'),
-                               PIP_OFFSET,
-                               'testId2')
+        pip2 = pipette.Pipette(load(pipettes[1], "testId"), PIP_OFFSET, "testId2")
     hardware._attached_instruments = {Mount.LEFT: pip, Mount.RIGHT: pip2}
     # load a labware with calibrations
     with patch.object(
-            get,
-            'get_robot_deck_attitude',
-            new=build_mock_deck_calibration()),\
-            patch.object(
-                get,
-                'load_tip_length_calibration',
-                new=build_mock_stored_tip_length()),\
-            patch.object(
-                get, 'get_pipette_offset',
-                new=build_mock_stored_pipette_offset()):
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+    ), patch.object(
+        get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+    ):
         uf = CheckCalibrationUserFlow(hardware=hardware)
-        assert uf.hw_pipette == \
-            hardware._attached_instruments[target_mount]
+        assert uf.hw_pipette == hardware._attached_instruments[target_mount]
 
 
-@pytest.mark.parametrize('pipettes,target_mount', pipette_combos)
+@pytest.mark.parametrize("pipettes,target_mount", pipette_combos)
 async def test_switching_to_second_pipette(pipettes, target_mount, hardware):
     pip, pip2 = None, None
     if pipettes[0]:
-        pip = pipette.Pipette(load(pipettes[0], 'testId'),
-                              PIP_OFFSET,
-                              'testId')
+        pip = pipette.Pipette(load(pipettes[0], "testId"), PIP_OFFSET, "testId")
     if pipettes[1]:
-        pip2 = pipette.Pipette(load(pipettes[1], 'testId'),
-                               PIP_OFFSET,
-                               'testId2')
+        pip2 = pipette.Pipette(load(pipettes[1], "testId"), PIP_OFFSET, "testId2")
     hardware._attached_instruments = {Mount.LEFT: pip, Mount.RIGHT: pip2}
     # load a labware with calibrations
     with patch.object(
-            get,
-            'get_robot_deck_attitude',
-            new=build_mock_deck_calibration()),\
-            patch.object(
-                get,
-                'load_tip_length_calibration',
-                new=build_mock_stored_tip_length()),\
-            patch.object(
-                get, 'get_pipette_offset',
-                new=build_mock_stored_pipette_offset()):
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+    ), patch.object(
+        get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+    ):
         uf = CheckCalibrationUserFlow(hardware=hardware)
         if pip and pip2:
             assert uf.mount == target_mount
@@ -125,70 +111,77 @@ async def test_switching_to_second_pipette(pipettes, target_mount, hardware):
                 await uf.change_active_pipette()
 
 
-def build_mock_stored_pipette_offset(kind='normal'):
-    if kind == 'normal':
+def build_mock_stored_pipette_offset(kind="normal"):
+    if kind == "normal":
         return MagicMock(
             return_value=CSTypes.PipetteOffsetByPipetteMount(
                 offset=[0, 1, 2],
-                tiprack='tiprack-id',
-                uri='opentrons/opentrons_96_filtertiprack_200ul/1',
+                tiprack="tiprack-id",
+                uri="opentrons/opentrons_96_filtertiprack_200ul/1",
                 source=CSTypes.SourceType.user,
-                status=CSTypes.CalibrationStatus(markedBad=False)))
-    elif kind == 'custom_tiprack':
+                status=CSTypes.CalibrationStatus(markedBad=False),
+            )
+        )
+    elif kind == "custom_tiprack":
         return MagicMock(
             return_value=CSTypes.PipetteOffsetByPipetteMount(
                 offset=[0, 1, 2],
-                tiprack='tiprack-id',
-                uri='custom/minimal_labware_def/1',
+                tiprack="tiprack-id",
+                uri="custom/minimal_labware_def/1",
                 source=CSTypes.SourceType.user,
-                status=CSTypes.CalibrationStatus(markedBad=False)))
+                status=CSTypes.CalibrationStatus(markedBad=False),
+            )
+        )
     else:
         return MagicMock(return_value=None)
 
 
-def build_mock_stored_tip_length(kind='normal'):
-    if kind == 'normal':
+def build_mock_stored_tip_length(kind="normal"):
+    if kind == "normal":
         tip_length = CSTypes.TipLengthCalibration(
             tip_length=30,
-            pipette='fake id',
-            tiprack='fake_hash',
-            last_modified='some time',
+            pipette="fake id",
+            tiprack="fake_hash",
+            last_modified="some time",
             source=CSTypes.SourceType.user,
             status=CSTypes.CalibrationStatus(markedBad=False),
-            uri='path/to_my_labware/1')
+            uri="path/to_my_labware/1",
+        )
         return MagicMock(return_value=tip_length)
-    elif kind == 'custom_tiprack':
+    elif kind == "custom_tiprack":
         tip_length = CSTypes.TipLengthCalibration(
             tip_length=30,
-            pipette='fake id',
-            tiprack='fake_hash',
-            last_modified='some time',
+            pipette="fake id",
+            tiprack="fake_hash",
+            last_modified="some time",
             source=CSTypes.SourceType.user,
             status=CSTypes.CalibrationStatus(markedBad=False),
-            uri='custom/minimal_labware_def/1')
+            uri="custom/minimal_labware_def/1",
+        )
         return MagicMock(return_value=tip_length)
     else:
         return MagicMock(return_value=None)
 
 
-def build_mock_deck_calibration(kind='normal'):
-    if kind == 'normal':
-        attitude = [
-            [1.0008, 0.0052, 0.0],
-            [-0.1, 0.9, 0.0],
-            [0.0, 0.0, 1.0]]
-        return MagicMock(return_value=CSTypes.DeckCalibration(
+def build_mock_deck_calibration(kind="normal"):
+    if kind == "normal":
+        attitude = [[1.0008, 0.0052, 0.0], [-0.1, 0.9, 0.0], [0.0, 0.0, 1.0]]
+        return MagicMock(
+            return_value=CSTypes.DeckCalibration(
                 attitude=attitude,
                 source=CSTypes.SourceType.user,
-                last_modified='date',
-                status=CSTypes.CalibrationStatus(markedBad=False)
-        ))
-    elif kind == 'identity':
-        return MagicMock(return_value=CSTypes.DeckCalibration(
+                last_modified="date",
+                status=CSTypes.CalibrationStatus(markedBad=False),
+            )
+        )
+    elif kind == "identity":
+        return MagicMock(
+            return_value=CSTypes.DeckCalibration(
                 attitude=robot_configs.DEFAULT_DECK_CALIBRATION_V2,
                 source=CSTypes.SourceType.user,
-                status=CSTypes.CalibrationStatus(markedBad=False)
-        ))
+                status=CSTypes.CalibrationStatus(markedBad=False),
+            )
+        )
     else:
         return MagicMock(return_value=None)
 
@@ -196,47 +189,42 @@ def build_mock_deck_calibration(kind='normal'):
 def test_load_labware(mock_hw):
     # load a labware with calibrations
     with patch.object(
-            get,
-            'get_robot_deck_attitude',
-            new=build_mock_deck_calibration()),\
-            patch.object(
-                get,
-                'load_tip_length_calibration',
-                new=build_mock_stored_tip_length()),\
-            patch.object(
-                get, 'get_pipette_offset',
-                new=build_mock_stored_pipette_offset()):
-        uf = CheckCalibrationUserFlow(
-            hardware=mock_hw, has_calibration_block=True)
-        assert uf.active_tiprack._implementation.get_display_name() ==\
-            'Opentrons 96 Filter Tip Rack 200 µL on 8'
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+    ), patch.object(
+        get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+    ):
+        uf = CheckCalibrationUserFlow(hardware=mock_hw, has_calibration_block=True)
+        assert (
+            uf.active_tiprack._implementation.get_display_name()
+            == "Opentrons 96 Filter Tip Rack 200 µL on 8"
+        )
         assert len(uf.get_required_labware()) == 2
 
 
-def test_load_custom_tiprack(mock_hw,
-                             custom_tiprack_def,
-                             clear_custom_tiprack_def_dir):
+def test_load_custom_tiprack(mock_hw, custom_tiprack_def, clear_custom_tiprack_def_dir):
     # save custom tiprack definition to custom tiprack directory
     modify._save_custom_tiprack_definition(
-        'custom/minimal_labware_def/1',
-        custom_tiprack_def
+        "custom/minimal_labware_def/1", custom_tiprack_def
     )
     # load a labware with calibrations
     with patch.object(
-            get,
-            'get_robot_deck_attitude',
-            new=build_mock_deck_calibration()),\
-            patch.object(
-                get,
-                'load_tip_length_calibration',
-                new=build_mock_stored_tip_length('custom_tiprack')),\
-            patch.object(
-                get, 'get_pipette_offset',
-                new=build_mock_stored_pipette_offset('custom_tiprack')):
-        uf = CheckCalibrationUserFlow(
-            hardware=mock_hw, has_calibration_block=True)
-        assert uf.active_tiprack._implementation.get_display_name() ==\
-            'minimal labware on 8'
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get,
+        "load_tip_length_calibration",
+        new=build_mock_stored_tip_length("custom_tiprack"),
+    ), patch.object(
+        get,
+        "get_pipette_offset",
+        new=build_mock_stored_pipette_offset("custom_tiprack"),
+    ):
+        uf = CheckCalibrationUserFlow(hardware=mock_hw, has_calibration_block=True)
+        assert (
+            uf.active_tiprack._implementation.get_display_name()
+            == "minimal labware on 8"
+        )
         assert len(uf.get_required_labware()) == 2
 
 
@@ -246,58 +234,48 @@ def test_bad_calibration(mock_hw):
 
     with pytest.raises(RobotServerError):
         with patch.object(
-            get,
-            'get_robot_deck_attitude',
-            new=build_mock_deck_calibration('identity')),\
-            patch.object(
-                get,
-                'load_tip_length_calibration',
-                new=build_mock_stored_tip_length()),\
-            patch.object(
-                get, 'get_pipette_offset',
-                new=build_mock_stored_pipette_offset()):
+            get, "get_robot_deck_attitude", new=build_mock_deck_calibration("identity")
+        ), patch.object(
+            get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+        ), patch.object(
+            get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+        ):
             CheckCalibrationUserFlow(hardware=mock_hw)
 
 
 @pytest.fixture
 def mock_user_flow(mock_hw):
     with patch.object(
-        get,
-        'get_robot_deck_attitude',
-        new=build_mock_deck_calibration()),\
-        patch.object(
-            get,
-            'load_tip_length_calibration',
-            new=build_mock_stored_tip_length()),\
-        patch.object(
-            get, 'get_pipette_offset',
-            new=build_mock_stored_pipette_offset()):
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+    ), patch.object(
+        get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+    ):
         m = CheckCalibrationUserFlow(hardware=mock_hw)
         initial_pt = Point(1, 1, 5)
         final_pt = Point(1, 1, 5)
-        m._get_reference_points_by_state =\
-            MagicMock(return_value=(initial_pt, final_pt))
+        m._get_reference_points_by_state = MagicMock(
+            return_value=(initial_pt, final_pt)
+        )
         yield m
 
 
 @pytest.fixture
 def mock_user_flow_bad_vectors(mock_hw):
     with patch.object(
-        get,
-        'get_robot_deck_attitude',
-        new=build_mock_deck_calibration()),\
-        patch.object(
-            get,
-            'load_tip_length_calibration',
-            new=build_mock_stored_tip_length()),\
-        patch.object(
-            get, 'get_pipette_offset',
-            new=build_mock_stored_pipette_offset()):
+        get, "get_robot_deck_attitude", new=build_mock_deck_calibration()
+    ), patch.object(
+        get, "load_tip_length_calibration", new=build_mock_stored_tip_length()
+    ), patch.object(
+        get, "get_pipette_offset", new=build_mock_stored_pipette_offset()
+    ):
         m = CheckCalibrationUserFlow(hardware=mock_hw)
         initial_pt = Point(1, 6, 5)
         final_pt = Point(1, 1, 0)
-        m._get_reference_points_by_state =\
-            MagicMock(return_value=(initial_pt, final_pt))
+        m._get_reference_points_by_state = MagicMock(
+            return_value=(initial_pt, final_pt)
+        )
         yield m
 
 
@@ -322,15 +300,14 @@ async def test_return_tip(mock_user_flow):
     uf = mock_user_flow
     uf._tip_origin_pt = Point(1, 1, 1)
     uf.hw_pipette._has_tip = True
-    z_offset = uf.hw_pipette.config.return_tip_height * \
-        uf._get_tip_length()
+    z_offset = uf.hw_pipette.config.return_tip_height * uf._get_tip_length()
     await uf.return_tip()
     # should move to return tip
     move_calls = [
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf.critical_point_override
+            critical_point=uf.critical_point_override,
         ),
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
@@ -346,12 +323,14 @@ async def test_jog(mock_user_flow):
 
 
 @pytest.mark.parametrize(
-    "state,point_id", [
+    "state,point_id",
+    [
         (CalibrationCheckState.comparingHeight, POINT_ONE_ID),
         (CalibrationCheckState.comparingPointOne, POINT_TWO_ID),
-        (CalibrationCheckState.comparingPointTwo, POINT_THREE_ID)])
-async def test_get_move_to_cal_point_location(mock_user_flow,
-                                              state, point_id):
+        (CalibrationCheckState.comparingPointTwo, POINT_THREE_ID),
+    ],
+)
+async def test_get_move_to_cal_point_location(mock_user_flow, state, point_id):
     uf = mock_user_flow
     uf._z_height_reference = 30
 
@@ -366,19 +345,21 @@ async def test_compare_z_height(mock_user_flow):
     uf = mock_user_flow
     uf._current_state = CalibrationCheckState.comparingTip
     await uf._hardware.move_to(
-            mount=uf.mount,
-            abs_position=Point(x=10, y=10, z=10),
-            critical_point=uf.hw_pipette.critical_point
-        )
+        mount=uf.mount,
+        abs_position=Point(x=10, y=10, z=10),
+        critical_point=uf.hw_pipette.critical_point,
+    )
     await uf.update_comparison_map()
     # The initial and final mocked points have a 5 mm
     # difference and so it should exceed the threshold
     expected_status = ComparisonStatus(
         differenceVector=(0.0, 0.0, 0.0),
         thresholdVector=(0.0, 0.0, 1.0),
-        exceedsThreshold=False)
+        exceedsThreshold=False,
+    )
     expected_tip_length = TipComparisonMap(
-        status='IN_THRESHOLD', comparingTip=expected_status)
+        status="IN_THRESHOLD", comparingTip=expected_status
+    )
     assert uf.comparison_map.first.tipLength == expected_tip_length
     assert uf.comparison_map.second.tipLength is None
 
@@ -393,24 +374,27 @@ async def test_compare_points(mock_user_flow):
     expected_status = ComparisonStatus(
         differenceVector=(0.0, 0.0, 0.0),
         thresholdVector=(1.8, 1.8, 0.0),
-        exceedsThreshold=False)
+        exceedsThreshold=False,
+    )
     height_status = ComparisonStatus(
         differenceVector=(0.0, 0.0, 0.0),
         thresholdVector=(0.0, 0.0, 0.8),
-        exceedsThreshold=False)
-    all_status = 'IN_THRESHOLD'
+        exceedsThreshold=False,
+    )
+    all_status = "IN_THRESHOLD"
     expected_pip = PipetteOffsetComparisonMap(
         status=all_status,
         comparingHeight=height_status,
-        comparingPointOne=expected_status)
+        comparingPointOne=expected_status,
+    )
     expected_deck = DeckComparisonMap(
-        status=all_status,
-        comparingPointOne=expected_status)
+        status=all_status, comparingPointOne=expected_status
+    )
     await uf._hardware.move_to(
-            mount=uf.mount,
-            abs_position=Point(x=10, y=10, z=10),
-            critical_point=uf.hw_pipette.critical_point
-        )
+        mount=uf.mount,
+        abs_position=Point(x=10, y=10, z=10),
+        critical_point=uf.hw_pipette.critical_point,
+    )
     await uf.update_comparison_map()
 
     assert uf.comparison_map.first.pipetteOffset == expected_pip
@@ -420,10 +404,10 @@ async def test_compare_points(mock_user_flow):
 
     uf._current_state = CalibrationCheckState.comparingPointTwo
     await uf._hardware.move_to(
-            mount=uf.mount,
-            abs_position=Point(x=10, y=10, z=10),
-            critical_point=uf.hw_pipette.critical_point
-        )
+        mount=uf.mount,
+        abs_position=Point(x=10, y=10, z=10),
+        critical_point=uf.hw_pipette.critical_point,
+    )
     await uf.update_comparison_map()
     expected_deck.comparingPointTwo = expected_status
     assert uf.comparison_map.first.pipetteOffset == expected_pip
@@ -435,7 +419,7 @@ async def test_compare_points(mock_user_flow):
     await uf._hardware.move_to(
         mount=uf.mount,
         abs_position=Point(x=10, y=10, z=10),
-        critical_point=uf.hw_pipette.critical_point
+        critical_point=uf.hw_pipette.critical_point,
     )
     await uf.update_comparison_map()
     expected_deck.comparingPointThree = expected_status
@@ -455,10 +439,9 @@ async def test_compare_points(mock_user_flow):
     new_pip = PipetteOffsetComparisonMap(
         status=all_status,
         comparingHeight=height_status,
-        comparingPointOne=expected_status)
-    new_deck = DeckComparisonMap(
-        status=all_status,
-        comparingPointOne=expected_status)
+        comparingPointOne=expected_status,
+    )
+    new_deck = DeckComparisonMap(status=all_status, comparingPointOne=expected_status)
 
     assert uf.comparison_map.first.pipetteOffset == expected_pip
     assert uf.comparison_map.first.deck is None
@@ -468,17 +451,20 @@ async def test_compare_points(mock_user_flow):
 
 async def test_mark_bad_calibration(mock_user_flow_bad_vectors):
     uf = mock_user_flow_bad_vectors
-    storage_path = 'opentrons.calibration_storage.modify'
-    with patch(f'{storage_path}.mark_bad') as m,\
-         patch(f'{storage_path}.create_tip_length_data'),\
-         patch(f'{storage_path}.save_tip_length_calibration'),\
-         patch(f'{storage_path}.save_pipette_calibration'),\
-         patch(f'{storage_path}.save_robot_deck_attitude'):
+    storage_path = "opentrons.calibration_storage.modify"
+    with patch(f"{storage_path}.mark_bad") as m, patch(
+        f"{storage_path}.create_tip_length_data"
+    ), patch(f"{storage_path}.save_tip_length_calibration"), patch(
+        f"{storage_path}.save_pipette_calibration"
+    ), patch(
+        f"{storage_path}.save_robot_deck_attitude"
+    ):
         uf._current_state = CalibrationCheckState.comparingTip
         await uf.update_comparison_map()
         expected_tip_length_call = [
             uf._tip_lengths[uf.mount],
-            CSTypes.SourceType.calibration_check]
+            CSTypes.SourceType.calibration_check,
+        ]
         m.assert_called_once_with(*expected_tip_length_call)
         m.reset_mock()
 
@@ -487,7 +473,8 @@ async def test_mark_bad_calibration(mock_user_flow_bad_vectors):
         await uf.update_comparison_map()
         expected_pip_offset_call = (
             uf._pipette_calibrations[uf.mount],
-            CSTypes.SourceType.calibration_check)
+            CSTypes.SourceType.calibration_check,
+        )
         m.assert_called_once_with(*expected_pip_offset_call)
         m.reset_mock()
 
@@ -505,6 +492,7 @@ async def test_mark_bad_calibration(mock_user_flow_bad_vectors):
 
         expected_deck_cal_call = [
             uf._deck_calibration,
-            CSTypes.SourceType.calibration_check]
+            CSTypes.SourceType.calibration_check,
+        ]
 
         m.assert_called_once_with(*expected_deck_cal_call)

--- a/robot-server/tests/robot/calibration/deck/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/deck/test_state_machine.py
@@ -1,45 +1,46 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand as CalCommand, DeckCalibrationCommand as DeckCommand
-from robot_server.robot.calibration.deck.state_machine import \
-    DeckCalibrationStateMachine
+from robot_server.service.session.models.command_definitions import (
+    CalibrationCommand as CalCommand,
+    DeckCalibrationCommand as DeckCommand,
+)
+from robot_server.robot.calibration.deck.state_machine import (
+    DeckCalibrationStateMachine,
+)
 
 valid_commands: List[Tuple[str, str, str]] = [
-    (CalCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-    (CalCommand.move_to_tip_rack, 'labwareLoaded', 'preparingPipette'),
-    (CalCommand.move_to_tip_rack, 'preparingPipette', 'preparingPipette'),
-    (CalCommand.jog, 'preparingPipette', 'preparingPipette'),
-    (CalCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-    (CalCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-    (CalCommand.move_to_deck, 'inspectingTip', 'joggingToDeck'),
-    (CalCommand.jog, 'joggingToDeck', 'joggingToDeck'),
-    (CalCommand.save_offset, 'joggingToDeck', 'joggingToDeck'),
-    (CalCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
-    (CalCommand.jog, 'savingPointOne', 'savingPointOne'),
-    (CalCommand.save_offset, 'savingPointOne', 'savingPointOne'),
-    (DeckCommand.move_to_point_two, 'savingPointOne', 'savingPointTwo'),
-    (CalCommand.jog, 'savingPointTwo', 'savingPointTwo'),
-    (CalCommand.save_offset, 'savingPointTwo', 'savingPointTwo'),
-    (DeckCommand.move_to_point_three, 'savingPointTwo', 'savingPointThree'),
-    (CalCommand.jog, 'savingPointThree', 'savingPointThree'),
-    (CalCommand.save_offset, 'savingPointThree', 'savingPointThree'),
-    (CalCommand.move_to_tip_rack, 'savingPointThree', 'calibrationComplete'),
-    (CalCommand.exit, 'calibrationComplete', 'sessionExited'),
-    (CalCommand.exit, 'sessionStarted', 'sessionExited'),
-    (CalCommand.exit, 'labwareLoaded', 'sessionExited'),
-    (CalCommand.exit, 'preparingPipette', 'sessionExited'),
-    (CalCommand.exit, 'savingPointOne', 'sessionExited'),
-    (CalCommand.exit, 'savingPointTwo', 'sessionExited'),
-    (CalCommand.exit, 'savingPointThree', 'sessionExited'),
-    (CalCommand.invalidate_last_action,
-     'preparingPipette', 'preparingPipette'),
-    (CalCommand.invalidate_last_action, 'joggingToDeck', 'preparingPipette'),
-    (CalCommand.invalidate_last_action, 'savingPointOne', 'preparingPipette'),
-    (CalCommand.invalidate_last_action, 'savingPointTwo', 'preparingPipette'),
-    (CalCommand.invalidate_last_action,
-     'savingPointThree', 'preparingPipette'),
+    (CalCommand.load_labware, "sessionStarted", "labwareLoaded"),
+    (CalCommand.move_to_tip_rack, "labwareLoaded", "preparingPipette"),
+    (CalCommand.move_to_tip_rack, "preparingPipette", "preparingPipette"),
+    (CalCommand.jog, "preparingPipette", "preparingPipette"),
+    (CalCommand.pick_up_tip, "preparingPipette", "inspectingTip"),
+    (CalCommand.invalidate_tip, "inspectingTip", "preparingPipette"),
+    (CalCommand.move_to_deck, "inspectingTip", "joggingToDeck"),
+    (CalCommand.jog, "joggingToDeck", "joggingToDeck"),
+    (CalCommand.save_offset, "joggingToDeck", "joggingToDeck"),
+    (CalCommand.move_to_point_one, "joggingToDeck", "savingPointOne"),
+    (CalCommand.jog, "savingPointOne", "savingPointOne"),
+    (CalCommand.save_offset, "savingPointOne", "savingPointOne"),
+    (DeckCommand.move_to_point_two, "savingPointOne", "savingPointTwo"),
+    (CalCommand.jog, "savingPointTwo", "savingPointTwo"),
+    (CalCommand.save_offset, "savingPointTwo", "savingPointTwo"),
+    (DeckCommand.move_to_point_three, "savingPointTwo", "savingPointThree"),
+    (CalCommand.jog, "savingPointThree", "savingPointThree"),
+    (CalCommand.save_offset, "savingPointThree", "savingPointThree"),
+    (CalCommand.move_to_tip_rack, "savingPointThree", "calibrationComplete"),
+    (CalCommand.exit, "calibrationComplete", "sessionExited"),
+    (CalCommand.exit, "sessionStarted", "sessionExited"),
+    (CalCommand.exit, "labwareLoaded", "sessionExited"),
+    (CalCommand.exit, "preparingPipette", "sessionExited"),
+    (CalCommand.exit, "savingPointOne", "sessionExited"),
+    (CalCommand.exit, "savingPointTwo", "sessionExited"),
+    (CalCommand.exit, "savingPointThree", "sessionExited"),
+    (CalCommand.invalidate_last_action, "preparingPipette", "preparingPipette"),
+    (CalCommand.invalidate_last_action, "joggingToDeck", "preparingPipette"),
+    (CalCommand.invalidate_last_action, "savingPointOne", "preparingPipette"),
+    (CalCommand.invalidate_last_action, "savingPointTwo", "preparingPipette"),
+    (CalCommand.invalidate_last_action, "savingPointThree", "preparingPipette"),
 ]
 
 
@@ -48,7 +49,7 @@ def state_machine():
     return DeckCalibrationStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', valid_commands)
+@pytest.mark.parametrize("command,from_state,to_state", valid_commands)
 async def test_valid_commands(command, from_state, to_state, state_machine):
     next_state = state_machine.get_next_state(from_state, command)
     assert next_state == to_state

--- a/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/pipette_offset/test_state_machine.py
@@ -1,37 +1,34 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand
+from robot_server.service.session.models.command_definitions import CalibrationCommand
 from robot_server.robot.calibration.pipette_offset.state_machine import (
     PipetteOffsetCalibrationStateMachine,
-    PipetteOffsetWithTipLengthStateMachine)
+    PipetteOffsetWithTipLengthStateMachine,
+)
 
 offset_valid_commands: List[Tuple[str, str, str]] = [
-    (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-    (CalibrationCommand.move_to_tip_rack, 'labwareLoaded', 'preparingPipette'),
-    (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
-    (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-    (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-    (CalibrationCommand.move_to_deck, 'inspectingTip', 'joggingToDeck'),
-    (CalibrationCommand.jog, 'joggingToDeck', 'joggingToDeck'),
-    (CalibrationCommand.save_offset, 'joggingToDeck', 'joggingToDeck'),
-    (CalibrationCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
-    (CalibrationCommand.jog, 'savingPointOne', 'savingPointOne'),
-    (CalibrationCommand.save_offset, 'savingPointOne', 'calibrationComplete'),
-    (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
-    (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
-    (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
-    (CalibrationCommand.exit, 'joggingToDeck', 'sessionExited'),
-    (CalibrationCommand.exit, 'savingPointOne', 'sessionExited'),
-    (CalibrationCommand.exit, 'inspectingTip', 'sessionExited'),
-    (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
-    (CalibrationCommand.invalidate_last_action,
-     'preparingPipette', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'joggingToDeck', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'savingPointOne', 'preparingPipette')
+    (CalibrationCommand.load_labware, "sessionStarted", "labwareLoaded"),
+    (CalibrationCommand.move_to_tip_rack, "labwareLoaded", "preparingPipette"),
+    (CalibrationCommand.jog, "preparingPipette", "preparingPipette"),
+    (CalibrationCommand.pick_up_tip, "preparingPipette", "inspectingTip"),
+    (CalibrationCommand.invalidate_tip, "inspectingTip", "preparingPipette"),
+    (CalibrationCommand.move_to_deck, "inspectingTip", "joggingToDeck"),
+    (CalibrationCommand.jog, "joggingToDeck", "joggingToDeck"),
+    (CalibrationCommand.save_offset, "joggingToDeck", "joggingToDeck"),
+    (CalibrationCommand.move_to_point_one, "joggingToDeck", "savingPointOne"),
+    (CalibrationCommand.jog, "savingPointOne", "savingPointOne"),
+    (CalibrationCommand.save_offset, "savingPointOne", "calibrationComplete"),
+    (CalibrationCommand.exit, "calibrationComplete", "sessionExited"),
+    (CalibrationCommand.exit, "sessionStarted", "sessionExited"),
+    (CalibrationCommand.exit, "labwareLoaded", "sessionExited"),
+    (CalibrationCommand.exit, "joggingToDeck", "sessionExited"),
+    (CalibrationCommand.exit, "savingPointOne", "sessionExited"),
+    (CalibrationCommand.exit, "inspectingTip", "sessionExited"),
+    (CalibrationCommand.exit, "preparingPipette", "sessionExited"),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", "preparingPipette"),
+    (CalibrationCommand.invalidate_last_action, "joggingToDeck", "preparingPipette"),
+    (CalibrationCommand.invalidate_last_action, "savingPointOne", "preparingPipette"),
 ]
 
 
@@ -40,60 +37,64 @@ def offset_state_machine():
     return PipetteOffsetCalibrationStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', offset_valid_commands)
+@pytest.mark.parametrize("command,from_state,to_state", offset_valid_commands)
 async def test_valid_offset_commands(
-        command, from_state, to_state, offset_state_machine):
+    command, from_state, to_state, offset_state_machine
+):
     next_state = offset_state_machine.get_next_state(from_state, command)
     assert next_state == to_state
 
 
 fused_valid_commands: List[Tuple[str, str, str]] = [
-    (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-    (CalibrationCommand.move_to_reference_point,
-     'labwareLoaded', 'measuringNozzleOffset'),
-    (CalibrationCommand.move_to_reference_point,
-     'inspectingTip', 'measuringTipOffset'),
-    (CalibrationCommand.save_offset,
-     'measuringNozzleOffset', 'measuringNozzleOffset'),
-    (CalibrationCommand.save_offset,
-     'measuringTipOffset', 'tipLengthComplete'),
-    (CalibrationCommand.save_offset,
-     'joggingToDeck', 'joggingToDeck'),
-    (CalibrationCommand.save_offset,
-     'savingPointOne', 'calibrationComplete'),
-    (CalibrationCommand.jog, 'measuringNozzleOffset', 'measuringNozzleOffset'),
-    (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
-    (CalibrationCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
-    (CalibrationCommand.jog, 'joggingToDeck', 'joggingToDeck'),
-    (CalibrationCommand.jog, 'savingPointOne', 'savingPointOne'),
-    (CalibrationCommand.move_to_tip_rack,
-     'measuringNozzleOffset', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringNozzleOffset', 'measuringNozzleOffset'),
-    (CalibrationCommand.invalidate_last_action,
-     'preparingPipette', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringTipOffset', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'joggingToDeck', 'preparingPipette'),
-    (CalibrationCommand.invalidate_last_action,
-     'savingPointOne', 'preparingPipette'),
-    (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-    (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-    (CalibrationCommand.set_has_calibration_block,
-     'tipLengthComplete', 'tipLengthComplete'),
-    (CalibrationCommand.move_to_deck, 'tipLengthComplete', 'joggingToDeck'),
-    (CalibrationCommand.move_to_point_one, 'joggingToDeck', 'savingPointOne'),
-    (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
-    (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
-    (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
-    (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
-    (CalibrationCommand.exit, 'inspectingTip', 'sessionExited'),
-    (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
-    (CalibrationCommand.exit, 'tipLengthComplete', 'sessionExited'),
-    (CalibrationCommand.exit, 'joggingToDeck', 'sessionExited'),
-    (CalibrationCommand.exit, 'savingPointOne', 'sessionExited'),
-    (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
+    (CalibrationCommand.load_labware, "sessionStarted", "labwareLoaded"),
+    (
+        CalibrationCommand.move_to_reference_point,
+        "labwareLoaded",
+        "measuringNozzleOffset",
+    ),
+    (CalibrationCommand.move_to_reference_point, "inspectingTip", "measuringTipOffset"),
+    (CalibrationCommand.save_offset, "measuringNozzleOffset", "measuringNozzleOffset"),
+    (CalibrationCommand.save_offset, "measuringTipOffset", "tipLengthComplete"),
+    (CalibrationCommand.save_offset, "joggingToDeck", "joggingToDeck"),
+    (CalibrationCommand.save_offset, "savingPointOne", "calibrationComplete"),
+    (CalibrationCommand.jog, "measuringNozzleOffset", "measuringNozzleOffset"),
+    (CalibrationCommand.jog, "preparingPipette", "preparingPipette"),
+    (CalibrationCommand.jog, "measuringTipOffset", "measuringTipOffset"),
+    (CalibrationCommand.jog, "joggingToDeck", "joggingToDeck"),
+    (CalibrationCommand.jog, "savingPointOne", "savingPointOne"),
+    (CalibrationCommand.move_to_tip_rack, "measuringNozzleOffset", "preparingPipette"),
+    (
+        CalibrationCommand.invalidate_last_action,
+        "measuringNozzleOffset",
+        "measuringNozzleOffset",
+    ),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", "preparingPipette"),
+    (
+        CalibrationCommand.invalidate_last_action,
+        "measuringTipOffset",
+        "preparingPipette",
+    ),
+    (CalibrationCommand.invalidate_last_action, "joggingToDeck", "preparingPipette"),
+    (CalibrationCommand.invalidate_last_action, "savingPointOne", "preparingPipette"),
+    (CalibrationCommand.pick_up_tip, "preparingPipette", "inspectingTip"),
+    (CalibrationCommand.invalidate_tip, "inspectingTip", "preparingPipette"),
+    (
+        CalibrationCommand.set_has_calibration_block,
+        "tipLengthComplete",
+        "tipLengthComplete",
+    ),
+    (CalibrationCommand.move_to_deck, "tipLengthComplete", "joggingToDeck"),
+    (CalibrationCommand.move_to_point_one, "joggingToDeck", "savingPointOne"),
+    (CalibrationCommand.exit, "sessionStarted", "sessionExited"),
+    (CalibrationCommand.exit, "labwareLoaded", "sessionExited"),
+    (CalibrationCommand.exit, "measuringNozzleOffset", "sessionExited"),
+    (CalibrationCommand.exit, "preparingPipette", "sessionExited"),
+    (CalibrationCommand.exit, "inspectingTip", "sessionExited"),
+    (CalibrationCommand.exit, "measuringTipOffset", "sessionExited"),
+    (CalibrationCommand.exit, "tipLengthComplete", "sessionExited"),
+    (CalibrationCommand.exit, "joggingToDeck", "sessionExited"),
+    (CalibrationCommand.exit, "savingPointOne", "sessionExited"),
+    (CalibrationCommand.exit, "calibrationComplete", "sessionExited"),
 ]
 
 
@@ -102,8 +103,7 @@ def fused_state_machine():
     return PipetteOffsetWithTipLengthStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', fused_valid_commands)
-async def test_valid_fused_commands(
-        command, from_state, to_state, fused_state_machine):
+@pytest.mark.parametrize("command,from_state,to_state", fused_valid_commands)
+async def test_valid_fused_commands(command, from_state, to_state, fused_state_machine):
     next_state = fused_state_machine.get_next_state(from_state, command)
     assert next_state == to_state

--- a/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_state_machine.py
@@ -1,45 +1,46 @@
 import pytest
 from typing import List, Tuple
 
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand
-from robot_server.robot.calibration.tip_length.state_machine import \
-    TipCalibrationStateMachine
+from robot_server.service.session.models.command_definitions import CalibrationCommand
+from robot_server.robot.calibration.tip_length.state_machine import (
+    TipCalibrationStateMachine,
+)
 
 valid_commands: List[Tuple[str, str, str]] = [
-  (CalibrationCommand.load_labware, 'sessionStarted', 'labwareLoaded'),
-  (CalibrationCommand.move_to_reference_point, 'labwareLoaded',
-   'measuringNozzleOffset'),
-  (CalibrationCommand.jog, 'measuringNozzleOffset',
-   'measuringNozzleOffset'),
-  (CalibrationCommand.save_offset, 'measuringNozzleOffset',
-   'measuringNozzleOffset'),
-  (CalibrationCommand.move_to_tip_rack, 'measuringNozzleOffset',
-   'preparingPipette'),
-  (CalibrationCommand.jog, 'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.pick_up_tip, 'preparingPipette', 'inspectingTip'),
-  (CalibrationCommand.invalidate_tip, 'inspectingTip', 'preparingPipette'),
-  (CalibrationCommand.move_to_reference_point, 'inspectingTip',
-   'measuringTipOffset'),
-  (CalibrationCommand.jog, 'measuringTipOffset', 'measuringTipOffset'),
-  (CalibrationCommand.save_offset, 'measuringTipOffset',
-   'measuringTipOffset'),
-  (CalibrationCommand.move_to_tip_rack, 'measuringTipOffset',
-   'calibrationComplete'),
-  (CalibrationCommand.exit, 'calibrationComplete', 'sessionExited'),
-  (CalibrationCommand.exit, 'sessionStarted', 'sessionExited'),
-  (CalibrationCommand.exit, 'labwareLoaded', 'sessionExited'),
-  (CalibrationCommand.exit, 'measuringNozzleOffset', 'sessionExited'),
-  (CalibrationCommand.exit, 'preparingPipette', 'sessionExited'),
-  (CalibrationCommand.exit, 'measuringTipOffset', 'sessionExited'),
-  (CalibrationCommand.invalidate_last_action,
-   'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.invalidate_last_action,
-   'measuringNozzleOffset', 'measuringNozzleOffset'),
-  (CalibrationCommand.invalidate_last_action,
-   'preparingPipette', 'preparingPipette'),
-  (CalibrationCommand.invalidate_last_action,
-   'measuringTipOffset', 'preparingPipette'),
+    (CalibrationCommand.load_labware, "sessionStarted", "labwareLoaded"),
+    (
+        CalibrationCommand.move_to_reference_point,
+        "labwareLoaded",
+        "measuringNozzleOffset",
+    ),
+    (CalibrationCommand.jog, "measuringNozzleOffset", "measuringNozzleOffset"),
+    (CalibrationCommand.save_offset, "measuringNozzleOffset", "measuringNozzleOffset"),
+    (CalibrationCommand.move_to_tip_rack, "measuringNozzleOffset", "preparingPipette"),
+    (CalibrationCommand.jog, "preparingPipette", "preparingPipette"),
+    (CalibrationCommand.pick_up_tip, "preparingPipette", "inspectingTip"),
+    (CalibrationCommand.invalidate_tip, "inspectingTip", "preparingPipette"),
+    (CalibrationCommand.move_to_reference_point, "inspectingTip", "measuringTipOffset"),
+    (CalibrationCommand.jog, "measuringTipOffset", "measuringTipOffset"),
+    (CalibrationCommand.save_offset, "measuringTipOffset", "measuringTipOffset"),
+    (CalibrationCommand.move_to_tip_rack, "measuringTipOffset", "calibrationComplete"),
+    (CalibrationCommand.exit, "calibrationComplete", "sessionExited"),
+    (CalibrationCommand.exit, "sessionStarted", "sessionExited"),
+    (CalibrationCommand.exit, "labwareLoaded", "sessionExited"),
+    (CalibrationCommand.exit, "measuringNozzleOffset", "sessionExited"),
+    (CalibrationCommand.exit, "preparingPipette", "sessionExited"),
+    (CalibrationCommand.exit, "measuringTipOffset", "sessionExited"),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", "preparingPipette"),
+    (
+        CalibrationCommand.invalidate_last_action,
+        "measuringNozzleOffset",
+        "measuringNozzleOffset",
+    ),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", "preparingPipette"),
+    (
+        CalibrationCommand.invalidate_last_action,
+        "measuringTipOffset",
+        "preparingPipette",
+    ),
 ]
 
 
@@ -48,7 +49,7 @@ def state_machine():
     return TipCalibrationStateMachine()
 
 
-@pytest.mark.parametrize('command,from_state,to_state', valid_commands)
+@pytest.mark.parametrize("command,from_state,to_state", valid_commands)
 async def test_valid_commands(command, from_state, to_state, state_machine):
     next_state = state_machine.get_next_state(from_state, command)
     assert next_state == to_state

--- a/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_user_flow.py
@@ -10,17 +10,16 @@ from opentrons.config.pipette_config import load
 from opentrons.calibration_storage import types as cal_types
 
 from robot_server.service.errors import RobotServerError
-from robot_server.service.session.models.command_definitions import \
-    CalibrationCommand
-from robot_server.robot.calibration.tip_length.user_flow import \
-    TipCalibrationUserFlow
+from robot_server.service.session.models.command_definitions import CalibrationCommand
+from robot_server.robot.calibration.tip_length.user_flow import TipCalibrationUserFlow
 
-stub_jog_data = {'vector': Point(1, 1, 1)}
+stub_jog_data = {"vector": Point(1, 1, 1)}
 
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(
     offset=[0, 0, 0],
     source=cal_types.SourceType.user,
-    status=cal_types.CalibrationStatus())
+    status=cal_types.CalibrationStatus(),
+)
 
 pipette_map = {
     "p10_single_v1.5": "opentrons_96_tiprack_10ul",
@@ -41,9 +40,7 @@ pipette_map = {
 @pytest.fixture(params=pipette_map.keys())
 def mock_hw_pipette_all_combos(request):
     model = request.param
-    return pipette.Pipette(load(model, 'testId'),
-                           PIP_CAL,
-                           'testId')
+    return pipette.Pipette(load(model, "testId"), PIP_CAL, "testId")
 
 
 @pytest.fixture(params=[Mount.RIGHT, Mount.LEFT])
@@ -53,7 +50,7 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
     hardware._current_pos = Point(0, 0, 0)
 
     async def async_mock_move_to(*args, **kwargs):
-        to_pt = kwargs.get('abs_position', Point(0, 0, 0))
+        to_pt = kwargs.get("abs_position", Point(0, 0, 0))
         hardware._current_pos = to_pt
 
     async def gantry_pos_mock(*args, **kwargs):
@@ -67,18 +64,16 @@ def mock_hw_all_combos(hardware, mock_hw_pipette_all_combos, request):
 
 @pytest.fixture
 def mock_hw(hardware):
-    pip = pipette.Pipette(load("p300_single_v2.1", 'testId'),
-                          PIP_CAL,
-                          'testId')
+    pip = pipette.Pipette(load("p300_single_v2.1", "testId"), PIP_CAL, "testId")
     hardware._attached_instruments = {Mount.RIGHT: pip}
     hardware._current_pos = Point(0, 0, 0)
 
     async def async_mock_move_rel(*args, **kwargs):
-        delta = kwargs.get('delta', Point(0, 0, 0))
+        delta = kwargs.get("delta", Point(0, 0, 0))
         hardware._current_pos += delta
 
     async def async_mock_move_to(*args, **kwargs):
-        to_pt = kwargs.get('abs_position', Point(0, 0, 0))
+        to_pt = kwargs.get("abs_position", Point(0, 0, 0))
         hardware._current_pos = to_pt
 
     async def gantry_pos_mock(*args, **kwargs):
@@ -98,15 +93,15 @@ def mock_hw(hardware):
 @pytest.fixture(params=[True, False])
 def mock_user_flow(mock_hw, request):
     has_calibration_block = request.param
-    mount = next(k for k, v in
-                 mock_hw._attached_instruments.items() if v)
+    mount = next(k for k, v in mock_hw._attached_instruments.items() if v)
     pip_model = mock_hw._attached_instruments[mount].model
-    tip_rack = get_labware_definition(pipette_map[pip_model], 'opentrons', '1')
+    tip_rack = get_labware_definition(pipette_map[pip_model], "opentrons", "1")
     m = TipCalibrationUserFlow(
         hardware=mock_hw,
         mount=mount,
         has_calibration_block=has_calibration_block,
-        tip_rack=tip_rack)
+        tip_rack=tip_rack,
+    )
 
     yield m
 
@@ -114,13 +109,13 @@ def mock_user_flow(mock_hw, request):
 @pytest.fixture(params=[True, False])
 def mock_user_flow_with_custom_tiprack(mock_hw, custom_tiprack_def, request):
     has_calibration_block = request.param
-    mount = next(k for k, v in
-                 mock_hw._attached_instruments.items() if v)
+    mount = next(k for k, v in mock_hw._attached_instruments.items() if v)
     m = TipCalibrationUserFlow(
         hardware=mock_hw,
         mount=mount,
         has_calibration_block=has_calibration_block,
-        tip_rack=custom_tiprack_def)
+        tip_rack=custom_tiprack_def,
+    )
 
     yield m
 
@@ -129,45 +124,33 @@ def mock_user_flow_with_custom_tiprack(mock_hw, custom_tiprack_def, request):
 def mock_user_flow_all_combos(mock_hw_all_combos, request):
     has_calibration_block = request.param
     hw = mock_hw_all_combos
-    mount = next(k for k, v in
-                 hw._attached_instruments.items() if v)
+    mount = next(k for k, v in hw._attached_instruments.items() if v)
     pip_model = hw._attached_instruments[mount].model
-    tip_rack = get_labware_definition(pipette_map[pip_model], 'opentrons', '1')
+    tip_rack = get_labware_definition(pipette_map[pip_model], "opentrons", "1")
     m = TipCalibrationUserFlow(
         hardware=hw,
         mount=mount,
         has_calibration_block=has_calibration_block,
-        tip_rack=tip_rack)
+        tip_rack=tip_rack,
+    )
 
     yield m
 
 
 hw_commands: List[Tuple[str, str, Dict[Any, Any], str]] = [
-    (CalibrationCommand.jog, 'measuringNozzleOffset',
-     stub_jog_data, 'move_rel'),
-    (CalibrationCommand.pick_up_tip, 'preparingPipette', {}, 'pick_up_tip'),
-    (CalibrationCommand.move_to_reference_point, 'labwareLoaded',
-     {}, 'move_to'),
-    (CalibrationCommand.move_to_reference_point, 'inspectingTip',
-     {}, 'move_to'),
-    (CalibrationCommand.move_to_tip_rack, 'measuringNozzleOffset',
-     {}, 'move_to'),
-    (CalibrationCommand.move_to_tip_rack, 'measuringTipOffset',
-     {}, 'move_to'),
-    (CalibrationCommand.invalidate_last_action,
-     'preparingPipette', {}, 'home'),
-    (CalibrationCommand.invalidate_last_action,
-     'preparingPipette', {}, 'move_to'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringTipOffset', {}, 'home'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringTipOffset', {}, 'drop_tip'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringTipOffset', {}, 'move_to'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringNozzleOffset', {}, 'home'),
-    (CalibrationCommand.invalidate_last_action,
-     'measuringNozzleOffset', {}, 'move_to'),
+    (CalibrationCommand.jog, "measuringNozzleOffset", stub_jog_data, "move_rel"),
+    (CalibrationCommand.pick_up_tip, "preparingPipette", {}, "pick_up_tip"),
+    (CalibrationCommand.move_to_reference_point, "labwareLoaded", {}, "move_to"),
+    (CalibrationCommand.move_to_reference_point, "inspectingTip", {}, "move_to"),
+    (CalibrationCommand.move_to_tip_rack, "measuringNozzleOffset", {}, "move_to"),
+    (CalibrationCommand.move_to_tip_rack, "measuringTipOffset", {}, "move_to"),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", {}, "home"),
+    (CalibrationCommand.invalidate_last_action, "preparingPipette", {}, "move_to"),
+    (CalibrationCommand.invalidate_last_action, "measuringTipOffset", {}, "home"),
+    (CalibrationCommand.invalidate_last_action, "measuringTipOffset", {}, "drop_tip"),
+    (CalibrationCommand.invalidate_last_action, "measuringTipOffset", {}, "move_to"),
+    (CalibrationCommand.invalidate_last_action, "measuringNozzleOffset", {}, "home"),
+    (CalibrationCommand.invalidate_last_action, "measuringNozzleOffset", {}, "move_to"),
 ]
 
 
@@ -175,7 +158,7 @@ async def test_move_to_tip_rack(mock_user_flow):
     uf = mock_user_flow
     await uf.move_to_tip_rack()
     cur_pt = await uf.get_current_point(None)
-    assert cur_pt == uf._deck['8'].wells()[0].top().point + Point(0, 0, 10)
+    assert cur_pt == uf._deck["8"].wells()[0].top().point + Point(0, 0, 10)
 
 
 async def test_move_to_reference_point(mock_user_flow_all_combos):
@@ -186,15 +169,16 @@ async def test_move_to_reference_point(mock_user_flow_all_combos):
     cur_pt = await uf.get_current_point(None)
     if uf._has_calibration_block:
         if uf._mount == Mount.LEFT:
-            assert cur_pt == \
-                uf._deck['3'].wells_by_name()['A1'].top().point + buff
+            assert cur_pt == uf._deck["3"].wells_by_name()["A1"].top().point + buff
         else:
-            assert cur_pt == \
-                uf._deck['1'].wells_by_name()['A2'].top().point + buff
+            assert cur_pt == uf._deck["1"].wells_by_name()["A2"].top().point + buff
     else:
-        assert cur_pt == \
-            uf._deck.get_fixed_trash().wells_by_name()['A1'].top().point + \
-            trash_offset + buff
+        assert (
+            cur_pt
+            == uf._deck.get_fixed_trash().wells_by_name()["A1"].top().point
+            + trash_offset
+            + buff
+        )
 
 
 async def test_jog(mock_user_flow):
@@ -217,15 +201,15 @@ async def test_invalidate_tip(mock_user_flow):
     uf = mock_user_flow
     uf._tip_origin_pt = Point(1, 1, 1)
     uf._hw_pipette._has_tip = True
-    z_offset = uf._hw_pipette.config.return_tip_height * \
-        uf._get_default_tip_length()
+    z_offset = uf._hw_pipette.config.return_tip_height * uf._get_default_tip_length()
     await uf.invalidate_tip()
     # should move to return tip
     move_calls = [
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf.critical_point_override,)
+            critical_point=uf.critical_point_override,
+        )
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
@@ -235,21 +219,21 @@ async def test_exit(mock_user_flow):
     uf = mock_user_flow
     uf._tip_origin_pt = Point(1, 1, 1)
     uf._hw_pipette._has_tip = True
-    z_offset = uf._hw_pipette.config.return_tip_height * \
-        uf._get_default_tip_length()
+    z_offset = uf._hw_pipette.config.return_tip_height * uf._get_default_tip_length()
     await uf.invalidate_tip()
     # should move to return tip
     move_calls = [
         call(
             mount=Mount.RIGHT,
             abs_position=Point(1, 1, 1 - z_offset),
-            critical_point=uf.critical_point_override)
+            critical_point=uf.critical_point_override,
+        )
     ]
     uf._hardware.move_to.assert_has_calls(move_calls)
     uf._hardware.drop_tip.assert_called()
 
 
-@pytest.mark.parametrize('command,current_state,data,hw_meth', hw_commands)
+@pytest.mark.parametrize("command,current_state,data,hw_meth", hw_commands)
 async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
     mock_user_flow._current_state = current_state
     await mock_user_flow.handle_command(command, data)
@@ -258,31 +242,32 @@ async def test_hw_calls(command, current_state, data, hw_meth, mock_user_flow):
 
 
 def test_load_trash(mock_user_flow):
-    assert mock_user_flow._deck['12'].load_name == \
-        'opentrons_1_trash_1100ml_fixed'
+    assert mock_user_flow._deck["12"].load_name == "opentrons_1_trash_1100ml_fixed"
 
 
 def test_load_deck(mock_user_flow_all_combos):
     uf = mock_user_flow_all_combos
     pip_model = uf._hw_pipette.model
     tip_rack = pipette_map[pip_model]
-    assert uf._deck['8'].load_name == tip_rack
+    assert uf._deck["8"].load_name == tip_rack
 
 
 def test_load_cal_block(mock_user_flow_all_combos):
     uf = mock_user_flow_all_combos
     if uf._has_calibration_block:
         if uf._mount == Mount.RIGHT:
-            assert uf._deck['1'].load_name == \
-                    'opentrons_calibrationblock_short_side_left'
-            assert uf._deck['3'] is None
+            assert (
+                uf._deck["1"].load_name == "opentrons_calibrationblock_short_side_left"
+            )
+            assert uf._deck["3"] is None
         else:
-            assert uf._deck['3'].load_name == \
-                    'opentrons_calibrationblock_short_side_right'
-            assert uf._deck['1'] is None
+            assert (
+                uf._deck["3"].load_name == "opentrons_calibrationblock_short_side_right"
+            )
+            assert uf._deck["1"] is None
     else:
-        assert uf._deck['1'] is None
-        assert uf._deck['3'] is None
+        assert uf._deck["1"] is None
+        assert uf._deck["3"] is None
 
 
 async def test_get_reference_location(mock_user_flow_all_combos):
@@ -291,64 +276,65 @@ async def test_get_reference_location(mock_user_flow_all_combos):
     cur_pt = await uf.get_current_point(None)
     if uf._has_calibration_block:
         if uf._mount == Mount.LEFT:
-            exp = uf._deck['3'].wells()[0].top().move(Point(0, 0, 5))
+            exp = uf._deck["3"].wells()[0].top().move(Point(0, 0, 5))
         else:
-            exp = uf._deck['1'].wells()[1].top().move(Point(0, 0, 5))
+            exp = uf._deck["1"].wells()[1].top().move(Point(0, 0, 5))
     else:
-        exp = uf._deck.get_fixed_trash().wells()[0].top().move(
-            Point(-57.84, -55, 5))
+        exp = uf._deck.get_fixed_trash().wells()[0].top().move(Point(-57.84, -55, 5))
     assert cur_pt == exp.point
 
 
 async def test_save_offsets(mock_user_flow):
     with patch(
-            'opentrons.calibration_storage.modify.create_tip_length_data'
+        "opentrons.calibration_storage.modify.create_tip_length_data"
     ) as create_tip_length_data_patch:
         uf = mock_user_flow
-        uf._current_state = 'measuringNozzleOffset'
+        uf._current_state = "measuringNozzleOffset"
         assert uf._nozzle_height_at_reference is None
         await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=10),
-            critical_point=uf.critical_point_override)
+            critical_point=uf.critical_point_override,
+        )
         await uf.save_offset()
         assert uf._nozzle_height_at_reference == 10
 
-        uf._current_state = 'measuringTipOffset'
+        uf._current_state = "measuringTipOffset"
         uf._hw_pipette._has_tip = True
         await uf._hardware.move_to(
             mount=uf._mount,
             abs_position=Point(x=10, y=10, z=40),
-            critical_point=uf.critical_point_override)
+            critical_point=uf.critical_point_override,
+        )
         await uf.save_offset()
         create_tip_length_data_patch.assert_called_with(ANY, 30)
 
 
 async def test_save_custom_tiprack_def(
-        mock_user_flow_with_custom_tiprack,
-        clear_custom_tiprack_def_dir):
+    mock_user_flow_with_custom_tiprack, clear_custom_tiprack_def_dir
+):
     uf = mock_user_flow_with_custom_tiprack
-    uf._current_state = 'measuringTipOffset'
+    uf._current_state = "measuringTipOffset"
     uf._hw_pipette._has_tip = True
     uf._nozzle_height_at_reference = 0
 
-    assert not os.path.exists(config.get_custom_tiprack_def_path()
-                              / 'custom/minimal_labware_def/1.json')
+    assert not os.path.exists(
+        config.get_custom_tiprack_def_path() / "custom/minimal_labware_def/1.json"
+    )
 
     await uf.save_offset()
-    assert os.path.exists(config.get_custom_tiprack_def_path()
-                          / 'custom/minimal_labware_def/1.json')
+    assert os.path.exists(
+        config.get_custom_tiprack_def_path() / "custom/minimal_labware_def/1.json"
+    )
 
 
-@pytest.mark.parametrize(argnames="mount",
-                         argvalues=[Mount.RIGHT, Mount.LEFT])
+@pytest.mark.parametrize(argnames="mount", argvalues=[Mount.RIGHT, Mount.LEFT])
 def test_no_pipette(hardware, mount):
     hardware._attached_instruments = {mount: None}
     with pytest.raises(RobotServerError) as error:
-        TipCalibrationUserFlow(hardware=hardware,
-                               mount=mount,
-                               has_calibration_block=None,
-                               tip_rack=None)
+        TipCalibrationUserFlow(
+            hardware=hardware, mount=mount, has_calibration_block=None, tip_rack=None
+        )
 
     assert error.value.content["errors"][0]["detail"] == (
         f"No pipette present on {mount} mount"

--- a/robot-server/tests/robot/calibration/tip_length/test_util.py
+++ b/robot-server/tests/robot/calibration/tip_length/test_util.py
@@ -6,92 +6,69 @@ from robot_server.robot.calibration import util
 @pytest.fixture
 def machine(loop):
     states = {
-              'imaginingTable',
-              'millingLumber',
-              'sawingToDimensions',
-              'assemblingTable'
-              'gluingUp'
-              'rethinkingDesign',
-              'sandingDown',
-              'applyingFinish',
-              'admiringWork'}
+        "imaginingTable",
+        "millingLumber",
+        "sawingToDimensions",
+        "assemblingTable" "gluingUp" "rethinkingDesign",
+        "sandingDown",
+        "applyingFinish",
+        "admiringWork",
+    }
     transitions = {
-        'imaginingTable': {
-            'mill': 'millingLumber'
-        },
-        'millingLumber': {
-            'saw': 'sawingToDimensions'
-        },
-        'sawingToDimensions': {
-            'assemble': 'assemblingTable',
-            'glueUp': 'gluingUp'
-        },
-        'assemblingTable': {
-            'glueUp': 'gluingUp',
-            'sand': 'sandingDown'
-        },
-        'gluingUp': {
-            'assemble': 'assemblingTable',
-            'sand': 'sandingDown'
-        },
-        'sandingDown': {
-            'applyFinish': 'applyingFinish'
-        },
-        'applyingFinish': {
-            'admire': 'admiringWork'
-        },
-        'rethinkingDesign': {
-            'saw': 'sawingToDimensions'
-        },
-        util.STATE_WILDCARD: {
-            'rethink': 'rethinkingDesign'
-        }
+        "imaginingTable": {"mill": "millingLumber"},
+        "millingLumber": {"saw": "sawingToDimensions"},
+        "sawingToDimensions": {"assemble": "assemblingTable", "glueUp": "gluingUp"},
+        "assemblingTable": {"glueUp": "gluingUp", "sand": "sandingDown"},
+        "gluingUp": {"assemble": "assemblingTable", "sand": "sandingDown"},
+        "sandingDown": {"applyFinish": "applyingFinish"},
+        "applyingFinish": {"admire": "admiringWork"},
+        "rethinkingDesign": {"saw": "sawingToDimensions"},
+        util.STATE_WILDCARD: {"rethink": "rethinkingDesign"},
     }
 
-    return util.SimpleStateMachine(states=states,
-                                   transitions=transitions)
+    return util.SimpleStateMachine(states=states, transitions=transitions)
 
 
 valid_transitions: List[Tuple[str, str, str]] = [
-    ('imaginingTable', 'mill', 'millingLumber'),
-    ('millingLumber', 'saw', 'sawingToDimensions'),
-    ('sawingToDimensions', 'glueUp', 'gluingUp'),
-    ('sawingToDimensions', 'assemble', 'assemblingTable'),
-    ('assemblingTable', 'glueUp', 'gluingUp'),
-    ('assemblingTable', 'sand', 'sandingDown'),
-    ('gluingUp', 'assemble', 'assemblingTable'),
-    ('gluingUp', 'sand', 'sandingDown'),
-    ('sandingDown', 'applyFinish', 'applyingFinish'),
-    ('applyingFinish', 'admire', 'admiringWork'),
-    ('rethinkingDesign', 'saw', 'sawingToDimensions'),
-    ('imaginingTable', 'rethink', 'rethinkingDesign'),
-    ('millingLumber', 'rethink', 'rethinkingDesign'),
-    ('sawingToDimensions', 'rethink', 'rethinkingDesign'),
-    ('assemblingTable', 'rethink', 'rethinkingDesign'),
-    ('gluingUp', 'rethink', 'rethinkingDesign'),
-    ('rethinkingDesign', 'rethink', 'rethinkingDesign'),
-    ('sandingDown', 'rethink', 'rethinkingDesign'),
-    ('applyingFinish', 'rethink', 'rethinkingDesign'),
-    ('admiringWork', 'rethink', 'rethinkingDesign'),
+    ("imaginingTable", "mill", "millingLumber"),
+    ("millingLumber", "saw", "sawingToDimensions"),
+    ("sawingToDimensions", "glueUp", "gluingUp"),
+    ("sawingToDimensions", "assemble", "assemblingTable"),
+    ("assemblingTable", "glueUp", "gluingUp"),
+    ("assemblingTable", "sand", "sandingDown"),
+    ("gluingUp", "assemble", "assemblingTable"),
+    ("gluingUp", "sand", "sandingDown"),
+    ("sandingDown", "applyFinish", "applyingFinish"),
+    ("applyingFinish", "admire", "admiringWork"),
+    ("rethinkingDesign", "saw", "sawingToDimensions"),
+    ("imaginingTable", "rethink", "rethinkingDesign"),
+    ("millingLumber", "rethink", "rethinkingDesign"),
+    ("sawingToDimensions", "rethink", "rethinkingDesign"),
+    ("assemblingTable", "rethink", "rethinkingDesign"),
+    ("gluingUp", "rethink", "rethinkingDesign"),
+    ("rethinkingDesign", "rethink", "rethinkingDesign"),
+    ("sandingDown", "rethink", "rethinkingDesign"),
+    ("applyingFinish", "rethink", "rethinkingDesign"),
+    ("admiringWork", "rethink", "rethinkingDesign"),
 ]
 
 
-@pytest.mark.parametrize('from_state,command,to_state', valid_transitions)
+@pytest.mark.parametrize("from_state,command,to_state", valid_transitions)
 async def test_valid_transitions(from_state, command, to_state, machine):
     resulting_state = machine.get_next_state(from_state, command)
     assert resulting_state == to_state
 
 
 invalid_transitions: List[Tuple[str, str]] = [
-    ('imaginingTable', 'glue'),
-    ('millingLumber', 'assemble'),
-    ('gluingUp', 'doSomethingUnrelatedToWoodworking'),
-    ('admiringWork', 'mill'),
-    ('admiringWork', '*'),
+    ("imaginingTable", "glue"),
+    ("millingLumber", "assemble"),
+    ("gluingUp", "doSomethingUnrelatedToWoodworking"),
+    ("admiringWork", "mill"),
+    ("admiringWork", "*"),
 ]
 
 
-@pytest.mark.parametrize('from_state,command', invalid_transitions)
+@pytest.mark.parametrize("from_state,command", invalid_transitions)
 async def test_invalid_transitions(from_state, command, machine):
     resulting_state = machine.get_next_state(from_state, command)
     assert resulting_state is None

--- a/robot-server/tests/service/helpers.py
+++ b/robot-server/tests/service/helpers.py
@@ -1,8 +1,7 @@
 from pydantic import BaseModel
 
 from robot_server.service.json_api import ResponseDataModel
-from robot_server.service.json_api.request import (
-    RequestModel)
+from robot_server.service.json_api.request import RequestModel
 
 
 class ItemModel(BaseModel):

--- a/robot-server/tests/service/json_api/test_request.py
+++ b/robot-server/tests/service/json_api/test_request.py
@@ -2,91 +2,75 @@ from pytest import raises
 
 from pydantic import ValidationError
 
-from robot_server.service.json_api.request import (
-    RequestModel)
+from robot_server.service.json_api.request import RequestModel
 from tests.service.helpers import ItemModel
 
 
 def test_attributes_as_dict():
     DictRequest = RequestModel[dict]
-    obj_to_validate = {
-        'data': {'some_data': 1}
-    }
+    obj_to_validate = {"data": {"some_data": 1}}
     my_request_obj = DictRequest(**obj_to_validate)
-    assert my_request_obj.dict() == {
-        'data': {'some_data': 1}
-    }
+    assert my_request_obj.dict() == {"data": {"some_data": 1}}
 
 
 def test_attributes_as_item_model():
     ItemRequest = RequestModel[ItemModel]
-    obj_to_validate = {
-        'data': {
-            'name': 'apple',
-            'quantity': 10,
-            'price': 1.20
-        }
-    }
+    obj_to_validate = {"data": {"name": "apple", "quantity": 10, "price": 1.20}}
     my_request_obj = ItemRequest(**obj_to_validate)
     assert my_request_obj.dict() == obj_to_validate
 
 
 def test_attributes_as_item_model_empty_dict():
     ItemRequest = RequestModel[ItemModel]
-    obj_to_validate = {
-        'data': {
-        }
-    }
+    obj_to_validate = {"data": {}}
     with raises(ValidationError) as e:
         ItemRequest(**obj_to_validate)
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'name'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }, {
-            'loc': ('data', 'quantity'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }, {
-            'loc': ('data', 'price'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }
+            "loc": ("data", "name"),
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+        {
+            "loc": ("data", "quantity"),
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+        {
+            "loc": ("data", "price"),
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
     ]
 
 
 def test_attributes_required():
     MyRequest = RequestModel[dict]
-    obj_to_validate = {
-        'data': None
-    }
+    obj_to_validate = {"data": None}
     with raises(ValidationError) as e:
         MyRequest(**obj_to_validate)
 
     assert e.value.errors() == [
         {
-            'loc': ('data',),
-            'msg': 'none is not an allowed value',
-            'type': 'type_error.none.not_allowed'
+            "loc": ("data",),
+            "msg": "none is not an allowed value",
+            "type": "type_error.none.not_allowed",
         },
     ]
 
 
 def test_data_required():
     MyRequest = RequestModel[dict]
-    obj_to_validate = {
-        'data': None
-    }
+    obj_to_validate = {"data": None}
     with raises(ValidationError) as e:
         MyRequest(**obj_to_validate)
 
     assert e.value.errors() == [
         {
-            'loc': ('data',),
-            'msg': 'none is not an allowed value',
-            'type': 'type_error.none.not_allowed'
+            "loc": ("data",),
+            "msg": "none is not an allowed value",
+            "type": "type_error.none.not_allowed",
         },
     ]
 
@@ -94,17 +78,9 @@ def test_data_required():
 def test_request_with_id():
     MyRequest = RequestModel[dict]
     obj_to_validate = {
-        'data': {
-            'type': 'item',
-            'attributes': {},
-            'id': 'abc123'
-        },
+        "data": {"type": "item", "attributes": {}, "id": "abc123"},
     }
     my_request_obj = MyRequest(**obj_to_validate)
     assert my_request_obj.dict() == {
-        'data': {
-            'type': 'item',
-            'attributes': {},
-            'id': 'abc123'
-        },
+        "data": {"type": "item", "attributes": {}, "id": "abc123"},
     }

--- a/robot-server/tests/service/json_api/test_resource_links.py
+++ b/robot-server/tests/service/json_api/test_resource_links.py
@@ -10,8 +10,8 @@ class ThingWithLink(BaseModel):
 
 def test_follows_structure():
     structure_to_validate = {
-        'links': {
-            'self': {'href': '/items/1', 'meta': None},
+        "links": {
+            "self": {"href": "/items/1", "meta": None},
         }
     }
     validated = ThingWithLink(**structure_to_validate)
@@ -20,16 +20,12 @@ def test_follows_structure():
 
 def test_must_be_self_key_with_string_value():
     invalid_structure_to_validate = {
-        'invalid': {
-            'key': 'value',
+        "invalid": {
+            "key": "value",
         }
     }
     with raises(ValidationError) as e:
         ThingWithLink(**invalid_structure_to_validate)
     assert e.value.errors() == [
-        {
-            'loc': ('links',),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }
+        {"loc": ("links",), "msg": "field required", "type": "value_error.missing"}
     ]

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -2,81 +2,69 @@ from pytest import raises
 from pydantic import ValidationError
 
 from robot_server.service.json_api.response import (
-    ResponseDataModel, ResponseModel, MultiResponseModel)
+    ResponseDataModel,
+    ResponseModel,
+    MultiResponseModel,
+)
 from tests.service.helpers import ItemResponseModel
 
 
 def test_attributes_as_dict():
     MyResponse = ResponseModel[ResponseDataModel]
     obj_to_validate = {
-        'data': {'id': '123'},
+        "data": {"id": "123"},
     }
     my_response_object = MyResponse(**obj_to_validate)
     assert my_response_object.dict() == {
-        'links': None,
-        'data': {
-            'id': '123',
-        }
+        "links": None,
+        "data": {
+            "id": "123",
+        },
     }
 
 
 def test_attributes_as_item_model():
     ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'links': None,
-        'data': {
-            'id': '123',
-            'name': 'apple',
-            'quantity': 10,
-            'price': 1.20
-        }
+        "links": None,
+        "data": {"id": "123", "name": "apple", "quantity": 10, "price": 1.20},
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'links': None,
-        'data': {
-            'id': '123',
-            'name': 'apple',
-            'quantity': 10,
-            'price': 1.20,
-        }
+        "links": None,
+        "data": {
+            "id": "123",
+            "name": "apple",
+            "quantity": 10,
+            "price": 1.20,
+        },
     }
 
 
 def test_list_item_model():
     ItemResponse = MultiResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'links': None,
-        'data': [
-            {
-                'id': '123',
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20
-            },
-            {
-                'id': '321',
-                'name': 'banana',
-                'quantity': 20,
-                'price': 2.34
-            },
+        "links": None,
+        "data": [
+            {"id": "123", "name": "apple", "quantity": 10, "price": 1.20},
+            {"id": "321", "name": "banana", "quantity": 20, "price": 2.34},
         ],
     }
     my_response_obj = ItemResponse(**obj_to_validate)
     assert my_response_obj.dict() == {
-        'links': None,
-        'data': [
+        "links": None,
+        "data": [
             {
-                'id': '123',
-                'name': 'apple',
-                'quantity': 10,
-                'price': 1.20,
+                "id": "123",
+                "name": "apple",
+                "quantity": 10,
+                "price": 1.20,
             },
             {
-                'id': '321',
-                'name': 'banana',
-                'quantity': 20,
-                'price': 2.34,
+                "id": "321",
+                "name": "banana",
+                "quantity": 20,
+                "price": 2.34,
             },
         ],
     }
@@ -85,8 +73,8 @@ def test_list_item_model():
 def test_attributes_as_item_model_empty_dict():
     ItemResponse = ResponseModel[ItemResponseModel]
     obj_to_validate = {
-        'data': {
-            'id': '123',
+        "data": {
+            "id": "123",
         }
     }
     with raises(ValidationError) as e:
@@ -94,67 +82,67 @@ def test_attributes_as_item_model_empty_dict():
 
     assert e.value.errors() == [
         {
-            'loc': ('data', 'name'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }, {
-            'loc': ('data', 'quantity'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
-        }, {
-            'loc': ('data', 'price'),
-            'msg': 'field required',
-            'type': 'value_error.missing'
+            "loc": ("data", "name"),
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+        {
+            "loc": ("data", "quantity"),
+            "msg": "field required",
+            "type": "value_error.missing",
+        },
+        {
+            "loc": ("data", "price"),
+            "msg": "field required",
+            "type": "value_error.missing",
         },
     ]
 
 
 def test_response_constructed_with_resource_object():
     ItemResponse = ResponseModel[ItemResponseModel]
-    item = ItemResponseModel(id="abc123", name='pear', price=1.2, quantity=10)
+    item = ItemResponseModel(id="abc123", name="pear", price=1.2, quantity=10)
     data = item.dict()
 
     assert ItemResponse(data=data).dict() == {
-        'links': None,
+        "links": None,
         "data": {
-            'id': 'abc123',
-            'name': 'pear',
-            'price': 1.2,
-            'quantity': 10,
-        }
+            "id": "abc123",
+            "name": "pear",
+            "price": 1.2,
+            "quantity": 10,
+        },
     }
 
 
 def test_response_constructed_with_resource_object_list():
     ItemResponse = MultiResponseModel[ItemResponseModel]
     items = [
-        ItemResponseModel(id="1", name='apple', price=1.5, quantity=3),
-        ItemResponseModel(id="2", name='pear', price=1.2, quantity=10),
-        ItemResponseModel(id="3", name='orange', price=2.2, quantity=5)
+        ItemResponseModel(id="1", name="apple", price=1.5, quantity=3),
+        ItemResponseModel(id="2", name="pear", price=1.2, quantity=10),
+        ItemResponseModel(id="3", name="orange", price=2.2, quantity=5),
     ]
-    response = ItemResponse(
-        data=items
-    )
+    response = ItemResponse(data=items)
     assert response.dict() == {
-        'links': None,
-        'data': [
+        "links": None,
+        "data": [
             {
-                'id': '1',
-                'name': 'apple',
-                'price': 1.5,
-                'quantity': 3,
+                "id": "1",
+                "name": "apple",
+                "price": 1.5,
+                "quantity": 3,
             },
             {
-                'id': '2',
-                'name': 'pear',
-                'price': 1.2,
-                'quantity': 10,
+                "id": "2",
+                "name": "pear",
+                "price": 1.2,
+                "quantity": 10,
             },
             {
-                'id': '3',
-                'name': 'orange',
-                'price': 2.2,
-                'quantity': 5,
+                "id": "3",
+                "name": "orange",
+                "price": 2.2,
+                "quantity": 5,
             },
-        ]
+        ],
     }

--- a/robot-server/tests/service/labware/test_labware_calibration_access.py
+++ b/robot-server/tests/service/labware/test_labware_calibration_access.py
@@ -6,15 +6,14 @@ from opentrons import config
 
 @pytest.fixture
 def grab_id(set_up_index_file_temporary_directory):
-    labware_to_access = 'opentrons_96_tiprack_10ul'
-    uri_to_check = f'opentrons/{labware_to_access}/1'
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    index_path = offset_path / 'index.json'
+    labware_to_access = "opentrons_96_tiprack_10ul"
+    uri_to_check = f"opentrons/{labware_to_access}/1"
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    index_path = offset_path / "index.json"
     index_file = file_operators.read_cal_file(str(index_path))
-    calibration_id = ''
-    for key, data in index_file['data'].items():
-        if data['uri'] == uri_to_check:
+    calibration_id = ""
+    for key, data in index_file["data"].items():
+        if data["uri"] == uri_to_check:
             calibration_id = key
     return calibration_id
 
@@ -22,52 +21,56 @@ def grab_id(set_up_index_file_temporary_directory):
 def test_access_individual_labware(api_client, grab_id):
     calibration_id = grab_id
     expected = {
-        'id': calibration_id,
-        'calibrationData': {
-            'offset': {
-                'value': [0.0, 0.0, 0.0],
-                'lastModified': None},
-            'tipLength': {
-                'value': None,
-                'lastModified': None}},
-        'loadName': 'opentrons_96_tiprack_10ul',
-        'namespace': 'opentrons',
-        'version': 1,
-        'parent': '',
-        'definitionHash': calibration_id}
+        "id": calibration_id,
+        "calibrationData": {
+            "offset": {"value": [0.0, 0.0, 0.0], "lastModified": None},
+            "tipLength": {"value": None, "lastModified": None},
+        },
+        "loadName": "opentrons_96_tiprack_10ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "parent": "",
+        "definitionHash": calibration_id,
+    }
 
-    resp = api_client.get(f'/labware/calibrations/{calibration_id}')
+    resp = api_client.get(f"/labware/calibrations/{calibration_id}")
     assert resp.status_code == 200
     body = resp.json()
-    data = body['data']
-    data['calibrationData']['offset']['lastModified'] = None
-    data['calibrationData']['tipLength']['lastModified'] = None
+    data = body["data"]
+    data["calibrationData"]["offset"]["lastModified"] = None
+    data["calibrationData"]["tipLength"]["lastModified"] = None
     assert data == expected
 
-    resp = api_client.get('/labware/calibrations/funnyId')
+    resp = api_client.get("/labware/calibrations/funnyId")
     assert resp.status_code == 404
     body = resp.json()
     assert body == {
-        'errors': [{
-            'id': 'UncategorizedError',
-            'title': 'Resource Not Found',
-            'detail': "Resource type 'calibration' with id "
-                      "'funnyId' was not found"
-        }]}
+        "errors": [
+            {
+                "id": "UncategorizedError",
+                "title": "Resource Not Found",
+                "detail": "Resource type 'calibration' with id "
+                "'funnyId' was not found",
+            }
+        ]
+    }
 
 
 def test_delete_individual_labware(api_client, grab_id):
     calibration_id = grab_id
-    resp = api_client.delete('/labware/calibrations/funnyId')
+    resp = api_client.delete("/labware/calibrations/funnyId")
     assert resp.status_code == 404
     body = resp.json()
     assert body == {
-        'errors': [{
-            'id': 'UncategorizedError',
-            'title': 'Resource Not Found',
-            'detail': "Resource type 'calibration' with id "
-                      "'funnyId' was not found"
-        }]}
+        "errors": [
+            {
+                "id": "UncategorizedError",
+                "title": "Resource Not Found",
+                "detail": "Resource type 'calibration' with id "
+                "'funnyId' was not found",
+            }
+        ]
+    }
 
-    resp = api_client.delete(f'/labware/calibrations/{calibration_id}')
+    resp = api_client.delete(f"/labware/calibrations/{calibration_id}")
     assert resp.status_code == 200

--- a/robot-server/tests/service/legacy/models/test_control.py
+++ b/robot-server/tests/service/legacy/models/test_control.py
@@ -4,27 +4,24 @@ from robot_server.service.legacy.models import control
 
 def test_robot_home_target():
     """Test validation that mount must be present if mount is pipette"""
-    with pytest.raises(ValueError,
-                       match="mount must be specified if target is pipette"):
+    with pytest.raises(
+        ValueError, match="mount must be specified if target is pipette"
+    ):
         control.RobotHomeTarget(target=control.HomeTarget.pipette)
 
 
 def test_robot_move_target_points_too_few():
-    with pytest.raises(ValueError,
-                       match="ensure this value has at least 3 items"):
-        control.RobotMoveTarget(target=control.MotionTarget.pipette,
-                                point=[1, 2])
+    with pytest.raises(ValueError, match="ensure this value has at least 3 items"):
+        control.RobotMoveTarget(target=control.MotionTarget.pipette, point=[1, 2])
 
 
 def test_robot_move_target_points_too_many():
-    with pytest.raises(ValueError,
-                       match="ensure this value has at most 3 items"):
-        control.RobotMoveTarget(target=control.MotionTarget.pipette,
-                                point=[1, 2, 3, 4])
+    with pytest.raises(ValueError, match="ensure this value has at most 3 items"):
+        control.RobotMoveTarget(target=control.MotionTarget.pipette, point=[1, 2, 3, 4])
 
 
 def test_robot_move_target_points_too_low():
-    with pytest.raises(ValueError,
-                       match="Sending a mount to a z position lower than 30"):
-        control.RobotMoveTarget(target=control.MotionTarget.mount,
-                                point=[1, 2, 3])
+    with pytest.raises(
+        ValueError, match="Sending a mount to a z position lower than 30"
+    ):
+        control.RobotMoveTarget(target=control.MotionTarget.mount, point=[1, 2, 3])

--- a/robot-server/tests/service/legacy/models/test_modules.py
+++ b/robot-server/tests/service/legacy/models/test_modules.py
@@ -2,22 +2,23 @@ from robot_server.service.legacy.models import modules
 
 
 def test_validate_command_no_type_conversion():
-    cmd = modules.SerialCommand(
-            command_type="a_valid_cmd",
-            args=["30"]
-        )
+    cmd = modules.SerialCommand(command_type="a_valid_cmd", args=["30"])
     assert type(cmd.args[0]) == str
     assert cmd.args[0] == "30"
 
 
 def test_validate_command_args_multiple_types():
     cmd = modules.SerialCommand(
-            command_type="a_valid_cmd",
-            args=[[{"temperature": 30, "hold_time_seconds": 20},
-                   {"temperature": 40, "hold_time_seconds": 35}],
-                  10,
-                  50.5]
-        )
+        command_type="a_valid_cmd",
+        args=[
+            [
+                {"temperature": 30, "hold_time_seconds": 20},
+                {"temperature": 40, "hold_time_seconds": 35},
+            ],
+            10,
+            50.5,
+        ],
+    )
     assert type(cmd.args[0]) == list
     assert type(cmd.args[1]) == int
     assert type(cmd.args[2]) == float

--- a/robot-server/tests/service/legacy/models/test_networking.py
+++ b/robot-server/tests/service/legacy/models/test_networking.py
@@ -12,10 +12,10 @@ def test_validate_configuration_deduce_security_eap():
     n = networking.WifiConfiguration(
         ssid="a",
         eapConfig={
-            'eapType': 'peap/eap-mschapv2',
-            'identity': 'test@hi.com',
-            'password': 'passwd'
-        }
+            "eapType": "peap/eap-mschapv2",
+            "identity": "test@hi.com",
+            "password": "passwd",
+        },
     )
     expected = networking.NetworkingSecurityType.wpa_eap
     assert n.securityType == expected
@@ -29,17 +29,15 @@ def test_validate_configuration_deduce_security_invalid():
             ssid="a",
             psk="ee",
             eapConfig={
-                'eapType': 'peap/eap-mschapv2',
-                'identity': 'test@hi.com',
-                'password': 'passwd'
-            }
+                "eapType": "peap/eap-mschapv2",
+                "identity": "test@hi.com",
+                "password": "passwd",
+            },
         )
 
 
 def test_validate_configuration_deduce_security_none():
-    n = networking.WifiConfiguration(
-        ssid="a"
-    )
+    n = networking.WifiConfiguration(ssid="a")
     expected = networking.NetworkingSecurityType.none
     assert n.securityType == expected
 
@@ -50,20 +48,16 @@ def test_validate_configuration_psk_invalid():
             ssid="a",
             securityType="wpa-psk",
             eapConfig={
-                'eapType': 'peap/eap-mschapv2',
-                'identity': 'test@hi.com',
-                'password': 'passwd'
-            }
+                "eapType": "peap/eap-mschapv2",
+                "identity": "test@hi.com",
+                "password": "passwd",
+            },
         )
 
 
 def test_validate_configuration_eap_invalid():
     with pytest.raises(ValueError):
-        networking.WifiConfiguration(
-            ssid="a",
-            securityType="wpa-eap",
-            psk="hohos"
-        )
+        networking.WifiConfiguration(ssid="a", securityType="wpa-eap", psk="hohos")
 
 
 def test_eap_config_validate_missing_eap_type():
@@ -74,8 +68,5 @@ def test_eap_config_validate_missing_eap_type():
 def test_eap_config_validate_invalid_eap_config():
     with pytest.raises(ValueError, match="Required .+ not present"):
         networking.WifiConfiguration(
-            ssid="a",
-            eapConfig={
-                'eapType': 'peap/eap-mschapv2'
-            }
+            ssid="a", eapConfig={"eapType": "peap/eap-mschapv2"}
         )

--- a/robot-server/tests/service/legacy/models/test_settings.py
+++ b/robot-server/tests/service/legacy/models/test_settings.py
@@ -3,39 +3,40 @@ import pytest
 from robot_server.service.legacy.models import settings
 
 
-@pytest.fixture(scope="session", params=[
-    "top",
-    "bottom",
-    "blowout",
-    "dropTip",
-    "pickUpCurrent",
-    "pickUpDistance",
-    "pickUpIncrement",
-    "pickUpPresses",
-    "pickUpSpeed",
-    "plungerCurrent",
-    "dropTipCurrent",
-    "dropTipSpeed",
-    "tipLength",
-    "quirks"
-])
+@pytest.fixture(
+    scope="session",
+    params=[
+        "top",
+        "bottom",
+        "blowout",
+        "dropTip",
+        "pickUpCurrent",
+        "pickUpDistance",
+        "pickUpIncrement",
+        "pickUpPresses",
+        "pickUpSpeed",
+        "plungerCurrent",
+        "dropTipCurrent",
+        "dropTipSpeed",
+        "tipLength",
+        "quirks",
+    ],
+)
 def mutable_config(request) -> str:
     return request.param
 
 
-@pytest.fixture(scope="session", params=[
-    "pickupTipShake",
-    "dropTipShake",
-    "doubleDropTip",
-    "needsUnstick"
-])
+@pytest.fixture(
+    scope="session",
+    params=["pickupTipShake", "dropTipShake", "doubleDropTip", "needsUnstick"],
+)
 def valid_quirk(request) -> str:
     return request.param
 
 
 def test_pipette_settings_update_fields_pass(mutable_config: str):
     """Should make mutable config bool like values into a float."""
-    s = settings.PipetteSettingsUpdate(fields={mutable_config: {'value': 1.0}})
+    s = settings.PipetteSettingsUpdate(fields={mutable_config: {"value": 1.0}})
     assert s.setting_fields[mutable_config].value == 1.0
     assert isinstance(s.setting_fields[mutable_config].value, float)
 
@@ -43,12 +44,12 @@ def test_pipette_settings_update_fields_pass(mutable_config: str):
 def test_pipette_settings_update_quirks_only_bool(valid_quirk: str):
     """Should reject non-boolean quirk values."""
     with pytest.raises(ValueError):
-        settings.PipetteSettingsUpdate(fields={valid_quirk: {'value': 1.3}})
+        settings.PipetteSettingsUpdate(fields={valid_quirk: {"value": 1.3}})
 
 
 def test_pipette_settings_update_quirks_pass(valid_quirk: str):
     """Should accept quirk bool."""
-    s = settings.PipetteSettingsUpdate(fields={valid_quirk: {'value': True}})
+    s = settings.PipetteSettingsUpdate(fields={valid_quirk: {"value": True}})
     assert s.setting_fields[valid_quirk].value is True
 
 
@@ -60,6 +61,5 @@ def test_pipette_settings_update_none(mutable_config: str):
 
 def test_pipette_settings_update_none_value(mutable_config: str):
     """Should accept none values."""
-    s = settings.PipetteSettingsUpdate(
-        fields={mutable_config: {'value': None}})
+    s = settings.PipetteSettingsUpdate(fields={mutable_config: {"value": None}})
     assert s.setting_fields[mutable_config].value is None

--- a/robot-server/tests/service/legacy/routers/test_camera.py
+++ b/robot-server/tests/service/legacy/routers/test_camera.py
@@ -6,9 +6,10 @@ from opentrons.system import camera
 
 @pytest.fixture
 def mock_take_picture():
-    with patch("robot_server.service.legacy.routers."
-               "camera.camera.take_picture",
-               spec=camera.take_picture) as m:
+    with patch(
+        "robot_server.service.legacy.routers." "camera.camera.take_picture",
+        spec=camera.take_picture,
+    ) as m:
         yield m
 
 
@@ -31,7 +32,7 @@ def test_camera_success(mock_take_picture, api_client):
 
     async def fake_picture(filename, loop=None):
         # Save the filename
-        state['filename'] = filename
+        state["filename"] = filename
         # Write some junk to the file
         with open(filename, "wb") as f:
             f.write(b"test image")
@@ -42,4 +43,4 @@ def test_camera_success(mock_take_picture, api_client):
     assert res.status_code == 200
     assert res.content == b"test image"
     # Make sure the tempfile was deleted
-    assert os.path.exists(state['filename']) is False
+    assert os.path.exists(state["filename"]) is False

--- a/robot-server/tests/service/legacy/routers/test_control.py
+++ b/robot-server/tests/service/legacy/routers/test_control.py
@@ -10,31 +10,26 @@ from robot_server.service.legacy.routers import control
 
 
 def test_robot_info(api_client):
-    res = api_client.get('/robot/positions')
+    res = api_client.get("/robot/positions")
     assert res.status_code == 200
 
     body = res.json()
-    assert body['positions']['change_pipette']['target'] == 'mount'
-    assert len(body['positions']['change_pipette']['left']) == 3
-    assert len(body['positions']['change_pipette']['right']) == 3
-    assert body['positions']['attach_tip']['target'] == 'pipette'
-    assert len(body['positions']['attach_tip']['point']) == 3
+    assert body["positions"]["change_pipette"]["target"] == "mount"
+    assert len(body["positions"]["change_pipette"]["left"]) == 3
+    assert len(body["positions"]["change_pipette"]["right"]) == 3
+    assert body["positions"]["attach_tip"]["target"] == "pipette"
+    assert len(body["positions"]["attach_tip"]["point"]) == 3
 
 
-@pytest.mark.parametrize(argnames="mount_name,mount",
-                         argvalues=[
-                             ["left", Mount.LEFT],
-                             ["right", Mount.RIGHT]
-                         ])
+@pytest.mark.parametrize(
+    argnames="mount_name,mount",
+    argvalues=[["left", Mount.LEFT], ["right", Mount.RIGHT]],
+)
 def test_home_pipette(api_client, hardware, mount_name, mount):
-    test_data = {
-        'target': 'pipette',
-        'mount': mount_name
-    }
+    test_data = {"target": "pipette", "mount": mount_name}
 
-    res = api_client.post('/robot/home', json=test_data)
-    assert res.json() == {"message": f"Pipette on {mount_name}"
-                                     f" homed successfully"}
+    res = api_client.post("/robot/home", json=test_data)
+    assert res.json() == {"message": f"Pipette on {mount_name}" f" homed successfully"}
     assert res.status_code == 200
     hardware.home.assert_called_once_with([Axis.by_mount(mount)])
     hardware.home_plunger.assert_called_once_with(mount)
@@ -42,42 +37,41 @@ def test_home_pipette(api_client, hardware, mount_name, mount):
 
 def test_home_robot(api_client, hardware):
     test_data = {
-        'target': 'robot',
+        "target": "robot",
     }
 
-    res = api_client.post('/robot/home', json=test_data)
+    res = api_client.post("/robot/home", json=test_data)
     assert res.json() == {"message": "Homing robot."}
     assert res.status_code == 200
     hardware.home.assert_called_once()
 
 
-@pytest.mark.parametrize(argnames="test_data",
-                         argvalues=[
-                             {},
-                             {'target': 'pipette', 'mount': 'fake_mount'},
-                             {'mount': 'left'},
-                             {'target': 'pipette'},
-                         ])
+@pytest.mark.parametrize(
+    argnames="test_data",
+    argvalues=[
+        {},
+        {"target": "pipette", "mount": "fake_mount"},
+        {"mount": "left"},
+        {"target": "pipette"},
+    ],
+)
 def test_home_pipette_bad_request(test_data, api_client):
-    res = api_client.post('/robot/home', json=test_data)
+    res = api_client.post("/robot/home", json=test_data)
     assert res.status_code == 422
 
 
 @pytest.fixture
 def hardware_move(hardware):
     """Fixture for move handler tests"""
-    state = {
-        'cur_pos': Point(0, 0, 0)
-    }
+    state = {"cur_pos": Point(0, 0, 0)}
 
-    async def mock_gantry_position(mount,
-                                   critical_point=None,
-                                   refresh=False):
-        return state['cur_pos']
+    async def mock_gantry_position(mount, critical_point=None, refresh=False):
+        return state["cur_pos"]
 
-    async def mock_move_to(mount, abs_position, speed=None,
-                           critical_point=None, max_speeds=None):
-        state['cur_pos'] = abs_position
+    async def mock_move_to(
+        mount, abs_position, speed=None, critical_point=None, max_speeds=None
+    ):
+        state["cur_pos"] = abs_position
 
     hardware.gantry_position.side_effect = mock_gantry_position
     hardware.move_to.side_effect = mock_move_to
@@ -85,124 +79,122 @@ def hardware_move(hardware):
     return hardware
 
 
-@pytest.mark.parametrize(argnames="test_data",
-                         argvalues=[
-                             {},
-                             {'target': 'other'},
-                             {'target': 'mount',
-                              # Too many points
-                              'point': (1, 2, 3, 4)},
-                             {'target': 'mount',
-                              'point': (1, 2, 33),
-                              # Bad mount
-                              'mount': 'middle'},
-                             {'target': 'mount',
-                              # [2] is < 30
-                              'point': (1, 2, 3),
-                              'mount': 'right'}
-                         ])
+@pytest.mark.parametrize(
+    argnames="test_data",
+    argvalues=[
+        {},
+        {"target": "other"},
+        {
+            "target": "mount",
+            # Too many points
+            "point": (1, 2, 3, 4),
+        },
+        {
+            "target": "mount",
+            "point": (1, 2, 33),
+            # Bad mount
+            "mount": "middle",
+        },
+        {
+            "target": "mount",
+            # [2] is < 30
+            "point": (1, 2, 3),
+            "mount": "right",
+        },
+    ],
+)
 def test_move_bad_request(test_data, api_client):
-    res = api_client.post('/robot/move', json=test_data)
+    res = api_client.post("/robot/move", json=test_data)
     assert res.status_code == 422
 
 
 def test_move_mount(api_client, hardware_move):
-    data = {
-        'target': 'mount',
-        'point': [100, 200, 50],
-        'mount': 'right'
-    }
-    res = api_client.post('/robot/move', json=data)
+    data = {"target": "mount", "point": [100, 200, 50], "mount": "right"}
+    res = api_client.post("/robot/move", json=data)
     assert res.status_code == 200
     assert res.json() == {
-        "message": "Move complete. New position: (100.0, 200.0, 50.0)"}
+        "message": "Move complete. New position: (100.0, 200.0, 50.0)"
+    }
 
     hardware_move.cache_instruments.assert_called_once()
 
-    hardware_move.gantry_position.assert_has_calls([
-        call(Mount.RIGHT, critical_point=CriticalPoint.MOUNT),
-        call(Mount.RIGHT),
-    ])
-    hardware_move.move_to.assert_has_calls([
-        call(Mount.RIGHT,
-             Point(100.0, 200.0, 0.0),
-             critical_point=CriticalPoint.MOUNT),
-        call(Mount.RIGHT,
-             Point(100.0, 200.0, 50.0),
-             critical_point=CriticalPoint.MOUNT),
-    ])
+    hardware_move.gantry_position.assert_has_calls(
+        [
+            call(Mount.RIGHT, critical_point=CriticalPoint.MOUNT),
+            call(Mount.RIGHT),
+        ]
+    )
+    hardware_move.move_to.assert_has_calls(
+        [
+            call(
+                Mount.RIGHT,
+                Point(100.0, 200.0, 0.0),
+                critical_point=CriticalPoint.MOUNT,
+            ),
+            call(
+                Mount.RIGHT,
+                Point(100.0, 200.0, 50.0),
+                critical_point=CriticalPoint.MOUNT,
+            ),
+        ]
+    )
 
 
 def test_move_pipette(api_client, hardware_move):
     data = {
-        'target': 'pipette',
-        'point': [50, 100, 25],
-        'mount': 'left',
-        'model': 'p300_single_v1'
+        "target": "pipette",
+        "point": [50, 100, 25],
+        "mount": "left",
+        "model": "p300_single_v1",
     }
-    res = api_client.post('/robot/move', json=data)
+    res = api_client.post("/robot/move", json=data)
     assert res.status_code == 200
-    assert res.json() == {
-        "message": "Move complete. New position: (50.0, 100.0, 25.0)"}
+    assert res.json() == {"message": "Move complete. New position: (50.0, 100.0, 25.0)"}
 
     hardware_move.cache_instruments.assert_called_once()
 
-    hardware_move.gantry_position.assert_has_calls([
-        call(Mount.LEFT, critical_point=None),
-        call(Mount.LEFT),
-    ])
-    hardware_move.move_to.assert_has_calls([
-        call(Mount.LEFT,
-             Point(50.0, 100.0, 0.0),
-             critical_point=None),
-        call(Mount.LEFT,
-             Point(50.0, 100.0, 25.0),
-             critical_point=None),
-    ])
+    hardware_move.gantry_position.assert_has_calls(
+        [
+            call(Mount.LEFT, critical_point=None),
+            call(Mount.LEFT),
+        ]
+    )
+    hardware_move.move_to.assert_has_calls(
+        [
+            call(Mount.LEFT, Point(50.0, 100.0, 0.0), critical_point=None),
+            call(Mount.LEFT, Point(50.0, 100.0, 25.0), critical_point=None),
+        ]
+    )
 
 
-@pytest.mark.parametrize(
-    argnames="on_value",
-    argvalues=[
-        True,
-        False
-    ]
-)
+@pytest.mark.parametrize(argnames="on_value", argvalues=[True, False])
 def test_rail_lights_get(on_value, api_client, hardware):
-    hardware.get_lights.return_value = {'rails': on_value}
-    resp = api_client.get('/robot/lights')
+    hardware.get_lights.return_value = {"rails": on_value}
+    resp = api_client.get("/robot/lights")
     assert resp.status_code == 200
     data = resp.json()
-    assert data == {'on': on_value}
+    assert data == {"on": on_value}
 
 
 @pytest.mark.parametrize(
     argnames="request_body",
     argvalues=[
         {},
-        {'on': 'not on'},
-    ]
+        {"on": "not on"},
+    ],
 )
 def test_robot_lights_set_bad(request_body, api_client, hardware):
-    resp = api_client.post('/robot/lights',
-                           json=request_body)
+    resp = api_client.post("/robot/lights", json=request_body)
     assert resp.status_code == 422
     hardware.set_lights.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    argnames="on_value",
-    argvalues=[
-        True,
-        False
-    ]
-)
+@pytest.mark.parametrize(argnames="on_value", argvalues=[True, False])
 def test_robot_lights_set(on_value, api_client, hardware):
-    resp = api_client.post('/robot/lights',
-                           json={'on': on_value})
+    resp = api_client.post("/robot/lights", json={"on": on_value})
     assert resp.status_code == 200
     data = resp.json()
-    assert data == {'on': on_value}
+    assert data == {"on": on_value}
     hardware.set_lights.assert_called_once_with(rails=on_value)
 
 
@@ -214,25 +206,23 @@ def test_identify(api_client, hardware):
     hardware.identify.assert_called_once_with(100)
 
 
-@pytest.mark.parametrize(argnames="blocking_call,blocking_call_data",
-                         argvalues=[
-                             # The blocking call is a home
-                             [control.post_home_robot,
-                              control.control.RobotHomeTarget(
-                                  target=control.control.HomeTarget.robot
-                              )
-                              ],
-                             # The blocking call is a move
-                             [control.post_move_robot,
-                              None
-                              ]
-                         ])
-async def test_concurrent_motion_fails(hardware,
-                                       loop,
-                                       blocking_call,
-                                       blocking_call_data):
+@pytest.mark.parametrize(
+    argnames="blocking_call,blocking_call_data",
+    argvalues=[
+        # The blocking call is a home
+        [
+            control.post_home_robot,
+            control.control.RobotHomeTarget(target=control.control.HomeTarget.robot),
+        ],
+        # The blocking call is a move
+        [control.post_move_robot, None],
+    ],
+)
+async def test_concurrent_motion_fails(
+    hardware, loop, blocking_call, blocking_call_data
+):
     """A test that while a HOME or MOVE is happening, other HOME and MOVE
-     requests will fail."""
+    requests will fail."""
 
     event = Event()
 
@@ -249,18 +239,16 @@ async def test_concurrent_motion_fails(hardware,
     lock = control.ThreadedAsyncLock()
 
     # Call will pause on event.
-    blocking = loop.create_task(blocking_call(
-        blocking_call_data,
-        hardware=hardware,
-        motion_lock=lock
-    ))
+    blocking = loop.create_task(
+        blocking_call(blocking_call_data, hardware=hardware, motion_lock=lock)
+    )
 
     # Wrap a failing coroutine
     async def failure(func):
         with pytest.raises(ApiError) as exc_info:
             await func
         assert exc_info.value.status_code == 403
-        assert exc_info.value.content["message"].find('Robot is currently moving') == 0
+        assert exc_info.value.content["message"].find("Robot is currently moving") == 0
 
     forbidden_home = loop.create_task(
         failure(
@@ -269,16 +257,14 @@ async def test_concurrent_motion_fails(hardware,
                     target=control.control.HomeTarget.robot
                 ),
                 hardware=hardware,
-                motion_lock=lock
+                motion_lock=lock,
             )
         )
     )
     forbidden_move = loop.create_task(
         failure(
             control.post_move_robot(
-                robot_move_target=None,
-                hardware=hardware,
-                motion_lock=lock
+                robot_move_target=None, hardware=hardware, motion_lock=lock
             )
         )
     )

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -8,8 +8,8 @@ from opentrons.system.log_control import MAX_RECORDS, DEFAULT_RECORDS
 
 def test_get_serial_log_with_defaults(api_client):
     logs = '{"serial": "serial logs"}'
-    res_bytes = logs.encode('utf-8')
-    expected = res_bytes.decode('utf-8')
+    res_bytes = logs.encode("utf-8")
+    expected = res_bytes.decode("utf-8")
 
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes
@@ -20,9 +20,7 @@ def test_get_serial_log_with_defaults(api_client):
         body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with(
-            "opentrons-api-serial", DEFAULT_RECORDS, "short"
-        )
+        m.assert_called_once_with("opentrons-api-serial", DEFAULT_RECORDS, "short")
 
 
 @pytest.mark.parametrize(
@@ -31,15 +29,15 @@ def test_get_serial_log_with_defaults(api_client):
         ("json", MAX_RECORDS - 1, "json"),
         ("text", MAX_RECORDS - 1, "short"),
         ("json", 1, "json"),
-        ("text", 1, "short")
-    ]
+        ("text", 1, "short"),
+    ],
 )
 def test_get_serial_log_with_params(
     api_client, format_param, records_param, mode_param
 ):
     logs = '{"serial": "serial logs"}'
-    res_bytes = logs.encode('utf-8')
-    if format_param == 'json':
+    res_bytes = logs.encode("utf-8")
+    if format_param == "json":
         expected = json.loads(res_bytes)
     else:
         expected = logs
@@ -52,31 +50,23 @@ def test_get_serial_log_with_params(
         response = api_client.get(
             f"/logs/serial.log?format={format_param}&records={records_param}"
         )
-        if format_param == 'json':
+        if format_param == "json":
             body = response.json()
         else:
             body = response.text
         assert body == expected
         assert response.status_code == 200
 
-        m.assert_called_once_with(
-            "opentrons-api-serial", records_param, mode_param
-        )
+        m.assert_called_once_with("opentrons-api-serial", records_param, mode_param)
 
 
 @pytest.mark.parametrize(
     "format_param, records_param",
-    [
-        ("json", 0),
-        ("text", MAX_RECORDS + 1),
-        ("invalid", MAX_RECORDS - 1)
-    ]
+    [("json", 0), ("text", MAX_RECORDS + 1), ("invalid", MAX_RECORDS - 1)],
 )
-def test_get_serial_log_with_invalid_params(
-    api_client, format_param, records_param
-):
+def test_get_serial_log_with_invalid_params(api_client, format_param, records_param):
     logs = '{"serial": "serial logs"}'
-    res_bytes = logs.encode('utf-8')
+    res_bytes = logs.encode("utf-8")
 
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes
@@ -92,8 +82,8 @@ def test_get_serial_log_with_invalid_params(
 
 def test_get_api_log_with_defaults(api_client):
     logs = '{"api": "application programing interface logs"}'
-    res_bytes = logs.encode('utf-8')
-    expected = res_bytes.decode('utf-8')
+    res_bytes = logs.encode("utf-8")
+    expected = res_bytes.decode("utf-8")
 
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes
@@ -113,15 +103,13 @@ def test_get_api_log_with_defaults(api_client):
         ("json", MAX_RECORDS - 1, "json"),
         ("text", MAX_RECORDS - 1, "short"),
         ("json", 1, "json"),
-        ("text", 1, "short")
-    ]
+        ("text", 1, "short"),
+    ],
 )
-def test_get_api_log_with_params(
-    api_client, format_param, records_param, mode_param
-):
+def test_get_api_log_with_params(api_client, format_param, records_param, mode_param):
     logs = '{"api": "application programing interface logs"}'
-    res_bytes = logs.encode('utf-8')
-    if format_param == 'json':
+    res_bytes = logs.encode("utf-8")
+    if format_param == "json":
         expected = json.loads(res_bytes)
     else:
         expected = logs
@@ -134,7 +122,7 @@ def test_get_api_log_with_params(
         response = api_client.get(
             f"/logs/api.log?format={format_param}&records={records_param}"
         )
-        if format_param == 'json':
+        if format_param == "json":
             body = response.json()
         else:
             body = response.text
@@ -145,17 +133,11 @@ def test_get_api_log_with_params(
 
 @pytest.mark.parametrize(
     "format_param, records_param",
-    [
-        ("json", 0),
-        ("text", MAX_RECORDS + 1),
-        ("invalid", MAX_RECORDS - 1)
-    ]
+    [("json", 0), ("text", MAX_RECORDS + 1), ("invalid", MAX_RECORDS - 1)],
 )
-def test_get_api_log_with_invalid_params(
-    api_client, format_param, records_param
-):
+def test_get_api_log_with_invalid_params(api_client, format_param, records_param):
     logs = '{"api": "application programing interface logs"}'
-    res_bytes = logs.encode('utf-8')
+    res_bytes = logs.encode("utf-8")
 
     async def mock_get_records_dumb(identifier, records, format_type):
         return res_bytes

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -5,25 +5,28 @@ import pytest
 import asyncio
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import MagDeck, Thermocycler, TempDeck
-from opentrons.hardware_control.modules import utils, UpdateError, \
-    BundledFirmware
+from opentrons.hardware_control.modules import utils, UpdateError, BundledFirmware
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
 @pytest.fixture
 def magdeck():
     usb_port = USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_magdeck1')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_magdeck1",
+    )
     m = asyncio.get_event_loop().run_until_complete(
         utils.build(
-            port='/dev/ot_module_magdeck1',
+            port="/dev/ot_module_magdeck1",
             usb_port=usb_port,
-            which='magdeck',
+            which="magdeck",
             simulating=True,
             interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
-            loop=asyncio.get_event_loop()
+            loop=asyncio.get_event_loop(),
         )
     )
     MagDeck.current_height = PropertyMock(return_value=321)
@@ -34,17 +37,21 @@ def magdeck():
 @pytest.fixture
 def tempdeck():
     usb_port = USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_tempdeck1')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_tempdeck1",
+    )
     t = asyncio.get_event_loop().run_until_complete(
         utils.build(
-            port='/dev/ot_module_tempdeck1',
+            port="/dev/ot_module_tempdeck1",
             usb_port=usb_port,
-            which='tempdeck',
+            which="tempdeck",
             simulating=True,
             interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
-            loop=asyncio.get_event_loop()
+            loop=asyncio.get_event_loop(),
         )
     )
     TempDeck.temperature = PropertyMock(return_value=123.0)
@@ -56,17 +63,21 @@ def tempdeck():
 @pytest.fixture
 def thermocycler():
     usb_port = USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_thermocycler1')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_thermocycler1",
+    )
     t = asyncio.get_event_loop().run_until_complete(
         utils.build(
-            port='/dev/ot_module_thermocycler1',
+            port="/dev/ot_module_thermocycler1",
             usb_port=usb_port,
-            which='thermocycler',
+            which="thermocycler",
             simulating=True,
             interrupt_callback=lambda x: None,
             execution_manager=ExecutionManager(loop=asyncio.get_event_loop()),
-            loop=asyncio.get_event_loop()
+            loop=asyncio.get_event_loop(),
         )
     )
     Thermocycler.lid_status = PropertyMock(return_value="open")
@@ -86,27 +97,27 @@ def thermocycler():
 def test_get_modules_magdeck(api_client, hardware, magdeck):
     hardware.attached_modules = [magdeck]
 
-    resp = api_client.get('/modules')
+    resp = api_client.get("/modules")
     body = resp.json()
     assert resp.status_code == 200
     assert body == {
-        'modules': [
+        "modules": [
             {
-                'displayName': 'magdeck',
-                'fwVersion': 'dummyVersionMD',
-                'hasAvailableUpdate': False,
-                'model': 'mag_deck_v1.1',
-                'moduleModel': 'magneticModuleV1',
-                'name': 'magdeck',
-                'port': '/dev/ot_module_magdeck1',
-                'usbPort': {'hub': None, 'port': None},
-                'revision': 'mag_deck_v1.1',
-                'serial': 'dummySerialMD',
-                'status': 'engaged',
-                'data': {
-                    'engaged': True,
-                    'height': 321,
-                }
+                "displayName": "magdeck",
+                "fwVersion": "dummyVersionMD",
+                "hasAvailableUpdate": False,
+                "model": "mag_deck_v1.1",
+                "moduleModel": "magneticModuleV1",
+                "name": "magdeck",
+                "port": "/dev/ot_module_magdeck1",
+                "usbPort": {"hub": None, "port": None},
+                "revision": "mag_deck_v1.1",
+                "serial": "dummySerialMD",
+                "status": "engaged",
+                "data": {
+                    "engaged": True,
+                    "height": 321,
+                },
             }
         ]
     }
@@ -115,29 +126,29 @@ def test_get_modules_magdeck(api_client, hardware, magdeck):
 def test_get_modules_tempdeck(api_client, hardware, tempdeck):
     hardware.attached_modules = [tempdeck]
 
-    for model in ('temp_deck_v1', 'temp_deck_v1.1', 'temp_deck_v2'):
-        tempdeck._device_info['model'] = model
-        resp = api_client.get('/modules')
+    for model in ("temp_deck_v1", "temp_deck_v1.1", "temp_deck_v2"):
+        tempdeck._device_info["model"] = model
+        resp = api_client.get("/modules")
         body = resp.json()
         assert resp.status_code == 200
         assert body == {
-            'modules': [
+            "modules": [
                 {
-                    'displayName': 'tempdeck',
-                    'fwVersion': 'dummyVersionTD',
-                    'hasAvailableUpdate': False,
-                    'model': model,
-                    'moduleModel': 'temperatureModuleV1',
-                    'name': 'tempdeck',
-                    'port': '/dev/ot_module_tempdeck1',
-                    'usbPort': {'hub': None, 'port': None},
-                    'revision': model,
-                    'serial': 'dummySerialTD',
-                    'status': 'idle',
-                    'data': {
-                        'currentTemp': 123,
-                        'targetTemp':  321,
-                    }
+                    "displayName": "tempdeck",
+                    "fwVersion": "dummyVersionTD",
+                    "hasAvailableUpdate": False,
+                    "model": model,
+                    "moduleModel": "temperatureModuleV1",
+                    "name": "tempdeck",
+                    "port": "/dev/ot_module_tempdeck1",
+                    "usbPort": {"hub": None, "port": None},
+                    "revision": model,
+                    "serial": "dummySerialTD",
+                    "status": "idle",
+                    "data": {
+                        "currentTemp": 123,
+                        "targetTemp": 321,
+                    },
                 }
             ]
         }
@@ -146,143 +157,145 @@ def test_get_modules_tempdeck(api_client, hardware, tempdeck):
 def test_get_modules_thermocycler(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    resp = api_client.get('/modules')
+    resp = api_client.get("/modules")
     body = resp.json()
     assert resp.status_code == 200
     assert body == {
-        'modules': [{
-            'displayName': 'thermocycler',
-            'fwVersion': 'dummyVersionTC',
-            'hasAvailableUpdate': False,
-            'model': 'dummyModelTC',
-            'moduleModel': 'thermocyclerModuleV1',
-            'name': 'thermocycler',
-            'port': '/dev/ot_module_thermocycler1',
-            'usbPort': {'hub': None, 'port': None},
-            'revision': 'dummyModelTC',
-            'serial': 'dummySerialTC',
-            'status': 'idle',
-            'data': {
-                'lid': "open",
-                'lidTarget': 1.2,
-                'lidTemp': 22,
-                'currentTemp': 100,
-                'targetTemp': 200,
-                'holdTime': 1,
-                'rampRate': 3,
-                'currentCycleIndex': 1,
-                'totalCycleCount': 3,
-                'currentStepIndex': 5,
-                'totalStepCount': 2,
+        "modules": [
+            {
+                "displayName": "thermocycler",
+                "fwVersion": "dummyVersionTC",
+                "hasAvailableUpdate": False,
+                "model": "dummyModelTC",
+                "moduleModel": "thermocyclerModuleV1",
+                "name": "thermocycler",
+                "port": "/dev/ot_module_thermocycler1",
+                "usbPort": {"hub": None, "port": None},
+                "revision": "dummyModelTC",
+                "serial": "dummySerialTC",
+                "status": "idle",
+                "data": {
+                    "lid": "open",
+                    "lidTarget": 1.2,
+                    "lidTemp": 22,
+                    "currentTemp": 100,
+                    "targetTemp": 200,
+                    "holdTime": 1,
+                    "rampRate": 3,
+                    "currentCycleIndex": 1,
+                    "totalCycleCount": 3,
+                    "currentStepIndex": 5,
+                    "totalStepCount": 2,
+                },
             }
-        }]
+        ]
     }
 
 
 def test_get_module_serial_magdeck(api_client, hardware, magdeck):
     hardware.attached_modules = [magdeck]
 
-    resp = api_client.get('/modules/dummySerialMD/data')
+    resp = api_client.get("/modules/dummySerialMD/data")
 
     body = resp.json()
     assert resp.status_code == 200
-    assert body == {"status": "engaged",
-                    "data": {
-                        "engaged": True,
-                        "height": 321.0
-                    }}
+    assert body == {"status": "engaged", "data": {"engaged": True, "height": 321.0}}
 
 
 def test_get_module_serial_tempdeck(api_client, hardware, tempdeck):
     hardware.attached_modules = [tempdeck]
 
-    resp = api_client.get('/modules/dummySerialTD/data')
+    resp = api_client.get("/modules/dummySerialTD/data")
 
     body = resp.json()
     assert resp.status_code == 200
-    assert body == {"status": "idle",
-                    "data": {
-                        "currentTemp": 123.0,
-                        "targetTemp": 321.0
-                    }}
+    assert body == {
+        "status": "idle",
+        "data": {"currentTemp": 123.0, "targetTemp": 321.0},
+    }
 
 
 def test_get_module_serial_thermocycler(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    resp = api_client.get('/modules/dummySerialTC/data')
+    resp = api_client.get("/modules/dummySerialTC/data")
 
     body = resp.json()
     assert resp.status_code == 200
-    assert body == {"status": "idle",
-                    "data": {
-                        'lid': "open",
-                        'lidTarget': 1.2,
-                        'lidTemp': 22,
-                        'currentTemp': 100,
-                        'targetTemp': 200,
-                        'holdTime': 1,
-                        'rampRate': 3,
-                        'currentCycleIndex': 1,
-                        'totalCycleCount': 3,
-                        'currentStepIndex': 5,
-                        'totalStepCount': 2,
-                    }}
+    assert body == {
+        "status": "idle",
+        "data": {
+            "lid": "open",
+            "lidTarget": 1.2,
+            "lidTemp": 22,
+            "currentTemp": 100,
+            "targetTemp": 200,
+            "holdTime": 1,
+            "rampRate": 3,
+            "currentCycleIndex": 1,
+            "totalCycleCount": 3,
+            "currentStepIndex": 5,
+            "totalStepCount": 2,
+        },
+    }
 
 
 def test_get_module_serial_no_match(api_client, hardware, magdeck):
     hardware.attached_modules = [magdeck]
 
-    resp = api_client.get('/modules/onions/data')
+    resp = api_client.get("/modules/onions/data")
 
     body = resp.json()
     assert resp.status_code == 404
-    assert 'message' in body
-    assert body['message'] == 'Module not found'
+    assert "message" in body
+    assert body["message"] == "Module not found"
 
 
 def test_get_module_serial_no_modules(api_client, hardware):
     hardware.attached_modules = []
 
-    resp = api_client.get('/modules/dummySerialMD/data')
+    resp = api_client.get("/modules/dummySerialMD/data")
 
     body = resp.json()
     assert resp.status_code == 404
-    assert 'message' in body
-    assert body['message'] == 'Module not found'
+    assert "message" in body
+    assert body["message"] == "Module not found"
 
 
 def test_execute_module_command(api_client, hardware, magdeck):
     hardware.attached_modules = [magdeck]
 
-    resp = api_client.post('/modules/dummySerialMD',
-                           json={'command_type': 'deactivate'})
+    resp = api_client.post(
+        "/modules/dummySerialMD", json={"command_type": "deactivate"}
+    )
     body = resp.json()
     assert resp.status_code == 200
-    assert 'message' in body
-    assert body['message'] == 'Success'
+    assert "message" in body
+    assert body["message"] == "Success"
 
 
 def test_execute_module_command_no_modules(api_client, hardware):
     hardware.attached_modules = []
 
-    resp = api_client.post('/modules/dummySerialMD',
-                           json={'command_type': 'deactivate'})
+    resp = api_client.post(
+        "/modules/dummySerialMD", json={"command_type": "deactivate"}
+    )
     body = resp.json()
     assert resp.status_code == 404
-    assert 'message' in body
-    assert body['message'] == 'No connected modules'
+    assert "message" in body
+    assert body["message"] == "No connected modules"
 
 
 def test_execute_module_command_bad_serial(api_client, hardware, magdeck):
     hardware.attached_modules = [magdeck]
 
-    resp = api_client.post('/modules/tooDummySerialMD',
-                           json={'command_type': 'deactivate'})
+    resp = api_client.post(
+        "/modules/tooDummySerialMD", json={"command_type": "deactivate"}
+    )
     body = resp.json()
     assert resp.status_code == 404
-    assert 'message' in body
-    assert body['message'] == 'Specified module not found'
+    assert "message" in body
+    assert body["message"] == "Specified module not found"
 
 
 def test_execute_module_command_bad_command(api_client, hardware, magdeck):
@@ -290,28 +303,28 @@ def test_execute_module_command_bad_command(api_client, hardware, magdeck):
 
     command_type = "something that doesn't exist"
 
-    resp = api_client.post('/modules/dummySerialMD',
-                           json={'command_type': command_type})
+    resp = api_client.post(
+        "/modules/dummySerialMD", json={"command_type": command_type}
+    )
     body = resp.json()
     assert resp.status_code == 400
-    assert 'message' in body
-    assert body['message'] == f'Module does not have command: {command_type}'
+    assert "message" in body
+    assert body["message"] == f"Module does not have command: {command_type}"
 
 
 def test_execute_module_command_bad_args(api_client, hardware, thermocycler):
     hardware.attached_modules = [thermocycler]
 
-    thermocycler.set_temperature = MagicMock(
-        side_effect=TypeError("found a 'str'")
-    )
+    thermocycler.set_temperature = MagicMock(side_effect=TypeError("found a 'str'"))
 
-    resp = api_client.post('modules/dummySerialTC',
-                           json={'command_type': 'set_temperature',
-                                 'args': ['30']})
+    resp = api_client.post(
+        "modules/dummySerialTC",
+        json={"command_type": "set_temperature", "args": ["30"]},
+    )
     body = resp.json()
     assert resp.status_code == 400
-    assert 'message' in body
-    assert 'TypeError' in body['message']
+    assert "message" in body
+    assert "TypeError" in body["message"]
 
 
 def test_execute_module_command_valid_args(api_client, hardware, thermocycler):
@@ -319,9 +332,9 @@ def test_execute_module_command_valid_args(api_client, hardware, thermocycler):
 
     thermocycler.set_temperature = MagicMock(return_value=None)
 
-    resp = api_client.post('modules/dummySerialTC',
-                           json={'command_type': 'set_temperature',
-                                 'args': [30]})
+    resp = api_client.post(
+        "modules/dummySerialTC", json={"command_type": "set_temperature", "args": [30]}
+    )
     assert resp.status_code == 200
 
 
@@ -329,35 +342,29 @@ def test_post_serial_update_no_bundled_fw(api_client, hardware, magdeck):
     magdeck._bundled_fw = None
 
     hardware.attached_modules = [magdeck]
-    resp = api_client.post('/modules/dummySerialMD/update')
+    resp = api_client.post("/modules/dummySerialMD/update")
 
     body = resp.json()
     assert resp.status_code == 500
-    assert body == {
-        'message': 'Bundled fw file not found for module of type: magdeck'
-    }
+    assert body == {"message": "Bundled fw file not found for module of type: magdeck"}
 
 
 def test_post_serial_update_no_modules(api_client, hardware):
-    resp = api_client.post('/modules/dummySerialMD/update')
+    resp = api_client.post("/modules/dummySerialMD/update")
 
     body = resp.json()
     assert resp.status_code == 404
-    assert body == {
-        'message': 'Module dummySerialMD not found'
-    }
+    assert body == {"message": "Module dummySerialMD not found"}
 
 
 def test_post_serial_update_no_match(api_client, hardware, tempdeck):
     hardware.attached_modules = [tempdeck]
 
-    resp = api_client.post('/modules/superDummySerialMD/update')
+    resp = api_client.post("/modules/superDummySerialMD/update")
 
     body = resp.json()
     assert resp.status_code == 404
-    assert body == {
-        'message': 'Module superDummySerialMD not found'
-    }
+    assert body == {"message": "Module superDummySerialMD not found"}
 
 
 def test_post_serial_update_error(api_client, hardware, magdeck):
@@ -370,13 +377,11 @@ def test_post_serial_update_error(api_client, hardware, magdeck):
 
     with patch("opentrons.hardware_control.modules.update_firmware") as p:
         p.side_effect = thrower
-        resp = api_client.post('/modules/dummySerialMD/update')
+        resp = api_client.post("/modules/dummySerialMD/update")
 
         body = resp.json()
         assert resp.status_code == 500
-        assert body == {
-            'message': 'Update error: not possible'
-        }
+        assert body == {"message": "Update error: not possible"}
 
 
 def test_post_serial_timeout_error(api_client, hardware, magdeck):
@@ -389,13 +394,11 @@ def test_post_serial_timeout_error(api_client, hardware, magdeck):
 
     with patch("opentrons.hardware_control.modules.update_firmware") as p:
         p.side_effect = thrower
-        resp = api_client.post('/modules/dummySerialMD/update')
+        resp = api_client.post("/modules/dummySerialMD/update")
 
         body = resp.json()
         assert resp.status_code == 500
-        assert body == {
-            'message': 'Module not responding'
-        }
+        assert body == {"message": "Module not responding"}
 
 
 def test_post_serial_update(api_client, hardware, tempdeck):
@@ -404,14 +407,12 @@ def test_post_serial_update(api_client, hardware, tempdeck):
     tempdeck._bundled_fw = BundledFirmware("1234", Path("c:/aaa"))
 
     with patch("opentrons.hardware_control.modules.update_firmware") as p:
-        resp = api_client.post('/modules/dummySerialTD/update')
+        resp = api_client.post("/modules/dummySerialTD/update")
 
-        p.assert_called_once_with(tempdeck,
-                                  tempdeck._bundled_fw.path,
-                                  asyncio.get_event_loop())
+        p.assert_called_once_with(
+            tempdeck, tempdeck._bundled_fw.path, asyncio.get_event_loop()
+        )
 
         body = resp.json()
         assert resp.status_code == 200
-        assert body == {
-            'message': 'Successfully updated module dummySerialTD'
-        }
+        assert body == {"message": "Successfully updated module dummySerialTD"}

--- a/robot-server/tests/service/legacy/routers/test_motors.py
+++ b/robot-server/tests/service/legacy/routers/test_motors.py
@@ -8,10 +8,10 @@ def test_engage_axes(api_client, hardware):
         "z": True,
         "a": True,
         "b": True,
-        "c": True
+        "c": True,
     }
 
-    res0 = api_client.get('/motors/engaged')
+    res0 = api_client.get("/motors/engaged")
     result0 = res0.json()
     assert res0.status_code == 200
     assert result0 == {
@@ -20,7 +20,7 @@ def test_engage_axes(api_client, hardware):
         "z": {"enabled": True},
         "a": {"enabled": True},
         "b": {"enabled": True},
-        "c": {"enabled": True}
+        "c": {"enabled": True},
     }
 
 
@@ -31,16 +31,15 @@ def test_engage_invalid_axes(api_client, hardware):
         "z": True,
         "a": True,
         "b": True,
-        "c": True
+        "c": True,
     }
 
-    res0 = api_client.get('/motors/engaged')
+    res0 = api_client.get("/motors/engaged")
     assert res0.status_code == 500
 
 
 def test_disengage_axes(api_client, hardware):
-    postres = api_client.post(
-        '/motors/disengage', json={'axes': ['x', 'b']})
+    postres = api_client.post("/motors/disengage", json={"axes": ["x", "b"]})
 
     hardware.disengage_axes.assert_called_once_with([Axis.X, Axis.B])
 
@@ -48,11 +47,9 @@ def test_disengage_axes(api_client, hardware):
     assert postres.json() == {"message": "Disengaged axes: x, b"}
 
 
-def test_disengage_axes_case_insensitive(api_client,
-                                         hardware):
+def test_disengage_axes_case_insensitive(api_client, hardware):
 
-    postres = api_client.post(
-        '/motors/disengage', json={'axes': ['Y', 'A']})
+    postres = api_client.post("/motors/disengage", json={"axes": ["Y", "A"]})
 
     hardware.disengage_axes.assert_called_once_with([Axis.Y, Axis.A])
 
@@ -61,8 +58,7 @@ def test_disengage_axes_case_insensitive(api_client,
 
 
 def test_disengage_invalid_axes(api_client, hardware):
-    postres = api_client.post(
-        '/motors/disengage', json={'axes': ['u']})
+    postres = api_client.post("/motors/disengage", json={"axes": ["u"]})
 
     hardware.disengage_axes.assert_not_called()
 
@@ -70,8 +66,7 @@ def test_disengage_invalid_axes(api_client, hardware):
 
 
 def test_disengage_no_axes(api_client, hardware):
-    postres = api_client.post(
-        '/motors/disengage', json={'axes': []})
+    postres = api_client.post("/motors/disengage", json={"axes": []})
 
     hardware.disengage_axes.assert_called_once_with([])
 

--- a/robot-server/tests/service/legacy/routers/test_networking.py
+++ b/robot-server/tests/service/legacy/routers/test_networking.py
@@ -8,42 +8,38 @@ from opentrons.system import nmcli, wifi
 
 
 def test_networking_status(api_client, monkeypatch):
-
     async def mock_is_connected():
-        return 'full'
+        return "full"
 
     connection_statuses = {
-        'wlan0': {
+        "wlan0": {
             # test "--" gets mapped to None
-            'ipAddress': None,
-            'macAddress': 'B8:27:EB:5F:A6:89',
+            "ipAddress": None,
+            "macAddress": "B8:27:EB:5F:A6:89",
             # test "--" gets mapped to None
-            'gatewayAddress': None,
-            'state': 'disconnected',
-            'type': 'wifi'
+            "gatewayAddress": None,
+            "state": "disconnected",
+            "type": "wifi",
         },
-        'eth0': {
-            'ipAddress': '169.254.229.173/16',
-            'macAddress': 'B8:27:EB:39:C0:9A',
+        "eth0": {
+            "ipAddress": "169.254.229.173/16",
+            "macAddress": "B8:27:EB:39:C0:9A",
             # test missing output gets mapped to None
-            'gatewayAddress': None,
-            'state': 'connecting (configuring)',
-            'type': 'ethernet'
-        }
+            "gatewayAddress": None,
+            "state": "connecting (configuring)",
+            "type": "ethernet",
+        },
     }
 
     async def mock_iface_info(k: nmcli.NETWORK_IFACES):
         return connection_statuses[k.value]
 
-    monkeypatch.setattr(nmcli, 'is_connected', mock_is_connected)
-    monkeypatch.setattr(nmcli, 'iface_info', mock_iface_info)
+    monkeypatch.setattr(nmcli, "is_connected", mock_is_connected)
+    monkeypatch.setattr(nmcli, "iface_info", mock_iface_info)
 
-    expected = {
-        'status': 'full',
-        'interfaces': connection_statuses
-    }
+    expected = {"status": "full", "interfaces": connection_statuses}
 
-    resp = api_client.get('/networking/status')
+    resp = api_client.get("/networking/status")
     body_json = resp.json()
     assert resp.status_code == 200
     assert body_json == expected
@@ -51,239 +47,263 @@ def test_networking_status(api_client, monkeypatch):
     async def mock_is_connected():
         raise FileNotFoundError("No")
 
-    monkeypatch.setattr(nmcli, 'is_connected', mock_is_connected)
-    resp = api_client.get('/networking/status')
+    monkeypatch.setattr(nmcli, "is_connected", mock_is_connected)
+    resp = api_client.get("/networking/status")
     assert resp.status_code == 500
 
 
 def test_wifi_list(api_client, monkeypatch):
     expected_res = [
-        {"ssid": "Opentrons", "signal": 81, "active": True,
-         "security": "WPA2 802.1X", "securityType": "wpa-eap"},
-        {"ssid": "Big Duck", "signal": 47, "active": False,
-         "security": "WPA2 802.1X", "securityType": "wpa-eap"},
-        {"ssid": "HP-Print-1-LaserJet Pro", "signal": 35, "active": False,
-         "security": "WPA2 802.1X", "securityType": "wpa-eap"},
-        {"ssid": "Guest Wireless", "signal": 24, "active": False,
-         "security": "WPA2 802.1X", "securityType": "wpa-eap"}
+        {
+            "ssid": "Opentrons",
+            "signal": 81,
+            "active": True,
+            "security": "WPA2 802.1X",
+            "securityType": "wpa-eap",
+        },
+        {
+            "ssid": "Big Duck",
+            "signal": 47,
+            "active": False,
+            "security": "WPA2 802.1X",
+            "securityType": "wpa-eap",
+        },
+        {
+            "ssid": "HP-Print-1-LaserJet Pro",
+            "signal": 35,
+            "active": False,
+            "security": "WPA2 802.1X",
+            "securityType": "wpa-eap",
+        },
+        {
+            "ssid": "Guest Wireless",
+            "signal": 24,
+            "active": False,
+            "security": "WPA2 802.1X",
+            "securityType": "wpa-eap",
+        },
     ]
 
     async def mock_available():
         return expected_res
 
-    monkeypatch.setattr(nmcli, 'available_ssids', mock_available)
+    monkeypatch.setattr(nmcli, "available_ssids", mock_available)
 
-    expected = {
-        "list": expected_res
-    }
+    expected = {"list": expected_res}
 
-    resp = api_client.get('/wifi/list')
+    resp = api_client.get("/wifi/list")
     j = resp.json()
     assert resp.status_code == 200
     assert j == expected
 
 
 def test_wifi_configure(api_client):
-    msg = "Device 'wlan0' successfully activated with" \
-          " '076aa998-0275-4aa0-bf85-e9629021e267'."
+    msg = (
+        "Device 'wlan0' successfully activated with"
+        " '076aa998-0275-4aa0-bf85-e9629021e267'."
+    )
 
     with patch("opentrons.system.nmcli.configure") as m:
         m.return_value = True, msg
 
-        expected = {'ssid': 'Opentrons', 'message': msg}
+        expected = {"ssid": "Opentrons", "message": msg}
 
         resp = api_client.post(
-            '/wifi/configure', json={'ssid': 'Opentrons', 'psk': 'scrt sqrl'})
+            "/wifi/configure", json={"ssid": "Opentrons", "psk": "scrt sqrl"}
+        )
         body = resp.json()
         assert resp.status_code == 201
         assert body == expected
 
-        m.assert_called_once_with(ssid="Opentrons",
-                                  eapConfig=None,
-                                  securityType=nmcli.SECURITY_TYPES.WPA_PSK,
-                                  psk="scrt sqrl",
-                                  hidden=False)
+        m.assert_called_once_with(
+            ssid="Opentrons",
+            eapConfig=None,
+            securityType=nmcli.SECURITY_TYPES.WPA_PSK,
+            psk="scrt sqrl",
+            hidden=False,
+        )
 
 
 def test_wifi_configure_value_error(api_client, monkeypatch):
-
-    async def mock_configure(ssid, eapConfig, securityType=None,
-                             psk=None, hidden=False):
+    async def mock_configure(
+        ssid, eapConfig, securityType=None, psk=None, hidden=False
+    ):
         raise ValueError("nope!")
 
-    monkeypatch.setattr(nmcli, 'configure', mock_configure)
+    monkeypatch.setattr(nmcli, "configure", mock_configure)
 
-    resp = api_client.post(
-        '/wifi/configure', json={'ssid': 'asasd', 'foo': 'bar'})
+    resp = api_client.post("/wifi/configure", json={"ssid": "asasd", "foo": "bar"})
     assert resp.status_code == 400
     body = resp.json()
     assert {"message": "nope!"} == body
 
 
 def test_wifi_configure_nmcli_error(api_client, monkeypatch):
-
-    async def mock_configure(ssid, eapConfig, securityType=None,
-                             psk=None, hidden=False):
+    async def mock_configure(
+        ssid, eapConfig, securityType=None, psk=None, hidden=False
+    ):
         return False, "no"
 
-    monkeypatch.setattr(nmcli, 'configure', mock_configure)
+    monkeypatch.setattr(nmcli, "configure", mock_configure)
 
-    resp = api_client.post(
-        '/wifi/configure', json={'ssid': 'asasd', 'foo': 'bar'})
+    resp = api_client.post("/wifi/configure", json={"ssid": "asasd", "foo": "bar"})
     assert resp.status_code == 401
     body = resp.json()
     assert {"message": "no"} == body
 
 
 def test_wifi_disconnect(api_client, monkeypatch):
-    msg1 = 'Connection \'ot_wifi\' successfully deactivated. ' \
-           'Connection \'ot_wifi\' (fa7ed807-23ef-41f0-ab3e-34' \
-           '99cc5a960e) successfully deleted'
+    msg1 = (
+        "Connection 'ot_wifi' successfully deactivated. "
+        "Connection 'ot_wifi' (fa7ed807-23ef-41f0-ab3e-34"
+        "99cc5a960e) successfully deleted"
+    )
 
     async def mock_disconnect(ssid):
         # Command: nmcli connection down ssid
         return True, msg1
 
-    monkeypatch.setattr(nmcli, 'wifi_disconnect', mock_disconnect)
+    monkeypatch.setattr(nmcli, "wifi_disconnect", mock_disconnect)
 
-    resp = api_client.post('/wifi/disconnect', json={})
+    resp = api_client.post("/wifi/disconnect", json={})
     assert resp.status_code == 422
 
-    resp = api_client.post('wifi/disconnect', json={'ssid': 'ot_wifi'})
+    resp = api_client.post("wifi/disconnect", json={"ssid": "ot_wifi"})
     body = resp.json()
     assert resp.status_code == 200
-    assert 'message' in body
+    assert "message" in body
 
-    msg2 = 'Connection \'ot_wifi\' successfully deactivated. \n' \
-           'Error: Could not remove ssid. No connection for ssid ot_wif123'
+    msg2 = (
+        "Connection 'ot_wifi' successfully deactivated. \n"
+        "Error: Could not remove ssid. No connection for ssid ot_wif123"
+    )
 
     async def mock_bad_disconnect(ssid):
         # Command: nmcli connection down ssid
         return True, msg2
 
-    monkeypatch.setattr(nmcli, 'wifi_disconnect', mock_bad_disconnect)
+    monkeypatch.setattr(nmcli, "wifi_disconnect", mock_bad_disconnect)
 
-    resp = api_client.post('wifi/disconnect', json={'ssid': 'ot_wifi'})
+    resp = api_client.post("wifi/disconnect", json={"ssid": "ot_wifi"})
     body = resp.json()
     assert resp.status_code == 207
-    assert 'message' in body
+    assert "message" in body
 
 
 @patch("opentrons.system.wifi.list_keys")
 def test_list_keys_no_keys(list_key_patch, api_client):
     list_key_patch.return_value = ()
 
-    empty_resp = api_client.get('/wifi/keys')
+    empty_resp = api_client.get("/wifi/keys")
     assert empty_resp.status_code == 200
     empty_body = empty_resp.json()
-    assert empty_body == {'keys': []}
+    assert empty_body == {"keys": []}
 
 
 @patch("opentrons.system.wifi.list_keys")
 def test_list_keys(list_key_patch, api_client):
     def gen():
-        dummy_names = ['ad12d1df199bc912', 'cbdda8124128cf', '812410990c5412']
+        dummy_names = ["ad12d1df199bc912", "cbdda8124128cf", "812410990c5412"]
         for n in dummy_names:
             yield wifi.Key(directory=n, file=f"{n[:4]}.pem")
 
     list_key_patch.side_effect = gen
 
-    resp = api_client.get('/wifi/keys')
+    resp = api_client.get("/wifi/keys")
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {'keys': [
-        {
-            "uri": "/wifi/keys/ad12d1df199bc912",
-            "id": "ad12d1df199bc912",
-            "name": "ad12.pem"
-        },
-        {
-            "uri": "/wifi/keys/cbdda8124128cf",
-            "id": "cbdda8124128cf",
-            "name": "cbdd.pem"
-        },
-        {
-            "uri": "/wifi/keys/812410990c5412",
-            "id": "812410990c5412",
-            "name": "8124.pem"
-        }
-    ]}
+    assert body == {
+        "keys": [
+            {
+                "uri": "/wifi/keys/ad12d1df199bc912",
+                "id": "ad12d1df199bc912",
+                "name": "ad12.pem",
+            },
+            {
+                "uri": "/wifi/keys/cbdda8124128cf",
+                "id": "cbdda8124128cf",
+                "name": "cbdd.pem",
+            },
+            {
+                "uri": "/wifi/keys/812410990c5412",
+                "id": "812410990c5412",
+                "name": "8124.pem",
+            },
+        ]
+    }
 
 
 def test_add_key_call(api_client):
     """Test that uploaded file is processed properly"""
     with tempfile.TemporaryDirectory() as source_td:
         # We should be able to add multiple keys
-        for fn in ['test1.pem', 'test2.pem', 'test3.pem']:
+        for fn in ["test1.pem", "test2.pem", "test3.pem"]:
             path = os.path.join(source_td, fn)
-            with open(path, 'w') as f:
+            with open(path, "w") as f:
                 f.write(str(random.getrandbits(20)))
 
             with patch("opentrons.system.wifi.add_key") as p:
-                p.return_value = wifi.AddKeyResult(created=True,
-                                                   key=wifi.Key(
-                                                       file="",
-                                                       directory=""
-                                                   ))
+                p.return_value = wifi.AddKeyResult(
+                    created=True, key=wifi.Key(file="", directory="")
+                )
 
-                api_client.post('/wifi/keys', files={'key': open(path, 'rb')})
+                api_client.post("/wifi/keys", files={"key": open(path, "rb")})
 
-                with open(path, 'rb') as f:
+                with open(path, "rb") as f:
                     p.assert_called_once_with(fn, f.read())
 
 
 def test_add_key_no_key(api_client):
     """Test response when no key supplied"""
     with patch("opentrons.system.wifi.add_key") as p:
-        r = api_client.post('/wifi/keys', data={})
+        r = api_client.post("/wifi/keys", data={})
 
         p.assert_not_called()
         assert r.status_code == 422
 
 
-@pytest.mark.parametrize("add_key_return,expected_status,expected_body", [
-    (wifi.AddKeyResult(created=True,
-                       key=wifi.Key(file="a", directory="b")),
-     201,
-     {'name': 'a', 'uri': '/wifi/keys/b', 'id': 'b'}
-     ),
-    (wifi.AddKeyResult(created=False,
-                       key=wifi.Key(file="x", directory="g")),
-     200,
-     {'name': 'x', 'uri': '/wifi/keys/g', 'id': 'g',
-      'message': 'Key file already present'}
-     )
-])
-def test_add_key_response(add_key_return, expected_status, expected_body,
-                          api_client):
+@pytest.mark.parametrize(
+    "add_key_return,expected_status,expected_body",
+    [
+        (
+            wifi.AddKeyResult(created=True, key=wifi.Key(file="a", directory="b")),
+            201,
+            {"name": "a", "uri": "/wifi/keys/b", "id": "b"},
+        ),
+        (
+            wifi.AddKeyResult(created=False, key=wifi.Key(file="x", directory="g")),
+            200,
+            {
+                "name": "x",
+                "uri": "/wifi/keys/g",
+                "id": "g",
+                "message": "Key file already present",
+            },
+        ),
+    ],
+)
+def test_add_key_response(add_key_return, expected_status, expected_body, api_client):
     with tempfile.TemporaryDirectory() as source_td:
 
         path = os.path.join(source_td, "t.pem")
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             f.write(str(random.getrandbits(20)))
 
         with patch("opentrons.system.wifi.add_key") as p:
             p.return_value = add_key_return
-            r = api_client.post('/wifi/keys', files={'key': open(path, 'rb')})
+            r = api_client.post("/wifi/keys", files={"key": open(path, "rb")})
             assert r.status_code == expected_status
             assert r.json() == expected_body
 
 
-@pytest.mark.parametrize("arg,remove_key_return,expected_status,expected_body",
-                         [
-                             ("12345",
-                              None,
-                              404,
-                              {'message': "No such key file 12345"}
-                              ),
-                             ("54321",
-                              "myfile.pem",
-                              200,
-                              {'message': 'Key file myfile.pem deleted'}
-                              )
-                         ])
-def test_remove_key(arg, remove_key_return,
-                    expected_status, expected_body, api_client):
+@pytest.mark.parametrize(
+    "arg,remove_key_return,expected_status,expected_body",
+    [
+        ("12345", None, 404, {"message": "No such key file 12345"}),
+        ("54321", "myfile.pem", 200, {"message": "Key file myfile.pem deleted"}),
+    ],
+)
+def test_remove_key(arg, remove_key_return, expected_status, expected_body, api_client):
     with patch("opentrons.system.wifi.remove_key") as p:
         p.return_value = remove_key_return
         r = api_client.delete("/wifi/keys/" + arg)
@@ -293,24 +313,24 @@ def test_remove_key(arg, remove_key_return,
 
 
 def test_eap_config_options(api_client):
-    resp = api_client.get('/wifi/eap-options')
+    resp = api_client.get("/wifi/eap-options")
 
     assert resp.status_code == 200
 
     body = resp.json()
     # Check that the body is shaped correctly but ignore the actual content
-    assert 'options' in body
-    option_keys = ('name', 'displayName', 'required', 'type')
-    option_types = ('string', 'password', 'file')
+    assert "options" in body
+    option_keys = ("name", "displayName", "required", "type")
+    option_types = ("string", "password", "file")
 
     def check_option(opt_dict):
         for key in option_keys:
             assert key in opt_dict
-        assert opt_dict['type'] in option_types
+        assert opt_dict["type"] in option_types
 
-    for opt in body['options']:
-        assert 'name' in opt
-        assert 'displayName' in opt
-        assert 'options' in opt
-        for method_opt in opt['options']:
+    for opt in body["options"]:
+        assert "name" in opt
+        assert "displayName" in opt
+        assert "options" in opt
+        for method_opt in opt["options"]:
             check_option(method_opt)

--- a/robot-server/tests/service/legacy/routers/test_pipettes.py
+++ b/robot-server/tests/service/legacy/routers/test_pipettes.py
@@ -4,44 +4,48 @@ from opentrons import types
 
 @pytest.fixture
 def attached_pipettes():
-    test_model = 'p300_multi_v1'
-    test_name = 'p300_multi'
-    test_id = '123abc'
+    test_model = "p300_multi_v1"
+    test_name = "p300_multi"
+    test_id = "123abc"
 
     return {
-        types.Mount.RIGHT: {'model': test_model,
-                            'pipette_id': test_id,
-                            'name': test_name,
-                            'tip_length': 123},
-        types.Mount.LEFT: {'model': test_model,
-                           'pipette_id': test_id,
-                           'name': test_name,
-                           'tip_length': 321}
+        types.Mount.RIGHT: {
+            "model": test_model,
+            "pipette_id": test_id,
+            "name": test_name,
+            "tip_length": 123,
+        },
+        types.Mount.LEFT: {
+            "model": test_model,
+            "pipette_id": test_id,
+            "name": test_name,
+            "tip_length": 321,
+        },
     }
 
 
 def test_get_pipettes(api_client, hardware, attached_pipettes):
     hardware.attached_instruments = attached_pipettes
     expected = {
-        'left': {
-            'model': attached_pipettes[types.Mount.LEFT]['model'],
-            'name': attached_pipettes[types.Mount.LEFT]['name'],
-            'tip_length': 321,
-            'mount_axis': 'z',
-            'plunger_axis': 'b',
-            'id': attached_pipettes[types.Mount.LEFT]['pipette_id']
+        "left": {
+            "model": attached_pipettes[types.Mount.LEFT]["model"],
+            "name": attached_pipettes[types.Mount.LEFT]["name"],
+            "tip_length": 321,
+            "mount_axis": "z",
+            "plunger_axis": "b",
+            "id": attached_pipettes[types.Mount.LEFT]["pipette_id"],
         },
-        'right': {
-            'model': attached_pipettes[types.Mount.RIGHT]['model'],
-            'name': attached_pipettes[types.Mount.RIGHT]['name'],
-            'tip_length': 123,
-            'mount_axis': 'a',
-            'plunger_axis': 'c',
-            'id': attached_pipettes[types.Mount.RIGHT]['pipette_id']
-        }
+        "right": {
+            "model": attached_pipettes[types.Mount.RIGHT]["model"],
+            "name": attached_pipettes[types.Mount.RIGHT]["name"],
+            "tip_length": 123,
+            "mount_axis": "a",
+            "plunger_axis": "c",
+            "id": attached_pipettes[types.Mount.RIGHT]["pipette_id"],
+        },
     }
 
-    resp = api_client.get('/pipettes')
+    resp = api_client.get("/pipettes")
 
     body = resp.json()
     assert resp.status_code == 200
@@ -52,7 +56,7 @@ def test_get_pipettes_refresh_true(api_client, hardware, attached_pipettes):
     """Test that cache instruments is called when refresh is true"""
     hardware.attached_instruments = attached_pipettes
 
-    resp = api_client.get('/pipettes?refresh=true')
+    resp = api_client.get("/pipettes?refresh=true")
 
     hardware.cache_instruments.assert_called_once()
 
@@ -63,7 +67,7 @@ def test_get_pipettes_refresh_false(api_client, hardware, attached_pipettes):
     """Test that cache instruments is not called when refresh is false"""
     hardware.attached_instruments = attached_pipettes
 
-    resp = api_client.get('/pipettes?refresh=false')
+    resp = api_client.get("/pipettes?refresh=false")
 
     hardware.cache_instruments.assert_not_called()
 

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -12,55 +12,19 @@ from opentrons.config import advanced_settings
 @pytest.mark.parametrize(
     "log_level, syslog_level, expected_message",
     [
-        (
-            "error",
-            "err",
-            {"message": "Upstreaming log level changed to error"}
-        ), (
-            "ERROR",
-            "err",
-            {"message": "Upstreaming log level changed to error"}
-        ), (
-            "warning",
-            "warning",
-            {"message": "Upstreaming log level changed to warning"}
-        ), (
-            "WARNING",
-            "warning",
-            {"message": "Upstreaming log level changed to warning"}
-        ), (
-            "info",
-            "info",
-            {"message": "Upstreaming log level changed to info"}
-        ), (
-            "INFO",
-            "info",
-            {"message": "Upstreaming log level changed to info"}
-        ), (
-            "debug",
-            "debug",
-            {"message": "Upstreaming log level changed to debug"}
-        ), (
-            "DEBUG",
-            "debug",
-            {"message": "Upstreaming log level changed to debug"}
-        ), (
-            None,
-            "emerg",
-            {"message": "Upstreaming logs disabled"}
-        ), (
-            None,
-            "emerg",
-            {"message": "Upstreaming logs disabled"}
-        )
-    ]
+        ("error", "err", {"message": "Upstreaming log level changed to error"}),
+        ("ERROR", "err", {"message": "Upstreaming log level changed to error"}),
+        ("warning", "warning", {"message": "Upstreaming log level changed to warning"}),
+        ("WARNING", "warning", {"message": "Upstreaming log level changed to warning"}),
+        ("info", "info", {"message": "Upstreaming log level changed to info"}),
+        ("INFO", "info", {"message": "Upstreaming log level changed to info"}),
+        ("debug", "debug", {"message": "Upstreaming log level changed to debug"}),
+        ("DEBUG", "debug", {"message": "Upstreaming log level changed to debug"}),
+        (None, "emerg", {"message": "Upstreaming logs disabled"}),
+        (None, "emerg", {"message": "Upstreaming logs disabled"}),
+    ],
 )
-def test_post_log_level_upstream(
-    api_client,
-    log_level,
-    syslog_level,
-    expected_message
-):
+def test_post_log_level_upstream(api_client, log_level, syslog_level, expected_message):
     with patch("opentrons.system.log_control.set_syslog_level") as m:
         m.return_value = 0, "stdout", "stderr"
         response = api_client.post(
@@ -93,140 +57,135 @@ def test_get_robot_settings(api_client, hardware):
     res = api_client.get("/settings/robot")
 
     assert res.status_code == 200
-    assert res.json() == {
-        "a": "test",
-        "b": "this",
-        "c": 5
-    }
+    assert res.json() == {"a": "test", "b": "this", "c": 5}
 
 
 @pytest.fixture
 def mock_pipette_data():
     return {
-        'p1': {
-            'info': {
-                'name': 'p1_name',
-                'model': 'p1_model',
+        "p1": {
+            "info": {
+                "name": "p1_name",
+                "model": "p1_model",
             },
-            'fields': {
-                'pickUpCurrent': {
-                    'units': 'mm',
-                    'type': 'float',
-                    'min': 0.0,
-                    'max': 2.0,
-                    'default': 1.0,
-                    'value': 0.5,
+            "fields": {
+                "pickUpCurrent": {
+                    "units": "mm",
+                    "type": "float",
+                    "min": 0.0,
+                    "max": 2.0,
+                    "default": 1.0,
+                    "value": 0.5,
                 },
-                'quirks': {
-                    'dropTipShake': True
-                }
-            }
-        },
-        'p2': {
-            'info': {
-                'name': 'p2_name',
-                'model': 'p2_model',
+                "quirks": {"dropTipShake": True},
             },
-            'fields': {
-                'pickUpIncrement': {
-                    'units': 'inch',
-                    'type': 'int',
-                    'min': 0,
-                    'max': 2,
-                    'default': 1.,
-                    'value': 2,
+        },
+        "p2": {
+            "info": {
+                "name": "p2_name",
+                "model": "p2_model",
+            },
+            "fields": {
+                "pickUpIncrement": {
+                    "units": "inch",
+                    "type": "int",
+                    "min": 0,
+                    "max": 2,
+                    "default": 1.0,
+                    "value": 2,
                 }
-            }
-        }
+            },
+        },
     }
 
 
 @pytest.fixture
 def mock_pipette_config(mock_pipette_data):
-    with patch("robot_server.service.legacy.routers."
-               "settings.pipette_config") as p:
+    with patch("robot_server.service.legacy.routers." "settings.pipette_config") as p:
         p.known_pipettes.return_value = list(mock_pipette_data.keys())
-        p.load_config_dict.side_effect = \
-            lambda id: (mock_pipette_data[id]['info'],
-                        mock_pipette_data[id]['info']['model'])
-        p.list_mutable_configs.side_effect = \
-            lambda pipette_id: mock_pipette_data[pipette_id]['fields']
+        p.load_config_dict.side_effect = lambda id: (
+            mock_pipette_data[id]["info"],
+            mock_pipette_data[id]["info"]["model"],
+        )
+        p.list_mutable_configs.side_effect = lambda pipette_id: mock_pipette_data[
+            pipette_id
+        ]["fields"]
         yield p
 
 
-def test_receive_pipette_settings(api_client,
-                                  mock_pipette_config,
-                                  mock_pipette_data):
+def test_receive_pipette_settings(api_client, mock_pipette_config, mock_pipette_data):
 
-    resp = api_client.get('/settings/pipettes')
+    resp = api_client.get("/settings/pipettes")
     assert resp.status_code == 200
     assert resp.json() == mock_pipette_data
 
 
-def test_receive_pipette_settings_unknown(api_client,
-                                          mock_pipette_config,
-                                          mock_pipette_data):
+def test_receive_pipette_settings_unknown(
+    api_client, mock_pipette_config, mock_pipette_data
+):
     # Non-existent pipette id and get 404
-    resp = api_client.get('/settings/pipettes/wannabepipette')
+    resp = api_client.get("/settings/pipettes/wannabepipette")
     assert resp.status_code == 404
 
 
-def test_receive_pipette_settings_found(api_client,
-                                        mock_pipette_config,
-                                        mock_pipette_data):
-    resp = api_client.get('/settings/pipettes/p1')
+def test_receive_pipette_settings_found(
+    api_client, mock_pipette_config, mock_pipette_data
+):
+    resp = api_client.get("/settings/pipettes/p1")
     assert resp.status_code == 200
-    assert resp.json() == mock_pipette_data['p1']
+    assert resp.json() == mock_pipette_data["p1"]
 
 
-def test_modify_pipette_settings_call_override(api_client,
-                                               mock_pipette_config,
-                                               mock_pipette_data):
-    pipette_id = 'p1'
+def test_modify_pipette_settings_call_override(
+    api_client, mock_pipette_config, mock_pipette_data
+):
+    pipette_id = "p1"
     changes = {
-        'fields': {
-            'pickUpCurrent': {'value': 1},
-            'dropTipShake': {'value': True},
-            'pickUpSpeed': {'value': None},
-            'pickUpDistance': None
+        "fields": {
+            "pickUpCurrent": {"value": 1},
+            "dropTipShake": {"value": True},
+            "pickUpSpeed": {"value": None},
+            "pickUpDistance": None,
         }
     }
 
     # Check that data is changed and matches the changes specified
-    resp = api_client.patch(
-        f'/settings/pipettes/{pipette_id}',
-        json=changes)
+    resp = api_client.patch(f"/settings/pipettes/{pipette_id}", json=changes)
     mock_pipette_config.override.assert_called_once_with(
-        fields={'pickUpCurrent': 1, 'dropTipShake': True,
-                'pickUpSpeed': None, 'pickUpDistance': None},
-        pipette_id=pipette_id)
+        fields={
+            "pickUpCurrent": 1,
+            "dropTipShake": True,
+            "pickUpSpeed": None,
+            "pickUpDistance": None,
+        },
+        pipette_id=pipette_id,
+    )
     patch_body = resp.json()
     assert resp.status_code == 200
-    assert patch_body == {'fields': mock_pipette_data[pipette_id]['fields'],
-                          'info': mock_pipette_data[pipette_id]["info"]}
+    assert patch_body == {
+        "fields": mock_pipette_data[pipette_id]["fields"],
+        "info": mock_pipette_data[pipette_id]["info"],
+    }
 
 
-@pytest.mark.parametrize(argnames=["body"],
-                         argvalues=[
-                             [{}],
-                             [{'fields': {}}]
-                         ])
+@pytest.mark.parametrize(argnames=["body"], argvalues=[[{}], [{"fields": {}}]])
 def test_modify_pipette_settings_do_not_call_override(
-        api_client, mock_pipette_config, mock_pipette_data, body):
-    pipette_id = 'p1'
+    api_client, mock_pipette_config, mock_pipette_data, body
+):
+    pipette_id = "p1"
 
-    resp = api_client.patch(
-        f'/settings/pipettes/{pipette_id}',
-        json=body)
+    resp = api_client.patch(f"/settings/pipettes/{pipette_id}", json=body)
     mock_pipette_config.override.assert_not_called()
     patch_body = resp.json()
     assert resp.status_code == 200
-    assert patch_body == {'fields': mock_pipette_data[pipette_id]['fields'],
-                          'info': mock_pipette_data[pipette_id]["info"]}
+    assert patch_body == {
+        "fields": mock_pipette_data[pipette_id]["fields"],
+        "info": mock_pipette_data[pipette_id]["info"],
+    }
 
 
 def test_modify_pipette_settings_failure(api_client, mock_pipette_config):
-    test_id = 'p1'
+    test_id = "p1"
 
     def mock_override(pipette_id, fields):
         raise ValueError("Failed!")
@@ -234,76 +193,89 @@ def test_modify_pipette_settings_failure(api_client, mock_pipette_config):
     mock_pipette_config.override.side_effect = mock_override
 
     resp = api_client.patch(
-        f'/settings/pipettes/{test_id}',
-        json={'fields': {'pickUpCurrent': {'value': 1}}})
+        f"/settings/pipettes/{test_id}",
+        json={"fields": {"pickUpCurrent": {"value": 1}}},
+    )
     mock_pipette_config.override.assert_called_once_with(
-        pipette_id=test_id,
-        fields={'pickUpCurrent': 1})
+        pipette_id=test_id, fields={"pickUpCurrent": 1}
+    )
     patch_body = resp.json()
     assert resp.status_code == 412
-    assert patch_body == {'message': "Failed!"}
+    assert patch_body == {"message": "Failed!"}
 
 
 def test_available_resets(api_client):
-    resp = api_client.get('/settings/reset/options')
+    resp = api_client.get("/settings/reset/options")
     body = resp.json()
-    options_list = body.get('options')
+    options_list = body.get("options")
     assert resp.status_code == 200
-    assert sorted(['deckCalibration', 'pipetteOffsetCalibrations',
-                   'labwareCalibration', 'bootScripts',
-                   'tipLengthCalibrations'])\
-        == sorted([item['id'] for item in options_list])
+    assert (
+        sorted(
+            [
+                "deckCalibration",
+                "pipetteOffsetCalibrations",
+                "labwareCalibration",
+                "bootScripts",
+                "tipLengthCalibrations",
+            ]
+        )
+        == sorted([item["id"] for item in options_list])
+    )
 
 
 @pytest.fixture
 def mock_reset():
-    with patch("robot_server.service.legacy.routers."
-               "settings.reset_util.reset") as m:
+    with patch("robot_server.service.legacy.routers." "settings.reset_util.reset") as m:
         yield m
 
 
-@pytest.mark.parametrize(argnames="body,called_with",
-                         argvalues=[
-                             # Empty body
-                             [{}, set()],
-                             # None true
-                             [{
-                                 'labwareCalibration': False,
-                                 'deckCalibration': False,
-                                 'bootScripts': False,
-                                 'pipetteOffsetCalibrations': False,
-                                 'tipLengthCalibrations': False,
-                             }, set()],
-                             # All set
-                             [{
-                                 'labwareCalibration': True,
-                                 'bootScripts': True,
-                                 'pipetteOffsetCalibrations': True,
-                                 'tipLengthCalibrations': True,
-                                 'deckCalibration': True,
-                             }, {ResetOptionId.labware_calibration,
-                                 ResetOptionId.boot_scripts,
-                                 ResetOptionId.deck_calibration,
-                                 ResetOptionId.pipette_offset,
-                                 ResetOptionId.tip_length_calibrations}],
-                             [{'labwareCalibration': True},
-                              {ResetOptionId.labware_calibration}],
-                             [{'bootScripts': True},
-                              {ResetOptionId.boot_scripts}],
-                             [{'pipetteOffsetCalibrations': True},
-                              {ResetOptionId.pipette_offset}],
-                             [{'tipLengthCalibrations': True},
-                              {ResetOptionId.tip_length_calibrations}]
-                         ])
-def test_reset_success(
-        api_client, mock_reset, body, called_with):
-    resp = api_client.post('/settings/reset', json=body)
+@pytest.mark.parametrize(
+    argnames="body,called_with",
+    argvalues=[
+        # Empty body
+        [{}, set()],
+        # None true
+        [
+            {
+                "labwareCalibration": False,
+                "deckCalibration": False,
+                "bootScripts": False,
+                "pipetteOffsetCalibrations": False,
+                "tipLengthCalibrations": False,
+            },
+            set(),
+        ],
+        # All set
+        [
+            {
+                "labwareCalibration": True,
+                "bootScripts": True,
+                "pipetteOffsetCalibrations": True,
+                "tipLengthCalibrations": True,
+                "deckCalibration": True,
+            },
+            {
+                ResetOptionId.labware_calibration,
+                ResetOptionId.boot_scripts,
+                ResetOptionId.deck_calibration,
+                ResetOptionId.pipette_offset,
+                ResetOptionId.tip_length_calibrations,
+            },
+        ],
+        [{"labwareCalibration": True}, {ResetOptionId.labware_calibration}],
+        [{"bootScripts": True}, {ResetOptionId.boot_scripts}],
+        [{"pipetteOffsetCalibrations": True}, {ResetOptionId.pipette_offset}],
+        [{"tipLengthCalibrations": True}, {ResetOptionId.tip_length_calibrations}],
+    ],
+)
+def test_reset_success(api_client, mock_reset, body, called_with):
+    resp = api_client.post("/settings/reset", json=body)
     assert resp.status_code == 200
     mock_reset.assert_called_once_with(called_with)
 
 
 def test_reset_invalid_option(api_client, mock_reset):
-    resp = api_client.post('/settings/reset', json={'aksgjajhadjasl': False})
+    resp = api_client.post("/settings/reset", json={"aksgjajhadjasl": False})
     assert resp.status_code == 422
     # TODO Blocked by https://github.com/Opentrons/opentrons/issues/5285
     # body = resp.json()
@@ -313,8 +285,7 @@ def test_reset_invalid_option(api_client, mock_reset):
 
 @pytest.fixture()
 def mock_robot_configs():
-    with patch("robot_server.service.legacy.routers."
-               "settings.robot_configs") as m:
+    with patch("robot_server.service.legacy.routers." "settings.robot_configs") as m:
         yield m
 
 
@@ -324,60 +295,57 @@ def mock_logging_set_level():
         yield m
 
 
-@pytest.mark.parametrize(argnames=["body"],
-                         argvalues=[
-                             [{}],
-                             [{'log_level': None}],
-                             [{'log_level': 'oafajhshda'}]
-                         ])
-def test_set_log_level_invalid(api_client, body,
-                               hardware, mock_logging_set_level,
-                               mock_robot_configs):
-    resp = api_client.post('/settings/log_level/local', json=body)
+@pytest.mark.parametrize(
+    argnames=["body"],
+    argvalues=[[{}], [{"log_level": None}], [{"log_level": "oafajhshda"}]],
+)
+def test_set_log_level_invalid(
+    api_client, body, hardware, mock_logging_set_level, mock_robot_configs
+):
+    resp = api_client.post("/settings/log_level/local", json=body)
     assert resp.status_code == 422
     mock_logging_set_level.assert_not_called()
     hardware.update_config.assert_not_called()
     mock_robot_configs.save_robot_settings.assert_not_called()
 
 
-@pytest.mark.parametrize(argnames=["body",
-                                   "expected_log_level",
-                                   "expected_log_level_name"],
-                         argvalues=[
-                             [{'log_level': 'debug'},
-                              logging.DEBUG, "DEBUG"],
-                             [{'log_level': 'deBug'},
-                              logging.DEBUG, "DEBUG"],
-                             [{'log_level': 'info'},
-                              logging.INFO, "INFO"],
-                             [{'log_level': 'INFO'},
-                              logging.INFO, "INFO"],
-                             [{'log_level': 'warning'},
-                              logging.WARNING, "WARNING"],
-                             [{'log_level': 'warninG'},
-                              logging.WARNING, "WARNING"],
-                             [{'log_level': 'error'},
-                              logging.ERROR, "ERROR"],
-                             [{'log_level': 'ERROR'},
-                              logging.ERROR, "ERROR"],
-                         ])
-def test_set_log_level(api_client, hardware,
-                       mock_robot_configs, mock_logging_set_level,
-                       body, expected_log_level, expected_log_level_name):
-    resp = api_client.post('/settings/log_level/local', json=body)
+@pytest.mark.parametrize(
+    argnames=["body", "expected_log_level", "expected_log_level_name"],
+    argvalues=[
+        [{"log_level": "debug"}, logging.DEBUG, "DEBUG"],
+        [{"log_level": "deBug"}, logging.DEBUG, "DEBUG"],
+        [{"log_level": "info"}, logging.INFO, "INFO"],
+        [{"log_level": "INFO"}, logging.INFO, "INFO"],
+        [{"log_level": "warning"}, logging.WARNING, "WARNING"],
+        [{"log_level": "warninG"}, logging.WARNING, "WARNING"],
+        [{"log_level": "error"}, logging.ERROR, "ERROR"],
+        [{"log_level": "ERROR"}, logging.ERROR, "ERROR"],
+    ],
+)
+def test_set_log_level(
+    api_client,
+    hardware,
+    mock_robot_configs,
+    mock_logging_set_level,
+    body,
+    expected_log_level,
+    expected_log_level_name,
+):
+    resp = api_client.post("/settings/log_level/local", json=body)
     assert resp.status_code == 200
     # Three calls for opentrons, robot_server, and uvicorn loggers
-    mock_logging_set_level.assert_has_calls([call(expected_log_level),
-                                             call(expected_log_level),
-                                             call(expected_log_level)])
-    hardware.update_config.assert_called_once_with(
-        log_level=expected_log_level_name)
+    mock_logging_set_level.assert_has_calls(
+        [call(expected_log_level), call(expected_log_level), call(expected_log_level)]
+    )
+    hardware.update_config.assert_called_once_with(log_level=expected_log_level_name)
     mock_robot_configs.save_robot_settings.assert_called_once()
 
 
 @pytest.fixture
 def mock_get_all_adv_settings():
-    with patch("robot_server.service.legacy.routers.settings.advanced_settings.get_all_adv_settings") as p:   # noqa: E501
+    with patch(
+        "robot_server.service.legacy.routers.settings.advanced_settings.get_all_adv_settings"  # noqa: E501
+    ) as p:
         p.return_value = {
             s.id: advanced_settings.Setting(value=False, definition=s)
             for s in advanced_settings.settings
@@ -387,63 +355,72 @@ def mock_get_all_adv_settings():
 
 @pytest.fixture
 def mock_is_restart_required():
-    with patch("robot_server.service.legacy.routers.settings.advanced_settings.is_restart_required") as p:   # noqa: E501
+    with patch(
+        "robot_server.service.legacy.routers.settings.advanced_settings.is_restart_required"  # noqa: E501
+    ) as p:
         yield p
 
 
 @pytest.fixture
 def mock_set_adv_setting():
-    with patch("robot_server.service.legacy.routers.settings.advanced_settings.set_adv_setting") as p:  # noqa: E501
+    with patch(
+        "robot_server.service.legacy.routers.settings.advanced_settings.set_adv_setting"
+    ) as p:
         yield p
 
 
 def validate_response_body(body, restart):
-    settings_list = body.get('settings')
+    settings_list = body.get("settings")
     assert type(settings_list) == list
     for obj in settings_list:
-        assert 'id' in obj, '"id" field not found in settings object'
-        assert 'title' in obj, '"title" not found for {}'.format(obj['id'])
-        assert 'description' in obj, '"description" not found for {}'.format(
-            obj['id'])
-        assert 'value' in obj, '"value" not found for {}'.format(obj['id'])
-        assert 'restart_required' in obj
-    assert 'links' in body
-    assert isinstance(body['links'], dict)
-    assert body['links'].get('restart') == restart
+        assert "id" in obj, '"id" field not found in settings object'
+        assert "title" in obj, '"title" not found for {}'.format(obj["id"])
+        assert "description" in obj, '"description" not found for {}'.format(obj["id"])
+        assert "value" in obj, '"value" not found for {}'.format(obj["id"])
+        assert "restart_required" in obj
+    assert "links" in body
+    assert isinstance(body["links"], dict)
+    assert body["links"].get("restart") == restart
 
 
-@pytest.mark.parametrize(argnames=["restart_required", "link"],
-                         argvalues=[
-                             [False, None],
-                             [True, "/server/restart"]
-                         ])
-def test_get(api_client, mock_get_all_adv_settings, mock_is_restart_required,
-             restart_required, link):
+@pytest.mark.parametrize(
+    argnames=["restart_required", "link"],
+    argvalues=[[False, None], [True, "/server/restart"]],
+)
+def test_get(
+    api_client,
+    mock_get_all_adv_settings,
+    mock_is_restart_required,
+    restart_required,
+    link,
+):
     mock_is_restart_required.return_value = restart_required
-    resp = api_client.get('/settings')
+    resp = api_client.get("/settings")
     body = resp.json()
     assert resp.status_code == 200
     validate_response_body(body, link)
 
 
-@pytest.mark.parametrize(argnames=["exc", "expected_status"],
-                         argvalues=[
-                             [ValueError("Failure"), 400],
-                             [advanced_settings.SettingException("Fail", "e"),
-                              500]
-                         ])
-def test_set_err(api_client, mock_is_restart_required,
-                 mock_set_adv_setting, exc, expected_status):
+@pytest.mark.parametrize(
+    argnames=["exc", "expected_status"],
+    argvalues=[
+        [ValueError("Failure"), 400],
+        [advanced_settings.SettingException("Fail", "e"), 500],
+    ],
+)
+def test_set_err(
+    api_client, mock_is_restart_required, mock_set_adv_setting, exc, expected_status
+):
     mock_is_restart_required.return_value = False
 
     def raiser(i, v):
         raise exc
+
     mock_set_adv_setting.side_effect = raiser
 
-    test_id = 'disableHomeOnBoot'
+    test_id = "disableHomeOnBoot"
 
-    resp = api_client.post(
-        '/settings', json={"id": test_id, "value": True})
+    resp = api_client.post("/settings", json={"id": test_id, "value": True})
     body = resp.json()
     assert resp.status_code == expected_status
     assert body == {"message": str(exc)}
@@ -452,10 +429,9 @@ def test_set_err(api_client, mock_is_restart_required,
 def test_set(api_client, mock_set_adv_setting, mock_is_restart_required):
     mock_is_restart_required.return_value = False
 
-    test_id = 'disableHomeOnBoot'
+    test_id = "disableHomeOnBoot"
 
-    resp = api_client.post(
-        '/settings', json={"id": test_id, "value": True})
+    resp = api_client.post("/settings", json={"id": test_id, "value": True})
     body = resp.json()
     assert resp.status_code == 200
     validate_response_body(body, None)

--- a/robot-server/tests/service/legacy/rpc/test_serialize.py
+++ b/robot-server/tests/service/legacy/rpc/test_serialize.py
@@ -18,16 +18,18 @@ def instance():
         def __iter__(self):
             return iter([0])
 
-    a1 = A({'b': 1, 'c': 'c', 'd': True, 'e': None})
-    a2 = A({'a': 1})
+    a1 = A({"b": 1, "c": "c", "d": True, "e": None})
+    a2 = A({"a": 1})
     a3 = A({})
 
-    root = A({
-                'a': a1,
-                'b': [a2, 'b', 1],
-                'c': {'a': 1, 'b': [1, 2, a3]},
-            })
-    root.update({'circular': root})
+    root = A(
+        {
+            "a": a1,
+            "b": [a2, "b", 1],
+            "c": {"a": 1, "b": [1, 2, a3]},
+        }
+    )
+    root.update({"circular": root})
 
     return (root, a1, a2, a3)
 
@@ -44,27 +46,31 @@ def test_get_object_tree(instance):
     r += [type(o) for o in r] + [dict]
     assert refs == {id(o): o for o in r}
     assert tree == {
-        'i': id(root),
-        't': type_id(root),
-        'v': {
+        "i": id(root),
+        "t": type_id(root),
+        "v": {
             0: 0,
-            'a': {
-                'i': id(a1),
-                't': type_id(a1),
-                'v': {
-                    0: 0,
-                    'b': 1,
-                    'c': 'c',
-                    'd': True,
-                    'e': None}},
-            'b': [{'i': id(a2), 't': type_id(a2), 'v': {0: 0, 'a': 1}}, 'b', 1],  # noqa: E501
-            'c': {
-                'i': tree['v']['c']['i'],
-                't': id(dict),
-                'v': {
-                    'a': 1,
-                    'b': [1, 2, {'i': id(a3), 't': type_id(a3), 'v': {0: 0}}]}},  # noqa: E501
-            'circular': {'i': id(root), 't': type_id(root), 'v': None}}}
+            "a": {
+                "i": id(a1),
+                "t": type_id(a1),
+                "v": {0: 0, "b": 1, "c": "c", "d": True, "e": None},
+            },
+            "b": [
+                {"i": id(a2), "t": type_id(a2), "v": {0: 0, "a": 1}},
+                "b",
+                1,
+            ],
+            "c": {
+                "i": tree["v"]["c"]["i"],
+                "t": id(dict),
+                "v": {
+                    "a": 1,
+                    "b": [1, 2, {"i": id(a3), "t": type_id(a3), "v": {0: 0}}],
+                },
+            },
+            "circular": {"i": id(root), "t": type_id(root), "v": None},
+        },
+    }
 
     assert json.dumps(tree)
 
@@ -73,23 +79,26 @@ def test_get_object_tree_shallow(instance):
     root, *_ = instance
     tree, refs = serialize.get_object_tree(root, max_depth=1)
     assert tree == {
-        'i': id(root),
-        't': type_id(root),
-        'v': {
-            0: 0, 'a': {}, 'b': {}, 'c': {},
-            'circular': {'i': id(root), 't': type_id(root), 'v': None}}}
+        "i": id(root),
+        "t": type_id(root),
+        "v": {
+            0: 0,
+            "a": {},
+            "b": {},
+            "c": {},
+            "circular": {"i": id(root), "t": type_id(root), "v": None},
+        },
+    }
     assert refs == {id(root): root, type_id(root): type(root)}
 
 
 def test_ordered_dict():
     b = OrderedDict()
-    b['b'] = 1
-    a = {'a': b}
+    b["b"] = 1
+    a = {"a": b}
     tree, refs = serialize.get_object_tree(a)
     assert tree == {
-        'i': id(a),
-        't': type_id(a),
-        'v': {'a': {
-                'i': id(b),
-                't': type_id(b),
-                'v': {'b': 1}}}}
+        "i": id(a),
+        "t": type_id(a),
+        "v": {"a": {"i": id(b), "t": type_id(b), "v": {"b": 1}}},
+    }

--- a/robot-server/tests/service/legacy/rpc/test_server.py
+++ b/robot-server/tests/service/legacy/rpc/test_server.py
@@ -29,14 +29,14 @@ def session(loop, api_client, request) -> Session:
     If not set root will be defaulted to None
     """
     # Root object
-    root = request.getfixturevalue('root')
+    root = request.getfixturevalue("root")
     # Test state
     state = {}
 
     async def get_server():
         # We want the server created here.
         _internal_server = rpc.RPCServer(None, root)
-        state['server'] = _internal_server
+        state["server"] = _internal_server
         return _internal_server
 
     # Override the RPC server dependency
@@ -48,14 +48,12 @@ def session(loop, api_client, request) -> Session:
 
     def call(**kwargs):
         _send_data = {
-            '$': {
-                'token': token
-            },
+            "$": {"token": token},
         }
         _send_data.update(kwargs)
         return socket.send_json(_send_data)
 
-    server = state['server']
+    server = state["server"]
 
     yield Session(server, socket, token, call)
 
@@ -64,7 +62,7 @@ def session(loop, api_client, request) -> Session:
 
 
 class Foo(object):
-    STATIC = 'static'
+    STATIC = "static"
 
     def __init__(self, value):
         self.value = value
@@ -82,16 +80,14 @@ class Foo(object):
         return Foo(self.value + foo.value)
 
     def throw(self):
-        raise Exception('Kaboom!')
+        raise Exception("Kaboom!")
 
     def throw_eipe(self):
         try:
-            raise Exception('Kaboom!')
+            raise Exception("Kaboom!")
         except Exception:
             t, v, b = sys.exc_info()
-        raise ExceptionInProtocolError(v, b,
-                                       'This is a test',
-                                       10)
+        raise ExceptionInProtocolError(v, b, "This is a test", 10)
 
 
 class Notifications(object):
@@ -100,8 +96,7 @@ class Notifications(object):
         self._queue = None
 
     def put(self, value):
-        asyncio.run_coroutine_threadsafe(
-            self.queue.put(value), self.loop)
+        asyncio.run_coroutine_threadsafe(self.queue.put(value), self.loop)
 
     def __aiter__(self):
         return self
@@ -186,164 +181,130 @@ def type_id(instance):
     return id(type(instance))
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_call(session, root):
     res = session.server.call_and_serialize(lambda: root)
-    assert res == {'v': {'value': 0}, 't': type_id(root), 'i': id(root)}
+    assert res == {"v": {"value": 0}, "t": type_id(root), "i": id(root)}
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_init(session, root):
     serialized_type = session.server.call_and_serialize(lambda: type(root))
     expected = {
-        'root': {
-            'i': id(root),
-            't': type_id(root),
-            'v': {'value': 0}
-        },
-        'type': serialized_type,
-        '$': {'type': rpc.CONTROL_MESSAGE, 'monitor': True}
+        "root": {"i": id(root), "t": type_id(root), "v": {"value": 0}},
+        "type": serialized_type,
+        "$": {"type": rpc.CONTROL_MESSAGE, "monitor": True},
     }
 
-    assert serialized_type['v']['STATIC'] == 'static', \
-        'Class attributes are serialized correctly'
+    assert (
+        serialized_type["v"]["STATIC"] == "static"
+    ), "Class attributes are serialized correctly"
     res = session.socket.receive_json()
     assert res == expected
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_exception_during_call(session, root):
     session.socket.receive_json()
     session.call()
     res = session.socket.receive_json()
-    assert res.pop('$') == {
-        'type': rpc.CALL_ACK_MESSAGE,
-        'token': session.token
-    }
+    assert res.pop("$") == {"type": rpc.CALL_ACK_MESSAGE, "token": session.token}
     res = session.socket.receive_json()
-    assert res.pop('$') == {
-        'type': rpc.CALL_NACK_MESSAGE,
-        'token': session.token
-    }
-    assert res.pop('reason').startswith('TypeError:')
+    assert res.pop("$") == {"type": rpc.CALL_NACK_MESSAGE, "token": session.token}
+    assert res.pop("reason").startswith("TypeError:")
     assert res == {}
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_get_object_by_id(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        name='get_object_by_id',
-        args=[type_id(root)])
+    session.call(name="get_object_by_id", args=[type_id(root)])
 
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()  # Get call result
-    expected = {'$': {
-        'token': session.token,
-        'status': 'success',
-        'type': rpc.CALL_RESULT_MESSAGE},
-        'data': {
-        'i': type_id(session.server.root),
-        't': id(type),
-        'v': {
-            'STATIC',
-            'value',
-            'throw',
-            'throw_eipe',
-            'next',
-            'combine',
-            'add'
-        }
-    }
+    expected = {
+        "$": {
+            "token": session.token,
+            "status": "success",
+            "type": rpc.CALL_RESULT_MESSAGE,
+        },
+        "data": {
+            "i": type_id(session.server.root),
+            "t": id(type),
+            "v": {"STATIC", "value", "throw", "throw_eipe", "next", "combine", "add"},
+        },
     }
     # We care only about dictionary keys, since we don't want
     # to track ids of function objects
-    res['data']['v'] = set(res['data']['v'])
+    res["data"]["v"] = set(res["data"]["v"])
 
     assert res == expected
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_call_on_result(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=id(root),
-        name='value',
-        args=[]
-    )
+    session.call(id=id(root), name="value", args=[])
 
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()  # Get call result
-    expected = {'$': {
-        'token': session.token,
-        'status': 'success',
-        'type': rpc.CALL_RESULT_MESSAGE},
-        'data': 0}
+    expected = {
+        "$": {
+            "token": session.token,
+            "status": "success",
+            "type": rpc.CALL_RESULT_MESSAGE,
+        },
+        "data": 0,
+    }
     assert res == expected
 
-    session.call(
-        id=id(root),
-        name='add',
-        args=[1]
-    )
+    session.call(id=id(root), name="add", args=[1])
 
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()  # Get call result
-    expected = {'$': {
-        'token': session.token,
-        'status': 'success',
-        'type': rpc.CALL_RESULT_MESSAGE},
-        'data': 1}
+    expected = {
+        "$": {
+            "token": session.token,
+            "status": "success",
+            "type": rpc.CALL_RESULT_MESSAGE,
+        },
+        "data": 1,
+    }
 
     assert res == expected
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_call_unknown_object(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=1234321,
-        name='value',
-        args=[]
-    )
+    session.call(id=1234321, name="value", args=[])
     session.socket.receive_json()  # Skip ack
 
     x = session.socket.receive_json()  # Skip ack
     assert x == {
-        "$": {
-            "token": session.token,
-            "type": rpc.CALL_NACK_MESSAGE
-        },
-        "reason": "ValueError: object with id 1234321 not found"
+        "$": {"token": session.token, "type": rpc.CALL_NACK_MESSAGE},
+        "reason": "ValueError: object with id 1234321 not found",
     }
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_call_unknown_method(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=id(root),
-        name='no_no_no',
-        args=[]
-    )
+    session.call(id=id(root), name="no_no_no", args=[])
     session.socket.receive_json()  # Skip ack
 
     x = session.socket.receive_json()  # Skip ack
     assert x == {
-        "$": {
-            "token": session.token,
-            "type": rpc.CALL_NACK_MESSAGE
-        },
-        "reason":
-            "AttributeError: type object 'Foo' has no attribute 'no_no_no'"
+        "$": {"token": session.token, "type": rpc.CALL_NACK_MESSAGE},
+        "reason": "AttributeError: type object 'Foo' has no attribute 'no_no_no'",
     }
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_ping(session, root):
     session.socket.receive_json()  # Skip init
 
@@ -353,50 +314,42 @@ def test_ping(session, root):
     assert {"$": {"type": rpc.PONG_MESSAGE}} == res
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_exception_on_call(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=id(root),
-        name='throw',
-        args=[]
-    )
+    session.call(id=id(root), name="throw", args=[])
 
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()  # Get call result
     expected_meta = {
-        'token': session.token,
-        'status': 'error',
-        'type': rpc.CALL_RESULT_MESSAGE
+        "token": session.token,
+        "status": "error",
+        "type": rpc.CALL_RESULT_MESSAGE,
     }
-    expected_message = 'Exception: Kaboom!'
+    expected_message = "Exception: Kaboom!"
 
-    assert res['$'] == expected_meta
-    assert res['data']['message'] == expected_message
-    assert isinstance(res['data']['traceback'], str)
+    assert res["$"] == expected_meta
+    assert res["data"]["message"] == expected_message
+    assert isinstance(res["data"]["traceback"], str)
 
-    session.call(
-        id=id(root),
-        name='throw_eipe',
-        args=[]
-    )
+    session.call(id=id(root), name="throw_eipe", args=[])
 
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()  # Get call result
     expected_meta = {
-        'token': session.token,
-        'status': 'error',
-        'type': rpc.CALL_RESULT_MESSAGE
+        "token": session.token,
+        "status": "error",
+        "type": rpc.CALL_RESULT_MESSAGE,
     }
-    expected_message = 'Exception [line 10]: This is a test'
+    expected_message = "Exception [line 10]: This is a test"
 
-    assert res['$'] == expected_meta
-    assert res['data']['message'] == expected_message
-    assert isinstance(res['data']['traceback'], str)
+    assert res["$"] == expected_meta
+    assert res["data"]["message"] == expected_message
+    assert isinstance(res["data"]["traceback"], str)
 
 
-@pytest.mark.parametrize('root', [Foo(0)])
+@pytest.mark.parametrize("root", [Foo(0)])
 def test_call_on_reference(session, root):
     # Flip root object outside of constructor to ensure
     # server is re-initialized properly
@@ -407,46 +360,38 @@ def test_call_on_reference(session, root):
 
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=id(root),
-        name='next',
-        args=[]
-    )
+    session.call(id=id(root), name="next", args=[])
 
     session.socket.receive_json()  # Skip ack
-    foo_id = (session.socket.receive_json())['data']['i']
+    foo_id = (session.socket.receive_json())["data"]["i"]
 
-    session.call(
-        id=id(root),
-        name='combine',
-        args=[{'i': foo_id}]
-    )
+    session.call(id=id(root), name="combine", args=[{"i": foo_id}])
     session.socket.receive_json()  # Skip ack
     res = session.socket.receive_json()
 
-    new_foo_id = res['data'].pop('i')
+    new_foo_id = res["data"].pop("i")
     assert foo_id != new_foo_id
 
-    expected = {'$': {
-        'token': session.token,
-        'status': 'success',
-        'type': rpc.CALL_RESULT_MESSAGE},
-        'data': {
-        # i was popped out above
-        't': type_id(root),
-        'v': {'value': 1}}}
+    expected = {
+        "$": {
+            "token": session.token,
+            "status": "success",
+            "type": rpc.CALL_RESULT_MESSAGE,
+        },
+        "data": {
+            # i was popped out above
+            "t": type_id(root),
+            "v": {"value": 1},
+        },
+    }
     assert res == expected
 
 
-@pytest.mark.parametrize('root', [NotifyTester()])
+@pytest.mark.parametrize("root", [NotifyTester()])
 def test_notifications(session, root):
     session.socket.receive_json()  # Skip init
 
-    session.call(
-        id=id(root),
-        name='start',
-        args=[]
-    )
+    session.call(id=id(root), name="start", args=[])
     session.socket.receive_json()  # Skip ack
 
     res = []
@@ -454,16 +399,12 @@ def test_notifications(session, root):
     # Wait for notifications
     for i in range(5):
         message = session.socket.receive_json()
-        res.append((message['$']['type'], message['data']))
+        res.append((message["$"]["type"], message["data"]))
 
     assert res == [(rpc.NOTIFICATION_MESSAGE, i) for i in range(5)]
 
     # Tell notifier to finish
-    session.call(
-        id=id(root),
-        name='finish',
-        args=[]
-    )
+    session.call(id=id(root), name="finish", args=[])
 
     session.socket.receive_json()  # Skip ack
 
@@ -474,23 +415,17 @@ def test_notifications(session, root):
         messages.append(session.socket.receive_json())
 
     # Sort by the data field (ie the string returned by each function)
-    messages.sort(key=lambda o: o['data'])
+    messages.sort(key=lambda o: o["data"])
 
     assert messages == [
         # Result of start call
         {
-            '$': {
-                'status': 'success',
-                'type': 0, 'token': session.token
-            },
-            'data': 'Done!'
+            "$": {"status": "success", "type": 0, "token": session.token},
+            "data": "Done!",
         },
         # Result of finish call
         {
-            '$': {
-                'status': 'success',
-                'type': 0, 'token': session.token
-            },
-            'data': 'Finishing'
-        }
+            "$": {"status": "success", "type": 0, "token": session.token},
+            "data": "Finishing",
+        },
     ]

--- a/robot-server/tests/service/notifications/conftest.py
+++ b/robot-server/tests/service/notifications/conftest.py
@@ -14,13 +14,16 @@ def topic_event() -> TopicEvent:
         event=Event(
             createdOn=datetime(2020, 1, 1),
             publisher="some_one",
-            data=SampleTwo(val1=1, val2="2")
-        ))
+            data=SampleTwo(val1=1, val2="2"),
+        ),
+    )
 
 
 @pytest.fixture
 def mock_subscriber(topic_event) -> AsyncGenerator:
     """A mock subscriber."""
+
     async def _f():
         yield topic_event
+
     return _f()

--- a/robot-server/tests/service/notifications/test_handle_subscriber.py
+++ b/robot-server/tests/service/notifications/test_handle_subscriber.py
@@ -17,32 +17,27 @@ async def test_create_subscriber(mock_socket: MagicMock) -> None:
     """Test that a subscriber is created correctly."""
     # Why two patch calls? `create` is the name of an arg to `patch.multiple`.
     with patch.object(handle_subscriber, "create") as mock_create:
-        with patch.multiple(handle_subscriber,
-                            route_events=DEFAULT,
-                            receive=DEFAULT) as values:
+        with patch.multiple(
+            handle_subscriber, route_events=DEFAULT, receive=DEFAULT
+        ) as values:
             await handle_subscriber.handle_socket(mock_socket, ["a", "b"])
             mock_create.assert_called_once_with(
-                        get_settings().notification_server_subscriber_address,
-                        ["a", "b"]
-                    )
-            values['route_events'].assert_called_once()
-            values['receive'].assert_called_once()
+                get_settings().notification_server_subscriber_address, ["a", "b"]
+            )
+            values["route_events"].assert_called_once()
+            values["receive"].assert_called_once()
 
 
 async def test_route_events(
-        mock_socket: MagicMock,
-        mock_subscriber: AsyncGenerator,
-        topic_event) -> None:
+    mock_socket: MagicMock, mock_subscriber: AsyncGenerator, topic_event
+) -> None:
     """Test that an event is read from subscriber and sent to websocket."""
     with patch.object(handle_subscriber, "send") as mock_send:
-        await handle_subscriber.route_events(mock_socket,
-                                             mock_subscriber)
+        await handle_subscriber.route_events(mock_socket, mock_subscriber)
         mock_send.assert_called_once_with(mock_socket, topic_event)
 
 
-async def test_send_entry(
-        topic_event,
-        mock_socket: MagicMock) -> None:
+async def test_send_entry(topic_event, mock_socket: MagicMock) -> None:
     """Test that entry is sent as json."""
     await handle_subscriber.send(mock_socket, topic_event)
     mock_socket.send_text.assert_called_once_with(topic_event.json())

--- a/robot-server/tests/service/notifications/test_router.py
+++ b/robot-server/tests/service/notifications/test_router.py
@@ -12,9 +12,7 @@ from robot_server.service.notifications import handle_subscriber
 def test_subscribe(api_client: TestClient):
     """Test that a connection can be established and topics discovered."""
     with patch.object(handle_subscriber, "handle_socket") as m:
-        api_client.websocket_connect(
-            "/notifications/subscribe?topic=a&topic=b&topic=c"
-        )
+        api_client.websocket_connect("/notifications/subscribe?topic=a&topic=b&topic=c")
         m.assert_called_once()
         assert m.call_args[0][1] == ["a", "b", "c"]
 
@@ -22,22 +20,15 @@ def test_subscribe(api_client: TestClient):
 def test_subscribe_no_topic(api_client: TestClient):
     """Test that query string must contain topic list."""
     with pytest.raises(WebSocketDisconnect):
-        api_client.websocket_connect(
-            "/notifications/subscribe"
-        )
+        api_client.websocket_connect("/notifications/subscribe")
 
 
 def test_integration(
-        api_client: TestClient,
-        mock_subscriber: AsyncGenerator,
-        topic_event) -> None:
+    api_client: TestClient, mock_subscriber: AsyncGenerator, topic_event
+) -> None:
     """Test receiving a single event."""
-    with patch.object(handle_subscriber,
-                      "create",
-                      return_value=mock_subscriber):
-        sock = api_client.websocket_connect(
-            "/notifications/subscribe?topic=t"
-        )
+    with patch.object(handle_subscriber, "create", return_value=mock_subscriber):
+        sock = api_client.websocket_connect("/notifications/subscribe?topic=t")
         event = sock.receive()
         assert event["text"] == topic_event.json()
         assert event["type"] == "websocket.send"

--- a/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
+++ b/robot-server/tests/service/pipette_offset/test_pipette_offset_management.py
@@ -1,51 +1,52 @@
-PIPETTE_ID = '123'
-LW_HASH = '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824'
-MOUNT = 'left'
-FAKE_PIPETTE_ID = 'fake'
-WRONG_MOUNT = 'right'
+PIPETTE_ID = "123"
+LW_HASH = "130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824"
+MOUNT = "left"
+FAKE_PIPETTE_ID = "fake"
+WRONG_MOUNT = "right"
 
 
 def test_access_pipette_offset_calibration(
-        api_client, set_up_pipette_offset_temp_directory,
-        server_temp_directory):
+    api_client, set_up_pipette_offset_temp_directory, server_temp_directory
+):
     expected = {
-        'id': f'{PIPETTE_ID}&{MOUNT}',
-        'offset': [0, 0, 0],
-        'pipette': '123',
-        'mount': MOUNT,
-        'tiprack': LW_HASH,
-        'lastModified': None,
-        'source': 'user',
-        'tiprackUri': 'opentrons/opentrons_96_filtertiprack_200ul/1',
-        'status': {
-            'markedAt': None, 'markedBad': False, 'source': None}
+        "id": f"{PIPETTE_ID}&{MOUNT}",
+        "offset": [0, 0, 0],
+        "pipette": "123",
+        "mount": MOUNT,
+        "tiprack": LW_HASH,
+        "lastModified": None,
+        "source": "user",
+        "tiprackUri": "opentrons/opentrons_96_filtertiprack_200ul/1",
+        "status": {"markedAt": None, "markedBad": False, "source": None},
     }
     # Note, status should only have markedBad key, but according
     # to this thread https://github.com/samuelcolvin/pydantic/issues/1223
     # it's not easy to specify in the model itself
 
     resp = api_client.get(
-        f'/calibration/pipette_offset?mount={MOUNT}&pipette_id={PIPETTE_ID}')
+        f"/calibration/pipette_offset?mount={MOUNT}&pipette_id={PIPETTE_ID}"
+    )
     assert resp.status_code == 200
-    data = resp.json()['data'][0]
-    data['lastModified'] = None
+    data = resp.json()["data"][0]
+    data["lastModified"] = None
     assert data == expected
 
     resp = api_client.get(
-        f'/calibration/pipette_offset?mount={MOUNT}&'
-        f'pipette_id={FAKE_PIPETTE_ID}')
+        f"/calibration/pipette_offset?mount={MOUNT}&" f"pipette_id={FAKE_PIPETTE_ID}"
+    )
     assert resp.status_code == 200
-    assert resp.json()['data'] == []
+    assert resp.json()["data"] == []
 
 
 def test_delete_pipette_offset_calibration(
-        api_client, set_up_pipette_offset_temp_directory):
+    api_client, set_up_pipette_offset_temp_directory
+):
     resp = api_client.delete(
-        f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'
-        f'mount={WRONG_MOUNT}')
+        f"/calibration/pipette_offset?pipette_id={PIPETTE_ID}&" f"mount={WRONG_MOUNT}"
+    )
     assert resp.status_code == 200
 
     resp = api_client.delete(
-        f'/calibration/pipette_offset?pipette_id={PIPETTE_ID}&'
-        f'mount={MOUNT}')
+        f"/calibration/pipette_offset?pipette_id={PIPETTE_ID}&" f"mount={MOUNT}"
+    )
     assert resp.status_code == 200

--- a/robot-server/tests/service/protocol/test_analyze.py
+++ b/robot-server/tests/service/protocol/test_analyze.py
@@ -9,9 +9,8 @@ from robot_server.service.protocol import analyze
 def test__extract_metadata_none():
     """It returns empty metadata when passed None"""
     assert analyze._extract_metadata(None) == models.Meta(
-        name=None,
-        author=None,
-        apiLevel=None)
+        name=None, author=None, apiLevel=None
+    )
 
 
 def test__extract_metadata_python():
@@ -19,37 +18,27 @@ def test__extract_metadata_python():
     protocol = PythonProtocol(
         text="abc",
         api_level=APIVersion(major=2, minor=2),
-        metadata={
-            "author": "some author",
-            "protocolName": "my protocol"
-        },
+        metadata={"author": "some author", "protocolName": "my protocol"},
         filename="",
         extra_labware={},
         contents="",
         bundled_labware={},
         bundled_data={},
-        bundled_python={}
+        bundled_python={},
     )
 
     assert analyze._extract_metadata(protocol) == models.Meta(
-        name="my protocol",
-        author="some author",
-        apiLevel="2.2"
+        name="my protocol", author="some author", apiLevel="2.2"
     )
 
 
 @pytest.mark.parametrize(
     argnames="metadata",
     argvalues=[
-        {
-            "author": "some author",
-            "protocolName": "my protocol"
-        },
-        {
-            "author": "some author",
-            "protocol-name": "my protocol"
-        }
-    ])
+        {"author": "some author", "protocolName": "my protocol"},
+        {"author": "some author", "protocol-name": "my protocol"},
+    ],
+)
 def test__extract_metadata_json(metadata):
     """It returns complete metadata when passed JSONProtocol"""
     protocol = JsonProtocol(
@@ -58,31 +47,21 @@ def test__extract_metadata_json(metadata):
         filename="",
         contents={},
         schema_version=2,
-        metadata=metadata
+        metadata=metadata,
     )
 
     assert analyze._extract_metadata(protocol) == models.Meta(
-        name="my protocol",
-        author="some author",
-        apiLevel="2.2"
+        name="my protocol", author="some author", apiLevel="2.2"
     )
 
 
 def test__extract_equipment_none():
     """It will return empty model if input is None"""
     r = analyze._extract_equipment(None)
-    assert r == models.RequiredEquipment(
-        modules=[],
-        labware=[],
-        pipettes=[]
-    )
+    assert r == models.RequiredEquipment(modules=[], labware=[], pipettes=[])
 
 
 def test__extract_equipment():
     """It will return full model from input"""
     r = analyze._extract_equipment(None)
-    assert r == models.RequiredEquipment(
-        modules=[],
-        labware=[],
-        pipettes=[]
-    )
+    assert r == models.RequiredEquipment(modules=[], labware=[], pipettes=[])

--- a/robot-server/tests/service/protocol/test_contents.py
+++ b/robot-server/tests/service/protocol/test_contents.py
@@ -18,8 +18,10 @@ def mock_tempdir():
 def test_create_temp_dir_error(mock_tempdir_constructor):
     """Test that create raises a ProtocolIOException if TemporyDirectory
     raises IOError"""
+
     def raiser(*args, **kwargs):
         raise IOError("failed")
+
     mock_tempdir_constructor.side_effect = raiser
     with pytest.raises(errors.ProtocolIOException):
         contents.create(None, None)
@@ -27,15 +29,16 @@ def test_create_temp_dir_error(mock_tempdir_constructor):
 
 @patch.object(contents, "TemporaryDirectory")
 @patch.object(contents, "save_upload")
-def test_create_save_upload_error(mock_save_upload,
-                                  mock_tempdir_constructor,
-                                  mock_tempdir):
+def test_create_save_upload_error(
+    mock_save_upload, mock_tempdir_constructor, mock_tempdir
+):
     """Test that save_upload raising IOError results in ProtocolIOException
     and removal of temporary directory."""
     mock_tempdir_constructor.return_value = mock_tempdir
 
     def raiser(*args, **kwargs):
         raise IOError("failed")
+
     # Save upload raises IOError
     mock_save_upload.side_effect = raiser
 
@@ -47,46 +50,44 @@ def test_create_save_upload_error(mock_save_upload,
 @patch.object(contents, "save_upload")
 def test_update_raises_error(mock_save_upload, mock_tempdir):
     """That updating the protocol will raise an error on IOException."""
+
     def raiser(*args, **kwargs):
         raise IOError("failed")
+
     # Save upload raises IOError
     mock_save_upload.side_effect = raiser
 
     test_contents = contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
         support_files=[],
-        directory=mock_tempdir
+        directory=mock_tempdir,
     )
     with pytest.raises(errors.ProtocolIOException, match="failed"):
         contents.update(
-            contents=test_contents,
-            upload_file=UploadFile(filename="abc.py"))
+            contents=test_contents, upload_file=UploadFile(filename="abc.py")
+        )
 
 
 @patch.object(contents, "save_upload")
 def test_update_replace_protocol(mock_save_upload, mock_tempdir):
     """That updating the protocol file updates protocol_file member."""
     test_contents = contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
         support_files=[],
-        directory=mock_tempdir
+        directory=mock_tempdir,
     )
     mock_save_upload.return_value = contents.FileMeta(
-        path=Path("abc.py"),
-        content_hash="222"
+        path=Path("abc.py"), content_hash="222"
     )
 
     r = contents.update(
-        contents=test_contents,
-        upload_file=UploadFile(filename="abc.py"))
+        contents=test_contents, upload_file=UploadFile(filename="abc.py")
+    )
 
     assert r == contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="222"),
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="222"),
         support_files=[],
-        directory=mock_tempdir
+        directory=mock_tempdir,
     )
 
 
@@ -94,31 +95,22 @@ def test_update_replace_protocol(mock_save_upload, mock_tempdir):
 def test_update_replace_support_file(mock_save_upload, mock_tempdir):
     """That updating a support file updates support_files member."""
     test_contents = contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
-        support_files=[
-            contents.FileMeta(path=Path("cba.py"),
-                              content_hash="2222")
-        ],
-        directory=mock_tempdir
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
+        support_files=[contents.FileMeta(path=Path("cba.py"), content_hash="2222")],
+        directory=mock_tempdir,
     )
     mock_save_upload.return_value = contents.FileMeta(
-        path=Path("cba.py"),
-        content_hash="3333"
+        path=Path("cba.py"), content_hash="3333"
     )
 
     r = contents.update(
-        contents=test_contents,
-        upload_file=UploadFile(filename="cba.py"))
+        contents=test_contents, upload_file=UploadFile(filename="cba.py")
+    )
 
     assert r == contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
-        support_files=[
-            contents.FileMeta(path=Path("cba.py"),
-                              content_hash="3333")
-        ],
-        directory=mock_tempdir
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
+        support_files=[contents.FileMeta(path=Path("cba.py"), content_hash="3333")],
+        directory=mock_tempdir,
     )
 
 
@@ -126,29 +118,22 @@ def test_update_replace_support_file(mock_save_upload, mock_tempdir):
 def test_update_adds_support_file(mock_save_upload, mock_tempdir):
     """That adding a support file updates support_files member."""
     test_contents = contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
-        support_files=[
-        ],
-        directory=mock_tempdir
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
+        support_files=[],
+        directory=mock_tempdir,
     )
     mock_save_upload.return_value = contents.FileMeta(
-        path=Path("cba.py"),
-        content_hash="3333"
+        path=Path("cba.py"), content_hash="3333"
     )
 
     r = contents.update(
-        contents=test_contents,
-        upload_file=UploadFile(filename="cba.py"))
+        contents=test_contents, upload_file=UploadFile(filename="cba.py")
+    )
 
     assert r == contents.Contents(
-        protocol_file=contents.FileMeta(path=Path("abc.py"),
-                                        content_hash="1111"),
-        support_files=[
-            contents.FileMeta(path=Path("cba.py"),
-                              content_hash="3333")
-        ],
-        directory=mock_tempdir
+        protocol_file=contents.FileMeta(path=Path("abc.py"), content_hash="1111"),
+        support_files=[contents.FileMeta(path=Path("cba.py"), content_hash="3333")],
+        directory=mock_tempdir,
     )
 
 
@@ -156,14 +141,13 @@ def test_update_adds_support_file(mock_save_upload, mock_tempdir):
 def contents_fixture() -> contents.Contents:
     return contents.create(
         protocol_file=UploadFile(filename="test_contents.py"),
-        support_files=[UploadFile(filename="test_environment.py")]
+        support_files=[UploadFile(filename="test_environment.py")],
     )
 
 
 def test_directory_creation(contents_fixture):
     """Test that directory exists."""
-    file_names = set(f.name for f in
-                     Path(contents_fixture.directory.name).iterdir())
+    file_names = set(f.name for f in Path(contents_fixture.directory.name).iterdir())
     assert len(file_names) == 2
     assert "test_contents.py" in file_names
     assert "test_environment.py" in file_names
@@ -171,8 +155,7 @@ def test_directory_creation(contents_fixture):
 
 def test_update(contents_fixture):
     contents.update(contents_fixture, UploadFile(filename="test_contents2.py"))
-    file_names = set(f.name for f in
-                     Path(contents_fixture.directory.name).iterdir())
+    file_names = set(f.name for f in Path(contents_fixture.directory.name).iterdir())
     assert len(file_names) == 3
     assert "test_contents2.py" in file_names
 

--- a/robot-server/tests/service/protocol/test_environment.py
+++ b/robot-server/tests/service/protocol/test_environment.py
@@ -12,10 +12,7 @@ from robot_server.service.protocol.environment import protocol_environment
 def mock_contents() -> Contents:
     mock_temp_dir = MagicMock()
     type(mock_temp_dir).name = PropertyMock(return_value="some_path")
-    return Contents(
-            protocol_file=None,
-            directory=mock_temp_dir
-        )
+    return Contents(protocol_file=None, directory=mock_temp_dir)
 
 
 @pytest.fixture
@@ -24,15 +21,12 @@ def mock_os_chdir():
         yield p
 
 
-def test_protocol_runner_context(mock_contents,
-                                 mock_os_chdir):
+def test_protocol_runner_context(mock_contents, mock_os_chdir):
     cwd = os.getcwd()
     path = sys.path.copy()
     with protocol_environment(mock_contents):
         # We are changing directory to the temp directory
-        mock_os_chdir.assert_called_with(
-            mock_contents.directory.name
-        )
+        mock_os_chdir.assert_called_with(mock_contents.directory.name)
         # Adding it to sys.path
         assert mock_contents.directory.name in sys.path
 

--- a/robot-server/tests/service/protocol/test_manager.py
+++ b/robot-server/tests/service/protocol/test_manager.py
@@ -6,8 +6,10 @@ from mock import MagicMock, patch
 from robot_server.service.protocol import errors
 from robot_server.service.protocol.contents import Contents
 from robot_server.service.protocol.manager import ProtocolManager, UploadFile
-from robot_server.service.protocol.protocol import UploadedProtocol, \
-    UploadedProtocolData
+from robot_server.service.protocol.protocol import (
+    UploadedProtocol,
+    UploadedProtocolData,
+)
 
 
 @pytest.fixture
@@ -25,15 +27,13 @@ def mock_uploaded_protocol():
 
 @pytest.fixture
 def mock_uploaded_control_constructor(mock_uploaded_protocol):
-    with patch("robot_server.service.protocol."
-               "manager.UploadedProtocol.create") as p:
+    with patch("robot_server.service.protocol." "manager.UploadedProtocol.create") as p:
+
         def side_effect(protocol_id, protocol_file, support_files):
             mock_uploaded_protocol.data = UploadedProtocolData(
                 identifier=protocol_id,
-                contents=Contents(
-                    protocol_file=None,
-                    directory=None),
-                analysis_result=None
+                contents=Contents(protocol_file=None, directory=None),
+                analysis_result=None,
             )
             return mock_uploaded_protocol
 
@@ -42,50 +42,53 @@ def mock_uploaded_control_constructor(mock_uploaded_protocol):
 
 
 @pytest.fixture
-def manager_with_mock_protocol(mock_uploaded_control_constructor,
-                               mock_upload_file):
+def manager_with_mock_protocol(mock_uploaded_control_constructor, mock_upload_file):
     manager = ProtocolManager()
     manager.create(mock_upload_file, [])
     return manager
 
 
 class TestCreate:
-    def test_create(self, mock_uploaded_control_constructor,
-                    mock_upload_file, mock_uploaded_protocol):
+    def test_create(
+        self,
+        mock_uploaded_control_constructor,
+        mock_upload_file,
+        mock_uploaded_protocol,
+    ):
         manager = ProtocolManager()
         p = manager.create(mock_upload_file, [])
         mock_uploaded_control_constructor.assert_called_once_with(
             protocol_id=Path(mock_upload_file.filename).stem,
             protocol_file=mock_upload_file,
-            support_files=[])
+            support_files=[],
+        )
         assert p == mock_uploaded_protocol
         assert manager._protocols[mock_uploaded_protocol.data.identifier] == p
 
-    def test_create_already_exists(self,
-                                   mock_upload_file,
-                                   manager_with_mock_protocol):
+    def test_create_already_exists(self, mock_upload_file, manager_with_mock_protocol):
         with pytest.raises(errors.ProtocolAlreadyExistsException):
             manager_with_mock_protocol.create(mock_upload_file, [])
 
-    def test_create_upload_limit_reached(self,
-                                         mock_upload_file,
-                                         manager_with_mock_protocol):
+    def test_create_upload_limit_reached(
+        self, mock_upload_file, manager_with_mock_protocol
+    ):
         ProtocolManager.MAX_COUNT = 1
         m = MagicMock(spec=UploadFile)
         m.filename = "123_" + mock_upload_file.filename
         with pytest.raises(errors.ProtocolUploadCountLimitReached):
             manager_with_mock_protocol.create(m, [])
 
-    @pytest.mark.parametrize(argnames="exception", argvalues=[
-        errors.ProtocolIOException,
-    ])
-    def test_create_raises(self,
-                           exception,
-                           mock_upload_file,
-                           mock_uploaded_protocol):
-        with patch("robot_server.service.protocol."
-                   "manager.UploadedProtocol.create") \
-                as mock_construct:
+    @pytest.mark.parametrize(
+        argnames="exception",
+        argvalues=[
+            errors.ProtocolIOException,
+        ],
+    )
+    def test_create_raises(self, exception, mock_upload_file, mock_uploaded_protocol):
+        with patch(
+            "robot_server.service.protocol." "manager.UploadedProtocol.create"
+        ) as mock_construct:
+
             def raiser(*args, **kwargs):
                 raise exception("error")
 
@@ -98,9 +101,10 @@ class TestCreate:
 
 class TestGet:
     def test_get(self, manager_with_mock_protocol, mock_uploaded_protocol):
-        assert manager_with_mock_protocol.get(
-            mock_uploaded_protocol.data.identifier
-        ) == mock_uploaded_protocol
+        assert (
+            manager_with_mock_protocol.get(mock_uploaded_protocol.data.identifier)
+            == mock_uploaded_protocol
+        )
 
     def test_not_found(self, manager_with_mock_protocol):
         with pytest.raises(errors.ProtocolNotFoundException):
@@ -109,8 +113,7 @@ class TestGet:
 
 class TestGetAll:
     def test_get_all(self, manager_with_mock_protocol, mock_uploaded_protocol):
-        assert list(manager_with_mock_protocol.get_all()) == \
-               [mock_uploaded_protocol]
+        assert list(manager_with_mock_protocol.get_all()) == [mock_uploaded_protocol]
 
     def test_get_none(self):
         manager = ProtocolManager()
@@ -119,10 +122,11 @@ class TestGetAll:
 
 class TestRemove:
     def test_remove(self, manager_with_mock_protocol, mock_uploaded_protocol):
-        manager_with_mock_protocol.remove(
-            mock_uploaded_protocol.data.identifier)
-        assert mock_uploaded_protocol.data.identifier not in \
-               manager_with_mock_protocol._protocols
+        manager_with_mock_protocol.remove(mock_uploaded_protocol.data.identifier)
+        assert (
+            mock_uploaded_protocol.data.identifier
+            not in manager_with_mock_protocol._protocols
+        )
         mock_uploaded_protocol.clean_up.assert_called_once()
 
     def test_remove_not_found(self, manager_with_mock_protocol):
@@ -131,9 +135,7 @@ class TestRemove:
 
 
 class TestRemoveAll:
-    def test_remove_all(self,
-                        manager_with_mock_protocol,
-                        mock_uploaded_protocol):
+    def test_remove_all(self, manager_with_mock_protocol, mock_uploaded_protocol):
         manager_with_mock_protocol.remove_all()
         mock_uploaded_protocol.clean_up.assert_called_once()
         assert manager_with_mock_protocol._protocols == {}

--- a/robot-server/tests/service/session/models/test_command.py
+++ b/robot-server/tests/service/session/models/test_command.py
@@ -11,15 +11,13 @@ from robot_server.service.session.models import command, command_definitions
         command_definitions.ProtocolCommand.start_run,
         command_definitions.CalibrationCommand.move_to_deck,
         command_definitions.CheckCalibrationCommand.compare_point,
-    ])
+    ],
+)
 def test_empty(command_def: command_definitions.CommandDefinition):
     """Test creation of empty command request and response."""
-    request = command.CommandRequest.parse_obj({
-        "data": {
-            "command": command_def.value,
-            "data": {}
-        }
-    })
+    request = command.CommandRequest.parse_obj(
+        {"data": {"command": command_def.value, "data": {}}}
+    )
     assert request.data.command == command_def
     assert request.data.data == command.EmptyModel()
 
@@ -31,7 +29,7 @@ def test_empty(command_def: command_definitions.CommandDefinition):
         created_at=dt,
         started_at=None,
         completed_at=None,
-        result=None
+        result=None,
     )
 
     assert response.command == command_def
@@ -53,14 +51,12 @@ def test_empty(command_def: command_definitions.CommandDefinition):
         command_definitions.PipetteCommand.drop_tip,
         command_definitions.PipetteCommand.pick_up_tip,
         command_definitions.CalibrationCommand.jog,
-        command_definitions.CalibrationCommand.set_has_calibration_block
-    ])
+        command_definitions.CalibrationCommand.set_has_calibration_block,
+    ],
+)
 def test_requires_data(command_def: command_definitions.CommandDefinition):
     """Test creation of command requiring data will fail with empty body."""
     with pytest.raises(ValidationError):
-        command.CommandRequest.parse_obj({
-            "data": {
-                "command": command_def.value,
-                "data": {}
-            }
-        })
+        command.CommandRequest.parse_obj(
+            {"data": {"command": command_def.value, "data": {}}}
+        )

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_command_executor.py
@@ -1,19 +1,25 @@
-from mock import MagicMock, patch, PropertyMock, AsyncMock
+from mock import MagicMock, patch, PropertyMock, AsyncMock  # type: ignore[attr-defined]
 from datetime import datetime
 import pytest
 
 from robot_server.service.session.command_execution.command import Command
 from robot_server.service.session.errors import UnsupportedCommandException
 from robot_server.service.session.models.command import SimpleCommandRequest
-from robot_server.service.session.models.command_definitions import \
-    ProtocolCommand
+from robot_server.service.session.models.command_definitions import ProtocolCommand
 from robot_server.service.session.models.common import EmptyModel
-from robot_server.service.session.session_types.protocol.execution import \
-    command_executor
-from robot_server.service.session.session_types.protocol.execution.command_executor import ProtocolCommandExecutor  # noqa: E501
-from robot_server.service.session.session_types.protocol.execution.worker import _Worker  # noqa: E501
-from robot_server.service.session.session_types.protocol.models import \
-    ProtocolSessionEvent, EventSource
+from robot_server.service.session.session_types.protocol.execution import (
+    command_executor,
+)
+from robot_server.service.session.session_types.protocol.execution.command_executor import (  # noqa: E501
+    ProtocolCommandExecutor,
+)
+from robot_server.service.session.session_types.protocol.execution.worker import (
+    _Worker,
+)
+from robot_server.service.session.session_types.protocol.models import (
+    ProtocolSessionEvent,
+    EventSource,
+)
 
 
 @pytest.fixture()
@@ -24,8 +30,8 @@ def mock_worker():
 
 @pytest.fixture
 def protocol_command_executor(mock_worker):
-    ProtocolCommandExecutor.create_worker = MagicMock(return_value=mock_worker)
-    return ProtocolCommandExecutor(None, None)
+    ProtocolCommandExecutor.create_worker = MagicMock(return_value=mock_worker)  # type: ignore[assignment]  # noqa: E501
+    return ProtocolCommandExecutor(None, None)  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -35,40 +41,34 @@ def dt() -> datetime:
 
 @pytest.fixture
 def patch_utc_now(dt: datetime):
-    with patch.object(command_executor, 'utc_now') as p:
+    with patch.object(command_executor, "utc_now") as p:
         p.return_value = dt
         yield p
 
 
-@pytest.mark.parametrize(argnames="current_state,accepted_commands",
-                         argvalues=[
-                             ['loaded',
-                              {ProtocolCommand.start_simulate,
-                               ProtocolCommand.start_run}
-                              ],
-                             ['running',
-                              {ProtocolCommand.cancel, ProtocolCommand.pause}
-                              ],
-                             ['finished',
-                              {ProtocolCommand.start_simulate,
-                               ProtocolCommand.start_run}
-                              ],
-                             ['stopped', {}],
-                             ['paused',
-                              {ProtocolCommand.cancel,
-                               ProtocolCommand.resume}],
-                             ['error', {}]
-                         ])
-async def test_command_state_reject(loop,
-                                    current_state, accepted_commands,
-                                    protocol_command_executor):
+@pytest.mark.parametrize(
+    argnames="current_state,accepted_commands",
+    argvalues=[
+        ["loaded", {ProtocolCommand.start_simulate, ProtocolCommand.start_run}],
+        ["running", {ProtocolCommand.cancel, ProtocolCommand.pause}],
+        ["finished", {ProtocolCommand.start_simulate, ProtocolCommand.start_run}],
+        ["stopped", {}],
+        ["paused", {ProtocolCommand.cancel, ProtocolCommand.resume}],
+        ["error", {}],
+    ],
+)
+async def test_command_state_reject(
+    loop, current_state, accepted_commands, protocol_command_executor
+):
     """Test that commands are rejected based on state"""
     protocol_command_executor.current_state = current_state
 
     for protocol_command in ProtocolCommand:
-        command = Command(request=SimpleCommandRequest(
-            command=protocol_command,
-            data=EmptyModel())
+        command = Command(
+            request=SimpleCommandRequest(
+                command=protocol_command,  # type: ignore[arg-type]
+                data=EmptyModel(),
+            )
         )
         if protocol_command in accepted_commands:
             # Will not raise if in accepted commands
@@ -78,23 +78,27 @@ async def test_command_state_reject(loop,
                 await protocol_command_executor.execute(command)
 
 
-@pytest.mark.parametrize(argnames="command,worker_method_name",
-                         argvalues=[
-                             [ProtocolCommand.start_run, "handle_run"],
-                             [ProtocolCommand.start_simulate, "handle_simulate"],  # noqa: E501
-                             [ProtocolCommand.cancel, "handle_cancel"],
-                             [ProtocolCommand.pause, "handle_pause"],
-                             [ProtocolCommand.resume, "handle_resume"]
-                         ])
-async def test_execute(loop, command, worker_method_name,
-                       protocol_command_executor, mock_worker):
+@pytest.mark.parametrize(
+    argnames="command,worker_method_name",
+    argvalues=[
+        [ProtocolCommand.start_run, "handle_run"],
+        [ProtocolCommand.start_simulate, "handle_simulate"],
+        [ProtocolCommand.cancel, "handle_cancel"],
+        [ProtocolCommand.pause, "handle_pause"],
+        [ProtocolCommand.resume, "handle_resume"],
+    ],
+)
+async def test_execute(
+    loop, command, worker_method_name, protocol_command_executor, mock_worker
+):
     # Patch the state command filter to allow all commands
-    with patch.object(ProtocolCommandExecutor,
-                      "STATE_COMMAND_MAP",
-                      new={protocol_command_executor.current_state: ProtocolCommand}):  # noqa: E501
-        protocol_command = Command(request=SimpleCommandRequest(
-            command=command,
-            data=EmptyModel())
+    with patch.object(
+        ProtocolCommandExecutor,
+        "STATE_COMMAND_MAP",
+        new={protocol_command_executor.current_state: ProtocolCommand},
+    ):
+        protocol_command = Command(
+            request=SimpleCommandRequest(command=command, data=EmptyModel())
         )
         await protocol_command_executor.execute(protocol_command)
         # Worker handler was called
@@ -105,122 +109,101 @@ async def test_execute(loop, command, worker_method_name,
 
 
 class TestOnProtocolEvent:
-
     async def test_topic_session_payload(self, protocol_command_executor):
         mock_session = MagicMock()
         mock_session.state = "some_state"
-        await protocol_command_executor.on_protocol_event({
-            'topic': 'session',
-            'payload': mock_session
-        })
+        await protocol_command_executor.on_protocol_event(
+            {"topic": "session", "payload": mock_session}
+        )
         assert protocol_command_executor.current_state == "some_state"
 
     async def test_topic_dict_payload(self, protocol_command_executor):
-        await protocol_command_executor.on_protocol_event({
-            'topic': 'session',
-            'payload': {
-                'state': 'some_state'
-            }
-        })
+        await protocol_command_executor.on_protocol_event(
+            {"topic": "session", "payload": {"state": "some_state"}}
+        )
         assert protocol_command_executor.current_state == "some_state"
 
-    @pytest.mark.parametrize(argnames="payload",
-                             argvalues=[{},
-                                        {'topic': 'soosion'},
-                                        {'$': 'soosion'}
-                                        ])
+    @pytest.mark.parametrize(
+        argnames="payload", argvalues=[{}, {"topic": "soosion"}, {"$": "soosion"}]
+    )
     async def test_body_invalid(self, protocol_command_executor, payload):
-        ProtocolCommandExecutor.current_state = PropertyMock()
+        ProtocolCommandExecutor.current_state = PropertyMock()  # type: ignore[assignment] # noqa: E501
         await protocol_command_executor.on_protocol_event(payload)
         assert len(protocol_command_executor.events) == 0
-        ProtocolCommandExecutor.current_state.assert_not_called()
+        ProtocolCommandExecutor.current_state.assert_not_called()  # type: ignore[attr-defined]  # noqa: E501
 
     async def test_before(self, protocol_command_executor, patch_utc_now, dt):
         payload = {
-            '$': 'before',
-            'name': 'some event',
-            'payload': {
-                'text': 'this is what happened'
-            }
+            "$": "before",
+            "name": "some event",
+            "payload": {"text": "this is what happened"},
         }
         await protocol_command_executor.on_protocol_event(payload)
         assert protocol_command_executor.events == [
-            ProtocolSessionEvent(source=EventSource.protocol_event,
-                                 event="some event.start",
-                                 commandId="1",
-                                 timestamp=dt,
-                                 params={'text': 'this is what happened'})
+            ProtocolSessionEvent(
+                source=EventSource.protocol_event,
+                event="some event.start",
+                commandId="1",
+                timestamp=dt,
+                params={"text": "this is what happened"},
+            )
         ]
 
-    async def test_before_text_is_none(self, protocol_command_executor,
-                                       patch_utc_now, dt):
-        payload = {
-            '$': 'before',
-            'name': 'some event',
-            'payload': {
-                'text': None
-            }
-        }
+    async def test_before_text_is_none(
+        self, protocol_command_executor, patch_utc_now, dt
+    ):
+        payload = {"$": "before", "name": "some event", "payload": {"text": None}}
         await protocol_command_executor.on_protocol_event(payload)
         assert protocol_command_executor.events == [
-            ProtocolSessionEvent(source=EventSource.protocol_event,
-                                 event="some event.start",
-                                 commandId="1",
-                                 timestamp=dt,
-                                 params={'text': None})
+            ProtocolSessionEvent(
+                source=EventSource.protocol_event,
+                event="some event.start",
+                commandId="1",
+                timestamp=dt,
+                params={"text": None},
+            )
         ]
 
-    async def test_before_text_is_format_string(self,
-                                                protocol_command_executor,
-                                                patch_utc_now,
-                                                dt):
+    async def test_before_text_is_format_string(
+        self, protocol_command_executor, patch_utc_now, dt
+    ):
         payload = {
-            '$': 'before',
-            'name': 'some event',
-            'payload': {
-                'text': '{oh} {no}',
-                'oh': 2,
-                'no': 5
-            }
+            "$": "before",
+            "name": "some event",
+            "payload": {"text": "{oh} {no}", "oh": 2, "no": 5},
         }
         await protocol_command_executor.on_protocol_event(payload)
         assert protocol_command_executor.events == [
-            ProtocolSessionEvent(source=EventSource.protocol_event,
-                                 event="some event.start",
-                                 commandId="1",
-                                 timestamp=dt,
-                                 params={'text': '2 5'})
+            ProtocolSessionEvent(
+                source=EventSource.protocol_event,
+                event="some event.start",
+                commandId="1",
+                timestamp=dt,
+                params={"text": "2 5"},
+            )
         ]
 
     async def test_after(self, protocol_command_executor, patch_utc_now, dt):
         payload = {
-            '$': 'after',
-            'name': 'some event',
-            'payload': {
-                'text': 'this is it',
-                'return': "done"
-            }
+            "$": "after",
+            "name": "some event",
+            "payload": {"text": "this is it", "return": "done"},
         }
         protocol_command_executor._id_maker.create_id()
         await protocol_command_executor.on_protocol_event(payload)
         assert protocol_command_executor.events == [
-            ProtocolSessionEvent(source=EventSource.protocol_event,
-                                 event="some event.end",
-                                 commandId="1",
-                                 timestamp=dt,
-                                 result="done"
-                                 )
+            ProtocolSessionEvent(
+                source=EventSource.protocol_event,
+                event="some event.end",
+                commandId="1",
+                timestamp=dt,
+                result="done",
+            )
         ]
 
     async def test_ids(self, protocol_command_executor, patch_utc_now, dt):
-        before = {
-            '$': 'before',
-            'name': 'event'
-        }
-        after = {
-            '$': 'after',
-            'name': 'event'
-        }
+        before = {"$": "before", "name": "event"}
+        after = {"$": "after", "name": "event"}
 
         await protocol_command_executor.on_protocol_event(before)
         await protocol_command_executor.on_protocol_event(after)
@@ -242,8 +225,18 @@ class TestOnProtocolEvent:
 
         ids = [x.commandId for x in protocol_command_executor.events]
         assert ids == [
-            "1", "1",
-            "2", "3", "3", "2",
-            "4", "5", "6", "6", "5", "4",
-            "7", "7"
+            "1",
+            "1",
+            "2",
+            "3",
+            "3",
+            "2",
+            "4",
+            "5",
+            "6",
+            "6",
+            "5",
+            "4",
+            "7",
+            "7",
         ]

--- a/robot-server/tests/service/session/session_types/protocol/execution/test_worker.py
+++ b/robot-server/tests/service/session/session_types/protocol/execution/test_worker.py
@@ -3,17 +3,21 @@ import typing
 from mock import MagicMock
 import pytest
 
-from robot_server.service.session.session_types.protocol \
-    .execution.protocol_runner import ProtocolRunner
-from robot_server.service.session.session_types.protocol \
-    .execution.worker import _Worker, WorkerListener, WorkerDirective
+from robot_server.service.session.session_types.protocol.execution.protocol_runner import (  # noqa: E501
+    ProtocolRunner,
+)
+from robot_server.service.session.session_types.protocol.execution.worker import (
+    _Worker,
+    WorkerListener,
+    WorkerDirective,
+)
 
 
 class DelegatingWorkerListener(WorkerListener):
     def __init__(self, delegate):
         self._delegate = delegate
 
-    async def on_directive(self, directive: 'WorkerDirective'):
+    async def on_directive(self, directive: "WorkerDirective"):
         await self._delegate.on_directive(directive)
 
     async def on_ready(self):
@@ -40,9 +44,11 @@ def mock_protocol_runner():
 
 @pytest.fixture
 async def worker(mock_protocol_runner, loop, mock_worker_listener):
-    w = _Worker(protocol_runner=mock_protocol_runner,
-                listener=DelegatingWorkerListener(mock_worker_listener),
-                loop=loop)
+    w = _Worker(
+        protocol_runner=mock_protocol_runner,
+        listener=DelegatingWorkerListener(mock_worker_listener),
+        loop=loop,
+    )
     yield w
     await w.close()
 
@@ -51,31 +57,38 @@ async def worker(mock_protocol_runner, loop, mock_worker_listener):
 def raiser():
     def _func():
         raise ValueError("")
+
     return _func
 
 
 class TestStartUp:
-    async def test_load_called(self, loop, worker, mock_protocol_runner,
-                               mock_worker_listener):
+    async def test_load_called(
+        self, loop, worker, mock_protocol_runner, mock_worker_listener
+    ):
         mock_protocol_runner.load.assert_called_once()
 
     async def test_load_failing_calls_listener(
-            self, loop, worker, mock_protocol_runner, raiser,
-            mock_worker_listener):
+        self, loop, worker, mock_protocol_runner, raiser, mock_worker_listener
+    ):
         mock_protocol_runner.load.side_effect = raiser
-        w = _Worker(protocol_runner=mock_protocol_runner,
-                    listener=DelegatingWorkerListener(mock_worker_listener),
-                    loop=loop)
+        w = _Worker(
+            protocol_runner=mock_protocol_runner,
+            listener=DelegatingWorkerListener(mock_worker_listener),
+            loop=loop,
+        )
         await w.close()
         mock_worker_listener.on_error.assert_called_once()
 
-    async def test_on_ready_called(self, loop, worker, mock_protocol_runner,
-                                   mock_worker_listener):
+    async def test_on_ready_called(
+        self, loop, worker, mock_protocol_runner, mock_worker_listener
+    ):
         event = asyncio.Event()
         mock_protocol_runner.load.side_effect = event.set
-        w = _Worker(protocol_runner=mock_protocol_runner,
-                    listener=DelegatingWorkerListener(mock_worker_listener),
-                    loop=loop)
+        w = _Worker(
+            protocol_runner=mock_protocol_runner,
+            listener=DelegatingWorkerListener(mock_worker_listener),
+            loop=loop,
+        )
         await event.wait()
         mock_worker_listener.on_ready.assert_called_once()
         await w.close()
@@ -89,8 +102,9 @@ class TestRun:
         await event.wait()
         mock_protocol_runner.run.assert_called_once()
 
-    async def test_handle_run_fails(self, loop, worker, mock_protocol_runner,
-                                    raiser, mock_worker_listener):
+    async def test_handle_run_fails(
+        self, loop, worker, mock_protocol_runner, raiser, mock_worker_listener
+    ):
         mock_protocol_runner.run.side_effect = raiser
         await worker.handle_run()
         await worker.close()
@@ -105,9 +119,9 @@ class TestSimulate:
         await event.wait()
         mock_protocol_runner.simulate.assert_called_once()
 
-    async def test_handle_simulate_fails(self, loop, worker,
-                                         mock_protocol_runner, raiser,
-                                         mock_worker_listener):
+    async def test_handle_simulate_fails(
+        self, loop, worker, mock_protocol_runner, raiser, mock_worker_listener
+    ):
         mock_protocol_runner.run.side_effect = raiser
         await worker.handle_run()
         await worker.close()
@@ -129,8 +143,7 @@ async def test_handle_resume(loop, worker, mock_protocol_runner):
     mock_protocol_runner.resume.assert_called_once()
 
 
-async def test_on_command(loop, worker,
-                          mock_protocol_runner, mock_worker_listener):
+async def test_on_command(loop, worker, mock_protocol_runner, mock_worker_listener):
     mock_protocol_runner.run.side_effect = lambda: worker._on_command(123)
     await worker.handle_run()
     await worker.close()

--- a/robot-server/tests/service/session/test_manager.py
+++ b/robot-server/tests/service/session/test_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-from mock import patch, AsyncMock
+from mock import patch, AsyncMock  # type: ignore[attr-defined]
 import pytest
 
 from robot_server.service.session.errors import SessionCreationException
@@ -11,37 +11,37 @@ from robot_server.service.session.models.session import SessionType
 @pytest.fixture
 async def session(session_manager, loop) -> BaseSession:
     """An added session"""
-    return await session_manager.add(session_type=SessionType.live_protocol,
-                                     session_meta_data=SessionMetaData())
+    return await session_manager.add(
+        session_type=SessionType.live_protocol, session_meta_data=SessionMetaData()
+    )
 
 
 @pytest.fixture
 def mock_session_create():
     """Patch of Session.create"""
-    with patch("robot_server.service.session."
-               "manager.LiveProtocolSession.create") as m:
+    with patch(
+        "robot_server.service.session." "manager.LiveProtocolSession.create"
+    ) as m:
         m.return_value = AsyncMock()
         yield m
 
 
-async def test_add_calls_session_create(session_manager,
-                                        mock_session_create,
-                                        session):
+async def test_add_calls_session_create(session_manager, mock_session_create, session):
     mock_session_create.assert_called_once()
-    assert mock_session_create.call_args[1]['configuration'] == \
-        session_manager._session_common
-    assert isinstance(mock_session_create.call_args[1]['instance_meta'],
-                      SessionMetaData)
+    assert (
+        mock_session_create.call_args[1]["configuration"]
+        == session_manager._session_common
+    )
+    assert isinstance(
+        mock_session_create.call_args[1]["instance_meta"], SessionMetaData
+    )
 
 
-async def test_add_no_class_doesnt_call_create(session_manager,
-                                               mock_session_create):
+async def test_add_no_class_doesnt_call_create(session_manager, mock_session_create):
     # Patch the type to class dict
-    with patch("robot_server.service.session.manager.SessionTypeToClass",
-               new={}):
+    with patch("robot_server.service.session.manager.SessionTypeToClass", new={}):
         with pytest.raises(SessionCreationException):
-            await session_manager.add(SessionType.live_protocol,
-                                      SessionMetaData())
+            await session_manager.add(SessionType.live_protocol, SessionMetaData())
         mock_session_create.assert_not_called()
 
 
@@ -60,8 +60,7 @@ async def test_remove_removes(session_manager, session):
 
 
 async def test_remove_calls_cleanup(session_manager):
-    session = await session_manager.add(SessionType.live_protocol,
-                                        SessionMetaData())
+    session = await session_manager.add(SessionType.live_protocol, SessionMetaData())
     session.clean_up = AsyncMock()
     await session_manager.remove(session.meta.identifier)
     session.clean_up.assert_called_once()
@@ -74,8 +73,9 @@ async def test_remove_active_session(session_manager, session):
 
 
 async def test_remove_inactive_session(session_manager, session):
-    active_session = await session_manager.add(SessionType.live_protocol,
-                                               SessionMetaData())
+    active_session = await session_manager.add(
+        SessionType.live_protocol, SessionMetaData()
+    )
     await session_manager.remove(session.meta.identifier)
     assert session_manager._active.active_id is active_session.meta.identifier
 
@@ -90,7 +90,10 @@ def test_get_by_id_not_found(session_manager):
 
 async def test_get_by_type(session_manager):
     sessions = await asyncio.gather(
-        *[session_manager.add(SessionType.live_protocol, SessionMetaData()) for _ in range(5)]  # noqa: E501
+        *[
+            session_manager.add(SessionType.live_protocol, SessionMetaData())
+            for _ in range(5)
+        ]
     )
     assert session_manager.get(SessionType.live_protocol) == tuple(sessions)
     assert session_manager.get(SessionType.calibration_check) == tuple()

--- a/robot-server/tests/service/test_logging.py
+++ b/robot-server/tests/service/test_logging.py
@@ -25,10 +25,11 @@ def mock_dict_config():
         [False, "booboo", rs_logging._dev_log_config(logging.INFO)],
         [True, "ERROR", rs_logging._robot_log_config(logging.ERROR)],
         [True, "booboo", rs_logging._robot_log_config(logging.INFO)],
-    ]
+    ],
 )
-def test_logging(mock_robot_config, mock_dict_config,
-                 is_robot, level_str, expected_dict_conf):
+def test_logging(
+    mock_robot_config, mock_dict_config, is_robot, level_str, expected_dict_conf
+):
     mock_robot_config.log_level = level_str
     with patch("robot_server.service.logging.IS_ROBOT", new=is_robot):
         rs_logging.initialize_logging()

--- a/robot-server/tests/service/tip_length/test_tip_length_management.py
+++ b/robot-server/tests/service/tip_length/test_tip_length_management.py
@@ -1,54 +1,58 @@
-PIPETTE_ID = '123'
-LW_HASH = '130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824'
-FAKE_PIPETTE_ID = 'fake_pip'
-WRONG_LW_HASH = 'wronghash'
+PIPETTE_ID = "123"
+LW_HASH = "130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824"
+FAKE_PIPETTE_ID = "fake_pip"
+WRONG_LW_HASH = "wronghash"
 
 
-def test_access_tip_length_calibration(
-        api_client, set_up_tip_length_temp_directory):
+def test_access_tip_length_calibration(api_client, set_up_tip_length_temp_directory):
     expected = {
-        'id': f'{LW_HASH}&{PIPETTE_ID}',
-        'tipLength': 30.5,
-        'pipette': PIPETTE_ID,
-        'tiprack': LW_HASH,
-        'lastModified': None,
-        'source': 'unknown',
-        'status': {
-            'markedAt': None, 'markedBad': False, 'source': None},
-        'uri': ''
+        "id": f"{LW_HASH}&{PIPETTE_ID}",
+        "tipLength": 30.5,
+        "pipette": PIPETTE_ID,
+        "tiprack": LW_HASH,
+        "lastModified": None,
+        "source": "unknown",
+        "status": {"markedAt": None, "markedBad": False, "source": None},
+        "uri": "",
     }
 
     resp = api_client.get(
-        f'/calibration/tip_length?pipette_id={PIPETTE_ID}&'
-        f'tiprack_hash={LW_HASH}')
+        f"/calibration/tip_length?pipette_id={PIPETTE_ID}&" f"tiprack_hash={LW_HASH}"
+    )
     assert resp.status_code == 200
-    data = resp.json()['data'][0]
-    data['lastModified'] = None
+    data = resp.json()["data"][0]
+    data["lastModified"] = None
     assert data == expected
 
     resp = api_client.get(
-        f'/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&'
-        f'tiprack_hash={WRONG_LW_HASH}')
+        f"/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&"
+        f"tiprack_hash={WRONG_LW_HASH}"
+    )
     assert resp.status_code == 200
-    assert resp.json()['data'] == []
+    assert resp.json()["data"] == []
 
 
 def test_delete_tip_length_calibration(
-        api_client, set_up_pipette_offset_temp_directory):
+    api_client, set_up_pipette_offset_temp_directory
+):
     resp = api_client.delete(
-        f'/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&'
-        f'tiprack_hash={WRONG_LW_HASH}')
+        f"/calibration/tip_length?pipette_id={FAKE_PIPETTE_ID}&"
+        f"tiprack_hash={WRONG_LW_HASH}"
+    )
     assert resp.status_code == 404
     body = resp.json()
     assert body == {
-        'errors': [{
-            'id': 'UncategorizedError',
-            'title': 'Resource Not Found',
-            'detail': "Resource type 'TipLengthCalibration' with id "
-                      "'wronghash&fake_pip' was not found"
-        }]}
+        "errors": [
+            {
+                "id": "UncategorizedError",
+                "title": "Resource Not Found",
+                "detail": "Resource type 'TipLengthCalibration' with id "
+                "'wronghash&fake_pip' was not found",
+            }
+        ]
+    }
 
     resp = api_client.delete(
-        f'/calibration/tip_length?pipette_id={PIPETTE_ID}&'
-        f'tiprack_hash={LW_HASH}')
+        f"/calibration/tip_length?pipette_id={PIPETTE_ID}&" f"tiprack_hash={LW_HASH}"
+    )
     assert resp.status_code == 200

--- a/robot-server/tests/system/test_system_router.py
+++ b/robot-server/tests/system/test_system_router.py
@@ -18,16 +18,14 @@ def mock_system_time() -> datetime:
 @pytest.fixture
 def mock_set_system_time(mock_system_time: datetime) -> Iterator[MagicMock]:
     """Patch set_system_time in time_utils."""
-    with patch.object(router, 'set_system_time') as p:
+    with patch.object(router, "set_system_time") as p:
         yield p
 
 
 @pytest.fixture
 def response_links() -> ResourceLinks:
     """Get expected /system/time resource links."""
-    return {
-        ResourceLinkKey.self: ResourceLink(href='/system/time')
-    }
+    return {ResourceLinkKey.self: ResourceLink(href="/system/time")}
 
 
 def test_raise_system_synchronized_error(
@@ -37,19 +35,23 @@ def test_raise_system_synchronized_error(
 ) -> None:
     """It should raise a SystemTimeAlreadySynchronized from set_system_time."""
     mock_set_system_time.side_effect = errors.SystemTimeAlreadySynchronized(
-        'Cannot set system time; already synchronized with NTP or RTC')
+        "Cannot set system time; already synchronized with NTP or RTC"
+    )
 
-    response = api_client.put("/system/time", json={
-        "data": {
-            "id": "time",
-            "systemTime": mock_system_time.isoformat()
-        }
-    })
-    assert response.json() == {'errors': [{
-        'id': 'UncategorizedError',
-        'detail': 'Cannot set system time; already synchronized with NTP '
-                  'or RTC',
-        'title': 'Action Forbidden'}]}
+    response = api_client.put(
+        "/system/time",
+        json={"data": {"id": "time", "systemTime": mock_system_time.isoformat()}},
+    )
+    assert response.json() == {
+        "errors": [
+            {
+                "id": "UncategorizedError",
+                "detail": "Cannot set system time; already synchronized with NTP "
+                "or RTC",
+                "title": "Action Forbidden",
+            }
+        ]
+    }
     assert response.status_code == 403
 
 
@@ -60,18 +62,22 @@ def test_raise_system_exception(
 ) -> None:
     """It should raise a SystemSetTimeException from set_system_time."""
     mock_set_system_time.side_effect = errors.SystemSetTimeException(
-        'Something went wrong')
+        "Something went wrong"
+    )
 
-    response = api_client.put("/system/time", json={
-        "data": {
-            "id": "time",
-            "systemTime": mock_system_time.isoformat()
-        }
-    })
-    assert response.json() == {'errors': [{
-        'id': 'UncategorizedError',
-        'detail': 'Something went wrong',
-        'title': 'Internal Server Error'}]}
+    response = api_client.put(
+        "/system/time",
+        json={"data": {"id": "time", "systemTime": mock_system_time.isoformat()}},
+    )
+    assert response.json() == {
+        "errors": [
+            {
+                "id": "UncategorizedError",
+                "detail": "Something went wrong",
+                "title": "Internal Server Error",
+            }
+        ]
+    }
     assert response.status_code == 500
 
 
@@ -88,17 +94,14 @@ def test_set_system_time(
     response = api_client.put(
         "/system/time",
         json={
-            'data': {
-                'systemTime': mock_system_time.isoformat(),
-                'id': 'time',
+            "data": {
+                "systemTime": mock_system_time.isoformat(),
+                "id": "time",
             },
         },
     )
     assert response.json() == {
-        'data': {
-            'systemTime': mock_system_time.isoformat(),
-            'id': 'time'
-        },
-        'links': response_links,
+        "data": {"systemTime": mock_system_time.isoformat(), "id": "time"},
+        "links": response_links,
     }
     assert response.status_code == 200

--- a/robot-server/tests/system/test_time_utils.py
+++ b/robot-server/tests/system/test_time_utils.py
@@ -10,23 +10,27 @@ from robot_server.system import errors, time_utils
 @pytest.fixture
 def mock_status_str() -> str:
     """Get mock output from `timedatectl`."""
-    return "Timezone=Etc/UTC\n" \
-           "LocalRTC=no\n" \
-           "CanNTP=yes\n" \
-           "NTP=yes\n" \
-           "NTPSynchronized=no\n" \
-           "TimeUSec=Fri 2020-08-14 21:44:16 UTC\n"
+    return (
+        "Timezone=Etc/UTC\n"
+        "LocalRTC=no\n"
+        "CanNTP=yes\n"
+        "NTP=yes\n"
+        "NTPSynchronized=no\n"
+        "TimeUSec=Fri 2020-08-14 21:44:16 UTC\n"
+    )
 
 
 @pytest.fixture
 def mock_status_dict() -> Dict[str, Union[str, bool]]:
     """Expected dictionary format of `mock_status_str`."""
-    return {'Timezone': 'Etc/UTC',
-            'LocalRTC': False,
-            'CanNTP': True,
-            'NTP': True,
-            'NTPSynchronized': False,
-            'TimeUSec': 'Fri 2020-08-14 21:44:16 UTC'}
+    return {
+        "Timezone": "Etc/UTC",
+        "LocalRTC": False,
+        "CanNTP": True,
+        "NTP": True,
+        "NTPSynchronized": False,
+        "TimeUSec": "Fri 2020-08-14 21:44:16 UTC",
+    }
 
 
 @pytest.fixture
@@ -46,7 +50,8 @@ def test_str_to_dict(
 
 @pytest.mark.parametrize(
     argnames=["mock_status_err_str"],
-    argvalues=[[""], ["There is no equal sign"], ["=== Too many ==="]])
+    argvalues=[[""], ["There is no equal sign"], ["=== Too many ==="]],
+)
 def test_str_to_dict_does_not_raise_error(mock_status_err_str: str) -> None:
     """It should not raise errors due to parsing failures."""
     res_dict = time_utils._str_to_dict(mock_status_err_str)
@@ -57,6 +62,7 @@ async def test_set_time_synchronized_error_response(
     mock_status_dict: Dict[str, Union[str, bool]],
 ) -> None:
     """It should raise an error if time is already synced."""
+
     async def async_mock_time_status(*args: Any, **kwargs: Any) -> Any:
         _stat = mock_status_dict
         _stat.update(NTPSynchronized=True)
@@ -73,6 +79,7 @@ async def test_set_time_general_error_response(
     mock_status_dict: Dict[str, Union[str, bool]],
 ) -> None:
     """It should raise an error it `date` fails."""
+
     async def async_mock_time_status(*args: Any, **kwargs: Any) -> Any:
         _stat = mock_status_dict
         _stat.update(NTPSynchronized=False)
@@ -93,6 +100,7 @@ async def test_set_time_response(
     mock_time: datetime,
 ) -> None:
     """It should return the correct datetime."""
+
     async def async_mock_time_status(*args: Any, **kwargs: Any) -> Any:
         _stat = mock_status_dict
         _stat.update(NTPSynchronized=False)
@@ -111,6 +119,7 @@ async def test_set_time_response(
         time_utils._set_time.assert_called_once()
 
         # Datetime is converted to the correct format with UTC for _set_time
-        await time_utils.set_system_time(datetime.fromisoformat(
-            "2020-08-14T16:44:16-05:00"))   # from EST
+        await time_utils.set_system_time(
+            datetime.fromisoformat("2020-08-14T16:44:16-05:00")
+        )  # from EST
         time_utils._set_time.assert_called_with("2020-08-14 21:44:16")  # to UTC

--- a/robot-server/tests/test_hardware_wrapper.py
+++ b/robot-server/tests/test_hardware_wrapper.py
@@ -4,7 +4,10 @@ from datetime import datetime, timezone
 
 from notify_server.models.hardware_event import DoorStatePayload
 from opentrons.hardware_control.types import (
-    HardwareEventType, DoorStateNotification, DoorState)
+    HardwareEventType,
+    DoorStateNotification,
+    DoorState,
+)
 from notify_server.models.event import Event
 from robot_server import hardware_wrapper
 from robot_server.settings import RobotServerSettings
@@ -18,8 +21,7 @@ def mock_time():
 
 @pytest.fixture
 def mock_utc(mock_time):
-    with patch.object(hardware_wrapper, 'utc_now',
-                      return_value=mock_time) as _mock:
+    with patch.object(hardware_wrapper, "utc_now", return_value=mock_time) as _mock:
         yield _mock
 
 
@@ -30,19 +32,21 @@ def mock_event_publisher():
 
 @pytest.fixture
 def simulating_wrapper(mock_event_publisher):
-    with patch.object(hardware_wrapper, 'get_settings',
-                      return_value=RobotServerSettings(
-                          simulator_configuration_file_path='simulators'
-                                                            '/test.json')):
-        return hardware_wrapper.HardwareWrapper(
-            event_publisher=mock_event_publisher)
+    with patch.object(
+        hardware_wrapper,
+        "get_settings",
+        return_value=RobotServerSettings(
+            simulator_configuration_file_path="simulators" "/test.json"
+        ),
+    ):
+        return hardware_wrapper.HardwareWrapper(event_publisher=mock_event_publisher)
 
 
 async def test_init_hw_event(simulating_wrapper):
-    """ Verify that hardware event publisher is initialized correctly.
+    """Verify that hardware event publisher is initialized correctly.
 
-        Test that init starts an _event_watcher.
-     """
+    Test that init starts an _event_watcher.
+    """
     simulating_wrapper._tm = AsyncMock()
     await simulating_wrapper.init_event_watchers()
     simulating_wrapper._tm.register_callback.assert_awaited_once_with(
@@ -51,20 +55,20 @@ async def test_init_hw_event(simulating_wrapper):
     simulating_wrapper._tm.reset_mock()
 
 
-async def test_door_event(simulating_wrapper,
-                          mock_utc,
-                          mock_time,
-                          mock_event_publisher):
-    """ Verify that a door event is published on hw event. """
+async def test_door_event(
+    simulating_wrapper, mock_utc, mock_time, mock_event_publisher
+):
+    """Verify that a door event is published on hw event."""
 
     hw_event = DoorStateNotification(
-        event=HardwareEventType.DOOR_SWITCH_CHANGE,
-        new_state=DoorState.OPEN)
-    pub_event = Event(createdOn=mock_time,
-                      publisher='HardwareWrapper._publish_hardware_event',
-                      data=DoorStatePayload(state=DoorState.OPEN))
+        event=HardwareEventType.DOOR_SWITCH_CHANGE, new_state=DoorState.OPEN
+    )
+    pub_event = Event(
+        createdOn=mock_time,
+        publisher="HardwareWrapper._publish_hardware_event",
+        data=DoorStatePayload(state=DoorState.OPEN),
+    )
     simulating_wrapper._publish_hardware_event(hw_event)
     mock_event_publisher.send_nowait.assert_called_once_with(
-        'hardware_events',
-        pub_event
+        "hardware_events", pub_event
     )


### PR DESCRIPTION
## Overview

The PR follows up on #8158 by "ripping off the bandaid" and applying `black` across the board in the `robot-server` project. CPX is the primary (or at least, defacto) owner of `robot-server` at the moment so this felt like the least disruptive place to continue the work of #7629 

## Changelog

1. Apply black format to all robot-server code
2. Move various `# type: ignore` and `# noqa` comments that got moved by formatting

## Review requests

Most important thing here is a **smoke test on real hardware**. Format changes should be safe, and tests are all still passing, including integration tests, so this should be pretty safe.

## Risk assessment

Medium mostly just due to number of files touched. The fact that tavern integration tests are passing is a good sign. A successful robot smoke test would go a long way to verifying that the risk is low.