### PR TITLE
fix(components, protocol-designer): fix TitledList alignment

### DIFF
--- a/components/src/__tests__/__snapshots__/lists.test.tsx.snap
+++ b/components/src/__tests__/__snapshots__/lists.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`TitledList renders TitledList with children correctly 1`] = `
   className="titled_list"
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <h3
       className="title title_enabled"
@@ -140,7 +140,7 @@ exports[`TitledList renders TitledList with onMouseEnter & onMouseLeave correctl
   onMouseLeave={[Function]}
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <h3
       className="title title_enabled"
@@ -164,7 +164,7 @@ exports[`TitledList renders TitledList with optional icon correctly 1`] = `
   className="titled_list"
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <svg
       aria-hidden="true"
@@ -193,7 +193,7 @@ exports[`TitledList renders TitledList without icon correctly 1`] = `
   className="titled_list"
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <h3
       className="title title_enabled"
@@ -217,7 +217,7 @@ exports[`TitledList renders collapsed TitledList correctly 1`] = `
   className="titled_list"
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <h3
       className="title title_enabled"
@@ -259,7 +259,7 @@ exports[`TitledList renders expanded TitledList correctly 1`] = `
   className="titled_list"
 >
   <div
-    className="title_bar"
+    className="titled_list_title_bar"
   >
     <h3
       className="title title_enabled"

--- a/components/src/lists/TitledList.tsx
+++ b/components/src/lists/TitledList.tsx
@@ -88,7 +88,7 @@ export function TitledList(props: TitledListProps): JSX.Element {
     [styles.hover_border]: !disabled && props.hovered,
   })
   // @ts-expect-error(sa, 2021-6-23): cast value to boolean
-  const titleBarClass = cx(styles.title_bar, {
+  const titleBarClass = cx(styles.titled_list_title_bar, {
     [styles.clickable]: props.onClick,
   })
 

--- a/components/src/lists/lists.css
+++ b/components/src/lists/lists.css
@@ -45,12 +45,28 @@
   color: var(--c-font-disabled);
 }
 
+/*
+  TODO(IL, 2021-07-30): when consumers of this class are migrated to CSS-in-JS, keep in mind
+  the meaning of .title_bar is vague, it is widely used by several unrelated components.
+  Also, it's almost the same as .titled_list_title_bar -- they are the same
+  except for flex-related rules.
+*/
 .title_bar {
   position: relative;
   display: flex;
-  flex-direction: column;
   text-decoration: none;
   padding: var(--list-padding-large) var(--list-padding-small);
+  flex-direction: column;
+}
+
+/* Specifically for TitledList */
+.titled_list_title_bar {
+  position: relative;
+  display: flex;
+  text-decoration: none;
+  padding: var(--list-padding-large) var(--list-padding-small);
+  flex-direction: row;
+  align-items: center;
 }
 
 .titled_list_selected {


### PR DESCRIPTION
# Overview

Fixes alignment of items in TitledList, specifically in the Liquids sidebar in PD.

Closes #8008

Reverts accidental changes introduced in #7543. The TitledList is an easy component to break, bc it's got several poorly-defined jobs to do and looks different in different places.

# Changelog

- effectively, revert CSS for TitledList to pre-#7543

# Review requests

Style problem explained in #8008

- Run App uses `TitledList` in: `ProtocolModuleList`, `LabwareGroup`, and `PipetteList`. These should all look the same as on `edge`.
- PD uses `TitledList` in: `LiquidGroupCard`, `PDTitledList`, and `StepItem`. Also, `PDTitledList` is used in turn in several places

# Risk assessment

High! Affects a brittle component used across different applications (at least, PD + Run App)