### PR TITLE
refactor(gcodewatcher): GCodeWatcher async drivers

### DIFF
--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
     g_code_functionality_def_base import GCodeFunctionalityDefBase
-from opentrons.drivers.smoothie_drivers.driver_3_0 import _byte_array_to_ascii_string
+from opentrons.drivers.smoothie_drivers.parse_utils import byte_array_to_ascii_string
 
 
 class ReadInstrumentIDGCodeFunctionalityDef(GCodeFunctionalityDefBase):
@@ -18,5 +18,5 @@ class ReadInstrumentIDGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         hex_string = response.split(':')[-1].strip()
-        instrument_id = _byte_array_to_ascii_string(bytearray.fromhex(hex_string))
+        instrument_id = byte_array_to_ascii_string(bytearray.fromhex(hex_string))
         return f'Read Instrument ID: {instrument_id}'

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
     g_code_functionality_def_base import GCodeFunctionalityDefBase
-from opentrons.drivers.smoothie_drivers.driver_3_0 import _byte_array_to_ascii_string
+from opentrons.drivers.smoothie_drivers.parse_utils import byte_array_to_ascii_string
 
 
 class ReadInstrumentModelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
@@ -19,5 +19,5 @@ class ReadInstrumentModelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         hex_string = response.split(':')[-1].strip()
-        instrument_model = _byte_array_to_ascii_string(bytearray.fromhex(hex_string))
+        instrument_model = byte_array_to_ascii_string(bytearray.fromhex(hex_string))
         return f'Read Instrument Model: {instrument_model}'

--- a/api/src/opentrons/hardware_control/g_code_parsing/protocol_runner.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/protocol_runner.py
@@ -112,7 +112,7 @@ class ProtocolRunner:
             loop=self._get_loop()
         )
         parsed_protocol = parse(protocol.text, protocol.filename)
-        watcher = GCodeWatcher()
-        execute.run_protocol(parsed_protocol, context=context)
+        with GCodeWatcher() as watcher:
+            execute.run_protocol(parsed_protocol, context=context)
         yield GCodeProgram.from_g_code_watcher(watcher)
         server_manager.stop()


### PR DESCRIPTION
# Overview

A refactor to have `GCodeWatcher` work with the new asyncio serial communications.

# Changelog

- `GCodeWatcher` monkey patches `SerialConnection.send_data`.
- `GCodeWatcher` is a context manager for patching / un-patching.
- use `byte_array_to_ascii_string` from the correct location.


# Review requests

This is a PR into the `api-driver-smoothie-refactor` branch. So we can merge #8098 

**The protocol runner unit tests are failing.  I believe this is due to the unpredictable nature of the tempdeck and thermocycler polling.**

# Risk assessment

None

