### PR TITLE
feat(api): Add G-Code Parser Makefile S3 Interface

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -199,11 +199,22 @@ plot-session:
 ###########################
 
 # Pull objects from S3 and output it's content to STDOUT
+# "object_name" is a required parameter
+# "object_name" is the name of the S3 object you want to pull from the g-code-comparison bucket
+# Example:
+#	make g-code-s3-pull object_name='smoothie-protocol-output.json'
 .PHONY: g-code-s3-pull
 g-code-s3-pull:
-	@aws s3 cp s3://g-code-comparison/$(OBJECT_NAME) -
+	@aws s3 cp s3://g-code-comparison/$(object_name) -
 
 # Push local file to S3
+# "source_file_path" and "object_name" are required parameters
+# "source_file_path" is the local path to the file you want to upload
+# "object_name" is what you want your file to be called in S3
+# Example:
+#	make g-code-s3-push \
+#	source_file_path=./api/tests/opentrons/data/g_code_validation_protocols/smoothie_protocol.py \
+#	object_name='smoothie-protocol-output.json'
 .PHONY: g-code-s3-push
 g-code-s3-push:
-	@aws s3 cp $(SOURCE_FILE_PATH) s3://g-code-comparison/$(OBJECT_NAME)
+	@aws s3 cp $(source_file_path) s3://g-code-comparison/$(object_name)

--- a/api/Makefile
+++ b/api/Makefile
@@ -193,3 +193,17 @@ term:
 .PHONY: plot-session
 plot-session:
 	$(python) util/plot_session.py $(plot_type) $(plot_type).pdf
+
+###########################
+# G-Code Parsing Commands #
+###########################
+
+# Pull objects from S3 and output it's content to STDOUT
+.PHONY: g-code-s3-pull
+g-code-s3-pull:
+	@aws s3 cp s3://g-code-comparison/$(OBJECT_NAME) -
+
+# Push local file to S3
+.PHONY: g-code-s3-push
+g-code-s3-push:
+	@aws s3 cp $(SOURCE_FILE_PATH) s3://g-code-comparison/$(OBJECT_NAME)

--- a/api/Makefile
+++ b/api/Makefile
@@ -198,6 +198,9 @@ plot-session:
 # G-Code Parsing Commands #
 ###########################
 
+# NOTE: The following 2 AWS commands `g-code-s3-pull` and `g-code-s3-push` expect you to have the following environment
+# variables defined:  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION `
+
 # Pull objects from S3 and output it's content to STDOUT
 # "object_name" is a required parameter
 # "object_name" is the name of the S3 object you want to pull from the g-code-comparison bucket


### PR DESCRIPTION
# Overview

Added make targets to push and pull files from S3

# Changelog

* Added `g-code-s3-push` to copy a local file to the `g-code-comparision` bucket
* Added `g-code-s3-pull` to print the content of a file in the `g-code-comparision` bucket to stdout
* Added documentation make targets
* Changed variable names to be lowercase


# Review requests

Is it a problem that you have to have the aws cli installed on your system for these commands to work? 
To my knowledge, the CI has the aws cli installed for usage

# Risk assessment

None