### PR TITLE
refactor(protocol-engine): protocol engine halt is async

### DIFF
--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -107,7 +107,7 @@ class ProtocolEngine:
 
         return self._state_store.commands.get(command_id=command.id)
 
-    def halt(self) -> None:
+    async def halt(self) -> None:
         """Halt execution, stopping all motion and cancelling future commands.
 
         This method is synchronous to allow the halt to reach hardware
@@ -116,7 +116,7 @@ class ProtocolEngine:
         """
         self._state_store.handle_action(StopAction())
         self._queue_worker.cancel()
-        self._hardware_api.halt()
+        await self._hardware_api.halt()
 
     async def stop(self, wait_until_complete: bool = False) -> None:
         """Gracefully stop the ProtocolEngine, waiting for it to become idle.

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -110,9 +110,8 @@ class ProtocolEngine:
     async def halt(self) -> None:
         """Halt execution, stopping all motion and cancelling future commands.
 
-        This method is synchronous to allow the halt to reach hardware
-        immediately. You should call `stop` after calling `halt` for cleanup
-        and to allow the engine to settle and recover.
+        You should call `stop` after calling `halt` for cleanup and to allow
+        the engine to settle and recover.
         """
         self._state_store.handle_action(StopAction())
         self._queue_worker.cancel()

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -258,7 +258,7 @@ async def test_stop_after_wait(
     )
 
 
-def test_halt(
+async def test_halt(
     decoy: Decoy,
     state_store: StateStore,
     queue_worker: QueueWorker,
@@ -266,10 +266,10 @@ def test_halt(
     subject: ProtocolEngine,
 ) -> None:
     """It should be able to halt the engine."""
-    subject.halt()
+    await subject.halt()
 
     decoy.verify(
         state_store.handle_action(StopAction()),
         queue_worker.cancel(),
-        hardware_api.halt(),
+        await hardware_api.halt(),
     )

--- a/robot-server/robot_server/sessions/router/actions_router.py
+++ b/robot-server/robot_server/sessions/router/actions_router.py
@@ -83,7 +83,7 @@ async def create_session_action(
         elif action.actionType == SessionActionType.PAUSE:
             engine_store.engine.pause()
         if action.actionType == SessionActionType.HALT:
-            engine_store.engine.halt()
+            await engine_store.engine.halt()
             task_runner.run(engine_store.engine.stop)
 
     except SessionNotFoundError as e:


### PR DESCRIPTION
# Overview

`API.halt` is now an async method. 

# Changelog

Make `ProtocolEngine.halt` async

# Review requests

It's all new to me. I don't know what's happening in here!

# Risk assessment

None. 