### PR TITLE
docs(api): Deprecate `resume()` and revise `pause()`/`delay()`/`resume()` docs

### DIFF
--- a/api/docs/v2/new_atomic_commands.rst
+++ b/api/docs/v2/new_atomic_commands.rst
@@ -438,21 +438,22 @@ Usually the above option is useful when moving inside of a well. Take a look at 
 .. versionadded:: 2.0
 
 
-Delay
-=====
+Delay for an Amount of Time
+===========================
 
-Sometimes you need to pause your protocol, for instance to wait for something to incubate. You can use :py:meth:`.ProtocolContext.delay` to pause your protocol for a specific amount of time. ``delay`` is a method of :py:class:`.ProtocolContext` since it concerns the protocol and the OT-2 as a whole.
+Sometimes you need to wait as a step in your protocol, for instance to wait for something to incubate. You can use :py:meth:`.ProtocolContext.delay` to wait your protocol for a specific amount of time. ``delay`` is a method of :py:class:`.ProtocolContext` since it concerns the protocol and the OT-2 as a whole.
 
-The value passed into ``delay()`` is the number of minutes or seconds the OT-2 will wait until moving on to the next command.
+The values passed into ``delay()`` specify the number of minutes and seconds that the OT-2 will wait until moving on to the next command.
 
 .. code-block:: python
 
-    protocol.delay(seconds=2)             # pause for 2 seconds
-    protocol.delay(minutes=5)             # pause for 5 minutes
-    protocol.delay(minutes=5, seconds=2)  # pause for 5 minutes and 2 seconds
+    protocol.delay(seconds=2)             # delay for 2 seconds
+    protocol.delay(minutes=5)             # delay for 5 minutes
+    protocol.delay(minutes=5, seconds=2)  # delay for 5 minutes and 2 seconds
 
-User-Specified Pause
-====================
+
+Pause Until Resumed
+===================
 
 The method :py:meth:`.ProtocolContext.pause` will pause protocol execution at a specific step.
 You can resume by pressing 'resume' in your Opentrons App. You can optionally specify a message that

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -204,12 +204,23 @@ Version 2.8
 
 Version 2.9
 +++++++++++
+
 - You can now access certain geometry data regarding a labware's well via a Well Object. See :ref:`new-labware-well-properties` for more information.
+
 
 Version 2.10
 ++++++++++++
+
 - In Python protocols requesting API version 2.10, moving to the same well twice in a row with different pipettes no longer results in strange diagonal movements.
+
 
 Version 2.11
 ++++++++++++
+
 - In Python protocols requesting API version 2.11, attempting to aspirate from or dispense to tip racks will raise an error.
+
+
+Version 2.12
+++++++++++++
+
+- :py:meth:`.ProtocolContext.resume` has been deprecated.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -587,20 +587,30 @@ class ProtocolContext(CommandPublisher):
     @publish.both(command=cmds.pause)
     @requires_version(2, 0)
     def pause(self, msg=None) -> None:
-        """ Pause execution of the protocol until resume is called.
+        """Pause execution of the protocol until it's resumed.
+
+        A human can resume the protocol through the Opentrons App.
 
         This function returns immediately, but the next function call that
         is blocked by a paused robot (anything that involves moving) will
-        not return until :py:meth:`resume` is called.
+        not return until the protocol is resumed.
 
-        :param str msg: A message to echo back to connected clients.
+        :param str msg: An optional message to show to connected clients. The
+            Opentrons App will show this in the run log.
         """
         self._implementation.pause(msg=msg)
 
     @publish.both(command=cmds.resume)
     @requires_version(2, 0)
     def resume(self) -> None:
-        """ Resume a previously-paused protocol """
+        """Resume the protocol after :py:meth:`pause`.
+
+        .. deprecated:: 2.12
+           The Python Protocol API supports no safe way for a protocol to resume itself.
+           See https://github.com/Opentrons/opentrons/issues/8209.
+           If you're looking for a way for your protocol to resume automatically
+           after a period of time, use :py:meth:`delay`.
+        """
         self._implementation.resume()
 
     @publish.both(command=cmds.comment)


### PR DESCRIPTION
# Overview

Documentation changes primarily to deprecate `ProtocolContext.resume()`, plus some other nearby revisions.

Closes #8209.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

Long-form docs:

<details>

![Screen Shot 2021-08-11 at 9 26 01 PM](https://user-images.githubusercontent.com/3236864/129124747-21c5867c-71be-43c3-9332-5ec69e2e8ba7.png)

</details>

Changelog:

<details>

![Screen Shot 2021-08-11 at 9 22 31 PM](https://user-images.githubusercontent.com/3236864/129124748-1a513083-01e1-4bc9-8862-378185035dce.png)

</details>

Reference docs:

<details>

![Screen Shot 2021-08-11 at 9 22 13 PM](https://user-images.githubusercontent.com/3236864/129124749-7e15d67c-c903-4688-b394-5a811f098885.png)

</details>

# Review requests

Is this a sensible way to do the versioning? I've marked the method as deprecated in API v2.12 (the next API version), left a changelog note for it, and *not* added a corresponding robot software version to [the table](https://docs.opentrons.com/v2/versioning.html#api-and-ot-2-software-versions) (because there are no production software changes associated with this).

# Risk assessment

None. Changes are just to docs.
