### PR TITLE
chore(lint): suppress js lint warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ lint-py:
 
 .PHONY: lint-js
 lint-js:
-	eslint ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)"
+	eslint --quiet ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)"
 	prettier --ignore-path .eslintignore --check $(FORMAT_FILE_GLOB)
 
 .PHONY: lint-json


### PR DESCRIPTION
# Overview

So this might be controversial, but if we're being honest we do not pay attention to eslint warnings. It's annoying to have to scroll through hundreds of warnings to find the one or two errors to fix, so I think we should either (1) suppress eslint warnings (which this PR does) or (2) actually have builds fail when there are warnings (which is not really possible because we don't have time to fix all of the warnings. And even if we did, idk if we should.)

What do folks think?

# Risk assessment
Low
