### PR TITLE
style(js): convert property access from bracket to dot where able

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
 
     // TODO(mc, 2021-01-29): fix these and remove warning overrides
     '@typescript-eslint/default-param-last': 'warn',
-    'dot-notation': 'warn',
     'lines-between-class-members': 'warn',
     'array-callback-return': 'warn',
     'no-prototype-builtins': 'warn',
@@ -52,13 +51,11 @@ module.exports = {
     {
       files: ['**/*.js'],
       parser: '@babel/eslint-parser',
-      extends: ['prettier'],
     },
     {
       // TODO(mc, 2021-03-18): remove to default these rules back to errors
       files: ['**/*.@(ts|tsx)'],
       rules: {
-        '@typescript-eslint/dot-notation': 'warn',
         '@typescript-eslint/strict-boolean-expressions': 'warn',
         '@typescript-eslint/prefer-nullish-coalescing': 'warn',
         '@typescript-eslint/prefer-optional-chain': 'warn',

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,11 @@ ROBOT_SERVER_DIR := robot-server
 # documentation
 BUILD_NUMBER ?=
 
-# watch, coverage, and update snapshot variables for tests
+# watch, coverage, update snapshot, and warning suppresion variables for tests and linting
 watch ?= false
 cover ?= true
 updateSnapshot ?= false
+quiet ?= false
 
 FORMAT_FILE_GLOB = ".*.@(js|ts|tsx|yml)" "**/*.@(ts|tsx|js|json|md|yml)"
 
@@ -189,7 +190,7 @@ lint-py:
 
 .PHONY: lint-js
 lint-js:
-	eslint ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)"
+	eslint --quiet=$(quiet) ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)"
 	prettier --ignore-path .eslintignore --check $(FORMAT_FILE_GLOB)
 
 .PHONY: lint-json

--- a/app/src/molecules/DeckMap/index.tsx
+++ b/app/src/molecules/DeckMap/index.tsx
@@ -54,7 +54,7 @@ const deckSetupLayerBlocklist = [
 ]
 
 function DeckMapComponent(props: Props): JSX.Element {
-  const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
+  const deckDef = React.useMemo(() => getDeckDefinitions().ot2_standard, [])
   const {
     modulesBySlot,
     labwareBySlot,

--- a/app/src/organisms/CalibrationPanels/DeckSetup.tsx
+++ b/app/src/organisms/CalibrationPanels/DeckSetup.tsx
@@ -97,7 +97,7 @@ function HealthCheckText({
 }
 
 export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
-  const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
+  const deckDef = React.useMemo(() => getDeckDefinitions().ot2_standard, [])
 
   const {
     tipRack,

--- a/app/src/organisms/CalibrationPanels/Introduction.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction.tsx
@@ -590,7 +590,7 @@ function RequiredLabwareCard(props: RequiredLabwareCardProps): JSX.Element {
   const imageSrc =
     loadName in labwareImages
       ? labwareImages[loadName as keyof typeof labwareImages]
-      : labwareImages['generic_custom_tiprack']
+      : labwareImages.generic_custom_tiprack
 
   return (
     <Flex

--- a/app/src/pages/Calibrate/CalibratePanel/PipetteList.tsx
+++ b/app/src/pages/Calibrate/CalibratePanel/PipetteList.tsx
@@ -75,8 +75,7 @@ export function PipetteListComponent(
           hash: string | null
         ): string => {
           const url =
-            urlsByMount[mount][hash ?? 'default'] ??
-            urlsByMount[mount]['default']
+            urlsByMount[mount][hash ?? 'default'] ?? urlsByMount[mount].default
           return url.path
         }
         return (

--- a/components/src/deck/Module.stories.tsx
+++ b/components/src/deck/Module.stories.tsx
@@ -30,7 +30,7 @@ export default {
 
 const Template: Story<React.ComponentProps<typeof ModuleComponent>> = args => {
   return (
-    <RobotWorkSpace deckDef={getDeckDefinitions()['ot2_standard']}>
+    <RobotWorkSpace deckDef={getDeckDefinitions().ot2_standard}>
       {({ deckSlotsById }: RobotWorkSpaceRenderProps) => {
         const slot = deckSlotsById['7']
         return (

--- a/components/src/deck/RobotWorkSpace.stories.tsx
+++ b/components/src/deck/RobotWorkSpace.stories.tsx
@@ -18,7 +18,7 @@ export default {
       defaultValue: 'ot2_standard',
     },
     deckLayerBlocklist: {
-      options: Object.keys(allDeckDefs['ot2_standard'].layers),
+      options: Object.keys(allDeckDefs.ot2_standard.layers),
       control: {
         type: 'check',
       },

--- a/labware-library/src/analytics/initializeFullstory.ts
+++ b/labware-library/src/analytics/initializeFullstory.ts
@@ -6,10 +6,10 @@ const FULLSTORY_ORG = process.env.OT_LL_FULLSTORY_ORG
 export const initializeFullstory = (): void => {
   console.debug('initializing Fullstory')
   // NOTE: this code snippet is distributed by Fullstory, last updated 2019-10-04
-  global['_fs_debug'] = false
-  global['_fs_host'] = 'fullstory.com'
-  global['_fs_org'] = FULLSTORY_ORG
-  global['_fs_namespace'] = FULLSTORY_NAMESPACE
+  global._fs_debug = false
+  global._fs_host = 'fullstory.com'
+  global._fs_org = FULLSTORY_ORG
+  global._fs_namespace = FULLSTORY_NAMESPACE
   ;(function (m, n, e, t, l, o, g, y) {
     if (e in m) {
       if (m.console && m.console.log) {
@@ -58,7 +58,7 @@ export const initializeFullstory = (): void => {
       g(o, v)
     }
     g.clearUserCookie = function () {}
-  })(global, global.document, global['_fs_namespace'], 'script', 'user')
+  })(global, global.document, global._fs_namespace, 'script', 'user')
 
   _setAnalyticsTags()
 }

--- a/labware-library/src/components/measurement-guide/index.ts
+++ b/labware-library/src/components/measurement-guide/index.ts
@@ -144,7 +144,7 @@ export function getFootprintDiagram(props: DiagramProps): string[] {
   if (category === 'aluminumBlock') {
     return insertCategory ? ALUM_BLOCK_FOOTPRINTS[insertCategory] : []
   } else if (category === 'tubeRack' && irregular) {
-    return FOOTPRINT_DIAGRAMS['irregular']
+    return FOOTPRINT_DIAGRAMS.irregular
   }
   return category ? FOOTPRINT_DIAGRAMS[category] : []
 }
@@ -153,8 +153,8 @@ export function getSpacingDiagram(props: DiagramProps): string[] {
   const { category, isMultiRow, shape } = props
   if (category === 'reservoir') {
     return isMultiRow
-      ? RESERVOIR_SPACING_DIAGRAMS['multiRow']
-      : RESERVOIR_SPACING_DIAGRAMS['singleRow']
+      ? RESERVOIR_SPACING_DIAGRAMS.multiRow
+      : RESERVOIR_SPACING_DIAGRAMS.singleRow
   }
 
   return shape ? SPACING_DIAGRAMS[shape] : []

--- a/protocol-designer/src/analytics/fullstory.ts
+++ b/protocol-designer/src/analytics/fullstory.ts
@@ -2,11 +2,11 @@
 import cookie from 'cookie'
 
 export const shutdownFullstory = (): void => {
-  if (window[window['_fs_namespace']]) {
-    window[window['_fs_namespace']].shutdown()
+  if (window[window._fs_namespace]) {
+    window[window._fs_namespace].shutdown()
   }
   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-  delete window[window['_fs_namespace']]
+  delete window[window._fs_namespace]
 }
 
 const _setAnalyticsTags = (): void => {
@@ -19,8 +19,8 @@ const _setAnalyticsTags = (): void => {
   // NOTE: fullstory expects the keys 'displayName' and 'email' verbatim
   // though all other key names must be fit the schema described here
   // https://help.fullstory.com/develop-js/137380
-  if (window[window['_fs_namespace']]) {
-    window[window['_fs_namespace']].setUserVars({
+  if (window[window._fs_namespace]) {
+    window[window._fs_namespace].setUserVars({
       displayName,
       email,
       commit_str,
@@ -32,10 +32,10 @@ const _setAnalyticsTags = (): void => {
 }
 
 // NOTE: this code snippet is distributed by Fullstory and formatting has been maintained
-window['_fs_debug'] = false
-window['_fs_host'] = 'fullstory.com'
-window['_fs_org'] = process.env.OT_PD_FULLSTORY_ORG
-window['_fs_namespace'] = 'FS'
+window._fs_debug = false
+window._fs_host = 'fullstory.com'
+window._fs_org = process.env.OT_PD_FULLSTORY_ORG
+window._fs_namespace = 'FS'
 
 export const initializeFullstory = (): void => {
   ;(function (m, n, e, t, l, o, g: any, y: any) {
@@ -86,6 +86,6 @@ export const initializeFullstory = (): void => {
       g(o, v)
     }
     g.clearUserCookie = function () {}
-  })(global, global.document, global['_fs_namespace'], 'script', 'user')
+  })(global, global.document, global._fs_namespace, 'script', 'user')
   _setAnalyticsTags()
 }

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMix.tsx
@@ -80,12 +80,12 @@ export const BatchEditMix = (props: BatchEditMixProps): JSX.Element => {
           >
             <Box className={styles.form_row}>
               <FlowRateField
-                {...propsForFields['aspirate_flowRate']}
+                {...propsForFields.aspirate_flowRate}
                 pipetteId={getPipetteIdForForm()}
                 flowRateType="aspirate"
               />
               <TipPositionField
-                {...propsForFields['mix_mmFromBottom']}
+                {...propsForFields.mix_mmFromBottom}
                 labwareId={getLabwareIdForPositioningField('mix_mmFromBottom')}
               />
               <WellOrderField
@@ -96,10 +96,10 @@ export const BatchEditMix = (props: BatchEditMixProps): JSX.Element => {
                 firstName="mix_wellOrder_first"
                 secondName="mix_wellOrder_second"
                 updateFirstWellOrder={
-                  propsForFields['mix_wellOrder_first'].updateValue
+                  propsForFields.mix_wellOrder_first.updateValue
                 }
                 updateSecondWellOrder={
-                  propsForFields['mix_wellOrder_second'].updateValue
+                  propsForFields.mix_wellOrder_second.updateValue
                 }
               />
             </Box>
@@ -121,7 +121,7 @@ export const BatchEditMix = (props: BatchEditMixProps): JSX.Element => {
           >
             <Box className={styles.form_row}>
               <FlowRateField
-                {...propsForFields['dispense_flowRate']}
+                {...propsForFields.dispense_flowRate}
                 pipetteId={getPipetteIdForForm()}
                 flowRateType="dispense"
               />
@@ -135,24 +135,24 @@ export const BatchEditMix = (props: BatchEditMixProps): JSX.Element => {
               propsForFields={propsForFields}
             />
             <CheckboxRowField
-              {...propsForFields['mix_touchTip_checkbox']}
+              {...propsForFields.mix_touchTip_checkbox}
               label={i18n.t('form.step_edit_form.field.touchTip.label')}
               className={styles.small_field}
             >
               <TipPositionField
-                {...propsForFields['mix_touchTip_mmFromBottom']}
+                {...propsForFields.mix_touchTip_mmFromBottom}
                 labwareId={getLabwareIdForPositioningField(
                   'mix_touchTip_mmFromBottom'
                 )}
               />
             </CheckboxRowField>
             <CheckboxRowField
-              {...propsForFields['blowout_checkbox']}
+              {...propsForFields.blowout_checkbox}
               label={i18n.t('form.step_edit_form.field.blowout.label')}
               className={styles.small_field}
             >
               <BlowoutLocationField
-                {...propsForFields['blowout_location']}
+                {...propsForFields.blowout_location}
                 className={styles.full_width}
                 options={getBlowoutLocationOptionsForForm({
                   stepType: 'mix',

--- a/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
+++ b/protocol-designer/src/components/BatchEditForm/BatchEditMoveLiquid.tsx
@@ -97,7 +97,7 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
 
       {prefix === 'aspirate' && (
         <CheckboxRowField
-          {...propsForFields['preWetTip']}
+          {...propsForFields.preWetTip}
           label={i18n.t('form.step_edit_form.field.preWetTip.label')}
           className={styles.small_field}
         />
@@ -132,15 +132,15 @@ const SourceDestBatchEditMoveLiquidFields = (props: {
 
       {prefix === 'dispense' && (
         <CheckboxRowField
-          {...propsForFields['blowout_checkbox']}
+          {...propsForFields.blowout_checkbox}
           label={i18n.t('form.step_edit_form.field.blowout.label')}
           className={styles.small_field}
         >
           <BlowoutLocationField
-            {...propsForFields['blowout_location']}
+            {...propsForFields.blowout_location}
             className={styles.full_width}
             options={getBlowoutLocationOptionsForForm({
-              path: propsForFields['path'].value as any,
+              path: propsForFields.path.value as any,
               stepType: 'moveLiquid',
             })}
           />

--- a/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
+++ b/protocol-designer/src/components/DeckSetup/DeckSetup.tsx
@@ -368,7 +368,7 @@ export const DeckSetup = (props: DeckSetupProps): JSX.Element => {
   const showGen1MultichannelCollisionWarnings =
     !_disableCollisionWarnings && _hasGen1MultichannelPipette
 
-  const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
+  const deckDef = React.useMemo(() => getDeckDefinitions().ot2_standard, [])
   const wrapperRef: React.RefObject<HTMLDivElement> = useOnClickOutside({
     onClickOutside: props.handleClickOutside,
   })
@@ -405,7 +405,7 @@ export const DeckSetup = (props: DeckSetupProps): JSX.Element => {
 }
 
 export const NullDeckState = (): JSX.Element => {
-  const deckDef = React.useMemo(() => getDeckDefinitions()['ot2_standard'], [])
+  const deckDef = React.useMemo(() => getDeckDefinitions().ot2_standard, [])
 
   return (
     <div className={styles.deck_row}>

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
@@ -29,7 +29,7 @@ export const LabwareHighlight = (
   if (
     formData &&
     formData.stepType === 'thermocycler' &&
-    formData['thermocyclerFormType'] === THERMOCYCLER_PROFILE
+    formData.thermocyclerFormType === THERMOCYCLER_PROFILE
   ) {
     isTcProfile = true
   }

--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -135,7 +135,7 @@ export class FilePage extends React.Component<Props, State> {
                       placeholder="Untitled"
                       name="protocolName"
                       onChange={handleChange}
-                      value={values['protocolName']}
+                      value={values.protocolName}
                     />
                   </FormGroup>
 

--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
@@ -65,7 +65,7 @@ const DisposalVolumeFieldComponent = (props: Props): JSX.Element => {
   const volumeField = (
     <div>
       <TextField
-        {...propsForFields['disposalVolume_volume']}
+        {...propsForFields.disposalVolume_volume}
         caption={volumeBoundsCaption}
         className={cx(styles.small_field, styles.orphan_field)}
         units={i18n.t('application.units.microliter')}
@@ -73,7 +73,7 @@ const DisposalVolumeFieldComponent = (props: Props): JSX.Element => {
     </div>
   )
 
-  const { value, updateValue } = propsForFields['disposalVolume_checkbox']
+  const { value, updateValue } = propsForFields.disposalVolume_checkbox
 
   return (
     <FormGroup label={i18n.t('form.step_edit_form.multiDispenseOptionsLabel')}>
@@ -96,7 +96,7 @@ const DisposalVolumeFieldComponent = (props: Props): JSX.Element => {
           <div className={styles.checkbox_row}>
             <div className={styles.sub_label_no_checkbox}>Blowout</div>
             <DropdownFormField
-              {...propsForFields['blowout_location']}
+              {...propsForFields.blowout_location}
               className={styles.large_field}
               options={props.disposalDestinationOptions}
             />

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
@@ -135,7 +135,7 @@ const mapSTP = (state: BaseState, ownProps: OP): SP => {
       .def
 
     // NOTE: only taking depth of first well in labware def, UI not currently equipped for multiple depths
-    const firstWell = labwareDef.wells['A1']
+    const firstWell = labwareDef.wells.A1
     if (firstWell) wellDepthMm = getWellsDepth(labwareDef, ['A1'])
   }
 

--- a/protocol-designer/src/components/StepEditForm/forms/MagnetForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MagnetForm.tsx
@@ -55,7 +55,7 @@ export const MagnetForm = (props: StepFormProps): JSX.Element => {
           className={styles.magnet_form_group}
         >
           <RadioGroupField
-            {...propsForFields['magnetAction']}
+            {...propsForFields.magnetAction}
             options={[
               {
                 name: i18n.t(
@@ -66,7 +66,7 @@ export const MagnetForm = (props: StepFormProps): JSX.Element => {
             ]}
           />
           <RadioGroupField
-            {...propsForFields['magnetAction']}
+            {...propsForFields.magnetAction}
             options={[
               {
                 name: i18n.t(
@@ -83,7 +83,7 @@ export const MagnetForm = (props: StepFormProps): JSX.Element => {
             className={styles.magnet_form_group}
           >
             <TextField
-              {...propsForFields['engageHeight']}
+              {...propsForFields.engageHeight}
               caption={engageHeightCaption}
               className={styles.small_field}
             />

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
@@ -42,9 +42,9 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
         </span>
       </div>
       <div className={styles.form_row}>
-        <PipetteField {...propsForFields['pipette']} />
+        <PipetteField {...propsForFields.pipette} />
         <VolumeField
-          {...propsForFields['volume']}
+          {...propsForFields.volume}
           label={i18n.t('form.step_edit_form.mixVolumeLabel')}
           stepType="mix"
           className={styles.small_field}
@@ -54,7 +54,7 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
           label={i18n.t('form.step_edit_form.mixRepetitions')}
         >
           <TextField
-            {...propsForFields['times']}
+            {...propsForFields.times}
             units={i18n.t('application.units.times')}
           />
         </FormGroup>
@@ -64,12 +64,12 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
           label={i18n.t('form.step_edit_form.labwareLabel.mixLabware')}
           className={styles.large_field}
         >
-          <LabwareField {...propsForFields['labware']} />
+          <LabwareField {...propsForFields.labware} />
         </FormGroup>
         <WellSelectionField
-          {...propsForFields['wells']}
-          labwareId={formData['labware']}
-          pipetteId={formData['pipette']}
+          {...propsForFields.wells}
+          labwareId={formData.labware}
+          pipetteId={formData.pipette}
         />
       </div>
       <div className={styles.section_divider} />
@@ -96,12 +96,12 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
           <div className={styles.section_column}>
             <div className={styles.form_row}>
               <FlowRateField
-                {...propsForFields['aspirate_flowRate']}
+                {...propsForFields.aspirate_flowRate}
                 pipetteId={formData.pipette}
                 flowRateType="aspirate"
               />
               <TipPositionField
-                {...propsForFields['mix_mmFromBottom']}
+                {...propsForFields.mix_mmFromBottom}
                 labwareId={
                   formData[
                     getLabwareFieldForPositioningField('mix_mmFromBottom')
@@ -110,15 +110,15 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
               />
               <WellOrderField
                 updateFirstWellOrder={
-                  propsForFields['mix_wellOrder_first'].updateValue
+                  propsForFields.mix_wellOrder_first.updateValue
                 }
                 updateSecondWellOrder={
-                  propsForFields['mix_wellOrder_second'].updateValue
+                  propsForFields.mix_wellOrder_second.updateValue
                 }
                 prefix="mix"
                 label={i18n.t('form.step_edit_form.field.well_order.label')}
-                firstValue={formData['mix_wellOrder_first']}
-                secondValue={formData['mix_wellOrder_second']}
+                firstValue={formData.mix_wellOrder_first}
+                secondValue={formData.mix_wellOrder_second}
                 firstName={'mix_wellOrder_first'}
                 secondName={'mix_wellOrder_second'}
               />
@@ -140,7 +140,7 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
           <div className={styles.section_column}>
             <div className={styles.form_row}>
               <FlowRateField
-                {...propsForFields['dispense_flowRate']}
+                {...propsForFields.dispense_flowRate}
                 pipetteId={formData.pipette}
                 flowRateType="dispense"
               />
@@ -159,12 +159,12 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
                 }
               />
               <CheckboxRowField
-                {...propsForFields['mix_touchTip_checkbox']}
+                {...propsForFields.mix_touchTip_checkbox}
                 className={styles.small_field}
                 label={i18n.t('form.step_edit_form.field.touchTip.label')}
               >
                 <TipPositionField
-                  {...propsForFields['mix_touchTip_mmFromBottom']}
+                  {...propsForFields.mix_touchTip_mmFromBottom}
                   labwareId={
                     formData[
                       getLabwareFieldForPositioningField(
@@ -176,12 +176,12 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
               </CheckboxRowField>
 
               <CheckboxRowField
-                {...propsForFields['blowout_checkbox']}
+                {...propsForFields.blowout_checkbox}
                 className={styles.small_field}
                 label={i18n.t('form.step_edit_form.field.blowout.label')}
               >
                 <BlowoutLocationField
-                  {...propsForFields['blowout_location']}
+                  {...propsForFields.blowout_location}
                   className={styles.full_width}
                   options={getBlowoutLocationOptionsForForm({
                     stepType: formData.stepType,
@@ -201,7 +201,7 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
       <div className={styles.section_wrapper}>
         <div className={styles.form_row}>
           <ChangeTipField
-            {...propsForFields['changeTip']}
+            {...propsForFields.changeTip}
             aspirateWells={formData.aspirate_wells}
             dispenseWells={formData.dispense_wells}
             path={formData.path}

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -101,7 +101,7 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
         {prefix === 'aspirate' && (
           <React.Fragment>
             <CheckboxRowField
-              {...propsForFields['preWetTip']}
+              {...propsForFields.preWetTip}
               label={i18n.t('form.step_edit_form.field.preWetTip.label')}
               className={styles.small_field}
             />
@@ -134,12 +134,12 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
 
         {prefix === 'dispense' && (
           <CheckboxRowField
-            {...propsForFields['blowout_checkbox']}
+            {...propsForFields.blowout_checkbox}
             label={i18n.t('form.step_edit_form.field.blowout.label')}
             className={styles.small_field}
           >
             <BlowoutLocationField
-              {...propsForFields['blowout_location']}
+              {...propsForFields.blowout_location}
               className={styles.full_width}
               options={getBlowoutLocationOptionsForForm({
                 path: formData.path,

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestHeaders.tsx
@@ -43,7 +43,7 @@ export const SourceDestHeaders = (props: Props): JSX.Element => {
         <WellSelectionField
           {...propsForFields[addFieldNamePrefix('wells')]}
           labwareId={formData[addFieldNamePrefix('labware')]}
-          pipetteId={formData['pipette']}
+          pipetteId={formData.pipette}
         />
       </div>
     </AspDispSection>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
@@ -32,9 +32,9 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
         </span>
       </div>
       <div className={styles.form_row}>
-        <PipetteField {...propsForFields['pipette']} />
+        <PipetteField {...propsForFields.pipette} />
         <VolumeField
-          {...propsForFields['volume']}
+          {...propsForFields.volume}
           label={i18n.t('form.step_edit_form.field.volume.label')}
           stepType={stepType}
           className={styles.large_field}
@@ -87,14 +87,14 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
       <div className={styles.section_wrapper}>
         <div className={cx(styles.form_row, styles.section_column)}>
           <ChangeTipField
-            {...propsForFields['changeTip']}
+            {...propsForFields.changeTip}
             aspirateWells={formData.aspirate_wells}
             dispenseWells={formData.dispense_wells}
             path={formData.path}
             stepType={formData.stepType}
           />
           <PathField
-            {...propsForFields['path']}
+            {...propsForFields.path}
             aspirate_airGap_checkbox={formData.aspirate_airGap_checkbox}
             aspirate_airGap_volume={formData.aspirate_airGap_volume}
             aspirate_wells={formData.aspirate_wells}

--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
@@ -51,7 +51,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
         <div className={styles.section_column}>
           <div className={styles.checkbox_row}>
             <RadioGroupField
-              {...propsForFields['pauseAction']}
+              {...propsForFields.pauseAction}
               options={[
                 {
                   name: i18n.t(
@@ -64,7 +64,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
           </div>
           <div className={styles.checkbox_row}>
             <RadioGroupField
-              {...propsForFields['pauseAction']}
+              {...propsForFields.pauseAction}
               options={[
                 {
                   name: i18n.t(
@@ -78,17 +78,17 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
           {pauseAction === PAUSE_UNTIL_TIME && (
             <div className={styles.form_row}>
               <TextField
-                {...propsForFields['pauseHour']}
+                {...propsForFields.pauseHour}
                 className={styles.small_field}
                 units={i18n.t('application.units.hours')}
               />
               <TextField
-                {...propsForFields['pauseMinute']}
+                {...propsForFields.pauseMinute}
                 className={styles.small_field}
                 units={i18n.t('application.units.minutes')}
               />
               <TextField
-                {...propsForFields['pauseSecond']}
+                {...propsForFields.pauseSecond}
                 className={styles.small_field}
                 units={i18n.t('application.units.seconds')}
               />
@@ -103,7 +103,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
           <div {...targetProps}>
             <div className={styles.checkbox_row}>
               <RadioGroupField
-                {...propsForFields['pauseAction']}
+                {...propsForFields.pauseAction}
                 className={cx({
                   [styles.disabled]: !pauseUntilTempEnabled,
                 })}
@@ -125,7 +125,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
                   )}
                 >
                   <StepFormDropdown
-                    {...propsForFields['moduleId']}
+                    {...propsForFields.moduleId}
                     options={moduleLabwareOptions}
                   />
                 </FormGroup>
@@ -135,7 +135,7 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
                   )}
                 >
                   <TextField
-                    {...propsForFields['pauseTemperature']}
+                    {...propsForFields.pauseTemperature}
                     className={styles.small_field}
                     units={i18n.t('application.units.degrees')}
                   />
@@ -153,11 +153,9 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
             >
               <textarea
                 className={styles.textarea_field}
-                value={propsForFields['pauseMessage'].value as string}
+                value={propsForFields.pauseMessage.value as string}
                 onChange={(e: React.ChangeEvent<any>) =>
-                  propsForFields['pauseMessage'].updateValue(
-                    e.currentTarget.value
-                  )
+                  propsForFields.pauseMessage.updateValue(e.currentTarget.value)
                 }
               />
             </FormGroup>

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
@@ -32,7 +32,7 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
           className={styles.temperature_form_group}
         >
           <StepFormDropdown
-            {...propsForFields['moduleId']}
+            {...propsForFields.moduleId}
             options={moduleLabwareOptions}
           />
         </FormGroup>
@@ -53,7 +53,7 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
           <>
             <div className={styles.checkbox_row}>
               <RadioGroupField
-                {...propsForFields['setTemperature']}
+                {...propsForFields.setTemperature}
                 options={[
                   {
                     name: i18n.t(
@@ -65,7 +65,7 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
               />
               {setTemperature === 'true' && (
                 <TextField
-                  {...propsForFields['targetTemperature']}
+                  {...propsForFields.targetTemperature}
                   className={styles.small_field}
                   units={i18n.t('application.units.degrees')}
                 />
@@ -73,7 +73,7 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
             </div>
             <div className={styles.checkbox_row}>
               <RadioGroupField
-                {...propsForFields['setTemperature']}
+                {...propsForFields.setTemperature}
                 options={[
                   {
                     name: i18n.t(

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/ProfileSettings.tsx
@@ -22,7 +22,7 @@ export const ProfileSettings = (props: Props): JSX.Element => {
         className={styles.profile_settings_group}
       >
         <TextField
-          {...propsForFields['profileVolume']}
+          {...propsForFields.profileVolume}
           className={styles.small_field}
           units={i18n.t('application.units.microliter')}
         />
@@ -32,7 +32,7 @@ export const ProfileSettings = (props: Props): JSX.Element => {
         className={styles.profile_settings_group}
       >
         <TextField
-          {...propsForFields['profileTargetLidTemp']}
+          {...propsForFields.profileTargetLidTemp}
           className={styles.small_field}
           units={i18n.t('application.units.degrees')}
         />

--- a/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/ThermocyclerForm/index.tsx
@@ -22,7 +22,7 @@ export const ThermocyclerForm = (props: StepFormProps): JSX.Element => {
       <div className={styles.tc_step_group}>
         <div className={styles.checkbox_row}>
           <RadioGroupField
-            {...propsForFields['thermocyclerFormType']}
+            {...propsForFields.thermocyclerFormType}
             className={styles.tc_step_option}
             options={[
               {
@@ -34,13 +34,12 @@ export const ThermocyclerForm = (props: StepFormProps): JSX.Element => {
             ]}
           />
         </div>
-        {propsForFields['thermocyclerFormType']?.value ===
-          THERMOCYCLER_STATE && (
+        {propsForFields.thermocyclerFormType?.value === THERMOCYCLER_STATE && (
           <StateFields propsForFields={propsForFields} formData={formData} />
         )}
         <div className={styles.checkbox_row}>
           <RadioGroupField
-            {...propsForFields['thermocyclerFormType']}
+            {...propsForFields.thermocyclerFormType}
             className={styles.tc_step_option}
             options={[
               {
@@ -54,8 +53,7 @@ export const ThermocyclerForm = (props: StepFormProps): JSX.Element => {
         </div>
       </div>
 
-      {propsForFields['thermocyclerFormType']?.value ===
-        THERMOCYCLER_PROFILE && (
+      {propsForFields.thermocyclerFormType?.value === THERMOCYCLER_PROFILE && (
         <div className={styles.profile_form}>
           <div className={styles.section_header}>
             <span className={styles.section_header_text}>

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
@@ -155,9 +155,9 @@ describe('MixForm', () => {
         firstValue: 'r2l',
         secondValue: 'b2t',
         updateFirstWellOrder:
-          props.propsForFields['mix_wellOrder_first'].updateValue,
+          props.propsForFields.mix_wellOrder_first.updateValue,
         updateSecondWellOrder:
-          props.propsForFields['mix_wellOrder_second'].updateValue,
+          props.propsForFields.mix_wellOrder_second.updateValue,
       })
     })
   })

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/SourceDestFields.test.tsx
@@ -218,9 +218,9 @@ describe('SourceDestFields', () => {
         firstValue: 'r2l',
         secondValue: 'b2t',
         updateFirstWellOrder:
-          props.propsForFields['aspirate_wellOrder_first'].updateValue,
+          props.propsForFields.aspirate_wellOrder_first.updateValue,
         updateSecondWellOrder:
-          props.propsForFields['aspirate_wellOrder_second'].updateValue,
+          props.propsForFields.aspirate_wellOrder_second.updateValue,
       })
     })
   })
@@ -253,9 +253,9 @@ describe('SourceDestFields', () => {
         firstValue: 'l2r',
         secondValue: 't2b',
         updateFirstWellOrder:
-          props.propsForFields['dispense_wellOrder_first'].updateValue,
+          props.propsForFields.dispense_wellOrder_first.updateValue,
         updateSecondWellOrder:
-          props.propsForFields['dispense_wellOrder_second'].updateValue,
+          props.propsForFields.dispense_wellOrder_second.updateValue,
       })
     })
   })

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -432,8 +432,8 @@ export const StepItemContents = (
 
   // headers
   if (stepType === 'moveLiquid') {
-    const sourceLabwareId = rawForm['aspirate_labware']
-    const destLabwareId = rawForm['dispense_labware']
+    const sourceLabwareId = rawForm.aspirate_labware
+    const destLabwareId = rawForm.dispense_labware
 
     result.push(
       <AspirateDispenseHeader
@@ -445,7 +445,7 @@ export const StepItemContents = (
   }
 
   if (stepType === 'mix') {
-    const mixLabwareId = rawForm['labware']
+    const mixLabwareId = rawForm.labware
     result.push(
       <MixHeader
         key="mix-header"

--- a/protocol-designer/src/load-file/migration/1_1_0.ts
+++ b/protocol-designer/src/load-file/migration/1_1_0.ts
@@ -265,20 +265,18 @@ export function updateStepFormKeys(fileData: PDProtocolFile): PDProtocolFile {
       const updatedFields = {
         stepName: formData['step-name'],
         stepDetails: formData['step-details'],
-        changeTip: formData['aspirate_changeTip'],
-        blowout_checkbox: formData['dispense_blowout_checkbox'],
+        changeTip: formData.aspirate_changeTip,
+        blowout_checkbox: formData.dispense_blowout_checkbox,
         blowout_location:
-          formData['dispense_blowout_location'] ||
-          formData['dispense_blowout_labware'],
-        aspirate_touchTip_checkbox: formData['aspirate_touchTip'],
-        dispense_touchTip_checkbox: formData['dispense_touchTip'],
-        disposalVolume_checkbox: formData['aspirate_disposalVol_checkbox'],
-        disposalVolume_volume: formData['aspirate_disposalVol_volume'],
-        preWetTip: formData['aspirate_preWetTip'],
-        aspirate_touchTip_mmFromBottom:
-          formData['aspirate_touchTipMmFromBottom'],
-        dispense_touchTip_mmFromBottom:
-          formData['dispense_touchTipMmFromBottom'],
+          formData.dispense_blowout_location ||
+          formData.dispense_blowout_labware,
+        aspirate_touchTip_checkbox: formData.aspirate_touchTip,
+        dispense_touchTip_checkbox: formData.dispense_touchTip,
+        disposalVolume_checkbox: formData.aspirate_disposalVol_checkbox,
+        disposalVolume_volume: formData.aspirate_disposalVol_volume,
+        preWetTip: formData.aspirate_preWetTip,
+        aspirate_touchTip_mmFromBottom: formData.aspirate_touchTipMmFromBottom,
+        dispense_touchTip_mmFromBottom: formData.dispense_touchTipMmFromBottom,
       }
       return {
         ...omitBy(updatedFields, isUndefined),
@@ -288,16 +286,16 @@ export function updateStepFormKeys(fileData: PDProtocolFile): PDProtocolFile {
       const updatedFields = {
         stepName: formData['step-name'],
         stepDetails: formData['step-details'],
-        changeTip: formData['aspirate_changeTip'],
-        mix_mmFromBottom: formData['dispense_mmFromBottom'],
-        mix_wellOrder_first: formData['aspirate_wellOrder_first'],
-        mix_wellOrder_second: formData['aspirate_wellOrder_second'],
-        mix_touchTip_checkbox: formData['touchTip'],
-        blowout_checkbox: formData['dispense_blowout_checkbox'],
+        changeTip: formData.aspirate_changeTip,
+        mix_mmFromBottom: formData.dispense_mmFromBottom,
+        mix_wellOrder_first: formData.aspirate_wellOrder_first,
+        mix_wellOrder_second: formData.aspirate_wellOrder_second,
+        mix_touchTip_checkbox: formData.touchTip,
+        blowout_checkbox: formData.dispense_blowout_checkbox,
         blowout_location:
-          formData['dispense_blowout_location'] ||
-          formData['dispense_blowout_labware'],
-        mix_touchTip_mmFromBottom: formData['mix_touchTipMmFromBottom'],
+          formData.dispense_blowout_location ||
+          formData.dispense_blowout_labware,
+        mix_touchTip_mmFromBottom: formData.mix_touchTipMmFromBottom,
       }
       return {
         ...omitBy(updatedFields, isUndefined),
@@ -346,7 +344,7 @@ export function replaceTCDStepsWithMoveLiquidStep(
       aspirate_wells_grouped: false,
     }
     const pipetteEntities = mapValues(
-      fileData['pipettes'],
+      fileData.pipettes,
       (pipette, pipetteId) => ({
         ...pipette,
         tiprackModel:

--- a/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/1_1_0.test.ts
@@ -218,18 +218,16 @@ describe('updateStepFormKeys', () => {
       const oldFields =
         stubbedTCDStepsFile['designer-application'].data.savedStepForms['1']
       const addedFields = {
-        aspirate_touchTip_checkbox: oldFields['aspirate_touchTip'],
-        aspirate_touchTip_mmFromBottom:
-          oldFields['aspirate_touchTipMmFromBottom'],
-        blowout_checkbox: oldFields['dispense_blowout_checkbox'],
-        blowout_location: oldFields['dispense_blowout_location'],
-        changeTip: oldFields['aspirate_changeTip'],
-        dispense_touchTip_checkbox: oldFields['dispense_touchTip'],
-        dispense_touchTip_mmFromBottom:
-          oldFields['dispense_touchTipMmFromBottom'],
-        disposalVolume_checkbox: oldFields['aspirate_disposalVol_checkbox'],
-        disposalVolume_volume: oldFields['aspirate_disposalVol_volume'],
-        preWetTip: oldFields['aspirate_preWetTip'],
+        aspirate_touchTip_checkbox: oldFields.aspirate_touchTip,
+        aspirate_touchTip_mmFromBottom: oldFields.aspirate_touchTipMmFromBottom,
+        blowout_checkbox: oldFields.dispense_blowout_checkbox,
+        blowout_location: oldFields.dispense_blowout_location,
+        changeTip: oldFields.aspirate_changeTip,
+        dispense_touchTip_checkbox: oldFields.dispense_touchTip,
+        dispense_touchTip_mmFromBottom: oldFields.dispense_touchTipMmFromBottom,
+        disposalVolume_checkbox: oldFields.aspirate_disposalVol_checkbox,
+        disposalVolume_volume: oldFields.aspirate_disposalVol_volume,
+        preWetTip: oldFields.aspirate_preWetTip,
         stepName: oldFields['step-name'],
         stepDetails: oldFields['step-details'],
       }
@@ -302,14 +300,14 @@ describe('updateStepFormKeys', () => {
       const addedFields = {
         stepName: oldFields['step-name'],
         stepDetails: oldFields['step-details'],
-        changeTip: oldFields['aspirate_changeTip'],
-        mix_mmFromBottom: oldFields['dispense_mmFromBottom'],
-        mix_wellOrder_first: oldFields['aspirate_wellOrder_first'],
-        mix_wellOrder_second: oldFields['aspirate_wellOrder_second'],
-        mix_touchTip_checkbox: oldFields['touchTip'],
-        mix_touchTip_mmFromBottom: oldFields['mix_touchTipMmFromBottom'],
-        blowout_checkbox: oldFields['dispense_blowout_checkbox'],
-        blowout_location: oldFields['dispense_blowout_location'],
+        changeTip: oldFields.aspirate_changeTip,
+        mix_mmFromBottom: oldFields.dispense_mmFromBottom,
+        mix_wellOrder_first: oldFields.aspirate_wellOrder_first,
+        mix_wellOrder_second: oldFields.aspirate_wellOrder_second,
+        mix_touchTip_checkbox: oldFields.touchTip,
+        mix_touchTip_mmFromBottom: oldFields.mix_touchTipMmFromBottom,
+        blowout_checkbox: oldFields.dispense_blowout_checkbox,
+        blowout_location: oldFields.dispense_blowout_location,
       }
       each(Object.keys(addedFields), fieldName => {
         each(

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -301,9 +301,8 @@ describe('createPresavedStepForm', () => {
           }
         } else {
           const thermocyclerModuleState =
-            defaultArgs.robotStateTimeline.timeline[0].robotState.modules[
-              'someThermocyclerModuleId'
-            ]
+            defaultArgs.robotStateTimeline.timeline[0].robotState.modules
+              .someThermocyclerModuleId
           thermocyclerModuleState.moduleState = {
             ...thermocyclerModuleState.moduleState,
             blockTargetTemp: 42,

--- a/protocol-designer/src/step-forms/test/getProfileItemsHaveErrors.test.ts
+++ b/protocol-designer/src/step-forms/test/getProfileItemsHaveErrors.test.ts
@@ -28,7 +28,7 @@ describe('getProfileItemsHaveErrors', () => {
           },
         }
         mockGetProfileFieldErrors.mockImplementation((name, value) => {
-          expect(profileItems['itemA']).toHaveProperty(name, value)
+          expect(profileItems.itemA).toHaveProperty(name, value)
           return mockGetProfileFieldErrorsReturn
         })
         const result = getProfileItemsHaveErrors(profileItems)

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateThermocycler.ts
@@ -14,7 +14,7 @@ const updatePatchOnThermocyclerFormType = (
 ): FormPatch => {
   // Profile => State
   if (
-    rawForm['thermocyclerFormType'] !== null &&
+    rawForm.thermocyclerFormType !== null &&
     fieldHasChanged(rawForm, patch, 'thermocyclerFormType')
   ) {
     return {

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -70,10 +70,8 @@ export function getMaxDisposalVolumeForMultidispense(
   const pipetteEntity = pipetteEntities[pipetteId]
   const pipetteCapacity = getPipetteCapacity(pipetteEntity)
   const volume = Number(values.volume)
-  const airGapChecked = values['aspirate_airGap_checkbox']
-  let airGapVolume = airGapChecked
-    ? Number(values['aspirate_airGap_volume'])
-    : 0
+  const airGapChecked = values.aspirate_airGap_checkbox
+  let airGapVolume = airGapChecked ? Number(values.aspirate_airGap_volume) : 0
   airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
   return round(pipetteCapacity - volume * 2 - airGapVolume, DISPOSAL_VOL_DIGITS)
 }
@@ -91,10 +89,8 @@ export function volumeInCapacityForMulti(
   const pipetteEntity = pipetteEntities[rawForm.pipette]
   const pipetteCapacity = pipetteEntity && getPipetteCapacity(pipetteEntity)
   const volume = Number(rawForm.volume)
-  const airGapChecked = rawForm['aspirate_airGap_checkbox']
-  let airGapVolume = airGapChecked
-    ? Number(rawForm['aspirate_airGap_volume'])
-    : 0
+  const airGapChecked = rawForm.aspirate_airGap_checkbox
+  let airGapVolume = airGapChecked ? Number(rawForm.aspirate_airGap_volume) : 0
   airGapVolume = Number.isFinite(airGapVolume) ? airGapVolume : 0
   return rawForm.path === 'multiAspirate'
     ? volumeInCapacityForMultiAspirate({

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -25,34 +25,34 @@ export const mixFormToArgs = (
     orderFirst,
     orderSecond
   )
-  const touchTip = Boolean(hydratedFormData['mix_touchTip_checkbox'])
+  const touchTip = Boolean(hydratedFormData.mix_touchTip_checkbox)
   const touchTipMmFromBottom =
-    hydratedFormData['mix_touchTip_mmFromBottom'] ||
+    hydratedFormData.mix_touchTip_mmFromBottom ||
     getWellsDepth(labware.def, orderedWells) +
       DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP
   const volume = hydratedFormData.volume || 0
   const times = hydratedFormData.times || 0
   const aspirateFlowRateUlSec =
-    hydratedFormData['aspirate_flowRate'] ||
+    hydratedFormData.aspirate_flowRate ||
     pipette.spec.defaultAspirateFlowRate.value
   const dispenseFlowRateUlSec =
-    hydratedFormData['dispense_flowRate'] ||
+    hydratedFormData.dispense_flowRate ||
     pipette.spec.defaultDispenseFlowRate.value
   // NOTE: for mix, there is only one tip offset field,
   // and it applies to both aspirate and dispense
   const aspirateOffsetFromBottomMm =
-    hydratedFormData['mix_mmFromBottom'] || DEFAULT_MM_FROM_BOTTOM_ASPIRATE
+    hydratedFormData.mix_mmFromBottom || DEFAULT_MM_FROM_BOTTOM_ASPIRATE
   const dispenseOffsetFromBottomMm =
-    hydratedFormData['mix_mmFromBottom'] || DEFAULT_MM_FROM_BOTTOM_DISPENSE
+    hydratedFormData.mix_mmFromBottom || DEFAULT_MM_FROM_BOTTOM_DISPENSE
   // It's radiobutton, so one should always be selected.
   // One changeTip option should always be selected.
   assert(
-    hydratedFormData['changeTip'],
+    hydratedFormData.changeTip,
     'mixFormToArgs expected non-falsey changeTip option'
   )
-  const changeTip = hydratedFormData['changeTip'] || DEFAULT_CHANGE_TIP_OPTION
-  const blowoutLocation = hydratedFormData['blowout_checkbox']
-    ? hydratedFormData['blowout_location']
+  const changeTip = hydratedFormData.changeTip || DEFAULT_CHANGE_TIP_OPTION
+  const blowoutLocation = hydratedFormData.blowout_checkbox
+    ? hydratedFormData.blowout_location
     : null
   // Blowout settings
   const blowoutFlowRateUlSec = dispenseFlowRateUlSec

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/pauseFormToArgs.ts
@@ -8,12 +8,12 @@ import { AwaitTemperatureArgs, PauseArgs } from '@opentrons/step-generation'
 export const pauseFormToArgs = (
   formData: FormData
 ): PauseArgs | AwaitTemperatureArgs | null => {
-  const hours = parseFloat(formData['pauseHour']) || 0
-  const minutes = parseFloat(formData['pauseMinute']) || 0
-  const seconds = parseFloat(formData['pauseSecond']) || 0
+  const hours = parseFloat(formData.pauseHour) || 0
+  const minutes = parseFloat(formData.pauseMinute) || 0
+  const seconds = parseFloat(formData.pauseSecond) || 0
   const totalSeconds = hours * 3600 + minutes * 60 + seconds
-  const temperature = parseFloat(formData['pauseTemperature'])
-  const message = formData['pauseMessage'] || ''
+  const temperature = parseFloat(formData.pauseTemperature)
+  const message = formData.pauseMessage || ''
 
   switch (formData.pauseAction) {
     case PAUSE_UNTIL_TEMP:

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -53,7 +53,7 @@ export const getCollidingWells = (
     (acc: WellGroup, elem): WellGroup => {
       // TODO IMMEDIATELY no magic string 'wellname'
       if ('wellname' in elem.dataset) {
-        const wellName = elem.dataset['wellname']
+        const wellName = elem.dataset.wellname
         // @ts-expect-error(sa, 2021-6-21): wellName might be undefined
         return { ...acc, [wellName]: null }
       }

--- a/protocol-library-kludge/src/URLDeck.tsx
+++ b/protocol-library-kludge/src/URLDeck.tsx
@@ -26,7 +26,7 @@ interface UrlData {
   modules: Record<DeckSlotId, ModuleModel>
 }
 
-const DECK_DEF = getDeckDefinitions()['ot2_standard']
+const DECK_DEF = getDeckDefinitions().ot2_standard
 
 const DECK_LAYER_BLOCKLIST = [
   'calibrationMarkings',

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -59,7 +59,7 @@ export const getTiprackVolume = (labwareDef: LabwareDefinition2): number => {
     )}, but 'isTiprack' isn't true`
   )
   // NOTE: Ian 2019-04-16 assuming all tips are the same volume across the rack
-  const volume = labwareDef.wells['A1'].totalLiquidVolume
+  const volume = labwareDef.wells.A1.totalLiquidVolume
   assert(
     volume >= 0,
     `getTiprackVolume expected tip volume to be at least 0, got ${volume}`

--- a/shared-data/pipette/fixtures/name/index.ts
+++ b/shared-data/pipette/fixtures/name/index.ts
@@ -7,12 +7,12 @@ const pipetteNameSpecFixtures = _pipetteNameSpecFixtures as Record<
 >
 
 export const fixtureP10Single: PipetteNameSpecs =
-  pipetteNameSpecFixtures['p10_single']
+  pipetteNameSpecFixtures.p10_single
 export const fixtureP10Multi: PipetteNameSpecs =
-  pipetteNameSpecFixtures['p10_multi']
+  pipetteNameSpecFixtures.p10_multi
 export const fixtureP300Single: PipetteNameSpecs =
-  pipetteNameSpecFixtures['p300_single']
+  pipetteNameSpecFixtures.p300_single
 export const fixtureP300Multi: PipetteNameSpecs =
-  pipetteNameSpecFixtures['p300_multi']
+  pipetteNameSpecFixtures.p300_multi
 export const fixtureP1000Single: PipetteNameSpecs =
-  pipetteNameSpecFixtures['p1000_single']
+  pipetteNameSpecFixtures.p1000_single

--- a/step-generation/src/__tests__/modulePipetteCollision.test.ts
+++ b/step-generation/src/__tests__/modulePipetteCollision.test.ts
@@ -16,15 +16,15 @@ let collisionArgs: {
 }
 beforeEach(() => {
   invariantContext = makeContext()
-  invariantContext.moduleEntities['magDeckId'] = {
+  invariantContext.moduleEntities.magDeckId = {
     id: 'magDeckId',
     type: MAGNETIC_MODULE_TYPE,
     model: MAGNETIC_MODULE_V1,
   }
   robotState = getInitialRobotStateStandard(invariantContext)
-  robotState.labware['destPlateId'].slot = '4'
-  robotState.labware['tiprack1Id'].slot = '10'
-  robotState.modules['magDeckId'] = {
+  robotState.labware.destPlateId.slot = '4'
+  robotState.labware.tiprack1Id.slot = '10'
+  robotState.modules.magDeckId = {
     slot: '1',
     moduleState: {
       type: MAGNETIC_MODULE_TYPE,
@@ -57,7 +57,7 @@ describe('modulePipetteCollision', () => {
     )
   })
   it('should return false when module is GEN2', () => {
-    invariantContext.moduleEntities['magDeckId'].model = MAGNETIC_MODULE_V2
+    invariantContext.moduleEntities.magDeckId.model = MAGNETIC_MODULE_V2
     expect(
       modulePipetteCollision({
         pipette: 'p10MultiId',


### PR DESCRIPTION
## Overview

Biting off some warnings as noted in #8264. This was one of the easiest / safest ones I saw. Knocks out 165-ish warnings

## Changelog

- convert property access from bracket to dot where able
    - Remove warning override
    - Run `eslint --fix`
 
## Review requests

- `eslint --fix` did its job and only made style changes
- Should I guard the fullstory snippets?

## Risk assessment

Very low; code style only changes
