### PR TITLE
fix(protocol-designer): fix bug with delay in Transfer steps

### DIFF
--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   maskToInteger,
   maskToFloat,
+  numberOrNull,
   onlyPositiveNumbers,
   defaultTo,
   composeMaskers,
@@ -136,14 +137,14 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
     castValue: Number,
   },
   aspirate_delay_mmFromBottom: {
-    castValue: Number,
+    castValue: numberOrNull,
   },
   dispense_delay_seconds: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers, defaultTo(1)),
     castValue: Number,
   },
   dispense_delay_mmFromBottom: {
-    castValue: Number,
+    castValue: numberOrNull,
   },
   pauseHour: {
     maskValue: composeMaskers(maskToInteger, onlyPositiveNumbers),

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -23,7 +23,14 @@ export const trimDecimals = (
   const trimRegex = new RegExp(`(\\d*[.]{1}\\d{${decimals}})(\\d*)`)
   return String(rawValue).replace(trimRegex, (match, group1) => group1)
 }
-
+// if it's null, keep it null. Otherwise, try to cast to number
+export const numberOrNull = (rawValue: unknown): number | null => {
+  if (rawValue === null) {
+    return null
+  } else {
+    return Number(rawValue)
+  }
+}
 /*********************
  **  Value Limiters  **
  **********************/

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/getDelayData.ts
@@ -1,4 +1,5 @@
 import { InnerDelayArgs } from '@opentrons/step-generation'
+import { getDefaultMmFromBottom } from '../../../components/StepEditForm/fields/TipPositionField/utils'
 import {
   DelayCheckboxFields,
   DelaySecondFields,
@@ -15,14 +16,22 @@ export function getMoveLiquidDelayData(
 ): InnerDelayArgs | null {
   const checkbox = hydratedFormData[checkboxField]
   const seconds = hydratedFormData[secondsField]
-  const mmFromBottom = hydratedFormData[mmFromBottomField]
-
+  let mmFromBottom: number | undefined
+  const mmFromBottomFormValue = hydratedFormData[mmFromBottomField]
+  if (typeof mmFromBottomFormValue === 'number') {
+    mmFromBottom = mmFromBottomFormValue
+  } else if (mmFromBottomFormValue === null) {
+    mmFromBottom = getDefaultMmFromBottom({
+      name: mmFromBottomField,
+      wellDepthMm: NaN /* NOTE: `wellDepthMm` should not be used for delay offsets */,
+    })
+  }
   if (
     checkbox &&
     typeof seconds === 'number' &&
     seconds > 0 &&
     typeof mmFromBottom === 'number' &&
-    mmFromBottom > 0
+    mmFromBottom >= 0
   ) {
     return {
       seconds,

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -135,6 +135,7 @@ export const moveLiquidFormToArgs = (
     'dispense_delay_seconds',
     'dispense_delay_mmFromBottom'
   )
+
   const blowoutLocation =
     (fields.blowout_checkbox && fields.blowout_location) || null
   const blowoutOffsetFromTopMm = DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/getDelayData.test.ts
@@ -2,96 +2,130 @@ import { getMoveLiquidDelayData, getMixDelayData } from '../getDelayData'
 
 describe('getMoveLiquidDelayData', () => {
   it('should return null if checkbox field is false', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: false,
+      aspirate_delay_seconds: 3,
+      aspirate_delay_mmFromBottom: 2,
+    }
     expect(
       getMoveLiquidDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: false, secondsField: 3, offsetField: 2 },
-        'checkboxField',
-        'secondsField',
-        'offsetField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
       )
     ).toBe(null)
   })
 
-  it('should return null if either number fields <= 0 / null', () => {
+  it('should return null if either seconds field is <= 0 or null, or if offset field is negative', () => {
     const cases = [
       [0, 5],
       [null, 5],
-      [10, 0],
-      [10, null],
       [-1, 2],
       [2, -1],
     ]
 
     cases.forEach(testCase => {
       const [secondsValue, offsetValue] = testCase
+      const fields: any = {
+        aspirate_delay_checkbox: true,
+        aspirate_delay_seconds: secondsValue,
+        aspirate_delay_mmFromBottom: offsetValue,
+      }
       expect(
         getMoveLiquidDelayData(
-          {
-            // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-            checkboxField: true,
-            secondsField: secondsValue,
-            offsetField: offsetValue,
-          },
-          'checkboxField',
-          'secondsField',
-          'offsetField'
+          fields,
+          'aspirate_delay_checkbox',
+          'aspirate_delay_seconds',
+          'aspirate_delay_mmFromBottom'
         )
       ).toBe(null)
     })
   })
 
   it('should return seconds & mmFromBottom if checkbox is checked', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 30,
+      aspirate_delay_mmFromBottom: 2,
+    }
     expect(
       getMoveLiquidDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 30, offsetField: 2 },
-        'checkboxField',
-        'secondsField',
-        'offsetField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
       )
     ).toEqual({ seconds: 30, mmFromBottom: 2 })
+  })
+
+  it('should allow mmFromBottom to be zero', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 30,
+      aspirate_delay_mmFromBottom: 0,
+    }
+    expect(
+      getMoveLiquidDelayData(
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds',
+        'aspirate_delay_mmFromBottom'
+      )
+    ).toEqual({ seconds: 30, mmFromBottom: 0 })
   })
 })
 
 describe('getMixDelayData', () => {
   it('should return null if the checkbox field is false', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: false,
+      aspirate_delay_seconds: 3,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: false, secondsField: 3 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return null if the seconds field is 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 0,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 0 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return null if the seconds field is less than 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: -1,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: -1 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toBe(null)
   })
   it('should return the seconds field if checckbox is checked and the seconds field is > 0', () => {
+    const fields: any = {
+      aspirate_delay_checkbox: true,
+      aspirate_delay_seconds: 10,
+    }
     expect(
       getMixDelayData(
-        // @ts-expect-error(sa, 2021-6-15): these are not valid properties on the fields key of HydratedMoveLiquidFormData
-        { checkboxField: true, secondsField: 10 },
-        'checkboxField',
-        'secondsField'
+        fields,
+        'aspirate_delay_checkbox',
+        'aspirate_delay_seconds'
       )
     ).toEqual(10)
   })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/moveLiquidFormToArgs.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../moveLiquidFormToArgs'
 import { getOrderedWells } from '../../../utils'
 import { HydratedMoveLiquidFormData, PathOption } from '../../../../form-types'
+import { DEFAULT_MM_FROM_BOTTOM_ASPIRATE } from '../../../../constants'
 
 jest.mock('../../../utils')
 jest.mock('assert')
@@ -191,10 +192,15 @@ describe('move liquid step form -> command creator args', () => {
       checkboxField: 'aspirate_delay_checkbox',
       formFields: {
         aspirate_delay_seconds: 11,
-        aspirate_delay_mmFromBottom: 12,
+        aspirate_delay_mmFromBottom: null, // use default
       },
       expectedArgsUnchecked: { aspirateDelay: null },
-      expectedArgsChecked: { aspirateDelay: { seconds: 11, mmFromBottom: 12 } },
+      expectedArgsChecked: {
+        aspirateDelay: {
+          seconds: 11,
+          mmFromBottom: DEFAULT_MM_FROM_BOTTOM_ASPIRATE,
+        },
+      },
     },
     {
       checkboxField: 'dispense_delay_checkbox',


### PR DESCRIPTION
# Overview

Closes #8153

# Changelog

- do not treat Transfer delays as "off" just bc they had a falsey mmOffsetFromBottom value

# Review requests

- test coverage OK
- should not be able to reproduce issue in #8153 (eg if you upload the protocol attached to that ticket, and re-export it, you should see the delay commands in the JSON as expected. Also if you make a protocol from scratch with asp/disp delays in a Transfer step, with default or zero mm offsets, the delays should show up in the exported JSON)

# Warning before merge (or at least, before release)

Whoever is responsible for the next PD release:

This PR can change behavior of protocols that have aspirate or dispense delays in a Transfer. Before, if the delay offset was either left default, or set to zero mm, the delay would be skipped as if the checkbox wasn't checked. Now, the delay will be included in the protocol.

We might want to message this more clearly upon import, or we might be okay with this being an implicit change? TBD.

# Risk assessment

Significant, because though it's a fix, it changes behavior of imported protocols (see above)