### PR TITLE
test(app): move testing matchers into components utils

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/ExtraAttentionWarning.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/ExtraAttentionWarning.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { when } from 'jest-when'
 import { fireEvent, screen } from '@testing-library/react'
-import { renderWithProviders } from '@opentrons/components/__utils__'
+import {
+  partialComponentPropsMatcher,
+  renderWithProviders,
+} from '@opentrons/components/__utils__'
 import { i18n } from '../../../../../i18n'
 import { ExtraAttentionWarning } from '../ExtraAttentionWarning'
 import { SecureLabwareModal } from '../SecureLabwareModal'
@@ -16,12 +19,6 @@ const render = (props: React.ComponentProps<typeof ExtraAttentionWarning>) => {
     i18nInstance: i18n,
   })
 }
-
-const partialComponentPropsMatcher = (argsToMatch: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) =>
-    equals(args[0], expect.objectContaining(argsToMatch))
-  )
 
 describe('ExtraAttentionWarning', () => {
   let props: React.ComponentProps<typeof ExtraAttentionWarning>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/__tests__/LabwareSetup.test.tsx
@@ -11,7 +11,11 @@ import {
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
 import { fireEvent, screen } from '@testing-library/react'
-import { renderWithProviders } from '@opentrons/components/__utils__'
+import {
+  renderWithProviders,
+  componentPropsMatcher,
+  partialComponentPropsMatcher,
+} from '@opentrons/components/__utils__'
 import { i18n } from '../../../../../i18n'
 import { LabwareSetup } from '..'
 import { LabwareSetupModal } from '../LabwareSetupModal'
@@ -41,18 +45,6 @@ jest.mock('@opentrons/shared-data', () => {
     inferModuleOrientationFromXCoordinate: jest.fn(),
   }
 })
-
-// this is needed because under the hood react calls components with two arguments (props and some second argument nobody seems to know)
-// https://github.com/timkindberg/jest-when/issues/66
-const componentPropsMatcher = (matcher: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) => equals(args[0], matcher))
-
-const partialComponentPropsMatcher = (argsToMatch: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) =>
-    equals(args[0], expect.objectContaining(argsToMatch))
-  )
 
 const mockLabwareInfoOverlay = LabwareInfoOverlay as jest.MockedFunction<
   typeof LabwareInfoOverlay

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/__tests__/ModuleSetup.test.tsx
@@ -3,7 +3,11 @@ import { when, resetAllWhenMocks } from 'jest-when'
 import { StaticRouter } from 'react-router-dom'
 import { RobotWorkSpace, ModuleViz } from '@opentrons/components'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
-import { renderWithProviders } from '@opentrons/components/__utils__'
+import {
+  renderWithProviders,
+  partialComponentPropsMatcher,
+  componentPropsMatcher,
+} from '@opentrons/components/__utils__'
 import { i18n } from '../../../../../i18n'
 import { ModuleSetup } from '..'
 import { ModuleInfo } from '../ModuleInfo'
@@ -29,16 +33,6 @@ jest.mock('@opentrons/shared-data', () => {
     inferModuleOrientationFromXCoordinate: jest.fn(),
   }
 })
-
-const componentPropsMatcher = (matcher: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) => equals(args[0], matcher))
-
-const partialComponentPropsMatcher = (argsToMatch: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) =>
-    equals(args[0], expect.objectContaining(argsToMatch))
-  )
 
 const mockModuleInfo = ModuleInfo as jest.MockedFunction<typeof ModuleInfo>
 

--- a/app/src/organisms/ProtocolSetup/__tests__/RunSetupCard.test.tsx
+++ b/app/src/organisms/ProtocolSetup/__tests__/RunSetupCard.test.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import { when } from 'jest-when'
 import '@testing-library/jest-dom'
 import { fireEvent } from '@testing-library/react'
-import { renderWithProviders } from '@opentrons/components/__utils__'
+import {
+  componentPropsMatcher,
+  renderWithProviders,
+} from '@opentrons/components/__utils__'
 import noModulesProtocol from '@opentrons/shared-data/protocol/fixtures/4/simpleV4.json'
 import withModulesProtocol from '@opentrons/shared-data/protocol/fixtures/4/testModulesProtocol.json'
 import standardDeckDef from '@opentrons/shared-data/deck/definitions/2/ot2_standard.json'
@@ -83,12 +86,6 @@ const mockGetProtocolPipetteTiprackData = getProtocolPipetteTipRackCalInfo as je
 const mockGetDeckCalData = calibrationSelectors.getDeckCalibrationData as jest.MockedFunction<
   typeof calibrationSelectors.getDeckCalibrationData
 >
-
-// this is needed because under the hood react calls components with two arguments (props and some second argument nobody seems to know)
-// https://github.com/timkindberg/jest-when/issues/66
-const componentPropsMatcher = (matcher: unknown) =>
-  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
-  when.allArgs((args, equals) => equals(args[0], matcher))
 
 const mockModuleRenderCoords = {
   mockModuleId: { x: 0, y: 0, z: 0, moduleModel: 'mockModule' as any },

--- a/components/__utils__/index.ts
+++ b/components/__utils__/index.ts
@@ -1,3 +1,4 @@
 export * from './mountWithStore'
 export * from './mountWithProviders'
 export * from './renderWithProviders'
+export * from './matchers'

--- a/components/__utils__/matchers.ts
+++ b/components/__utils__/matchers.ts
@@ -1,0 +1,13 @@
+import { when } from 'jest-when'
+
+// these are needed because under the hood react calls components with two arguments (props and some second argument nobody seems to know)
+// https://github.com/timkindberg/jest-when/issues/66
+export const componentPropsMatcher = (matcher: unknown) =>
+  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
+  when.allArgs((args, equals) => equals(args[0], matcher))
+
+export const partialComponentPropsMatcher = (argsToMatch: unknown) =>
+  // @ts-expect-error(sa, 2021-08-03): when.allArgs not part of type definition yet for jest-when
+  when.allArgs((args, equals) =>
+    equals(args[0], expect.objectContaining(argsToMatch))
+  )


### PR DESCRIPTION
# Overview

Move testing matchers into components utils

# Changelog

- Move testing matchers into components utils

# Review requests
This seem cool?

# Risk assessment

Low
