### PR TITLE
wip(api, robot-server): add protocol control via front button

### DIFF
--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -22,11 +22,13 @@ from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
 from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
+from .button_watcher import ButtonWatcher, ButtonEvent
 
 __all__ = [
     'API', 'Controller', 'Simulator', 'Pipette', 'PauseManager',
     'SynchronousAdapter', 'HardwareAPILike', 'CriticalPoint',
     'NoTipAttachedError', 'TipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
     'ThreadManager', 'ExecutionManager', 'ExecutionState',
-    'ExecutionCancelledError', 'ThreadedAsyncLock', 'ThreadedAsyncForbidden'
+    'ExecutionCancelledError', 'ThreadedAsyncLock', 'ThreadedAsyncForbidden',
+    "ButtonWatcher", "ButtonEvent"
 ]

--- a/api/src/opentrons/hardware_control/button_watcher.py
+++ b/api/src/opentrons/hardware_control/button_watcher.py
@@ -1,0 +1,155 @@
+"""Watch buttons for press and hold events.
+
+NOTE: This interface currently only watches the front button. It
+can/should be extended to also watch the window switches.
+"""
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+from typing import NamedTuple, Optional, Set
+
+from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
+
+
+class ButtonEvent(str, Enum):
+    PRESS = "press"
+    HOLD = "hold"
+
+
+class LineEventType(int, Enum):
+    """Convenience duplicate of gpiod.RISING_EDGE and gpiod.FALLING_EDGE."""
+
+    RISING_EDGE = 1
+    FALLING_EDGE = 2
+
+
+class LineEvent(NamedTuple):
+    """Convenience wrapper of gpiod.LineEvent."""
+
+    type: LineEventType
+    sec: int
+    nsec: int
+
+
+class ButtonWatcher:
+    """An interface to watch buttons and return interaction events."""
+
+    def __init__(
+        self,
+        gpio: GPIODriverLike,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        *,
+        button_reader: Optional[ButtonReader] = None,
+        button_tracker: Optional[ButtonTracker] = None,
+    ) -> None:
+        self._loop = loop or asyncio.get_running_loop()
+        self._button_reader = button_reader or ButtonReader(gpio=gpio, loop=loop)
+        self._button_tracker = button_tracker or ButtonTracker(loop=loop)
+
+    async def watch(self) -> ButtonEvent:
+        """Watch for the next button event."""
+        button_event = None
+        button_event_task = self._loop.create_task(self._button_tracker.get_event())
+
+        while button_event is None:
+            button_read_task = self._loop.create_task(self._button_reader.read())
+            tasks: Set[asyncio.Task] = {button_event_task, button_read_task}
+
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self._loop,
+            )
+
+            if button_event_task in done:
+                button_read_task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True, loop=self._loop)
+                button_event = button_event_task.result()
+
+            else:
+                line_event = button_read_task.result()
+                self._button_tracker.track(line_event)
+
+        return button_event
+
+
+class ButtonTracker:
+    """Track `gpiod.LineEvent`s into presses and holds."""
+
+    HOLD_TIME: float = 2.0
+
+    def __init__(
+        self,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        self._loop = loop or asyncio.get_running_loop()
+        self._pressed: asyncio.Event = asyncio.Event()
+        self._released: asyncio.Event = asyncio.Event()
+
+    def track(self, line_event: LineEvent) -> None:
+        """Debounce line events into usable button events."""
+        next_type = line_event.type
+
+        if next_type == LineEventType.FALLING_EDGE:
+            self._pressed.set()
+        else:
+            self._released.set()
+
+    async def get_event(self) -> ButtonEvent:
+        await self._pressed.wait()
+
+        release_task = self._loop.create_task(self._wait_for_release())
+        hold_task = self._loop.create_task(self._wait_for_hold())
+        tasks: Set[asyncio.Task] = {release_task, hold_task}
+
+        done, pending = await asyncio.wait(
+            tasks,
+            return_when=asyncio.FIRST_COMPLETED,
+            loop=self._loop,
+        )
+
+        if hold_task in done:
+            button_event = ButtonEvent.HOLD
+            release_task.cancel()
+        else:
+            button_event = ButtonEvent.PRESS
+            hold_task.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True, loop=self._loop)
+        self._pressed.clear()
+        self._released.clear()
+        return button_event
+
+    async def _wait_for_release(self) -> None:
+        await self._released.wait()
+
+    async def _wait_for_hold(self) -> None:
+        await asyncio.sleep(self.HOLD_TIME, loop=self._loop)
+
+
+class ButtonReader:
+    """An interface to read button events."""
+
+    def __init__(
+        self,
+        gpio: GPIODriverLike,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        """Initialize the ButtonReader."""
+        self._gpio = gpio
+        self._loop = loop or asyncio.get_running_loop()
+
+    async def read(self) -> LineEvent:
+        button_line = self._gpio.lines["button_input"]
+        file_descriptor = button_line.event_get_fd()  # type: ignore[attr-defined]
+        ready_event = asyncio.Event()
+
+        self._loop.add_reader(file_descriptor, ready_event.set)
+
+        try:
+            await ready_event.wait()
+            event = button_line.event_read()  # type: ignore[attr-defined]
+            return LineEvent(type=event.type, sec=event.sec, nsec=event.nsec)
+        finally:
+            self._loop.remove_reader(file_descriptor)

--- a/api/src/opentrons/protocol_runner/__init__.py
+++ b/api/src/opentrons/protocol_runner/__init__.py
@@ -5,5 +5,6 @@ protocol_runner.py for more details.
 """
 from .protocol_runner import ProtocolRunner
 from .protocol_file import ProtocolFile, ProtocolFileType
+from .button_controller import ButtonController
 
-__all__ = ["ProtocolRunner", "ProtocolFile", "ProtocolFileType"]
+__all__ = ["ProtocolRunner", "ProtocolFile", "ProtocolFileType", "ButtonController"]

--- a/api/src/opentrons/protocol_runner/button_controller.py
+++ b/api/src/opentrons/protocol_runner/button_controller.py
@@ -1,0 +1,82 @@
+"""Button control logic.
+
+This module has to be fairly flexible to support both ProtocolEngine
+and RPC-based protocol runs. This can be replaced / updated to be more
+engine-specific whenever RPC is dropped.
+"""
+import asyncio
+import logging
+from typing import Set
+
+from opentrons.hardware_control import API as HardwareAPI, ButtonWatcher, ButtonEvent
+from opentrons.protocol_engine import ProtocolEngine
+from .protocol_runner import ProtocolRunner
+
+log = logging.getLogger(__name__)
+
+
+class ButtonController:
+    """Interface to control a protocol run via button presses."""
+
+    def __init__(self, hardware_api: HardwareAPI) -> None:
+        """Initialize the ButtonController with access to the HardwareAPI."""
+        self._button_watcher = ButtonWatcher(gpio=hardware_api._backend.gpio_chardev)
+
+    async def control(
+        self,
+        protocol_runner: ProtocolRunner,
+        protocol_engine: ProtocolEngine,
+    ) -> None:
+        """Control a given ProtocolRunner and ProtocolEngine via hardware buttons."""
+        get_stop_requested = protocol_engine.state_view.commands.get_stop_requested
+
+        log.info("HEY: controlling run with button")
+
+        while not get_stop_requested():
+            log.info("HEY: getting next button event")
+            event = await self._get_next_event(protocol_engine)
+            log.info("HEY: got it", event)
+
+            if event == ButtonEvent.HOLD:
+                await self._handle_hold(protocol_runner, protocol_engine)
+            else:
+                self._handle_press(protocol_runner, protocol_engine)
+
+    async def _get_next_event(self, protocol_engine: ProtocolEngine) -> ButtonEvent:
+        get_stop_requested = protocol_engine.state_view.commands.get_stop_requested
+
+        watch_button = asyncio.create_task(self._button_watcher.watch())
+        watch_stop = asyncio.create_task(protocol_engine.wait_for(get_stop_requested))
+
+        tasks: Set[asyncio.Task] = {watch_button, watch_stop}
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+        if watch_stop in done:
+            watch_button.cancel()
+        else:
+            watch_stop.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+        return await watch_button
+
+    async def _handle_hold(
+        self,
+        protocol_runner: ProtocolRunner,
+        protocol_engine: ProtocolEngine,
+    ) -> None:
+        if not protocol_engine.state_view.commands.get_stop_requested():
+            await protocol_runner.stop()
+
+    def _handle_press(
+        self,
+        protocol_runner: ProtocolRunner,
+        protocol_engine: ProtocolEngine,
+    ) -> None:
+        if not protocol_engine.state_view.commands.get_stop_requested():
+            if protocol_engine.state_view.commands.get_is_running():
+                log.info("HEY: pausing runner")
+                protocol_runner.pause()
+            else:
+                log.info("HEY: playing runner")
+                protocol_runner.play()

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -27,6 +27,7 @@ class ProtocolRunner:
     def __init__(
         self,
         protocol_engine: ProtocolEngine,
+        *,
         task_queue: Optional[TaskQueue] = None,
         json_file_reader: Optional[JsonFileReader] = None,
         json_command_translator: Optional[JsonCommandTranslator] = None,

--- a/api/tests/opentrons/protocol_runner/test_button_controller.py
+++ b/api/tests/opentrons/protocol_runner/test_button_controller.py
@@ -1,0 +1,169 @@
+"""Tests for the ButtonController interface."""
+import asyncio
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import API as HardwareAPI, ButtonEvent
+from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocol_runner import ProtocolRunner
+from opentrons.protocol_runner.button_controller import ButtonController
+
+
+@pytest.fixture
+def hardware_api(decoy: Decoy) -> HardwareAPI:
+    """Get a mocked out HardwareAPI."""
+    return decoy.mock(cls=HardwareAPI)
+
+
+@pytest.fixture
+def protocol_engine(decoy: Decoy) -> ProtocolEngine:
+    """Get a mocked out ProtocolEngine."""
+    return decoy.mock(cls=ProtocolEngine)
+
+
+@pytest.fixture
+def protocol_runner(decoy: Decoy) -> ProtocolEngine:
+    """Get a mocked out ProtocolEngine."""
+    return decoy.mock(cls=ProtocolEngine)
+
+
+@pytest.fixture
+def subject(hardware_api: HardwareAPI) -> ButtonController:
+    """Get a ButtonController test subject with its dependencies mocked out."""
+    return ButtonController(hardware_api=hardware_api)
+
+
+async def test_stops_when_protocol_complete(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    protocol_runner: ProtocolRunner,
+    subject: ButtonController,
+) -> None:
+    """It should resolve if the protocol has been stopped."""
+    decoy.when(protocol_engine.state_view.commands.get_stop_requested()).then_return(
+        True
+    )
+
+    await subject.control(
+        protocol_engine=protocol_engine,
+        protocol_runner=protocol_runner,
+    )
+
+
+async def test_handles_press_event(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    protocol_runner: ProtocolRunner,
+    hardware_api: HardwareAPI,
+    subject: ButtonController,
+) -> None:
+    """It should get a button press event and play/pause the runner."""
+    decoy.when(protocol_engine.state_view.commands.get_stop_requested()).then_return(
+        False,
+        False,
+        False,
+        False,
+        True,
+    )
+
+    decoy.when(protocol_engine.state_view.commands.get_is_running()).then_return(
+        False,
+        True,
+    )
+
+    decoy.when(await hardware_api.button_watcher.watch()).then_return(
+        ButtonEvent.PRESS,
+        ButtonEvent.PRESS,
+    )
+
+    await subject.control(
+        protocol_engine=protocol_engine,
+        protocol_runner=protocol_runner,
+    )
+
+    decoy.verify(
+        protocol_runner.play(),
+        protocol_runner.pause(),
+    )
+
+
+async def test_handles_hold_event(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    protocol_runner: ProtocolRunner,
+    hardware_api: HardwareAPI,
+    subject: ButtonController,
+) -> None:
+    """It should get a button hold event and stop the runner."""
+    decoy.when(protocol_engine.state_view.commands.get_stop_requested()).then_return(
+        False,
+        False,
+        True,
+    )
+
+    decoy.when(await hardware_api.button_watcher.watch()).then_return(ButtonEvent.HOLD)
+
+    await subject.control(
+        protocol_engine=protocol_engine,
+        protocol_runner=protocol_runner,
+    )
+
+    decoy.verify(await protocol_runner.stop())
+
+
+async def test_ignores_event_if_becomes_stopped(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    protocol_runner: ProtocolRunner,
+    hardware_api: HardwareAPI,
+    subject: ButtonController,
+) -> None:
+    """It should get a button hold event and stop the runner."""
+    decoy.when(protocol_engine.state_view.commands.get_is_running()).then_return(False)
+
+    decoy.when(protocol_engine.state_view.commands.get_stop_requested()).then_return(
+        False,
+        True,
+    )
+
+    decoy.when(await hardware_api.button_watcher.watch()).then_return(
+        ButtonEvent.PRESS, ButtonEvent.HOLD
+    )
+
+    await subject.control(
+        protocol_engine=protocol_engine,
+        protocol_runner=protocol_runner,
+    )
+
+    decoy.verify(await protocol_runner.stop(), times=0)
+    decoy.verify(protocol_runner.play(), times=0)
+    decoy.verify(protocol_runner.pause(), times=0)
+
+
+async def test_races_event_with_becoming_stopped(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    protocol_runner: ProtocolRunner,
+    hardware_api: HardwareAPI,
+    subject: ButtonController,
+) -> None:
+    """It should stop waiting for button events when a stop is requested."""
+    decoy.when(protocol_engine.state_view.commands.get_is_running()).then_return(False)
+
+    decoy.when(protocol_engine.state_view.commands.get_stop_requested()).then_return(
+        False
+    )
+
+    decoy.when(
+        await protocol_engine.wait_for(
+            protocol_engine.state_view.commands.get_stop_requested,
+        )
+    ).then_return(True)
+
+    hardware_api.button_watcher.watch = lambda: asyncio.sleep(100)  # type: ignore[assignment, return-value]  # noqa: E501
+
+    with pytest.raises(asyncio.CancelledError):
+        await subject.control(
+            protocol_engine=protocol_engine,
+            protocol_runner=protocol_runner,
+        )

--- a/robot-server/robot_server/service/task_runner.py
+++ b/robot-server/robot_server/service/task_runner.py
@@ -4,14 +4,15 @@ This module is mostly a thin wrapper around fastapi.BackgroundTasks
 that adds logging. It should be tested primarily through integration
 and end-to-end tests.
 """
+import asyncio
+import logging
 from fastapi import BackgroundTasks
-from logging import getLogger
-from typing import Awaitable, Callable
+from typing import Any, Awaitable, Callable
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
-TaskFunc = Callable[[], Awaitable[None]]
+TaskFunc = Callable[..., Awaitable[None]]
 
 
 class TaskRunner:
@@ -26,7 +27,12 @@ class TaskRunner:
         """
         self._background_tasks = background_tasks
 
-    def run(self, func: TaskFunc) -> None:
+    def run(
+        self,
+        func: TaskFunc,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """Run an async function in the background.
 
         Will log when the function completes, including any error
@@ -36,13 +42,19 @@ class TaskRunner:
             func: An async, argumentless, None-returning function to run
                 in the background. Use functools.partial to add arguments,
                 if required.
+            *args: Positional arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
         """
         func_name = func.__qualname__
 
+        log.info(f"HEY: running {func_name}")
+
         async def _run_async_task() -> None:
             try:
-                await func()
+                await func(*args, **kwargs)
                 log.debug(f"Background task {func_name} succeeded")
+            except asyncio.CancelledError:
+                log.info(f"Background task {func_name} cancelled")
             except Exception as e:
                 log.warning(f"Background task {func_name} failed", exc_info=e)
 

--- a/robot-server/robot_server/sessions/dependencies.py
+++ b/robot-server/robot_server/sessions/dependencies.py
@@ -4,18 +4,18 @@ from starlette.datastructures import State
 from typing import cast
 
 from opentrons.hardware_control import ThreadManager, API as HardwareAPI
+from opentrons.protocol_runner import ButtonController
 
 from robot_server.service.dependencies import get_app_state, get_hardware
 
 from .engine_store import EngineStore
 from .session_store import SessionStore
 
-
 _SESSION_STORE_KEY = "session_store"
 _ENGINE_STORE_KEY = "engine_store"
 
 
-def get_session_store(state: State = Depends(get_app_state)) -> SessionStore:
+async def get_session_store(state: State = Depends(get_app_state)) -> SessionStore:
     """Get a singleton SessionStore to keep track of created sessions."""
     session_store = getattr(state, _SESSION_STORE_KEY, None)
 
@@ -26,7 +26,7 @@ def get_session_store(state: State = Depends(get_app_state)) -> SessionStore:
     return session_store
 
 
-def get_engine_store(
+async def get_engine_store(
     state: State = Depends(get_app_state),
     hardware: ThreadManager = Depends(get_hardware),
 ) -> EngineStore:
@@ -38,3 +38,10 @@ def get_engine_store(
         setattr(state, _ENGINE_STORE_KEY, engine_store)
 
     return engine_store
+
+
+async def get_button_controller(
+    hardware_api: ThreadManager = Depends(get_hardware),
+) -> ButtonController:
+    """Get a ButtonController wired to the HardwareAPI."""
+    return ButtonController(hardware_api=cast(HardwareAPI, hardware_api))

--- a/robot-server/tests/sessions/router/conftest.py
+++ b/robot-server/tests/sessions/router/conftest.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient
 from typing import AsyncIterator
 
+from opentrons.protocol_runner import ButtonController
+
 from robot_server.errors import exception_handlers
 from robot_server.service.dependencies import get_current_time, get_unique_id
 from robot_server.service.task_runner import TaskRunner
@@ -15,7 +17,11 @@ from robot_server.protocols import ProtocolStore, get_protocol_store
 from robot_server.sessions.session_view import SessionView
 from robot_server.sessions.session_store import SessionStore
 from robot_server.sessions.engine_store import EngineStore
-from robot_server.sessions.dependencies import get_session_store, get_engine_store
+from robot_server.sessions.dependencies import (
+    get_session_store,
+    get_engine_store,
+    get_button_controller,
+)
 
 
 @pytest.fixture
@@ -49,12 +55,19 @@ def engine_store(decoy: Decoy) -> EngineStore:
 
 
 @pytest.fixture
+def button_controller(decoy: Decoy) -> ButtonController:
+    """Get a mock ButtonController interface."""
+    return decoy.mock(cls=ButtonController)
+
+
+@pytest.fixture
 def app(
     task_runner: TaskRunner,
     session_store: SessionStore,
     session_view: SessionView,
     engine_store: EngineStore,
     protocol_store: ProtocolStore,
+    button_controller: ButtonController,
     unique_id: str,
     current_time: datetime,
 ) -> FastAPI:
@@ -65,6 +78,7 @@ def app(
     app.dependency_overrides[get_session_store] = lambda: session_store
     app.dependency_overrides[get_engine_store] = lambda: engine_store
     app.dependency_overrides[get_protocol_store] = lambda: protocol_store
+    app.dependency_overrides[get_button_controller] = lambda: button_controller
     app.dependency_overrides[get_unique_id] = lambda: unique_id
     app.dependency_overrides[get_current_time] = lambda: current_time
 

--- a/robot-server/tests/sessions/router/test_base_router.py
+++ b/robot-server/tests/sessions/router/test_base_router.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from tests.helpers import verify_response
 
+from opentrons.protocol_runner import ButtonController
+
 from robot_server.service.task_runner import TaskRunner
 
 from robot_server.protocols import (
@@ -56,6 +58,7 @@ async def test_create_session(
     session_view: SessionView,
     session_store: SessionStore,
     engine_store: EngineStore,
+    button_controller: ButtonController,
     unique_id: str,
     current_time: datetime,
     async_client: AsyncClient,
@@ -98,6 +101,11 @@ async def test_create_session(
     decoy.verify(
         await engine_store.create(),
         task_runner.run(engine_store.runner.join),
+        task_runner.run(
+            func=button_controller.control,
+            protocol_runner=engine_store.runner,
+            protocol_engine=engine_store.engine,
+        ),
         session_store.upsert(session=session),
     )
 


### PR DESCRIPTION
## Overview

**Work in progress**. This branch is, at best, a prototype. It needs a lot of work and probably [anyio](https://anyio.readthedocs.io/en/stable/) before it's ready for prime time.

That being said, this branch has HTTP-driven ProtocolEngine runs fully controllable (start, pause, resume, cancel) via the OT-2's front button. More to follow...

Closes #8085, when it's done

## Changelog

TODO

## Review requests

TODO

## Risk assessment

TODO