### PR TITLE
fix(protocol-designer): fix whitescreen when adding additional temp steps

### DIFF
--- a/protocol-designer/src/components/StepEditForm/FormAlerts.ts
+++ b/protocol-designer/src/components/StepEditForm/FormAlerts.ts
@@ -12,7 +12,7 @@ import {
   getVisibleProfileFormLevelErrors,
 } from './utils'
 import { Dispatch } from 'redux'
-import { StepIdType } from '../../form-types'
+import { ProfileItem, StepIdType } from '../../form-types'
 import { StepFieldName } from '../../steplist/fieldLevel'
 import { BaseState } from '../../types'
 import { ProfileFormError } from '../../steplist/formLevel/profileErrors'
@@ -46,7 +46,9 @@ const mapStateToProps = (state: BaseState, ownProps: OP): SP => {
     errors: formLevelErrors,
   })
   // deal with special-case dynamic field form-level errors
-  const { profileItemsById } = stepFormSelectors.getHydratedUnsavedForm(state)
+  const unsavedForm = stepFormSelectors.getHydratedUnsavedForm(state)
+  const profileItemsById: Record<string, ProfileItem> | null | undefined =
+    unsavedForm?.profileItemsById
   let visibleDynamicFieldFormErrors: ProfileFormError[] = []
 
   if (profileItemsById != null) {

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -543,15 +543,18 @@ export const getInvariantContext: Selector<
   })
 )
 // TODO(IL, 2020-03-24) type this as Selector<HydratedFormData>. See #3161
-export const getHydratedUnsavedForm: Selector<BaseState, any> = createSelector(
+export const getHydratedUnsavedForm: Selector<
+  BaseState,
+  FormData | null
+> = createSelector(
   getUnsavedForm,
   getInvariantContext,
   (unsavedForm, invariantContext) => {
-    if (!unsavedForm) return null
+    if (unsavedForm == null) return null
 
     const hydratedForm = _getHydratedForm(unsavedForm, invariantContext)
 
-    return hydratedForm
+    return hydratedForm ?? null
   }
 )
 export const getDynamicFieldFormErrorsForUnsavedForm: Selector<


### PR DESCRIPTION
# Overview

Closes #7819

Unfortunately it's a types problem! If we had good typing for FormData / HydratedFormData, Flow would have errored at accessing a key on an object that could be `null`.

# Changelog


# Review requests

- [ ] Should no longer be able to replicate whitescreen, following steps outlined in  #7819

# Risk assessment

Low, PD-only bug fix