### PR TITLE
feat(app): add id attributes for e2e testing

### DIFF
--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/ExtraAttentionWarning.tsx
@@ -89,6 +89,7 @@ export const ExtraAttentionWarning = (
         marginY={SPACING_3}
         backgroundColor={COLOR_WARNING_LIGHT}
         color={C_DARK_GRAY}
+        id={'ExtraAttentionWarning'}
       >
         <Box margin={SPACING_3}>
           <Flex margin={SPACING_2}>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareSetupModal.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/LabwareSetupModal.tsx
@@ -112,6 +112,7 @@ export const LabwareSetupModal = (
               onClick={props.onCloseClick}
               width={SIZE_4}
               backgroundColor={C_BLUE}
+              id={'LabwareSetupModal_closeButton'}
             >
               {t('shared:close')}
             </PrimaryBtn>

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/LabwareSetup/index.tsx
@@ -104,6 +104,7 @@ export const LabwareSetup = (props: LabwareSetupProps): JSX.Element | null => {
           viewBox={DECK_MAP_VIEWBOX}
           className={styles.deck_map}
           deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
+          id={'LabwareSetup_deckMap'}
         >
           {() => {
             return (
@@ -154,6 +155,7 @@ export const LabwareSetup = (props: LabwareSetupProps): JSX.Element | null => {
             marginRight={SPACING_3}
             onClick={() => console.log('check labware positions!')}
             color={C_BLUE}
+            id={'LabwareSetup_checkLabwarePositionsButton'}
           >
             {t('check_labware_positions')}
           </SecondaryBtn>
@@ -162,6 +164,7 @@ export const LabwareSetup = (props: LabwareSetupProps): JSX.Element | null => {
             disabled={proceedToRunDisabled}
             as={LinkComponent}
             backgroundColor={C_BLUE}
+            id={'LabwareSetup_proceedToRunButton'}
             {...linkProps}
             {...targetProps}
           >

--- a/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
+++ b/app/src/organisms/ProtocolSetup/RunSetupCard/ModuleSetup/index.tsx
@@ -80,6 +80,7 @@ export const ModuleSetup = (props: ModuleSetupProps): JSX.Element | null => {
           viewBox={DECK_VIEW_BOX}
           className={styles.deck_map}
           deckLayerBlocklist={DECK_LAYER_BLOCKLIST}
+          id={'ModuleSetup_deckMap'}
         >
           {() => {
             return (
@@ -115,6 +116,7 @@ export const ModuleSetup = (props: ModuleSetupProps): JSX.Element | null => {
           title={t('proceed_to_labware_setup_step')}
           onClick={expandLabwareSetupStep}
           backgroundColor={C_BLUE}
+          id={'ModuleSetup_proceedToLabwareSetup'}
         >
           {t('proceed_to_labware_setup_step')}
         </PrimaryBtn>

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -127,7 +127,11 @@ export function UploadInput(props: UploadInputProps): JSX.Element {
         css={dropZoneStyles}
       >
         <Icon width={SIZE_3} name="upload" marginBottom={SPACING_4} />
-        <span aria-controls="file_input" role="button">
+        <span
+          aria-controls="file_input"
+          role="button"
+          id={'UploadInput_fileUploadLabel'}
+        >
           {t('drag_file_here')}
         </span>
         <input

--- a/app/src/organisms/ProtocolUpload/UploadInput.tsx
+++ b/app/src/organisms/ProtocolUpload/UploadInput.tsx
@@ -111,7 +111,11 @@ export function UploadInput(props: UploadInputProps): JSX.Element {
       <Text as="h1" css={FONT_HEADER_DARK} marginBottom={SPACING_3}>
         {t('open_a_protocol')}
       </Text>
-      <PrimaryBtn onClick={handleClick} marginBottom={SPACING_4}>
+      <PrimaryBtn
+        onClick={handleClick}
+        marginBottom={SPACING_4}
+        id={'UploadInput_protocolUploadButton'}
+      >
         {t('choose_file')}
       </PrimaryBtn>
       <label
@@ -148,6 +152,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element {
         href={PROTOCOL_LIBRARY_URL}
         width="19rem"
         marginBottom={SPACING_3}
+        id={'UploadInput_protocolLibraryButton'}
       >
         {t('browse_protocol_library')}
       </SecondaryBtn>
@@ -156,6 +161,7 @@ export function UploadInput(props: UploadInputProps): JSX.Element {
         external
         href={PROTOCOL_DESIGNER_URL}
         width="19rem"
+        id={'UploadInput_protocolDesignerButton'}
       >
         {t('launch_protocol_designer')}
       </SecondaryBtn>

--- a/components/src/deck/RobotWorkSpace.tsx
+++ b/components/src/deck/RobotWorkSpace.tsx
@@ -11,12 +11,13 @@ export interface RobotWorkSpaceProps {
   className?: string
   children?: (props: RobotWorkSpaceRenderProps) => React.ReactNode
   deckLayerBlocklist?: string[]
+  id?: string
 }
 
 type GetRobotCoordsFromDOMCoords = RobotWorkSpaceRenderProps['getRobotCoordsFromDOMCoords']
 
 export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
-  const { children, deckDef, deckLayerBlocklist = [], viewBox } = props
+  const { children, deckDef, deckLayerBlocklist = [], viewBox, id } = props
   const wrapperRef = React.useRef<SVGSVGElement>(null)
 
   // NOTE: getScreenCTM in Chrome a DOMMatrix type,
@@ -55,6 +56,7 @@ export function RobotWorkSpace(props: RobotWorkSpaceProps): JSX.Element | null {
       className={cx(styles.robot_work_space, props.className)}
       viewBox={viewBox || wholeDeckViewBox}
       ref={wrapperRef}
+      id={id}
     >
       {deckDef && (
         <DeckFromData def={deckDef} layerBlocklist={deckLayerBlocklist} />


### PR DESCRIPTION
# Overview

closes #8261, see ticket for what the ids are

# Review requests
I followed the pattern we use in pd which is `id={ComponentName_description}` where `ComponentName` is in PascalCase and `description` is in camelCase. Is this cool with people?

# Risk assessment

Low
