### PR TITLE
fix(api): Make tip pickup error say "pick up tip," not "drop tip"

### DIFF
--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -65,7 +65,7 @@ class InstrumentContextSimulation(AbstractInstrument):
     def pick_up_tip(self, well: WellImplementation, tip_length: float,
                     presses: typing.Optional[int],
                     increment: typing.Optional[float]) -> None:
-        self._raise_if_tip("drop tip")
+        self._raise_if_tip("pick up tip")
         self._pipette_dict['has_tip'] = True
         self._pipette_dict['current_volume'] = 0
 


### PR DESCRIPTION
# Overview

Currently, if you do:

```python
pipette.pick_up_tip()
pipette.pick_up_tip()
```

The error message will say:

> cannot drop tip with a tip attached

But it should say:

> cannot pick up tip with a tip attached

# Changelog

* Fix the error message.

# Risk assessment

Very low. Only changes an error message.
