### PR TITLE
feat(api): Add filtering of polling messages to G-Code Parser

### DIFF
--- a/api/src/opentrons/hardware_control/g_code_parsing/errors.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/errors.py
@@ -32,3 +32,13 @@ class UnparsableCLICommandError(ValueError):
         )
         self.invalid_command = invalid_command
         self.joined_commands = joined_commands
+
+
+class PollingGCodeAdditionError(ValueError):
+    def __init__(self, invalid_g_code) -> None:
+
+        super().__init__(
+            f'Cannot add "{invalid_g_code}" to GCodeProgram because it is'
+            f'a polling command'
+        )
+        self.invalid_g_code = invalid_g_code

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code.py
@@ -179,6 +179,16 @@ class GCode:
         THERMOCYCLER_IDENT: THERMOCYCLER_G_CODE_EXPLANATION_MAPPING
     }
 
+    # These are a list of codes that are called using polling.
+    # We want to filter these codes out because they are not
+    # actually called by users.
+    POLLING_CODES = [
+        TEMPDECK_G_CODE.GET_TEMP.value,
+        THERMOCYCLER_G_CODE.GET_LID_TEMP.value,
+        THERMOCYCLER_G_CODE.GET_PLATE_TEMP.value,
+        THERMOCYCLER_G_CODE.GET_LID_STATUS.value
+    ]
+
     @classmethod
     def from_raw_code(cls, raw_code: str, device: str, response: str) -> List[GCode]:
         g_code_list = []
@@ -268,6 +278,9 @@ class GCode:
         For instance, "G0 X100 Y200"
         """
         return f'{self.g_code} {self.g_code_body}'.strip()
+
+    def is_polling_command(self) -> bool:
+        return self.g_code in self.POLLING_CODES
 
     @property
     def response(self):

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_differ.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_differ.py
@@ -93,7 +93,9 @@ def first_g_code_program() -> GCodeProgram:
         for code, response in raw_codes
     ]
 
-    return GCodeProgram([code[0] for code in g_code_list])
+    program = GCodeProgram()
+    program.add_g_codes([code[0] for code in g_code_list])
+    return program
 
 
 @pytest.fixture
@@ -109,7 +111,9 @@ def second_g_code_program() -> GCodeProgram:
         for code, response in raw_codes
     ]
 
-    return GCodeProgram([code[0] for code in g_code_list])
+    program = GCodeProgram()
+    program.add_g_codes([code[0] for code in g_code_list])
+    return program
 
 
 def test_naive_insertion():

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_program.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_program.py
@@ -1,0 +1,61 @@
+import pytest
+from opentrons.hardware_control.g_code_parsing import g_code_watcher
+from opentrons.hardware_control.g_code_parsing.g_code import GCode
+from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program\
+    import GCodeProgram
+from opentrons.hardware_control.g_code_parsing.errors import PollingGCodeAdditionError
+
+
+@pytest.fixture
+def watcher() -> g_code_watcher.GCodeWatcher:
+    def temp_return(self):
+        return [
+            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
+            g_code_watcher.WatcherData(
+                'M105', 'tempdeck', 'T:86.500 C:66.223\r\nok\r\nok\r\n'
+            ),
+            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
+            g_code_watcher.WatcherData(
+                'M119', 'thermocycler', 'Lid:open\r\nok\r\nok\r\n'
+            ),
+            g_code_watcher.WatcherData(
+                'M105', 'thermocycler', 'T:40.000 C:23.823\r\nok\r\nok\r\n'
+            ),
+            g_code_watcher.WatcherData(
+                'M141', 'thermocycler', 'T:40.0 C:23.700\r\nok\r\nok\r\n'
+            ),
+            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
+
+        ]
+    old_function = g_code_watcher.GCodeWatcher.get_command_list
+    g_code_watcher.GCodeWatcher.get_command_list = temp_return
+    yield g_code_watcher.GCodeWatcher()
+    g_code_watcher.GCodeWatcher = old_function
+
+
+@pytest.fixture
+def polling_command() -> GCode:
+    return GCode.from_raw_code(
+        'M141', 'thermocycler', 'T:40.0 C:23.700\r\nok\r\nok\r\n'
+    )[0]
+
+
+def test_filter_codes(watcher):
+    actual_codes = [
+        g_code.g_code for g_code in GCodeProgram.from_g_code_watcher(watcher).g_codes
+    ]
+    expected_codes = ['M400', 'M400', 'M400']
+
+    assert actual_codes == expected_codes
+
+
+def test_add_code_polling_command(polling_command):
+    program = GCodeProgram()
+    with pytest.raises(PollingGCodeAdditionError):
+        program.add_g_code(polling_command)
+
+
+def test_add_codes_polling_command(polling_command):
+    program = GCodeProgram()
+    with pytest.raises(PollingGCodeAdditionError):
+        program.add_g_codes([polling_command, polling_command])


### PR DESCRIPTION
# Overview

Add filtering of any polling G-Code commands

# Changelog

* Add `is_polling_command` to G-Code object.
* Add usage of `is_polling_command` to adding G-Codes to `GCodeProgram` object
* Remove passing of G-Code list to `GCodeProgram` to remove ability to add unfiltered GCode lists
* Update tests to reflect above change
* Add tests for filtering G-Codes

# Review requests

Make sure I am monkey patching correctly in `test_g_code_program.py`

# Risk assessment

None