### PR TITLE
style(api): format Python files with black 

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -59,18 +59,6 @@ ot_tests_to_typecheck := \
 	tests/opentrons/protocol_engine \
 	tests/opentrons/protocol_runner
 
-# files and modules to format
-# TODO(mc, 2021-07-23): expand this to all files until we can format `.`
-ot_files_to_format := \
-	src/opentrons/motion_planning \
-	src/opentrons/protocol_api_experimental \
-	src/opentrons/protocol_engine \
-	src/opentrons/protocol_runner \
-	tests/opentrons/motion_planning  \
-	tests/opentrons/protocol_api_experimental \
-	tests/opentrons/protocol_engine \
-	tests/opentrons/protocol_runner
-
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'src/**/.mypy_cache'
@@ -107,13 +95,13 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy src/opentrons $(ot_tests_to_typecheck)
-	$(python) -m black --check $(ot_files_to_format)
-	$(python) -m flake8 setup.py src/opentrons tests
+	$(python) -m mypy src $(ot_tests_to_typecheck)
+	$(python) -m black --check src tests setup.py
+	$(python) -m flake8 src tests setup.py
 
 .PHONY: format
 format:
-	$(python) -m black $(ot_files_to_format)
+	$(python) -m black src tests setup.py
 
 docs/build/html/v%: docs/v%
 	$(sphinx_build) -b html -d docs/build/doctrees -n $< $@

--- a/api/setup.py
+++ b/api/setup.py
@@ -8,49 +8,51 @@ import os.path
 from setuptools import setup, find_packages
 
 HERE = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(os.path.join(HERE, '..', 'scripts'))
+sys.path.append(os.path.join(HERE, "..", "scripts"))
 
 from python_build_utils import normalize_version  # noqa: E402
 
 # make stdout blocking since Travis sets it to nonblocking
-if os.name == 'posix':
+if os.name == "posix":
     import fcntl
+
     flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL)
     fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
 
 
 def get_version():
-    buildno = os.getenv('BUILD_NUMBER')
+    buildno = os.getenv("BUILD_NUMBER")
     if buildno:
-        normalize_opts = {'extra_tag': buildno}
+        normalize_opts = {"extra_tag": buildno}
     else:
         normalize_opts = {}
-    return normalize_version('api', **normalize_opts)
+    return normalize_version("api", **normalize_opts)
 
 
 VERSION = get_version()
 
-DISTNAME = 'opentrons'
-LICENSE = 'Apache 2.0'
+DISTNAME = "opentrons"
+LICENSE = "Apache 2.0"
 AUTHOR = "Opentrons"
 EMAIL = "engineering@opentrons.com"
 URL = "https://github.com/OpenTrons/opentrons"
-DOWNLOAD_URL = ''
+DOWNLOAD_URL = ""
 CLASSIFIERS = [
-    'Development Status :: 5 - Production/Stable',
-    'Environment :: Console',
-    'Operating System :: OS Independent',
-    'Intended Audience :: Science/Research',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Topic :: Scientific/Engineering',
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Scientific/Engineering",
 ]
 KEYWORDS = ["robots", "protocols", "synbio", "pcr", "automation", "lab"]
 DESCRIPTION = (
     "The Opentrons API is a simple framework designed to make "
-    "writing automated biology lab protocols easy.")
-PACKAGES = find_packages(where='src')
+    "writing automated biology lab protocols easy."
+)
+PACKAGES = find_packages(where="src")
 INSTALL_REQUIRES = [
     f"opentrons-shared-data=={VERSION}",
     "aionotify==0.2.0",
@@ -75,7 +77,7 @@ def read(*parts):
 
 if __name__ == "__main__":
     setup(
-        python_requires='>=3.7',
+        python_requires=">=3.7",
         name=DISTNAME,
         description=DESCRIPTION,
         license=LICENSE,
@@ -91,18 +93,17 @@ if __name__ == "__main__":
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
         include_package_data=True,
-        package_dir={'': 'src'},
-        package_data={'opentrons': ['py.typed', 'package.json']},
+        package_dir={"": "src"},
+        package_data={"opentrons": ["py.typed", "package.json"]},
         entry_points={
-            'console_scripts': [
-                'opentrons_simulate = opentrons.simulate:main',
-                'opentrons_execute = opentrons.execute:main',
+            "console_scripts": [
+                "opentrons_simulate = opentrons.simulate:main",
+                "opentrons_execute = opentrons.execute:main",
             ]
         },
         project_urls={
-            'opentrons.com': "https://www.opentrons.com",
-            'Source Code On Github':
-            "https://github.com/Opentrons/opentrons/tree/edge/api",
-            'Documentation': "https://docs.opentrons.com"
-        }
+            "opentrons.com": "https://www.opentrons.com",
+            "Source Code On Github": "https://github.com/Opentrons/opentrons/tree/edge/api",  # noqa: E501
+            "Documentation": "https://docs.opentrons.com",
+        },
     )

--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -10,8 +10,13 @@ from typing import List, Tuple
 
 from opentrons.drivers.serial_communication import get_ports_by_name
 from opentrons.hardware_control import API, ThreadManager
-from opentrons.config import (feature_flags as ff, name,
-                              robot_configs, IS_ROBOT, ROBOT_FIRMWARE_DIR)
+from opentrons.config import (
+    feature_flags as ff,
+    name,
+    robot_configs,
+    IS_ROBOT,
+    ROBOT_FIRMWARE_DIR,
+)
 from opentrons.util import logging_config
 from opentrons.protocols.types import ApiDeprecationError
 from opentrons.protocols.api_support.types import APIVersion
@@ -19,24 +24,25 @@ from opentrons.protocols.api_support.types import APIVersion
 version = sys.version_info[0:2]
 if version < (3, 7):
     raise RuntimeError(
-        'opentrons requires Python 3.7 or above, this is {0}.{1}'.format(
-            version[0], version[1]))
+        "opentrons requires Python 3.7 or above, this is {0}.{1}".format(
+            version[0], version[1]
+        )
+    )
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 try:
-    with open(os.path.join(HERE, 'package.json')) as pkg:
+    with open(os.path.join(HERE, "package.json")) as pkg:
         package_json = json.load(pkg)
-        __version__ = package_json.get('version')
+        __version__ = package_json.get("version")
 except (FileNotFoundError, OSError):
-    __version__ = 'unknown'
+    __version__ = "unknown"
 
 from opentrons import config  # noqa: E402
 
-LEGACY_MODULES = [
-    'robot', 'reset', 'instruments', 'containers', 'labware', 'modules']
+LEGACY_MODULES = ["robot", "reset", "instruments", "containers", "labware", "modules"]
 
-__all__ = ['version', 'HERE', 'config']
+__all__ = ["version", "HERE", "config"]
 
 
 def __getattr__(attrname):
@@ -57,13 +63,14 @@ log = logging.getLogger(__name__)
 
 try:
     import systemd.daemon  # type: ignore
+
     systemdd_notify = partial(systemd.daemon.notify, "READY=1")
 except ImportError:
     log.info("Systemd couldn't be imported, not notifying")
     systemdd_notify = partial(lambda: None)
 
 
-SMOOTHIE_HEX_RE = re.compile('smoothie-(.*).hex')
+SMOOTHIE_HEX_RE = re.compile("smoothie-(.*).hex")
 
 
 def _find_smoothie_file() -> Tuple[Path, str]:
@@ -74,7 +81,7 @@ def _find_smoothie_file() -> Tuple[Path, str]:
     if IS_ROBOT:
         resources.extend(ROBOT_FIRMWARE_DIR.iterdir())  # type: ignore
 
-    resources_path = Path(HERE) / 'resources'
+    resources_path = Path(HERE) / "resources"
     resources.extend(resources_path.iterdir())
 
     for path in resources:
@@ -95,7 +102,7 @@ async def initialize_robot() -> ThreadManager:
     # Check if smoothie emulator is to be used
     port = os.environ.get("OT_SMOOTHIE_EMULATOR_URI")
     if not port:
-        smoothie_id = os.environ.get('OT_SMOOTHIE_ID', 'AMA')
+        smoothie_id = os.environ.get("OT_SMOOTHIE_ID", "AMA")
         # Let this raise an exception.
         port = get_ports_by_name(device_name=smoothie_id)[0]
 
@@ -103,16 +110,16 @@ async def initialize_robot() -> ThreadManager:
 
     packed_smoothie_fw_file, packed_smoothie_fw_ver = _find_smoothie_file()
     systemdd_notify()
-    hardware = ThreadManager(API.build_hardware_controller,
-                             threadmanager_nonblocking=True,
-                             port=port,
-                             firmware=(packed_smoothie_fw_file,
-                                       packed_smoothie_fw_ver))
+    hardware = ThreadManager(
+        API.build_hardware_controller,
+        threadmanager_nonblocking=True,
+        port=port,
+        firmware=(packed_smoothie_fw_file, packed_smoothie_fw_ver),
+    )
     try:
         await hardware.managed_thread_ready_async()
     except RuntimeError:
-        log.exception(
-            'Could not build hardware controller, forcing virtual')
+        log.exception("Could not build hardware controller, forcing virtual")
         return ThreadManager(API.build_hardware_simulator)
 
     loop = asyncio.get_event_loop()
@@ -136,8 +143,7 @@ async def initialize_robot() -> ThreadManager:
     return hardware
 
 
-async def initialize() \
-        -> ThreadManager:
+async def initialize() -> ThreadManager:
     """
     Initialize the Opentrons hardware returning a hardware instance.
     """

--- a/api/src/opentrons/algorithms/__init__.py
+++ b/api/src/opentrons/algorithms/__init__.py
@@ -1,4 +1,3 @@
-
 """Algorithms Module.
 
 This module should only contain generic implementations for

--- a/api/src/opentrons/algorithms/graph.py
+++ b/api/src/opentrons/algorithms/graph.py
@@ -16,9 +16,7 @@ class Vertex(Generic[VertexName, VertexLike]):
     of a graph.
     """
 
-    def __init__(
-            self, vertex: VertexLike,
-            neighbors: List[VertexName]) -> None:
+    def __init__(self, vertex: VertexLike, neighbors: List[VertexName]) -> None:
         """Vertex class initializer.
 
         :param vertex: A node dataclass
@@ -93,9 +91,11 @@ class Graph(Generic[VertexName, VertexLike]):
     # passed into sort. See
     # https://github.com/python/typing/issues/760
     def __init__(
-            self, sorted_graph: List[Vertex],
-            lookup_table: Dict[VertexName, Vertex],
-            sort_by: Callable[[Vertex], str]) -> None:
+        self,
+        sorted_graph: List[Vertex],
+        lookup_table: Dict[VertexName, Vertex],
+        sort_by: Callable[[Vertex], str],
+    ) -> None:
         """Graph class initializer.
 
         :param sorted_graph: The initial graph, sorted
@@ -110,8 +110,7 @@ class Graph(Generic[VertexName, VertexLike]):
         self._lookup_table = lookup_table
 
     @classmethod
-    def build(cls, graph: List[VertexLike],
-              sort_by: Callable = default_sort) -> Graph:
+    def build(cls, graph: List[VertexLike], sort_by: Callable = default_sort) -> Graph:
         """Graph class builder.
 
         :param graph: A list of nodes to add to the graph.

--- a/api/src/opentrons/algorithms/types.py
+++ b/api/src/opentrons/algorithms/types.py
@@ -8,7 +8,7 @@ from typing import TypeVar, Generic, List
 from dataclasses import dataclass
 
 
-VertexName = TypeVar('VertexName')
+VertexName = TypeVar("VertexName")
 
 
 @dataclass(frozen=True)
@@ -34,4 +34,4 @@ class GenericNode(Generic[VertexName]):
         return hash((self.name, *self.sub_names))
 
 
-VertexLike = TypeVar('VertexLike', bound=GenericNode)
+VertexLike = TypeVar("VertexLike", bound=GenericNode)

--- a/api/src/opentrons/api/__init__.py
+++ b/api/src/opentrons/api/__init__.py
@@ -2,9 +2,4 @@ from .session import Session, SessionManager
 from .routers import MainRouter
 from .calibration import CalibrationManager
 
-__all__ = [
-    'Session',
-    'SessionManager',
-    'MainRouter',
-    'CalibrationManager'
-]
+__all__ = ["Session", "SessionManager", "MainRouter", "CalibrationManager"]

--- a/api/src/opentrons/api/calibration.py
+++ b/api/src/opentrons/api/calibration.py
@@ -20,20 +20,21 @@ from .util import robot_is_busy, RobotBusy
 
 log = logging.getLogger(__name__)
 
-State = Union[Literal['moving'], Literal['ready']]
-VALID_STATES: Set[State] = {'moving', 'ready'}
+State = Union[Literal["moving"], Literal["ready"]]
+VALID_STATES: Set[State] = {"moving", "ready"}
 
 
 def _well0(cont: labware.Labware) -> labware.Well:
     return cont.wells()[0]
 
 
-Func = TypeVar('Func', bound=Callable)
+Func = TypeVar("Func", bound=Callable)
 
 
 def _home_if_first_call(func: Func) -> Func:
-    """ Decorator to make a function home if it is the first one called in
+    """Decorator to make a function home if it is the first one called in
     this session."""
+
     @functools.wraps(func)
     def decorated(*args: Any, **kwargs: Any) -> Any:
         self = args[0]
@@ -42,12 +43,13 @@ def _home_if_first_call(func: Func) -> Func:
             self._hardware.home()
             self._has_homed = True
         return func(*args, **kwargs)
+
     return cast(Func, decorated)
 
 
 class Message(TypedDict):
-    topic: Literal['calibration']
-    name: Literal['state']
+    topic: Literal["calibration"]
+    name: Literal["state"]
     payload: CalibrationManager
 
 
@@ -56,18 +58,20 @@ class CalibrationManager(RobotBusy):
     Serves endpoints that are primarily used in
     opentrons/app/ui/robot/api-client/client.js
     """
-    TOPIC: Final = 'calibration'
+
+    TOPIC: Final = "calibration"
 
     def __init__(
-            self,
-            hardware: SynchronousAdapter,
-            loop: asyncio.AbstractEventLoop = None,
-            broker: Broker = None,
-            lock: ThreadedAsyncLock = None) -> None:
+        self,
+        hardware: SynchronousAdapter,
+        loop: asyncio.AbstractEventLoop = None,
+        broker: Broker = None,
+        lock: ThreadedAsyncLock = None,
+    ) -> None:
         self._broker = broker or Broker()
         self._hardware = hardware
         self._loop = loop
-        self.state = 'ready'
+        self.state = "ready"
         self._lock = lock or ThreadedAsyncLock()
         self._has_homed = False
 
@@ -77,8 +81,7 @@ class CalibrationManager(RobotBusy):
 
     def _set_state(self, state: State) -> None:
         if state not in VALID_STATES:
-            raise ValueError(
-                'State {0} not in {1}'.format(state, VALID_STATES))
+            raise ValueError("State {0} not in {1}".format(state, VALID_STATES))
         self.state = state
         self._on_state_changed()
 
@@ -86,59 +89,71 @@ class CalibrationManager(RobotBusy):
     @_home_if_first_call
     def tip_probe(self, instrument: Instrument) -> None:
         log.warning("Deprecated call to tip_probe, update app")
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def pick_up_tip(self, instrument: Instrument, container: Container) -> None:
         if not isinstance(container, Container):
             raise ValueError(
-                'Invalid object type {0}. Expected models.Container'
-                .format(type(container)))
+                "Invalid object type {0}. Expected models.Container".format(
+                    type(container)
+                )
+            )
 
         inst = instrument._instrument
-        log.info('Picking up tip from {} in {} with {}'.format(
-            container.name, container.slot, instrument.name))
-        self._set_state('moving')
+        log.info(
+            "Picking up tip from {} in {} with {}".format(
+                container.name, container.slot, instrument.name
+            )
+        )
+        self._set_state("moving")
         with instrument._context.temp_connect(self._hardware):
             loc = _well0(container._container)
-            instrument._context.location_cache =\
-                Location(self._hardware.gantry_position(
+            instrument._context.location_cache = Location(
+                self._hardware.gantry_position(
                     Mount[inst.mount.upper()],
                     critical_point=CriticalPoint.NOZZLE,
-                    refresh=True),
-                    loc)
+                    refresh=True,
+                ),
+                loc,
+            )
             loc_leg = _well0(container._container)
             inst.pick_up_tip(loc_leg)
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def drop_tip(self, instrument: Instrument, container: Container) -> None:
         if not isinstance(container, Container):
             raise ValueError(
-                'Invalid object type {0}. Expected models.Container'
-                .format(type(container)))
+                "Invalid object type {0}. Expected models.Container".format(
+                    type(container)
+                )
+            )
 
         inst = instrument._instrument
-        log.info('Dropping tip from {} in {} with {}'.format(
-            container.name, container.slot, instrument.name))
-        self._set_state('moving')
+        log.info(
+            "Dropping tip from {} in {} with {}".format(
+                container.name, container.slot, instrument.name
+            )
+        )
+        self._set_state("moving")
         with instrument._context.temp_connect(self._hardware):
             instrument._context.location_cache = None
             inst.drop_tip(_well0(container._container))
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def return_tip(self, instrument: Instrument) -> None:
         inst = instrument._instrument
-        log.info('Returning tip from {}'.format(instrument.name))
-        self._set_state('moving')
+        log.info("Returning tip from {}".format(instrument.name))
+        self._set_state("moving")
         with instrument._context.temp_connect(self._hardware):
             instrument._context.location_cache = None
             inst.return_tip()
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
@@ -149,100 +164,107 @@ class CalibrationManager(RobotBusy):
     def _move_to_front(self, instrument: Instrument) -> None:
         """Private move_to_front that can be called internally"""
         inst = instrument._instrument
-        log.info('Moving {}'.format(instrument.name))
-        self._set_state('moving')
+        log.info("Moving {}".format(instrument.name))
+        self._set_state("moving")
         current = self._hardware.gantry_position(
+            Mount[inst.mount.upper()], critical_point=CriticalPoint.NOZZLE, refresh=True
+        )
+        dest = instrument._context.deck.position_for(5).point._replace(z=150)
+        self._hardware.move_to(
+            Mount[inst.mount.upper()], current, critical_point=CriticalPoint.NOZZLE
+        )
+        self._hardware.move_to(
             Mount[inst.mount.upper()],
+            dest._replace(z=current.z),
             critical_point=CriticalPoint.NOZZLE,
-            refresh=True)
-        dest = instrument._context.deck.position_for(5) \
-            .point._replace(z=150)
-        self._hardware.move_to(Mount[inst.mount.upper()],
-                               current,
-                               critical_point=CriticalPoint.NOZZLE)
-        self._hardware.move_to(Mount[inst.mount.upper()],
-                               dest._replace(z=current.z),
-                               critical_point=CriticalPoint.NOZZLE)
-        self._hardware.move_to(Mount[inst.mount.upper()],
-                               dest, critical_point=CriticalPoint.NOZZLE)
-        self._set_state('ready')
+        )
+        self._hardware.move_to(
+            Mount[inst.mount.upper()], dest, critical_point=CriticalPoint.NOZZLE
+        )
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def move_to(self, instrument: Instrument, container: Container) -> None:
         if not isinstance(container, Container):
             raise ValueError(
-                'Invalid object type {0}. Expected models.Container'
-                .format(type(container)))
+                "Invalid object type {0}. Expected models.Container".format(
+                    type(container)
+                )
+            )
 
         inst = instrument._instrument
         cont = container._container
         target = _well0(cont).top()
 
-        log.info('Moving {} to {} in {}'.format(
-            instrument.name, container.name, container.slot))
-        self._set_state('moving')
+        log.info(
+            "Moving {} to {} in {}".format(
+                instrument.name, container.name, container.slot
+            )
+        )
+        self._set_state("moving")
 
         with instrument._context.temp_connect(self._hardware):
             instrument._context.location_cache = None
             inst.move_to(target)
 
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def jog(self, instrument: Instrument, distance: float, axis: str) -> None:
         inst = instrument._instrument
-        log.info('Jogging {} by {} in {}'.format(
-            instrument.name, distance, axis))
-        self._set_state('moving')
+        log.info("Jogging {} by {} in {}".format(instrument.name, distance, axis))
+        self._set_state("moving")
         try:
             self._hardware.move_rel(
-                Mount[inst.mount.upper()], Point(**{axis: distance}),
-                check_bounds=MotionChecks.HIGH)
+                Mount[inst.mount.upper()],
+                Point(**{axis: distance}),
+                check_bounds=MotionChecks.HIGH,
+            )
         except OutOfBoundsMove:
-            log.exception('Out of bounds jog')
-        self._set_state('ready')
+            log.exception("Out of bounds jog")
+        self._set_state("ready")
 
     @robot_is_busy
     @_home_if_first_call
     def home(self, instrument: Instrument) -> None:
         inst = instrument._instrument
-        log.info('Homing {}'.format(instrument.name))
-        self._set_state('moving')
+        log.info("Homing {}".format(instrument.name))
+        self._set_state("moving")
         with instrument._context.temp_connect(self._hardware):
             instrument._context.location_cache = None
             inst.home()
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     def home_all(self, instrument: Instrument) -> None:
         # NOTE: this only takes instrument as a param, because we need
         # its reference to the ProtocolContext. This is code smell that
         # will be removed once sessions are managed better
-        log.info('Homing via Calibration Manager')
-        self._set_state('moving')
+        log.info("Homing via Calibration Manager")
+        self._set_state("moving")
         with instrument._context.temp_connect(self._hardware):
             instrument._context.home()
-        self._set_state('ready')
+        self._set_state("ready")
 
     @robot_is_busy
     def update_container_offset(
-            self, container: Container, instrument: Instrument) -> None:
+        self, container: Container, instrument: Instrument
+    ) -> None:
         inst = instrument._instrument
-        log.info('Updating {} in {}'.format(container.name, container.slot))
-        if 'centerMultichannelOnWells' in container._container.quirks:
+        log.info("Updating {} in {}".format(container.name, container.slot))
+        if "centerMultichannelOnWells" in container._container.quirks:
             cp: Optional[CriticalPoint] = CriticalPoint.XY_CENTER
         else:
             cp = None
-        here = self._hardware.gantry_position(Mount[inst.mount.upper()],
-                                              critical_point=cp,
-                                              refresh=True)
+        here = self._hardware.gantry_position(
+            Mount[inst.mount.upper()], critical_point=cp, refresh=True
+        )
         # Reset calibration so we don’t actually calibrate the offset
         # relative to the old calibration
         container._container.set_calibration(Point(0, 0, 0))
-        if ff.calibrate_to_bottom() and not (
-                container._container.is_tiprack):
+        if ff.calibrate_to_bottom() and not (container._container.is_tiprack):
             orig = _well0(container._container).geometry.bottom()
         else:
             orig = _well0(container._container).geometry.top()
@@ -251,9 +273,9 @@ class CalibrationManager(RobotBusy):
 
     def _snapshot(self) -> Message:
         return {
-            'topic': CalibrationManager.TOPIC,
-            'name': 'state',
-            'payload': copy(self)
+            "topic": CalibrationManager.TOPIC,
+            "name": "state",
+            "payload": copy(self),
         }
 
     def _on_state_changed(self) -> None:

--- a/api/src/opentrons/api/dev_types.py
+++ b/api/src/opentrons/api/dev_types.py
@@ -1,8 +1,7 @@
 from typing import Optional, List
 from typing_extensions import Literal, TypedDict
 
-State = Literal[
-    'loaded', 'running', 'finished', 'stopped', 'paused', 'error', None]
+State = Literal["loaded", "running", "finished", "stopped", "paused", "error", None]
 
 
 class StateInfo(TypedDict, total=False):
@@ -39,7 +38,7 @@ class SnapPayload(TypedDict):
 
 
 class Message(TypedDict):
-    topic: Literal['session']
+    topic: Literal["session"]
     payload: SnapPayload
 
 

--- a/api/src/opentrons/api/models.py
+++ b/api/src/opentrons/api/models.py
@@ -1,27 +1,26 @@
 from typing import cast, List, Optional, Tuple
 from opentrons.types import Point
-from opentrons.protocol_api import (
-    labware, InstrumentContext, ProtocolContext)
+from opentrons.protocol_api import labware, InstrumentContext, ProtocolContext
 
 from opentrons.protocols.geometry import module_geometry
 
 
 def _get_parent_slot_and_position(
-        labware_obj: labware.Labware) -> Tuple[str, Optional[Point]]:
+    labware_obj: labware.Labware,
+) -> Tuple[str, Optional[Point]]:
     if isinstance(labware_obj.parent, (module_geometry.ModuleGeometry)):
-        return (
-            cast(str, labware_obj.parent.parent),
-            labware_obj.parent.labware_offset)
+        return (cast(str, labware_obj.parent.parent), labware_obj.parent.labware_offset)
     else:
         return (cast(str, labware_obj.parent), None)
 
 
 class Container:
     def __init__(
-            self,
-            container: labware.Labware,
-            instruments: List[InstrumentContext],
-            context: ProtocolContext) -> None:
+        self,
+        container: labware.Labware,
+        instruments: List[InstrumentContext],
+        context: ProtocolContext,
+    ) -> None:
         self._container = container
         self._context = context
         self.id = id(container)
@@ -36,19 +35,19 @@ class Container:
         self.position = position
         self.is_legacy = False
         self.is_tiprack = container.is_tiprack
-        self.definition_hash = labware.get_labware_hash_with_parent(
-            container)
+        self.definition_hash = labware.get_labware_hash_with_parent(container)
         self.instruments = [
-            Instrument(instrument, [], self._context)
-            for instrument in instruments]
+            Instrument(instrument, [], self._context) for instrument in instruments
+        ]
 
 
 class Instrument:
     def __init__(
-            self,
-            instrument: InstrumentContext,
-            containers: List[labware.Labware],
-            context: ProtocolContext) -> None:
+        self,
+        instrument: InstrumentContext,
+        containers: List[labware.Labware],
+        context: ProtocolContext,
+    ) -> None:
         containers = containers or []
         self._instrument = instrument
         self._context = context
@@ -61,28 +60,29 @@ class Instrument:
         self.channels = instrument.channels
         self.mount = instrument.mount
         self.containers = [
-            Container(container, [], self._context)
-            for container in containers
+            Container(container, [], self._context) for container in containers
         ]
         self.tip_racks = [
             Container(container, [], self._context)
-            for container in instrument.tip_racks]
+            for container in instrument.tip_racks
+        ]
         if context:
-            self.tip_racks.extend([
-                c for c in self.containers if c._container.is_tiprack])
+            self.tip_racks.extend(
+                [c for c in self.containers if c._container.is_tiprack]
+            )
         self.requested_as = instrument.requested_as
 
 
 class Module:
     def __init__(
-            self,
-            module: module_geometry.ModuleGeometry,
-            context: ProtocolContext) -> None:
+        self, module: module_geometry.ModuleGeometry, context: ProtocolContext
+    ) -> None:
         self.id = id(module)
         _type_lookup = {
-            module_geometry.ModuleType.MAGNETIC: 'magdeck',
-            module_geometry.ModuleType.TEMPERATURE: 'tempdeck',
-            module_geometry.ModuleType.THERMOCYCLER: 'thermocycler'}
+            module_geometry.ModuleType.MAGNETIC: "magdeck",
+            module_geometry.ModuleType.TEMPERATURE: "tempdeck",
+            module_geometry.ModuleType.THERMOCYCLER: "thermocycler",
+        }
         self.name = _type_lookup[module.module_type]
         self.model = module.model.value
         self.slot = module.parent

--- a/api/src/opentrons/api/routers.py
+++ b/api/src/opentrons/api/routers.py
@@ -4,35 +4,32 @@ from opentrons.broker import Notifications, Broker
 from opentrons.hardware_control import ThreadManager, ThreadedAsyncLock
 from .session import SessionManager, Session
 from .dev_types import Message as SessionMessage
-from .calibration import (CalibrationManager, Message as CalibrationMessage)
+from .calibration import CalibrationManager, Message as CalibrationMessage
 
 
 class MainRouter:
     def __init__(
-            self,
-            hardware: ThreadManager,
-            loop: AbstractEventLoop = None,
-            lock: ThreadedAsyncLock = None) -> None:
+        self,
+        hardware: ThreadManager,
+        loop: AbstractEventLoop = None,
+        lock: ThreadedAsyncLock = None,
+    ) -> None:
         topics = [Session.TOPIC, CalibrationManager.TOPIC]
         self._broker = Broker()
         self._notifications: Notifications[
-            Union[SessionMessage, CalibrationMessage]] = Notifications(
-                topics, self._broker, loop=loop)
+            Union[SessionMessage, CalibrationMessage]
+        ] = Notifications(topics, self._broker, loop=loop)
 
         checked_hw = hardware.sync
         self.session_manager = SessionManager(
-            hardware=checked_hw,
-            loop=loop,
-            broker=self._broker,
-            lock=lock)
-        self.calibration_manager = CalibrationManager(hardware=checked_hw,
-                                                      loop=loop,
-                                                      broker=self._broker,
-                                                      lock=lock)
+            hardware=checked_hw, loop=loop, broker=self._broker, lock=lock
+        )
+        self.calibration_manager = CalibrationManager(
+            hardware=checked_hw, loop=loop, broker=self._broker, lock=lock
+        )
 
     @property
-    def notifications(self) -> Notifications[
-            Union[SessionMessage, CalibrationMessage]]:
+    def notifications(self) -> Notifications[Union[SessionMessage, CalibrationMessage]]:
         return self._notifications
 
     @property

--- a/api/src/opentrons/api/util.py
+++ b/api/src/opentrons/api/util.py
@@ -13,17 +13,18 @@ class RobotBusy(ABC):
         ...
 
 
-Func = TypeVar('Func', bound=Callable[..., Any])
+Func = TypeVar("Func", bound=Callable[..., Any])
 
 
 def robot_is_busy(func: Func) -> Func:
-    """ Decorator to mark a function as putting the robot in a busy
+    """Decorator to mark a function as putting the robot in a busy
     state. Simultaneous attempts to call a busy function (from same or
     separate thread) will result in an exception.
      Must wrap a class of type RobotBusy.
 
      :raises ThreadedAsyncForbidden: on call during busy.
-     """
+    """
+
     @functools.wraps(func)
     def decorated(*args: Any, **kwargs: Any) -> Any:
         self = args[0]
@@ -42,13 +43,15 @@ def requires_http_protocols_disabled(func: Func) -> Func:
 
     :raises RuntimeError: if enableHttpProtocolSessions is enabled
     """
+
     @functools.wraps(func)
     def decorated(*args: Any, **kwargs: Any) -> Any:
         if enable_http_protocol_sessions():
             raise RuntimeError(
                 "Please disable the 'Enable Experimental HTTP Protocol "
                 "Sessions' advanced setting for this robot if you'd like to "
-                "upload protocols from the Opentrons App")
+                "upload protocols from the Opentrons App"
+            )
         return func(*args, **kwargs)
 
     return cast(Func, decorated)

--- a/api/src/opentrons/broker.py
+++ b/api/src/opentrons/broker.py
@@ -4,8 +4,16 @@ from asyncio import Queue
 from contextlib import contextmanager
 import logging
 from typing import (
-    Any, Callable, Dict, Sequence, overload, Generic, TypeVar,
-    cast, TYPE_CHECKING)
+    Any,
+    Callable,
+    Dict,
+    Sequence,
+    overload,
+    Generic,
+    TypeVar,
+    cast,
+    TYPE_CHECKING,
+)
 from typing_extensions import Literal
 
 from opentrons.commands import types
@@ -21,7 +29,7 @@ MODULE_LOG = logging.getLogger(__name__)
 UntypedMessage = Dict[str, Any]
 
 
-_HandledMessages = TypeVar('_HandledMessages')
+_HandledMessages = TypeVar("_HandledMessages")
 
 
 class Notifications(Generic[_HandledMessages]):
@@ -30,7 +38,8 @@ class Notifications(Generic[_HandledMessages]):
         self.queue: Queue[UntypedMessage] = Queue(loop=self.loop)
         self.snoozed = False
         self._unsubscribe = [
-            broker.subscribe(topic, self.on_notify) for topic in topics]
+            broker.subscribe(topic, self.on_notify) for topic in topics
+        ]
 
     @contextmanager
     def snooze(self):
@@ -60,28 +69,29 @@ class Broker:
 
     @overload
     def subscribe(
-            self,
-            topic: Literal['command'],
-            handler: Callable[[types.CommandMessage], None]) -> Callable[[], None]: ...
+        self, topic: Literal["command"], handler: Callable[[types.CommandMessage], None]
+    ) -> Callable[[], None]:
+        ...
 
     @overload
     def subscribe(
-            self,
-            topic: Literal['calibration'],
-            handler: Callable[[CalibrationStateMessage], None])\
-        -> Callable[[], None]: ...
+        self,
+        topic: Literal["calibration"],
+        handler: Callable[[CalibrationStateMessage], None],
+    ) -> Callable[[], None]:
+        ...
 
     @overload
     def subscribe(
-            self,
-            topic: Literal['session'],
-            handler: Callable[[SessionStateMessage], None]) -> Callable[[], None]: ...
+        self, topic: Literal["session"], handler: Callable[[SessionStateMessage], None]
+    ) -> Callable[[], None]:
+        ...
 
     @overload
     def subscribe(
-            self,
-            topic: str,
-            handler: Callable[[UntypedMessage], None]) -> Callable[[], None]: ...
+        self, topic: str, handler: Callable[[UntypedMessage], None]
+    ) -> Callable[[], None]:
+        ...
 
     def subscribe(self, topic, handler):
         if handler in self.subscriptions.setdefault(topic, []):
@@ -94,21 +104,22 @@ class Broker:
         return unsubscribe
 
     @overload
-    def publish(
-            self, topic: Literal['command'], message: types.CommandMessage) -> None: ...
+    def publish(self, topic: Literal["command"], message: types.CommandMessage) -> None:
+        ...
 
     @overload
     def publish(
-            self,
-            topic: Literal['calibration'],
-            message: CalibrationStateMessage) -> None: ...
+        self, topic: Literal["calibration"], message: CalibrationStateMessage
+    ) -> None:
+        ...
 
     @overload
-    def publish(
-            self, topic: Literal['session'], message: SessionStateMessage) -> None: ...
+    def publish(self, topic: Literal["session"], message: SessionStateMessage) -> None:
+        ...
 
     @overload
-    def publish(self, topic: str, message: UntypedMessage) -> None: ...
+    def publish(self, topic: str, message: UntypedMessage) -> None:
+        ...
 
     def publish(self, topic, message):
         [handler(message) for handler in self.subscriptions.get(topic, [])]

--- a/api/src/opentrons/calibration_storage/delete.py
+++ b/api/src/opentrons/calibration_storage/delete.py
@@ -15,11 +15,9 @@ def clear_calibrations():
     Delete all calibration files for labware. This includes deleting tip-length
     data for tipracks.
     """
-    calibration_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    calibration_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
     try:
-        targets = [
-            f for f in calibration_path.iterdir() if f.suffix == '.json']
+        targets = [f for f in calibration_path.iterdir() if f.suffix == ".json"]
         for target in targets:
             target.unlink()
     except FileNotFoundError:
@@ -34,12 +32,11 @@ def _remove_offset_from_index(calibration_id: local_types.CalibrationID):
     :raises FileNotFoundError: If index file does not exist or
     the specified id is not in the index file.
     """
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    index_path = offset_path / 'index.json'
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    index_path = offset_path / "index.json"
     blob = io.read_cal_file(str(index_path))
 
-    del blob['data'][calibration_id]
+    del blob["data"][calibration_id]
     io.save_to_file(index_path, blob)
 
 
@@ -49,9 +46,8 @@ def delete_offset_file(calibration_id: local_types.CalibrationID):
 
     :param calibration_id: labware hash
     """
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    offset = offset_path / f'{calibration_id}.json'
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    offset = offset_path / f"{calibration_id}.json"
     try:
         _remove_offset_from_index(calibration_id)
         offset.unlink()
@@ -64,7 +60,7 @@ def _remove_tip_length_from_index(tiprack: str, pipette: str):
     Remove tip length data from the index file
     """
     tip_length_dir = config.get_tip_length_cal_path()
-    index_path = tip_length_dir / 'index.json'
+    index_path = tip_length_dir / "index.json"
     blob = io.read_cal_file(str(index_path))
 
     if tiprack in blob and pipette in blob[tiprack]:
@@ -81,7 +77,7 @@ def delete_tip_length_calibration(tiprack: str, pipette: str):
     :param pipette: pipette serial number
     """
     tip_length_dir = config.get_tip_length_cal_path()
-    tip_length_path = tip_length_dir / f'{pipette}.json'
+    tip_length_path = tip_length_dir / f"{pipette}.json"
     blob = io.read_cal_file(str(tip_length_path))
 
     if tiprack in blob:
@@ -99,8 +95,7 @@ def clear_tip_length_calibration():
     """
     tip_length_path = config.get_tip_length_cal_path()
     try:
-        targets = (
-            f for f in tip_length_path.iterdir() if f.suffix == '.json')
+        targets = (f for f in tip_length_path.iterdir() if f.suffix == ".json")
         for target in targets:
             target.unlink()
     except FileNotFoundError:
@@ -116,8 +111,8 @@ def _remove_pipette_offset_from_index(pipette: str, mount: Mount):
     :raises FileNotFoundError: If index file does not exist or
     the specified id is not in the index file.
     """
-    offset_dir = config.get_opentrons_path('pipette_calibration_dir')
-    index_path = offset_dir / 'index.json'
+    offset_dir = config.get_opentrons_path("pipette_calibration_dir")
+    index_path = offset_dir / "index.json"
     blob = io.read_cal_file(str(index_path))
 
     try:
@@ -136,8 +131,8 @@ def delete_pipette_offset_file(pipette: str, mount: Mount):
     :param pipette: pipette serial number
     :param mount: pipette mount
     """
-    offset_dir = config.get_opentrons_path('pipette_calibration_dir')
-    offset_path = offset_dir / mount.name.lower() / f'{pipette}.json'
+    offset_dir = config.get_opentrons_path("pipette_calibration_dir")
+    offset_path = offset_dir / mount.name.lower() / f"{pipette}.json"
 
     try:
         _remove_pipette_offset_from_index(pipette, mount)
@@ -155,10 +150,10 @@ def clear_pipette_offset_calibrations():
         for item in p.iterdir():
             if item.is_dir():
                 _remove_json_files_in_directories(item)
-            elif item.suffix == '.json':
+            elif item.suffix == ".json":
                 item.unlink()
 
-    offset_dir = config.get_opentrons_path('pipette_calibration_dir')
+    offset_dir = config.get_opentrons_path("pipette_calibration_dir")
     try:
         _remove_json_files_in_directories(offset_dir)
     except FileNotFoundError:
@@ -170,7 +165,7 @@ def delete_robot_deck_attitude():
     Delete the robot deck attitude calibration.
     """
 
-    robot_dir = config.get_opentrons_path('robot_calibration_dir')
-    gantry_path = robot_dir / 'deck_calibration.json'
+    robot_dir = config.get_opentrons_path("robot_calibration_dir")
+    gantry_path = robot_dir / "deck_calibration.json"
     if gantry_path.exists():
         gantry_path.unlink()

--- a/api/src/opentrons/calibration_storage/dev_types.py
+++ b/api/src/opentrons/calibration_storage/dev_types.py
@@ -18,7 +18,7 @@ class TipLengthCalibration(TypedDict):
     lastModified: datetime
     source: SourceType
     status: CalibrationStatusDict
-    uri: typing.Union[LabwareUri, Literal['']]
+    uri: typing.Union[LabwareUri, Literal[""]]
 
 
 class ModuleDict(TypedDict):
@@ -31,6 +31,7 @@ class CalibrationIndexDict(TypedDict):
     The dict that is returned from
     the index.json file.
     """
+
     uri: str
     slot: str
     module: ModuleDict
@@ -51,6 +52,7 @@ class CalibrationDict(TypedDict):
     The dict that is returned from a labware
     offset file.
     """
+
     default: OffsetDict
     tipLength: TipLengthDict
 

--- a/api/src/opentrons/calibration_storage/file_operators.py
+++ b/api/src/opentrons/calibration_storage/file_operators.py
@@ -18,8 +18,8 @@ EncoderType = typing.Type[json.JSONEncoder]
 
 
 def read_cal_file(
-        filepath: StrPath,
-        decoder: DecoderType = DateTimeDecoder) -> typing.Dict:
+    filepath: StrPath, decoder: DecoderType = DateTimeDecoder
+) -> typing.Dict:
     """
     Function used to read data from a file
 
@@ -34,23 +34,22 @@ def read_cal_file(
     # This can be done when the labware endpoints
     # are refactored to grab tip length calibration
     # from the correct locations.
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         calibration_data = json.load(f, cls=decoder)
     if isinstance(calibration_data.values(), dict):
         for value in calibration_data.values():
-            if value.get('lastModified'):
-                assert isinstance(
-                    value['lastModified'], datetime.datetime), \
-                    "invalid decoded value type for lastModified: got " \
-                    f"{type(value['lastModified']).__name__}," \
+            if value.get("lastModified"):
+                assert isinstance(value["lastModified"], datetime.datetime), (
+                    "invalid decoded value type for lastModified: got "
+                    f"{type(value['lastModified']).__name__},"
                     "expected datetime"
+                )
     return calibration_data
 
 
 def save_to_file(
-        filepath: StrPath,
-        data: typing.Mapping,
-        encoder: EncoderType = DateTimeEncoder):
+    filepath: StrPath, data: typing.Mapping, encoder: EncoderType = DateTimeEncoder
+):
     """
     Function used to save data to a file
 
@@ -59,5 +58,5 @@ def save_to_file(
     :param encoder: if there is any specialized encoder needed.
     The default encoder is the date time encoder.
     """
-    with open(filepath, 'w') as f:
+    with open(filepath, "w") as f:
         json.dump(data, f, cls=encoder)

--- a/api/src/opentrons/calibration_storage/get.py
+++ b/api/src/opentrons/calibration_storage/get.py
@@ -12,9 +12,8 @@ from typing_extensions import Literal
 from opentrons import config
 from opentrons.types import Point, Mount
 
-from . import (
-    types as local_types,
-    file_operators as io, helpers, migration, modify)
+from . import types as local_types, file_operators as io, helpers, migration, modify
+
 if typing.TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
     from opentrons_shared_data.pipette.dev_types import LabwareUri
@@ -25,28 +24,26 @@ log = logging.getLogger(__name__)
 
 
 def _format_calibration_type(
-        data: 'CalibrationDict') -> local_types.LabwareCalibrationTypes:
+    data: "CalibrationDict",
+) -> local_types.LabwareCalibrationTypes:
     offset = local_types.OffsetData(
-        value=data['default']['offset'],
-        last_modified=data['default']['lastModified']
+        value=data["default"]["offset"], last_modified=data["default"]["lastModified"]
     )
     # TODO(6/16): Tip calibration no longer exists in
     # the labware calibraiton file. We should
     # have a follow-up PR to grab tip lengths
     # based on the loaded pips + labware
     return local_types.LabwareCalibrationTypes(
-            offset=offset,
-            tip_length=local_types.TipLengthData())
+        offset=offset, tip_length=local_types.TipLengthData()
+    )
 
 
-def _format_parent(
-        data: 'CalibrationIndexDict')\
-            -> local_types.ParentOptions:
+def _format_parent(data: "CalibrationIndexDict") -> local_types.ParentOptions:
     # Since the slot is not saved and the data in the index is actually
     # the labware hash to aid lookup, we erase it here.
-    options = local_types.ParentOptions(slot='')
-    if data['module']:
-        options.module = data['module']['parent']
+    options = local_types.ParentOptions(slot="")
+    if data["module"]:
+        options.module = data["module"]["parent"]
     return options
 
 
@@ -59,23 +56,23 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
     labware calibration files found on the robot.
     """
     all_calibrations: typing.List[local_types.CalibrationInformation] = []
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    index_path = offset_path / 'index.json'
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    index_path = offset_path / "index.json"
     if not index_path.exists():
         return all_calibrations
 
     migration.check_index_version(index_path)
     index_file = io.read_cal_file(str(index_path))
-    calibration_index = index_file.get('data', {})
+    calibration_index = index_file.get("data", {})
     for key, data in calibration_index.items():
-        cal_path = offset_path / f'{key}.json'
+        cal_path = offset_path / f"{key}.json"
         if cal_path.exists():
             try:
                 cal_blob = io.read_cal_file(str(cal_path))
             except json.JSONDecodeError:
                 log.error(
-                    f"Skipping corrupt calibration file (bad JSON): {str(cal_path)}")
+                    f"Skipping corrupt calibration file (bad JSON): {str(cal_path)}"
+                )
                 continue
             calibration = _format_calibration_type(cal_blob)  # type: ignore
             try:
@@ -84,43 +81,47 @@ def get_all_calibrations() -> typing.List[local_types.CalibrationInformation]:
                         calibration=calibration,
                         parent=_format_parent(data),
                         labware_id=key,
-                        uri=data['uri']))
+                        uri=data["uri"],
+                    )
+                )
             except (KeyError, ValueError):
                 log.exception(
-                    f"Skipping corrupt calibration file (bad data) {str(cal_path)}")
+                    f"Skipping corrupt calibration file (bad data) {str(cal_path)}"
+                )
                 continue
     return all_calibrations
 
 
 def _get_tip_length_data(
-        pip_id: str, labware_hash: str,
-        labware_load_name: str, labware_uri: 'LabwareUri'
+    pip_id: str, labware_hash: str, labware_load_name: str, labware_uri: "LabwareUri"
 ) -> local_types.TipLengthCalibration:
     try:
-        pip_tip_length_path = config.get_tip_length_cal_path()/f'{pip_id}.json'
-        tip_rack_data =\
-            io.read_cal_file(str(pip_tip_length_path))
+        pip_tip_length_path = config.get_tip_length_cal_path() / f"{pip_id}.json"
+        tip_rack_data = io.read_cal_file(str(pip_tip_length_path))
         tip_length_info = tip_rack_data[labware_hash]
         return local_types.TipLengthCalibration(
-            tip_length=tip_length_info['tipLength'],
+            tip_length=tip_length_info["tipLength"],
             pipette=pip_id,
             tiprack=labware_hash,
-            last_modified=tip_length_info['lastModified'],
+            last_modified=tip_length_info["lastModified"],
             source=_get_calibration_source(tip_length_info),
             status=_get_calibration_status(tip_length_info),
-            uri=labware_uri)
+            uri=labware_uri,
+        )
     except (FileNotFoundError, KeyError, json.JSONDecodeError):
         raise local_types.TipLengthCalNotFound(
-            f'Tip length of {labware_load_name} has not been '
-            f'calibrated for this pipette: {pip_id} and cannot'
-            'be loaded')
+            f"Tip length of {labware_load_name} has not been "
+            f"calibrated for this pipette: {pip_id} and cannot"
+            "be loaded"
+        )
 
 
 def get_labware_calibration(
-        lookup_path: local_types.StrPath,
-        definition: 'LabwareDefinition',
-        parent: str = '',
-        slot: str = '') -> Point:
+    lookup_path: local_types.StrPath,
+    definition: "LabwareDefinition",
+    parent: str = "",
+    slot: str = "",
+) -> Point:
     """
     Find the delta of a given labware, if it exists.
 
@@ -128,23 +129,21 @@ def get_labware_calibration(
     :return: A point which represents the delta from well A1 origin of
     a labware
     """
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
     offset = Point(0, 0, 0)
     labware_path = offset_path / lookup_path
     if labware_path.exists():
         modify.add_existing_labware_to_index_file(definition, parent, slot)
-        migration.check_index_version(offset_path / 'index.json')
+        migration.check_index_version(offset_path / "index.json")
         calibration_data = io.read_cal_file(str(labware_path))
-        offset_array = calibration_data['default']['offset']
+        offset_array = calibration_data["default"]["offset"]
         offset = Point(x=offset_array[0], y=offset_array[1], z=offset_array[2])
     return offset
 
 
 def load_tip_length_calibration(
-        pip_id: str,
-        definition: 'LabwareDefinition'
-        ) -> local_types.TipLengthCalibration:
+    pip_id: str, definition: "LabwareDefinition"
+) -> local_types.TipLengthCalibration:
     """
     Function used to grab the current tip length associated
     with a particular tiprack.
@@ -154,16 +153,16 @@ def load_tip_length_calibration(
     """
     labware_hash = helpers.hash_labware_def(definition)
     labware_uri = helpers.uri_from_definition(definition)
-    load_name = definition['parameters']['loadName']
+    load_name = definition["parameters"]["loadName"]
     return _get_tip_length_data(
         pip_id=pip_id,
         labware_hash=labware_hash,
         labware_load_name=load_name,
-        labware_uri=labware_uri)
+        labware_uri=labware_uri,
+    )
 
 
-def get_all_tip_length_calibrations() \
-            -> typing.List[local_types.TipLengthCalibration]:
+def get_all_tip_length_calibrations() -> typing.List[local_types.TipLengthCalibration]:
     """
     A helper function that will list all of the tip length calibrations.
 
@@ -171,78 +170,81 @@ def get_all_tip_length_calibrations() \
     tip length calibration files found on the robot.
     """
     all_calibrations: typing.List[local_types.TipLengthCalibration] = []
-    tip_length_dir = config.get_opentrons_path('tip_length_calibration_dir')
-    index_path = tip_length_dir / 'index.json'
+    tip_length_dir = config.get_opentrons_path("tip_length_calibration_dir")
+    index_path = tip_length_dir / "index.json"
     if not index_path.exists():
         return all_calibrations
 
     index_file = io.read_cal_file(str(index_path))
     unique_pips = set(itertools.chain(*index_file.values()))
     for pip in unique_pips:
-        cal_path = tip_length_dir / f'{pip}.json'
+        cal_path = tip_length_dir / f"{pip}.json"
         if cal_path.exists():
             try:
                 data = io.read_cal_file(str(cal_path))
             except json.JSONDecodeError:
                 log.error(
-                    f"Skipping corrupt calibration file (bad json): {str(cal_path)}")
+                    f"Skipping corrupt calibration file (bad json): {str(cal_path)}"
+                )
                 continue
             for tiprack, info in data.items():
                 all_calibrations.append(
                     local_types.TipLengthCalibration(
-                        tip_length=info['tipLength'],
+                        tip_length=info["tipLength"],
                         pipette=pip,
                         tiprack=tiprack,
-                        last_modified=info['lastModified'],
+                        last_modified=info["lastModified"],
                         source=_get_calibration_source(info),
                         status=_get_calibration_status(info),
-                        uri=_get_tip_rack_uri(info)))
+                        uri=_get_tip_rack_uri(info),
+                    )
+                )
     return all_calibrations
 
 
 def _get_calibration_source(data: typing.Dict) -> local_types.SourceType:
-    if 'source' not in data.keys():
+    if "source" not in data.keys():
         return local_types.SourceType.unknown
     else:
-        return local_types.SourceType[data['source']]
+        return local_types.SourceType[data["source"]]
 
 
-def _get_calibration_status(
-        data: typing.Dict) -> local_types.CalibrationStatus:
-    if 'status' not in data.keys():
+def _get_calibration_status(data: typing.Dict) -> local_types.CalibrationStatus:
+    if "status" not in data.keys():
         return local_types.CalibrationStatus()
     else:
-        return local_types.CalibrationStatus(**data['status'])
+        return local_types.CalibrationStatus(**data["status"])
 
 
-def _get_tip_rack_uri(data: typing.Dict) -> typing.Union['LabwareUri', Literal['']]:
-    if 'uri' not in data.keys():
+def _get_tip_rack_uri(data: typing.Dict) -> typing.Union["LabwareUri", Literal[""]]:
+    if "uri" not in data.keys():
         # We cannot reverse look-up a labware definition using a hash
         # so we must return an empty string if no uri is found.
-        return ''
+        return ""
     else:
-        return typing.cast('LabwareUri', data['uri'])
+        return typing.cast("LabwareUri", data["uri"])
 
 
-def get_robot_deck_attitude() \
-            -> typing.Optional[local_types.DeckCalibration]:
-    robot_dir = config.get_opentrons_path('robot_calibration_dir')
-    gantry_path = robot_dir / 'deck_calibration.json'
+def get_robot_deck_attitude() -> typing.Optional[local_types.DeckCalibration]:
+    robot_dir = config.get_opentrons_path("robot_calibration_dir")
+    gantry_path = robot_dir / "deck_calibration.json"
     if gantry_path.exists():
         try:
             data = io.read_cal_file(gantry_path)
         except json.JSONDecodeError:
             log.error(
-                f"Skipping corrupt calibration file (bad json): {str(gantry_path)}")
+                f"Skipping corrupt calibration file (bad json): {str(gantry_path)}"
+            )
             return None
         try:
             return local_types.DeckCalibration(
-                attitude=data['attitude'],
+                attitude=data["attitude"],
                 source=_get_calibration_source(data),
-                pipette_calibrated_with=data['pipette_calibrated_with'],
-                tiprack=data['tiprack'],
-                last_modified=data['last_modified'],
-                status=_get_calibration_status(data))
+                pipette_calibrated_with=data["pipette_calibrated_with"],
+                tiprack=data["tiprack"],
+                last_modified=data["last_modified"],
+                status=_get_calibration_status(data),
+            )
         except Exception:
             return None
     else:
@@ -250,32 +252,34 @@ def get_robot_deck_attitude() \
 
 
 def get_pipette_offset(
-        pip_id: str,
-        mount: Mount
+    pip_id: str, mount: Mount
 ) -> typing.Optional[local_types.PipetteOffsetByPipetteMount]:
-    pip_dir = config.get_opentrons_path('pipette_calibration_dir')
-    offset_path = pip_dir / mount.name.lower() / f'{pip_id}.json'
+    pip_dir = config.get_opentrons_path("pipette_calibration_dir")
+    offset_path = pip_dir / mount.name.lower() / f"{pip_id}.json"
     if offset_path.exists():
         try:
             data = io.read_cal_file(offset_path)
         except json.JSONDecodeError:
             log.error(
-                f"Skipping corrupt calibration file (bad json): {str(offset_path)}")
+                f"Skipping corrupt calibration file (bad json): {str(offset_path)}"
+            )
             return None
-        assert 'offset' in data.keys(), 'Not valid pipette calibration data'
+        assert "offset" in data.keys(), "Not valid pipette calibration data"
         return local_types.PipetteOffsetByPipetteMount(
-            offset=data['offset'],
+            offset=data["offset"],
             source=_get_calibration_source(data),
-            tiprack=data['tiprack'],
-            uri=data['uri'],
-            last_modified=data['last_modified'],
-            status=_get_calibration_status(data))
+            tiprack=data["tiprack"],
+            uri=data["uri"],
+            last_modified=data["last_modified"],
+            status=_get_calibration_status(data),
+        )
     else:
         return None
 
 
-def get_all_pipette_offset_calibrations() \
-            -> typing.List[local_types.PipetteOffsetCalibration]:
+def get_all_pipette_offset_calibrations() -> typing.List[
+    local_types.PipetteOffsetCalibration
+]:
     """
     A helper function that will list all of the pipette offset
     calibrations.
@@ -284,56 +288,60 @@ def get_all_pipette_offset_calibrations() \
     pipette offset calibration files found on the robot.
     """
     all_calibrations: typing.List[local_types.PipetteOffsetCalibration] = []
-    pip_dir = config.get_opentrons_path('pipette_calibration_dir')
-    index_path = pip_dir / 'index.json'
+    pip_dir = config.get_opentrons_path("pipette_calibration_dir")
+    index_path = pip_dir / "index.json"
     if not index_path.exists():
         return all_calibrations
 
     index_file = io.read_cal_file(str(index_path))
     for mount_key, pips in index_file.items():
         for pip in pips:
-            cal_path = pip_dir / mount_key / f'{pip}.json'
+            cal_path = pip_dir / mount_key / f"{pip}.json"
             if cal_path.exists():
                 try:
                     data = io.read_cal_file(str(cal_path))
                 except json.JSONDecodeError:
                     log.error(
                         "Skipping corrupt calibration file (bad json): "
-                        + f"{str(cal_path)}")
+                        + f"{str(cal_path)}"
+                    )
                     continue
                 try:
                     all_calibrations.append(
                         local_types.PipetteOffsetCalibration(
                             pipette=pip,
                             mount=mount_key,
-                            offset=data['offset'],
-                            tiprack=data['tiprack'],
-                            uri=data['uri'],
-                            last_modified=data['last_modified'],
+                            offset=data["offset"],
+                            tiprack=data["tiprack"],
+                            uri=data["uri"],
+                            last_modified=data["last_modified"],
                             source=_get_calibration_source(data),
-                            status=_get_calibration_status(data)))
+                            status=_get_calibration_status(data),
+                        )
+                    )
                 except (KeyError, ValueError):
                     log.exception(
                         "Skipping corrupt calibration file (bad data): "
-                        + f"{str(cal_path)}")
+                        + f"{str(cal_path)}"
+                    )
                     continue
     return all_calibrations
 
 
-def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> 'LabwareDefinition':
+def get_custom_tiprack_definition_for_tlc(labware_uri: str) -> "LabwareDefinition":
     """
     Return the custom tiprack definition saved in the custom tiprack directory
     during tip length calibration
     """
     custom_tiprack_dir = config.get_custom_tiprack_def_path()
-    custom_tiprack_path = custom_tiprack_dir / f'{labware_uri}.json'
+    custom_tiprack_path = custom_tiprack_dir / f"{labware_uri}.json"
     try:
-        with open(custom_tiprack_path, 'rb') as f:
-            return json.loads(f.read().decode('utf-8'))
+        with open(custom_tiprack_path, "rb") as f:
+            return json.loads(f.read().decode("utf-8"))
     except FileNotFoundError:
         raise FileNotFoundError(
-            f'Custom tiprack {labware_uri} not found in the custom tiprack'
-            'directory on the robot. Please recalibrate tip length and '
-            'pipette offset with this tiprack before performing calibration '
-            'health check.'
+            f"Custom tiprack {labware_uri} not found in the custom tiprack"
+            "directory on the robot. Please recalibrate tip length and "
+            "pipette offset with this tiprack before performing calibration "
+            "health check."
         )

--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -34,11 +34,11 @@ def convert_to_dict(obj) -> Dict:
     # https://github.com/python/mypy/issues/6568
     # Unfortnately, since it's not currently supported I have an
     # assert check instead.
-    assert is_dataclass(obj), 'This function is intended for dataclasses only'
+    assert is_dataclass(obj), "This function is intended for dataclasses only"
     return asdict(obj, dict_factory=dict_filter_none)
 
 
-def hash_labware_def(labware_def: 'LabwareDefinition') -> str:
+def hash_labware_def(labware_def: "LabwareDefinition") -> str:
     """
     Helper function to take in a labware definition and return
     a hashed string of key elemenets from the labware definition
@@ -48,54 +48,49 @@ def hash_labware_def(labware_def: 'LabwareDefinition') -> str:
     :returns: sha256 string
     """
     # remove keys that do not affect run
-    blocklist = ['metadata', 'brand', 'groups']
-    def_no_metadata = {
-        k: v for k, v in labware_def.items() if k not in blocklist}
-    sorted_def_str = json.dumps(
-        def_no_metadata, sort_keys=True, separators=(',', ':'))
-    return sha256(sorted_def_str.encode('utf-8')).hexdigest()
+    blocklist = ["metadata", "brand", "groups"]
+    def_no_metadata = {k: v for k, v in labware_def.items() if k not in blocklist}
+    sorted_def_str = json.dumps(def_no_metadata, sort_keys=True, separators=(",", ":"))
+    return sha256(sorted_def_str.encode("utf-8")).hexdigest()
 
 
-def details_from_uri(uri: str, delimiter='/') -> local_types.UriDetails:
+def details_from_uri(uri: str, delimiter="/") -> local_types.UriDetails:
     """
     Unpack a labware URI to get the namespace, loadname and version
     """
     if uri:
         info = uri.split(delimiter)
         return local_types.UriDetails(
-            namespace=info[0], load_name=info[1], version=int(info[2]))
+            namespace=info[0], load_name=info[1], version=int(info[2])
+        )
     else:
         # Here we are assuming that the 'uri' passed in is actually
         # the loadname, though sometimes it may be an empty string.
-        return local_types.UriDetails(
-            namespace='', load_name=uri, version=1)
+        return local_types.UriDetails(namespace="", load_name=uri, version=1)
 
 
-def uri_from_details(namespace: str, load_name: str,
-                     version: Union[str, int],
-                     delimiter='/') -> 'LabwareUri':
-    """ Build a labware URI from its details.
+def uri_from_details(
+    namespace: str, load_name: str, version: Union[str, int], delimiter="/"
+) -> "LabwareUri":
+    """Build a labware URI from its details.
 
     A labware URI is a string that uniquely specifies a labware definition.
 
     :returns str: The URI.
     """
-    return cast(
-        'LabwareUri',
-        f'{namespace}{delimiter}{load_name}{delimiter}{version}')
+    return cast("LabwareUri", f"{namespace}{delimiter}{load_name}{delimiter}{version}")
 
 
-def uri_from_definition(
-        definition: 'LabwareDefinition', delimiter='/') -> 'LabwareUri':
-    """ Build a labware URI from its definition.
+def uri_from_definition(definition: "LabwareDefinition", delimiter="/") -> "LabwareUri":
+    """Build a labware URI from its definition.
 
     A labware URI is a string that uniquely specifies a labware definition.
 
     :returns str: The URI.
     """
     return uri_from_details(
-        namespace=definition['namespace'],
-        load_name=definition['parameters']['loadName'],
-        version=definition['version'],
-        delimiter=delimiter
+        namespace=definition["namespace"],
+        load_name=definition["parameters"]["loadName"],
+        version=definition["version"],
+        delimiter=delimiter,
     )

--- a/api/src/opentrons/calibration_storage/migration.py
+++ b/api/src/opentrons/calibration_storage/migration.py
@@ -8,7 +8,7 @@ MAX_VERSION = 1
 def check_index_version(index_path: local_types.StrPath):
     try:
         index_file = io.read_cal_file(str(index_path))
-        version = index_file.get('version', 0)
+        version = index_file.get("version", 0)
         if version == 0:
             migrate_index_0_to_1(index_path)
     except FileNotFoundError:
@@ -39,18 +39,16 @@ def migrate_index_0_to_1(index_path: local_types.StrPath):
     updated_entries: typing.Dict = {}
     for key, data in index_file.items():
         uri = key
-        full_hash = data['slot']
-        if data['module']:
-            parent, full_parent = list(data['module'].items())[0]
-            module = {
-                'parent': parent,
-                'fullParent': full_parent}
+        full_hash = data["slot"]
+        if data["module"]:
+            parent, full_parent = list(data["module"].items())[0]
+            module = {"parent": parent, "fullParent": full_parent}
         else:
             module = {}
         updated_entries[full_hash] = {
-            "uri": f'{uri}',
+            "uri": f"{uri}",
             "slot": full_hash,
-            "module": module
-            }
-    migrated_file = {'version': 1, 'data': updated_entries}
+            "module": module,
+        }
+    migrated_file = {"version": 1, "data": updated_entries}
     io.save_to_file(index_path, migrated_file)

--- a/api/src/opentrons/calibration_storage/modify.py
+++ b/api/src/opentrons/calibration_storage/modify.py
@@ -14,16 +14,16 @@ from opentrons.types import Mount, Point
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.util.helpers import utc_now
 
-from . import (
-    file_operators as io,
-    types as local_types,
-    helpers,
-    migration)
+from . import file_operators as io, types as local_types, helpers, migration
 
 if typing.TYPE_CHECKING:
     from .dev_types import (
-        TipLengthCalibration, PipTipLengthCalibration,
-        DeckCalibrationData, PipetteCalibrationData, CalibrationStatusDict)
+        TipLengthCalibration,
+        PipTipLengthCalibration,
+        DeckCalibrationData,
+        PipetteCalibrationData,
+        CalibrationStatusDict,
+    )
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -37,50 +37,46 @@ def _add_to_index_offset_file(parent: str, slot: str, uri: str, lw_hash: str):
     :param slot
     :param lw_hash: The labware hash of the calibration
     """
-    offset =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    index_file = offset / 'index.json'
+    offset = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    index_file = offset / "index.json"
     if index_file.exists():
         migration.check_index_version(index_file)
         blob = io.read_cal_file(str(index_file))
     else:
         blob = {}
 
-    full_id = f'{lw_hash}{parent}'
+    full_id = f"{lw_hash}{parent}"
     try:
-        blob['data'][full_id]
+        blob["data"][full_id]
     except KeyError:
         if parent:
-            mod_dict = {
-                'parent': parent,
-                'fullParent': f'{slot}-{parent}'}
+            mod_dict = {"parent": parent, "fullParent": f"{slot}-{parent}"}
         else:
             mod_dict = {}
-        new_index_data = {
-            "uri": f'{uri}',
-            "slot": full_id,
-            "module": mod_dict}
-        if blob.get('data'):
-            blob['data'][full_id] = new_index_data
+        new_index_data = {"uri": f"{uri}", "slot": full_id, "module": mod_dict}
+        if blob.get("data"):
+            blob["data"][full_id] = new_index_data
         else:
-            blob['data'] = {full_id: new_index_data}
-        blob['version'] = migration.MAX_VERSION
+            blob["data"] = {full_id: new_index_data}
+        blob["version"] = migration.MAX_VERSION
         io.save_to_file(index_file, blob)
 
 
 def add_existing_labware_to_index_file(
-        definition: 'LabwareDefinition', parent: str = '', slot: str = ''):
+    definition: "LabwareDefinition", parent: str = "", slot: str = ""
+):
     labware_hash = helpers.hash_labware_def(definition)
     uri = helpers.uri_from_definition(definition)
     _add_to_index_offset_file(parent, slot, uri, labware_hash)
 
 
 def save_labware_calibration(
-        labware_path: local_types.StrPath,
-        definition: 'LabwareDefinition',
-        delta: Point,
-        slot: str = '',
-        parent: str = ''):
+    labware_path: local_types.StrPath,
+    definition: "LabwareDefinition",
+    delta: Point,
+    slot: str = "",
+    parent: str = "",
+):
     """
     Function to be used whenever an updated delta is found for the first well
     of a given labware. If an offset file does not exist, create the file
@@ -94,22 +90,20 @@ def save_labware_calibration(
     [not yet implemented so it will currently only be an empty string]
     :param parent: parent of the labware, either a slot or a module.
     """
-    offset_path =\
-        config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    offset_path = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
     labware_offset_path = offset_path / labware_path
     labware_hash = helpers.hash_labware_def(definition)
     uri = helpers.uri_from_definition(definition)
     _add_to_index_offset_file(parent, slot, uri, labware_hash)
-    calibration_data = _helper_offset_data_format(
-        str(labware_offset_path), delta)
+    calibration_data = _helper_offset_data_format(str(labware_offset_path), delta)
     io.save_to_file(labware_offset_path, calibration_data)
 
 
 def create_tip_length_data(
-        definition: 'LabwareDefinition',
-        length: float,
-        cal_status: local_types.CalibrationStatus = None
-        ) -> 'PipTipLengthCalibration':
+    definition: "LabwareDefinition",
+    length: float,
+    cal_status: local_types.CalibrationStatus = None,
+) -> "PipTipLengthCalibration":
     """
     Function to correctly format tip length data.
 
@@ -122,32 +116,32 @@ def create_tip_length_data(
         status = cal_status
     else:
         status = local_types.CalibrationStatus()
-    status_dict: 'CalibrationStatusDict' =\
-        helpers.convert_to_dict(status)  # type: ignore
+    status_dict: "CalibrationStatusDict" = helpers.convert_to_dict(  # type: ignore[assignment]  # noqa: E501
+        status
+    )
 
-    tip_length_data: 'TipLengthCalibration' = {
-        'tipLength': length,
-        'lastModified': utc_now(),
-        'source': local_types.SourceType.user,
-        'status': status_dict,
-        'uri': labware_uri
+    tip_length_data: "TipLengthCalibration" = {
+        "tipLength": length,
+        "lastModified": utc_now(),
+        "source": local_types.SourceType.user,
+        "status": status_dict,
+        "uri": labware_uri,
     }
 
-    if not definition.get('namespace') == OPENTRONS_NAMESPACE:
+    if not definition.get("namespace") == OPENTRONS_NAMESPACE:
         _save_custom_tiprack_definition(labware_uri, definition)
 
     data = {labware_hash: tip_length_data}
     return data
 
 
-def _save_custom_tiprack_definition(
-        labware_uri: str, definition: 'LabwareDefinition'):
-    namespace, load_name, version = labware_uri.split('/')
+def _save_custom_tiprack_definition(labware_uri: str, definition: "LabwareDefinition"):
+    namespace, load_name, version = labware_uri.split("/")
     custom_tr_dir_path = config.get_custom_tiprack_def_path()
-    custom_namespace_dir = custom_tr_dir_path/f'{namespace}/{load_name}'
+    custom_namespace_dir = custom_tr_dir_path / f"{namespace}/{load_name}"
     custom_namespace_dir.mkdir(parents=True, exist_ok=True)
 
-    custom_tr_def_path = custom_namespace_dir/f'{version}.json'
+    custom_tr_def_path = custom_namespace_dir / f"{version}.json"
     io.save_to_file(custom_tr_def_path, definition)
 
 
@@ -156,19 +150,18 @@ def _helper_offset_data_format(filepath: str, delta: Point) -> dict:
         calibration_data = {
             "default": {
                 "offset": [delta.x, delta.y, delta.z],
-                "lastModified": utc_now()
+                "lastModified": utc_now(),
             }
         }
     else:
         calibration_data = io.read_cal_file(filepath)
-        calibration_data['default']['offset'] = [delta.x, delta.y, delta.z]
-        calibration_data['default']['lastModified'] =\
-            utc_now()
+        calibration_data["default"]["offset"] = [delta.x, delta.y, delta.z]
+        calibration_data["default"]["lastModified"] = utc_now()
     return calibration_data
 
 
 def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
-    index_file = config.get_tip_length_cal_path()/'index.json'
+    index_file = config.get_tip_length_cal_path() / "index.json"
     try:
         index_data = io.read_cal_file(str(index_file))
     except FileNotFoundError:
@@ -182,8 +175,7 @@ def _append_to_index_tip_length_file(pip_id: str, lw_hash: str):
     io.save_to_file(index_file, index_data)
 
 
-def save_tip_length_calibration(
-        pip_id: str, tip_length_cal: 'PipTipLengthCalibration'):
+def save_tip_length_calibration(pip_id: str, tip_length_cal: "PipTipLengthCalibration"):
     """
     Function used to save tip length calibration to file.
 
@@ -193,7 +185,7 @@ def save_tip_length_calibration(
     """
     tip_length_dir_path = config.get_tip_length_cal_path()
     tip_length_dir_path.mkdir(parents=True, exist_ok=True)
-    pip_tip_length_path = tip_length_dir_path/f'{pip_id}.json'
+    pip_tip_length_path = tip_length_dir_path / f"{pip_id}.json"
 
     for lw_hash in tip_length_cal.keys():
         _append_to_index_tip_length_file(pip_id, lw_hash)
@@ -209,35 +201,36 @@ def save_tip_length_calibration(
 
 
 def save_robot_deck_attitude(
-        transform: local_types.AttitudeMatrix,
-        pip_id: typing.Optional[str],
-        lw_hash: typing.Optional[str],
-        source: local_types.SourceType = None,
-        cal_status: local_types.CalibrationStatus = None):
-    robot_dir = config.get_opentrons_path('robot_calibration_dir')
+    transform: local_types.AttitudeMatrix,
+    pip_id: typing.Optional[str],
+    lw_hash: typing.Optional[str],
+    source: local_types.SourceType = None,
+    cal_status: local_types.CalibrationStatus = None,
+):
+    robot_dir = config.get_opentrons_path("robot_calibration_dir")
     robot_dir.mkdir(parents=True, exist_ok=True)
-    gantry_path = robot_dir/'deck_calibration.json'
+    gantry_path = robot_dir / "deck_calibration.json"
     if cal_status:
         status = cal_status
     else:
         status = local_types.CalibrationStatus()
-    status_dict: 'CalibrationStatusDict' =\
-        helpers.convert_to_dict(status)  # type: ignore
+    status_dict: "CalibrationStatusDict" = helpers.convert_to_dict(  # type: ignore[assignment]  # noqa: E501
+        status
+    )  # type: ignore
 
-    gantry_dict: 'DeckCalibrationData' = {
-        'attitude': transform,
-        'pipette_calibrated_with': pip_id,
-        'last_modified': utc_now(),
-        'tiprack': lw_hash,
-        'source': source or local_types.SourceType.user,
-        'status': status_dict
+    gantry_dict: "DeckCalibrationData" = {
+        "attitude": transform,
+        "pipette_calibrated_with": pip_id,
+        "last_modified": utc_now(),
+        "tiprack": lw_hash,
+        "source": source or local_types.SourceType.user,
+        "status": status_dict,
     }
     io.save_to_file(gantry_path, gantry_dict)
 
 
 def _add_to_pipette_offset_index_file(pip_id: str, mount: Mount):
-    index_file = config.get_opentrons_path(
-        'pipette_calibration_dir') / 'index.json'
+    index_file = config.get_opentrons_path("pipette_calibration_dir") / "index.json"
     try:
         index_data = index_data = io.read_cal_file(str(index_file))
     except FileNotFoundError:
@@ -253,27 +246,30 @@ def _add_to_pipette_offset_index_file(pip_id: str, mount: Mount):
 
 
 def save_pipette_calibration(
-        offset: Point,
-        pip_id: str, mount: Mount,
-        tiprack_hash: str, tiprack_uri: str,
-        cal_status: local_types.CalibrationStatus = None):
-    pip_dir = config.get_opentrons_path(
-        'pipette_calibration_dir') / mount.name.lower()
+    offset: Point,
+    pip_id: str,
+    mount: Mount,
+    tiprack_hash: str,
+    tiprack_uri: str,
+    cal_status: local_types.CalibrationStatus = None,
+):
+    pip_dir = config.get_opentrons_path("pipette_calibration_dir") / mount.name.lower()
     pip_dir.mkdir(parents=True, exist_ok=True)
     if cal_status:
         status = cal_status
     else:
         status = local_types.CalibrationStatus()
-    status_dict: 'CalibrationStatusDict' =\
-        helpers.convert_to_dict(status)  # type: ignore
-    offset_path = pip_dir/f'{pip_id}.json'
-    offset_dict: 'PipetteCalibrationData' = {
-        'offset': [offset.x, offset.y, offset.z],
-        'tiprack': tiprack_hash,
-        'uri': tiprack_uri,
-        'last_modified': utc_now(),
-        'source': local_types.SourceType.user,
-        'status': status_dict
+    status_dict: "CalibrationStatusDict" = helpers.convert_to_dict(  # type: ignore[assignment]  # noqa: E501
+        status
+    )  # type: ignore
+    offset_path = pip_dir / f"{pip_id}.json"
+    offset_dict: "PipetteCalibrationData" = {
+        "offset": [offset.x, offset.y, offset.z],
+        "tiprack": tiprack_hash,
+        "uri": tiprack_uri,
+        "last_modified": utc_now(),
+        "source": local_types.SourceType.user,
+        "status": status_dict,
     }
     io.save_to_file(offset_path, offset_dict)
     _add_to_pipette_offset_index_file(pip_id, mount)
@@ -281,29 +277,32 @@ def save_pipette_calibration(
 
 @typing.overload
 def mark_bad(
-    calibration: local_types.DeckCalibration,
-    source_marked_bad: local_types.SourceType
-    ) -> local_types.DeckCalibration: ...
+    calibration: local_types.DeckCalibration, source_marked_bad: local_types.SourceType
+) -> local_types.DeckCalibration:
+    ...
 
 
 @typing.overload
 def mark_bad(
     calibration: local_types.PipetteOffsetCalibration,
-    source_marked_bad: local_types.SourceType
-    ) -> local_types.PipetteOffsetCalibration: ...
+    source_marked_bad: local_types.SourceType,
+) -> local_types.PipetteOffsetCalibration:
+    ...
 
 
 @typing.overload
 def mark_bad(
     calibration: local_types.TipLengthCalibration,
-    source_marked_bad: local_types.SourceType
-    ) -> local_types.TipLengthCalibration: ...
+    source_marked_bad: local_types.SourceType,
+) -> local_types.TipLengthCalibration:
+    ...
 
 
 def mark_bad(calibration, source_marked_bad: local_types.SourceType):
     caldict = asdict(calibration)
     # remove current status key
-    del caldict['status']
+    del caldict["status"]
     status = local_types.CalibrationStatus(
-        markedBad=True, source=source_marked_bad, markedAt=utc_now())
+        markedBad=True, source=source_marked_bad, markedAt=utc_now()
+    )
     return type(calibration)(**caldict, status=status)

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -8,7 +8,7 @@ from os import PathLike
 from typing_extensions import Literal
 from opentrons_shared_data.pipette.dev_types import LabwareUri
 
-CalibrationID = typing.NewType('CalibrationID', str)
+CalibrationID = typing.NewType("CalibrationID", str)
 StrPath = typing.Union[str, PathLike]
 AttitudeMatrix = typing.List[typing.List[float]]
 PipetteOffset = typing.List[float]
@@ -16,11 +16,12 @@ PipetteOffset = typing.List[float]
 
 class SourceType(str, Enum):
     """Calibration source type"""
+
     default = "default"
     factory = "factory"
     user = "user"
     calibration_check = "calibration_check"
-    legacy = 'legacy'
+    legacy = "legacy"
     unknown = "unknown"
 
 
@@ -48,6 +49,7 @@ class OffsetData:
     Class to categorize the shape of a
     given calibration data.
     """
+
     value: typing.List[float]
     last_modified: typing.Optional[datetime]
 
@@ -58,6 +60,7 @@ class TipLengthData:
     Class to categorize the shape of a
     given calibration data.
     """
+
     value: typing.Optional[float] = None
     last_modified: typing.Optional[datetime] = None
 
@@ -72,8 +75,9 @@ class ParentOptions:
 
     The slot value will be the empty string.
     """
+
     slot: str
-    module: str = ''
+    module: str = ""
 
 
 @dataclass
@@ -82,6 +86,7 @@ class LabwareCalibrationTypes:
     Class to categorize what calibration
     data might be stored for a labware.
     """
+
     offset: OffsetData
     tip_length: TipLengthData
 
@@ -92,6 +97,7 @@ class CalibrationInformation:
     Class to store important calibration
     info for labware.
     """
+
     calibration: LabwareCalibrationTypes
     parent: ParentOptions
     labware_id: str
@@ -106,7 +112,7 @@ class TipLengthCalibration:
     pipette: str
     tiprack: str
     last_modified: datetime
-    uri: typing.Union[LabwareUri, Literal['']]
+    uri: typing.Union[LabwareUri, Literal[""]]
 
 
 @dataclass
@@ -124,6 +130,7 @@ class PipetteOffsetByPipetteMount:
     """
     Class to store pipette offset without pipette and mount info
     """
+
     offset: PipetteOffset
     source: SourceType
     status: CalibrationStatus
@@ -137,6 +144,7 @@ class PipetteOffsetCalibration:
     """
     Class to store pipette offset calibration with pipette and mount info
     """
+
     pipette: str
     mount: str
     offset: PipetteOffset

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -14,140 +14,139 @@ if TYPE_CHECKING:
 
 
 def home(mount: str) -> command_types.HomeCommand:
-    text = f'Homing pipette plunger on mount {mount}'
-    return {
-        'name': command_types.HOME,
-        'payload': {
-            'axis': mount,
-            'text': text
-        }
-    }
+    text = f"Homing pipette plunger on mount {mount}"
+    return {"name": command_types.HOME, "payload": {"axis": mount, "text": text}}
 
 
 def aspirate(
-        instrument: InstrumentContext,
-        volume: float,
-        location: Union[Well, Location],
-        rate: float) -> command_types.AspirateCommand:
+    instrument: InstrumentContext,
+    volume: float,
+    location: Union[Well, Location],
+    rate: float,
+) -> command_types.AspirateCommand:
     location_text = stringify_location(location)
-    template = 'Aspirating {volume} uL from {location} at {flow} uL/sec'
+    template = "Aspirating {volume} uL from {location} at {flow} uL/sec"
     flow_rate = rate * FlowRates(instrument._implementation).aspirate
-    text = template.format(
-        volume=float(volume), location=location_text, flow=flow_rate)
+    text = template.format(volume=float(volume), location=location_text, flow=flow_rate)
 
     return {
-        'name': command_types.ASPIRATE,
-        'payload': {
-            'instrument': instrument,
-            'volume': volume,
-            'location': location,
-            'rate': rate,
-            'text': text
-        }
+        "name": command_types.ASPIRATE,
+        "payload": {
+            "instrument": instrument,
+            "volume": volume,
+            "location": location,
+            "rate": rate,
+            "text": text,
+        },
     }
 
 
 def dispense(
-        instrument: InstrumentContext,
-        volume: float,
-        location: Union[Well, Location],
-        rate: float) -> command_types.DispenseCommand:
+    instrument: InstrumentContext,
+    volume: float,
+    location: Union[Well, Location],
+    rate: float,
+) -> command_types.DispenseCommand:
     location_text = stringify_location(location)
-    template = 'Dispensing {volume} uL into {location} at {flow} uL/sec'
+    template = "Dispensing {volume} uL into {location} at {flow} uL/sec"
     flow_rate = rate * FlowRates(instrument._implementation).dispense
-    text = template.format(
-        volume=float(volume), location=location_text, flow=flow_rate)
+    text = template.format(volume=float(volume), location=location_text, flow=flow_rate)
 
     return {
-        'name': command_types.DISPENSE,
-        'payload': {
-            'instrument': instrument,
-            'volume': volume,
-            'location': location,
-            'rate': rate,
-            'text': text
-        }
+        "name": command_types.DISPENSE,
+        "payload": {
+            "instrument": instrument,
+            "volume": volume,
+            "location": location,
+            "rate": rate,
+            "text": text,
+        },
     }
 
 
 def consolidate(
-        instrument: InstrumentContext,
-        volume: Union[float, List[float]],
-        source: List[Union[Location, Well]],
-        dest: Union[Location, Well]) -> command_types.ConsolidateCommand:
-    text = 'Consolidating {volume} from {source} to {dest}'.format(
+    instrument: InstrumentContext,
+    volume: Union[float, List[float]],
+    source: List[Union[Location, Well]],
+    dest: Union[Location, Well],
+) -> command_types.ConsolidateCommand:
+    text = "Consolidating {volume} from {source} to {dest}".format(
         volume=transform_volumes(volume),
         source=stringify_location(source),
-        dest=stringify_location(dest)
+        dest=stringify_location(dest),
     )
     locations: List[Union[Location, Well]] = listify(source) + listify(dest)
     return {
-        'name': command_types.CONSOLIDATE,
-        'payload': {
-            'instrument': instrument,
-            'locations': locations,
-            'volume': volume,
-            'source': source,
-            'dest': dest,
-            'text': text
-        }
+        "name": command_types.CONSOLIDATE,
+        "payload": {
+            "instrument": instrument,
+            "locations": locations,
+            "volume": volume,
+            "source": source,
+            "dest": dest,
+            "text": text,
+        },
     }
 
 
 def distribute(
-        instrument: InstrumentContext,
-        volume: Union[float, List[float]],
-        source: Union[Location, Well],
-        dest: List[Union[Location, Well]]) -> command_types.DistributeCommand:
-    text = 'Distributing {volume} from {source} to {dest}'.format(
+    instrument: InstrumentContext,
+    volume: Union[float, List[float]],
+    source: Union[Location, Well],
+    dest: List[Union[Location, Well]],
+) -> command_types.DistributeCommand:
+    text = "Distributing {volume} from {source} to {dest}".format(
         volume=transform_volumes(volume),
         source=stringify_location(source),
-        dest=stringify_location(dest)
+        dest=stringify_location(dest),
     )
     locations: List[Union[Location, Well]] = listify(source) + listify(dest)
     return {
-        'name': command_types.DISTRIBUTE,
-        'payload': {
-            'instrument': instrument,
-            'locations': locations,
-            'volume': volume,
-            'source': source,
-            'dest': dest,
-            'text': text
-        }
+        "name": command_types.DISTRIBUTE,
+        "payload": {
+            "instrument": instrument,
+            "locations": locations,
+            "volume": volume,
+            "source": source,
+            "dest": dest,
+            "text": text,
+        },
     }
 
 
 def transfer(
-        instrument: InstrumentContext,
-        volume: Union[float, List[float]],
-        source: List[Union[Location, Well]],
-        dest: List[Union[Location, Well]]) -> command_types.TransferCommand:
-    text = 'Transferring {volume} from {source} to {dest}'.format(
+    instrument: InstrumentContext,
+    volume: Union[float, List[float]],
+    source: List[Union[Location, Well]],
+    dest: List[Union[Location, Well]],
+) -> command_types.TransferCommand:
+    text = "Transferring {volume} from {source} to {dest}".format(
         volume=transform_volumes(volume),
         source=stringify_location(source),
-        dest=stringify_location(dest)
+        dest=stringify_location(dest),
     )
     locations: List[Union[Location, Well]] = listify(source) + listify(dest)
     return {
-        'name': command_types.TRANSFER,
-        'payload': {
-            'instrument': instrument,
-            'locations': locations,
-            'volume': volume,
-            'source': source,
-            'dest': dest,
-            'text': text
-        }
+        "name": command_types.TRANSFER,
+        "payload": {
+            "instrument": instrument,
+            "locations": locations,
+            "volume": volume,
+            "source": source,
+            "dest": dest,
+            "text": text,
+        },
     }
 
 
 @overload
-def transform_volumes(volumes: Union[float, int]) -> float: ...
+def transform_volumes(volumes: Union[float, int]) -> float:
+    ...
 
 
 @overload
-def transform_volumes(volumes: List[Union[float]]) -> List[float]: ...
+def transform_volumes(volumes: List[Union[float]]) -> List[float]:
+    ...
 
 
 def transform_volumes(volumes):
@@ -157,116 +156,89 @@ def transform_volumes(volumes):
         return [float(vol) for vol in volumes]
 
 
-def mix(instrument: InstrumentContext,
-        repetitions: int,
-        volume: float,
-        location: Union[Well, Location, None]) -> command_types.MixCommand:
-    text = 'Mixing {repetitions} times with a volume of {volume} ul'.format(
+def mix(
+    instrument: InstrumentContext,
+    repetitions: int,
+    volume: float,
+    location: Union[Well, Location, None],
+) -> command_types.MixCommand:
+    text = "Mixing {repetitions} times with a volume of {volume} ul".format(
         repetitions=repetitions, volume=float(volume)
     )
     return {
-        'name': command_types.MIX,
-        'payload': {
-            'instrument': instrument,
-            'location': location,
-            'volume': volume,
-            'repetitions': repetitions,
-            'text': text
-        }
+        "name": command_types.MIX,
+        "payload": {
+            "instrument": instrument,
+            "location": location,
+            "volume": volume,
+            "repetitions": repetitions,
+            "text": text,
+        },
     }
 
 
 def blow_out(
-        instrument: InstrumentContext,
-        location: Union[Well, Location, None]) -> command_types.BlowOutCommand:
+    instrument: InstrumentContext, location: Union[Well, Location, None]
+) -> command_types.BlowOutCommand:
     location_text = stringify_location(location)
-    text = 'Blowing out'
+    text = "Blowing out"
 
     if location is not None:
-        text += ' at {location}'.format(location=location_text)
+        text += " at {location}".format(location=location_text)
 
     return {
-        'name': command_types.BLOW_OUT,
-        'payload': {
-            'instrument': instrument,
-            'location': location,
-            'text': text
-        }
+        "name": command_types.BLOW_OUT,
+        "payload": {"instrument": instrument, "location": location, "text": text},
     }
 
 
 def touch_tip(instrument: InstrumentContext) -> command_types.TouchTipCommand:
-    text = 'Touching tip'
+    text = "Touching tip"
 
     return {
-        'name': command_types.TOUCH_TIP,
-        'payload': {
-            'instrument': instrument,
-            'text': text
-        }
+        "name": command_types.TOUCH_TIP,
+        "payload": {"instrument": instrument, "text": text},
     }
 
 
 def air_gap() -> command_types.AirGapCommand:
-    text = 'Air gap'
-    return {
-        'name': command_types.AIR_GAP,
-        'payload': {
-            'text': text
-        }
-    }
+    text = "Air gap"
+    return {"name": command_types.AIR_GAP, "payload": {"text": text}}
 
 
 def return_tip() -> command_types.ReturnTipCommand:
-    text = 'Returning tip'
-    return {
-        'name': command_types.RETURN_TIP,
-        'payload': {
-            'text': text
-        }
-    }
+    text = "Returning tip"
+    return {"name": command_types.RETURN_TIP, "payload": {"text": text}}
 
 
 def pick_up_tip(
-        instrument: InstrumentContext,
-        location: Union[Location, Well]) -> command_types.PickUpTipCommand:
+    instrument: InstrumentContext, location: Union[Location, Well]
+) -> command_types.PickUpTipCommand:
     location_text = stringify_location(location)
-    text = f'Picking up tip from {location_text}'
+    text = f"Picking up tip from {location_text}"
     return {
-        'name': command_types.PICK_UP_TIP,
-        'payload': {
-            'instrument': instrument,
-            'location': location,
-            'text': text
-        }
+        "name": command_types.PICK_UP_TIP,
+        "payload": {"instrument": instrument, "location": location, "text": text},
     }
 
 
 def drop_tip(
-        instrument: InstrumentContext,
-        location: Union[Location, Well]) -> command_types.DropTipCommand:
+    instrument: InstrumentContext, location: Union[Location, Well]
+) -> command_types.DropTipCommand:
     location_text = stringify_location(location)
-    text = 'Dropping tip into {location}'.format(location=location_text)
+    text = "Dropping tip into {location}".format(location=location_text)
     return {
-        'name': command_types.DROP_TIP,
-        'payload': {
-            'instrument': instrument,
-            'location': location,
-            'text': text
-        }
+        "name": command_types.DROP_TIP,
+        "payload": {"instrument": instrument, "location": location, "text": text},
     }
 
 
 def move_to(
-        instrument: InstrumentContext,
-        location: Union[Location, Well]) -> command_types.MoveToCommand:
+    instrument: InstrumentContext, location: Union[Location, Well]
+) -> command_types.MoveToCommand:
     location_text = stringify_location(location)
-    text = 'Moving to {location}'.format(location=location_text)
+    text = "Moving to {location}".format(location=location_text)
     return {
-        'name': command_types.MOVE_TO,
-        'payload': {
-            'instrument': instrument,
-            'location': location,
-            'text': text
-        }
+        "name": command_types.MOVE_TO,
+        "payload": {"instrument": instrument, "location": location, "text": text},
     }

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -30,6 +30,5 @@ def _stringify_new_loc(loc: Union[Location, Well]) -> str:
 
 
 def stringify_location(location: CommandLocation) -> str:
-    loc_str_list = [_stringify_new_loc(loc)
-                    for loc in listify(location)]
-    return ', '.join(loc_str_list)
+    loc_str_list = [_stringify_new_loc(loc) for loc in listify(location)]
+    return ", ".join(loc_str_list)

--- a/api/src/opentrons/commands/introspection.py
+++ b/api/src/opentrons/commands/introspection.py
@@ -10,20 +10,23 @@ if TYPE_CHECKING:
     from opentrons.protocol_api import InstrumentContext
     from opentrons.protocol_api.labware import Labware, Well
     from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
     ReferredObjects = Tuple[
-        List[InstrumentContext], List[Labware], List[ModuleGeometry]]
+        List[InstrumentContext], List[Labware], List[ModuleGeometry]
+    ]
 
 
 def _labware_from_location(loc: Union[Location, Well]) -> Labware:
     if isinstance(loc, Location):
         if not loc.labware:
-            raise ValueError('Cannot handle location without labware')
+            raise ValueError("Cannot handle location without labware")
         labware, _ = loc.labware.get_parent_labware_and_well()
         if not labware:
-            raise ValueError(f'Cannot handle location {loc}')
+            raise ValueError(f"Cannot handle location {loc}")
         return labware
     else:
         return loc.parent
+
 
 # The casts and type: ignores in _get_locations and _get_instruments are necessary
 # until we either a) refactor this so payloads have tags that mypy can use to
@@ -32,39 +35,54 @@ def _labware_from_location(loc: Union[Location, Well]) -> Labware:
 
 
 def _get_locations(
-        command: command_types.HasLocationPayload) -> List[Optional[Labware]]:
-    if 'location' in command and command['location']:  # type: ignore
-        return [_labware_from_location(
-            cast(command_types.SingleLocationPayload, command)['location'])]
-    elif 'locations' in command and command['locations']:  # type: ignore
-        return [_labware_from_location(loc) for loc in
-                cast(command_types.MultiLocationPayload, command)['locations']]
+    command: command_types.HasLocationPayload,
+) -> List[Optional[Labware]]:
+    if "location" in command and command["location"]:  # type: ignore
+        return [
+            _labware_from_location(
+                cast(command_types.SingleLocationPayload, command)["location"]
+            )
+        ]
+    elif "locations" in command and command["locations"]:  # type: ignore
+        return [
+            _labware_from_location(loc)
+            for loc in cast(command_types.MultiLocationPayload, command)["locations"]
+        ]
     else:
         return []
 
 
 def _get_instruments(
-        command: command_types.HasInstrumentPayload) -> List[InstrumentContext]:
-    if 'instrument' in command:  # type: ignore
-        return [cast(command_types.SingleInstrumentPayload, command)['instrument']]
+    command: command_types.HasInstrumentPayload,
+) -> List[InstrumentContext]:
+    if "instrument" in command:  # type: ignore
+        return [cast(command_types.SingleInstrumentPayload, command)["instrument"]]
     else:  # type: ignore
         return [
-            inst for inst
-            in cast(command_types.MultiInstrumentPayload, command)['instruments']]
+            inst
+            for inst in cast(command_types.MultiInstrumentPayload, command)[
+                "instruments"
+            ]
+        ]
 
 
 def get_referred_objects(command: command_types.CommandPayload) -> ReferredObjects:
-    if 'location' in command or 'locations' in command:
-        locations = [lw for lw in _get_locations(
-            cast(command_types.HasLocationPayload, command)) if lw is not None]
+    if "location" in command or "locations" in command:
+        locations = [
+            lw
+            for lw in _get_locations(cast(command_types.HasLocationPayload, command))
+            if lw is not None
+        ]
     else:
         locations = []
-    if 'instrument' in command or 'instruments' in command:
+    if "instrument" in command or "instruments" in command:
         instruments = _get_instruments(
-            cast(command_types.HasInstrumentPayload, command))
+            cast(command_types.HasInstrumentPayload, command)
+        )
     else:
         instruments = []
 
     maybe_modules = [
-        labware_like.LabwareLike(labware).module_parent() for labware in locations]
+        labware_like.LabwareLike(labware).module_parent() for labware in locations
+    ]
     return instruments, locations, [mod for mod in maybe_modules if mod]

--- a/api/src/opentrons/commands/module_commands.py
+++ b/api/src/opentrons/commands/module_commands.py
@@ -8,78 +8,59 @@ from . import types as command_types
 
 def magdeck_engage() -> command_types.MagdeckEngageCommand:
     text = "Engaging Magnetic Module"
-    return {
-        'name': command_types.MAGDECK_ENGAGE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.MAGDECK_ENGAGE, "payload": {"text": text}}
 
 
 def magdeck_disengage() -> command_types.MagdeckDisengageCommand:
     text = "Disengaging Magnetic Module"
-    return {
-        'name': command_types.MAGDECK_DISENGAGE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.MAGDECK_DISENGAGE, "payload": {"text": text}}
 
 
 def magdeck_calibrate() -> command_types.MagdeckCalibrateCommand:
     text = "Calibrating Magnetic Module"
-    return {
-        'name': command_types.MAGDECK_CALIBRATE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.MAGDECK_CALIBRATE, "payload": {"text": text}}
 
 
 def tempdeck_set_temp(celsius: float) -> command_types.TempdeckSetTempCommand:
-    temp = round(float(celsius),
-                 utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
-    text = f"Setting Temperature Module temperature " \
-           f"to {temp} °C (rounded off to nearest integer)"
+    temp = round(float(celsius), utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
+    text = (
+        f"Setting Temperature Module temperature "
+        f"to {temp} °C (rounded off to nearest integer)"
+    )
     return {
-        'name': command_types.TEMPDECK_SET_TEMP,
-        'payload': {
-            'celsius': celsius,
-            'text': text
-        }
+        "name": command_types.TEMPDECK_SET_TEMP,
+        "payload": {"celsius": celsius, "text": text},
     }
 
 
 def tempdeck_await_temp(celsius: float) -> command_types.TempdeckAwaitTempCommand:
-    text = "Waiting for Temperature Module to reach temperature " \
-           "{temp} °C (rounded off to nearest integer)".format(
-            temp=round(float(celsius),
-                       utils.TEMPDECK_GCODE_ROUNDING_PRECISION))
+    text = (
+        "Waiting for Temperature Module to reach temperature "
+        "{temp} °C (rounded off to nearest integer)".format(
+            temp=round(float(celsius), utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
+        )
+    )
     return {
-        'name': command_types.TEMPDECK_AWAIT_TEMP,
-        'payload': {
-            'celsius': celsius,
-            'text': text
-        }
+        "name": command_types.TEMPDECK_AWAIT_TEMP,
+        "payload": {"celsius": celsius, "text": text},
     }
 
 
 def tempdeck_deactivate() -> command_types.TempdeckDeactivateCommand:
     text = "Deactivating Temperature Module"
-    return {
-        'name': command_types.TEMPDECK_DEACTIVATE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.TEMPDECK_DEACTIVATE, "payload": {"text": text}}
 
 
 def thermocycler_open() -> command_types.ThermocyclerOpenCommand:
     text = "Opening Thermocycler lid"
-    return {
-        'name': command_types.THERMOCYCLER_OPEN,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.THERMOCYCLER_OPEN, "payload": {"text": text}}
 
 
 def thermocycler_set_block_temp(
-        temperature: float,
-        hold_time_seconds: float,
-        hold_time_minutes: float) -> command_types.ThermocyclerSetBlockTempCommand:
+    temperature: float, hold_time_seconds: float, hold_time_minutes: float
+) -> command_types.ThermocyclerSetBlockTempCommand:
     temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
-    text = f'Setting Thermocycler well block temperature to {temp} °C'
+    text = f"Setting Thermocycler well block temperature to {temp} °C"
     total_seconds = None
     # TODO: BC 2019-09-05 this time resolving logic is partially duplicated
     # in the thermocycler api class definition, with this command logger
@@ -92,95 +73,80 @@ def thermocycler_set_block_temp(
 
         clean_seconds = total_seconds % 60
         clean_minutes = (total_seconds - clean_seconds) / 60
-        text += ' with a hold time of '
+        text += " with a hold time of "
         if clean_minutes > 0:
-            text += f'{clean_minutes} minutes and '
-        text += f'{clean_seconds} seconds'
+            text += f"{clean_minutes} minutes and "
+        text += f"{clean_seconds} seconds"
     return {
-        'name': command_types.THERMOCYCLER_SET_BLOCK_TEMP,
-        'payload': {
-            'temperature': temperature,
-            'hold_time': total_seconds,
-            'text': text
-        }
+        "name": command_types.THERMOCYCLER_SET_BLOCK_TEMP,
+        "payload": {
+            "temperature": temperature,
+            "hold_time": total_seconds,
+            "text": text,
+        },
     }
 
 
 def thermocycler_execute_profile(
-        steps: List[ThermocyclerStep],
-        repetitions: int) -> command_types.ThermocyclerExecuteProfileCommand:
-    text = f'Thermocycler starting {repetitions} repetitions' \
-            ' of cycle composed of the following steps: {steps}'
+    steps: List[ThermocyclerStep], repetitions: int
+) -> command_types.ThermocyclerExecuteProfileCommand:
+    text = (
+        f"Thermocycler starting {repetitions} repetitions"
+        " of cycle composed of the following steps: {steps}"
+    )
     return {
-        'name': command_types.THERMOCYCLER_EXECUTE_PROFILE,
-        'payload': {
-            'text': text,
-            'steps': steps
-        }
+        "name": command_types.THERMOCYCLER_EXECUTE_PROFILE,
+        "payload": {"text": text, "steps": steps},
     }
 
 
 def thermocycler_wait_for_hold() -> command_types.ThermocyclerWaitForHoldCommand:
     text = "Waiting for hold time duration"
-    return {
-        'name': command_types.THERMOCYCLER_WAIT_FOR_HOLD,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.THERMOCYCLER_WAIT_FOR_HOLD, "payload": {"text": text}}
 
 
 def thermocycler_wait_for_temp() -> command_types.ThermocyclerWaitForTempCommand:
     text = "Waiting for Thermocycler to reach target"
-    return {
-        'name': command_types.THERMOCYCLER_WAIT_FOR_TEMP,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.THERMOCYCLER_WAIT_FOR_TEMP, "payload": {"text": text}}
 
 
 def thermocycler_set_lid_temperature(
-        temperature: float) -> command_types.ThermocyclerSetLidTempCommand:
+    temperature: float,
+) -> command_types.ThermocyclerSetLidTempCommand:
     temp = round(float(temperature), utils.TC_GCODE_ROUNDING_PRECISION)
-    text = f'Setting Thermocycler lid temperature to {temp} °C'
-    return {
-        'name': command_types.THERMOCYCLER_SET_LID_TEMP,
-        'payload': {'text': text}
-    }
+    text = f"Setting Thermocycler lid temperature to {temp} °C"
+    return {"name": command_types.THERMOCYCLER_SET_LID_TEMP, "payload": {"text": text}}
 
 
 def thermocycler_deactivate_lid() -> command_types.ThermocyclerDeactivateLidCommand:
     text = "Deactivating Thermocycler lid heating"
     return {
-        'name': command_types.THERMOCYCLER_DEACTIVATE_LID,
-        'payload': {'text': text}
+        "name": command_types.THERMOCYCLER_DEACTIVATE_LID,
+        "payload": {"text": text},
     }
 
 
 def thermocycler_deactivate_block() -> command_types.ThermocyclerDeactivateBlockCommand:
     text = "Deactivating Thermocycler well block heating"
     return {
-        'name': command_types.THERMOCYCLER_DEACTIVATE_BLOCK,
-        'payload': {'text': text}
+        "name": command_types.THERMOCYCLER_DEACTIVATE_BLOCK,
+        "payload": {"text": text},
     }
 
 
 def thermocycler_deactivate() -> command_types.ThermocyclerDeactivateCommand:
     text = "Deactivating Thermocycler"
-    return {
-        'name': command_types.THERMOCYCLER_DEACTIVATE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.THERMOCYCLER_DEACTIVATE, "payload": {"text": text}}
 
 
 def thermocycler_wait_for_lid_temp() -> command_types.ThermocyclerWaitForLidTempCommand:
     text = "Waiting for Thermocycler lid to reach target temperature"
     return {
-        'name': command_types.THERMOCYCLER_WAIT_FOR_LID_TEMP,
-        'payload': {'text': text}
+        "name": command_types.THERMOCYCLER_WAIT_FOR_LID_TEMP,
+        "payload": {"text": text},
     }
 
 
 def thermocycler_close() -> command_types.ThermocyclerCloseCommand:
     text = "Closing Thermocycler lid"
-    return {
-        'name': command_types.THERMOCYCLER_CLOSE,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.THERMOCYCLER_CLOSE, "payload": {"text": text}}

--- a/api/src/opentrons/commands/paired_commands.py
+++ b/api/src/opentrons/commands/paired_commands.py
@@ -11,185 +11,163 @@ if TYPE_CHECKING:
     from opentrons.types import Location
 
 
-Apiv2Locations = Sequence[Union['Location', 'Well']]
-Apiv2Instruments = Sequence['InstrumentContext']
+Apiv2Locations = Sequence[Union["Location", "Well"]]
+Apiv2Instruments = Sequence["InstrumentContext"]
 
 
 def combine_locations(location: Sequence) -> str:
     if len(location) > 1:
         loc1 = stringify_location(location[0])
         loc2 = stringify_location(location[1])
-        return f'{loc1} and {loc2}'
+        return f"{loc1} and {loc2}"
     elif len(location) == 1:
         loc1 = stringify_location(location[0])
-        return f'{loc1}'
+        return f"{loc1}"
     else:
-        return ''
+        return ""
 
 
 def paired_aspirate(
-        instruments: Apiv2Instruments, volume: float,
-        locations: Apiv2Locations, rate: float,
-        pub_type: str) -> command_types.AspirateCommand:
+    instruments: Apiv2Instruments,
+    volume: float,
+    locations: Apiv2Locations,
+    rate: float,
+    pub_type: str,
+) -> command_types.AspirateCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
-        rate * FlowRates(instr._implementation).aspirate
-        for instr in instruments)
-    text_type = f'{pub_type}: Aspirating '
-    text_content = f'{volume} uL from {loc_text} at {flow_rate} uL/sec'
+        rate * FlowRates(instr._implementation).aspirate for instr in instruments
+    )
+    text_type = f"{pub_type}: Aspirating "
+    text_content = f"{volume} uL from {loc_text} at {flow_rate} uL/sec"
     text = text_type + text_content
     return {
-        'name': command_types.ASPIRATE,
-        'payload': {
-            'instruments': instruments,
-            'volume': volume,
-            'locations': locations,
-            'rate': rate,
-            'text': text
-        }
+        "name": command_types.ASPIRATE,
+        "payload": {
+            "instruments": instruments,
+            "volume": volume,
+            "locations": locations,
+            "rate": rate,
+            "text": text,
+        },
     }
 
 
 def paired_dispense(
-        instruments: Apiv2Instruments, volume: float,
-        locations: Apiv2Locations, rate: float,
-        pub_type: str) -> command_types.DispenseCommand:
+    instruments: Apiv2Instruments,
+    volume: float,
+    locations: Apiv2Locations,
+    rate: float,
+    pub_type: str,
+) -> command_types.DispenseCommand:
     loc_text = combine_locations(locations)
     flow_rate = min(
-        rate * FlowRates(instr._implementation).dispense
-        for instr in instruments)
-    text_type = f'{pub_type}: Dispensing '
-    text_content = f'{volume} uL into {loc_text} at {flow_rate} uL/sec'
+        rate * FlowRates(instr._implementation).dispense for instr in instruments
+    )
+    text_type = f"{pub_type}: Dispensing "
+    text_content = f"{volume} uL into {loc_text} at {flow_rate} uL/sec"
     text = text_type + text_content
     return {
-        'name': command_types.DISPENSE,
-        'payload': {
-            'instruments': instruments,
-            'volume': volume,
-            'locations': locations,
-            'rate': rate,
-            'text': text
-        }
+        "name": command_types.DISPENSE,
+        "payload": {
+            "instruments": instruments,
+            "volume": volume,
+            "locations": locations,
+            "rate": rate,
+            "text": text,
+        },
     }
 
 
 def paired_mix(
-        instruments: Apiv2Instruments, locations: Optional[Apiv2Locations],
-        repetitions: int, volume: float, pub_type: str) -> command_types.MixCommand:
-    text_type = f'{pub_type}: Mixing '
-    text_content = '{repetitions} times with a volume of {volume} ul'
+    instruments: Apiv2Instruments,
+    locations: Optional[Apiv2Locations],
+    repetitions: int,
+    volume: float,
+    pub_type: str,
+) -> command_types.MixCommand:
+    text_type = f"{pub_type}: Mixing "
+    text_content = "{repetitions} times with a volume of {volume} ul"
     text = text_type + text_content
     return {
-        'name': command_types.MIX,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'volume': volume,
-            'repetitions': repetitions,
-            'text': text
-        }
+        "name": command_types.MIX,
+        "payload": {
+            "instruments": instruments,
+            "locations": locations,
+            "volume": volume,
+            "repetitions": repetitions,
+            "text": text,
+        },
     }
 
 
 def paired_blow_out(
-        instruments: Apiv2Instruments,
-        locations: Optional[Apiv2Locations],
-        pub_type: str) -> command_types.BlowOutCommand:
-    text = f'{pub_type}: Blowing out'
+    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations], pub_type: str
+) -> command_types.BlowOutCommand:
+    text = f"{pub_type}: Blowing out"
 
     if locations is not None:
         location_text = combine_locations(locations)
-        text += f' at {location_text}'
+        text += f" at {location_text}"
 
     return {
-        'name': command_types.BLOW_OUT,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'text': text
-        }
+        "name": command_types.BLOW_OUT,
+        "payload": {"instruments": instruments, "locations": locations, "text": text},
     }
 
 
 def paired_touch_tip(
-        instruments: Apiv2Instruments,
-        locations: Optional[Apiv2Locations],
-        pub_type: str) -> command_types.TouchTipCommand:
-    text = f'{pub_type}: Touching tip'
+    instruments: Apiv2Instruments, locations: Optional[Apiv2Locations], pub_type: str
+) -> command_types.TouchTipCommand:
+    text = f"{pub_type}: Touching tip"
 
     if locations is not None:
         location_text = combine_locations(locations)
-        text += f' at {location_text}'
+        text += f" at {location_text}"
     return {
-        'name': command_types.TOUCH_TIP,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'text': text
-        }
+        "name": command_types.TOUCH_TIP,
+        "payload": {"instruments": instruments, "locations": locations, "text": text},
     }
 
 
 def air_gap() -> command_types.AirGapCommand:
-    text = 'Air gap'
-    return {
-        'name': command_types.AIR_GAP,
-        'payload': {
-            'text': text
-        }
-    }
+    text = "Air gap"
+    return {"name": command_types.AIR_GAP, "payload": {"text": text}}
 
 
 def return_tip() -> command_types.ReturnTipCommand:
-    text = 'Returning tip'
-    return {
-        'name': command_types.RETURN_TIP,
-        'payload': {
-            'text': text
-        }
-    }
+    text = "Returning tip"
+    return {"name": command_types.RETURN_TIP, "payload": {"text": text}}
 
 
 def paired_pick_up_tip(
-        instruments: Apiv2Instruments,
-        locations: Apiv2Locations, pub_type: str) -> command_types.PickUpTipCommand:
+    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+) -> command_types.PickUpTipCommand:
     location_text = combine_locations(locations)
-    text = f'{pub_type}: Picking up tip from {location_text}'
+    text = f"{pub_type}: Picking up tip from {location_text}"
     return {
-        'name': command_types.PICK_UP_TIP,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'text': text
-        }
+        "name": command_types.PICK_UP_TIP,
+        "payload": {"instruments": instruments, "locations": locations, "text": text},
     }
 
 
 def paired_drop_tip(
-        instruments: Apiv2Instruments,
-        locations: Apiv2Locations, pub_type: str) -> command_types.DropTipCommand:
+    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+) -> command_types.DropTipCommand:
     location_text = combine_locations(locations)
-    text = f'{pub_type}: Dropping tip into {location_text}'
+    text = f"{pub_type}: Dropping tip into {location_text}"
     return {
-        'name': command_types.DROP_TIP,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'text': text
-        }
+        "name": command_types.DROP_TIP,
+        "payload": {"instruments": instruments, "locations": locations, "text": text},
     }
 
 
 def paired_move_to(
-        instruments: Apiv2Instruments,
-        locations: Apiv2Locations, pub_type: str) -> command_types.MoveToCommand:
+    instruments: Apiv2Instruments, locations: Apiv2Locations, pub_type: str
+) -> command_types.MoveToCommand:
     location_text = combine_locations(locations)
-    text = f'{pub_type}: Moving to {location_text}'
+    text = f"{pub_type}: Moving to {location_text}"
     return {
-        'name': command_types.MOVE_TO,
-        'payload': {
-            'instruments': instruments,
-            'locations': locations,
-            'text': text
-        }
+        "name": command_types.MOVE_TO,
+        "payload": {"instruments": instruments, "locations": locations, "text": text},
     }

--- a/api/src/opentrons/commands/protocol_commands.py
+++ b/api/src/opentrons/commands/protocol_commands.py
@@ -5,52 +5,43 @@ from . import types as command_types
 
 def comment(msg: str) -> command_types.CommentCommand:
     text = msg
-    return {
-        'name': command_types.COMMENT,
-        'payload': {'text': text}
-    }
+    return {"name": command_types.COMMENT, "payload": {"text": text}}
 
 
 def delay(
-        seconds: float,
-        minutes: float,
-        msg: str = None) -> command_types.DelayCommand:
+    seconds: float, minutes: float, msg: str = None
+) -> command_types.DelayCommand:
     td = timedelta(minutes=minutes, seconds=seconds)
     actual_min, actual_sec = divmod(td.total_seconds(), 60)
 
     text = (
-        f"Delaying for {int(actual_min)} minutes and "
-        f"{round(actual_sec, 3)} seconds"
+        f"Delaying for {int(actual_min)} minutes and " f"{round(actual_sec, 3)} seconds"
     )
 
     if msg:
         text = f"{text}. {msg}"
 
     return {
-        'name': command_types.DELAY,
-        'payload': {
-            'minutes': actual_min,
-            'seconds': actual_sec,
-            'text': text
-        }
+        "name": command_types.DELAY,
+        "payload": {"minutes": actual_min, "seconds": actual_sec, "text": text},
     }
 
 
 def pause(msg: str = None) -> command_types.PauseCommand:
-    text = 'Pausing robot operation'
+    text = "Pausing robot operation"
     if msg:
-        text = text + ': {}'.format(msg)
+        text = text + ": {}".format(msg)
     return {
-        'name': command_types.PAUSE,
-        'payload': {
-            'text': text,
-            'userMessage': msg,
-        }
+        "name": command_types.PAUSE,
+        "payload": {
+            "text": text,
+            "userMessage": msg,
+        },
     }
 
 
 def resume() -> command_types.ResumeCommand:
     return {
-        'name': command_types.RESUME,
-        'payload': {'text': 'Resuming robot operation'}
+        "name": command_types.RESUME,
+        "payload": {"text": "Resuming robot operation"},
     }

--- a/api/src/opentrons/commands/publisher.py
+++ b/api/src/opentrons/commands/publisher.py
@@ -44,106 +44,100 @@ CmdFunction = Callable[..., command_types.Command]
 
 
 def do_publish(
-        broker: Broker,
-        cmd: CmdFunction,
-        f: Callable,
-        when: command_types.MessageSequenceId,
-        res: Any,
-        meta: Any,
-        *args: Any, **kwargs: Any) -> None:
-    """ Implement the publish so it can be called outside the decorator """
-    publish_command = functools.partial(
-        broker.publish,
-        topic=command_types.COMMAND)
+    broker: Broker,
+    cmd: CmdFunction,
+    f: Callable,
+    when: command_types.MessageSequenceId,
+    res: Any,
+    meta: Any,
+    *args: Any,
+    **kwargs: Any
+) -> None:
+    """Implement the publish so it can be called outside the decorator"""
+    publish_command = functools.partial(broker.publish, topic=command_types.COMMAND)
     call_args = _get_args(f, args, kwargs)
-    if when == 'before':
-        broker.logger.info("{}: {}".format(
-            f.__qualname__,
-            {k: v for k, v in call_args.items() if str(k) != 'self'}))
+    if when == "before":
+        broker.logger.info(
+            "{}: {}".format(
+                f.__qualname__, {k: v for k, v in call_args.items() if str(k) != "self"}
+            )
+        )
     getfullargspec = getfullargspec_cache.get(cmd)
     command_args = dict(
-        zip(
-            reversed(getfullargspec.args),
-            reversed(getfullargspec.defaults
-                     or [])))
+        zip(reversed(getfullargspec.args), reversed(getfullargspec.defaults or []))
+    )
 
     # TODO (artyom, 20170927): we are doing this to be able to use
     # the decorator in Instrument class methods, in which case
     # self is effectively an instrument.
     # To narrow the scope of this hack, we are checking if the
     # command is expecting instrument first.
-    if 'instrument' in getfullargspec.args:
+    if "instrument" in getfullargspec.args:
         # We are also checking if call arguments have 'self' and
         # don't have instruments specified, in which case
         # instruments should take precedence.
-        if 'instrument' not in call_args and 'self' in call_args:
-            call_args['instrument'] = call_args['self']
+        if "instrument" not in call_args and "self" in call_args:
+            call_args["instrument"] = call_args["self"]
 
-    command_args.update({
-        key: call_args[key]
-        for key in
-        (set(getfullargspec.args)
-         & call_args.keys())
-    })
+    command_args.update(
+        {key: call_args[key] for key in (set(getfullargspec.args) & call_args.keys())}
+    )
 
     if meta:
-        command_args['meta'] = meta
+        command_args["meta"] = meta
 
     payload = cmd(**command_args)
 
-    publish_command(
-        message={**payload, '$': when})
+    publish_command(message={**payload, "$": when})
 
 
 def publish_paired(
-        broker: Broker,
-        cmd: CmdFunction,
-        when: command_types.MessageSequenceId,
-        res: Any,
-        *args: Any,
-        pub_type: str = 'Paired Pipettes') -> None:
-    """ Implement a second publisher outside of the decorator that
+    broker: Broker,
+    cmd: CmdFunction,
+    when: command_types.MessageSequenceId,
+    res: Any,
+    *args: Any,
+    pub_type: str = "Paired Pipettes"
+) -> None:
+    """Implement a second publisher outside of the decorator that
     relies on the method providing all of the arguments required
     rather than binding defaults to the signature"""
-    publish_command = functools.partial(
-        broker.publish,
-        topic=command_types.COMMAND)
+    publish_command = functools.partial(broker.publish, topic=command_types.COMMAND)
 
     payload = cmd(*args, pub_type)
 
-    publish_command(message={**payload, '$': when})
+    publish_command(message={**payload, "$": when})
 
 
 def _publish_dec(
-        before: bool,
-        after: bool,
-        command: CmdFunction,
-        meta: Any = None):  # noqa: ANN202
+    before: bool, after: bool, command: CmdFunction, meta: Any = None
+):  # noqa: ANN202
     def _decorator(f: Callable):  # noqa: ANN202
         @functools.wraps(
-            f,
-            updated=functools.WRAPPER_UPDATES + ('__globals__',))  # type: ignore
+            f, updated=functools.WRAPPER_UPDATES + ("__globals__",)  # type: ignore[operator]  # noqa: E501
+        )
         def _decorated(*args, **kwargs):  # noqa: ANN202,ANN003,ANN002
             try:
                 broker = cast(Broker, args[0].broker)
             except AttributeError:
-                raise RuntimeError("Only methods of CommandPublisher \
-                    classes should be decorated.")
+                raise RuntimeError(
+                    "Only methods of CommandPublisher \
+                    classes should be decorated."
+                )
             if before:
-                do_publish(
-                    broker, command, f, 'before', None, meta, *args, **kwargs)
+                do_publish(broker, command, f, "before", None, meta, *args, **kwargs)
             res = f(*args, **kwargs)
             if after:
-                do_publish(
-                    broker, command, f, 'after', res, meta, *args, **kwargs)
+                do_publish(broker, command, f, "after", res, meta, *args, **kwargs)
             return res
+
         return _decorated
 
     return _decorator
 
 
 class publish:
-    """ Class that allows namespaced decorators with valid mypy types
+    """Class that allows namespaced decorators with valid mypy types
 
     These were previously defined by adding them as attributes to the
     publish function, which is not currently supported by mypy:
@@ -155,15 +149,13 @@ class publish:
     Only commands inheriting from class CommandPublisher should contain
     decorators.
     """
+
     before = functools.partial(_publish_dec, before=True, after=False)
     after = functools.partial(_publish_dec, before=False, after=True)
     both = functools.partial(_publish_dec, before=True, after=True)
 
 
-def _get_args(
-        f: Callable,
-        args: Tuple,
-        kwargs: Mapping[str, Any]) -> Dict[str, Any]:
+def _get_args(f: Callable, args: Tuple, kwargs: Mapping[str, Any]) -> Dict[str, Any]:
     # Create the initial dictionary with args that have defaults
     res = {}
     sig = signature_cache.get(f)
@@ -171,7 +163,7 @@ def _get_args(
     if ismethod and args[0] is f.__self__:  # type: ignore
         args = args[1:]
     if ismethod:
-        res['self'] = f.__self__  # type: ignore
+        res["self"] = f.__self__  # type: ignore
 
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -12,53 +12,53 @@ from opentrons.types import Location
 
 
 # type for subscriptions
-COMMAND: Final = 'command'
+COMMAND: Final = "command"
 
 # Robot #
 
-DELAY: Final = 'command.DELAY'
-HOME: Final = 'command.HOME'
-PAUSE: Final = 'command.PAUSE'
-RESUME: Final = 'command.RESUME'
-COMMENT: Final = 'command.COMMENT'
+DELAY: Final = "command.DELAY"
+HOME: Final = "command.HOME"
+PAUSE: Final = "command.PAUSE"
+RESUME: Final = "command.RESUME"
+COMMENT: Final = "command.COMMENT"
 
 # Pipette #
 
-ASPIRATE: Final = 'command.ASPIRATE'
-DISPENSE: Final = 'command.DISPENSE'
-MIX: Final = 'command.MIX'
-CONSOLIDATE: Final = 'command.CONSOLIDATE'
-DISTRIBUTE: Final = 'command.DISTRIBUTE'
-TRANSFER: Final = 'command.TRANSFER'
-PICK_UP_TIP: Final = 'command.PICK_UP_TIP'
-DROP_TIP: Final = 'command.DROP_TIP'
-BLOW_OUT: Final = 'command.BLOW_OUT'
-AIR_GAP: Final = 'command.AIR_GAP'
-TOUCH_TIP: Final = 'command.TOUCH_TIP'
-RETURN_TIP: Final = 'command.RETURN_TIP'
-MOVE_TO: Final = 'command.MOVE_TO'
+ASPIRATE: Final = "command.ASPIRATE"
+DISPENSE: Final = "command.DISPENSE"
+MIX: Final = "command.MIX"
+CONSOLIDATE: Final = "command.CONSOLIDATE"
+DISTRIBUTE: Final = "command.DISTRIBUTE"
+TRANSFER: Final = "command.TRANSFER"
+PICK_UP_TIP: Final = "command.PICK_UP_TIP"
+DROP_TIP: Final = "command.DROP_TIP"
+BLOW_OUT: Final = "command.BLOW_OUT"
+AIR_GAP: Final = "command.AIR_GAP"
+TOUCH_TIP: Final = "command.TOUCH_TIP"
+RETURN_TIP: Final = "command.RETURN_TIP"
+MOVE_TO: Final = "command.MOVE_TO"
 
 # Modules #
 
-MAGDECK_CALIBRATE: Final = 'command.MAGDECK_CALIBRATE'
-MAGDECK_DISENGAGE: Final = 'command.MAGDECK_DISENGAGE'
-MAGDECK_ENGAGE: Final = 'command.MAGDECK_ENGAGE'
+MAGDECK_CALIBRATE: Final = "command.MAGDECK_CALIBRATE"
+MAGDECK_DISENGAGE: Final = "command.MAGDECK_DISENGAGE"
+MAGDECK_ENGAGE: Final = "command.MAGDECK_ENGAGE"
 
-TEMPDECK_DEACTIVATE: Final = 'command.TEMPDECK_DEACTIVATE'
-TEMPDECK_SET_TEMP: Final = 'command.TEMPDECK_SET_TEMP'
-TEMPDECK_AWAIT_TEMP: Final = 'command.TEMPDECK_AWAIT_TEMP'
+TEMPDECK_DEACTIVATE: Final = "command.TEMPDECK_DEACTIVATE"
+TEMPDECK_SET_TEMP: Final = "command.TEMPDECK_SET_TEMP"
+TEMPDECK_AWAIT_TEMP: Final = "command.TEMPDECK_AWAIT_TEMP"
 
-THERMOCYCLER_OPEN: Final = 'command.THERMOCYCLER_OPEN'
-THERMOCYCLER_CLOSE: Final = 'command.THERMOCYCLER_CLOSE'
-THERMOCYCLER_SET_BLOCK_TEMP: Final = 'command.THERMOCYCLER_SET_BLOCK_TEMP'
-THERMOCYCLER_EXECUTE_PROFILE: Final = 'command.THERMOCYCLER_EXECUTE_PROFILE'
-THERMOCYCLER_DEACTIVATE: Final = 'command.THERMOCYCLER_DEACTIVATE'
-THERMOCYCLER_WAIT_FOR_HOLD: Final = 'command.THERMOCYCLER_WAIT_FOR_HOLD'
-THERMOCYCLER_WAIT_FOR_TEMP: Final = 'command.THERMOCYCLER_WAIT_FOR_TEMP'
-THERMOCYCLER_WAIT_FOR_LID_TEMP: Final = 'command.THERMOCYCLER_WAIT_FOR_LID_TEMP'
-THERMOCYCLER_SET_LID_TEMP: Final = 'command.THERMOCYCLER_SET_LID_TEMP'
-THERMOCYCLER_DEACTIVATE_LID: Final = 'command.THERMOCYCLER_DEACTIVATE_LID'
-THERMOCYCLER_DEACTIVATE_BLOCK: Final = 'command.THERMOCYCLER_DEACTIVATE_BLOCK'
+THERMOCYCLER_OPEN: Final = "command.THERMOCYCLER_OPEN"
+THERMOCYCLER_CLOSE: Final = "command.THERMOCYCLER_CLOSE"
+THERMOCYCLER_SET_BLOCK_TEMP: Final = "command.THERMOCYCLER_SET_BLOCK_TEMP"
+THERMOCYCLER_EXECUTE_PROFILE: Final = "command.THERMOCYCLER_EXECUTE_PROFILE"
+THERMOCYCLER_DEACTIVATE: Final = "command.THERMOCYCLER_DEACTIVATE"
+THERMOCYCLER_WAIT_FOR_HOLD: Final = "command.THERMOCYCLER_WAIT_FOR_HOLD"
+THERMOCYCLER_WAIT_FOR_TEMP: Final = "command.THERMOCYCLER_WAIT_FOR_TEMP"
+THERMOCYCLER_WAIT_FOR_LID_TEMP: Final = "command.THERMOCYCLER_WAIT_FOR_LID_TEMP"
+THERMOCYCLER_SET_LID_TEMP: Final = "command.THERMOCYCLER_SET_LID_TEMP"
+THERMOCYCLER_DEACTIVATE_LID: Final = "command.THERMOCYCLER_DEACTIVATE_LID"
+THERMOCYCLER_DEACTIVATE_BLOCK: Final = "command.THERMOCYCLER_DEACTIVATE_BLOCK"
 
 
 class TextOnlyPayload(TypedDict):
@@ -82,8 +82,11 @@ class OptionalSingleLocationPayload(TypedDict):
 
 
 HasLocationPayload = Union[
-    SingleLocationPayload, MultiLocationPayload,
-    OptionalSingleLocationPayload, OptionalMultiLocationPayload]
+    SingleLocationPayload,
+    MultiLocationPayload,
+    OptionalSingleLocationPayload,
+    OptionalMultiLocationPayload,
+]
 
 
 class SingleInstrumentPayload(TypedDict):
@@ -102,7 +105,7 @@ class CommentCommandPayload(TextOnlyPayload):
 
 
 class CommentCommand(TypedDict):
-    name: Literal['command.COMMENT']
+    name: Literal["command.COMMENT"]
     payload: CommentCommandPayload
 
 
@@ -112,7 +115,7 @@ class DelayCommandPayload(TextOnlyPayload):
 
 
 class DelayCommand(TypedDict):
-    name: Literal['command.DELAY']
+    name: Literal["command.DELAY"]
     payload: DelayCommandPayload
 
 
@@ -121,7 +124,7 @@ class PauseCommandPayload(TextOnlyPayload):
 
 
 class PauseCommand(TypedDict):
-    name: Literal['command.PAUSE']
+    name: Literal["command.PAUSE"]
     payload: PauseCommandPayload
 
 
@@ -130,7 +133,7 @@ class ResumeCommandPayload(TextOnlyPayload):
 
 
 class ResumeCommand(TypedDict):
-    name: Literal['command.RESUME']
+    name: Literal["command.RESUME"]
     payload: ResumeCommandPayload
 
 
@@ -139,7 +142,7 @@ class MagdeckEngageCommandPayload(TextOnlyPayload):
 
 
 class MagdeckEngageCommand(TypedDict):
-    name: Literal['command.MAGDECK_ENGAGE']
+    name: Literal["command.MAGDECK_ENGAGE"]
     payload: MagdeckEngageCommandPayload
 
 
@@ -148,7 +151,7 @@ class MagdeckDisengageCommandPayload(TextOnlyPayload):
 
 
 class MagdeckDisengageCommand(TypedDict):
-    name: Literal['command.MAGDECK_DISENGAGE']
+    name: Literal["command.MAGDECK_DISENGAGE"]
     payload: MagdeckDisengageCommandPayload
 
 
@@ -157,7 +160,7 @@ class MagdeckCalibrateCommandPayload(TextOnlyPayload):
 
 
 class MagdeckCalibrateCommand(TypedDict):
-    name: Literal['command.MAGDECK_CALIBRATE']
+    name: Literal["command.MAGDECK_CALIBRATE"]
     payload: MagdeckCalibrateCommandPayload
 
 
@@ -166,7 +169,7 @@ class TempdeckSetTempCommandPayload(TextOnlyPayload):
 
 
 class TempdeckSetTempCommand(TypedDict):
-    name: Literal['command.TEMPDECK_SET_TEMP']
+    name: Literal["command.TEMPDECK_SET_TEMP"]
     payload: TempdeckSetTempCommandPayload
 
 
@@ -175,7 +178,7 @@ class TempdeckAwaitTempCommandPayload(TextOnlyPayload):
 
 
 class TempdeckAwaitTempCommand(TypedDict):
-    name: Literal['command.TEMPDECK_AWAIT_TEMP']
+    name: Literal["command.TEMPDECK_AWAIT_TEMP"]
     payload: TempdeckAwaitTempCommandPayload
 
 
@@ -184,7 +187,7 @@ class TempdeckDeactivateCommandPayload(TextOnlyPayload):
 
 
 class TempdeckDeactivateCommand(TypedDict):
-    name: Literal['command.TEMPDECK_DEACTIVATE']
+    name: Literal["command.TEMPDECK_DEACTIVATE"]
     payload: TempdeckDeactivateCommandPayload
 
 
@@ -193,7 +196,7 @@ class ThermocyclerOpenCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerOpenCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_OPEN']
+    name: Literal["command.THERMOCYCLER_OPEN"]
     payload: ThermocyclerOpenCommandPayload
 
 
@@ -203,7 +206,7 @@ class ThermocyclerSetBlockTempCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerSetBlockTempCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_SET_BLOCK_TEMP']
+    name: Literal["command.THERMOCYCLER_SET_BLOCK_TEMP"]
     payload: ThermocyclerSetBlockTempCommandPayload
 
 
@@ -212,7 +215,7 @@ class ThermocyclerExecuteProfileCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerExecuteProfileCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_EXECUTE_PROFILE']
+    name: Literal["command.THERMOCYCLER_EXECUTE_PROFILE"]
     payload: ThermocyclerExecuteProfileCommandPayload
 
 
@@ -221,7 +224,7 @@ class ThermocyclerWaitForHoldCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerWaitForHoldCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_WAIT_FOR_HOLD']
+    name: Literal["command.THERMOCYCLER_WAIT_FOR_HOLD"]
     payload: ThermocyclerWaitForHoldCommandPayload
 
 
@@ -230,7 +233,7 @@ class ThermocyclerWaitForTempCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerWaitForTempCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_WAIT_FOR_TEMP']
+    name: Literal["command.THERMOCYCLER_WAIT_FOR_TEMP"]
     payload: ThermocyclerWaitForTempCommandPayload
 
 
@@ -239,7 +242,7 @@ class ThermocyclerSetLidTempCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerSetLidTempCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_SET_LID_TEMP']
+    name: Literal["command.THERMOCYCLER_SET_LID_TEMP"]
     payload: ThermocyclerSetLidTempCommandPayload
 
 
@@ -248,7 +251,7 @@ class ThermocyclerDeactivateLidCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerDeactivateLidCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_DEACTIVATE_LID']
+    name: Literal["command.THERMOCYCLER_DEACTIVATE_LID"]
     payload: ThermocyclerDeactivateLidCommandPayload
 
 
@@ -257,7 +260,7 @@ class ThermocyclerDeactivateBlockCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerDeactivateBlockCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_DEACTIVATE_BLOCK']
+    name: Literal["command.THERMOCYCLER_DEACTIVATE_BLOCK"]
     payload: ThermocyclerDeactivateBlockCommandPayload
 
 
@@ -266,7 +269,7 @@ class ThermocyclerDeactivateCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerDeactivateCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_DEACTIVATE']
+    name: Literal["command.THERMOCYCLER_DEACTIVATE"]
     payload: ThermocyclerDeactivateCommandPayload
 
 
@@ -275,7 +278,7 @@ class ThermocyclerWaitForLidTempCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerWaitForLidTempCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_WAIT_FOR_LID_TEMP']
+    name: Literal["command.THERMOCYCLER_WAIT_FOR_LID_TEMP"]
     payload: ThermocyclerWaitForLidTempCommandPayload
 
 
@@ -284,7 +287,7 @@ class ThermocyclerCloseCommandPayload(TextOnlyPayload):
 
 
 class ThermocyclerCloseCommand(TypedDict):
-    name: Literal['command.THERMOCYCLER_CLOSE']
+    name: Literal["command.THERMOCYCLER_CLOSE"]
     payload: ThermocyclerCloseCommandPayload
 
 
@@ -293,112 +296,121 @@ class HomeCommandPayload(TextOnlyPayload):
 
 
 class HomeCommand(TypedDict):
-    name: Literal['command.HOME']
+    name: Literal["command.HOME"]
     payload: HomeCommandPayload
 
 
 class SimpleLHCommandPayload(
-        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload
+):
     volume: float
     rate: float
 
 
 class SimplePairedLHCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload
+):
     volume: float
     rate: float
 
 
 class AspirateCommand(TypedDict):
-    name: Literal['command.ASPIRATE']
+    name: Literal["command.ASPIRATE"]
     payload: Union[SimpleLHCommandPayload, SimplePairedLHCommandPayload]
 
 
 class DispenseCommand(TypedDict):
-    name: Literal['command.DISPENSE']
+    name: Literal["command.DISPENSE"]
     payload: Union[SimpleLHCommandPayload, SimplePairedLHCommandPayload]
 
 
 class ConsolidateCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload
+):
     volume: Union[float, List[float]]
     source: List[Union[Location, Well]]
     dest: Union[Location, Well]
 
 
 class ConsolidateCommand(TypedDict):
-    name: Literal['command.CONSOLIDATE']
+    name: Literal["command.CONSOLIDATE"]
     payload: ConsolidateCommandPayload
 
 
 class DistributeCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload
+):
     volume: Union[float, List[float]]
     source: Union[Location, Well]
     dest: List[Union[Location, Well]]
 
 
 class DistributeCommand(TypedDict):
-    name: Literal['command.DISTRIBUTE']
+    name: Literal["command.DISTRIBUTE"]
     payload: DistributeCommandPayload
 
 
 class TransferCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload
+):
     volume: Union[float, List[float]]
     source: List[Union[Location, Well]]
     dest: List[Union[Location, Well]]
 
 
 class TransferCommand(TypedDict):
-    name: Literal['command.TRANSFER']
+    name: Literal["command.TRANSFER"]
     payload: TransferCommandPayload
 
 
 class MixCommandPayload(
-        TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload
+):
     volume: float
     repetitions: int
 
 
 class PairedMixCommandPayload(
-        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload
+):
     volume: float
     repetitions: int
 
 
 class MixCommand(TypedDict):
-    name: Literal['command.MIX']
+    name: Literal["command.MIX"]
     payload: Union[MixCommandPayload, PairedMixCommandPayload]
 
 
 class BlowOutCommandPayload(
-        TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, OptionalSingleLocationPayload, SingleInstrumentPayload
+):
     pass
 
 
 class PairedBlowOutCommandPayload(
-        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload
+):
     pass
 
 
 class BlowOutCommand(TypedDict):
-    name: Literal['command.BLOW_OUT']
+    name: Literal["command.BLOW_OUT"]
     payload: Union[BlowOutCommandPayload, PairedBlowOutCommandPayload]
 
 
-class TouchTipCommandPayload(
-        TextOnlyPayload, SingleInstrumentPayload):
+class TouchTipCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
     pass
 
 
 class PairedTouchTipCommandPayload(
-        TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, OptionalMultiLocationPayload, MultiInstrumentPayload
+):
     pass
 
 
 class TouchTipCommand(TypedDict):
-    name: Literal['command.TOUCH_TIP']
+    name: Literal["command.TOUCH_TIP"]
     payload: Union[TouchTipCommandPayload, PairedTouchTipCommandPayload]
 
 
@@ -407,7 +419,7 @@ class AirGapCommandPayload(TextOnlyPayload):
 
 
 class AirGapCommand(TypedDict):
-    name: Literal['command.AIR_GAP']
+    name: Literal["command.AIR_GAP"]
     payload: AirGapCommandPayload
 
 
@@ -416,75 +428,106 @@ class ReturnTipCommandPayload(TextOnlyPayload):
 
 
 class ReturnTipCommand(TypedDict):
-    name: Literal['command.RETURN_TIP']
+    name: Literal["command.RETURN_TIP"]
     payload: ReturnTipCommandPayload
 
 
 class PickUpTipCommandPayload(
-        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload
+):
     pass
 
 
 class PairedPickUpTipCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload
+):
     pass
 
 
 class PickUpTipCommand(TypedDict):
-    name: Literal['command.PICK_UP_TIP']
+    name: Literal["command.PICK_UP_TIP"]
     payload: Union[PickUpTipCommandPayload, PairedPickUpTipCommandPayload]
     pass
 
 
 class DropTipCommandPayload(
-        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload
+):
     pass
 
 
 class PairedDropTipCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload
+):
     pass
 
 
 class DropTipCommand(TypedDict):
-    name: Literal['command.DROP_TIP']
+    name: Literal["command.DROP_TIP"]
     payload: Union[DropTipCommandPayload, PairedDropTipCommandPayload]
 
 
 class MoveToCommand(TypedDict):
-    name: Literal['command.MOVE_TO']
+    name: Literal["command.MOVE_TO"]
     payload: Union[MoveToCommandPayload, PairedMoveToCommandPayload]
 
 
 class MoveToCommandPayload(
-        TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload):
+    TextOnlyPayload, SingleLocationPayload, SingleInstrumentPayload
+):
     pass
 
 
 class PairedMoveToCommandPayload(
-        TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload):
+    TextOnlyPayload, MultiLocationPayload, MultiInstrumentPayload
+):
     pass
 
 
 Command = Union[
-    DropTipCommand, PickUpTipCommand, ReturnTipCommand, AirGapCommand,
-    TouchTipCommand, BlowOutCommand, MixCommand, TransferCommand,
-    DistributeCommand, ConsolidateCommand, DispenseCommand, AspirateCommand,
-    HomeCommand, ThermocyclerCloseCommand, ThermocyclerWaitForLidTempCommand,
-    ThermocyclerDeactivateCommand, ThermocyclerDeactivateBlockCommand,
-    ThermocyclerDeactivateLidCommand, ThermocyclerSetLidTempCommand,
-    ThermocyclerWaitForTempCommand, ThermocyclerWaitForHoldCommand,
-    ThermocyclerExecuteProfileCommand, ThermocyclerSetBlockTempCommand,
+    DropTipCommand,
+    PickUpTipCommand,
+    ReturnTipCommand,
+    AirGapCommand,
+    TouchTipCommand,
+    BlowOutCommand,
+    MixCommand,
+    TransferCommand,
+    DistributeCommand,
+    ConsolidateCommand,
+    DispenseCommand,
+    AspirateCommand,
+    HomeCommand,
+    ThermocyclerCloseCommand,
+    ThermocyclerWaitForLidTempCommand,
+    ThermocyclerDeactivateCommand,
+    ThermocyclerDeactivateBlockCommand,
+    ThermocyclerDeactivateLidCommand,
+    ThermocyclerSetLidTempCommand,
+    ThermocyclerWaitForTempCommand,
+    ThermocyclerWaitForHoldCommand,
+    ThermocyclerExecuteProfileCommand,
+    ThermocyclerSetBlockTempCommand,
     ThermocyclerOpenCommand,
-    TempdeckDeactivateCommand, TempdeckAwaitTempCommand,
-    TempdeckSetTempCommand, MagdeckCalibrateCommand, MagdeckDisengageCommand,
-    MagdeckEngageCommand, ResumeCommand, PauseCommand, DelayCommand,
-    CommentCommand, MoveToCommand]
+    TempdeckDeactivateCommand,
+    TempdeckAwaitTempCommand,
+    TempdeckSetTempCommand,
+    MagdeckCalibrateCommand,
+    MagdeckDisengageCommand,
+    MagdeckEngageCommand,
+    ResumeCommand,
+    PauseCommand,
+    DelayCommand,
+    CommentCommand,
+    MoveToCommand,
+]
 
 
 CommandPayload = Union[
-    CommentCommandPayload, ResumeCommandPayload,
-    MagdeckEngageCommandPayload, MagdeckDisengageCommandPayload,
+    CommentCommandPayload,
+    ResumeCommandPayload,
+    MagdeckEngageCommandPayload,
+    MagdeckDisengageCommandPayload,
     MagdeckCalibrateCommandPayload,
     ThermocyclerOpenCommandPayload,
     ThermocyclerWaitForHoldCommandPayload,
@@ -495,32 +538,40 @@ CommandPayload = Union[
     ThermocyclerDeactivateCommandPayload,
     ThermocyclerWaitForLidTempCommand,
     ThermocyclerCloseCommandPayload,
-    AirGapCommandPayload, ReturnTipCommandPayload,
-    DropTipCommandPayload, PairedDropTipCommandPayload,
-    PickUpTipCommandPayload, PairedPickUpTipCommandPayload,
-    TouchTipCommandPayload, PairedTouchTipCommandPayload,
-    BlowOutCommandPayload, PairedBlowOutCommandPayload,
-    MixCommandPayload, PairedMixCommandPayload,
-    TransferCommandPayload, DistributeCommandPayload, ConsolidateCommandPayload,
-    SimpleLHCommandPayload, SimplePairedLHCommandPayload,
+    AirGapCommandPayload,
+    ReturnTipCommandPayload,
+    DropTipCommandPayload,
+    PairedDropTipCommandPayload,
+    PickUpTipCommandPayload,
+    PairedPickUpTipCommandPayload,
+    TouchTipCommandPayload,
+    PairedTouchTipCommandPayload,
+    BlowOutCommandPayload,
+    PairedBlowOutCommandPayload,
+    MixCommandPayload,
+    PairedMixCommandPayload,
+    TransferCommandPayload,
+    DistributeCommandPayload,
+    ConsolidateCommandPayload,
+    SimpleLHCommandPayload,
+    SimplePairedLHCommandPayload,
     HomeCommandPayload,
     ThermocyclerExecuteProfileCommandPayload,
     ThermocyclerSetBlockTempCommandPayload,
     TempdeckAwaitTempCommandPayload,
     TempdeckSetTempCommandPayload,
-    PauseCommandPayload, DelayCommandPayload,
-    MoveToCommandPayload, PairedMoveToCommandPayload
+    PauseCommandPayload,
+    DelayCommandPayload,
+    MoveToCommandPayload,
+    PairedMoveToCommandPayload,
 ]
 
 
-MessageSequenceId = Union[Literal['before'], Literal['after']]
+MessageSequenceId = Union[Literal["before"], Literal["after"]]
 
 
-CommandMessageSequence = TypedDict('CommandMessageSequence',
-
-                                   {'$': MessageSequenceId})
-CommandMessageMeta = TypedDict('CommandMessageMeta',
-                               {'meta': Any}, total=False)
+CommandMessageSequence = TypedDict("CommandMessageSequence", {"$": MessageSequenceId})
+CommandMessageMeta = TypedDict("CommandMessageMeta", {"meta": Any}, total=False)
 
 
 class CommandMessageFields(CommandMessageMeta, CommandMessageSequence):
@@ -583,83 +634,85 @@ class HomeMessage(CommandMessageFields, HomeCommand):
     pass
 
 
-class ThermocyclerCloseMessage(
-        CommandMessageFields, ThermocyclerCloseCommand):
+class ThermocyclerCloseMessage(CommandMessageFields, ThermocyclerCloseCommand):
     pass
 
 
 class ThermocyclerWaitForLidTempMessage(
-        CommandMessageFields, ThermocyclerWaitForLidTempCommand):
+    CommandMessageFields, ThermocyclerWaitForLidTempCommand
+):
     pass
 
 
 class ThermocyclerDeactivateMessage(
-        CommandMessageFields, ThermocyclerDeactivateCommand):
+    CommandMessageFields, ThermocyclerDeactivateCommand
+):
     pass
 
 
 class ThermocyclerDeactivateBlockMessage(
-        CommandMessageFields, ThermocyclerDeactivateBlockCommand):
+    CommandMessageFields, ThermocyclerDeactivateBlockCommand
+):
     pass
 
 
 class ThermocyclerDeactivateLidMessage(
-        CommandMessageFields, ThermocyclerDeactivateLidCommand):
+    CommandMessageFields, ThermocyclerDeactivateLidCommand
+):
     pass
 
 
 class ThermocyclerSetLidTempMessage(
-        CommandMessageFields, ThermocyclerSetLidTempCommand):
+    CommandMessageFields, ThermocyclerSetLidTempCommand
+):
     pass
 
 
 class ThermocyclerWaitForTempMessage(
-        CommandMessageFields, ThermocyclerWaitForTempCommand):
+    CommandMessageFields, ThermocyclerWaitForTempCommand
+):
     pass
 
 
 class ThermocyclerWaitForHoldMessage(
-        CommandMessageFields, ThermocyclerWaitForHoldCommand):
+    CommandMessageFields, ThermocyclerWaitForHoldCommand
+):
     pass
 
 
 class ThermocyclerExecuteProfileMessage(
-        CommandMessageFields, ThermocyclerExecuteProfileCommand):
+    CommandMessageFields, ThermocyclerExecuteProfileCommand
+):
     pass
 
 
 class ThermocyclerSetBlockTempMessage(
-        CommandMessageFields, ThermocyclerSetBlockTempCommand):
+    CommandMessageFields, ThermocyclerSetBlockTempCommand
+):
     pass
 
 
-class ThermocyclerOpenMessage(
-        CommandMessageFields, ThermocyclerOpenCommand):
+class ThermocyclerOpenMessage(CommandMessageFields, ThermocyclerOpenCommand):
     pass
 
 
-class TempdeckDeactivateMessage(
-        CommandMessageFields, TempdeckDeactivateCommand):
+class TempdeckDeactivateMessage(CommandMessageFields, TempdeckDeactivateCommand):
     pass
 
 
-class TempdeckAwaitTempMessage(
-        CommandMessageFields, TempdeckAwaitTempCommand):
+class TempdeckAwaitTempMessage(CommandMessageFields, TempdeckAwaitTempCommand):
     pass
 
 
-class TempdeckSetTempMessage(
-        CommandMessageFields, TempdeckSetTempCommand):
+class TempdeckSetTempMessage(CommandMessageFields, TempdeckSetTempCommand):
     pass
 
 
-class MagdeckCalibrateMessage(
-        CommandMessageFields, MagdeckCalibrateCommand):
+class MagdeckCalibrateMessage(CommandMessageFields, MagdeckCalibrateCommand):
     pass
 
 
-class MagdeckDisengageMessage(
-        CommandMessageFields, MagdeckDisengageCommand):
+class MagdeckDisengageMessage(CommandMessageFields, MagdeckDisengageCommand):
     pass
 
 
@@ -684,14 +737,38 @@ class CommentMessage(CommandMessageFields, CommentCommand):
 
 
 CommandMessage = Union[
-    DropTipMessage, PickUpTipMessage, ReturnTipMessage, AirGapMessage,
-    TouchTipMessage, BlowOutMessage, MixMessage, TransferMessage,
-    DistributeMessage, ConsolidateMessage, DispenseMessage, AspirateMessage,
-    HomeMessage, ThermocyclerCloseMessage, ThermocyclerWaitForLidTempMessage,
-    ThermocyclerDeactivateMessage, ThermocyclerDeactivateBlockMessage,
-    ThermocyclerDeactivateLidMessage, ThermocyclerSetLidTempMessage,
-    ThermocyclerWaitForTempMessage, ThermocyclerWaitForHoldMessage,
-    ThermocyclerExecuteProfileMessage, ThermocyclerSetBlockTempMessage,
-    ThermocyclerOpenMessage, TempdeckSetTempMessage, TempdeckDeactivateMessage,
-    MagdeckEngageMessage, MagdeckDisengageMessage, MagdeckCalibrateMessage,
-    CommentMessage, DelayMessage, PauseMessage, ResumeMessage, MoveToMessage]
+    DropTipMessage,
+    PickUpTipMessage,
+    ReturnTipMessage,
+    AirGapMessage,
+    TouchTipMessage,
+    BlowOutMessage,
+    MixMessage,
+    TransferMessage,
+    DistributeMessage,
+    ConsolidateMessage,
+    DispenseMessage,
+    AspirateMessage,
+    HomeMessage,
+    ThermocyclerCloseMessage,
+    ThermocyclerWaitForLidTempMessage,
+    ThermocyclerDeactivateMessage,
+    ThermocyclerDeactivateBlockMessage,
+    ThermocyclerDeactivateLidMessage,
+    ThermocyclerSetLidTempMessage,
+    ThermocyclerWaitForTempMessage,
+    ThermocyclerWaitForHoldMessage,
+    ThermocyclerExecuteProfileMessage,
+    ThermocyclerSetBlockTempMessage,
+    ThermocyclerOpenMessage,
+    TempdeckSetTempMessage,
+    TempdeckDeactivateMessage,
+    MagdeckEngageMessage,
+    MagdeckDisengageMessage,
+    MagdeckCalibrateMessage,
+    CommentMessage,
+    DelayMessage,
+    PauseMessage,
+    ResumeMessage,
+    MoveToMessage,
+]

--- a/api/src/opentrons/commands/util.py
+++ b/api/src/opentrons/commands/util.py
@@ -17,6 +17,7 @@ def from_list(commands):
     that represents a DFS traversal of a command tree,
     returns a dictionary representing command tree.
     """
+
     def subtrees(commands, level):
         if not commands:
             return
@@ -25,7 +26,7 @@ def from_list(commands):
         parent, *commands = commands
 
         for command in commands:
-            if command['level'] > level:
+            if command["level"] > level:
                 acc.append(command)
             else:
                 yield (parent, acc)
@@ -36,9 +37,9 @@ def from_list(commands):
     def walk(commands, level=0):
         return [
             {
-                'description': key['description'],
-                'children': walk(subtree, level + 1),
-                'id': key['id']
+                "description": key["description"],
+                "children": walk(subtree, level + 1),
+                "id": key["id"],
             }
             for key, subtree in subtrees(commands, level)
         ]

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -34,18 +34,20 @@ import sys
 from enum import Enum, auto
 from typing import Dict, NamedTuple, Optional, Union
 
-_CONFIG_FILENAME = 'config.json'
-_LEGACY_INDICES = (Path('/mnt') / 'usbdrive' / 'config' / 'index.json',
-                   Path('/data') / 'index.json')
+_CONFIG_FILENAME = "config.json"
+_LEGACY_INDICES = (
+    Path("/mnt") / "usbdrive" / "config" / "index.json",
+    Path("/data") / "index.json",
+)
 
 log = logging.getLogger(__file__)
 
-IS_WIN = sys.platform.startswith('win')
-IS_OSX = sys.platform == 'darwin'
-IS_LINUX = sys.platform.startswith('linux')
-IS_ROBOT = bool(IS_LINUX and os.environ.get('RUNNING_ON_PI'))
+IS_WIN = sys.platform.startswith("win")
+IS_OSX = sys.platform == "darwin"
+IS_LINUX = sys.platform.startswith("linux")
+IS_ROBOT = bool(IS_LINUX and os.environ.get("RUNNING_ON_PI"))
 #: This is the correct thing to check to see if we’re running on a robot
-IS_VIRTUAL = bool(os.environ.get('ENABLE_VIRTUAL_SMOOTHIE'))
+IS_VIRTUAL = bool(os.environ.get("ENABLE_VIRTUAL_SMOOTHIE"))
 
 
 class SystemArchitecture(Enum):
@@ -57,27 +59,27 @@ class SystemArchitecture(Enum):
 ARCHITECTURE: SystemArchitecture = SystemArchitecture.HOST
 #: The system architecture running
 
-OT_SYSTEM_VERSION = '0.0.0'
+OT_SYSTEM_VERSION = "0.0.0"
 #: The semver string of the system
 
 
 if IS_ROBOT:
-    if 'OT_SYSTEM_VERSION' in os.environ:
-        OT_SYSTEM_VERSION = os.environ['OT_SYSTEM_VERSION']
+    if "OT_SYSTEM_VERSION" in os.environ:
+        OT_SYSTEM_VERSION = os.environ["OT_SYSTEM_VERSION"]
         ARCHITECTURE = SystemArchitecture.BALENA
     else:
         try:
-            with open('/etc/VERSION.json') as vj:
+            with open("/etc/VERSION.json") as vj:
                 contents = json.load(vj)
-            OT_SYSTEM_VERSION = contents['buildroot_version']
+            OT_SYSTEM_VERSION = contents["buildroot_version"]
             ARCHITECTURE = SystemArchitecture.BUILDROOT
         except Exception:
             log.exception("Could not find version file in /etc/VERSION.json")
-    JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path]\
-        = Path('/var/lib/jupyter/notebooks/')
-    JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path]\
-        = JUPYTER_NOTEBOOK_ROOT_DIR / 'labware'  # type: ignore
-    ROBOT_FIRMWARE_DIR: Optional[Path] = Path('/usr/lib/firmware/')
+    JUPYTER_NOTEBOOK_ROOT_DIR: Optional[Path] = Path("/var/lib/jupyter/notebooks/")
+    JUPYTER_NOTEBOOK_LABWARE_DIR: Optional[Path] = (
+        JUPYTER_NOTEBOOK_ROOT_DIR / "labware"  # type: ignore[operator]
+    )
+    ROBOT_FIRMWARE_DIR: Optional[Path] = Path("/usr/lib/firmware/")
 else:
     JUPYTER_NOTEBOOK_ROOT_DIR = None
     JUPYTER_NOTEBOOK_LABWARE_DIR = None
@@ -86,16 +88,19 @@ else:
 
 def name() -> str:
     if IS_ROBOT and ARCHITECTURE == SystemArchitecture.BALENA:
-        return 'opentrons-{}'.format(
-            os.environ.get('RESIN_DEVICE_NAME_AT_INIT', 'dev'))
+        return "opentrons-{}".format(os.environ.get("RESIN_DEVICE_NAME_AT_INIT", "dev"))
     if IS_ROBOT and ARCHITECTURE == SystemArchitecture.BUILDROOT:
         try:
-            return subprocess.check_output(
-                ['hostnamectl', '--pretty', 'status']).strip().decode()
+            return (
+                subprocess.check_output(["hostnamectl", "--pretty", "status"])
+                .strip()
+                .decode()
+            )
         except Exception:
             log.exception(
-                "Couldn't load name from /etc/machine-info, defaulting to dev")
-    return 'opentrons-dev'
+                "Couldn't load name from /etc/machine-info, defaulting to dev"
+            )
+    return "opentrons-dev"
 
 
 class ConfigElementType(enum.Enum):
@@ -112,102 +117,132 @@ class ConfigElement(NamedTuple):
 
 
 CONFIG_ELEMENTS = (
-    ConfigElement('labware_database_file',
-                  'API V1 Labware Database',
-                  Path('opentrons.db'),
-                  ConfigElementType.FILE,
-                  'The SQLite database where labware definitions and offsets'
-                  ' are stored'),
-    ConfigElement('labware_calibration_offsets_dir_v2',
-                  'API V2 Calibration Offsets Directory',
-                  Path('labware') / 'v2' / 'offsets',
-                  ConfigElementType.DIR,
-                  'The location where APIV2 labware calibration is stored'),
-    ConfigElement('labware_user_definitions_dir_v2',
-                  'API V2 Custom Labware Directory',
-                  Path('labware') / 'v2' / 'custom_definitions',
-                  ConfigElementType.DIR,
-                  'The location where APIV2 labware definitions are stored'),
-    ConfigElement('feature_flags_file',
-                  'Feature Flags',
-                  Path('feature_flags.json'),
-                  ConfigElementType.FILE,
-                  'The file storing the feature flags accessible via '
-                  'Opentrons app'),
-    ConfigElement('robot_settings_file',
-                  'Robot Settings',
-                  Path('robot_settings.json'),
-                  ConfigElementType.FILE,
-                  'The file storing settings relevant to motion'),
-    ConfigElement('deck_calibration_file',
-                  'Deck Calibration',
-                  Path('deck_calibration.json'),
-                  ConfigElementType.FILE,
-                  'The file storing the deck calibration'),
-    ConfigElement('log_dir',
-                  'Log Directory',
-                  Path('logs'),
-                  ConfigElementType.FILE,
-                  'The location for saving log files'),
-    ConfigElement('api_log_file',
-                  'API Log File',
-                  Path('logs') / 'api.log',
-                  ConfigElementType.FILE,
-                  'The location of the file to save API logs to. If this is an'
-                  ' absolute path, it will be used directly. If it is a '
-                  'relative path it will be relative to log_dir'),
-    ConfigElement('serial_log_file',
-                  'Serial Log File',
-                  Path('logs') / 'serial.log',
-                  ConfigElementType.FILE,
-                  'The location of the file to save serial logs to. If this is'
-                  ' an absolute path, it will be used directly. If it is a '
-                  'relative path it will be relative to log_dir'
-                  'The location of the file to save serial logs to'),
+    ConfigElement(
+        "labware_database_file",
+        "API V1 Labware Database",
+        Path("opentrons.db"),
+        ConfigElementType.FILE,
+        "The SQLite database where labware definitions and offsets" " are stored",
+    ),
+    ConfigElement(
+        "labware_calibration_offsets_dir_v2",
+        "API V2 Calibration Offsets Directory",
+        Path("labware") / "v2" / "offsets",
+        ConfigElementType.DIR,
+        "The location where APIV2 labware calibration is stored",
+    ),
+    ConfigElement(
+        "labware_user_definitions_dir_v2",
+        "API V2 Custom Labware Directory",
+        Path("labware") / "v2" / "custom_definitions",
+        ConfigElementType.DIR,
+        "The location where APIV2 labware definitions are stored",
+    ),
+    ConfigElement(
+        "feature_flags_file",
+        "Feature Flags",
+        Path("feature_flags.json"),
+        ConfigElementType.FILE,
+        "The file storing the feature flags accessible via " "Opentrons app",
+    ),
+    ConfigElement(
+        "robot_settings_file",
+        "Robot Settings",
+        Path("robot_settings.json"),
+        ConfigElementType.FILE,
+        "The file storing settings relevant to motion",
+    ),
+    ConfigElement(
+        "deck_calibration_file",
+        "Deck Calibration",
+        Path("deck_calibration.json"),
+        ConfigElementType.FILE,
+        "The file storing the deck calibration",
+    ),
+    ConfigElement(
+        "log_dir",
+        "Log Directory",
+        Path("logs"),
+        ConfigElementType.FILE,
+        "The location for saving log files",
+    ),
+    ConfigElement(
+        "api_log_file",
+        "API Log File",
+        Path("logs") / "api.log",
+        ConfigElementType.FILE,
+        "The location of the file to save API logs to. If this is an"
+        " absolute path, it will be used directly. If it is a "
+        "relative path it will be relative to log_dir",
+    ),
+    ConfigElement(
+        "serial_log_file",
+        "Serial Log File",
+        Path("logs") / "serial.log",
+        ConfigElementType.FILE,
+        "The location of the file to save serial logs to. If this is"
+        " an absolute path, it will be used directly. If it is a "
+        "relative path it will be relative to log_dir"
+        "The location of the file to save serial logs to",
+    ),
     # Unlike other config elements, the wifi keys dir is still in
     # /data/user_storage/opentrons_data because these paths are fed directly to
     # NetworkManager and stored in connections files there. To change this
     # directory, we would have to modify those connections files, presumably on
     # boot, which is a level of complexity that makes it worth having an
     # annoying path.
-    ConfigElement('wifi_keys_dir',
-                  'Wifi Keys Dir',
-                  Path('user_storage/opentrons_data/network_keys'),
-                  ConfigElementType.DIR,
-                  'The directory in which to save any key material for wifi'
-                  ' auth. Not relevant outside of a robot.'),
-    ConfigElement('hardware_controller_lockfile',
-                  'Hardware Controller Lockfile',
-                  Path('hardware.lock'),
-                  ConfigElementType.FILE,
-                  'The file to use for a hardware controller lockfile.'),
-    ConfigElement('pipette_config_overrides_dir',
-                  'Pipette Config User Overrides',
-                  Path('pipettes'),
-                  ConfigElementType.DIR,
-                  'The dir where settings overrides for pipettes are stored'),
-    ConfigElement('tip_length_calibration_dir',
-                  'Tip Length Calibration Directory',
-                  Path('tip_lengths'),
-                  ConfigElementType.DIR,
-                  'The dir where tip length calibration of each tiprack for '
-                  'each unique pipette is stored'),
-    ConfigElement('robot_calibration_dir',
-                  'Robot Calibration Directory',
-                  Path('robot'),
-                  ConfigElementType.DIR,
-                  'The dir where robot calibration is stored'),
-    ConfigElement('pipette_calibration_dir',
-                  'Pipette Calibration Directory',
-                  Path('robot') / 'pipettes',
-                  ConfigElementType.DIR,
-                  'The dir where pipette calibration is stored'),
-    ConfigElement('custom_tiprack_dir',
-                  'Custom Tiprack Directory',
-                  Path('tip_lengths') / 'custom_tiprack_definitions',
-                  ConfigElementType.DIR,
-                  'The dir where custom tiprack definitions for tip length '
-                  'calibration are stored')
+    ConfigElement(
+        "wifi_keys_dir",
+        "Wifi Keys Dir",
+        Path("user_storage/opentrons_data/network_keys"),
+        ConfigElementType.DIR,
+        "The directory in which to save any key material for wifi"
+        " auth. Not relevant outside of a robot.",
+    ),
+    ConfigElement(
+        "hardware_controller_lockfile",
+        "Hardware Controller Lockfile",
+        Path("hardware.lock"),
+        ConfigElementType.FILE,
+        "The file to use for a hardware controller lockfile.",
+    ),
+    ConfigElement(
+        "pipette_config_overrides_dir",
+        "Pipette Config User Overrides",
+        Path("pipettes"),
+        ConfigElementType.DIR,
+        "The dir where settings overrides for pipettes are stored",
+    ),
+    ConfigElement(
+        "tip_length_calibration_dir",
+        "Tip Length Calibration Directory",
+        Path("tip_lengths"),
+        ConfigElementType.DIR,
+        "The dir where tip length calibration of each tiprack for "
+        "each unique pipette is stored",
+    ),
+    ConfigElement(
+        "robot_calibration_dir",
+        "Robot Calibration Directory",
+        Path("robot"),
+        ConfigElementType.DIR,
+        "The dir where robot calibration is stored",
+    ),
+    ConfigElement(
+        "pipette_calibration_dir",
+        "Pipette Calibration Directory",
+        Path("robot") / "pipettes",
+        ConfigElementType.DIR,
+        "The dir where pipette calibration is stored",
+    ),
+    ConfigElement(
+        "custom_tiprack_dir",
+        "Custom Tiprack Directory",
+        Path("tip_lengths") / "custom_tiprack_definitions",
+        ConfigElementType.DIR,
+        "The dir where custom tiprack definitions for tip length "
+        "calibration are stored",
+    ),
 )
 #: The available configuration file elements to modify. All of these can be
 #: changed by editing opentrons.json, where the keys are the name elements,
@@ -219,7 +254,7 @@ CONFIG_ELEMENTS = (
 
 
 def infer_config_base_dir() -> Path:
-    """ Return the directory to store data in.
+    """Return the directory to store data in.
 
     Defaults are ~/.opentrons if not on a pi; OT_API_CONFIG_DIR is
     respected here.
@@ -233,13 +268,12 @@ def infer_config_base_dir() -> Path:
 
     :return pathlib.Path: The path to the desired root settings dir.
     """
-    if 'OT_API_CONFIG_DIR' in os.environ:
-        return Path(os.environ['OT_API_CONFIG_DIR'])
+    if "OT_API_CONFIG_DIR" in os.environ:
+        return Path(os.environ["OT_API_CONFIG_DIR"])
     elif IS_ROBOT:
-        return Path('/data')
+        return Path("/data")
     else:
-        search = (Path.cwd(),
-                  Path.home() / '.opentrons')
+        search = (Path.cwd(), Path.home() / ".opentrons")
         for path in search:
             if (path / _CONFIG_FILENAME).exists():
                 return path
@@ -248,7 +282,7 @@ def infer_config_base_dir() -> Path:
 
 
 def load_and_migrate() -> Dict[str, Path]:
-    """ Ensure the settings directory tree is properly configured.
+    """Ensure the settings directory tree is properly configured.
 
     This function does most of its work on the actual robot. It will move
     all settings files from wherever they happen to be to the proper
@@ -265,7 +299,7 @@ def load_and_migrate() -> Dict[str, Path]:
 
 
 def _load_with_overrides(base) -> Dict[str, str]:
-    """ Load an config or write its defaults """
+    """Load an config or write its defaults"""
     should_write = False
     overrides = _get_environ_overrides()
     try:
@@ -288,14 +322,16 @@ def _load_with_overrides(base) -> Dict[str, str]:
             write_config(index, path=base)
         except Exception as e:
             sys.stderr.write(
-                "Error writing config to {}: {}\nProceeding memory-only\n"
-                .format(str(base), e))
+                "Error writing config to {}: {}\nProceeding memory-only\n".format(
+                    str(base), e
+                )
+            )
     index.update(overrides)
     return index
 
 
 def _ensure_paths_and_types(index: Dict[str, str]) -> Dict[str, Path]:
-    """ Take the direct results of loading the config and make sure
+    """Take the direct results of loading the config and make sure
     the filesystem reflects them.
     """
     configs_by_name = {ce.name: ce for ce in CONFIG_ELEMENTS}
@@ -314,23 +350,25 @@ def _ensure_paths_and_types(index: Dict[str, str]) -> Dict[str, Path]:
         else:
             raise RuntimeError(
                 f"unhandled kind in ConfigElements: {key}: "
-                f"{configs_by_name[key].kind}")
+                f"{configs_by_name[key].kind}"
+            )
     return correct_types
 
 
 def _get_environ_overrides() -> Dict[str, str]:
-    """ Pull any overrides for the config elements from the environ and return
+    """Pull any overrides for the config elements from the environ and return
     a mapping from the names to the values (as strings). Config elements that
     are not overridden will not be in the mapping.
     """
     return {
-        ce.name: os.environ['OT_API_' + ce.name.upper()]
+        ce.name: os.environ["OT_API_" + ce.name.upper()]
         for ce in CONFIG_ELEMENTS
-        if 'OT_API_' + ce.name.upper() in os.environ}
+        if "OT_API_" + ce.name.upper() in os.environ
+    }
 
 
 def _legacy_index() -> Union[None, Dict[str, str]]:
-    """ Try and load an index file from the various places it might exist.
+    """Try and load an index file from the various places it might exist.
 
     If the legacy file cannot be found or cannot be parsed, return None.
 
@@ -347,7 +385,7 @@ def _legacy_index() -> Union[None, Dict[str, str]]:
 
 
 def _erase_old_indices():
-    """ Remove old index files so they don't pollute future loads.
+    """Remove old index files so they don't pollute future loads.
 
     This method should only be called on a robot.
     """
@@ -357,7 +395,7 @@ def _erase_old_indices():
 
 
 def _find_most_recent_backup(normal_path: Optional[str]) -> Optional[str]:
-    """ Find the most recent old settings to migrate.
+    """Find the most recent old settings to migrate.
 
     The input is the path to an unqualified settings file - e.g.
     /mnt/usbdrive/config/robotSettings.json
@@ -377,9 +415,10 @@ def _find_most_recent_backup(normal_path: Optional[str]) -> Optional[str]:
 
     dirname, basename = os.path.split(normal_path)
     root, ext = os.path.splitext(basename)
-    backups = [fi for fi in os.listdir(dirname)
-               if fi.startswith(root) and fi.endswith(ext)]
-    ts_re = re.compile(r'.*-([0-9]+)' + ext + '$')
+    backups = [
+        fi for fi in os.listdir(dirname) if fi.startswith(root) and fi.endswith(ext)
+    ]
+    ts_re = re.compile(r".*-([0-9]+)" + ext + "$")
 
     def ts_compare(filename):
         match = ts_re.match(filename)
@@ -397,14 +436,18 @@ def _find_most_recent_backup(normal_path: Optional[str]) -> Optional[str]:
 def _do_migrate(index: Dict[str, str]):
     base = infer_config_base_dir()
     new_index = generate_config_index(_get_environ_overrides(), base)
-    moves = (('/data/user_storage/opentrons_data/opentrons.db',
-              new_index['labware_database_file']),
-             (_find_most_recent_backup(index.get('robotSettingsFile')),
-              new_index['robot_settings_file']),
-             (index.get('deckCalibrationFile'),
-              new_index['deck_calibration_file']),
-             (index.get('featureFlagFile'),
-              new_index['feature_flags_file']))
+    moves = (
+        (
+            "/data/user_storage/opentrons_data/opentrons.db",
+            new_index["labware_database_file"],
+        ),
+        (
+            _find_most_recent_backup(index.get("robotSettingsFile")),
+            new_index["robot_settings_file"],
+        ),
+        (index.get("deckCalibrationFile"), new_index["deck_calibration_file"]),
+        (index.get("featureFlagFile"), new_index["feature_flags_file"]),
+    )
     sys.stdout.write(f"config migration: new base {base}\n")
     for old, new in moves:
         if not old:
@@ -431,8 +474,7 @@ def _migrate_robot():
         _erase_old_indices()
 
 
-def generate_config_index(defaults: Dict[str, str],
-                          base_dir=None) -> Dict[str, Path]:
+def generate_config_index(defaults: Dict[str, str], base_dir=None) -> Dict[str, Path]:
     """
     Determines where existing info can be found in the system, and creates a
     corresponding data dict that can be written to index.json in the
@@ -455,23 +497,19 @@ def generate_config_index(defaults: Dict[str, str],
     """
     base = Path(base_dir) if base_dir else infer_config_base_dir()
 
-    def parse_or_default(
-            ce: ConfigElement, val: Optional[str]) -> Path:
+    def parse_or_default(ce: ConfigElement, val: Optional[str]) -> Path:
         if not val:
             return base / ce.default
         else:
             return Path(val)
 
     return {
-        ce.name: parse_or_default(ce,
-                                  defaults.get(ce.name))
-        for ce in CONFIG_ELEMENTS
+        ce.name: parse_or_default(ce, defaults.get(ce.name)) for ce in CONFIG_ELEMENTS
     }
 
 
-def write_config(config_data: Dict[str, Path],
-                 path: Path = None):
-    """ Save the config file.
+def write_config(config_data: Dict[str, Path], path: Path = None):
+    """Save the config file.
 
     :param config_data: The index to save
     :param base_dir: The place to save the file. If ``None``,
@@ -483,13 +521,16 @@ def write_config(config_data: Dict[str, Path],
     valid_names = [ce.name for ce in CONFIG_ELEMENTS]
     try:
         os.makedirs(path, exist_ok=True)
-        with (path / _CONFIG_FILENAME).open('w') as base_f:
-            json.dump({k: str(v) for k, v in config_data.items()
-                       if k in valid_names},
-                      base_f, indent=2)
+        with (path / _CONFIG_FILENAME).open("w") as base_f:
+            json.dump(
+                {k: str(v) for k, v in config_data.items() if k in valid_names},
+                base_f,
+                indent=2,
+            )
     except OSError as e:
-        sys.stderr.write("Config index write to {} failed: {}\n"
-                         .format(path / _CONFIG_FILENAME, e))
+        sys.stderr.write(
+            "Config index write to {} failed: {}\n".format(path / _CONFIG_FILENAME, e)
+        )
 
 
 def reload():
@@ -513,8 +554,8 @@ CONFIG = load_and_migrate()
 
 
 def get_tip_length_cal_path():
-    return get_opentrons_path('tip_length_calibration_dir')
+    return get_opentrons_path("tip_length_calibration_dir")
 
 
 def get_custom_tiprack_def_path():
-    return get_opentrons_path('custom_tiprack_dir')
+    return get_opentrons_path("custom_tiprack_dir")

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -3,8 +3,7 @@ import logging
 import os
 import sys
 from functools import lru_cache
-from typing import Any, Dict, Mapping, Tuple, Union, \
-    Optional, TYPE_CHECKING, NamedTuple
+from typing import Any, Dict, Mapping, Tuple, Union, Optional, TYPE_CHECKING, NamedTuple
 
 from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 from opentrons.system import log_control
@@ -30,10 +29,15 @@ class SettingsData(NamedTuple):
 
 
 class SettingDefinition:
-    def __init__(self, _id: str, title: str, description: str,
-                 old_id: str = None,
-                 restart_required: bool = False,
-                 show_if: Tuple[str, bool] = None):
+    def __init__(
+        self,
+        _id: str,
+        title: str,
+        description: str,
+        old_id: str = None,
+        restart_required: bool = False,
+        show_if: Tuple[str, bool] = None,
+    ):
         self.id = _id
         #: The id of the setting for programmatic access through
         #: get_adv_setting
@@ -50,7 +54,7 @@ class SettingDefinition:
         #: to show this setting in http endpoints
 
     def __repr__(self):
-        return '{}: {}'.format(self.__class__, self.id)
+        return "{}: {}".format(self.__class__, self.id)
 
     def should_show(self) -> bool:
         """
@@ -59,8 +63,7 @@ class SettingDefinition:
         """
         if not self.show_if:
             return True
-        return get_setting_with_env_overload(self.show_if[0]) == \
-            self.show_if[1]
+        return get_setting_with_env_overload(self.show_if[0]) == self.show_if[1]
 
     async def on_change(self, value: Optional[bool]):
         """
@@ -74,25 +77,26 @@ class SettingDefinition:
 class DisableLogIntegrationSettingDefinition(SettingDefinition):
     def __init__(self):
         super().__init__(
-            _id='disableLogAggregation',
-            title='Disable Opentrons Log Collection',
-            description='Prevent the robot from sending its logs to Opentrons'
-                        ' for analysis. Opentrons uses these logs to'
-                        ' troubleshoot robot issues and spot error trends.')
+            _id="disableLogAggregation",
+            title="Disable Opentrons Log Collection",
+            description="Prevent the robot from sending its logs to Opentrons"
+            " for analysis. Opentrons uses these logs to"
+            " troubleshoot robot issues and spot error trends.",
+        )
 
     async def on_change(self, value: Optional[bool]):
         """Special side effect for this setting"""
         if ARCHITECTURE == SystemArchitecture.BUILDROOT:
             code, stdout, stderr = await log_control.set_syslog_level(
-                'emerg' if value else 'info'
+                "emerg" if value else "info"
             )
             if code != 0:
                 log.error(
                     f"Could not set log control: {code}: stdout={stdout}"
-                    f" stderr={stderr}")
+                    f" stderr={stderr}"
+                )
                 raise SettingException(
-                    f'Failed to set log upstreaming: {code}',
-                    'log-config-failure'
+                    f"Failed to set log upstreaming: {code}", "log-config-failure"
                 )
         await super().on_change(value)
 
@@ -107,46 +111,46 @@ class Setting(NamedTuple):
 # api/tests/opentrons/config/test_advanced_settings_migration.py
 settings = [
     SettingDefinition(
-        _id='shortFixedTrash',
-        old_id='short-fixed-trash',
-        title='Short (55mm) fixed trash',
-        description='Trash box is 55mm tall (rather than the 77mm default)'
+        _id="shortFixedTrash",
+        old_id="short-fixed-trash",
+        title="Short (55mm) fixed trash",
+        description="Trash box is 55mm tall (rather than the 77mm default)",
     ),
     SettingDefinition(
-        _id='calibrateToBottom',
-        old_id='calibrate-to-bottom',
-        title='Calibrate to bottom',
-        description='Calibrate using the bottom-center of well A1 for each'
-                    ' labware (rather than the top-center)'
+        _id="calibrateToBottom",
+        old_id="calibrate-to-bottom",
+        title="Calibrate to bottom",
+        description="Calibrate using the bottom-center of well A1 for each"
+        " labware (rather than the top-center)",
     ),
     SettingDefinition(
-        _id='deckCalibrationDots',
-        old_id='dots-deck-type',
-        title='Deck calibration to dots',
-        description='Perform deck calibration to dots rather than crosses, for'
-                    ' robots that do not have crosses etched on the deck'
+        _id="deckCalibrationDots",
+        old_id="dots-deck-type",
+        title="Deck calibration to dots",
+        description="Perform deck calibration to dots rather than crosses, for"
+        " robots that do not have crosses etched on the deck",
     ),
     SettingDefinition(
-        _id='disableHomeOnBoot',
-        old_id='disable-home-on-boot',
-        title='Disable home on boot',
-        description='Prevent robot from homing motors on boot'
+        _id="disableHomeOnBoot",
+        old_id="disable-home-on-boot",
+        title="Disable home on boot",
+        description="Prevent robot from homing motors on boot",
     ),
     SettingDefinition(
-        _id='useOldAspirationFunctions',
-        title='Use older aspirate behavior',
-        description='Aspirate with the less accurate volumetric calibrations'
-                    ' that were used before version 3.7.0. Use this if you'
-                    ' need consistency with pre-v3.7.0 results. This only'
-                    ' affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.'
+        _id="useOldAspirationFunctions",
+        title="Use older aspirate behavior",
+        description="Aspirate with the less accurate volumetric calibrations"
+        " that were used before version 3.7.0. Use this if you"
+        " need consistency with pre-v3.7.0 results. This only"
+        " affects GEN1 P10S, P10M, P50S, P50M, and P300S pipettes.",
     ),
     SettingDefinition(
-        _id='enableDoorSafetySwitch',
-        title='Enable robot door safety switch',
+        _id="enableDoorSafetySwitch",
+        title="Enable robot door safety switch",
         description="Automatically pause protocols when robot door opens. "
-                    "Opening the robot door during a run will "
-                    "pause your robot only after it has completed its "
-                    "current motion."
+        "Opening the robot door during a run will "
+        "pause your robot only after it has completed its "
+        "current motion.",
     ),
     SettingDefinition(
         _id="disableFastProtocolUpload",
@@ -161,11 +165,11 @@ settings = [
         restart_required=False,
     ),
     SettingDefinition(
-        _id='enableHttpProtocolSessions',
-        title='Enable experimental HTTP protocol sessions',
-        description='Do not activate this unless you are a developer. '
-                    'Activating this will disable protocol running from the '
-                    'Opentrons application.',
+        _id="enableHttpProtocolSessions",
+        title="Enable experimental HTTP protocol sessions",
+        description="Do not activate this unless you are a developer. "
+        "Activating this will disable protocol running from the "
+        "Opentrons application.",
         restart_required=True,
     ),
     SettingDefinition(
@@ -184,10 +188,10 @@ if ARCHITECTURE == SystemArchitecture.BUILDROOT:
     settings.append(DisableLogIntegrationSettingDefinition())
 
 
-settings_by_id: Dict[str, SettingDefinition] = \
-    {s.id: s for s in settings}
-settings_by_old_id: Dict[str, SettingDefinition] = \
-    {s.old_id: s for s in settings if s.old_id}
+settings_by_id: Dict[str, SettingDefinition] = {s.id: s for s in settings}
+settings_by_old_id: Dict[str, SettingDefinition] = {
+    s.old_id: s for s in settings if s.old_id
+}
 
 
 def get_adv_setting(setting: str) -> Optional[Setting]:
@@ -199,19 +203,20 @@ def get_adv_setting(setting: str) -> Optional[Setting]:
 @lru_cache(maxsize=1)
 def get_all_adv_settings() -> Dict[str, Setting]:
     """Get all the advanced setting values and definitions"""
-    settings_file = CONFIG['feature_flags_file']
+    settings_file = CONFIG["feature_flags_file"]
 
     values, _ = _read_settings_file(settings_file)
 
     return {
         key: Setting(value=value, definition=settings_by_id[key])
-        for key, value in values.items() if key in settings_by_id
+        for key, value in values.items()
+        if key in settings_by_id
     }
 
 
 async def set_adv_setting(_id: str, value: Optional[bool]):
     _id = _clean_id(_id)
-    settings_file = CONFIG['feature_flags_file']
+    settings_file = CONFIG["feature_flags_file"]
     setting_data = _read_settings_file(settings_file)
     if _id not in setting_data.settings_map:
         raise ValueError(f"{_id} is not recognized")
@@ -219,9 +224,7 @@ async def set_adv_setting(_id: str, value: Optional[bool]):
     await settings_by_id[_id].on_change(value)
 
     setting_data.settings_map[_id] = value
-    _write_settings_file(setting_data.settings_map,
-                         setting_data.version,
-                         settings_file)
+    _write_settings_file(setting_data.settings_map, setting_data.version, settings_file)
     # Clear the lru cache
     get_all_adv_settings.cache_clear()
 
@@ -232,20 +235,19 @@ def _clean_id(_id: str) -> str:
     return _id
 
 
-def _read_json_file(path: Union[str, 'Path']) -> Dict[str, Any]:
+def _read_json_file(path: Union[str, "Path"]) -> Dict[str, Any]:
     try:
-        with open(path, 'r') as fd:
+        with open(path, "r") as fd:
             data = json.load(fd)
     except FileNotFoundError:
         data = {}
     except json.JSONDecodeError as e:
-        sys.stderr.write(
-            f'Could not load advanced settings file {path}: {e}\n')
+        sys.stderr.write(f"Could not load advanced settings file {path}: {e}\n")
         data = {}
     return data
 
 
-def _read_settings_file(settings_file: 'Path') -> SettingsData:
+def _read_settings_file(settings_file: "Path") -> SettingsData:
     """
     Read the settings file, which is a json object with settings IDs as keys
     and boolean values. For each key, look up the `Settings` object with that
@@ -262,23 +264,20 @@ def _read_settings_file(settings_file: 'Path') -> SettingsData:
     settings, version = _migrate(data)
     settings = _ensure(settings)
 
-    if data.get('_version') != version:
+    if data.get("_version") != version:
         _write_settings_file(settings, version, settings_file)
 
     return SettingsData(settings_map=settings, version=version)
 
 
-def _write_settings_file(data: Mapping[str, Any],
-                         version: int,
-                         settings_file: 'Path'):
+def _write_settings_file(data: Mapping[str, Any], version: int, settings_file: "Path"):
     try:
-        with settings_file.open('w') as fd:
-            json.dump({**data, '_version': version}, fd)
+        with settings_file.open("w") as fd:
+            json.dump({**data, "_version": version}, fd)
             fd.flush()
             os.fsync(fd.fileno())
     except OSError:
-        log.exception(
-            f'Failed to write advanced settings file to {settings_file}')
+        log.exception(f"Failed to write advanced settings file to {settings_file}")
 
 
 def _migrate0to1(previous: Mapping[str, Any]) -> SettingsMap:
@@ -308,7 +307,7 @@ def _migrate1to2(previous: SettingsMap) -> SettingsMap:
     disableLogAggregation config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['disableLogAggregation'] = None
+    newmap["disableLogAggregation"] = None
     return newmap
 
 
@@ -318,8 +317,8 @@ def _migrate2to3(previous: SettingsMap) -> SettingsMap:
     enableApi1BackCompat config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['enableApi1BackCompat'] = None
-    newmap['useProtocolApi2'] = None
+    newmap["enableApi1BackCompat"] = None
+    newmap["useProtocolApi2"] = None
     return newmap
 
 
@@ -329,7 +328,7 @@ def _migrate3to4(previous: SettingsMap) -> SettingsMap:
     useV1HttpApi config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['useV1HttpApi'] = None
+    newmap["useV1HttpApi"] = None
     return newmap
 
 
@@ -339,7 +338,7 @@ def _migrate4to5(previous: SettingsMap) -> SettingsMap:
     enableDoorSafetyFeature config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['enableDoorSafetySwitch'] = None
+    newmap["enableDoorSafetySwitch"] = None
     return newmap
 
 
@@ -349,7 +348,7 @@ def _migrate5to6(previous: SettingsMap) -> SettingsMap:
     enableTipLengthCalibration config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['enableTipLengthCalibration'] = None
+    newmap["enableTipLengthCalibration"] = None
     return newmap
 
 
@@ -359,7 +358,7 @@ def _migrate6to7(previous: SettingsMap) -> SettingsMap:
     enableHttpProtocolSessions config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['enableHttpProtocolSessions'] = None
+    newmap["enableHttpProtocolSessions"] = None
     return newmap
 
 
@@ -369,7 +368,7 @@ def _migrate7to8(previous: SettingsMap) -> SettingsMap:
     enableFastProtocolUpload config element.
     """
     newmap = {k: v for k, v in previous.items()}
-    newmap['enableFastProtocolUpload'] = None
+    newmap["enableFastProtocolUpload"] = None
     return newmap
 
 
@@ -393,16 +392,30 @@ def _migrate9to10(previous: SettingsMap) -> SettingsMap:
     - Removes deprecated enableFastProtocolUpload option
     - Adds disableFastProtocolUpload option
     """
-    removals = ['useProtocolApi2', 'enableApi1BackCompat', 'useV1HttpApi',
-                'enableTipLengthCalibration', 'enableFastProtocolUpload']
+    removals = [
+        "useProtocolApi2",
+        "enableApi1BackCompat",
+        "useV1HttpApi",
+        "enableTipLengthCalibration",
+        "enableFastProtocolUpload",
+    ]
     newmap = {k: v for k, v in previous.items() if k not in removals}
     newmap["disableFastProtocolUpload"] = None
     return newmap
 
 
-_MIGRATIONS = [_migrate0to1, _migrate1to2, _migrate2to3, _migrate3to4,
-               _migrate4to5, _migrate5to6, _migrate6to7, _migrate7to8,
-               _migrate8to9, _migrate9to10]
+_MIGRATIONS = [
+    _migrate0to1,
+    _migrate1to2,
+    _migrate2to3,
+    _migrate3to4,
+    _migrate4to5,
+    _migrate5to6,
+    _migrate6to7,
+    _migrate7to8,
+    _migrate8to9,
+    _migrate9to10,
+]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below
 for how the migration functions are applied. Each migration function should
@@ -417,14 +430,16 @@ def _migrate(data: Mapping[str, Any]) -> SettingsData:
     settings and version migrated to
     """
     next = dict(data)
-    version = next.pop('_version', 0)
+    version = next.pop("_version", 0)
     target_version = len(_MIGRATIONS)
     migrations = _MIGRATIONS[version:]
 
     if len(migrations) > 0:
         log.info(
-            "Migrating advanced settings from version {} to {}"
-            .format(version, target_version))
+            "Migrating advanced settings from version {} to {}".format(
+                version, target_version
+            )
+        )
 
     for m in migrations:
         next = m(next)
@@ -447,9 +462,9 @@ def _ensure(data: Mapping[str, Any]) -> SettingsMap:
 
 
 def get_setting_with_env_overload(setting_name) -> bool:
-    env_name = 'OT_API_FF_' + setting_name
+    env_name = "OT_API_FF_" + setting_name
     if env_name in os.environ:
-        return os.environ[env_name].lower() in {'1', 'true', 'on'}
+        return os.environ[env_name].lower() in {"1", "true", "on"}
     else:
         s = get_adv_setting(setting_name)
         return s.value is True if s is not None else False

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -2,31 +2,31 @@ from opentrons.config import advanced_settings as advs
 
 
 def short_fixed_trash() -> bool:
-    return advs.get_setting_with_env_overload('shortFixedTrash')
+    return advs.get_setting_with_env_overload("shortFixedTrash")
 
 
 def calibrate_to_bottom() -> bool:
-    return advs.get_setting_with_env_overload('calibrateToBottom')
+    return advs.get_setting_with_env_overload("calibrateToBottom")
 
 
 def dots_deck_type() -> bool:
-    return advs.get_setting_with_env_overload('deckCalibrationDots')
+    return advs.get_setting_with_env_overload("deckCalibrationDots")
 
 
 def disable_home_on_boot() -> bool:
-    return advs.get_setting_with_env_overload('disableHomeOnBoot')
+    return advs.get_setting_with_env_overload("disableHomeOnBoot")
 
 
 def use_old_aspiration_functions() -> bool:
-    return advs.get_setting_with_env_overload('useOldAspirationFunctions')
+    return advs.get_setting_with_env_overload("useOldAspirationFunctions")
 
 
 def enable_door_safety_switch() -> bool:
-    return advs.get_setting_with_env_overload('enableDoorSafetySwitch')
+    return advs.get_setting_with_env_overload("enableDoorSafetySwitch")
 
 
 def enable_http_protocol_sessions() -> bool:
-    return advs.get_setting_with_env_overload('enableHttpProtocolSessions')
+    return advs.get_setting_with_env_overload("enableHttpProtocolSessions")
 
 
 def enable_protocol_engine() -> bool:
@@ -36,4 +36,4 @@ def enable_protocol_engine() -> bool:
 
 
 def disable_fast_protocol_upload() -> bool:
-    return advs.get_setting_with_env_overload('disableFastProtocolUpload')
+    return advs.get_setting_with_env_overload("disableFastProtocolUpload")

--- a/api/src/opentrons/config/pipette_config.py
+++ b/api/src/opentrons/config/pipette_config.py
@@ -3,18 +3,20 @@ from dataclasses import dataclass
 import logging
 import json
 import numbers
-from typing import (Any, Dict, List, Union, Tuple,
-                    Sequence, TYPE_CHECKING)
+from typing import Any, Dict, List, Union, Tuple, Sequence, TYPE_CHECKING
 
 from opentrons import config
 from opentrons.config import feature_flags as ff
-from opentrons_shared_data.pipette import (
-    model_config, name_config, fuse_specs)
+from opentrons_shared_data.pipette import model_config, name_config, fuse_specs
 
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import (
-        PipetteName, PipetteModel, UlPerMm, Quirk,
-        PipetteFusedSpec, LabwareUri
+        PipetteName,
+        PipetteModel,
+        UlPerMm,
+        Quirk,
+        PipetteFusedSpec,
+        LabwareUri,
     )
 
 
@@ -87,19 +89,17 @@ NOZZLE_OFFSET_DEFAULT = [0.0, 0.0, 0.0]
 
 LOW_CURRENT_DEFAULT = 0.05
 
-config_models = list(model_config()['config'].keys())
+config_models = list(model_config()["config"].keys())
 config_names = list(name_config().keys())
-configs = model_config()['config']
+configs = model_config()["config"]
 #: A list of pipette model names for which we have config entries
-MUTABLE_CONFIGS = model_config()['mutableConfigs']
+MUTABLE_CONFIGS = model_config()["mutableConfigs"]
 #: A list of mutable configs for pipettes
-VALID_QUIRKS = model_config()['validQuirks']
+VALID_QUIRKS = model_config()["validQuirks"]
 #: A list of valid quirks for pipettes
 
 
-def load(
-        pipette_model: PipetteModel,
-        pipette_id: str = None) -> PipetteConfig:
+def load(pipette_model: PipetteModel, pipette_id: str = None) -> PipetteConfig:
     """
     Load pipette config data
 
@@ -137,21 +137,24 @@ def load(
     if pipette_id:
         try:
             override = load_overrides(pipette_id)
-            if 'quirks' in override.keys():
-                override['quirks'] = [
-                    qname for qname, qval in override['quirks'].items()
-                    if qval]
+            if "quirks" in override.keys():
+                override["quirks"] = [
+                    qname for qname, qval in override["quirks"].items() if qval
+                ]
             for legacy_key in (
-                    'defaultAspirateFlowRate',
-                    'defaultDispenseFlowRate',
-                    'defaultBlowOutFlowRate'):
+                "defaultAspirateFlowRate",
+                "defaultDispenseFlowRate",
+                "defaultBlowOutFlowRate",
+            ):
                 override.pop(legacy_key, None)
 
         except FileNotFoundError:
             save_overrides(pipette_id, {}, pipette_model)
             log.info(
                 "Save defaults for pipette model {} and id {}".format(
-                    pipette_model, pipette_id))
+                    pipette_model, pipette_id
+                )
+            )
         else:
             cfg.update(override)  # type: ignore
 
@@ -164,67 +167,60 @@ def load(
     # intelligently
     if ff.use_old_aspiration_functions():
         log.debug("Using old aspiration functions")
-        ul_per_mm = cfg['ulPerMm'][0]
+        ul_per_mm = cfg["ulPerMm"][0]
     else:
-        ul_per_mm = cfg['ulPerMm'][-1]
+        ul_per_mm = cfg["ulPerMm"][-1]
 
-    smoothie_configs = cfg['smoothieConfigs']
+    smoothie_configs = cfg["smoothieConfigs"]
     res = PipetteConfig(
-        top=ensure_value(
-            cfg, 'top', MUTABLE_CONFIGS),
-        bottom=ensure_value(
-            cfg, 'bottom', MUTABLE_CONFIGS),
-        blow_out=ensure_value(
-            cfg, 'blowout', MUTABLE_CONFIGS),
-        drop_tip=ensure_value(
-            cfg, 'dropTip', MUTABLE_CONFIGS),
-        pick_up_current=ensure_value(cfg, 'pickUpCurrent', MUTABLE_CONFIGS),
-        pick_up_distance=ensure_value(cfg, 'pickUpDistance', MUTABLE_CONFIGS),
-        pick_up_increment=ensure_value(
-            cfg, 'pickUpIncrement', MUTABLE_CONFIGS),
-        pick_up_presses=ensure_value(cfg, 'pickUpPresses', MUTABLE_CONFIGS),
-        pick_up_speed=ensure_value(cfg, 'pickUpSpeed', MUTABLE_CONFIGS),
-        aspirate_flow_rate=cfg['defaultAspirateFlowRate']['value'],
-        dispense_flow_rate=cfg['defaultDispenseFlowRate']['value'],
-        channels=ensure_value(cfg, 'channels', MUTABLE_CONFIGS),
-        nozzle_offset=cfg.get(  # type: ignore
-            'nozzleOffset', NOZZLE_OFFSET_DEFAULT),
-        plunger_current=ensure_value(cfg, 'plungerCurrent', MUTABLE_CONFIGS),
-        drop_tip_current=ensure_value(cfg, 'dropTipCurrent', MUTABLE_CONFIGS),
-        drop_tip_speed=ensure_value(cfg, 'dropTipSpeed', MUTABLE_CONFIGS),
-        min_volume=ensure_value(cfg, 'minVolume', MUTABLE_CONFIGS),
-        max_volume=ensure_value(cfg, 'maxVolume', MUTABLE_CONFIGS),
+        top=ensure_value(cfg, "top", MUTABLE_CONFIGS),
+        bottom=ensure_value(cfg, "bottom", MUTABLE_CONFIGS),
+        blow_out=ensure_value(cfg, "blowout", MUTABLE_CONFIGS),
+        drop_tip=ensure_value(cfg, "dropTip", MUTABLE_CONFIGS),
+        pick_up_current=ensure_value(cfg, "pickUpCurrent", MUTABLE_CONFIGS),
+        pick_up_distance=ensure_value(cfg, "pickUpDistance", MUTABLE_CONFIGS),
+        pick_up_increment=ensure_value(cfg, "pickUpIncrement", MUTABLE_CONFIGS),
+        pick_up_presses=ensure_value(cfg, "pickUpPresses", MUTABLE_CONFIGS),
+        pick_up_speed=ensure_value(cfg, "pickUpSpeed", MUTABLE_CONFIGS),
+        aspirate_flow_rate=cfg["defaultAspirateFlowRate"]["value"],
+        dispense_flow_rate=cfg["defaultDispenseFlowRate"]["value"],
+        channels=ensure_value(cfg, "channels", MUTABLE_CONFIGS),
+        nozzle_offset=cfg.get("nozzleOffset", NOZZLE_OFFSET_DEFAULT),  # type: ignore
+        plunger_current=ensure_value(cfg, "plungerCurrent", MUTABLE_CONFIGS),
+        drop_tip_current=ensure_value(cfg, "dropTipCurrent", MUTABLE_CONFIGS),
+        drop_tip_speed=ensure_value(cfg, "dropTipSpeed", MUTABLE_CONFIGS),
+        min_volume=ensure_value(cfg, "minVolume", MUTABLE_CONFIGS),
+        max_volume=ensure_value(cfg, "maxVolume", MUTABLE_CONFIGS),
         ul_per_mm=ul_per_mm,
-        quirks=validate_quirks(ensure_value(cfg, 'quirks', MUTABLE_CONFIGS)),
-        tip_overlap=cfg['tipOverlap'],
-        tip_length=ensure_value(cfg, 'tipLength', MUTABLE_CONFIGS),
-        display_name=ensure_value(cfg, 'displayName', MUTABLE_CONFIGS),
-        name=cfg['name'],
-        back_compat_names=cfg.get('backCompatNames', []),
-        return_tip_height=cfg.get('returnTipHeight', 0.5),
-        blow_out_flow_rate=cfg['defaultBlowOutFlowRate']['value'],
-        max_travel=smoothie_configs['travelDistance'],
-        home_position=smoothie_configs['homePosition'],
-        steps_per_mm=smoothie_configs['stepsPerMM'],
-        idle_current=cfg.get('idleCurrent', LOW_CURRENT_DEFAULT),
-        default_blow_out_flow_rates=cfg['defaultBlowOutFlowRate'].get(
-            'valuesByApiLevel',
-            {'2.0': cfg['defaultBlowOutFlowRate']['value']}),
-        default_dispense_flow_rates=cfg['defaultDispenseFlowRate'].get(
-            'valuesByApiLevel',
-            {'2.0': cfg['defaultDispenseFlowRate']['value']}),
-        default_aspirate_flow_rates=cfg['defaultAspirateFlowRate'].get(
-            'valuesByApiLevel',
-            {'2.0': cfg['defaultAspirateFlowRate']['value']}),
+        quirks=validate_quirks(ensure_value(cfg, "quirks", MUTABLE_CONFIGS)),
+        tip_overlap=cfg["tipOverlap"],
+        tip_length=ensure_value(cfg, "tipLength", MUTABLE_CONFIGS),
+        display_name=ensure_value(cfg, "displayName", MUTABLE_CONFIGS),
+        name=cfg["name"],
+        back_compat_names=cfg.get("backCompatNames", []),
+        return_tip_height=cfg.get("returnTipHeight", 0.5),
+        blow_out_flow_rate=cfg["defaultBlowOutFlowRate"]["value"],
+        max_travel=smoothie_configs["travelDistance"],
+        home_position=smoothie_configs["homePosition"],
+        steps_per_mm=smoothie_configs["stepsPerMM"],
+        idle_current=cfg.get("idleCurrent", LOW_CURRENT_DEFAULT),
+        default_blow_out_flow_rates=cfg["defaultBlowOutFlowRate"].get(
+            "valuesByApiLevel", {"2.0": cfg["defaultBlowOutFlowRate"]["value"]}
+        ),
+        default_dispense_flow_rates=cfg["defaultDispenseFlowRate"].get(
+            "valuesByApiLevel", {"2.0": cfg["defaultDispenseFlowRate"]["value"]}
+        ),
+        default_aspirate_flow_rates=cfg["defaultAspirateFlowRate"].get(
+            "valuesByApiLevel", {"2.0": cfg["defaultAspirateFlowRate"]["value"]}
+        ),
         model=pipette_model,
-        default_tipracks=cfg['defaultTipracks']
+        default_tipracks=cfg["defaultTipracks"],
     )
 
     return res
 
 
-def piecewise_volume_conversion(
-        ul: float, sequence: List[List[float]]) -> float:
+def piecewise_volume_conversion(ul: float, sequence: List[List[float]]) -> float:
     """
     Takes a volume in microliters and a sequence representing a piecewise
     function for the slope and y-intercept of a ul/mm function, where each
@@ -252,8 +248,7 @@ def piecewise_volume_conversion(
 TypeOverrides = Dict[str, Union[float, bool, None]]
 
 
-def validate_overrides(data: TypeOverrides,
-                       config_model: Dict) -> None:
+def validate_overrides(data: TypeOverrides, config_model: Dict) -> None:
     """
     Check that override fields are valid.
 
@@ -263,21 +258,21 @@ def validate_overrides(data: TypeOverrides,
     """
     for key, value in data.items():
         field_config = config_model.get(key)
-        is_quirk = key in config_model['quirks'] and key in VALID_QUIRKS
+        is_quirk = key in config_model["quirks"] and key in VALID_QUIRKS
 
         if is_quirk:
             # If it's a quirk it must be a bool or None
             if value is not None and not isinstance(value, bool):
-                raise ValueError(f'{value} is invalid for {key}')
+                raise ValueError(f"{value} is invalid for {key}")
         elif not field_config:
             # If it's not a quirk we must have a field config
-            raise ValueError(f'Unknown field {key}')
+            raise ValueError(f"Unknown field {key}")
         elif value is not None:
             # If value is not None it must be numeric and between min and max
             if isinstance(value, bool) or not isinstance(value, numbers.Number):
-                raise ValueError(f'{value} is invalid for {key}')
-            elif value < field_config['min'] or value > field_config['max']:
-                raise ValueError(f'{key} out of range with {value}')
+                raise ValueError(f"{value} is invalid for {key}")
+            elif value < field_config["min"] or value > field_config["max"]:
+                raise ValueError(f"{key} out of range with {value}")
 
 
 def override(pipette_id: str, fields: TypeOverrides):
@@ -293,9 +288,7 @@ def override(pipette_id: str, fields: TypeOverrides):
     save_overrides(pipette_id, fields, model)
 
 
-def save_overrides(pipette_id: str,
-                   overrides: TypeOverrides,
-                   model: PipetteModel):
+def save_overrides(pipette_id: str, overrides: TypeOverrides, model: PipetteModel):
     """
     Save overrides for the pipette.
 
@@ -304,14 +297,14 @@ def save_overrides(pipette_id: str,
     :param model: The model of pipette
     :return: None
     """
-    override_dir = config.CONFIG['pipette_config_overrides_dir']
+    override_dir = config.CONFIG["pipette_config_overrides_dir"]
     model_configs = configs[model]
-    model_configs_quirks = {key: True for key in model_configs['quirks']}
+    model_configs_quirks = {key: True for key in model_configs["quirks"]}
     try:
         existing = load_overrides(pipette_id)
         # Add quirks setting for pipettes already with a pipette id file
-        if 'quirks' not in existing.keys():
-            existing['quirks'] = model_configs_quirks
+        if "quirks" not in existing.keys():
+            existing["quirks"] = model_configs_quirks
     except FileNotFoundError:
         existing = model_configs_quirks  # type: ignore
 
@@ -323,47 +316,47 @@ def save_overrides(pipette_id: str,
                 del existing[key]
         elif isinstance(value, bool):
             existing, model_configs = change_quirks(
-                {key: value}, existing, model_configs)
+                {key: value}, existing, model_configs
+            )
         else:
             # type ignores are here because mypy needs typed dict accesses to
             # be string literals sadly enough
             model_config_value = model_configs[key]  # type: ignore
-            if not model_config_value.get('default'):
-                model_config_value['default']\
-                    = model_config_value['value']
-            model_config_value['value'] = value
+            if not model_config_value.get("default"):
+                model_config_value["default"] = model_config_value["value"]
+            model_config_value["value"] = value
             existing[key] = model_config_value
     assert model in config_models
-    existing['model'] = model
-    with (override_dir/f'{pipette_id}.json').open('w') as file:
+    existing["model"] = model
+    with (override_dir / f"{pipette_id}.json").open("w") as file:
         json.dump(existing, file)
 
 
 def change_quirks(override_quirks, existing, model_configs):
-    if not existing.get('quirks'):
+    if not existing.get("quirks"):
         # ensure quirk key exists
-        existing['quirks'] = override_quirks
+        existing["quirks"] = override_quirks
     for quirk, setting in override_quirks.items():
         # setting values again if above case true, but
         # meant for use-cases where we may only be given an update
         # for one setting
-        existing['quirks'][quirk] = setting
-        if setting not in model_configs['quirks']:
-            model_configs['quirks'].append(quirk)
+        existing["quirks"][quirk] = setting
+        if setting not in model_configs["quirks"]:
+            model_configs["quirks"].append(quirk)
         elif not setting:
-            model_configs['quirks'].remove(quirk)
+            model_configs["quirks"].remove(quirk)
     return existing, model_configs
 
 
 def load_overrides(pipette_id: str) -> Dict[str, Any]:
-    overrides = config.CONFIG['pipette_config_overrides_dir']
+    overrides = config.CONFIG["pipette_config_overrides_dir"]
     try:
-        with (overrides/f'{pipette_id}.json').open() as fi:
+        with (overrides / f"{pipette_id}.json").open() as fi:
             return json.load(fi)
     except json.JSONDecodeError as e:
-        log.warning(f'pipette override for {pipette_id} is corrupt: {e}')
-        (overrides/f'{pipette_id}.json').unlink()
-        raise FileNotFoundError(str(overrides/f'{pipette_id}.json'))
+        log.warning(f"pipette override for {pipette_id} is corrupt: {e}")
+        (overrides / f"{pipette_id}.json").unlink()
+        raise FileNotFoundError(str(overrides / f"{pipette_id}.json"))
 
 
 def validate_quirks(quirks: List[str]):
@@ -372,14 +365,15 @@ def validate_quirks(quirks: List[str]):
         if quirk in VALID_QUIRKS:
             valid_quirks.append(quirk)
         else:
-            log.warning(f'{quirk} is not a valid quirk')
+            log.warning(f"{quirk} is not a valid quirk")
     return valid_quirks
 
 
 def ensure_value(
-        config: PipetteFusedSpec,
-        name: Union[str, Tuple[str, ...]],
-        mutable_config_list: List[str]):
+    config: PipetteFusedSpec,
+    name: Union[str, Tuple[str, ...]],
+    mutable_config_list: List[str],
+):
     """
     Pull value of config data from file. Shape can either be a dictionary with
     a value key -- indicating that it can be changed -- or another
@@ -393,50 +387,52 @@ def ensure_value(
         config = config[element]  # type: ignore
 
     value = config[path[-1]]  # type: ignore
-    if path[-1] != 'quirks' and path[-1] in mutable_config_list:
-        value = value['value']
+    if path[-1] != "quirks" and path[-1] in mutable_config_list:
+        value = value["value"]
     return value
 
 
 def known_pipettes() -> Sequence[str]:
-    """ List pipette IDs for which we have known overrides """
-    return [fi.stem
-            for fi in config.CONFIG['pipette_config_overrides_dir'].iterdir()
-            if fi.is_file() and '.json' in fi.suffixes]
+    """List pipette IDs for which we have known overrides"""
+    return [
+        fi.stem
+        for fi in config.CONFIG["pipette_config_overrides_dir"].iterdir()
+        if fi.is_file() and ".json" in fi.suffixes
+    ]
 
 
 def add_default(cfg):
     if isinstance(cfg, dict):
-        if 'value' in cfg.keys():
-            cfg['default'] = cfg['value']
+        if "value" in cfg.keys():
+            cfg["default"] = cfg["value"]
         else:
             for top_level_key in cfg.keys():
                 add_default(cfg[top_level_key])
 
 
-def load_config_dict(pipette_id: str) -> Tuple[
-        'PipetteFusedSpec', 'PipetteModel']:
-    """ Give updated config with overrides for a pipette. This will add
+def load_config_dict(pipette_id: str) -> Tuple["PipetteFusedSpec", "PipetteModel"]:
+    """Give updated config with overrides for a pipette. This will add
     the default value for a mutable config before returning the modified
     config value.
     """
     override = load_overrides(pipette_id)
-    model = override['model']
+    model = override["model"]
     config = fuse_specs(model)
 
-    if 'quirks' not in override.keys():
-        override['quirks'] = {key: True for key in config['quirks']}
+    if "quirks" not in override.keys():
+        override["quirks"] = {key: True for key in config["quirks"]}
     else:
         # 20210210 AL - There have been bugs that allow settings invalid
         # quirks. Sanitize quirks by removing invalid ones that may have
         # been saved erroneously.
-        override['quirks'] = {
-            key: value for key, value
-            in override['quirks'].items() if key in VALID_QUIRKS
+        override["quirks"] = {
+            key: value
+            for key, value in override["quirks"].items()
+            if key in VALID_QUIRKS
         }
 
     for top_level_key in config.keys():
-        if top_level_key != 'quirks':
+        if top_level_key != "quirks":
             add_default(config[top_level_key])  # type: ignore
 
     config.update(override)  # type: ignore
@@ -453,7 +449,7 @@ def list_mutable_configs(pipette_id: str) -> Dict[str, Any]:
     try:
         config, model = load_config_dict(pipette_id)
     except FileNotFoundError:
-        log.info(f'Pipette id {pipette_id} not found')
+        log.info(f"Pipette id {pipette_id} not found")
         return cfg
 
     for key in config:

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, Dict, Set
 from opentrons.config import IS_ROBOT
 from opentrons.calibration_storage import delete
 
-DATA_BOOT_D = Path('/data/boot.d')
+DATA_BOOT_D = Path("/data/boot.d")
 
 log = logging.getLogger(__name__)
 
@@ -24,41 +24,33 @@ class CommonResetOption(NamedTuple):
 
 class ResetOptionId(str, Enum):
     """The available reset options"""
-    labware_calibration = 'labwareCalibration'
-    boot_scripts = 'bootScripts'
-    deck_calibration = 'deckCalibration'
-    pipette_offset = 'pipetteOffsetCalibrations'
-    tip_length_calibrations = 'tipLengthCalibrations'
+
+    labware_calibration = "labwareCalibration"
+    boot_scripts = "bootScripts"
+    deck_calibration = "deckCalibration"
+    pipette_offset = "pipetteOffsetCalibrations"
+    tip_length_calibrations = "tipLengthCalibrations"
 
 
 _settings_reset_options = {
-    ResetOptionId.labware_calibration:
-        CommonResetOption(
-            name='Labware Calibration',
-            description='Clear labware calibration'
-        ),
-    ResetOptionId.boot_scripts:
-        CommonResetOption(
-            name='Boot Scripts',
-            description='Clear custom boot scripts'
-        ),
-    ResetOptionId.deck_calibration:
-        CommonResetOption(
-            name='Deck Calibration',
-            description='Clear deck calibration (will also clear pipette '
-                        'offset)'
-        ),
-    ResetOptionId.pipette_offset:
-        CommonResetOption(
-            name='Pipette Offset Calibrations',
-            description='Clear pipette offset calibrations'
-        ),
-    ResetOptionId.tip_length_calibrations:
-        CommonResetOption(
-            name='Tip Length Calibrations',
-            description='Clear tip length calibrations (will also clear '
-                        'pipette offset)'
-        )
+    ResetOptionId.labware_calibration: CommonResetOption(
+        name="Labware Calibration", description="Clear labware calibration"
+    ),
+    ResetOptionId.boot_scripts: CommonResetOption(
+        name="Boot Scripts", description="Clear custom boot scripts"
+    ),
+    ResetOptionId.deck_calibration: CommonResetOption(
+        name="Deck Calibration",
+        description="Clear deck calibration (will also clear pipette " "offset)",
+    ),
+    ResetOptionId.pipette_offset: CommonResetOption(
+        name="Pipette Offset Calibrations",
+        description="Clear pipette offset calibrations",
+    ),
+    ResetOptionId.tip_length_calibrations: CommonResetOption(
+        name="Tip Length Calibrations",
+        description="Clear tip length calibrations (will also clear " "pipette offset)",
+    ),
 }
 
 
@@ -95,7 +87,7 @@ def reset_boot_scripts():
         if os.path.exists(DATA_BOOT_D):
             shutil.rmtree(DATA_BOOT_D)
     else:
-        log.debug(f'Not on pi, not removing {DATA_BOOT_D}')
+        log.debug(f"Not on pi, not removing {DATA_BOOT_D}")
 
 
 def reset_deck_calibration():

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -33,60 +33,60 @@ MOUNT_CURRENT_HIGH_REFRESH = 0.5
 Z_RETRACT_DISTANCE = 2
 
 HIGH_CURRENT: CurrentDict = {
-    'default': {
-        'X': X_CURRENT_HIGH,
-        'Y': Y_CURRENT_HIGH,
-        'Z': MOUNT_CURRENT_HIGH_REFRESH,
-        'A': MOUNT_CURRENT_HIGH_REFRESH,
-        'B': PLUNGER_CURRENT_HIGH,
-        'C': PLUNGER_CURRENT_HIGH
+    "default": {
+        "X": X_CURRENT_HIGH,
+        "Y": Y_CURRENT_HIGH,
+        "Z": MOUNT_CURRENT_HIGH_REFRESH,
+        "A": MOUNT_CURRENT_HIGH_REFRESH,
+        "B": PLUNGER_CURRENT_HIGH,
+        "C": PLUNGER_CURRENT_HIGH,
     },
-    '2.1': {
-        'X': X_CURRENT_HIGH,
-        'Y': Y_CURRENT_HIGH,
-        'Z': MOUNT_CURRENT_HIGH,
-        'A': MOUNT_CURRENT_HIGH,
-        'B': PLUNGER_CURRENT_HIGH,
-        'C': PLUNGER_CURRENT_HIGH
-    }
+    "2.1": {
+        "X": X_CURRENT_HIGH,
+        "Y": Y_CURRENT_HIGH,
+        "Z": MOUNT_CURRENT_HIGH,
+        "A": MOUNT_CURRENT_HIGH,
+        "B": PLUNGER_CURRENT_HIGH,
+        "C": PLUNGER_CURRENT_HIGH,
+    },
 }
 
 LOW_CURRENT: CurrentDict = {
-    'default': {
-        'X': XY_CURRENT_LOW_REFRESH,
-        'Y': XY_CURRENT_LOW_REFRESH,
-        'Z': MOUNT_CURRENT_LOW,
-        'A': MOUNT_CURRENT_LOW,
-        'B': PLUNGER_CURRENT_LOW,
-        'C': PLUNGER_CURRENT_LOW
+    "default": {
+        "X": XY_CURRENT_LOW_REFRESH,
+        "Y": XY_CURRENT_LOW_REFRESH,
+        "Z": MOUNT_CURRENT_LOW,
+        "A": MOUNT_CURRENT_LOW,
+        "B": PLUNGER_CURRENT_LOW,
+        "C": PLUNGER_CURRENT_LOW,
     },
-    '2.1': {
-        'X': X_CURRENT_LOW,
-        'Y': Y_CURRENT_LOW,
-        'Z': MOUNT_CURRENT_LOW,
-        'A': MOUNT_CURRENT_LOW,
-        'B': PLUNGER_CURRENT_LOW,
-        'C': PLUNGER_CURRENT_LOW
-    }
+    "2.1": {
+        "X": X_CURRENT_LOW,
+        "Y": Y_CURRENT_LOW,
+        "Z": MOUNT_CURRENT_LOW,
+        "A": MOUNT_CURRENT_LOW,
+        "B": PLUNGER_CURRENT_LOW,
+        "C": PLUNGER_CURRENT_LOW,
+    },
 }
 
 DEFAULT_CURRENT: CurrentDict = {
-    'default': {
-        'X': HIGH_CURRENT['default']['X'],
-        'Y': HIGH_CURRENT['default']['Y'],
-        'Z': HIGH_CURRENT['default']['Z'],
-        'A': HIGH_CURRENT['default']['A'],
-        'B': LOW_CURRENT['default']['B'],
-        'C': LOW_CURRENT['default']['C']
+    "default": {
+        "X": HIGH_CURRENT["default"]["X"],
+        "Y": HIGH_CURRENT["default"]["Y"],
+        "Z": HIGH_CURRENT["default"]["Z"],
+        "A": HIGH_CURRENT["default"]["A"],
+        "B": LOW_CURRENT["default"]["B"],
+        "C": LOW_CURRENT["default"]["C"],
     },
-    '2.1': {
-        'X': HIGH_CURRENT['2.1']['X'],
-        'Y': HIGH_CURRENT['2.1']['Y'],
-        'Z': HIGH_CURRENT['2.1']['Z'],
-        'A': HIGH_CURRENT['2.1']['A'],
-        'B': LOW_CURRENT['2.1']['B'],
-        'C': LOW_CURRENT['2.1']['C']
-    }
+    "2.1": {
+        "X": HIGH_CURRENT["2.1"]["X"],
+        "Y": HIGH_CURRENT["2.1"]["Y"],
+        "Z": HIGH_CURRENT["2.1"]["Z"],
+        "A": HIGH_CURRENT["2.1"]["A"],
+        "B": LOW_CURRENT["2.1"]["B"],
+        "C": LOW_CURRENT["2.1"]["C"],
+    },
 }
 
 X_MAX_SPEED = 600
@@ -97,27 +97,29 @@ B_MAX_SPEED = 40
 C_MAX_SPEED = 40
 
 DEFAULT_MAX_SPEEDS: AxisDict = {
-    'X': X_MAX_SPEED,
-    'Y': Y_MAX_SPEED,
-    'Z': Z_MAX_SPEED,
-    'A': A_MAX_SPEED,
-    'B': B_MAX_SPEED,
-    'C': C_MAX_SPEED
+    "X": X_MAX_SPEED,
+    "Y": Y_MAX_SPEED,
+    "Z": Z_MAX_SPEED,
+    "A": A_MAX_SPEED,
+    "B": B_MAX_SPEED,
+    "C": C_MAX_SPEED,
 }
 
-DEFAULT_CURRENT_STRING = ' '.join(
-    ['{}{}'.format(key, value) for key, value in DEFAULT_CURRENT.items()])
+DEFAULT_CURRENT_STRING = " ".join(
+    ["{}{}".format(key, value) for key, value in DEFAULT_CURRENT.items()]
+)
 
 DEFAULT_DECK_CALIBRATION_V2: List[List[float]] = [
     [1.00, 0.00, 0.00],
     [0.00, 1.00, 0.00],
-    [0.00, 0.00, 1.00]]
+    [0.00, 0.00, 1.00],
+]
 
 DEFAULT_SIMULATION_CALIBRATION: List[List[float]] = [
     [1.0, 0.0, 0.0, 0.0],
     [0.0, 1.0, 0.0, 0.0],
     [0.0, 0.0, 1.0, -25.0],
-    [0.0, 0.0, 0.0, 1.0]
+    [0.0, 0.0, 0.0, 1.0],
 ]
 
 X_ACCELERATION = 3000
@@ -128,56 +130,58 @@ B_ACCELERATION = 200
 C_ACCELERATION = 200
 
 DEFAULT_ACCELERATION: Dict[str, float] = {
-    'X': X_ACCELERATION,
-    'Y': Y_ACCELERATION,
-    'Z': Z_ACCELERATION,
-    'A': A_ACCELERATION,
-    'B': B_ACCELERATION,
-    'C': C_ACCELERATION
+    "X": X_ACCELERATION,
+    "Y": Y_ACCELERATION,
+    "Z": Z_ACCELERATION,
+    "A": A_ACCELERATION,
+    "B": B_ACCELERATION,
+    "C": C_ACCELERATION,
 }
 
 DEFAULT_PIPETTE_CONFIGS: Dict[str, float] = {
-    'homePosition': 220,
-    'stepsPerMM': 768,
-    'maxTravel': 30
+    "homePosition": 220,
+    "stepsPerMM": 768,
+    "maxTravel": 30,
 }
 
 DEFAULT_GANTRY_STEPS_PER_MM: Dict[str, float] = {
-    'X': 80.00,
-    'Y': 80.00,
-    'Z': 400,
-    'A': 400
+    "X": 80.00,
+    "Y": 80.00,
+    "Z": 400,
+    "A": 400,
 }
 
 
 DEFAULT_MOUNT_OFFSET = [-34, 0, 0]
 DEFAULT_PIPETTE_OFFSET = [0.0, 0.0, 0.0]
 SERIAL_SPEED = 115200
-DEFAULT_LOG_LEVEL = 'INFO'
+DEFAULT_LOG_LEVEL = "INFO"
 
 
 def _build_hw_versioned_current_dict(
-        from_conf: Optional[Dict[str, Any]], default: CurrentDict) -> CurrentDict:
+    from_conf: Optional[Dict[str, Any]], default: CurrentDict
+) -> CurrentDict:
     if not from_conf or not isinstance(from_conf, dict):
         return default
     # special case: if this is a valid old (i.e. not model-specific) current
     # setup, migrate it.
-    if 'default' not in from_conf and not (set('XYZABC')-set(from_conf.keys())):
+    if "default" not in from_conf and not (set("XYZABC") - set(from_conf.keys())):
         new_dct = deepcopy(default)
         # Because there's no case in which a machine with a more recent revision
         # than 2.1 should have a valid and edited robot config when updating
         # to this code, we should default it to 2.1 to avoid breaking other
         # robots
-        new_dct['2.1'] = cast(AxisDict, from_conf)
+        new_dct["2.1"] = cast(AxisDict, from_conf)
         return new_dct
     return cast(CurrentDict, from_conf)
 
 
-DictType = TypeVar('DictType', bound=Dict)
+DictType = TypeVar("DictType", bound=Dict)
 
 
 def _build_dict_with_default(
-        from_conf: Union[DictType, str, None], default: DictType) -> DictType:
+    from_conf: Union[DictType, str, None], default: DictType
+) -> DictType:
     if not isinstance(from_conf, dict):
         return default
     else:
@@ -185,62 +189,62 @@ def _build_dict_with_default(
 
 
 def current_for_revision(
-        current_dict: CurrentDict,
-        revision: BoardRevision) -> AxisDict:
+    current_dict: CurrentDict, revision: BoardRevision
+) -> AxisDict:
     if revision == BoardRevision.UNKNOWN:
-        return current_dict.get('2.1', current_dict['default'])
+        return current_dict.get("2.1", current_dict["default"])
     elif revision.real_name() in current_dict:
         return current_dict[revision.real_name()]  # type: ignore
     else:
-        return current_dict['default']
+        return current_dict["default"]
 
 
 def build_config(robot_settings: Dict[str, Any]) -> RobotConfig:
     return RobotConfig(
-        name=robot_settings.get('name', 'Ada Lovelace'),
+        name=robot_settings.get("name", "Ada Lovelace"),
         version=ROBOT_CONFIG_VERSION,
         gantry_steps_per_mm=_build_dict_with_default(
-            robot_settings.get('steps_per_mm'), DEFAULT_GANTRY_STEPS_PER_MM),
+            robot_settings.get("steps_per_mm"), DEFAULT_GANTRY_STEPS_PER_MM
+        ),
         acceleration=_build_dict_with_default(
-            robot_settings.get('acceleration'), DEFAULT_ACCELERATION),
-        serial_speed=robot_settings.get('serial_speed', SERIAL_SPEED),
+            robot_settings.get("acceleration"), DEFAULT_ACCELERATION
+        ),
+        serial_speed=robot_settings.get("serial_speed", SERIAL_SPEED),
         default_current=_build_hw_versioned_current_dict(
-            robot_settings.get('default_current'), DEFAULT_CURRENT),
+            robot_settings.get("default_current"), DEFAULT_CURRENT
+        ),
         low_current=_build_hw_versioned_current_dict(
-            robot_settings.get('low_current'), LOW_CURRENT),
+            robot_settings.get("low_current"), LOW_CURRENT
+        ),
         high_current=_build_hw_versioned_current_dict(
-            robot_settings.get('high_current'), HIGH_CURRENT),
-        default_max_speed=robot_settings.get(
-            'default_max_speed', DEFAULT_MAX_SPEEDS),
-        log_level=robot_settings.get('log_level', DEFAULT_LOG_LEVEL),
+            robot_settings.get("high_current"), HIGH_CURRENT
+        ),
+        default_max_speed=robot_settings.get("default_max_speed", DEFAULT_MAX_SPEEDS),
+        log_level=robot_settings.get("log_level", DEFAULT_LOG_LEVEL),
         default_pipette_configs=robot_settings.get(
-            'default_pipette_configs', DEFAULT_PIPETTE_CONFIGS),
-        z_retract_distance=robot_settings.get(
-            'z_retract_distance', Z_RETRACT_DISTANCE),
-        left_mount_offset=robot_settings.get(
-            'left_mount_offset', DEFAULT_MOUNT_OFFSET),
+            "default_pipette_configs", DEFAULT_PIPETTE_CONFIGS
+        ),
+        z_retract_distance=robot_settings.get("z_retract_distance", Z_RETRACT_DISTANCE),
+        left_mount_offset=robot_settings.get("left_mount_offset", DEFAULT_MOUNT_OFFSET),
     )
 
 
-def config_to_save(
-        config: RobotConfig) -> Dict[str, Any]:
+def config_to_save(config: RobotConfig) -> Dict[str, Any]:
     return asdict(config)
 
 
 def load() -> RobotConfig:
-    settings_file = CONFIG['robot_settings_file']
+    settings_file = CONFIG["robot_settings_file"]
     log.debug("Loading robot settings from {}".format(settings_file))
     robot_settings = _load_json(settings_file) or {}
     return build_config(robot_settings)
 
 
-def save_robot_settings(config: RobotConfig,
-                        rs_filename: str = None,
-                        tag: str = None):
+def save_robot_settings(config: RobotConfig, rs_filename: str = None, tag: str = None):
     config_dict = config_to_save(config)
 
     # Save everything else in a different file
-    filename = rs_filename or CONFIG['robot_settings_file']
+    filename = rs_filename or CONFIG["robot_settings_file"]
     if tag:
         root, ext = os.path.splitext(filename)
         filename = "{}-{}{}".format(root, tag, ext)
@@ -251,6 +255,7 @@ def save_robot_settings(config: RobotConfig,
 
 def backup_configuration(config: RobotConfig, tag: str = None) -> None:
     import time
+
     if not tag:
         tag = str(int(time.time() * 1000))
     save_robot_settings(config, tag=tag)
@@ -263,19 +268,19 @@ def get_legacy_gantry_calibration() -> Optional[List[List[float]]]:
     This should happen only if the new deck calibration file does not exist.
     The legacy calibration should then be migrated to the new format.
     """
-    gantry_cal = _load_json(CONFIG['deck_calibration_file'])
-    if 'gantry_calibration' in gantry_cal:
-        return gantry_cal['gantry_calibration']
+    gantry_cal = _load_json(CONFIG["deck_calibration_file"])
+    if "gantry_calibration" in gantry_cal:
+        return gantry_cal["gantry_calibration"]
     else:
         return None
 
 
 def clear() -> None:
-    _clear_file(CONFIG['robot_settings_file'])
+    _clear_file(CONFIG["robot_settings_file"])
 
 
 def _clear_file(filename: Union[str, Path]) -> None:
-    log.debug('Deleting {}'.format(filename))
+    log.debug("Deleting {}".format(filename))
     if os.path.exists(filename):
         os.remove(filename)
 
@@ -283,13 +288,13 @@ def _clear_file(filename: Union[str, Path]) -> None:
 # TODO: move to util (write a default load, save JSON function)
 def _load_json(filename: Union[str, Path]) -> Dict[str, Any]:
     try:
-        with open(filename, 'r') as file:
+        with open(filename, "r") as file:
             res = json.load(file)
     except FileNotFoundError:
-        log.warning('{0} not found. Loading defaults'.format(filename))
+        log.warning("{0} not found. Loading defaults".format(filename))
         res = {}
     except json.decoder.JSONDecodeError:
-        log.warning('{0} is corrupt. Loading defaults'.format(filename))
+        log.warning("{0} is corrupt. Loading defaults".format(filename))
         res = {}
     return res
 
@@ -297,9 +302,9 @@ def _load_json(filename: Union[str, Path]) -> Dict[str, Any]:
 def _save_json(data: Dict[str, Any], filename: Union[str, Path]) -> None:
     try:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
-        with open(filename, 'w') as file:
+        with open(filename, "w") as file:
             json.dump(data, file, sort_keys=True, indent=4)
             file.flush()
             os.fsync(file.fileno())
     except OSError:
-        log.exception('Write failed with exception:')
+        log.exception("Write failed with exception:")

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -17,12 +17,10 @@ class CurrentDictDefault(TypedDict):
 
 
 CurrentDictModelEntries = TypedDict(
-    'CurrentDictModelEntries',
-    {'2.1': AxisDict,
-     'A': AxisDict,
-     'B': AxisDict,
-     'C': AxisDict},
-    total=False)
+    "CurrentDictModelEntries",
+    {"2.1": AxisDict, "A": AxisDict, "B": AxisDict, "C": AxisDict},
+    total=False,
+)
 
 
 class CurrentDict(CurrentDictDefault, CurrentDictModelEntries):
@@ -38,7 +36,7 @@ class RobotConfig:
     serial_speed: int
     default_pipette_configs: Dict[str, float]
     default_current: CurrentDict
-    low_current:  CurrentDict
+    low_current: CurrentDict
     high_current: CurrentDict
     default_max_speed: AxisDict
     log_level: str

--- a/api/src/opentrons/drivers/asyncio/communication/__init__.py
+++ b/api/src/opentrons/drivers/asyncio/communication/__init__.py
@@ -1,8 +1,9 @@
-from .serial_connection import (
-    SerialConnection
-)
+from .serial_connection import SerialConnection
 from opentrons.drivers.asyncio.communication.errors import (
-    SerialException, NoResponse, AlarmResponse, ErrorResponse
+    SerialException,
+    NoResponse,
+    AlarmResponse,
+    ErrorResponse,
 )
 from .async_serial import AsyncSerial
 
@@ -12,5 +13,5 @@ __all__ = [
     "SerialException",
     "NoResponse",
     "AlarmResponse",
-    "ErrorResponse"
+    "ErrorResponse",
 ]

--- a/api/src/opentrons/drivers/asyncio/communication/async_serial.py
+++ b/api/src/opentrons/drivers/asyncio/communication/async_serial.py
@@ -5,7 +5,7 @@ import contextlib
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Optional
 
-from serial import Serial, serial_for_url   # type: ignore
+from serial import Serial, serial_for_url  # type: ignore
 
 
 class AsyncSerial:
@@ -13,9 +13,12 @@ class AsyncSerial:
 
     @classmethod
     async def create(
-            cls, port: str, baud_rate: int,
-            timeout: Optional[float] = None, write_timeout: Optional[float] = None,
-            loop: Optional[asyncio.AbstractEventLoop] = None
+        cls,
+        port: str,
+        baud_rate: int,
+        timeout: Optional[float] = None,
+        write_timeout: Optional[float] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> AsyncSerial:
         """
         Create an AsyncSerial instance.
@@ -32,17 +35,19 @@ class AsyncSerial:
         serial = await loop.run_in_executor(
             executor=executor,
             func=lambda: serial_for_url(
-                url=port, baudrate=baud_rate,
-                timeout=timeout, write_timeout=write_timeout
-            )
+                url=port,
+                baudrate=baud_rate,
+                timeout=timeout,
+                write_timeout=write_timeout,
+            ),
         )
         return cls(serial=serial, executor=executor, loop=loop)
 
     def __init__(
-            self,
-            serial: Serial,
-            executor: ThreadPoolExecutor,
-            loop: asyncio.AbstractEventLoop
+        self,
+        serial: Serial,
+        executor: ThreadPoolExecutor,
+        loop: asyncio.AbstractEventLoop,
     ) -> None:
         """
         Constructor
@@ -70,8 +75,7 @@ class AsyncSerial:
         """
         with self._timeout_override("timeout", timeout):
             return await self._loop.run_in_executor(
-                executor=self._executor,
-                func=lambda: self._serial.read_until(match)
+                executor=self._executor, func=lambda: self._serial.read_until(match)
             )
 
     async def write(self, data: bytes, timeout: Optional[float] = None) -> None:
@@ -87,9 +91,9 @@ class AsyncSerial:
             None
         """
         await self._loop.run_in_executor(
-                executor=self._executor,
-                func=lambda: self._sync_write(data=data, timeout=timeout)
-            )
+            executor=self._executor,
+            func=lambda: self._sync_write(data=data, timeout=timeout),
+        )
 
     def _sync_write(self, data: bytes, timeout: Optional[float] = None) -> None:
         """
@@ -113,8 +117,7 @@ class AsyncSerial:
         Returns: None
         """
         return await self._loop.run_in_executor(
-            executor=self._executor,
-            func=self._serial.open
+            executor=self._executor, func=self._serial.open
         )
 
     async def close(self) -> None:
@@ -124,8 +127,7 @@ class AsyncSerial:
         Returns: None
         """
         return await self._loop.run_in_executor(
-            executor=self._executor,
-            func=self._serial.close
+            executor=self._executor, func=self._serial.close
         )
 
     async def is_open(self) -> bool:

--- a/api/src/opentrons/drivers/asyncio/communication/errors.py
+++ b/api/src/opentrons/drivers/asyncio/communication/errors.py
@@ -12,17 +12,14 @@ class SerialException(Exception):
 
 class NoResponse(SerialException):
     def __init__(self, port: str, command: str):
-        super().__init__(
-            port=port, description=f"No response to '{command}'"
-        )
+        super().__init__(port=port, description=f"No response to '{command}'")
         self.command = command
 
 
 class FailedCommand(SerialException):
     def __init__(self, port: str, response: str):
         super().__init__(
-            port=port,
-            description=f"'Received error response '{response}'"
+            port=port, description=f"'Received error response '{response}'"
         )
         self.response = response
 

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -13,17 +13,16 @@ log = logging.getLogger(__name__)
 
 
 class SerialConnection:
-
     @classmethod
     async def create(
-            cls,
-            port: str,
-            baud_rate: int,
-            timeout: float,
-            ack: str,
-            name: Optional[str] = None,
-            retry_wait_time_seconds: float = 0.1,
-            loop: Optional[asyncio.AbstractEventLoop] = None,
+        cls,
+        port: str,
+        baud_rate: int,
+        timeout: float,
+        ack: str,
+        name: Optional[str] = None,
+        retry_wait_time_seconds: float = 0.1,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> SerialConnection:
         """
         Create a connection.
@@ -39,21 +38,25 @@ class SerialConnection:
 
         Returns: SerialConnection
         """
-        serial = await AsyncSerial.create(port=port, baud_rate=baud_rate,
-                                          timeout=timeout, loop=loop)
+        serial = await AsyncSerial.create(
+            port=port, baud_rate=baud_rate, timeout=timeout, loop=loop
+        )
         name = name or port
         return cls(
-            serial=serial, port=port, name=name,
-            ack=ack, retry_wait_time_seconds=retry_wait_time_seconds
+            serial=serial,
+            port=port,
+            name=name,
+            ack=ack,
+            retry_wait_time_seconds=retry_wait_time_seconds,
         )
 
     def __init__(
-            self,
-            serial: AsyncSerial,
-            port: str,
-            name: str,
-            ack: str,
-            retry_wait_time_seconds: float
+        self,
+        serial: AsyncSerial,
+        port: str,
+        name: str,
+        ack: str,
+        retry_wait_time_seconds: float,
     ) -> None:
         """
         Constructor
@@ -73,8 +76,7 @@ class SerialConnection:
         self._send_data_lock = asyncio.Lock()
 
     async def send_command(
-            self, command: CommandBuilder, retries: int = 0,
-            timeout: Optional[float] = None
+        self, command: CommandBuilder, retries: int = 0, timeout: Optional[float] = None
     ) -> str:
         """
         Send a command and return the response.
@@ -88,11 +90,12 @@ class SerialConnection:
 
         Raises: SerialException
         """
-        return await self.send_data(data=command.build(), retries=retries,
-                                    timeout=timeout)
+        return await self.send_data(
+            data=command.build(), retries=retries, timeout=timeout
+        )
 
     async def send_data(
-            self, data: str, retries: int = 0, timeout: Optional[float] = None
+        self, data: str, retries: int = 0, timeout: Optional[float] = None
     ) -> str:
         """
         Send data and return the response.
@@ -110,7 +113,7 @@ class SerialConnection:
             return await self._send_data(data=data, retries=retries, timeout=timeout)
 
     async def _send_data(
-            self, data: str, retries: int = 0, timeout: Optional[float] = None
+        self, data: str, retries: int = 0, timeout: Optional[float] = None
     ) -> str:
         """
         Send data and return the response.
@@ -127,22 +130,22 @@ class SerialConnection:
         data_encode = data.encode()
 
         for retry in range(retries + 1):
-            log.debug(f'{self.name}: Write -> {data_encode!r}')
+            log.debug(f"{self.name}: Write -> {data_encode!r}")
             await self._serial.write(data=data_encode)
 
             response = await self._serial.read_until(match=self._ack, timeout=timeout)
-            log.debug(f'{self.name}: Read <- {response!r}')
+            log.debug(f"{self.name}: Read <- {response!r}")
 
             if self._ack in response:
                 # Remove ack from response
-                response = response.replace(self._ack, b'')
+                response = response.replace(self._ack, b"")
                 str_response = self.process_raw_response(
                     command=data, response=response.decode()
                 )
                 self.raise_on_error(response=str_response)
                 return str_response
 
-            log.info(f'{self.name}: retry number {retry}/{retries}')
+            log.info(f"{self.name}: retry number {retry}/{retries}")
 
             await self.on_retry()
 

--- a/api/src/opentrons/drivers/command_builder.py
+++ b/api/src/opentrons/drivers/command_builder.py
@@ -17,8 +17,8 @@ class CommandBuilder:
         self._elements: List[str] = []
 
     def add_float(
-            self, prefix: str, value: float,
-            precision: Optional[int]) -> CommandBuilder:
+        self, prefix: str, value: float, precision: Optional[int]
+    ) -> CommandBuilder:
         """
         Add a float value.
 

--- a/api/src/opentrons/drivers/mag_deck/__init__.py
+++ b/api/src/opentrons/drivers/mag_deck/__init__.py
@@ -3,8 +3,4 @@ from .simulator import SimulatingDriver
 from .driver import MagDeckDriver
 
 
-__all__ = [
-    "AbstractMagDeckDriver",
-    "SimulatingDriver",
-    "MagDeckDriver"
-]
+__all__ = ["AbstractMagDeckDriver", "SimulatingDriver", "MagDeckDriver"]

--- a/api/src/opentrons/drivers/mag_deck/abstract.py
+++ b/api/src/opentrons/drivers/mag_deck/abstract.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 
 class AbstractMagDeckDriver(ABC):
-
     @abstractmethod
     async def connect(self) -> None:
         ...

--- a/api/src/opentrons/drivers/mag_deck/driver.py
+++ b/api/src/opentrons/drivers/mag_deck/driver.py
@@ -38,8 +38,8 @@ class GCODE(str, Enum):
 
 MAG_DECK_BAUDRATE = 115200
 
-MAG_DECK_COMMAND_TERMINATOR = '\r\n\r\n'
-MAG_DECK_ACK = 'ok\r\nok\r\n'
+MAG_DECK_COMMAND_TERMINATOR = "\r\n\r\n"
+MAG_DECK_ACK = "ok\r\nok\r\n"
 
 
 # Number of digits after the decimal point for millimeter values
@@ -52,10 +52,9 @@ class MagDeckError(Exception):
 
 
 class MagDeckDriver(AbstractMagDeckDriver):
-
     @classmethod
     async def create(
-            cls, port: str, loop: Optional[asyncio.AbstractEventLoop] = None
+        cls, port: str, loop: Optional[asyncio.AbstractEventLoop] = None
     ) -> MagDeckDriver:
         """
         Create a mag deck driver.
@@ -67,9 +66,11 @@ class MagDeckDriver(AbstractMagDeckDriver):
         Returns: driver
         """
         connection = await SerialConnection.create(
-            port=port, baud_rate=MAG_DECK_BAUDRATE,
-            timeout=DEFAULT_MAG_DECK_TIMEOUT, ack=MAG_DECK_ACK,
-            loop=loop
+            port=port,
+            baud_rate=MAG_DECK_BAUDRATE,
+            timeout=DEFAULT_MAG_DECK_TIMEOUT,
+            ack=MAG_DECK_ACK,
+            loop=loop,
         )
         return cls(connection=connection)
 
@@ -96,9 +97,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
 
     async def home(self) -> None:
         """Homes the magnet"""
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.HOME
         )
         await self._send_command(c)
@@ -109,9 +108,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
         from home.
         To be used for calibrating MagDeck
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.PROBE_PLATE
         )
         await self._send_command(c)
@@ -121,31 +118,25 @@ class MagDeckDriver(AbstractMagDeckDriver):
         Default plate_height for the device is 30;
         calculated as MAX_TRAVEL_DISTANCE(45mm) - 15mm
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_PLATE_HEIGHT
         )
         response = await self._send_command(c)
         data = utils.parse_key_values(response)
-        return utils.parse_number(str(data.get('height')),
-                                  GCODE_ROUNDING_PRECISION)
+        return utils.parse_number(str(data.get("height")), GCODE_ROUNDING_PRECISION)
 
     async def get_mag_position(self) -> float:
         """
         Default mag_position for the device is 0.0
         i.e. it boots with the current position as 0.0
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_CURRENT_POSITION
         )
 
         response = await self._send_command(c)
         data = utils.parse_key_values(response)
-        return utils.parse_number(str(data.get('Z')),
-                                  GCODE_ROUNDING_PRECISION)
+        return utils.parse_number(str(data.get("Z")), GCODE_ROUNDING_PRECISION)
 
     async def move(self, position_mm: float) -> None:
         """
@@ -153,12 +144,12 @@ class MagDeckDriver(AbstractMagDeckDriver):
         position_mm-> a point along Z. Does not self-check if the position
         is outside of the deck's linear range
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
-            gcode=GCODE.MOVE
-        ).add_float(
-            prefix="Z", value=position_mm, precision=GCODE_ROUNDING_PRECISION
+        c = (
+            CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.MOVE)
+            .add_float(
+                prefix="Z", value=position_mm, precision=GCODE_ROUNDING_PRECISION
+            )
         )
         await self._send_command(c)
 
@@ -179,9 +170,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
         Example input from Mag-Deck's serial response:
             "serial:aa11bb22 model:aa11bb22 version:aa11bb22"
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEVICE_INFO
         )
         response = await self._send_command(c)
@@ -195,9 +184,7 @@ class MagDeckDriver(AbstractMagDeckDriver):
         The connection can be restored by performing a .disconnect()
         followed by a .connect() to the same symlink node
         """
-        c = CommandBuilder(
-            terminator=MAG_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.PROGRAMMING_MODE
         )
         await self._send_command(c)
@@ -213,7 +200,6 @@ class MagDeckDriver(AbstractMagDeckDriver):
             command response
         """
         response = await self._connection.send_command(
-            command=command,
-            retries=DEFAULT_COMMAND_RETRIES
+            command=command, retries=DEFAULT_COMMAND_RETRIES
         )
         return response

--- a/api/src/opentrons/drivers/mag_deck/simulator.py
+++ b/api/src/opentrons/drivers/mag_deck/simulator.py
@@ -4,17 +4,15 @@ from .abstract import AbstractMagDeckDriver
 
 
 MAG_DECK_MODELS = {
-    'magneticModuleV1': 'mag_deck_v1.1',
-    'magneticModuleV2': 'mag_deck_v20'
+    "magneticModuleV1": "mag_deck_v1.1",
+    "magneticModuleV2": "mag_deck_v20",
 }
 
 
 class SimulatingDriver(AbstractMagDeckDriver):
-
     def __init__(self, sim_model: str = None):
         self._height = 0.0
-        self._model = MAG_DECK_MODELS[sim_model] if sim_model\
-            else 'mag_deck_v1.1'
+        self._model = MAG_DECK_MODELS[sim_model] if sim_model else "mag_deck_v1.1"
 
     async def probe_plate(self):
         pass
@@ -26,9 +24,11 @@ class SimulatingDriver(AbstractMagDeckDriver):
         self._height = location
 
     async def get_device_info(self) -> Dict[str, str]:
-        return {'serial': 'dummySerialMD',
-                'model': self._model,
-                'version': 'dummyVersionMD'}
+        return {
+            "serial": "dummySerialMD",
+            "model": self._model,
+            "version": "dummyVersionMD",
+        }
 
     async def connect(self):
         pass

--- a/api/src/opentrons/drivers/rpi_drivers/__init__.py
+++ b/api/src/opentrons/drivers/rpi_drivers/__init__.py
@@ -11,20 +11,23 @@ class RevisionPinsError(Exception):
     pass
 
 
-def build_gpio_chardev(chip_name: str) -> 'GPIODriverLike':
+def build_gpio_chardev(chip_name: str) -> "GPIODriverLike":
     try:
         from .gpio import GPIOCharDev
+
         return GPIOCharDev(chip_name)
     except (ImportError, OSError):
         MODULE_LOG.warning(
-            'Failed to initialize character device, will not '
-            'be able to control gpios (lights, button, smoothie'
-            'kill, smoothie reset). Only one connection can be'
-            ' made to the gpios at a time. '
-            'If you need to control gpios, first stop the robot '
-            'server with systemctl stop opentrons-robot-server. '
-            'Until you restart the server with systemctl start '
-            'opentrons-robot-server, you will be unable to '
-            'control the robot using the Opentrons app.')
+            "Failed to initialize character device, will not "
+            "be able to control gpios (lights, button, smoothie"
+            "kill, smoothie reset). Only one connection can be"
+            " made to the gpios at a time. "
+            "If you need to control gpios, first stop the robot "
+            "server with systemctl stop opentrons-robot-server. "
+            "Until you restart the server with systemctl start "
+            "opentrons-robot-server, you will be unable to "
+            "control the robot using the Opentrons app."
+        )
         from .gpio_simulator import SimulatingGPIOCharDev
+
         return SimulatingGPIOCharDev(chip_name)

--- a/api/src/opentrons/drivers/rpi_drivers/dev_types.py
+++ b/api/src/opentrons/drivers/rpi_drivers/dev_types.py
@@ -6,8 +6,8 @@ from .types import GPIOPin
 
 
 class GPIODriverLike(Protocol):
-    """ Interface for the GPIO drivers
-    """
+    """Interface for the GPIO drivers"""
+
     def __init__(self, chip_name: str):
         ...
 
@@ -39,10 +39,9 @@ class GPIODriverLike(Protocol):
     def set_low(self, output_pin: GPIOPin):
         ...
 
-    def set_button_light(self,
-                         red: bool = False,
-                         green: bool = False,
-                         blue: bool = False):
+    def set_button_light(
+        self, red: bool = False, green: bool = False, blue: bool = False
+    ):
         ...
 
     def set_rail_lights(self, on: bool = True):
@@ -82,8 +81,10 @@ class GPIODriverLike(Protocol):
         ...
 
     def start_door_switch_watcher(
-            self, loop: asyncio.AbstractEventLoop,
-            update_door_state: Callable[[DoorState], None]):
+        self,
+        loop: asyncio.AbstractEventLoop,
+        update_door_state: Callable[[DoorState], None],
+    ):
         ...
 
     def release_line(self, pin: GPIOPin):

--- a/api/src/opentrons/drivers/rpi_drivers/gpio.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio.py
@@ -15,12 +15,13 @@ Raspberry Pi GPIO control module
 
 MODULE_LOG = logging.getLogger(__name__)
 
-DTOVERLAY_PATH = '/proc/device-tree/soc/gpio@7e200000/gpio_rev_bit_pins'
+DTOVERLAY_PATH = "/proc/device-tree/soc/gpio@7e200000/gpio_rev_bit_pins"
 
 
 def _event_callback(
-            update_door_state: Callable[[DoorState], None],
-            get_door_state: Callable[..., DoorState]):
+    update_door_state: Callable[[DoorState], None],
+    get_door_state: Callable[..., DoorState],
+):
     try:
         update_door_state(get_door_state())
     except Exception:
@@ -49,9 +50,7 @@ class GPIOCharDev:
     def board_rev(self, boardrev: BoardRevision):
         self._board_rev = boardrev
 
-    def _request_line(
-            self,
-            pin: GPIOPin, request_type) -> gpiod.Line:
+    def _request_line(self, pin: GPIOPin, request_type) -> gpiod.Line:
         name = pin.name
         offset = pin.by_board_rev(self.board_rev)
 
@@ -59,8 +58,7 @@ class GPIOCharDev:
 
         def _retry_request_line(retries: int = 0):
             try:
-                line.request(
-                    consumer=name, type=request_type, default_vals=[0])
+                line.request(consumer=name, type=request_type, default_vals=[0])
             except OSError as e:
                 retries -= 1
                 if retries <= 0:
@@ -69,40 +67,38 @@ class GPIOCharDev:
                 return _retry_request_line(retries)
             return line
 
-        if name == 'blue_button':
+        if name == "blue_button":
             return _retry_request_line(3)
         else:
             return _retry_request_line()
 
     def _initialize(self) -> Dict[str, gpiod.Line]:
-        MODULE_LOG.info(
-            "Registering Central Routing Board Revision GPIOs")
+        MODULE_LOG.info("Registering Central Routing Board Revision GPIOs")
         lines = {}
-        rev_pins = gpio_group.by_names(['rev_0', 'rev_1'])
+        rev_pins = gpio_group.by_names(["rev_0", "rev_1"])
         for rev in rev_pins.pins:
             lines[rev.name] = self._request_line(rev, gpiod.LINE_REQ_DIR_IN)
         return lines
 
     def _determine_board_revision(self):
-        """Read revision bit pins and return the board revision
-        """
+        """Read revision bit pins and return the board revision"""
         try:
             rev_bits = self.read_revision_bits()
             return BoardRevision.by_bits(rev_bits)
         except RevisionPinsError:
             MODULE_LOG.info(
-                'Failed to detect central routing board revision gpio '
-                'pins, defaulting to 2.1 (OG)')
+                "Failed to detect central routing board revision gpio "
+                "pins, defaulting to 2.1 (OG)"
+            )
             return BoardRevision.OG
         except Exception:
             MODULE_LOG.exception(
-                'Unexpected error from reading central routing board '
-                'revision bits')
+                "Unexpected error from reading central routing board " "revision bits"
+            )
             return BoardRevision.UNKNOWN
 
     def config_by_board_rev(self):
-        MODULE_LOG.info(
-            "Configuring GPIOs by central routing roard revision")
+        MODULE_LOG.info("Configuring GPIOs by central routing roard revision")
         # get board revision based on rev bits
         self.board_rev = self._determine_board_revision()
 
@@ -110,14 +106,14 @@ class GPIOCharDev:
         output_pins = gpio_group.by_type(PinDir.output)
         for output in output_pins.pins:
             self._lines[output.name] = self._request_line(
-                output, gpiod.LINE_REQ_DIR_OUT)
+                output, gpiod.LINE_REQ_DIR_OUT
+            )
 
         # setup input lines
         input_pins = gpio_group.by_type(PinDir.input)
         sorted_inputs = input_pins.group_by_pins(self.board_rev)
         for pins in sorted_inputs:
-            line = self._request_line(
-                pins[0], gpiod.LINE_REQ_EV_BOTH_EDGES)
+            line = self._request_line(pins[0], gpiod.LINE_REQ_EV_BOTH_EDGES)
             for pin in pins:
                 self._lines[pin.name] = line
 
@@ -150,14 +146,14 @@ class GPIOCharDev:
     def set_low(self, output_pin: GPIOPin):
         self.lines[output_pin.name].set_value(0)
 
-    def set_button_light(self,
-                         red: bool = False,
-                         green: bool = False,
-                         blue: bool = False):
+    def set_button_light(
+        self, red: bool = False, green: bool = False, blue: bool = False
+    ):
         color_pins = {
             gpio_group.red_button: red,
             gpio_group.green_button: green,
-            gpio_group.blue_button: blue}
+            gpio_group.blue_button: blue,
+        }
         for pin, state in color_pins.items():
             if state:
                 self.set_high(pin)
@@ -199,13 +195,15 @@ class GPIOCharDev:
             return self.lines[input_pin.name].get_value()
         except KeyError:
             raise RuntimeError(
-                f"GPIO {input_pin.name} is not registered and cannot"
-                "be read")
+                f"GPIO {input_pin.name} is not registered and cannot" "be read"
+            )
 
     def get_button_light(self) -> Tuple[bool, bool, bool]:
-        return (bool(self._read(gpio_group.red_button)),
-                bool(self._read(gpio_group.green_button)),
-                bool(self._read(gpio_group.blue_button)))
+        return (
+            bool(self._read(gpio_group.red_button)),
+            bool(self._read(gpio_group.green_button)),
+            bool(self._read(gpio_group.blue_button)),
+        )
 
     def get_rail_lights(self) -> bool:
         return bool(self._read(gpio_group.frame_leds))
@@ -224,14 +222,16 @@ class GPIOCharDev:
         return bool(self._read(gpio_group.door_sw_filt))
 
     def read_revision_bits(self) -> Tuple[bool, bool]:
-        """ Read revision bit GPIO pins
+        """Read revision bit GPIO pins
 
         If the gpio_rev_bit_pins device tree overlay is enabled,
         returns the pins' values. Otherwise, return RevisionPinsError
         """
         if pathlib.Path(DTOVERLAY_PATH).exists():
-            return (bool(self._read(gpio_group.rev_0)),
-                    bool(self._read(gpio_group.rev_1)))
+            return (
+                bool(self._read(gpio_group.rev_0)),
+                bool(self._read(gpio_group.rev_1)),
+            )
         else:
             raise RevisionPinsError
 
@@ -244,8 +244,10 @@ class GPIOCharDev:
             return DoorState.CLOSED
 
     def start_door_switch_watcher(
-            self, loop: asyncio.AbstractEventLoop,
-            update_door_state: Callable[[DoorState], None]):
+        self,
+        loop: asyncio.AbstractEventLoop,
+        update_door_state: Callable[[DoorState], None],
+    ):
         current_door_value = self.read_window_switches()
         if current_door_value == 0:
             update_door_state(DoorState.OPEN)
@@ -253,13 +255,15 @@ class GPIOCharDev:
             update_door_state(DoorState.CLOSED)
 
         try:
-            door_fd = self.lines['window_door_sw'].event_get_fd()
-            loop.add_reader(door_fd, _event_callback,
-                            update_door_state, self.get_door_state)
+            door_fd = self.lines["window_door_sw"].event_get_fd()
+            loop.add_reader(
+                door_fd, _event_callback, update_door_state, self.get_door_state
+            )
         except Exception:
             MODULE_LOG.exception(
                 "Failed to add fd reader, cannot not monitor window door "
-                "switch properly")
+                "switch properly"
+            )
 
     def release_line(self, pin: GPIOPin):
         self.lines[pin.name].release()
@@ -267,8 +271,7 @@ class GPIOCharDev:
 
     def stop_door_switch_watcher(self, loop: asyncio.AbstractEventLoop):
         try:
-            door_fd = self.lines['window_door_sw'].event_get_fd()
+            door_fd = self.lines["window_door_sw"].event_get_fd()
             loop.remove_reader(door_fd)
         except Exception:
-            MODULE_LOG.exception(
-                "Failed to remove window door switch fd reader")
+            MODULE_LOG.exception("Failed to remove window door switch fd reader")

--- a/api/src/opentrons/drivers/rpi_drivers/gpio_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/gpio_simulator.py
@@ -46,8 +46,7 @@ class SimulatingGPIOCharDev:
         pass
 
     def config_by_board_rev(self):
-        self.board_rev = BoardRevision.by_bits(
-            self.read_revision_bits())
+        self.board_rev = BoardRevision.by_bits(self.read_revision_bits())
 
     def set_high(self, output_pin: GPIOPin):
         self._values[output_pin.name] = 1
@@ -55,10 +54,9 @@ class SimulatingGPIOCharDev:
     def set_low(self, output_pin: GPIOPin):
         self._values[output_pin.name] = 0
 
-    def set_button_light(self,
-                         red: bool = False,
-                         green: bool = False,
-                         blue: bool = False):
+    def set_button_light(
+        self, red: bool = False, green: bool = False, blue: bool = False
+    ):
         pass
 
     def set_rail_lights(self, on: bool = True):
@@ -77,9 +75,11 @@ class SimulatingGPIOCharDev:
         return self._values[input_pin.name]
 
     def get_button_light(self) -> Tuple[bool, bool, bool]:
-        return (bool(self._read(gpio_group.red_button)),
-                bool(self._read(gpio_group.green_button)),
-                bool(self._read(gpio_group.blue_button)))
+        return (
+            bool(self._read(gpio_group.red_button)),
+            bool(self._read(gpio_group.green_button)),
+            bool(self._read(gpio_group.blue_button)),
+        )
 
     def get_rail_lights(self) -> bool:
         return bool(self._read(gpio_group.frame_leds))
@@ -98,8 +98,7 @@ class SimulatingGPIOCharDev:
         return bool(self._read(gpio_group.door_sw_filt))
 
     def read_revision_bits(self) -> Tuple[bool, bool]:
-        return (bool(self._read(gpio_group.rev_0)),
-                bool(self._read(gpio_group.rev_1)))
+        return (bool(self._read(gpio_group.rev_0)), bool(self._read(gpio_group.rev_1)))
 
     def get_door_state(self) -> DoorState:
         val = self.read_window_switches()
@@ -109,8 +108,10 @@ class SimulatingGPIOCharDev:
             return DoorState.OPEN
 
     def start_door_switch_watcher(
-            self, loop: asyncio.AbstractEventLoop,
-            update_door_state: Callable[[DoorState], None]):
+        self,
+        loop: asyncio.AbstractEventLoop,
+        update_door_state: Callable[[DoorState], None],
+    ):
         current_door_value = self.read_window_switches()
         if current_door_value == 0:
             update_door_state(DoorState.OPEN)

--- a/api/src/opentrons/drivers/rpi_drivers/interfaces.py
+++ b/api/src/opentrons/drivers/rpi_drivers/interfaces.py
@@ -8,7 +8,6 @@ from .types import USBPort
 
 
 class USBDriverInterface(Protocol):
-
     @staticmethod
     def read_bus() -> List[str]:
         ...
@@ -47,6 +46,6 @@ class USBDriverInterface(Protocol):
         ...
 
     def match_virtual_ports(
-            self, virtual_port: List[ModuleAtPort]
-            ) -> List[ModuleAtPort]:
+        self, virtual_port: List[ModuleAtPort]
+    ) -> List[ModuleAtPort]:
         ...

--- a/api/src/opentrons/drivers/rpi_drivers/usb.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb.py
@@ -21,9 +21,9 @@ from .types import USBPort
 # Example usb path might look like:
 # '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev'.
 # There is only 1 bus that supports USB on the raspberry pi.
-BUS_PATH = '/sys/bus/usb/devices/usb1/'
-PORT_PATTERN = r'(/\d-\d(\.?\d)+)+:'
-DEVICE_PATH = r'\d.\d/tty/tty(\w{4})/dev'
+BUS_PATH = "/sys/bus/usb/devices/usb1/"
+PORT_PATTERN = r"(/\d-\d(\.?\d)+)+:"
+DEVICE_PATH = r"\d.\d/tty/tty(\w{4})/dev"
 USB_PORT_INFO = re.compile(PORT_PATTERN + DEVICE_PATH)
 
 
@@ -42,19 +42,21 @@ class USBBus(USBDriverInterface):
         Use the sys bus path to find all of the USBs with
         active devices connected to them.
         """
-        read = ['']
+        read = [""]
         try:
-            read = subprocess.check_output(
-                ['find', BUS_PATH, '-name', 'dev']).decode().splitlines()
+            read = (
+                subprocess.check_output(["find", BUS_PATH, "-name", "dev"])
+                .decode()
+                .splitlines()
+            )
         except Exception:
             pass
         return read
 
     @staticmethod
     def read_symlink(virtual_port: str) -> str:
-        """
-        """
-        symlink = ''
+        """ """
+        symlink = ""
         try:
             symlink = os.readlink(virtual_port)
         except OSError:
@@ -117,9 +119,8 @@ class USBBus(USBDriverInterface):
             match = USB_PORT_INFO.search(port)
             if match:
                 port_matches.append(
-                    USBPort.build(
-                        match.group(0).strip('/'),
-                        self.board_revision))
+                    USBPort.build(match.group(0).strip("/"), self.board_revision)
+                )
         return port_matches
 
     def find_port(self, device_path: str) -> USBPort:
@@ -138,8 +139,8 @@ class USBBus(USBDriverInterface):
             if port.device_path.find(device_path):
                 return port
         return USBPort(
-            name='', sub_names=[], hub=None,
-            port_number=None, device_path=device_path)
+            name="", sub_names=[], hub=None, port_number=None, device_path=device_path
+        )
 
     def sort_ports(self) -> None:
         """
@@ -164,8 +165,8 @@ class USBBus(USBDriverInterface):
             self.usb_dev = updated_bus
 
     def match_virtual_ports(
-            self, virtual_ports: List[ModuleAtPort]
-            ) -> List[ModuleAtPort]:
+        self, virtual_ports: List[ModuleAtPort]
+    ) -> List[ModuleAtPort]:
         """
         Match Virtual Ports
 

--- a/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
+++ b/api/src/opentrons/drivers/rpi_drivers/usb_simulator.py
@@ -27,13 +27,12 @@ class USBBusSimulator(USBDriverInterface):
         Use the sys bus path to find all of the USBs with
         active devices connected to them.
         """
-        return ['']
+        return [""]
 
     @staticmethod
     def read_symlink(virtual_port: str) -> str:
-        """
-        """
-        return ''
+        """ """
+        return ""
 
     @property
     def board_revision(self) -> BoardRevision:
@@ -97,13 +96,12 @@ class USBBusSimulator(USBDriverInterface):
         generally contains tty/tty* in its name.
         :returns: The matching port, or an empty port dataclass
         """
-        return USBPort(
-            name='', sub_names=[], device_path=device_path)
+        return USBPort(name="", sub_names=[], device_path=device_path)
 
     def sort_ports(self) -> None:
         pass
 
     def match_virtual_ports(
-            self, virtual_port: List[ModuleAtPort]
-            ) -> List[ModuleAtPort]:
+        self, virtual_port: List[ModuleAtPort]
+    ) -> List[ModuleAtPort]:
         return virtual_port

--- a/api/src/opentrons/drivers/serial_communication.py
+++ b/api/src/opentrons/drivers/serial_communication.py
@@ -17,8 +17,7 @@ class SerialNoResponse(Exception):
 def get_ports_by_name(device_name):
     """Returns all serial devices with a given name"""
     filtered_devices = filter(
-        lambda device: device_name in device[1],
-        list_ports.comports()
+        lambda device: device_name in device[1], list_ports.comports()
     )
     device_ports = [device[0] for device in filtered_devices]
     return device_ports
@@ -66,26 +65,26 @@ def _write_to_device_and_return(cmd, ack, device_connection, tag=None):
 
     encoded_write = cmd.encode()
     encoded_ack = ack.encode()
-    log.debug(f'{tag}: Write -> {encoded_write}')
+    log.debug(f"{tag}: Write -> {encoded_write}")
     device_connection.write(encoded_write)
     response = device_connection.read_until(encoded_ack)
-    log.debug(f'{tag}: Read <- {response}')
+    log.debug(f"{tag}: Read <- {response}")
     if encoded_ack not in response:
-        log.warning(f'{tag}: timed out after {device_connection.timeout}')
+        log.warning(f"{tag}: timed out after {device_connection.timeout}")
         raise SerialNoResponse(
-            'No response from serial port after {} second(s)'.format(
-                device_connection.timeout))
+            "No response from serial port after {} second(s)".format(
+                device_connection.timeout
+            )
+        )
     clean_response = _parse_serial_response(response, encoded_ack)
     if clean_response:
         return clean_response.decode()
-    return ''
+    return ""
 
 
 def _connect(port_name, baudrate):
     ser = serial.serial_for_url(
-        url=port_name,
-        baudrate=baudrate,
-        timeout=DEFAULT_SERIAL_TIMEOUT
+        url=port_name, baudrate=baudrate, timeout=DEFAULT_SERIAL_TIMEOUT
     )
     log.debug(ser)
     return ser
@@ -101,20 +100,18 @@ def _attempt_command_recovery(command, ack, serial_conn, tag=None):
         log.debug(f"{tag}: No valid response during _attempt_command_recovery")
         raise RuntimeError(
             "Recovery attempted - no valid serial response "
-            "for command: {} in {} seconds".format(
-                command.encode(), RECOVERY_TIMEOUT))
+            "for command: {} in {} seconds".format(command.encode(), RECOVERY_TIMEOUT)
+        )
     return response
 
 
 def write_and_return(
-        command, ack, serial_connection,
-        timeout=DEFAULT_WRITE_TIMEOUT, tag=None):
+    command, ack, serial_connection, timeout=DEFAULT_WRITE_TIMEOUT, tag=None
+):
     """Write a command and return the response"""
     clear_buffer(serial_connection)
-    with serial_with_temp_timeout(
-            serial_connection, timeout) as device_connection:
-        response = _write_to_device_and_return(
-            command, ack, device_connection, tag)
+    with serial_with_temp_timeout(serial_connection, timeout) as device_connection:
+        response = _write_to_device_and_return(command, ack, device_connection, tag)
     return response
 
 

--- a/api/src/opentrons/drivers/smoothie_drivers/__init__.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/__init__.py
@@ -1,7 +1,4 @@
 from .driver_3_0 import SmoothieDriver
 from .simulator import SimulatingDriver
 
-__all__ = [
-    "SmoothieDriver",
-    "SimulatingDriver"
-]
+__all__ = ["SmoothieDriver", "SimulatingDriver"]

--- a/api/src/opentrons/drivers/smoothie_drivers/connection.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/connection.py
@@ -12,9 +12,7 @@ class RemoveUnwantedCharactersMixin:
 
     def process_raw_response(self, command: str, response: str) -> str:
         """Process the raw response."""
-        return self._remove_unwanted_characters(
-            command=command, response=response
-        )
+        return self._remove_unwanted_characters(command=command, response=response)
 
     @staticmethod
     def _remove_unwanted_characters(command: str, response: str) -> str:
@@ -28,25 +26,23 @@ class RemoveUnwantedCharactersMixin:
             return len(_s) > 1
 
         # Split at spaces.
-        tokens = (c.strip() for c in command.strip().split(' '))
+        tokens = (c.strip() for c in command.strip().split(" "))
         # A list of commands to remove from response. Including the entire
         # command.
-        remove_from_response = [command] + [
-            c for c in tokens if _is_token_command(c)
-        ]
+        remove_from_response = [command] + [c for c in tokens if _is_token_command(c)]
 
         # also removing any inadvertent newline/return characters
         # this is ok because all data we need from Smoothie is returned on
         # the first line in the response
-        remove_from_response += ['\r', '\n']
+        remove_from_response += ["\r", "\n"]
         modified_response = str(response)
 
         for cmd in remove_from_response:
-            modified_response = modified_response.replace(cmd, '')
+            modified_response = modified_response.replace(cmd, "")
 
         if modified_response != response:
-            log.debug(f'Removed characters from response: {response}')
-            log.debug(f'Newly formatted response: {modified_response}')
+            log.debug(f"Removed characters from response: {response}")
+            log.debug(f"Newly formatted response: {modified_response}")
 
         return modified_response.strip()
 

--- a/api/src/opentrons/drivers/smoothie_drivers/constants.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/constants.py
@@ -39,19 +39,19 @@ class GCODE(str, Enum):
 
 
 HOMED_POSITION: Final = {
-    'X': 418.0,
-    'Y': 353.0,
-    'Z': 218.0,
-    'A': 218.0,
-    'B': 19.0,
-    'C': 19.0
+    "X": 418.0,
+    "Y": 353.0,
+    "Z": 218.0,
+    "A": 218.0,
+    "B": 19.0,
+    "C": 19.0,
 }
 
 Y_BOUND_OVERRIDE: Final = 370
 
-SMOOTHIE_COMMAND_TERMINATOR = '\r\n\r\n'
+SMOOTHIE_COMMAND_TERMINATOR = "\r\n\r\n"
 
-SMOOTHIE_ACK = 'ok\r\nok\r\n'
+SMOOTHIE_ACK = "ok\r\nok\r\n"
 
 PLUNGER_BACKLASH_MM = 0.3
 
@@ -81,14 +81,14 @@ DEFAULT_AXES_SPEED = 400
 
 XY_HOMING_SPEED = 80
 
-HOME_SEQUENCE = ['ZABC', 'X', 'Y']
+HOME_SEQUENCE = ["ZABC", "X", "Y"]
 
-AXES = ''.join(HOME_SEQUENCE)
+AXES = "".join(HOME_SEQUENCE)
 
-DISABLE_AXES = ''
+DISABLE_AXES = ""
 """Ignore these axis when sending move or home command"""
 
-MOVEMENT_ERROR_MARGIN = 1/160  # Largest movement in mm for any step
+MOVEMENT_ERROR_MARGIN = 1 / 160  # Largest movement in mm for any step
 
 SEC_PER_MIN = 60
 
@@ -107,14 +107,14 @@ DEFAULT_STABILIZE_DELAY = 0.1
 DEFAULT_COMMAND_RETRIES = 3
 
 MICROSTEPPING_GCODES = {
-    'B': {
-        'ENABLE': GCODE.MICROSTEPPING_B_ENABLE,
-        'DISABLE': GCODE.MICROSTEPPING_B_DISABLE,
+    "B": {
+        "ENABLE": GCODE.MICROSTEPPING_B_ENABLE,
+        "DISABLE": GCODE.MICROSTEPPING_B_DISABLE,
     },
-    'C': {
-        'ENABLE': GCODE.MICROSTEPPING_C_ENABLE,
-        'DISABLE': GCODE.MICROSTEPPING_C_DISABLE,
-    }
+    "C": {
+        "ENABLE": GCODE.MICROSTEPPING_C_ENABLE,
+        "DISABLE": GCODE.MICROSTEPPING_C_DISABLE,
+    },
 }
 
 GCODE_ROUNDING_PRECISION = 3

--- a/api/src/opentrons/drivers/smoothie_drivers/errors.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/errors.py
@@ -1,15 +1,14 @@
-
 class SmoothieError(Exception):
     def __init__(self, ret_code: str = None, command: str = None) -> None:
-        self.ret_code = ret_code or ''
+        self.ret_code = ret_code or ""
         self.command = command
         super().__init__()
 
     def __repr__(self):
-        return f'<SmoothieError: {self.ret_code} from {self.command}>'
+        return f"<SmoothieError: {self.ret_code} from {self.command}>"
 
     def __str__(self):
-        return f'SmoothieError: {self.command} returned {self.ret_code}'
+        return f"SmoothieError: {self.command} returned {self.ret_code}"
 
 
 class SmoothieAlarm(Exception):
@@ -19,10 +18,10 @@ class SmoothieAlarm(Exception):
         super().__init__()
 
     def __repr__(self):
-        return f'<SmoothieAlarm: {self.ret_code} from {self.command}>'
+        return f"<SmoothieAlarm: {self.ret_code} from {self.command}>"
 
     def __str__(self):
-        return f'SmoothieAlarm: {self.command} returned {self.ret_code}'
+        return f"SmoothieAlarm: {self.command} returned {self.ret_code}"
 
 
 class TipProbeError(SmoothieAlarm):
@@ -32,8 +31,10 @@ class TipProbeError(SmoothieAlarm):
         super().__init__(ret_code, command)
 
     def __repr__(self):
-        return f'<TipProbeError: {self.ret_code} from {self.command}'
+        return f"<TipProbeError: {self.ret_code} from {self.command}"
 
     def __str__(self):
-        return 'Tip probe could not complete: the switch was never touched. '\
-            'This may be because there is no tip on the pipette.'
+        return (
+            "Tip probe could not complete: the switch was never touched. "
+            "This may be because there is no tip on the pipette."
+        )

--- a/api/src/opentrons/drivers/smoothie_drivers/simulator.py
+++ b/api/src/opentrons/drivers/smoothie_drivers/simulator.py
@@ -1,5 +1,7 @@
-from opentrons.drivers.smoothie_drivers.constants import HOMED_POSITION, \
-    Y_BOUND_OVERRIDE
+from opentrons.drivers.smoothie_drivers.constants import (
+    HOMED_POSITION,
+    Y_BOUND_OVERRIDE,
+)
 
 
 class SimulatingDriver:
@@ -34,14 +36,14 @@ class SimulatingDriver:
         pass
 
     def update_pipette_config(self, axis, data):
-        '''
+        """
         Updates the following configs for a given pipette mount based on
         the detected pipette type:
         - homing positions M365.0
         - Max Travel M365.1
         - endstop debounce M365.2 (NOT for zprobe debounce)
         - retract from endstop distance M365.3
-        '''
+        """
         pass
 
     @property
@@ -80,5 +82,5 @@ class SimulatingDriver:
     @property
     def axis_bounds(self):
         position = HOMED_POSITION.copy()
-        position['Y'] = Y_BOUND_OVERRIDE
+        position["Y"] = Y_BOUND_OVERRIDE
         return position

--- a/api/src/opentrons/drivers/temp_deck/abstract.py
+++ b/api/src/opentrons/drivers/temp_deck/abstract.py
@@ -5,7 +5,6 @@ from opentrons.drivers.types import Temperature
 
 
 class AbstractTempDeckDriver(ABC):
-
     @abstractmethod
     async def connect(self) -> None:
         ...

--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -17,8 +17,7 @@ from enum import Enum
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.asyncio.communication import SerialConnection
-from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, \
-    Temperature
+from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, Temperature
 
 log = logging.getLogger(__name__)
 
@@ -37,8 +36,8 @@ class GCODE(str, Enum):
 
 TEMP_DECK_BAUDRATE = 115200
 
-TEMP_DECK_COMMAND_TERMINATOR = '\r\n\r\n'
-TEMP_DECK_ACK = 'ok\r\nok\r\n'
+TEMP_DECK_COMMAND_TERMINATOR = "\r\n\r\n"
+TEMP_DECK_ACK = "ok\r\nok\r\n"
 
 
 class TempDeckError(Exception):
@@ -46,10 +45,9 @@ class TempDeckError(Exception):
 
 
 class TempDeckDriver(AbstractTempDeckDriver):
-
     @classmethod
     async def create(
-            cls, port: str, loop: Optional[asyncio.AbstractEventLoop] = None
+        cls, port: str, loop: Optional[asyncio.AbstractEventLoop] = None
     ) -> TempDeckDriver:
         """
         Create a temp deck driver.
@@ -61,9 +59,11 @@ class TempDeckDriver(AbstractTempDeckDriver):
         Returns: driver
         """
         connection = await SerialConnection.create(
-            port=port, baud_rate=TEMP_DECK_BAUDRATE,
-            timeout=DEFAULT_TEMP_DECK_TIMEOUT, ack=TEMP_DECK_ACK,
-            loop=loop
+            port=port,
+            baud_rate=TEMP_DECK_BAUDRATE,
+            timeout=DEFAULT_TEMP_DECK_TIMEOUT,
+            ack=TEMP_DECK_ACK,
+            loop=loop,
         )
         return cls(connection=connection)
 
@@ -94,9 +94,7 @@ class TempDeckDriver(AbstractTempDeckDriver):
 
         Returns: None
         """
-        c = CommandBuilder(
-            terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DISENGAGE
         )
         await self._send_command(command=c)
@@ -110,13 +108,15 @@ class TempDeckDriver(AbstractTempDeckDriver):
 
         Returns: None
         """
-        c = CommandBuilder(
-            terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
-            gcode=GCODE.SET_TEMP
-        ).add_float(prefix="S",
-                    value=celsius,
-                    precision=utils.TEMPDECK_GCODE_ROUNDING_PRECISION)
+        c = (
+            CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.SET_TEMP)
+            .add_float(
+                prefix="S",
+                value=celsius,
+                precision=utils.TEMPDECK_GCODE_ROUNDING_PRECISION,
+            )
+        )
         await self._send_command(command=c)
 
     async def get_temperature(self) -> Temperature:
@@ -126,15 +126,13 @@ class TempDeckDriver(AbstractTempDeckDriver):
         Returns: Temperature object
 
         """
-        c = CommandBuilder(
-            terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_TEMP
         )
         response = await self._send_command(command=c)
         return utils.parse_temperature_response(
             temperature_string=response,
-            rounding_val=utils.TEMPDECK_GCODE_ROUNDING_PRECISION
+            rounding_val=utils.TEMPDECK_GCODE_ROUNDING_PRECISION,
         )
 
     async def get_device_info(self) -> Dict[str, str]:
@@ -154,15 +152,11 @@ class TempDeckDriver(AbstractTempDeckDriver):
         Example input from Temp-Deck's serial response:
             "serial:aa11bb22 model:aa11bb22 version:aa11bb22"
         """
-        c = CommandBuilder(
-            terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEVICE_INFO
         )
         response = await self._send_command(command=c)
-        return utils.parse_device_information(
-            device_info_string=response
-        )
+        return utils.parse_device_information(device_info_string=response)
 
     async def enter_programming_mode(self) -> None:
         """
@@ -170,9 +164,7 @@ class TempDeckDriver(AbstractTempDeckDriver):
 
         Returns: None
         """
-        c = CommandBuilder(
-            terminator=TEMP_DECK_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.PROGRAMMING_MODE
         )
         await self._send_command(command=c)
@@ -188,7 +180,6 @@ class TempDeckDriver(AbstractTempDeckDriver):
             command response
         """
         response = await self._connection.send_command(
-            command=command,
-            retries=DEFAULT_COMMAND_RETRIES
+            command=command, retries=DEFAULT_COMMAND_RETRIES
         )
         return response

--- a/api/src/opentrons/drivers/temp_deck/simulator.py
+++ b/api/src/opentrons/drivers/temp_deck/simulator.py
@@ -1,11 +1,10 @@
 from typing import Optional, Dict
 
-from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, \
-    Temperature
+from opentrons.drivers.temp_deck.abstract import AbstractTempDeckDriver, Temperature
 
 TEMP_DECK_MODELS = {
-    'temperatureModuleV1': 'temp_deck_v1.1',
-    'temperatureModuleV2': 'temp_deck_v20'
+    "temperatureModuleV1": "temp_deck_v1.1",
+    "temperatureModuleV2": "temp_deck_v20",
 }
 
 
@@ -13,8 +12,7 @@ class SimulatingDriver(AbstractTempDeckDriver):
     def __init__(self, sim_model: str = None):
         self._temp = Temperature(target=None, current=0)
         self._port: Optional[str] = None
-        self._model = TEMP_DECK_MODELS[sim_model] if sim_model\
-            else 'temp_deck_v1.1'
+        self._model = TEMP_DECK_MODELS[sim_model] if sim_model else "temp_deck_v1.1"
 
     async def set_temperature(self, celsius: float):
         self._temp.target = celsius
@@ -39,6 +37,8 @@ class SimulatingDriver(AbstractTempDeckDriver):
         pass
 
     async def get_device_info(self) -> Dict[str, str]:
-        return {'serial': 'dummySerialTD',
-                'model': self._model,
-                'version': 'dummyVersionTD'}
+        return {
+            "serial": "dummySerialTD",
+            "model": self._model,
+            "version": "dummyVersionTD",
+        }

--- a/api/src/opentrons/drivers/thermocycler/__init__.py
+++ b/api/src/opentrons/drivers/thermocycler/__init__.py
@@ -3,8 +3,4 @@ from .simulator import SimulatingDriver
 from .abstract import AbstractThermocyclerDriver
 
 
-__all__ = [
-    "ThermocyclerDriver",
-    "SimulatingDriver",
-    "AbstractThermocyclerDriver"
-]
+__all__ = ["ThermocyclerDriver", "SimulatingDriver", "AbstractThermocyclerDriver"]

--- a/api/src/opentrons/drivers/thermocycler/abstract.py
+++ b/api/src/opentrons/drivers/thermocycler/abstract.py
@@ -5,7 +5,6 @@ from opentrons.drivers.types import Temperature, ThermocyclerLidStatus, PlateTem
 
 
 class AbstractThermocyclerDriver(ABC):
-
     @abstractmethod
     async def connect(self) -> None:
         """Connect to thermocycler"""
@@ -48,10 +47,11 @@ class AbstractThermocyclerDriver(ABC):
 
     @abstractmethod
     async def set_plate_temperature(
-            self,
-            temp: float,
-            hold_time: Optional[float] = None,
-            volume: Optional[float] = None) -> None:
+        self,
+        temp: float,
+        hold_time: Optional[float] = None,
+        volume: Optional[float] = None,
+    ) -> None:
         """Send set plate temperature command"""
         ...
 

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -7,13 +7,9 @@ from typing import Optional, Dict
 
 from opentrons.drivers import utils
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.asyncio.communication import (
-    SerialConnection, AsyncSerial
-)
+from opentrons.drivers.asyncio.communication import SerialConnection, AsyncSerial
 from opentrons.drivers.thermocycler.abstract import AbstractThermocyclerDriver
-from opentrons.drivers.types import (
-    Temperature, PlateTemperature, ThermocyclerLidStatus
-)
+from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +30,7 @@ class GCODE(str, Enum):
     DEVICE_INFO = "M115"
 
 
-LID_TARGET_DEFAULT = 105    # Degree celsius (floats)
+LID_TARGET_DEFAULT = 105  # Degree celsius (floats)
 LID_TARGET_MIN = 37
 LID_TARGET_MAX = 110
 BLOCK_TARGET_MIN = 0
@@ -48,18 +44,17 @@ TC_BOOTLOADER_BAUDRATE = 1200
 # TODO (Laura 20190327) increased the thermocycler command timeout
 # temporarily until we can change the firmware to asynchronously handle
 # the lid being open and closed
-SERIAL_ACK = '\r\n'
+SERIAL_ACK = "\r\n"
 TC_COMMAND_TERMINATOR = SERIAL_ACK
-TC_ACK = 'ok' + SERIAL_ACK + 'ok' + SERIAL_ACK
+TC_ACK = "ok" + SERIAL_ACK + "ok" + SERIAL_ACK
 DEFAULT_TC_TIMEOUT = 40
 DEFAULT_COMMAND_RETRIES = 3
 
 
 class ThermocyclerDriver(AbstractThermocyclerDriver):
-
     @classmethod
     async def create(
-            cls, port: str, loop: Optional[asyncio.AbstractEventLoop]
+        cls, port: str, loop: Optional[asyncio.AbstractEventLoop]
     ) -> ThermocyclerDriver:
         """
         Create a temp deck driver.
@@ -71,8 +66,11 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
         Returns: driver
         """
         connection = await SerialConnection.create(
-            port=port, baud_rate=TC_BAUDRATE,
-            timeout=DEFAULT_TC_TIMEOUT, ack=TC_ACK, loop=loop
+            port=port,
+            baud_rate=TC_BAUDRATE,
+            timeout=DEFAULT_TC_TIMEOUT,
+            ack=TC_ACK,
+            loop=loop,
         )
         return cls(connection=connection)
 
@@ -99,160 +97,138 @@ class ThermocyclerDriver(AbstractThermocyclerDriver):
 
     async def open_lid(self) -> None:
         """Send open lid command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.OPEN_LID
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def close_lid(self) -> None:
         """Send close lid command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.CLOSE_LID
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def get_lid_status(self) -> ThermocyclerLidStatus:
         """Send get lid status command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_LID_STATUS
         )
         response = await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
-        return ThermocyclerLidStatus(utils.parse_key_values(value=response)['Lid'])
+            command=c, retries=DEFAULT_COMMAND_RETRIES
+        )
+        return ThermocyclerLidStatus(utils.parse_key_values(value=response)["Lid"])
 
     async def set_lid_temperature(self, temp: float) -> None:
         """Set the lid temperature"""
         temp = min(LID_TARGET_MAX, max(LID_TARGET_MIN, temp))
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
-            gcode=GCODE.SET_LID_TEMP
-        ).add_float(
-            prefix="S", value=temp, precision=utils.TC_GCODE_ROUNDING_PRECISION
+        c = (
+            CommandBuilder(terminator=TC_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.SET_LID_TEMP)
+            .add_float(
+                prefix="S", value=temp, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def get_lid_temperature(self) -> Temperature:
         """Send a get lid temperature command."""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_LID_TEMP
         )
         response = await self._connection.send_command(
             command=c, retries=DEFAULT_COMMAND_RETRIES
         )
         return utils.parse_temperature_response(
-            temperature_string=response, rounding_val=utils.TC_GCODE_ROUNDING_PRECISION)
+            temperature_string=response, rounding_val=utils.TC_GCODE_ROUNDING_PRECISION
+        )
 
     async def set_plate_temperature(
-            self,
-            temp: float,
-            hold_time: Optional[float] = None,
-            volume: Optional[float] = None) -> None:
+        self,
+        temp: float,
+        hold_time: Optional[float] = None,
+        volume: Optional[float] = None,
+    ) -> None:
         """Send set plate temperature command"""
         temp = min(BLOCK_TARGET_MAX, max(BLOCK_TARGET_MIN, temp))
 
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
-            gcode=GCODE.SET_PLATE_TEMP
-        ).add_float(
-            prefix="S", value=temp, precision=utils.TC_GCODE_ROUNDING_PRECISION
+        c = (
+            CommandBuilder(terminator=TC_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.SET_PLATE_TEMP)
+            .add_float(
+                prefix="S", value=temp, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
         )
         if hold_time is not None:
-            c = c.add_float(prefix="H", value=hold_time,
-                            precision=utils.TC_GCODE_ROUNDING_PRECISION)
+            c = c.add_float(
+                prefix="H", value=hold_time, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
         if volume is not None:
-            c = c.add_float(prefix="V", value=volume,
-                            precision=utils.TC_GCODE_ROUNDING_PRECISION)
+            c = c.add_float(
+                prefix="V", value=volume, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
 
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def get_plate_temperature(self) -> PlateTemperature:
         """Send a get plate temperature command."""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.GET_PLATE_TEMP
         )
         response = await self._connection.send_command(
             command=c, retries=DEFAULT_COMMAND_RETRIES
         )
         return utils.parse_plate_temperature_response(
-            temperature_string=response,
-            rounding_val=utils.TC_GCODE_ROUNDING_PRECISION
+            temperature_string=response, rounding_val=utils.TC_GCODE_ROUNDING_PRECISION
         )
 
     async def set_ramp_rate(self, ramp_rate: float) -> None:
         """Send a set ramp rate command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
-            gcode=GCODE.SET_RAMP_RATE
-        ).add_float(
-            prefix="S", value=ramp_rate, precision=utils.TC_GCODE_ROUNDING_PRECISION
+        c = (
+            CommandBuilder(terminator=TC_COMMAND_TERMINATOR)
+            .add_gcode(gcode=GCODE.SET_RAMP_RATE)
+            .add_float(
+                prefix="S", value=ramp_rate, precision=utils.TC_GCODE_ROUNDING_PRECISION
+            )
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def deactivate_all(self) -> None:
         """Send deactivate all command."""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEACTIVATE_ALL
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def deactivate_lid(self) -> None:
         """Send deactivate lid command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEACTIVATE_LID
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def deactivate_block(self) -> None:
         """Send deactivate block command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEACTIVATE_BLOCK
         )
-        await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
+        await self._connection.send_command(command=c, retries=DEFAULT_COMMAND_RETRIES)
 
     async def get_device_info(self) -> Dict[str, str]:
         """Send get device info command"""
-        c = CommandBuilder(
-            terminator=TC_COMMAND_TERMINATOR
-        ).add_gcode(
+        c = CommandBuilder(terminator=TC_COMMAND_TERMINATOR).add_gcode(
             gcode=GCODE.DEVICE_INFO
         )
         response = await self._connection.send_command(
-            command=c, retries=DEFAULT_COMMAND_RETRIES)
-        return utils.parse_device_information(
-            device_info_string=response
+            command=c, retries=DEFAULT_COMMAND_RETRIES
         )
+        return utils.parse_device_information(device_info_string=response)
 
     async def enter_programming_mode(self) -> None:
         """Enter programming mode."""
         trigger_connection = await AsyncSerial.create(
-            self._connection.port, TC_BOOTLOADER_BAUDRATE, timeout=1)
+            self._connection.port, TC_BOOTLOADER_BAUDRATE, timeout=1
+        )
         await asyncio.sleep(0.05)
         await trigger_connection.close()
         await self._connection.close()

--- a/api/src/opentrons/drivers/thermocycler/simulator.py
+++ b/api/src/opentrons/drivers/thermocycler/simulator.py
@@ -10,9 +10,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
     def __init__(self):
         self._ramp_rate: Optional[float] = None
         self._lid_status = ThermocyclerLidStatus.OPEN
-        self._lid_temperature = Temperature(
-            current=self.DEFAULT_TEMP, target=None
-        )
+        self._lid_temperature = Temperature(current=self.DEFAULT_TEMP, target=None)
         self._plate_temperature = PlateTemperature(
             current=self.DEFAULT_TEMP, target=None, hold=None
         )
@@ -38,9 +36,12 @@ class SimulatingDriver(AbstractThermocyclerDriver):
     async def get_lid_temperature(self) -> Temperature:
         return self._lid_temperature
 
-    async def set_plate_temperature(self, temp: float,
-                                    hold_time: Optional[float] = None,
-                                    volume: Optional[float] = None) -> None:
+    async def set_plate_temperature(
+        self,
+        temp: float,
+        hold_time: Optional[float] = None,
+        volume: Optional[float] = None,
+    ) -> None:
         self._plate_temperature.target = temp
         self._plate_temperature.current = temp
         self._plate_temperature.hold = hold_time
@@ -52,7 +53,7 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         self._ramp_rate = ramp_rate
 
     async def set_lid_temperature(self, temp: float) -> None:
-        """ Set the lid temperature in deg Celsius """
+        """Set the lid temperature in deg Celsius"""
         self._lid_temperature.target = temp
         self._lid_temperature.current = temp
 
@@ -71,9 +72,11 @@ class SimulatingDriver(AbstractThermocyclerDriver):
         await self.deactivate_block()
 
     async def get_device_info(self):
-        return {'serial': 'dummySerialTC',
-                'model': 'dummyModelTC',
-                'version': 'dummyVersionTC'}
+        return {
+            "serial": "dummySerialTC",
+            "model": "dummyModelTC",
+            "version": "dummyVersionTC",
+        }
 
     async def enter_programming_mode(self):
         pass

--- a/api/src/opentrons/drivers/types.py
+++ b/api/src/opentrons/drivers/types.py
@@ -19,6 +19,7 @@ MoveSplits = Dict[str, MoveSplit]
 @dataclass
 class Temperature:
     """Tempdeck temperature and thermocycler plate temperature."""
+
     current: float
     target: Optional[float]
 
@@ -26,13 +27,15 @@ class Temperature:
 @dataclass
 class PlateTemperature(Temperature):
     """Thermocycler lid temperature"""
+
     hold: Optional[float]
 
 
 class ThermocyclerLidStatus(str, Enum):
     """Thermocycler lid status."""
-    UNKNOWN = 'unknown'
-    CLOSED = 'closed'
-    IN_BETWEEN = 'in_between'
-    OPEN = 'open'
-    MAX = 'max'
+
+    UNKNOWN = "unknown"
+    CLOSED = "closed"
+    IN_BETWEEN = "in_between"
+    OPEN = "open"
+    MAX = "max"

--- a/api/src/opentrons/drivers/utils.py
+++ b/api/src/opentrons/drivers/utils.py
@@ -32,53 +32,52 @@ def parse_string_value_from_substring(substring: str) -> str:
     the key, and "aa11bb22" is string value to be returned
     """
     try:
-        value = substring.split(':')[1]
+        value = substring.split(":")[1]
         return str(value)
     except (ValueError, IndexError, TypeError, AttributeError):
-        log.exception('Unexpected arg to parse_string_value_from_substring:')
+        log.exception("Unexpected arg to parse_string_value_from_substring:")
         raise ParseError(
-            error_message='Unexpected arg to parse_string_value_from_substring',
-            parse_source=substring
+            error_message="Unexpected arg to parse_string_value_from_substring",
+            parse_source=substring,
         )
 
 
 def parse_temperature_response(
-        temperature_string: str, rounding_val: int
+    temperature_string: str, rounding_val: int
 ) -> Temperature:
     """Example input: "T:none C:25"""
     data = parse_key_values(temperature_string)
     try:
         return Temperature(
-            current=parse_number(data['C'], rounding_val),
-            target=parse_optional_number(data['T'], rounding_val)
+            current=parse_number(data["C"], rounding_val),
+            target=parse_optional_number(data["T"], rounding_val),
         )
     except KeyError:
         raise ParseError(
-            error_message='Unexpected argument to parse_temperature_response',
-            parse_source=temperature_string
+            error_message="Unexpected argument to parse_temperature_response",
+            parse_source=temperature_string,
         )
 
 
 def parse_plate_temperature_response(
-        temperature_string: str, rounding_val: int
+    temperature_string: str, rounding_val: int
 ) -> PlateTemperature:
     """Example input: "T:none C:25 H:123"""
     data = parse_key_values(temperature_string)
     try:
         return PlateTemperature(
-            current=parse_number(data['C'], rounding_val),
-            target=parse_optional_number(data['T'], rounding_val),
-            hold=parse_optional_number(data['H'], rounding_val)
+            current=parse_number(data["C"], rounding_val),
+            target=parse_optional_number(data["T"], rounding_val),
+            hold=parse_optional_number(data["H"], rounding_val),
         )
     except KeyError:
         raise ParseError(
-            error_message='Unexpected argument to parse_plate_temperature_response',
-            parse_source=temperature_string
+            error_message="Unexpected argument to parse_plate_temperature_response",
+            parse_source=temperature_string,
         )
 
 
-def parse_device_information(
-        device_info_string: str) -> Dict[str, str]:
+def parse_device_information(device_info_string: str) -> Dict[str, str]:
     """
     Parse the modules's device information response.
 
@@ -87,22 +86,22 @@ def parse_device_information(
     res = parse_key_values(device_info_string)
 
     try:
-        return {key: res[key] for key in ['model', 'version', 'serial']}
+        return {key: res[key] for key in ["model", "version", "serial"]}
     except KeyError as e:
         raise ParseError(
             error_message=f"Missing key '{str(e)}' in parse_device_information",
-            parse_source=device_info_string
+            parse_source=device_info_string,
         )
 
 
 def parse_key_values(value: str) -> Dict[str, str]:
     """Convert string in the format:
-        'key1:value1 key2:value2'
-        to dict
-        {'key1': 'value1', 'key2': 'value2'}
+    'key1:value1 key2:value2'
+    to dict
+    {'key1': 'value1', 'key2': 'value2'}
     """
     res = {
-        g.groupdict()['key']: g.groupdict()['value']
+        g.groupdict()["key"]: g.groupdict()["value"]
         for g in KEY_VALUE_REGEX.finditer(value)
     }
     return res
@@ -119,32 +118,28 @@ def parse_number(value: str, rounding_val: int) -> float:
         return round(float(value), rounding_val)
     except ValueError:
         raise ParseError(
-            error_message='Unexpected argument to parse_number',
-            parse_source=value
+            error_message="Unexpected argument to parse_number", parse_source=value
         )
 
 
 class AxisMoveTimestamp:
-    """ Keeps track of the last time axes were known to move """
+    """Keeps track of the last time axes were known to move"""
 
     def __init__(self, axis_iter: Sequence[str]):
-        self._moved_at: Dict[str, Optional[float]] = {
-            ax: None for ax in axis_iter
-        }
+        self._moved_at: Dict[str, Optional[float]] = {ax: None for ax in axis_iter}
 
     def mark_moved(self, axis_iter: Sequence[str]):
-        """ Indicate that a set of axes just moved """
+        """Indicate that a set of axes just moved"""
         now = time.monotonic()
         self._moved_at.update({ax: now for ax in axis_iter})
 
     def time_since_moved(self) -> Mapping[str, Optional[float]]:
-        """ Get a mapping of the time since each known axis moved """
+        """Get a mapping of the time since each known axis moved"""
         now = time.monotonic()
-        return {ax: now-val if val else None
-                for ax, val, in self._moved_at.items()}
+        return {ax: now - val if val else None for ax, val, in self._moved_at.items()}
 
     def reset_moved(self, axis_iter: Iterable[str]):
-        """ Reset the clocks for a set of axes """
+        """Reset the clocks for a set of axes"""
         self._moved_at.update({ax: None for ax in axis_iter})
 
 

--- a/api/src/opentrons/hardware_control/__init__.py
+++ b/api/src/opentrons/hardware_control/__init__.py
@@ -15,18 +15,35 @@ from .api import API, PauseManager
 from .controller import Controller
 from .simulator import Simulator
 from .pipette import Pipette
-from .types import (HardwareAPILike, CriticalPoint,
-                    NoTipAttachedError, TipAttachedError,
-                    ExecutionState, ExecutionCancelledError)
+from .types import (
+    HardwareAPILike,
+    CriticalPoint,
+    NoTipAttachedError,
+    TipAttachedError,
+    ExecutionState,
+    ExecutionCancelledError,
+)
 from .constants import DROP_TIP_RELEASE_DISTANCE
 from .thread_manager import ThreadManager
 from .execution_manager import ExecutionManager
 from .threaded_async_lock import ThreadedAsyncLock, ThreadedAsyncForbidden
 
 __all__ = [
-    'API', 'Controller', 'Simulator', 'Pipette', 'PauseManager',
-    'SynchronousAdapter', 'HardwareAPILike', 'CriticalPoint',
-    'NoTipAttachedError', 'TipAttachedError', 'DROP_TIP_RELEASE_DISTANCE',
-    'ThreadManager', 'ExecutionManager', 'ExecutionState',
-    'ExecutionCancelledError', 'ThreadedAsyncLock', 'ThreadedAsyncForbidden'
+    "API",
+    "Controller",
+    "Simulator",
+    "Pipette",
+    "PauseManager",
+    "SynchronousAdapter",
+    "HardwareAPILike",
+    "CriticalPoint",
+    "NoTipAttachedError",
+    "TipAttachedError",
+    "DROP_TIP_RELEASE_DISTANCE",
+    "ThreadManager",
+    "ExecutionManager",
+    "ExecutionState",
+    "ExecutionCancelledError",
+    "ThreadedAsyncLock",
+    "ThreadedAsyncForbidden",
 ]

--- a/api/src/opentrons/hardware_control/__main__.py
+++ b/api/src/opentrons/hardware_control/__main__.py
@@ -16,28 +16,27 @@ from . import API
 from opentrons.config import robot_configs as rc
 from opentrons.config.types import RobotConfig
 
-LOG = logging.getLogger('opentrons.hardware_control.__main__')
+LOG = logging.getLogger("opentrons.hardware_control.__main__")
 
 
 def exception_handler(loop, context):
-    message = ''
-    if 'exception' in context:
+    message = ""
+    if "exception" in context:
         message += f'exception: {repr(context["exception"])}'
-    if 'future' in context:
+    if "future" in context:
         message += f' while running future {repr(context["future"])}'
-    if 'protocol' in context:
+    if "protocol" in context:
         message += f' from protocol {repr(context["protocol"])}'
-    if 'transport' in context:
+    if "transport" in context:
         message += f' from transport {repr(context["transport"])}'
-    if 'socket' in context:
+    if "socket" in context:
         message += f' from socket {repr(context["socket"])}'
     LOG.error(f"Unhandled exception in event loop: {message}")
     loop.default_exception_handler(context)
 
 
-async def arun(config: RobotConfig = None,
-               port: str = None):
-    """ Asynchronous entrypoint for the server
+async def arun(config: RobotConfig = None, port: str = None):
+    """Asynchronous entrypoint for the server
 
     :param config: Optional config override
     :param port: Optional smoothie port override
@@ -46,9 +45,8 @@ async def arun(config: RobotConfig = None,
     hc = await API.build_hardware_controller(rconf, port)  # noqa: F841
 
 
-def run(config: RobotConfig = None,
-        port: str = None):
-    """ Synchronous entrypoint for the server.
+def run(config: RobotConfig = None, port: str = None):
+    """Synchronous entrypoint for the server.
 
     Mostly builds a loop and calls arun.
 
@@ -61,12 +59,13 @@ def run(config: RobotConfig = None,
     loop.run_forever()
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Opentrons hardware control server')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Opentrons hardware control server")
     parser.add_argument(
-        '-s', '--smoothie-port',
-        help='Port on which to talk to smoothie, autodetected by default',
-        default=None)
+        "-s",
+        "--smoothie-port",
+        help="Port on which to talk to smoothie, autodetected by default",
+        default=None,
+    )
     args = parser.parse_args()
     run(port=args.port)

--- a/api/src/opentrons/hardware_control/adapters.py
+++ b/api/src/opentrons/hardware_control/adapters.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 # functionality. It is more readable and protected from
 # unintentional recursion.
 class SynchronousAdapter(HardwareAPILike):
-    """ A wrapper to make every call into :py:class:`.hardware_control.API`
+    """A wrapper to make every call into :py:class:`.hardware_control.API`
     synchronous.
 
     This class expects to wrap an asynchronous object running in its own thread
@@ -40,15 +40,15 @@ class SynchronousAdapter(HardwareAPILike):
     >>> sync_api.home()
     """
 
-    def __init__(self, asynchronous_instance: 'HasLoop') -> None:
-        """ Build the SynchronousAdapter.
+    def __init__(self, asynchronous_instance: "HasLoop") -> None:
+        """Build the SynchronousAdapter.
 
         :param asynchronous_instance: The asynchronous class instance to wrap
         """
         self._obj_to_adapt = asynchronous_instance
 
     def __repr__(self):
-        return '<SynchronousAdapter>'
+        return "<SynchronousAdapter>"
 
     @staticmethod
     def call_coroutine_sync(loop, to_call, *args, **kwargs):
@@ -56,10 +56,10 @@ class SynchronousAdapter(HardwareAPILike):
         return fut.result()
 
     def __getattribute__(self, attr_name):
-        """ Retrieve attributes from our API and wrap coroutines """
+        """Retrieve attributes from our API and wrap coroutines"""
         # Almost every attribute retrieved from us will be for people actually
         # looking for an attribute of the hardware API, so check there first.
-        obj_to_adapt = object.__getattribute__(self, '_obj_to_adapt')
+        obj_to_adapt = object.__getattribute__(self, "_obj_to_adapt")
         try:
             inner_attr = getattr(obj_to_adapt, attr_name)
         except AttributeError:
@@ -78,8 +78,10 @@ class SynchronousAdapter(HardwareAPILike):
         if asyncio.iscoroutinefunction(check):
             # Return a synchronized version of the coroutine
             return functools.partial(
-                object.__getattribute__(self, 'call_coroutine_sync'),
-                obj_to_adapt._loop, inner_attr)
+                object.__getattribute__(self, "call_coroutine_sync"),
+                obj_to_adapt._loop,
+                inner_attr,
+            )
         elif asyncio.iscoroutine(check):
             # Catch awaitable properties and reify the future before returning
             fut = asyncio.run_coroutine_threadsafe(check, obj_to_adapt._loop)

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -4,8 +4,18 @@ from dataclasses import replace
 import logging
 import pathlib
 from collections import OrderedDict
-from typing import (Any, Dict, Union, List, Optional, Tuple,
-                    TYPE_CHECKING, cast, overload, Sequence)
+from typing import (
+    Any,
+    Dict,
+    Union,
+    List,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+    cast,
+    overload,
+    Sequence,
+)
 
 from opentrons_shared_data.pipette import name_config
 from opentrons import types as top_types
@@ -14,29 +24,38 @@ from functools import lru_cache
 from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig
 
-from .util import (
-    use_or_initialize_loop, DeckTransformState, check_motion_bounds)
-from .pipette import (
-    Pipette, generate_hardware_configs, load_from_config_and_check_skip)
+from .util import use_or_initialize_loop, DeckTransformState, check_motion_bounds
+from .pipette import Pipette, generate_hardware_configs, load_from_config_and_check_skip
 from .controller import Controller
 from .simulator import Simulator
-from .constants import (SHAKE_OFF_TIPS_SPEED, SHAKE_OFF_TIPS_DROP_DISTANCE,
-                        SHAKE_OFF_TIPS_PICKUP_DISTANCE,
-                        DROP_TIP_RELEASE_DISTANCE)
+from .constants import (
+    SHAKE_OFF_TIPS_SPEED,
+    SHAKE_OFF_TIPS_DROP_DISTANCE,
+    SHAKE_OFF_TIPS_PICKUP_DISTANCE,
+    DROP_TIP_RELEASE_DISTANCE,
+)
 from .execution_manager import ExecutionManager
 from .pause_manager import PauseManager
 from .module_control import AttachedModulesControl
-from .types import (Axis, HardwareAPILike, CriticalPoint,
-                    MustHomeError, NoTipAttachedError, DoorState,
-                    DoorStateNotification, PipettePair, TipAttachedError,
-                    HardwareAction, PairedPipetteConfigValueError,
-                    MotionChecks, PauseType)
+from .types import (
+    Axis,
+    HardwareAPILike,
+    CriticalPoint,
+    MustHomeError,
+    NoTipAttachedError,
+    DoorState,
+    DoorStateNotification,
+    PipettePair,
+    TipAttachedError,
+    HardwareAction,
+    PairedPipetteConfigValueError,
+    MotionChecks,
+    PauseType,
+)
 from . import modules, robot_calibration as rb_cal
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import (
-        UlPerMmAction, PipetteName
-    )
+    from opentrons_shared_data.pipette.dev_types import UlPerMmAction, PipetteName
     from .dev_types import PipetteDict
 
 
@@ -48,7 +67,7 @@ PipetteHandlingData = Tuple[Pipette, top_types.Mount]
 
 
 class API(HardwareAPILike):
-    """ This API is the primary interface to the hardware controller.
+    """This API is the primary interface to the hardware controller.
 
     Because the hardware manager controls access to the system's hardware
     as a whole, it is designed as a class of which only one should be
@@ -58,14 +77,15 @@ class API(HardwareAPILike):
     but its purpose is to be gathered here to provide a single interface.
     """
 
-    CLS_LOG = mod_log.getChild('API')
+    CLS_LOG = mod_log.getChild("API")
 
-    def __init__(self,
-                 backend: Union[Controller, Simulator],
-                 loop: asyncio.AbstractEventLoop,
-                 config: RobotConfig
-                 ) -> None:
-        """ Initialize an API instance.
+    def __init__(
+        self,
+        backend: Union[Controller, Simulator],
+        loop: asyncio.AbstractEventLoop,
+        config: RobotConfig,
+    ) -> None:
+        """Initialize an API instance.
 
         This should rarely be explicitly invoked by an external user; instead,
         one of the factory methods build_hardware_controller or
@@ -83,7 +103,7 @@ class API(HardwareAPILike):
 
         self._attached_instruments: InstrumentsByMount = {
             top_types.Mount.LEFT: None,
-            top_types.Mount.RIGHT: None
+            top_types.Mount.RIGHT: None,
         }
         self._last_moved_mount: Optional[top_types.Mount] = None
         # The motion lock synchronizes calls to long-running physical tasks
@@ -104,8 +124,7 @@ class API(HardwareAPILike):
         self._calculate_valid_attitude.cache_clear()
         self._robot_calibration = rb_cal.load()
 
-    def set_robot_calibration(
-            self, robot_calibration: rb_cal.RobotCalibration):
+    def set_robot_calibration(self, robot_calibration: rb_cal.RobotCalibration):
         self._calculate_valid_attitude.cache_clear()
         self._robot_calibration = robot_calibration
 
@@ -118,29 +137,30 @@ class API(HardwareAPILike):
         self._door_state = door_state
 
     def _update_door_state(self, door_state: DoorState):
-        mod_log.info(
-            f'Updating the window switch status: {door_state}')
+        mod_log.info(f"Updating the window switch status: {door_state}")
         self.door_state = door_state
         self._pause_manager.set_door(self.door_state)
         for cb in self._callbacks:
             hw_event = DoorStateNotification(
-                new_state=door_state,
-                blocking=self._pause_manager.blocked_by_door)
+                new_state=door_state, blocking=self._pause_manager.blocked_by_door
+            )
             try:
                 cb(hw_event)
             except Exception:
-                mod_log.exception('Errored during door state event callback')
+                mod_log.exception("Errored during door state event callback")
 
     def _reset_last_mount(self):
         self._last_moved_mount = None
 
     @classmethod
     async def build_hardware_controller(
-            cls, config: RobotConfig = None,
-            port: str = None,
-            loop: asyncio.AbstractEventLoop = None,
-            firmware: Tuple[pathlib.Path, str] = None) -> 'API':
-        """ Build a hardware controller that will actually talk to hardware.
+        cls,
+        config: RobotConfig = None,
+        port: str = None,
+        loop: asyncio.AbstractEventLoop = None,
+        firmware: Tuple[pathlib.Path, str] = None,
+    ) -> "API":
+        """Build a hardware controller that will actually talk to hardware.
 
         This method should not be used outside of a real robot, and on a
         real robot only one true hardware controller may be active at one
@@ -171,18 +191,19 @@ class API(HardwareAPILike):
                 fw_version = backend.fw_version
             except Exception:
                 mod_log.exception(
-                    'Motor driver could not connect, reprogramming if possible'
+                    "Motor driver could not connect, reprogramming if possible"
                 )
                 fw_version = None
 
             if firmware is not None:
                 if fw_version != firmware[1]:
-                    await backend.update_firmware(
-                        str(firmware[0]), checked_loop, True)
+                    await backend.update_firmware(str(firmware[0]), checked_loop, True)
                     await backend.connect(port)
             elif firmware is None and fw_version is None:
-                msg = 'Motor controller could not be connected and no '\
-                    'firmware was provided for (re)programming'
+                msg = (
+                    "Motor controller could not be connected and no "
+                    "firmware was provided for (re)programming"
+                )
                 mod_log.error(msg)
                 raise RuntimeError(msg)
 
@@ -192,21 +213,22 @@ class API(HardwareAPILike):
             backend.module_controls = module_controls
             checked_loop.create_task(backend.watch(loop=checked_loop))
             backend.start_gpio_door_watcher(
-                loop=checked_loop,
-                update_door_state=api_instance._update_door_state)
+                loop=checked_loop, update_door_state=api_instance._update_door_state
+            )
             return api_instance
         finally:
             blink_task.cancel()
 
     @classmethod
     async def build_hardware_simulator(
-            cls,
-            attached_instruments: Dict[top_types.Mount, Dict[str, Optional[str]]] = None,  # noqa: E501
-            attached_modules: List[str] = None,
-            config: RobotConfig = None,
-            loop: asyncio.AbstractEventLoop = None,
-            strict_attached_instruments: bool = True) -> 'API':
-        """ Build a simulating hardware controller.
+        cls,
+        attached_instruments: Dict[top_types.Mount, Dict[str, Optional[str]]] = None,
+        attached_modules: List[str] = None,
+        config: RobotConfig = None,
+        loop: asyncio.AbstractEventLoop = None,
+        strict_attached_instruments: bool = True,
+    ) -> "API":
+        """Build a simulating hardware controller.
 
         This method may be used both on a real robot and on dev machines.
         Multiple simulating hardware controllers may be active at one time.
@@ -223,8 +245,10 @@ class API(HardwareAPILike):
         backend = await Simulator.build(
             attached_instruments,
             attached_modules,
-            checked_config, checked_loop,
-            strict_attached_instruments)
+            checked_config,
+            checked_loop,
+            strict_attached_instruments,
+        )
         api_instance = cls(backend, loop=checked_loop, config=checked_config)
         await api_instance.cache_instruments()
         module_controls = await AttachedModulesControl.build(api_instance)
@@ -233,12 +257,11 @@ class API(HardwareAPILike):
         return api_instance
 
     def __repr__(self):
-        return '<{} using backend {}>'.format(type(self),
-                                              type(self._backend))
+        return "<{} using backend {}>".format(type(self), type(self._backend))
 
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
-        """ The event loop used by this instance. """
+        """The event loop used by this instance."""
         return self._loop
 
     def set_loop(self, loop: asyncio.AbstractEventLoop):
@@ -247,7 +270,7 @@ class API(HardwareAPILike):
 
     @property
     def is_simulator(self):
-        """ `True` if this is a simulator; `False` otherwise. """
+        """`True` if this is a simulator; `False` otherwise."""
         return isinstance(self._backend, Simulator)
 
     def validate_calibration(self) -> DeckTransformState:
@@ -263,10 +286,11 @@ class API(HardwareAPILike):
     @lru_cache(maxsize=1)
     def _calculate_valid_attitude(self) -> DeckTransformState:
         return rb_cal.validate_attitude_deck_calibration(
-            self._robot_calibration.deck_calibration)
+            self._robot_calibration.deck_calibration
+        )
 
     async def register_callback(self, cb):
-        """ Allows the caller to register a callback, and returns a closure
+        """Allows the caller to register a callback, and returns a closure
         that can be used to unregister the provided callback
         """
         self._callbacks.add(cb)
@@ -285,7 +309,7 @@ class API(HardwareAPILike):
         """
         from_backend = self._backend.fw_version
         if from_backend is None:
-            return 'unknown'
+            return "unknown"
         else:
             return from_backend
 
@@ -300,7 +324,7 @@ class API(HardwareAPILike):
     # Incidentals (i.e. not motion) API
 
     async def set_lights(self, button: bool = None, rails: bool = None):
-        """ Control the robot lights.
+        """Control the robot lights.
 
         :param button: If specified, turn the button light on (`True`) or
                        off (`False`). If not specified, do not change the
@@ -312,14 +336,14 @@ class API(HardwareAPILike):
         self._backend.set_lights(button, rails)
 
     def get_lights(self) -> Dict[str, bool]:
-        """ Return the current status of the robot lights.
+        """Return the current status of the robot lights.
 
         :returns: A dict of the lights: `{'button': bool, 'rails': bool}`
         """
         return self._backend.get_lights()
 
     async def identify(self, duration_s: int = 5):
-        """ Blink the button light to identify the robot.
+        """Blink the button light to identify the robot.
 
         :param int duration_s: The duration to blink for, in seconds.
         """
@@ -334,14 +358,15 @@ class API(HardwareAPILike):
         await self.set_lights(button=True)
 
     async def delay(self, duration_s: float):
-        """ Delay execution by pausing and sleeping.
-        """
+        """Delay execution by pausing and sleeping."""
         await self._wait_for_is_running()
         self.pause(PauseType.DELAY)
         try:
             if not self.is_simulator:
+
                 async def sleep_for_seconds(seconds: float):
                     await asyncio.sleep(seconds)
+
                 delay_task = self._loop.create_task(sleep_for_seconds(duration_s))
                 await self._execution_manager.register_cancellable_task(delay_task)
         finally:
@@ -356,15 +381,15 @@ class API(HardwareAPILike):
         :param mount: If specified, reset that mount. If not specified,
                       reset both
         """
+
         def _reset(m: top_types.Mount):
             self._log.info(f"Resetting configuration for {m}")
             p = self._attached_instruments[m]
             if not p:
                 return
             new_p = Pipette(
-                p._config,
-                rb_cal.load_pipette_offset(p.pipette_id, m),
-                p.pipette_id)
+                p._config, rb_cal.load_pipette_offset(p.pipette_id, m), p.pipette_id
+            )
             new_p.act_as(p.acting_as)
             self._attached_instruments[m] = new_p
 
@@ -375,8 +400,8 @@ class API(HardwareAPILike):
             _reset(mount)
 
     async def cache_instruments(
-            self,
-            require: Dict[top_types.Mount, 'PipetteName'] = None):
+        self, require: Dict[top_types.Mount, "PipetteName"] = None
+    ):
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.
@@ -404,40 +429,38 @@ class API(HardwareAPILike):
         checked_require = require or {}
         for mount, name in checked_require.items():
             if name not in name_config():
-                raise RuntimeError(f'{name} is not a valid pipette name')
+                raise RuntimeError(f"{name} is not a valid pipette name")
         found = await self._backend.get_attached_instruments(checked_require)
 
         for mount, instrument_data in found.items():
-            config = instrument_data.get('config')
+            config = instrument_data.get("config")
             req_instr = checked_require.get(mount, None)
-            pip_id = instrument_data.get('id')
+            pip_id = instrument_data.get("id")
             pip_offset_cal = rb_cal.load_pipette_offset(pip_id, mount)
             p, may_skip = load_from_config_and_check_skip(
                 config,
                 self._attached_instruments[mount],
                 req_instr,
                 pip_id,
-                pip_offset_cal)
+                pip_offset_cal,
+            )
             self._attached_instruments[mount] = p
             if req_instr and p:
                 p.act_as(req_instr)
 
             if may_skip:
-                self._log.info(
-                    f"Skipping configuration on {mount.name}")
+                self._log.info(f"Skipping configuration on {mount.name}")
                 continue
 
-            self._log.info(
-                f"Doing full configuration on {mount.name}")
+            self._log.info(f"Doing full configuration on {mount.name}")
             hw_config = generate_hardware_configs(
-                p, self._config, self._backend.board_revision)
+                p, self._config, self._backend.board_revision
+            )
             await self._backend.configure_mount(mount, hw_config)
-        mod_log.info("Instruments found: {}".format(
-            self._attached_instruments))
+        mod_log.info("Instruments found: {}".format(self._attached_instruments))
 
-    def get_attached_instruments(self) -> Dict[top_types.Mount,
-                                               'PipetteDict']:
-        """ Get the status dicts of the cached attached instruments.
+    def get_attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
+        """Get the status dicts of the cached attached instruments.
 
         Also available as :py:meth:`get_attached_instruments`.
 
@@ -456,52 +479,65 @@ class API(HardwareAPILike):
             for m in (top_types.Mount.LEFT, top_types.Mount.RIGHT)
         }
 
-    def get_attached_instrument(self, mount: top_types.Mount) -> 'PipetteDict':
+    def get_attached_instrument(self, mount: top_types.Mount) -> "PipetteDict":
         instr = self._attached_instruments[mount]
         result: Dict[str, Any] = {}
         if instr:
-            configs = ['name', 'min_volume', 'max_volume', 'channels',
-                       'aspirate_flow_rate', 'dispense_flow_rate',
-                       'pipette_id', 'current_volume', 'display_name',
-                       'tip_length', 'model', 'blow_out_flow_rate',
-                       'working_volume', 'tip_overlap', 'available_volume',
-                       'return_tip_height', 'default_aspirate_flow_rates',
-                       'default_blow_out_flow_rates',
-                       'default_dispense_flow_rates']
+            configs = [
+                "name",
+                "min_volume",
+                "max_volume",
+                "channels",
+                "aspirate_flow_rate",
+                "dispense_flow_rate",
+                "pipette_id",
+                "current_volume",
+                "display_name",
+                "tip_length",
+                "model",
+                "blow_out_flow_rate",
+                "working_volume",
+                "tip_overlap",
+                "available_volume",
+                "return_tip_height",
+                "default_aspirate_flow_rates",
+                "default_blow_out_flow_rates",
+                "default_dispense_flow_rates",
+            ]
 
             instr_dict = instr.as_dict()
             # TODO (spp, 2021-08-27): Revisit this logic. Why do we need to build
             #  this dict newly every time? Any why only a few items are being updated?
             for key in configs:
                 result[key] = instr_dict[key]
-            result['has_tip'] = instr.has_tip
-            result['tip_length'] = instr.current_tip_length
-            result['aspirate_speed'] = self._plunger_speed(
-                instr, instr.aspirate_flow_rate, 'aspirate')
-            result['dispense_speed'] = self._plunger_speed(
-                instr, instr.dispense_flow_rate, 'dispense')
-            result['blow_out_speed'] = self._plunger_speed(
-                instr, instr.blow_out_flow_rate, 'dispense')
-            result['ready_to_aspirate'] = instr.ready_to_aspirate
-            result['default_blow_out_speeds'] = {
-                alvl: self._plunger_speed(instr, fr, 'dispense')
-                for alvl, fr
-                in instr.config.default_aspirate_flow_rates.items()
+            result["has_tip"] = instr.has_tip
+            result["tip_length"] = instr.current_tip_length
+            result["aspirate_speed"] = self._plunger_speed(
+                instr, instr.aspirate_flow_rate, "aspirate"
+            )
+            result["dispense_speed"] = self._plunger_speed(
+                instr, instr.dispense_flow_rate, "dispense"
+            )
+            result["blow_out_speed"] = self._plunger_speed(
+                instr, instr.blow_out_flow_rate, "dispense"
+            )
+            result["ready_to_aspirate"] = instr.ready_to_aspirate
+            result["default_blow_out_speeds"] = {
+                alvl: self._plunger_speed(instr, fr, "dispense")
+                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
             }
-            result['default_dispense_speeds'] = {
-                alvl: self._plunger_speed(instr, fr, 'dispense')
-                for alvl, fr
-                in instr.config.default_dispense_flow_rates.items()
+            result["default_dispense_speeds"] = {
+                alvl: self._plunger_speed(instr, fr, "dispense")
+                for alvl, fr in instr.config.default_dispense_flow_rates.items()
             }
-            result['default_aspirate_speeds'] = {
-                alvl: self._plunger_speed(instr, fr, 'aspirate')
-                for alvl, fr
-                in instr.config.default_aspirate_flow_rates.items()
+            result["default_aspirate_speeds"] = {
+                alvl: self._plunger_speed(instr, fr, "aspirate")
+                for alvl, fr in instr.config.default_aspirate_flow_rates.items()
             }
-        return cast('PipetteDict', result)
+        return cast("PipetteDict", result)
 
     @property
-    def attached_instruments(self) -> Dict[top_types.Mount, 'PipetteDict']:
+    def attached_instruments(self) -> Dict[top_types.Mount, "PipetteDict"]:
         return self.get_attached_instruments()
 
     @property
@@ -509,11 +545,12 @@ class API(HardwareAPILike):
         return self._backend.module_controls.available_modules
 
     async def update_firmware(
-            self,
-            firmware_file: str,
-            loop: asyncio.AbstractEventLoop = None,
-            explicit_modeset: bool = True) -> str:
-        """ Update the firmware on the Smoothie board.
+        self,
+        firmware_file: str,
+        loop: asyncio.AbstractEventLoop = None,
+        explicit_modeset: bool = True,
+    ) -> str:
+        """Update the firmware on the Smoothie board.
 
         :param firmware_file: The path to the firmware file.
         :param explicit_modeset: `True` to force the smoothie into programming
@@ -527,9 +564,9 @@ class API(HardwareAPILike):
             checked_loop = self._loop
         else:
             checked_loop = loop
-        return await self._backend.update_firmware(firmware_file,
-                                                   checked_loop,
-                                                   explicit_modeset)
+        return await self._backend.update_firmware(
+            firmware_file, checked_loop, explicit_modeset
+        )
 
     # Global actions API
     def pause(self, pause_type: PauseType):
@@ -553,7 +590,7 @@ class API(HardwareAPILike):
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
     def pause_with_message(self, message):
-        self._log.warning('Pause with message: {}'.format(message))
+        self._log.warning("Pause with message: {}".format(message))
         for cb in self._callbacks:
             cb(message)
         self.pause(PauseType.PAUSE)
@@ -579,7 +616,7 @@ class API(HardwareAPILike):
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
     async def halt(self):
-        """ Immediately stop motion.
+        """Immediately stop motion.
 
         Calls to :py:meth:`stop` through the synch adapter while other calls
         are ongoing will typically wait until those calls are done, since most
@@ -591,8 +628,7 @@ class API(HardwareAPILike):
         :py:meth:`stop`.
         """
         await self._backend.hard_halt()
-        asyncio.run_coroutine_threadsafe(self._execution_manager.cancel(),
-                                         self._loop)
+        asyncio.run_coroutine_threadsafe(self._execution_manager.cancel(), self._loop)
 
     async def stop(self, home_after: bool = True):
         """
@@ -614,7 +650,7 @@ class API(HardwareAPILike):
             await self._execution_manager.wait_for_is_running()
 
     async def reset(self):
-        """ Reset the stored state of the system.
+        """Reset the stored state of the system.
 
         This will re-scan instruments and models, clearing any cached
         information about their presence or state.
@@ -622,12 +658,13 @@ class API(HardwareAPILike):
         self._pause_manager.reset()
         await self._execution_manager.reset()
         self._attached_instruments = {
-            k: None for k in self._attached_instruments.keys()}
+            k: None for k in self._attached_instruments.keys()
+        }
         await self.cache_instruments()
 
     # Gantry/frame (i.e. not pipette) action API
     async def home_z(self, mount: top_types.Mount = None):
-        """ Home the two z-axes """
+        """Home the two z-axes"""
         self._reset_last_mount()
         if not mount:
             axes = [Axis.Z, Axis.A]
@@ -636,12 +673,12 @@ class API(HardwareAPILike):
         await self.home(axes)
 
     async def _do_plunger_home(
-            self,
-            axis: Axis = None,
-            mount: top_types.Mount = None,
-            acquire_lock: bool = True):
-        assert (axis is not None) ^ (mount is not None),\
-            'specify either axis or mount'
+        self,
+        axis: Axis = None,
+        mount: top_types.Mount = None,
+        acquire_lock: bool = True,
+    ):
+        assert (axis is not None) ^ (mount is not None), "specify either axis or mount"
         if axis:
             checked_axis = axis
             checked_mount = Axis.to_mount(checked_axis)
@@ -656,14 +693,15 @@ class API(HardwareAPILike):
                 await stack.enter_async_context(self._motion_lock)
             with self._backend.save_current():
                 self._backend.set_active_current(
-                    {checked_axis: instr.config.plunger_current})
+                    {checked_axis: instr.config.plunger_current}
+                )
                 await self._backend.home([checked_axis.name.upper()])
                 # either we were passed False for our acquire_lock and we
                 # should pass it on, or we acquired the lock above and
                 # shouldn't do it again
-                await self._move_plunger(checked_mount,
-                                         (instr.config.bottom,),
-                                         acquire_lock=False)
+                await self._move_plunger(
+                    checked_mount, (instr.config.bottom,), acquire_lock=False
+                )
 
     async def home_plunger(self, mount: top_types.Mount):
         """
@@ -674,11 +712,10 @@ class API(HardwareAPILike):
         :type mount: :py:class:`.top_types.Mount`
         """
         await self.current_position(mount=mount, refresh=True)
-        await self._do_plunger_home(mount=mount,
-                                    acquire_lock=True)
+        await self._do_plunger_home(mount=mount, acquire_lock=True)
 
     async def home(self, axes: List[Axis] = None):
-        """ Home the entire robot and initialize current position.
+        """Home the entire robot and initialize current position.
         :param axes: A list of axes to home. Default is `None`, which will
                      home everything.
         """
@@ -689,8 +726,7 @@ class API(HardwareAPILike):
         gantry = [ax for ax in checked_axes if ax in Axis.gantry_axes()]
         smoothie_gantry = [ax.name.upper() for ax in gantry]
         smoothie_pos = {}
-        plungers = [ax for ax in checked_axes
-                    if ax not in Axis.gantry_axes()]
+        plungers = [ax for ax in checked_axes if ax not in Axis.gantry_axes()]
 
         async with self._motion_lock:
             if smoothie_gantry:
@@ -699,10 +735,7 @@ class API(HardwareAPILike):
             for plunger in plungers:
                 await self._do_plunger_home(axis=plunger, acquire_lock=False)
 
-    async def add_tip(
-            self,
-            mount: top_types.Mount,
-            tip_length: float):
+    async def add_tip(self, mount: top_types.Mount, tip_length: float):
         instr = self._attached_instruments[mount]
         attached = self.attached_instruments
         instr_dict = attached[mount]
@@ -710,10 +743,10 @@ class API(HardwareAPILike):
             instr.add_tip(tip_length=tip_length)
             # TODO (spp, 2021-08-27): These items are being updated in a local copy
             #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict['has_tip'] = True
-            instr_dict['tip_length'] = tip_length
+            instr_dict["has_tip"] = True
+            instr_dict["tip_length"] = tip_length
         else:
-            mod_log.warning('attach tip called while tip already attached')
+            mod_log.warning("attach tip called while tip already attached")
 
     async def remove_tip(self, mount: top_types.Mount):
         instr = self._attached_instruments[mount]
@@ -723,14 +756,13 @@ class API(HardwareAPILike):
             instr.remove_tip()
             # TODO (spp, 2021-08-27): These items are being updated in a local copy
             #  of the PipetteDict, which gets thrown away. Fix this.
-            instr_dict['has_tip'] = False
-            instr_dict['tip_length'] = 0.0
+            instr_dict["has_tip"] = False
+            instr_dict["tip_length"] = 0.0
         else:
-            mod_log.warning('detach tip called with no tip')
+            mod_log.warning("detach tip called with no tip")
 
-    def _deck_from_smoothie(
-            self, smoothie_pos: Dict[str, float]) -> Dict[Axis, float]:
-        """ Build a deck-abs position store from the smoothie's position
+    def _deck_from_smoothie(self, smoothie_pos: Dict[str, float]) -> Dict[Axis, float]:
+        """Build a deck-abs position store from the smoothie's position
 
         This should take the smoothie style position {'X': float, etc}
         and turn it into the position dict used here {Axis.X: float} in
@@ -748,34 +780,39 @@ class API(HardwareAPILike):
               added to the smoothie coordinates here.
         """
         with_enum = {Axis[k]: v for k, v in smoothie_pos.items()}
-        plunger_axes = {k: v for k, v in with_enum.items()
-                        if k not in Axis.gantry_axes()}
+        plunger_axes = {
+            k: v for k, v in with_enum.items() if k not in Axis.gantry_axes()
+        }
         right = (
-            with_enum[Axis.X], with_enum[Axis.Y],
-            with_enum[Axis.by_mount(top_types.Mount.RIGHT)])
-        left = (with_enum[Axis.X],
-                with_enum[Axis.Y],
-                with_enum[Axis.by_mount(top_types.Mount.LEFT)])
+            with_enum[Axis.X],
+            with_enum[Axis.Y],
+            with_enum[Axis.by_mount(top_types.Mount.RIGHT)],
+        )
+        left = (
+            with_enum[Axis.X],
+            with_enum[Axis.Y],
+            with_enum[Axis.by_mount(top_types.Mount.LEFT)],
+        )
 
-        gantry_calibration =\
-            self.robot_calibration.deck_calibration.attitude
-        right_deck = linal.apply_reverse(
-            gantry_calibration, right)
-        left_deck = linal.apply_reverse(
-            gantry_calibration, left)
-        deck_pos = {Axis.X: right_deck[0],
-                    Axis.Y: right_deck[1],
-                    Axis.by_mount(top_types.Mount.RIGHT): right_deck[2],
-                    Axis.by_mount(top_types.Mount.LEFT): left_deck[2]}
+        gantry_calibration = self.robot_calibration.deck_calibration.attitude
+        right_deck = linal.apply_reverse(gantry_calibration, right)
+        left_deck = linal.apply_reverse(gantry_calibration, left)
+        deck_pos = {
+            Axis.X: right_deck[0],
+            Axis.Y: right_deck[1],
+            Axis.by_mount(top_types.Mount.RIGHT): right_deck[2],
+            Axis.by_mount(top_types.Mount.LEFT): left_deck[2],
+        }
         deck_pos.update(plunger_axes)
         return deck_pos
 
     async def current_position(
-            self,
-            mount: top_types.Mount,
-            critical_point: CriticalPoint = None,
-            refresh: bool = False) -> Dict[Axis, float]:
-        """ Return the postion (in deck coords) of the critical point of the
+        self,
+        mount: top_types.Mount,
+        critical_point: CriticalPoint = None,
+        refresh: bool = False,
+    ) -> Dict[Axis, float]:
+        """Return the postion (in deck coords) of the critical point of the
         specified mount.
 
         This returns cached position to avoid hitting the smoothie driver
@@ -794,7 +831,8 @@ class API(HardwareAPILike):
         async with self._motion_lock:
             if refresh:
                 self._current_position = self._deck_from_smoothie(
-                    await self._backend.update_position())
+                    await self._backend.update_position()
+                )
             if mount == top_types.Mount.RIGHT:
                 offset = top_types.Point(0, 0, 0)
             else:
@@ -806,15 +844,16 @@ class API(HardwareAPILike):
                 Axis.X: self._current_position[Axis.X] + offset[0] + cp.x,
                 Axis.Y: self._current_position[Axis.Y] + offset[1] + cp.y,
                 z_ax: self._current_position[z_ax] + offset[2] + cp.z,
-                plunger_ax: self._current_position[plunger_ax]
+                plunger_ax: self._current_position[plunger_ax],
             }
 
     async def gantry_position(
-            self,
-            mount: top_types.Mount,
-            critical_point: CriticalPoint = None,
-            refresh: bool = False) -> top_types.Point:
-        """ Return the position of the critical point as pertains to the gantry
+        self,
+        mount: top_types.Mount,
+        critical_point: CriticalPoint = None,
+        refresh: bool = False,
+    ) -> top_types.Point:
+        """Return the position of the critical point as pertains to the gantry
 
         This ignores the plunger position and gives the Z-axis a predictable
         name (as :py:attr:`.Point.z`).
@@ -826,30 +865,32 @@ class API(HardwareAPILike):
         smoothie driver (see :py:meth:`current_position`).
         """
         cur_pos = await self.current_position(mount, critical_point, refresh)
-        return top_types.Point(x=cur_pos[Axis.X],
-                               y=cur_pos[Axis.Y],
-                               z=cur_pos[Axis.by_mount(mount)])
+        return top_types.Point(
+            x=cur_pos[Axis.X], y=cur_pos[Axis.Y], z=cur_pos[Axis.by_mount(mount)]
+        )
 
     @overload
-    def _mounts(
-        self,
-        z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]: ...
+    def _mounts(self, z_axis: PipettePair) -> Tuple[top_types.Mount, top_types.Mount]:
+        ...
 
     @overload
-    def _mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]: ...
+    def _mounts(self, z_axis: top_types.Mount) -> Tuple[top_types.Mount]:
+        ...
 
     def _mounts(self, z_axis):
         if isinstance(z_axis, PipettePair):
             return (z_axis.primary, z_axis.secondary)
-        return (z_axis, )
+        return (z_axis,)
 
     async def move_to(
-            self, mount: Union[top_types.Mount, PipettePair],
-            abs_position: top_types.Point,
-            speed: float = None,
-            critical_point: CriticalPoint = None,
-            max_speeds: Dict[Axis, float] = None):
-        """ Move the critical point of the specified mount to a location
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        abs_position: top_types.Point,
+        speed: float = None,
+        critical_point: CriticalPoint = None,
+        max_speeds: Dict[Axis, float] = None,
+    ):
+        """Move the critical point of the specified mount to a location
         relative to the deck, at the specified speed. 'speed' sets the speed
         of all robot axes to the given value. So, if multiple axes are to be
         moved, they will do so at the same speed
@@ -909,38 +950,42 @@ class API(HardwareAPILike):
         if secondary_mount:
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = Axis.by_mount(secondary_mount)
-            primary_cp = self._critical_point_for(
-                primary_mount, critical_point)
-            s_cp = self._critical_point_for(
-                secondary_mount, critical_point)
+            primary_cp = self._critical_point_for(primary_mount, critical_point)
+            s_cp = self._critical_point_for(secondary_mount, critical_point)
             target_position = OrderedDict(
-                ((Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                 (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                 (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
-                 (secondary_z, abs_position.z - s_offset.z - s_cp.z)
-                 ))
+                (
+                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
+                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
+                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
+                    (secondary_z, abs_position.z - s_offset.z - s_cp.z),
+                )
+            )
         else:
-            primary_cp =\
-                self._critical_point_for(primary_mount, critical_point)
+            primary_cp = self._critical_point_for(primary_mount, critical_point)
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = None
             target_position = OrderedDict(
-                ((Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
-                 (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
-                 (primary_z, abs_position.z - primary_offset.z - primary_cp.z)
-                 ))
+                (
+                    (Axis.X, abs_position.x - primary_offset.x - primary_cp.x),
+                    (Axis.Y, abs_position.y - primary_offset.y - primary_cp.y),
+                    (primary_z, abs_position.z - primary_offset.z - primary_cp.z),
+                )
+            )
 
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
-            target_position, speed=speed,
-            max_speeds=max_speeds, secondary_z=secondary_z)
+            target_position, speed=speed, max_speeds=max_speeds, secondary_z=secondary_z
+        )
 
-    async def move_rel(self, mount: Union[top_types.Mount, PipettePair],
-                       delta: top_types.Point,
-                       speed: float = None,
-                       max_speeds: Dict[Axis, float] = None,
-                       check_bounds: MotionChecks = MotionChecks.NONE):
-        """ Move the critical point of the specified mount by a specified
+    async def move_rel(
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        delta: top_types.Point,
+        speed: float = None,
+        max_speeds: Dict[Axis, float] = None,
+        check_bounds: MotionChecks = MotionChecks.NONE,
+    ):
+        """Move the critical point of the specified mount by a specified
         displacement in a specified direction, at the specified speed.
         'speed' sets the speed of all axes to the given value. So, if multiple
         axes are to be moved, they will do so at the same speed
@@ -961,28 +1006,35 @@ class API(HardwareAPILike):
             primary_z = Axis.by_mount(primary_mount)
             secondary_z = Axis.by_mount(secondary_mount)
             target_position = OrderedDict(
-                ((Axis.X, self._current_position[Axis.X] + delta.x),
-                 (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                 (primary_z, self._current_position[primary_z] + delta.z),
-                 (secondary_z, self._current_position[secondary_z] + delta.z))
+                (
+                    (Axis.X, self._current_position[Axis.X] + delta.x),
+                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
+                    (primary_z, self._current_position[primary_z] + delta.z),
+                    (secondary_z, self._current_position[secondary_z] + delta.z),
+                )
             )
         else:
             z_axis = Axis.by_mount(primary_mount)
             secondary_z = None
             target_position = OrderedDict(
-                ((Axis.X, self._current_position[Axis.X] + delta.x),
-                 (Axis.Y, self._current_position[Axis.Y] + delta.y),
-                 (z_axis, self._current_position[z_axis] + delta.z))
+                (
+                    (Axis.X, self._current_position[Axis.X] + delta.x),
+                    (Axis.Y, self._current_position[Axis.Y] + delta.y),
+                    (z_axis, self._current_position[z_axis] + delta.z),
+                )
             )
 
         await self._cache_and_maybe_retract_mount(primary_mount)
         await self._move(
-            target_position, speed=speed,
-            max_speeds=max_speeds, secondary_z=secondary_z,
-            check_bounds=check_bounds)
+            target_position,
+            speed=speed,
+            max_speeds=max_speeds,
+            secondary_z=secondary_z,
+            check_bounds=check_bounds,
+        )
 
     async def _cache_and_maybe_retract_mount(self, mount: top_types.Mount):
-        """ Retract the 'other' mount if necessary
+        """Retract the 'other' mount if necessary
 
         If `mount` does not match the value in :py:attr:`_last_moved_mount`
         (and :py:attr:`_last_moved_mount` exists) then retract the mount
@@ -993,13 +1045,19 @@ class API(HardwareAPILike):
             await self.retract(self._last_moved_mount, 10)
         self._last_moved_mount = mount
 
-    async def _move_plunger(self, mount: Union[top_types.Mount, PipettePair],
-                            dist: Sequence[float], speed: float = None,
-                            acquire_lock: bool = True):
-        all_axes_pos = OrderedDict((
-            (Axis.X, self._current_position[Axis.X]),
-            (Axis.Y, self._current_position[Axis.Y]),
-        ))
+    async def _move_plunger(
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        dist: Sequence[float],
+        speed: float = None,
+        acquire_lock: bool = True,
+    ):
+        all_axes_pos = OrderedDict(
+            (
+                (Axis.X, self._current_position[Axis.X]),
+                (Axis.Y, self._current_position[Axis.Y]),
+            )
+        )
         plunger_pos = OrderedDict()
         mounts = self._mounts(mount)
         secondary_z = None
@@ -1011,19 +1069,32 @@ class API(HardwareAPILike):
             if idx == 1:
                 secondary_z = z
         all_axes_pos.update(plunger_pos)
-        await self._move(all_axes_pos, speed, False,
-                         acquire_lock=acquire_lock,
-                         secondary_z=secondary_z)
+        await self._move(
+            all_axes_pos,
+            speed,
+            False,
+            acquire_lock=acquire_lock,
+            secondary_z=secondary_z,
+        )
 
     async def _move_relative_n_axes(
-            self, mount: Union[top_types.Mount, PipettePair],
-            target: Sequence[float], speed: float = None):
-        all_axes_pos = OrderedDict((
-            (Axis.X, self._current_position[Axis.X] + target[0]),
-            (Axis.Y, self._current_position[Axis.Y] + target[1])))
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        target: Sequence[float],
+        speed: float = None,
+    ):
+        all_axes_pos = OrderedDict(
+            (
+                (Axis.X, self._current_position[Axis.X] + target[0]),
+                (Axis.Y, self._current_position[Axis.Y] + target[1]),
+            )
+        )
         mounts = self._mounts(mount)
         secondary_z = None
-        for idx, m, in enumerate(mounts):
+        for (
+            idx,
+            m,
+        ) in enumerate(mounts):
             z = Axis.by_mount(m)
             t_index = idx + 2
             all_axes_pos[z] = self._current_position[z] + target[t_index]
@@ -1032,9 +1103,9 @@ class API(HardwareAPILike):
         await self._move(all_axes_pos, speed=speed, secondary_z=secondary_z)
 
     def _get_transformed(
-            self,
-            to_transform_primary: Tuple[float, ...],
-            to_transform_secondary: Tuple[float, ...]
+        self,
+        to_transform_primary: Tuple[float, ...],
+        to_transform_secondary: Tuple[float, ...],
     ) -> Tuple[Tuple, Tuple]:
         # Type ignored below because linal.apply_transform (rightly) specifies
         # Tuple[float, float, float] and the implied type from
@@ -1043,19 +1114,25 @@ class API(HardwareAPILike):
         # above that makes this OK
         primary_transformed = linal.apply_transform(
             self.robot_calibration.deck_calibration.attitude,
-            to_transform_primary)  # type: ignore
+            to_transform_primary,  # type: ignore[arg-type]
+        )
         secondary_transformed = linal.apply_transform(
             self.robot_calibration.deck_calibration.attitude,
-            to_transform_secondary)  # type: ignore
+            to_transform_secondary,  # type: ignore[arg-type]
+        )
         return primary_transformed, secondary_transformed
 
-    async def _move(self, target_position: 'OrderedDict[Axis, float]',
-                    speed: float = None, home_flagged_axes: bool = True,
-                    max_speeds: Dict[Axis, float] = None,
-                    acquire_lock: bool = True,
-                    secondary_z: Axis = None,
-                    check_bounds: MotionChecks = MotionChecks.NONE):
-        """ Worker function to apply robot motion.
+    async def _move(
+        self,
+        target_position: "OrderedDict[Axis, float]",
+        speed: float = None,
+        home_flagged_axes: bool = True,
+        max_speeds: Dict[Axis, float] = None,
+        acquire_lock: bool = True,
+        secondary_z: Axis = None,
+        check_bounds: MotionChecks = MotionChecks.NONE,
+    ):
+        """Worker function to apply robot motion.
 
         Robot motion means the kind of motions that are relevant to the robot,
         i.e. only one pipette plunger and mount move at the same time, and an
@@ -1069,27 +1146,37 @@ class API(HardwareAPILike):
         await self._wait_for_is_running()
         # Transform only the x, y, and (z or a) axes specified since this could
         # get the b or c axes as well
-        to_transform_primary = tuple((tp
-                                      for ax, tp in target_position.items()
-                                      if (ax in Axis.gantry_axes()
-                                          and ax != secondary_z)))
+        to_transform_primary = tuple(
+            (
+                tp
+                for ax, tp in target_position.items()
+                if (ax in Axis.gantry_axes() and ax != secondary_z)
+            )
+        )
         if secondary_z:
-            to_transform_secondary = tuple(
-                (0, 0, target_position[secondary_z]))
+            to_transform_secondary = tuple((0, 0, target_position[secondary_z]))
         else:
             to_transform_secondary = tuple((0, 0, 0))
         # Pre-fill the dict we’ll send to the backend with the axes we don’t
         # need to transform
-        smoothie_pos = {ax.name: pos for ax, pos in target_position.items()
-                        if ax not in Axis.gantry_axes()}
+        smoothie_pos = {
+            ax.name: pos
+            for ax, pos in target_position.items()
+            if ax not in Axis.gantry_axes()
+        }
         if len(to_transform_primary) != 3:
-            self._log.error("Move derived {} axes to transform from {}"
-                            .format(len(to_transform_primary),
-                                    target_position))
-            raise ValueError("Moves must specify either exactly an "
-                             "x, y, and (z or a) or none of them")
-        primary_transformed, secondary_transformed =\
-            self._get_transformed(to_transform_primary, to_transform_secondary)
+            self._log.error(
+                "Move derived {} axes to transform from {}".format(
+                    len(to_transform_primary), target_position
+                )
+            )
+            raise ValueError(
+                "Moves must specify either exactly an "
+                "x, y, and (z or a) or none of them"
+            )
+        primary_transformed, secondary_transformed = self._get_transformed(
+            to_transform_primary, to_transform_secondary
+        )
         transformed = (*primary_transformed, secondary_transformed[2])
         # Since target_position is an OrderedDict with the axes ordered by
         # (x, y, z, a, b, c), and we’ll only have one of a or z (as checked
@@ -1097,13 +1184,12 @@ class API(HardwareAPILike):
         # fuse the specified axes and the transformed values back together.
         # While we do this iteration, we’ll also check axis bounds.
         bounds = self._backend.axis_bounds
-        to_check = {ax: transformed[idx]
-                    for idx, ax in enumerate(target_position.keys())
-                    if ax in Axis.gantry_axes()}
-        check_motion_bounds(
-            to_check,
-            target_position,
-            bounds, check_bounds)
+        to_check = {
+            ax: transformed[idx]
+            for idx, ax in enumerate(target_position.keys())
+            if ax in Axis.gantry_axes()
+        }
+        check_motion_bounds(to_check, target_position, bounds, check_bounds)
         smoothie_pos.update({ax.name: pos for ax, pos in to_check.items()})
         checked_maxes = max_speeds or {}
         str_maxes = {ax.name: val for ax, val in checked_maxes.items()}
@@ -1111,20 +1197,22 @@ class API(HardwareAPILike):
             if acquire_lock:
                 await stack.enter_async_context(self._motion_lock)
             try:
-                await self._backend.move(smoothie_pos, speed=speed,
-                                         home_flagged_axes=home_flagged_axes,
-                                         axis_max_speeds=str_maxes)
+                await self._backend.move(
+                    smoothie_pos,
+                    speed=speed,
+                    home_flagged_axes=home_flagged_axes,
+                    axis_max_speeds=str_maxes,
+                )
             except Exception:
-                self._log.exception('Move failed')
+                self._log.exception("Move failed")
                 self._current_position.clear()
                 raise
             else:
                 self._current_position.update(target_position)
 
     def get_engaged_axes(self) -> Dict[Axis, bool]:
-        """ Which axes are engaged and holding. """
-        return {Axis[ax]: eng
-                for ax, eng in self._backend.engaged_axes().items()}
+        """Which axes are engaged and holding."""
+        return {Axis[ax]: eng for ax, eng in self._backend.engaged_axes().items()}
 
     @property
     def engaged_axes(self):
@@ -1133,17 +1221,14 @@ class API(HardwareAPILike):
     async def disengage_axes(self, which: List[Axis]):
         await self._backend.disengage_axes([ax.name for ax in which])
 
-    async def _fast_home(
-            self, axes: Sequence[str],
-            margin: float) -> Dict[str, float]:
-        converted_axes = ''.join(axes)
+    async def _fast_home(self, axes: Sequence[str], margin: float) -> Dict[str, float]:
+        converted_axes = "".join(axes)
         return await self._backend.fast_home(converted_axes, margin)
 
     async def retract(
-            self,
-            mount: Union[top_types.Mount, PipettePair],
-            margin: float = 10):
-        """ Pull the specified mount up to its home position.
+        self, mount: Union[top_types.Mount, PipettePair], margin: float = 10
+    ):
+        """Pull the specified mount up to its home position.
 
         Works regardless of critical point or home status.
         """
@@ -1153,16 +1238,16 @@ class API(HardwareAPILike):
             secondary_ax = Axis.by_mount(mount.secondary).name.upper()
             smoothie_ax: Tuple[str, ...] = (primary_ax, secondary_ax)
         else:
-            smoothie_ax = (Axis.by_mount(mount).name.upper(), )
+            smoothie_ax = (Axis.by_mount(mount).name.upper(),)
 
         async with self._motion_lock:
             smoothie_pos = await self._fast_home(smoothie_ax, margin)
             self._current_position = self._deck_from_smoothie(smoothie_pos)
 
     def _critical_point_for(
-            self, mount: top_types.Mount,
-            cp_override: CriticalPoint = None) -> top_types.Point:
-        """ Return the current critical point of the specified mount.
+        self, mount: top_types.Mount, cp_override: CriticalPoint = None
+    ) -> top_types.Point:
+        """Return the current critical point of the specified mount.
 
         The mount's critical point is the position of the mount itself, if no
         pipette is attached, or the pipette's critical point (which depends on
@@ -1181,20 +1266,20 @@ class API(HardwareAPILike):
 
     # Gantry/frame (i.e. not pipette) config API
     def get_config(self) -> RobotConfig:
-        """ Get the robot's configuration object.
+        """Get the robot's configuration object.
 
         :returns .RobotConfig: The object.
         """
         return self._config
 
     def set_config(self, config: RobotConfig):
-        """ Replace the currently-loaded config """
+        """Replace the currently-loaded config"""
         self._config = config
 
     config = property(fget=get_config, fset=set_config)
 
     async def update_config(self, **kwargs):
-        """ Update values of the robot's configuration.
+        """Update values of the robot's configuration.
 
         `kwargs` should contain keys of the robot's configuration. For
         instance, `update_config(log_level='debug)` would change the API
@@ -1210,8 +1295,8 @@ class API(HardwareAPILike):
 
     # Pipette action API
     async def prepare_for_aspirate(
-            self, mount: Union[top_types.Mount, PipettePair],
-            rate: float = 1.0):
+        self, mount: Union[top_types.Mount, PipettePair], rate: float = 1.0
+    ):
         """
         Prepare the pipette for aspiration.
 
@@ -1230,20 +1315,23 @@ class API(HardwareAPILike):
         raise an exception if this method has not previously been called.
         """
         instruments = self._instruments_for(mount)
-        self._ready_for_tip_action(
-            instruments, HardwareAction.PREPARE_ASPIRATE)
+        self._ready_for_tip_action(instruments, HardwareAction.PREPARE_ASPIRATE)
 
         with_zero = filter(lambda i: i[0].current_volume == 0, instruments)
         for instr in with_zero:
             speed = self._plunger_speed(
-                instr[0],
-                instr[0].blow_out_flow_rate, 'aspirate')
-            bottom = (instr[0].config.bottom, )
+                instr[0], instr[0].blow_out_flow_rate, "aspirate"
+            )
+            bottom = (instr[0].config.bottom,)
             await self._move_plunger(instr[1], bottom, speed=(speed * rate))
             instr[0].ready_to_aspirate = True
 
-    async def aspirate(self, mount: Union[top_types.Mount, PipettePair],
-                       volume: float = None, rate: float = 1.0):
+    async def aspirate(
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        volume: float = None,
+        rate: float = 1.0,
+    ):
         """
         Aspirate a volume of liquid (in microliters/uL) using this pipette
         from the *current location*. If no volume is passed, `aspirate` will
@@ -1267,12 +1355,14 @@ class API(HardwareAPILike):
         self._ready_for_tip_action(instruments, HardwareAction.ASPIRATE)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments}
+            for instr in instruments
+        }
 
         if volume is None:
             mod_log.debug(
                 "No aspirate volume defined. Aspirating up to "
-                "max_volume for the pipette")
+                "max_volume for the pipette"
+            )
             asp_vol = tuple(instr[0].available_volume for instr in instruments)
         else:
             asp_vol = tuple(volume for instr in instruments)
@@ -1280,26 +1370,28 @@ class API(HardwareAPILike):
         if all([vol == 0 for vol in asp_vol]):
             return
         elif 0 in asp_vol:
-            raise PairedPipetteConfigValueError(
-                "Cannot only aspirate from one pipette")
+            raise PairedPipetteConfigValueError("Cannot only aspirate from one pipette")
 
         for instr, vol in zip(instruments, asp_vol):
-            assert instr[0].ok_to_add_volume(vol), \
-                "Cannot aspirate more than pipette max volume"
+            assert instr[0].ok_to_add_volume(
+                vol
+            ), "Cannot aspirate more than pipette max volume"
 
-        dist = tuple(self._plunger_position(
-                     instr[0],
-                     instr[0].current_volume + vol, 'aspirate')
-                     for instr, vol in zip(instruments, asp_vol))
+        dist = tuple(
+            self._plunger_position(instr[0], instr[0].current_volume + vol, "aspirate")
+            for instr, vol in zip(instruments, asp_vol)
+        )
         speed = min(
             self._plunger_speed(
-                instr[0], instr[0].aspirate_flow_rate * rate, 'aspirate')
-            for instr in instruments)
+                instr[0], instr[0].aspirate_flow_rate * rate, "aspirate"
+            )
+            for instr in instruments
+        )
         try:
             self._backend.set_active_current(plunger_currents)
             await self._move_plunger(mount, dist, speed=speed)
         except Exception:
-            self._log.exception('Aspirate failed')
+            self._log.exception("Aspirate failed")
             for instr in instruments:
                 instr[0].set_current_volume(0)
             raise
@@ -1307,8 +1399,12 @@ class API(HardwareAPILike):
             for instr, vol in zip(instruments, asp_vol):
                 instr[0].add_current_volume(vol)
 
-    async def dispense(self, mount: Union[top_types.Mount, PipettePair],
-                       volume: float = None, rate: float = 1.0):
+    async def dispense(
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        volume: float = None,
+        rate: float = 1.0,
+    ):
         """
         Dispense a volume of liquid in microliters(uL) using this pipette
         at the current location. If no volume is specified, `dispense` will
@@ -1324,39 +1420,44 @@ class API(HardwareAPILike):
 
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments}
+            for instr in instruments
+        }
         if volume is None:
             disp_vol = tuple(instr[0].current_volume for instr in instruments)
-            mod_log.debug("No dispense volume specified. Dispensing all "
-                          "remaining liquid ({}uL) from pipette".format
-                          (disp_vol))
+            mod_log.debug(
+                "No dispense volume specified. Dispensing all "
+                "remaining liquid ({}uL) from pipette".format(disp_vol)
+            )
         else:
             disp_vol = tuple(volume for instr in instruments)
 
         # Ensure we don't dispense more than the current volume
         disp_vol = tuple(
             min(instr[0].current_volume, vol)
-            for instr, vol in zip(instruments, disp_vol))
+            for instr, vol in zip(instruments, disp_vol)
+        )
 
         if all([vol == 0 for vol in disp_vol]):
             return
         elif 0 in disp_vol:
-            raise PairedPipetteConfigValueError(
-                "Cannot only dispense from one pipette")
+            raise PairedPipetteConfigValueError("Cannot only dispense from one pipette")
 
-        dist = tuple(self._plunger_position(
-                     instr[0],
-                     instr[0].current_volume - vol, 'dispense')
-                     for instr, vol in zip(instruments, disp_vol))
-        speed = min(self._plunger_speed(instr[0],
-                    instr[0].dispense_flow_rate * rate, 'dispense')
-                    for instr in instruments)
+        dist = tuple(
+            self._plunger_position(instr[0], instr[0].current_volume - vol, "dispense")
+            for instr, vol in zip(instruments, disp_vol)
+        )
+        speed = min(
+            self._plunger_speed(
+                instr[0], instr[0].dispense_flow_rate * rate, "dispense"
+            )
+            for instr in instruments
+        )
 
         try:
             self._backend.set_active_current(plunger_currents)
             await self._move_plunger(mount, dist, speed=speed)
         except Exception:
-            self._log.exception('Dispense failed')
+            self._log.exception("Dispense failed")
             for instr in instruments:
                 instr[0].set_current_volume(0)
             raise
@@ -1364,21 +1465,22 @@ class API(HardwareAPILike):
             for instr, vol in zip(instruments, disp_vol):
                 instr[0].remove_current_volume(vol)
 
-    def _plunger_position(self, instr: Pipette, ul: float,
-                          action: 'UlPerMmAction') -> float:
+    def _plunger_position(
+        self, instr: Pipette, ul: float, action: "UlPerMmAction"
+    ) -> float:
         mm = ul / instr.ul_per_mm(ul, action)
         position = mm + instr.config.bottom
         return round(position, 6)
 
     def _plunger_speed(
-            self, instr: Pipette, ul_per_s: float,
-            action: 'UlPerMmAction') -> float:
+        self, instr: Pipette, ul_per_s: float, action: "UlPerMmAction"
+    ) -> float:
         mm_per_s = ul_per_s / instr.ul_per_mm(instr.config.max_volume, action)
         return round(mm_per_s, 6)
 
     def _plunger_flowrate(
-            self, instr: Pipette, mm_per_s: float,
-            action: 'UlPerMmAction') -> float:
+        self, instr: Pipette, mm_per_s: float, action: "UlPerMmAction"
+    ) -> float:
         ul_per_s = mm_per_s * instr.ul_per_mm(instr.config.max_volume, action)
         return round(ul_per_s, 6)
 
@@ -1391,17 +1493,19 @@ class API(HardwareAPILike):
         self._ready_for_tip_action(instruments, HardwareAction.BLOWOUT)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments}
+            for instr in instruments
+        }
         blow_out = tuple(instr[0].config.blow_out for instr in instruments)
 
         self._backend.set_active_current(plunger_currents)
-        speed = max(self._plunger_speed(
-            instr[0], instr[0].blow_out_flow_rate, 'dispense')
-            for instr in instruments)
+        speed = max(
+            self._plunger_speed(instr[0], instr[0].blow_out_flow_rate, "dispense")
+            for instr in instruments
+        )
         try:
             await self._move_plunger(mount, blow_out, speed=speed)
         except Exception:
-            self._log.exception('Blow out failed')
+            self._log.exception("Blow out failed")
             raise
         finally:
             for instr in instruments:
@@ -1409,13 +1513,14 @@ class API(HardwareAPILike):
                 instr[0].ready_to_aspirate = False
 
     @overload
-    def _instruments_for(
-        self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]: ...
+    def _instruments_for(self, mount: top_types.Mount) -> Tuple[PipetteHandlingData]:
+        ...
 
     @overload
     def _instruments_for(
-        self, mount: PipettePair) ->\
-        Tuple[PipetteHandlingData, PipetteHandlingData]: ...
+        self, mount: PipettePair
+    ) -> Tuple[PipetteHandlingData, PipetteHandlingData]:
+        ...
 
     def _instruments_for(self, mount):
         if isinstance(mount, PipettePair):
@@ -1427,39 +1532,45 @@ class API(HardwareAPILike):
         else:
             primary_mount = mount
             instr1 = self._attached_instruments[primary_mount]
-            return ((instr1, primary_mount), )
+            return ((instr1, primary_mount),)
 
     def _ready_for_pick_up_tip(self, targets: Sequence[PipetteHandlingData]):
         for pipettes in targets:
             if not pipettes[0]:
                 raise top_types.PipetteNotAttachedError(
-                    f'No pipette attached to {pipettes[1].name} mount')
+                    f"No pipette attached to {pipettes[1].name} mount"
+                )
             if pipettes[0].has_tip:
-                raise TipAttachedError(
-                    'Cannot pick up tip with a tip attached')
-            self._log.debug(f'Picking up tip on {pipettes[0].name}')
+                raise TipAttachedError("Cannot pick up tip with a tip attached")
+            self._log.debug(f"Picking up tip on {pipettes[0].name}")
 
     def _ready_for_tip_action(
-            self, targets: Sequence[PipetteHandlingData],
-            action: HardwareAction):
+        self, targets: Sequence[PipetteHandlingData], action: HardwareAction
+    ):
         for pipettes in targets:
             if not pipettes[0]:
                 raise top_types.PipetteNotAttachedError(
-                    f'No pipette attached to {pipettes[1].name} mount')
+                    f"No pipette attached to {pipettes[1].name} mount"
+                )
             if not pipettes[0].has_tip:
                 raise NoTipAttachedError(
-                    f'Cannot perform {action} without a tip attached')
-            if (action == HardwareAction.ASPIRATE and
-                pipettes[0].current_volume == 0 and
-                    not pipettes[0].ready_to_aspirate):
-                raise RuntimeError('Pipette not ready to aspirate')
-            self._log.debug(f'{action} on {pipettes[0].name}')
+                    f"Cannot perform {action} without a tip attached"
+                )
+            if (
+                action == HardwareAction.ASPIRATE
+                and pipettes[0].current_volume == 0
+                and not pipettes[0].ready_to_aspirate
+            ):
+                raise RuntimeError("Pipette not ready to aspirate")
+            self._log.debug(f"{action} on {pipettes[0].name}")
 
-    async def pick_up_tip(self,
-                          mount: Union[top_types.Mount, PipettePair],
-                          tip_length: float,
-                          presses: int = None,
-                          increment: float = None):
+    async def pick_up_tip(
+        self,
+        mount: Union[top_types.Mount, PipettePair],
+        tip_length: float,
+        presses: int = None,
+        increment: float = None,
+    ):
         """
         Pick up tip from current location.
 
@@ -1480,48 +1591,50 @@ class API(HardwareAPILike):
         self._ready_for_pick_up_tip(instruments)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments}
+            for instr in instruments
+        }
         z_axis_currents = {
             Axis.by_mount(instr[1]): instr[0].config.pick_up_current
-            for instr in instruments}
+            for instr in instruments
+        }
 
         self._backend.set_active_current(plunger_currents)
         # Initialize plunger to bottom position
-        bottom_positions = tuple(
-            instr[0].config.bottom for instr in instruments)
-        await self._move_plunger(
-            mount, bottom_positions)
+        bottom_positions = tuple(instr[0].config.bottom for instr in instruments)
+        await self._move_plunger(mount, bottom_positions)
 
         if not presses or presses < 0:
             all_presses = tuple(
-                instr[0].config.pick_up_presses for instr in instruments)
+                instr[0].config.pick_up_presses for instr in instruments
+            )
             if len(all_presses) > 1 and all_presses[0] != all_presses[1]:
                 raise PairedPipetteConfigValueError(
-                    "Number of pipette pickups must match")
+                    "Number of pipette pickups must match"
+                )
             checked_presses = all_presses[0]
         else:
             checked_presses = presses
 
         if not increment or increment < 0:
             check_incr = tuple(
-                instr[0].config.pick_up_increment for instr in instruments)
+                instr[0].config.pick_up_increment for instr in instruments
+            )
         else:
             check_incr = tuple(increment for instr in instruments)
 
-        pick_up_speed = min(
-            instr[0].config.pick_up_speed for instr in instruments)
+        pick_up_speed = min(instr[0].config.pick_up_speed for instr in instruments)
         # Press the nozzle into the tip <presses> number of times,
         # moving further by <increment> mm after each press
         for i in range(checked_presses):
             # move nozzle down into the tip
             with self._backend.save_current():
                 self._backend.set_active_current(z_axis_currents)
-                dist = tuple(-1.0 * instr[0].config.pick_up_distance
-                             + -1.0 * incrt * i
-                             for instr, incrt in zip(instruments, check_incr))
+                dist = tuple(
+                    -1.0 * instr[0].config.pick_up_distance + -1.0 * incrt * i
+                    for instr, incrt in zip(instruments, check_incr)
+                )
                 target_pos = (0, 0, *dist)
-                await self._move_relative_n_axes(
-                    mount, target_pos, pick_up_speed)
+                await self._move_relative_n_axes(mount, target_pos, pick_up_speed)
 
             # move nozzle back up
             backup_pos = (0, 0, *tuple(-d for d in dist))
@@ -1533,45 +1646,46 @@ class API(HardwareAPILike):
         # neighboring tips tend to get stuck in the space between
         # the volume chamber and the drop-tip sleeve on p1000.
         # This extra shake ensures those tips are removed
-        if any(['pickupTipShake' in instr[0].config.quirks
-                for instr in instruments]):
+        if any(["pickupTipShake" in instr[0].config.quirks for instr in instruments]):
             await self._shake_off_tips_pick_up(mount)
             await self._shake_off_tips_pick_up(mount)
 
         # Here we add in the debounce distance for the switch as
         # a safety precaution
-        retract_target = max(instr[0].config.pick_up_distance
-                             + incrt * checked_presses + 2
-                             for instr, incrt in zip(instruments, check_incr))
+        retract_target = max(
+            instr[0].config.pick_up_distance + incrt * checked_presses + 2
+            for instr, incrt in zip(instruments, check_incr)
+        )
 
         await self.retract(mount, retract_target)
 
     def set_current_tiprack_diameter(
-            self, mount: Union[top_types.Mount, PipettePair],
-            tiprack_diameter: float):
+        self, mount: Union[top_types.Mount, PipettePair], tiprack_diameter: float
+    ):
         instruments = self._instruments_for(mount)
         for instr in instruments:
             assert instr[0]
             self._log.info(
                 "Updating tip rack diameter on pipette mount: "
-                f"{instr[1]}, tip diameter: {tiprack_diameter} mm")
+                f"{instr[1]}, tip diameter: {tiprack_diameter} mm"
+            )
             instr[0].current_tiprack_diameter = tiprack_diameter
 
     def set_working_volume(
-            self, mount: Union[top_types.Mount, PipettePair],
-            tip_volume: int):
+        self, mount: Union[top_types.Mount, PipettePair], tip_volume: int
+    ):
         instruments = self._instruments_for(mount)
         for instr in instruments:
             assert instr[0]
             self._log.info(
                 "Updating working volume on pipette mount:"
-                f"{instr[1]}, tip volume: {tip_volume} ul")
+                f"{instr[1]}, tip volume: {tip_volume} ul"
+            )
             instr[0].working_volume = tip_volume
 
     async def drop_tip(
-            self,
-            mount: Union[top_types.Mount, PipettePair],
-            home_after=True):
+        self, mount: Union[top_types.Mount, PipettePair], home_after=True
+    ):
         """
         Drop tip at the current location
 
@@ -1586,12 +1700,15 @@ class API(HardwareAPILike):
         self._ready_for_tip_action(instruments, HardwareAction.DROPTIP)
         plunger_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.plunger_current
-            for instr in instruments}
+            for instr in instruments
+        }
         drop_tip_currents = {
             Axis.of_plunger(instr[1]): instr[0].config.drop_tip_current
-            for instr in instruments}
+            for instr in instruments
+        }
         plunger_axes = tuple(
-            Axis.of_plunger(instr[1]).name.upper() for instr in instruments)
+            Axis.of_plunger(instr[1]).name.upper() for instr in instruments
+        )
 
         bottom = tuple(instr[0].config.bottom for instr in instruments)
         droptip = tuple(instr[0].config.drop_tip for instr in instruments)
@@ -1601,27 +1718,22 @@ class API(HardwareAPILike):
             self._backend.set_active_current(plunger_currents)
             await self._move_plunger(mount, bottom)
             self._backend.set_active_current(drop_tip_currents)
-            await self._move_plunger(
-                mount, droptip, speed=speed)
+            await self._move_plunger(mount, droptip, speed=speed)
             if home_after:
                 safety_margin = abs(max(bottom) - max(droptip))
                 smoothie_pos = await self._backend.fast_home(
-                    plunger_axes, safety_margin)
-                self._current_position = self._deck_from_smoothie(
-                    smoothie_pos)
+                    plunger_axes, safety_margin
+                )
+                self._current_position = self._deck_from_smoothie(smoothie_pos)
                 self._backend.set_active_current(plunger_currents)
                 await self._move_plunger(mount, bottom)
 
-        if any(['doubleDropTip' in instr[0].config.quirks
-                for instr in instruments]):
+        if any(["doubleDropTip" in instr[0].config.quirks for instr in instruments]):
             await _drop_tip()
         await _drop_tip()
 
-        if any(['dropTipShake' in instr[0].config.quirks
-                for instr in instruments]):
-            diameter = min(
-                instr[0].current_tiprack_diameter
-                for instr in instruments)
+        if any(["dropTipShake" in instr[0].config.quirks for instr in instruments]):
+            diameter = min(instr[0].current_tiprack_diameter for instr in instruments)
             await self._shake_off_tips_drop(mount, diameter)
         self._backend.set_active_current(plunger_currents)
         for instr in instruments:
@@ -1641,7 +1753,7 @@ class API(HardwareAPILike):
 
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # move left
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)    # move right
+        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)  # move right
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # original position
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
@@ -1649,9 +1761,7 @@ class API(HardwareAPILike):
         up_pos = top_types.Point(0, 0, DROP_TIP_RELEASE_DISTANCE)
         await self.move_rel(mount, up_pos)
 
-    async def _shake_off_tips_pick_up(
-            self,
-            mount: Union[top_types.Mount, PipettePair]):
+    async def _shake_off_tips_pick_up(self, mount: Union[top_types.Mount, PipettePair]):
         # tips don't always fall off, especially if resting against
         # tiprack or other tips below it. To ensure the tip has fallen
         # first, shake the pipette to dislodge partially-sealed tips,
@@ -1660,13 +1770,13 @@ class API(HardwareAPILike):
 
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # move left
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)    # move right
+        shake_pos = top_types.Point(2 * shake_off_dist, 0, 0)  # move right
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(-shake_off_dist, 0, 0)  # original position
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(0, -shake_off_dist, 0)  # move front
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
-        shake_pos = top_types.Point(0, 2 * shake_off_dist, 0)    # move back
+        shake_pos = top_types.Point(0, 2 * shake_off_dist, 0)  # move back
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
         shake_pos = top_types.Point(0, -shake_off_dist, 0)  # original position
         await self.move_rel(mount, shake_pos, speed=SHAKE_OFF_TIPS_SPEED)
@@ -1675,18 +1785,24 @@ class API(HardwareAPILike):
         await self.move_rel(mount, up_pos)
 
     async def find_modules(
-            self, by_model: modules.types.ModuleModel,
-            resolved_type: modules.types.ModuleType
-            ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
+        self,
+        by_model: modules.types.ModuleModel,
+        resolved_type: modules.types.ModuleType,
+    ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
         modules_result = await self._backend.module_controls.parse_modules(
-            by_model, resolved_type)
+            by_model, resolved_type
+        )
         return modules_result
 
     # Pipette config api
-    def calibrate_plunger(self,
-                          mount: top_types.Mount,
-                          top: float = None, bottom: float = None,
-                          blow_out: float = None, drop_tip: float = None):
+    def calibrate_plunger(
+        self,
+        mount: top_types.Mount,
+        top: float = None,
+        bottom: float = None,
+        blow_out: float = None,
+        drop_tip: float = None,
+    ):
         """
         Set calibration values for the pipette plunger.
         This can be called multiple times as the user sets each value,
@@ -1701,30 +1817,32 @@ class API(HardwareAPILike):
         instr = self._attached_instruments[mount]
         if not instr:
             raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount.name))
+                "No pipette attached to {} mount".format(mount.name)
+            )
 
         pos_dict: Dict = {
-            'top': instr.config.top,
-            'bottom': instr.config.bottom,
-            'blow_out': instr.config.blow_out,
-            'drop_tip': instr.config.drop_tip}
+            "top": instr.config.top,
+            "bottom": instr.config.bottom,
+            "blow_out": instr.config.blow_out,
+            "drop_tip": instr.config.drop_tip,
+        }
         if top is not None:
-            pos_dict['top'] = top
+            pos_dict["top"] = top
         if bottom is not None:
-            pos_dict['bottom'] = bottom
+            pos_dict["bottom"] = bottom
         if blow_out is not None:
-            pos_dict['blow_out'] = blow_out
+            pos_dict["blow_out"] = blow_out
         if bottom is not None:
-            pos_dict['drop_tip'] = drop_tip
+            pos_dict["drop_tip"] = drop_tip
         for key in pos_dict.keys():
             instr.update_config_item(key, pos_dict[key])
 
-    def set_flow_rate(self, mount,
-                      aspirate=None, dispense=None, blow_out=None):
+    def set_flow_rate(self, mount, aspirate=None, dispense=None, blow_out=None):
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
             raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount))
+                "No pipette attached to {} mount".format(mount)
+            )
         if aspirate:
             this_pipette.aspirate_flow_rate = aspirate
         if dispense:
@@ -1732,26 +1850,28 @@ class API(HardwareAPILike):
         if blow_out:
             this_pipette.blow_out_flow_rate = blow_out
 
-    def set_pipette_speed(self, mount,
-                          aspirate=None, dispense=None, blow_out=None):
+    def set_pipette_speed(self, mount, aspirate=None, dispense=None, blow_out=None):
         this_pipette = self._attached_instruments[mount]
         if not this_pipette:
             raise top_types.PipetteNotAttachedError(
-                "No pipette attached to {} mount".format(mount))
+                "No pipette attached to {} mount".format(mount)
+            )
         if aspirate:
             this_pipette.aspirate_flow_rate = self._plunger_flowrate(
-                this_pipette, aspirate, 'aspirate')
+                this_pipette, aspirate, "aspirate"
+            )
         if dispense:
             this_pipette.dispense_flow_rate = self._plunger_flowrate(
-                this_pipette, dispense, 'dispense')
+                this_pipette, dispense, "dispense"
+            )
         if blow_out:
             this_pipette.blow_out_flow_rate = self._plunger_flowrate(
-                this_pipette, blow_out, 'dispense')
+                this_pipette, blow_out, "dispense"
+            )
 
     def get_instrument_max_height(
-            self,
-            mount: top_types.Mount,
-            critical_point: CriticalPoint = None) -> float:
+        self, mount: top_types.Mount, critical_point: CriticalPoint = None
+    ) -> float:
         """Return max achievable height of the attached instrument
         based on the current critical point
         """
@@ -1759,11 +1879,10 @@ class API(HardwareAPILike):
         assert pip
         cp = self._critical_point_for(mount, critical_point)
 
-        max_height = pip.config.home_position - \
-            self._config.z_retract_distance + cp.z
+        max_height = pip.config.home_position - self._config.z_retract_distance + cp.z
 
         return max_height
 
     def clean_up(self):
-        """ Get the API ready to stop cleanly. """
+        """Get the API ready to stop cleanly."""
         self._backend.clean_up()

--- a/api/src/opentrons/hardware_control/controller.py
+++ b/api/src/opentrons/hardware_control/controller.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager, ExitStack
 import logging
-from typing import (Any, Dict, List, Optional, Tuple,
-                    TYPE_CHECKING, Union, Sequence)
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union, Sequence
 from typing_extensions import Final
+
 try:
     import aionotify  # type: ignore
 except (OSError, ModuleNotFoundError):
@@ -21,40 +21,38 @@ from .module_control import AttachedModulesControl
 from .types import AionotifyEvent, BoardRevision, Axis
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import (
-        PipetteModel, PipetteName
-    )
+    from opentrons_shared_data.pipette.dev_types import PipetteModel, PipetteName
     from .dev_types import (
-        AttachedInstrument, AttachedInstruments,
-        InstrumentHardwareConfigs)
-    from opentrons.drivers.rpi_drivers.dev_types\
-        import GPIODriverLike
+        AttachedInstrument,
+        AttachedInstruments,
+        InstrumentHardwareConfigs,
+    )
+    from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 class Controller:
-    """ The concrete instance of the controller for actually controlling
+    """The concrete instance of the controller for actually controlling
     hardware.
     """
 
     @classmethod
-    async def build(
-            cls, config: RobotConfig) -> Controller:
-        """ Build a Controller instance.
+    async def build(cls, config: RobotConfig) -> Controller:
+        """Build a Controller instance.
 
         Use this factory method rather than the initializer to handle proper
         GPIO initialization.
 
         :param config: A loaded robot config.
         """
-        gpio = build_gpio_chardev('gpiochip0')
+        gpio = build_gpio_chardev("gpiochip0")
         gpio.config_by_board_rev()
         await gpio.setup()
         return cls(config, gpio)
 
     def __init__(self, config: RobotConfig, gpio: GPIODriverLike):
-        """ Build a Controller instance.
+        """Build a Controller instance.
 
         Always prefer using :py:meth:`.build` to create an instance of this class. For
         more information on arguments, see that method. If you want to use this
@@ -62,12 +60,13 @@ class Controller:
         """
         if not opentrons.config.IS_ROBOT:
             MODULE_LOG.warning(
-                'This is intended to run on a robot, and while it can connect '
-                'to a smoothie via a usb/serial adapter unexpected things '
-                'using gpios (such as smoothie reset or light management) '
-                'will fail. If you are seeing this message and you are '
-                'running on a robot, you need to set the RUNNING_ON_PI '
-                'environmental variable to 1.')
+                "This is intended to run on a robot, and while it can connect "
+                "to a smoothie via a usb/serial adapter unexpected things "
+                "using gpios (such as smoothie reset or light management) "
+                "will fail. If you are seeing this message and you are "
+                "running on a robot, you need to set the RUNNING_ON_PI "
+                "environmental variable to 1."
+            )
 
         self.config = config or opentrons.config.robot_configs.load()
 
@@ -84,16 +83,18 @@ class Controller:
             self._event_watcher = self._build_event_watcher()
         except AttributeError:
             MODULE_LOG.warning(
-                'Failed to initiate aionotify, cannot watch modules '
-                'or door, likely because not running on linux')
+                "Failed to initiate aionotify, cannot watch modules "
+                "or door, likely because not running on linux"
+            )
 
     @staticmethod
     def _build_event_watcher():
         watcher = aionotify.Watcher()
         watcher.watch(
-            alias='modules',
-            path='/dev',
-            flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE))
+            alias="modules",
+            path="/dev",
+            flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE),
+        )
         return watcher
 
     @property
@@ -107,7 +108,7 @@ class Controller:
     @property
     def module_controls(self) -> AttachedModulesControl:
         if not self._module_controls:
-            raise AttributeError('Module controls not found.')
+            raise AttributeError("Module controls not found.")
         return self._module_controls
 
     @module_controls.setter
@@ -121,69 +122,71 @@ class Controller:
         await self._smoothie_driver.update_position()
         return self._smoothie_driver.position
 
-    async def move(self, target_position: Dict[str, float],
-                   home_flagged_axes: bool = True, speed: float = None,
-                   axis_max_speeds: Dict[str, float] = None):
+    async def move(
+        self,
+        target_position: Dict[str, float],
+        home_flagged_axes: bool = True,
+        speed: float = None,
+        axis_max_speeds: Dict[str, float] = None,
+    ):
         with ExitStack() as cmstack:
             if axis_max_speeds:
                 cmstack.enter_context(
-                    self._smoothie_driver.restore_axis_max_speed(
-                        axis_max_speeds))
+                    self._smoothie_driver.restore_axis_max_speed(axis_max_speeds)
+                )
             await self._smoothie_driver.move(
-                target_position, home_flagged_axes=home_flagged_axes,
-                speed=speed)
+                target_position, home_flagged_axes=home_flagged_axes, speed=speed
+            )
 
     async def home(self, axes: List[str] = None) -> Dict[str, float]:
         if axes:
-            args: Tuple[Any, ...] = (''.join(axes),)
+            args: Tuple[Any, ...] = ("".join(axes),)
         else:
             args = tuple()
         return await self._smoothie_driver.home(*args)
 
-    async def fast_home(
-            self, axes: Sequence[str],
-            margin: float) -> Dict[str, float]:
-        converted_axes = ''.join(axes)
+    async def fast_home(self, axes: Sequence[str], margin: float) -> Dict[str, float]:
+        converted_axes = "".join(axes)
         return await self._smoothie_driver.fast_home(converted_axes, margin)
 
     async def _query_mount(
-            self,
-            mount: Mount,
-            expected: Union[PipetteModel, PipetteName, None]
+        self, mount: Mount, expected: Union[PipetteModel, PipetteName, None]
     ) -> AttachedInstrument:
-        found_model: Optional[PipetteModel]\
-            = await self._smoothie_driver.read_pipette_model(  # type: ignore
-            mount.name.lower())
+        found_model: Optional[
+            PipetteModel
+        ] = await self._smoothie_driver.read_pipette_model(  # type: ignore
+            mount.name.lower()
+        )
         if found_model and found_model not in pipette_config.config_models:
             # TODO: Consider how to handle this error - it bubbles up now
             # and will cause problems at higher levels
-            MODULE_LOG.error(
-                f'Bad model on {mount.name}: {found_model}')
+            MODULE_LOG.error(f"Bad model on {mount.name}: {found_model}")
             found_model = None
-        found_id = await self._smoothie_driver.read_pipette_id(
-            mount.name.lower())
+        found_id = await self._smoothie_driver.read_pipette_id(mount.name.lower())
 
         if found_model:
             config = pipette_config.load(found_model, found_id)
             if expected:
                 acceptable = [config.name] + config.back_compat_names
                 if expected not in acceptable:
-                    raise RuntimeError(f'mount {mount}: instrument'
-                                       f' {expected} was requested'
-                                       f' but {config.model} is present')
-            return {'config': config,
-                    'id': found_id}
+                    raise RuntimeError(
+                        f"mount {mount}: instrument"
+                        f" {expected} was requested"
+                        f" but {config.model} is present"
+                    )
+            return {"config": config, "id": found_id}
         else:
             if expected:
                 raise RuntimeError(
-                    f'mount {mount}: instrument {expected} was'
-                    f' requested, but no instrument is present')
-            return {'config': None, 'id': None}
+                    f"mount {mount}: instrument {expected} was"
+                    f" requested, but no instrument is present"
+                )
+            return {"config": None, "id": None}
 
     async def get_attached_instruments(
-            self, expected: Dict[Mount, PipetteName])\
-            -> AttachedInstruments:
-        """ Find the instruments attached to our mounts.
+        self, expected: Dict[Mount, PipetteName]
+    ) -> AttachedInstruments:
+        """Find the instruments attached to our mounts.
         :param expected: is ignored, it is just meant to enforce
                           the same interface as the simulator, where
                           required instruments can be manipulated.
@@ -194,8 +197,10 @@ class Controller:
             attached to that mount, or `None`). Both mounts will always be
             specified.
         """
-        return {mount: await self._query_mount(mount, expected.get(mount))
-                for mount in Mount}
+        return {
+            mount: await self._query_mount(mount, expected.get(mount))
+            for mount in Mount
+        }
 
     def set_active_current(self, axis_currents: Dict[Axis, float]):
         """
@@ -204,7 +209,8 @@ class Controller:
         pipette axis to a low current (dwelling current) after each move
         """
         self._smoothie_driver.set_active_current(
-            {axis.name: amp for axis, amp in axis_currents.items()})
+            {axis.name: amp for axis, amp in axis_currents.items()}
+        )
 
     @contextmanager
     def save_current(self):
@@ -221,7 +227,7 @@ class Controller:
             MODULE_LOG.debug("incomplete read error when quitting watcher")
             return
         if event is not None:
-            if 'ot_module' in event.name:
+            if "ot_module" in event.name:
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)
@@ -242,10 +248,12 @@ class Controller:
 
     @property
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
-        """ The (minimum, maximum) bounds for each axis. """
-        return {Axis[ax]: (0, pos) for ax, pos
-                in self._smoothie_driver.axis_bounds.items()
-                if ax not in 'BC'}
+        """The (minimum, maximum) bounds for each axis."""
+        return {
+            Axis[ax]: (0, pos)
+            for ax, pos in self._smoothie_driver.axis_bounds.items()
+            if ax not in "BC"
+        }
 
     @property
     def fw_version(self) -> Optional[str]:
@@ -254,12 +262,10 @@ class Controller:
     async def update_fw_version(self):
         self._cached_fw_version = await self._smoothie_driver.get_fw_version()
 
-    async def update_firmware(self,
-                              filename: str,
-                              loop: asyncio.AbstractEventLoop,
-                              modeset: bool) -> str:
-        msg = await self._smoothie_driver.update_firmware(
-            filename, loop, modeset)
+    async def update_firmware(
+        self, filename: str, loop: asyncio.AbstractEventLoop, modeset: bool
+    ) -> str:
+        msg = await self._smoothie_driver.update_firmware(filename, loop, modeset)
         await self.update_fw_version()
         return msg
 
@@ -267,7 +273,7 @@ class Controller:
         return self._smoothie_driver.engaged_axes
 
     async def disengage_axes(self, axes: List[str]) -> None:
-        await self._smoothie_driver.disengage_axis(''.join(axes))
+        await self._smoothie_driver.disengage_axis("".join(axes))
 
     def set_lights(self, button: Optional[bool], rails: Optional[bool]):
         if button is not None:
@@ -277,8 +283,8 @@ class Controller:
 
     def get_lights(self) -> Dict[str, bool]:
         return {
-            'button': self.gpio_chardev.get_button_light()[2],
-            'rails': self.gpio_chardev.get_rail_lights()
+            "button": self.gpio_chardev.get_button_light()[2],
+            "rails": self.gpio_chardev.get_rail_lights(),
         }
 
     def pause(self):
@@ -294,8 +300,7 @@ class Controller:
         await self._smoothie_driver.hard_halt()
 
     async def probe(self, axis: str, distance: float) -> Dict[str, float]:
-        """ Run a probe and return the new position dict
-        """
+        """Run a probe and return the new position dict"""
         return await self._smoothie_driver.probe_axis(axis, distance)
 
     def clean_up(self):
@@ -303,10 +308,10 @@ class Controller:
             loop = asyncio.get_event_loop()
         except RuntimeError:
             return
-        if hasattr(self, '_event_watcher'):
+        if hasattr(self, "_event_watcher"):
             if loop.is_running() and self._event_watcher:
                 self._event_watcher.close()
-        if hasattr(self, 'gpio_chardev'):
+        if hasattr(self, "gpio_chardev"):
             try:
                 if not loop.is_closed():
                     self.gpio_chardev.stop_door_switch_watcher(loop)
@@ -314,23 +319,26 @@ class Controller:
                 pass
 
     async def configure_mount(
-            self, mount: Mount, config: InstrumentHardwareConfigs
+        self, mount: Mount, config: InstrumentHardwareConfigs
     ) -> None:
         mount_axis = Axis.by_mount(mount)
         plunger_axis = Axis.of_plunger(mount)
 
         await self._smoothie_driver.update_steps_per_mm(
-            {plunger_axis.name: config['steps_per_mm']})
+            {plunger_axis.name: config["steps_per_mm"]}
+        )
         await self._smoothie_driver.update_pipette_config(
-            mount_axis.name, {'home': config['home_pos']})
+            mount_axis.name, {"home": config["home_pos"]}
+        )
         await self._smoothie_driver.update_pipette_config(
-            plunger_axis.name, {'max_travel': config['max_travel']})
+            plunger_axis.name, {"max_travel": config["max_travel"]}
+        )
         self._smoothie_driver.set_dwelling_current(
-            {plunger_axis.name: config['idle_current']})
-        ms = config['splits']
+            {plunger_axis.name: config["idle_current"]}
+        )
+        ms = config["splits"]
         if ms:
-            self._smoothie_driver.configure_splits_for(
-                {plunger_axis.name: ms})
+            self._smoothie_driver.configure_splits_for({plunger_axis.name: ms})
 
     def __del__(self):
         self.clean_up()

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 # this file defines types that require dev dependencies
 # and are only relevant for static typechecking. this file should only
 # be imported if typing.TYPE_CHECKING is True
@@ -8,7 +9,9 @@ from typing import Optional, Dict, Union
 from typing_extensions import Protocol, TypedDict, Literal
 
 from opentrons_shared_data.pipette.dev_types import (
-    PipetteModel, PipetteName, ChannelCount
+    PipetteModel,
+    PipetteName,
+    ChannelCount,
 )
 
 from opentrons.drivers.types import MoveSplit
@@ -66,7 +69,7 @@ class PipetteDict(TypedDict):
     return_tip_height: float
     default_aspirate_flow_rates: Dict[str, float]
     default_dispense_flow_rates: Dict[str, float]
-    default_blow_out_flow_rates: Dict[str,  float]
+    default_blow_out_flow_rates: Dict[str, float]
     default_aspirate_speeds: Dict[str, float]
     default_dispense_speeds: Dict[str, float]
     default_blow_out_speeds: Dict[str, float]

--- a/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
+++ b/api/src/opentrons/hardware_control/emulation/abstract_emulator.py
@@ -13,9 +13,9 @@ class AbstractEmulator(ABC):
     @staticmethod
     def get_terminator() -> bytes:
         """Get the command terminator for messages coming from PI."""
-        return b'\r\n\r\n'
+        return b"\r\n\r\n"
 
     @staticmethod
     def get_ack() -> bytes:
         """Get the command ack send to the PI."""
-        return b'ok\r\nok\r\n'
+        return b"ok\r\nok\r\n"

--- a/api/src/opentrons/hardware_control/emulation/app.py
+++ b/api/src/opentrons/hardware_control/emulation/app.py
@@ -1,13 +1,13 @@
 import asyncio
 import logging
-from opentrons.hardware_control.emulation.connection_handler import \
-    ConnectionHandler
+from opentrons.hardware_control.emulation.connection_handler import ConnectionHandler
 from opentrons.hardware_control.emulation.magdeck import MagDeckEmulator
 from opentrons.hardware_control.emulation.parser import Parser
 from opentrons.hardware_control.emulation.settings import Settings
 from opentrons.hardware_control.emulation.tempdeck import TempDeckEmulator
 from opentrons.hardware_control.emulation.thermocycler import ThermocyclerEmulator
 from opentrons.hardware_control.emulation.smoothie import SmoothieEmulator
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,6 +21,7 @@ class ServerManager:
     """
     Class to start and stop emulated smoothie and modules.
     """
+
     def __init__(self, settings=Settings()) -> None:
         host = settings.host
         self._mag_emulator = MagDeckEmulator(parser=Parser())
@@ -56,7 +57,7 @@ class ServerManager:
             self._mag_server,
             self._temp_server,
             self._therm_server,
-            self._smoothie_server
+            self._smoothie_server,
         )
 
     @staticmethod
@@ -81,5 +82,5 @@ class ServerManager:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format='%(asctime)s:%(message)s', level=logging.DEBUG)
+    logging.basicConfig(format="%(asctime)s:%(message)s", level=logging.DEBUG)
     asyncio.run(ServerManager().run())

--- a/api/src/opentrons/hardware_control/emulation/connection_handler.py
+++ b/api/src/opentrons/hardware_control/emulation/connection_handler.py
@@ -15,8 +15,9 @@ class ConnectionHandler:
         """Construct with an emulator."""
         self._emulator = emulator
 
-    async def __call__(self, reader: asyncio.StreamReader,
-                       writer: asyncio.StreamWriter) -> None:
+    async def __call__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         """New connection callback."""
         emulator_name = self._emulator.__class__.__name__
         logger.debug("%s Connected.", emulator_name)
@@ -26,12 +27,12 @@ class ConnectionHandler:
             try:
                 response = self._emulator.handle(line.decode().strip())
                 if response:
-                    response = f'{response}\r\n'
+                    response = f"{response}\r\n"
                     logger.debug("%s Sending: %s", emulator_name, response)
                     writer.write(response.encode())
             except Exception as e:
                 logger.exception("%s exception", emulator_name)
-                writer.write(f'Error: {str(e)}\r\n'.encode())
+                writer.write(f"Error: {str(e)}\r\n".encode())
 
             writer.write(self._emulator.get_ack())
             await writer.drain()

--- a/api/src/opentrons/hardware_control/emulation/magdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/magdeck.py
@@ -27,7 +27,7 @@ class MagDeckEmulator(AbstractEmulator):
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
-        joined = ' '.join(r for r in results if r)
+        joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
     def reset(self):
@@ -40,7 +40,7 @@ class MagDeckEmulator(AbstractEmulator):
         if command.gcode == GCODE.HOME:
             self.height = 0
         elif command.gcode == GCODE.MOVE:
-            position = command.params['Z']
+            position = command.params["Z"]
             assert isinstance(position, float), f"invalid position '{position}'"
             self.position = position
         elif command.gcode == GCODE.PROBE_PLATE:

--- a/api/src/opentrons/hardware_control/emulation/parser.py
+++ b/api/src/opentrons/hardware_control/emulation/parser.py
@@ -35,8 +35,8 @@ class Parser:
         for i in self.GCODE_RE.finditer(line):
             if previous:
                 yield self._create_command(
-                    line[previous.start(): previous.end()],
-                    line[previous.end(): i.start()]
+                    line[previous.start() : previous.end()],
+                    line[previous.end() : i.start()],
                 )
             else:
                 # This is the first match. It better be at the beginning or
@@ -47,8 +47,7 @@ class Parser:
         if previous:
             # Create command from final GCODE and remainder of the line.
             yield self._create_command(
-                line[previous.start(): previous.end()],
-                line[previous.end():]
+                line[previous.start() : previous.end()], line[previous.end() :]
             )
         elif line:
             # There are no GCODEs and it's a non-empty line.
@@ -70,6 +69,6 @@ class Parser:
             gcode=gcode,
             body=body.strip(),
             params={
-                p['prefix']: float(p['number']) if p['number'] else None for p in pars
-            }
+                p["prefix"]: float(p["number"]) if p["number"] else None for p in pars
+            },
         )

--- a/api/src/opentrons/hardware_control/emulation/simulations.py
+++ b/api/src/opentrons/hardware_control/emulation/simulations.py
@@ -54,11 +54,12 @@ class Temperature(Simulation):
 
 class TemperatureWithHold(Temperature):
     """A model with a current, target temperature and hold time. The current
-     temperate is always moving towards the target.
+    temperate is always moving towards the target.
 
-     When the current temperature is within close enough from target the hold time
-     decrements once per tick.
+    When the current temperature is within close enough from target the hold time
+    decrements once per tick.
     """
+
     def __init__(self, per_tick: float, current: float) -> None:
         """Construct a temperature with hold simulation."""
         super().__init__(per_tick=per_tick, current=current)

--- a/api/src/opentrons/hardware_control/emulation/smoothie.py
+++ b/api/src/opentrons/hardware_control/emulation/smoothie.py
@@ -32,30 +32,24 @@ class SmoothieEmulator(AbstractEmulator):
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
-        joined = ' '.join(r for r in results if r)
+        joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
     def reset(self):
         _, fw_version = _find_smoothie_file()
-        self._version_string = \
-            f"Build version: {fw_version}, Build date: CURRENT, " \
+        self._version_string = (
+            f"Build version: {fw_version}, Build date: CURRENT, "
             f"MCU: NONE, System Clock: NONE"
+        )
 
-        self._pos = {
-            'A': 0.0,
-            'B': 0.0,
-            'C': 0.0,
-            'X': 0.0,
-            'Y': 0.0,
-            'Z': 0.0
-        }
+        self._pos = {"A": 0.0, "B": 0.0, "C": 0.0, "X": 0.0, "Y": 0.0, "Z": 0.0}
         self._home_status: Dict[str, bool] = {
-            'X': False,
-            'Y': False,
-            'Z': False,
-            'A': False,
-            'B': False,
-            'C': False,
+            "X": False,
+            "Y": False,
+            "Z": False,
+            "A": False,
+            "B": False,
+            "C": False,
         }
         self._speed = 0.0
 
@@ -139,7 +133,7 @@ class SmoothieEmulator(AbstractEmulator):
         """Moves the gantry to the position provided in the command"""
         for key, value in command.params.items():
             assert isinstance(value, float), f"invalid value '{value}'"
-            if 'F' == key:
+            if "F" == key:
                 self._speed = value
             else:
                 self._pos[key] = value
@@ -171,12 +165,14 @@ class SmoothieEmulator(AbstractEmulator):
         Returns:
             A dict of L and/or R to the string value following it.
         """
-        pars = (i.groupdict() for i in
-                SmoothieEmulator.WRITE_INSTRUMENT_RE.finditer(command.body))
+        pars = (
+            i.groupdict()
+            for i in SmoothieEmulator.WRITE_INSTRUMENT_RE.finditer(command.body)
+        )
         result = {
-            p['mount']: p['value'] + '0' * (
-                SmoothieEmulator.INSTRUMENT_AND_MODEL_STRING_LENGTH - len(p['value'])
-            )
+            p["mount"]: p["value"]
+            + "0"
+            * (SmoothieEmulator.INSTRUMENT_AND_MODEL_STRING_LENGTH - len(p["value"]))
             for p in pars
         }
 

--- a/api/src/opentrons/hardware_control/emulation/tempdeck.py
+++ b/api/src/opentrons/hardware_control/emulation/tempdeck.py
@@ -32,26 +32,27 @@ class TempDeckEmulator(AbstractEmulator):
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
-        joined = ' '.join(r for r in results if r)
+        joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
     def reset(self):
-        self._temperature = Temperature(
-            per_tick=.25, current=0.0
-        )
+        self._temperature = Temperature(per_tick=0.25, current=0.0)
 
     def _handle(self, command: Command) -> Optional[str]:
         """Handle a command."""
         logger.info(f"Got command {command}")
         if command.gcode == GCODE.GET_TEMP:
-            res = f"T:{util.OptionalValue(self._temperature.target)} " \
-                  f"C:{self._temperature.current}"
+            res = (
+                f"T:{util.OptionalValue(self._temperature.target)} "
+                f"C:{self._temperature.current}"
+            )
             self._temperature.tick()
             return res
         elif command.gcode == GCODE.SET_TEMP:
-            temperature = command.params['S']
-            assert isinstance(temperature, float),\
-                f"invalid temperature '{temperature}'"
+            temperature = command.params["S"]
+            assert isinstance(
+                temperature, float
+            ), f"invalid temperature '{temperature}'"
             self._temperature.set_target(temperature)
         elif command.gcode == GCODE.DISENGAGE:
             self._temperature.deactivate(util.TEMPERATURE_ROOM)

--- a/api/src/opentrons/hardware_control/emulation/thermocycler.py
+++ b/api/src/opentrons/hardware_control/emulation/thermocycler.py
@@ -31,13 +31,11 @@ class ThermocyclerEmulator(AbstractEmulator):
     def handle(self, line: str) -> Optional[str]:
         """Handle a line"""
         results = (self._handle(c) for c in self._parser.parse(line))
-        joined = ' '.join(r for r in results if r)
+        joined = " ".join(r for r in results if r)
         return None if not joined else joined
 
     def reset(self):
-        self._lid_temperate = Temperature(
-            per_tick=2, current=util.TEMPERATURE_ROOM
-        )
+        self._lid_temperate = Temperature(per_tick=2, current=util.TEMPERATURE_ROOM)
         self._plate_temperate = TemperatureWithHold(
             per_tick=2, current=util.TEMPERATURE_ROOM
         )
@@ -59,14 +57,17 @@ class ThermocyclerEmulator(AbstractEmulator):
         elif command.gcode == GCODE.GET_LID_STATUS:
             return f"Lid:{self.lid_status}"
         elif command.gcode == GCODE.SET_LID_TEMP:
-            temperature = command.params['S']
-            assert isinstance(temperature, float),\
-                f"invalid temperature '{temperature}'"
+            temperature = command.params["S"]
+            assert isinstance(
+                temperature, float
+            ), f"invalid temperature '{temperature}'"
             self._lid_temperate.set_target(temperature)
         elif command.gcode == GCODE.GET_LID_TEMP:
-            res = f"T:{util.OptionalValue(self._lid_temperate.target)} " \
-                  f"C:{self._lid_temperate.current} " \
-                  f"H:none Total_H:none"
+            res = (
+                f"T:{util.OptionalValue(self._lid_temperate.target)} "
+                f"C:{self._lid_temperate.current} "
+                f"H:none Total_H:none"
+            )
             self._lid_temperate.tick()
             return res
         elif command.gcode == GCODE.EDIT_PID_PARAMS:
@@ -74,11 +75,11 @@ class ThermocyclerEmulator(AbstractEmulator):
         elif command.gcode == GCODE.SET_PLATE_TEMP:
             for prefix, value in command.params.items():
                 assert isinstance(value, float), f"invalid value '{value}'"
-                if prefix == 'S':
+                if prefix == "S":
                     self._plate_temperate.set_target(value)
-                elif prefix == 'V':
+                elif prefix == "V":
                     self.plate_volume.val = value
-                elif prefix == 'H':
+                elif prefix == "H":
                     self._plate_temperate.set_hold(value)
         elif command.gcode == GCODE.GET_PLATE_TEMP:
             plate_target = util.OptionalValue(self._plate_temperate.target)
@@ -86,18 +87,18 @@ class ThermocyclerEmulator(AbstractEmulator):
             plate_time_remaining = util.OptionalValue(
                 self._plate_temperate.time_remaining
             )
-            plate_total_hold_time = util.OptionalValue(
-                self._plate_temperate.total_hold
-            )
+            plate_total_hold_time = util.OptionalValue(self._plate_temperate.total_hold)
 
-            res = f"T:{plate_target} " \
-                  f"C:{plate_current} " \
-                  f"H:{plate_time_remaining} " \
-                  f"Total_H:{plate_total_hold_time} "
+            res = (
+                f"T:{plate_target} "
+                f"C:{plate_current} "
+                f"H:{plate_time_remaining} "
+                f"Total_H:{plate_total_hold_time} "
+            )
             self._plate_temperate.tick()
             return res
         elif command.gcode == GCODE.SET_RAMP_RATE:
-            self.plate_ramp_rate.val = command.params['S']
+            self.plate_ramp_rate.val = command.params["S"]
         elif command.gcode == GCODE.DEACTIVATE_ALL:
             self._plate_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
             self._lid_temperate.deactivate(temperature=util.TEMPERATURE_ROOM)
@@ -111,4 +112,4 @@ class ThermocyclerEmulator(AbstractEmulator):
 
     @staticmethod
     def get_terminator() -> bytes:
-        return b'\r\n'
+        return b"\r\n"

--- a/api/src/opentrons/hardware_control/emulation/util.py
+++ b/api/src/opentrons/hardware_control/emulation/util.py
@@ -3,7 +3,7 @@ from typing import Optional, Generic, TypeVar
 TEMPERATURE_ROOM = 23
 
 
-ValueType = TypeVar('ValueType')
+ValueType = TypeVar("ValueType")
 
 
 class OptionalValue(Generic[ValueType]):
@@ -14,6 +14,7 @@ class OptionalValue(Generic[ValueType]):
     the thermocycler means the hold time is not set:
         H:none T:1.23
     """
+
     _value: Optional[ValueType]
 
     def __init__(self, value: Optional[ValueType] = None):

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -3,13 +3,14 @@ from typing import Set
 from .types import ExecutionState, ExecutionCancelledError
 
 
-class ExecutionManager():
-    """ This class holds onto a flag that is up/set while the hardware
+class ExecutionManager:
+    """This class holds onto a flag that is up/set while the hardware
     hardware controller is running and down/cleared when the hardware
     controller is "paused".
 
     It also handles loop clean up through its cancel method.
     """
+
     def __init__(self, loop: asyncio.AbstractEventLoop):
         self._state: ExecutionState = ExecutionState.RUNNING
         self._condition = asyncio.Condition(loop=loop)

--- a/api/src/opentrons/hardware_control/g_code_parsing/cli.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/cli.py
@@ -6,20 +6,25 @@ from typing import Union, Dict, Any, List
 import sys
 from dataclasses import dataclass
 
-from opentrons.hardware_control.emulation.settings import SmoothieSettings, \
-    PipetteSettings, Settings
+from opentrons.hardware_control.emulation.settings import (
+    SmoothieSettings,
+    PipetteSettings,
+    Settings,
+)
 from opentrons.hardware_control.g_code_parsing.errors import UnparsableCLICommandError
 from opentrons.hardware_control.g_code_parsing.g_code_differ import GCodeDiffer
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+)
 from opentrons.hardware_control.g_code_parsing.protocol_runner import ProtocolRunner
 
 
 class CLICommand(abc.ABC):
     """ABC which all CLI command classes should inherit from"""
+
     able_to_respond_with_error_code = False
     respond_with_error_code = False
-    error_message = 'Error message not defined'
+    error_message = "Error message not defined"
 
     @abc.abstractmethod
     def execute(self) -> str:
@@ -30,11 +35,12 @@ class CLICommand(abc.ABC):
 @dataclass
 class RunCommand(CLICommand):
     """The "run" command of the CLI."""
+
     protocol_file_path: str
     text_mode: str
     left_pipette_config: PipetteSettings
     right_pipette_config: PipetteSettings
-    host: str = '0.0.0.0'
+    host: str = "0.0.0.0"
 
     def execute(self) -> str:
         """
@@ -42,13 +48,9 @@ class RunCommand(CLICommand):
         :return: Text explanation of G-Code program ran
         """
         smoothie_settings = SmoothieSettings(
-            left=self.left_pipette_config,
-            right=self.right_pipette_config
+            left=self.left_pipette_config, right=self.right_pipette_config
         )
-        settings = Settings(
-            smoothie=smoothie_settings,
-            host=self.host
-        )
+        settings = Settings(smoothie=smoothie_settings, host=self.host)
         with ProtocolRunner(settings).run_protocol(self.protocol_file_path) as program:
             return program.get_text_explanation(self.text_mode)
 
@@ -56,22 +58,23 @@ class RunCommand(CLICommand):
 @dataclass
 class DiffCommand(CLICommand):
     """The "diff" command of the CLI"""
+
     file_path_1: str
     file_path_2: str
     able_to_respond_with_error_code: bool
     respond_with_error_code = False
-    error_message = 'Compared files are different'
+    error_message = "Compared files are different"
 
     def execute(self) -> str:
         """
         Opens both files and compares them to each other.
         :return: HTML encoded diff of files
         """
-        with \
-                open(self.file_path_1, 'r') as file_1, \
-                open(self.file_path_2, 'r') as file_2:
-            file_1_text = '\n'.join(file_1.readlines())
-            file_2_text = '\n'.join(file_2.readlines())
+        with open(self.file_path_1, "r") as file_1, open(
+            self.file_path_2, "r"
+        ) as file_2:
+            file_1_text = "\n".join(file_1.readlines())
+            file_2_text = "\n".join(file_2.readlines())
 
             differ = GCodeDiffer(file_1_text, file_2_text)
             strings_equal = differ.strings_are_equal()
@@ -82,7 +85,7 @@ class DiffCommand(CLICommand):
             if not strings_equal:
                 text = differ.get_html_diff()
             else:
-                text = 'No difference between compared strings'
+                text = "No difference between compared strings"
 
             return text
 
@@ -93,18 +96,19 @@ class GCodeCLI:
     Takes input from command line, parses it and performs any post-processing.
     The provides run_command method to run passed input.
     """
-    COMMAND_KEY = 'command'
 
-    RUN_PROTOCOL_COMMAND = 'run'
-    PROTOCOL_FILE_PATH_KEY = 'protocol_file_path'
-    TEXT_MODE_KEY_NAME = 'text_mode'
-    LEFT_PIPETTE_KEY_NAME = 'left_pipette'
-    RIGHT_PIPETTE_KEY_NAME = 'right_pipette'
+    COMMAND_KEY = "command"
 
-    DIFF_FILES_COMMAND = 'diff'
-    FILE_PATH_1_KEY = 'file_path_1'
-    FILE_PATH_2_KEY = 'file_path_2'
-    ERROR_ON_DIFFERENT_FILES = 'error_on_different_files'
+    RUN_PROTOCOL_COMMAND = "run"
+    PROTOCOL_FILE_PATH_KEY = "protocol_file_path"
+    TEXT_MODE_KEY_NAME = "text_mode"
+    LEFT_PIPETTE_KEY_NAME = "left_pipette"
+    RIGHT_PIPETTE_KEY_NAME = "right_pipette"
+
+    DIFF_FILES_COMMAND = "diff"
+    FILE_PATH_1_KEY = "file_path_1"
+    FILE_PATH_2_KEY = "file_path_2"
+    ERROR_ON_DIFFERENT_FILES = "error_on_different_files"
     DEFAULT_PIPETTE_CONFIG = SmoothieSettings()
 
     @classmethod
@@ -131,9 +135,7 @@ class GCodeCLI:
         return cls._post_process_args(parsed_dict)
 
     @classmethod
-    def to_command(
-            cls, processed_args
-    ) -> CLICommand:
+    def to_command(cls, processed_args) -> CLICommand:
         """
         Parse passed arguments to a cli command class
         :param processed_args: Arguments that have been ran through both the
@@ -147,7 +149,7 @@ class GCodeCLI:
                 protocol_file_path=processed_args[cls.PROTOCOL_FILE_PATH_KEY],
                 text_mode=processed_args[cls.TEXT_MODE_KEY_NAME],
                 left_pipette_config=processed_args[cls.LEFT_PIPETTE_KEY_NAME],
-                right_pipette_config=processed_args[cls.RIGHT_PIPETTE_KEY_NAME]
+                right_pipette_config=processed_args[cls.RIGHT_PIPETTE_KEY_NAME],
             )
         elif cls.DIFF_FILES_COMMAND == passed_command_name:
             command = DiffCommand(
@@ -155,7 +157,7 @@ class GCodeCLI:
                 file_path_2=processed_args[cls.FILE_PATH_2_KEY],
                 able_to_respond_with_error_code=processed_args[
                     cls.ERROR_ON_DIFFERENT_FILES
-                ]
+                ],
             )
         else:
             raise UnparsableCLICommandError(
@@ -191,74 +193,68 @@ class GCodeCLI:
         input
         :return: Parser object
         """
-        parser = argparse.ArgumentParser(
-            description='CLI for G-Code Parser'
-        )
+        parser = argparse.ArgumentParser(description="CLI for G-Code Parser")
         subparsers = parser.add_subparsers(
-            title='Supported commands',
+            title="Supported commands",
             dest=cls.COMMAND_KEY,
             required=True,
-            metavar=f'{cls.RUN_PROTOCOL_COMMAND} | {cls.DIFF_FILES_COMMAND}'
-
+            metavar=f"{cls.RUN_PROTOCOL_COMMAND} | {cls.DIFF_FILES_COMMAND}",
         )
 
         run_parser = subparsers.add_parser(
             cls.RUN_PROTOCOL_COMMAND,
-            help='Run a protocol against emulation',
-            formatter_class=argparse.RawTextHelpFormatter
-
+            help="Run a protocol against emulation",
+            formatter_class=argparse.RawTextHelpFormatter,
         )
         run_parser.add_argument(
-            'protocol_file_path',
-            type=str,
-            help='Path to protocol you want to run'
+            "protocol_file_path", type=str, help="Path to protocol you want to run"
         )
         run_parser.add_argument(
-            '--text-mode',
+            "--text-mode",
             type=str,
             default=SupportedTextModes.CONCISE.value,
             choices=SupportedTextModes.get_valid_modes(),
             dest=cls.TEXT_MODE_KEY_NAME,
-            help=f'{SupportedTextModes.DEFAULT.value}: Verbose output containing '
-                 f'G-Code, Explanation, and Response'
-                 f'\n{SupportedTextModes.CONCISE.value}: Same as default but all '
-                 f'newlines, tabs, and headers removed'
-                 f'\n{SupportedTextModes.G_CODE.value}: Only raw G-Code and raw '
-                 f'response\n',
-            metavar=' | '.join(SupportedTextModes.get_valid_modes())
+            help=f"{SupportedTextModes.DEFAULT.value}: Verbose output containing "
+            f"G-Code, Explanation, and Response"
+            f"\n{SupportedTextModes.CONCISE.value}: Same as default but all "
+            f"newlines, tabs, and headers removed"
+            f"\n{SupportedTextModes.G_CODE.value}: Only raw G-Code and raw "
+            f"response\n",
+            metavar=" | ".join(SupportedTextModes.get_valid_modes()),
         )
         run_parser.add_argument(
-            '--left-pipette',
+            "--left-pipette",
             type=str,
             default=json.dumps(SmoothieSettings().left.__dict__),
-            help='Configuration for left pipette. Expects JSON string.'
-                 f'\nDefaults to "{SmoothieSettings().left.model}" if not specified.'
-                 '\nExample: {"model": "p20_multi_v2.0", "id": "P3HMV202020041605"}',
-            metavar='left_pipette_config'
+            help="Configuration for left pipette. Expects JSON string."
+            f'\nDefaults to "{SmoothieSettings().left.model}" if not specified.'
+            '\nExample: {"model": "p20_multi_v2.0", "id": "P3HMV202020041605"}',
+            metavar="left_pipette_config",
         )
         run_parser.add_argument(
-            '--right-pipette',
+            "--right-pipette",
             type=str,
             default=json.dumps(SmoothieSettings().right.__dict__),
-            help='Configuration for right pipette. Expects JSON string.'
-                 f'\nDefaults to "{SmoothieSettings().right.model}" if not specified.'
-                 '\nExample: {"model": "p20_single_v2.0", "id": "P20SV202020070101"}',
-            metavar='right_pipette_config'
+            help="Configuration for right pipette. Expects JSON string."
+            f'\nDefaults to "{SmoothieSettings().right.model}" if not specified.'
+            '\nExample: {"model": "p20_single_v2.0", "id": "P20SV202020070101"}',
+            metavar="right_pipette_config",
         )
 
         diff_parser = subparsers.add_parser(
-            cls.DIFF_FILES_COMMAND, help='Diff 2 G-Code files'
+            cls.DIFF_FILES_COMMAND, help="Diff 2 G-Code files"
         )
         diff_parser.add_argument(
-            f'--{cls.ERROR_ON_DIFFERENT_FILES}',
-            help='If set, return code 1 on files with different content',
-            action='store_true',
+            f"--{cls.ERROR_ON_DIFFERENT_FILES}",
+            help="If set, return code 1 on files with different content",
+            action="store_true",
         )
         diff_parser.add_argument(
-            cls.FILE_PATH_1_KEY, type=str, help='Path to first file'
+            cls.FILE_PATH_1_KEY, type=str, help="Path to first file"
         )
         diff_parser.add_argument(
-            cls.FILE_PATH_2_KEY, type=str, help='Path to second file'
+            cls.FILE_PATH_2_KEY, type=str, help="Path to second file"
         )
 
         return parser
@@ -272,8 +268,10 @@ class GCodeCLI:
 
     @property
     def respond_with_error(self):
-        return self._command.able_to_respond_with_error_code and \
-               self._command.respond_with_error_code
+        return (
+            self._command.able_to_respond_with_error_code
+            and self._command.respond_with_error_code
+        )
 
     @property
     def error_message(self):
@@ -284,7 +282,7 @@ class GCodeCLI:
         return self._args
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli = GCodeCLI()
     print(cli.run_command())
 

--- a/api/src/opentrons/hardware_control/g_code_parsing/errors.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/errors.py
@@ -11,12 +11,13 @@ class UnparsableGCodeError(ValueError):
 
 class InvalidTextModeError(ValueError):
     """Error raised if passed text mode is not a valid mode"""
+
     def __init__(self, invalid_mode: str, valid_modes: List[str]) -> None:
-        joined_valid_modes = ', '.join(valid_modes)
+        joined_valid_modes = ", ".join(valid_modes)
 
         super().__init__(
             f'Mode named "{invalid_mode}" not found. '
-            f'Valid modes are: {joined_valid_modes}'
+            f"Valid modes are: {joined_valid_modes}"
         )
         self.invalid_mode = invalid_mode
         self.joined_valid_modes = joined_valid_modes
@@ -24,11 +25,11 @@ class InvalidTextModeError(ValueError):
 
 class UnparsableCLICommandError(ValueError):
     def __init__(self, invalid_command, valid_commands: List[str]) -> None:
-        joined_commands = ', '.join(valid_commands)
+        joined_commands = ", ".join(valid_commands)
 
         super().__init__(
             f'Command named "{invalid_command}" not valid. '
-            f'Valid commands are: {joined_commands}'
+            f"Valid commands are: {joined_commands}"
         )
         self.invalid_command = invalid_command
         self.joined_commands = joined_commands
@@ -39,6 +40,6 @@ class PollingGCodeAdditionError(ValueError):
 
         super().__init__(
             f'Cannot add "{invalid_g_code}" to GCodeProgram because it is'
-            f'a polling command'
+            f"a polling command"
         )
         self.invalid_g_code = invalid_g_code

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code.py
@@ -9,8 +9,9 @@ from opentrons.drivers.temp_deck.driver import GCODE as TEMPDECK_G_CODE
 from opentrons.drivers.thermocycler.driver import GCODE as THERMOCYCLER_G_CODE
 from opentrons.hardware_control.g_code_parsing.utils import reverse_enum
 from opentrons.hardware_control.emulation.parser import Parser
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import Explanation
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    Explanation,
+)
 from .g_code_functionality_defs import smoothie, magdeck, tempdeck, thermocycler
 
 
@@ -23,148 +24,94 @@ class GCode:
     SMOOTHIE_G_CODE_EXPLANATION_MAPPING = {
         # Weird Enum thing stopping me from using values from
         # enum for MOVE and SET_SPEED see g_code.py get_gcode_function for explanation
-        'MOVE':
-            smoothie.MoveGCodeFunctionalityDef,
-        'SET_SPEED':
-            smoothie.SetSpeedGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.WAIT.name:
-            smoothie.WaitGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.HOME.name:
-            smoothie.HomeGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.SET_CURRENT.name:
-            smoothie.SetCurrentGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.DWELL.name:
-            smoothie.DwellGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.CURRENT_POSITION.name:
-            smoothie.CurrentPositionGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.LIMIT_SWITCH_STATUS.name:
-            smoothie.LimitSwitchStatusGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PROBE.name:
-            smoothie.ProbeGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.ABSOLUTE_COORDS.name:
-            smoothie.AbsoluteCoordinateModeGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.RELATIVE_COORDS.name:
-            smoothie.RelativeCoordinateModeGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.RESET_FROM_ERROR.name:
-            smoothie.ResetFromErrorGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PUSH_SPEED.name:
-            smoothie.PushSpeedGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.POP_SPEED.name:
-            smoothie.PopSpeedGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.STEPS_PER_MM.name:
-            smoothie.StepsPerMMGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.SET_MAX_SPEED.name:
-            smoothie.SetMaxSpeedGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.ACCELERATION.name:
-            smoothie.AccelerationGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.DISENGAGE_MOTOR.name:
-            smoothie.DisengageMotorGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.HOMING_STATUS.name:
-            smoothie.HomingStatusGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.MICROSTEPPING_B_DISABLE.name:
-            smoothie.MicrosteppingBDisableGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.MICROSTEPPING_B_ENABLE.name:
-            smoothie.MicrosteppingBEnableGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.MICROSTEPPING_C_DISABLE.name:
-            smoothie.MicrosteppingCDisableGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.MICROSTEPPING_C_ENABLE.name:
-            smoothie.MicrosteppingCEnableGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PIPETTE_HOME.name:
-            smoothie.SetPipetteHomeGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PIPETTE_RETRACT.name:
-            smoothie.SetPipetteRetractGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PIPETTE_DEBOUNCE.name:
-            smoothie.SetPipetteDebounceGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.PIPETTE_MAX_TRAVEL.name:
-            smoothie.SetPipetteMaxTravelGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.READ_INSTRUMENT_MODEL.name:
-            smoothie.ReadInstrumentModelGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.READ_INSTRUMENT_ID.name:
-            smoothie.ReadInstrumentIDGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.WRITE_INSTRUMENT_ID.name:
-            smoothie.WriteInstrumentIDGCodeFunctionalityDef,
-        SMOOTHIE_G_CODE.WRITE_INSTRUMENT_MODEL.name:
-            smoothie.WriteInstrumentModelGCodeFunctionalityDef,
+        "MOVE": smoothie.MoveGCodeFunctionalityDef,
+        "SET_SPEED": smoothie.SetSpeedGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.WAIT.name: smoothie.WaitGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.HOME.name: smoothie.HomeGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.SET_CURRENT.name: smoothie.SetCurrentGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.DWELL.name: smoothie.DwellGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.CURRENT_POSITION.name: smoothie.CurrentPositionGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.LIMIT_SWITCH_STATUS.name: smoothie.LimitSwitchStatusGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.PROBE.name: smoothie.ProbeGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.ABSOLUTE_COORDS.name: smoothie.AbsoluteCoordinateModeGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.RELATIVE_COORDS.name: smoothie.RelativeCoordinateModeGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.RESET_FROM_ERROR.name: smoothie.ResetFromErrorGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.PUSH_SPEED.name: smoothie.PushSpeedGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.POP_SPEED.name: smoothie.PopSpeedGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.STEPS_PER_MM.name: smoothie.StepsPerMMGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.SET_MAX_SPEED.name: smoothie.SetMaxSpeedGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.ACCELERATION.name: smoothie.AccelerationGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.DISENGAGE_MOTOR.name: smoothie.DisengageMotorGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.HOMING_STATUS.name: smoothie.HomingStatusGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.MICROSTEPPING_B_DISABLE.name: smoothie.MicrosteppingBDisableGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.MICROSTEPPING_B_ENABLE.name: smoothie.MicrosteppingBEnableGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.MICROSTEPPING_C_DISABLE.name: smoothie.MicrosteppingCDisableGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.MICROSTEPPING_C_ENABLE.name: smoothie.MicrosteppingCEnableGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.PIPETTE_HOME.name: smoothie.SetPipetteHomeGCodeFunctionalityDef,
+        SMOOTHIE_G_CODE.PIPETTE_RETRACT.name: smoothie.SetPipetteRetractGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.PIPETTE_DEBOUNCE.name: smoothie.SetPipetteDebounceGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.PIPETTE_MAX_TRAVEL.name: smoothie.SetPipetteMaxTravelGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.READ_INSTRUMENT_MODEL.name: smoothie.ReadInstrumentModelGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.READ_INSTRUMENT_ID.name: smoothie.ReadInstrumentIDGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.WRITE_INSTRUMENT_ID.name: smoothie.WriteInstrumentIDGCodeFunctionalityDef,  # noqa: E501
+        SMOOTHIE_G_CODE.WRITE_INSTRUMENT_MODEL.name: smoothie.WriteInstrumentModelGCodeFunctionalityDef,  # noqa: E501
     }
 
     MAGDECK_G_CODE_EXPLANATION_MAPPING = {
-        MAGDECK_G_CODE.HOME.name:
-            magdeck.HomeGCodeFunctionalityDef,
-        MAGDECK_G_CODE.MOVE.name:
-            magdeck.MoveGCodeFunctionalityDef,
-        MAGDECK_G_CODE.GET_CURRENT_POSITION.name:
-            magdeck.CurrentPositionGCodeFunctionalityDef,
-        MAGDECK_G_CODE.PROBE_PLATE.name:
-            magdeck.ProbeGCodeFunctionalityDef,
-        MAGDECK_G_CODE.GET_PLATE_HEIGHT.name:
-            magdeck.GetPlateHeightGCodeFunctionalityDef,
-        MAGDECK_G_CODE.DEVICE_INFO.name:
-            magdeck.DeviceInfoGCodeFunctionalityDef
+        MAGDECK_G_CODE.HOME.name: magdeck.HomeGCodeFunctionalityDef,
+        MAGDECK_G_CODE.MOVE.name: magdeck.MoveGCodeFunctionalityDef,
+        MAGDECK_G_CODE.GET_CURRENT_POSITION.name: magdeck.CurrentPositionGCodeFunctionalityDef,  # noqa: E501
+        MAGDECK_G_CODE.PROBE_PLATE.name: magdeck.ProbeGCodeFunctionalityDef,
+        MAGDECK_G_CODE.GET_PLATE_HEIGHT.name: magdeck.GetPlateHeightGCodeFunctionalityDef,  # noqa: E501
+        MAGDECK_G_CODE.DEVICE_INFO.name: magdeck.DeviceInfoGCodeFunctionalityDef,
     }
 
     TEMPDECK_G_CODE_EXPLANATION_MAPPING = {
-        TEMPDECK_G_CODE.DISENGAGE.name:
-            tempdeck.DisengageGCodeFunctionalityDef,
-        TEMPDECK_G_CODE.SET_TEMP.name:
-            tempdeck.SetTempGCodeFunctionalityDef,
-        TEMPDECK_G_CODE.GET_TEMP.name:
-            tempdeck.GetTempGCodeFunctionalityDef,
-        TEMPDECK_G_CODE.DEVICE_INFO.name:
-            tempdeck.DeviceInfoGCodeFunctionalityDef
+        TEMPDECK_G_CODE.DISENGAGE.name: tempdeck.DisengageGCodeFunctionalityDef,
+        TEMPDECK_G_CODE.SET_TEMP.name: tempdeck.SetTempGCodeFunctionalityDef,
+        TEMPDECK_G_CODE.GET_TEMP.name: tempdeck.GetTempGCodeFunctionalityDef,
+        TEMPDECK_G_CODE.DEVICE_INFO.name: tempdeck.DeviceInfoGCodeFunctionalityDef,
     }
 
     THERMOCYCLER_G_CODE_EXPLANATION_MAPPING = {
-        THERMOCYCLER_G_CODE.CLOSE_LID.name:
-            thermocycler.CloseLidGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.DEVICE_INFO.name:
-            thermocycler.DeviceInfoGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.GET_PLATE_TEMP.name:
-            thermocycler.GetPlateTempGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.GET_LID_STATUS.name:
-            thermocycler.LidStatusGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.OPEN_LID.name:
-            thermocycler.OpenLidGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.SET_PLATE_TEMP.name:
-            thermocycler.SetPlateTempGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.SET_LID_TEMP.name:
-            thermocycler.SetLidTempGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.GET_LID_TEMP.name:
-            thermocycler.GetLidTempGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.SET_RAMP_RATE.name:
-            thermocycler.SetRampRateGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.DEACTIVATE_LID.name:
-            thermocycler.DeactivateLidGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.DEACTIVATE_BLOCK.name:
-            thermocycler.DeactivateBlockGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.DEACTIVATE_ALL.name:
-            thermocycler.DeactivateAllGCodeFunctionalityDef,
-        THERMOCYCLER_G_CODE.EDIT_PID_PARAMS.name:
-            thermocycler.EditPIDParamsGCodeFunctionalityDef
+        THERMOCYCLER_G_CODE.CLOSE_LID.name: thermocycler.CloseLidGCodeFunctionalityDef,
+        THERMOCYCLER_G_CODE.DEVICE_INFO.name: thermocycler.DeviceInfoGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.GET_PLATE_TEMP.name: thermocycler.GetPlateTempGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.GET_LID_STATUS.name: thermocycler.LidStatusGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.OPEN_LID.name: thermocycler.OpenLidGCodeFunctionalityDef,
+        THERMOCYCLER_G_CODE.SET_PLATE_TEMP.name: thermocycler.SetPlateTempGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.SET_LID_TEMP.name: thermocycler.SetLidTempGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.GET_LID_TEMP.name: thermocycler.GetLidTempGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.SET_RAMP_RATE.name: thermocycler.SetRampRateGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.DEACTIVATE_LID.name: thermocycler.DeactivateLidGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.DEACTIVATE_BLOCK.name: thermocycler.DeactivateBlockGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.DEACTIVATE_ALL.name: thermocycler.DeactivateAllGCodeFunctionalityDef,  # noqa: E501
+        THERMOCYCLER_G_CODE.EDIT_PID_PARAMS.name: thermocycler.EditPIDParamsGCodeFunctionalityDef,  # noqa: E501
     }
 
     # Smoothie G-Code Parsing Characters
-    SET_SPEED_CHARACTER = 'F'
-    MOVE_CHARACTERS = ['X', 'Y', 'Z', 'A', 'B', 'C']
-    SET_SPEED_NAME = 'SET_SPEED'
-    MOVE_NAME = 'MOVE'
+    SET_SPEED_CHARACTER = "F"
+    MOVE_CHARACTERS = ["X", "Y", "Z", "A", "B", "C"]
+    SET_SPEED_NAME = "SET_SPEED"
+    MOVE_NAME = "MOVE"
 
-    SMOOTHIE_IDENT = 'smoothie'
+    SMOOTHIE_IDENT = "smoothie"
     SMOOTHIE_G_CODE_LOOKUP = reverse_enum(SMOOTHIE_G_CODE)
 
-    MAGDECK_IDENT = 'magdeck'
+    MAGDECK_IDENT = "magdeck"
     MAGDECK_G_CODE_LOOKUP = reverse_enum(MAGDECK_G_CODE)
 
-    TEMPDECK_IDENT = 'tempdeck'
+    TEMPDECK_IDENT = "tempdeck"
     TEMPDECK_G_CODE_LOOKUP = reverse_enum(TEMPDECK_G_CODE)
 
-    THERMOCYCLER_IDENT = 'thermocycler'
+    THERMOCYCLER_IDENT = "thermocycler"
     THERMOCYCLER_G_CODE_LOOKUP = reverse_enum(THERMOCYCLER_G_CODE)
 
     DEVICE_GCODE_LOOKUP = {
         SMOOTHIE_IDENT: SMOOTHIE_G_CODE_LOOKUP,
         MAGDECK_IDENT: MAGDECK_G_CODE_LOOKUP,
         TEMPDECK_IDENT: TEMPDECK_G_CODE_LOOKUP,
-        THERMOCYCLER_IDENT: THERMOCYCLER_G_CODE_LOOKUP
+        THERMOCYCLER_IDENT: THERMOCYCLER_G_CODE_LOOKUP,
     }
 
     SPECIAL_HANDLING_REQUIRED_G_CODES = [
@@ -176,7 +123,7 @@ class GCode:
         SMOOTHIE_IDENT: SMOOTHIE_G_CODE_EXPLANATION_MAPPING,
         MAGDECK_IDENT: MAGDECK_G_CODE_EXPLANATION_MAPPING,
         TEMPDECK_IDENT: TEMPDECK_G_CODE_EXPLANATION_MAPPING,
-        THERMOCYCLER_IDENT: THERMOCYCLER_G_CODE_EXPLANATION_MAPPING
+        THERMOCYCLER_IDENT: THERMOCYCLER_G_CODE_EXPLANATION_MAPPING,
     }
 
     # These are a list of codes that are called using polling.
@@ -186,7 +133,7 @@ class GCode:
         TEMPDECK_G_CODE.GET_TEMP.value,
         THERMOCYCLER_G_CODE.GET_LID_TEMP.value,
         THERMOCYCLER_G_CODE.GET_PLATE_TEMP.value,
-        THERMOCYCLER_G_CODE.GET_LID_STATUS.value
+        THERMOCYCLER_G_CODE.GET_LID_STATUS.value,
     ]
 
     @classmethod
@@ -209,7 +156,7 @@ class GCode:
                 # From the body of the G-Code, we pull the L or R for left or right
                 # pipette. Everything else in the string is the hex code
                 left_or_right = g_code.body.strip()[0]
-                if left_or_right not in ['R', 'L']:
+                if left_or_right not in ["R", "L"]:
                     raise UnparsableGCodeError(raw_code)
                 params = {left_or_right: g_code.body.strip()[1:]}
 
@@ -218,11 +165,7 @@ class GCode:
         return g_code_list
 
     def __init__(
-            self,
-            device_name: str,
-            g_code: str,
-            g_code_args: dict,
-            response: str
+        self, device_name: str, g_code: str, g_code_args: dict, response: str
     ) -> None:
         self._device_name = device_name
         self._g_code = g_code
@@ -231,10 +174,10 @@ class GCode:
 
     @staticmethod
     def _cleanup_response(response):
-        pre_space_cleanup = response.replace('ok', ' ')\
-            .replace('\r', ' ')\
-            .replace('\n', ' ')
-        return re.sub(' +', ' ', pre_space_cleanup).strip()
+        pre_space_cleanup = (
+            response.replace("ok", " ").replace("\r", " ").replace("\n", " ")
+        )
+        return re.sub(" +", " ", pre_space_cleanup).strip()
 
     @property
     def device_name(self) -> str:
@@ -265,10 +208,9 @@ class GCode:
         For instance, the line G0 X100 Y200 would be:
         "X100 Y200"
         """
-        return ' '.join(
-            str(k) + str(v if v is not None else '')
-            for k, v
-            in self.g_code_args.items()
+        return " ".join(
+            str(k) + str(v if v is not None else "")
+            for k, v in self.g_code_args.items()
         )
 
     @property
@@ -277,7 +219,7 @@ class GCode:
         The entire string representation of the G-Code Command.
         For instance, "G0 X100 Y200"
         """
-        return f'{self.g_code} {self.g_code_body}'.strip()
+        return f"{self.g_code} {self.g_code_body}".strip()
 
     def is_polling_command(self) -> bool:
         return self.g_code in self.POLLING_CODES
@@ -295,12 +237,11 @@ class GCode:
             in the respective driver
         """
         # Parsing for G0 command that can either be MOVE or SET_SPEED
-        if self._device_name == self.SMOOTHIE_IDENT and self.g_code == 'G0':
+        if self._device_name == self.SMOOTHIE_IDENT and self.g_code == "G0":
             contains_set_speed_character = self.SET_SPEED_CHARACTER in self.g_code_body
-            contains_move_characters = any([
-                move_char in self.g_code_body
-                for move_char in self.MOVE_CHARACTERS
-            ])
+            contains_move_characters = any(
+                [move_char in self.g_code_body for move_char in self.MOVE_CHARACTERS]
+            )
 
             # For the following if/else I was going to grab the enum names
             # from SMOOTHIE_G_CODE but due to the way that enums work, if I
@@ -315,9 +256,9 @@ class GCode:
             # https://docs.python.org/3/library/enum.html#duplicating-enum-members-and-values
 
             if contains_set_speed_character and not contains_move_characters:
-                g_code_function = 'SET_SPEED'
+                g_code_function = "SET_SPEED"
             else:
-                g_code_function = 'MOVE'
+                g_code_function = "MOVE"
 
             return g_code_function
 
@@ -325,30 +266,28 @@ class GCode:
         try:
             g_code_function = device[self.g_code]
         except KeyError:
-            raise UnparsableGCodeError(f'{self.g_code} {self.g_code_body}')
+            raise UnparsableGCodeError(f"{self.g_code} {self.g_code_body}")
 
         return g_code_function
 
     def get_explanation(self) -> Explanation:
         g_code_function = self.get_gcode_function()
         try:
-            explanation_class = \
-                self.EXPLANATION_LOOKUP[self.device_name][g_code_function]
+            explanation_class = self.EXPLANATION_LOOKUP[self.device_name][
+                g_code_function
+            ]
 
         except KeyError:
             return Explanation(
                 self.g_code,
                 self.get_gcode_function(),
                 self.g_code_args,
-                f'No explanation defined for {self.get_gcode_function()}',
-                self.response
+                f"No explanation defined for {self.get_gcode_function()}",
+                self.response,
             )
         except Exception:
             raise
         else:
             return explanation_class.generate_explanation(
-                self.g_code,
-                self.get_gcode_function(),
-                self.g_code_args,
-                self.response
+                self.g_code, self.get_gcode_function(), self.g_code_args, self.response
             )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_differ.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_differ.py
@@ -2,43 +2,47 @@ from __future__ import annotations
 
 from typing import Tuple
 from diff_match_patch import diff_match_patch as dmp  # type: ignore
-from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import \
-    GCodeProgram
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes
+from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import (
+    GCodeProgram,
+)
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+)
 
 
 class GCodeDiffer:
-    INSERTION_TYPE = 'Insertion'
+    INSERTION_TYPE = "Insertion"
     INSERTION_VALUE = 1
-    EQUALITY_TYPE = 'Equality'
+    EQUALITY_TYPE = "Equality"
     EQUALITY_VALUE = 0
-    DELETION_TYPE = 'Deletion'
+    DELETION_TYPE = "Deletion"
     DELETION_VALUE = -1
 
     DIFF_TYPE_LOOKUP = {
         DELETION_VALUE: DELETION_TYPE,
         EQUALITY_VALUE: EQUALITY_TYPE,
-        INSERTION_VALUE: INSERTION_TYPE
+        INSERTION_VALUE: INSERTION_TYPE,
     }
 
-    INSERTION_STYLE = "<ins style=\"" \
-                      "background:#e6ffe6;" \
-                      "font-size:large;" \
-                      "font-weight:bold;" \
-                      "\">%s</ins>"
+    INSERTION_STYLE = (
+        '<ins style="'
+        "background:#e6ffe6;"
+        "font-size:large;"
+        "font-weight:bold;"
+        '">%s</ins>'
+    )
 
-    DELETION_STYLE = "<del style=\"" \
-                     "background:#ffe6e6;" \
-                     "font-size:large;" \
-                     "font-weight:bold;" \
-                     "\">%s</del>"
+    DELETION_STYLE = (
+        '<del style="'
+        "background:#ffe6e6;"
+        "font-size:large;"
+        "font-weight:bold;"
+        '">%s</del>'
+    )
 
     @classmethod
     def from_g_code_program(
-            cls,
-            program_1: GCodeProgram,
-            program_2: GCodeProgram
+        cls, program_1: GCodeProgram, program_2: GCodeProgram
     ) -> GCodeDiffer:
         string_1 = program_1.get_text_explanation(SupportedTextModes.CONCISE.value)
         string_2 = program_2.get_text_explanation(SupportedTextModes.CONCISE.value)
@@ -51,10 +55,7 @@ class GCodeDiffer:
     def get_diff(self, timeout_secs=10):
         differ = dmp()
         differ.Diff_Timeout = timeout_secs
-        return differ.diff_main(
-            text1=self._string_1,
-            text2=self._string_2
-        )
+        return differ.diff_main(text1=self._string_1, text2=self._string_2)
 
     def get_html_diff(self):
         return self._render_diff_as_html(self.get_diff())
@@ -82,7 +83,7 @@ class GCodeDiffer:
         return "".join(html)
 
     def save_html_diff_to_file(self, file_path):
-        with open(file_path, 'w') as file:
+        with open(file_path, "w") as file:
             file.write(self.get_html_diff())
 
     def strings_are_equal(self):

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/g_code_functionality_def_base.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/g_code_functionality_def_base.py
@@ -8,11 +8,12 @@ class Explanation:
     """
     Dataclass containing information about the ran G-Code.
     """
-    CODE_KEY = 'Code'
-    COMMAND_NAME_KEY = 'Command Name'
-    PROVIDED_ARGS_KEY = 'Provided Arguments'
-    COMMAND_EXPLANATION_KEY = 'Command Explanation'
-    RESPONSE_KEY = 'Response'
+
+    CODE_KEY = "Code"
+    COMMAND_NAME_KEY = "Command Name"
+    PROVIDED_ARGS_KEY = "Provided Arguments"
+    COMMAND_EXPLANATION_KEY = "Command Explanation"
+    RESPONSE_KEY = "Response"
 
     code: str
     command_name: str
@@ -26,7 +27,7 @@ class Explanation:
             self.COMMAND_NAME_KEY: self.command_name,
             self.PROVIDED_ARGS_KEY: self.provided_args,
             self.COMMAND_EXPLANATION_KEY: self.command_explanation,
-            self.RESPONSE_KEY: self.response
+            self.RESPONSE_KEY: self.response,
         }
 
 
@@ -36,27 +37,21 @@ class GCodeFunctionalityDefBase(ABC):
     each G-Code. It is required that each child class implements
     _generate_command_explanations
     """
+
     @classmethod
     def generate_explanation(
-        cls,
-        code,
-        command_name,
-        provided_args,
-        response
+        cls, code, command_name, provided_args, response
     ) -> Explanation:
         return Explanation(
             code,
             command_name,
             provided_args,
             cls._generate_command_explanation(provided_args),
-            cls._generate_response_explanation(response)
+            cls._generate_response_explanation(response),
         )
 
     @classmethod
-    def _generate_command_explanation(
-            cls,
-            g_code_args: Dict[str, str]
-    ) -> str:
+    def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         ...
 
     @classmethod
@@ -66,4 +61,4 @@ class GCodeFunctionalityDefBase(ABC):
         All child classes should either parse response into human readable text or
         return an empty string
         """
-        return ''
+        return ""

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/__init__.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/__init__.py
@@ -1,17 +1,19 @@
 from .home_g_code_functionality_def import HomeGCodeFunctionalityDef
 from .move_g_code_functionality_def import MoveGCodeFunctionalityDef
-from .current_position_g_code_functionality_def import \
-    CurrentPositionGCodeFunctionalityDef
+from .current_position_g_code_functionality_def import (
+    CurrentPositionGCodeFunctionalityDef,
+)
 from .probe_g_code_functionality_def import ProbeGCodeFunctionalityDef
-from .get_plate_height_g_code_functionality_def import \
-    GetPlateHeightGCodeFunctionalityDef
+from .get_plate_height_g_code_functionality_def import (
+    GetPlateHeightGCodeFunctionalityDef,
+)
 from .device_info_g_code_functionality_def import DeviceInfoGCodeFunctionalityDef
 
 __all__ = [
-    'HomeGCodeFunctionalityDef',
-    'MoveGCodeFunctionalityDef',
-    'CurrentPositionGCodeFunctionalityDef',
-    'ProbeGCodeFunctionalityDef',
-    'GetPlateHeightGCodeFunctionalityDef',
-    'DeviceInfoGCodeFunctionalityDef'
+    "HomeGCodeFunctionalityDef",
+    "MoveGCodeFunctionalityDef",
+    "CurrentPositionGCodeFunctionalityDef",
+    "ProbeGCodeFunctionalityDef",
+    "GetPlateHeightGCodeFunctionalityDef",
+    "DeviceInfoGCodeFunctionalityDef",
 ]

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/current_position_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/current_position_g_code_functionality_def.py
@@ -1,20 +1,21 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class CurrentPositionGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'Z:(\d+.\d+)')
+    RESPONSE_RE = re.compile(r"Z:(\d+.\d+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Reading current position of magnets'
+        return "Reading current position of magnets"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
         if match is not None:
-            message = f'Current height of magnets are {match.group(1)}mm'
+            message = f"Current height of magnets are {match.group(1)}mm"
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/device_info_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/device_info_g_code_functionality_def.py
@@ -1,25 +1,28 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeviceInfoGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'serial:(.*?)model:(.*?)version:(.*?)$')
+    RESPONSE_RE = re.compile(r"serial:(.*?)model:(.*?)version:(.*?)$")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting magdeck device info'
+        return "Getting magdeck device info"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
         if match is not None:
             serial_number, model, fw_version = match.groups()
-            message = f'Magdeck info:' \
-                      f'\n\tSerial Number: {serial_number.strip()}' \
-                      f'\n\tModel: {model.strip()}' \
-                      f'\n\tFirmware Version: {fw_version.strip()}'
+            message = (
+                f"Magdeck info:"
+                f"\n\tSerial Number: {serial_number.strip()}"
+                f"\n\tModel: {model.strip()}"
+                f"\n\tFirmware Version: {fw_version.strip()}"
+            )
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/get_plate_height_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/get_plate_height_g_code_functionality_def.py
@@ -1,22 +1,23 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class GetPlateHeightGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'height:(\d+.\d+)')
+    RESPONSE_RE = re.compile(r"height:(\d+.\d+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Calculating magdeck labware height'
+        return "Calculating magdeck labware height"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
 
         if match is not None:
-            message = f'Magdeck calculated labware height at {match.group(1)}mm'
+            message = f"Magdeck calculated labware height at {match.group(1)}mm"
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/home_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/home_g_code_functionality_def.py
@@ -1,9 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class HomeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Homing the magdeck'
+        return "Homing the magdeck"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/move_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/move_g_code_functionality_def.py
@@ -1,13 +1,14 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MoveGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    HEIGHT_ARG = 'Z'
+    HEIGHT_ARG = "Z"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         height = g_code_args[cls.HEIGHT_ARG]
-        return f'Setting magnet height to {height}mm'
+        return f"Setting magnet height to {height}mm"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/probe_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/magdeck/probe_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class ProbeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Magdeck probing attached labware to get height in mm'
+        return "Magdeck probing attached labware to get height in mm"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/__init__.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/__init__.py
@@ -1,96 +1,101 @@
-from .absolute_coordinate_mode_g_code_functionality_def import \
-    AbsoluteCoordinateModeGCodeFunctionalityDef
-from .acceleration_g_code_functionality_def import \
-    AccelerationGCodeFunctionalityDef
-from .current_position_g_code_functionality_def import \
-    CurrentPositionGCodeFunctionalityDef
-from .disengage_motor_g_code_functionality_def import \
-    DisengageMotorGCodeFunctionalityDef
-from .dwell_g_code_functionality_def import \
-    DwellGCodeFunctionalityDef
-from .home_g_code_functionality_def import \
-    HomeGCodeFunctionalityDef
-from .homing_status_g_code_functionality_def import \
-    HomingStatusGCodeFunctionalityDef
-from .limit_switch_status_g_code_functionality_def import \
-    LimitSwitchStatusGCodeFunctionalityDef
-from .microstepping_b_disable_g_code_functionality_def import \
-    MicrosteppingBDisableGCodeFunctionalityDef
-from .microstepping_b_enable_g_code_functionality_def import \
-    MicrosteppingBEnableGCodeFunctionalityDef
-from .microstepping_c_disable_g_code_functionality_def import \
-    MicrosteppingCDisableGCodeFunctionalityDef
-from .microstepping_c_enable_g_code_functionality_def import \
-    MicrosteppingCEnableGCodeFunctionalityDef
-from .move_g_code_functionality_def import \
-    MoveGCodeFunctionalityDef
-from .pop_speed_g_code_functionality_def import \
-    PopSpeedGCodeFunctionalityDef
-from .probe_g_code_functionality_def import \
-    ProbeGCodeFunctionalityDef
-from .push_speed_g_code_functionality_def import \
-    PushSpeedGCodeFunctionalityDef
-from .relative_coordinate_mode_g_code_functionality_def import \
-    RelativeCoordinateModeGCodeFunctionalityDef
-from .reset_from_error_g_code_functionality_def import \
-    ResetFromErrorGCodeFunctionalityDef
-from .set_current_g_code_functionality_def import \
-    SetCurrentGCodeFunctionalityDef
-from .set_max_speed_g_code_functionality_def import \
-    SetMaxSpeedGCodeFunctionalityDef
-from .set_pipette_debounce_g_code_functionality_def import \
-    SetPipetteDebounceGCodeFunctionalityDef
-from .set_pipette_home_g_code_functionality_def import \
-    SetPipetteHomeGCodeFunctionalityDef
-from .set_pipette_max_travel_g_code_functionality_def import \
-    SetPipetteMaxTravelGCodeFunctionalityDef
-from .set_pipette_retract_g_code_functionality_def import \
-    SetPipetteRetractGCodeFunctionalityDef
-from .set_speed_g_code_functionality_def import \
-    SetSpeedGCodeFunctionalityDef
-from .steps_per_mm_g_code_functionality_def import \
-    StepsPerMMGCodeFunctionalityDef
-from .wait_g_code_functionality_def import \
-    WaitGCodeFunctionalityDef
-from .read_instrument_id_g_code_functionality_def import \
-    ReadInstrumentIDGCodeFunctionalityDef
-from .read_instrument_model_g_code_functionality_def import \
-    ReadInstrumentModelGCodeFunctionalityDef
-from .write_instrument_id_g_code_functionality_def import \
-    WriteInstrumentIDGCodeFunctionalityDef
-from .write_instrument_model_g_code_functionality_def import \
-    WriteInstrumentModelGCodeFunctionalityDef
+from .absolute_coordinate_mode_g_code_functionality_def import (
+    AbsoluteCoordinateModeGCodeFunctionalityDef,
+)
+from .acceleration_g_code_functionality_def import AccelerationGCodeFunctionalityDef
+from .current_position_g_code_functionality_def import (
+    CurrentPositionGCodeFunctionalityDef,
+)
+from .disengage_motor_g_code_functionality_def import (
+    DisengageMotorGCodeFunctionalityDef,
+)
+from .dwell_g_code_functionality_def import DwellGCodeFunctionalityDef
+from .home_g_code_functionality_def import HomeGCodeFunctionalityDef
+from .homing_status_g_code_functionality_def import HomingStatusGCodeFunctionalityDef
+from .limit_switch_status_g_code_functionality_def import (
+    LimitSwitchStatusGCodeFunctionalityDef,
+)
+from .microstepping_b_disable_g_code_functionality_def import (
+    MicrosteppingBDisableGCodeFunctionalityDef,
+)
+from .microstepping_b_enable_g_code_functionality_def import (
+    MicrosteppingBEnableGCodeFunctionalityDef,
+)
+from .microstepping_c_disable_g_code_functionality_def import (
+    MicrosteppingCDisableGCodeFunctionalityDef,
+)
+from .microstepping_c_enable_g_code_functionality_def import (
+    MicrosteppingCEnableGCodeFunctionalityDef,
+)
+from .move_g_code_functionality_def import MoveGCodeFunctionalityDef
+from .pop_speed_g_code_functionality_def import PopSpeedGCodeFunctionalityDef
+from .probe_g_code_functionality_def import ProbeGCodeFunctionalityDef
+from .push_speed_g_code_functionality_def import PushSpeedGCodeFunctionalityDef
+from .relative_coordinate_mode_g_code_functionality_def import (
+    RelativeCoordinateModeGCodeFunctionalityDef,
+)
+from .reset_from_error_g_code_functionality_def import (
+    ResetFromErrorGCodeFunctionalityDef,
+)
+from .set_current_g_code_functionality_def import SetCurrentGCodeFunctionalityDef
+from .set_max_speed_g_code_functionality_def import SetMaxSpeedGCodeFunctionalityDef
+from .set_pipette_debounce_g_code_functionality_def import (
+    SetPipetteDebounceGCodeFunctionalityDef,
+)
+from .set_pipette_home_g_code_functionality_def import (
+    SetPipetteHomeGCodeFunctionalityDef,
+)
+from .set_pipette_max_travel_g_code_functionality_def import (
+    SetPipetteMaxTravelGCodeFunctionalityDef,
+)
+from .set_pipette_retract_g_code_functionality_def import (
+    SetPipetteRetractGCodeFunctionalityDef,
+)
+from .set_speed_g_code_functionality_def import SetSpeedGCodeFunctionalityDef
+from .steps_per_mm_g_code_functionality_def import StepsPerMMGCodeFunctionalityDef
+from .wait_g_code_functionality_def import WaitGCodeFunctionalityDef
+from .read_instrument_id_g_code_functionality_def import (
+    ReadInstrumentIDGCodeFunctionalityDef,
+)
+from .read_instrument_model_g_code_functionality_def import (
+    ReadInstrumentModelGCodeFunctionalityDef,
+)
+from .write_instrument_id_g_code_functionality_def import (
+    WriteInstrumentIDGCodeFunctionalityDef,
+)
+from .write_instrument_model_g_code_functionality_def import (
+    WriteInstrumentModelGCodeFunctionalityDef,
+)
 
 __all__ = [
-    'CurrentPositionGCodeFunctionalityDef',
-    'DwellGCodeFunctionalityDef',
-    'HomeGCodeFunctionalityDef',
-    'LimitSwitchStatusGCodeFunctionalityDef',
-    'MoveGCodeFunctionalityDef',
-    'SetCurrentGCodeFunctionalityDef',
-    'SetSpeedGCodeFunctionalityDef',
-    'WaitGCodeFunctionalityDef',
-    'ProbeGCodeFunctionalityDef',
-    'AbsoluteCoordinateModeGCodeFunctionalityDef',
-    'RelativeCoordinateModeGCodeFunctionalityDef',
-    'ResetFromErrorGCodeFunctionalityDef',
-    'PushSpeedGCodeFunctionalityDef',
-    'PopSpeedGCodeFunctionalityDef',
-    'StepsPerMMGCodeFunctionalityDef',
-    'SetMaxSpeedGCodeFunctionalityDef',
-    'AccelerationGCodeFunctionalityDef',
-    'DisengageMotorGCodeFunctionalityDef',
-    'HomingStatusGCodeFunctionalityDef',
-    'MicrosteppingCEnableGCodeFunctionalityDef',
-    'MicrosteppingCDisableGCodeFunctionalityDef',
-    'MicrosteppingBEnableGCodeFunctionalityDef',
-    'MicrosteppingBDisableGCodeFunctionalityDef',
-    'SetPipetteRetractGCodeFunctionalityDef',
-    'SetPipetteDebounceGCodeFunctionalityDef',
-    'SetPipetteHomeGCodeFunctionalityDef',
-    'SetPipetteMaxTravelGCodeFunctionalityDef',
-    'ReadInstrumentIDGCodeFunctionalityDef',
-    'ReadInstrumentModelGCodeFunctionalityDef',
-    'WriteInstrumentIDGCodeFunctionalityDef',
-    'WriteInstrumentModelGCodeFunctionalityDef',
+    "CurrentPositionGCodeFunctionalityDef",
+    "DwellGCodeFunctionalityDef",
+    "HomeGCodeFunctionalityDef",
+    "LimitSwitchStatusGCodeFunctionalityDef",
+    "MoveGCodeFunctionalityDef",
+    "SetCurrentGCodeFunctionalityDef",
+    "SetSpeedGCodeFunctionalityDef",
+    "WaitGCodeFunctionalityDef",
+    "ProbeGCodeFunctionalityDef",
+    "AbsoluteCoordinateModeGCodeFunctionalityDef",
+    "RelativeCoordinateModeGCodeFunctionalityDef",
+    "ResetFromErrorGCodeFunctionalityDef",
+    "PushSpeedGCodeFunctionalityDef",
+    "PopSpeedGCodeFunctionalityDef",
+    "StepsPerMMGCodeFunctionalityDef",
+    "SetMaxSpeedGCodeFunctionalityDef",
+    "AccelerationGCodeFunctionalityDef",
+    "DisengageMotorGCodeFunctionalityDef",
+    "HomingStatusGCodeFunctionalityDef",
+    "MicrosteppingCEnableGCodeFunctionalityDef",
+    "MicrosteppingCDisableGCodeFunctionalityDef",
+    "MicrosteppingBEnableGCodeFunctionalityDef",
+    "MicrosteppingBDisableGCodeFunctionalityDef",
+    "SetPipetteRetractGCodeFunctionalityDef",
+    "SetPipetteDebounceGCodeFunctionalityDef",
+    "SetPipetteHomeGCodeFunctionalityDef",
+    "SetPipetteMaxTravelGCodeFunctionalityDef",
+    "ReadInstrumentIDGCodeFunctionalityDef",
+    "ReadInstrumentModelGCodeFunctionalityDef",
+    "WriteInstrumentIDGCodeFunctionalityDef",
+    "WriteInstrumentModelGCodeFunctionalityDef",
 ]

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/absolute_coordinate_mode_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/absolute_coordinate_mode_g_code_functionality_def.py
@@ -1,9 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class AbsoluteCoordinateModeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Switching to Absolute Coordinate Mode'
+        return "Switching to Absolute Coordinate Mode"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/acceleration_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/acceleration_g_code_functionality_def.py
@@ -1,22 +1,23 @@
 from typing import Dict
 from string import Template
 from enum import Enum
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class AccelerationGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['S', 'X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["S", "X", "Y", "Z", "A", "B", "C"]
 
     class ValDefinedMessage(str, Enum):
-        S = 'Default: $ident'
-        Y = 'Y-Axis: $ident'
-        X = 'X-Axis: $ident'
-        Z = 'Left Pipette Arm: $ident'
-        B = 'Left Pipette Suction: $ident'
-        A = 'Right Pipette Arm: $ident'
-        C = 'Right Pipette Suction: $ident'
+        S = "Default: $ident"
+        Y = "Y-Axis: $ident"
+        X = "X-Axis: $ident"
+        Z = "Left Pipette Arm: $ident"
+        B = "Left Pipette Suction: $ident"
+        A = "Right Pipette Arm: $ident"
+        C = "Right Pipette Suction: $ident"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -28,5 +29,6 @@ class AccelerationGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                 message = pos_message_template.substitute(ident=g_code_arg_val)
                 message_list.append(message)
 
-        return 'Setting acceleration for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return "Setting acceleration for the following axes:\n\t" + "\n\t".join(
+            message_list
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/current_position_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/current_position_g_code_functionality_def.py
@@ -1,31 +1,26 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class CurrentPositionGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'(?P<axis>[ABCXYZ]):(?P<value>-?\d+.\d+)')
+    RESPONSE_RE = re.compile(r"(?P<axis>[ABCXYZ]):(?P<value>-?\d+.\d+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting current position for all axes'
+        return "Getting current position for all axes"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         matches = sorted(
-            [
-                match.groupdict()
-                for match in cls.RESPONSE_RE.finditer(response)
-            ],
-            key=lambda i: i['axis']
+            [match.groupdict() for match in cls.RESPONSE_RE.finditer(response)],
+            key=lambda i: i["axis"],
         )
 
-        position_string = '\n\t'.join(
-            [
-                f"{match['axis']} Axis: {match['value']}"
-                for match in matches
-            ]
+        position_string = "\n\t".join(
+            [f"{match['axis']} Axis: {match['value']}" for match in matches]
         )
 
-        return '\n\t'.join(['The current position of the robot is:', position_string])
+        return "\n\t".join(["The current position of the robot is:", position_string])

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/disengage_motor_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/disengage_motor_g_code_functionality_def.py
@@ -1,20 +1,16 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DisengageMotorGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C"]
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         passed_args = g_code_args.keys()
-        current_keys = [
-            key
-            for key
-            in cls.EXPECTED_ARGS
-            if key in passed_args
-        ]
+        current_keys = [key for key in cls.EXPECTED_ARGS if key in passed_args]
 
-        axis_to_home = ', '.join(current_keys)
-        return f'Disengaging motor for the following axes: {axis_to_home}'
+        axis_to_home = ", ".join(current_keys)
+        return f"Disengaging motor for the following axes: {axis_to_home}"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/dwell_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/dwell_g_code_functionality_def.py
@@ -1,13 +1,14 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DwellGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    DWELL_ARG_KEY = 'P'
+    DWELL_ARG_KEY = "P"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         duration = g_code_args[cls.DWELL_ARG_KEY]
-        return f'Pausing movement for {duration}ms'
+        return f"Pausing movement for {duration}ms"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/home_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/home_g_code_functionality_def.py
@@ -1,20 +1,16 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class HomeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C"]
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         passed_args = g_code_args.keys()
-        current_keys = [
-            key
-            for key
-            in cls.EXPECTED_ARGS
-            if key in passed_args
-        ]
+        current_keys = [key for key in cls.EXPECTED_ARGS if key in passed_args]
 
-        axis_to_home = ', '.join(current_keys)
-        return f'Homing the following axes: {axis_to_home}'
+        axis_to_home = ", ".join(current_keys)
+        return f"Homing the following axes: {axis_to_home}"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/homing_status_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/homing_status_g_code_functionality_def.py
@@ -1,31 +1,26 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class HomingStatusGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'(?P<axis>[ABCXYZ]):(?P<value>[\d.]+)')
+    RESPONSE_RE = re.compile(r"(?P<axis>[ABCXYZ]):(?P<value>[\d.]+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting homing status for all axes'
+        return "Getting homing status for all axes"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         matches = sorted(
-            [
-                match.groupdict()
-                for match in cls.RESPONSE_RE.finditer(response)
-            ],
-            key=lambda i: i['axis']
+            [match.groupdict() for match in cls.RESPONSE_RE.finditer(response)],
+            key=lambda i: i["axis"],
         )
 
-        position_string = '\n\t'.join(
-            [
-                f"{match['axis']} Axis: {match['value']}"
-                for match in matches
-            ]
+        position_string = "\n\t".join(
+            [f"{match['axis']} Axis: {match['value']}" for match in matches]
         )
 
-        return '\n\t'.join(['The homing status of the robot is:', position_string])
+        return "\n\t".join(["The homing status of the robot is:", position_string])

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/limit_switch_status_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/limit_switch_status_g_code_functionality_def.py
@@ -1,13 +1,13 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class LimitSwitchStatusGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting the limit switch status'
+        return "Getting the limit switch status"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_b_disable_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_b_disable_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MicrosteppingBDisableGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Disabling microstepping on B-Axis'
+        return "Disabling microstepping on B-Axis"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_b_enable_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_b_enable_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MicrosteppingBEnableGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Enabling microstepping on B-Axis'
+        return "Enabling microstepping on B-Axis"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_c_disable_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_c_disable_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MicrosteppingCDisableGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Disabling microstepping on C-Axis'
+        return "Disabling microstepping on C-Axis"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_c_enable_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/microstepping_c_enable_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MicrosteppingCEnableGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Enabling microstepping on C-Axis'
+        return "Enabling microstepping on C-Axis"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/move_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/move_g_code_functionality_def.py
@@ -1,22 +1,23 @@
 from typing import Dict
 from string import Template
 from enum import Enum
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class MoveGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C', 'F']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C", "F"]
 
     class ValDefinedMessage(str, Enum):
-        Y = 'The gantry to $ident on the Y-Axis'
-        X = 'The gantry to $ident on the X-Axis'
-        Z = 'The left pipette arm height to $ident'
-        B = 'The left pipette suction to $ident'
-        A = 'The right pipette arm height to $ident'
-        C = 'The right pipette suction to $ident'
-        F = 'At a speed of $ident'
+        Y = "The gantry to $ident on the Y-Axis"
+        X = "The gantry to $ident on the X-Axis"
+        Z = "The left pipette arm height to $ident"
+        B = "The left pipette suction to $ident"
+        A = "The right pipette arm height to $ident"
+        C = "The right pipette suction to $ident"
+        F = "At a speed of $ident"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -28,4 +29,4 @@ class MoveGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                 message = pos_message_template.substitute(ident=g_code_arg_val)
                 message_list.append(message)
 
-        return 'Moving the robot as follows:\n\t' + '\n\t'.join(message_list)
+        return "Moving the robot as follows:\n\t" + "\n\t".join(message_list)

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/pop_speed_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/pop_speed_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class PopSpeedGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Loading previously saved speed'
+        return "Loading previously saved speed"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/probe_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/probe_g_code_functionality_def.py
@@ -1,48 +1,48 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class ProbeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    SPEED_ARG_KEY = 'F'
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C', 'F']
-    RESPONSE_RW = re.compile('PRB:(?P<x>.*?),(?P<y>.*?),(?P<z>.*?):')
+    SPEED_ARG_KEY = "F"
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C", "F"]
+    RESPONSE_RW = re.compile("PRB:(?P<x>.*?),(?P<y>.*?),(?P<z>.*?):")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         passed_args = g_code_args.keys()
-        current_keys = [
-            key
-            for key
-            in cls.EXPECTED_ARGS
-            if key in passed_args
-        ]
+        current_keys = [key for key in cls.EXPECTED_ARGS if key in passed_args]
 
         speed = None
 
         if cls.SPEED_ARG_KEY in current_keys:
             speed = g_code_args[cls.SPEED_ARG_KEY]
             current_keys.remove(cls.SPEED_ARG_KEY)
-        probing_to_values = ','.join([str(g_code_args[key]) for key in current_keys])
-        axis_to_probe = ', '.join(current_keys)
+        probing_to_values = ",".join([str(g_code_args[key]) for key in current_keys])
+        axis_to_probe = ", ".join(current_keys)
 
         if speed is None:
-            message = f'Probing {probing_to_values} on the {axis_to_probe} axis'
+            message = f"Probing {probing_to_values} on the {axis_to_probe} axis"
         else:
-            message = f'Probing {probing_to_values} on the {axis_to_probe} axis, ' \
-                      f'at a speed of {speed}'
+            message = (
+                f"Probing {probing_to_values} on the {axis_to_probe} axis, "
+                f"at a speed of {speed}"
+            )
 
         return message
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RW.search(response)
-        message = 'Could not parse response'
+        message = "Could not parse response"
         if match is not None:
             pars = match.groupdict()
-            message = f"Probed to :" \
-                      f"\n\tX Axis: {pars['x']}" \
-                      f"\n\tY Axis: {pars['y']}" \
-                      f"\n\tZ Axis: {pars['z']}"
+            message = (
+                f"Probed to :"
+                f"\n\tX Axis: {pars['x']}"
+                f"\n\tY Axis: {pars['y']}"
+                f"\n\tZ Axis: {pars['z']}"
+            )
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/push_speed_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/push_speed_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class PushSpeedGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Saving current speed so temporary speed can be set'
+        return "Saving current speed so temporary speed can be set"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_id_g_code_functionality_def.py
@@ -1,22 +1,20 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 from opentrons.drivers.smoothie_drivers.parse_utils import byte_array_to_ascii_string
 
 
 class ReadInstrumentIDGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    SIDE_EXPANSION_DICT = {
-        'L': 'Left',
-        'R': 'Right'
-    }
+    SIDE_EXPANSION_DICT = {"L": "Left", "R": "Right"}
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         left_or_right = cls.SIDE_EXPANSION_DICT[list(g_code_args.keys())[0]]
-        return f'Reading instrument ID for {left_or_right} pipette'
+        return f"Reading instrument ID for {left_or_right} pipette"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        hex_string = response.split(':')[-1].strip()
+        hex_string = response.split(":")[-1].strip()
         instrument_id = byte_array_to_ascii_string(bytearray.fromhex(hex_string))
-        return f'Read Instrument ID: {instrument_id}'
+        return f"Read Instrument ID: {instrument_id}"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/read_instrument_model_g_code_functionality_def.py
@@ -1,23 +1,21 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 from opentrons.drivers.smoothie_drivers.parse_utils import byte_array_to_ascii_string
 
 
 class ReadInstrumentModelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    SIDE_EXPANSION_DICT = {
-        'L': 'Left',
-        'R': 'Right'
-    }
+    SIDE_EXPANSION_DICT = {"L": "Left", "R": "Right"}
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         left_or_right = cls.SIDE_EXPANSION_DICT[list(g_code_args.keys())[0]]
 
-        return f'Reading instrument model for {left_or_right} pipette'
+        return f"Reading instrument model for {left_or_right} pipette"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        hex_string = response.split(':')[-1].strip()
+        hex_string = response.split(":")[-1].strip()
         instrument_model = byte_array_to_ascii_string(bytearray.fromhex(hex_string))
-        return f'Read Instrument Model: {instrument_model}'
+        return f"Read Instrument Model: {instrument_model}"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/relative_coordinate_mode_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/relative_coordinate_mode_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class RelativeCoordinateModeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Switching to Relative Coordinate Mode'
+        return "Switching to Relative Coordinate Mode"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/reset_from_error_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/reset_from_error_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class ResetFromErrorGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Resetting OT-2 from error state'
+        return "Resetting OT-2 from error state"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_current_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_current_g_code_functionality_def.py
@@ -1,27 +1,25 @@
 from typing import Dict
 from string import Template
 from enum import Enum
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetCurrentGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C"]
 
     class ValDefinedMessage(str, Enum):
-        Y = 'Y-Axis Motor: $current'
-        X = 'X-Axis Motor: $current'
-        Z = 'Z-Axis Motor: $current'
-        B = 'B-Axis Motor: $current'
-        A = 'A-Axis Motor: $current'
-        C = 'C-Axis Motor: $current'
+        Y = "Y-Axis Motor: $current"
+        X = "X-Axis Motor: $current"
+        Z = "Z-Axis Motor: $current"
+        B = "B-Axis Motor: $current"
+        A = "A-Axis Motor: $current"
+        C = "C-Axis Motor: $current"
 
     @classmethod
-    def _generate_command_explanation(
-            cls,
-            g_code_args: Dict[str, str]
-    ) -> str:
+    def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         message_list = []
         for arg in cls.EXPECTED_ARGS:
             g_code_arg_val = g_code_args.get(arg)
@@ -30,4 +28,4 @@ class SetCurrentGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                 message = message_template.substitute(current=g_code_arg_val)
                 message_list.append(message)
 
-        return 'Setting the current (in amps) to:\n\t' + '\n\t'.join(message_list)
+        return "Setting the current (in amps) to:\n\t" + "\n\t".join(message_list)

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_max_speed_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_max_speed_g_code_functionality_def.py
@@ -1,14 +1,15 @@
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetMaxSpeedGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $speed')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $speed")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -20,5 +21,6 @@ class SetMaxSpeedGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                     cls.VAL_DEFINED_MESSAGE.substitute(name=arg, speed=g_code_arg_val)
                 )
 
-        return 'Setting the max speed for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return "Setting the max speed for the following axes:\n\t" + "\n\t".join(
+            message_list
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_debounce_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_debounce_g_code_functionality_def.py
@@ -1,14 +1,15 @@
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetPipetteDebounceGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['B', 'C', 'Z', 'A']
+    EXPECTED_ARGS = ["B", "C", "Z", "A"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $time')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $time")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -20,5 +21,7 @@ class SetPipetteDebounceGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                     cls.VAL_DEFINED_MESSAGE.substitute(name=arg, time=g_code_arg_val)
                 )
 
-        return 'Setting the pipette endstop debounce time for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return (
+            "Setting the pipette endstop debounce time for the following axes:\n\t"
+            + "\n\t".join(message_list)
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_home_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_home_g_code_functionality_def.py
@@ -1,14 +1,15 @@
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetPipetteHomeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['Z', 'A']
+    EXPECTED_ARGS = ["Z", "A"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $height')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $height")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -20,5 +21,7 @@ class SetPipetteHomeGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                     cls.VAL_DEFINED_MESSAGE.substitute(name=arg, height=g_code_arg_val)
                 )
 
-        return 'Setting the pipette home height for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return (
+            "Setting the pipette home height for the following axes:\n\t"
+            + "\n\t".join(message_list)
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_max_travel_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_max_travel_g_code_functionality_def.py
@@ -1,14 +1,15 @@
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetPipetteMaxTravelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['A', 'Z', 'B', 'C']
+    EXPECTED_ARGS = ["A", "Z", "B", "C"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $height')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $height")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -20,5 +21,7 @@ class SetPipetteMaxTravelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                     cls.VAL_DEFINED_MESSAGE.substitute(name=arg, height=g_code_arg_val)
                 )
 
-        return 'Setting the pipette max travel height for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return (
+            "Setting the pipette max travel height for the following axes:\n\t"
+            + "\n\t".join(message_list)
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_retract_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_pipette_retract_g_code_functionality_def.py
@@ -1,14 +1,15 @@
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetPipetteRetractGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['B', 'C', 'Z', 'A']
+    EXPECTED_ARGS = ["B", "C", "Z", "A"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $distance')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $distance")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -18,11 +19,11 @@ class SetPipetteRetractGCodeFunctionalityDef(GCodeFunctionalityDefBase):
             if g_code_arg_val is not None:
                 message_list.append(
                     cls.VAL_DEFINED_MESSAGE.substitute(
-                        name=arg,
-                        distance=g_code_arg_val
+                        name=arg, distance=g_code_arg_val
                     )
                 )
 
-        return 'Setting the pipette endstop retract distance ' \
-               'for the following axes:\n\t'\
-               + '\n\t'.join(message_list)
+        return (
+            "Setting the pipette endstop retract distance "
+            "for the following axes:\n\t" + "\n\t".join(message_list)
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_speed_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/set_speed_g_code_functionality_def.py
@@ -1,13 +1,14 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetSpeedGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    SPEED_ARG_KEY = 'F'
+    SPEED_ARG_KEY = "F"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         speed = g_code_args[cls.SPEED_ARG_KEY]
-        return f'Setting speed to {speed}'
+        return f"Setting speed to {speed}"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/steps_per_mm_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/steps_per_mm_g_code_functionality_def.py
@@ -1,17 +1,18 @@
 import re
 from typing import Dict
 from string import Template
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class StepsPerMMGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['X', 'Y', 'Z', 'A', 'B', 'C']
+    EXPECTED_ARGS = ["X", "Y", "Z", "A", "B", "C"]
 
-    VAL_DEFINED_MESSAGE = Template('$name-Axis: $steps steps per mm')
+    VAL_DEFINED_MESSAGE = Template("$name-Axis: $steps steps per mm")
 
-    RESPONSE_RE = re.compile(r'(?P<axis>[ABCXYZ]):(?P<value>[\d.]+)')
+    RESPONSE_RE = re.compile(r"(?P<axis>[ABCXYZ]):(?P<value>[\d.]+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -23,16 +24,17 @@ class StepsPerMMGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                     cls.VAL_DEFINED_MESSAGE.substitute(name=arg, steps=g_code_arg_val)
                 )
 
-        return 'Setting the following axes steps per mm:\n\t' \
-               + '\n\t'.join(message_list)
+        return "Setting the following axes steps per mm:\n\t" + "\n\t".join(
+            message_list
+        )
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        steps_string = '\n\t'.join(
+        steps_string = "\n\t".join(
             [
                 f"{match['axis']} Axis: {match['value']}"
                 for match in cls.RESPONSE_RE.finditer(response)
             ]
         )
 
-        return '\n\t'.join(['Current set steps per mm:', steps_string])
+        return "\n\t".join(["Current set steps per mm:", steps_string])

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/wait_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/wait_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class WaitGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Waiting for motors to stop moving'
+        return "Waiting for motors to stop moving"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/write_instrument_id_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/write_instrument_id_g_code_functionality_def.py
@@ -1,18 +1,18 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class WriteInstrumentIDGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    SIDE_EXPANSION_DICT = {
-        'L': 'Left',
-        'R': 'Right'
-    }
+    SIDE_EXPANSION_DICT = {"L": "Left", "R": "Right"}
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         l_or_r = list(g_code_args.keys())[0]
         left_or_right = cls.SIDE_EXPANSION_DICT[l_or_r]
 
-        return f'Writing instrument ID {g_code_args[l_or_r]} for ' \
-               f'{left_or_right} pipette'
+        return (
+            f"Writing instrument ID {g_code_args[l_or_r]} for "
+            f"{left_or_right} pipette"
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/write_instrument_model_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/smoothie/write_instrument_model_g_code_functionality_def.py
@@ -1,18 +1,18 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class WriteInstrumentModelGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    SIDE_EXPANSION_DICT = {
-        'L': 'Left',
-        'R': 'Right'
-    }
+    SIDE_EXPANSION_DICT = {"L": "Left", "R": "Right"}
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         l_or_r = list(g_code_args.keys())[0]
         left_or_right = cls.SIDE_EXPANSION_DICT[l_or_r]
 
-        return f'Writing instrument model {g_code_args[l_or_r]} for ' \
-               f'{left_or_right} pipette'
+        return (
+            f"Writing instrument model {g_code_args[l_or_r]} for "
+            f"{left_or_right} pipette"
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/__init__.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/__init__.py
@@ -4,8 +4,8 @@ from .get_temp_g_code_functionality_def import GetTempGCodeFunctionalityDef
 from .set_temp_g_code_functionality_def import SetTempGCodeFunctionalityDef
 
 __all__ = [
-    'DeviceInfoGCodeFunctionalityDef',
-    'DisengageGCodeFunctionalityDef',
-    'GetTempGCodeFunctionalityDef',
-    'SetTempGCodeFunctionalityDef'
+    "DeviceInfoGCodeFunctionalityDef",
+    "DisengageGCodeFunctionalityDef",
+    "GetTempGCodeFunctionalityDef",
+    "SetTempGCodeFunctionalityDef",
 ]

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/device_info_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/device_info_g_code_functionality_def.py
@@ -1,25 +1,28 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeviceInfoGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'serial:(.*?)model:(.*?)version:(.*?)$')
+    RESPONSE_RE = re.compile(r"serial:(.*?)model:(.*?)version:(.*?)$")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting tempdeck device info'
+        return "Getting tempdeck device info"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
         if match is not None:
             serial_number, model, fw_version = match.groups()
-            message = f'Tempdeck info:' \
-                      f'\n\tSerial Number: {serial_number.strip()}' \
-                      f'\n\tModel: {model.strip()}' \
-                      f'\n\tFirmware Version: {fw_version.strip()}'
+            message = (
+                f"Tempdeck info:"
+                f"\n\tSerial Number: {serial_number.strip()}"
+                f"\n\tModel: {model.strip()}"
+                f"\n\tFirmware Version: {fw_version.strip()}"
+            )
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/disengage_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/disengage_g_code_functionality_def.py
@@ -1,11 +1,13 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DisengageGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Halting holding temperature. Reducing temperature to ' \
-               '55C if it is greater than 55C'
+        return (
+            "Halting holding temperature. Reducing temperature to "
+            "55C if it is greater than 55C"
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/get_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/get_temp_g_code_functionality_def.py
@@ -1,28 +1,33 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class GetTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'T:(?P<set_temp>.*?)C:(?P<current_temp>\d+.\d+)')
+    RESPONSE_RE = re.compile(r"T:(?P<set_temp>.*?)C:(?P<current_temp>\d+.\d+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting temperature'
+        return "Getting temperature"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
 
         if match is not None:
-            current_temp = match.groupdict()['current_temp'].strip()
-            set_temp = match.groupdict()['set_temp'].strip()
-            if set_temp == 'none':
-                message = f'Temp deck is disengaged. ' \
-                          f'Current temperature is {current_temp}C'
+            current_temp = match.groupdict()["current_temp"].strip()
+            set_temp = match.groupdict()["set_temp"].strip()
+            if set_temp == "none":
+                message = (
+                    f"Temp deck is disengaged. "
+                    f"Current temperature is {current_temp}C"
+                )
             else:
-                message = f'Set temperature is {set_temp}C. ' \
-                          f'Current temperature is {current_temp}C'
+                message = (
+                    f"Set temperature is {set_temp}C. "
+                    f"Current temperature is {current_temp}C"
+                )
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/set_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/tempdeck/set_temp_g_code_functionality_def.py
@@ -1,19 +1,20 @@
 from typing import Dict
 from string import Template
 from enum import Enum
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['S', 'P', 'I', 'D']
+    EXPECTED_ARGS = ["S", "P", "I", "D"]
 
     class ValDefinedMessage(str, Enum):
-        S = 'Temperature: ${val}C'
-        P = 'Kp: $val'
-        I = 'Ki: $val'  # noqa: E741
-        D = 'Kd: $val'
+        S = "Temperature: ${val}C"
+        P = "Kp: $val"
+        I = "Ki: $val"  # noqa: E741
+        D = "Kd: $val"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -25,5 +26,6 @@ class SetTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
                 message = message_temp.substitute(val=g_code_arg_val)
                 message_list.append(message)
 
-        return 'Setting temperature values to the following:\n\t' \
-               + '\n\t'.join(message_list)
+        return "Setting temperature values to the following:\n\t" + "\n\t".join(
+            message_list
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/__init__.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/__init__.py
@@ -8,23 +8,24 @@ from .set_lid_temp_g_code_functionality_def import SetLidTempGCodeFunctionalityD
 from .get_lid_temp_g_code_functionality_def import GetLidTempGCodeFunctionalityDef
 from .set_ramp_rate_g_code_functionality_def import SetRampRateGCodeFunctionalityDef
 from .deactivate_lid_g_code_functionality_def import DeactivateLidGCodeFunctionalityDef
-from .deactivate_block_g_code_functionality_def import \
-    DeactivateBlockGCodeFunctionalityDef
+from .deactivate_block_g_code_functionality_def import (
+    DeactivateBlockGCodeFunctionalityDef,
+)
 from .deactivate_all_g_code_functionality_def import DeactivateAllGCodeFunctionalityDef
 from .edit_pid_params_g_code_functionality_def import EditPIDParamsGCodeFunctionalityDef
 
 __all__ = [
-    'CloseLidGCodeFunctionalityDef',
-    'DeviceInfoGCodeFunctionalityDef',
-    'GetPlateTempGCodeFunctionalityDef',
-    'LidStatusGCodeFunctionalityDef',
-    'OpenLidGCodeFunctionalityDef',
-    'SetPlateTempGCodeFunctionalityDef',
-    'SetLidTempGCodeFunctionalityDef',
-    'GetLidTempGCodeFunctionalityDef',
-    'SetRampRateGCodeFunctionalityDef',
-    'DeactivateLidGCodeFunctionalityDef',
-    'DeactivateBlockGCodeFunctionalityDef',
-    'DeactivateAllGCodeFunctionalityDef',
-    'EditPIDParamsGCodeFunctionalityDef',
+    "CloseLidGCodeFunctionalityDef",
+    "DeviceInfoGCodeFunctionalityDef",
+    "GetPlateTempGCodeFunctionalityDef",
+    "LidStatusGCodeFunctionalityDef",
+    "OpenLidGCodeFunctionalityDef",
+    "SetPlateTempGCodeFunctionalityDef",
+    "SetLidTempGCodeFunctionalityDef",
+    "GetLidTempGCodeFunctionalityDef",
+    "SetRampRateGCodeFunctionalityDef",
+    "DeactivateLidGCodeFunctionalityDef",
+    "DeactivateBlockGCodeFunctionalityDef",
+    "DeactivateAllGCodeFunctionalityDef",
+    "EditPIDParamsGCodeFunctionalityDef",
 ]

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/close_lid_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/close_lid_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class CloseLidGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Closing thermocycler lid'
+        return "Closing thermocycler lid"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_all_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_all_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeactivateAllGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Deactivating thermocycler block and lid'
+        return "Deactivating thermocycler block and lid"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_block_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_block_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeactivateBlockGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Deactivating thermocycler block'
+        return "Deactivating thermocycler block"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_lid_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/deactivate_lid_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeactivateLidGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Deactivating thermocycler lid'
+        return "Deactivating thermocycler lid"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/device_info_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/device_info_g_code_functionality_def.py
@@ -1,25 +1,28 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class DeviceInfoGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'serial:(.*?)model:(.*?)version:(.*?)$')
+    RESPONSE_RE = re.compile(r"serial:(.*?)model:(.*?)version:(.*?)$")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting thermocycler device info'
+        return "Getting thermocycler device info"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
         if match is not None:
             serial_number, model, fw_version = match.groups()
-            message = f'Thermocycler info:' \
-                      f'\n\tSerial Number: {serial_number.strip()}' \
-                      f'\n\tModel: {model.strip()}' \
-                      f'\n\tFirmware Version: {fw_version.strip()}'
+            message = (
+                f"Thermocycler info:"
+                f"\n\tSerial Number: {serial_number.strip()}"
+                f"\n\tModel: {model.strip()}"
+                f"\n\tFirmware Version: {fw_version.strip()}"
+            )
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/edit_pid_params_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/edit_pid_params_g_code_functionality_def.py
@@ -1,18 +1,19 @@
 from typing import Dict
 from string import Template
 from enum import Enum
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class EditPIDParamsGCodeFunctionalityDef(GCodeFunctionalityDefBase):
     # Using this list to output string in specific order
-    EXPECTED_ARGS = ['P', 'I', 'D']
+    EXPECTED_ARGS = ["P", "I", "D"]
 
     class ValDefinedMessage(str, Enum):
-        P = '\n\tKp: $val'
-        I = '\n\tKi: $val'  # noqa: E741
-        D = '\n\tKd: $val'
+        P = "\n\tKp: $val"
+        I = "\n\tKi: $val"  # noqa: E741
+        D = "\n\tKd: $val"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
@@ -28,9 +29,9 @@ class EditPIDParamsGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        message = 'Edit successful'
+        message = "Edit successful"
 
-        if 'ERROR' in response.upper() and 'BUSY' in response.upper():
-            message = 'Cannot set PID values. Thermocycler busy'
+        if "ERROR" in response.upper() and "BUSY" in response.upper():
+            message = "Cannot set PID values. Thermocycler busy"
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/get_lid_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/get_lid_temp_g_code_functionality_def.py
@@ -1,28 +1,33 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class GetLidTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-    RESPONSE_RE = re.compile(r'T:(?P<set_temp>.*?)C:(?P<current_temp>\d+.\d+)')
+    RESPONSE_RE = re.compile(r"T:(?P<set_temp>.*?)C:(?P<current_temp>\d+.\d+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting temperature for thermocycler lid'
+        return "Getting temperature for thermocycler lid"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = ''
+        message = ""
 
         if match is not None:
-            current_temp = match.groupdict()['current_temp'].strip()
-            set_temp = match.groupdict()['set_temp'].strip()
-            if set_temp == 'none':
-                message = f'Temperature for thermocycler lid is not set' \
-                          f'\nCurrent temperature of lid is {current_temp}C'
+            current_temp = match.groupdict()["current_temp"].strip()
+            set_temp = match.groupdict()["set_temp"].strip()
+            if set_temp == "none":
+                message = (
+                    f"Temperature for thermocycler lid is not set"
+                    f"\nCurrent temperature of lid is {current_temp}C"
+                )
             else:
-                message = f'Set temperature for thermocycler lid is {set_temp}C' \
-                          f'\nCurrent temperature of lid is {current_temp}C'
+                message = (
+                    f"Set temperature for thermocycler lid is {set_temp}C"
+                    f"\nCurrent temperature of lid is {current_temp}C"
+                )
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/get_plate_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/get_plate_temp_g_code_functionality_def.py
@@ -3,34 +3,35 @@ from typing import Dict
 from string import Template
 from distutils.util import strtobool
 from opentrons.drivers.utils import parse_key_values
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class GetPlateTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    VALID_KEYS = ['T', 'C', 'H', 'TOTAL_H', 'AT_TARGET']
+    VALID_KEYS = ["T", "C", "H", "TOTAL_H", "AT_TARGET"]
 
     class ResponseMessages(Enum):
-        T = Template('\n\tTarget temperature is: ${val}C')
-        C = Template('\n\tCurrent temperature is: ${val}C')
-        H = Template('\n\tRemaining hold time is: ${val}ms')
-        TOTAL_H = Template('\n\tTotal hold time is: ${val}ms')
+        T = Template("\n\tTarget temperature is: ${val}C")
+        C = Template("\n\tCurrent temperature is: ${val}C")
+        H = Template("\n\tRemaining hold time is: ${val}ms")
+        TOTAL_H = Template("\n\tTotal hold time is: ${val}ms")
 
-        T_NEG = '\n\tTarget temperature not set'
-        H_NEG = '\n\tHold time not set'
+        T_NEG = "\n\tTarget temperature not set"
+        H_NEG = "\n\tHold time not set"
 
         # TOTAL_H_NEG is blank because H_NEG's message is sufficent explanation for
         # the both of them
-        TOTAL_H_NEG = ''
+        TOTAL_H_NEG = ""
 
-        AT_TARGET_TRUE = '\n\tAt target temperature'
-        AT_TARGET_FALSE = '\n\tNot at target temperature'
-        AT_TARGET_UNPARSABLE = '\n\tTarget temperature is unparsable: '
+        AT_TARGET_TRUE = "\n\tAt target temperature"
+        AT_TARGET_FALSE = "\n\tNot at target temperature"
+        AT_TARGET_UNPARSABLE = "\n\tTarget temperature is unparsable: "
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting temperature values for thermocycler'
+        return "Getting temperature values for thermocycler"
 
     @classmethod
     def _parse_at_target(cls, key, value):
@@ -52,31 +53,31 @@ class GetPlateTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
-        message = 'Temperature values for thermocycler are as follows:'
+        message = "Temperature values for thermocycler are as follows:"
         parsed_response_vals = parse_key_values(response)
-        target_temp_set = parsed_response_vals['T'] != 'none'
+        target_temp_set = parsed_response_vals["T"] != "none"
 
         for key, value in parsed_response_vals.items():
             key = key.upper()  # Makes enum values cleaner
 
             # The key will actually be AT_TARGET?
             # Need to remove the question mark
-            if 'AT_TARGET' in key:
-                key = 'AT_TARGET'
+            if "AT_TARGET" in key:
+                key = "AT_TARGET"
 
             # If target temp is not set then there is no point to display
             # these values
-            if not target_temp_set and key in ['H', 'TOTAL_H', 'AT_TARGET']:
+            if not target_temp_set and key in ["H", "TOTAL_H", "AT_TARGET"]:
                 continue
 
             if key in cls.VALID_KEYS:
-                if key == 'AT_TARGET':
+                if key == "AT_TARGET":
                     message += cls._parse_at_target(key, value)
                     continue
 
                 # The value "none" is used to denote "not set"
-                if value == 'none':
-                    message += cls.ResponseMessages[key + '_NEG'].value
+                if value == "none":
+                    message += cls.ResponseMessages[key + "_NEG"].value
                     continue
 
                 template = cls.ResponseMessages[key].value

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/lid_status_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/lid_status_g_code_functionality_def.py
@@ -1,24 +1,25 @@
 import re
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class LidStatusGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    RESPONSE_RE = re.compile(r'Lid:(\w+)')
+    RESPONSE_RE = re.compile(r"Lid:(\w+)")
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Getting status of thermocycler lid'
+        return "Getting status of thermocycler lid"
 
     @classmethod
     def _generate_response_explanation(cls, response: str) -> str:
         match = cls.RESPONSE_RE.match(response)
-        message = 'Lid Status: '
+        message = "Lid Status: "
         if match is not None:
             message += match.group(1).strip().capitalize()
         else:
-            message += 'Unknown'
+            message += "Unknown"
 
         return message

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/open_lid_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/open_lid_g_code_functionality_def.py
@@ -1,10 +1,10 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class OpenLidGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Opening thermocycler lid'
+        return "Opening thermocycler lid"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_lid_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_lid_temp_g_code_functionality_def.py
@@ -1,13 +1,14 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetLidTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    PLATE_TEMP_ARG_KEY = 'S'
+    PLATE_TEMP_ARG_KEY = "S"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         temp = g_code_args[cls.PLATE_TEMP_ARG_KEY]
-        return f'Setting thermocycler lid temp to {temp}C'
+        return f"Setting thermocycler lid temp to {temp}C"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_plate_temp_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_plate_temp_g_code_functionality_def.py
@@ -1,13 +1,14 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetPlateTempGCodeFunctionalityDef(GCodeFunctionalityDefBase):
 
-    PLATE_TEMP_ARG_KEY = 'S'
+    PLATE_TEMP_ARG_KEY = "S"
 
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
         temp = g_code_args[cls.PLATE_TEMP_ARG_KEY]
-        return f'Setting thermocycler plate temp to {temp}C'
+        return f"Setting thermocycler plate temp to {temp}C"

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_ramp_rate_g_code_functionality_def.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_functionality_defs/thermocycler/set_ramp_rate_g_code_functionality_def.py
@@ -1,11 +1,13 @@
 from typing import Dict
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import GCodeFunctionalityDefBase
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    GCodeFunctionalityDefBase,
+)
 
 
 class SetRampRateGCodeFunctionalityDef(GCodeFunctionalityDefBase):
-
     @classmethod
     def _generate_command_explanation(cls, g_code_args: Dict[str, str]) -> str:
-        return 'Setting thermocycler ramp rate.' \
-               '\nNote: This is an unimplemented feature, setting this does nothing'
+        return (
+            "Setting thermocycler ramp rate."
+            "\nNote: This is an unimplemented feature, setting this does nothing"
+        )

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/g_code_program.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/g_code_program.py
@@ -12,6 +12,7 @@ class GCodeProgram:
     Class for parsing various G-Code files and programs into a
     list of GCode objects
     """
+
     @classmethod
     def from_g_code_watcher(cls, watcher: GCodeWatcher) -> GCodeProgram:
         """
@@ -23,10 +24,8 @@ class GCodeProgram:
         g_codes = []
         for watcher_data in watcher.get_command_list():
             g_code_list = GCode.from_raw_code(
-                    watcher_data.raw_g_code,
-                    watcher_data.device,
-                    watcher_data.response
-                )
+                watcher_data.raw_g_code, watcher_data.device, watcher_data.response
+            )
             for g_code in g_code_list:
                 # Filtering out polling commands here because they are not actually
                 # called by the user. They are called by the systems and we don't
@@ -51,11 +50,10 @@ class GCodeProgram:
         """Add a list of G-Codes to the end of a program"""
         # See from_g_code_watcher for explanation
         polling_commands = [
-            g_code for g_code in g_code_list
-            if g_code.is_polling_command()
+            g_code for g_code in g_code_list if g_code.is_polling_command()
         ]
         if len(polling_commands) > 0:
-            g_codes = ', '.join(g_code.g_code for g_code in polling_commands)
+            g_codes = ", ".join(g_code.g_code for g_code in polling_commands)
             raise PollingGCodeAdditionError(g_codes)
 
         self._g_codes.extend(g_code_list)
@@ -72,11 +70,7 @@ class GCodeProgram:
     def get_json(self) -> str:
         """Get JSON representation of all G-Codes"""
         return json.dumps(
-            [
-                code.get_explanation().to_dict()
-                for code in self._g_codes
-            ],
-            indent=4
+            [code.get_explanation().to_dict() for code in self._g_codes], indent=4
         )
 
     def get_text_explanation(self, mode: Union[SupportedTextModes, str]) -> str:
@@ -90,23 +84,16 @@ class GCodeProgram:
             text_mode = SupportedTextModes.get_text_mode_by_enum_value(mode)
         else:
             text_mode = SupportedTextModes.get_text_mode(mode)
-        return '\n'.join(
-            [
-                text_mode.builder(code)
-                for code in self._g_codes
-            ]
-        )
+        return "\n".join([text_mode.builder(code) for code in self._g_codes])
 
     def save_text_explanation_to_file(
-            self,
-            file_path: str,
-            mode: Union[SupportedTextModes, str]
+        self, file_path: str, mode: Union[SupportedTextModes, str]
     ):
 
-        with open(file_path, 'w') as file:
+        with open(file_path, "w") as file:
             file.write(self.get_text_explanation(mode))
 
     def save_json_to_file(self, file_path: str) -> None:
         """Save JSON to passed file name"""
-        with open(file_path, 'w') as file:
+        with open(file_path, "w") as file:
             file.write(self.get_json())

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_program/supported_text_modes.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.g_code_parsing.errors import InvalidTextModeErro
 from typing import Callable
 from enum import Enum
 
-MULTIPLE_SPACE_REGEX = re.compile(' +')
+MULTIPLE_SPACE_REGEX = re.compile(" +")
 
 
 # Can't use a dataclass because mypy doesn't like a dataclass
@@ -18,6 +18,7 @@ class TextMode:
     Class representing the name of a text mode and it's
     function to build the correct text
     """
+
     def __init__(self, name: str, builder: Callable[[GCode], str]) -> None:
         self._name = name
         self._builder = builder
@@ -58,12 +59,14 @@ def default_builder(code: GCode):
     :param code: G-Code object to parse into a string
     :return: Textual description
     """
-    message = f'Device: {code.device_name}\n' \
-              f'Code: {code.g_code} {code.g_code_body}\n' \
-              f'Explanation: {code.get_explanation().command_explanation}\n' \
-              f'Response: {code.get_explanation().response}' \
-              f'\n-----------------------------------------'
-    return MULTIPLE_SPACE_REGEX.sub(' ', message).strip()
+    message = (
+        f"Device: {code.device_name}\n"
+        f"Code: {code.g_code} {code.g_code_body}\n"
+        f"Explanation: {code.get_explanation().command_explanation}\n"
+        f"Response: {code.get_explanation().response}"
+        f"\n-----------------------------------------"
+    )
+    return MULTIPLE_SPACE_REGEX.sub(" ", message).strip()
 
 
 def concise_builder(code: GCode):
@@ -79,12 +82,12 @@ def concise_builder(code: GCode):
     :param code: G-Code object to parse into a string
     :return: Textual description
     """
-    message = f'{code.device_name}: {code.g_code} {code.g_code_body} -> ' \
-              f'{code.get_explanation().command_explanation} -> ' \
-              f'{code.get_explanation().response}'\
-        .replace('\n', ' ')\
-        .replace('\t', '')
-    return MULTIPLE_SPACE_REGEX.sub(' ', message).strip()
+    message = (
+        f"{code.device_name}: {code.g_code} {code.g_code_body} -> "
+        f"{code.get_explanation().command_explanation} -> "
+        f"{code.get_explanation().response}".replace("\n", " ").replace("\t", "")
+    )
+    return MULTIPLE_SPACE_REGEX.sub(" ", message).strip()
 
 
 def g_code_only_builder(code: GCode):
@@ -100,8 +103,8 @@ def g_code_only_builder(code: GCode):
     :param code: G-Code object to parse into a string
     :return: Textual description
     """
-    message = f'{code.device_name}: {code.g_code_line} -> {code.response}'
-    return MULTIPLE_SPACE_REGEX.sub(' ', message).strip()
+    message = f"{code.device_name}: {code.g_code_line} -> {code.response}"
+    return MULTIPLE_SPACE_REGEX.sub(" ", message).strip()
 
 
 class SupportedTextModes(Enum):
@@ -118,9 +121,10 @@ class SupportedTextModes(Enum):
     Concise: Same as Default but with all newlines and tabs removed to fit everything on
         a single line
     """
-    DEFAULT = 'Default'
-    CONCISE = 'Concise'
-    G_CODE = 'G-Code'
+
+    DEFAULT = "Default"
+    CONCISE = "Concise"
+    G_CODE = "G-Code"
 
     @classmethod
     def get_valid_modes(cls):
@@ -133,7 +137,7 @@ class SupportedTextModes(Enum):
         _internal_mapping = {
             cls.DEFAULT.value: TextMode(cls.DEFAULT.value, default_builder),
             cls.CONCISE.value: TextMode(cls.CONCISE.value, concise_builder),
-            cls.G_CODE.value: TextMode(cls.G_CODE.value, g_code_only_builder)
+            cls.G_CODE.value: TextMode(cls.G_CODE.value, g_code_only_builder),
         }
         members = [member.value for member in list(cls.__members__.values())]
         if key not in members:

--- a/api/src/opentrons/hardware_control/g_code_parsing/g_code_watcher.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/g_code_watcher.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 from typing import List, Optional
 from opentrons.drivers.asyncio.communication import SerialConnection
 from dataclasses import dataclass
-from opentrons.hardware_control.emulation.app import \
-    TEMPDECK_PORT, THERMOCYCLER_PORT, SMOOTHIE_PORT, MAGDECK_PORT
+from opentrons.hardware_control.emulation.app import (
+    TEMPDECK_PORT,
+    THERMOCYCLER_PORT,
+    SMOOTHIE_PORT,
+    MAGDECK_PORT,
+)
 
 
 @dataclass
@@ -20,10 +24,10 @@ class GCodeWatcher:
     """
 
     DEVICE_LOOKUP_BY_PORT = {
-        SMOOTHIE_PORT: 'smoothie',
-        TEMPDECK_PORT: 'tempdeck',
-        THERMOCYCLER_PORT: 'thermocycler',
-        MAGDECK_PORT: 'magdeck',
+        SMOOTHIE_PORT: "smoothie",
+        TEMPDECK_PORT: "tempdeck",
+        THERMOCYCLER_PORT: "thermocycler",
+        MAGDECK_PORT: "magdeck",
     }
 
     def __init__(self) -> None:
@@ -32,8 +36,13 @@ class GCodeWatcher:
 
     def __enter__(self) -> GCodeWatcher:
         """Patch the send command function"""
-        async def _patch(_self: SerialConnection, data: str, retries: int = 0,
-                         timeout: Optional[float] = None) -> str:
+
+        async def _patch(
+            _self: SerialConnection,
+            data: str,
+            retries: int = 0,
+            timeout: Optional[float] = None,
+        ) -> str:
             """
             Side-effect function that gathers arguments passed to
             SerialConnection.send_data and stores them internally.
@@ -50,9 +59,7 @@ class GCodeWatcher:
             response = await self._original_send_data(_self, data, retries, timeout)
             self._command_list.append(
                 WatcherData(
-                    raw_g_code=data,
-                    device=self._parse_device(_self),
-                    response=response
+                    raw_g_code=data, device=self._parse_device(_self), response=response
                 )
             )
             return response
@@ -73,7 +80,7 @@ class GCodeWatcher:
         of the device is
         """
         serial_port = serial_connection.port
-        device_port = serial_port[serial_port.rfind(':') + 1:]
+        device_port = serial_port[serial_port.rfind(":") + 1 :]
         return cls.DEVICE_LOOKUP_BY_PORT[int(device_port)]
 
     def get_command_list(self) -> List[WatcherData]:

--- a/api/src/opentrons/hardware_control/g_code_parsing/protocol_runner.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/protocol_runner.py
@@ -13,21 +13,22 @@ from opentrons.protocol_api import ProtocolContext
 from opentrons.config.robot_configs import build_config
 from opentrons.hardware_control.emulation.app import ServerManager
 from opentrons.hardware_control import API, ThreadManager
-from opentrons.hardware_control.emulation.app import \
-    MAGDECK_PORT,\
-    TEMPDECK_PORT,\
-    THERMOCYCLER_PORT,\
-    SMOOTHIE_PORT
-from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import \
-    GCodeProgram
+from opentrons.hardware_control.emulation.app import (
+    MAGDECK_PORT,
+    TEMPDECK_PORT,
+    THERMOCYCLER_PORT,
+    SMOOTHIE_PORT,
+)
+from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import (
+    GCodeProgram,
+)
 from opentrons.hardware_control.g_code_parsing.g_code_watcher import GCodeWatcher
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 
 
-Protocol = namedtuple(
-    'Protocol',
-    ['text', 'filename', 'filelike'])
+Protocol = namedtuple("Protocol", ["text", "filename", "filelike"])
 
 
 class ProtocolRunner:
@@ -41,6 +42,7 @@ class ProtocolRunner:
         2. Call run_protocol method
         3. Gather parsed data from returned GCodeProgram
     """
+
     URI_TEMPLATE = "socket://127.0.0.1:%s"
 
     def __init__(self, smoothie_config: Settings) -> None:
@@ -50,7 +52,7 @@ class ProtocolRunner:
     @staticmethod
     def _get_loop() -> asyncio.AbstractEventLoop:
         """Create an event loop"""
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             _loop = asyncio.ProactorEventLoop()
         else:
             _loop = asyncio.new_event_loop()
@@ -60,18 +62,23 @@ class ProtocolRunner:
     @staticmethod
     def _set_env_vars() -> None:
         """Set URLs of where to find modules and config for smoothie"""
-        os.environ['OT_MAGNETIC_EMULATOR_URI'] = \
+        os.environ["OT_MAGNETIC_EMULATOR_URI"] = (
             ProtocolRunner.URI_TEMPLATE % MAGDECK_PORT
-        os.environ['OT_THERMOCYCLER_EMULATOR_URI'] = \
+        )
+        os.environ["OT_THERMOCYCLER_EMULATOR_URI"] = (
             ProtocolRunner.URI_TEMPLATE % THERMOCYCLER_PORT
-        os.environ['OT_TEMPERATURE_EMULATOR_URI'] = \
+        )
+        os.environ["OT_TEMPERATURE_EMULATOR_URI"] = (
             ProtocolRunner.URI_TEMPLATE % TEMPDECK_PORT
+        )
 
     @staticmethod
     def _start_emulation_app(server_manager: ServerManager) -> None:
         """Start emulated OT-2"""
+
         def runit():
             asyncio.run(server_manager.run())
+
         t = threading.Thread(target=runit)
         t.daemon = True
         t.start()
@@ -83,14 +90,14 @@ class ProtocolRunner:
         emulator = ThreadManager(
             API.build_hardware_controller,
             conf,
-            ProtocolRunner.URI_TEMPLATE % SMOOTHIE_PORT
+            ProtocolRunner.URI_TEMPLATE % SMOOTHIE_PORT,
         )
         return emulator
 
     @staticmethod
     def _get_protocol(file_path: str) -> Protocol:
         with open(file_path) as file:
-            text = ''.join(list(file))
+            text = "".join(list(file))
             file.seek(0)
 
         return Protocol(text=text, filename=file_path, filelike=file)
@@ -109,7 +116,7 @@ class ProtocolRunner:
         protocol = self._get_protocol(file_path)
         context = ProtocolContext(
             implementation=ProtocolContextImplementation(hardware=emulated_hardware),
-            loop=self._get_loop()
+            loop=self._get_loop(),
         )
         parsed_protocol = parse(protocol.text, protocol.filename)
         with GCodeWatcher() as watcher:

--- a/api/src/opentrons/hardware_control/g_code_parsing/utils.py
+++ b/api/src/opentrons/hardware_control/g_code_parsing/utils.py
@@ -10,12 +10,12 @@ WRITE_REGEX = re.compile(r"(.*?) \| (.*?) \|(.*?)$")
 
 
 def reverse_enum(
-        enum_to_reverse: Union[
-            Type[SMOOTHIE_G_CODE],
-            Type[MAGDECK_G_CODE],
-            Type[TEMPDECK_G_CODE],
-            Type[THERMOCYCLER_G_CODE]
-        ]
+    enum_to_reverse: Union[
+        Type[SMOOTHIE_G_CODE],
+        Type[MAGDECK_G_CODE],
+        Type[TEMPDECK_G_CODE],
+        Type[THERMOCYCLER_G_CODE],
+    ]
 ) -> Dict:
     """
     Returns dictionary with keys and values switched from passed Enum
@@ -26,8 +26,5 @@ def reverse_enum(
     # about keys not existing as an attribute. I am not calling it
     # as an attribute. I am calling it as a function.
     members = enum_to_reverse.__members__.keys()
-    values = [
-        enum_to_reverse[member]
-        for member in members
-    ]
+    values = [enum_to_reverse[member] for member in members]
     return dict(zip(values, members))

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -16,7 +16,7 @@ from . import modules
 
 log = logging.getLogger(__name__)
 
-MODULE_PORT_REGEX = re.compile('|'.join(modules.MODULE_HW_BY_NAME.keys()), re.I)
+MODULE_PORT_REGEX = re.compile("|".join(modules.MODULE_HW_BY_NAME.keys()), re.I)
 
 
 class AttachedModulesControl:
@@ -45,13 +45,13 @@ class AttachedModulesControl:
         return self._api
 
     async def build_module(
-            self,
-            port: str,
-            usb_port: types.USBPort,
-            model: str,
-            loop: asyncio.AbstractEventLoop,
-            sim_model: str = None
-            ) -> modules.AbstractModule:
+        self,
+        port: str,
+        usb_port: types.USBPort,
+        model: str,
+        loop: asyncio.AbstractEventLoop,
+        sim_model: str = None,
+    ) -> modules.AbstractModule:
         return await modules.build(
             port=port,
             usb_port=usb_port,
@@ -60,10 +60,11 @@ class AttachedModulesControl:
             interrupt_callback=self.api.pause_with_message,
             loop=loop,
             execution_manager=self.api._execution_manager,
-            sim_model=sim_model)
+            sim_model=sim_model,
+        )
 
     async def unregister_modules(
-            self, mods_at_ports: List[modules.ModuleAtPort]
+        self, mods_at_ports: List[modules.ModuleAtPort]
     ) -> None:
         """
         De-register Modules.
@@ -79,18 +80,20 @@ class AttachedModulesControl:
             try:
                 self._available_modules.remove(removed_mod)
             except ValueError:
-                log.exception(f"Removed Module {removed_mod} not"
-                              " found in attached modules")
+                log.exception(
+                    f"Removed Module {removed_mod} not" " found in attached modules"
+                )
         for removed_mod in removed_modules:
-            log.info(f"Module {removed_mod.name()} detached"
-                     f" from port {removed_mod.port}")
+            log.info(
+                f"Module {removed_mod.name()} detached" f" from port {removed_mod.port}"
+            )
             await removed_mod.cleanup()
 
     async def register_modules(
-            self,
-            new_mods_at_ports: List[modules.ModuleAtPort] = None,
-            removed_mods_at_ports: List[modules.ModuleAtPort] = None
-            ) -> None:
+        self,
+        new_mods_at_ports: List[modules.ModuleAtPort] = None,
+        removed_mods_at_ports: List[modules.ModuleAtPort] = None,
+    ) -> None:
         """
         Register Modules.
 
@@ -105,23 +108,25 @@ class AttachedModulesControl:
 
         # destroy removed mods
         await self.unregister_modules(removed_mods_at_ports)
-        sorted_mods_at_port =\
-            self.api._backend._usb.match_virtual_ports(new_mods_at_ports)
+        sorted_mods_at_port = self.api._backend._usb.match_virtual_ports(
+            new_mods_at_ports
+        )
 
         # build new mods
         for mod in sorted_mods_at_port:
             new_instance = await self.build_module(
-                    port=mod.port,
-                    usb_port=mod.usb_port,
-                    model=mod.name,
-                    loop=self.api.loop)
+                port=mod.port, usb_port=mod.usb_port, model=mod.name, loop=self.api.loop
+            )
             self._available_modules.append(new_instance)
-            log.info(f"Module {mod.name} discovered and attached"
-                     f" at port {mod.port}, new_instance: {new_instance}")
+            log.info(
+                f"Module {mod.name} discovered and attached"
+                f" at port {mod.port}, new_instance: {new_instance}"
+            )
 
     async def parse_modules(
-                self, by_model: modules.types.ModuleModel,
-                resolved_type: modules.types.ModuleType
+        self,
+        by_model: modules.types.ModuleModel,
+        resolved_type: modules.types.ModuleType,
     ) -> Tuple[List[modules.AbstractModule], Optional[modules.AbstractModule]]:
         """
         Parse Modules.
@@ -134,45 +139,44 @@ class AttachedModulesControl:
         matching_modules = []
         simulated_module = None
         mod_type = {
-            modules.types.ModuleType.MAGNETIC: 'magdeck',
-            modules.types.ModuleType.TEMPERATURE: 'tempdeck',
-            modules.types.ModuleType.THERMOCYCLER: 'thermocycler'
+            modules.types.ModuleType.MAGNETIC: "magdeck",
+            modules.types.ModuleType.TEMPERATURE: "tempdeck",
+            modules.types.ModuleType.THERMOCYCLER: "thermocycler",
         }[resolved_type]
         for module in self.available_modules:
             if mod_type == module.name():
                 matching_modules.append(module)
         if self.api.is_simulator:
             module_builder = {
-                'magdeck': modules.MagDeck.build,
-                'tempdeck': modules.TempDeck.build,
-                'thermocycler': modules.Thermocycler.build
+                "magdeck": modules.MagDeck.build,
+                "tempdeck": modules.TempDeck.build,
+                "thermocycler": modules.Thermocycler.build,
             }[mod_type]
             if module_builder:
                 simulating_module = await module_builder(
-                    port='',
-                    usb_port=self.api._backend._usb.find_port(''),
+                    port="",
+                    usb_port=self.api._backend._usb.find_port(""),
                     simulating=True,
                     loop=self.api.loop,
-                    execution_manager=ExecutionManager(
-                        loop=self.api.loop),
-                    sim_model=by_model.value
+                    execution_manager=ExecutionManager(loop=self.api.loop),
+                    sim_model=by_model.value,
                 )
                 simulated_module = simulating_module
         return matching_modules, simulated_module
 
     def scan(self) -> List[modules.ModuleAtPort]:
-        """ Scan for connected modules and return list of
-            tuples of serial ports and device names
+        """Scan for connected modules and return list of
+        tuples of serial ports and device names
         """
         if IS_ROBOT and IS_LINUX:
-            devices = glob('/dev/ot_module*')
+            devices = glob("/dev/ot_module*")
         else:
             devices = []
 
         discovered_modules = []
 
         for port in devices:
-            symlink_port = port.split('dev/')[1]
+            symlink_port = port.split("dev/")[1]
             module_at_port = self.get_module_at_port(symlink_port)
             if module_at_port:
                 discovered_modules.append(module_at_port)
@@ -186,23 +190,19 @@ class AttachedModulesControl:
 
         emulator_uri = os.environ.get("OT_TEMPERATURE_EMULATOR_URI")
         if emulator_uri:
-            discovered_modules.append(
-                ModuleAtPort(port=emulator_uri, name="tempdeck")
-            )
+            discovered_modules.append(ModuleAtPort(port=emulator_uri, name="tempdeck"))
 
         emulator_uri = os.environ.get("OT_MAGNETIC_EMULATOR_URI")
         if emulator_uri:
-            discovered_modules.append(
-                ModuleAtPort(port=emulator_uri, name="magdeck")
-            )
+            discovered_modules.append(ModuleAtPort(port=emulator_uri, name="magdeck"))
 
-        log.debug('Discovered modules: {}'.format(discovered_modules))
+        log.debug("Discovered modules: {}".format(discovered_modules))
         return discovered_modules
 
     @staticmethod
     def get_module_at_port(port: str) -> Optional[modules.ModuleAtPort]:
-        """ Given a port, returns either a ModuleAtPort
-            if it is a recognized module, or None if not recognized.
+        """Given a port, returns either a ModuleAtPort
+        if it is a recognized module, or None if not recognized.
         """
         match = MODULE_PORT_REGEX.search(port)
         if match:
@@ -210,11 +210,11 @@ class AttachedModulesControl:
             if name not in modules.MODULE_HW_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None
-            return modules.ModuleAtPort(port=f'/dev/{port}', name=name)
+            return modules.ModuleAtPort(port=f"/dev/{port}", name=name)
         return None
 
     async def handle_module_appearance(self, event: AionotifyEvent):
-        """ Only called upon availability of aionotify. Check that
+        """Only called upon availability of aionotify. Check that
         the file system has changed and either remove or add modules
         depending on the result.
 
@@ -226,19 +226,16 @@ class AttachedModulesControl:
         new_modules = None
         removed_modules = None
         if maybe_module_at_port is not None:
-            if hasattr(event.flags, 'DELETE'):
+            if hasattr(event.flags, "DELETE"):
                 removed_modules = [maybe_module_at_port]
-                log.info(
-                    f'Module Removed: {maybe_module_at_port}')
-            elif hasattr(event.flags, 'CREATE'):
+                log.info(f"Module Removed: {maybe_module_at_port}")
+            elif hasattr(event.flags, "CREATE"):
                 new_modules = [maybe_module_at_port]
-                log.info(
-                    f'Module Added: {maybe_module_at_port}')
+                log.info(f"Module Added: {maybe_module_at_port}")
             try:
                 await self.register_modules(
                     removed_mods_at_ports=removed_modules,
                     new_mods_at_ports=new_modules,
                 )
             except Exception:
-                log.exception(
-                    'Exception in Module registration')
+                log.exception("Exception in Module registration")

--- a/api/src/opentrons/hardware_control/modules/__init__.py
+++ b/api/src/opentrons/hardware_control/modules/__init__.py
@@ -4,12 +4,27 @@ from .magdeck import MagDeck
 from .thermocycler import Thermocycler
 from .update import update_firmware
 from .utils import MODULE_HW_BY_NAME, build
-from .types import (ThermocyclerStep, InterruptCallback, UploadFunction,
-                    BundledFirmware, UpdateError, ModuleAtPort)
+from .types import (
+    ThermocyclerStep,
+    InterruptCallback,
+    UploadFunction,
+    BundledFirmware,
+    UpdateError,
+    ModuleAtPort,
+)
 
 __all__ = [
-    'MODULE_HW_BY_NAME', 'build', 'update_firmware',
-    'ThermocyclerStep', 'AbstractModule', 'TempDeck',
-    'MagDeck', 'Thermocycler', 'InterruptCallback',
-    'UploadFunction', 'BundledFirmware', 'UpdateError', 'ModuleAtPort'
+    "MODULE_HW_BY_NAME",
+    "build",
+    "update_firmware",
+    "ThermocyclerStep",
+    "AbstractModule",
+    "TempDeck",
+    "MagDeck",
+    "Thermocycler",
+    "InterruptCallback",
+    "UploadFunction",
+    "BundledFirmware",
+    "UpdateError",
+    "ModuleAtPort",
 ]

--- a/api/src/opentrons/hardware_control/modules/plate_temp_status.py
+++ b/api/src/opentrons/hardware_control/modules/plate_temp_status.py
@@ -55,6 +55,5 @@ class PlateTemperatureStatus:
             return False
         else:
             return all(
-                abs(target - t) < PlateTemperatureStatus.TEMP_THRESHOLD
-                for t in history
+                abs(target - t) < PlateTemperatureStatus.TEMP_THRESHOLD for t in history
             )

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -1,78 +1,91 @@
 from enum import Enum
 from dataclasses import dataclass
 from typing import (
-    Dict, NamedTuple, Callable, Any, Type, TypeVar,
-    Tuple, Awaitable, Mapping, Union, TYPE_CHECKING)
+    Dict,
+    NamedTuple,
+    Callable,
+    Any,
+    Type,
+    TypeVar,
+    Tuple,
+    Awaitable,
+    Mapping,
+    Union,
+    TYPE_CHECKING,
+)
 from pathlib import Path
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 if TYPE_CHECKING:
     from opentrons_shared_data.module.dev_types import (
-        ThermocyclerModuleType, MagneticModuleType, TemperatureModuleType)
+        ThermocyclerModuleType,
+        MagneticModuleType,
+        TemperatureModuleType,
+    )
 
 ThermocyclerStep = Dict[str, float]
 
 InterruptCallback = Callable[[str], None]
 
-UploadFunction = Callable[[str, str, Dict[str, Any]],
-                          Awaitable[Tuple[bool, str]]]
+UploadFunction = Callable[[str, str, Dict[str, Any]], Awaitable[Tuple[bool, str]]]
 
 LiveData = Mapping[str, Union[str, Mapping[str, Union[float, str, None]]]]
 
 
-E = TypeVar('E', bound='_ProvideLookup')
+E = TypeVar("E", bound="_ProvideLookup")
 
 
 class _ProvideLookup(Enum):
     @classmethod
-    def from_str(cls: Type[E], typename: str) -> 'E':
+    def from_str(cls: Type[E], typename: str) -> "E":
         for m in cls.__members__.values():
             if m.value == typename:
                 return m
-        raise AttributeError(f'No such type {typename}')
+        raise AttributeError(f"No such type {typename}")
 
 
 class ModuleType(_ProvideLookup):
-    THERMOCYCLER: 'ThermocyclerModuleType' = 'thermocyclerModuleType'
-    TEMPERATURE: 'TemperatureModuleType' = 'temperatureModuleType'
-    MAGNETIC: 'MagneticModuleType' = 'magneticModuleType'
+    THERMOCYCLER: "ThermocyclerModuleType" = "thermocyclerModuleType"
+    TEMPERATURE: "TemperatureModuleType" = "temperatureModuleType"
+    MAGNETIC: "MagneticModuleType" = "magneticModuleType"
 
 
 class MagneticModuleModel(_ProvideLookup):
-    MAGNETIC_V1: str = 'magneticModuleV1'
-    MAGNETIC_V2: str = 'magneticModuleV2'
+    MAGNETIC_V1: str = "magneticModuleV1"
+    MAGNETIC_V2: str = "magneticModuleV2"
 
 
 class TemperatureModuleModel(_ProvideLookup):
-    TEMPERATURE_V1: str = 'temperatureModuleV1'
-    TEMPERATURE_V2: str = 'temperatureModuleV2'
+    TEMPERATURE_V1: str = "temperatureModuleV1"
+    TEMPERATURE_V2: str = "temperatureModuleV2"
 
 
 class ThermocyclerModuleModel(_ProvideLookup):
-
     @classmethod
-    def from_str(cls: Type['ThermocyclerModuleModel'],
-                 typename: str) -> 'ThermocyclerModuleModel':
+    def from_str(
+        cls: Type["ThermocyclerModuleModel"], typename: str
+    ) -> "ThermocyclerModuleModel":
         return super().from_str(typename)
 
-    THERMOCYCLER_V1: str = 'thermocyclerModuleV1'
+    THERMOCYCLER_V1: str = "thermocyclerModuleV1"
 
 
 @dataclass
 class ModuleAtPort:
     port: str
     name: str
-    usb_port: USBPort = USBPort(name='', sub_names=[])
+    usb_port: USBPort = USBPort(name="", sub_names=[])
 
 
 class BundledFirmware(NamedTuple):
-    """ Represents a versioned firmware file, generally bundled into the fs"""
+    """Represents a versioned firmware file, generally bundled into the fs"""
+
     version: str
     path: Path
 
     def __repr__(self) -> str:
-        return f'<BundledFirmware {self.version}, path={self.path}>'
+        return f"<BundledFirmware {self.version}, path={self.path}>"
 
 
 class UpdateError(RuntimeError):
@@ -80,19 +93,20 @@ class UpdateError(RuntimeError):
 
 
 class ModuleInfo(NamedTuple):
-    model: str        # A module model such as "magneticModuleV2"
-    fw_version: str   # The version of the firmware
+    model: str  # A module model such as "magneticModuleV2"
+    fw_version: str  # The version of the firmware
     hw_revision: str  # the revision of the hardware
-    serial: str       # the serial number
+    serial: str  # the serial number
 
 
 ModuleModel = Union[
-    MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel]
+    MagneticModuleModel, TemperatureModuleModel, ThermocyclerModuleModel
+]
 
 
 class TemperatureStatus(str, Enum):
-    HOLDING = 'holding at target'
-    COOLING = 'cooling'
-    HEATING = 'heating'
-    IDLE = 'idle'
-    ERROR = 'error'
+    HOLDING = "holding at target"
+    COOLING = "cooling"
+    HEATING = "heating"
+    IDLE = "idle"
+    ERROR = "error"

--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -11,23 +11,23 @@ log = logging.getLogger(__name__)
 
 
 async def update_firmware(
-        module: AbstractModule,
-        firmware_file: str,
-        loop: Optional[asyncio.AbstractEventLoop]):
-    """ Apply update of given firmware file to given module.
+    module: AbstractModule,
+    firmware_file: str,
+    loop: Optional[asyncio.AbstractEventLoop],
+):
+    """Apply update of given firmware file to given module.
 
-        raises an UpdateError with the reason for the failure.
+    raises an UpdateError with the reason for the failure.
     """
     flash_port = await module.prep_for_update()
     kwargs: Dict[str, Any] = {
-        'stdout': asyncio.subprocess.PIPE,
-        'stderr': asyncio.subprocess.PIPE,
-        'loop': loop
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
+        "loop": loop,
     }
-    successful, res = await module.bootloader()(
-        flash_port, firmware_file, kwargs)
+    successful, res = await module.bootloader()(flash_port, firmware_file, kwargs)
     if not successful:
-        log.info(f'Bootloader reponse: {res}')
+        log.info(f"Bootloader reponse: {res}")
         raise UpdateError(res)
 
 
@@ -39,40 +39,43 @@ async def find_bootloader_port():
     """
 
     for attempt in range(3):
-        bootloader_ports = glob('/dev/ot_module_*_bootloader*')
+        bootloader_ports = glob("/dev/ot_module_*_bootloader*")
         if bootloader_ports:
             if len(bootloader_ports) == 1:
-                log.info(f'Found bootloader at port {bootloader_ports[0]}')
+                log.info(f"Found bootloader at port {bootloader_ports[0]}")
                 return bootloader_ports[0]
             elif len(bootloader_ports) > 1:
-                raise OSError('Multiple new bootloader ports'
-                              'found on mode switch')
+                raise OSError("Multiple new bootloader ports" "found on mode switch")
         await asyncio.sleep(2)
     raise Exception("No ot_module bootloaders found in /dev. Try again")
 
 
-async def upload_via_avrdude(port: str,
-                             firmware_file_path: str,
-                             kwargs: Dict[str, Any]) -> Tuple[bool, str]:
+async def upload_via_avrdude(
+    port: str, firmware_file_path: str, kwargs: Dict[str, Any]
+) -> Tuple[bool, str]:
     """
     Run firmware upload command for hardware module with avrdude bootloader.
 
     Returns tuple of success boolean and message from bootloader.
     """
     # avrdude_options
-    PART_NO = 'atmega32u4'
-    PROGRAMMER_ID = 'avr109'
-    BAUDRATE = '57600'
+    PART_NO = "atmega32u4"
+    PROGRAMMER_ID = "avr109"
+    BAUDRATE = "57600"
 
-    config_file_path = Path('/etc/avrdude.conf')
+    config_file_path = Path("/etc/avrdude.conf")
     proc = await asyncio.create_subprocess_exec(
-        'avrdude', '-C{}'.format(config_file_path), '-v',
-        '-p{}'.format(PART_NO),
-        '-c{}'.format(PROGRAMMER_ID),
-        '-P{}'.format(port),
-        '-b{}'.format(BAUDRATE), '-D',
-        '-Uflash:w:{}:i'.format(firmware_file_path),
-        **kwargs)
+        "avrdude",
+        "-C{}".format(config_file_path),
+        "-v",
+        "-p{}".format(PART_NO),
+        "-c{}".format(PROGRAMMER_ID),
+        "-P{}".format(port),
+        "-b{}".format(BAUDRATE),
+        "-D",
+        "-Uflash:w:{}:i".format(firmware_file_path),
+        **kwargs,
+    )
     await proc.wait()
 
     _result = await proc.communicate()
@@ -81,24 +84,25 @@ async def upload_via_avrdude(port: str,
     if avrdude_res[0]:
         log.debug(result)
     else:
-        log.error("Failed to update module firmware for {}: {}"
-                  .format(port, avrdude_res[1]))
+        log.error(
+            "Failed to update module firmware for {}: {}".format(port, avrdude_res[1])
+        )
     return avrdude_res
 
 
 def _format_avrdude_response(raw_response: str) -> Tuple[bool, str]:
-    avrdude_log = ''
+    avrdude_log = ""
     for line in raw_response.splitlines():
-        if 'avrdude:' in line and line != raw_response.splitlines()[1]:
-            avrdude_log += line.lstrip('avrdude:') + '..'
-            if 'flash verified' in line:
-                return True, line.lstrip('avrdude: ')
+        if "avrdude:" in line and line != raw_response.splitlines()[1]:
+            avrdude_log += line.lstrip("avrdude:") + ".."
+            if "flash verified" in line:
+                return True, line.lstrip("avrdude: ")
     return False, avrdude_log
 
 
-async def upload_via_bossa(port: str,
-                           firmware_file_path: str,
-                           kwargs: Dict[str, Any]) -> Tuple[bool, str]:
+async def upload_via_bossa(
+    port: str, firmware_file_path: str, kwargs: Dict[str, Any]
+) -> Tuple[bool, str]:
     """
     Run firmware upload command for hardware module with SAMBA bootloader.
 
@@ -110,11 +114,18 @@ async def upload_via_bossa(port: str,
     # so we resolve to real path
     resolved_symlink = os.path.realpath(port)
     log.info(
-        f"device at symlinked port: {port} "
-        f"resolved to path: {resolved_symlink}")
-    bossa_args = ['bossac', f'-p{resolved_symlink}',
-                  '-e', '-w', '-v', '-R',
-                  '--offset=0x2000', f'{firmware_file_path}']
+        f"device at symlinked port: {port} " f"resolved to path: {resolved_symlink}"
+    )
+    bossa_args = [
+        "bossac",
+        f"-p{resolved_symlink}",
+        "-e",
+        "-w",
+        "-v",
+        "-R",
+        "--offset=0x2000",
+        f"{firmware_file_path}",
+    ]
 
     proc = await asyncio.create_subprocess_exec(*bossa_args, **kwargs)
     stdout, stderr = await proc.communicate()
@@ -126,4 +137,4 @@ async def upload_via_bossa(port: str,
         log.error(f"Failed to update module firmware for {port}: {res}")
         log.error(f"Error given: {stderr.decode()}")
         return False, res
-    return False, ''
+    return False, ""

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from opentrons.drivers.rpi_drivers.types import USBPort
+
 # NOTE: Must import all modules so they actually create the subclasses
 from . import update, tempdeck, magdeck, thermocycler, types  # noqa: F401
 from .mod_abc import AbstractModule
@@ -13,20 +14,19 @@ log = logging.getLogger(__name__)
 
 # TODO (lc 05-12-2021) This is pretty gross. We should think
 # of a better way to do this.
-MODULE_HW_BY_NAME = {
-    cls.name(): cls for cls in AbstractModule.__subclasses__()
-}
+MODULE_HW_BY_NAME = {cls.name(): cls for cls in AbstractModule.__subclasses__()}
 
 
 async def build(
-        port: str,
-        which: str,
-        simulating: bool,
-        usb_port: USBPort,
-        interrupt_callback: InterruptCallback,
-        loop: asyncio.AbstractEventLoop,
-        execution_manager: ExecutionManager,
-        sim_model: str = None) -> AbstractModule:
+    port: str,
+    which: str,
+    simulating: bool,
+    usb_port: USBPort,
+    interrupt_callback: InterruptCallback,
+    loop: asyncio.AbstractEventLoop,
+    execution_manager: ExecutionManager,
+    sim_model: str = None,
+) -> AbstractModule:
     return await MODULE_HW_BY_NAME[which].build(
         port,
         usb_port,
@@ -34,5 +34,5 @@ async def build(
         simulating=simulating,
         loop=loop,
         execution_manager=execution_manager,
-        sim_model=sim_model
+        sim_model=sim_model,
     )

--- a/api/src/opentrons/hardware_control/pause_manager.py
+++ b/api/src/opentrons/hardware_control/pause_manager.py
@@ -6,7 +6,7 @@ from .types import DoorState, PauseType, PauseResumeError
 
 
 class PauseManager:
-    """ This class determines whether or not the hardware controller should
+    """This class determines whether or not the hardware controller should
     pause or resume by evaluating the pause and resume types. The use of two
     pause types are used to separate the delay resume (triggered when the delay
     timer runs out) and the pause resume (trigged by user via the app).

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -103,11 +103,11 @@ class Poller(Generic[DataT]):
     """Asyncio poller."""
 
     def __init__(
-            self,
-            interval_seconds: float,
-            reader: Reader[DataT],
-            listener: Listener[DataT],
-            loop: Optional[asyncio.AbstractEventLoop] = None
+        self,
+        interval_seconds: float,
+        reader: Reader[DataT],
+        listener: Listener[DataT],
+        loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         """
         Constructor.

--- a/api/src/opentrons/hardware_control/robot_calibration.py
+++ b/api/src/opentrons/hardware_control/robot_calibration.py
@@ -29,7 +29,9 @@ def build_temporary_identity_calibration() -> RobotCalibration:
         deck_calibration=types.DeckCalibration(
             attitude=linal.identity_deck_transform().tolist(),
             source=types.SourceType.default,
-            status=types.CalibrationStatus()))
+            status=types.CalibrationStatus(),
+        )
+    )
 
 
 def validate_attitude_deck_calibration(deck_cal: types.DeckCalibration):
@@ -84,12 +86,16 @@ def validate_gantry_calibration(gantry_cal: List[List[float]]):
 
 
 def migrate_affine_xy_to_attitude(
-        gantry_cal: List[List[float]]) -> types.AttitudeMatrix:
-    masked_transform = np.array([
-        [True, True, True, False],
-        [True, True, True, False],
-        [False, False, False, False],
-        [False, False, False, False]])
+    gantry_cal: List[List[float]],
+) -> types.AttitudeMatrix:
+    masked_transform = np.array(
+        [
+            [True, True, True, False],
+            [True, True, True, False],
+            [False, False, False, False],
+            [False, False, False, False],
+        ]
+    )
     masked_array = np.ma.masked_array(gantry_cal, ~masked_transform)
     attitude_array = np.zeros((3, 3))
     np.put(attitude_array, [0, 1, 2], masked_array[0].compressed())
@@ -99,8 +105,11 @@ def migrate_affine_xy_to_attitude(
 
 
 def save_attitude_matrix(
-        expected: linal.SolvePoints, actual: linal.SolvePoints,
-        pipette_id: str, tiprack_hash: str):
+    expected: linal.SolvePoints,
+    actual: linal.SolvePoints,
+    pipette_id: str,
+    tiprack_hash: str,
+):
     attitude = linal.solve_attitude(expected, actual)
     modify.save_robot_deck_attitude(attitude, pipette_id, tiprack_hash)
 
@@ -113,12 +122,16 @@ def load_attitude_matrix() -> types.DeckCalibration:
             log.debug(
                 "Attitude deck calibration matrix not found. Migrating "
                 "existing affine deck calibration matrix to {}".format(
-                    config.get_opentrons_path('robot_calibration_dir')))
+                    config.get_opentrons_path("robot_calibration_dir")
+                )
+            )
             attitude = migrate_affine_xy_to_attitude(gantry_cal)
-            modify.save_robot_deck_attitude(transform=attitude,
-                                            pip_id=None,
-                                            lw_hash=None,
-                                            source=types.SourceType.legacy)
+            modify.save_robot_deck_attitude(
+                transform=attitude,
+                pip_id=None,
+                lw_hash=None,
+                source=types.SourceType.legacy,
+            )
             calibration_data = get.get_robot_deck_attitude()
 
     if calibration_data:
@@ -128,17 +141,19 @@ def load_attitude_matrix() -> types.DeckCalibration:
         return types.DeckCalibration(
             attitude=config.robot_configs.DEFAULT_DECK_CALIBRATION_V2,
             source=types.SourceType.default,
-            status=types.CalibrationStatus())
+            status=types.CalibrationStatus(),
+        )
 
 
 def load_pipette_offset(
-        pip_id: Optional[str],
-        mount: Mount) -> types.PipetteOffsetByPipetteMount:
+    pip_id: Optional[str], mount: Mount
+) -> types.PipetteOffsetByPipetteMount:
     # load default if pipette offset data do not exist
     pip_cal_obj = types.PipetteOffsetByPipetteMount(
         offset=config.robot_configs.DEFAULT_PIPETTE_OFFSET,
         source=types.SourceType.default,
-        status=types.CalibrationStatus())
+        status=types.CalibrationStatus(),
+    )
     if pip_id:
         pip_offset_data = get.get_pipette_offset(pip_id, mount)
         if pip_offset_data:
@@ -147,5 +162,4 @@ def load_pipette_offset(
 
 
 def load() -> RobotCalibration:
-    return RobotCalibration(
-        deck_calibration=load_attitude_matrix())
+    return RobotCalibration(deck_calibration=load_attitude_matrix())

--- a/api/src/opentrons/hardware_control/simulator.py
+++ b/api/src/opentrons/hardware_control/simulator.py
@@ -3,17 +3,13 @@ import asyncio
 import copy
 import logging
 from threading import Event
-from typing import (Dict, Optional, List, Tuple,
-                    TYPE_CHECKING, Sequence)
+from typing import Dict, Optional, List, Tuple, TYPE_CHECKING, Sequence
 from contextlib import contextmanager
 
 from opentrons_shared_data.pipette import dummy_model_for_name
 
 from opentrons import types
-from opentrons.config.pipette_config import (config_models,
-                                             config_names,
-                                             configs,
-                                             load)
+from opentrons.config.pipette_config import config_models, config_names, configs, load
 from opentrons.config.types import RobotConfig
 from opentrons.drivers.smoothie_drivers import SimulatingDriver
 
@@ -28,30 +24,33 @@ from .module_control import AttachedModulesControl
 if TYPE_CHECKING:
     from opentrons_shared_data.pipette.dev_types import PipetteName
     from .dev_types import (
-        AttachedInstrument, AttachedInstruments,
-        InstrumentSpec, InstrumentHardwareConfigs)
-    from opentrons.drivers.rpi_drivers.dev_types\
-        import GPIODriverLike
+        AttachedInstrument,
+        AttachedInstruments,
+        InstrumentSpec,
+        InstrumentHardwareConfigs,
+    )
+    from opentrons.drivers.rpi_drivers.dev_types import GPIODriverLike
 
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 class Simulator:
-    """ This is a subclass of hardware_control that only simulates the
+    """This is a subclass of hardware_control that only simulates the
     hardware actions. It is suitable for use on a dev machine or on
     a robot with no smoothie connected.
     """
 
     @classmethod
     async def build(
-            cls,
-            attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
-            attached_modules: List[str],
-            config: RobotConfig,
-            loop: asyncio.AbstractEventLoop,
-            strict_attached_instruments: bool = True) -> Simulator:
-        """ Build the simulator.
+        cls,
+        attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
+        attached_modules: List[str],
+        config: RobotConfig,
+        loop: asyncio.AbstractEventLoop,
+        strict_attached_instruments: bool = True,
+    ) -> Simulator:
+        """Build the simulator.
 
         Use this factory method rather than the initializer to handle proper GPIO
         initialization.
@@ -88,7 +87,7 @@ class Simulator:
                                             requesting instruments that _are_
                                             present get the full number.
         """
-        gpio = SimulatingGPIOCharDev('gpiochip0')
+        gpio = SimulatingGPIOCharDev("gpiochip0")
         await gpio.setup()
         return cls(
             attached_instruments,
@@ -96,16 +95,19 @@ class Simulator:
             config,
             loop,
             gpio,
-            strict_attached_instruments)
+            strict_attached_instruments,
+        )
 
     def __init__(
-            self,
-            attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
-            attached_modules: List[str],
-            config: RobotConfig, loop: asyncio.AbstractEventLoop,
-            gpio_chardev: GPIODriverLike,
-            strict_attached_instruments: bool = True) -> None:
-        """ Initialize the simulator.
+        self,
+        attached_instruments: Dict[types.Mount, Dict[str, Optional[str]]],
+        attached_modules: List[str],
+        config: RobotConfig,
+        loop: asyncio.AbstractEventLoop,
+        gpio_chardev: GPIODriverLike,
+        strict_attached_instruments: bool = True,
+    ) -> None:
+        """Initialize the simulator.
 
         Always prefer using :py:meth:`.build` to create an instance of this class. For
         more information on arguments, see that method. If you want to use this
@@ -117,25 +119,27 @@ class Simulator:
         self._gpio_chardev = gpio_chardev
 
         def _sanitize_attached_instrument(
-                passed_ai: Dict[str, Optional[str]] = None)\
-                -> InstrumentSpec:
-            if not passed_ai or not passed_ai.get('model'):
-                return {'model': None, 'id': None}
-            if passed_ai['model'] in config_models:
+            passed_ai: Dict[str, Optional[str]] = None
+        ) -> InstrumentSpec:
+            if not passed_ai or not passed_ai.get("model"):
+                return {"model": None, "id": None}
+            if passed_ai["model"] in config_models:
                 return passed_ai  # type: ignore
-            if passed_ai['model'] in config_names:
+            if passed_ai["model"] in config_names:
                 return {
-                    'model':
-                    dummy_model_for_name(passed_ai['model']),  # type: ignore
-                    'id': passed_ai.get('id')}
+                    "model": dummy_model_for_name(passed_ai["model"]),  # type: ignore
+                    "id": passed_ai.get("id"),
+                }
             raise KeyError(
-                'If you specify attached_instruments, the model '
-                'should be pipette names or pipette models, but '
-                f'{passed_ai["model"]} is not')
+                "If you specify attached_instruments, the model "
+                "should be pipette names or pipette models, but "
+                f'{passed_ai["model"]} is not'
+            )
 
         self._attached_instruments = {
             m: _sanitize_attached_instrument(attached_instruments.get(m))
-            for m in types.Mount}
+            for m in types.Mount
+        }
         self._stubbed_attached_modules = attached_modules
         self._position = copy.copy(self._smoothie_driver.homed_position)
         # Engaged axes start all true in smoothie for some reason so we
@@ -144,7 +148,7 @@ class Simulator:
         # using a flag
 
         self._engaged_axes = {ax: True for ax in self._smoothie_driver.homed_position}
-        self._lights = {'button': False, 'rails': False}
+        self._lights = {"button": False, "rails": False}
         self._run_flag = Event()
         self._run_flag.set()
         self._log = MODULE_LOG.getChild(repr(self))
@@ -163,7 +167,7 @@ class Simulator:
     @property
     def module_controls(self) -> AttachedModulesControl:
         if not self._module_controls:
-            raise AttributeError('Module controls not found.')
+            raise AttributeError("Module controls not found.")
         return self._module_controls
 
     @module_controls.setter
@@ -173,77 +177,83 @@ class Simulator:
     async def update_position(self) -> Dict[str, float]:
         return self._position
 
-    async def move(self, target_position: Dict[str, float],
-                   home_flagged_axes: bool = True, speed: float = None,
-                   axis_max_speeds: Dict[str, float] = None):
+    async def move(
+        self,
+        target_position: Dict[str, float],
+        home_flagged_axes: bool = True,
+        speed: float = None,
+        axis_max_speeds: Dict[str, float] = None,
+    ):
         self._position.update(target_position)
-        self._engaged_axes.update({ax: True
-                                   for ax in target_position})
+        self._engaged_axes.update({ax: True for ax in target_position})
 
     async def home(self, axes: List[str] = None) -> Dict[str, float]:
         # driver_3_0-> HOMED_POSITION
-        checked_axes = axes or 'XYZABC'
-        self._position.update({ax: self._smoothie_driver.homed_position[ax]
-                               for ax in checked_axes})
-        self._engaged_axes.update({ax: True
-                                   for ax in checked_axes})
+        checked_axes = axes or "XYZABC"
+        self._position.update(
+            {ax: self._smoothie_driver.homed_position[ax] for ax in checked_axes}
+        )
+        self._engaged_axes.update({ax: True for ax in checked_axes})
         return self._position
 
-    async def fast_home(
-            self, axis: Sequence[str], margin: float) -> Dict[str, float]:
+    async def fast_home(self, axis: Sequence[str], margin: float) -> Dict[str, float]:
         for ax in axis:
             self._position[ax] = self._smoothie_driver.homed_position[ax]
             self._engaged_axes[ax] = True
         return self._position
 
     def _attached_to_mount(
-            self,
-            mount: types.Mount,
-            expected_instr: Optional[PipetteName]
+        self, mount: types.Mount, expected_instr: Optional[PipetteName]
     ) -> AttachedInstrument:
-        init_instr = self._attached_instruments.get(
-            mount,
-            {'model': None, 'id': None})
-        found_model = init_instr['model']
-        back_compat: List['PipetteName'] = []
+        init_instr = self._attached_instruments.get(mount, {"model": None, "id": None})
+        found_model = init_instr["model"]
+        back_compat: List["PipetteName"] = []
         if found_model:
-            back_compat = configs[found_model].get('backCompatNames', [])
-        if expected_instr and found_model\
-                and (not found_model.startswith(expected_instr)
-                     and expected_instr not in back_compat):
+            back_compat = configs[found_model].get("backCompatNames", [])
+        if (
+            expected_instr
+            and found_model
+            and (
+                not found_model.startswith(expected_instr)
+                and expected_instr not in back_compat
+            )
+        ):
             if self._strict_attached:
                 raise RuntimeError(
-                    'mount {}: expected instrument {} but got {}'
-                    .format(mount.name, expected_instr, found_model))
+                    "mount {}: expected instrument {} but got {}".format(
+                        mount.name, expected_instr, found_model
+                    )
+                )
             else:
                 return {
-                    'config': load(dummy_model_for_name(expected_instr)),
-                    'id': None}
+                    "config": load(dummy_model_for_name(expected_instr)),
+                    "id": None,
+                }
         elif found_model and expected_instr:
             # Instrument detected matches instrument expected (note:
             # "instrument detected" means passed as an argument to the
             # constructor of this class)
-            return {'config': load(found_model, init_instr['id']),
-                    'id': init_instr['id']}
+            return {
+                "config": load(found_model, init_instr["id"]),
+                "id": init_instr["id"],
+            }
         elif found_model:
             # Instrument detected and no expected instrument specified
-            return {'config': load(found_model, init_instr['id']),
-                    'id': init_instr['id']}
+            return {
+                "config": load(found_model, init_instr["id"]),
+                "id": init_instr["id"],
+            }
         elif expected_instr:
             # Expected instrument specified and no instrument detected
-            return {
-                'config': load(dummy_model_for_name(expected_instr)),
-                'id': None}
+            return {"config": load(dummy_model_for_name(expected_instr)), "id": None}
         else:
             # No instrument detected or expected
-            return {
-                'config': None,
-                'id': None}
+            return {"config": None, "id": None}
 
     async def get_attached_instruments(
-            self, expected: Dict[types.Mount, PipetteName]
+        self, expected: Dict[types.Mount, PipetteName]
     ) -> AttachedInstruments:
-        """ Update the internal cache of attached instruments.
+        """Update the internal cache of attached instruments.
 
         This method allows after-init-time specification of attached simulated
         instruments. The method will return
@@ -271,12 +281,10 @@ class Simulator:
 
     async def watch(self):
         new_mods_at_ports = [
-            modules.ModuleAtPort(
-                port=f'/dev/ot_module_sim_{mod}{str(idx)}', name=mod)
-            for idx, mod
-            in enumerate(self._stubbed_attached_modules)]
-        await self.module_controls.register_modules(
-            new_mods_at_ports=new_mods_at_ports)
+            modules.ModuleAtPort(port=f"/dev/ot_module_sim_{mod}{str(idx)}", name=mod)
+            for idx, mod in enumerate(self._stubbed_attached_modules)
+        ]
+        await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
 
     @contextmanager
     def save_current(self):
@@ -284,14 +292,16 @@ class Simulator:
 
     @property
     def axis_bounds(self) -> Dict[Axis, Tuple[float, float]]:
-        """ The (minimum, maximum) bounds for each axis. """
-        return {Axis[ax]: (0, pos) for ax, pos
-                in self._smoothie_driver.axis_bounds.items()
-                if ax not in 'BC'}
+        """The (minimum, maximum) bounds for each axis."""
+        return {
+            Axis[ax]: (0, pos)
+            for ax, pos in self._smoothie_driver.axis_bounds.items()
+            if ax not in "BC"
+        }
 
     @property
     def fw_version(self) -> Optional[str]:
-        return 'Virtual Smoothie'
+        return "Virtual Smoothie"
 
     async def update_fw_version(self):
         pass
@@ -301,7 +311,7 @@ class Simulator:
         return self._board_revision
 
     async def update_firmware(self, filename, loop, modeset) -> str:
-        return 'Did nothing (simulating)'
+        return "Did nothing (simulating)"
 
     def engaged_axes(self):
         return self._engaged_axes
@@ -311,9 +321,9 @@ class Simulator:
 
     def set_lights(self, button: Optional[bool], rails: Optional[bool]):
         if button is not None:
-            self._lights['button'] = button
+            self._lights["button"] = button
         if rails is not None:
-            self._lights['rails'] = rails
+            self._lights["rails"] = rails
 
     def get_lights(self) -> Dict[str, bool]:
         return self._lights
@@ -338,19 +348,23 @@ class Simulator:
         pass
 
     async def configure_mount(
-            self, mount: types.Mount, config: InstrumentHardwareConfigs):
+        self, mount: types.Mount, config: InstrumentHardwareConfigs
+    ):
         mount_axis = Axis.by_mount(mount)
         plunger_axis = Axis.of_plunger(mount)
 
         self._smoothie_driver.update_steps_per_mm(
-            {plunger_axis.name: config['steps_per_mm']})
+            {plunger_axis.name: config["steps_per_mm"]}
+        )
         self._smoothie_driver.update_pipette_config(
-            mount_axis.name, {'home': config['home_pos']})
+            mount_axis.name, {"home": config["home_pos"]}
+        )
         self._smoothie_driver.update_pipette_config(
-            plunger_axis.name, {'max_travel': config['max_travel']})
+            plunger_axis.name, {"max_travel": config["max_travel"]}
+        )
         self._smoothie_driver.set_dwelling_current(
-            {plunger_axis.name: config['idle_current']})
-        ms = config['splits']
+            {plunger_axis.name: config["idle_current"]}
+        )
+        ms = config["splits"]
         if ms:
-            self._smoothie_driver.configure_splits_for(
-                {plunger_axis.name: ms})
+            self._smoothie_driver.configure_splits_for({plunger_axis.name: ms})

--- a/api/src/opentrons/hardware_control/simulator_setup.py
+++ b/api/src/opentrons/hardware_control/simulator_setup.py
@@ -19,8 +19,9 @@ class ModuleCall:
 
 @dataclass(frozen=True)
 class SimulatorSetup:
-    attached_instruments: Dict[Mount, Dict[str, Optional[str]]] =\
-        field(default_factory=dict)
+    attached_instruments: Dict[Mount, Dict[str, Optional[str]]] = field(
+        default_factory=dict
+    )
     attached_modules: Dict[str, List[ModuleCall]] = field(default_factory=dict)
     config: Optional[RobotConfig] = None
     strict_attached_instruments: bool = True
@@ -47,15 +48,14 @@ async def create_simulator(setup: SimulatorSetup, loop=None) -> API:
 
 async def load_simulator(path: Path, loop=None) -> API:
     """Create a simulator from a JSON file."""
-    return await create_simulator(setup=load_simulator_setup(path),
-                                  loop=loop)
+    return await create_simulator(setup=load_simulator_setup(path), loop=loop)
 
 
 def save_simulator_setup(simulator_setup: SimulatorSetup, path: Path):
     """Write a simulator setup to a file."""
     as_dict = asdict(simulator_setup)
     as_dict = {k: _prepare_for_dict(k, v) for (k, v) in as_dict.items()}
-    with path.open('w') as f:
+    with path.open("w") as f:
         json.dump(as_dict, f)
 
 
@@ -64,24 +64,23 @@ def load_simulator_setup(path: Path) -> SimulatorSetup:
     with path.open() as f:
         obj = json.load(f)
         return SimulatorSetup(
-            **{k: _prepare_for_simulator_setup(k, v) for (k, v)
-               in obj.items()})
+            **{k: _prepare_for_simulator_setup(k, v) for (k, v) in obj.items()}
+        )
 
 
 def _prepare_for_dict(key, value):
     """Convert an element in SimulatorSetup to be a serializable dict"""
-    if key == 'attached_instruments' and value:
+    if key == "attached_instruments" and value:
         return {mount.name.lower(): data for (mount, data) in value.items()}
     return value
 
 
 def _prepare_for_simulator_setup(key, value):
     """Convert value to a SimulatorSetup"""
-    if key == 'attached_instruments' and value:
+    if key == "attached_instruments" and value:
         return {Mount[mount.upper()]: data for (mount, data) in value.items()}
-    if key == 'config' and value:
+    if key == "config" and value:
         return robot_configs.build_config(value)
-    if key == 'attached_modules' and value:
-        return {k: [ModuleCall(**data) for data in v] for (k, v)
-                in value.items()}
+    if key == "attached_modules" and value:
+        return {k: [ModuleCall(**data) for data in v] for (k, v) in value.items()}
     return value

--- a/api/src/opentrons/hardware_control/threaded_async_lock.py
+++ b/api/src/opentrons/hardware_control/threaded_async_lock.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 class ThreadedAsyncLock:
-    """ A thread-safe async lock
+    """A thread-safe async lock
 
     This is required to properly lock access to motion calls, which are
     a) done in async contexts (rpc methods and http methods) and should
@@ -26,11 +26,11 @@ class ThreadedAsyncLock:
     def __init__(self):
         self._thread_lock = threading.Lock()
 
-    def lock(self) -> '_Internal':
+    def lock(self) -> "_Internal":
         """Create a context manager that locks access to a code block"""
         return _Internal(lock=self._thread_lock, forbid=False)
 
-    def forbid(self) -> '_Internal':
+    def forbid(self) -> "_Internal":
         """Create a context manager that forbids concurrent attempts to
         access to a code block"""
         return _Internal(lock=self._thread_lock, forbid=True)
@@ -40,8 +40,10 @@ class ThreadedAsyncForbidden(Exception):
     """Exception indicating that lock is acquired and that blocking
     is forbidden"""
 
-    def __init__(self, msg="Robot is currently moving. Please wait and try "
-                           "this command again."):
+    def __init__(
+        self,
+        msg="Robot is currently moving. Please wait and try " "this command again.",
+    ):
         super().__init__(msg)
 
 
@@ -61,9 +63,11 @@ class _Internal:
         self._forbid = forbid
 
     async def __aenter__(self):
-        pref = f"[ThreadedAsyncLock tid {threading.get_ident()} "\
+        pref = (
+            f"[ThreadedAsyncLock tid {threading.get_ident()} "
             f"task {asyncio.current_task()}] "
-        log.debug(pref + 'will acquire')
+        )
+        log.debug(pref + "will acquire")
         then = time.perf_counter()
         while not self._thread_lock.acquire(blocking=False):
             if self._forbid:
@@ -71,11 +75,13 @@ class _Internal:
                 raise ThreadedAsyncForbidden()
             await asyncio.sleep(0.1)
         now = time.perf_counter()
-        log.debug(pref + f'acquired in {now-then}s')
+        log.debug(pref + f"acquired in {now-then}s")
 
     async def __aexit__(self, exc_type, exc, tb):
-        log.debug(f"[ThreadedAsyncLock tid {threading.get_ident()} "
-                  f"task {asyncio.current_task()}] will release")
+        log.debug(
+            f"[ThreadedAsyncLock tid {threading.get_ident()} "
+            f"task {asyncio.current_task()}] will release"
+        )
         self._thread_lock.release()
 
     def __enter__(self):

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -19,10 +19,10 @@ class OutOfBoundsMove(RuntimeError):
         super().__init__()
 
     def __str__(self) -> str:
-        return f'OutOfBoundsMove: {self.message}'
+        return f"OutOfBoundsMove: {self.message}"
 
     def __repr__(self) -> str:
-        return f'<{str(self.__class__)}: {self.message}>'
+        return f"<{str(self.__class__)}: {self.message}>"
 
 
 class MotionChecks(enum.Enum):
@@ -42,30 +42,28 @@ class Axis(enum.Enum):
 
     @classmethod
     def by_mount(cls, mount: top_types.Mount):
-        bm = {top_types.Mount.LEFT: cls.Z,
-              top_types.Mount.RIGHT: cls.A}
+        bm = {top_types.Mount.LEFT: cls.Z, top_types.Mount.RIGHT: cls.A}
         return bm[mount]
 
     @classmethod
-    def gantry_axes(cls) -> Tuple['Axis', 'Axis', 'Axis', 'Axis']:
-        """ The axes which are tied to the gantry and require the deck
+    def gantry_axes(cls) -> Tuple["Axis", "Axis", "Axis", "Axis"]:
+        """The axes which are tied to the gantry and require the deck
         calibration transform
         """
         return (cls.X, cls.Y, cls.Z, cls.A)
 
     @classmethod
     def of_plunger(cls, mount: top_types.Mount):
-        pm = {top_types.Mount.LEFT: cls.B,
-              top_types.Mount.RIGHT: cls.C}
+        pm = {top_types.Mount.LEFT: cls.B, top_types.Mount.RIGHT: cls.C}
         return pm[mount]
 
     @classmethod
-    def to_mount(cls, inst: 'Axis'):
+    def to_mount(cls, inst: "Axis"):
         return {
             cls.Z: top_types.Mount.LEFT,
             cls.A: top_types.Mount.RIGHT,
             cls.B: top_types.Mount.LEFT,
-            cls.C: top_types.Mount.RIGHT
+            cls.C: top_types.Mount.RIGHT,
         }[inst]
 
     def __str__(self):
@@ -86,8 +84,7 @@ class HardwareEventType(enum.Enum):
 
 @dataclass
 class DoorStateNotification:
-    event: 'DoorStateNotificationType' = \
-        HardwareEventType.DOOR_SWITCH_CHANGE
+    event: "DoorStateNotificationType" = HardwareEventType.DOOR_SWITCH_CHANGE
     new_state: DoorState = DoorState.CLOSED
     blocking: bool = False
 
@@ -98,8 +95,8 @@ HardwareEvent = Union[DoorStateNotification]
 
 
 class HardwareAPILike(abc.ABC):
-    """ A dummy class useful in isinstance checks to accept an API or adapter
-    """
+    """A dummy class useful in isinstance checks to accept an API or adapter"""
+
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         ...
@@ -120,7 +117,7 @@ class HardwareAPILike(abc.ABC):
         ...
 
 
-RevisionLiteral = Literal['2.1', 'A', 'B', 'C', 'UNKNOWN']
+RevisionLiteral = Literal["2.1", "A", "B", "C", "UNKNOWN"]
 
 
 class BoardRevision(enum.Enum):
@@ -136,24 +133,25 @@ class BoardRevision(enum.Enum):
             (True, True): cls.OG,
             (False, True): cls.A,
             (True, False): cls.B,
-            (False, False): cls.C
+            (False, False): cls.C,
         }
         return br[rev_bits]
 
-    def real_name(self) -> Union[RevisionLiteral, Literal['UNKNOWN']]:
-        rn = '2.1' if self.name == 'OG' else self.name
-        return cast(Union[RevisionLiteral, Literal['UNKNOWN']], rn)
+    def real_name(self) -> Union[RevisionLiteral, Literal["UNKNOWN"]]:
+        rn = "2.1" if self.name == "OG" else self.name
+        return cast(Union[RevisionLiteral, Literal["UNKNOWN"]], rn)
 
     def __str__(self) -> str:
         return self.real_name()
 
 
 class CriticalPoint(enum.Enum):
-    """ Possibilities for the point to move in a move call.
+    """Possibilities for the point to move in a move call.
 
     The active critical point determines the offsets that are added to the
     gantry position when moving a pipette around.
     """
+
     MOUNT = enum.auto()
     """
     For legacy reasons, the position of the end of a P300 single. The default
@@ -206,22 +204,24 @@ class PipettePair(enum.Enum):
 
     @property
     def primary(self) -> top_types.Mount:
-        if self.name == 'PRIMARY_RIGHT':
+        if self.name == "PRIMARY_RIGHT":
             return top_types.Mount.RIGHT
         else:
             return top_types.Mount.LEFT
 
     @property
     def secondary(self) -> top_types.Mount:
-        if self.name == 'PRIMARY_RIGHT':
+        if self.name == "PRIMARY_RIGHT":
             return top_types.Mount.LEFT
         else:
             return top_types.Mount.RIGHT
 
     @classmethod
-    def of_mount(cls, mount: top_types.Mount) -> 'PipettePair':
-        pair = {top_types.Mount.LEFT: cls.PRIMARY_LEFT,
-                top_types.Mount.RIGHT: cls.PRIMARY_RIGHT}
+    def of_mount(cls, mount: top_types.Mount) -> "PipettePair":
+        pair = {
+            top_types.Mount.LEFT: cls.PRIMARY_LEFT,
+            top_types.Mount.RIGHT: cls.PRIMARY_RIGHT,
+        }
         return pair[mount]
 
 
@@ -247,15 +247,14 @@ class AionotifyEvent:
     name: str
 
     @classmethod
-    def build(cls, name: str, flags: List[enum.Enum]) -> 'AionotifyEvent':
+    def build(cls, name: str, flags: List[enum.Enum]) -> "AionotifyEvent":
         # See https://github.com/python/mypy/issues/5317
         # as to why mypy cannot detect that list
         # comprehension or variables cannot be dynamically
         # determined to meet the argument criteria for
         # enums. Hence, the type ignore below.
         flag_list = [f.name for f in flags]
-        Flag = enum.Enum('Flag',  # type: ignore
-                         flag_list)
+        Flag = enum.Enum("Flag", flag_list)  # type: ignore
         return cls(flags=Flag, name=name)
 
 

--- a/api/src/opentrons/hardware_control/util.py
+++ b/api/src/opentrons/hardware_control/util.py
@@ -10,34 +10,34 @@ from opentrons.types import Point
 mod_log = logging.getLogger(__name__)
 
 
-def _handle_loop_exception(loop: asyncio.AbstractEventLoop,
-                           context: Dict[str, Any]):
+def _handle_loop_exception(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]):
     mod_log.error(f"Caught exception: {context}")
 
 
-def use_or_initialize_loop(loop: Optional[asyncio.AbstractEventLoop]
-                           ) -> asyncio.AbstractEventLoop:
+def use_or_initialize_loop(
+    loop: Optional[asyncio.AbstractEventLoop],
+) -> asyncio.AbstractEventLoop:
     checked_loop = loop or asyncio.get_event_loop()
     checked_loop.set_exception_handler(_handle_loop_exception)
     return checked_loop
 
 
 def plan_arc(
-        origin_point: Point,
-        dest_point: Point,
-        z_height: float,
-        origin_cp: CriticalPoint = None,
-        dest_cp: CriticalPoint = None,
-        extra_waypoints: List[Tuple[float, float]] = None)\
-        -> List[Tuple[Point, Optional[CriticalPoint]]]:
+    origin_point: Point,
+    dest_point: Point,
+    z_height: float,
+    origin_cp: CriticalPoint = None,
+    dest_cp: CriticalPoint = None,
+    extra_waypoints: List[Tuple[float, float]] = None,
+) -> List[Tuple[Point, Optional[CriticalPoint]]]:
 
     assert z_height >= max(origin_point.z, dest_point.z)
     checked_wp = extra_waypoints or []
-    return [(origin_point._replace(z=z_height), origin_cp)]\
-        + [(Point(x=wp[0], y=wp[1], z=z_height), dest_cp)
-           for wp in checked_wp]\
-        + [(dest_point._replace(z=z_height), dest_cp),
-           (dest_point, dest_cp)]
+    return (
+        [(origin_point._replace(z=z_height), origin_cp)]
+        + [(Point(x=wp[0], y=wp[1], z=z_height), dest_cp) for wp in checked_wp]
+        + [(dest_point._replace(z=z_height), dest_cp), (dest_point, dest_cp)]
+    )
 
 
 class DeckTransformState(Enum):
@@ -51,10 +51,11 @@ class DeckTransformState(Enum):
 
 
 def check_motion_bounds(
-        target_smoothie: Mapping[Axis, float],
-        target_deck: Mapping[Axis, float],
-        bounds: Mapping[Axis, Tuple[float, float]],
-        checks: MotionChecks):
+    target_smoothie: Mapping[Axis, float],
+    target_deck: Mapping[Axis, float],
+    bounds: Mapping[Axis, Tuple[float, float]],
+    checks: MotionChecks,
+):
     """
     Log or raise an error (depending on checks) if a specified
     target position is outside the acceptable bounds of motion
@@ -66,16 +67,17 @@ def check_motion_bounds(
     entirely filled; it is used only for logging
     """
     bounds_message_format = (
-        'Out of bounds move: {axis}=({tsp} motor controller, {tdp} deck) too '
-        '{dir} for limit {limsp}')
+        "Out of bounds move: {axis}=({tsp} motor controller, {tdp} deck) too "
+        "{dir} for limit {limsp}"
+    )
     for ax in target_smoothie.keys():
         if target_smoothie[ax] < bounds[ax][0]:
             bounds_message = bounds_message_format.format(
                 axis=ax,
                 tsp=target_smoothie[ax],
-                tdp=target_deck.get(ax, 'unknown'),
-                dir='low',
-                limsp=bounds.get(ax, ('unknown',))[0],
+                tdp=target_deck.get(ax, "unknown"),
+                dir="low",
+                limsp=bounds.get(ax, ("unknown",))[0],
             )
             mod_log.warning(bounds_message)
             if checks.value & MotionChecks.LOW.value:
@@ -84,9 +86,9 @@ def check_motion_bounds(
             bounds_message = bounds_message_format.format(
                 axis=ax,
                 tsp=target_smoothie[ax],
-                tdp=target_deck.get(ax, 'unknown'),
-                dir='high',
-                limsp=bounds.get(ax, (None, 'unknown'))[1],
+                tdp=target_deck.get(ax, "unknown"),
+                dir="high",
+                limsp=bounds.get(ax, (None, "unknown"))[1],
             )
             mod_log.warning(bounds_message)
             if checks.value & MotionChecks.HIGH.value:

--- a/api/src/opentrons/protocol_api/__init__.py
+++ b/api/src/opentrons/protocol_api/__init__.py
@@ -4,19 +4,28 @@ This package defines classes and functions for access through a protocol to
 control the OT2.
 
 """
-from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION, MIN_SUPPORTED_VERSION  # noqa: F401, E501
+from opentrons.protocols.api_support.definitions import (
+    MAX_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION,
+)
 from . import labware
-from .contexts import (ProtocolContext,
-                       InstrumentContext,
-                       PairedInstrumentContext,
-                       TemperatureModuleContext,
-                       MagneticModuleContext,
-                       ThermocyclerContext)
+from .contexts import (
+    ProtocolContext,
+    InstrumentContext,
+    PairedInstrumentContext,
+    TemperatureModuleContext,
+    MagneticModuleContext,
+    ThermocyclerContext,
+)
 
-__all__ = ['ProtocolContext',
-           'InstrumentContext',
-           'TemperatureModuleContext',
-           'MagneticModuleContext',
-           'ThermocyclerContext',
-           'PairedInstrumentContext',
-           'labware']
+__all__ = [
+    "MAX_SUPPORTED_VERSION",
+    "MIN_SUPPORTED_VERSION",
+    "ProtocolContext",
+    "InstrumentContext",
+    "TemperatureModuleContext",
+    "MagneticModuleContext",
+    "ThermocyclerContext",
+    "PairedInstrumentContext",
+    "labware",
+]

--- a/api/src/opentrons/protocol_api/contexts.py
+++ b/api/src/opentrons/protocol_api/contexts.py
@@ -2,11 +2,19 @@ from .protocol_context import ProtocolContext
 from .instrument_context import InstrumentContext
 from .paired_instrument_context import PairedInstrumentContext
 from .module_contexts import (
-    ModuleContext, ThermocyclerContext, MagneticModuleContext,
-    TemperatureModuleContext)
+    ModuleContext,
+    ThermocyclerContext,
+    MagneticModuleContext,
+    TemperatureModuleContext,
+)
 
 
 __all__ = [
-    'ProtocolContext', 'InstrumentContext', 'ModuleContext', 'PairedInstrumentContext',
-    'ThermocyclerContext', 'MagneticModuleContext', 'TemperatureModuleContext'
+    "ProtocolContext",
+    "InstrumentContext",
+    "ModuleContext",
+    "PairedInstrumentContext",
+    "ThermocyclerContext",
+    "MagneticModuleContext",
+    "TemperatureModuleContext",
 ]

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    List, Optional, Sequence, TYPE_CHECKING, Union)
+from typing import List, Optional, Sequence, TYPE_CHECKING, Union
 from opentrons.broker import Broker
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons import types, hardware_control as hc
@@ -10,34 +9,42 @@ from opentrons.commands import commands as cmds
 from opentrons.commands.publisher import CommandPublisher, do_publish, publish
 from opentrons.hardware_control.types import PipettePair
 from opentrons.protocols.advanced_control.mix import mix_from_kwargs
-from opentrons.protocols.api_support.instrument import \
-    validate_blowout_location, tip_length_for, validate_tiprack, \
-    determine_drop_target, validate_can_aspirate, validate_can_dispense
+from opentrons.protocols.api_support.instrument import (
+    validate_blowout_location,
+    tip_length_for,
+    validate_tiprack,
+    determine_drop_target,
+    validate_can_aspirate,
+    validate_can_dispense,
+)
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocol_api.module_contexts import ThermocyclerContext
 from opentrons.protocols.api_support.util import (
-    FlowRates, PlungerSpeeds, Clearances, clamp_value, requires_version)
-from opentrons.protocols.context.instrument import \
-    AbstractInstrument
+    FlowRates,
+    PlungerSpeeds,
+    Clearances,
+    clamp_value,
+    requires_version,
+)
+from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.api_support.types import APIVersion
-from .labware import (
-    Labware, OutOfTipsError, Well, next_available_tip)
+from .labware import Labware, OutOfTipsError, Well, next_available_tip
 from opentrons.protocols.advanced_control import transfers
 from .paired_instrument_context import (
-    PairedInstrumentContext, UnsupportedInstrumentPairingError)
+    PairedInstrumentContext,
+    UnsupportedInstrumentPairingError,
+)
 
 if TYPE_CHECKING:
     from opentrons.protocol_api import ProtocolContext
 
 AdvancedLiquidHandling = Union[
-    Well,
-    types.Location,
-    List[Union[Well, types.Location]],
-    List[List[Well]]]
+    Well, types.Location, List[Union[Well, types.Location]], List[List[Well]]
+]
 
 
 class InstrumentContext(CommandPublisher):
-    """ A context for a specific pipette or instrument.
+    """A context for a specific pipette or instrument.
 
     This can be used to call methods related to pipettes - moves or
     aspirates or dispenses, or higher-level methods.
@@ -54,15 +61,16 @@ class InstrumentContext(CommandPublisher):
 
     """
 
-    def __init__(self,
-                 implementation: AbstractInstrument,
-                 ctx: ProtocolContext,
-                 broker: Broker,
-                 log_parent: logging.Logger,
-                 at_version: APIVersion,
-                 tip_racks: List[Labware] = None,
-                 trash: Optional[Labware] = None,
-                 ) -> None:
+    def __init__(
+        self,
+        implementation: AbstractInstrument,
+        ctx: ProtocolContext,
+        broker: Broker,
+        log_parent: logging.Logger,
+        at_version: APIVersion,
+        tip_racks: List[Labware] = None,
+        trash: Optional[Labware] = None,
+    ) -> None:
 
         super().__init__(broker)
         self._api_version = at_version
@@ -91,8 +99,7 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def starting_tip(self) -> Union[Well, None]:
-        """ The starting tip from which the pipette pick up
-        """
+        """The starting tip from which the pipette pick up"""
         return self._starting_tip
 
     @starting_tip.setter
@@ -101,8 +108,7 @@ class InstrumentContext(CommandPublisher):
 
     @requires_version(2, 0)
     def reset_tipracks(self):
-        """ Reload all tips in each tip rack and reset starting tip
-        """
+        """Reload all tips in each tip rack and reset starting tip"""
         for tiprack in self.tip_racks:
             tiprack.reset()
         self.starting_tip = None
@@ -110,7 +116,7 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def default_speed(self) -> float:
-        """ The speed at which the robot's gantry moves.
+        """The speed at which the robot's gantry moves.
 
         By default, 400 mm/s. Changing this value will change the speed of the
         pipette when moving between labware. In addition to changing the
@@ -124,10 +130,12 @@ class InstrumentContext(CommandPublisher):
         self._implementation.set_default_speed(speed)
 
     @requires_version(2, 0)  # noqa: C901
-    def aspirate(self,
-                 volume: Optional[float] = None,
-                 location: Union[types.Location, Well] = None,
-                 rate: float = 1.0) -> InstrumentContext:
+    def aspirate(
+        self,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> InstrumentContext:
         """
         Aspirate a given volume of liquid from the specified location, using
         this pipette.
@@ -161,20 +169,22 @@ class InstrumentContext(CommandPublisher):
             ``instr.aspirate(location=wellplate['A1'])``
 
         """
-        self._log.debug("aspirate {} from {} at {}"
-                        .format(volume,
-                                location if location else 'current position',
-                                rate))
+        self._log.debug(
+            "aspirate {} from {} at {}".format(
+                volume, location if location else "current position", rate
+            )
+        )
 
         if isinstance(location, Well):
             dest = location.bottom().move(
-                types.Point(0, 0, self.well_bottom_clearance.aspirate))
+                types.Point(0, 0, self.well_bottom_clearance.aspirate)
+            )
         elif isinstance(location, types.Location):
             dest = location
         elif location is not None:
             raise TypeError(
-                'location should be a Well or Location, but it is {}'
-                .format(location))
+                "location should be a Well or Location, but it is {}".format(location)
+            )
         elif self._ctx.location_cache:
             dest = self._ctx.location_cache
         else:
@@ -182,7 +192,8 @@ class InstrumentContext(CommandPublisher):
                 "If aspirate is called without an explicit location, another"
                 " method that moves to a location (such as move_to or "
                 "dispense) must previously have been called so the robot "
-                "knows where it is.")
+                "knows where it is."
+            )
         if self.api_version >= APIVersion(2, 11):
             validate_can_aspirate(dest)
 
@@ -190,11 +201,12 @@ class InstrumentContext(CommandPublisher):
             # Make sure we're at the top of the labware and clear of any
             # liquid to prepare the pipette for aspiration
 
-            if self.api_version < APIVersion(2, 3) or \
-                    not self._implementation.is_ready_to_aspirate():
+            if (
+                self.api_version < APIVersion(2, 3)
+                or not self._implementation.is_ready_to_aspirate()
+            ):
                 if dest.labware.is_well:
-                    self.move_to(dest.labware.as_well().top(),
-                                 publish=False)
+                    self.move_to(dest.labware.as_well().top(), publish=False)
                 else:
                     # TODO(seth,2019/7/29): This should be a warning exposed
                     #  via rpc to the runapp
@@ -203,27 +215,49 @@ class InstrumentContext(CommandPublisher):
                         "well relative position, we can't move to the top of"
                         " the well to prepare for aspiration. This might "
                         "cause over aspiration if the previous command is a "
-                        "blow_out.")
+                        "blow_out."
+                    )
                 self._implementation.prepare_for_aspirate()
             self.move_to(dest, publish=False)
         elif dest != self._ctx.location_cache:
             self.move_to(dest, publish=False)
 
-        c_vol = self._implementation.get_available_volume() \
-            if not volume else volume
+        c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        do_publish(self.broker, cmds.aspirate, self.aspirate,
-                   'before', None, None, self, c_vol, dest, rate)
+        do_publish(
+            self.broker,
+            cmds.aspirate,
+            self.aspirate,
+            "before",
+            None,
+            None,
+            self,
+            c_vol,
+            dest,
+            rate,
+        )
         self._implementation.aspirate(volume=c_vol, rate=rate)
-        do_publish(self.broker, cmds.aspirate, self.aspirate,
-                   'after', self, None, self, c_vol, dest, rate)
+        do_publish(
+            self.broker,
+            cmds.aspirate,
+            self.aspirate,
+            "after",
+            self,
+            None,
+            self,
+            c_vol,
+            dest,
+            rate,
+        )
         return self
 
     @requires_version(2, 0)
-    def dispense(self,
-                 volume: Optional[float] = None,
-                 location: Union[types.Location, Well] = None,
-                 rate: float = 1.0) -> InstrumentContext:
+    def dispense(
+        self,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> InstrumentContext:
         """
         Dispense a volume of liquid (in microliters/uL) using this pipette
         into the specified location.
@@ -264,23 +298,26 @@ class InstrumentContext(CommandPublisher):
             ``instr.dispense(location=wellplate['A1'])``
 
         """
-        self._log.debug("dispense {} from {} at {}"
-                        .format(volume,
-                                location if location else 'current position',
-                                rate))
+        self._log.debug(
+            "dispense {} from {} at {}".format(
+                volume, location if location else "current position", rate
+            )
+        )
         if isinstance(location, Well):
             if LabwareLike(location).is_fixed_trash():
                 loc = location.top()
             else:
                 loc = location.bottom().move(
-                    types.Point(0, 0, self.well_bottom_clearance.dispense))
+                    types.Point(0, 0, self.well_bottom_clearance.dispense)
+                )
             self.move_to(loc, publish=False)
         elif isinstance(location, types.Location):
             loc = location
             self.move_to(location, publish=False)
         elif location is not None:
             raise TypeError(
-                f'location should be a Well or Location, but it is {location}')
+                f"location should be a Well or Location, but it is {location}"
+            )
         elif self._ctx.location_cache:
             loc = self._ctx.location_cache
         else:
@@ -288,25 +325,48 @@ class InstrumentContext(CommandPublisher):
                 "If dispense is called without an explicit location, another"
                 " method that moves to a location (such as move_to or "
                 "aspirate) must previously have been called so the robot "
-                "knows where it is.")
+                "knows where it is."
+            )
         if self.api_version >= APIVersion(2, 11):
             validate_can_dispense(loc)
 
         c_vol = self.current_volume if not volume else volume
 
-        do_publish(self.broker, cmds.dispense, self.dispense,
-                   'before', None, None, self, c_vol, loc, rate)
+        do_publish(
+            self.broker,
+            cmds.dispense,
+            self.dispense,
+            "before",
+            None,
+            None,
+            self,
+            c_vol,
+            loc,
+            rate,
+        )
         self._implementation.dispense(volume=c_vol, rate=rate)
-        do_publish(self.broker, cmds.dispense, self.dispense,
-                   'after', self, None, self, c_vol, loc, rate)
+        do_publish(
+            self.broker,
+            cmds.dispense,
+            self.dispense,
+            "after",
+            self,
+            None,
+            self,
+            c_vol,
+            loc,
+            rate,
+        )
         return self
 
     @requires_version(2, 0)
-    def mix(self,
-            repetitions: int = 1,
-            volume: Optional[float] = None,
-            location: Union[types.Location, Well] = None,
-            rate: float = 1.0) -> InstrumentContext:
+    def mix(
+        self,
+        repetitions: int = 1,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> InstrumentContext:
         """
         Mix a volume of liquid (uL) using this pipette, by repeatedly
         aspirating and dispensing in the same place.
@@ -344,33 +404,51 @@ class InstrumentContext(CommandPublisher):
 
         """
         self._log.debug(
-            'mixing {}uL with {} repetitions in {} at rate={}'.format(
-                volume, repetitions,
-                location if location else 'current position', rate))
+            "mixing {}uL with {} repetitions in {} at rate={}".format(
+                volume, repetitions, location if location else "current position", rate
+            )
+        )
         if not self._implementation.has_tip():
-            raise hc.NoTipAttachedError('Pipette has no tip. Aborting mix()')
+            raise hc.NoTipAttachedError("Pipette has no tip. Aborting mix()")
 
-        c_vol = self._implementation.get_available_volume() \
-            if not volume else volume
+        c_vol = self._implementation.get_available_volume() if not volume else volume
 
-        do_publish(self.broker, cmds.mix, self.mix,
-                   'before', None, None,
-                   self, repetitions, c_vol, location)
+        do_publish(
+            self.broker,
+            cmds.mix,
+            self.mix,
+            "before",
+            None,
+            None,
+            self,
+            repetitions,
+            c_vol,
+            location,
+        )
         self.aspirate(volume, location, rate)
         while repetitions - 1 > 0:
             self.dispense(volume, rate=rate)
             self.aspirate(volume, rate=rate)
             repetitions -= 1
         self.dispense(volume, rate=rate)
-        do_publish(self.broker, cmds.mix, self.mix,
-                   'after', None, None,
-                   self, repetitions, c_vol, location)
+        do_publish(
+            self.broker,
+            cmds.mix,
+            self.mix,
+            "after",
+            None,
+            None,
+            self,
+            repetitions,
+            c_vol,
+            location,
+        )
         return self
 
     @requires_version(2, 0)
-    def blow_out(self,
-                 location: Union[types.Location, Well] = None
-                 ) -> InstrumentContext:
+    def blow_out(
+        self, location: Union[types.Location, Well] = None
+    ) -> InstrumentContext:
         """
         Blow liquid out of the tip.
 
@@ -395,8 +473,10 @@ class InstrumentContext(CommandPublisher):
 
         if isinstance(location, Well):
             if location.parent.is_tiprack:
-                self._log.warning('Blow_out being performed on a tiprack. '
-                                  'Please re-check your code')
+                self._log.warning(
+                    "Blow_out being performed on a tiprack. "
+                    "Please re-check your code"
+                )
             loc = location.top()
             self.move_to(loc, publish=False)
         elif isinstance(location, types.Location):
@@ -404,8 +484,8 @@ class InstrumentContext(CommandPublisher):
             self.move_to(loc, publish=False)
         elif location is not None:
             raise TypeError(
-                'location should be a Well or Location, but it is {}'
-                .format(location))
+                "location should be a Well or Location, but it is {}".format(location)
+            )
         elif self._ctx.location_cache:
             # if location cache exists, pipette blows out immediately at
             # current location, no movement is needed
@@ -415,28 +495,47 @@ class InstrumentContext(CommandPublisher):
                 "If blow out is called without an explicit location, another"
                 " method that moves to a location (such as move_to or "
                 "dispense) must previously have been called so the robot "
-                "knows where it is.")
+                "knows where it is."
+            )
 
-        do_publish(self.broker, cmds.blow_out, self.blow_out, 'before',
-                   None, None, self, location or self._ctx.location_cache)
+        do_publish(
+            self.broker,
+            cmds.blow_out,
+            self.blow_out,
+            "before",
+            None,
+            None,
+            self,
+            location or self._ctx.location_cache,
+        )
         self._implementation.blow_out()
-        do_publish(self.broker, cmds.blow_out, self.blow_out, 'after',
-                   None, None, self, location or self._ctx.location_cache)
+        do_publish(
+            self.broker,
+            cmds.blow_out,
+            self.blow_out,
+            "after",
+            None,
+            None,
+            self,
+            location or self._ctx.location_cache,
+        )
         return self
 
     def _determine_speed(self, speed: float):
         if self.api_version < APIVersion(2, 4):
-            return clamp_value(speed, 80, 20, 'touch_tip:')
+            return clamp_value(speed, 80, 20, "touch_tip:")
         else:
-            return clamp_value(speed, 80, 1, 'touch_tip:')
+            return clamp_value(speed, 80, 1, "touch_tip:")
 
     @publish.both(command=cmds.touch_tip)
     @requires_version(2, 0)
-    def touch_tip(self,
-                  location: Optional[Well] = None,
-                  radius: float = 1.0,
-                  v_offset: float = -1.0,
-                  speed: float = 60.0) -> InstrumentContext:
+    def touch_tip(
+        self,
+        location: Optional[Well] = None,
+        radius: float = 1.0,
+        v_offset: float = -1.0,
+        speed: float = 60.0,
+    ) -> InstrumentContext:
         """
         Touch the pipette tip to the sides of a well, with the intent of
         removing left-over droplets
@@ -472,7 +571,7 @@ class InstrumentContext(CommandPublisher):
 
         """
         if not self._implementation.has_tip():
-            raise hc.NoTipAttachedError('Pipette has no tip to touch_tip()')
+            raise hc.NoTipAttachedError("Pipette has no tip to touch_tip()")
 
         checked_speed = self._determine_speed(speed)
 
@@ -480,7 +579,7 @@ class InstrumentContext(CommandPublisher):
         if location is None:
             last_location = self._ctx.location_cache
             if not last_location:
-                raise RuntimeError('No valid current location cache present')
+                raise RuntimeError("No valid current location cache present")
             else:
                 well = last_location.labware
                 # type checked below
@@ -488,37 +587,39 @@ class InstrumentContext(CommandPublisher):
             well = LabwareLike(location)
 
         if well.is_well:
-            if 'touchTipDisabled' in well.quirks_from_any_parent():
+            if "touchTipDisabled" in well.quirks_from_any_parent():
                 self._log.info(f"Ignoring touch tip on labware {well}")
                 return self
             if well.parent.as_labware().is_tiprack:
-                self._log.warning('Touch_tip being performed on a tiprack. '
-                                  'Please re-check your code')
+                self._log.warning(
+                    "Touch_tip being performed on a tiprack. "
+                    "Please re-check your code"
+                )
 
             if self.api_version < APIVersion(2, 4):
                 to_loc = well.as_well().top()
             else:
-                move_with_z_offset =\
-                    well.as_well().top().point + types.Point(0, 0, v_offset)
+                move_with_z_offset = well.as_well().top().point + types.Point(
+                    0, 0, v_offset
+                )
                 to_loc = types.Location(move_with_z_offset, well)
             self.move_to(to_loc, publish=False)
         else:
-            raise TypeError(
-                'location should be a Well, but it is {}'.format(location))
+            raise TypeError("location should be a Well, but it is {}".format(location))
 
         self._implementation.touch_tip(
             location=well.as_well()._impl,
             radius=radius,
             v_offset=v_offset,
-            speed=checked_speed
+            speed=checked_speed,
         )
         return self
 
     @publish.both(command=cmds.air_gap)
     @requires_version(2, 0)
-    def air_gap(self,
-                volume: Optional[float] = None,
-                height: Optional[float] = None) -> InstrumentContext:
+    def air_gap(
+        self, volume: Optional[float] = None, height: Optional[float] = None
+    ) -> InstrumentContext:
         """
         Pull air into the pipette current tip at the current location
 
@@ -551,13 +652,13 @@ class InstrumentContext(CommandPublisher):
 
         """
         if not self._implementation.has_tip():
-            raise hc.NoTipAttachedError('Pipette has no tip. Aborting air_gap')
+            raise hc.NoTipAttachedError("Pipette has no tip. Aborting air_gap")
 
         if height is None:
             height = 5
         loc = self._ctx.location_cache
         if not loc or not loc.labware.is_well:
-            raise RuntimeError('No previous Well cached to perform air gap')
+            raise RuntimeError("No previous Well cached to perform air gap")
         target = loc.labware.as_well().top(height)
         self.move_to(target, publish=False)
         self.aspirate(volume)
@@ -578,25 +679,27 @@ class InstrumentContext(CommandPublisher):
             See the ``home_after`` parameter in :py:obj:`drop_tip`.
         """
         if not self._implementation.has_tip():
-            self._log.warning('Pipette has no tip to return')
+            self._log.warning("Pipette has no tip to return")
         loc = self._last_tip_picked_up_from
         if not isinstance(loc, Well):
-            raise TypeError('Last tip location should be a Well but it is: '
-                            '{}'.format(loc))
+            raise TypeError(
+                "Last tip location should be a Well but it is: " "{}".format(loc)
+            )
         return_height = self._implementation.get_return_height()
-        drop_loc = determine_drop_target(self.api_version,
-                                         loc,
-                                         return_height,
-                                         APIVersion(2, 3))
+        drop_loc = determine_drop_target(
+            self.api_version, loc, return_height, APIVersion(2, 3)
+        )
         self.drop_tip(drop_loc, home_after=home_after)
 
         return self
 
     @requires_version(2, 0)
     def pick_up_tip(
-            self, location: Union[types.Location, Well] = None,
-            presses: Optional[int] = None,
-            increment: Optional[float] = None) -> InstrumentContext:
+        self,
+        location: Union[types.Location, Well] = None,
+        presses: Optional[int] = None,
+        increment: Optional[float] = None,
+    ) -> InstrumentContext:
         """
         Pick up a tip for the pipette to run liquid-handling commands with
 
@@ -650,20 +753,29 @@ class InstrumentContext(CommandPublisher):
             tiprack = location.parent
             target = location
         elif not location:
-            tiprack, target = next_available_tip(self.starting_tip,
-                                                 self.tip_racks,
-                                                 self.channels)
+            tiprack, target = next_available_tip(
+                self.starting_tip, self.tip_racks, self.channels
+            )
         else:
             raise TypeError(
                 "If specified, location should be an instance of "
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
-                " However, it is a {}".format(location))
+                " However, it is a {}".format(location)
+            )
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
         validate_tiprack(self.name, tiprack, self._log)
-        do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
-                   'before', None, None, self, location=target)
+        do_publish(
+            self.broker,
+            cmds.pick_up_tip,
+            self.pick_up_tip,
+            "before",
+            None,
+            None,
+            self,
+            location=target,
+        )
 
         self.move_to(target.top(), publish=False)
 
@@ -671,11 +783,19 @@ class InstrumentContext(CommandPublisher):
             well=target._impl,
             tip_length=self._tip_length_for(tiprack),
             presses=presses,
-            increment=increment
+            increment=increment,
         )
         # Note that the hardware API pick_up_tip action includes homing z after
-        do_publish(self.broker, cmds.pick_up_tip, self.pick_up_tip,
-                   'after', self, None, self, location=target)
+        do_publish(
+            self.broker,
+            cmds.pick_up_tip,
+            self.pick_up_tip,
+            "after",
+            self,
+            None,
+            self,
+            location=target,
+        )
 
         tiprack.use_tips(target, self.channels)
         self._last_tip_picked_up_from = target
@@ -684,10 +804,8 @@ class InstrumentContext(CommandPublisher):
 
     @requires_version(2, 0)
     def drop_tip(
-            self,
-            location: Union[types.Location, Well] = None,
-            home_after: bool = True)\
-            -> InstrumentContext:
+        self, location: Union[types.Location, Well] = None, home_after: bool = True
+    ) -> InstrumentContext:
         """
         Drop the current tip.
 
@@ -766,15 +884,16 @@ class InstrumentContext(CommandPublisher):
                     "tiprack.wells()[0].top()) it must be a location "
                     "relative to a well, since that is where a tip is "
                     "dropped. The passed location, however, is in "
-                    "reference to {}".format(location.labware))
+                    "reference to {}".format(location.labware)
+                )
         elif location and isinstance(location, Well):
             if LabwareLike(location).is_fixed_trash():
                 target = location.top()
             else:
                 return_height = self._implementation.get_return_height()
-                target = determine_drop_target(self.api_version,
-                                               location,
-                                               return_height)
+                target = determine_drop_target(
+                    self.api_version, location, return_height
+                )
         elif not location:
             target = self.trash_container.wells()[0].top()
         else:
@@ -782,49 +901,70 @@ class InstrumentContext(CommandPublisher):
                 "If specified, location should be an instance of "
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
-                " However, it is a {}".format(location))
-        do_publish(self.broker, cmds.drop_tip, self.drop_tip,
-                   'before', None, None, self, location=target)
+                " However, it is a {}".format(location)
+            )
+        do_publish(
+            self.broker,
+            cmds.drop_tip,
+            self.drop_tip,
+            "before",
+            None,
+            None,
+            self,
+            location=target,
+        )
         self.move_to(target, publish=False)
 
         self._implementation.drop_tip(home_after=home_after)
-        do_publish(self.broker, cmds.drop_tip, self.drop_tip,
-                   'after', self, None, self, location=target)
+        do_publish(
+            self.broker,
+            cmds.drop_tip,
+            self.drop_tip,
+            "after",
+            self,
+            None,
+            self,
+            location=target,
+        )
 
-        if self.api_version < APIVersion(2, 2) \
-                and target.labware.is_well \
-                and target.labware.as_well().parent.is_tiprack:
+        if (
+            self.api_version < APIVersion(2, 2)
+            and target.labware.is_well
+            and target.labware.as_well().parent.is_tiprack
+        ):
             # If this is a tiprack we can try and add the tip back to the
             # tracker
             try:
                 target.labware.as_well().parent.return_tips(
-                    target.labware.as_well(), self.channels)
+                    target.labware.as_well(), self.channels
+                )
             except AssertionError:
                 # Similarly to :py:meth:`return_tips`, the failure case here
                 # just means the tip can't be reused, so don't actually stop
                 # the protocol
-                self._log.exception(f'Could not return tip to {target}')
+                self._log.exception(f"Could not return tip to {target}")
         self._last_tip_picked_up_from = None
         return self
 
     @requires_version(2, 0)
     def home(self) -> InstrumentContext:
-        """ Home the robot.
+        """Home the robot.
 
         :returns: This instance.
         """
-        def home_dummy(mount): pass
+
+        def home_dummy(mount):
+            pass
+
         mount_name = self._implementation.get_mount().name.lower()
-        do_publish(self.broker, cmds.home, home_dummy,
-                   'before', None, None, mount_name)
+        do_publish(self.broker, cmds.home, home_dummy, "before", None, None, mount_name)
         self._implementation.home()
-        do_publish(self.broker, cmds.home, home_dummy,
-                   'after', self, None, mount_name)
+        do_publish(self.broker, cmds.home, home_dummy, "after", self, None, mount_name)
         return self
 
     @requires_version(2, 0)
     def home_plunger(self) -> InstrumentContext:
-        """ Home the plunger associated with this mount
+        """Home the plunger associated with this mount
 
         :returns: This instance.
         """
@@ -833,11 +973,14 @@ class InstrumentContext(CommandPublisher):
 
     @publish.both(command=cmds.distribute)
     @requires_version(2, 0)
-    def distribute(self,
-                   volume: Union[float, Sequence[float]],
-                   source: Well,
-                   dest: List[Well],
-                   *args, **kwargs) -> InstrumentContext:
+    def distribute(
+        self,
+        volume: Union[float, Sequence[float]],
+        source: Well,
+        dest: List[Well],
+        *args,
+        **kwargs,
+    ) -> InstrumentContext:
         """
         Move a volume of liquid from one source to multiple destinations.
 
@@ -852,24 +995,25 @@ class InstrumentContext(CommandPublisher):
                        minimum volume of the pipette
         :returns: This instance
         """
-        self._log.debug("Distributing {} from {} to {}"
-                        .format(volume, source, dest))
-        kwargs['mode'] = 'distribute'
-        kwargs['disposal_volume'] = kwargs.get(
-            'disposal_volume', self.min_volume)
-        kwargs['mix_after'] = (0, 0)
-        blowout_location = kwargs.get('blowout_location')
-        validate_blowout_location(self.api_version, 'distribute', blowout_location)
+        self._log.debug("Distributing {} from {} to {}".format(volume, source, dest))
+        kwargs["mode"] = "distribute"
+        kwargs["disposal_volume"] = kwargs.get("disposal_volume", self.min_volume)
+        kwargs["mix_after"] = (0, 0)
+        blowout_location = kwargs.get("blowout_location")
+        validate_blowout_location(self.api_version, "distribute", blowout_location)
 
         return self.transfer(volume, source, dest, **kwargs)
 
     @publish.both(command=cmds.consolidate)
     @requires_version(2, 0)
-    def consolidate(self,
-                    volume: Union[float, Sequence[float]],
-                    source: List[Well],
-                    dest: Well,
-                    *args, **kwargs) -> InstrumentContext:
+    def consolidate(
+        self,
+        volume: Union[float, Sequence[float]],
+        source: List[Well],
+        dest: Well,
+        *args,
+        **kwargs,
+    ) -> InstrumentContext:
         """
         Move liquid from multiple wells (sources) to a single well(destination)
 
@@ -883,24 +1027,25 @@ class InstrumentContext(CommandPublisher):
                        and ``disposal_volume`` is ignored and set to 0.
         :returns: This instance
         """
-        self._log.debug("Consolidate {} from {} to {}"
-                        .format(volume, source, dest))
-        kwargs['mode'] = 'consolidate'
-        kwargs['mix_before'] = (0, 0)
-        kwargs['disposal_volume'] = 0
-        blowout_location = kwargs.get('blowout_location')
-        validate_blowout_location(self.api_version, 'consolidate', blowout_location)
+        self._log.debug("Consolidate {} from {} to {}".format(volume, source, dest))
+        kwargs["mode"] = "consolidate"
+        kwargs["mix_before"] = (0, 0)
+        kwargs["disposal_volume"] = 0
+        blowout_location = kwargs.get("blowout_location")
+        validate_blowout_location(self.api_version, "consolidate", blowout_location)
 
         return self.transfer(volume, source, dest, **kwargs)
 
     @publish.both(command=cmds.transfer)  # noqa: C901
     @requires_version(2, 0)
-    def transfer(self,
-                 volume: Union[float, Sequence[float]],
-                 source: AdvancedLiquidHandling,
-                 dest: AdvancedLiquidHandling,
-                 trash=True,
-                 **kwargs) -> InstrumentContext:
+    def transfer(
+        self,
+        volume: Union[float, Sequence[float]],
+        source: AdvancedLiquidHandling,
+        dest: AdvancedLiquidHandling,
+        trash=True,
+        **kwargs,
+    ) -> InstrumentContext:
         # source: Union[Well, List[Well], List[List[Well]]],
         # dest: Union[Well, List[Well], List[List[Well]]],
         # TODO: Reach consensus on kwargs
@@ -997,13 +1142,12 @@ class InstrumentContext(CommandPublisher):
 
         :returns: This instance
         """
-        self._log.debug("Transfer {} from {} to {}".format(
-            volume, source, dest))
+        self._log.debug("Transfer {} from {} to {}".format(volume, source, dest))
 
-        blowout_location = kwargs.get('blowout_location')
-        validate_blowout_location(self.api_version, 'transfer', blowout_location)
+        blowout_location = kwargs.get("blowout_location")
+        validate_blowout_location(self.api_version, "transfer", blowout_location)
 
-        kwargs['mode'] = kwargs.get('mode', 'transfer')
+        kwargs["mode"] = kwargs.get("mode", "transfer")
 
         mix_strategy, mix_opts = mix_from_kwargs(kwargs)
 
@@ -1012,11 +1156,11 @@ class InstrumentContext(CommandPublisher):
         else:
             drop_tip = transfers.DropTipStrategy.RETURN
 
-        new_tip = kwargs.get('new_tip')
+        new_tip = kwargs.get("new_tip")
         if isinstance(new_tip, str):
             new_tip = types.TransferTipPolicy[new_tip.upper()]
 
-        blow_out = kwargs.get('blow_out')
+        blow_out = kwargs.get("blow_out")
         blow_out_strategy = None
 
         if blow_out and not blowout_location:
@@ -1025,76 +1169,85 @@ class InstrumentContext(CommandPublisher):
             else:
                 blow_out_strategy = transfers.BlowOutStrategy.TRASH
         elif blow_out and blowout_location:
-            if blowout_location == 'source well':
+            if blowout_location == "source well":
                 blow_out_strategy = transfers.BlowOutStrategy.SOURCE
-            elif blowout_location == 'destination well':
+            elif blowout_location == "destination well":
                 blow_out_strategy = transfers.BlowOutStrategy.DEST
-            elif blowout_location == 'trash':
+            elif blowout_location == "trash":
                 blow_out_strategy = transfers.BlowOutStrategy.TRASH
 
         if new_tip != types.TransferTipPolicy.NEVER:
-            tr, next_tip = next_available_tip(self.starting_tip,
-                                              self.tip_racks,
-                                              self.channels)
+            tr, next_tip = next_available_tip(
+                self.starting_tip, self.tip_racks, self.channels
+            )
             max_volume = min(next_tip.max_volume, self.max_volume)
         else:
-            max_volume = self.hw_pipette['working_volume']
+            max_volume = self.hw_pipette["working_volume"]
 
         touch_tip = None
-        if kwargs.get('touch_tip'):
+        if kwargs.get("touch_tip"):
             touch_tip = transfers.TouchTipStrategy.ALWAYS
 
         default_args = transfers.Transfer()
 
-        disposal = kwargs.get('disposal_volume')
+        disposal = kwargs.get("disposal_volume")
         if disposal is None:
             disposal = default_args.disposal_volume
 
-        air_gap = kwargs.get('air_gap', default_args.air_gap)
+        air_gap = kwargs.get("air_gap", default_args.air_gap)
         if air_gap < 0 or air_gap >= max_volume:
             raise ValueError(
                 "air_gap must be between 0uL and the pipette's expected "
-                f"working volume, {max_volume}uL")
+                f"working volume, {max_volume}uL"
+            )
 
         transfer_args = transfers.Transfer(
             new_tip=new_tip or default_args.new_tip,
             air_gap=air_gap,
-            carryover=kwargs.get('carryover') or default_args.carryover,
-            gradient_function=(kwargs.get('gradient_function') or
-                               default_args.gradient_function),
+            carryover=kwargs.get("carryover") or default_args.carryover,
+            gradient_function=(
+                kwargs.get("gradient_function") or default_args.gradient_function
+            ),
             disposal_volume=disposal,
             mix_strategy=mix_strategy,
             drop_tip_strategy=drop_tip,
-            blow_out_strategy=blow_out_strategy or
-            default_args.blow_out_strategy,
-            touch_tip_strategy=(touch_tip or
-                                default_args.touch_tip_strategy)
+            blow_out_strategy=blow_out_strategy or default_args.blow_out_strategy,
+            touch_tip_strategy=(touch_tip or default_args.touch_tip_strategy),
         )
-        transfer_options = transfers.TransferOptions(transfer=transfer_args,
-                                                     mix=mix_opts)
-        plan = transfers.TransferPlan(volume, source, dest, self, max_volume,
-                                      self.api_version, kwargs['mode'],
-                                      transfer_options)
+        transfer_options = transfers.TransferOptions(
+            transfer=transfer_args, mix=mix_opts
+        )
+        plan = transfers.TransferPlan(
+            volume,
+            source,
+            dest,
+            self,
+            max_volume,
+            self.api_version,
+            kwargs["mode"],
+            transfer_options,
+        )
         self._execute_transfer(plan)
         return self
 
     def _execute_transfer(self, plan: transfers.TransferPlan):
         for cmd in plan:
-            getattr(self, cmd['method'])(*cmd['args'], **cmd['kwargs'])
+            getattr(self, cmd["method"])(*cmd["args"], **cmd["kwargs"])
 
     @requires_version(2, 0)
     def delay(self):
         return self._implementation.delay()
 
     @requires_version(2, 0)
-    def move_to(self,
-                location: types.Location,
-                force_direct: bool = False,
-                minimum_z_height: Optional[float] = None,
-                speed: Optional[float] = None,
-                publish: bool = True
-                ) -> InstrumentContext:
-        """ Move the instrument.
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool = False,
+        minimum_z_height: Optional[float] = None,
+        speed: Optional[float] = None,
+        publish: bool = True,
+    ) -> InstrumentContext:
+        """Move the instrument.
 
         :param location: The location to move to.
         :type location: :py:class:`.types.Location`
@@ -1119,29 +1272,45 @@ class InstrumentContext(CommandPublisher):
                 mod.flag_unsafe_move(to_loc=location, from_loc=from_loc)
 
         if publish:
-            do_publish(self.broker, cmds.move_to, self.move_to, 'before',
-                       None, None, self, location or self._ctx.location_cache)
+            do_publish(
+                self.broker,
+                cmds.move_to,
+                self.move_to,
+                "before",
+                None,
+                None,
+                self,
+                location or self._ctx.location_cache,
+            )
         self._implementation.move_to(
             location=location,
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
-            speed=speed
+            speed=speed,
         )
         if publish:
-            do_publish(self.broker, cmds.move_to, self.move_to, 'after',
-                       None, None, self, location or self._ctx.location_cache)
+            do_publish(
+                self.broker,
+                cmds.move_to,
+                self.move_to,
+                "after",
+                None,
+                None,
+                self,
+                location or self._ctx.location_cache,
+            )
         return self
 
     @property  # type: ignore
     @requires_version(2, 0)
     def mount(self) -> str:
-        """ Return the name of the mount this pipette is attached to """
+        """Return the name of the mount this pipette is attached to"""
         return self._implementation.get_mount().name.lower()
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def speed(self) -> 'PlungerSpeeds':
-        """ The speeds (in mm/s) configured for the pipette plunger.
+    def speed(self) -> "PlungerSpeeds":
+        """The speeds (in mm/s) configured for the pipette plunger.
 
         This is an object with attributes ``aspirate``, ``dispense``, and
         ``blow_out`` holding the plunger speeds for the corresponding
@@ -1167,8 +1336,8 @@ class InstrumentContext(CommandPublisher):
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def flow_rate(self) -> 'FlowRates':
-        """ The speeds (in uL/s) configured for the pipette.
+    def flow_rate(self) -> "FlowRates":
+        """The speeds (in uL/s) configured for the pipette.
 
         This is an object with attributes ``aspirate``, ``dispense``, and
         ``blow_out`` holding the flow rates for the corresponding operation.
@@ -1195,13 +1364,12 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def type(self) -> str:
-        """ One of `'single'` or `'multi'`.
-        """
+        """One of `'single'` or `'multi'`."""
         model = self.name
-        if 'single' in model:
-            return 'single'
-        elif 'multi' in model:
-            return 'multi'
+        if "single" in model:
+            return "single"
+        elif "multi" in model:
+            return "multi"
         else:
             raise RuntimeError("Bad pipette name: {}".format(model))
 
@@ -1223,7 +1391,7 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def trash_container(self) -> Labware:
-        """ The trash container associated with this pipette.
+        """The trash container associated with this pipette.
 
         This is the property used to determine where to drop tips and blow out
         liquids when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without
@@ -1298,7 +1466,7 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def hw_pipette(self) -> PipetteDict:
-        """ View the information returned by the hardware API directly.
+        """View the information returned by the hardware API directly.
 
         :raises: a :py:class:`.types.PipetteNotAttachedError` if the pipette is
                  no longer attached (should not happen).
@@ -1308,19 +1476,19 @@ class InstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def channels(self) -> int:
-        """ The number of channels on the pipette. """
+        """The number of channels on the pipette."""
         return self._implementation.get_channels()
 
     @property  # type: ignore
     @requires_version(2, 2)
     def return_height(self) -> float:
-        """ The height to return a tip to its tiprack. """
+        """The height to return a tip to its tiprack."""
         return self._implementation.get_return_height()
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def well_bottom_clearance(self) -> 'Clearances':
-        """ The distance above the bottom of a well to aspirate or dispense.
+    def well_bottom_clearance(self) -> "Clearances":
+        """The distance above the bottom of a well to aspirate or dispense.
 
         This is an object with attributes ``aspirate`` and ``dispense``,
         describing the default heights of the corresponding operation. The
@@ -1341,18 +1509,18 @@ class InstrumentContext(CommandPublisher):
         return self._implementation.get_well_bottom_clearance()
 
     def __repr__(self):
-        return '<{}: {} in {}>'.format(self.__class__.__name__,
-                                       self._implementation.get_model(),
-                                       self._implementation.get_mount().name)
+        return "<{}: {} in {}>".format(
+            self.__class__.__name__,
+            self._implementation.get_model(),
+            self._implementation.get_mount().name,
+        )
 
     def __str__(self):
-        return '{} on {} mount'.format(self.hw_pipette['display_name'],
-                                       self.mount)
+        return "{} on {} mount".format(self.hw_pipette["display_name"], self.mount)
 
     @requires_version(2, 7)
-    def pair_with(
-            self, instrument: InstrumentContext) -> PairedInstrumentContext:
-        """ This function allows you to pair both of your pipettes and use
+    def pair_with(self, instrument: InstrumentContext) -> PairedInstrumentContext:
+        """This function allows you to pair both of your pipettes and use
         them simultaneously. The function implicitly decides a primary
         and secondary pipette based on which instrument you call this
         function on.
@@ -1419,8 +1587,8 @@ class InstrumentContext(CommandPublisher):
         """
         if instrument.name != self.name:
             raise UnsupportedInstrumentPairingError(
-                'At this time, you cannot pair'
-                f'{instrument.name} with {self.name}')
+                "At this time, you cannot pair" f"{instrument.name} with {self.name}"
+            )
 
         return PairedInstrumentContext(
             primary_instrument=self,
@@ -1430,9 +1598,9 @@ class InstrumentContext(CommandPublisher):
             api_version=self.api_version,
             hardware_manager=self._ctx._implementation.get_hardware(),
             trash=self.trash_container,
-            log_parent=self._log
+            log_parent=self._log,
         )
 
     def _tip_length_for(self, tiprack: Labware) -> float:
-        """ Get the tip length, including overlap, for a tip from this rack """
+        """Get the tip length, including overlap, for a tip from this rack"""
         return tip_length_for(self.hw_pipette, tiprack)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -11,28 +11,27 @@ import logging
 
 from pathlib import Path
 from itertools import dropwhile
-from typing import (
-    Any, AnyStr, List, Dict,
-    Optional, Union, Tuple,
-    TYPE_CHECKING)
+from typing import Any, AnyStr, List, Dict, Optional, Union, Tuple, TYPE_CHECKING
 
 
-from opentrons.protocols.api_support.util import (
-    requires_version, labware_column_shift)
-from opentrons.protocols.context.labware import \
-    AbstractLabware
+from opentrons.protocols.api_support.util import requires_version, labware_column_shift
+from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols import labware as labware_module
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.api_support.definitions import (
-    MAX_SUPPORTED_VERSION)
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry.deck_item import DeckItem
+
 if TYPE_CHECKING:
-    from opentrons.protocols.geometry.module_geometry import ModuleGeometry  # noqa: F401, E501
+    from opentrons.protocols.geometry.module_geometry import (  # noqa: F401
+        ModuleGeometry,
+    )
     from opentrons_shared_data.labware.dev_types import (
-        LabwareDefinition, LabwareParameters)
+        LabwareDefinition,
+        LabwareParameters,
+    )
 
 
 MODULE_LOG = logging.getLogger(__name__)
@@ -53,9 +52,12 @@ class Well:
     It provides functions to return positions used in operations on the well
     such as :py:meth:`top`, :py:meth:`bottom`
     """
-    def __init__(self,
-                 well_implementation: WellImplementation,
-                 api_level: Optional[APIVersion] = None):
+
+    def __init__(
+        self,
+        well_implementation: WellImplementation,
+        api_level: Optional[APIVersion] = None,
+    ):
         """
         Create a well, and track the Point corresponding to the top-center of
         the well (this Point is in absolute deck coordinates)
@@ -72,9 +74,8 @@ class Well:
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def parent(self) -> 'Labware':
-        return Labware(implementation=self._geometry.parent,
-                       api_level=self.api_version)
+    def parent(self) -> "Labware":
+        return Labware(implementation=self._geometry.parent, api_level=self.api_version)
 
     @property  # type: ignore
     @requires_version(2, 0)
@@ -192,8 +193,9 @@ class Well:
         Private version of from_center_cartesian. Present only for backward
         compatibility.
         """
-        MODULE_LOG.warning("This method is deprecated. Please use "
-                           "'from_center_cartesian' instead.")
+        MODULE_LOG.warning(
+            "This method is deprecated. Please use " "'from_center_cartesian' instead."
+        )
         return self.from_center_cartesian(x, y, z)
 
     def __repr__(self):
@@ -239,10 +241,10 @@ class Labware(DeckItem):
        labware.columns_by_name()[0][0]
 
     """
+
     def __init__(
-            self,
-            implementation: AbstractLabware,
-            api_level: Optional[APIVersion] = None) -> None:
+        self, implementation: AbstractLabware, api_level: Optional[APIVersion] = None
+    ) -> None:
         """
         :param implementation: The class that implements the public interface
                                of the class.
@@ -256,9 +258,10 @@ class Labware(DeckItem):
             api_level = MAX_SUPPORTED_VERSION
         if api_level > MAX_SUPPORTED_VERSION:
             raise RuntimeError(
-                f'API version {api_level} is not supported by this '
-                f'robot software. Please either reduce your requested API '
-                f'version or update your robot.')
+                f"API version {api_level} is not supported by this "
+                f"robot software. Please either reduce your requested API "
+                f"version or update your robot."
+            )
         self._api_version = api_level
         self._implementation = implementation
 
@@ -277,7 +280,7 @@ class Labware(DeckItem):
     @property  # type: ignore
     @requires_version(2, 0)
     def uri(self) -> str:
-        """ A string fully identifying the labware.
+        """A string fully identifying the labware.
 
         :returns: The uri, ``"namespace/loadname/version"``
         """
@@ -286,48 +289,47 @@ class Labware(DeckItem):
     @property  # type: ignore
     @requires_version(2, 0)
     def parent(self) -> LocationLabware:
-        """ The parent of this labware. Usually a slot name.
-        """
+        """The parent of this labware. Usually a slot name."""
         return self._implementation.get_geometry().parent.labware.object
 
     @property  # type: ignore
     @requires_version(2, 0)
     def name(self) -> str:
-        """ Can either be the canonical name of the labware, which is used to
-        load it, or the label of the labware specified by a user. """
+        """Can either be the canonical name of the labware, which is used to
+        load it, or the label of the labware specified by a user."""
         return self._implementation.get_name()
 
     @name.setter  # type: ignore
     def name(self, new_name):
-        """ Set the labware name"""
+        """Set the labware name"""
         self._implementation.set_name(new_name)
 
     @property  # type: ignore
     @requires_version(2, 0)
     def load_name(self) -> str:
-        """ The API load name of the labware definition """
+        """The API load name of the labware definition"""
         return self._implementation.load_name
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def parameters(self) -> 'LabwareParameters':
+    def parameters(self) -> "LabwareParameters":
         """Internal properties of a labware including type and quirks"""
         return self._implementation.get_parameters()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def quirks(self) -> List[str]:
-        """ Quirks specific to this labware. """
+        """Quirks specific to this labware."""
         return self._implementation.get_quirks()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def magdeck_engage_height(self) -> Optional[float]:
         p = self._implementation.get_parameters()
-        if not p['isMagneticModuleCompatible']:
+        if not p["isMagneticModuleCompatible"]:
             return None
         else:
-            return p['magneticModuleEngageHeight']
+            return p["magneticModuleEngageHeight"]
 
     def set_calibration(self, delta: Point):
         """
@@ -392,10 +394,7 @@ class Labware(DeckItem):
         :return: Dictionary of well objects keyed by well name
         """
         wells = self._implementation.get_wells_by_name()
-        return {
-            k: self._well_from_impl(v)
-            for k, v in wells.items()
-        }
+        return {k: self._well_from_impl(v) for k, v in wells.items()}
 
     @requires_version(2, 0)
     def wells_by_index(self) -> Dict[str, Well]:
@@ -404,7 +403,8 @@ class Labware(DeckItem):
             Use :py:meth:`wells_by_name` or dict access instead.
         """
         MODULE_LOG.warning(
-            'wells_by_index is deprecated. Use wells_by_name or dict access instead.')
+            "wells_by_index is deprecated. Use wells_by_name or dict access instead."
+        )
         return self.wells_by_name()
 
     @requires_version(2, 0)
@@ -447,11 +447,7 @@ class Labware(DeckItem):
         :return: Dictionary of Well lists keyed by row name
         """
         row_dict = self._implementation.get_well_grid().get_row_dict()
-        return {
-            k: [
-                self._well_from_impl(w) for w in v
-            ] for k, v in row_dict.items()
-        }
+        return {k: [self._well_from_impl(w) for w in v] for k, v in row_dict.items()}
 
     @requires_version(2, 0)
     def rows_by_index(self) -> Dict[str, List[Well]]:
@@ -459,8 +455,7 @@ class Labware(DeckItem):
         .. deprecated:: 2.0
             Use :py:meth:`rows_by_name` instead.
         """
-        MODULE_LOG.warning(
-            'rows_by_index is deprecated. Use rows_by_name instead.')
+        MODULE_LOG.warning("rows_by_index is deprecated. Use rows_by_name instead.")
         return self.rows_by_name()
 
     @requires_version(2, 0)
@@ -505,11 +500,7 @@ class Labware(DeckItem):
         :return: Dictionary of Well lists keyed by column name
         """
         column_dict = self._implementation.get_well_grid().get_column_dict()
-        return {
-            k: [
-                self._well_from_impl(w) for w in v
-            ] for k, v in column_dict.items()
-        }
+        return {k: [self._well_from_impl(w) for w in v] for k, v in column_dict.items()}
 
     @requires_version(2, 0)
     def columns_by_index(self) -> Dict[str, List[Well]]:
@@ -518,7 +509,8 @@ class Labware(DeckItem):
             Use :py:meth:`columns_by_name` instead.
         """
         MODULE_LOG.warning(
-            'columns_by_index is deprecated. Use columns_by_name instead.')
+            "columns_by_index is deprecated. Use columns_by_name instead."
+        )
         return self.columns_by_name()
 
     @property  # type: ignore
@@ -534,7 +526,7 @@ class Labware(DeckItem):
 
     @property
     def _is_tiprack(self) -> bool:
-        """ as is_tiprack but not subject to version checking for speed """
+        """as is_tiprack but not subject to version checking for speed"""
         return self._implementation.is_tiprack()
 
     @property  # type: ignore
@@ -551,9 +543,9 @@ class Labware(DeckItem):
     def tip_length(self, length: float):
         self._implementation.set_tip_length(length)
 
-    def next_tip(self,
-                 num_tips: int = 1,
-                 starting_tip: Optional[Well] = None) -> Optional[Well]:
+    def next_tip(
+        self, num_tips: int = 1, starting_tip: Optional[Well] = None
+    ) -> Optional[Well]:
         """
         Find the next valid well for pick-up.
 
@@ -568,11 +560,10 @@ class Labware(DeckItem):
         :type starting_tip: :py:class:`.Well`
         :return: the :py:class:`.Well` meeting the target criteria, or None
         """
-        assert num_tips > 0, 'Bad call to next_tip: num_tips <= 0'
+        assert num_tips > 0, "Bad call to next_tip: num_tips <= 0"
 
         well = self._implementation.get_tip_tracker().next_tip(
-            num_tips=num_tips,
-            starting_tip=starting_tip._impl if starting_tip else None
+            num_tips=num_tips, starting_tip=starting_tip._impl if starting_tip else None
         )
         return self._well_from_impl(well) if well else None
 
@@ -596,14 +587,14 @@ class Labware(DeckItem):
         :param num_channels: The number of channels for the current pipette
         :type num_channels: int
         """
-        assert num_channels > 0, 'Bad call to use_tips: num_channels<=0'
+        assert num_channels > 0, "Bad call to use_tips: num_channels<=0"
 
         fail_if_full = self._api_version < APIVersion(2, 2)
 
         self._implementation.get_tip_tracker().use_tips(
             start_well=start_well._impl,
             num_channels=num_channels,
-            fail_if_full=fail_if_full
+            fail_if_full=fail_if_full,
         )
 
     def __repr__(self):
@@ -630,11 +621,9 @@ class Labware(DeckItem):
         :return: The :py:class:`.Well` meeting the target criteria, or ``None``
         """
         # This logic is the inverse of :py:meth:`next_tip`
-        assert num_tips > 0, 'Bad call to previous_tip: num_tips <= 0'
+        assert num_tips > 0, "Bad call to previous_tip: num_tips <= 0"
 
-        well = self._implementation.get_tip_tracker().previous_tip(
-            num_tips=num_tips
-        )
+        well = self._implementation.get_tip_tracker().previous_tip(num_tips=num_tips)
         return self._well_from_impl(well) if well else None
 
     def return_tips(self, start_well: Well, num_channels: int = 1):
@@ -659,29 +648,26 @@ class Labware(DeckItem):
         :type num_channels: int
         """
         # This logic is the inverse of :py:meth:`use_tips`
-        assert num_channels > 0, 'Bad call to return_tips: num_channels <= 0'
+        assert num_channels > 0, "Bad call to return_tips: num_channels <= 0"
 
         self._implementation.get_tip_tracker().return_tips(
-            start_well=start_well._impl,
-            num_channels=num_channels
+            start_well=start_well._impl, num_channels=num_channels
         )
 
     @requires_version(2, 0)
     def reset(self):
-        """Reset all tips in a tiprack
-        """
+        """Reset all tips in a tiprack"""
         if self._is_tiprack:
             self._implementation.reset_tips()
 
     def _well_from_impl(self, well: WellImplementation) -> Well:
-        return Well(well_implementation=well,
-                    api_level=self._api_version)
+        return Well(well_implementation=well, api_level=self._api_version)
 
 
 def save_definition(
-    labware_def: 'LabwareDefinition',
+    labware_def: "LabwareDefinition",
     force: bool = False,
-    location: Optional[Path] = None
+    location: Optional[Path] = None,
 ) -> None:
     """
     Save a labware definition
@@ -691,15 +677,15 @@ def save_definition(
         Cannot overwrite Opentrons definitions.
     :param location: The path of the labware definition.
     """
-    labware_module.save_definition(labware_def=labware_def,
-                                   force=force,
-                                   location=location)
+    labware_module.save_definition(
+        labware_def=labware_def, force=force, location=location
+    )
 
 
-def verify_definition(contents: Union[
-        AnyStr, 'LabwareDefinition', Dict[str, Any]])\
-        -> 'LabwareDefinition':
-    """ Verify that an input string is a labware definition and return it.
+def verify_definition(
+    contents: Union[AnyStr, "LabwareDefinition", Dict[str, Any]]
+) -> "LabwareDefinition":
+    """Verify that an input string is a labware definition and return it.
 
     If the definition is invalid, an exception is raised; otherwise parse the
     json and return the valid definition.
@@ -715,9 +701,9 @@ def get_labware_definition(
     load_name: str,
     namespace: Optional[str] = None,
     version: Optional[int] = None,
-    bundled_defs: Dict[str, 'LabwareDefinition'] = None,
-    extra_defs: Dict[str, 'LabwareDefinition'] = None
-) -> 'LabwareDefinition':
+    bundled_defs: Dict[str, "LabwareDefinition"] = None,
+    extra_defs: Dict[str, "LabwareDefinition"] = None,
+) -> "LabwareDefinition":
     """
     Look up and return a definition by load_name + namespace + version and
         return it or raise an exception
@@ -737,7 +723,7 @@ def get_labware_definition(
         namespace=namespace,
         version=version,
         bundled_defs=bundled_defs,
-        extra_defs=extra_defs
+        extra_defs=extra_defs,
     )
 
 
@@ -758,9 +744,8 @@ def split_tipracks(tip_racks: List[Labware]) -> Tuple[Labware, List[Labware]]:
 
 
 def select_tiprack_from_list(
-        tip_racks: List[Labware],
-        num_channels: int,
-        starting_point: Optional[Well] = None) -> Tuple[Labware, Well]:
+    tip_racks: List[Labware], num_channels: int, starting_point: Optional[Well] = None
+) -> Tuple[Labware, Well]:
 
     try:
         first, rest = split_tipracks(tip_racks)
@@ -769,8 +754,8 @@ def select_tiprack_from_list(
 
     if starting_point and starting_point.parent != first:
         raise TipSelectionError(
-            'The starting tip you selected '
-            f'does not exist in {first}')
+            "The starting tip you selected " f"does not exist in {first}"
+        )
     elif starting_point:
         first_well = starting_point
     else:
@@ -784,10 +769,11 @@ def select_tiprack_from_list(
 
 
 def select_tiprack_from_list_paired_pipettes(
-        tip_racks: List[Labware],
-        p_channels: int,
-        s_channels: int,
-        starting_point: Optional[Well] = None) -> Tuple[Labware, Well]:
+    tip_racks: List[Labware],
+    p_channels: int,
+    s_channels: int,
+    starting_point: Optional[Well] = None,
+) -> Tuple[Labware, Well]:
     """
     Helper function utilized in :py:attr:`PairedInstrumentContext`
     to determine which pipette tiprack to pick up from.
@@ -810,8 +796,8 @@ def select_tiprack_from_list_paired_pipettes(
 
     if starting_point and starting_point.parent != first:
         raise TipSelectionError(
-            'The starting tip you selected '
-            f'does not exist in {first}')
+            "The starting tip you selected " f"does not exist in {first}"
+        )
     elif starting_point:
         primary_well = starting_point
     else:
@@ -820,56 +806,48 @@ def select_tiprack_from_list_paired_pipettes(
     try:
         secondary_point = labware_column_shift(primary_well, first)
     except IndexError:
-        return select_tiprack_from_list_paired_pipettes(
-            rest, p_channels, s_channels)
+        return select_tiprack_from_list_paired_pipettes(rest, p_channels, s_channels)
 
     primary_next_tip = first.next_tip(p_channels, starting_point)
     secondary_next_tip = first.next_tip(s_channels, secondary_point)
     if primary_next_tip and secondary_next_tip:
         return first, primary_next_tip
     else:
-        return select_tiprack_from_list_paired_pipettes(
-            rest, p_channels, s_channels)
+        return select_tiprack_from_list_paired_pipettes(rest, p_channels, s_channels)
 
 
 def filter_tipracks_to_start(
-        starting_point: Well,
-        tipracks: List[Labware]) -> List[Labware]:
-    return list(dropwhile(
-        lambda tr: starting_point.parent != tr, tipracks))
+    starting_point: Well, tipracks: List[Labware]
+) -> List[Labware]:
+    return list(dropwhile(lambda tr: starting_point.parent != tr, tipracks))
 
 
 def next_available_tip(
-        starting_tip: Optional[Well],
-        tip_racks: List[Labware],
-        channels: int) -> Tuple[Labware, Well]:
+    starting_tip: Optional[Well], tip_racks: List[Labware], channels: int
+) -> Tuple[Labware, Well]:
     start = starting_tip
     if start is None:
-        return select_tiprack_from_list(
-            tip_racks, channels)
+        return select_tiprack_from_list(tip_racks, channels)
     else:
         return select_tiprack_from_list(
-            filter_tipracks_to_start(start, tip_racks),
-            channels, start)
+            filter_tipracks_to_start(start, tip_racks), channels, start
+        )
 
 
-def get_labware_hash(labware: 'Labware') -> str:
-    return labware_module.get_labware_hash(
-        labware._implementation
-    )
+def get_labware_hash(labware: "Labware") -> str:
+    return labware_module.get_labware_hash(labware._implementation)
 
 
-def get_labware_hash_with_parent(labware: 'Labware') -> str:
-    return labware_module.get_labware_hash_with_parent(
-        labware._implementation
-    )
+def get_labware_hash_with_parent(labware: "Labware") -> str:
+    return labware_module.get_labware_hash_with_parent(labware._implementation)
 
 
 def load_from_definition(
-        definition: 'LabwareDefinition',
-        parent: Location,
-        label: Optional[str] = None,
-        api_level: Optional[APIVersion] = None) -> Labware:
+    definition: "LabwareDefinition",
+    parent: Location,
+    label: Optional[str] = None,
+    api_level: Optional[APIVersion] = None,
+) -> Labware:
     """
     Return a labware object constructed from a provided labware definition dict
 
@@ -891,15 +869,13 @@ def load_from_definition(
     """
     return Labware(
         implementation=labware_module.load_from_definition(
-            definition=definition,
-            parent=parent,
-            label=label
+            definition=definition, parent=parent, label=label
         ),
-        api_level=api_level
+        api_level=api_level,
     )
 
 
-def save_calibration(labware: 'Labware', delta: Point):
+def save_calibration(labware: "Labware", delta: Point):
     labware_module.save_calibration(labware._implementation, delta)
 
 
@@ -909,9 +885,9 @@ def load(
     label: Optional[str] = None,
     namespace: Optional[str] = None,
     version: int = 1,
-    bundled_defs: Optional[Dict[str, 'LabwareDefinition']] = None,
-    extra_defs: Optional[Dict[str, 'LabwareDefinition']] = None,
-    api_level: Optional[APIVersion] = None
+    bundled_defs: Optional[Dict[str, "LabwareDefinition"]] = None,
+    extra_defs: Optional[Dict[str, "LabwareDefinition"]] = None,
+    api_level: Optional[APIVersion] = None,
 ) -> Labware:
     """
     Return a labware object constructed from a labware definition dict looked
@@ -949,7 +925,7 @@ def load(
             namespace=namespace,
             version=version,
             bundled_defs=bundled_defs,
-            extra_defs=extra_defs
+            extra_defs=extra_defs,
         ),
         api_level=api_level,
     )

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -11,45 +11,44 @@ from opentrons.commands import module_commands as cmds
 from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.protocols.api_support.types import APIVersion
 
-from .labware import (
-    Labware, load, load_from_definition)
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry,\
-    ThermocyclerGeometry
+from .labware import Labware, load, load_from_definition
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    ThermocyclerGeometry,
+)
 from opentrons.protocols.api_support.util import requires_version
 
 if TYPE_CHECKING:
-    from.protocol_context import ProtocolContext
-    from opentrons_shared_data.labware.dev_types import (LabwareDefinition)
+    from .protocol_context import ProtocolContext
+    from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
 ModuleTypes = Union[
-    'TemperatureModuleContext',
-    'MagneticModuleContext',
-    'ThermocyclerContext'
+    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
 ]
 
 ENGAGE_HEIGHT_UNIT_CNV = 2
 STANDARD_MAGDECK_LABWARE = [
-    'biorad_96_wellplate_200ul_pcr',
-    'nest_96_wellplate_100ul_pcr_full_skirt',
-    'usascientific_96_wellplate_2.4ml_deep']
+    "biorad_96_wellplate_200ul_pcr",
+    "nest_96_wellplate_100ul_pcr_full_skirt",
+    "usascientific_96_wellplate_2.4ml_deep",
+]
 
 MODULE_LOG = logging.getLogger(__name__)
 
-GeometryType = TypeVar('GeometryType', bound=ModuleGeometry)
-class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
-    """ An object representing a connected module.
+GeometryType = TypeVar("GeometryType", bound=ModuleGeometry)
 
+
+class ModuleContext(CommandPublisher, Generic[GeometryType]):
+    """An object representing a connected module.
 
     .. versionadded:: 2.0
-
     """
 
-    def __init__(self,
-                 ctx: ProtocolContext,
-                 geometry: GeometryType,
-                 at_version: APIVersion) -> None:
-        """ Build the ModuleContext.
+    def __init__(
+        self, ctx: ProtocolContext, geometry: GeometryType, at_version: APIVersion
+    ) -> None:
+        """Build the ModuleContext.
 
         This usually should not be instantiated directly; instead, modules
         should be loaded using :py:meth:`ProtocolContext.load_module`.
@@ -69,7 +68,7 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
 
     @requires_version(2, 0)
     def load_labware_object(self, labware: Labware) -> Labware:
-        """ Specify the presence of a piece of labware on the module.
+        """Specify the presence of a piece of labware on the module.
 
         :param labware: The labware object. This object should be already
                         initialized and its parent should be set to this
@@ -84,13 +83,13 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
 
     @requires_version(2, 0)
     def load_labware(
-            self,
-            name: str,
-            label: Optional[str] = None,
-            namespace: Optional[str] = None,
-            version: int = 1,
-            ) -> Labware:
-        """ Specify the presence of a piece of labware on the module.
+        self,
+        name: str,
+        label: Optional[str] = None,
+        namespace: Optional[str] = None,
+        version: int = 1,
+    ) -> Labware:
+        """Specify the presence of a piece of labware on the module.
 
         :param name: The name of the labware object.
         :param str label: An optional special name to give the labware. If
@@ -106,22 +105,26 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
         .. versionadded:: 2.1
             The *label,* *namespace,* and *version* parameters.
         """
-        if self.api_version < APIVersion(2, 1) and\
-                (label or namespace or version):
+        if self.api_version < APIVersion(2, 1) and (label or namespace or version):
             MODULE_LOG.warning(
-                f'You have specified API {self.api_version}, but you '
-                'are trying to utilize new load_labware parameters in 2.1')
-        lw = load(name, self._geometry.location,
-                  label, namespace, version,
-                  bundled_defs=self._ctx._implementation.get_bundled_labware(),
-                  extra_defs=self._ctx._implementation.get_extra_labware())
+                f"You have specified API {self.api_version}, but you "
+                "are trying to utilize new load_labware parameters in 2.1"
+            )
+        lw = load(
+            name,
+            self._geometry.location,
+            label,
+            namespace,
+            version,
+            bundled_defs=self._ctx._implementation.get_bundled_labware(),
+            extra_defs=self._ctx._implementation.get_extra_labware(),
+        )
         return self.load_labware_object(lw)
 
     @requires_version(2, 0)
     def load_labware_from_definition(
-            self,
-            definition: 'LabwareDefinition',
-            label: Optional[str] = None) -> Labware:
+        self, definition: "LabwareDefinition", label: Optional[str] = None
+    ) -> Labware:
         """
         Specify the presence of a labware on the module, using an
         inline definition.
@@ -133,47 +136,49 @@ class ModuleContext(CommandPublisher, Generic[GeometryType]):  # noqa: E302
                           Opentrons app.
         :returns: The initialized and loaded labware object.
         """
-        lw = load_from_definition(
-            definition, self._geometry.location, label)
+        lw = load_from_definition(definition, self._geometry.location, label)
         return self.load_labware_object(lw)
 
     @requires_version(2, 1)
-    def load_labware_by_name(self,
-                             name: str,
-                             label: Optional[str] = None,
-                             namespace: Optional[str] = None,
-                             version: int = 1,) -> Labware:
+    def load_labware_by_name(
+        self,
+        name: str,
+        label: Optional[str] = None,
+        namespace: Optional[str] = None,
+        version: int = 1,
+    ) -> Labware:
         """
         .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
         MODULE_LOG.warning(
-            'load_labware_by_name is deprecated. Use load_labware instead.')
+            "load_labware_by_name is deprecated. Use load_labware instead."
+        )
         return self.load_labware(name, label, namespace, version)
 
     @property  # type: ignore
     @requires_version(2, 0)
     def labware(self) -> Optional[Labware]:
-        """ The labware (if any) present on this module. """
+        """The labware (if any) present on this module."""
         return self._geometry.labware
 
     @property  # type: ignore
     @requires_version(2, 0)
     def geometry(self) -> ModuleGeometry:
-        """ The object representing the module as an item on the deck
+        """The object representing the module as an item on the deck
 
         :returns: ModuleGeometry
         """
         return self._geometry
 
     def __repr__(self):
-        return "{} at {} lw {}".format(self.__class__.__name__,
-                                       self._geometry,
-                                       self.labware)
+        return "{} at {} lw {}".format(
+            self.__class__.__name__, self._geometry, self.labware
+        )
 
 
 class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
-    """ An object representing a connected Temperature Module.
+    """An object representing a connected Temperature Module.
 
     It should not be instantiated directly; instead, it should be
     created through :py:meth:`.ProtocolContext.load_module` using:
@@ -203,12 +208,15 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     .. versionadded:: 2.0
 
     """
-    def __init__(self,
-                 ctx: ProtocolContext,
-                 hw_module: modules.tempdeck.TempDeck,
-                 geometry: ModuleGeometry,
-                 at_version: APIVersion,
-                 loop: asyncio.AbstractEventLoop) -> None:
+
+    def __init__(
+        self,
+        ctx: ProtocolContext,
+        hw_module: modules.tempdeck.TempDeck,
+        geometry: ModuleGeometry,
+        at_version: APIVersion,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
         self._module = hw_module
         self._loop = loop
         super().__init__(ctx, geometry, at_version)
@@ -216,7 +224,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.tempdeck_set_temp)
     @requires_version(2, 0)
     def set_temperature(self, celsius: float):
-        """ Set the target temperature, in C.
+        """Set the target temperature, in C.
 
         Must be between 4 and 95C based on Opentrons QA.
 
@@ -227,7 +235,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.tempdeck_set_temp)
     @requires_version(2, 3)
     def start_set_temperature(self, celsius: float):
-        """ Start setting the target temperature, in C.
+        """Start setting the target temperature, in C.
 
         Must be between 4 and 95C based on Opentrons QA.
 
@@ -238,7 +246,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.tempdeck_await_temp)
     @requires_version(2, 3)
     def await_temperature(self, celsius: float):
-        """ Wait until module reaches temperature, in C.
+        """Wait until module reaches temperature, in C.
 
         Must be between 4 and 95C based on Opentrons QA.
 
@@ -249,26 +257,25 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.tempdeck_deactivate)
     @requires_version(2, 0)
     def deactivate(self):
-        """ Stop heating (or cooling) and turn off the fan.
-        """
+        """Stop heating (or cooling) and turn off the fan."""
         return self._module.deactivate()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def temperature(self):
-        """ Current temperature in C"""
+        """Current temperature in C"""
         return self._module.temperature
 
     @property  # type: ignore
     @requires_version(2, 0)
     def target(self):
-        """ Current target temperature in C"""
+        """Current target temperature in C"""
         return self._module.target
 
     @property  # type: ignore
     @requires_version(2, 3)
     def status(self):
-        """ The status of the module.
+        """The status of the module.
 
         Returns 'holding at target', 'cooling', 'heating', or 'idle'
 
@@ -277,7 +284,7 @@ class TemperatureModuleContext(ModuleContext[ModuleGeometry]):
 
 
 class MagneticModuleContext(ModuleContext[ModuleGeometry]):
-    """ An object representing a connected Temperature Module.
+    """An object representing a connected Temperature Module.
 
     It should not be instantiated directly; instead, it should be
     created through :py:meth:`.ProtocolContext.load_module`.
@@ -285,12 +292,15 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     .. versionadded:: 2.0
 
     """
-    def __init__(self,
-                 ctx: ProtocolContext,
-                 hw_module: modules.magdeck.MagDeck,
-                 geometry: ModuleGeometry,
-                 at_version: APIVersion,
-                 loop: asyncio.AbstractEventLoop) -> None:
+
+    def __init__(
+        self,
+        ctx: ProtocolContext,
+        hw_module: modules.magdeck.MagDeck,
+        geometry: ModuleGeometry,
+        at_version: APIVersion,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
         self._module = hw_module
         self._loop = loop
         super().__init__(ctx, geometry, at_version)
@@ -298,7 +308,7 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.magdeck_calibrate)
     @requires_version(2, 0)
     def calibrate(self):
-        """ Calibrate the Magnetic Module.
+        """Calibrate the Magnetic Module.
 
         The calibration is used to establish the position of the lawbare on
         top of the magnetic module.
@@ -314,16 +324,19 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
             MODULE_LOG.warning(
                 "This labware ({}) is not explicitly compatible with the"
                 " Magnetic Module. You will have to specify a height when"
-                " calling engage().")
+                " calling engage()."
+            )
         return super().load_labware_object(labware)
 
     @publish.both(command=cmds.magdeck_engage)
     @requires_version(2, 0)
-    def engage(self,
-               height: Optional[float] = None,
-               offset: Optional[float] = None,
-               height_from_base: Optional[float] = None):
-        """ Raise the Magnetic Module's magnets.
+    def engage(
+        self,
+        height: Optional[float] = None,
+        offset: Optional[float] = None,
+        height_from_base: Optional[float] = None,
+    ):
+        """Raise the Magnetic Module's magnets.
 
         The destination of the magnets can be specified in several different
         ways, based on internally stored default heights for labware:
@@ -356,10 +369,13 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         """
         if height is not None:
             dist = height
-        elif height_from_base is not None and\
-                self._ctx._api_version >= APIVersion(2, 2):
-            dist = height_from_base +\
-                modules.magdeck.OFFSET_TO_LABWARE_BOTTOM[self._module.model()]
+        elif height_from_base is not None and self._ctx._api_version >= APIVersion(
+            2, 2
+        ):
+            dist = (
+                height_from_base
+                + modules.magdeck.OFFSET_TO_LABWARE_BOTTOM[self._module.model()]
+            )
         elif self.labware and self.labware.magdeck_engage_height is not None:
             dist = self._determine_lw_engage_height()
             if offset:
@@ -367,12 +383,14 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
         else:
             raise ValueError(
                 "Currently loaded labware {} does not have a known engage "
-                "height; please specify explicitly with the height param"
-                .format(self.labware))
+                "height; please specify explicitly with the height param".format(
+                    self.labware
+                )
+            )
         self._module.engage(dist)
 
     def _determine_lw_engage_height(self) -> float:
-        """ Return engage height based on Protocol API and module versions
+        """Return engage height based on Protocol API and module versions
 
         For API Version 2.3 or later:
            - Multiply non-standard labware engage heights by 2 for gen1 modules
@@ -384,8 +402,8 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
 
         engage_height = self.labware.magdeck_engage_height
 
-        is_api_breakpoint = (self._ctx._api_version >= APIVersion(2, 3))
-        is_v1_module = (self._module.model() == 'magneticModuleV1')
+        is_api_breakpoint = self._ctx._api_version >= APIVersion(2, 3)
+        is_v1_module = self._module.model() == "magneticModuleV1"
         is_standard_lw = self.labware.load_name in STANDARD_MAGDECK_LABWARE
 
         if is_api_breakpoint and is_v1_module and not is_standard_lw:
@@ -398,45 +416,50 @@ class MagneticModuleContext(ModuleContext[ModuleGeometry]):
     @publish.both(command=cmds.magdeck_disengage)
     @requires_version(2, 0)
     def disengage(self):
-        """ Lower the magnets back into the Magnetic Module.
-        """
+        """Lower the magnets back into the Magnetic Module."""
         self._module.deactivate()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def status(self):
-        """ The status of the module. either 'engaged' or 'disengaged' """
+        """The status of the module. either 'engaged' or 'disengaged'"""
         return self._module.status
 
 
 class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
-    """ An object representing a connected Temperature Module.
+    """An object representing a connected Temperature Module.
 
     It should not be instantiated directly; instead, it should be
     created through :py:meth:`.ProtocolContext.load_module`.
 
     .. versionadded:: 2.0
     """
-    def __init__(self,
-                 ctx: ProtocolContext,
-                 hw_module: modules.thermocycler.Thermocycler,
-                 geometry: ThermocyclerGeometry,
-                 at_version: APIVersion,
-                 loop: asyncio.AbstractEventLoop) -> None:
+
+    def __init__(
+        self,
+        ctx: ProtocolContext,
+        hw_module: modules.thermocycler.Thermocycler,
+        geometry: ThermocyclerGeometry,
+        at_version: APIVersion,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
         self._module = hw_module
         self._loop = loop
         super().__init__(ctx, geometry, at_version)
 
     def _prepare_for_lid_move(self):
-        loaded_instruments = [instr for mount, instr in
-                              self._ctx._instruments.items()
-                              if instr is not None]
+        loaded_instruments = [
+            instr
+            for mount, instr in self._ctx._instruments.items()
+            if instr is not None
+        ]
         try:
             instr = loaded_instruments[0]
         except IndexError:
             MODULE_LOG.warning(
                 "Cannot assure a safe gantry position to avoid colliding"
-                " with the lid of the Thermocycler Module.")
+                " with the lid of the Thermocycler Module."
+            )
         else:
             ctx_impl = self._ctx._implementation
             instr_impl = instr._implementation
@@ -446,25 +469,27 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             high_point = hardware.current_position(instr_impl.get_mount())
             trash_top = self._ctx.fixed_trash.wells()[0].top()
             safe_point = trash_top.point._replace(
-                    z=high_point[Axis.by_mount(instr_impl.get_mount())])
+                z=high_point[Axis.by_mount(instr_impl.get_mount())]
+            )
             instr.move_to(types.Location(safe_point, None), force_direct=True)
 
-    def flag_unsafe_move(self,
-                         to_loc: types.Location,
-                         from_loc: types.Location):
+    def flag_unsafe_move(self, to_loc: types.Location, from_loc: types.Location):
         to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
         from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
-        if self.labware is not None and \
-                (self.labware == to_lw or self.labware == from_lw) and \
-                self.lid_position != 'open':
+        if (
+            self.labware is not None
+            and (self.labware == to_lw or self.labware == from_lw)
+            and self.lid_position != "open"
+        ):
             raise RuntimeError(
                 "Cannot move to labware loaded in Thermocycler"
-                " when lid is not fully open.")
+                " when lid is not fully open."
+            )
 
     @publish.both(command=cmds.thermocycler_open)
     @requires_version(2, 0)
     def open_lid(self):
-        """ Opens the lid"""
+        """Opens the lid"""
         self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.open()  # type: ignore
         return self._geometry.lid_status
@@ -472,20 +497,22 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @publish.both(command=cmds.thermocycler_close)
     @requires_version(2, 0)
     def close_lid(self):
-        """ Closes the lid"""
+        """Closes the lid"""
         self._prepare_for_lid_move()
         self._geometry.lid_status = self._module.close()  # type: ignore
         return self._geometry.lid_status
 
     @publish.both(command=cmds.thermocycler_set_block_temp)
     @requires_version(2, 0)
-    def set_block_temperature(self,
-                              temperature: float,
-                              hold_time_seconds: Optional[float] = None,
-                              hold_time_minutes: Optional[float] = None,
-                              ramp_rate: Optional[float] = None,
-                              block_max_volume: Optional[float] = None):
-        """ Set the target temperature for the well block, in °C.
+    def set_block_temperature(
+        self,
+        temperature: float,
+        hold_time_seconds: Optional[float] = None,
+        hold_time_minutes: Optional[float] = None,
+        ramp_rate: Optional[float] = None,
+        block_max_volume: Optional[float] = None,
+    ):
+        """Set the target temperature for the well block, in °C.
 
         Valid operational range yet to be determined.
 
@@ -515,16 +542,17 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         """
 
         return self._module.set_temperature(
-                temperature=temperature,
-                hold_time_seconds=hold_time_seconds,
-                hold_time_minutes=hold_time_minutes,
-                ramp_rate=ramp_rate,
-                volume=block_max_volume)
+            temperature=temperature,
+            hold_time_seconds=hold_time_seconds,
+            hold_time_minutes=hold_time_minutes,
+            ramp_rate=ramp_rate,
+            volume=block_max_volume,
+        )
 
     @publish.both(command=cmds.thermocycler_set_lid_temperature)
     @requires_version(2, 0)
     def set_lid_temperature(self, temperature: float):
-        """ Set the target temperature for the heated lid, in °C.
+        """Set the target temperature for the heated lid, in °C.
 
         :param temperature: The target temperature, in °C clamped to the
                             range 20°C to 105°C.
@@ -539,11 +567,13 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
 
     @publish.both(command=cmds.thermocycler_execute_profile)
     @requires_version(2, 0)
-    def execute_profile(self,
-                        steps: List[modules.ThermocyclerStep],
-                        repetitions: int,
-                        block_max_volume: Optional[float] = None):
-        """ Execute a Thermocycler Profile defined as a cycle of
+    def execute_profile(
+        self,
+        steps: List[modules.ThermocyclerStep],
+        repetitions: int,
+        block_max_volume: Optional[float] = None,
+    ):
+        """Execute a Thermocycler Profile defined as a cycle of
         :py:attr:`steps` to repeat for a given number of :py:attr:`repetitions`
 
         :param steps: List of unique steps that make up a single cycle.
@@ -566,41 +596,41 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
         if repetitions <= 0:
             raise ValueError("repetitions must be a positive integer")
         for step in steps:
-            if step.get('temperature') is None:
-                raise ValueError(
-                        "temperature must be defined for each step in cycle")
-            hold_mins = step.get('hold_time_minutes')
-            hold_secs = step.get('hold_time_seconds')
+            if step.get("temperature") is None:
+                raise ValueError("temperature must be defined for each step in cycle")
+            hold_mins = step.get("hold_time_minutes")
+            hold_secs = step.get("hold_time_seconds")
             if hold_mins is None and hold_secs is None:
                 raise ValueError(
-                        "either hold_time_minutes or hold_time_seconds must be"
-                        "defined for each step in cycle")
-        return self._module.cycle_temperatures(steps=steps,
-                                               repetitions=repetitions,
-                                               volume=block_max_volume)
+                    "either hold_time_minutes or hold_time_seconds must be"
+                    "defined for each step in cycle"
+                )
+        return self._module.cycle_temperatures(
+            steps=steps, repetitions=repetitions, volume=block_max_volume
+        )
 
     @publish.both(command=cmds.thermocycler_deactivate_lid)
     @requires_version(2, 0)
     def deactivate_lid(self):
-        """ Turn off the heated lid """
+        """Turn off the heated lid"""
         self._module.deactivate_lid()
 
     @publish.both(command=cmds.thermocycler_deactivate_block)
     @requires_version(2, 0)
     def deactivate_block(self):
-        """ Turn off the well block temperature controller"""
+        """Turn off the well block temperature controller"""
         self._module.deactivate_block()
 
     @publish.both(command=cmds.thermocycler_deactivate)
     @requires_version(2, 0)
     def deactivate(self):
-        """ Turn off the well block temperature controller, and heated lid """
+        """Turn off the well block temperature controller, and heated lid"""
         self._module.deactivate()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def lid_position(self):
-        """ Lid open/close status string"""
+        """Lid open/close status string"""
         return self._module.lid_status
 
     @property  # type: ignore
@@ -616,59 +646,59 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
     @property  # type: ignore
     @requires_version(2, 0)
     def block_temperature(self):
-        """ Current temperature in degrees C """
+        """Current temperature in degrees C"""
         return self._module.temperature
 
     @property  # type: ignore
     @requires_version(2, 0)
     def block_target_temperature(self):
-        """ Target temperature in degrees C """
+        """Target temperature in degrees C"""
         return self._module.target
 
     @property  # type: ignore
     @requires_version(2, 0)
     def lid_temperature(self):
-        """ Current temperature in degrees C """
+        """Current temperature in degrees C"""
         return self._module.lid_temp
 
     @property  # type: ignore
     @requires_version(2, 0)
     def lid_target_temperature(self):
-        """ Target temperature in degrees C """
+        """Target temperature in degrees C"""
         return self._module.lid_target
 
     @property  # type: ignore
     @requires_version(2, 0)
     def ramp_rate(self):
-        """ Current ramp rate in degrees C/sec"""
+        """Current ramp rate in degrees C/sec"""
         return self._module.ramp_rate
 
     @property  # type: ignore
     @requires_version(2, 0)
     def hold_time(self):
-        """ Remaining hold time in sec"""
+        """Remaining hold time in sec"""
         return self._module.hold_time
 
     @property  # type: ignore
     @requires_version(2, 0)
     def total_cycle_count(self):
-        """ Number of repetitions for current set cycle"""
+        """Number of repetitions for current set cycle"""
         return self._module.total_cycle_count
 
     @property  # type: ignore
     @requires_version(2, 0)
     def current_cycle_index(self):
-        """ Index of the current set cycle repetition"""
+        """Index of the current set cycle repetition"""
         return self._module.current_cycle_index
 
     @property  # type: ignore
     @requires_version(2, 0)
     def total_step_count(self):
-        """ Number of steps within the current cycle"""
+        """Number of steps within the current cycle"""
         return self._module.total_step_count
 
     @property  # type: ignore
     @requires_version(2, 0)
     def current_step_index(self):
-        """ Index of the current step within the current cycle"""
+        """Index of the current step within the current cycle"""
         return self._module.current_step_index

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -7,17 +7,23 @@ from typing import TYPE_CHECKING, Union, Tuple, List, Optional, Dict
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons import types, hardware_control as hc
 from opentrons.commands import paired_commands as cmds
-from opentrons.commands.publisher import (
-    CommandPublisher, publish_paired, publish)
+from opentrons.commands.publisher import CommandPublisher, publish_paired, publish
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.context.protocol_api.paired_instrument import\
-    PairedInstrument
+from opentrons.protocols.context.protocol_api.paired_instrument import PairedInstrument
 
 from opentrons.protocols.api_support.util import (
-    requires_version, labware_column_shift, Clearances, clamp_value)
+    requires_version,
+    labware_column_shift,
+    Clearances,
+    clamp_value,
+)
 from .labware import (
-    Labware, Well, OutOfTipsError, select_tiprack_from_list_paired_pipettes,
-    filter_tipracks_to_start)
+    Labware,
+    Well,
+    OutOfTipsError,
+    select_tiprack_from_list_paired_pipettes,
+    filter_tipracks_to_start,
+)
 
 if TYPE_CHECKING:
     from .protocol_context import ProtocolContext
@@ -40,37 +46,45 @@ class PipettePairPickUpTipError(Exception):
 
 
 class PairedInstrumentContext(CommandPublisher):
-
-    def __init__(self,
-                 primary_instrument: InstrumentContext,
-                 secondary_instrument: InstrumentContext,
-                 ctx: ProtocolContext,
-                 pair_policy: hc_types.PipettePair,
-                 api_version: APIVersion,
-                 hardware_manager: HardwareManager,
-                 trash: Labware,
-                 log_parent: logging.Logger) -> None:
+    def __init__(
+        self,
+        primary_instrument: InstrumentContext,
+        secondary_instrument: InstrumentContext,
+        ctx: ProtocolContext,
+        pair_policy: hc_types.PipettePair,
+        api_version: APIVersion,
+        hardware_manager: HardwareManager,
+        trash: Labware,
+        log_parent: logging.Logger,
+    ) -> None:
         super().__init__(ctx.broker)
         self._instruments = {
             pair_policy.primary: primary_instrument,
-            pair_policy.secondary: secondary_instrument}
+            pair_policy.secondary: secondary_instrument,
+        }
         self._api_version = api_version
         self._log = log_parent.getChild(repr(self))
         self._tip_racks = list(
-            set(primary_instrument.tip_racks) &
-            set(secondary_instrument.tip_racks))
+            set(primary_instrument.tip_racks) & set(secondary_instrument.tip_racks)
+        )
         self._pair_policy = pair_policy
 
         self._starting_tip: Union[Well, None] = None
         self._last_tip_picked_up_from: Union[Well, None] = None
 
         self._well_bottom_clearance = Clearances(
-            default_aspirate=1.0, default_dispense=1.0)
+            default_aspirate=1.0, default_dispense=1.0
+        )
 
         self.trash_container = trash
         self.paired_instrument_obj = PairedInstrument(
-            primary_instrument, secondary_instrument, pair_policy,
-            ctx, hardware_manager, self._log)
+            primary_instrument,
+            secondary_instrument,
+            pair_policy,
+            ctx,
+            hardware_manager,
+            self._log,
+        )
 
     @property  # type: ignore
     @requires_version(2, 7)
@@ -85,8 +99,7 @@ class PairedInstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 7)
     def starting_tip(self) -> Union[Well, None]:
-        """ The starting tip from which the pipette pick up
-        """
+        """The starting tip from which the pipette pick up"""
         return self._starting_tip
 
     @starting_tip.setter
@@ -95,8 +108,7 @@ class PairedInstrumentContext(CommandPublisher):
 
     @requires_version(2, 7)
     def reset_tipracks(self):
-        """ Reload all tips in each tip rack and reset starting tip
-        """
+        """Reload all tips in each tip rack and reset starting tip"""
         for tiprack in self.tip_racks:
             tiprack.reset()
         self.starting_tip = None
@@ -104,7 +116,7 @@ class PairedInstrumentContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 7)
     def well_bottom_clearance(self) -> Clearances:
-        """ The distance above the bottom of a well to aspirate or dispense.
+        """The distance above the bottom of a well to aspirate or dispense.
 
         This is an object with attributes ``aspirate`` and ``dispense``,
         describing the default heights of the corresponding operation. The
@@ -132,9 +144,11 @@ class PairedInstrumentContext(CommandPublisher):
 
     @requires_version(2, 7)
     def pick_up_tip(
-            self, location: Union[types.Location, Well] = None,
-            presses: Optional[int] = None,
-            increment: Optional[float] = None) -> PairedInstrumentContext:
+        self,
+        location: Union[types.Location, Well] = None,
+        presses: Optional[int] = None,
+        increment: Optional[float] = None,
+    ) -> PairedInstrumentContext:
         """
         Pick up a tip for the pipette to run liquid-handling commands with
         a paired pipette object.
@@ -215,19 +229,15 @@ class PairedInstrumentContext(CommandPublisher):
         if location and isinstance(location, types.Location):
             if location.labware.is_labware:
                 tiprack = location.labware.as_labware()
-                primary_channels =\
-                    self._instruments[self._pair_policy.primary].channels
-                target: Well =\
-                    tiprack.next_tip(primary_channels)  # type: ignore
+                primary_channels = self._instruments[self._pair_policy.primary].channels
+                target: Well = tiprack.next_tip(primary_channels)  # type: ignore
                 if not target:
                     raise OutOfTipsError
             elif location.labware.is_well:
                 tiprack = location.labware.parent.as_labware()
                 target = location.labware.as_well()
             else:
-                raise TypeError(
-                    "The location must be in a well or labware."
-                )
+                raise TypeError("The location must be in a well or labware.")
         elif location and isinstance(location, Well):
             tiprack = location.parent
             target = location
@@ -238,7 +248,8 @@ class PairedInstrumentContext(CommandPublisher):
                 "If specified, location should be an instance of "
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
-                " However, it is a {}".format(location))
+                " However, it is a {}".format(location)
+            )
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
 
         # We must check that you can also pick up from
@@ -249,21 +260,22 @@ class PairedInstrumentContext(CommandPublisher):
 
         instruments = list(self._instruments.values())
         targets = [target, secondary_target]
-        publish_paired(self.broker, cmds.paired_pick_up_tip,
-                       'before', None, instruments, targets)
+        publish_paired(
+            self.broker, cmds.paired_pick_up_tip, "before", None, instruments, targets
+        )
         self.paired_instrument_obj.pick_up_tip(
-            target, secondary_target, tiprack, presses, increment, tip_length)
+            target, secondary_target, tiprack, presses, increment, tip_length
+        )
         self._last_tip_picked_up_from = target
-        publish_paired(self.broker, cmds.paired_pick_up_tip,
-                       'after', self, instruments, targets)
+        publish_paired(
+            self.broker, cmds.paired_pick_up_tip, "after", self, instruments, targets
+        )
         return self
 
     @requires_version(2, 7)
     def drop_tip(
-            self,
-            location: Union[types.Location, Well] = None,
-            home_after: bool = True)\
-            -> PairedInstrumentContext:
+        self, location: Union[types.Location, Well] = None, home_after: bool = True
+    ) -> PairedInstrumentContext:
         """
         Drop the current tip.
 
@@ -318,7 +330,8 @@ class PairedInstrumentContext(CommandPublisher):
                     "tiprack.wells()[0].top()) it must be a location "
                     "relative to a well, since that is where a tip is "
                     "dropped. The passed location, however, is in "
-                    "reference to {}".format(location.labware))
+                    "reference to {}".format(location.labware)
+                )
         elif location and isinstance(location, Well):
             if LabwareLike(location).is_fixed_trash():
                 target = location.top()
@@ -334,28 +347,34 @@ class PairedInstrumentContext(CommandPublisher):
                 "If specified, location should be an instance of "
                 "types.Location (e.g. the return value from "
                 "tiprack.wells()[0].top()) or a Well (e.g. tiprack.wells()[0]."
-                " However, it is a {}".format(location))
+                " However, it is a {}".format(location)
+            )
 
         instruments = list(self._instruments.values())
         if not is_trash and tiprack and isinstance(target.labware, Well):
             targets = [
                 target,
-                self._get_secondary_target(tiprack, target.labware.as_well())]
+                self._get_secondary_target(tiprack, target.labware.as_well()),
+            ]
         else:
             targets = [target]
-        publish_paired(self.broker, cmds.paired_drop_tip,
-                       'before', None, instruments, targets)
+        publish_paired(
+            self.broker, cmds.paired_drop_tip, "before", None, instruments, targets
+        )
         self.paired_instrument_obj.drop_tip(target, home_after)
-        publish_paired(self.broker, cmds.paired_drop_tip,
-                       'after', self, instruments, targets)
+        publish_paired(
+            self.broker, cmds.paired_drop_tip, "after", self, instruments, targets
+        )
         self._last_tip_picked_up_from = None
         return self
 
     @requires_version(2, 7)
-    def aspirate(self,
-                 volume: Optional[float] = None,
-                 location: Union[types.Location, Well] = None,
-                 rate: float = 1.0) -> PairedInstrumentContext:
+    def aspirate(
+        self,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> PairedInstrumentContext:
         """
         Aspirate a volume of liquid (in microliters/uL) using both pipettes
         from a specified location. You must pass in the location you
@@ -400,22 +419,22 @@ class PairedInstrumentContext(CommandPublisher):
             ``instr.aspirate(location=wellplate['A1'])``
 
         """
-        self._log.debug("aspirate {} from {} at {}"
-                        .format(volume,
-                                location if location else 'current position',
-                                rate))
+        self._log.debug(
+            "aspirate {} from {} at {}".format(
+                volume, location if location else "current position", rate
+            )
+        )
 
         loc: Optional[types.Location] = None
         if isinstance(location, Well):
             point, well = location.bottom()
             loc = types.Location(
-                point + types.Point(0, 0,
-                                    self.well_bottom_clearance.aspirate),
-                well)
+                point + types.Point(0, 0, self.well_bottom_clearance.aspirate), well
+            )
         elif location is not None and not isinstance(location, types.Location):
             raise TypeError(
-                'location should be a Well or Location, but it is {}'
-                .format(location))
+                "location should be a Well or Location, but it is {}".format(location)
+            )
         else:
             loc = location
 
@@ -425,28 +444,45 @@ class PairedInstrumentContext(CommandPublisher):
             c_vol = volume
 
         instruments = list(self._instruments.values())
-        primary_loc, aspirate_func =\
-            self.paired_instrument_obj.aspirate(volume, loc, rate)
+        primary_loc, aspirate_func = self.paired_instrument_obj.aspirate(
+            volume, loc, rate
+        )
         if primary_loc.labware.is_well:
             well = primary_loc.labware.as_well()
             labware = well.parent
-            locations = [
-                primary_loc,
-                self._get_secondary_target(labware, well)]
+            locations = [primary_loc, self._get_secondary_target(labware, well)]
         else:
             locations = [primary_loc]
-        publish_paired(self.broker, cmds.paired_aspirate, 'before',
-                       None, instruments, c_vol, locations, rate)
+        publish_paired(
+            self.broker,
+            cmds.paired_aspirate,
+            "before",
+            None,
+            instruments,
+            c_vol,
+            locations,
+            rate,
+        )
         aspirate_func()
-        publish_paired(self.broker, cmds.paired_aspirate, 'after',
-                       self, instruments, c_vol, locations, rate)
+        publish_paired(
+            self.broker,
+            cmds.paired_aspirate,
+            "after",
+            self,
+            instruments,
+            c_vol,
+            locations,
+            rate,
+        )
         return self
 
     @requires_version(2, 7)
-    def dispense(self,
-                 volume: Optional[float] = None,
-                 location: Union[types.Location, Well] = None,
-                 rate: float = 1.0) -> PairedInstrumentContext:
+    def dispense(
+        self,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> PairedInstrumentContext:
         """
         Dispense a volume of liquid (in microliters/uL) using both pipettes
         into the specified location.  You must pass in the location you
@@ -493,23 +529,23 @@ class PairedInstrumentContext(CommandPublisher):
             ``instr.dispense(location=wellplate['A1'])``
 
         """
-        self._log.debug("dispense {} from {} at {}"
-                        .format(volume,
-                                location if location else 'current position',
-                                rate))
+        self._log.debug(
+            "dispense {} from {} at {}".format(
+                volume, location if location else "current position", rate
+            )
+        )
         if isinstance(location, Well):
             if LabwareLike(location).is_fixed_trash():
                 loc = location.top()
             else:
                 point, well = location.bottom()
                 loc = types.Location(
-                    point + types.Point(0, 0,
-                                        self.well_bottom_clearance.dispense),
-                    well)
+                    point + types.Point(0, 0, self.well_bottom_clearance.dispense), well
+                )
         elif location is not None and not isinstance(location, types.Location):
             raise TypeError(
-                'location should be a Well or Location, but it is {}'
-                .format(location))
+                "location should be a Well or Location, but it is {}".format(location)
+            )
         else:
             loc = location
 
@@ -519,29 +555,44 @@ class PairedInstrumentContext(CommandPublisher):
             c_vol = volume
 
         instruments = list(self._instruments.values())
-        primary_loc, dispense_func =\
-            self.paired_instrument_obj.dispense(volume, loc, rate)
+        primary_loc, dispense_func = self.paired_instrument_obj.dispense(
+            volume, loc, rate
+        )
 
         if isinstance(primary_loc.labware, Well):
             well = primary_loc.labware.as_well()
             labware = well.parent
-            locations = [
-                primary_loc,
-                self._get_secondary_target(labware, well)]
+            locations = [primary_loc, self._get_secondary_target(labware, well)]
         else:
             locations = [primary_loc]
-        publish_paired(self.broker, cmds.paired_dispense, 'before',
-                       None, instruments, c_vol, locations, rate)
+        publish_paired(
+            self.broker,
+            cmds.paired_dispense,
+            "before",
+            None,
+            instruments,
+            c_vol,
+            locations,
+            rate,
+        )
         dispense_func()
-        publish_paired(self.broker, cmds.paired_dispense, 'after',
-                       self, instruments, c_vol, locations, rate)
+        publish_paired(
+            self.broker,
+            cmds.paired_dispense,
+            "after",
+            self,
+            instruments,
+            c_vol,
+            locations,
+            rate,
+        )
         return self
 
     @publish.both(command=cmds.air_gap)
     @requires_version(2, 7)
-    def air_gap(self,
-                volume: Optional[float] = None,
-                height: Optional[float] = None) -> PairedInstrumentContext:
+    def air_gap(
+        self, volume: Optional[float] = None, height: Optional[float] = None
+    ) -> PairedInstrumentContext:
         """
         Pull air into the pipette current tip at the current location
 
@@ -574,9 +625,8 @@ class PairedInstrumentContext(CommandPublisher):
 
         """
         for instr in self._instruments.values():
-            if not instr.hw_pipette['has_tip']:
-                raise hc.NoTipAttachedError(
-                    'Pipette has no tip. Aborting air_gap')
+            if not instr.hw_pipette["has_tip"]:
+                raise hc.NoTipAttachedError("Pipette has no tip. Aborting air_gap")
 
         if height is None:
             height = 5
@@ -584,9 +634,9 @@ class PairedInstrumentContext(CommandPublisher):
         return self
 
     @requires_version(2, 7)
-    def blow_out(self,
-                 location: Union[types.Location, Well] = None
-                 ) -> PairedInstrumentContext:
+    def blow_out(
+        self, location: Union[types.Location, Well] = None
+    ) -> PairedInstrumentContext:
         """
         Blow liquid out of the tip.
 
@@ -610,14 +660,15 @@ class PairedInstrumentContext(CommandPublisher):
         """
         if isinstance(location, Well):
             if location.parent.is_tiprack:
-                self._log.warning('Blow_out being performed on a tiprack. '
-                                  'Please re-check your code')
+                self._log.warning(
+                    "Blow_out being performed on a tiprack. "
+                    "Please re-check your code"
+                )
             loc = location.top()
-        elif location is not None and\
-                not isinstance(location, types.Location):
+        elif location is not None and not isinstance(location, types.Location):
             raise TypeError(
-                'location should be a Well or Location, but it is {}'
-                .format(location))
+                "location should be a Well or Location, but it is {}".format(location)
+            )
         else:
             loc = location
 
@@ -626,19 +677,23 @@ class PairedInstrumentContext(CommandPublisher):
             locations = self._get_locations(loc)
 
         instruments = list(self._instruments.values())
-        publish_paired(self.broker, cmds.paired_blow_out,
-                       'before', None, instruments, locations)
+        publish_paired(
+            self.broker, cmds.paired_blow_out, "before", None, instruments, locations
+        )
         self.paired_instrument_obj.blow_out(loc)
-        publish_paired(self.broker, cmds.paired_blow_out,
-                       'after', self, instruments, locations)
+        publish_paired(
+            self.broker, cmds.paired_blow_out, "after", self, instruments, locations
+        )
         return self
 
     @requires_version(2, 7)
-    def mix(self,
-            repetitions: int = 1,
-            volume: Optional[float] = None,
-            location: Union[types.Location, Well] = None,
-            rate: float = 1.0) -> PairedInstrumentContext:
+    def mix(
+        self,
+        repetitions: int = 1,
+        volume: Optional[float] = None,
+        location: Union[types.Location, Well] = None,
+        rate: float = 1.0,
+    ) -> PairedInstrumentContext:
         """
         Mix a volume of liquid (uL) using this pipette.
         If no location is specified, the pipette will mix from its current
@@ -672,13 +727,13 @@ class PairedInstrumentContext(CommandPublisher):
 
         """
         self._log.debug(
-            'mixing {}uL with {} repetitions in {} at rate={}'.format(
-                volume, repetitions,
-                location if location else 'current position', rate))
+            "mixing {}uL with {} repetitions in {} at rate={}".format(
+                volume, repetitions, location if location else "current position", rate
+            )
+        )
         for instr in self._instruments.values():
-            if not instr.hw_pipette['has_tip']:
-                raise hc.NoTipAttachedError(
-                    'Pipette has no tip. Aborting mix()')
+            if not instr.hw_pipette["has_tip"]:
+                raise hc.NoTipAttachedError("Pipette has no tip. Aborting mix()")
 
         if not volume:
             c_vol = self._get_minimum_available_volume(self._instruments)
@@ -689,24 +744,42 @@ class PairedInstrumentContext(CommandPublisher):
         locations: Optional[List] = None
         if location:
             locations = self._get_locations(location)
-        publish_paired(self.broker, cmds.paired_mix, 'before', None,
-                       instruments, locations, repetitions, c_vol)
+        publish_paired(
+            self.broker,
+            cmds.paired_mix,
+            "before",
+            None,
+            instruments,
+            locations,
+            repetitions,
+            c_vol,
+        )
         self.aspirate(volume, location, rate)
         while repetitions - 1 > 0:
             self.dispense(volume, rate=rate)
             self.aspirate(volume, rate=rate)
             repetitions -= 1
         self.dispense(volume, rate=rate)
-        publish_paired(self.broker, cmds.paired_mix, 'after', self,
-                       instruments, locations, repetitions, c_vol)
+        publish_paired(
+            self.broker,
+            cmds.paired_mix,
+            "after",
+            self,
+            instruments,
+            locations,
+            repetitions,
+            c_vol,
+        )
         return self
 
     @requires_version(2, 7)
-    def touch_tip(self,
-                  location: Optional[Well] = None,
-                  radius: float = 1.0,
-                  v_offset: float = -1.0,
-                  speed: float = 60.0) -> PairedInstrumentContext:
+    def touch_tip(
+        self,
+        location: Optional[Well] = None,
+        radius: float = 1.0,
+        v_offset: float = -1.0,
+        speed: float = 60.0,
+    ) -> PairedInstrumentContext:
         """
         Touch the pipette tip to the sides of a well, with the intent of
         removing left-over droplets. For :py:class:`PairedInstrumentContext`
@@ -743,31 +816,31 @@ class PairedInstrumentContext(CommandPublisher):
 
         """
         for instr in self._instruments.values():
-            if not instr.hw_pipette['has_tip']:
-                raise hc.NoTipAttachedError(
-                    'Pipette has no tip to touch_tip()')
+            if not instr.hw_pipette["has_tip"]:
+                raise hc.NoTipAttachedError("Pipette has no tip to touch_tip()")
 
-        checked_speed = clamp_value(speed, 80, 1, 'touch_tip:')
+        checked_speed = clamp_value(speed, 80, 1, "touch_tip:")
 
         instruments = list(self._instruments.values())
         locations: Optional[List] = None
         if location:
             locations = [
                 location,
-                self._get_secondary_target(location.parent, location)]
+                self._get_secondary_target(location.parent, location),
+            ]
 
-        publish_paired(self.broker, cmds.paired_touch_tip,
-                       'before', None, instruments, locations)
-        self.paired_instrument_obj.touch_tip(
-            location, radius, v_offset, checked_speed)
-        publish_paired(self.broker, cmds.paired_touch_tip,
-                       'after', self, instruments, locations)
+        publish_paired(
+            self.broker, cmds.paired_touch_tip, "before", None, instruments, locations
+        )
+        self.paired_instrument_obj.touch_tip(location, radius, v_offset, checked_speed)
+        publish_paired(
+            self.broker, cmds.paired_touch_tip, "after", self, instruments, locations
+        )
         return self
 
     @publish.both(command=cmds.return_tip)
     @requires_version(2, 7)
-    def return_tip(self,
-                   home_after: bool = True) -> PairedInstrumentContext:
+    def return_tip(self, home_after: bool = True) -> PairedInstrumentContext:
         """
         If a tip is currently attached to both of the pipettes, then it will
         return the tip to it's location in the tiprack.
@@ -777,23 +850,25 @@ class PairedInstrumentContext(CommandPublisher):
         :returns: This instance
         """
         for mount, instr in self._instruments.items():
-            if not instr.hw_pipette['has_tip']:
-                self._log.warning('Pipette has no tip to return')
+            if not instr.hw_pipette["has_tip"]:
+                self._log.warning("Pipette has no tip to return")
         loc = self._last_tip_picked_up_from
         if not isinstance(loc, Well):
-            raise TypeError('Last tip location should be a Well but it is: '
-                            f'{loc}')
+            raise TypeError("Last tip location should be a Well but it is: " f"{loc}")
         primary_pipette = self._instruments[self._pair_policy.primary]
         drop_loc = self._drop_tip_target(loc, primary_pipette)
         self.drop_tip(drop_loc, home_after=home_after)
         return self
 
     @requires_version(2, 7)
-    def move_to(self, location: types.Location, force_direct: bool = False,
-                minimum_z_height: Optional[float] = None,
-                speed: Optional[float] = None
-                ) -> PairedInstrumentContext:
-        """ Move the full gantry with the primary pipette used as the basis
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool = False,
+        minimum_z_height: Optional[float] = None,
+        speed: Optional[float] = None,
+    ) -> PairedInstrumentContext:
+        """Move the full gantry with the primary pipette used as the basis
         for the XY position within a given labware.
 
         :param location: The location to move to.
@@ -813,12 +888,15 @@ class PairedInstrumentContext(CommandPublisher):
         if location:
             locations = self._get_locations(location)
 
-        publish_paired(self.broker, cmds.paired_move_to,
-                       'before', None, instruments, locations)
+        publish_paired(
+            self.broker, cmds.paired_move_to, "before", None, instruments, locations
+        )
         self.paired_instrument_obj.move_to(
-            location, force_direct, minimum_z_height, speed)
-        publish_paired(self.broker, cmds.paired_move_to,
-                       'after', None, instruments, locations)
+            location, force_direct, minimum_z_height, speed
+        )
+        publish_paired(
+            self.broker, cmds.paired_move_to, "after", None, instruments, locations
+        )
         return self
 
     def _next_available_tip(self) -> Tuple[Labware, Well]:
@@ -826,17 +904,19 @@ class PairedInstrumentContext(CommandPublisher):
         # both the primary and secondary tip with a spacing
         # of approximately 34 mm.
         start = self.starting_tip
-        primary_channels =\
-            self._instruments[self._pair_policy.primary].channels
-        secondary_channels =\
-            self._instruments[self._pair_policy.secondary].channels
+        primary_channels = self._instruments[self._pair_policy.primary].channels
+        secondary_channels = self._instruments[self._pair_policy.secondary].channels
         if start is None:
             return select_tiprack_from_list_paired_pipettes(
-                self.tip_racks, primary_channels, secondary_channels)
+                self.tip_racks, primary_channels, secondary_channels
+            )
         else:
             return select_tiprack_from_list_paired_pipettes(
                 filter_tipracks_to_start(start, self.tip_racks),
-                primary_channels, secondary_channels, starting_point=start)
+                primary_channels,
+                secondary_channels,
+                starting_point=start,
+            )
 
     def _get_locations(self, location: Union[types.Location, Well]) -> List:
         if isinstance(location, Well):
@@ -850,9 +930,7 @@ class PairedInstrumentContext(CommandPublisher):
         return []
 
     @staticmethod
-    def _drop_tip_target(
-            location: Well,
-            pipette: InstrumentContext) -> types.Location:
+    def _drop_tip_target(location: Well, pipette: InstrumentContext) -> types.Location:
         tr = location.parent
         assert tr.is_tiprack
         z_height = pipette.return_height * tr.tip_length
@@ -870,23 +948,23 @@ class PairedInstrumentContext(CommandPublisher):
             else:
                 spacing = SBS_96_WELL_SPACING
                 modulo_value = 8
-            return labware_column_shift(
-                primary_loc, labware, spacing, modulo_value)
+            return labware_column_shift(primary_loc, labware, spacing, modulo_value)
         except IndexError:
             raise PipettePairPickUpTipError(
-                f'The location you specified ({primary_loc}) is'
-                'incompatible with a PipettePair pickup.')
+                f"The location you specified ({primary_loc}) is"
+                "incompatible with a PipettePair pickup."
+            )
 
     @staticmethod
     def _get_minimum_available_volume(
-            instruments: Dict[types.Mount, InstrumentContext]) -> float:
+        instruments: Dict[types.Mount, InstrumentContext]
+    ) -> float:
         return min(
-            instr.hw_pipette['available_volume']
-            for instr in instruments.values())
+            instr.hw_pipette["available_volume"] for instr in instruments.values()
+        )
 
     @staticmethod
     def _get_minimum_current_volume(
-            instruments: Dict[types.Mount, InstrumentContext]) -> float:
-        return min(
-            instr.hw_pipette['current_volume']
-            for instr in instruments.values())
+        instruments: Dict[types.Mount, InstrumentContext]
+    ) -> float:
+        return min(instr.hw_pipette["current_volume"] for instr in instruments.values())

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1,50 +1,63 @@
 import asyncio
 import contextlib
 import logging
-from typing import (Dict, Iterator, List, Callable,
-                    Optional, Tuple, Union, TYPE_CHECKING, cast)
+from typing import (
+    Dict,
+    Iterator,
+    List,
+    Callable,
+    Optional,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+    cast,
+)
 from collections import OrderedDict
 
-from opentrons.hardware_control import (SynchronousAdapter, ThreadManager)
+from opentrons.hardware_control import SynchronousAdapter, ThreadManager
 from opentrons import types
 from opentrons.hardware_control import API
 from opentrons.commands import protocol_commands as cmds, types as cmd_types
 from opentrons.commands.publisher import CommandPublisher, publish
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.context.protocol_api.instrument_context import \
-    InstrumentContextImplementation
-from opentrons.protocols.context.simulator.instrument_context import \
-    InstrumentContextSimulation
+from opentrons.protocols.context.protocol_api.instrument_context import (
+    InstrumentContextImplementation,
+)
+from opentrons.protocols.context.simulator.instrument_context import (
+    InstrumentContextSimulation,
+)
 from opentrons.protocols.types import Protocol
 from .labware import Labware
-from opentrons.protocols.context.labware import \
-    AbstractLabware
-from opentrons.protocols.context.protocol import \
-    AbstractProtocol
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry, ModuleType)
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.context.protocol import AbstractProtocol
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry, ModuleType
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from .instrument_context import InstrumentContext
 from .module_contexts import (
-    ModuleContext, MagneticModuleContext, TemperatureModuleContext,
-    ThermocyclerContext)
+    ModuleContext,
+    MagneticModuleContext,
+    TemperatureModuleContext,
+    ThermocyclerContext,
+)
 from opentrons.protocols.api_support.util import (
-    AxisMaxSpeeds, requires_version, APIVersionError)
+    AxisMaxSpeeds,
+    requires_version,
+    APIVersionError,
+)
+
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 MODULE_LOG = logging.getLogger(__name__)
 
 ModuleTypes = Union[
-    'TemperatureModuleContext',
-    'MagneticModuleContext',
-    'ThermocyclerContext'
+    "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
 ]
 
 
 class ProtocolContext(CommandPublisher):
-    """ The Context class is a container for the state of a protocol.
+    """The Context class is a container for the state of a protocol.
 
     It encapsulates many of the methods formerly found in the Robot class,
     including labware, instrument, and module loading, as well as core
@@ -60,13 +73,14 @@ class ProtocolContext(CommandPublisher):
 
     """
 
-    def __init__(self,
-                 implementation: AbstractProtocol,
-                 loop: asyncio.AbstractEventLoop = None,
-                 broker=None,
-                 api_version: Optional[APIVersion] = None,
-                 ) -> None:
-        """ Build a :py:class:`.ProtocolContext`.
+    def __init__(
+        self,
+        implementation: AbstractProtocol,
+        loop: asyncio.AbstractEventLoop = None,
+        broker=None,
+        api_version: Optional[APIVersion] = None,
+    ) -> None:
+        """Build a :py:class:`.ProtocolContext`.
 
         :param loop: An event loop to use. If not specified, this ctor will
                      (eventually) call :py:meth:`asyncio.get_event_loop`.
@@ -82,12 +96,14 @@ class ProtocolContext(CommandPublisher):
         self._api_version = api_version or MAX_SUPPORTED_VERSION
         if self._api_version > MAX_SUPPORTED_VERSION:
             raise RuntimeError(
-                f'API version {self._api_version} is not supported by this '
-                f'robot software. Please either reduce your requested API '
-                f'version or update your robot.')
+                f"API version {self._api_version} is not supported by this "
+                f"robot software. Please either reduce your requested API "
+                f"version or update your robot."
+            )
         self._loop = loop or asyncio.get_event_loop()
-        self._instruments: Dict[types.Mount, Optional[InstrumentContext]]\
-            = {mount: None for mount in types.Mount}
+        self._instruments: Dict[types.Mount, Optional[InstrumentContext]] = {
+            mount: None for mount in types.Mount
+        }
         self._modules: List[ModuleContext] = []
 
         self._log = MODULE_LOG.getChild(self.__class__.__name__)
@@ -96,24 +112,22 @@ class ProtocolContext(CommandPublisher):
         self.clear_commands()
 
     @classmethod
-    def build_using(cls,
-                    implementation: AbstractProtocol,
-                    protocol: Protocol,
-                    *args, **kwargs):
-        """ Build an API instance for the specified parsed protocol
+    def build_using(
+        cls, implementation: AbstractProtocol, protocol: Protocol, *args, **kwargs
+    ):
+        """Build an API instance for the specified parsed protocol
 
         This is used internally to provision the context with bundle
         contents or api levels.
         """
-        kwargs['api_version'] = getattr(
-            protocol, 'api_level', MAX_SUPPORTED_VERSION)
-        kwargs['implementation'] = implementation
+        kwargs["api_version"] = getattr(protocol, "api_level", MAX_SUPPORTED_VERSION)
+        kwargs["implementation"] = implementation
         return cls(*args, **kwargs)
 
     @property  # type: ignore
     @requires_version(2, 0)
     def api_version(self) -> APIVersion:
-        """ Return the API version supported by this protocol context.
+        """Return the API version supported by this protocol context.
 
         The supported API version was specified when the protocol context
         was initialized. It may be lower than the highest version supported
@@ -128,13 +142,14 @@ class ProtocolContext(CommandPublisher):
         # user facing hardware control http api.
         self._log.warning(
             "This function will be deprecated in later versions."
-            "Please use with caution.")
+            "Please use with caution."
+        )
         return self._implementation.get_hardware()
 
     @property  # type: ignore
     @requires_version(2, 0)
     def bundled_data(self) -> Dict[str, bytes]:
-        """ Accessor for data files bundled with this protocol, if any.
+        """Accessor for data files bundled with this protocol, if any.
 
         This is a dictionary mapping the filenames of bundled datafiles, with
         extensions but without paths (e.g. if a file is stored in the bundle as
@@ -144,19 +159,19 @@ class ProtocolContext(CommandPublisher):
         return self._implementation.get_bundled_data()
 
     def cleanup(self):
-        """ Finalize and clean up the protocol context. """
+        """Finalize and clean up the protocol context."""
         if self._unsubscribe_commands:
             self._unsubscribe_commands()
             self._unsubscribe_commands = None
 
     def __del__(self):
-        if getattr(self, '_unsubscribe_commands', None):
+        if getattr(self, "_unsubscribe_commands", None):
             self._unsubscribe_commands()  # type: ignore
 
     @property  # type: ignore
     @requires_version(2, 0)
     def max_speeds(self) -> AxisMaxSpeeds:
-        """ Per-axis speed limits when moving this instrument.
+        """Per-axis speed limits when moving this instrument.
 
         Changing this value changes the speed limit for each non-plunger
         axis of the robot, when moving this pipette. Note that this does
@@ -197,20 +212,21 @@ class ProtocolContext(CommandPublisher):
             self._unsubscribe_commands()
 
         def on_command(message):
-            payload = message.get('payload')
-            text = payload.get('text')
+            payload = message.get("payload")
+            text = payload.get("text")
             if text is None:
                 return
 
-            if message['$'] == 'before':
+            if message["$"] == "before":
                 self._commands.append(text.format(**payload))
 
         self._unsubscribe_commands = self.broker.subscribe(
-            cmd_types.COMMAND, on_command)
+            cmd_types.COMMAND, on_command
+        )
 
     @contextlib.contextmanager
     def temp_connect(self, hardware: Union[ThreadManager, SynchronousAdapter]):
-        """ Connect temporarily to the specified hardware controller.
+        """Connect temporarily to the specified hardware controller.
 
         This should be used as a context manager:
 
@@ -237,9 +253,11 @@ class ProtocolContext(CommandPublisher):
             for mod_ctx in self._modules:
                 if isinstance(mod_ctx, ThermocyclerContext):
                     tc_context = mod_ctx
-                    hw_tc = next(hw_mod for hw_mod in
-                                 hardware.attached_modules
-                                 if hw_mod.name() == 'thermocycler')
+                    hw_tc = next(
+                        hw_mod
+                        for hw_mod in hardware.attached_modules
+                        if hw_mod.name() == "thermocycler"
+                    )
                     if hw_tc:
                         old_tc = mod_ctx._module
                         mod_ctx._module = hw_tc
@@ -256,14 +274,13 @@ class ProtocolContext(CommandPublisher):
                     continue
                 impl = instrument_ctx._implementation
                 if isinstance(impl, InstrumentContextSimulation):
-                    instrument_ctx._implementation = \
-                        InstrumentContextImplementation(
-                            protocol_interface=self._implementation,
-                            mount=impl.get_mount(),
-                            default_speed=impl.get_default_speed(),
-                            instrument_name=impl.get_instrument_name(),
-                            api_version=self._api_version
-                        )
+                    instrument_ctx._implementation = InstrumentContextImplementation(
+                        protocol_interface=self._implementation,
+                        mount=impl.get_mount(),
+                        default_speed=impl.get_default_speed(),
+                        instrument_name=impl.get_instrument_name(),
+                        api_version=self._api_version,
+                    )
 
             yield self
         finally:
@@ -278,7 +295,7 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def connect(self, hardware: API):
-        """ Connect to a running hardware API.
+        """Connect to a running hardware API.
 
         This can be either a simulator or a full hardware controller.
 
@@ -290,8 +307,7 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def disconnect(self):
-        """ Disconnect from currently-connected hardware and simulate instead
-        """
+        """Disconnect from currently-connected hardware and simulate instead"""
         self._implementation.disconnect()
 
     @requires_version(2, 0)
@@ -300,12 +316,12 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def load_labware_from_definition(
-            self,
-            labware_def: 'LabwareDefinition',
-            location: types.DeckLocation,
-            label: Optional[str] = None,
+        self,
+        labware_def: "LabwareDefinition",
+        location: types.DeckLocation,
+        label: Optional[str] = None,
     ) -> Labware:
-        """ Specify the presence of a piece of labware on the OT2 deck.
+        """Specify the presence of a piece of labware on the OT2 deck.
 
         This function loads the labware definition specified by `labware_def`
         to the location specified by `location`.
@@ -320,22 +336,20 @@ class ProtocolContext(CommandPublisher):
                           Opentrons app.
         """
         implementation = self._implementation.load_labware_from_definition(
-            labware_def=labware_def,
-            location=location,
-            label=label
+            labware_def=labware_def, location=location, label=label
         )
         return Labware(implementation=implementation)
 
     @requires_version(2, 0)
     def load_labware(
-            self,
-            load_name: str,
-            location: types.DeckLocation,
-            label: Optional[str] = None,
-            namespace: Optional[str] = None,
-            version: Optional[int] = None,
+        self,
+        load_name: str,
+        location: types.DeckLocation,
+        label: Optional[str] = None,
+        namespace: Optional[str] = None,
+        version: Optional[int] = None,
     ) -> Labware:
-        """ Load a labware onto the deck given its name.
+        """Load a labware onto the deck given its name.
 
         For labware already defined by Opentrons, this is a convenient way
         to collapse the two stages of labware initialization (creating
@@ -362,32 +376,32 @@ class ProtocolContext(CommandPublisher):
             location=location,
             label=label,
             namespace=namespace,
-            version=version
+            version=version,
         )
         return Labware(implementation=implementation)
 
     @requires_version(2, 0)
     def load_labware_by_name(
-            self,
-            load_name: str,
-            location: types.DeckLocation,
-            label: Optional[str] = None,
-            namespace: Optional[str] = None,
-            version: int = 1
+        self,
+        load_name: str,
+        location: types.DeckLocation,
+        label: Optional[str] = None,
+        namespace: Optional[str] = None,
+        version: int = 1,
     ) -> Labware:
         """
         .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
         MODULE_LOG.warning(
-            'load_labware_by_name is deprecated. Use load_labware instead.')
-        return self.load_labware(
-            load_name, location, label, namespace, version)
+            "load_labware_by_name is deprecated. Use load_labware instead."
+        )
+        return self.load_labware(load_name, location, label, namespace, version)
 
     @property  # type: ignore
     @requires_version(2, 0)
     def loaded_labwares(self) -> Dict[int, Labware]:
-        """ Get the labwares that have been loaded into the protocol context.
+        """Get the labwares that have been loaded into the protocol context.
 
         Slots with nothing in them will not be present in the return value.
 
@@ -404,8 +418,8 @@ class ProtocolContext(CommandPublisher):
         :returns: Dict mapping deck slot number to labware, sorted in order of
                   the locations.
         """
-        def _only_labwares() -> Iterator[
-                Tuple[int, Labware]]:
+
+        def _only_labwares() -> Iterator[Tuple[int, Labware]]:
             for slotnum, slotitem in self._implementation.get_deck().items():
                 if isinstance(slotitem, AbstractLabware):
                     yield slotnum, Labware(implementation=slotitem)
@@ -419,10 +433,12 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def load_module(
-            self, module_name: str,
-            location: Optional[types.DeckLocation] = None,
-            configuration: Optional[str] = None) -> ModuleTypes:
-        """ Load a module onto the deck given its name.
+        self,
+        module_name: str,
+        location: Optional[types.DeckLocation] = None,
+        configuration: Optional[str] = None,
+    ) -> ModuleTypes:
+        """Load a module onto the deck given its name.
 
         This is the function to call to use a module in your protocol, like
         :py:meth:`load_instrument` is the method to call to use an instrument
@@ -452,22 +468,21 @@ class ProtocolContext(CommandPublisher):
         """
         if self._api_version < APIVersion(2, 4) and configuration:
             raise APIVersionError(
-                f'You have specified API {self._api_version}, but you are'
-                'using thermocycler parameters only available in 2.4')
+                f"You have specified API {self._api_version}, but you are"
+                "using thermocycler parameters only available in 2.4"
+            )
 
         module = self._implementation.load_module(
-            module_name=module_name,
-            location=location,
-            configuration=configuration)
+            module_name=module_name, location=location, configuration=configuration
+        )
 
         if not module:
-            raise RuntimeError(
-                f'Could not find specified module: {module_name}')
+            raise RuntimeError(f"Could not find specified module: {module_name}")
 
         mod_class = {
             ModuleType.MAGNETIC: MagneticModuleContext,
             ModuleType.TEMPERATURE: TemperatureModuleContext,
-            ModuleType.THERMOCYCLER: ThermocyclerContext
+            ModuleType.THERMOCYCLER: ThermocyclerContext,
         }[module.type]
 
         module_context = mod_class(
@@ -478,8 +493,8 @@ class ProtocolContext(CommandPublisher):
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def loaded_modules(self) -> Dict[int, 'ModuleContext']:
-        """ Get the modules loaded into the protocol context.
+    def loaded_modules(self) -> Dict[int, "ModuleContext"]:
+        """Get the modules loaded into the protocol context.
 
         This is a map of deck positions to modules loaded by previous calls
         to :py:meth:`load_module`. It is not necessarily the same as the
@@ -492,7 +507,8 @@ class ProtocolContext(CommandPublisher):
                                            contexts. The elements may not be
                                            ordered by slot number.
         """
-        def _modules() -> Iterator[Tuple[int, 'ModuleContext']]:
+
+        def _modules() -> Iterator[Tuple[int, "ModuleContext"]]:
             for module in self._modules:
                 yield int(str(module.geometry.parent)), module
 
@@ -500,12 +516,13 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def load_instrument(
-            self,
-            instrument_name: str,
-            mount: Union[types.Mount, str],
-            tip_racks: List[Labware] = None,
-            replace: bool = False) -> 'InstrumentContext':
-        """ Load a specific instrument required by the protocol.
+        self,
+        instrument_name: str,
+        mount: Union[types.Mount, str],
+        tip_racks: List[Labware] = None,
+        replace: bool = False,
+    ) -> "InstrumentContext":
+        """Load a specific instrument required by the protocol.
 
         This value will actually be checked when the protocol runs, to
         ensure that the correct instrument is attached in the specified
@@ -535,20 +552,23 @@ class ProtocolContext(CommandPublisher):
                 raise ValueError(
                     "If mount is specified as a string, it should be either"
                     "'left' or 'right' (ignoring capitalization, which the"
-                    " system strips), not {}".format(mount))
+                    " system strips), not {}".format(mount)
+                )
         elif isinstance(mount, types.Mount):
             checked_mount = mount
         else:
             raise TypeError(
                 "mount should be either an instance of opentrons.types.Mount"
-                " or a string, but is {}.".format(mount))
-        self._log.info("Trying to load {} on {} mount"
-                       .format(instrument_name, checked_mount.name.lower()))
+                " or a string, but is {}.".format(mount)
+            )
+        self._log.info(
+            "Trying to load {} on {} mount".format(
+                instrument_name, checked_mount.name.lower()
+            )
+        )
 
         impl = self._implementation.load_instrument(
-            instrument_name=instrument_name,
-            mount=checked_mount,
-            replace=replace
+            instrument_name=instrument_name, mount=checked_mount, replace=replace
         )
 
         new_instr = InstrumentContext(
@@ -564,8 +584,8 @@ class ProtocolContext(CommandPublisher):
 
     @property  # type: ignore
     @requires_version(2, 0)
-    def loaded_instruments(self) -> Dict[str, 'InstrumentContext']:
-        """ Get the instruments that have been loaded into the protocol.
+    def loaded_instruments(self) -> Dict[str, "InstrumentContext"]:
+        """Get the instruments that have been loaded into the protocol.
 
         This is a map of mount name to instruments previously loaded with
         :py:meth:`load_instrument`. It is not necessarily the same as the
@@ -580,9 +600,11 @@ class ProtocolContext(CommandPublisher):
                   If a mount has no loaded instrument,
                   that key will be missing from the dict.
         """
-        return {mount.name.lower(): instr for mount, instr
-                in self._instruments.items()
-                if instr}
+        return {
+            mount.name.lower(): instr
+            for mount, instr in self._instruments.items()
+            if instr
+        }
 
     @publish.both(command=cmds.pause)
     @requires_version(2, 0)
@@ -629,7 +651,7 @@ class ProtocolContext(CommandPublisher):
     @publish.both(command=cmds.delay)
     @requires_version(2, 0)
     def delay(self, seconds=0, minutes=0, msg=None):
-        """ Delay protocol execution for a specific amount of time.
+        """Delay protocol execution for a specific amount of time.
 
         :param float seconds: A time to delay in seconds
         :param float minutes: A time to delay in minutes
@@ -641,15 +663,13 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 0)
     def home(self):
-        """ Homes the robot.
-        """
+        """Homes the robot."""
         self._log.debug("home")
         self._implementation.home()
 
     @property
     def location_cache(self) -> Optional[types.Location]:
-        """ The cache used by the robot to determine where it last was.
-        """
+        """The cache used by the robot to determine where it last was."""
         return self._implementation.get_last_location()
 
     @location_cache.setter
@@ -659,7 +679,7 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def deck(self) -> Deck:
-        """ The object holding the deck layout of the robot.
+        """The object holding the deck layout of the robot.
 
         This object behaves like a dictionary with keys for both numeric
         and string slot numbers (for instance, ``protocol.deck[1]`` and
@@ -683,7 +703,7 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def fixed_trash(self) -> Labware:
-        """ The trash fixed to slot 12 of the robot deck.
+        """The trash fixed to slot 12 of the robot deck.
 
         It has one well and should be accessed like labware in your protocol.
         e.g. ``protocol.fixed_trash['A1']``
@@ -707,11 +727,11 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 5)
     def rail_lights_on(self) -> bool:
-        """ Returns True if the rail lights are on """
+        """Returns True if the rail lights are on"""
         return self._implementation.get_rail_lights_on()
 
     @property  # type: ignore
     @requires_version(2, 5)
     def door_closed(self) -> bool:
-        """ Returns True if the robot door is closed """
+        """Returns True if the robot door is closed"""
         return self._implementation.door_closed()

--- a/api/src/opentrons/protocols/advanced_control/mix.py
+++ b/api/src/opentrons/protocols/advanced_control/mix.py
@@ -4,8 +4,8 @@ from opentrons.protocols.advanced_control.transfers import MixStrategy, Mix
 
 
 def mix_from_kwargs(
-        top_kwargs: typing.Dict[str, typing.Any])\
-        -> typing.Tuple[MixStrategy, Mix]:
+    top_kwargs: typing.Dict[str, typing.Any]
+) -> typing.Tuple[MixStrategy, Mix]:
     """A utility function to determine mix strategy from key word arguments
     to InstrumentContext.mix"""
 
@@ -27,28 +27,36 @@ def mix_from_kwargs(
         return True
 
     mix_opts = Mix()
-    if _mix_requested(top_kwargs, 'mix_before')\
-       and _mix_requested(top_kwargs, 'mix_after'):
+    if _mix_requested(top_kwargs, "mix_before") and _mix_requested(
+        top_kwargs, "mix_after"
+    ):
         mix_strategy = MixStrategy.BOTH
-        before_opts = top_kwargs['mix_before']
-        after_opts = top_kwargs['mix_after']
+        before_opts = top_kwargs["mix_before"]
+        after_opts = top_kwargs["mix_after"]
         mix_opts = mix_opts._replace(
             mix_after=mix_opts.mix_after._replace(
-                repetitions=after_opts[0], volume=after_opts[1]),
+                repetitions=after_opts[0], volume=after_opts[1]
+            ),
             mix_before=mix_opts.mix_before._replace(
-                repetitions=before_opts[0], volume=before_opts[1]))
-    elif _mix_requested(top_kwargs, 'mix_before'):
+                repetitions=before_opts[0], volume=before_opts[1]
+            ),
+        )
+    elif _mix_requested(top_kwargs, "mix_before"):
         mix_strategy = MixStrategy.BEFORE
-        before_opts = top_kwargs['mix_before']
+        before_opts = top_kwargs["mix_before"]
         mix_opts = mix_opts._replace(
             mix_before=mix_opts.mix_before._replace(
-                repetitions=before_opts[0], volume=before_opts[1]))
-    elif _mix_requested(top_kwargs, 'mix_after'):
+                repetitions=before_opts[0], volume=before_opts[1]
+            )
+        )
+    elif _mix_requested(top_kwargs, "mix_after"):
         mix_strategy = MixStrategy.AFTER
-        after_opts = top_kwargs['mix_after']
+        after_opts = top_kwargs["mix_after"]
         mix_opts = mix_opts._replace(
             mix_after=mix_opts.mix_after._replace(
-                repetitions=after_opts[0], volume=after_opts[1]))
+                repetitions=after_opts[0], volume=after_opts[1]
+            )
+        )
     else:
         mix_strategy = MixStrategy.NEVER
     return mix_strategy, mix_opts

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -1,7 +1,18 @@
 import enum
-from typing import (Any, Dict, List, Optional, Union, NamedTuple,
-                    Callable, Generator, Iterator, Tuple,
-                    TYPE_CHECKING, TypeVar)
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Union,
+    NamedTuple,
+    Callable,
+    Generator,
+    Iterator,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+)
 from opentrons.protocol_api.labware import Well
 from opentrons import types
 from opentrons.protocols.api_support.types import APIVersion
@@ -195,14 +206,15 @@ class PickUpTipOpts(NamedTuple):
     :py:meth:`InstrumentContext.pick_up_tip` when it is called during
     the transfer.
     """
+
     location: Optional[types.Location] = None
     presses: Optional[int] = None
     increment: Optional[int] = None
 
 
-PickUpTipOpts.location.__doc__ = ':py:class:`types.Location`'
-PickUpTipOpts.presses.__doc__ = ':py:class:`int`'
-PickUpTipOpts.increment.__doc__ = ':py:class:`int`'
+PickUpTipOpts.location.__doc__ = ":py:class:`types.Location`"
+PickUpTipOpts.presses.__doc__ = ":py:class:`int`"
+PickUpTipOpts.increment.__doc__ = ":py:class:`int`"
 
 
 class MixOpts(NamedTuple):
@@ -219,15 +231,16 @@ class MixOpts(NamedTuple):
     rate: Optional[float] = None
 
 
-MixOpts.repetitions.__doc__ = ':py:class:`int`'
-MixOpts.volume.__doc__ = ':py:class:`float`'
-MixOpts.rate.__doc__ = ':py:class:`float`'
+MixOpts.repetitions.__doc__ = ":py:class:`int`"
+MixOpts.volume.__doc__ = ":py:class:`float`"
+MixOpts.rate.__doc__ = ":py:class:`float`"
 
 
 class Mix(NamedTuple):
     """
     Options to control mix behavior before aspirate and after dispense.
     """
+
     mix_before: MixOpts = MixOpts()
     mix_after: MixOpts = MixOpts()
 
@@ -249,10 +262,11 @@ class BlowOutOpts(NamedTuple):
     This location will be passed to :py:meth:`InstrumentContext.blow_out`
     when called during the transfer
     """
+
     location: Optional[Union[types.Location, Well]] = None
 
 
-BlowOutOpts.location.__doc__ = ':py:class:`types.Location`'
+BlowOutOpts.location.__doc__ = ":py:class:`types.Location`"
 
 
 class TouchTipOpts(NamedTuple):
@@ -263,14 +277,15 @@ class TouchTipOpts(NamedTuple):
     :py:meth:`InstrumentContext.touch_tip` when called during the
     transfer.
     """
+
     radius: Optional[float] = None
     v_offset: Optional[float] = None
     speed: Optional[float] = None
 
 
-TouchTipOpts.radius.__doc__ = ':py:class:`float`'
-TouchTipOpts.v_offset.__doc__ = ':py:class:`float`'
-TouchTipOpts.speed.__doc__ = ':py:class:`float`'
+TouchTipOpts.radius.__doc__ = ":py:class:`float`"
+TouchTipOpts.v_offset.__doc__ = ":py:class:`float`"
+TouchTipOpts.speed.__doc__ = ":py:class:`float`"
 
 
 class AspirateOpts(NamedTuple):
@@ -280,10 +295,11 @@ class AspirateOpts(NamedTuple):
     This option will be passed to :py:meth:`InstrumentContext.aspirate`
     when called during the transfer.
     """
+
     rate: Optional[float] = 1.0
 
 
-AspirateOpts.rate.__doc__ = ':py:class:`float`'
+AspirateOpts.rate.__doc__ = ":py:class:`float`"
 
 
 class DispenseOpts(NamedTuple):
@@ -293,16 +309,18 @@ class DispenseOpts(NamedTuple):
     This option will be passed to :py:meth:`InstrumentContext.dispense`
     when called during the transfer.
     """
+
     rate: Optional[float] = 1.0
 
 
-DispenseOpts.rate.__doc__ = ':py:class:`float`'
+DispenseOpts.rate.__doc__ = ":py:class:`float`"
 
 
 class TransferOptions(NamedTuple):
     """
     All available options for a transfer, distribute or consolidate function
     """
+
     transfer: Transfer = Transfer()
     pick_up_tip: PickUpTipOpts = PickUpTipOpts()
     mix: Mix = Mix()
@@ -352,7 +370,7 @@ TransferOptions.dispense.__doc__ = """
 
 
 class TransferPlan:
-    """ Calculate and carry state for an arbitrary transfer
+    """Calculate and carry state for an arbitrary transfer
 
     This class encapsulates the logic around planning an M:N transfer.
 
@@ -361,20 +379,21 @@ class TransferPlan:
     iterated to resolve methods to call to execute the plan.
     """
 
-    def __init__(self,
-                 volume,
-                 sources,
-                 dests,
-                 # todo(mm, 2021-03-10):
-                 # Refactor to not need an InstrumentContext, so we can more
-                 # easily test this class's logic on its own.
-                 instr: 'InstrumentContext',
-                 max_volume: float,
-                 api_version: APIVersion,
-                 mode: str,
-                 options: Optional[TransferOptions] = None
-                 ) -> None:
-        """ Build the transfer plan.
+    def __init__(
+        self,
+        volume,
+        sources,
+        dests,
+        # todo(mm, 2021-03-10):
+        # Refactor to not need an InstrumentContext, so we can more
+        # easily test this class's logic on its own.
+        instr: "InstrumentContext",
+        max_volume: float,
+        api_version: APIVersion,
+        mode: str,
+        options: Optional[TransferOptions] = None,
+    ) -> None:
+        """Build the transfer plan.
 
         This method initializes the object and does the work of preparing the
         transfer plan. Its arguments are as those of
@@ -389,14 +408,13 @@ class TransferPlan:
         # then avoid iterating through its Wells.
         # ii. if using single channel pipettes, flatten a multi-dimensional
         # list of Wells into a 1 dimensional list of Wells
-        if self._instr.hw_pipette['channels'] > 1:
+        if self._instr.hw_pipette["channels"] > 1:
             sources, dests = self._multichannel_transfer(sources, dests)
         else:
             if isinstance(sources, List) and isinstance(sources[0], List):
                 # Source is a List[List[Well]]
                 sources = [well for well_list in sources for well in well_list]
-            elif isinstance(sources, Well)\
-                    or isinstance(sources, types.Location):
+            elif isinstance(sources, Well) or isinstance(sources, types.Location):
                 sources = [sources]
             if isinstance(dests, List) and isinstance(dests[0], List):
                 # Dest is a List[List[Well]]
@@ -422,15 +440,17 @@ class TransferPlan:
 
     def __iter__(self):
         if self._strategy.new_tip == types.TransferTipPolicy.ONCE:
-            yield self._format_dict('pick_up_tip', kwargs=self._tip_opts)
-        yield from {TransferMode.CONSOLIDATE: self._plan_consolidate,
-                    TransferMode.DISTRIBUTE: self._plan_distribute,
-                    TransferMode.TRANSFER: self._plan_transfer}[self._mode]()
+            yield self._format_dict("pick_up_tip", kwargs=self._tip_opts)
+        yield from {
+            TransferMode.CONSOLIDATE: self._plan_consolidate,
+            TransferMode.DISTRIBUTE: self._plan_distribute,
+            TransferMode.TRANSFER: self._plan_transfer,
+        }[self._mode]()
         if self._strategy.new_tip == types.TransferTipPolicy.ONCE:
             if self._strategy.drop_tip_strategy == DropTipStrategy.RETURN:
-                yield self._format_dict('return_tip')
+                yield self._format_dict("return_tip")
             else:
-                yield self._format_dict('drop_tip')
+                yield self._format_dict("drop_tip")
 
     def _plan_transfer(self):
         """
@@ -464,18 +484,22 @@ class TransferPlan:
             -> Blow out -> Touch tip -> Drop tip*
         """
         # reform source target lists
-        sources, dests = self._extend_source_target_lists(
-            self._sources, self._dests)
+        sources, dests = self._extend_source_target_lists(self._sources, self._dests)
         plan_iter = self._expand_for_volume_constraints(
-            self._volumes, zip(sources, dests),
+            self._volumes,
+            zip(sources, dests),
             self._instr.max_volume
             - self._strategy.disposal_volume
-            - self._strategy.air_gap)
+            - self._strategy.air_gap,
+        )
         for step_vol, (src, dest) in plan_iter:
             if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:
-                yield self._format_dict('pick_up_tip', kwargs=self._tip_opts)
-            max_vol = self._max_volume - \
-                self._strategy.disposal_volume - self._strategy.air_gap
+                yield self._format_dict("pick_up_tip", kwargs=self._tip_opts)
+            max_vol = (
+                self._max_volume
+                - self._strategy.disposal_volume
+                - self._strategy.air_gap
+            )
             xferred_vol = 0.0
             while xferred_vol < step_vol:
                 # TODO: account for unequal length sources, dests
@@ -488,22 +512,26 @@ class TransferPlan:
 
     @staticmethod
     def _extend_source_target_lists(
-            sources: List[Union[Well, types.Location]],
-            targets: List[Union[Well, types.Location]]):
-        """Extend source or target list to match the length of the other
-        """
+        sources: List[Union[Well, types.Location]],
+        targets: List[Union[Well, types.Location]],
+    ):
+        """Extend source or target list to match the length of the other"""
         if len(sources) < len(targets):
             if len(targets) % len(sources) != 0:
-                raise ValueError(
-                    'Source and destination lists must be divisible')
-            sources = [source for source in sources
-                       for i in range(int(len(targets) / len(sources)))]
+                raise ValueError("Source and destination lists must be divisible")
+            sources = [
+                source
+                for source in sources
+                for i in range(int(len(targets) / len(sources)))
+            ]
         elif len(sources) > len(targets):
             if len(sources) % len(targets) != 0:
-                raise ValueError(
-                    'Source and destination lists must be divisible')
-            targets = [target for target in targets
-                       for i in range(int(len(sources) / len(targets)))]
+                raise ValueError("Source and destination lists must be divisible")
+            targets = [
+                target
+                for target in targets
+                for i in range(int(len(sources) / len(targets)))
+            ]
         return sources, targets
 
     def _plan_distribute(self):
@@ -549,27 +577,32 @@ class TransferPlan:
         # First method keeps distribute consistent with current behavior while
         # the other maintains consistency in default behaviors of all functions
         plan_iter = self._expand_for_volume_constraints(
-            self._volumes, self._dests,
+            self._volumes,
+            self._dests,
             # todo(mm, 2021-03-09): Is it right for this to be
             # _instr_.max_volume? Does/should this take the tip maximum volume
             # into account?
             self._instr.max_volume
             - self._strategy.disposal_volume
-            - self._strategy.air_gap)
+            - self._strategy.air_gap,
+        )
 
         done = False
         current_xfer = next(plan_iter)
         if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:
-            yield self._format_dict('pick_up_tip', kwargs=self._tip_opts)
+            yield self._format_dict("pick_up_tip", kwargs=self._tip_opts)
         while not done:
             asp_grouped: List[Tuple[float, Well]] = []
             try:
-                while (sum(a[0] for a in asp_grouped) +
-                       self._strategy.disposal_volume +
-                       self._strategy.air_gap +
-                       current_xfer[0]) <= self._max_volume:
+                while (
+                    sum(a[0] for a in asp_grouped)
+                    + self._strategy.disposal_volume
+                    + self._strategy.air_gap
+                    + current_xfer[0]
+                ) <= self._max_volume:
                     append_xfer = self._check_volume_not_zero(
-                        self._api_version, current_xfer[0])
+                        self._api_version, current_xfer[0]
+                    )
                     if append_xfer:
                         asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
@@ -578,26 +611,26 @@ class TransferPlan:
             if not asp_grouped:
                 break
 
-            yield from self._aspirate_actions(sum(a[0] for a in asp_grouped) +
-                                              self._strategy.disposal_volume,
-                                              self._sources[0])
+            yield from self._aspirate_actions(
+                sum(a[0] for a in asp_grouped) + self._strategy.disposal_volume,
+                self._sources[0],
+            )
             for step in asp_grouped:
                 yield from self._dispense_actions(
                     vol=step[0],
                     src=self._sources[0],
                     dest=step[1],
-                    is_disp_next=step is not asp_grouped[-1])
+                    is_disp_next=step is not asp_grouped[-1],
+                )
         yield from self._new_tip_action()
 
-    Target = TypeVar('Target')
+    Target = TypeVar("Target")
 
     @staticmethod
     def _expand_for_volume_constraints(
-            volumes: Iterator[float],
-            targets: Iterator[Target],
-            max_volume: float)\
-            -> Generator[Tuple[float, 'Target'], None, None]:
-        """ Split a sequence of proposed transfers if necessary to keep each
+        volumes: Iterator[float], targets: Iterator[Target], max_volume: float
+    ) -> Generator[Tuple[float, "Target"], None, None]:
+        """Split a sequence of proposed transfers if necessary to keep each
         transfer under the given max volume.
         """
         for volume, target in zip(volumes, targets):
@@ -651,20 +684,26 @@ class TransferPlan:
             # todo(mm, 2021-03-09): Is it right to use _instr.max_volume here?
             # Why don't we account for tip max volume, disposal volume, or air
             # gap?
-            self._volumes, self._sources, self._instr.max_volume)
+            self._volumes,
+            self._sources,
+            self._instr.max_volume,
+        )
         current_xfer = next(plan_iter)
         if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:
-            yield self._format_dict('pick_up_tip', kwargs=self._tip_opts)
+            yield self._format_dict("pick_up_tip", kwargs=self._tip_opts)
         done = False
         while not done:
             asp_grouped: List[Tuple[float, Well]] = []
             try:
-                while (sum([a[0] for a in asp_grouped]) +
-                       self._strategy.disposal_volume +
-                       self._strategy.air_gap * len(asp_grouped) +
-                       current_xfer[0]) <= self._max_volume:
+                while (
+                    sum([a[0] for a in asp_grouped])
+                    + self._strategy.disposal_volume
+                    + self._strategy.air_gap * len(asp_grouped)
+                    + current_xfer[0]
+                ) <= self._max_volume:
                     append_xfer = self._check_volume_not_zero(
-                        self._api_version, current_xfer[0])
+                        self._api_version, current_xfer[0]
+                    )
                     if append_xfer:
                         asp_grouped.append(current_xfer)
                     current_xfer = next(plan_iter)
@@ -681,37 +720,36 @@ class TransferPlan:
                 vol=sum([a[0] + self._strategy.air_gap for a in asp_grouped])
                 - self._strategy.air_gap,
                 src=None,
-                dest=self._dests[0])
+                dest=self._dests[0],
+            )
         yield from self._new_tip_action()
 
     def _aspirate_actions(self, vol, loc):
         yield from self._before_aspirate(loc)
-        yield self._format_dict('aspirate',
-                                [vol, loc, self._options.aspirate.rate])
+        yield self._format_dict("aspirate", [vol, loc, self._options.aspirate.rate])
         yield from self._after_aspirate()
 
     def _dispense_actions(self, vol, dest, src=None, is_disp_next=False):
         if self._strategy.air_gap:
             vol += self._strategy.air_gap
-        yield self._format_dict('dispense',
-                                [vol, dest, self._options.dispense.rate])
-        yield from self._after_dispense(
-            dest=dest, src=src, is_disp_next=is_disp_next)
+        yield self._format_dict("dispense", [vol, dest, self._options.dispense.rate])
+        yield from self._after_dispense(dest=dest, src=src, is_disp_next=is_disp_next)
 
     def _before_aspirate(self, loc):
-        if self._strategy.mix_strategy == MixStrategy.BEFORE or \
-                self._strategy.mix_strategy == MixStrategy.BOTH:
+        if (
+            self._strategy.mix_strategy == MixStrategy.BEFORE
+            or self._strategy.mix_strategy == MixStrategy.BOTH
+        ):
             if self._instr.current_volume == 0:
                 mix_before_opts = self._mix_before_opts._asdict()
-                mix_before_opts['location'] = loc
-                yield self._format_dict(
-                    'mix', kwargs=mix_before_opts)
+                mix_before_opts["location"] = loc
+                yield self._format_dict("mix", kwargs=mix_before_opts)
 
     def _after_aspirate(self):
         if self._strategy.air_gap:
-            yield self._format_dict('air_gap', [self._strategy.air_gap])
+            yield self._format_dict("air_gap", [self._strategy.air_gap])
         if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
-            yield self._format_dict('touch_tip', kwargs=self._touch_tip_opts)
+            yield self._format_dict("touch_tip", kwargs=self._touch_tip_opts)
 
     def _after_dispense(self, dest, src, is_disp_next=False):  # noqa: C901
         # This sequence of actions is subject to change
@@ -720,72 +758,77 @@ class TransferPlan:
             # between aspirate and dispense.
             if self._instr.current_volume == 0:
                 # If we're empty, then this is when after mixes come into play
-                if self._strategy.mix_strategy == MixStrategy.AFTER or \
-                        self._strategy.mix_strategy == MixStrategy.BOTH:
+                if (
+                    self._strategy.mix_strategy == MixStrategy.AFTER
+                    or self._strategy.mix_strategy == MixStrategy.BOTH
+                ):
                     mix_after_opts = self._mix_after_opts._asdict()
-                    mix_after_opts['location'] = dest
-                    yield self._format_dict('mix', kwargs=mix_after_opts)
+                    mix_after_opts["location"] = dest
+                    yield self._format_dict("mix", kwargs=mix_after_opts)
             if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
-                yield self._format_dict('touch_tip',
-                                        kwargs=self._touch_tip_opts)
+                yield self._format_dict("touch_tip", kwargs=self._touch_tip_opts)
 
-            if self._strategy.blow_out_strategy == \
-                    BlowOutStrategy.SOURCE:
-                yield self._format_dict('blow_out', [src])
-            elif self._strategy.blow_out_strategy \
-                    == BlowOutStrategy.DEST:
-                yield self._format_dict('blow_out', [dest])
-            elif self._strategy.blow_out_strategy == \
-                    BlowOutStrategy.CUSTOM_LOCATION:
-                yield self._format_dict('blow_out', kwargs=self._blow_opts)
-            elif self._strategy.blow_out_strategy == BlowOutStrategy.TRASH or \
-                    self._strategy.disposal_volume:
-                yield self._format_dict('blow_out', [
-                    self._instr.trash_container.wells()[0]])
+            if self._strategy.blow_out_strategy == BlowOutStrategy.SOURCE:
+                yield self._format_dict("blow_out", [src])
+            elif self._strategy.blow_out_strategy == BlowOutStrategy.DEST:
+                yield self._format_dict("blow_out", [dest])
+            elif self._strategy.blow_out_strategy == BlowOutStrategy.CUSTOM_LOCATION:
+                yield self._format_dict("blow_out", kwargs=self._blow_opts)
+            elif (
+                self._strategy.blow_out_strategy == BlowOutStrategy.TRASH
+                or self._strategy.disposal_volume
+            ):
+                yield self._format_dict(
+                    "blow_out", [self._instr.trash_container.wells()[0]]
+                )
         else:
             # Used by distribute
             if self._strategy.air_gap:
-                yield self._format_dict('air_gap', [self._strategy.air_gap])
+                yield self._format_dict("air_gap", [self._strategy.air_gap])
             if self._strategy.touch_tip_strategy == TouchTipStrategy.ALWAYS:
-                yield self._format_dict('touch_tip',
-                                        kwargs=self._touch_tip_opts)
+                yield self._format_dict("touch_tip", kwargs=self._touch_tip_opts)
 
     def _new_tip_action(self):
         if self._strategy.new_tip == types.TransferTipPolicy.ALWAYS:
             if self._strategy.drop_tip_strategy == DropTipStrategy.RETURN:
-                yield self._format_dict('return_tip')
+                yield self._format_dict("return_tip")
             else:
-                yield self._format_dict('drop_tip')
+                yield self._format_dict("drop_tip")
 
-    def _format_dict(self, method: str,
-                     args: List = None,
-                     kwargs: Union['Dictable', Dict[str, Any]] = None):
+    def _format_dict(
+        self,
+        method: str,
+        args: List = None,
+        kwargs: Union["Dictable", Dict[str, Any]] = None,
+    ):
         if kwargs:
             if isinstance(kwargs, Dict):
                 params = {key: val for key, val in kwargs.items() if val}
             else:
-                params = {key: val
-                          for key, val in kwargs._asdict().items() if val}
+                params = {key: val for key, val in kwargs._asdict().items() if val}
         else:
             params = {}
         if not args:
             args = []
-        return {'method': method, 'args': args, 'kwargs': params}
+        return {"method": method, "args": args, "kwargs": params}
 
     def _create_volume_list(self, volume, total_xfers):
         if isinstance(volume, (float, int)):
             return [volume] * total_xfers
         elif isinstance(volume, tuple):
             return self._create_volume_gradient(
-                volume[0], volume[-1], total_xfers,
-                self._strategy.gradient_function)
+                volume[0], volume[-1], total_xfers, self._strategy.gradient_function
+            )
         else:
             if not isinstance(volume, List):
-                raise TypeError("Volume expected as a number or List or"
-                                " tuple but got {}".format(volume))
+                raise TypeError(
+                    "Volume expected as a number or List or"
+                    " tuple but got {}".format(volume)
+                )
             elif not len(volume) == total_xfers:
-                raise RuntimeError("List of volumes should be equal to number "
-                                   "of transfers")
+                raise RuntimeError(
+                    "List of volumes should be equal to number " "of transfers"
+                )
             return volume
 
     def _create_volume_gradient(self, min_v, max_v, total, gradient=None):
@@ -803,7 +846,8 @@ class TransferPlan:
     def _check_valid_well_list(self, well_list, id, old_well_list):
         if self._api_version >= APIVersion(2, 2) and len(well_list) < 1:
             raise RuntimeError(
-                f"Invalid {id} for multichannel transfer: {old_well_list}")
+                f"Invalid {id} for multichannel transfer: {old_well_list}"
+            )
 
     @staticmethod
     def _check_volume_not_zero(api_version: APIVersion, volume: float) -> bool:
@@ -818,16 +862,20 @@ class TransferPlan:
     def _multichannel_transfer(self, s, d):
         # TODO: add a check for container being multi-channel compatible?
         # Helper function for multi-channel use-case
-        assert isinstance(s, Well) or isinstance(s, types.Location) or \
-            (isinstance(s, List) and isinstance(s[0], Well)) or \
-            (isinstance(s, List) and isinstance(s[0], List)) or \
-            (isinstance(s, List) and isinstance(s[0], types.Location)), \
-            'Source should be a Well or List[Well] but is {}'.format(s)
-        assert isinstance(d, Well) or isinstance(d, types.Location) or \
-            (isinstance(d, List) and isinstance(d[0], Well)) or \
-            (isinstance(d, List) and isinstance(d[0], List)) or \
-            (isinstance(d, List) and isinstance(d[0], types.Location)), \
-            'Target should be a Well or List[Well] but is {}'.format(d)
+        assert (
+            isinstance(s, Well)
+            or isinstance(s, types.Location)
+            or (isinstance(s, List) and isinstance(s[0], Well))
+            or (isinstance(s, List) and isinstance(s[0], List))
+            or (isinstance(s, List) and isinstance(s[0], types.Location))
+        ), "Source should be a Well or List[Well] but is {}".format(s)
+        assert (
+            isinstance(d, Well)
+            or isinstance(d, types.Location)
+            or (isinstance(d, List) and isinstance(d[0], Well))
+            or (isinstance(d, List) and isinstance(d[0], List))
+            or (isinstance(d, List) and isinstance(d[0], types.Location))
+        ), "Target should be a Well or List[Well] but is {}".format(d)
 
         # TODO: Account for cases where a src/dest list has a non-first-row
         # well (eg, 'B1') and would expect the robot/pipette to
@@ -841,7 +889,7 @@ class TransferPlan:
         for well in s:
             if self._is_valid_row(well):
                 new_src.append(well)
-        self._check_valid_well_list(new_src, 'source', s)
+        self._check_valid_well_list(new_src, "source", s)
 
         if isinstance(d, List) and isinstance(d[0], List):
             # s is a List[List]]; flatten to 1D list
@@ -852,7 +900,7 @@ class TransferPlan:
         for well in d:
             if self._is_valid_row(well):
                 new_dst.append(well)
-        self._check_valid_well_list(new_dst, 'target', d)
+        self._check_valid_well_list(new_dst, "target", d)
         return new_src, new_dst
 
     def _is_valid_row(self, well: Union[Well, types.Location]):
@@ -866,10 +914,10 @@ class TransferPlan:
         else:
             # Allow the first 2 rows to be accessible to 384-well plates;
             # otherwise, only the first row is accessible
-            if test_well.parent.parameters['format'] == '384Standard':
+            if test_well.parent.parameters["format"] == "384Standard":
                 valid_wells = [
-                    well for row in test_well.parent.rows()[:2]
-                    for well in row]
+                    well for row in test_well.parent.rows()[:2] for well in row
+                ]
                 return test_well in valid_wells
             else:
                 return test_well in test_well.parent.rows()[0]

--- a/api/src/opentrons/protocols/api_support/constants.py
+++ b/api/src/opentrons/protocols/api_support/constants.py
@@ -2,10 +2,10 @@ from pathlib import Path
 
 from opentrons.config import get_opentrons_path
 
-OPENTRONS_NAMESPACE = 'opentrons'
-CUSTOM_NAMESPACE = 'custom_beta'
+OPENTRONS_NAMESPACE = "opentrons"
+CUSTOM_NAMESPACE = "custom_beta"
 STANDARD_DEFS_PATH = Path("labware/definitions/2")
-USER_DEFS_PATH = get_opentrons_path('labware_user_definitions_dir_v2')
+USER_DEFS_PATH = get_opentrons_path("labware_user_definitions_dir_v2")
 
-SHORT_TRASH_DECK = 'ot2_short_trash'
-STANDARD_DECK = 'ot2_standard'
+SHORT_TRASH_DECK = "ot2_short_trash"
+STANDARD_DECK = "ot2_standard"

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -7,98 +7,103 @@ from opentrons.calibration_storage.types import TipLengthCalNotFound
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons_shared_data.protocol.dev_types import LiquidHandlingCommand, \
-    BlowoutLocation
+from opentrons_shared_data.protocol.dev_types import (
+    LiquidHandlingCommand,
+    BlowoutLocation,
+)
 
 
 def validate_blowout_location(
-        api_version: APIVersion,
-        liquid_handling_command: LiquidHandlingCommand,
-        blowout_location: Optional[Any]) -> None:
+    api_version: APIVersion,
+    liquid_handling_command: LiquidHandlingCommand,
+    blowout_location: Optional[Any],
+) -> None:
     """Validate the blowout location."""
     if blowout_location and api_version < APIVersion(2, 8):
         raise ValueError(
-            'Cannot specify blowout location when using api' +
-            ' version below 2.8, current version is {api_version}'
-            .format(api_version=api_version))
+            "Cannot specify blowout location when using api"
+            + " version below 2.8, current version is {api_version}".format(
+                api_version=api_version
+            )
+        )
 
-    elif liquid_handling_command == 'consolidate' \
-            and blowout_location == 'source well':
+    elif liquid_handling_command == "consolidate" and blowout_location == "source well":
+        raise ValueError("blowout location for consolidate cannot be source well")
+    elif (
+        liquid_handling_command == "distribute"
+        and blowout_location == "destination well"
+    ):
+        raise ValueError("blowout location for distribute cannot be destination well")
+    elif (
+        liquid_handling_command == "transfer"
+        and blowout_location
+        and blowout_location not in [location.value for location in BlowoutLocation]
+    ):
         raise ValueError(
-            "blowout location for consolidate cannot be source well")
-    elif liquid_handling_command == 'distribute' \
-            and blowout_location == 'destination well':
-        raise ValueError(
-            "blowout location for distribute cannot be destination well")
-    elif liquid_handling_command == 'transfer' and \
-            blowout_location and \
-            blowout_location not in \
-            [location.value for location in BlowoutLocation]:
-        raise ValueError(
-            "blowout location should be either 'source well', " +
-            " 'destination well', or 'trash'" +
-            f" but it is {blowout_location}")
+            "blowout location should be either 'source well', "
+            + " 'destination well', or 'trash'"
+            + f" but it is {blowout_location}"
+        )
 
 
 def tip_length_for(pipette: PipetteDict, tiprack: Labware) -> float:
-    """ Get the tip length, including overlap, for a tip from this rack """
+    """Get the tip length, including overlap, for a tip from this rack"""
 
     def _build_length_from_overlap() -> float:
-        tip_overlap = pipette['tip_overlap'].get(
-            tiprack.uri,
-            pipette['tip_overlap']['default'])
+        tip_overlap = pipette["tip_overlap"].get(
+            tiprack.uri, pipette["tip_overlap"]["default"]
+        )
         tip_length = tiprack.tip_length
         return tip_length - tip_overlap
 
     try:
         return get.load_tip_length_calibration(
-            pipette['pipette_id'],
-            tiprack._implementation.get_definition()
-            ).tip_length
+            pipette["pipette_id"], tiprack._implementation.get_definition()
+        ).tip_length
     except TipLengthCalNotFound:
         return _build_length_from_overlap()
 
 
 VALID_PIP_TIPRACK_VOL = {
-    'p10': [10, 20],
-    'p20': [10, 20],
-    'p50': [200, 300],
-    'p300': [200, 300],
-    'p1000': [1000]
+    "p10": [10, 20],
+    "p20": [10, 20],
+    "p50": [200, 300],
+    "p300": [200, 300],
+    "p1000": [1000],
 }
 
 
 def validate_tiprack(
-        instrument_name: str,
-        tiprack: Labware,
-        log: logging.Logger) -> None:
+    instrument_name: str, tiprack: Labware, log: logging.Logger
+) -> None:
     """Validate a tiprack logging a warning message."""
     # TODO AA 2020-06-24 - we should instead add the acceptable Opentrons
     #  tipracks to the pipette as a refactor
-    if tiprack._implementation.get_definition()['namespace'] \
-            == 'opentrons':
+    if tiprack._implementation.get_definition()["namespace"] == "opentrons":
         tiprack_vol = tiprack.wells()[0].max_volume
-        valid_vols = VALID_PIP_TIPRACK_VOL[instrument_name.split('_')[0]]
+        valid_vols = VALID_PIP_TIPRACK_VOL[instrument_name.split("_")[0]]
         if tiprack_vol not in valid_vols:
             log.warning(
-                f'The pipette {instrument_name} and its tiprack '
-                f'{tiprack.load_name} in slot {tiprack.parent} appear to '
-                'be mismatched. Please check your protocol before running '
-                'on the robot.')
+                f"The pipette {instrument_name} and its tiprack "
+                f"{tiprack.load_name} in slot {tiprack.parent} appear to "
+                "be mismatched. Please check your protocol before running "
+                "on the robot."
+            )
 
 
 def determine_drop_target(
-        api_version: APIVersion,
-        location: Well,
-        return_height: float,
-        version_breakpoint: APIVersion = None) -> types.Location:
+    api_version: APIVersion,
+    location: Well,
+    return_height: float,
+    version_breakpoint: APIVersion = None,
+) -> types.Location:
     """Determine the drop target based on well and api version."""
     version_breakpoint = version_breakpoint or APIVersion(2, 2)
     if api_version < version_breakpoint:
         bot = location.bottom()
         return types.Location(
-            point=bot.point._replace(z=bot.point.z + 10),
-            labware=location)
+            point=bot.point._replace(z=bot.point.z + 10), labware=location
+        )
     else:
         tr = location.parent
         assert tr.is_tiprack
@@ -107,7 +112,7 @@ def determine_drop_target(
 
 
 def validate_can_aspirate(location: types.Location) -> None:
-    """ Can one aspirate on the given `location` or not? This method is
+    """Can one aspirate on the given `location` or not? This method is
     pretty basic and will probably remain so (?) as the future holds neat
     ambitions for how validation is implemented. And as robots become more
     intelligent more rigorous testing will be possible
@@ -123,7 +128,7 @@ def validate_can_aspirate(location: types.Location) -> None:
 
 
 def validate_can_dispense(location: types.Location) -> None:
-    """ Can one dispense to the given `location` or not? This method is
+    """Can one dispense to the given `location` or not? This method is
     pretty basic and will probably remain so (?) as the future holds neat
     ambitions for how validation is implemented. And as robots become more
     intelligent more rigorous testing will be possible

--- a/api/src/opentrons/protocols/api_support/labware_like.py
+++ b/api/src/opentrons/protocols/api_support/labware_like.py
@@ -7,12 +7,7 @@ if TYPE_CHECKING:
 
 
 WrappableLabwareLike = Union[
-    'Labware',
-    'Well',
-    str,
-    'ModuleGeometry',
-    'LabwareLike',
-    None
+    "Labware", "Well", str, "ModuleGeometry", "LabwareLike", None
 ]
 
 
@@ -67,12 +62,14 @@ class LabwareLike:
 
     @property
     def has_parent(self) -> bool:
-        return self._type in {LabwareLikeType.LABWARE,
-                              LabwareLikeType.WELL,
-                              LabwareLikeType.MODULE}
+        return self._type in {
+            LabwareLikeType.LABWARE,
+            LabwareLikeType.WELL,
+            LabwareLikeType.MODULE,
+        }
 
     @property
-    def parent(self) -> 'LabwareLike':
+    def parent(self) -> "LabwareLike":
         # Type ignoring because type checker is not aware that has_parent
         # performs the validation.
         parent = None
@@ -100,34 +97,41 @@ class LabwareLike:
     def is_module(self) -> bool:
         return self.object_type == LabwareLikeType.MODULE
 
-    def as_well(self) -> 'Well':
+    def as_well(self) -> "Well":
         # Import locally to avoid circular dependency
         from opentrons.protocol_api.labware import Well
+
         return cast(Well, self.object)
 
-    def as_labware(self) -> 'Labware':
+    def as_labware(self) -> "Labware":
         # Import locally to avoid circular dependency
         from opentrons.protocol_api.labware import Labware
+
         return cast(Labware, self.object)
 
-    def as_module(self) -> 'ModuleGeometry':
+    def as_module(self) -> "ModuleGeometry":
         from opentrons.protocols.geometry.module_geometry import ModuleGeometry
+
         return cast(ModuleGeometry, self.object)
 
-    def get_parent_labware_and_well(self) -> Tuple[Optional['Labware'],
-                                                   Optional['Well']]:
+    def get_parent_labware_and_well(
+        self,
+    ) -> Tuple[Optional["Labware"], Optional["Well"]]:
         """Attempt to split into a labware and well."""
         if self.is_labware:
             return self.as_labware(), None
         elif self.is_well and self.parent:
-            return self.parent.as_labware(), self.as_well(),
+            return (
+                self.parent.as_labware(),
+                self.as_well(),
+            )
         else:
             return None, None
 
     def first_parent(self) -> Optional[str]:
-        """ Return the topmost parent of this location. It should be
+        """Return the topmost parent of this location. It should be
         either a string naming a slot or a None if the location isn't
-        associated with a slot """
+        associated with a slot"""
 
         # cycle-detecting recursive climbing
         seen: Set[LabwareLike] = set()
@@ -135,7 +139,7 @@ class LabwareLike:
         # internal function to have the cycle detector different per call
         def _fp_recurse(location: LabwareLike):
             if location in seen:
-                raise RuntimeError('Cycle in labware parent')
+                raise RuntimeError("Cycle in labware parent")
             seen.add(location)
             if location.is_empty:
                 return None
@@ -146,13 +150,13 @@ class LabwareLike:
 
         return _fp_recurse(self)
 
-    def module_parent(self) -> Optional['ModuleGeometry']:
+    def module_parent(self) -> Optional["ModuleGeometry"]:
         """
         Return the closest parent of this LabwareLike (including, possibly,
         the wrapped object) that is a ModuleGeometry
         """
-        def recursive_get_module_parent(
-                obj: LabwareLike) -> Optional['ModuleGeometry']:
+
+        def recursive_get_module_parent(obj: LabwareLike) -> Optional["ModuleGeometry"]:
             if obj.is_module:
                 return obj.as_module()
             next_obj = obj.parent
@@ -166,9 +170,9 @@ class LabwareLike:
         return recursive_get_module_parent(self)
 
     def quirks_from_any_parent(self) -> Set[str]:
-        """ Walk the tree of wells and labwares and extract quirks """
-        def recursive_get_quirks(obj: LabwareLike, found: List[str]) \
-                -> List[str]:
+        """Walk the tree of wells and labwares and extract quirks"""
+
+        def recursive_get_quirks(obj: LabwareLike, found: List[str]) -> List[str]:
             if obj.is_labware:
                 return found + obj.as_labware().quirks
             elif obj.is_well:
@@ -180,11 +184,11 @@ class LabwareLike:
 
     def is_fixed_trash(self) -> bool:
         """Check if fixedTrash quirk is in any parent."""
-        return 'fixedTrash' in self.quirks_from_any_parent()
+        return "fixedTrash" in self.quirks_from_any_parent()
 
     def center_multichannel_on_wells(self) -> bool:
         """Check if centerMultichannelOnWells quirk is in any parent."""
-        return 'centerMultichannelOnWells' in self.quirks_from_any_parent()
+        return "centerMultichannelOnWells" in self.quirks_from_any_parent()
 
     def __str__(self) -> str:
         return self._as_str
@@ -193,9 +197,11 @@ class LabwareLike:
         return str(self)
 
     def __eq__(self, other):
-        return other is not None and \
-               isinstance(other, LabwareLike) and \
-               self.object == other.object
+        return (
+            other is not None
+            and isinstance(other, LabwareLike)
+            and self.object == other.object
+        )
 
     def __hash__(self):
         return id(self)

--- a/api/src/opentrons/protocols/api_support/tip_tracker.py
+++ b/api/src/opentrons/protocols/api_support/tip_tracker.py
@@ -12,10 +12,9 @@ class TipTracker:
     def __init__(self, columns: WellColumns):
         self._columns = columns
 
-    def next_tip(self,
-                 num_tips: int = 1,
-                 starting_tip: Optional[WellImplementation] = None) \
-            -> Optional[WellImplementation]:
+    def next_tip(
+        self, num_tips: int = 1, starting_tip: Optional[WellImplementation] = None
+    ) -> Optional[WellImplementation]:
         """
         Find the next valid well for pick-up.
 
@@ -34,21 +33,24 @@ class TipTracker:
         if starting_tip:
             # Remove columns preceding the one with the pipette's starting tip
             drop_undefined_columns = list(
-                dropwhile(lambda x: starting_tip not in x, columns))
+                dropwhile(lambda x: starting_tip not in x, columns)
+            )
             # Remove tips preceding the starting tip in the first column
             drop_undefined_columns[0] = list(
-                dropwhile(lambda w: starting_tip is not w,
-                          drop_undefined_columns[0]))
+                dropwhile(lambda w: starting_tip is not w, drop_undefined_columns[0])
+            )
             columns = drop_undefined_columns
 
         drop_leading_empties = [
-            list(dropwhile(lambda x: not x.has_tip(), column))
-            for column in columns]
+            list(dropwhile(lambda x: not x.has_tip(), column)) for column in columns
+        ]
         drop_at_first_gap = [
             list(takewhile(lambda x: x.has_tip(), column))
-            for column in drop_leading_empties]
+            for column in drop_leading_empties
+        ]
         long_enough = [
-            column for column in drop_at_first_gap if len(column) >= num_tips]
+            column for column in drop_at_first_gap if len(column) >= num_tips
+        ]
 
         try:
             first_long_enough = long_enough[0]
@@ -58,10 +60,12 @@ class TipTracker:
 
         return result
 
-    def use_tips(self,
-                 start_well: WellImplementation,
-                 num_channels: int = 1,
-                 fail_if_full: bool = False):
+    def use_tips(
+        self,
+        start_well: WellImplementation,
+        num_channels: int = 1,
+        fail_if_full: bool = False,
+    ):
         """
         Removes tips from the tip tracker.
 
@@ -92,7 +96,7 @@ class TipTracker:
         # max of 4 tips, and picking up from the 2nd-to-bottom well in a
         # column would get a maximum of 2 tips)
         num_tips = min(len(target_column) - well_idx, num_channels)
-        target_wells = target_column[well_idx: well_idx + num_tips]
+        target_wells = target_column[well_idx : well_idx + num_tips]
 
         # In API version 2.2, we no longer reset the tip tracker when a tip
         # is dropped back into a tiprack well. This fixes a behavior where
@@ -103,8 +107,9 @@ class TipTracker:
         # dirty tips and non-present tips; but until then, we can avoid the
         # exception.
         if fail_if_full:
-            assert all(well.has_tip() for well in target_wells),\
-                '{} is out of tips'.format(str(self))
+            assert all(
+                well.has_tip() for well in target_wells
+            ), "{} is out of tips".format(str(self))
 
         for well in target_wells:
             well.set_has_tip(False)
@@ -123,21 +128,21 @@ class TipTracker:
         """
         columns = self._columns
         drop_leading_filled = [
-            list(dropwhile(lambda x: x.has_tip(), column))
-            for column in columns]
+            list(dropwhile(lambda x: x.has_tip(), column)) for column in columns
+        ]
         drop_at_first_gap = [
             list(takewhile(lambda x: not x.has_tip(), column))
-            for column in drop_leading_filled]
+            for column in drop_leading_filled
+        ]
         long_enough = [
-            column for column in drop_at_first_gap if len(column) >= num_tips]
+            column for column in drop_at_first_gap if len(column) >= num_tips
+        ]
         try:
             return long_enough[0][0]
         except IndexError:
             return None
 
-    def return_tips(self,
-                    start_well: WellImplementation,
-                    num_channels: int = 1):
+    def return_tips(self, start_well: WellImplementation, num_channels: int = 1):
         """
         Re-adds tips to the tip tracker
 
@@ -165,6 +170,6 @@ class TipTracker:
         drop_targets = target_column[well_idx:end_idx]
         for well in drop_targets:
             if well.has_tip():
-                raise AssertionError(f'Well {repr(well)} has a tip')
+                raise AssertionError(f"Well {repr(well)} has a tip")
         for well in drop_targets:
             well.set_has_tip(True)

--- a/api/src/opentrons/protocols/api_support/types.py
+++ b/api/src/opentrons/protocols/api_support/types.py
@@ -6,8 +6,8 @@ class APIVersion(NamedTuple):
     minor: int
 
     @classmethod
-    def from_string(cls, inp: str) -> 'APIVersion':
-        parts = inp.split('.')
+    def from_string(cls, inp: str) -> "APIVersion":
+        parts = inp.split(".")
         if len(parts) != 2:
             raise ValueError(inp)
         intparts = [int(p) for p in parts]
@@ -15,4 +15,4 @@ class APIVersion(NamedTuple):
         return cls(major=intparts[0], minor=intparts[1])
 
     def __str__(self):
-        return f'{self.major}.{self.minor}'
+        return f"{self.major}.{self.minor}"

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -5,16 +5,20 @@ from collections import UserDict
 import functools
 import logging
 from dataclasses import dataclass, field, astuple
-from typing import (Any, Callable, Dict, Optional,
-                    TYPE_CHECKING, Union, List)
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union, List
 
 from opentrons import types as top_types
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.hardware_control import (types, SynchronousAdapter, API,
-                                        HardwareAPILike, ThreadManager)
+from opentrons.hardware_control import (
+    types,
+    SynchronousAdapter,
+    API,
+    HardwareAPILike,
+    ThreadManager,
+)
+
 if TYPE_CHECKING:
-    from opentrons.protocols.context.instrument import \
-        AbstractInstrument
+    from opentrons.protocols.context.instrument import AbstractInstrument
     from opentrons.protocol_api.labware import Well, Labware
     from opentrons.protocols.geometry.deck import Deck
     from opentrons.hardware_control.dev_types import HasLoop
@@ -26,6 +30,7 @@ class APIVersionError(Exception):
     """
     Error raised when a protocol attempts to access behavior not implemented
     """
+
     pass
 
 
@@ -48,20 +53,21 @@ class EdgeList:
 
 
 def determine_edge_path(
-        where: 'Well', mount: top_types.Mount,
-        default_edges: EdgeList, deck: 'Deck') -> EdgeList:
+    where: "Well", mount: top_types.Mount, default_edges: EdgeList, deck: "Deck"
+) -> EdgeList:
     left_path = EdgeList(
         left=default_edges.left,
         right=None,
         center=default_edges.center,
         up=default_edges.up,
-        down=default_edges.down)
+        down=default_edges.down,
+    )
     right_path = EdgeList(
         left=None,
         right=default_edges.right,
         center=default_edges.center,
         up=default_edges.up,
-        down=default_edges.down
+        down=default_edges.down,
     )
     labware = where.parent
 
@@ -73,7 +79,7 @@ def determine_edge_path(
     left_pip_criteria = mount is l_mount and where in r_col
 
     next_to_mod = deck.is_edge_move_unsafe(mount, labware)
-    if labware.parent in ['3', '6', '9'] and left_pip_criteria:
+    if labware.parent in ["3", "6", "9"] and left_pip_criteria:
         return left_path
     elif left_pip_criteria and next_to_mod:
         return left_path
@@ -83,9 +89,13 @@ def determine_edge_path(
 
 
 def build_edges(
-        where: 'Well', offset: float, mount: top_types.Mount,
-        deck: 'Deck', radius: float = 1.0,
-        version: APIVersion = APIVersion(2, 7)) -> List[top_types.Point]:
+    where: "Well",
+    offset: float,
+    mount: top_types.Mount,
+    deck: "Deck",
+    radius: float = 1.0,
+    version: APIVersion = APIVersion(2, 7),
+) -> List[top_types.Point]:
     # Determine the touch_tip edges/points
     offset_pt = top_types.Point(0, 0, offset)
     edge_list = EdgeList(
@@ -93,7 +103,7 @@ def build_edges(
         left=where.from_center_cartesian(x=-radius, y=0, z=1) + offset_pt,
         center=where.from_center_cartesian(x=0, y=0, z=1) + offset_pt,
         up=where.from_center_cartesian(x=0, y=radius, z=1) + offset_pt,
-        down=where.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt
+        down=where.from_center_cartesian(x=0, y=-radius, z=1) + offset_pt,
     )
 
     if version < APIVersion(2, 4):
@@ -105,9 +115,11 @@ def build_edges(
 
 
 def labware_column_shift(
-        initial_well: 'Well', tiprack: 'Labware',
-        well_spacing: int = 4,
-        modulo_value: int = 8) -> 'Well':
+    initial_well: "Well",
+    tiprack: "Labware",
+    well_spacing: int = 4,
+    modulo_value: int = 8,
+) -> "Well":
     unshifted_index = tiprack.wells().index(initial_well)
     unshifted_column = unshifted_index // modulo_value
     shifted_column = unshifted_column + well_spacing
@@ -116,54 +128,63 @@ def labware_column_shift(
 
 
 class FlowRates:
-    """ Utility class for rich setters/getters for flow rates """
+    """Utility class for rich setters/getters for flow rates"""
 
-    def __init__(self,
-                 instr: AbstractInstrument) -> None:
+    def __init__(self, instr: AbstractInstrument) -> None:
         self._instr = instr
 
     def set_defaults(self, api_level: APIVersion):
         pipette = self._instr.get_pipette()
         self.aspirate = _find_value_for_api_version(
-            api_level, pipette['default_aspirate_flow_rates'])
+            api_level, pipette["default_aspirate_flow_rates"]
+        )
         self.dispense = _find_value_for_api_version(
-            api_level, pipette['default_dispense_flow_rates'])
+            api_level, pipette["default_dispense_flow_rates"]
+        )
         self.blow_out = _find_value_for_api_version(
-            api_level, pipette['default_blow_out_flow_rates'])
+            api_level, pipette["default_blow_out_flow_rates"]
+        )
 
     @property
     def aspirate(self) -> float:
-        return self._instr.get_pipette()['aspirate_flow_rate']
+        return self._instr.get_pipette()["aspirate_flow_rate"]
 
     @aspirate.setter
     def aspirate(self, new_val: float):
         self._instr.set_flow_rate(
             aspirate=_assert_gzero(
-                new_val, 'flow rate should be a numerical value in ul/s'))
+                new_val, "flow rate should be a numerical value in ul/s"
+            )
+        )
 
     @property
     def dispense(self) -> float:
-        return self._instr.get_pipette()['dispense_flow_rate']
+        return self._instr.get_pipette()["dispense_flow_rate"]
 
     @dispense.setter
     def dispense(self, new_val: float):
         self._instr.set_flow_rate(
             dispense=_assert_gzero(
-                new_val, 'flow rate should be a numerical value in ul/s'))
+                new_val, "flow rate should be a numerical value in ul/s"
+            )
+        )
 
     @property
     def blow_out(self) -> float:
-        return self._instr.get_pipette()['blow_out_flow_rate']
+        return self._instr.get_pipette()["blow_out_flow_rate"]
 
     @blow_out.setter
     def blow_out(self, new_val: float):
         self._instr.set_flow_rate(
             blow_out=_assert_gzero(
-                new_val, 'flow rate should be a numerical value in ul/s'))
+                new_val, "flow rate should be a numerical value in ul/s"
+            )
+        )
 
 
-def _find_value_for_api_version(for_version: APIVersion,
-                                values: Dict[str, float]) -> float:
+def _find_value_for_api_version(
+    for_version: APIVersion, values: Dict[str, float]
+) -> float:
     """
     Parse a dict that looks like
     {"2.0": 5,
@@ -171,8 +192,7 @@ def _find_value_for_api_version(for_version: APIVersion,
     (aka the flow rate values from pipette config) and return the value for
     the highest api level that is at or underneath ``for_version``
     """
-    sorted_versions = sorted({APIVersion.from_string(k): v
-                              for k, v in values.items()})
+    sorted_versions = sorted({APIVersion.from_string(k): v for k, v in values.items()})
     last = values[str(sorted_versions[0])]
     for version in sorted_versions:
         if version > for_version:
@@ -182,47 +202,44 @@ def _find_value_for_api_version(for_version: APIVersion,
 
 
 class PlungerSpeeds:
-    """ Utility class for rich setters/getters for speeds """
+    """Utility class for rich setters/getters for speeds"""
 
-    def __init__(self,
-                 instr: AbstractInstrument) -> None:
+    def __init__(self, instr: AbstractInstrument) -> None:
         self._instr = instr
 
     @property
     def aspirate(self) -> float:
-        return self._instr.get_pipette()['aspirate_speed']
+        return self._instr.get_pipette()["aspirate_speed"]
 
     @aspirate.setter
     def aspirate(self, new_val: float):
         self._instr.set_pipette_speed(
-            aspirate=_assert_gzero(
-                new_val, 'speed should be a numerical value in mm/s'))
+            aspirate=_assert_gzero(new_val, "speed should be a numerical value in mm/s")
+        )
 
     @property
     def dispense(self) -> float:
-        return self._instr.get_pipette()['dispense_speed']
+        return self._instr.get_pipette()["dispense_speed"]
 
     @dispense.setter
     def dispense(self, new_val: float):
         self._instr.set_pipette_speed(
-            dispense=_assert_gzero(
-                new_val, 'speed should be a numerical value in mm/s'))
+            dispense=_assert_gzero(new_val, "speed should be a numerical value in mm/s")
+        )
 
     @property
     def blow_out(self) -> float:
-        return self._instr.get_pipette()['blow_out_speed']
+        return self._instr.get_pipette()["blow_out_speed"]
 
     @blow_out.setter
     def blow_out(self, new_val: float):
         self._instr.set_pipette_speed(
-            blow_out=_assert_gzero(
-                new_val, 'speed should be a numerical value in mm/s'))
+            blow_out=_assert_gzero(new_val, "speed should be a numerical value in mm/s")
+        )
 
 
 class Clearances:
-    def __init__(self,
-                 default_aspirate: float,
-                 default_dispense: float) -> None:
+    def __init__(self, default_aspirate: float, default_dispense: float) -> None:
         self._aspirate = default_aspirate
         self._dispense = default_dispense
 
@@ -244,7 +261,7 @@ class Clearances:
 
 
 class AxisMaxSpeeds(UserDict):
-    """ Special mapping allowing internal storage by Mount enums and
+    """Special mapping allowing internal storage by Mount enums and
     user access by string
     """
 
@@ -271,7 +288,8 @@ class AxisMaxSpeeds(UserDict):
 
         checked_key = AxisMaxSpeeds._verify_key(key)
         checked_val = _assert_gzero(
-            value, 'max speeds should be numerical values in mm/s')
+            value, "max speeds should be numerical values in mm/s"
+        )
 
         self.data[checked_key] = checked_val
 
@@ -280,7 +298,7 @@ class AxisMaxSpeeds(UserDict):
         del self.data[checked_key]
 
     def __iter__(self):
-        """ keys() and dict iteration return string keys """
+        """keys() and dict iteration return string keys"""
         return (k.name for k in self.data.keys())
 
     def keys(self):
@@ -290,9 +308,7 @@ class AxisMaxSpeeds(UserDict):
         return ((k.name, v) for k, v in self.data.items())
 
 
-HardwareToManage = Union[ThreadManager,
-                         SynchronousAdapter,
-                         'HasLoop']
+HardwareToManage = Union[ThreadManager, SynchronousAdapter, "HasLoop"]
 
 
 # TODO: BC 2020-03-02 This class's utility as a utility class is drying up.
@@ -332,8 +348,8 @@ class HardwareManager:
             self._current = SynchronousAdapter(hardware)
         else:
             raise TypeError(
-                "hardware should be API or synch adapter but is {}"
-                .format(hardware))
+                "hardware should be API or synch adapter but is {}".format(hardware)
+            )
         return self._current
 
     def reset_hw(self):
@@ -343,35 +359,32 @@ class HardwareManager:
 
 
 def clamp_value(
-        input_value: float, max_value: float, min_value: float,
-        log_tag: str = '') -> float:
+    input_value: float, max_value: float, min_value: float, log_tag: str = ""
+) -> float:
     if input_value > max_value:
-        MODULE_LOG.info(
-            f'{log_tag} clamped input {input_value} to {max_value}')
+        MODULE_LOG.info(f"{log_tag} clamped input {input_value} to {max_value}")
         return max_value
     if input_value < min_value:
-        MODULE_LOG.info(
-            f'{log_tag} clamped input {input_value} to {min_value}')
+        MODULE_LOG.info(f"{log_tag} clamped input {input_value} to {min_value}")
         return min_value
     return input_value
 
 
-def requires_version(
-        major: int, minor: int) -> Callable[[Callable], Callable]:
-    """ Decorator. Apply to Protocol API methods or attributes to indicate
+def requires_version(major: int, minor: int) -> Callable[[Callable], Callable]:
+    """Decorator. Apply to Protocol API methods or attributes to indicate
     the first version in which the method or attribute was present.
     """
+
     def _set_version(decorated_obj: Callable) -> Callable:
         added_version = APIVersion(major, minor)
-        setattr(decorated_obj, '__opentrons_version_added',
-                added_version)
-        if hasattr(decorated_obj, '__doc__'):
+        setattr(decorated_obj, "__opentrons_version_added", added_version)
+        if hasattr(decorated_obj, "__doc__"):
             # Add the versionadded stanza to everything decorated if we can
-            docstr = decorated_obj.__doc__ or ''
+            docstr = decorated_obj.__doc__ or ""
             # this newline and initial space has to be there for sphinx to
             # parse this correctly and not add it into for instance a
             # previous code-block
-            docstr += f'\n\n        .. versionadded:: {added_version}\n\n'
+            docstr += f"\n\n        .. versionadded:: {added_version}\n\n"
             decorated_obj.__doc__ = docstr
 
         @functools.wraps(decorated_obj)
@@ -383,14 +396,14 @@ def requires_version(
             if APIVersion(2, 0) <= current_version < added_in:
                 # __qualname__ is *probably* set on every kind of object we care
                 # about, but the docs leave it ambiguous, so fall back to str().
-                name = getattr(decorated_obj, "__qualname__",
-                               str(decorated_obj))
+                name = getattr(decorated_obj, "__qualname__", str(decorated_obj))
 
                 raise APIVersionError(
-                    f'{name} was added in {added_in}, but your '
-                    f'protocol requested version {current_version}. You '
-                    f'must increase your API version to {added_in} to '
-                    'use this functionality.')
+                    f"{name} was added in {added_in}, but your "
+                    f"protocol requested version {current_version}. You "
+                    f"must increase your API version to {added_in} to "
+                    "use this functionality."
+                )
             return decorated_obj(*args, **kwargs)
 
         return _check_version_wrapper

--- a/api/src/opentrons/protocols/api_support/well_grid.py
+++ b/api/src/opentrons/protocols/api_support/well_grid.py
@@ -25,8 +25,7 @@ class WellGrid:
         """
         self._grid = self._create_row_column(wells)
         self._row_headers = sorted(self._grid.rows.keys())
-        self._column_headers = sorted(self._grid.columns.keys(),
-                                      key=lambda k: int(k))
+        self._column_headers = sorted(self._grid.columns.keys(), key=lambda k: int(k))
         self._rows = [self._grid.rows[h] for h in self._row_headers]
         self._columns = [self._grid.columns[h] for h in self._column_headers]
 

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -14,34 +14,36 @@ from .types import BundleContents
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-MAIN_PROTOCOL_FILENAME = 'protocol.ot2.py'
-LABWARE_DIR = 'labware'
-DATA_DIR = 'data'
+MAIN_PROTOCOL_FILENAME = "protocol.ot2.py"
+LABWARE_DIR = "labware"
+DATA_DIR = "data"
 
 
 def _has_files_at_root(zipFile):
     for zipInfo in zipFile.infolist():
-        if zipInfo.filename.count('/') == 0:
+        if zipInfo.filename.count("/") == 0:
             return True
     return False
 
 
 def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa: C901
-    """ Extract a bundle and verify its contents and structure. """
+    """Extract a bundle and verify its contents and structure."""
     if not _has_files_at_root(bundle):
         raise RuntimeError(
-            'No files found in ZIP file\'s root directory. When selecting '
-            'files to zip, make sure to directly select the files '
-            'themselves. Do not select their parent directory, which would '
-            'result in nesting all files inside that directory in the ZIP.')
+            "No files found in ZIP file's root directory. When selecting "
+            "files to zip, make sure to directly select the files "
+            "themselves. Do not select their parent directory, which would "
+            "result in nesting all files inside that directory in the ZIP."
+        )
     try:
-        with bundle.open(MAIN_PROTOCOL_FILENAME, 'r') as protocol_file:
-            py_protocol = protocol_file.read().decode('utf-8')
+        with bundle.open(MAIN_PROTOCOL_FILENAME, "r") as protocol_file:
+            py_protocol = protocol_file.read().decode("utf-8")
     except KeyError:
         raise RuntimeError(
-            f'Bundled protocol should have a {MAIN_PROTOCOL_FILENAME} ' +
-            'file in the root directory')
-    bundled_labware: Dict[str, 'LabwareDefinition'] = {}
+            f"Bundled protocol should have a {MAIN_PROTOCOL_FILENAME} "
+            + "file in the root directory"
+        )
+    bundled_labware: Dict[str, "LabwareDefinition"] = {}
     bundled_data = {}
     bundled_python = {}
     for zipInfo in bundle.infolist():
@@ -52,40 +54,36 @@ def extract_bundle(bundle: ZipFile) -> BundleContents:  # noqa: C901
         # (note: the __MACOSX dir would contain '__MACOSX/foo.py'
         # and other files. This would break our inferences, so we need
         # to exclude all contents of that directory)
-        if rootpath == '__MACOSX' or zipInfo.is_dir():
+        if rootpath == "__MACOSX" or zipInfo.is_dir():
             continue
 
         with bundle.open(zipInfo) as f:
-            if rootpath == LABWARE_DIR and filepath.suffix == '.json':
-                labware_def = json.loads(f.read().decode('utf-8'))
+            if rootpath == LABWARE_DIR and filepath.suffix == ".json":
+                labware_def = json.loads(f.read().decode("utf-8"))
                 labware_key = uri_from_definition(labware_def)
                 if labware_key in bundled_labware:
-                    raise RuntimeError(
-                        f'Conflicting labware in bundle: {labware_key}')
+                    raise RuntimeError(f"Conflicting labware in bundle: {labware_key}")
                 bundled_labware[labware_key] = labware_def
             elif rootpath == DATA_DIR:
                 # note: data files are read as binary
                 bundled_data[str(filepath.relative_to(DATA_DIR))] = f.read()
-            elif (filepath.suffix == '.py' and
-                  str(filepath) != MAIN_PROTOCOL_FILENAME):
-                bundled_python[str(filepath)] = f.read().decode('utf-8')
+            elif filepath.suffix == ".py" and str(filepath) != MAIN_PROTOCOL_FILENAME:
+                bundled_python[str(filepath)] = f.read().decode("utf-8")
 
     if not bundled_labware:
-        raise RuntimeError('No labware definitions found in bundle.')
+        raise RuntimeError("No labware definitions found in bundle.")
 
-    return BundleContents(py_protocol, bundled_labware,
-                          bundled_data, bundled_python)
+    return BundleContents(py_protocol, bundled_labware, bundled_data, bundled_python)
 
 
-def create_bundle(contents: BundleContents,
-                  into_file: BinaryIO):
-    """ Create a bundle from assumed-good contents """
-    with ZipFile(into_file, mode='w') as zf:
+def create_bundle(contents: BundleContents, into_file: BinaryIO):
+    """Create a bundle from assumed-good contents"""
+    with ZipFile(into_file, mode="w") as zf:
         zf.writestr(MAIN_PROTOCOL_FILENAME, contents.protocol)
         for dataname, datafile in contents.bundled_data.items():
             name = PurePath(dataname).name
-            zf.writestr(f'{DATA_DIR}/{name}', datafile)
+            zf.writestr(f"{DATA_DIR}/{name}", datafile)
         for lwdef in contents.bundled_labware.values():
-            zipsafe = uri_from_definition(lwdef, '-')
-            zf.writestr(f'{LABWARE_DIR}/{zipsafe}.json', json.dumps(lwdef))
-        zf.writestr('.bundle_beta', str(date.today()))
+            zipsafe = uri_from_definition(lwdef, "-")
+            zf.writestr(f"{LABWARE_DIR}/{zipsafe}.json", json.dumps(lwdef))
+        zf.writestr(".bundle_beta", str(date.today()))

--- a/api/src/opentrons/protocols/context/instrument.py
+++ b/api/src/opentrons/protocols/context/instrument.py
@@ -7,13 +7,11 @@ import typing
 
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
-from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, \
-    FlowRates
+from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
 from opentrons.protocols.context.well import WellImplementation
 
 
 class AbstractInstrument(ABC):
-
     @abstractmethod
     def get_default_speed(self) -> float:
         ...
@@ -23,15 +21,11 @@ class AbstractInstrument(ABC):
         ...
 
     @abstractmethod
-    def aspirate(self,
-                 volume: float,
-                 rate: float) -> None:
+    def aspirate(self, volume: float, rate: float) -> None:
         ...
 
     @abstractmethod
-    def dispense(self,
-                 volume: float,
-                 rate: float) -> None:
+    def dispense(self, volume: float, rate: float) -> None:
         ...
 
     @abstractmethod
@@ -39,19 +33,19 @@ class AbstractInstrument(ABC):
         ...
 
     @abstractmethod
-    def touch_tip(self,
-                  location: WellImplementation,
-                  radius: float,
-                  v_offset: float,
-                  speed: float) -> None:
+    def touch_tip(
+        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+    ) -> None:
         ...
 
     @abstractmethod
-    def pick_up_tip(self,
-                    well: WellImplementation,
-                    tip_length: float,
-                    presses: typing.Optional[int],
-                    increment: typing.Optional[float]) -> None:
+    def pick_up_tip(
+        self,
+        well: WellImplementation,
+        tip_length: float,
+        presses: typing.Optional[int],
+        increment: typing.Optional[float],
+    ) -> None:
         ...
 
     @abstractmethod
@@ -71,11 +65,13 @@ class AbstractInstrument(ABC):
         ...
 
     @abstractmethod
-    def move_to(self,
-                location: types.Location,
-                force_direct: bool,
-                minimum_z_height: typing.Optional[float],
-                speed: typing.Optional[float]) -> None:
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool,
+        minimum_z_height: typing.Optional[float],
+        speed: typing.Optional[float],
+    ) -> None:
         ...
 
     @abstractmethod
@@ -148,16 +144,18 @@ class AbstractInstrument(ABC):
 
     @abstractmethod
     def set_flow_rate(
-            self,
-            aspirate: typing.Optional[float] = None,
-            dispense: typing.Optional[float] = None,
-            blow_out: typing.Optional[float] = None) -> None:
+        self,
+        aspirate: typing.Optional[float] = None,
+        dispense: typing.Optional[float] = None,
+        blow_out: typing.Optional[float] = None,
+    ) -> None:
         ...
 
     @abstractmethod
     def set_pipette_speed(
-            self,
-            aspirate: typing.Optional[float] = None,
-            dispense: typing.Optional[float] = None,
-            blow_out: typing.Optional[float] = None) -> None:
+        self,
+        aspirate: typing.Optional[float] = None,
+        dispense: typing.Optional[float] = None,
+        blow_out: typing.Optional[float] = None,
+    ) -> None:
         ...

--- a/api/src/opentrons/protocols/context/labware.py
+++ b/api/src/opentrons/protocols/context/labware.py
@@ -9,8 +9,7 @@ from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point
-from opentrons_shared_data.labware.dev_types import (
-    LabwareParameters, LabwareDefinition)
+from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
 
 class AbstractLabware(DeckItem):

--- a/api/src/opentrons/protocols/context/protocol.py
+++ b/api/src/opentrons/protocols/context/protocol.py
@@ -4,20 +4,16 @@ from __future__ import annotations
 
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
-from typing import (Dict, Optional)
+from typing import Dict, Optional
 
 from opentrons import types
 from opentrons.hardware_control import API, SynchronousAdapter
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry, ModuleType)
-from opentrons.protocols.context.instrument \
-    import AbstractInstrument
-from opentrons.protocols.api_support.util import (
-    AxisMaxSpeeds, HardwareManager)
-from opentrons.protocols.context.labware import \
-    AbstractLabware
+from opentrons.protocols.geometry.module_geometry import ModuleGeometry, ModuleType
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.api_support.util import AxisMaxSpeeds, HardwareManager
+from opentrons.protocols.context.labware import AbstractLabware
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -27,13 +23,13 @@ InstrumentDict = Dict[types.Mount, Optional[AbstractInstrument]]
 @dataclass(frozen=True)
 class LoadModuleResult:
     """The result of load_module"""
+
     type: ModuleType
     geometry: ModuleGeometry
     module: SynchronousAdapter
 
 
 class AbstractProtocol(ABC):
-
     @abstractmethod
     def get_bundled_data(self) -> Dict[str, bytes]:
         """Get a mapping of name to contents"""
@@ -73,30 +69,31 @@ class AbstractProtocol(ABC):
 
     @abstractmethod
     def load_labware_from_definition(
-            self,
-            labware_def: LabwareDefinition,
-            location: types.DeckLocation,
-            label: Optional[str],
+        self,
+        labware_def: LabwareDefinition,
+        location: types.DeckLocation,
+        label: Optional[str],
     ) -> AbstractLabware:
         ...
 
     @abstractmethod
     def load_labware(
-            self,
-            load_name: str,
-            location: types.DeckLocation,
-            label: Optional[str],
-            namespace: Optional[str],
-            version: Optional[int],
+        self,
+        load_name: str,
+        location: types.DeckLocation,
+        label: Optional[str],
+        namespace: Optional[str],
+        version: Optional[int],
     ) -> AbstractLabware:
         ...
 
     @abstractmethod
     def load_module(
-            self,
-            module_name: str,
-            location: Optional[types.DeckLocation],
-            configuration: Optional[str]) -> Optional[LoadModuleResult]:
+        self,
+        module_name: str,
+        location: Optional[types.DeckLocation],
+        configuration: Optional[str],
+    ) -> Optional[LoadModuleResult]:
         ...
 
     @abstractmethod
@@ -105,10 +102,8 @@ class AbstractProtocol(ABC):
 
     @abstractmethod
     def load_instrument(
-            self,
-            instrument_name: str,
-            mount: types.Mount,
-            replace: bool) -> AbstractInstrument:
+        self, instrument_name: str, mount: types.Mount, replace: bool
+    ) -> AbstractInstrument:
         ...
 
     @abstractmethod
@@ -116,8 +111,7 @@ class AbstractProtocol(ABC):
         ...
 
     @abstractmethod
-    def pause(self,
-              msg: Optional[str]) -> None:
+    def pause(self, msg: Optional[str]) -> None:
         ...
 
     @abstractmethod
@@ -125,14 +119,11 @@ class AbstractProtocol(ABC):
         ...
 
     @abstractmethod
-    def comment(self,
-                msg: str) -> None:
+    def comment(self, msg: str) -> None:
         ...
 
     @abstractmethod
-    def delay(self,
-              seconds: float,
-              msg: Optional[str]) -> None:
+    def delay(self, seconds: float, msg: Optional[str]) -> None:
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -6,13 +6,15 @@ from opentrons.hardware_control import CriticalPoint
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike
-from opentrons.protocols.api_support.util import Clearances, build_edges, \
-    FlowRates, PlungerSpeeds
+from opentrons.protocols.api_support.util import (
+    Clearances,
+    build_edges,
+    FlowRates,
+    PlungerSpeeds,
+)
 from opentrons.protocols.geometry import planning
-from opentrons.protocols.context.instrument import \
-    AbstractInstrument
-from opentrons.protocols.context.protocol import \
-    AbstractProtocol
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.context.well import WellImplementation
 
 
@@ -28,13 +30,15 @@ class InstrumentContextImplementation(AbstractInstrument):
     _flow_rates: FlowRates
     _speeds: PlungerSpeeds
 
-    def __init__(self,
-                 protocol_interface: AbstractProtocol,
-                 mount: types.Mount,
-                 instrument_name: str,
-                 default_speed: float,
-                 api_version: Optional[APIVersion] = None):
-        """"Constructor"""
+    def __init__(
+        self,
+        protocol_interface: AbstractProtocol,
+        mount: types.Mount,
+        instrument_name: str,
+        default_speed: float,
+        api_version: Optional[APIVersion] = None,
+    ):
+        """ "Constructor"""
         # TODO AL 20201110 - Remove need for api_version in this module
         self._api_version = api_version or MAX_SUPPORTED_VERSION
         self._protocol_interface = protocol_interface
@@ -42,8 +46,7 @@ class InstrumentContextImplementation(AbstractInstrument):
         self._instrument_name = instrument_name
         self._default_speed = default_speed
         self._well_bottom_clearances = Clearances(
-            default_aspirate=1.0,
-            default_dispense=1.0
+            default_aspirate=1.0, default_dispense=1.0
         )
         self._flow_rates = FlowRates(self)
         self._speeds = PlungerSpeeds(self)
@@ -75,11 +78,9 @@ class InstrumentContextImplementation(AbstractInstrument):
         """Blow liquid out of the tip."""
         self._protocol_interface.get_hardware().hardware.blow_out(self._mount)
 
-    def touch_tip(self,
-                  location: WellImplementation,
-                  radius: float,
-                  v_offset: float,
-                  speed: float) -> None:
+    def touch_tip(
+        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+    ) -> None:
         """
         Touch the pipette tip to the sides of a well, with the intent of
         removing left-over droplets
@@ -96,41 +97,33 @@ class InstrumentContextImplementation(AbstractInstrument):
             mount=self._mount,
             deck=self._protocol_interface.get_deck(),
             radius=radius,
-            version=self._api_version
+            version=self._api_version,
         )
         for edge in edges:
             self._protocol_interface.get_hardware().hardware.move_to(
-                self._mount,
-                edge,
-                speed
+                self._mount, edge, speed
             )
 
-    def pick_up_tip(self,
-                    well: WellImplementation,
-                    tip_length: float,
-                    presses: Optional[int],
-                    increment: Optional[float]) -> None:
+    def pick_up_tip(
+        self,
+        well: WellImplementation,
+        tip_length: float,
+        presses: Optional[int],
+        increment: Optional[float],
+    ) -> None:
         """Pick up a tip for the pipette to run liquid-handling commands."""
         hw = self._protocol_interface.get_hardware().hardware
         geometry = well.get_geometry()
 
-        hw.set_current_tiprack_diameter(
-            self._mount, geometry.diameter)
+        hw.set_current_tiprack_diameter(self._mount, geometry.diameter)
 
-        hw.pick_up_tip(
-            self._mount,
-            tip_length,
-            presses,
-            increment
-        )
-        hw.set_working_volume(
-            self._mount, geometry.max_volume)
+        hw.pick_up_tip(self._mount, tip_length, presses, increment)
+        hw.set_working_volume(self._mount, geometry.max_volume)
 
     def drop_tip(self, home_after: bool) -> None:
         """Drop the tip."""
         self._protocol_interface.get_hardware().hardware.drop_tip(
-            self._mount,
-            home_after=home_after
+            self._mount, home_after=home_after
         )
 
     def home(self) -> None:
@@ -140,25 +133,23 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def home_plunger(self) -> None:
         """Home the plunger associated with this mount."""
-        self._protocol_interface.get_hardware().hardware.home_plunger(
-            self._mount
-        )
+        self._protocol_interface.get_hardware().hardware.home_plunger(self._mount)
 
     def delay(self) -> None:
         """Delay protocol execution."""
         self._protocol_interface.delay(seconds=0, msg=None)
 
-    def move_to(self,
-                location: types.Location,
-                force_direct: bool,
-                minimum_z_height: Optional[float],
-                speed: Optional[float]) -> None:
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool,
+        minimum_z_height: Optional[float],
+        speed: Optional[float],
+    ) -> None:
         """Move the instrument."""
         # prevent direct movement bugs in PAPI version >= 2.10
         location_cache_mount = (
-            self._mount
-            if self._api_version >= APIVersion(2, 10) else
-            None
+            self._mount if self._api_version >= APIVersion(2, 10) else None
         )
 
         last_location = self._protocol_interface.get_last_location(
@@ -175,34 +166,38 @@ class InstrumentContextImplementation(AbstractInstrument):
 
         hardware = self._protocol_interface.get_hardware().hardware
 
-        from_center = from_lw.center_multichannel_on_wells() \
-            if from_lw else False
+        from_center = from_lw.center_multichannel_on_wells() if from_lw else False
         cp_override = CriticalPoint.XY_CENTER if from_center else None
 
         from_loc = types.Location(
-            hardware.gantry_position(
-                self._mount, critical_point=cp_override),
-            from_lw)
+            hardware.gantry_position(self._mount, critical_point=cp_override), from_lw
+        )
 
         instr_max_height = hardware.get_instrument_max_height(self._mount)
-        moves = planning.plan_moves(from_loc, location,
-                                    self._protocol_interface.get_deck(),
-                                    instr_max_height,
-                                    force_direct=force_direct,
-                                    minimum_z_height=minimum_z_height)
+        moves = planning.plan_moves(
+            from_loc,
+            location,
+            self._protocol_interface.get_deck(),
+            instr_max_height,
+            force_direct=force_direct,
+            minimum_z_height=minimum_z_height,
+        )
 
         try:
             for move in moves:
                 hardware.move_to(
-                    self._mount, move[0], critical_point=move[1], speed=speed,
-                    max_speeds=self._protocol_interface.get_max_speeds().data)
+                    self._mount,
+                    move[0],
+                    critical_point=move[1],
+                    speed=speed,
+                    max_speeds=self._protocol_interface.get_max_speeds().data,
+                )
         except Exception:
             self._protocol_interface.set_last_location(None)
             raise
         else:
             self._protocol_interface.set_last_location(
-                location=location,
-                mount=location_cache_mount
+                location=location, mount=location_cache_mount
             )
 
     def get_mount(self) -> types.Mount:
@@ -215,27 +210,27 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def get_pipette_name(self) -> str:
         """Get the pipette name."""
-        return self.get_pipette()['name']
+        return self.get_pipette()["name"]
 
     def get_model(self) -> str:
         """Get the model name."""
-        return self.get_pipette()['model']
+        return self.get_pipette()["model"]
 
     def get_min_volume(self) -> float:
         """Get the min volume."""
-        return self.get_pipette()['min_volume']
+        return self.get_pipette()["min_volume"]
 
     def get_max_volume(self) -> float:
         """Get the max volume."""
-        return self.get_pipette()['max_volume']
+        return self.get_pipette()["max_volume"]
 
     def get_current_volume(self) -> float:
         """Get the current volume."""
-        return self.get_pipette()['current_volume']
+        return self.get_pipette()["current_volume"]
 
     def get_available_volume(self) -> float:
         """Get the available volume."""
-        return self.get_pipette()['available_volume']
+        return self.get_pipette()["available_volume"]
 
     def get_pipette(self) -> PipetteDict:
         """Get the hardware pipette dictionary."""
@@ -247,23 +242,23 @@ class InstrumentContextImplementation(AbstractInstrument):
 
     def get_channels(self) -> int:
         """Number of channels."""
-        return self.get_pipette()['channels']
+        return self.get_pipette()["channels"]
 
     def has_tip(self) -> bool:
         """Whether a tip is attached."""
-        return self.get_pipette()['has_tip']
+        return self.get_pipette()["has_tip"]
 
     def is_ready_to_aspirate(self) -> bool:
-        return self.get_pipette()['ready_to_aspirate']
+        return self.get_pipette()["ready_to_aspirate"]
 
     def prepare_for_aspirate(self) -> None:
-        self._protocol_interface.get_hardware(
-
-        ).hardware.prepare_for_aspirate(self._mount)
+        self._protocol_interface.get_hardware().hardware.prepare_for_aspirate(
+            self._mount
+        )
 
     def get_return_height(self) -> float:
         """The height to return a tip to its tiprack."""
-        return self.get_pipette().get('return_tip_height', 0.5)
+        return self.get_pipette().get("return_tip_height", 0.5)
 
     def get_well_bottom_clearance(self) -> Clearances:
         """The distance above the bottom of a well to aspirate or dispense."""
@@ -276,10 +271,11 @@ class InstrumentContextImplementation(AbstractInstrument):
         return self._speeds
 
     def set_flow_rate(
-            self,
-            aspirate: Optional[float] = None,
-            dispense: Optional[float] = None,
-            blow_out: Optional[float] = None) -> None:
+        self,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
+    ) -> None:
         """Set the flow rates."""
         self._protocol_interface.get_hardware().hardware.set_flow_rate(
             mount=self._mount,
@@ -289,10 +285,11 @@ class InstrumentContextImplementation(AbstractInstrument):
         )
 
     def set_pipette_speed(
-            self,
-            aspirate: Optional[float] = None,
-            dispense: Optional[float] = None,
-            blow_out: Optional[float] = None) -> None:
+        self,
+        aspirate: Optional[float] = None,
+        dispense: Optional[float] = None,
+        blow_out: Optional[float] = None,
+    ) -> None:
         """Set pipette speeds."""
         self._protocol_interface.get_hardware().hardware.set_pipette_speed(
             mount=self._mount,

--- a/api/src/opentrons/protocols/context/protocol_api/labware.py
+++ b/api/src/opentrons/protocols/context/protocol_api/labware.py
@@ -3,22 +3,21 @@ from typing import List, Dict, Optional
 from opentrons.calibration_storage import helpers
 from opentrons.protocols.geometry.labware_geometry import LabwareGeometry
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocols.context.labware import \
-    AbstractLabware
+from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.protocols.api_support.tip_tracker import TipTracker
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.protocols.api_support.well_grid import WellGrid
 from opentrons.types import Point, Location
-from opentrons_shared_data.labware.dev_types import LabwareParameters, \
-    LabwareDefinition
+from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
 
 
 class LabwareImplementation(AbstractLabware):
-
-    def __init__(self,
-                 definition: LabwareDefinition,
-                 parent: Location,
-                 label: Optional[str] = None):
+    def __init__(
+        self,
+        definition: LabwareDefinition,
+        parent: Location,
+        label: Optional[str] = None,
+    ):
         """
         Construct an implementation of a labware object.
 
@@ -40,25 +39,21 @@ class LabwareImplementation(AbstractLabware):
             dn = label
             self._name = dn
         else:
-            dn = definition['metadata']['displayName']
-            self._name = definition['parameters']['loadName']
+            dn = definition["metadata"]["displayName"]
+            self._name = definition["parameters"]["loadName"]
 
         self._display_name = f"{dn} on {str(parent.labware)}"
         # Directly from definition
-        self._well_definition = definition['wells']
-        self._parameters = definition['parameters']
+        self._well_definition = definition["wells"]
+        self._parameters = definition["parameters"]
         self._definition = definition
 
         self._geometry = LabwareGeometry(definition, parent)
         # flatten list of list of well names.
-        self._ordering = [
-            well for col in definition['ordering'] for well in col
-        ]
+        self._ordering = [well for col in definition["ordering"] for well in col]
         self._wells: List[WellImplementation] = []
         self._well_name_grid = WellGrid(wells=self._wells)
-        self._tip_tracker = TipTracker(
-            columns=self._well_name_grid.get_columns()
-        )
+        self._tip_tracker = TipTracker(columns=self._well_name_grid.get_columns())
 
         self._calibrated_offset = Point(0, 0, 0)
         # Will cause building of the wells
@@ -83,32 +78,30 @@ class LabwareImplementation(AbstractLabware):
         return self._parameters
 
     def get_quirks(self) -> List[str]:
-        return self._parameters.get('quirks', [])
+        return self._parameters.get("quirks", [])
 
     def set_calibration(self, delta: Point) -> None:
         self._calibrated_offset = Point(
             x=self._geometry.offset.x + delta.x,
             y=self._geometry.offset.y + delta.y,
-            z=self._geometry.offset.z + delta.z
+            z=self._geometry.offset.z + delta.z,
         )
         # The wells must be rebuilt
         self._wells = self._build_wells()
         self._well_name_grid = WellGrid(wells=self._wells)
-        self._tip_tracker = TipTracker(
-            columns=self._well_name_grid.get_columns()
-        )
+        self._tip_tracker = TipTracker(columns=self._well_name_grid.get_columns())
 
     def get_calibrated_offset(self) -> Point:
         return self._calibrated_offset
 
     def is_tiprack(self) -> bool:
-        return self._parameters['isTiprack']
+        return self._parameters["isTiprack"]
 
     def get_tip_length(self) -> float:
-        return self._parameters['tipLength']
+        return self._parameters["tipLength"]
 
     def set_tip_length(self, length: float):
-        self._parameters['tipLength'] = length
+        self._parameters["tipLength"] = length
 
     def reset_tips(self) -> None:
         if self.is_tiprack():
@@ -125,9 +118,7 @@ class LabwareImplementation(AbstractLabware):
         return self._wells
 
     def get_wells_by_name(self) -> Dict[str, WellImplementation]:
-        return {
-            well.get_name(): well for well in self._wells
-        }
+        return {well.get_name(): well for well in self._wells}
 
     def get_geometry(self) -> LabwareGeometry:
         return self._geometry
@@ -142,7 +133,7 @@ class LabwareImplementation(AbstractLabware):
 
     @property
     def load_name(self) -> str:
-        return self._parameters['loadName']
+        return self._parameters["loadName"]
 
     def _build_wells(self) -> List[WellImplementation]:
         return [
@@ -150,11 +141,11 @@ class LabwareImplementation(AbstractLabware):
                 well_geometry=WellGeometry(
                     well_props=self._well_definition[well],
                     parent_point=self._calibrated_offset,
-                    parent_object=self
+                    parent_object=self,
                 ),
                 display_name="{} of {}".format(well, self._display_name),
                 has_tip=self.is_tiprack(),
-                name=well
+                name=well,
             )
             for well in self._ordering
         ]

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -11,18 +11,22 @@ from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.context.protocol_api.instrument_context import \
-    InstrumentContextImplementation
-from opentrons.protocols.context.instrument import \
-    AbstractInstrument
-from opentrons.protocols.context.labware import \
-    AbstractLabware
-from opentrons.protocols.context.protocol import \
-    AbstractProtocol, InstrumentDict, LoadModuleResult
+from opentrons.protocols.context.protocol_api.instrument_context import (
+    InstrumentContextImplementation,
+)
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.context.protocol import (
+    AbstractProtocol,
+    InstrumentDict,
+    LoadModuleResult,
+)
 from opentrons.protocols.api_support.util import (
-    AxisMaxSpeeds, HardwareToManage, HardwareManager)
-from opentrons.protocols.labware import load_from_definition, \
-    get_labware_definition
+    AxisMaxSpeeds,
+    HardwareToManage,
+    HardwareManager,
+)
+from opentrons.protocols.labware import load_from_definition, get_labware_definition
 from opentrons.protocols.types import Protocol
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -32,20 +36,20 @@ if TYPE_CHECKING:
 
 MODULE_LOG = logging.getLogger(__name__)
 
-SHORT_TRASH_DECK = 'ot2_short_trash'
-STANDARD_DECK = 'ot2_standard'
+SHORT_TRASH_DECK = "ot2_short_trash"
+STANDARD_DECK = "ot2_standard"
 
 
 class ProtocolContextImplementation(AbstractProtocol):
-
-    def __init__(self,
-                 api_version: Optional[APIVersion] = None,
-                 hardware: Optional[HardwareToManage] = None,
-                 bundled_labware: Dict[str, LabwareDefinition] = None,
-                 bundled_data: Dict[str, bytes] = None,
-                 extra_labware: Dict[str, LabwareDefinition] = None,
-                 ) -> None:
-        """ Build a :py:class:`.ProtocolContextImplementation`.
+    def __init__(
+        self,
+        api_version: Optional[APIVersion] = None,
+        hardware: Optional[HardwareToManage] = None,
+        bundled_labware: Dict[str, LabwareDefinition] = None,
+        bundled_data: Dict[str, bytes] = None,
+        extra_labware: Dict[str, LabwareDefinition] = None,
+    ) -> None:
+        """Build a :py:class:`.ProtocolContextImplementation`.
 
         :param api_version: The API version to use. If this is ``None``, uses
                             the max supported version.
@@ -70,12 +74,11 @@ class ProtocolContextImplementation(AbstractProtocol):
         # TODO AL 20201110 - Find a way to omit api_version from this class.
         #  it is used in creating module geometry and instrument context.
         self._api_version = api_version or MAX_SUPPORTED_VERSION
-        deck_load_name = SHORT_TRASH_DECK if fflags.short_fixed_trash() \
-            else STANDARD_DECK
+        deck_load_name = (
+            SHORT_TRASH_DECK if fflags.short_fixed_trash() else STANDARD_DECK
+        )
         self._deck_layout = Deck(load_name=deck_load_name)
-        self._instruments: InstrumentDict = {
-            mount: None for mount in types.Mount
-        }
+        self._instruments: InstrumentDict = {mount: None for mount in types.Mount}
         self._modules: List[LoadModuleResult] = []
 
         self._hw_manager = HardwareManager(hardware)
@@ -88,22 +91,19 @@ class ProtocolContextImplementation(AbstractProtocol):
         self._default_max_speeds = AxisMaxSpeeds()
         self._last_location: Optional[types.Location] = None
         self._last_mount: Optional[types.Mount] = None
-        self._loaded_modules: Set['AbstractModule'] = set()
+        self._loaded_modules: Set["AbstractModule"] = set()
 
     @classmethod
-    def build_using(cls,
-                    protocol: Protocol,
-                    *args, **kwargs):
-        """ Build an API instance for the specified parsed protocol
+    def build_using(cls, protocol: Protocol, *args, **kwargs):
+        """Build an API instance for the specified parsed protocol
 
         This is used internally to provision the context with bundle
         contents or api levels.
         """
-        kwargs['bundled_data'] = getattr(protocol, 'bundled_data', None)
-        kwargs['bundled_labware'] = getattr(protocol, 'bundled_labware', None)
-        kwargs['extra_labware'] = getattr(protocol, 'extra_labware', None)
-        kwargs['api_version'] = getattr(
-            protocol, 'api_level', MAX_SUPPORTED_VERSION)
+        kwargs["bundled_data"] = getattr(protocol, "bundled_data", None)
+        kwargs["bundled_labware"] = getattr(protocol, "bundled_labware", None)
+        kwargs["extra_labware"] = getattr(protocol, "extra_labware", None)
+        kwargs["api_version"] = getattr(protocol, "api_level", MAX_SUPPORTED_VERSION)
         return cls(*args, **kwargs)
 
     def get_bundled_data(self) -> Dict[str, bytes]:
@@ -140,7 +140,7 @@ class ProtocolContextImplementation(AbstractProtocol):
         self._hw_manager.hardware.cache_instruments()
 
     def disconnect(self) -> None:
-        """"Disconnect from the hardware."""
+        """ "Disconnect from the hardware."""
         self._hw_manager.reset_hw()
 
     def is_simulating(self) -> bool:
@@ -148,10 +148,11 @@ class ProtocolContextImplementation(AbstractProtocol):
         return self._hw_manager.hardware.is_simulator
 
     def load_labware_from_definition(
-            self,
-            labware_def: LabwareDefinition,
-            location: types.DeckLocation,
-            label: Optional[str]) -> AbstractLabware:
+        self,
+        labware_def: LabwareDefinition,
+        location: types.DeckLocation,
+        label: Optional[str],
+    ) -> AbstractLabware:
         """Load a labware from definition"""
         parent = self.get_deck().position_for(location)
         labware_obj = load_from_definition(labware_def, parent, label)
@@ -159,47 +160,54 @@ class ProtocolContextImplementation(AbstractProtocol):
         return labware_obj
 
     def load_labware(
-            self,
-            load_name: str,
-            location: types.DeckLocation,
-            label: Optional[str],
-            namespace: Optional[str],
-            version: Optional[int]) -> AbstractLabware:
+        self,
+        load_name: str,
+        location: types.DeckLocation,
+        label: Optional[str],
+        namespace: Optional[str],
+        version: Optional[int],
+    ) -> AbstractLabware:
         """Load a labware."""
         labware_def = get_labware_definition(
-            load_name, namespace, version,
+            load_name,
+            namespace,
+            version,
             bundled_defs=self._bundled_labware,
-            extra_defs=self._extra_labware)
-        return self.load_labware_from_definition(
-            labware_def, location, label)
+            extra_defs=self._extra_labware,
+        )
+        return self.load_labware_from_definition(labware_def, location, label)
 
     def load_module(
-            self,
-            module_name: str,
-            location: Optional[types.DeckLocation],
-            configuration: Optional[str]) -> Optional[LoadModuleResult]:
+        self,
+        module_name: str,
+        location: Optional[types.DeckLocation],
+        configuration: Optional[str],
+    ) -> Optional[LoadModuleResult]:
         """Load a module."""
         resolved_model = module_geometry.resolve_module_model(module_name)
         resolved_type = module_geometry.resolve_module_type(resolved_model)
         resolved_location = self._deck_layout.resolve_module_location(
-            resolved_type, location)
+            resolved_type, location
+        )
 
         # Load the geometry
         geometry = module_geometry.load_module(
             model=resolved_model,
             parent=self._deck_layout.position_for(resolved_location),
             api_level=self._api_version,
-            configuration=configuration)
+            configuration=configuration,
+        )
 
         # Try to find in the hardware instance
         available_modules, simulating_module = self._hw_manager.hardware.find_modules(
-            resolved_model, resolved_type)
+            resolved_model, resolved_type
+        )
 
         hc_mod_instance = None
         for mod in available_modules:
             compatible = module_geometry.models_compatible(
-                module_geometry.module_model_from_string(mod.model()),
-                resolved_model)
+                module_geometry.module_model_from_string(mod.model()), resolved_model
+            )
             if compatible and mod not in self._loaded_modules:
                 self._loaded_modules.add(mod)
                 hc_mod_instance = SynchronousAdapter(mod)
@@ -211,9 +219,9 @@ class ProtocolContextImplementation(AbstractProtocol):
         if not hc_mod_instance:
             return None
 
-        result = LoadModuleResult(type=resolved_type,
-                                  geometry=geometry,
-                                  module=hc_mod_instance)
+        result = LoadModuleResult(
+            type=resolved_type, geometry=geometry, module=hc_mod_instance
+        )
 
         self._modules.append(result)
         self._deck_layout[resolved_location] = geometry
@@ -221,24 +229,26 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def get_loaded_modules(self) -> Dict[int, LoadModuleResult]:
         """Get a mapping of deck location to loaded module."""
-        return OrderedDict({int(str(module.geometry.parent)): module
-                            for module in self._modules})
+        return OrderedDict(
+            {int(str(module.geometry.parent)): module for module in self._modules}
+        )
 
-    def load_instrument(self,
-                        instrument_name: str,
-                        mount: types.Mount,
-                        replace: bool) -> AbstractInstrument:
+    def load_instrument(
+        self, instrument_name: str, mount: types.Mount, replace: bool
+    ) -> AbstractInstrument:
         """Load an instrument."""
         instr = self._instruments[mount]
         if instr and not replace:
             raise RuntimeError(
                 f"Instrument already present in {mount.name.lower()} "
-                f"mount: {instr.get_instrument_name()}")
+                f"mount: {instr.get_instrument_name()}"
+            )
 
-        attached = {att_mount: instr.get('name', None)
-                    for att_mount, instr
-                    in self._hw_manager.hardware.attached_instruments.items()
-                    if instr}
+        attached = {
+            att_mount: instr.get("name", None)
+            for att_mount, instr in self._hw_manager.hardware.attached_instruments.items()  # noqa: E501
+            if instr
+        }
         attached[mount] = instrument_name
         self._hw_manager.hardware.cache_instruments(attached)
         # If the cache call didn’t raise, the instrument is attached
@@ -247,7 +257,7 @@ class ProtocolContextImplementation(AbstractProtocol):
             protocol_interface=self,
             mount=mount,
             instrument_name=instrument_name,
-            default_speed=400.0
+            default_speed=400.0,
         )
         self._instruments[mount] = new_instr
         self._log.info("Instrument {} loaded".format(new_instr))
@@ -284,7 +294,7 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def get_fixed_trash(self) -> DeckItem:
         """The trash fixed to slot 12 of the robot deck."""
-        trash = self._deck_layout['12']
+        trash = self._deck_layout["12"]
         if not trash:
             raise RuntimeError("Robot must have a trash container in 12")
         return trash
@@ -295,7 +305,7 @@ class ProtocolContextImplementation(AbstractProtocol):
 
     def get_rail_lights_on(self) -> bool:
         """Get the rail light state."""
-        return self._hw_manager.hardware.get_lights()['rails']
+        return self._hw_manager.hardware.get_lights()["rails"]
 
     def door_closed(self) -> bool:
         """Check if door is closed."""

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -5,25 +5,24 @@ from opentrons.hardware_control import NoTipAttachedError, TipAttachedError
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.types import HardwareAction
 from opentrons.protocols.api_support.labware_like import LabwareLike
-from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, \
-    Clearances
+from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clearances
 from opentrons.protocols.geometry import planning
-from opentrons.protocols.context.instrument import \
-    AbstractInstrument
-from opentrons.protocols.context.protocol import \
-    AbstractProtocol
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.context.well import WellImplementation
 
 
 class InstrumentContextSimulation(AbstractInstrument):
     """A simulation of an instrument context."""
 
-    def __init__(self,
-                 protocol_interface: AbstractProtocol,
-                 pipette_dict: PipetteDict,
-                 mount: types.Mount,
-                 instrument_name: str,
-                 default_speed: float = 400.0):
+    def __init__(
+        self,
+        protocol_interface: AbstractProtocol,
+        pipette_dict: PipetteDict,
+        mount: types.Mount,
+        instrument_name: str,
+        default_speed: float = 400.0,
+    ):
         """Constructor."""
         self._protocol_interface = protocol_interface
         self._mount = mount
@@ -33,8 +32,11 @@ class InstrumentContextSimulation(AbstractInstrument):
         self._flow_rate = FlowRates(self)
         self._plunger_speeds = PlungerSpeeds(self)
         # Cache the maximum instrument height
-        self._instrument_max_height = protocol_interface\
-            .get_hardware().hardware.get_instrument_max_height(self._mount)
+        self._instrument_max_height = (
+            protocol_interface.get_hardware().hardware.get_instrument_max_height(
+                self._mount
+            )
+        )
 
     def get_default_speed(self) -> float:
         return self._default_speed
@@ -45,33 +47,39 @@ class InstrumentContextSimulation(AbstractInstrument):
     def aspirate(self, volume: float, rate: float) -> None:
         self._raise_if_no_tip(HardwareAction.ASPIRATE.name)
         new_volume = self.get_current_volume() + volume
-        assert new_volume <= self._pipette_dict['working_volume'],\
-            "Cannot aspirate more than pipette max volume"
-        self._pipette_dict['current_volume'] = new_volume
+        assert (
+            new_volume <= self._pipette_dict["working_volume"]
+        ), "Cannot aspirate more than pipette max volume"
+        self._pipette_dict["current_volume"] = new_volume
 
     def dispense(self, volume: float, rate: float) -> None:
         self._raise_if_no_tip(HardwareAction.DISPENSE.name)
-        self._pipette_dict['current_volume'] -= volume
+        self._pipette_dict["current_volume"] -= volume
 
     def blow_out(self) -> None:
         self._raise_if_no_tip(HardwareAction.BLOWOUT.name)
-        self._pipette_dict['current_volume'] = 0
-        self._pipette_dict['ready_to_aspirate'] = False
+        self._pipette_dict["current_volume"] = 0
+        self._pipette_dict["ready_to_aspirate"] = False
 
-    def touch_tip(self, location: WellImplementation, radius: float,
-                  v_offset: float, speed: float) -> None:
+    def touch_tip(
+        self, location: WellImplementation, radius: float, v_offset: float, speed: float
+    ) -> None:
         pass
 
-    def pick_up_tip(self, well: WellImplementation, tip_length: float,
-                    presses: typing.Optional[int],
-                    increment: typing.Optional[float]) -> None:
+    def pick_up_tip(
+        self,
+        well: WellImplementation,
+        tip_length: float,
+        presses: typing.Optional[int],
+        increment: typing.Optional[float],
+    ) -> None:
         self._raise_if_tip("pick up tip")
-        self._pipette_dict['has_tip'] = True
-        self._pipette_dict['current_volume'] = 0
+        self._pipette_dict["has_tip"] = True
+        self._pipette_dict["current_volume"] = 0
 
     def drop_tip(self, home_after: bool) -> None:
         self._raise_if_no_tip(HardwareAction.DROPTIP.name)
-        self._pipette_dict['has_tip'] = False
+        self._pipette_dict["has_tip"] = False
 
     def home(self) -> None:
         self._protocol_interface.set_last_location(None)
@@ -82,9 +90,13 @@ class InstrumentContextSimulation(AbstractInstrument):
     def delay(self) -> None:
         pass
 
-    def move_to(self, location: types.Location, force_direct: bool,
-                minimum_z_height: typing.Optional[float],
-                speed: typing.Optional[float]) -> None:
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool,
+        minimum_z_height: typing.Optional[float],
+        speed: typing.Optional[float],
+    ) -> None:
         """Simulation of only the motion planning portion of move_to."""
         last_location = self._protocol_interface.get_last_location()
         if last_location:
@@ -93,12 +105,14 @@ class InstrumentContextSimulation(AbstractInstrument):
             from_loc = types.Location(types.Point(0, 0, 0), LabwareLike(None))
 
         # We just want to catch planning errors.
-        planning.plan_moves(from_loc,
-                            location,
-                            self._protocol_interface.get_deck(),
-                            self._instrument_max_height,
-                            force_direct=force_direct,
-                            minimum_z_height=minimum_z_height)
+        planning.plan_moves(
+            from_loc,
+            location,
+            self._protocol_interface.get_deck(),
+            self._instrument_max_height,
+            force_direct=force_direct,
+            minimum_z_height=minimum_z_height,
+        )
 
         self._protocol_interface.set_last_location(location)
 
@@ -109,40 +123,40 @@ class InstrumentContextSimulation(AbstractInstrument):
         return self._instrument_name
 
     def get_pipette_name(self) -> str:
-        return self._pipette_dict['name']
+        return self._pipette_dict["name"]
 
     def get_model(self) -> str:
-        return self._pipette_dict['model']
+        return self._pipette_dict["model"]
 
     def get_min_volume(self) -> float:
-        return self._pipette_dict['min_volume']
+        return self._pipette_dict["min_volume"]
 
     def get_max_volume(self) -> float:
-        return self._pipette_dict['max_volume']
+        return self._pipette_dict["max_volume"]
 
     def get_current_volume(self) -> float:
-        return self._pipette_dict['current_volume']
+        return self._pipette_dict["current_volume"]
 
     def get_available_volume(self) -> float:
-        return self._pipette_dict['available_volume']
+        return self._pipette_dict["available_volume"]
 
     def get_pipette(self) -> PipetteDict:
         return self._pipette_dict
 
     def get_channels(self) -> int:
-        return self._pipette_dict['channels']
+        return self._pipette_dict["channels"]
 
     def has_tip(self) -> bool:
-        return self._pipette_dict['has_tip']
+        return self._pipette_dict["has_tip"]
 
     def is_ready_to_aspirate(self) -> bool:
-        return self._pipette_dict['ready_to_aspirate']
+        return self._pipette_dict["ready_to_aspirate"]
 
     def prepare_for_aspirate(self) -> None:
         self._raise_if_no_tip(HardwareAction.PREPARE_ASPIRATE.name)
 
     def get_return_height(self) -> float:
-        return self._pipette_dict['return_tip_height']
+        return self._pipette_dict["return_tip_height"]
 
     def get_well_bottom_clearance(self) -> Clearances:
         return Clearances(default_aspirate=1, default_dispense=1)
@@ -153,36 +167,38 @@ class InstrumentContextSimulation(AbstractInstrument):
     def get_flow_rate(self) -> FlowRates:
         return self._flow_rate
 
-    def set_flow_rate(self, aspirate: typing.Optional[float] = None,
-                      dispense: typing.Optional[float] = None,
-                      blow_out: typing.Optional[float] = None) -> None:
+    def set_flow_rate(
+        self,
+        aspirate: typing.Optional[float] = None,
+        dispense: typing.Optional[float] = None,
+        blow_out: typing.Optional[float] = None,
+    ) -> None:
         if aspirate is not None:
-            self._pipette_dict['aspirate_flow_rate'] = aspirate
+            self._pipette_dict["aspirate_flow_rate"] = aspirate
         if dispense is not None:
-            self._pipette_dict['dispense_flow_rate'] = dispense
+            self._pipette_dict["dispense_flow_rate"] = dispense
         if blow_out is not None:
-            self._pipette_dict['blow_out_flow_rate'] = blow_out
+            self._pipette_dict["blow_out_flow_rate"] = blow_out
 
-    def set_pipette_speed(self, aspirate: typing.Optional[float] = None,
-                          dispense: typing.Optional[float] = None,
-                          blow_out: typing.Optional[float] = None) -> None:
+    def set_pipette_speed(
+        self,
+        aspirate: typing.Optional[float] = None,
+        dispense: typing.Optional[float] = None,
+        blow_out: typing.Optional[float] = None,
+    ) -> None:
         if aspirate is not None:
-            self._pipette_dict['aspirate_speed'] = aspirate
+            self._pipette_dict["aspirate_speed"] = aspirate
         if dispense is not None:
-            self._pipette_dict['dispense_speed'] = dispense
+            self._pipette_dict["dispense_speed"] = dispense
         if blow_out is not None:
-            self._pipette_dict['blow_out_speed'] = blow_out
+            self._pipette_dict["blow_out_speed"] = blow_out
 
     def _raise_if_no_tip(self, action: str) -> None:
         """Raise NoTipAttachedError if no tip."""
         if not self.has_tip():
-            raise NoTipAttachedError(
-                f'Cannot perform {action} without a tip attached'
-            )
+            raise NoTipAttachedError(f"Cannot perform {action} without a tip attached")
 
     def _raise_if_tip(self, action: str) -> None:
         """Raise TipAttachedError if tip."""
         if self.has_tip():
-            raise TipAttachedError(
-                f'Cannot {action} with a tip attached'
-            )
+            raise TipAttachedError(f"Cannot {action} with a tip attached")

--- a/api/src/opentrons/protocols/context/simulator/protocol_context.py
+++ b/api/src/opentrons/protocols/context/simulator/protocol_context.py
@@ -1,36 +1,36 @@
 from opentrons import types
-from opentrons.protocols.context.instrument import \
-    AbstractInstrument
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
-from opentrons.protocols.context.simulator.instrument_context import \
-    InstrumentContextSimulation
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.protocols.context.simulator.instrument_context import (
+    InstrumentContextSimulation,
+)
 
 
 class ProtocolContextSimulation(ProtocolContextImplementation):
-    def load_instrument(self,
-                        instrument_name: str,
-                        mount: types.Mount,
-                        replace: bool) -> AbstractInstrument:
+    def load_instrument(
+        self, instrument_name: str, mount: types.Mount, replace: bool
+    ) -> AbstractInstrument:
         """Create a simulating instrument context."""
         instr = self._instruments[mount]
         if instr and not replace:
             raise RuntimeError(
                 f"Instrument already present in {mount.name.lower()} "
-                f"mount: {instr.get_instrument_name()}")
+                f"mount: {instr.get_instrument_name()}"
+            )
 
-        attached = {att_mount: instr.get('name', None)
-                    for att_mount, instr
-                    in self._hw_manager.hardware.attached_instruments.items()
-                    if instr}
+        attached = {
+            att_mount: instr.get("name", None)
+            for att_mount, instr in self._hw_manager.hardware.attached_instruments.items()  # noqa: E501
+            if instr
+        }
         attached[mount] = instrument_name
         self._hw_manager.hardware.cache_instruments(attached)
 
         new_instr = InstrumentContextSimulation(
             protocol_interface=self,
-            pipette_dict=self._hw_manager.hardware.get_attached_instruments()[
-                mount
-            ],
+            pipette_dict=self._hw_manager.hardware.get_attached_instruments()[mount],
             mount=mount,
             instrument_name=instrument_name,
         )

--- a/api/src/opentrons/protocols/context/well.py
+++ b/api/src/opentrons/protocols/context/well.py
@@ -10,11 +10,9 @@ class WellImplementation:
 
     pattern = re.compile(WELL_NAME_PATTERN, re.X)
 
-    def __init__(self,
-                 well_geometry: WellGeometry,
-                 display_name: str,
-                 has_tip: bool,
-                 name: str):
+    def __init__(
+        self, well_geometry: WellGeometry, display_name: str, has_tip: bool, name: str
+    ):
         """
         Construct a well
 
@@ -33,8 +31,10 @@ class WellImplementation:
         self._name = name
 
         match = WellImplementation.pattern.match(name)
-        assert match, f"could not match '{name}' using " \
-                      f"pattern '{WellImplementation.pattern.pattern}'"
+        assert match, (
+            f"could not match '{name}' using "
+            f"pattern '{WellImplementation.pattern.pattern}'"
+        )
         self._row_name = match.group(1)
         self._column_name = match.group(2)
         self._geometry = well_geometry
@@ -68,6 +68,7 @@ class WellImplementation:
 
     def __eq__(self, other) -> bool:
         """Assume that if name is the same then it's the same well"""
-        return \
-            isinstance(other, WellImplementation) and\
-            self.get_name() == other.get_name()
+        return (
+            isinstance(other, WellImplementation)
+            and self.get_name() == other.get_name()
+        )

--- a/api/src/opentrons/protocols/execution/dev_types.py
+++ b/api/src/opentrons/protocols/execution/dev_types.py
@@ -3,18 +3,28 @@ from typing import Callable, Dict, TYPE_CHECKING
 from typing_extensions import Protocol, TypedDict
 
 from opentrons_shared_data.protocol.dev_types import (
-    BlowoutParams, DelayParams, PipetteAccessParams,
-    StandardLiquidHandlingParams, TouchTipParams, MoveToSlotParams,
-    TemperatureParams, ModuleIDParams, MagneticModuleEngageParams,
-    ThermocyclerRunProfileParams, ThermocyclerSetTargetBlockParams,
-    MoveToWellParams
+    BlowoutParams,
+    DelayParams,
+    PipetteAccessParams,
+    StandardLiquidHandlingParams,
+    TouchTipParams,
+    MoveToSlotParams,
+    TemperatureParams,
+    ModuleIDParams,
+    MagneticModuleEngageParams,
+    ThermocyclerRunProfileParams,
+    ThermocyclerSetTargetBlockParams,
+    MoveToWellParams,
 )
 
 if TYPE_CHECKING:
     from opentrons.protocol_api.protocol_context import ProtocolContext
     from opentrons.protocol_api.instrument_context import InstrumentContext
     from opentrons.protocol_api.module_contexts import (
-        MagneticModuleContext, ThermocyclerContext, TemperatureModuleContext)
+        MagneticModuleContext,
+        ThermocyclerContext,
+        TemperatureModuleContext,
+    )
     from opentrons.protocol_api.labware import Labware
 
 
@@ -27,12 +37,14 @@ if TYPE_CHECKING:
 #  - please include this file as close to a leaf as possible
 
 if Protocol is not None:
+
     class Dictable(Protocol):
-        """ A protocol defining the _asdict interface to
+        """A protocol defining the _asdict interface to
         classes generated from typing.NamedTuple, which cannot
         be used as a type annotation because it is a type ctor
         not a type (https://github.com/python/mypy/issues/3915)
         """
+
         async def _asdict(self):
             ...
 
@@ -41,93 +53,129 @@ if Protocol is not None:
 # opentrons_shared_data.protocol.constants because of
 # https://github.com/python/mypy/issues/4128
 PipetteDispatch = TypedDict(
-    'PipetteDispatch',
+    "PipetteDispatch",
     {
-        'delay': Callable[['ProtocolContext', 'DelayParams'], None],
-        'blowout': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'BlowoutParams'], None],
-        'pickUpTip': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'PipetteAccessParams'], None],
-        'dropTip': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'PipetteAccessParams'], None],
-        'aspirate': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'StandardLiquidHandlingParams'], None],
-        'dispense': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'StandardLiquidHandlingParams'], None],
-        'touchTip': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'TouchTipParams'], None],
-        'moveToSlot': Callable[
-            ['ProtocolContext',
-             Dict[str, 'InstrumentContext'],
-             'MoveToSlotParams'], None],
-        'moveToWell': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'MoveToWellParams'], None],
-        'airGap': Callable[
-            [Dict[str, 'InstrumentContext'],
-             Dict[str, 'Labware'],
-             'StandardLiquidHandlingParams'], None],
+        "delay": Callable[["ProtocolContext", "DelayParams"], None],
+        "blowout": Callable[
+            [Dict[str, "InstrumentContext"], Dict[str, "Labware"], "BlowoutParams"],
+            None,
+        ],
+        "pickUpTip": Callable[
+            [
+                Dict[str, "InstrumentContext"],
+                Dict[str, "Labware"],
+                "PipetteAccessParams",
+            ],
+            None,
+        ],
+        "dropTip": Callable[
+            [
+                Dict[str, "InstrumentContext"],
+                Dict[str, "Labware"],
+                "PipetteAccessParams",
+            ],
+            None,
+        ],
+        "aspirate": Callable[
+            [
+                Dict[str, "InstrumentContext"],
+                Dict[str, "Labware"],
+                "StandardLiquidHandlingParams",
+            ],
+            None,
+        ],
+        "dispense": Callable[
+            [
+                Dict[str, "InstrumentContext"],
+                Dict[str, "Labware"],
+                "StandardLiquidHandlingParams",
+            ],
+            None,
+        ],
+        "touchTip": Callable[
+            [Dict[str, "InstrumentContext"], Dict[str, "Labware"], "TouchTipParams"],
+            None,
+        ],
+        "moveToSlot": Callable[
+            ["ProtocolContext", Dict[str, "InstrumentContext"], "MoveToSlotParams"],
+            None,
+        ],
+        "moveToWell": Callable[
+            [Dict[str, "InstrumentContext"], Dict[str, "Labware"], "MoveToWellParams"],
+            None,
+        ],
+        "airGap": Callable[
+            [
+                Dict[str, "InstrumentContext"],
+                Dict[str, "Labware"],
+                "StandardLiquidHandlingParams",
+            ],
+            None,
+        ],
     },
-    total=False)
+    total=False,
+)
 
 
 JsonV4MagneticModuleDispatch = TypedDict(
-    'JsonV4MagneticModuleDispatch',
+    "JsonV4MagneticModuleDispatch",
     {
-        'magneticModule/engageMagnet': Callable[
-            ['MagneticModuleContext', 'MagneticModuleEngageParams'], None],
-        'magneticModule/disengageMagnet': Callable[
-            ['MagneticModuleContext', 'ModuleIDParams'], None],
-    })
+        "magneticModule/engageMagnet": Callable[
+            ["MagneticModuleContext", "MagneticModuleEngageParams"], None
+        ],
+        "magneticModule/disengageMagnet": Callable[
+            ["MagneticModuleContext", "ModuleIDParams"], None
+        ],
+    },
+)
 
 JsonV4TemperatureModuleDispatch = TypedDict(
-    'JsonV4TemperatureModuleDispatch',
+    "JsonV4TemperatureModuleDispatch",
     {
-        'temperatureModule/setTargetTemperature': Callable[
-            ['TemperatureModuleContext', 'TemperatureParams'], None],
-        'temperatureModule/deactivate': Callable[
-            ['TemperatureModuleContext', 'ModuleIDParams'], None],
-        'temperatureModule/awaitTemperature': Callable[
-            ['TemperatureModuleContext', 'TemperatureParams'], None]
-    }
+        "temperatureModule/setTargetTemperature": Callable[
+            ["TemperatureModuleContext", "TemperatureParams"], None
+        ],
+        "temperatureModule/deactivate": Callable[
+            ["TemperatureModuleContext", "ModuleIDParams"], None
+        ],
+        "temperatureModule/awaitTemperature": Callable[
+            ["TemperatureModuleContext", "TemperatureParams"], None
+        ],
+    },
 )
 
 JsonV4ThermocyclerDispatch = TypedDict(
-    'JsonV4ThermocyclerDispatch',
+    "JsonV4ThermocyclerDispatch",
     {
-        'thermocycler/closeLid': Callable[
-            ['ThermocyclerContext', 'ModuleIDParams'], None],
-        'thermocycler/openLid': Callable[
-            ['ThermocyclerContext', 'ModuleIDParams'], None],
-        'thermocycler/deactivateBlock': Callable[
-            ['ThermocyclerContext', 'ModuleIDParams'], None],
-        'thermocycler/deactivateLid': Callable[
-            ['ThermocyclerContext', 'ModuleIDParams'], None],
-        'thermocycler/setTargetBlockTemperature': Callable[
-            ['ThermocyclerContext', 'ThermocyclerSetTargetBlockParams'],
-            None],
-        'thermocycler/setTargetLidTemperature': Callable[
-            ['ThermocyclerContext', 'TemperatureParams'], None],
-        'thermocycler/runProfile': Callable[
-            ['ThermocyclerContext', 'ThermocyclerRunProfileParams'], None],
-        'thermocycler/awaitBlockTemperature': Callable[
-            ['ThermocyclerContext', 'TemperatureParams'], None],
-        'thermocycler/awaitLidTemperature': Callable[
-            ['ThermocyclerContext', 'TemperatureParams'], None],
-        'thermocycler/awaitProfileComplete': Callable[
-            ['ThermocyclerContext', 'ModuleIDParams'], None]
-    }
+        "thermocycler/closeLid": Callable[
+            ["ThermocyclerContext", "ModuleIDParams"], None
+        ],
+        "thermocycler/openLid": Callable[
+            ["ThermocyclerContext", "ModuleIDParams"], None
+        ],
+        "thermocycler/deactivateBlock": Callable[
+            ["ThermocyclerContext", "ModuleIDParams"], None
+        ],
+        "thermocycler/deactivateLid": Callable[
+            ["ThermocyclerContext", "ModuleIDParams"], None
+        ],
+        "thermocycler/setTargetBlockTemperature": Callable[
+            ["ThermocyclerContext", "ThermocyclerSetTargetBlockParams"], None
+        ],
+        "thermocycler/setTargetLidTemperature": Callable[
+            ["ThermocyclerContext", "TemperatureParams"], None
+        ],
+        "thermocycler/runProfile": Callable[
+            ["ThermocyclerContext", "ThermocyclerRunProfileParams"], None
+        ],
+        "thermocycler/awaitBlockTemperature": Callable[
+            ["ThermocyclerContext", "TemperatureParams"], None
+        ],
+        "thermocycler/awaitLidTemperature": Callable[
+            ["ThermocyclerContext", "TemperatureParams"], None
+        ],
+        "thermocycler/awaitProfileComplete": Callable[
+            ["ThermocyclerContext", "ModuleIDParams"], None
+        ],
+    },
 )

--- a/api/src/opentrons/protocols/execution/errors.py
+++ b/api/src/opentrons/protocols/execution/errors.py
@@ -1,5 +1,5 @@
 class ExceptionInProtocolError(Exception):
-    """ This exception wraps an exception that was raised from a protocol
+    """This exception wraps an exception that was raised from a protocol
     for proper error message formatting by the rpc, since it's only here that
     we can properly figure out formatting
     """
@@ -12,7 +12,8 @@ class ExceptionInProtocolError(Exception):
         super().__init__(original_exc, original_tb, message, line)
 
     def __str__(self):
-        return '{}{}: {}'.format(
+        return "{}{}: {}".format(
             self.original_exc.__class__.__name__,
-            ' [line {}]'.format(self.line) if self.line else '',
-            self.message)
+            " [line {}]".format(self.line) if self.line else "",
+            self.message,
+        )

--- a/api/src/opentrons/protocols/execution/execute.py
+++ b/api/src/opentrons/protocols/execution/execute.py
@@ -3,8 +3,11 @@ import logging
 from opentrons.protocol_api.contexts import ProtocolContext
 from opentrons.protocols.execution.execute_python import run_python
 from opentrons.protocols.execution.json_dispatchers import (
-    pipette_command_map, temperature_module_command_map,
-    magnetic_module_command_map, thermocycler_module_command_map)
+    pipette_command_map,
+    temperature_module_command_map,
+    magnetic_module_command_map,
+    thermocycler_module_command_map,
+)
 from opentrons.protocols.execution import execute_json_v4, execute_json_v3
 
 from opentrons.protocols.types import PythonProtocol, Protocol
@@ -13,9 +16,8 @@ from opentrons.protocols.api_support.types import APIVersion
 MODULE_LOG = logging.getLogger(__name__)
 
 
-def run_protocol(protocol: Protocol,
-                 context: ProtocolContext):
-    """ Run a protocol.
+def run_protocol(protocol: Protocol, context: ProtocolContext):
+    """Run a protocol.
 
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
     :param context: The context to use.
@@ -24,32 +26,34 @@ def run_protocol(protocol: Protocol,
         if protocol.api_level >= APIVersion(2, 0):
             run_python(protocol, context)
         else:
-            raise RuntimeError(
-                f'Unsupported python API version: {protocol.api_level}'
-            )
+            raise RuntimeError(f"Unsupported python API version: {protocol.api_level}")
     else:
-        if protocol.contents['schemaVersion'] == 3:
-            ins = execute_json_v3.load_pipettes_from_json(
-                context, protocol.contents)
-            lw = execute_json_v3.load_labware_from_json_defs(
-                context, protocol.contents)
+        if protocol.contents["schemaVersion"] == 3:
+            ins = execute_json_v3.load_pipettes_from_json(context, protocol.contents)
+            lw = execute_json_v3.load_labware_from_json_defs(context, protocol.contents)
             execute_json_v3.dispatch_json(context, protocol.contents, ins, lw)
-        elif protocol.contents['schemaVersion'] in [4, 5]:
+        elif protocol.contents["schemaVersion"] in [4, 5]:
             # reuse the v3 fns for loading labware and pipettes
             # b/c the v4 protocol has no changes for these keys
-            ins = execute_json_v3.load_pipettes_from_json(
-                context, protocol.contents)
+            ins = execute_json_v3.load_pipettes_from_json(context, protocol.contents)
 
-            modules = execute_json_v4.load_modules_from_json(
-                context, protocol.contents)
+            modules = execute_json_v4.load_modules_from_json(context, protocol.contents)
 
             lw = execute_json_v4.load_labware_from_json_defs(
-                context, protocol.contents, modules)
+                context, protocol.contents, modules
+            )
             execute_json_v4.dispatch_json(
-                context, protocol.contents, ins, lw, modules,
-                pipette_command_map, magnetic_module_command_map,
+                context,
+                protocol.contents,
+                ins,
+                lw,
+                modules,
+                pipette_command_map,
+                magnetic_module_command_map,
                 temperature_module_command_map,
-                thermocycler_module_command_map)
+                thermocycler_module_command_map,
+            )
         else:
             raise RuntimeError(
-                f'Unsupported JSON protocol schema: {protocol.schema_version}')
+                f"Unsupported JSON protocol schema: {protocol.schema_version}"
+            )

--- a/api/src/opentrons/protocols/execution/execute_json_v3.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v3.py
@@ -6,38 +6,48 @@ from opentrons.protocol_api import labware
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.types import Point, Location
 from opentrons_shared_data.protocol.constants import (
-    JsonPipetteCommand, JsonRobotCommand)
+    JsonPipetteCommand,
+    JsonRobotCommand,
+)
 
 
 if TYPE_CHECKING:
     from opentrons_shared_data.protocol.dev_types import (
-        JsonProtocolV3, JsonProtocol,
-        PipetteAccessParams, StandardLiquidHandlingParams,
-        DelayParams, FlowRateParams, TouchTipParams,
-        PipetteAccessWithOffsetParams, BlowoutParams, MoveToSlotParams)
+        JsonProtocolV3,
+        JsonProtocol,
+        PipetteAccessParams,
+        StandardLiquidHandlingParams,
+        DelayParams,
+        FlowRateParams,
+        TouchTipParams,
+        PipetteAccessWithOffsetParams,
+        BlowoutParams,
+        MoveToSlotParams,
+    )
     from opentrons.protocols.execution.dev_types import PipetteDispatch
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 def load_pipettes_from_json(
-        ctx: ProtocolContext,
-        protocol: 'JsonProtocol') -> Dict[str, InstrumentContext]:
-    pipette_data = protocol['pipettes']
+    ctx: ProtocolContext, protocol: "JsonProtocol"
+) -> Dict[str, InstrumentContext]:
+    pipette_data = protocol["pipettes"]
     pipettes_by_id = {}
     for pipette_id, props in pipette_data.items():
-        mount = props['mount']
-        name = props['name']
+        mount = props["mount"]
+        name = props["name"]
         instr = ctx.load_instrument(name, mount)
         pipettes_by_id[pipette_id] = instr
 
     return pipettes_by_id
 
 
-def _get_well(loaded_labware: Dict[str, labware.Labware],
-              params: 'PipetteAccessParams') -> labware.Well:
-    labwareId = params['labware']
-    well = params['well']
+def _get_well(
+    loaded_labware: Dict[str, labware.Labware], params: "PipetteAccessParams"
+) -> labware.Well:
+    labwareId = params["labware"]
+    well = params["well"]
     plate = loaded_labware[labwareId]
     return plate[well]
 
@@ -45,16 +55,14 @@ def _get_well(loaded_labware: Dict[str, labware.Labware],
 # TODO (Ian 2019-04-05) once Pipette commands allow flow rate as an
 # absolute value (not % value) as an argument in
 # aspirate/dispense/blowout/air_gap fns, remove this
-def _set_flow_rate(
-        pipette: InstrumentContext,
-        params: 'FlowRateParams') -> None:
+def _set_flow_rate(pipette: InstrumentContext, params: "FlowRateParams") -> None:
     """
     Set flow rate in uL/mm, to value obtained from command's params.
     """
-    flow_rate_param = params['flowRate']
+    flow_rate_param = params["flowRate"]
 
     if not (flow_rate_param > 0):
-        raise RuntimeError('Positive flowRate param required')
+        raise RuntimeError("Positive flowRate param required")
 
     pipette.flow_rate.aspirate = flow_rate_param
     pipette.flow_rate.dispense = flow_rate_param
@@ -62,105 +70,118 @@ def _set_flow_rate(
 
 
 def load_labware_from_json_defs(
-        ctx: ProtocolContext,
-        protocol: 'JsonProtocolV3') -> Dict[str, labware.Labware]:
-    protocol_labware = protocol['labware']
-    definitions = protocol['labwareDefinitions']
+    ctx: ProtocolContext, protocol: "JsonProtocolV3"
+) -> Dict[str, labware.Labware]:
+    protocol_labware = protocol["labware"]
+    definitions = protocol["labwareDefinitions"]
     loaded_labware = {}
 
     for labware_id, props in protocol_labware.items():
-        slot = props['slot']
-        definition = definitions[props['definitionId']]
-        label = props.get('displayName', None)
+        slot = props["slot"]
+        definition = definitions[props["definitionId"]]
+        label = props.get("displayName", None)
         loaded_labware[labware_id] = ctx.load_labware_from_definition(
-            definition, slot, label)
+            definition, slot, label
+        )
 
     return loaded_labware
 
 
 def _get_location_with_offset(
-        loaded_labware: Dict[str, labware.Labware],
-        params: 'PipetteAccessWithOffsetParams') -> Location:
+    loaded_labware: Dict[str, labware.Labware], params: "PipetteAccessWithOffsetParams"
+) -> Location:
     well = _get_well(loaded_labware, params)
 
     # Never move to the bottom of the fixed trash
     if LabwareLike(well).is_fixed_trash():
         return well.top()
 
-    offset_from_bottom = params['offsetFromBottomMm']
+    offset_from_bottom = params["offsetFromBottomMm"]
     bottom = well.bottom()
     return bottom.move(Point(z=offset_from_bottom))
 
 
-def _delay(context: ProtocolContext, params: 'DelayParams') -> None:
-    wait = params['wait']
-    message = params.get('message')
+def _delay(context: ProtocolContext, params: "DelayParams") -> None:
+    wait = params["wait"]
+    message = params.get("message")
     if wait is None or wait is False:
-        raise ValueError('Delay must be true, or a number')
+        raise ValueError("Delay must be true, or a number")
     elif wait is True:
-        message = message or 'Pausing until user resumes'
+        message = message or "Pausing until user resumes"
         context.pause(msg=message)
     else:
         context.delay(seconds=wait, msg=message)
 
 
-def _blowout(instruments: Dict[str, InstrumentContext],
-             loaded_labware: Dict[str, labware.Labware],
-             params: 'BlowoutParams') -> None:
-    pipette_id = params['pipette']
+def _blowout(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "BlowoutParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     well = _get_well(loaded_labware, params)
     _set_flow_rate(pipette, params)
     pipette.blow_out(well)
 
 
-def _pick_up_tip(instruments: Dict[str, InstrumentContext],
-                 loaded_labware: Dict[str, labware.Labware],
-                 params: 'PipetteAccessParams') -> None:
-    pipette_id = params['pipette']
+def _pick_up_tip(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "PipetteAccessParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     well = _get_well(loaded_labware, params)
     pipette.pick_up_tip(well)
 
 
-def _drop_tip(instruments: Dict[str, InstrumentContext],
-              loaded_labware: Dict[str, labware.Labware],
-              params: 'PipetteAccessParams') -> None:
-    pipette_id = params['pipette']
+def _drop_tip(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "PipetteAccessParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     well = _get_well(loaded_labware, params)
     pipette.drop_tip(well)
 
 
-def _aspirate(instruments: Dict[str, InstrumentContext],
-              loaded_labware: Dict[str, labware.Labware],
-              params: 'StandardLiquidHandlingParams') -> None:
-    pipette_id = params['pipette']
+def _aspirate(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "StandardLiquidHandlingParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     location = _get_location_with_offset(loaded_labware, params)
-    volume = params['volume']
+    volume = params["volume"]
     _set_flow_rate(pipette, params)
     pipette.aspirate(volume, location)
 
 
-def _dispense(instruments: Dict[str, InstrumentContext],
-              loaded_labware: Dict[str, labware.Labware],
-              params: 'StandardLiquidHandlingParams') -> None:
-    pipette_id = params['pipette']
+def _dispense(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "StandardLiquidHandlingParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     location = _get_location_with_offset(loaded_labware, params)
-    volume = params['volume']
+    volume = params["volume"]
     _set_flow_rate(pipette, params)
     pipette.dispense(volume, location)
 
 
-def _air_gap(instruments: Dict[str, InstrumentContext],
-             loaded_labware: Dict[str, labware.Labware],
-             params: 'StandardLiquidHandlingParams') -> None:
-    pipette_id = params['pipette']
+def _air_gap(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "StandardLiquidHandlingParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
-    offset_from_bottom = params['offsetFromBottomMm']
-    volume = params['volume']
+    offset_from_bottom = params["offsetFromBottomMm"]
+    volume = params["volume"]
     _set_flow_rate(pipette, params)
     well = _get_well(loaded_labware, params)
     offset_from_top = offset_from_bottom - well.geometry._depth
@@ -173,10 +194,12 @@ def _air_gap(instruments: Dict[str, InstrumentContext],
     pipette.air_gap(volume, offset_from_top)
 
 
-def _touch_tip(instruments: Dict[str, InstrumentContext],
-               loaded_labware: Dict[str, labware.Labware],
-               params: 'TouchTipParams') -> None:
-    pipette_id = params['pipette']
+def _touch_tip(
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+    params: "TouchTipParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
     location = _get_location_with_offset(loaded_labware, params)
     well = _get_well(loaded_labware, params)
@@ -185,30 +208,29 @@ def _touch_tip(instruments: Dict[str, InstrumentContext],
     pipette.touch_tip(well, v_offset=v_offset)
 
 
-def _move_to_slot(context: ProtocolContext,
-                  instruments: Dict[str, InstrumentContext],
-                  params: 'MoveToSlotParams') -> None:
-    pipette_id = params['pipette']
+def _move_to_slot(
+    context: ProtocolContext,
+    instruments: Dict[str, InstrumentContext],
+    params: "MoveToSlotParams",
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
-    slot = params['slot']
+    slot = params["slot"]
     if slot not in context.deck:
-        raise ValueError('Invalid "slot" for "moveToSlot": {}'
-                         .format(slot))
+        raise ValueError('Invalid "slot" for "moveToSlot": {}'.format(slot))
     slot_obj = context.deck.position_for(slot)
 
-    offset = params.get('offset', {})
-    offsetPoint = Point(
-        offset.get('x', 0),
-        offset.get('y', 0),
-        offset.get('z', 0))
+    offset = params.get("offset", {})
+    offsetPoint = Point(offset.get("x", 0), offset.get("y", 0), offset.get("z", 0))
 
     pipette.move_to(
         slot_obj.move(offsetPoint),
-        force_direct=params.get('forceDirect'),
-        minimum_z_height=params.get('minimumZHeight'))
+        force_direct=params.get("forceDirect"),
+        minimum_z_height=params.get("minimumZHeight"),
+    )
 
 
-dispatcher_map: 'PipetteDispatch' = {
+dispatcher_map: "PipetteDispatch" = {
     JsonRobotCommand.delay.value: _delay,
     JsonPipetteCommand.blowout.value: _blowout,
     JsonPipetteCommand.pickUpTip.value: _pick_up_tip,
@@ -216,15 +238,17 @@ dispatcher_map: 'PipetteDispatch' = {
     JsonPipetteCommand.aspirate.value: _aspirate,
     JsonPipetteCommand.dispense.value: _dispense,
     JsonPipetteCommand.touchTip.value: _touch_tip,
-    JsonPipetteCommand.moveToSlot.value: _move_to_slot
+    JsonPipetteCommand.moveToSlot.value: _move_to_slot,
 }
 
 
-def dispatch_json(context: ProtocolContext,
-                  protocol_data: 'JsonProtocolV3',
-                  instruments: Dict[str, InstrumentContext],
-                  loaded_labware: Dict[str, labware.Labware]) -> None:
-    commands = protocol_data['commands']
+def dispatch_json(
+    context: ProtocolContext,
+    protocol_data: "JsonProtocolV3",
+    instruments: Dict[str, InstrumentContext],
+    loaded_labware: Dict[str, labware.Labware],
+) -> None:
+    commands = protocol_data["commands"]
 
     pipette_commands = {
         JsonPipetteCommand.blowout.value,
@@ -236,18 +260,17 @@ def dispatch_json(context: ProtocolContext,
     }
 
     for command_item in commands:
-        command_type = command_item['command']
-        params = command_item['params']
+        command_type = command_item["command"]
+        params = command_item["params"]
 
         # different `_command` helpers take different args
         if command_type in pipette_commands:
-            dispatcher_map[command_type](  # type: ignore
-                instruments, loaded_labware, params)  # type: ignore
+            dispatcher_map[command_type](  # type: ignore[call-arg]
+                instruments, loaded_labware, params  # type: ignore[arg-type]
+            )
         elif command_type == JsonRobotCommand.delay.value:
             dispatcher_map[command_type](context, params)  # type: ignore
         elif command_type == JsonPipetteCommand.moveToSlot.value:
-            dispatcher_map[command_type](
-                context, instruments, params)  # type: ignore
+            dispatcher_map[command_type](context, instruments, params)  # type: ignore
         else:
-            raise RuntimeError(
-                "Unsupported command type {}".format(command_type))
+            raise RuntimeError("Unsupported command type {}".format(command_type))

--- a/api/src/opentrons/protocols/execution/execute_json_v4.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v4.py
@@ -1,12 +1,18 @@
 import logging
 from typing import Dict, List, TYPE_CHECKING, Union
-from opentrons.protocol_api.contexts import ProtocolContext, \
-    MagneticModuleContext, TemperatureModuleContext, ModuleContext, \
-    ThermocyclerContext
+from opentrons.protocol_api.contexts import (
+    ProtocolContext,
+    MagneticModuleContext,
+    TemperatureModuleContext,
+    ModuleContext,
+    ThermocyclerContext,
+)
 from .execute_json_v3 import _delay, _move_to_slot
 from opentrons.protocols.execution.types import LoadedLabware, Instruments
 from opentrons_shared_data.protocol.constants import (
-    JsonRobotCommand, JsonPipetteCommand)
+    JsonRobotCommand,
+    JsonPipetteCommand,
+)
 
 
 if TYPE_CHECKING:
@@ -14,62 +20,67 @@ if TYPE_CHECKING:
         JsonProtocolV4,
         JsonProtocolV5,
         MagneticModuleEngageParams,
-        ModuleIDParams, TemperatureParams,
+        ModuleIDParams,
+        TemperatureParams,
         ThermocyclerSetTargetBlockParams,
-        ThermocyclerRunProfileParams, Command,
-        TemperatureModuleCommandId, MagneticModuleCommandId,
-        ThermocyclerCommandId
+        ThermocyclerRunProfileParams,
+        Command,
+        TemperatureModuleCommandId,
+        MagneticModuleCommandId,
+        ThermocyclerCommandId,
     )
     from opentrons.protocols.execution.dev_types import (
-        PipetteDispatch, JsonV4MagneticModuleDispatch,
+        PipetteDispatch,
+        JsonV4MagneticModuleDispatch,
         JsonV4TemperatureModuleDispatch,
-        JsonV4ThermocyclerDispatch)
+        JsonV4ThermocyclerDispatch,
+    )
 
 MODULE_LOG = logging.getLogger(__name__)
 
 # Special string for slot used by thermocycler in JSON protocols.
-TC_SPANNING_SLOT = 'span7_8_10_11'
+TC_SPANNING_SLOT = "span7_8_10_11"
 
 
 def load_labware_from_json_defs(
-        ctx: ProtocolContext,
-        protocol: 'JsonProtocolV4',
-        modules: Dict[str, ModuleContext]) -> LoadedLabware:
-    protocol_labware = protocol['labware']
-    definitions = protocol['labwareDefinitions']
+    ctx: ProtocolContext, protocol: "JsonProtocolV4", modules: Dict[str, ModuleContext]
+) -> LoadedLabware:
+    protocol_labware = protocol["labware"]
+    definitions = protocol["labwareDefinitions"]
     loaded_labware = {}
 
     for labware_id, props in protocol_labware.items():
-        slot = props['slot']
-        definition = definitions[props['definitionId']]
-        label = props.get('displayName', None)
+        slot = props["slot"]
+        definition = definitions[props["definitionId"]]
+        label = props.get("displayName", None)
         if slot in modules:
-            loaded_labware[labware_id] = \
-                modules[slot].load_labware_from_definition(definition, label)
+            loaded_labware[labware_id] = modules[slot].load_labware_from_definition(
+                definition, label
+            )
         else:
-            loaded_labware[labware_id] = \
-                ctx.load_labware_from_definition(definition, slot, label)
+            loaded_labware[labware_id] = ctx.load_labware_from_definition(
+                definition, slot, label
+            )
 
     return loaded_labware
 
 
 def load_modules_from_json(
-        ctx: ProtocolContext,
-        protocol: 'JsonProtocolV4') -> Dict[str, ModuleContext]:
-    module_data = protocol['modules']
+    ctx: ProtocolContext, protocol: "JsonProtocolV4"
+) -> Dict[str, ModuleContext]:
+    module_data = protocol["modules"]
     modules_by_id = {}
 
     # the sort order doesn't matter, we just need it to be stable
     # to ensure `load_module` side-effects are deterministic
     # (eg, multiple module support)
     sorted_modules = sorted(
-        module_data.items(),
-        key=lambda v: v[1]['slot'] +
-        v[1]['model'])
+        module_data.items(), key=lambda v: v[1]["slot"] + v[1]["model"]
+    )
 
     for module_id, module_props in sorted_modules:
-        model = module_props['model']
-        slot = module_props['slot']
+        model = module_props["model"]
+        slot = module_props["slot"]
         if slot == TC_SPANNING_SLOT:
             instr = ctx.load_module(model)
         else:
@@ -80,109 +91,116 @@ def load_modules_from_json(
 
 
 def _engage_magnet(
-        module: MagneticModuleContext,
-        params: 'MagneticModuleEngageParams') -> None:
-    engage_height = params['engageHeight']
+    module: MagneticModuleContext, params: "MagneticModuleEngageParams"
+) -> None:
+    engage_height = params["engageHeight"]
     module.engage(height_from_base=engage_height)
 
 
-def _disengage_magnet(
-        module: MagneticModuleContext,
-        params: 'ModuleIDParams') -> None:
+def _disengage_magnet(module: MagneticModuleContext, params: "ModuleIDParams") -> None:
     module.disengage()
 
 
-def _temperature_module_set_temp(module: TemperatureModuleContext,
-                                 params: 'TemperatureParams') -> None:
-    temperature = params['temperature']
+def _temperature_module_set_temp(
+    module: TemperatureModuleContext, params: "TemperatureParams"
+) -> None:
+    temperature = params["temperature"]
     module.start_set_temperature(temperature)
 
 
-def _temperature_module_deactivate(module: TemperatureModuleContext,
-                                   params: 'ModuleIDParams') -> None:
+def _temperature_module_deactivate(
+    module: TemperatureModuleContext, params: "ModuleIDParams"
+) -> None:
     module.deactivate()
 
 
-def _temperature_module_await_temp(module: TemperatureModuleContext,
-                                   params: 'TemperatureParams') -> None:
-    temperature = params['temperature']
+def _temperature_module_await_temp(
+    module: TemperatureModuleContext, params: "TemperatureParams"
+) -> None:
+    temperature = params["temperature"]
     module.await_temperature(temperature)
 
 
-def _thermocycler_close_lid(module: ThermocyclerContext,
-                            params: 'ModuleIDParams') -> None:
+def _thermocycler_close_lid(
+    module: ThermocyclerContext, params: "ModuleIDParams"
+) -> None:
     module.close_lid()
 
 
-def _thermocycler_open_lid(module: ThermocyclerContext,
-                           params: 'ModuleIDParams') -> None:
+def _thermocycler_open_lid(
+    module: ThermocyclerContext, params: "ModuleIDParams"
+) -> None:
     module.open_lid()
 
 
-def _thermocycler_deactivate_block(module: ThermocyclerContext,
-                                   params: 'ModuleIDParams') -> None:
+def _thermocycler_deactivate_block(
+    module: ThermocyclerContext, params: "ModuleIDParams"
+) -> None:
     module.deactivate_block()
 
 
-def _thermocycler_deactivate_lid(module: ThermocyclerContext,
-                                 params: 'ModuleIDParams') -> None:
+def _thermocycler_deactivate_lid(
+    module: ThermocyclerContext, params: "ModuleIDParams"
+) -> None:
     module.deactivate_lid()
 
 
 def _thermocycler_set_block_temperature(
-        module: ThermocyclerContext,
-        params: 'ThermocyclerSetTargetBlockParams') -> None:
-    temperature = params['temperature']
+    module: ThermocyclerContext, params: "ThermocyclerSetTargetBlockParams"
+) -> None:
+    temperature = params["temperature"]
     module.set_block_temperature(temperature)
 
 
 def _thermocycler_set_lid_temperature(
-        module: ThermocyclerContext,
-        params: 'TemperatureParams') -> None:
-    temperature = params['temperature']
+    module: ThermocyclerContext, params: "TemperatureParams"
+) -> None:
+    temperature = params["temperature"]
     module.set_lid_temperature(temperature)
 
 
 def _thermocycler_run_profile(
-        module: ThermocyclerContext,
-        params: 'ThermocyclerRunProfileParams') -> None:
-    volume = params['volume']
-    profile = [{
-        'temperature': p['temperature'],
-        'hold_time_seconds': p['holdTime']
-    } for p in params['profile']]
-    module.execute_profile(
-        steps=profile,
-        block_max_volume=volume,
-        repetitions=1)
+    module: ThermocyclerContext, params: "ThermocyclerRunProfileParams"
+) -> None:
+    volume = params["volume"]
+    profile = [
+        {"temperature": p["temperature"], "hold_time_seconds": p["holdTime"]}
+        for p in params["profile"]
+    ]
+    module.execute_profile(steps=profile, block_max_volume=volume, repetitions=1)
 
 
-def assert_no_async_tc_behavior(commands: List['Command']) -> None:
+def assert_no_async_tc_behavior(commands: List["Command"]) -> None:
     # awaiters[i] corresponds to setters[i]
     setters = [
         "thermocycler/setTargetBlockTemperature",
         "thermocycler/setTargetLidTemperature",
-        "thermocycler/runProfile"]
+        "thermocycler/runProfile",
+    ]
     awaiters = [
         "thermocycler/awaitBlockTemperature",
         "thermocycler/awaitLidTemperature",
-        "thermocycler/awaitProfileComplete"]
+        "thermocycler/awaitProfileComplete",
+    ]
 
-    command_types = [c['command'] for c in commands]
+    command_types = [c["command"] for c in commands]
 
     first_command = command_types[0]
     if first_command in awaiters:
         raise RuntimeError(
-            ("Unsupported behavior. Cannot {} as the " +
-             "first command of a protocol")
-            .format(first_command))
+            (
+                "Unsupported behavior. Cannot {} as the "
+                + "first command of a protocol"
+            ).format(first_command)
+        )
 
     last_command = command_types[-1]
     if last_command in setters:
         raise RuntimeError(
-            ("Unsupported behavior. Cannot {} as the " +
-             "last command of a protocol")
-            .format(last_command))
+            (
+                "Unsupported behavior. Cannot {} as the " + "last command of a protocol"
+            ).format(last_command)
+        )
 
     # [a, b, c, d] -> [a, b], [b, c], [c, d]
     for a, b in zip(command_types, command_types[1:]):
@@ -192,120 +210,127 @@ def assert_no_async_tc_behavior(commands: List['Command']) -> None:
             expected_awaiter = awaiters[setters.index(a)]
             if b != expected_awaiter:
                 raise RuntimeError(
-                    ("Unsupported behavior. {} must be immediately" +
-                     "followed by {}")
-                    .format(a, expected_awaiter))
+                    (
+                        "Unsupported behavior. {} must be immediately"
+                        + "followed by {}"
+                    ).format(a, expected_awaiter)
+                )
         # an awaiter must be preceded by a setter
         elif b in awaiters:
             expected_setter = setters[awaiters.index(b)]
             raise RuntimeError(
-                ("Unsupported behavior. {} must be immediately " +
-                 "preceded by {}").format(b, expected_setter))
+                (
+                    "Unsupported behavior. {} must be immediately " + "preceded by {}"
+                ).format(b, expected_setter)
+            )
 
 
 def assert_tc_commands_do_not_use_unimplemented_params(
-        commands: List['Command']) -> None:
+    commands: List["Command"],
+) -> None:
     # raise errors if commands include optional param keys that
     # the executor/api does not currently support
-    unsupported_keys_by_command = {
-        "thermocycler/setTargetBlockTemperature": ["volume"]
-    }
+    unsupported_keys_by_command = {"thermocycler/setTargetBlockTemperature": ["volume"]}
     for c in commands:
-        command_type = c['command']
-        params = c['params']
-        unsupported_keys = unsupported_keys_by_command.get(
-            command_type, [])
+        command_type = c["command"]
+        params = c["params"]
+        unsupported_keys = unsupported_keys_by_command.get(command_type, [])
         for k in unsupported_keys:
             if k in params:
-                raise RuntimeError((
-                    "{} does not support {} param. " +
-                    "This may be implemented in a later version of " +
-                    "the robot server").format(command_type, k))
+                raise RuntimeError(
+                    (
+                        "{} does not support {} param. "
+                        + "This may be implemented in a later version of "
+                        + "the robot server"
+                    ).format(command_type, k)
+                )
 
 
 def dispatch_json(
-        context: ProtocolContext,
-        protocol_data: Union['JsonProtocolV4', 'JsonProtocolV5'],
-        instruments: Instruments,
-        loaded_labware: LoadedLabware,
-        modules: Dict[str, ModuleContext],
-        pipette_command_map: 'PipetteDispatch',
-        magnetic_module_command_map: 'JsonV4MagneticModuleDispatch',
-        temperature_module_command_map: 'JsonV4TemperatureModuleDispatch',
-        thermocycler_module_command_map: 'JsonV4ThermocyclerDispatch'
+    context: ProtocolContext,
+    protocol_data: Union["JsonProtocolV4", "JsonProtocolV5"],
+    instruments: Instruments,
+    loaded_labware: LoadedLabware,
+    modules: Dict[str, ModuleContext],
+    pipette_command_map: "PipetteDispatch",
+    magnetic_module_command_map: "JsonV4MagneticModuleDispatch",
+    temperature_module_command_map: "JsonV4TemperatureModuleDispatch",
+    thermocycler_module_command_map: "JsonV4ThermocyclerDispatch",
 ) -> None:
-    commands = protocol_data['commands']
+    commands = protocol_data["commands"]
 
     assert_no_async_tc_behavior(commands)
     assert_tc_commands_do_not_use_unimplemented_params(commands)
 
     for command_item in commands:
-        command_type = command_item['command']
-        params = command_item['params']
+        command_type = command_item["command"]
+        params = command_item["params"]
         # because of https://github.com/python/mypy/issues/8940
         # we can't narrow down types using in sadly
         if command_type in pipette_command_map:
             pipette_command_map[command_type](  # type: ignore
-                instruments, loaded_labware, params)
+                instruments, loaded_labware, params
+            )
         elif command_type in magnetic_module_command_map:
             handleMagnetCommand(
                 params,  # type: ignore
                 modules,
                 command_type,  # type: ignore
-                magnetic_module_command_map
+                magnetic_module_command_map,
             )
         elif command_type in temperature_module_command_map:
-            handleTemperatureCommand(params,  # type: ignore
-                                     modules,
-                                     command_type,  # type: ignore
-                                     temperature_module_command_map)
+            handleTemperatureCommand(
+                params,  # type: ignore
+                modules,
+                command_type,  # type: ignore
+                temperature_module_command_map,
+            )
         elif command_type in thermocycler_module_command_map:
-            handleThermocyclerCommand(params,  # type: ignore
-                                      modules,  # type: ignore
-                                      command_type,  # type: ignore
-                                      thermocycler_module_command_map)
-        elif command_item['command'] == JsonRobotCommand.delay.value:
+            handleThermocyclerCommand(
+                params,  # type: ignore
+                modules,  # type: ignore
+                command_type,  # type: ignore
+                thermocycler_module_command_map,
+            )
+        elif command_item["command"] == JsonRobotCommand.delay.value:
             _delay(context, params)  # type: ignore
         elif command_type == JsonPipetteCommand.moveToSlot.value:
             _move_to_slot(context, instruments, params)  # type: ignore
         else:
-            raise RuntimeError(
-                "Unsupported command type {}".format(command_type))
+            raise RuntimeError("Unsupported command type {}".format(command_type))
 
 
 def handleTemperatureCommand(
-        params: Union['TemperatureParams', 'ModuleIDParams'],
-        modules: Dict[str, ModuleContext],
-        command_type: 'TemperatureModuleCommandId',
-        temperature_module_command_map
+    params: Union["TemperatureParams", "ModuleIDParams"],
+    modules: Dict[str, ModuleContext],
+    command_type: "TemperatureModuleCommandId",
+    temperature_module_command_map,
 ) -> None:
-    module_id = params['module']
+    module_id = params["module"]
     module = modules[module_id]
     if isinstance(module, TemperatureModuleContext):
-        temperature_module_command_map[command_type](
-            module, params
-        )
+        temperature_module_command_map[command_type](module, params)
     else:
         raise RuntimeError(
-            "Temperature Module does not match " +
-            "TemperatureModuleContext interface"
+            "Temperature Module does not match " + "TemperatureModuleContext interface"
         )
 
 
 def handleThermocyclerCommand(
-        params: Union['ModuleIDParams', 'TemperatureParams',
-                      'ThermocyclerRunProfileParams',
-                      'ThermocyclerSetTargetBlockParams'],
-        modules: Dict[str, ThermocyclerContext],
-        command_type: 'ThermocyclerCommandId',
-        thermocycler_module_command_map
+    params: Union[
+        "ModuleIDParams",
+        "TemperatureParams",
+        "ThermocyclerRunProfileParams",
+        "ThermocyclerSetTargetBlockParams",
+    ],
+    modules: Dict[str, ThermocyclerContext],
+    command_type: "ThermocyclerCommandId",
+    thermocycler_module_command_map,
 ) -> None:
-    module_id = params['module']
+    module_id = params["module"]
     module = modules[module_id]
     if isinstance(module, ThermocyclerContext):
-        thermocycler_module_command_map[command_type](
-            module, params
-        )
+        thermocycler_module_command_map[command_type](module, params)
     else:
         raise RuntimeError(
             "Thermocycler Module does not match ThermocyclerContext interface"
@@ -313,17 +338,15 @@ def handleThermocyclerCommand(
 
 
 def handleMagnetCommand(
-        params: Union['ModuleIDParams', 'MagneticModuleEngageParams'],
-        modules: Dict[str, ModuleContext],
-        command_type: 'MagneticModuleCommandId',
-        magnetic_module_command_map
+    params: Union["ModuleIDParams", "MagneticModuleEngageParams"],
+    modules: Dict[str, ModuleContext],
+    command_type: "MagneticModuleCommandId",
+    magnetic_module_command_map,
 ) -> None:
-    module_id = params['module']
+    module_id = params["module"]
     module = modules[module_id]
     if isinstance(module, MagneticModuleContext):
-        magnetic_module_command_map[command_type](
-            module, params
-        )
+        magnetic_module_command_map[command_type](module, params)
     else:
         raise RuntimeError(
             "Magnetic Module does not match MagneticModuleContext interface"

--- a/api/src/opentrons/protocols/execution/execute_json_v5.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v5.py
@@ -3,30 +3,26 @@ from typing import TYPE_CHECKING
 from opentrons.types import Point
 from opentrons.protocols.execution.types import LoadedLabware, Instruments
 from .execute_json_v3 import _get_well
+
 if TYPE_CHECKING:
-    from opentrons_shared_data.protocol.dev_types import (
-        MoveToWellParams
-    )
+    from opentrons_shared_data.protocol.dev_types import MoveToWellParams
 
 MODULE_LOG = logging.getLogger(__name__)
 
 
 def _move_to_well(
-        instruments: Instruments,
-        loaded_labware: LoadedLabware,
-        params: 'MoveToWellParams') -> None:
-    pipette_id = params['pipette']
+    instruments: Instruments, loaded_labware: LoadedLabware, params: "MoveToWellParams"
+) -> None:
+    pipette_id = params["pipette"]
     pipette = instruments[pipette_id]
 
     well = _get_well(loaded_labware, params)
 
-    offset = params.get('offset', {})
-    offsetPoint = Point(
-        offset.get('x', 0),
-        offset.get('y', 0),
-        offset.get('z', 0))
+    offset = params.get("offset", {})
+    offsetPoint = Point(offset.get("x", 0), offset.get("y", 0), offset.get("z", 0))
 
     pipette.move_to(
         well.bottom().move(offsetPoint),
-        force_direct=params.get('forceDirect'),
-        minimum_z_height=params.get('minimumZHeight'))
+        force_direct=params.get("forceDirect"),
+        minimum_z_height=params.get("minimumZHeight"),
+    )

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -25,8 +25,8 @@ def _runfunc_ok(run_func: Any):
             if param.default == inspect.Parameter.empty:
                 raise SyntaxError(
                     "Function 'run{}' must be called with more than one "
-                    "argument but would be called as 'run(ctx)'"
-                    .format(str(sig)))
+                    "argument but would be called as 'run(ctx)'".format(str(sig))
+                )
 
 
 def _find_protocol_error(tb, proto_name):
@@ -41,24 +41,23 @@ def _find_protocol_error(tb, proto_name):
         raise KeyError
 
 
-def run_python(
-        proto: PythonProtocol, context: ProtocolContext):
+def run_python(proto: PythonProtocol, context: ProtocolContext):
     new_globs: Dict[Any, Any] = {}
     exec(proto.contents, new_globs)
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
-    if proto.filename and proto.filename.endswith('zip'):
-        filename = 'protocol.ot2.py'
+    if proto.filename and proto.filename.endswith("zip"):
+        filename = "protocol.ot2.py"
     else:
-        filename = proto.filename or '<protocol>'
+        filename = proto.filename or "<protocol>"
     try:
-        _runfunc_ok(new_globs.get('run'))
+        _runfunc_ok(new_globs.get("run"))
     except SyntaxError as se:
         raise MalformedProtocolError(str(se))
-    new_globs['__context'] = context
+    new_globs["__context"] = context
     try:
-        exec('run(__context)', new_globs)
+        exec("run(__context)", new_globs)
     except (SmoothieAlarm, asyncio.CancelledError, ExecutionCancelledError):
         # this is a protocol cancel and shouldn't have special logging
         raise

--- a/api/src/opentrons/protocols/execution/json_dispatchers.py
+++ b/api/src/opentrons/protocols/execution/json_dispatchers.py
@@ -1,37 +1,49 @@
 from typing import TYPE_CHECKING
 from opentrons.protocols.execution.execute_json_v3 import (
-    _blowout, _pick_up_tip, _drop_tip, _aspirate, _dispense, _touch_tip,
-    _air_gap)
-from opentrons.protocols.execution.execute_json_v4 import _engage_magnet, \
-    _disengage_magnet, _temperature_module_set_temp, \
-    _temperature_module_deactivate, \
-    _temperature_module_await_temp, \
-    _thermocycler_close_lid, \
-    _thermocycler_open_lid, \
-    _thermocycler_deactivate_block, \
-    _thermocycler_deactivate_lid, \
-    _thermocycler_set_block_temperature, \
-    _thermocycler_set_lid_temperature, \
-    _thermocycler_run_profile
+    _blowout,
+    _pick_up_tip,
+    _drop_tip,
+    _aspirate,
+    _dispense,
+    _touch_tip,
+    _air_gap,
+)
+from opentrons.protocols.execution.execute_json_v4 import (
+    _engage_magnet,
+    _disengage_magnet,
+    _temperature_module_set_temp,
+    _temperature_module_deactivate,
+    _temperature_module_await_temp,
+    _thermocycler_close_lid,
+    _thermocycler_open_lid,
+    _thermocycler_deactivate_block,
+    _thermocycler_deactivate_lid,
+    _thermocycler_set_block_temperature,
+    _thermocycler_set_lid_temperature,
+    _thermocycler_run_profile,
+)
 from opentrons.protocols.execution.execute_json_v5 import _move_to_well
 
 from opentrons.protocol_api.module_contexts import ThermocyclerContext
 
 
 from opentrons_shared_data.protocol.constants import (
-    JsonPipetteCommand, JsonMagneticModuleCommand,
-    JsonTemperatureModuleCommand, JsonThermocyclerCommand
+    JsonPipetteCommand,
+    JsonMagneticModuleCommand,
+    JsonTemperatureModuleCommand,
+    JsonThermocyclerCommand,
 )
 
 if TYPE_CHECKING:
     from opentrons.protocols.execution.dev_types import (
-        PipetteDispatch, JsonV4MagneticModuleDispatch,
+        PipetteDispatch,
+        JsonV4MagneticModuleDispatch,
         JsonV4TemperatureModuleDispatch,
-        JsonV4ThermocyclerDispatch
+        JsonV4ThermocyclerDispatch,
     )
 
 
-pipette_command_map: 'PipetteDispatch' = {
+pipette_command_map: "PipetteDispatch" = {
     JsonPipetteCommand.blowout.value: _blowout,
     JsonPipetteCommand.pickUpTip.value: _pick_up_tip,
     JsonPipetteCommand.dropTip.value: _drop_tip,
@@ -39,22 +51,18 @@ pipette_command_map: 'PipetteDispatch' = {
     JsonPipetteCommand.dispense.value: _dispense,
     JsonPipetteCommand.touchTip.value: _touch_tip,
     JsonPipetteCommand.airGap.value: _air_gap,
-    JsonPipetteCommand.moveToWell.value: _move_to_well
+    JsonPipetteCommand.moveToWell.value: _move_to_well,
 }
 
-magnetic_module_command_map: 'JsonV4MagneticModuleDispatch' = {
+magnetic_module_command_map: "JsonV4MagneticModuleDispatch" = {
     JsonMagneticModuleCommand.magneticModuleEngageMagnet.value: _engage_magnet,
-    JsonMagneticModuleCommand.magneticModuleDisengageMagnet.value:
-    _disengage_magnet,
+    JsonMagneticModuleCommand.magneticModuleDisengageMagnet.value: _disengage_magnet,
 }
 
-temperature_module_command_map: 'JsonV4TemperatureModuleDispatch' = {
-    JsonTemperatureModuleCommand.temperatureModuleSetTargetTemperature.value:
-        _temperature_module_set_temp,
-    JsonTemperatureModuleCommand.temperatureModuleDeactivate.value:
-        _temperature_module_deactivate,
-    JsonTemperatureModuleCommand.temperatureModuleAwaitTemperature.value:
-        _temperature_module_await_temp
+temperature_module_command_map: "JsonV4TemperatureModuleDispatch" = {
+    JsonTemperatureModuleCommand.temperatureModuleSetTargetTemperature.value: _temperature_module_set_temp,  # noqa: E501
+    JsonTemperatureModuleCommand.temperatureModuleDeactivate.value: _temperature_module_deactivate,  # noqa: E501
+    JsonTemperatureModuleCommand.temperatureModuleAwaitTemperature.value: _temperature_module_await_temp,  # noqa: E501
 }
 
 
@@ -62,27 +70,18 @@ def tc_do_nothing(module: ThermocyclerContext, params) -> None:
     pass
 
 
-thermocycler_module_command_map: 'JsonV4ThermocyclerDispatch' = {
-    JsonThermocyclerCommand.thermocyclerCloseLid.value:
-    _thermocycler_close_lid,
+thermocycler_module_command_map: "JsonV4ThermocyclerDispatch" = {
+    JsonThermocyclerCommand.thermocyclerCloseLid.value: _thermocycler_close_lid,
     JsonThermocyclerCommand.thermocyclerOpenLid.value: _thermocycler_open_lid,
-    JsonThermocyclerCommand.thermocyclerDeactivateBlock.value:
-    _thermocycler_deactivate_block,
-    JsonThermocyclerCommand.thermocyclerDeactivateLid.value:
-    _thermocycler_deactivate_lid,
-    JsonThermocyclerCommand.thermocyclerSetTargetBlockTemperature.value:
-    _thermocycler_set_block_temperature,
-    JsonThermocyclerCommand.thermocyclerSetTargetLidTemperature.value:
-    _thermocycler_set_lid_temperature,
-    JsonThermocyclerCommand.thermocyclerRunProfile.value:
-    _thermocycler_run_profile,
+    JsonThermocyclerCommand.thermocyclerDeactivateBlock.value: _thermocycler_deactivate_block,  # noqa: E501
+    JsonThermocyclerCommand.thermocyclerDeactivateLid.value: _thermocycler_deactivate_lid,  # noqa: E501
+    JsonThermocyclerCommand.thermocyclerSetTargetBlockTemperature.value: _thermocycler_set_block_temperature,  # noqa: E501
+    JsonThermocyclerCommand.thermocyclerSetTargetLidTemperature.value: _thermocycler_set_lid_temperature,  # noqa: E501
+    JsonThermocyclerCommand.thermocyclerRunProfile.value: _thermocycler_run_profile,
     # NOTE: the thermocyclerAwaitX commands are expected to always
     # follow a corresponding SetX command, which is implemented as
     # blocking. Then nothing needs to be done for awaitX commands.
-    JsonThermocyclerCommand.thermocyclerAwaitBlockTemperature.value:
-    tc_do_nothing,
-    JsonThermocyclerCommand.thermocyclerAwaitLidTemperature.value:
-    tc_do_nothing,
-    JsonThermocyclerCommand.thermocyclerAwaitProfileComplete.value:
-    tc_do_nothing,
+    JsonThermocyclerCommand.thermocyclerAwaitBlockTemperature.value: tc_do_nothing,
+    JsonThermocyclerCommand.thermocyclerAwaitLidTemperature.value: tc_do_nothing,
+    JsonThermocyclerCommand.thermocyclerAwaitProfileComplete.value: tc_do_nothing,
 }

--- a/api/src/opentrons/protocols/geometry/deck.py
+++ b/api/src/opentrons/protocols/geometry/deck.py
@@ -8,8 +8,11 @@ from opentrons.protocol_api.labware import load as load_lw, Labware
 from opentrons.protocols.api_support.constants import STANDARD_DECK
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.geometry.deck_item import DeckItem
-from opentrons.protocols.geometry.module_geometry import ModuleGeometry, \
-    ModuleType, ThermocyclerGeometry
+from opentrons.protocols.geometry.module_geometry import (
+    ModuleGeometry,
+    ModuleType,
+    ThermocyclerGeometry,
+)
 from opentrons_shared_data.deck import load as load_deck
 
 if TYPE_CHECKING:
@@ -22,7 +25,7 @@ MODULE_LOG = logging.getLogger(__name__)
 
 # Amount of slots in a single deck row
 ROW_LENGTH = 3
-FIXED_TRASH_ID = 'fixedTrash'
+FIXED_TRASH_ID = "fixedTrash"
 
 
 @dataclass
@@ -32,6 +35,7 @@ class CalibrationPosition:
     aspects of the robot's movement system as defined by
     opentrons/shared-data/deck/schemas/2.json
     """
+
     id: str
     position: List[float]
     displayName: str
@@ -44,19 +48,20 @@ class Deck(UserDict):
         col_offset = 132.5
         for idx in range(1, 13):
             self.data[idx] = None
-        self._positions = {idx + 1: types.Point((idx % 3) * col_offset,
-                                                idx // 3 * row_offset,
-                                                0)
-                           for idx in range(12)}
+        self._positions = {
+            idx + 1: types.Point((idx % 3) * col_offset, idx // 3 * row_offset, 0)
+            for idx in range(12)
+        }
         self._highest_z = 0.0
         self._definition = load_deck(load_name, 2)
         self._load_fixtures()
 
     def _load_fixtures(self):
-        for f in self._definition['locations']['fixtures']:
-            slot_name = self._check_name(f['slot'])  # type: ignore
-            loaded_f = load_lw(f['labware'],  # type: ignore
-                               self.position_for(slot_name))
+        for f in self._definition["locations"]["fixtures"]:
+            slot_name = self._check_name(f["slot"])  # type: ignore
+            loaded_f = load_lw(
+                f["labware"], self.position_for(slot_name)  # type: ignore
+            )
             self.__setitem__(slot_name, loaded_f)
 
     @staticmethod
@@ -98,21 +103,24 @@ class Deck(UserDict):
         overlapping_items = self.get_collisions_for_item(slot_key_int, val)
         if item is not None:
             if slot_key_int == 12:
-                if FIXED_TRASH_ID in item.parameters.get('quirks', []):
+                if FIXED_TRASH_ID in item.parameters.get("quirks", []):
                     pass
                 else:
-                    raise ValueError(f'Deck location {key} '
-                                     'is for fixed trash only')
+                    raise ValueError(f"Deck location {key} " "is for fixed trash only")
             else:
-                raise ValueError(f'Deck location {key} already'
-                                 f'  has an item: {self.data[slot_key_int]}')
+                raise ValueError(
+                    f"Deck location {key} already"
+                    f"  has an item: {self.data[slot_key_int]}"
+                )
         elif overlapping_items:
-            flattened_overlappers = [repr(item) for sublist in
-                                     overlapping_items.values()
-                                     for item in sublist]
-            raise ValueError(f'Could not load {val} as deck location {key} '
-                             'is obscured by '
-                             f'{", ".join(flattened_overlappers)}')
+            flattened_overlappers = [
+                repr(item) for sublist in overlapping_items.values() for item in sublist
+            ]
+            raise ValueError(
+                f"Could not load {val} as deck location {key} "
+                "is obscured by "
+                f'{", ".join(flattened_overlappers)}'
+            )
         self.data[slot_key_int] = val
         self._highest_z = max(val.highest_z, self._highest_z)
 
@@ -123,8 +131,7 @@ class Deck(UserDict):
             return False
         return key_int in self.data
 
-    def is_edge_move_unsafe(
-            self, mount: types.Mount, target: 'Labware') -> bool:
+    def is_edge_move_unsafe(self, mount: types.Mount, target: "Labware") -> bool:
         """
         Check if slot next to target labware contains a module. Only relevant
         depending on the mount you are using and the column you are moving
@@ -168,101 +175,112 @@ class Deck(UserDict):
         for item in [lw for lw in self.data.values() if lw]:
             self._highest_z = max(item.highest_z, self._highest_z)
 
-    def get_slot_definition(self, slot_name) -> 'SlotDefV2':
-        slots = self._definition['locations']['orderedSlots']
-        slot_def = next(
-            (slot for slot in slots if slot['id'] == slot_name), None)
+    def get_slot_definition(self, slot_name) -> "SlotDefV2":
+        slots = self._definition["locations"]["orderedSlots"]
+        slot_def = next((slot for slot in slots if slot["id"] == slot_name), None)
         if not slot_def:
-            slot_ids = [slot['id'] for slot in slots]
-            raise ValueError(f'slot {slot_name} could not be found,'
-                             f'valid deck slots are: {slot_ids}')
+            slot_ids = [slot["id"] for slot in slots]
+            raise ValueError(
+                f"slot {slot_name} could not be found,"
+                f"valid deck slots are: {slot_ids}"
+            )
         return slot_def
 
     def get_slot_center(self, slot_name) -> types.Point:
         defn = self.get_slot_definition(slot_name)
         return types.Point(
-            defn['position'][0] + defn['boundingBox']['xDimension']/2,
-            defn['position'][1] + defn['boundingBox']['yDimension']/2,
-            defn['position'][2] + defn['boundingBox']['zDimension']/2)
+            defn["position"][0] + defn["boundingBox"]["xDimension"] / 2,
+            defn["position"][1] + defn["boundingBox"]["yDimension"] / 2,
+            defn["position"][2] + defn["boundingBox"]["zDimension"] / 2,
+        )
 
     def resolve_module_location(
-            self, module_type: ModuleType,
-            location: Optional[types.DeckLocation]) -> types.DeckLocation:
-        dn_from_type = {ModuleType.MAGNETIC: 'Magnetic Module',
-                        ModuleType.THERMOCYCLER: 'Thermocycler',
-                        ModuleType.TEMPERATURE: 'Temperature Module'}
+        self, module_type: ModuleType, location: Optional[types.DeckLocation]
+    ) -> types.DeckLocation:
+        dn_from_type = {
+            ModuleType.MAGNETIC: "Magnetic Module",
+            ModuleType.THERMOCYCLER: "Thermocycler",
+            ModuleType.TEMPERATURE: "Temperature Module",
+        }
         if isinstance(location, str) or isinstance(location, int):
-            slot_def = self.get_slot_definition(
-                str(location))
-            compatible_modules = slot_def['compatibleModuleTypes']
+            slot_def = self.get_slot_definition(str(location))
+            compatible_modules = slot_def["compatibleModuleTypes"]
             if module_type.value in compatible_modules:
                 return location
             else:
                 raise AssertionError(
-                    f'A {dn_from_type[module_type]} cannot be loaded'
-                    f' into slot {location}')
+                    f"A {dn_from_type[module_type]} cannot be loaded"
+                    f" into slot {location}"
+                )
         else:
             valid_slots = [
-                slot['id'] for slot in self.slots
-                if module_type.value in slot['compatibleModuleTypes']]
+                slot["id"]
+                for slot in self.slots
+                if module_type.value in slot["compatibleModuleTypes"]
+            ]
             if len(valid_slots) == 1:
                 return valid_slots[0]
             elif not valid_slots:
                 raise ValueError(
-                    'A {dn_from_type[module_type]} cannot be used with this '
-                    'deck')
+                    "A {dn_from_type[module_type]} cannot be used with this " "deck"
+                )
             else:
                 raise AssertionError(
-                    f'{dn_from_type[module_type]}s do not have default'
-                    ' location, you must specify a slot')
+                    f"{dn_from_type[module_type]}s do not have default"
+                    " location, you must specify a slot"
+                )
 
     @property
     def highest_z(self) -> float:
-        """ Return the tallest known point on the deck. """
+        """Return the tallest known point on the deck."""
         return self._highest_z
 
     @property
-    def slots(self) -> List['SlotDefV2']:
-        """ Return the definition of the loaded robot deck. """
-        return self._definition['locations']['orderedSlots']
+    def slots(self) -> List["SlotDefV2"]:
+        """Return the definition of the loaded robot deck."""
+        return self._definition["locations"]["orderedSlots"]
 
     @property
     def calibration_positions(self) -> List[CalibrationPosition]:
-        raw_positions = self._definition['locations']['calibrationPoints']
+        raw_positions = self._definition["locations"]["calibrationPoints"]
         return [CalibrationPosition(**pos) for pos in raw_positions]
 
     def get_calibration_position(self, id: str) -> CalibrationPosition:
         calibration_position = next(
-            (pos for pos in self.calibration_positions if pos.id == id),
-            None)
+            (pos for pos in self.calibration_positions if pos.id == id), None
+        )
         if not calibration_position:
             pos_ids = [pos.id for pos in self.calibration_positions]
-            raise ValueError(f'calibration position {id} '
-                             'could not be found, '
-                             f'valid calibration position ids are: {pos_ids}')
+            raise ValueError(
+                f"calibration position {id} "
+                "could not be found, "
+                f"valid calibration position ids are: {pos_ids}"
+            )
         return calibration_position
 
     def get_fixed_trash(self) -> Optional[Labware]:
-        fixtures = self._definition['locations']['fixtures']
-        ft = next((f for f in fixtures if f['id'] == FIXED_TRASH_ID), None)
+        fixtures = self._definition["locations"]["fixtures"]
+        ft = next((f for f in fixtures if f["id"] == FIXED_TRASH_ID), None)
         return (
-            self.data[self._check_name(ft.get('slot'))]  # type: ignore
-            if ft else None
+            self.data[self._check_name(ft.get("slot"))] if ft else None  # type: ignore
         )
 
     def get_non_fixture_slots(self) -> List[types.DeckLocation]:
-        fixtures = self._definition['locations']['fixtures']
-        fixture_slots = {self._check_name(f.get('slot'))  # type: ignore
-                         for f in fixtures if f.get('slot')}  # type: ignore
+        fixtures = self._definition["locations"]["fixtures"]
+        fixture_slots = {
+            self._check_name(f.get("slot"))  # type: ignore[misc]
+            for f in fixtures
+            if f.get("slot")  # type: ignore[misc]
+        }
         return [s for s in self.data.keys() if s not in fixture_slots]
 
-    def get_collisions_for_item(self,
-                                slot_key: types.DeckLocation,
-                                item: DeckItem) -> Dict[types.DeckLocation,
-                                                        List[DeckItem]]:
-        """ Return the loaded deck items that collide
-            with the given item.
+    def get_collisions_for_item(
+        self, slot_key: types.DeckLocation, item: DeckItem
+    ) -> Dict[types.DeckLocation, List[DeckItem]]:
+        """Return the loaded deck items that collide
+        with the given item.
         """
+
         def get_item_covered_slot_keys(sk, i):
             if isinstance(i, ThermocyclerGeometry):
                 return i.covered_slots

--- a/api/src/opentrons/protocols/geometry/deck_item.py
+++ b/api/src/opentrons/protocols/geometry/deck_item.py
@@ -2,7 +2,6 @@ import abc
 
 
 class DeckItem(abc.ABC):
-
     @property  # type: ignore
     @abc.abstractmethod
     def highest_z(self):

--- a/api/src/opentrons/protocols/geometry/labware_geometry.py
+++ b/api/src/opentrons/protocols/geometry/labware_geometry.py
@@ -34,23 +34,16 @@ class AbstractLabwareGeometry(ABC):
 
 
 class LabwareGeometry(AbstractLabwareGeometry):
-
-    def __init__(self,
-                 definition: LabwareDefinition,
-                 parent: Location):
+    def __init__(self, definition: LabwareDefinition, parent: Location):
         """Constructor"""
         self._parent = parent
-        offset = definition['cornerOffsetFromSlot']
-        self._offset = Point(
-            offset['x'],
-            offset['y'],
-            offset['z']
-        ) + parent.point
+        offset = definition["cornerOffsetFromSlot"]
+        self._offset = Point(offset["x"], offset["y"], offset["z"]) + parent.point
 
-        dimensions = definition['dimensions']
-        self._x_dimension = dimensions['xDimension']
-        self._y_dimension = dimensions['yDimension']
-        self._z_dimension = dimensions['zDimension']
+        dimensions = definition["dimensions"]
+        self._x_dimension = dimensions["xDimension"]
+        self._y_dimension = dimensions["yDimension"]
+        self._z_dimension = dimensions["zDimension"]
 
     @property
     def parent(self) -> Location:

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -9,22 +9,26 @@ by :py:mod:`.module_contexts`)
 import functools
 import logging
 import re
-from typing import (Mapping, Optional,
-                    Union, TYPE_CHECKING)
+from typing import Mapping, Optional, Union, TYPE_CHECKING
 
 import numpy as np  # type: ignore
 import jsonschema  # type: ignore
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 
 from opentrons_shared_data import module
 from opentrons.hardware_control.modules.types import (
-    ModuleModel, ModuleType, MagneticModuleModel,
-    TemperatureModuleModel, ThermocyclerModuleModel)
+    ModuleModel,
+    ModuleType,
+    MagneticModuleModel,
+    TemperatureModuleModel,
+    ThermocyclerModuleModel,
+)
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import (
-    MAX_SUPPORTED_VERSION, V2_MODULE_DEF_VERSION)
+    MAX_SUPPORTED_VERSION,
+    V2_MODULE_DEF_VERSION,
+)
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocol_api.labware import Labware
 
@@ -32,14 +36,17 @@ from .types import GenericConfiguration, ThermocyclerConfiguration
 
 if TYPE_CHECKING:
     from opentrons_shared_data.module.dev_types import (
-        ModuleDefinitionV1, ModuleDefinitionV2)
+        ModuleDefinitionV1,
+        ModuleDefinitionV2,
+    )
 
 
 def module_model_from_string(model_string: str) -> ModuleModel:
     for model_enum in {
-            MagneticModuleModel,
-            TemperatureModuleModel,
-            ThermocyclerModuleModel}:
+        MagneticModuleModel,
+        TemperatureModuleModel,
+        ThermocyclerModuleModel,
+    }:
         try:
             return model_enum.from_str(model_string)  # type: ignore
         except AttributeError:
@@ -73,15 +80,17 @@ class ModuleGeometry(DeckItem):
         # If a module is the parent of a labware it affects calibration
         return True
 
-    def __init__(self,
-                 display_name: str,
-                 model: ModuleModel,
-                 module_type: ModuleType,
-                 offset: Point,
-                 overall_height: float,
-                 height_over_labware: float,
-                 parent: Location,
-                 api_level: APIVersion) -> None:
+    def __init__(
+        self,
+        display_name: str,
+        model: ModuleModel,
+        module_type: ModuleType,
+        offset: Point,
+        overall_height: float,
+        height_over_labware: float,
+        parent: Location,
+        api_level: APIVersion,
+    ) -> None:
         """
         Create a Module for tracking the position of a module.
 
@@ -114,24 +123,20 @@ class ModuleGeometry(DeckItem):
         self._api_version = api_level
         self._parent = parent
         self._module_type = module_type
-        self._display_name = "{} on {}".format(
-            display_name, str(parent.labware))
+        self._display_name = "{} on {}".format(display_name, str(parent.labware))
         self._model = model
         self._offset = offset
         self._height = overall_height + self._parent.point.z
         self._over_labware = height_over_labware
         self._labware: Optional[Labware] = None
-        self._location = Location(
-            point=self._offset + self._parent.point,
-            labware=self)
+        self._location = Location(point=self._offset + self._parent.point, labware=self)
 
     @property
     def api_version(self) -> APIVersion:
         return self._api_version
 
     def add_labware(self, labware: Labware) -> Labware:
-        assert not self._labware,\
-            '{} is already on this module'.format(self._labware)
+        assert not self._labware, "{} is already on this module".format(self._labware)
         self._labware = labware
         return self._labware
 
@@ -148,7 +153,7 @@ class ModuleGeometry(DeckItem):
 
     @property
     def module_type(self) -> ModuleType:
-        """ The Moduletype """
+        """The Moduletype"""
         return self._module_type
 
     @property
@@ -187,18 +192,19 @@ class ModuleGeometry(DeckItem):
 
 
 class ThermocyclerGeometry(ModuleGeometry):
-    def __init__(self,
-                 display_name: str,
-                 model: ModuleModel,
-                 module_type: ModuleType,
-                 offset: Point,
-                 overall_height: float,
-                 height_over_labware: float,
-                 lid_height: float,
-                 parent: Location,
-                 api_level: APIVersion,
-                 configuration: GenericConfiguration =
-                 ThermocyclerConfiguration.FULL) -> None:
+    def __init__(
+        self,
+        display_name: str,
+        model: ModuleModel,
+        module_type: ModuleType,
+        offset: Point,
+        overall_height: float,
+        height_over_labware: float,
+        lid_height: float,
+        parent: Location,
+        api_level: APIVersion,
+        configuration: GenericConfiguration = ThermocyclerConfiguration.FULL,
+    ) -> None:
         """
         Create a Module for tracking the position of a module.
 
@@ -233,10 +239,17 @@ class ThermocyclerGeometry(ModuleGeometry):
                               either be FULL or SEMI.
         """
         super().__init__(
-            display_name, model, module_type, offset, overall_height,
-            height_over_labware, parent, api_level)
+            display_name,
+            model,
+            module_type,
+            offset,
+            overall_height,
+            height_over_labware,
+            parent,
+            api_level,
+        )
         self._lid_height = lid_height
-        self._lid_status = 'open'   # Needs to reflect true status
+        self._lid_status = "open"  # Needs to reflect true status
         self._configuration = configuration
         if self.is_semi_configuration:
             self._offset = self._offset + Point(-23.28, 0, 0)
@@ -277,17 +290,15 @@ class ThermocyclerGeometry(ModuleGeometry):
     def labware_accessor(self, labware: Labware) -> Labware:
         # Block first three columns from being accessed
         definition = labware._implementation.get_definition()
-        definition['ordering'] = definition['ordering'][2::]
+        definition["ordering"] = definition["ordering"][2::]
         return Labware(
             implementation=LabwareImplementation(definition, super().location),
-            api_level=self._api_version
+            api_level=self._api_version,
         )
 
     def add_labware(self, labware: Labware) -> Labware:
-        assert not self._labware,\
-            '{} is already on this module'.format(self._labware)
-        assert self.lid_status != 'closed', \
-            'Cannot place labware in closed module'
+        assert not self._labware, "{} is already on this module".format(self._labware)
+        assert self.lid_status != "closed", "Cannot place labware in closed module"
         if self.is_semi_configuration:
             self._labware = self.labware_accessor(labware)
         else:
@@ -295,123 +306,133 @@ class ThermocyclerGeometry(ModuleGeometry):
         return self._labware
 
 
-def _load_from_v1(definition: 'ModuleDefinitionV1',
-                  parent: Location,
-                  api_level: APIVersion) -> ModuleGeometry:
-    """ Load a module geometry from a v1 definition.
+def _load_from_v1(
+    definition: "ModuleDefinitionV1", parent: Location, api_level: APIVersion
+) -> ModuleGeometry:
+    """Load a module geometry from a v1 definition.
 
     The definition should be schema checked before being passed to this
     function; all definitions passed here are assumed to be valid.
     """
-    mod_name = definition['loadName']
+    mod_name = definition["loadName"]
     model_lookup: Mapping[str, ModuleModel] = {
-        'thermocycler': ThermocyclerModuleModel.THERMOCYCLER_V1,
-        'magdeck': MagneticModuleModel.MAGNETIC_V1,
-        'tempdeck': TemperatureModuleModel.TEMPERATURE_V1}
+        "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
+        "magdeck": MagneticModuleModel.MAGNETIC_V1,
+        "tempdeck": TemperatureModuleModel.TEMPERATURE_V1,
+    }
     type_lookup = {
-        'thermocycler': ModuleType.THERMOCYCLER,
-        'tempdeck': ModuleType.TEMPERATURE,
-        'magdeck': ModuleType.MAGNETIC
+        "thermocycler": ModuleType.THERMOCYCLER,
+        "tempdeck": ModuleType.TEMPERATURE,
+        "magdeck": ModuleType.MAGNETIC,
     }
     model = model_lookup[mod_name]
-    offset = Point(definition["labwareOffset"]["x"],
-                   definition["labwareOffset"]["y"],
-                   definition["labwareOffset"]["z"])
-    overall_height = definition["dimensions"]["bareOverallHeight"]\
-
+    offset = Point(
+        definition["labwareOffset"]["x"],
+        definition["labwareOffset"]["y"],
+        definition["labwareOffset"]["z"],
+    )
+    overall_height = definition["dimensions"]["bareOverallHeight"]
     height_over_labware = definition["dimensions"]["overLabwareHeight"]
 
     if model in ThermocyclerModuleModel:
-        lid_height = definition['dimensions']['lidHeight']
-        mod: ModuleGeometry = \
-            ThermocyclerGeometry(definition["displayName"],
-                                 model,
-                                 type_lookup[mod_name],
-                                 offset,
-                                 overall_height,
-                                 height_over_labware,
-                                 lid_height,
-                                 parent,
-                                 api_level)
+        lid_height = definition["dimensions"]["lidHeight"]
+        mod: ModuleGeometry = ThermocyclerGeometry(
+            definition["displayName"],
+            model,
+            type_lookup[mod_name],
+            offset,
+            overall_height,
+            height_over_labware,
+            lid_height,
+            parent,
+            api_level,
+        )
     else:
-        mod = ModuleGeometry(definition['displayName'],
-                             model,
-                             type_lookup[mod_name],
-                             offset,
-                             overall_height,
-                             height_over_labware,
-                             parent, api_level)
+        mod = ModuleGeometry(
+            definition["displayName"],
+            model,
+            type_lookup[mod_name],
+            offset,
+            overall_height,
+            height_over_labware,
+            parent,
+            api_level,
+        )
     return mod
 
 
-def _load_from_v2(definition: 'ModuleDefinitionV2',
-                  parent: Location,
-                  api_level: APIVersion,
-                  configuration: GenericConfiguration) -> ModuleGeometry:
-    """ Load a module geometry from a v2 definition.
+def _load_from_v2(
+    definition: "ModuleDefinitionV2",
+    parent: Location,
+    api_level: APIVersion,
+    configuration: GenericConfiguration,
+) -> ModuleGeometry:
+    """Load a module geometry from a v2 definition.
 
     The definition should be schema checked before being passed to this
      function; all definitions passed here are assumed to be valid.
     """
-    pre_transform = np.array((definition['labwareOffset']['x'],
-                              definition['labwareOffset']['y'],
-                              1))
+    pre_transform = np.array(
+        (definition["labwareOffset"]["x"], definition["labwareOffset"]["y"], 1)
+    )
     if not parent.labware.is_slot:
-        par = ''
+        par = ""
         log.warning(
-            f'module location parent labware was {parent.labware} which is'
-            'not a slot name; slot transforms will not be loaded')
+            f"module location parent labware was {parent.labware} which is"
+            "not a slot name; slot transforms will not be loaded"
+        )
     else:
         par = str(parent.labware.object)
 
     # this needs to change to look up the current deck type if/when we add
     # that notion
-    xforms_ser = definition['slotTransforms']\
-        .get('ot2_standard', {})\
-        .get(par, {'labwareOffset': [[1, 0, 0], [0, 1, 0], [0, 0, 1]]})
-    xform_ser = xforms_ser['labwareOffset']
+    xforms_ser = (
+        definition["slotTransforms"]
+        .get("ot2_standard", {})
+        .get(par, {"labwareOffset": [[1, 0, 0], [0, 1, 0], [0, 0, 1]]})
+    )
+    xform_ser = xforms_ser["labwareOffset"]
 
     # apply the slot transform if any
     xform = np.array(xform_ser)
     xformed = np.dot(xform, pre_transform)
-    if definition['moduleType'] in {
-            ModuleType.MAGNETIC.value,
-            ModuleType.TEMPERATURE.value}:
+    if definition["moduleType"] in {
+        ModuleType.MAGNETIC.value,
+        ModuleType.TEMPERATURE.value,
+    }:
         return ModuleGeometry(
             parent=parent,
             api_level=api_level,
-            offset=Point(xformed[0],
-                         xformed[1],
-                         definition['labwareOffset']['z']),
-            overall_height=definition['dimensions']['bareOverallHeight'],
-            height_over_labware=definition['dimensions']['overLabwareHeight'],
-            model=module_model_from_string(definition['model']),
-            module_type=ModuleType.from_str(definition['moduleType']),
-            display_name=definition['displayName'])
-    elif definition['moduleType'] == ModuleType.THERMOCYCLER.value:
+            offset=Point(xformed[0], xformed[1], definition["labwareOffset"]["z"]),
+            overall_height=definition["dimensions"]["bareOverallHeight"],
+            height_over_labware=definition["dimensions"]["overLabwareHeight"],
+            model=module_model_from_string(definition["model"]),
+            module_type=ModuleType.from_str(definition["moduleType"]),
+            display_name=definition["displayName"],
+        )
+    elif definition["moduleType"] == ModuleType.THERMOCYCLER.value:
         return ThermocyclerGeometry(
             parent=parent,
             api_level=api_level,
-            offset=Point(xformed[0],
-                         xformed[1],
-                         definition['labwareOffset']['z']),
-            overall_height=definition['dimensions']['bareOverallHeight'],
-            height_over_labware=definition['dimensions']['overLabwareHeight'],
-            model=module_model_from_string(definition['model']),
-            module_type=ModuleType.from_str(definition['moduleType']),
-            display_name=definition['displayName'],
-            lid_height=definition['dimensions']['lidHeight'],
-            configuration=configuration)
+            offset=Point(xformed[0], xformed[1], definition["labwareOffset"]["z"]),
+            overall_height=definition["dimensions"]["bareOverallHeight"],
+            height_over_labware=definition["dimensions"]["overLabwareHeight"],
+            model=module_model_from_string(definition["model"]),
+            module_type=ModuleType.from_str(definition["moduleType"]),
+            display_name=definition["displayName"],
+            lid_height=definition["dimensions"]["lidHeight"],
+            configuration=configuration,
+        )
     else:
         raise RuntimeError(f'Unknown module type {definition["moduleType"]}')
 
 
 def load_module_from_definition(
-        definition: Union['ModuleDefinitionV1', 'ModuleDefinitionV2'],
-        parent: Location,
-        api_level: APIVersion = None,
-        configuration: GenericConfiguration =
-        ThermocyclerConfiguration.FULL) -> ModuleGeometry:
+    definition: Union["ModuleDefinitionV1", "ModuleDefinitionV2"],
+    parent: Location,
+    api_level: APIVersion = None,
+    configuration: GenericConfiguration = ThermocyclerConfiguration.FULL,
+) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a specified definition
     matching the v1 module definition schema
@@ -435,57 +456,58 @@ def load_module_from_definition(
         # but unfortunately we can't tell mypy that because it can only
         # discriminate unions based on literal tags or similar, not the
         # presence or absence of keys
-        v1def: 'ModuleDefinitionV1' = definition  # type: ignore
+        v1def: "ModuleDefinitionV1" = definition  # type: ignore
         return _load_from_v1(v1def, parent, api_level)
-    if schema == 'module/schemas/2':
-        schema_doc = module.load_schema('2')
+    if schema == "module/schemas/2":
+        schema_doc = module.load_schema("2")
         try:
             jsonschema.validate(definition, schema_doc)
         except jsonschema.ValidationError:
             log.exception("Failed to validate module def schema")
-            raise RuntimeError('The specified module definition is not valid.')
+            raise RuntimeError("The specified module definition is not valid.")
         # mypy can't tell these apart, but we've schema validated it - this is
         # the right type
-        v2def: 'ModuleDefinitionV2' = definition  # type: ignore
+        v2def: "ModuleDefinitionV2" = definition  # type: ignore
         return _load_from_v2(v2def, parent, api_level, configuration)
     elif isinstance(schema, str):
-        maybe_schema = re.match('^module/schemas/([0-9]+)$', schema)
+        maybe_schema = re.match("^module/schemas/([0-9]+)$", schema)
         if maybe_schema:
             raise RuntimeError(
                 f"Module definitions of schema version {maybe_schema.group(1)}"
-                " are not supported in this robot software release.")
+                " are not supported in this robot software release."
+            )
     log.error(f"Bad module definition (schema specifier {schema})")
-    raise RuntimeError(
-        'The specified module definition is not valid.')
+    raise RuntimeError("The specified module definition is not valid.")
 
 
-def _load_v1_module_def(module_model: ModuleModel) -> 'ModuleDefinitionV1':
-    v1names = {MagneticModuleModel.MAGNETIC_V1: 'magdeck',
-               TemperatureModuleModel.TEMPERATURE_V1: 'tempdeck',
-               ThermocyclerModuleModel.THERMOCYCLER_V1: 'thermocycler'}
+def _load_v1_module_def(module_model: ModuleModel) -> "ModuleDefinitionV1":
+    v1names = {
+        MagneticModuleModel.MAGNETIC_V1: "magdeck",
+        TemperatureModuleModel.TEMPERATURE_V1: "tempdeck",
+        ThermocyclerModuleModel.THERMOCYCLER_V1: "thermocycler",
+    }
     try:
         name = v1names[module_model]
     except KeyError:
         raise NoSuchModuleError(
-            f'Could not find module {module_model.value}',
-            module_model)
-    return module.load_definition('1', name)
+            f"Could not find module {module_model.value}", module_model
+        )
+    return module.load_definition("1", name)
 
 
-def _load_v2_module_def(module_model: ModuleModel) -> 'ModuleDefinitionV2':
+def _load_v2_module_def(module_model: ModuleModel) -> "ModuleDefinitionV2":
     try:
-        return module.load_definition('2', module_model.value)
+        return module.load_definition("2", module_model.value)
     except module.ModuleNotFoundError:
         raise NoSuchModuleError(
-            f'Could not find the module {module_model.value}.',
-            module_model)
+            f"Could not find the module {module_model.value}.", module_model
+        )
 
 
 @functools.lru_cache(maxsize=128)
 def _load_module_definition(
-        api_level: APIVersion,
-        module_model: ModuleModel) -> Union['ModuleDefinitionV2',
-                                            'ModuleDefinitionV1']:
+    api_level: APIVersion, module_model: ModuleModel
+) -> Union["ModuleDefinitionV2", "ModuleDefinitionV1"]:
     """
     Load the appropriate module definition for this api version
     """
@@ -495,22 +517,25 @@ def _load_module_definition(
             return _load_v1_module_def(module_model)
         except NoSuchModuleError:
             try:
-                dname = _load_v2_module_def(module_model)['displayName']
+                dname = _load_v2_module_def(module_model)["displayName"]
             except NoSuchModuleError:
                 dname = module_model.value
             raise NoSuchModuleError(
-                f'API version {api_level} does not support the module '
-                f'{dname}. Please use at least version '
-                f'{V2_MODULE_DEF_VERSION} to use this module.', module_model)
+                f"API version {api_level} does not support the module "
+                f"{dname}. Please use at least version "
+                f"{V2_MODULE_DEF_VERSION} to use this module.",
+                module_model,
+            )
     else:
         return _load_v2_module_def(module_model)
 
 
 def load_module(
-        model: ModuleModel,
-        parent: Location,
-        api_level: APIVersion = None,
-        configuration: str = None) -> ModuleGeometry:
+    model: ModuleModel,
+    parent: Location,
+    api_level: APIVersion = None,
+    configuration: str = None,
+) -> ModuleGeometry:
     """
     Return a :py:class:`ModuleGeometry` object from a definition looked up
     by name.
@@ -539,55 +564,59 @@ def load_module(
         # Thermocycler configurations, but there could be others
         # in the future
         return load_module_from_definition(
-            defn, parent, api_level,
-            ThermocyclerConfiguration.configuration_type(configuration))
+            defn,
+            parent,
+            api_level,
+            ThermocyclerConfiguration.configuration_type(configuration),
+        )
     else:
         return load_module_from_definition(defn, parent, api_level)
 
 
 def resolve_module_model(module_name: str) -> ModuleModel:
-    """ Turn any of the supported load names into module model names """
+    """Turn any of the supported load names into module model names"""
 
     model_map: Mapping[str, ModuleModel] = {
-        'magneticModuleV1': MagneticModuleModel.MAGNETIC_V1,
-        'magneticModuleV2': MagneticModuleModel.MAGNETIC_V2,
-        'temperatureModuleV1': TemperatureModuleModel.TEMPERATURE_V1,
-        'temperatureModuleV2': TemperatureModuleModel.TEMPERATURE_V2,
-        'thermocyclerModuleV1': ThermocyclerModuleModel.THERMOCYCLER_V1,
+        "magneticModuleV1": MagneticModuleModel.MAGNETIC_V1,
+        "magneticModuleV2": MagneticModuleModel.MAGNETIC_V2,
+        "temperatureModuleV1": TemperatureModuleModel.TEMPERATURE_V1,
+        "temperatureModuleV2": TemperatureModuleModel.TEMPERATURE_V2,
+        "thermocyclerModuleV1": ThermocyclerModuleModel.THERMOCYCLER_V1,
     }
 
     alias_map: Mapping[str, ModuleModel] = {
-        'magdeck': MagneticModuleModel.MAGNETIC_V1,
-        'magnetic module': MagneticModuleModel.MAGNETIC_V1,
-        'magnetic module gen2': MagneticModuleModel.MAGNETIC_V2,
-        'tempdeck': TemperatureModuleModel.TEMPERATURE_V1,
-        'temperature module': TemperatureModuleModel.TEMPERATURE_V1,
-        'temperature module gen2': TemperatureModuleModel.TEMPERATURE_V2,
-        'thermocycler': ThermocyclerModuleModel.THERMOCYCLER_V1,
-        'thermocycler module': ThermocyclerModuleModel.THERMOCYCLER_V1,
+        "magdeck": MagneticModuleModel.MAGNETIC_V1,
+        "magnetic module": MagneticModuleModel.MAGNETIC_V1,
+        "magnetic module gen2": MagneticModuleModel.MAGNETIC_V2,
+        "tempdeck": TemperatureModuleModel.TEMPERATURE_V1,
+        "temperature module": TemperatureModuleModel.TEMPERATURE_V1,
+        "temperature module gen2": TemperatureModuleModel.TEMPERATURE_V2,
+        "thermocycler": ThermocyclerModuleModel.THERMOCYCLER_V1,
+        "thermocycler module": ThermocyclerModuleModel.THERMOCYCLER_V1,
     }
 
     lower_name = module_name.lower()
-    resolved_name = model_map.get(module_name, None) \
-        or alias_map.get(lower_name, None)
+    resolved_name = model_map.get(module_name, None) or alias_map.get(lower_name, None)
     if not resolved_name:
         raise ValueError(
-            f'{module_name} is not a valid module load name.\n'
-            'Valid names (ignoring case): ''"' + '", "'
-            .join(alias_map.keys()) + '"\n' +
-            'You can also refer to modules by their ' +
-            'exact model: ''"' + '", "'
-            .join(model_map.keys()) + '"'
-            )
+            f"{module_name} is not a valid module load name.\n"
+            "Valid names (ignoring case): "
+            '"'
+            + '", "'.join(alias_map.keys())
+            + '"\n'
+            + "You can also refer to modules by their "
+            + "exact model: "
+            '"' + '", "'.join(model_map.keys()) + '"'
+        )
     return resolved_name
 
 
 def resolve_module_type(module_model: ModuleModel) -> ModuleType:
-    return ModuleType.from_str(_load_v2_module_def(module_model)['moduleType'])
+    return ModuleType.from_str(_load_v2_module_def(module_model)["moduleType"])
 
 
 def models_compatible(model_a: ModuleModel, model_b: ModuleModel) -> bool:
-    """ Check if two module models may be considered the same """
+    """Check if two module models may be considered the same"""
     if model_a == model_b:
         return True
-    return model_b.value in _load_v2_module_def(model_a)['compatibleWith']
+    return model_b.value in _load_v2_module_def(model_a)["compatibleWith"]

--- a/api/src/opentrons/protocols/geometry/types.py
+++ b/api/src/opentrons/protocols/geometry/types.py
@@ -1,17 +1,16 @@
 from enum import Enum, auto
 from typing import Type, TypeVar
 
-Configuration = TypeVar('Configuration', bound='GenericConfiguration')
+Configuration = TypeVar("Configuration", bound="GenericConfiguration")
 
 
 class GenericConfiguration(Enum):
     @classmethod
-    def configuration_type(
-            cls: Type[Configuration], config: str) -> 'Configuration':
+    def configuration_type(cls: Type[Configuration], config: str) -> "Configuration":
         for m in cls.__members__.values():
             if m.name == config.upper():
                 return m
-        raise AttributeError(f'{config} not available')
+        raise AttributeError(f"{config} not available")
 
 
 class ThermocyclerConfiguration(GenericConfiguration):

--- a/api/src/opentrons/protocols/geometry/well_geometry.py
+++ b/api/src/opentrons/protocols/geometry/well_geometry.py
@@ -5,19 +5,22 @@ from typing import Optional, cast, TYPE_CHECKING
 
 from opentrons.types import Point
 from opentrons_shared_data.labware.dev_types import (
-    WellDefinition, CircularWellDefinition, RectangularWellDefinition)
+    WellDefinition,
+    CircularWellDefinition,
+    RectangularWellDefinition,
+)
 
 if TYPE_CHECKING:
-    from opentrons.protocols.context.labware import \
-        AbstractLabware
+    from opentrons.protocols.context.labware import AbstractLabware
 
 
 class WellGeometry:
-
-    def __init__(self,
-                 well_props: WellDefinition,
-                 parent_point: Point,
-                 parent_object: AbstractLabware):
+    def __init__(
+        self,
+        well_props: WellDefinition,
+        parent_point: Point,
+        parent_object: AbstractLabware,
+    ):
         """
         Construct a well geometry object.
 
@@ -26,10 +29,12 @@ class WellGeometry:
         :param parent_object: The parent labware
         """
 
-        self._position\
-            = Point(well_props['x'],
-                    well_props['y'],
-                    well_props['z'] + well_props['depth']) + parent_point
+        self._position = (
+            Point(
+                well_props["x"], well_props["y"], well_props["z"] + well_props["depth"]
+            )
+            + parent_point
+        )
 
         if not parent_object:
             raise ValueError("Wells must have a parent")
@@ -40,23 +45,22 @@ class WellGeometry:
         self._width: Optional[float] = None
         self._diameter: Optional[float] = None
 
-        shape = well_props['shape']
-        if shape == 'rectangular':
+        shape = well_props["shape"]
+        if shape == "rectangular":
             rect_props = cast(RectangularWellDefinition, well_props)
-            self._length = rect_props['xDimension']
-            self._width = rect_props['yDimension']
+            self._length = rect_props["xDimension"]
+            self._width = rect_props["yDimension"]
             self._x_size = self._length
             self._y_size = self._width
-        elif shape == 'circular':
+        elif shape == "circular":
             circular_props = cast(CircularWellDefinition, well_props)
-            self._diameter = circular_props['diameter']
+            self._diameter = circular_props["diameter"]
             self._x_size = self._y_size = self._diameter
         else:
-            raise ValueError(
-                f'Shape "{shape}" is not a supported well shape')
+            raise ValueError(f'Shape "{shape}" is not a supported well shape')
 
-        self._max_volume = well_props['totalLiquidVolume']
-        self._depth = well_props['depth']
+        self._max_volume = well_props["totalLiquidVolume"]
+        self._depth = well_props["depth"]
 
     @property
     def parent(self) -> AbstractLabware:
@@ -87,8 +91,7 @@ class WellGeometry:
     def max_volume(self) -> float:
         return self._max_volume
 
-    def from_center_cartesian(
-            self, x: float, y: float, z: float) -> Point:
+    def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
         Specifies an arbitrary point in deck coordinates based
         on percentages of the radius in each axis. For example, to specify the
@@ -130,4 +133,5 @@ class WellGeometry:
         return Point(
             x=center.x + (x * (x_size / 2.0)),
             y=center.y + (y * (y_size / 2.0)),
-            z=center.z + (z * (z_size / 2.0)))
+            z=center.z + (z * (z_size / 2.0)),
+        )

--- a/api/src/opentrons/protocols/labware/__init__.py
+++ b/api/src/opentrons/protocols/labware/__init__.py
@@ -1,7 +1,13 @@
 from .definition import (
-    get_labware_definition, get_all_labware_definitions, save_calibration,
-    save_definition, get_labware_hash, get_labware_hash_with_parent,
-    delete_all_custom_labware, verify_definition)
+    get_labware_definition,
+    get_all_labware_definitions,
+    save_calibration,
+    save_definition,
+    get_labware_hash,
+    get_labware_hash_with_parent,
+    delete_all_custom_labware,
+    verify_definition,
+)
 from .load import load, load_from_definition
 
 

--- a/api/src/opentrons/protocols/labware/definition.py
+++ b/api/src/opentrons/protocols/labware/definition.py
@@ -5,20 +5,22 @@ import shutil
 from dataclasses import dataclass
 
 from pathlib import Path
-from typing import (
-    Any, AnyStr, List, Dict, Union)
+from typing import Any, AnyStr, List, Dict, Union
 
 import jsonschema  # type: ignore
 
 from opentrons.protocols.api_support.util import ModifiedList
 from opentrons.calibration_storage import helpers, modify
-from opentrons.protocols.context.labware import \
-    AbstractLabware
+from opentrons.protocols.context.labware import AbstractLabware
 from opentrons.types import Point
 from opentrons_shared_data import load_shared_data, get_shared_data_root
 from opentrons.protocols.geometry.deck_item import DeckItem
 from opentrons.protocols.api_support.constants import (
-    OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE, STANDARD_DEFS_PATH, USER_DEFS_PATH)
+    OPENTRONS_NAMESPACE,
+    CUSTOM_NAMESPACE,
+    STANDARD_DEFS_PATH,
+    USER_DEFS_PATH,
+)
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 
@@ -30,7 +32,7 @@ def get_labware_definition(
     namespace: str = None,
     version: int = None,
     bundled_defs: Dict[str, LabwareDefinition] = None,
-    extra_defs: Dict[str, LabwareDefinition] = None
+    extra_defs: Dict[str, LabwareDefinition] = None,
 ) -> LabwareDefinition:
     """
     Look up and return a definition by load_name + namespace + version and
@@ -50,18 +52,19 @@ def get_labware_definition(
 
     if bundled_defs is not None:
         return _get_labware_definition_from_bundle(
-            bundled_defs, load_name, namespace, version)
+            bundled_defs, load_name, namespace, version
+        )
 
     checked_extras = extra_defs or {}
 
     try:
         return _get_labware_definition_from_bundle(
-            checked_extras, load_name, namespace, version)
+            checked_extras, load_name, namespace, version
+        )
     except (FileNotFoundError, RuntimeError):
         pass
 
-    return _get_standard_labware_definition(
-        load_name, namespace, version)
+    return _get_standard_labware_definition(load_name, namespace, version)
 
 
 def get_all_labware_definitions() -> List[str]:
@@ -88,9 +91,7 @@ def get_all_labware_definitions() -> List[str]:
 
 
 def save_definition(
-    labware_def: LabwareDefinition,
-    force: bool = False,
-    location: Path = None
+    labware_def: LabwareDefinition, force: bool = False, location: Path = None
 ) -> None:
     """
     Save a labware definition
@@ -100,38 +101,41 @@ def save_definition(
         Cannot overwrite Opentrons definitions.
     :param location: File path
     """
-    namespace = labware_def['namespace']
-    load_name = labware_def['parameters']['loadName']
-    version = labware_def['version']
+    namespace = labware_def["namespace"]
+    load_name = labware_def["parameters"]["loadName"]
+    version = labware_def["version"]
 
     verify_definition(labware_def)
 
     if not namespace or not load_name or not version:
         raise RuntimeError(
-            'Could not save definition, labware def is missing a field: ' +
-            f'{namespace}, {load_name}, {version}')
+            "Could not save definition, labware def is missing a field: "
+            + f"{namespace}, {load_name}, {version}"
+        )
 
     if namespace == OPENTRONS_NAMESPACE:
         raise RuntimeError(
-            f'Saving definitions to the "{OPENTRONS_NAMESPACE}" namespace ' +
-            'is not permitted')
+            f'Saving definitions to the "{OPENTRONS_NAMESPACE}" namespace '
+            + "is not permitted"
+        )
 
     def_path = _get_path_to_labware(load_name, namespace, version, location)
 
     if not force and def_path.is_file():
         raise RuntimeError(
-            f'The given definition ({namespace}/{load_name} v{version}) ' +
-            'already exists. Cannot save definition without force=True')
+            f"The given definition ({namespace}/{load_name} v{version}) "
+            + "already exists. Cannot save definition without force=True"
+        )
 
     Path(def_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(def_path, 'w') as f:
+    with open(def_path, "w") as f:
         json.dump(labware_def, f)
 
 
-def verify_definition(contents: Union[
-        AnyStr, LabwareDefinition, Dict[str, Any]])\
-        -> LabwareDefinition:
-    """ Verify that an input string is a labware definition and return it.
+def verify_definition(
+    contents: Union[AnyStr, LabwareDefinition, Dict[str, Any]]
+) -> LabwareDefinition:
+    """Verify that an input string is a labware definition and return it.
 
     If the definition is invalid, an exception is raised; otherwise parse the
     json and return the valid definition.
@@ -140,7 +144,7 @@ def verify_definition(contents: Union[
     :raises jsonschema.ValidationError: If the definition is not valid.
     :returns: The parsed definition
     """
-    schema_body = load_shared_data('labware/schemas/2.json').decode('utf-8')
+    schema_body = load_shared_data("labware/schemas/2.json").decode("utf-8")
     labware_schema_v2 = json.loads(schema_body)
 
     if isinstance(contents, dict):
@@ -159,16 +163,14 @@ def delete_all_custom_labware() -> None:
         shutil.rmtree(USER_DEFS_PATH)
 
 
-def save_calibration(
-        labware: AbstractLabware,
-        delta: Point) -> None:
+def save_calibration(labware: AbstractLabware, delta: Point) -> None:
     """Save a calibration"""
     index_info = IndexFileInformation.from_labware(labware)
     modify.save_labware_calibration(
         labware_path=index_info.path,
         definition=index_info.definition,
         delta=delta,
-        parent=index_info.parent
+        parent=index_info.parent,
     )
     labware.set_calibration(delta=delta)
 
@@ -194,33 +196,34 @@ def _get_labware_definition_from_bundle(
     load_name = load_name.lower()
 
     bundled_candidates = [
-        b for b in bundled_labware.values()
-        if b['parameters']['loadName'] == load_name]
+        b for b in bundled_labware.values() if b["parameters"]["loadName"] == load_name
+    ]
     if namespace:
         namespace = namespace.lower()
         bundled_candidates = [
-            b for b in bundled_candidates if b['namespace'] == namespace]
+            b for b in bundled_candidates if b["namespace"] == namespace
+        ]
     if version:
-        bundled_candidates = [
-            b for b in bundled_candidates if b['version'] == version]
+        bundled_candidates = [b for b in bundled_candidates if b["version"] == version]
 
     if len(bundled_candidates) == 1:
         return bundled_candidates[0]
     elif len(bundled_candidates) > 1:
         raise RuntimeError(
-            f'Ambiguous labware access. Bundle contains multiple '
-            f'labware with load name {load_name}, '
-            f'namespace {namespace}, and version {version}.')
+            f"Ambiguous labware access. Bundle contains multiple "
+            f"labware with load name {load_name}, "
+            f"namespace {namespace}, and version {version}."
+        )
     else:
         raise RuntimeError(
-            f'No labware found in bundle with load name {load_name}, '
-            f'namespace {namespace}, and version {version}.')
+            f"No labware found in bundle with load name {load_name}, "
+            f"namespace {namespace}, and version {version}."
+        )
 
 
 def _get_standard_labware_definition(
-        load_name: str,
-        namespace: str = None,
-        version: int = None) -> LabwareDefinition:
+    load_name: str, namespace: str = None, version: int = None
+) -> LabwareDefinition:
 
     if version is None:
         checked_version = 1
@@ -243,19 +246,21 @@ def _get_standard_labware_definition(
         for fallback_namespace in [OPENTRONS_NAMESPACE, CUSTOM_NAMESPACE]:
             try:
                 return _get_standard_labware_definition(
-                    load_name, fallback_namespace, checked_version)
+                    load_name, fallback_namespace, checked_version
+                )
             except FileNotFoundError:
                 pass
 
-        raise FileNotFoundError(error_msg_string.format(
-                load_name, checked_version, OPENTRONS_NAMESPACE))
+        raise FileNotFoundError(
+            error_msg_string.format(load_name, checked_version, OPENTRONS_NAMESPACE)
+        )
 
     namespace = namespace.lower()
     def_path = _get_path_to_labware(load_name, namespace, checked_version)
 
     try:
-        with open(def_path, 'rb') as f:
-            labware_def = json.loads(f.read().decode('utf-8'))
+        with open(def_path, "rb") as f:
+            labware_def = json.loads(f.read().decode("utf-8"))
     except FileNotFoundError:
         raise FileNotFoundError(
             f'Labware "{load_name}" not found with version {checked_version} '
@@ -278,7 +283,7 @@ def _get_parent_identifier(labware: AbstractLabware) -> str:
         # treat a given labware on a given module type as same
         return parent.load_name
     else:
-        return ''  # treat all slots as same
+        return ""  # treat all slots as same
 
 
 def get_labware_hash(labware: AbstractLabware) -> str:
@@ -286,13 +291,13 @@ def get_labware_hash(labware: AbstractLabware) -> str:
 
 
 def get_labware_hash_with_parent(labware: AbstractLabware) -> str:
-    return helpers.hash_labware_def(
-        labware.get_definition()
-    ) + _get_parent_identifier(labware)
+    return helpers.hash_labware_def(labware.get_definition()) + _get_parent_identifier(
+        labware
+    )
 
 
 def _get_labware_path(labware: AbstractLabware) -> str:
-    return f'{get_labware_hash_with_parent(labware)}.json'
+    return f"{get_labware_hash_with_parent(labware)}.json"
 
 
 @dataclass(frozen=True)
@@ -302,22 +307,23 @@ class IndexFileInformation:
     path: str
 
     @classmethod
-    def from_labware(cls, labware: AbstractLabware) -> 'IndexFileInformation':
+    def from_labware(cls, labware: AbstractLabware) -> "IndexFileInformation":
         return IndexFileInformation(
             definition=labware.get_definition(),
             path=_get_labware_path(labware),
-            parent=_get_parent_identifier(labware)
+            parent=_get_parent_identifier(labware),
         )
 
 
 def _get_path_to_labware(
-        load_name: str, namespace: str, version: int, base_path: Path = None
-        ) -> Path:
+    load_name: str, namespace: str, version: int, base_path: Path = None
+) -> Path:
     if namespace == OPENTRONS_NAMESPACE:
         # all labware in OPENTRONS_NAMESPACE is stored in shared data
-        return get_shared_data_root() / STANDARD_DEFS_PATH \
-               / load_name / f'{version}.json'
+        return (
+            get_shared_data_root() / STANDARD_DEFS_PATH / load_name / f"{version}.json"
+        )
     if not base_path:
         base_path = USER_DEFS_PATH
-    def_path = base_path / namespace / load_name / f'{version}.json'
+    def_path = base_path / namespace / load_name / f"{version}.json"
     return def_path

--- a/api/src/opentrons/protocols/labware/load.py
+++ b/api/src/opentrons/protocols/labware/load.py
@@ -2,13 +2,13 @@ import logging
 from typing import Dict
 
 from opentrons.protocols.labware.definition import (
-    IndexFileInformation, get_labware_definition)
+    IndexFileInformation,
+    get_labware_definition,
+)
 
 from opentrons.calibration_storage import get
-from opentrons.protocols.context.labware import \
-    AbstractLabware
-from opentrons.protocols.context.protocol_api.labware import \
-    LabwareImplementation
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.types import Location
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
@@ -17,9 +17,8 @@ MODULE_LOG = logging.getLogger(__name__)
 
 
 def load_from_definition(
-        definition: LabwareDefinition,
-        parent: Location,
-        label: str = None) -> AbstractLabware:
+    definition: LabwareDefinition, parent: Location, label: str = None
+) -> AbstractLabware:
     """
     Return a labware object constructed from a provided labware definition dict
 
@@ -35,13 +34,13 @@ def load_from_definition(
     :param str label: An optional label that will override the labware's
                       display name from its definition
     """
-    labware = LabwareImplementation(
-            definition=definition, parent=parent, label=label)
+    labware = LabwareImplementation(definition=definition, parent=parent, label=label)
     index_info = IndexFileInformation.from_labware(labware)
     offset = get.get_labware_calibration(
         definition=index_info.definition,
         lookup_path=index_info.path,
-        parent=index_info.parent)
+        parent=index_info.parent,
+    )
     labware.set_calibration(offset)
     return labware
 
@@ -79,7 +78,6 @@ def load(
         searched.
     """
     definition = get_labware_definition(
-        load_name, namespace, version,
-        bundled_defs=bundled_defs,
-        extra_defs=extra_defs)
+        load_name, namespace, version, bundled_defs=bundled_defs, extra_defs=extra_defs
+    )
     return load_from_definition(definition, parent, label)

--- a/api/src/opentrons/protocols/models/__init__.py
+++ b/api/src/opentrons/protocols/models/__init__.py
@@ -6,10 +6,7 @@
 # from the name of its parent submodule. e.g. re-exporting models.json_protocol.Labware
 # as models.Labware could be confusing.
 
-from .labware_definition import (
-    LabwareDefinition,
-    WellDefinition
-)
+from .labware_definition import LabwareDefinition, WellDefinition
 from .json_protocol import Model as JsonProtocol
 
 __all__ = [

--- a/api/src/opentrons/protocols/models/json_protocol.py
+++ b/api/src/opentrons/protocols/models/json_protocol.py
@@ -15,47 +15,61 @@ from typing_extensions import Literal
 from .labware_definition import LabwareDefinition as LabwareDefinition
 from opentrons_shared_data.protocol import dev_types
 
-CommandAspirate: dev_types.AspirateCommandId = 'aspirate'
-CommandDispense: dev_types.DispenseCommandId = 'dispense'
-CommandAirGap: dev_types.AirGapCommandId = 'airGap'
-CommandBlowout: dev_types.BlowoutCommandId = 'blowout'
-CommandTouchTip: dev_types.TouchTipCommandId = 'touchTip'
-CommandPickUpTip: dev_types.PickUpTipCommandId = 'pickUpTip'
-CommandDropTip: dev_types.DropTipCommandId = 'dropTip'
-CommandMoveToSlot: dev_types.MoveToSlotCommandId = 'moveToSlot'
-CommandMoveToWell: dev_types.MoveToWellCommandId = 'moveToWell'
-CommandDelay: dev_types.DelayCommandId = 'delay'
-CommandMagneticModuleEngage: \
-    dev_types.MagneticModuleEngageCommandId = 'magneticModule/engageMagnet'
-CommandMagneticModuleDisengage:\
-    dev_types.MagneticModuleDisengageCommandId = 'magneticModule/disengageMagnet'
-CommandTemperatureModuleSetTarget: \
-    dev_types.TemperatureModuleSetTargetCommandId = \
-    'temperatureModule/setTargetTemperature'
-CommandTemperatureModuleAwait: \
-    dev_types.TemperatureModuleAwaitCommandId = 'temperatureModule/awaitTemperature'
-CommandTemperatureModuleDeactivate: \
-    dev_types.TemperatureModuleDeactivateCommandId = 'temperatureModule/deactivate'
-CommandThermocyclerSetTargetBlock: \
-    dev_types.ThermocyclerSetTargetBlockCommandId = 'thermocycler/setTargetBlockTemperature'  # noqa: E501
-CommandThermocyclerSetTargetLid: \
-    dev_types.ThermocyclerSetTargetLidCommandId = 'thermocycler/setTargetLidTemperature'  # noqa: E501
-CommandThermocyclerAwaitLidTemperature:\
-    dev_types.ThermocyclerAwaitLidTemperatureCommandId = 'thermocycler/awaitLidTemperature'  # noqa: E501
-CommandThermocyclerAwaitBlockTemperature:\
-    dev_types.ThermocyclerAwaitBlockTemperatureCommandId = 'thermocycler/awaitBlockTemperature'  # noqa: E501
-CommandThermocyclerDeactivateBlock:\
-    dev_types.ThermocyclerDeactivateBlockCommandId = 'thermocycler/deactivateBlock'
-CommandThermocyclerDeactivateLid:\
-    dev_types.ThermocyclerDeactivateLidCommandId = 'thermocycler/deactivateLid'
-CommandThermocyclerOpenLid:\
-    dev_types.ThermocyclerOpenLidCommandId = 'thermocycler/openLid'
-CommandThermocyclerCloseLid:\
-    dev_types.ThermocyclerCloseLidCommandId = 'thermocycler/closeLid'
-CommandThermocyclerRunProfile:\
-    dev_types.ThermocyclerRunProfileCommandId = 'thermocycler/runProfile'
-CommandThermocyclerAwaitProfile:\
-    dev_types.ThermocyclerAwaitProfileCommandId = 'thermocycler/awaitProfileComplete'
+CommandAspirate: dev_types.AspirateCommandId = "aspirate"
+CommandDispense: dev_types.DispenseCommandId = "dispense"
+CommandAirGap: dev_types.AirGapCommandId = "airGap"
+CommandBlowout: dev_types.BlowoutCommandId = "blowout"
+CommandTouchTip: dev_types.TouchTipCommandId = "touchTip"
+CommandPickUpTip: dev_types.PickUpTipCommandId = "pickUpTip"
+CommandDropTip: dev_types.DropTipCommandId = "dropTip"
+CommandMoveToSlot: dev_types.MoveToSlotCommandId = "moveToSlot"
+CommandMoveToWell: dev_types.MoveToWellCommandId = "moveToWell"
+CommandDelay: dev_types.DelayCommandId = "delay"
+CommandMagneticModuleEngage: dev_types.MagneticModuleEngageCommandId = (
+    "magneticModule/engageMagnet"
+)
+CommandMagneticModuleDisengage: dev_types.MagneticModuleDisengageCommandId = (
+    "magneticModule/disengageMagnet"
+)
+CommandTemperatureModuleSetTarget: dev_types.TemperatureModuleSetTargetCommandId = (
+    "temperatureModule/setTargetTemperature"
+)
+CommandTemperatureModuleAwait: dev_types.TemperatureModuleAwaitCommandId = (
+    "temperatureModule/awaitTemperature"
+)
+CommandTemperatureModuleDeactivate: dev_types.TemperatureModuleDeactivateCommandId = (
+    "temperatureModule/deactivate"
+)
+CommandThermocyclerSetTargetBlock: dev_types.ThermocyclerSetTargetBlockCommandId = (
+    "thermocycler/setTargetBlockTemperature"
+)
+CommandThermocyclerSetTargetLid: dev_types.ThermocyclerSetTargetLidCommandId = (
+    "thermocycler/setTargetLidTemperature"
+)
+CommandThermocyclerAwaitLidTemperature: dev_types.ThermocyclerAwaitLidTemperatureCommandId = (  # noqa: E501
+    "thermocycler/awaitLidTemperature"
+)
+CommandThermocyclerAwaitBlockTemperature: dev_types.ThermocyclerAwaitBlockTemperatureCommandId = (  # noqa: E501
+    "thermocycler/awaitBlockTemperature"
+)
+CommandThermocyclerDeactivateBlock: dev_types.ThermocyclerDeactivateBlockCommandId = (
+    "thermocycler/deactivateBlock"
+)
+CommandThermocyclerDeactivateLid: dev_types.ThermocyclerDeactivateLidCommandId = (
+    "thermocycler/deactivateLid"
+)
+CommandThermocyclerOpenLid: dev_types.ThermocyclerOpenLidCommandId = (
+    "thermocycler/openLid"
+)
+CommandThermocyclerCloseLid: dev_types.ThermocyclerCloseLidCommandId = (
+    "thermocycler/closeLid"
+)
+CommandThermocyclerRunProfile: dev_types.ThermocyclerRunProfileCommandId = (
+    "thermocycler/runProfile"
+)
+CommandThermocyclerAwaitProfile: dev_types.ThermocyclerAwaitProfileCommandId = (
+    "thermocycler/awaitProfileComplete"
+)
 
 
 class Metadata(BaseModel):
@@ -64,19 +78,19 @@ class Metadata(BaseModel):
     """
 
     protocolName: Optional[str] = Field(
-        None, description='A short, human-readable name for the protocol'
+        None, description="A short, human-readable name for the protocol"
     )
     author: Optional[str] = Field(
-        None, description='The author or organization who created the protocol'
+        None, description="The author or organization who created the protocol"
     )
     description: Optional[Optional[str]] = Field(
-        None, description='A text description of the protocol.'
+        None, description="A text description of the protocol."
     )
     created: Optional[float] = Field(
-        None, description='UNIX timestamp when this file was created'
+        None, description="UNIX timestamp when this file was created"
     )
     lastModified: Optional[Optional[float]] = Field(
-        None, description='UNIX timestamp when this file was last modified'
+        None, description="UNIX timestamp when this file was last modified"
     )
     category: Optional[Optional[str]] = Field(
         None, description='Category of protocol (eg, "Basic Pipetting")'
@@ -85,7 +99,7 @@ class Metadata(BaseModel):
         None, description='Subcategory of protocol (eg, "Cell Plating")'
     )
     tags: Optional[List[str]] = Field(
-        None, description='Tags to be used in searching for this protocol'
+        None, description="Tags to be used in searching for this protocol"
     )
 
 
@@ -97,24 +111,23 @@ class DesignerApplication(BaseModel):
 
     name: Optional[str] = Field(
         None,
-        description='Name of the application that created the protocol. Should '
-                    'be namespaced under the organization or individual who '
-                    'owns the organization, eg "opentrons/protocol-designer"',
+        description="Name of the application that created the protocol. Should "
+        "be namespaced under the organization or individual who "
+        'owns the organization, eg "opentrons/protocol-designer"',
     )
     version: Optional[str] = Field(
-        None, description='Version of the application that created the protocol'
+        None, description="Version of the application that created the protocol"
     )
     data: Optional[Dict[str, Any]] = Field(
-        None,
-        description='Any data used by the application that created this protocol'
+        None, description="Any data used by the application that created this protocol"
     )
 
 
 class Robot(BaseModel):
-    model: Literal['OT-2 Standard'] = Field(
+    model: Literal["OT-2 Standard"] = Field(
         ...,
-        description='Model of the robot this protocol is written for '
-                    '(currently only OT-2 Standard is supported)',
+        description="Model of the robot this protocol is written for "
+        "(currently only OT-2 Standard is supported)",
     )
 
 
@@ -128,7 +141,8 @@ class OffsetFromBottomMm(BaseModel):
     """
 
     offsetFromBottomMm: float = Field(
-        ..., description='Millimeters for pipette location offsets')
+        ..., description="Millimeters for pipette location offsets"
+    )
 
 
 class PipetteAccessParams(BaseModel):
@@ -143,7 +157,7 @@ class VolumeParams(BaseModel):
 
 class FlowRate(BaseModel):
     flowRate: float = Field(
-        ..., description='Flow rate in uL/sec. Must be greater than 0', ge=0.0
+        ..., description="Flow rate in uL/sec. Must be greater than 0", ge=0.0
     )
 
 
@@ -164,7 +178,7 @@ class LiquidCommand(BaseModel):
     Aspirate / dispense / air gap commands
     """
 
-    command: Literal['aspirate', 'dispense', 'airGap']
+    command: Literal["aspirate", "dispense", "airGap"]
     params: Params
 
 
@@ -173,7 +187,7 @@ class BlowoutCommand(BaseModel):
     Blowout command
     """
 
-    command: Literal['blowout']
+    command: Literal["blowout"]
     params: Params1
 
 
@@ -182,7 +196,7 @@ class TouchTipCommand(BaseModel):
     Touch tip commands
     """
 
-    command: Literal['touchTip']
+    command: Literal["touchTip"]
     params: Params2
 
 
@@ -191,7 +205,7 @@ class PickUpDropTipCommand(BaseModel):
     Pick up tip / drop tip commands
     """
 
-    command: Literal['pickUpTip', 'dropTip']
+    command: Literal["pickUpTip", "dropTip"]
     params: PipetteAccessParams
 
 
@@ -210,29 +224,29 @@ class Params3(BaseModel):
     slot: str = Field(
         ...,
         description="string '1'-'12', or special string 'span7_8_10_11' signify "
-                    "it's a slot on the OT-2 deck. If it's a UUID, it's the "
-                    "slot on the module referenced by that ID.",
+        "it's a slot on the OT-2 deck. If it's a UUID, it's the "
+        "slot on the module referenced by that ID.",
     )
     offset: Optional[Offset] = Field(
-        None, description='Optional offset from slot bottom left corner, in mm'
+        None, description="Optional offset from slot bottom left corner, in mm"
     )
     minimumZHeight: Optional[float] = Field(
         None,
         description="Optional minimal Z margin in mm. If this is larger than "
-                    "the API's default safe Z margin, it will make the arc "
-                    "higher. If it's smaller, it will have no effect. Specifying "
-                    "this for movements that would not arc (moving within the "
-                    "same well in the same labware) will cause an arc movement "
-                    "instead.",
+        "the API's default safe Z margin, it will make the arc "
+        "higher. If it's smaller, it will have no effect. Specifying "
+        "this for movements that would not arc (moving within the "
+        "same well in the same labware) will cause an arc movement "
+        "instead.",
         ge=0.0,
     )
     forceDirect: Optional[bool] = Field(
         None,
         description="Default is false. If true, moving from one labware/well to "
-                    "another will not arc to the default safe z, but instead will "
-                    "move directly to the specified location. This will also force "
-                    "the 'minimumZHeight' param to be ignored. A 'direct' movement "
-                    "is in X/Y/Z simultaneously",
+        "another will not arc to the default safe z, but instead will "
+        "move directly to the specified location. This will also force "
+        "the 'minimumZHeight' param to be ignored. A 'direct' movement "
+        "is in X/Y/Z simultaneously",
     )
 
 
@@ -242,20 +256,19 @@ class MoveToSlotCommand(BaseModel):
     subject to change in future releases.
     """
 
-    command: Literal['moveToSlot']
+    command: Literal["moveToSlot"]
     params: Params3
 
 
 class DelayCommandParams(BaseModel):
     wait: Union[Literal[True], float] = Field(
         ...,
-        description='either a number of seconds to wait (fractional values OK), '
-                    'or `true` to wait indefinitely until the user manually '
-                    'resumes the protocol',
+        description="either a number of seconds to wait (fractional values OK), "
+        "or `true` to wait indefinitely until the user manually "
+        "resumes the protocol",
     )
     message: Optional[str] = Field(
-        None,
-        description='optional message describing the delay'
+        None, description="optional message describing the delay"
     )
 
 
@@ -264,19 +277,19 @@ class DelayCommand(BaseModel):
     Delay command
     """
 
-    command: Literal['delay']
+    command: Literal["delay"]
     params: DelayCommandParams
 
 
 class Params5(BaseModel):
     engageHeight: float = Field(
         ...,
-        description='Height in mm(*) from bottom plane of labware (above if positive, '
-                    'below if negative). *NOTE: for magneticModuleV1 (aka GEN1), these '
-                    'are not true mm but an arbitrary unit equal to 0.5mm. So '
-                    '`engageHeight: 2` means 1mm above the labware plane if the '
-                    'command is for a GEN1 magnetic module, but would mean 2mm '
-                    'above the labware plane for GEN2 module',
+        description="Height in mm(*) from bottom plane of labware (above if positive, "
+        "below if negative). *NOTE: for magneticModuleV1 (aka GEN1), these "
+        "are not true mm but an arbitrary unit equal to 0.5mm. So "
+        "`engageHeight: 2` means 1mm above the labware plane if the "
+        "command is for a GEN1 magnetic module, but would mean 2mm "
+        "above the labware plane for GEN2 module",
     )
     module: str
 
@@ -286,7 +299,7 @@ class MagneticModuleEngageCommand(BaseModel):
     Magnetic module engage command. Engages magnet to specified height
     """
 
-    command: Literal['magneticModule/engageMagnet']
+    command: Literal["magneticModule/engageMagnet"]
     params: Params5
 
 
@@ -295,7 +308,7 @@ class MagneticModuleDisengageCommand(BaseModel):
     Magnetic module disengage command. Moves magnet down to disengaged (home) position
     """
 
-    command: Literal['magneticModule/disengageMagnet']
+    command: Literal["magneticModule/disengageMagnet"]
     params: ModuleOnlyParams
 
 
@@ -311,7 +324,7 @@ class TemperatureModuleSetTargetCommand(BaseModel):
     until the temperature is reached.
     """
 
-    command: Literal['temperatureModule/setTargetTemperature']
+    command: Literal["temperatureModule/setTargetTemperature"]
     params: Params6
 
 
@@ -326,7 +339,7 @@ class TemperatureModuleAwaitTemperatureCommand(BaseModel):
     until the specified temperature is reached.
     """
 
-    command: Literal['temperatureModule/awaitTemperature']
+    command: Literal["temperatureModule/awaitTemperature"]
     params: Params7
 
 
@@ -336,7 +349,7 @@ class TemperatureModuleDeactivateCommand(BaseModel):
     its temperature and drift to ambient temperature.
     """
 
-    command: Literal['temperatureModule/deactivate']
+    command: Literal["temperatureModule/deactivate"]
     params: ModuleOnlyParams
 
 
@@ -353,7 +366,7 @@ class ThermocyclerSetTargetBlockTemperatureCommand(BaseModel):
     the temperature is reached.
     """
 
-    command: Literal['thermocycler/setTargetBlockTemperature']
+    command: Literal["thermocycler/setTargetBlockTemperature"]
     params: Params8
 
 
@@ -369,7 +382,7 @@ class ThermocyclerSetTargetLidTemperatureCommand(BaseModel):
     the temperature is reached.
     """
 
-    command: Literal['thermocycler/setTargetLidTemperature']
+    command: Literal["thermocycler/setTargetLidTemperature"]
     params: Params9
 
 
@@ -384,7 +397,7 @@ class ThermocyclerAwaitBlockTemperatureCommand(BaseModel):
     until the specified temperature is reached.
     """
 
-    command: Literal['thermocycler/awaitBlockTemperature']
+    command: Literal["thermocycler/awaitBlockTemperature"]
     params: Params10
 
 
@@ -399,7 +412,7 @@ class ThermocyclerAwaitLidTemperatureCommand(BaseModel):
     until the specified temperature is reached.
     """
 
-    command: Literal['thermocycler/awaitLidTemperature']
+    command: Literal["thermocycler/awaitLidTemperature"]
     params: Params11
 
 
@@ -409,7 +422,7 @@ class ThermocyclerDeactivateBlockCommand(BaseModel):
     its block temperature.
     """
 
-    command: Literal['thermocycler/deactivateBlock']
+    command: Literal["thermocycler/deactivateBlock"]
     params: ModuleOnlyParams
 
 
@@ -419,7 +432,7 @@ class ThermocyclerDeactivateLidCommand(BaseModel):
     its lid temperature.
     """
 
-    command: Literal['thermocycler/deactivateLid']
+    command: Literal["thermocycler/deactivateLid"]
     params: ModuleOnlyParams
 
 
@@ -429,7 +442,7 @@ class ThermocyclerOpenLidCommand(BaseModel):
     fully open.
     """
 
-    command: Literal['thermocycler/openLid']
+    command: Literal["thermocycler/openLid"]
     params: ModuleOnlyParams
 
 
@@ -439,17 +452,14 @@ class ThermocyclerCloseLidCommand(BaseModel):
     fully closed.
     """
 
-    command: Literal['thermocycler/closeLid']
+    command: Literal["thermocycler/closeLid"]
     params: ModuleOnlyParams
 
 
 class ProfileItem(BaseModel):
-    temperature: float = Field(
-        ...,
-        description='Target temperature of profile step')
+    temperature: float = Field(..., description="Target temperature of profile step")
     holdTime: float = Field(
-        ...,
-        description='Time (in seconds) to hold once temperature is reached'
+        ..., description="Time (in seconds) to hold once temperature is reached"
     )
 
 
@@ -467,7 +477,7 @@ class ThermocyclerRunProfile(BaseModel):
     be given until a 'thermocycler/awaitProfileComplete' command is executed.
     """
 
-    command: Literal['thermocycler/runProfile']
+    command: Literal["thermocycler/runProfile"]
     params: Params12
 
 
@@ -477,7 +487,7 @@ class ThermocyclerAwaitProfileCompleteCommand(BaseModel):
     execution until profile execution is complete.
     """
 
-    command: Literal['thermocycler/awaitProfileComplete']
+    command: Literal["thermocycler/awaitProfileComplete"]
     params: ModuleOnlyParams
 
 
@@ -496,25 +506,24 @@ class Params13(BaseModel):
     labware: str
     well: str
     offset: Optional[Offset1] = Field(
-        None,
-        description='Optional offset from well bottom center, in mm'
+        None, description="Optional offset from well bottom center, in mm"
     )
     minimumZHeight: Optional[float] = Field(
         None,
         description="Optional minimal Z margin in mm. If this is larger than "
-                    "the API's default safe Z margin, it will make the arc higher. "
-                    "If it's smaller, it will have no effect. Specifying this for "
-                    "movements that would not arc (moving within the same well in "
-                    "the same labware) will cause an arc movement instead.",
+        "the API's default safe Z margin, it will make the arc higher. "
+        "If it's smaller, it will have no effect. Specifying this for "
+        "movements that would not arc (moving within the same well in "
+        "the same labware) will cause an arc movement instead.",
         ge=0.0,
     )
     forceDirect: Optional[bool] = Field(
         None,
         description="Default is false. If true, moving from one labware/well "
-                    "to another will not arc to the default safe z, but instead "
-                    "will move directly to the specified location. This will also "
-                    "force the 'minimumZHeight' param to be ignored. A 'direct' "
-                    "movement is in X/Y/Z simultaneously",
+        "to another will not arc to the default safe z, but instead "
+        "will move directly to the specified location. This will also "
+        "force the 'minimumZHeight' param to be ignored. A 'direct' "
+        "movement is in X/Y/Z simultaneously",
     )
 
 
@@ -529,7 +538,7 @@ class MoveToWellCommand(BaseModel):
     nozzle.
     """
 
-    command: Literal['moveToWell']
+    command: Literal["moveToWell"]
     params: Params13
 
 
@@ -567,13 +576,13 @@ class Pipettes(BaseModel):
     class Config:
         extra = Extra.allow
 
-    mount: Literal['left', 'right'] = Field(
-        ..., description='Where the pipette is mounted'
+    mount: Literal["left", "right"] = Field(
+        ..., description="Where the pipette is mounted"
     )
     name: str = Field(
         ...,
-        description='Name of a pipette. Does not contain info about specific '
-                    'model/version. Should match keys in pipetteNameSpecs.json file',
+        description="Name of a pipette. Does not contain info about specific "
+        "model/version. Should match keys in pipetteNameSpecs.json file",
     )
 
 
@@ -588,17 +597,16 @@ class Labware(BaseModel):
     slot: str = Field(
         ...,
         description="string '1'-'12', or special string 'span7_8_10_11' signify "
-                    "it's a slot on the OT-2 deck. If it's a UUID, it's the "
-                    "slot on the module referenced by that ID.",
+        "it's a slot on the OT-2 deck. If it's a UUID, it's the "
+        "slot on the module referenced by that ID.",
     )
     definitionId: str = Field(
-        ...,
-        description='reference to this labware\'s ID in "labwareDefinitions"'
+        ..., description='reference to this labware\'s ID in "labwareDefinitions"'
     )
     displayName: Optional[str] = Field(
         None,
-        description='An optional human-readable nickname for this labware. '
-                    'Eg "Buffer Trough"',
+        description="An optional human-readable nickname for this labware. "
+        'Eg "Buffer Trough"',
     )
 
 
@@ -613,65 +621,62 @@ class Modules(BaseModel):
     slot: str = Field(
         ...,
         description="string '1'-'12', or special string 'span7_8_10_11' signify "
-                    "it's a slot on the OT-2 deck. If it's a UUID, it's the "
-                    "slot on the module referenced by that ID.",
+        "it's a slot on the OT-2 deck. If it's a UUID, it's the "
+        "slot on the module referenced by that ID.",
     )
     model: str = Field(
         ...,
         description="model of module. Eg 'magneticModuleV1' or 'magneticModuleV2'. "
-                    "This should match a top-level key in "
-                    "shared-data/module/definitions/2.json",
+        "This should match a top-level key in "
+        "shared-data/module/definitions/2.json",
     )
 
 
 class Model(BaseModel):
     otSharedSchema: Optional[
-        Literal['#/protocol/schemas/5', '#/protocol/schemas/4']
+        Literal["#/protocol/schemas/5", "#/protocol/schemas/4"]
     ] = Field(
         None,
-        alias='$otSharedSchema',
-        description='The path to a valid Opentrons shared schema relative to '
-                    'the shared-data directory, without its extension.',
+        alias="$otSharedSchema",
+        description="The path to a valid Opentrons shared schema relative to "
+        "the shared-data directory, without its extension.",
     )
     schemaVersion: Literal[1, 2, 3, 4, 5] = Field(
-        ..., description='Schema version of a protocol is a single integer'
+        ..., description="Schema version of a protocol is a single integer"
     )
-    metadata: Metadata = Field(
-        ...,
-        description='Optional metadata about the protocol'
-    )
+    metadata: Metadata = Field(..., description="Optional metadata about the protocol")
     designerApplication: Optional[DesignerApplication] = Field(
         None,
-        description='Optional data & metadata not required to execute the protocol, '
-                    'used by the application that created this protocol',
+        description="Optional data & metadata not required to execute the protocol, "
+        "used by the application that created this protocol",
     )
     robot: Robot
     pipettes: Dict[str, Pipettes] = Field(
         ...,
-        description='The pipettes used in this protocol, keyed by an arbitrary '
-                    'unique ID',
+        description="The pipettes used in this protocol, keyed by an arbitrary "
+        "unique ID",
     )
     labwareDefinitions: Dict[str, LabwareDefinition] = Field(
         ...,
-        description='All labware definitions used by labware in this protocol, '
-                    'keyed by UUID',
+        description="All labware definitions used by labware in this protocol, "
+        "keyed by UUID",
     )
     labware: Dict[str, Labware] = Field(
         ...,
-        description='All types of labware used in this protocol, and references '
-                    'to their definitions',
+        description="All types of labware used in this protocol, and references "
+        "to their definitions",
     )
     modules: Optional[Dict[str, Modules]] = Field(
-        None, description='All modules used in this protocol'
+        None, description="All modules used in this protocol"
     )
     commands: List[AllCommands] = Field(
         None,
         description="An array of command objects representing steps to be executed "
-                    "on the robot"
+        "on the robot",
     )
     commandAnnotations: Optional[Dict[str, Any]] = Field(
         None,
-        description='An optional object of annotations associated with commands. '
-                    'Its usage has not yet been defined, so its shape is not '
-                    'enforced by this schema.',
+        description="An optional object of annotations associated with commands. "
+        "Its usage has not yet been defined, so its shape is not "
+        "enforced by this schema.",
     )

--- a/api/src/opentrons/protocols/models/labware_definition.py
+++ b/api/src/opentrons/protocols/models/labware_definition.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Extra, Field
 from typing_extensions import Literal
 
-SAFE_STRING_REGEX = '^[a-z0-9._]+$'
+SAFE_STRING_REGEX = "^[a-z0-9._]+$"
 
 
 class CornerOffsetFromSlot(BaseModel):
@@ -29,24 +29,24 @@ class CornerOffsetFromSlot(BaseModel):
 
 
 class BrandData(BaseModel):
-    brand: str = Field(..., description='Brand/manufacturer name')
+    brand: str = Field(..., description="Brand/manufacturer name")
     brandId: Optional[List[str]] = Field(
         None,
-        description='An array of manufacture numbers pertaining to a given labware',
+        description="An array of manufacture numbers pertaining to a given labware",
     )
     links: Optional[List[str]] = Field(
-        None, description='URLs for manufacturer page(s)'
+        None, description="URLs for manufacturer page(s)"
     )
 
 
 class DisplayCategory(str, Enum):
-    tipRack = 'tipRack'
-    tubeRack = 'tubeRack'
-    reservoir = 'reservoir'
-    trash = 'trash'
-    wellPlate = 'wellPlate'
-    aluminumBlock = 'aluminumBlock'
-    other = 'other'
+    tipRack = "tipRack"
+    tubeRack = "tubeRack"
+    reservoir = "reservoir"
+    trash = "trash"
+    wellPlate = "wellPlate"
+    aluminumBlock = "aluminumBlock"
+    other = "other"
 
 
 class Metadata(BaseModel):
@@ -54,20 +54,15 @@ class Metadata(BaseModel):
     Properties used for search and display
     """
 
-    displayName: str = Field(
-        ...,
-        description='Easy to remember name of labware')
+    displayName: str = Field(..., description="Easy to remember name of labware")
     displayCategory: DisplayCategory = Field(
-        ...,
-        description='Label(s) used in UI to categorize labware'
+        ..., description="Label(s) used in UI to categorize labware"
     )
-    displayVolumeUnits: Literal['µL', 'mL', 'L'] = Field(
-        ...,
-        description='Volume units for display'
+    displayVolumeUnits: Literal["µL", "mL", "L"] = Field(
+        ..., description="Volume units for display"
     )
     tags: Optional[List[str]] = Field(
-        None,
-        description='List of descriptions for a given labware'
+        None, description="List of descriptions for a given labware"
     )
 
 
@@ -77,46 +72,42 @@ class Parameters(BaseModel):
     """
 
     format: Literal[
-        '96Standard', '384Standard', 'trough', 'irregular', 'trash'
+        "96Standard", "384Standard", "trough", "irregular", "trash"
     ] = Field(
-        ...,
-        description='Property to determine compatibility with multichannel pipette'
+        ..., description="Property to determine compatibility with multichannel pipette"
     )
     quirks: Optional[List[str]] = Field(
         None,
-        description='Property to classify a specific behavior this labware '
-                    'should have',
+        description="Property to classify a specific behavior this labware "
+        "should have",
     )
     isTiprack: bool = Field(
-        ...,
-        description='Flag marking whether a labware is a tiprack or not'
+        ..., description="Flag marking whether a labware is a tiprack or not"
     )
     tipLength: Optional[float] = Field(
         None,
         ge=0.0,
-        description='Required if labware is tiprack, specifies length of tip'
-                    ' from drawing or as measured with calipers',
+        description="Required if labware is tiprack, specifies length of tip"
+        " from drawing or as measured with calipers",
     )
     tipOverlap: Optional[float] = Field(
         None,
         ge=0.0,
-        description='Required if labware is tiprack, specifies the length of '
-                    'the area of the tip that overlaps the nozzle of the pipette',
+        description="Required if labware is tiprack, specifies the length of "
+        "the area of the tip that overlaps the nozzle of the pipette",
     )
     loadName: str = Field(
         ...,
-        description='Name used to reference a labware definition',
-        regex=SAFE_STRING_REGEX
+        description="Name used to reference a labware definition",
+        regex=SAFE_STRING_REGEX,
     )
     isMagneticModuleCompatible: bool = Field(
         ...,
-        description='Flag marking whether a labware is compatible by default '
-                    'with the Magnetic Module',
+        description="Flag marking whether a labware is compatible by default "
+        "with the Magnetic Module",
     )
     magneticModuleEngageHeight: Optional[float] = Field(
-        None,
-        ge=0.0,
-        description='Distance to move magnetic module magnets to engage'
+        None, ge=0.0, description="Distance to move magnetic module magnets to engage"
     )
 
 
@@ -138,45 +129,37 @@ class WellDefinition(BaseModel):
     x: float = Field(
         ...,
         ge=0.0,
-        description='x location of center-bottom of well in reference to '
-                    'left-front-bottom of labware',
+        description="x location of center-bottom of well in reference to "
+        "left-front-bottom of labware",
     )
     y: float = Field(
         ...,
         ge=0.0,
-        description='y location of center-bottom of well in reference to '
-                    'left-front-bottom of labware',
+        description="y location of center-bottom of well in reference to "
+        "left-front-bottom of labware",
     )
     z: float = Field(
         ...,
         ge=0.0,
-        description='z location of center-bottom of well in reference to '
-                    'left-front-bottom of labware',
+        description="z location of center-bottom of well in reference to "
+        "left-front-bottom of labware",
     )
     totalLiquidVolume: float = Field(
-        ...,
-        ge=0.0,
-        description='Total well, tube, or tip volume in microliters'
+        ..., ge=0.0, description="Total well, tube, or tip volume in microliters"
     )
     xDimension: Optional[float] = Field(
-        None,
-        ge=0.0,
-        description='x dimension of rectangular wells'
+        None, ge=0.0, description="x dimension of rectangular wells"
     )
     yDimension: Optional[float] = Field(
-        None,
-        ge=0.0,
-        description='y dimension of rectangular wells'
+        None, ge=0.0, description="y dimension of rectangular wells"
     )
     diameter: Optional[float] = Field(
-        None,
-        ge=0.0,
-        description='diameter of circular wells'
+        None, ge=0.0, description="diameter of circular wells"
     )
-    shape: Literal['rectangular', 'circular'] = Field(
+    shape: Literal["rectangular", "circular"] = Field(
         ...,
         description="If 'rectangular', use xDimension and "
-                    "yDimension; if 'circular' use diameter",
+        "yDimension; if 'circular' use diameter",
     )
 
 
@@ -186,76 +169,72 @@ class Metadata1(BaseModel):
     """
 
     displayName: Optional[str] = Field(
-        None, description='User-readable name for the well group'
+        None, description="User-readable name for the well group"
     )
     displayCategory: Optional[DisplayCategory] = Field(
-        None, description='Label(s) used in UI to categorize well groups'
+        None, description="Label(s) used in UI to categorize well groups"
     )
-    wellBottomShape: Optional[Literal['flat', 'u', 'v']] = Field(
-        None, description='Bottom shape of the well for UI purposes'
+    wellBottomShape: Optional[Literal["flat", "u", "v"]] = Field(
+        None, description="Bottom shape of the well for UI purposes"
     )
 
 
 class Group(BaseModel):
     wells: List[str] = Field(
-        ..., description='An array of wells that contain the same metadata',
-        min_items=1
+        ..., description="An array of wells that contain the same metadata", min_items=1
     )
     metadata: Metadata1 = Field(
-        ..., description='Metadata specific to a grid of wells in a labware'
+        ..., description="Metadata specific to a grid of wells in a labware"
     )
     brand: Optional[BrandData] = Field(
-        None, description='Brand data for the well group (e.g. for tubes)'
+        None, description="Brand data for the well group (e.g. for tubes)"
     )
 
 
 class LabwareDefinition(BaseModel):
     schemaVersion: Literal[1, 2] = Field(
-        ..., description='Which schema version a labware is using'
+        ..., description="Which schema version a labware is using"
     )
     version: int = Field(
         ...,
-        description='Version of the labware definition itself '
-                    '(eg myPlate v1/v2/v3). An incrementing integer',
+        description="Version of the labware definition itself "
+        "(eg myPlate v1/v2/v3). An incrementing integer",
         ge=1.0,
     )
     namespace: str = Field(..., regex=SAFE_STRING_REGEX)
     metadata: Metadata = Field(
-        ..., description='Properties used for search and display'
+        ..., description="Properties used for search and display"
     )
     brand: BrandData = Field(
         ...,
-        description='Real-world labware that the definition is modeled '
-                    'from and/or compatible with',
+        description="Real-world labware that the definition is modeled "
+        "from and/or compatible with",
     )
     parameters: Parameters = Field(
         ...,
-        description='Internal describers used to determine pipette movement '
-                    'to labware',
+        description="Internal describers used to determine pipette movement "
+        "to labware",
     )
     ordering: List[List[str]] = Field(
         ...,
-        description='Generated array that keeps track of how wells should be '
-                    'ordered in a labware',
+        description="Generated array that keeps track of how wells should be "
+        "ordered in a labware",
     )
     cornerOffsetFromSlot: CornerOffsetFromSlot = Field(
         ...,
-        description='Distance from left-front-bottom corner of slot to '
-                    'left-front-bottom corner of labware bounding box. Used for '
-                    'labware that spans multiple slots. For labware that does '
-                    'not span multiple slots, x/y/z should all be zero.',
+        description="Distance from left-front-bottom corner of slot to "
+        "left-front-bottom corner of labware bounding box. Used for "
+        "labware that spans multiple slots. For labware that does "
+        "not span multiple slots, x/y/z should all be zero.",
     )
-    dimensions: Dimensions = Field(
-        ...,
-        description='Outer dimensions of a labware'
-    )
+    dimensions: Dimensions = Field(..., description="Outer dimensions of a labware")
     wells: Dict[str, WellDefinition] = Field(
         ...,
-        description='Unordered object of well objects with position and '
-                    'dimensional information',
+        description="Unordered object of well objects with position and "
+        "dimensional information",
     )
     groups: List[Group] = Field(
         ...,
-        description='Logical well groupings for metadata/display purposes; '
-                    'changes in groups do not affect protocol execution',
+        description="Logical well groupings for metadata/display purposes; "
+        "changes in groups do not affect protocol execution",
     )

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -16,48 +16,49 @@ import jsonschema  # type: ignore
 
 from opentrons_shared_data import load_shared_data, protocol
 from .api_support.types import APIVersion
-from .types import (Protocol, PythonProtocol, JsonProtocol,
-                    Metadata, MalformedProtocolError,
-                    ApiDeprecationError)
+from .types import (
+    Protocol,
+    PythonProtocol,
+    JsonProtocol,
+    Metadata,
+    MalformedProtocolError,
+    ApiDeprecationError,
+)
 from .bundle import extract_bundle
 
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
-    from opentrons_shared_data.protocol.dev_types import (
-        JsonProtocol as JsonProtocolDef
-    )
+    from opentrons_shared_data.protocol.dev_types import JsonProtocol as JsonProtocolDef
 
 MODULE_LOG = logging.getLogger(__name__)
 
 # match e.g. "2.0" but not "hi", "2", "2.0.1"
-API_VERSION_RE = re.compile(r'^(\d+)\.(\d+)$')
+API_VERSION_RE = re.compile(r"^(\d+)\.(\d+)$")
 MAX_SUPPORTED_JSON_SCHEMA_VERSION = 5
 API_VERSION_FOR_JSON_V5_AND_BELOW = APIVersion(2, 8)
 
 
 def _validate_v2_ast(protocol_ast: ast.Module):
-    defs = [fdef for fdef in protocol_ast.body
-            if isinstance(fdef, ast.FunctionDef)]
-    rundefs = [fdef for fdef in defs
-               if fdef.name == 'run']
+    defs = [fdef for fdef in protocol_ast.body if isinstance(fdef, ast.FunctionDef)]
+    rundefs = [fdef for fdef in defs if fdef.name == "run"]
     # There must be precisely 1 one run function
     if len(rundefs) > 1:
         lines = [str(d.lineno) for d in rundefs]
-        linestr = ', '.join(lines)
+        linestr = ", ".join(lines)
         raise MalformedProtocolError(
-            f'More than one run function is defined (lines {linestr})')
+            f"More than one run function is defined (lines {linestr})"
+        )
     if not rundefs:
-        raise MalformedProtocolError(
-            "No function 'run(ctx)' defined")
+        raise MalformedProtocolError("No function 'run(ctx)' defined")
     if infer_version_from_imports(protocol_ast):
         raise MalformedProtocolError(
-            'Protocol API v1 modules such as robot, instruments, and labware '
-            'may not be imported in Protocol API V2 protocols'
+            "Protocol API v1 modules such as robot, instruments, and labware "
+            "may not be imported in Protocol API V2 protocols"
         )
 
 
 def version_from_string(vstr: str) -> APIVersion:
-    """ Parse an API version from a string
+    """Parse an API version from a string
 
     :param str vstr: The version string to parse
     :returns APIVersion: The parsed version
@@ -66,44 +67,45 @@ def version_from_string(vstr: str) -> APIVersion:
     matches = API_VERSION_RE.match(vstr)
     if not matches:
         raise ValueError(
-            f'apiLevel {vstr} is incorrectly formatted. It should '
-            'major.minor, where both major and minor are numbers.')
-    return APIVersion(
-        major=int(matches.group(1)), minor=int(matches.group(2)))
+            f"apiLevel {vstr} is incorrectly formatted. It should "
+            "major.minor, where both major and minor are numbers."
+        )
+    return APIVersion(major=int(matches.group(1)), minor=int(matches.group(2)))
 
 
-def _parse_json(
-        protocol_contents: str, filename: str = None) -> JsonProtocol:
-    """ Parse a protocol known or at least suspected to be json """
+def _parse_json(protocol_contents: str, filename: str = None) -> JsonProtocol:
+    """Parse a protocol known or at least suspected to be json"""
     protocol_json = json.loads(protocol_contents)
     version, validated = validate_json(protocol_json)
     return JsonProtocol(
-        text=protocol_contents, filename=filename, contents=validated,
-        schema_version=version, api_level=API_VERSION_FOR_JSON_V5_AND_BELOW,
-        metadata=validated['metadata']
+        text=protocol_contents,
+        filename=filename,
+        contents=validated,
+        schema_version=version,
+        api_level=API_VERSION_FOR_JSON_V5_AND_BELOW,
+        metadata=validated["metadata"],
     )
 
 
 def _parse_python(
     protocol_contents: str,
     filename: str = None,
-    bundled_labware: Dict[str, 'LabwareDefinition'] = None,
+    bundled_labware: Dict[str, "LabwareDefinition"] = None,
     bundled_data: Dict[str, bytes] = None,
     bundled_python: Dict[str, str] = None,
-    extra_labware: Dict[str, 'LabwareDefinition'] = None,
+    extra_labware: Dict[str, "LabwareDefinition"] = None,
 ) -> PythonProtocol:
-    """ Parse a protocol known or at least suspected to be python """
-    filename_checked = filename or '<protocol>'
-    if filename_checked.endswith('.zip'):
-        ast_filename = 'protocol.ot2.py'
+    """Parse a protocol known or at least suspected to be python"""
+    filename_checked = filename or "<protocol>"
+    if filename_checked.endswith(".zip"):
+        ast_filename = "protocol.ot2.py"
     else:
         ast_filename = filename_checked
 
-    parsed = ast.parse(protocol_contents,
-                       filename=ast_filename)
+    parsed = ast.parse(protocol_contents, filename=ast_filename)
 
     metadata = extract_metadata(parsed)
-    protocol = compile(parsed, filename=ast_filename, mode='exec')
+    protocol = compile(parsed, filename=ast_filename, mode="exec")
     version = get_version(metadata, parsed)
 
     if version >= APIVersion(2, 0):
@@ -113,31 +115,35 @@ def _parse_python(
 
     result = PythonProtocol(
         text=protocol_contents,
-        filename=getattr(protocol, 'co_filename', '<protocol>'),
+        filename=getattr(protocol, "co_filename", "<protocol>"),
         contents=protocol,
         metadata=metadata,
         api_level=version,
         bundled_labware=bundled_labware,
         bundled_data=bundled_data,
         bundled_python=bundled_python,
-        extra_labware=extra_labware)
+        extra_labware=extra_labware,
+    )
 
     return result
 
 
 def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:
-    """ Parse a bundled Python protocol """
+    """Parse a bundled Python protocol"""
     contents = extract_bundle(bundle)
 
     result = _parse_python(
-        contents.protocol, filename,
+        contents.protocol,
+        filename,
         contents.bundled_labware,
         contents.bundled_data,
-        contents.bundled_python)
+        contents.bundled_python,
+    )
 
     if result.api_level < APIVersion(2, 0):
-        raise RuntimeError('Bundled protocols must use Protocol API V2, ' +
-                           f'got {result.api_level}')
+        raise RuntimeError(
+            "Bundled protocols must use Protocol API V2, " + f"got {result.api_level}"
+        )
 
     return result
 
@@ -145,10 +151,10 @@ def _parse_bundle(bundle: ZipFile, filename: str = None) -> PythonProtocol:
 def parse(
     protocol_file: Union[str, bytes],
     filename: str = None,
-    extra_labware: Dict[str, 'LabwareDefinition'] = None,
-    extra_data: Dict[str, bytes] = None
+    extra_labware: Dict[str, "LabwareDefinition"] = None,
+    extra_data: Dict[str, bytes] = None,
 ) -> Protocol:
-    """ Parse a protocol from text.
+    """Parse a protocol from text.
 
     :param protocol_file: The protocol file, or for single-file protocols, a
                         string of the protocol contents.
@@ -165,47 +171,55 @@ def parse(
                         data in the protocol for later simulation or
                         execution.
     """
-    if filename and filename.endswith('.zip'):
+    if filename and filename.endswith(".zip"):
         if not isinstance(protocol_file, bytes):
-            raise RuntimeError('Please update your Run App version to '
-                               'support uploading a .zip file')
+            raise RuntimeError(
+                "Please update your Run App version to " "support uploading a .zip file"
+            )
 
         with ZipFile(BytesIO(protocol_file)) as bundle:
             result = _parse_bundle(bundle, filename)
         return result
     else:
         if isinstance(protocol_file, bytes):
-            protocol_str = protocol_file.decode('utf-8')
+            protocol_str = protocol_file.decode("utf-8")
         else:
             protocol_str = protocol_file
 
-        if filename and filename.endswith('.json'):
+        if filename and filename.endswith(".json"):
             return _parse_json(protocol_str, filename)
-        elif filename and filename.endswith('.py'):
+        elif filename and filename.endswith(".py"):
             return _parse_python(
-                protocol_str, filename, extra_labware=extra_labware,
-                bundled_data=extra_data)
+                protocol_str,
+                filename,
+                extra_labware=extra_labware,
+                bundled_data=extra_data,
+            )
 
         # our jsonschema says the top level json kind is object
-        if protocol_str and protocol_str[0] in ('{', b'{'):
+        if protocol_str and protocol_str[0] in ("{", b"{"):
             return _parse_json(protocol_str, filename)
         else:
             return _parse_python(
-                protocol_str, filename, extra_labware=extra_labware,
-                bundled_data=extra_data)
+                protocol_str,
+                filename,
+                extra_labware=extra_labware,
+                bundled_data=extra_data,
+            )
 
 
 def extract_metadata(parsed: ast.Module) -> Metadata:
     metadata: Metadata = {}
-    assigns = [
-        obj for obj in parsed.body if isinstance(obj, ast.Assign)]
+    assigns = [obj for obj in parsed.body if isinstance(obj, ast.Assign)]
     for obj in assigns:
         # XXX This seems brittle and could probably do with
         # - enough love that we can remove the type: ignores
         # - some thought about exactly what types are allowed in metadata
-        if isinstance(obj.targets[0], ast.Name) \
-                and obj.targets[0].id == 'metadata' \
-                and isinstance(obj.value, ast.Dict):
+        if (
+            isinstance(obj.targets[0], ast.Name)
+            and obj.targets[0].id == "metadata"
+            and isinstance(obj.value, ast.Dict)
+        ):
             keys = [k.s for k in obj.value.keys]  # type: ignore
             values = [v.s for v in obj.value.values]  # type: ignore
             metadata = dict(zip(keys, values))
@@ -217,27 +231,33 @@ def infer_version_from_imports(parsed: ast.Module) -> Optional[APIVersion]:
     # Imports in the form of `import opentrons.robot` will have an entry in
     # parsed.body[i].names[j].name in the form "opentrons.robot". Find those
     # imports and transform them to strip away the 'opentrons.' part.
-    ot_imports = ['.'.join(name.name.split('.')[1:]) for name in
-                  itertools.chain.from_iterable(
-                      [obj.names for obj in parsed.body
-                       if isinstance(obj, ast.Import)])
-                  if 'opentrons' in name.name]
+    ot_imports = [
+        ".".join(name.name.split(".")[1:])
+        for name in itertools.chain.from_iterable(
+            [obj.names for obj in parsed.body if isinstance(obj, ast.Import)]
+        )
+        if "opentrons" in name.name
+    ]
 
     # Imports in the form of `from opentrons import robot` (with or without an
     # `as ___` statement) will have an entry in parsed.body[i].module
     # containing "opentrons"
     ot_from_imports = [
-        name.name for name in
-        itertools.chain.from_iterable(
-            [obj.names for obj in parsed.body
-             if isinstance(obj, ast.ImportFrom)
-             and obj.module
-             and 'opentrons' in obj.module])
+        name.name
+        for name in itertools.chain.from_iterable(
+            [
+                obj.names
+                for obj in parsed.body
+                if isinstance(obj, ast.ImportFrom)
+                and obj.module
+                and "opentrons" in obj.module
+            ]
+        )
     ]
 
     # If any of these are populated, filter for entries with v1-specific terms
     opentrons_imports = set(ot_imports + ot_from_imports)
-    v1_markers = set(('robot', 'instruments', 'modules', 'containers'))
+    v1_markers = set(("robot", "instruments", "modules", "containers"))
     v1evidence = v1_markers.intersection(opentrons_imports)
     if v1evidence:
         return APIVersion(1, 0)
@@ -246,15 +266,15 @@ def infer_version_from_imports(parsed: ast.Module) -> Optional[APIVersion]:
 
 
 def version_from_metadata(metadata: Metadata) -> APIVersion:
-    """ Build an API version from metadata, if we can.
+    """Build an API version from metadata, if we can.
 
     If there is no apiLevel key, raise a KeyError.
     If the apiLevel value is malformed, raise a ValueError.
     """
-    if 'apiLevel' not in metadata:
-        raise KeyError('apiLevel')
-    requested_level = str(metadata['apiLevel'])
-    if requested_level == '1':
+    if "apiLevel" not in metadata:
+        raise KeyError("apiLevel")
+    requested_level = str(metadata["apiLevel"])
+    if requested_level == "1":
         return APIVersion(1, 0)
 
     return version_from_string(requested_level)
@@ -283,61 +303,64 @@ def get_version(metadata: Metadata, parsed: ast.Module) -> APIVersion:
     inferred = infer_version_from_imports(parsed)
     if not inferred:
         raise RuntimeError(
-            'If this is not an API v1 protocol, you must specify the target '
-            'api level in the apiLevel key of the metadata. For instance, '
-            'metadata={"apiLevel": "2.0"}')
+            "If this is not an API v1 protocol, you must specify the target "
+            "api level in the apiLevel key of the metadata. For instance, "
+            'metadata={"apiLevel": "2.0"}'
+        )
     return inferred
 
 
 def _get_protocol_schema_version(protocol_json: Dict[Any, Any]) -> int:
     # v3 and above uses `schemaVersion: integer`
-    version = protocol_json.get('schemaVersion')
+    version = protocol_json.get("schemaVersion")
     if version:
         return int(version)
     # v1 uses 1.x.x and v2 uses 2.x.x
-    legacyKebabVersion = protocol_json.get('protocol-schema')
+    legacyKebabVersion = protocol_json.get("protocol-schema")
     # No minor/patch schemas ever were released,
     # do not permit protocols with nonexistent schema versions to load
-    if legacyKebabVersion == '1.0.0':
+    if legacyKebabVersion == "1.0.0":
         return 1
-    elif legacyKebabVersion == '2.0.0':
+    elif legacyKebabVersion == "2.0.0":
         return 2
     elif legacyKebabVersion:
         raise RuntimeError(
-            f'No such schema version: "{legacyKebabVersion}". Did you mean ' +
-            '"1.0.0" or "2.0.0"?')
+            f'No such schema version: "{legacyKebabVersion}". Did you mean '
+            + '"1.0.0" or "2.0.0"?'
+        )
     # no truthy value for schemaVersion or protocol-schema
     raise RuntimeError(
-        'Could not determine schema version for protocol. ' +
-        'Make sure there is a version number under "schemaVersion"')
+        "Could not determine schema version for protocol. "
+        + 'Make sure there is a version number under "schemaVersion"'
+    )
 
 
 def _get_schema_for_protocol(version_num: int) -> protocol.Schema:
-    """ Retrieve the json schema for a protocol schema version
-    """
+    """Retrieve the json schema for a protocol schema version"""
     # TODO(IL, 2020/03/05): use $otSharedSchema, but maybe wait until
     # deprecating v1/v2 JSON protocols?
     if version_num > MAX_SUPPORTED_JSON_SCHEMA_VERSION:
         raise RuntimeError(
-            f'JSON Protocol version {version_num} is not yet ' +
-            'supported in this version of the API')
+            f"JSON Protocol version {version_num} is not yet "
+            + "supported in this version of the API"
+        )
     try:
-        schema = load_shared_data(
-            f'protocol/schemas/{version_num}.json')
+        schema = load_shared_data(f"protocol/schemas/{version_num}.json")
     except FileNotFoundError:
         schema = None  # type: ignore
     if not schema:
-        raise RuntimeError('JSON Protocol schema "{}" does not exist'
-                           .format(version_num))
-    return json.loads(schema.decode('utf-8'))
+        raise RuntimeError(
+            'JSON Protocol schema "{}" does not exist'.format(version_num)
+        )
+    return json.loads(schema.decode("utf-8"))
 
 
-def validate_json(
-        protocol_json: Dict[Any, Any]) -> Tuple[int, 'JsonProtocolDef']:
-    """ Validates a json protocol and returns its schema version """
+def validate_json(protocol_json: Dict[Any, Any]) -> Tuple[int, "JsonProtocolDef"]:
+    """Validates a json protocol and returns its schema version"""
     # Check if this is actually a labware
-    labware_schema_v2 = json.loads(load_shared_data(
-        'labware/schemas/2.json').decode('utf-8'))
+    labware_schema_v2 = json.loads(
+        load_shared_data("labware/schemas/2.json").decode("utf-8")
+    )
     try:
         jsonschema.validate(protocol_json, labware_schema_v2)
     except jsonschema.ValidationError:
@@ -345,35 +368,36 @@ def validate_json(
     else:
         MODULE_LOG.error("labware uploaded instead of protocol")
         raise RuntimeError(
-            'The file you are trying to open is a JSON labware definition, '
-            'and therefore can not be opened here. Please try '
-            'uploading a JSON protocol file instead.')
+            "The file you are trying to open is a JSON labware definition, "
+            "and therefore can not be opened here. Please try "
+            "uploading a JSON protocol file instead."
+        )
 
     # this is now either a protocol or something corrupt
     version_num = _get_protocol_schema_version(protocol_json)
     if version_num <= 2:
         raise RuntimeError(
-            f'JSON protocol version {version_num} is '
-            'deprecated. Please upload your protocol into Protocol '
-            'Designer and save it to migrate the protocol to a later '
-            'version. This error might mean a labware '
-            'definition was specified instead of a protocol.')
+            f"JSON protocol version {version_num} is "
+            "deprecated. Please upload your protocol into Protocol "
+            "Designer and save it to migrate the protocol to a later "
+            "version. This error might mean a labware "
+            "definition was specified instead of a protocol."
+        )
     if version_num > MAX_SUPPORTED_JSON_SCHEMA_VERSION:
         raise RuntimeError(
-            f'The protocol you are trying to open is a JSONv{version_num} '
-            'protocol and is not supported by your current robot server '
-            'version. Please update your OT-2 App and robot server to the '
-            'latest version and try again.'
+            f"The protocol you are trying to open is a JSONv{version_num} "
+            "protocol and is not supported by your current robot server "
+            "version. Please update your OT-2 App and robot server to the "
+            "latest version and try again."
         )
     protocol_schema = _get_schema_for_protocol(version_num)
 
     # instruct schema how to resolve all $ref's used in protocol schemas
     resolver = jsonschema.RefResolver(
-        protocol_schema.get('$id', ''),
+        protocol_schema.get("$id", ""),
         protocol_schema,
-        store={
-            "opentronsLabwareSchemaV2": labware_schema_v2
-        })
+        store={"opentronsLabwareSchemaV2": labware_schema_v2},
+    )
 
     # do the validation
     try:
@@ -381,7 +405,8 @@ def validate_json(
     except jsonschema.ValidationError:
         MODULE_LOG.exception("JSON protocol validation failed")
         raise RuntimeError(
-            'This may be a corrupted file or a JSON file that is not an '
-            'Opentrons JSON protocol.')
+            "This may be a corrupted file or a JSON file that is not an "
+            "Opentrons JSON protocol."
+        )
     else:
         return version_num, protocol_json  # type: ignore

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -5,7 +5,8 @@ from .api_support.definitions import MIN_SUPPORTED_VERSION
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
     from opentrons_shared_data.protocol.dev_types import (
-        JsonProtocol as JsonProtocolDef, Metadata as JsonProtocolMetadata
+        JsonProtocol as JsonProtocolDef,
+        Metadata as JsonProtocolMetadata,
     )
     from .api_support.types import APIVersion
 
@@ -16,25 +17,25 @@ Metadata = Dict[str, Union[str, int]]
 class ProtocolCommon:
     text: str
     filename: Optional[str]
-    api_level: 'APIVersion'
-    metadata: Union[Metadata, 'JsonProtocolMetadata']
+    api_level: "APIVersion"
+    metadata: Union[Metadata, "JsonProtocolMetadata"]
 
 
 @dataclass(frozen=True)
 class JsonProtocol(ProtocolCommon):
     schema_version: int
-    contents: 'JsonProtocolDef'
+    contents: "JsonProtocolDef"
 
 
 @dataclass(frozen=True)
 class PythonProtocol(ProtocolCommon):
     contents: Any  # This is the output of compile() which we can't type
     # these 'bundled_' attrs should only be included when the protocol is a zip
-    bundled_labware: Optional[Dict[str, 'LabwareDefinition']]
+    bundled_labware: Optional[Dict[str, "LabwareDefinition"]]
     bundled_data: Optional[Dict[str, bytes]]
     bundled_python: Optional[Dict[str, str]]
     # this should only be included when the protocol is not a zip
-    extra_labware: Optional[Dict[str, 'LabwareDefinition']]
+    extra_labware: Optional[Dict[str, "LabwareDefinition"]]
 
 
 Protocol = Union[JsonProtocol, PythonProtocol]
@@ -42,7 +43,7 @@ Protocol = Union[JsonProtocol, PythonProtocol]
 
 class BundleContents(NamedTuple):
     protocol: str
-    bundled_labware: Dict[str, 'LabwareDefinition']
+    bundled_labware: Dict[str, "LabwareDefinition"]
     bundled_data: Dict[str, bytes]
     bundled_python: Dict[str, str]
 
@@ -85,7 +86,7 @@ class MalformedProtocolError(Exception):
         return self.message + PROTOCOL_MALFORMED
 
     def __repr__(self):
-        return '<{}: {}>'.format(self.__class__.__name__, self.message)
+        return "<{}: {}>".format(self.__class__.__name__, self.message)
 
 
 class ApiDeprecationError(Exception):
@@ -94,8 +95,7 @@ class ApiDeprecationError(Exception):
         super().__init__(version)
 
     def __str__(self):
-        return PYTHON_API_VERSION_DEPRECATED.format(
-            self.version, MIN_SUPPORTED_VERSION)
+        return PYTHON_API_VERSION_DEPRECATED.format(self.version, MIN_SUPPORTED_VERSION)
 
     def __repr__(self):
-        return '<{}: {}>'.format(self.__class__.__name__, self.version)
+        return "<{}: {}>".format(self.__class__.__name__, self.version)

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -8,8 +8,7 @@ class CameraException(Exception):
     pass
 
 
-async def take_picture(filename: Path,
-                       loop: asyncio.AbstractEventLoop = None):
+async def take_picture(filename: Path, loop: asyncio.AbstractEventLoop = None):
     """Take a picture and save it to filename
 
     :param filename: Name of file to save picture to
@@ -22,16 +21,17 @@ async def take_picture(filename: Path,
     except OSError:
         pass
 
-    cmd = 'ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1'
+    cmd = "ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1"
 
     if IS_OSX:
         # Purely for development on macos
         cmd = 'ffmpeg -f avfoundation -framerate 1  -s 640x480  -i "0" -ss 0:0:1 -frames 1'  # noqa: E501
 
     proc = await asyncio.create_subprocess_shell(
-        f'{cmd} {filename}',
+        f"{cmd} {filename}",
         stderr=asyncio.subprocess.PIPE,
-        loop=loop or asyncio.get_event_loop())
+        loop=loop or asyncio.get_event_loop(),
+    )
 
     res = await proc.stderr.read()  # type: ignore
     res = res.decode().strip()
@@ -40,4 +40,4 @@ async def take_picture(filename: Path,
     if proc.returncode != 0:
         raise CameraException(res)
     if not filename.exists():
-        raise CameraException('picture not saved')
+        raise CameraException("picture not saved")

--- a/api/src/opentrons/system/log_control.py
+++ b/api/src/opentrons/system/log_control.py
@@ -16,21 +16,25 @@ MAX_RECORDS = 100000
 DEFAULT_RECORDS = 50000
 
 
-async def get_records_dumb(selector: str, records: int,
-                           mode: str) -> bytes:
-    """ Dump the log files.
+async def get_records_dumb(selector: str, records: int, mode: str) -> bytes:
+    """Dump the log files.
 
     :param selector: The syslog selector to limit responses to
     :param records: The maximum number of records to print
     :param mode: A journalctl dump mode. Should be either "short" or "json".
     """
     proc = await asyncio.create_subprocess_exec(
-        'journalctl', '--no-pager',
-        '-t', selector,
-        '-n', str(records),
-        '-o', mode,
-        '-a',
-        stdout=subprocess.PIPE)
+        "journalctl",
+        "--no-pager",
+        "-t",
+        selector,
+        "-n",
+        str(records),
+        "-o",
+        mode,
+        "-a",
+        stdout=subprocess.PIPE,
+    )
     stdout, _ = await proc.communicate()
     return stdout
 
@@ -52,11 +56,14 @@ async def set_syslog_level(level: str) -> Tuple[int, str, str]:
                                    ``syslog-ng-ctl``. ``0`` is success,
                                    anything else is failure
     """
-    with open('/var/lib/syslog-ng/min-level', 'w') as ml:
+    with open("/var/lib/syslog-ng/min-level", "w") as ml:
         ml.write(level)
     proc = await asyncio.create_subprocess_exec(
-        'syslog-ng-ctl', 'reload',
-        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        "syslog-ng-ctl",
+        "reload",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
     stdout, stderr = await proc.communicate()
     if proc.returncode is None:
         snc_reload_result = -1

--- a/api/src/opentrons/system/nmcli.py
+++ b/api/src/opentrons/system/nmcli.py
@@ -35,8 +35,7 @@ class EAPType(NamedTuple):
 
 
 class _EAP_OUTER_TYPES(enum.Enum):
-    """ The types of phase-1 EAP we support.
-    """
+    """The types of phase-1 EAP we support."""
 
     # The string values of these supported EAP types should match both what
     # is expected by nmcli/wpa_supplicant (in 802-1x.eap) and the keys in
@@ -44,142 +43,200 @@ class _EAP_OUTER_TYPES(enum.Enum):
     # Note: if a file field has an optional password, the password field `name`
     # must start with the `name` of the file field
     TLS = EAPType(
-        name='tls',
-        displayName='EAP-TLS',
-        args=[{'name': 'identity',
-               'displayName': 'Username',
-               'nmName': 'identity',
-               'required': True,
-               'type': 'string'},
-              {'name': 'caCert',
-               'displayName': 'CA Certificate File',
-               'nmName': 'ca-cert',
-               'required': False,
-               'type': 'file'},
-              {'name': 'clientCert',
-               'displayName': 'Client Certificate File',
-               'nmName': 'client-cert',
-               'required': True,
-               'type': 'file'},
-              {'name': 'privateKey',
-               'displayName': 'Private Key File',
-               'nmName': 'private-key',
-               'required': True,
-               'type': 'file'},
-              {'name': 'privateKeyPassword',
-               'displayName': 'Private Key Password',
-               'nmName': 'private-key-password',
-               'required': False,
-               'type': 'password'}])
+        name="tls",
+        displayName="EAP-TLS",
+        args=[
+            {
+                "name": "identity",
+                "displayName": "Username",
+                "nmName": "identity",
+                "required": True,
+                "type": "string",
+            },
+            {
+                "name": "caCert",
+                "displayName": "CA Certificate File",
+                "nmName": "ca-cert",
+                "required": False,
+                "type": "file",
+            },
+            {
+                "name": "clientCert",
+                "displayName": "Client Certificate File",
+                "nmName": "client-cert",
+                "required": True,
+                "type": "file",
+            },
+            {
+                "name": "privateKey",
+                "displayName": "Private Key File",
+                "nmName": "private-key",
+                "required": True,
+                "type": "file",
+            },
+            {
+                "name": "privateKeyPassword",
+                "displayName": "Private Key Password",
+                "nmName": "private-key-password",
+                "required": False,
+                "type": "password",
+            },
+        ],
+    )
     PEAP = EAPType(
-        name='peap',
-        displayName='EAP-PEAP',
-        args=[{'name': 'identity',
-               'displayName': 'Username',
-               'nmName': 'identity',
-               'required': True,
-               'type': 'string'},
-              {'name': 'anonymousIdentity',
-               'displayName': 'Anonymous Identity',
-               'nmName': 'anonymous-identity',
-               'required': False,
-               'type': 'string'},
-              {'name': 'caCert',
-               'displayName': 'CA Certificate File',
-               'nmName': 'ca-cert',
-               'required': False,
-               'type': 'file'}])
+        name="peap",
+        displayName="EAP-PEAP",
+        args=[
+            {
+                "name": "identity",
+                "displayName": "Username",
+                "nmName": "identity",
+                "required": True,
+                "type": "string",
+            },
+            {
+                "name": "anonymousIdentity",
+                "displayName": "Anonymous Identity",
+                "nmName": "anonymous-identity",
+                "required": False,
+                "type": "string",
+            },
+            {
+                "name": "caCert",
+                "displayName": "CA Certificate File",
+                "nmName": "ca-cert",
+                "required": False,
+                "type": "file",
+            },
+        ],
+    )
     TTLS = EAPType(
-        name='ttls',
-        displayName='EAP-TTLS',
-        args=[{'name': 'identity',
-               'displayName': 'Username',
-               'nmName': 'identity',
-               'required': True,
-               'type': 'string'},
-              {'name': 'anonymousIdentity',
-               'displayName': 'Anonymous Identity',
-               'nmName': 'anonymous-identity',
-               'required': False,
-               'type': 'string'},
-              {'name': 'caCert',
-               'displayName': 'CA Certificate File',
-               'nmName': 'ca-cert',
-               'required': False,
-               'type': 'file'},
-              {'name': 'clientCert',
-               'displayName': 'Client Certificate File',
-               'nmName': 'client-cert',
-               'required': False,
-               'type': 'file'},
-              {'name': 'privateKey',
-               'displayName': 'Private Key File',
-               'nmName': 'private-key',
-               'required': False,
-               'type': 'file'},
-              {'name': 'privateKeyPassword',
-               'displayName': 'Private Key Password',
-               'nmName': 'private-key-password',
-               'required': False,
-               'type': 'password'}])
+        name="ttls",
+        displayName="EAP-TTLS",
+        args=[
+            {
+                "name": "identity",
+                "displayName": "Username",
+                "nmName": "identity",
+                "required": True,
+                "type": "string",
+            },
+            {
+                "name": "anonymousIdentity",
+                "displayName": "Anonymous Identity",
+                "nmName": "anonymous-identity",
+                "required": False,
+                "type": "string",
+            },
+            {
+                "name": "caCert",
+                "displayName": "CA Certificate File",
+                "nmName": "ca-cert",
+                "required": False,
+                "type": "file",
+            },
+            {
+                "name": "clientCert",
+                "displayName": "Client Certificate File",
+                "nmName": "client-cert",
+                "required": False,
+                "type": "file",
+            },
+            {
+                "name": "privateKey",
+                "displayName": "Private Key File",
+                "nmName": "private-key",
+                "required": False,
+                "type": "file",
+            },
+            {
+                "name": "privateKeyPassword",
+                "displayName": "Private Key Password",
+                "nmName": "private-key-password",
+                "required": False,
+                "type": "password",
+            },
+        ],
+    )
 
     def qualified_name(self) -> str:
         return self.value.name
 
 
 class _EAP_PHASE2_TYPES(enum.Enum):
-    """ The types of EAP phase 2 auth (for tunneled EAP) we support
-    """
+    """The types of EAP phase 2 auth (for tunneled EAP) we support"""
 
     # The string values of these supported EAP types should match both what
     # is expected by nmcli/wpa_supplicant (in 802-1x.phase2-autheap) and the
     # keys in the CONFIG_REQUIRES dict above
     MSCHAP_V2 = EAPType(
-        name='mschapv2',
-        displayName='MS-CHAP v2',
-        args=[{'name': 'password',
-               'displayName': 'Password',
-               'nmName': 'password',
-               'required': True,
-               'type': 'password'}])
+        name="mschapv2",
+        displayName="MS-CHAP v2",
+        args=[
+            {
+                "name": "password",
+                "displayName": "Password",
+                "nmName": "password",
+                "required": True,
+                "type": "password",
+            }
+        ],
+    )
     MD5 = EAPType(
-        name='md5',
-        displayName='MD5',
-        args=[{'name': 'password',
-               'displayName': 'Password',
-               'nmName': 'password',
-               'required': True,
-               'type': 'password'}])
+        name="md5",
+        displayName="MD5",
+        args=[
+            {
+                "name": "password",
+                "displayName": "Password",
+                "nmName": "password",
+                "required": True,
+                "type": "password",
+            }
+        ],
+    )
     TLS = EAPType(
-        name='tls',
-        displayName='TLS',
-        args=[{'name': 'phase2CaCert',
-               'displayName': 'Inner CA Certificate File',
-               'nmName': 'phase2-ca-cert',
-               'required': False,
-               'type': 'file'},
-              {'name': 'phase2ClientCert',
-               'displayName': 'Inner Client Certificate File',
-               'nmName': 'phase2-client-cert',
-               'required': True,
-               'type': 'file'},
-              {'name': 'phase2PrivateKey',
-               'displayName': 'Inner Private Key File',
-               'nmName': 'phase2-private-key',
-               'required': True,
-               'type': 'file'},
-              {'name': 'phase2PrivateKeyPassword',
-               'displayName': 'Inner Private Key Password',
-               'nmName': 'phase2-private-key-password',
-               'required': False,
-               'type': 'password'}])
+        name="tls",
+        displayName="TLS",
+        args=[
+            {
+                "name": "phase2CaCert",
+                "displayName": "Inner CA Certificate File",
+                "nmName": "phase2-ca-cert",
+                "required": False,
+                "type": "file",
+            },
+            {
+                "name": "phase2ClientCert",
+                "displayName": "Inner Client Certificate File",
+                "nmName": "phase2-client-cert",
+                "required": True,
+                "type": "file",
+            },
+            {
+                "name": "phase2PrivateKey",
+                "displayName": "Inner Private Key File",
+                "nmName": "phase2-private-key",
+                "required": True,
+                "type": "file",
+            },
+            {
+                "name": "phase2PrivateKeyPassword",
+                "displayName": "Inner Private Key Password",
+                "nmName": "phase2-private-key-password",
+                "required": False,
+                "type": "password",
+            },
+        ],
+    )
 
     def qualified_name(self) -> str:
-        return 'eap-' + self.value.name
+        return "eap-" + self.value.name
 
 
 class EAP_TYPES(enum.Enum):
-    """ The types of EAP we support, fusing inner and outer methods """
+    """The types of EAP we support, fusing inner and outer methods"""
+
     TTLS_EAPTLS = (_EAP_OUTER_TYPES.TTLS, _EAP_PHASE2_TYPES.TLS)
     TTLS_EAPMSCHAPV2 = (_EAP_OUTER_TYPES.TTLS, _EAP_PHASE2_TYPES.MSCHAP_V2)
     TTLS_MD5 = (_EAP_OUTER_TYPES.TTLS, _EAP_PHASE2_TYPES.MD5)
@@ -193,11 +250,11 @@ class EAP_TYPES(enum.Enum):
     def qualified_name(self) -> str:
         name = self.outer.qualified_name()
         if self.inner:
-            name += '/' + self.inner.qualified_name()
+            name += "/" + self.inner.qualified_name()
         return name
 
     @classmethod
-    def by_qualified_name(cls, qname: str) -> 'EAP_TYPES':
+    def by_qualified_name(cls, qname: str) -> "EAP_TYPES":
         for val in cls.__members__.values():
             if val.qualified_name() == qname:
                 return val
@@ -214,54 +271,52 @@ class EAP_TYPES(enum.Enum):
     def display_name(self) -> str:
         name = self.outer.value.displayName
         if self.inner:
-            name += ' with ' + self.inner.value.displayName
+            name += " with " + self.inner.value.displayName
         return name
 
 
 class SECURITY_TYPES(enum.Enum):
-    """ The types of security that this module supports.
-    """
+    """The types of security that this module supports."""
 
     # The string values of these supported security types are passed
     # directly to nmcli; they should match the security types allowed
     # in the network-manager settings for 802-11-wireless-security.key-mgmt
-    NONE = 'none'
-    WPA_PSK = 'wpa-psk'
-    WPA_EAP = 'wpa-eap'
+    NONE = "none"
+    WPA_PSK = "wpa-psk"
+    WPA_EAP = "wpa-eap"
 
 
 class CONNECTION_TYPES(enum.Enum):
-    """ Types of connection (used to parse nmcli results)
-    """
+    """Types of connection (used to parse nmcli results)"""
 
     # These connection types are used to parse nmcli results and should be
     # valid results for the last element when splitting connection.type by ’-’
-    WIRELESS = 'wireless'
-    ETHERNET = 'ethernet'
+    WIRELESS = "wireless"
+    ETHERNET = "ethernet"
 
 
 class NETWORK_IFACES(enum.Enum):
-    """ Network interface names that we manage here.
-    """
-    WIFI = 'wlan0'
-    ETH_LL = 'eth0'
+    """Network interface names that we manage here."""
+
+    WIFI = "wlan0"
+    ETH_LL = "eth0"
 
 
 def _add_security_type_to_scan(scan_out: Dict[str, Any]) -> Dict[str, Any]:
-    sec = scan_out['security']
-    if '802.1X' in sec:
-        scan_out['securityType'] = 'wpa-eap'
-    elif 'WPA2' in sec:
-        scan_out['securityType'] = 'wpa-psk'
-    elif '' == sec:
-        scan_out['securityType'] = 'none'
+    sec = scan_out["security"]
+    if "802.1X" in sec:
+        scan_out["securityType"] = "wpa-eap"
+    elif "WPA2" in sec:
+        scan_out["securityType"] = "wpa-psk"
+    elif "" == sec:
+        scan_out["securityType"] = "none"
     else:
-        scan_out['securityType'] = 'unsupported'
+        scan_out["securityType"] = "unsupported"
     return scan_out
 
 
 async def available_ssids() -> List[Dict[str, Any]]:
-    """ List the visible (broadcasting SSID) wireless networks.
+    """List the visible (broadcasting SSID) wireless networks.
 
     Returns a list of the SSIDs. They may contain spaces and should be escaped
     if later passed to a shell.
@@ -269,37 +324,37 @@ async def available_ssids() -> List[Dict[str, Any]]:
     # Force nmcli to actually scan rather than reuse cached results. We ignore
     # errors here because NetworkManager yells at you if you do it twice in a
     # row without another operation in between
-    cmd = ['device', 'wifi', 'rescan']
+    cmd = ["device", "wifi", "rescan"]
     _1, _2 = await _call(cmd, suppress_err=True)
 
-    fields = ['ssid', 'signal', 'active', 'security']
-    cmd = ['--terse',
-           '--fields',
-           ','.join(fields),
-           'device',
-           'wifi',
-           'list']
+    fields = ["ssid", "signal", "active", "security"]
+    cmd = ["--terse", "--fields", ",".join(fields), "device", "wifi", "list"]
     out, err = await _call(cmd)
     if err:
         raise RuntimeError(err)
     output = _dict_from_terse_tabular(
-        fields, out,
-        transformers={'signal': lambda s: int(s) if s.isdigit() else None,
-                      'active': lambda a: a.lower() == 'yes',
-                      'ssid': lambda s: s if s != '--' else None})
+        fields,
+        out,
+        transformers={
+            "signal": lambda s: int(s) if s.isdigit() else None,
+            "active": lambda a: a.lower() == "yes",
+            "ssid": lambda s: s if s != "--" else None,
+        },
+    )
 
-    return [_add_security_type_to_scan(nw) for nw in output if nw['ssid']]
+    return [_add_security_type_to_scan(nw) for nw in output if nw["ssid"]]
 
 
 async def is_connected() -> str:
-    """ Return nmcli's connection measure: none/portal/limited/full/unknown"""
-    res, _ = await _call(['networking', 'connectivity', 'check'])
+    """Return nmcli's connection measure: none/portal/limited/full/unknown"""
+    res, _ = await _call(["networking", "connectivity", "check"])
     return res
 
 
 async def connections(
-        for_type: Optional[CONNECTION_TYPES] = None) -> List[Dict[str, str]]:
-    """ Return the list of configured connections.
+    for_type: Optional[CONNECTION_TYPES] = None,
+) -> List[Dict[str, str]]:
+    """Return the list of configured connections.
 
     This is all connections that nmcli knows about and manages.
     Each connection is a dict containing some basic information - the
@@ -309,20 +364,22 @@ async def connections(
     If for_type is not None, it should be a str containing an element of
     CONNECTION_TYPES, and results will be limited to that connection type.
     """
-    fields = ['name', 'type', 'active']
-    res, _ = await _call(['-t', '-f', ','.join(fields), 'connection', 'show'])
+    fields = ["name", "type", "active"]
+    res, _ = await _call(["-t", "-f", ",".join(fields), "connection", "show"])
     found = _dict_from_terse_tabular(
         fields,
         res,
         # ’ethernet’ or ’wireless’ from ’802-11-wireless’ or ’802-4-ethernet’
         # and bools from ’yes’ or ’no
-        transformers={'type': lambda s: s.split('-')[-1],
-                      'active': lambda s: s.lower() == 'yes'}
+        transformers={
+            "type": lambda s: s.split("-")[-1],
+            "active": lambda s: s.lower() == "yes",
+        },
     )
     if for_type is not None:
         should_return = []
         for c in found:
-            if c['type'] == for_type.value:
+            if c["type"] == for_type.value:
                 should_return.append(c)
         return should_return
     else:
@@ -330,26 +387,34 @@ async def connections(
 
 
 async def connection_exists(ssid: str) -> Optional[str]:
-    """ If there is already a connection for this ssid, return the name of
+    """If there is already a connection for this ssid, return the name of
     the connection; if there is not, return None.
     """
     nmcli_conns = await connections()
-    for wifi in [c['name']
-                 for c in nmcli_conns if c['type'] == 'wireless']:
-        res, _ = await _call(['-t', '-f', '802-11-wireless.ssid',
-                              '-m', 'tabular',
-                              'connection', 'show', wifi])
+    for wifi in [c["name"] for c in nmcli_conns if c["type"] == "wireless"]:
+        res, _ = await _call(
+            [
+                "-t",
+                "-f",
+                "802-11-wireless.ssid",
+                "-m",
+                "tabular",
+                "connection",
+                "show",
+                wifi,
+            ]
+        )
         if res == ssid:
             return wifi
     return None
 
 
 async def _trim_old_connections(
-        new_name: str, con_type: CONNECTION_TYPES) -> Tuple[bool, str]:
-    """ Delete all connections of con_type but the one specified.
-    """
+    new_name: str, con_type: CONNECTION_TYPES
+) -> Tuple[bool, str]:
+    """Delete all connections of con_type but the one specified."""
     existing_cons = await connections(for_type=con_type)
-    not_us = [c['name'] for c in existing_cons if c['name'] != new_name]
+    not_us = [c["name"] for c in existing_cons if c["name"] != new_name]
     ok = True
     res = []
     for c in not_us:
@@ -358,16 +423,15 @@ async def _trim_old_connections(
         if not this_ok:
             # This is not a failure case for connection, and indeed the new
             # connection is already established, so just warn about it
-            log.warning("Could not remove wifi connection {}: {}"
-                        .format(c, remove_res))
+            log.warning("Could not remove wifi connection {}: {}".format(c, remove_res))
             res.append(remove_res)
         else:
             log.debug("Removed old wifi connection {}".format(c))
-    return ok, ';'.join(res)
+    return ok, ";".join(res)
 
 
 def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
-    """ Add configuration options suitable for an nmcli con add command
+    """Add configuration options suitable for an nmcli con add command
     for WPA-EAP configuration. These options are mostly in the
     802-1x group.
 
@@ -376,55 +440,69 @@ def _add_eap_args(eap_args: Dict[str, str]) -> List[str]:
     (the qualified_name() of one of the members of EAP_TYPES) and the
     required arguments for that EAP type.
     """
-    args = ['wifi-sec.key-mgmt', 'wpa-eap']
-    eap_type = EAP_TYPES.by_qualified_name(eap_args['eapType'])
+    args = ["wifi-sec.key-mgmt", "wpa-eap"]
+    eap_type = EAP_TYPES.by_qualified_name(eap_args["eapType"])
     type_args = eap_type.args()
-    args += ['802-1x.eap', eap_type.outer.value.name]
+    args += ["802-1x.eap", eap_type.outer.value.name]
     if eap_type.inner:
-        args += ['802-1x.phase2-autheap', eap_type.inner.value.name]
+        args += ["802-1x.phase2-autheap", eap_type.inner.value.name]
     for ta in type_args:
-        if ta['name'] in eap_args:
-            if ta['type'] == 'file':
+        if ta["name"] in eap_args:
+            if ta["type"] == "file":
                 # Keyfiles must be prepended with file:// so nm-cli
                 # knows that we’re not giving it DER-encoded blobs
                 if config.ARCHITECTURE == config.SystemArchitecture.BALENA:
                     _make_host_symlink_if_necessary()
-                    path = _rewrite_key_path_to_host_path(eap_args[ta['name']])
+                    path = _rewrite_key_path_to_host_path(eap_args[ta["name"]])
                 else:
-                    path = eap_args[ta['name']]
-                val = 'file://' + path
+                    path = eap_args[ta["name"]]
+                val = "file://" + path
             else:
-                val = eap_args[ta['name']]
-            args += ['802-1x.' + ta['nmName'], val]
+                val = eap_args[ta["name"]]
+            args += ["802-1x." + ta["nmName"], val]
     return args
 
 
-def _build_con_add_cmd(ssid: str, security_type: SECURITY_TYPES,
-                       psk: Optional[str], hidden: bool,
-                       eap_args: Optional[Dict[str, Any]]) -> List[str]:
-    """ Build the nmcli connection add command to configure the new network.
+def _build_con_add_cmd(
+    ssid: str,
+    security_type: SECURITY_TYPES,
+    psk: Optional[str],
+    hidden: bool,
+    eap_args: Optional[Dict[str, Any]],
+) -> List[str]:
+    """Build the nmcli connection add command to configure the new network.
 
     The parameters are the same as configure but without the defaults; this
     should be called only by configure.
     """
-    configure_cmd = ['connection', 'add',
-                     'save', 'yes',
-                     'autoconnect', 'yes',
-                     'ifname', 'wlan0',
-                     'type', 'wifi',
-                     'con-name', ssid,
-                     'wifi.ssid', ssid,
-                     '802-11-wireless.cloned-mac-address', 'permanent']
+    configure_cmd = [
+        "connection",
+        "add",
+        "save",
+        "yes",
+        "autoconnect",
+        "yes",
+        "ifname",
+        "wlan0",
+        "type",
+        "wifi",
+        "con-name",
+        ssid,
+        "wifi.ssid",
+        ssid,
+        "802-11-wireless.cloned-mac-address",
+        "permanent",
+    ]
     if hidden:
-        configure_cmd += ['wifi.hidden', 'true']
+        configure_cmd += ["wifi.hidden", "true"]
     if security_type == SECURITY_TYPES.WPA_PSK:
-        configure_cmd += ['wifi-sec.key-mgmt', security_type.value]
+        configure_cmd += ["wifi-sec.key-mgmt", security_type.value]
         if psk is None:
-            raise ValueError('wpa-psk security type requires psk')
-        configure_cmd += ['wifi-sec.psk', psk]
+            raise ValueError("wpa-psk security type requires psk")
+        configure_cmd += ["wifi-sec.psk", psk]
     elif security_type == SECURITY_TYPES.WPA_EAP:
         if eap_args is None:
-            raise ValueError('wpa-eap security type requires eap_args')
+            raise ValueError("wpa-eap security type requires eap_args")
         configure_cmd += _add_eap_args(eap_args)
     elif security_type == SECURITY_TYPES.NONE:
         pass
@@ -434,13 +512,15 @@ def _build_con_add_cmd(ssid: str, security_type: SECURITY_TYPES,
     return configure_cmd
 
 
-async def configure(ssid: str,
-                    securityType: SECURITY_TYPES,
-                    psk: Optional[str] = None,
-                    hidden: bool = False,
-                    eapConfig: Optional[Dict[str, Any]] = None,
-                    upRetries: int = 2) -> Tuple[bool, str]:
-    """ Configure a connection but do not bring it up (though it is configured
+async def configure(
+    ssid: str,
+    securityType: SECURITY_TYPES,
+    psk: Optional[str] = None,
+    hidden: bool = False,
+    eapConfig: Optional[Dict[str, Any]] = None,
+    upRetries: int = 2,
+) -> Tuple[bool, str]:
+    """Configure a connection but do not bring it up (though it is configured
     for autoconnect).
 
     Returns (success, message) where ``success`` is a ``bool`` and ``message``
@@ -463,10 +543,9 @@ async def configure(ssid: str,
         # TODO(seth, 8/29/2018): We may need to do connection modifies
         # here for EAP configuration if e.g. we’re passing a keyfile in a
         # different http request
-        _1, _2 = await _call(['connection', 'delete', already])
+        _1, _2 = await _call(["connection", "delete", already])
 
-    configure_cmd = _build_con_add_cmd(
-        ssid, securityType, psk, hidden, eapConfig)
+    configure_cmd = _build_con_add_cmd(ssid, securityType, psk, hidden, eapConfig)
     res, err = await _call(configure_cmd)
 
     # nmcli connection add returns a string that looks like
@@ -474,23 +553,21 @@ async def configure(ssid: str,
     # This unfortunately doesn’t respect the --terse flag, so we need to
     # regex out the name or the uuid to use later in connection up; the
     # uuid is slightly more regular, so that’s what we use.
-    uuid_matches = re.search(
-        r"Connection '(.*)'[\s]+\(([\w\d-]+)\) successfully", res)
+    uuid_matches = re.search(r"Connection '(.*)'[\s]+\(([\w\d-]+)\) successfully", res)
     if not uuid_matches:
-        return False, err.split('\r')[-1]
+        return False, err.split("\r")[-1]
     name = uuid_matches.group(1)
     uuid = uuid_matches.group(2)
     for _ in range(upRetries):
-        res, err = await _call(['connection', 'up', 'uuid', uuid])
-        if 'Connection successfully activated' in res:
+        res, err = await _call(["connection", "up", "uuid", uuid])
+        if "Connection successfully activated" in res:
             # If we successfully added the connection, remove other wifi
             # connections so they don’t accumulate over time
 
-            _3, _4 = await _trim_old_connections(name,
-                                                 CONNECTION_TYPES.WIRELESS)
+            _3, _4 = await _trim_old_connections(name, CONNECTION_TYPES.WIRELESS)
             return True, res
     else:
-        return False, err.split('\r')[-1]
+        return False, err.split("\r")[-1]
 
 
 async def wifi_disconnect(ssid: str) -> Tuple[bool, str]:
@@ -507,20 +584,20 @@ async def wifi_disconnect(ssid: str) -> Tuple[bool, str]:
     Returns (True, msg) if the network was disconnected from successfully,
             (False, msg) otherwise
     """
-    res, err = await _call(['connection', 'down', ssid])
-    if 'successfully deactivated' in res:
+    res, err = await _call(["connection", "down", ssid])
+    if "successfully deactivated" in res:
         rem_ok, rem_res = await remove(ssid)
         if rem_ok:
-            res = res + '.\n ' + rem_res
+            res = res + ".\n " + rem_res
         else:
-            res = res + '.\n Error: Could not remove ssid. ' + rem_res
+            res = res + ".\n Error: Could not remove ssid. " + rem_res
         return True, res
     else:
         return False, err
 
 
 async def remove(ssid: str = None, name: str = None) -> Tuple[bool, str]:
-    """ Remove a network. Depending on what is known, specify either ssid
+    """Remove a network. Depending on what is known, specify either ssid
     (in which case this function will call ``connection_exists`` to get the
     nmcli connection name) or the nmcli connection name directly.
 
@@ -529,17 +606,17 @@ async def remove(ssid: str = None, name: str = None) -> Tuple[bool, str]:
     if None is not ssid:
         name = await connection_exists(ssid)
     if None is not name:
-        res, err = await _call(['connection', 'delete', name])
-        if 'successfully deleted' in res:
+        res, err = await _call(["connection", "delete", name])
+        if "successfully deleted" in res:
             return True, res
         else:
             return False, err
     else:
-        return False, 'No connection for ssid {}'.format(ssid)
+        return False, "No connection for ssid {}".format(ssid)
 
 
 async def iface_info(which_iface: NETWORK_IFACES) -> Dict[str, Optional[str]]:
-    """ Get the basic network configuration of an interface.
+    """Get the basic network configuration of an interface.
 
     Returns a dict containing the info:
     {
@@ -555,18 +632,25 @@ async def iface_info(which_iface: NETWORK_IFACES) -> Dict[str, Optional[str]]:
     #  IP4.ADDRESS[1]:10.10.2.221/22
     # capture the field name (without the number in brackets) and the value
     # using regex instead of split because there may be ":" in the value
-    _DEV_INFO_LINE_RE = re.compile(r'([\w.]+)(?:\[\d+])?:(.*)')
+    _DEV_INFO_LINE_RE = re.compile(r"([\w.]+)(?:\[\d+])?:(.*)")
     # example device info: 30 (disconnected)
     # capture the string without the number
-    _IFACE_STATE_RE = re.compile(r'\d+ \((.+)\)')
+    _IFACE_STATE_RE = re.compile(r"\d+ \((.+)\)")
 
-    info: Dict[str, Optional[str]] = {'ipAddress': None,
-                                      'macAddress': None,
-                                      'gatewayAddress': None,
-                                      'state': None,
-                                      'type': None}
-    fields = ['GENERAL.HWADDR', 'IP4.ADDRESS',
-              'IP4.GATEWAY', 'GENERAL.TYPE', 'GENERAL.STATE']
+    info: Dict[str, Optional[str]] = {
+        "ipAddress": None,
+        "macAddress": None,
+        "gatewayAddress": None,
+        "state": None,
+        "type": None,
+    }
+    fields = [
+        "GENERAL.HWADDR",
+        "IP4.ADDRESS",
+        "IP4.GATEWAY",
+        "GENERAL.TYPE",
+        "GENERAL.STATE",
+    ]
     # Note on this specific command: Most nmcli commands default to a tabular
     # output mode, where if there are multiple things to pull a couple specific
     # fields from it you’ll get a table where rows are, say, connections, and
@@ -574,32 +658,41 @@ async def iface_info(which_iface: NETWORK_IFACES) -> Dict[str, Optional[str]]:
     # ‘dev show <dev-name>’ default to a multiline representation, and even if
     # explicitly ask for it to be tabular, it’s not quite the same as the other
     # commands. So we have to special-case the parsing.
-    res, err = await _call(['--mode', 'multiline',
-                            '--escape', 'no',
-                            '--terse', '--fields', ','.join(fields),
-                            'dev', 'show', which_iface.value])
+    res, err = await _call(
+        [
+            "--mode",
+            "multiline",
+            "--escape",
+            "no",
+            "--terse",
+            "--fields",
+            ",".join(fields),
+            "dev",
+            "show",
+            which_iface.value,
+        ]
+    )
 
     field_map = {}
-    for line in res.split('\n'):
+    for line in res.split("\n"):
         # pull the key (without brackets) and the value out of the line
         match = _DEV_INFO_LINE_RE.fullmatch(line)
         if match is None:
-            raise ValueError(
-                "Bad nmcli result; out: {}; err: {}".format(res, err))
+            raise ValueError("Bad nmcli result; out: {}; err: {}".format(res, err))
         key, val = match.groups()
         # nmcli can put "--" instead of "" for None
-        field_map[key] = None if val == '--' else val
+        field_map[key] = None if val == "--" else val
 
-    info['macAddress'] = field_map.get('GENERAL.HWADDR')
-    info['ipAddress'] = field_map.get('IP4.ADDRESS')
-    info['gatewayAddress'] = field_map.get('IP4.GATEWAY')
-    info['type'] = field_map.get('GENERAL.TYPE')
-    state_val = field_map.get('GENERAL.STATE')
+    info["macAddress"] = field_map.get("GENERAL.HWADDR")
+    info["ipAddress"] = field_map.get("IP4.ADDRESS")
+    info["gatewayAddress"] = field_map.get("IP4.GATEWAY")
+    info["type"] = field_map.get("GENERAL.TYPE")
+    state_val = field_map.get("GENERAL.STATE")
 
     if state_val:
         state_match = _IFACE_STATE_RE.fullmatch(state_val)
         if state_match:
-            info['state'] = state_match.group(1)
+            info["state"] = state_match.group(1)
 
     return info
 
@@ -611,52 +704,48 @@ async def _call(cmd: List[str], suppress_err: bool = False) -> Tuple[str, str]:
 
     :return: (stdout, stderr)
     """
-    to_exec = [quote(c) for c in ['nmcli'] + cmd]
-    cmd_str = ' '.join(to_exec)
+    to_exec = [quote(c) for c in ["nmcli"] + cmd]
+    cmd_str = " ".join(to_exec)
     # We have to use a shell invocation here because nmcli will not accept
     # secrets specified on the command line unless it’s in a shell. The other
     # option is editing the connection configuration file in /etc/ afterwards
     # (or using d-bus and pretending to be an auth agent)
     proc = await as_subprocess.create_subprocess_shell(
-        cmd_str,
-        stdout=as_subprocess.PIPE, stderr=as_subprocess.PIPE)
+        cmd_str, stdout=as_subprocess.PIPE, stderr=as_subprocess.PIPE
+    )
     out, err = await proc.communicate()
     out_str, err_str = out.decode().strip(), err.decode().strip()
     sanitized = sanitize_args(to_exec)
-    log.debug('{}: stdout={}'.format(' '.join(sanitized), out_str))
+    log.debug("{}: stdout={}".format(" ".join(sanitized), out_str))
     if err_str and not suppress_err:
-        log.warning('{}: stderr={}'.format(' '.join(sanitized), err_str))
+        log.warning("{}: stderr={}".format(" ".join(sanitized), err_str))
     return out_str, err_str
 
 
 def sanitize_args(cmd: List[str]) -> List[str]:
-    """ Filter the command so that it no longer contains passwords
-    """
+    """Filter the command so that it no longer contains passwords"""
     sanitized = []
     for idx, fieldname in enumerate(cmd):
+
         def _is_password(cmdstr):
-            return 'wifi-sec.psk' in cmdstr\
-                or 'password' in cmdstr.lower()
+            return "wifi-sec.psk" in cmdstr or "password" in cmdstr.lower()
+
         if idx > 0 and _is_password(cmd[idx - 1]):
-            sanitized.append('****')
+            sanitized.append("****")
         else:
             sanitized.append(fieldname)
     return sanitized
 
 
-def _parse_colonsep_response(
-        response_fullstring: str) -> List[List[str]]:
-    reader = csv.reader(response_fullstring.split('\n'),
-                        delimiter=':', escapechar='\\')
+def _parse_colonsep_response(response_fullstring: str) -> List[List[str]]:
+    reader = csv.reader(response_fullstring.split("\n"), delimiter=":", escapechar="\\")
     return [row for row in reader if row]
 
 
 def _dict_from_terse_tabular(
-        names: List[str],
-        inp: str,
-        transformers: Dict[str, Callable[[str], Any]] = {})\
-        -> List[Dict[str, Any]]:
-    """ Parse NMCLI terse tabular output into a list of Python dict.
+    names: List[str], inp: str, transformers: Dict[str, Callable[[str], Any]] = {}
+) -> List[Dict[str, Any]]:
+    """Parse NMCLI terse tabular output into a list of Python dict.
 
     ``names`` is a list of strings of field names to apply to the input data,
     which is assumed to be colon separated.
@@ -676,11 +765,16 @@ def _dict_from_terse_tabular(
             transformers[n] = lambda s: s
     for fields in _parse_colonsep_response(inp):
         if len(fields) != len(names):
-            log.warning(f'ignoring unparsable fields <{fields}>')
+            log.warning(f"ignoring unparsable fields <{fields}>")
             continue
-        res.append(dict([
-            (elem[0], transformers[elem[0]](elem[1]))
-            for elem in zip(names, fields)]))
+        res.append(
+            dict(
+                [
+                    (elem[0], transformers[elem[0]](elem[1]))
+                    for elem in zip(names, fields)
+                ]
+            )
+        )
     return res
 
 
@@ -713,39 +807,40 @@ def _dict_from_terse_tabular(
 # running it directly from a shell which _won’t_ correctly pass the data,
 # we need to parse the environment of pid1.
 
+
 def _get_host_data_prefix() -> str:
-    return os.path.join('mnt', 'data', 'resin-data', _get_resin_app_id())
+    return os.path.join("mnt", "data", "resin-data", _get_resin_app_id())
 
 
 def _get_resin_app_id() -> str:
     if not config.IS_ROBOT:
-        raise RuntimeError('Resin app id is only available on the pi')
-    p1_env = open('/proc/1/environ').read()
+        raise RuntimeError("Resin app id is only available on the pi")
+    p1_env = open("/proc/1/environ").read()
     # /proc/x/environ is pretty much just the raw memory segment of the
     # process that represents its environment. It contains a
     # NUL-separated list of strings.
-    app_id = re.search('RESIN_APP_ID=([^\x00]*)\x00',
-                       p1_env)
+    app_id = re.search("RESIN_APP_ID=([^\x00]*)\x00", p1_env)
     if not app_id:
-        raise RuntimeError(
-            'Cannot find resin app id! /proc/1/env={}'.format(p1_env))
+        raise RuntimeError("Cannot find resin app id! /proc/1/env={}".format(p1_env))
     return app_id.group(1)
 
 
 def _rewrite_key_path_to_host_path(key_path) -> str:
     resin_id = _get_resin_app_id()
     key_abspath = os.path.abspath(key_path)
-    if key_abspath.startswith('/data'):
-        key_relpath = os.path.relpath(key_abspath, '/data')
-        key_hostpath = os.path.join('/', 'mnt', 'data', 'resin-data',
-                                    resin_id, key_relpath)
-        log.debug("Rewrote key path {} to {} for host"
-                  .format(key_path, key_hostpath))
+    if key_abspath.startswith("/data"):
+        key_relpath = os.path.relpath(key_abspath, "/data")
+        key_hostpath = os.path.join(
+            "/", "mnt", "data", "resin-data", resin_id, key_relpath
+        )
+        log.debug("Rewrote key path {} to {} for host".format(key_path, key_hostpath))
         return key_hostpath
     else:
-        log.warning('Wifi keys that are not in /data may not work unless'
-                    'they are specified in a path common to the host and'
-                    ' the container')
+        log.warning(
+            "Wifi keys that are not in /data may not work unless"
+            "they are specified in a path common to the host and"
+            " the container"
+        )
         return key_path
 
 
@@ -754,4 +849,4 @@ def _make_host_symlink_if_necessary():
     if not os.path.islink(_get_host_data_prefix()):
         parent = os.path.abspath(os.path.join(host_data_prefix, os.pardir))
         os.makedirs(parent, exist_ok=True)
-        os.symlink('/data', host_data_prefix)
+        os.symlink("/data", host_data_prefix)

--- a/api/src/opentrons/system/resin.py
+++ b/api/src/opentrons/system/resin.py
@@ -3,7 +3,7 @@ import os
 import logging
 
 log = logging.getLogger(__name__)
-lock_file_path = '/tmp/resin/resin-updates.lock'
+lock_file_path = "/tmp/resin/resin-updates.lock"
 
 
 def lock_updates():
@@ -11,12 +11,12 @@ def lock_updates():
         import fcntl
 
         try:
-            with open(lock_file_path, 'w') as fd:
-                fd.write('a')
+            with open(lock_file_path, "w") as fd:
+                fd.write("a")
                 fcntl.flock(fd, fcntl.LOCK_EX)
                 fd.close()
         except OSError:
-            log.warning('Unable to create resin-update lock file')
+            log.warning("Unable to create resin-update lock file")
 
 
 def unlock_updates():

--- a/api/src/opentrons/system/smoothie_update.py
+++ b/api/src/opentrons/system/smoothie_update.py
@@ -4,13 +4,11 @@ import shutil
 
 
 def _ensure_programmer_executable():
-    """ Find the lpc21isp executable and ensure it is executable
-    """
+    """Find the lpc21isp executable and ensure it is executable"""
     # Find the lpc21isp executable, explicitly allowing the case where it
     # is not executable (since that’s exactly what we’re trying to fix)
-    updater_executable = shutil.which('lpc21isp',
-                                      mode=os.F_OK)
-    assert updater_executable, 'could not find lpc21isp'
+    updater_executable = shutil.which("lpc21isp", mode=os.F_OK)
+    assert updater_executable, "could not find lpc21isp"
     # updater_executable might be None; we’re passing it here unchecked
     # because if it is None, we’re about to fail when we try to program
     # the smoothie, and we want the exception to bubble up.

--- a/api/src/opentrons/tools/args_handler.py
+++ b/api/src/opentrons/tools/args_handler.py
@@ -7,15 +7,13 @@ from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
 def root_argparser(description: str = None):
     parse = argparse.ArgumentParser(description=description)
-    parse.add_argument('-p', '--port',
-                       help='serial port of the smoothie',
-                       default='', type=str)
+    parse.add_argument(
+        "-p", "--port", help="serial port of the smoothie", default="", type=str
+    )
     return parse
 
 
-async def build_driver(
-        port: str = None)\
-        -> Tuple[API, SmoothieDriver]:
+async def build_driver(port: str = None) -> Tuple[API, SmoothieDriver]:
     hardware = await API.build_hardware_controller(port=port)
     driver = cast(SmoothieDriver, hardware._backend._smoothie_driver)
     return hardware, driver

--- a/api/src/opentrons/tools/write_pipette_memory.py
+++ b/api/src/opentrons/tools/write_pipette_memory.py
@@ -3,77 +3,77 @@ from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
 from . import args_handler
 
-BAD_BARCODE_MESSAGE = 'Unexpected Serial -> {}'
-WRITE_FAIL_MESSAGE = 'Data not saved, HOLD BUTTON'
+BAD_BARCODE_MESSAGE = "Unexpected Serial -> {}"
+WRITE_FAIL_MESSAGE = "Data not saved, HOLD BUTTON"
 
 # must iterate through v1.4 and v1.3 first, because v1 barcodes did not
 # have characters to specify the version number
-VERSIONS = ['v2.2', 'v2.1', 'v2', 'v1.6', 'v1.5', 'v1.4', 'v1.3', 'v1']
+VERSIONS = ["v2.2", "v2.1", "v2", "v1.6", "v1.5", "v1.4", "v1.3", "v1"]
 
 MODELS = {
-    'v1': {
-        'P10S': 'p10_single_v1',
-        'P10M': 'p10_multi_v1',
-        'P50S': 'p50_single_v1',
-        'P50M': 'p50_multi_v1',
-        'P300S': 'p300_single_v1',
-        'P300M': 'p300_multi_v1',
-        'P1000S': 'p1000_single_v1'
+    "v1": {
+        "P10S": "p10_single_v1",
+        "P10M": "p10_multi_v1",
+        "P50S": "p50_single_v1",
+        "P50M": "p50_multi_v1",
+        "P300S": "p300_single_v1",
+        "P300M": "p300_multi_v1",
+        "P1000S": "p1000_single_v1",
     },
-    'v1.3': {
-        'P10SV13': 'p10_single_v1.3',
-        'P10MV13': 'p10_multi_v1.3',
-        'P50SV13': 'p50_single_v1.3',
-        'P50MV13': 'p50_multi_v1.3',
-        'P3HSV13': 'p300_single_v1.3',
-        'P3HMV13': 'p300_multi_v1.3',
-        'P1KSV13': 'p1000_single_v1.3'
+    "v1.3": {
+        "P10SV13": "p10_single_v1.3",
+        "P10MV13": "p10_multi_v1.3",
+        "P50SV13": "p50_single_v1.3",
+        "P50MV13": "p50_multi_v1.3",
+        "P3HSV13": "p300_single_v1.3",
+        "P3HMV13": "p300_multi_v1.3",
+        "P1KSV13": "p1000_single_v1.3",
     },
-    'v1.4': {
-        'P10SV14': 'p10_single_v1.4',
-        'P10MV14': 'p10_multi_v1.4',
-        'P50SV14': 'p50_single_v1.4',
-        'P50MV14': 'p50_multi_v1.4',
-        'P3HSV14': 'p300_single_v1.4',
-        'P3HMV14': 'p300_multi_v1.4',
-        'P1KSV14': 'p1000_single_v1.4'
+    "v1.4": {
+        "P10SV14": "p10_single_v1.4",
+        "P10MV14": "p10_multi_v1.4",
+        "P50SV14": "p50_single_v1.4",
+        "P50MV14": "p50_multi_v1.4",
+        "P3HSV14": "p300_single_v1.4",
+        "P3HMV14": "p300_multi_v1.4",
+        "P1KSV14": "p1000_single_v1.4",
     },
-    'v1.5': {
-        'P10SV15': 'p10_single_v1.5',
-        'P10MV15': 'p10_multi_v1.5',
-        'P50SV15': 'p50_single_v1.5',
-        'P50MV15': 'p50_multi_v1.5',
-        'P3HSV15': 'p300_single_v1.5',
-        'P3HMV15': 'p300_multi_v1.5',
-        'P1KSV15': 'p1000_single_v1.5'
+    "v1.5": {
+        "P10SV15": "p10_single_v1.5",
+        "P10MV15": "p10_multi_v1.5",
+        "P50SV15": "p50_single_v1.5",
+        "P50MV15": "p50_multi_v1.5",
+        "P3HSV15": "p300_single_v1.5",
+        "P3HMV15": "p300_multi_v1.5",
+        "P1KSV15": "p1000_single_v1.5",
     },
-    'v1.6': {
-        'P10MV16': 'p10_multi_v1.6',
+    "v1.6": {
+        "P10MV16": "p10_multi_v1.6",
     },
-    'v2': {
-        'P3HSV20': 'p300_single_v2.0',
-        'P3HMV20': 'p300_multi_v2.0',
-        'P1KSV20': 'p1000_single_v2.0',
-        'P20SV20': 'p20_single_v2.0',
-        'P20MV20': 'p20_multi_v2.0',
+    "v2": {
+        "P3HSV20": "p300_single_v2.0",
+        "P3HMV20": "p300_multi_v2.0",
+        "P1KSV20": "p1000_single_v2.0",
+        "P20SV20": "p20_single_v2.0",
+        "P20MV20": "p20_multi_v2.0",
     },
-    'v2.1': {
-        'P3HSV21': 'p300_single_v2.1',
-        'P1KSV21': 'p1000_single_v2.1',
-        'P20SV21': 'p20_single_v2.1',
-        'P3HMV21': 'p300_multi_v2.1',
-        'P20MV21': 'p20_multi_v2.1',
+    "v2.1": {
+        "P3HSV21": "p300_single_v2.1",
+        "P1KSV21": "p1000_single_v2.1",
+        "P20SV21": "p20_single_v2.1",
+        "P3HMV21": "p300_multi_v2.1",
+        "P20MV21": "p20_multi_v2.1",
     },
-    'v2.2': {
-        'P20MV22': 'p20_multi_v2.2',
-        'P20SV22': 'p20_single_v2.2',
-        'P1KSV22': 'p1000_single_v2.2',
-    }
+    "v2.2": {
+        "P20MV22": "p20_multi_v2.2",
+        "P20SV22": "p20_single_v2.2",
+        "P1KSV22": "p1000_single_v2.2",
+    },
 }
 
 
 async def write_identifiers(
-        mount: str, new_id: str, new_model: str, driver: SmoothieDriver
+    mount: str, new_id: str, new_model: str, driver: SmoothieDriver
 ) -> None:
     """
     Send a bytearray to the specified mount, so that Smoothieware can
@@ -91,11 +91,9 @@ async def check_previous_data(mount: str, driver: SmoothieDriver) -> None:
     old_id = await driver.read_pipette_id(mount)
     old_model = await driver.read_pipette_model(mount)
     if old_id and old_model:
-        print(
-            'Overwriting old data: id={0}, model={1}'.format(
-                old_id, old_model))
+        print("Overwriting old data: id={0}, model={1}".format(old_id, old_model))
     else:
-        print('No old data on this pipette')
+        print("No old data on this pipette")
 
 
 def _assert_the_same(a, b):
@@ -108,13 +106,13 @@ def _user_submitted_barcode(max_length: int) -> str:
     User can enter a serial number as a string of HEX values
     Length of byte array must equal `num`
     """
-    barcode = input('BUTTON + SCAN: ').strip()
+    barcode = input("BUTTON + SCAN: ").strip()
     if len(barcode) > max_length:
         raise Exception(BAD_BARCODE_MESSAGE.format(barcode))
     # remove all characters before the letter P
     # for example, remove ASCII selector code "\x1b(B" on chinese keyboards
-    barcode = barcode[barcode.index('P'):]
-    barcode = barcode.split('\r')[0].split('\n')[0]  # remove any newlines
+    barcode = barcode[barcode.index("P") :]
+    barcode = barcode.split("\r")[0].split("\n")[0]  # remove any newlines
     return barcode
 
 
@@ -132,21 +130,23 @@ async def _do_wpm(mount: str, driver: SmoothieDriver) -> None:
         model = _parse_model_from_barcode(barcode)
         await check_previous_data(mount, driver)
         await write_identifiers(mount, barcode, model, driver)
-        print('PASS: Saved -> {0} (model {1})'.format(barcode, model))
+        print("PASS: Saved -> {0} (model {1})".format(barcode, model))
     except KeyboardInterrupt:
         exit()
     except Exception as e:
-        print('FAIL: {}'.format(e))
+        print("FAIL: {}".format(e))
 
 
 async def main() -> None:
-    parser = args_handler.root_argparser(
-        "Write model and serial to a pipette's eeprom")
-    parser.add_argument('-m', '--mount',
-                        help='mount to use',
-                        default='right',
-                        type=str,
-                        choices=['left', 'right'])
+    parser = args_handler.root_argparser("Write model and serial to a pipette's eeprom")
+    parser.add_argument(
+        "-m",
+        "--mount",
+        help="mount to use",
+        default="right",
+        type=str,
+        choices=["left", "right"],
+    )
     args = parser.parse_args()
     _, driver = await args_handler.build_driver(args.port)
     while True:

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
 
 
 class PipetteNotAttachedError(KeyError):
-    """ An error raised if a pipette is accessed that is not attached """
+    """An error raised if a pipette is accessed that is not attached"""
+
     pass
 
 
@@ -24,34 +25,33 @@ class Point(NamedTuple):
         if not isinstance(other, Point):
             return False
         pairs = ((self.x, other.x), (self.y, other.y), (self.z, other.z))
-        return all(isclose(s, o,
-                           rel_tol=1e-05, abs_tol=1e-08) for s, o in pairs)
+        return all(isclose(s, o, rel_tol=1e-05, abs_tol=1e-08) for s, o in pairs)
 
-    def __add__(self, other: Any) -> 'Point':
+    def __add__(self, other: Any) -> "Point":
         if not isinstance(other, Point):
             return NotImplemented
         return Point(self.x + other.x, self.y + other.y, self.z + other.z)
 
-    def __sub__(self, other: Any) -> 'Point':
+    def __sub__(self, other: Any) -> "Point":
         if not isinstance(other, Point):
             return NotImplemented
         return Point(self.x - other.x, self.y - other.y, self.z - other.z)
 
-    def __mul__(self, other: Union[int, float]) -> 'Point':
+    def __mul__(self, other: Union[int, float]) -> "Point":
         if not isinstance(other, (float, int)):
             return NotImplemented
         return Point(self.x * other, self.y * other, self.z * other)
 
-    def __rmul__(self, other: Union[int, float]) -> 'Point':
+    def __rmul__(self, other: Union[int, float]) -> "Point":
         if not isinstance(other, (float, int)):
             return NotImplemented
         return Point(self.x * other, self.y * other, self.z * other)
 
-    def __abs__(self) -> 'Point':
+    def __abs__(self) -> "Point":
         return Point(abs(self.x), abs(self.y), abs(self.z))
 
     def __str__(self):
-        return '({}, {}, {})'.format(self.x, self.y, self.z)
+        return "({}, {}, {})".format(self.x, self.y, self.z)
 
     def magnitude_to(self, other: Any) -> float:
         if not isinstance(other, Point):
@@ -59,15 +59,14 @@ class Point(NamedTuple):
         x_diff = self.x - other.x
         y_diff = self.y - other.y
         z_diff = self.z - other.z
-        return sqrt(x_diff**2 + y_diff**2 + z_diff**2)
+        return sqrt(x_diff ** 2 + y_diff ** 2 + z_diff ** 2)
 
 
-LocationLabware = Union['Labware', 'Well', str,
-                        'ModuleGeometry', LabwareLike, None]
+LocationLabware = Union["Labware", "Well", str, "ModuleGeometry", LabwareLike, None]
 
 
 class Location:
-    """ A location to target as a motion.
+    """A location to target as a motion.
 
     The location contains a :py:class:`.Point` (in
     :ref:`protocol-api-deck-coords`) and possibly an associated
@@ -107,14 +106,21 @@ class Location:
 
     def __iter__(self):
         """Iterable interface to support unpacking. Like a tuple."""
-        return iter((self._point, self._labware,))
+        return iter(
+            (
+                self._point,
+                self._labware,
+            )
+        )
 
     def __eq__(self, other):
-        return isinstance(other, Location) \
-            and other._point == self._point \
+        return (
+            isinstance(other, Location)
+            and other._point == self._point
             and other._labware == self._labware
+        )
 
-    def move(self, point: Point) -> 'Location':
+    def move(self, point: Point) -> "Location":
         """
         Alter the point stored in the location while preserving the labware.
 
@@ -133,8 +139,7 @@ class Location:
             >>> assert loc.point == Point(1, 1, 1)  # True
 
         """
-        return Location(point=self.point + point,
-                        labware=self._labware.object)
+        return Location(point=self.point + point, labware=self._labware.object)
 
     def __repr__(self) -> str:
         return f"Location(point={repr(self._point)}, labware={self._labware})"
@@ -149,8 +154,8 @@ class Mount(enum.Enum):
         return self.name
 
     @classmethod
-    def string_to_mount(cls, mount: str) -> 'Mount':
-        if mount == 'right':
+    def string_to_mount(cls, mount: str) -> "Mount":
+        if mount == "right":
             return cls.RIGHT
         else:
             return cls.LEFT
@@ -172,6 +177,7 @@ class MountType(str, enum.Enum):
 # https://github.com/Opentrons/opentrons/pull/6943#discussion_r519029833
 class DeckSlotName(int, enum.Enum):
     """Deck slot identifiers."""
+
     SLOT_1 = 1
     SLOT_2 = 2
     SLOT_3 = 3

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def labware_from_paths(paths: List[str]) -> Dict[str, 'LabwareDefinition']:
-    labware_defs: Dict[str, 'LabwareDefinition'] = {}
+def labware_from_paths(paths: List[str]) -> Dict[str, "LabwareDefinition"]:
+    labware_defs: Dict[str, "LabwareDefinition"] = {}
 
     for strpath in paths:
         log.info(f"local labware: checking path {strpath}")
@@ -27,9 +27,9 @@ def labware_from_paths(paths: List[str]) -> Dict[str, 'LabwareDefinition']:
         else:
             path = pathlib.Path.cwd() / purepath
         if not path.is_dir():
-            raise RuntimeError(f'{path} is not a directory')
+            raise RuntimeError(f"{path} is not a directory")
         for child in path.iterdir():
-            if child.is_file() and child.suffix.endswith('json'):
+            if child.is_file() and child.suffix.endswith("json"):
                 try:
                     defn = labware.verify_definition(child.read_bytes())
                 except (ValidationError, JSONDecodeError) as e:
@@ -38,9 +38,9 @@ def labware_from_paths(paths: List[str]) -> Dict[str, 'LabwareDefinition']:
                 else:
                     uri = helpers.uri_from_definition(defn)
                     labware_defs[uri] = defn
-                    log.info(f'loaded labware {uri} from {child}')
+                    log.info(f"loaded labware {uri} from {child}")
             else:
-                log.info(f'ignoring {child} in labware path')
+                log.info(f"ignoring {child} in labware path")
     return labware_defs
 
 
@@ -55,12 +55,12 @@ def datafiles_from_paths(paths: List[str]) -> Dict[str, bytes]:
             path = pathlib.Path.cwd() / purepath
         if path.is_file():
             datafiles[path.name] = path.read_bytes()
-            log.info(f'read {path} into custom data as {path.name}')
+            log.info(f"read {path} into custom data as {path.name}")
         elif path.is_dir():
             for child in path.iterdir():
                 if child.is_file():
                     datafiles[child.name] = child.read_bytes()
-                    log.info(f'read {child} into data path as {child.name}')
+                    log.info(f"read {child} into data path as {child.name}")
                 else:
-                    log.info(f'ignoring {child} in data path')
+                    log.info(f"ignoring {child} in data path")
     return datafiles

--- a/api/src/opentrons/util/helpers.py
+++ b/api/src/opentrons/util/helpers.py
@@ -2,9 +2,11 @@ import typing
 from datetime import datetime, timezone
 
 
-def deep_get(obj: typing.Union[typing.Mapping, typing.Sequence],
-             key: typing.Sequence[typing.Union[str, int]],
-             default=None):
+def deep_get(
+    obj: typing.Union[typing.Mapping, typing.Sequence],
+    key: typing.Sequence[typing.Union[str, int]],
+    default=None,
+):
     """
     Utility to get deeply nested element in a list, tuple or dict without
      resorting to some_dict.get('k1', {}).get('k2', {}).get('k3', {})....etc.

--- a/api/src/opentrons/util/linal.py
+++ b/api/src/opentrons/util/linal.py
@@ -10,38 +10,26 @@ mod_log = logging.getLogger(__name__)
 
 # (TODO(lc, 8/11/2020): temporary type until
 # old calibration data is removed.
-AxisPosition = Union[
-    Tuple[float, float, float], Tuple[float, float]]
+AxisPosition = Union[Tuple[float, float, float], Tuple[float, float]]
 
 SolvePoints = Tuple[
-    Tuple[float, float, float],
-    Tuple[float, float, float],
-    Tuple[float, float, float]]
+    Tuple[float, float, float], Tuple[float, float, float], Tuple[float, float, float]
+]
 
 
 def identity_deck_transform() -> np.ndarray:
-    """ The default deck transform """
+    """The default deck transform"""
     return np.identity(3)
 
 
-def solve_attitude(
-        expected: SolvePoints,
-        actual: SolvePoints
-        ) -> AttitudeMatrix:
-    ex = np.array([
-        list(point)
-        for point in expected
-    ]).transpose()
-    ac = np.array([
-            list(point)
-            for point in actual
-        ]).transpose()
+def solve_attitude(expected: SolvePoints, actual: SolvePoints) -> AttitudeMatrix:
+    ex = np.array([list(point) for point in expected]).transpose()
+    ac = np.array([list(point) for point in actual]).transpose()
     t = np.dot(ac, inv(ex))
 
-    mask_transform = np.array([
-        [True, True, False],
-        [True, True, False],
-        [False, False, False]])
+    mask_transform = np.array(
+        [[True, True, False], [True, True, False], [False, False, False]]
+    )
     masked_array = np.ma.masked_array(t, ~mask_transform)
 
     no_z_component = np.zeros((3, 3))
@@ -51,8 +39,9 @@ def solve_attitude(
     return transform.round(4).tolist()
 
 
-def solve(expected: List[Tuple[float, float]],
-          actual: List[Tuple[float, float]]) -> np.ndarray:
+def solve(
+    expected: List[Tuple[float, float]], actual: List[Tuple[float, float]]
+) -> np.ndarray:
     """
     Takes two lists of 3 x-y points each, and calculates the matrix
     representing the transformation from one space to the other.
@@ -99,15 +88,9 @@ def solve(expected: List[Tuple[float, float]],
     # [ (x1, y1),
     #   (x2, y2),
     #   (x3, y3) ]
-    ex = np.array([
-            list(point) + [1]
-            for point in expected
-        ]).transpose()
+    ex = np.array([list(point) + [1] for point in expected]).transpose()
 
-    ac = np.array([
-            list(point) + [1]
-            for point in actual
-        ]).transpose()
+    ac = np.array([list(point) + [1] for point in actual]).transpose()
     # Shape of `ex` and `ac`:
     # [ x1 x2 x3 ]
     # [ y1 y2 y3 ]
@@ -147,11 +130,7 @@ def add_z(xy: np.ndarray, z: float) -> np.ndarray:
     # [ 0  0  0  1 ]
 
     # Then, insert the z row to create a properly formed 3-D transform matrix:
-    xyz = insert(
-        interm,
-        2,
-        [0, 0, 1, z],
-        axis=0)
+    xyz = insert(interm, 2, [0, 0, 1, z], axis=0)
     # Result:
     # [ 1  0  0  x ]
     # [ 0  1  0  y ]
@@ -162,8 +141,8 @@ def add_z(xy: np.ndarray, z: float) -> np.ndarray:
 
 
 def add_matrices(
-        t1: Tuple[float, float, float],
-        t2: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    t1: Tuple[float, float, float], t2: Tuple[float, float, float]
+) -> Tuple[float, float, float]:
     """
     Simple method to convert tuples to numpy arrays and add them.
     """
@@ -171,8 +150,8 @@ def add_matrices(
 
 
 def apply_transform(
-        t: Union[List[List[float]], np.ndarray],
-        pos: AxisPosition) -> Tuple[float, float, float]:
+    t: Union[List[List[float]], np.ndarray], pos: AxisPosition
+) -> Tuple[float, float, float]:
     """
     Change of base using a transform matrix. Primarily used to render a point
     in space in a way that is more readable for the user.
@@ -185,8 +164,7 @@ def apply_transform(
 
 
 def apply_reverse(
-        t: Union[List[List[float]], np.ndarray],
-        pos: AxisPosition) -> Tuple[float, float, float]:
-    """ Like apply_transform but inverts the transform first
-    """
+    t: Union[List[List[float]], np.ndarray], pos: AxisPosition
+) -> Tuple[float, float, float]:
+    """Like apply_transform but inverts the transform first"""
     return apply_transform(inv(t), pos)

--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -7,59 +7,57 @@ from opentrons.config import CONFIG, ARCHITECTURE, SystemArchitecture
 
 
 def _balena_config(level_value: int) -> Dict[str, Any]:
-    serial_log_filename = CONFIG['serial_log_file']
-    api_log_filename = CONFIG['api_log_file']
+    serial_log_filename = CONFIG["serial_log_file"]
+    api_log_filename = CONFIG["api_log_file"]
     return {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'basic': {
-                'format':
-                '%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s'
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "basic": {
+                "format": (
+                    "%(asctime)s %(name)s %(levelname)s [Line %(lineno)s] %(message)s"
+                )
             }
         },
-        'handlers': {
-            'debug': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'basic',
-                'level': level_value
+        "handlers": {
+            "debug": {
+                "class": "logging.StreamHandler",
+                "formatter": "basic",
+                "level": level_value,
             },
-            'serial': {
-                'class': 'logging.handlers.RotatingFileHandler',
-                'formatter': 'basic',
-                'filename': serial_log_filename,
-                'maxBytes': 5000000,
-                'level': logging.DEBUG,
-                'backupCount': 3
+            "serial": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "basic",
+                "filename": serial_log_filename,
+                "maxBytes": 5000000,
+                "level": logging.DEBUG,
+                "backupCount": 3,
             },
-            'api': {
-                'class': 'logging.handlers.RotatingFileHandler',
-                'formatter': 'basic',
-                'filename': api_log_filename,
-                'maxBytes': 1000000,
-                'level': logging.DEBUG,
-                'backupCount': 5
-            }
+            "api": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "basic",
+                "filename": api_log_filename,
+                "maxBytes": 1000000,
+                "level": logging.DEBUG,
+                "backupCount": 5,
+            },
         },
-        'loggers': {
-            'opentrons': {
-                'handlers': ['debug', 'api'],
-                'level': level_value,
+        "loggers": {
+            "opentrons": {
+                "handlers": ["debug", "api"],
+                "level": level_value,
             },
-            'opentrons.deck_calibration': {
-                'handlers': ['debug', 'api'],
-                'level': level_value,
+            "opentrons.deck_calibration": {
+                "handlers": ["debug", "api"],
+                "level": level_value,
             },
-            'opentrons.drivers.asyncio.communication.serial_connection': {
-                'handlers': ['serial'],
-                'level': logging.DEBUG,
-                'propagate': False
+            "opentrons.drivers.asyncio.communication.serial_connection": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
             },
-            '__main__': {
-                'handlers': ['api'],
-                'level': level_value
-            },
-        }
+            "__main__": {"handlers": ["api"], "level": level_value},
+        },
     }
 
 
@@ -68,49 +66,42 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
     # linux systems and we probably don't want to use it on linux desktops
     # either
     return {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'message_only': {
-                'format': '%(message)s'
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "message_only": {"format": "%(message)s"},
+        },
+        "handlers": {
+            "api": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api",
+            },
+            "serial": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api-serial",
             },
         },
-        'handlers': {
-            'api': {
-                'class': 'systemd.journal.JournalHandler',
-                'level': logging.DEBUG,
-                'formatter': 'message_only',
-                'SYSLOG_IDENTIFIER': 'opentrons-api',
+        "loggers": {
+            "opentrons.drivers.asyncio.communication.serial_connection": {
+                "handlers": ["serial"],
+                "level": logging.DEBUG,
+                "propagate": False,
             },
-            'serial': {
-                'class': 'systemd.journal.JournalHandler',
-                'level': logging.DEBUG,
-                'formatter': 'message_only',
-                'SYSLOG_IDENTIFIER': 'opentrons-api-serial',
-            }
+            "opentrons": {
+                "handlers": ["api"],
+                "level": level_value,
+            },
+            "__main__": {"handlers": ["api"], "level": level_value},
         },
-        'loggers': {
-            'opentrons.drivers.asyncio.communication.serial_connection': {
-                'handlers': ['serial'],
-                'level': logging.DEBUG,
-                'propagate': False
-            },
-            'opentrons': {
-                'handlers': ['api'],
-                'level': level_value,
-            },
-            '__main__': {
-                'handlers': ['api'],
-                'level': level_value
-            },
-        },
-
     }
 
 
 def _host_config(level_value: int) -> Dict[str, Any]:
-    """ Host logging, for now the same as balena logging
-    """
+    """Host logging, for now the same as balena logging"""
     return _balena_config(level_value)
 
 
@@ -118,7 +109,7 @@ def _config(arch: SystemArchitecture, level_value: int) -> Dict[str, Any]:
     return {
         SystemArchitecture.BALENA: _balena_config,
         SystemArchitecture.BUILDROOT: _buildroot_config,
-        SystemArchitecture.HOST: _host_config
+        SystemArchitecture.HOST: _host_config,
     }[arch](level_value)
 
 
@@ -127,12 +118,13 @@ def log_init(level_name: str):
     Function that sets log levels and format strings. Checks for the
     OT_API_LOG_LEVEL environment variable otherwise defaults to INFO
     """
-    fallback_log_level = 'INFO'
+    fallback_log_level = "INFO"
     ot_log_level = level_name.upper()
     if ot_log_level not in logging._nameToLevel:
         sys.stderr.write(
-            f'OT Log Level {ot_log_level} not found. '
-            f'Defaulting to {fallback_log_level}\n')
+            f"OT Log Level {ot_log_level} not found. "
+            f"Defaulting to {fallback_log_level}\n"
+        )
         ot_log_level = fallback_log_level
     level_value = logging._nameToLevel[ot_log_level]
     logging_config = _config(ARCHITECTURE, level_value)

--- a/api/tests/opentrons/algorithms/test_dfs.py
+++ b/api/tests/opentrons/algorithms/test_dfs.py
@@ -12,9 +12,7 @@ from typing import Callable, List, Tuple, Any
 from opentrons.algorithms import dfs, types
 
 
-def convert_to_vertex(
-        graph_dict: dict,
-        cast_type: Callable) -> List[types.GenericNode]:
+def convert_to_vertex(graph_dict: dict, cast_type: Callable) -> List[types.GenericNode]:
     """Convert to Vertex.
 
     Helper function to convert a json file to a list of
@@ -22,25 +20,24 @@ def convert_to_vertex(
     """
     graph = []
     for key, value in graph_dict.items():
-        vertex = types.GenericNode(
-            name=cast_type(key),
-            sub_names=value)
+        vertex = types.GenericNode(name=cast_type(key), sub_names=value)
         graph.append(vertex)
     return graph
 
 
-def load_graph() -> Tuple[Tuple[List[types.GenericNode], str],
-                          Tuple[List[types.GenericNode], str]]:
+def load_graph() -> Tuple[
+    Tuple[List[types.GenericNode], str], Tuple[List[types.GenericNode], str]
+]:
     """Load Graphs.
 
     Helper function to load the test json graph files.
     """
     path = Path(os.path.abspath(os.path.dirname(__file__)))
-    with (path / 'fixture_alphabetical_graph.json').open() as f:
+    with (path / "fixture_alphabetical_graph.json").open() as f:
         alphabet = convert_to_vertex(json.load(f), str)
-    with (path / 'fixture_numerical_graph.json').open() as f:
+    with (path / "fixture_numerical_graph.json").open() as f:
         numbers = convert_to_vertex(json.load(f), int)
-    return (alphabet, 'string'), (numbers, 'integer')
+    return (alphabet, "string"), (numbers, "integer")
 
 
 @pytest.fixture(scope="session", params=load_graph())
@@ -65,13 +62,10 @@ def test_vertices(dfs_graph: dfs.DFS) -> None:
     """
     _dfs, _type = dfs_graph
     graph = _dfs.graph
-    if _type == 'string':
-        additional_vertex = types.GenericNode(
-            name='K', sub_names=['H', 'J', 'A'])
+    if _type == "string":
+        additional_vertex = types.GenericNode(name="K", sub_names=["H", "J", "A"])
     else:
-        additional_vertex = types.GenericNode(
-            name=12, sub_names=[1, 9, 5]
-        )
+        additional_vertex = types.GenericNode(name=12, sub_names=[1, 9, 5])
     graph.add_vertex(additional_vertex)
     vertex_obj = graph.get_vertex(additional_vertex.name)
     assert additional_vertex.name in graph._lookup_table.keys()
@@ -89,11 +83,11 @@ def test_neighbors(dfs_graph: dfs.DFS) -> None:
     """
     _dfs, _type = dfs_graph
     graph = _dfs.graph
-    if _type == 'string':
-        key = 'A'
-        neighbor = 'J'
-        og_neighbors = ['B', 'E']
-        sorted_neighbors = ['B', 'E', 'J']
+    if _type == "string":
+        key = "A"
+        neighbor = "J"
+        og_neighbors = ["B", "E"]
+        sorted_neighbors = ["B", "E", "J"]
     else:
         key = 1
         neighbor = 4
@@ -115,8 +109,8 @@ def test_depth_first_search(dfs_graph: dfs.DFS) -> None:
     """
     _dfs, _type = dfs_graph
     visited_vertices = _dfs.dfs()
-    if _type == 'string':
-        sort = {'A', 'B', 'F', 'G', 'C', 'J', 'I', 'H', 'D', 'E'}
+    if _type == "string":
+        sort = {"A", "B", "F", "G", "C", "J", "I", "H", "D", "E"}
     else:
         sort = {1, 2, 6, 7, 3, 10, 9, 8, 4, 5}
     assert sort == visited_vertices

--- a/api/tests/opentrons/api/test_calibration.py
+++ b/api/tests/opentrons/api/test_calibration.py
@@ -6,136 +6,114 @@ from opentrons.types import Point, Mount
 from opentrons.hardware_control import CriticalPoint, API
 from opentrons.hardware_control.types import MotionChecks
 
-state = partial(state, 'calibration')
+state = partial(state, "calibration")
 
 
 @pytest.mark.api2_only
 async def test_move_to_front_api2(main_router, model):
     main_router.calibration_manager._hardware.home()
-    with mock.patch.object(API, 'move_to') as patch:
+    with mock.patch.object(API, "move_to") as patch:
         main_router.calibration_manager.move_to_front(model.instrument)
-        patch.assert_called_with(Mount.RIGHT, Point(132.5, 90.5, 150),
-                                 critical_point=CriticalPoint.NOZZLE)
+        patch.assert_called_with(
+            Mount.RIGHT, Point(132.5, 90.5, 150), critical_point=CriticalPoint.NOZZLE
+        )
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 async def test_pick_up_tip(main_router, model):
-    with mock.patch.object(
-            model.instrument._instrument, 'pick_up_tip') as pick_up_tip:
-        main_router.calibration_manager.pick_up_tip(
-            model.instrument,
-            model.container)
+    with mock.patch.object(model.instrument._instrument, "pick_up_tip") as pick_up_tip:
+        main_router.calibration_manager.pick_up_tip(model.instrument, model.container)
 
-        pick_up_tip.assert_called_with(
-            model.container._container.wells()[0])
+        pick_up_tip.assert_called_with(model.container._container.wells()[0])
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 async def test_drop_tip(main_router, model):
-    with mock.patch.object(
-            model.instrument._instrument, 'drop_tip') as drop_tip:
-        main_router.calibration_manager.drop_tip(
-            model.instrument,
-            model.container)
+    with mock.patch.object(model.instrument._instrument, "drop_tip") as drop_tip:
+        main_router.calibration_manager.drop_tip(model.instrument, model.container)
 
-        drop_tip.assert_called_with(
-            model.container._container.wells()[0])
+        drop_tip.assert_called_with(model.container._container.wells()[0])
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 async def test_return_tip(main_router, model):
-    with mock.patch.object(
-            model.instrument._instrument, 'return_tip') as return_tip:
+    with mock.patch.object(model.instrument._instrument, "return_tip") as return_tip:
         main_router.calibration_manager.return_tip(model.instrument)
 
         return_tip.assert_called_with()
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 @pytest.mark.api2_only
 async def test_home_api2(main_router, model):
-    main_router.calibration_manager.home(
-        model.instrument)
+    main_router.calibration_manager.home(model.instrument)
 
-    await main_router.wait_until(state('moving'))
-    await main_router.wait_until(state('ready'))
+    await main_router.wait_until(state("moving"))
+    await main_router.wait_until(state("ready"))
 
 
 @pytest.mark.api2_only
 async def test_home_all_api2(main_router, model):
-    with mock.patch.object(model.instrument._context, 'home') as home:
-        main_router.calibration_manager.home_all(
-            model.instrument)
+    with mock.patch.object(model.instrument._context, "home") as home:
+        main_router.calibration_manager.home_all(model.instrument)
 
         home.assert_called_once()
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 async def test_move_to_top(main_router, model):
-    with mock.patch.object(model.instrument._instrument, 'move_to') as move_to:
-        main_router.calibration_manager.move_to(
-            model.instrument,
-            model.container)
+    with mock.patch.object(model.instrument._instrument, "move_to") as move_to:
+        main_router.calibration_manager.move_to(model.instrument, model.container)
         target = model.container._container.wells()[0].top()
         move_to.assert_called_with(target)
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 @pytest.mark.api2_only
 async def test_jog_api2(main_router, model):
     main_router.calibration_manager.home(model.instrument)
-    with mock.patch.object(API, 'move_rel') as jog:
-        for distance, axis in zip((1, 2, 3), 'xyz'):
-            main_router.calibration_manager.jog(
-                model.instrument,
-                distance,
-                axis
-            )
+    with mock.patch.object(API, "move_rel") as jog:
+        for distance, axis in zip((1, 2, 3), "xyz"):
+            main_router.calibration_manager.jog(model.instrument, distance, axis)
 
         expected = [
             mock.call(Mount.RIGHT, point, check_bounds=MotionChecks.HIGH)
-            for point in [Point(x=1), Point(y=2), Point(z=3)]]
+            for point in [Point(x=1), Point(y=2), Point(z=3)]
+        ]
 
         assert jog.mock_calls == expected
 
-        await main_router.wait_until(state('moving'))
-        await main_router.wait_until(state('ready'))
+        await main_router.wait_until(state("moving"))
+        await main_router.wait_until(state("ready"))
 
 
 @pytest.mark.api2_only
 async def test_update_container_offset_v2(main_router, model):
     with mock.patch(
-        'opentrons.protocol_api.labware.save_calibration') as call,\
-            mock.patch.object(API,
-                              'gantry_position') as gp:
+        "opentrons.protocol_api.labware.save_calibration"
+    ) as call, mock.patch.object(API, "gantry_position") as gp:
         gp.return_value = Point(0, 0, 0)
         main_router.calibration_manager.update_container_offset(
-            model.container,
-            model.instrument
+            model.container, model.instrument
         )
-        diff = (Point(0, 0, 0)
-                - model.container._container.wells()[0].top().point)
-        call.assert_called_with(model.container._container,
-                                diff)
+        diff = Point(0, 0, 0) - model.container._container.wells()[0].top().point
+        call.assert_called_with(model.container._container, diff)
 
 
 @pytest.mark.api2_only
-async def test_jog_calibrate_bottom_v2(
-        main_router,
-        model,
-        calibrate_bottom_flag):
+async def test_jog_calibrate_bottom_v2(main_router, model, calibrate_bottom_flag):
 
     # Check that the feature flag correctly implements calibrate to bottom
     container = model.container._container
@@ -144,24 +122,22 @@ async def test_jog_calibrate_bottom_v2(
 
     main_router.calibration_manager.home(model.instrument)
     main_router.calibration_manager.move_to(model.instrument, model.container)
-    main_router.calibration_manager.jog(model.instrument, 1, 'x')
-    main_router.calibration_manager.jog(model.instrument, 2, 'y')
-    main_router.calibration_manager.jog(model.instrument, 3, 'z')
-    main_router.calibration_manager.jog(model.instrument, -height, 'z')
+    main_router.calibration_manager.jog(model.instrument, 1, "x")
+    main_router.calibration_manager.jog(model.instrument, 2, "y")
+    main_router.calibration_manager.jog(model.instrument, 3, "z")
+    main_router.calibration_manager.jog(model.instrument, -height, "z")
 
     main_router.calibration_manager.update_container_offset(
-        model.container,
-        model.instrument
+        model.container, model.instrument
     )
 
-    assert list(model.container._container.wells()[0].bottom().point)\
-        == pytest.approx(old_bottom + Point(1, 2, 3))
+    assert list(model.container._container.wells()[0].bottom().point) == pytest.approx(
+        old_bottom + Point(1, 2, 3)
+    )
 
 
 @pytest.mark.api2_only
-async def test_jog_calibrate_top_v2(
-        main_router,
-        model):
+async def test_jog_calibrate_top_v2(main_router, model):
 
     # Check that the old behavior remains the same without the feature flag
 
@@ -169,13 +145,13 @@ async def test_jog_calibrate_top_v2(
     old_top = container.wells()[0].top().point
     main_router.calibration_manager.home(model.instrument)
     main_router.calibration_manager.move_to(model.instrument, model.container)
-    main_router.calibration_manager.jog(model.instrument, 1, 'x')
-    main_router.calibration_manager.jog(model.instrument, 2, 'y')
-    main_router.calibration_manager.jog(model.instrument, 3, 'z')
+    main_router.calibration_manager.jog(model.instrument, 1, "x")
+    main_router.calibration_manager.jog(model.instrument, 2, "y")
+    main_router.calibration_manager.jog(model.instrument, 3, "z")
 
     main_router.calibration_manager.update_container_offset(
-        model.container,
-        model.instrument
+        model.container, model.instrument
     )
-    assert list(model.container._container.wells()[0].top().point)\
-        == pytest.approx(old_top + Point(1, 2, 3))
+    assert list(model.container._container.wells()[0].top().point) == pytest.approx(
+        old_top + Point(1, 2, 3)
+    )

--- a/api/tests/opentrons/api/test_session.py
+++ b/api/tests/opentrons/api/test_session.py
@@ -5,8 +5,7 @@ import pytest
 import base64
 
 from opentrons.api import session
-from opentrons.api.session import (
-    _accumulate, _dedupe)
+from opentrons.api.session import _accumulate, _dedupe
 from opentrons.hardware_control import ThreadedAsyncForbidden
 
 from tests.opentrons.conftest import state
@@ -16,50 +15,42 @@ from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
 from opentrons.protocol_api.labware import load
 from opentrons.types import Location, Point
-state = partial(state, 'session')
+
+state = partial(state, "session")
 
 
 async def test_async_notifications(main_router):
-    main_router.broker.publish(
-        'session', {'name': 'foo', 'payload': {'bar': 'baz'}})
+    main_router.broker.publish("session", {"name": "foo", "payload": {"bar": "baz"}})
     # Get async iterator
     aiter = main_router.notifications.__aiter__()
     # Then read the first item
     res = await aiter.__anext__()
-    assert res == {'name': 'foo', 'payload': {'bar': 'baz'}}
+    assert res == {"name": "foo", "payload": {"bar": "baz"}}
 
 
 @pytest.mark.parametrize(
-    'proto_with_error', [
-        '''
+    "proto_with_error",
+    [
+        """
 metadata={"apiLevel": "2.0"}
 blah
-def run(ctx): pass'''
-    ])
-def test_load_protocol_with_error(session_manager, hardware,
-                                  proto_with_error):
+def run(ctx): pass"""
+    ],
+)
+def test_load_protocol_with_error(session_manager, hardware, proto_with_error):
     with pytest.raises(NameError) as e:
-        session = session_manager.create(
-            name='<blank>', contents=proto_with_error)
+        session = session_manager.create(name="<blank>", contents=proto_with_error)
         assert session is None
 
-    args, = e.value.args
+    (args,) = e.value.args
     assert args == "name 'blah' is not defined"
 
 
-@pytest.mark.parametrize(
-    'protocol_file',
-    ['testosaur_v2.py'])
-async def test_load_and_run_v2(
-        main_router,
-        protocol,
-        protocol_file,
-        loop):
-    session = main_router.session_manager.create(
-        name='<blank>',
-        contents=protocol.text)
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py"])
+async def test_load_and_run_v2(main_router, protocol, protocol_file, loop):
+    session = main_router.session_manager.create(name="<blank>", contents=protocol.text)
     assert main_router.notifications.queue.qsize() == 1
-    assert session.state == 'loaded'
+    assert session.state == "loaded"
     assert session.command_log == {}
 
     def run():
@@ -73,67 +64,77 @@ async def test_load_and_run_v2(
     res = []
     index = 0
     async for notification in main_router.notifications:
-        payload = notification['payload']
+        payload = notification["payload"]
         index += 1  # Command log in sync with add-command events emitted
         if type(payload) is dict:
-            state = payload.get('state')
+            state = payload.get("state")
         else:
             state = payload.state
         res.append(state)
-        if state == 'finished':
+        if state == "finished":
             break
 
-    assert [key for key, _ in itertools.groupby(res)] == \
-        ['loaded', 'running', 'finished']
-    assert main_router.notifications.queue.qsize() == 0,\
-        'Notification should be empty after receiving "finished" event'
+    assert [key for key, _ in itertools.groupby(res)] == [
+        "loaded",
+        "running",
+        "finished",
+    ]
+    assert (
+        main_router.notifications.queue.qsize() == 0
+    ), 'Notification should be empty after receiving "finished" event'
     session.run()
     assert len(session.command_log) == len(old_log)
     assert session.protocol_text == protocol.text
 
 
 def test_accumulate():
-    res = \
-        _accumulate([
-            (['a'], ['d'], ['g', 'h'], [('l', 'm')]),
-            (['b', 'c'], ['e', 'f'], ['i'], [('m', 'n')])
-        ])
+    res = _accumulate(
+        [
+            (["a"], ["d"], ["g", "h"], [("l", "m")]),
+            (["b", "c"], ["e", "f"], ["i"], [("m", "n")]),
+        ]
+    )
 
-    assert res == (['a', 'b', 'c'], ['d', 'e', 'f'],
-                   ['g', 'h', 'i'], [('l', 'm'), ('m', 'n')])
+    assert res == (
+        ["a", "b", "c"],
+        ["d", "e", "f"],
+        ["g", "h", "i"],
+        [("l", "m"), ("m", "n")],
+    )
     assert _accumulate([]) == ([], [], [], [])
 
 
 def test_dedupe():
-    first = load('opentrons_96_tiprack_300ul',
-                 Location(point=Point(0, 0, 0), labware='1'))
-    second = load('opentrons_96_tiprack_300ul',
-                  Location(point=Point(1, 2, 3), labware='2'))
-    third = load('opentrons_96_tiprack_20ul',
-                 Location(point=Point(4, 5, 6), labware='3'))
+    first = load(
+        "opentrons_96_tiprack_300ul", Location(point=Point(0, 0, 0), labware="1")
+    )
+    second = load(
+        "opentrons_96_tiprack_300ul", Location(point=Point(1, 2, 3), labware="2")
+    )
+    third = load(
+        "opentrons_96_tiprack_20ul", Location(point=Point(4, 5, 6), labware="3")
+    )
 
     iterable = (
-        [first]*10
-        + [second]*10
+        [first] * 10
+        + [second] * 10
         # This is the key part of this test. Well.parent now builds a new
         # Labware item that therefore breaks identity checking.
-        + [third['A1'].parent for elem in range(10)])
-    assert sorted(_dedupe(iterable), key=lambda lw: lw.name)\
-        == sorted([first, second, third], key=lambda lw: lw.name)
+        + [third["A1"].parent for elem in range(10)]
+    )
+    assert sorted(_dedupe(iterable), key=lambda lw: lw.name) == sorted(
+        [first, second, third], key=lambda lw: lw.name
+    )
 
 
-@pytest.mark.parametrize('protocol_file', ['testosaur-gen2-v2.py'])
+@pytest.mark.parametrize("protocol_file", ["testosaur-gen2-v2.py"])
 async def test_requested_as(session_manager, protocol, protocol_file):
-    session = session_manager.create(name='<blank>', contents=protocol.text)
-    assert session.get_instruments()[0].requested_as == 'p300_single_gen2'
+    session = session_manager.create(name="<blank>", contents=protocol.text)
+    assert session.get_instruments()[0].requested_as == "p300_single_gen2"
 
 
 async def test_session_metadata_v2(main_router):
-    expected = {
-        'hello': 'world',
-        'what?': 'no',
-        'apiLevel': '2.0'
-    }
+    expected = {"hello": "world", "what?": "no", "apiLevel": "2.0"}
 
     prot = """
 this = 0
@@ -149,30 +150,32 @@ def run(ctx):
     print('hi there')
 """
 
-    session = main_router.session_manager.create(
-        name='<blank>',
-        contents=prot)
+    session = main_router.session_manager.create(name="<blank>", contents=prot)
     assert session.metadata == expected
 
 
 async def test_too_high_version(main_router):
-    minor_over = APIVersion(MAX_SUPPORTED_VERSION.major,
-                            MAX_SUPPORTED_VERSION.minor + 1)
-    minor_over_mdata = {'apiLevel': str(minor_over)}
-    proto = 'metadata=' + str(minor_over_mdata) + """
+    minor_over = APIVersion(
+        MAX_SUPPORTED_VERSION.major, MAX_SUPPORTED_VERSION.minor + 1
+    )
+    minor_over_mdata = {"apiLevel": str(minor_over)}
+    proto = (
+        "metadata="
+        + str(minor_over_mdata)
+        + """
 
 def run(ctx):
     pass
 """
+    )
     with pytest.raises(RuntimeError):
-        main_router.session_manager.create(
-            name='<blank>',
-            contents=proto)
+        main_router.session_manager.create(name="<blank>", contents=proto)
 
 
-async def test_session_extra_labware(main_router, get_labware_fixture,
-                                     virtual_smoothie_env):
-    proto = '''
+async def test_session_extra_labware(
+    main_router, get_labware_fixture, virtual_smoothie_env
+):
+    proto = """
 metadata = {"apiLevel": "2.0"}
 
 def run(ctx):
@@ -182,46 +185,39 @@ def run(ctx):
                                 tip_racks=[tiprack])
     instr.pick_up_tip()
     instr.aspirate(300, tr["A1"])
-'''
-    extra_labware = [
-        get_labware_fixture('fixture_12_trough')
-    ]
+"""
+    extra_labware = [get_labware_fixture("fixture_12_trough")]
     session = main_router.session_manager.create_with_extra_labware(
-        name='<blank>',
-        contents=proto,
-        extra_labware=extra_labware)
+        name="<blank>", contents=proto, extra_labware=extra_labware
+    )
     assert not session.errors
     session_conts = session.get_containers()
     for lw in extra_labware:
-        assert lw['parameters']['loadName'] in [
-            c.name for c in session_conts]
+        assert lw["parameters"]["loadName"] in [c.name for c in session_conts]
     session.run()
     assert not session.errors
     with pytest.raises(ExceptionInProtocolError):
-        main_router.session_manager.create(
-            name='<blank>',
-            contents=proto)
+        main_router.session_manager.create(name="<blank>", contents=proto)
 
 
-async def test_session_bundle(main_router, get_bundle_fixture,
-                              virtual_smoothie_env):
-    bundle = get_bundle_fixture('simple_bundle')
-    b64d = base64.b64encode(bundle['binary_zipfile'])
-    session1 = main_router.session_manager.create(name='bundle.zip',
-                                                  contents=b64d,
-                                                  is_binary=True)
+async def test_session_bundle(main_router, get_bundle_fixture, virtual_smoothie_env):
+    bundle = get_bundle_fixture("simple_bundle")
+    b64d = base64.b64encode(bundle["binary_zipfile"])
+    session1 = main_router.session_manager.create(
+        name="bundle.zip", contents=b64d, is_binary=True
+    )
     session2 = main_router.session_manager.create_from_bundle(
-        name='bundle.zip',
-        contents=b64d)
+        name="bundle.zip", contents=b64d
+    )
     assert session1._protocol == session2._protocol
 
 
-async def test_session_unused_hardware(main_router,
-                                       virtual_smoothie_env,
-                                       get_json_protocol_fixture):
+async def test_session_unused_hardware(
+    main_router, virtual_smoothie_env, get_json_protocol_fixture
+):
     # both python v2 and json should have their instruments and modules appear
     # in the session properties even if they are not used
-    proto = '''
+    proto = """
 metadata = {"apiLevel": "2.0"}
 def run(ctx):
     rack1 = ctx.load_labware('opentrons_96_tiprack_300ul', '1')
@@ -236,27 +232,24 @@ def run(ctx):
     left.aspirate(50, plate['A1'])
     left.dispense(50, plate['A2'])
     left.drop_tip()
-    '''
-    session = main_router.session_manager.create('dummy-pipette',
-                                                 proto)
-    assert 'p300_single_v1' in [pip.name for pip in session.instruments]
-    assert 'p10_multi_v1' in [pip.name for pip in session.instruments]
-    assert 'magdeck' in [mod.name for mod in session.modules]
-    assert 'magneticModuleV1' in [mod.model for mod in session.modules]
-    assert 'temperatureModuleV1' in [mod.model for mod in session.modules]
-    assert 'tempdeck' in [mod.name for mod in session.modules]
+    """
+    session = main_router.session_manager.create("dummy-pipette", proto)
+    assert "p300_single_v1" in [pip.name for pip in session.instruments]
+    assert "p10_multi_v1" in [pip.name for pip in session.instruments]
+    assert "magdeck" in [mod.name for mod in session.modules]
+    assert "magneticModuleV1" in [mod.model for mod in session.modules]
+    assert "temperatureModuleV1" in [mod.model for mod in session.modules]
+    assert "tempdeck" in [mod.name for mod in session.modules]
 
     # json protocols don't support modules so we only have to check pipettes
-    jsonp = get_json_protocol_fixture('3', 'unusedPipette', decode=False)
-    session2 = main_router.session_manager.create('dummy-pipette-json',
-                                                  jsonp)
-    assert 'p50_single_v1' in [pip.name for pip in session2.instruments]
-    assert 'p10_single_v1' in [pip.name for pip in session2.instruments]
+    jsonp = get_json_protocol_fixture("3", "unusedPipette", decode=False)
+    session2 = main_router.session_manager.create("dummy-pipette-json", jsonp)
+    assert "p50_single_v1" in [pip.name for pip in session2.instruments]
+    assert "p10_single_v1" in [pip.name for pip in session2.instruments]
 
 
-async def test_session_move_to_labware(main_router,
-                                       virtual_smoothie_env):
-    proto = '''
+async def test_session_move_to_labware(main_router, virtual_smoothie_env):
+    proto = """
 metadata = {"apiLevel": "2.0"}
 def run(ctx):
     rack1 = ctx.load_labware('opentrons_96_tiprack_300ul', '1')
@@ -267,20 +260,18 @@ def run(ctx):
     left.move_to(plate['A1'].top())
     left.move_to(plate['A2'].top())
     left.drop_tip()
-    '''
-    session = main_router.session_manager.create('dummy-pipette',
-                                                 proto)
-    assert 'p300_single_v1' in [pip.name for pip in session.instruments]
+    """
+    session = main_router.session_manager.create("dummy-pipette", proto)
+    assert "p300_single_v1" in [pip.name for pip in session.instruments]
 
     # Labware that does not have a liquid handling event, but is interacted
     # with using a pipette should still show up in the list of labware.
-    assert 'corning_96_wellplate_360ul_flat' in [lw.type for lw in session.containers]
+    assert "corning_96_wellplate_360ul_flat" in [lw.type for lw in session.containers]
 
 
 async def test_session_run_concurrently(
-        main_router,
-        get_labware_fixture,
-        virtual_smoothie_env):
+    main_router, get_labware_fixture, virtual_smoothie_env
+):
     """This test proves that we are not able to start a protocol run while
     one is active.
 
@@ -291,16 +282,14 @@ async def test_session_run_concurrently(
     a pause is started twice.
     """
     # Create a protocol that does nothing but pause.
-    proto = '''
+    proto = """
 metadata = {"apiLevel": "2.0"}
 
 def run(ctx):
     ctx.pause()
-'''
+"""
     session = main_router.session_manager.create_with_extra_labware(
-        name='<blank>',
-        contents=proto,
-        extra_labware=[]
+        name="<blank>", contents=proto, extra_labware=[]
     )
 
     from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -324,7 +313,7 @@ def run(ctx):
             for _ in range(max_workers * 5):
                 tasks.append(m.submit(run_while_running))
             # wait to enter pause
-            while session.state != 'paused':
+            while session.state != "paused":
                 sleep(0.05)
             # Now resume
             tasks.append(m.submit(lambda: session.resume()))
@@ -333,44 +322,49 @@ def run(ctx):
                 future.result()
 
 
-@pytest.mark.parametrize(argnames="create_func,extra_kwargs",
-                         argvalues=[
-                             [session.SessionManager.create, {}],
-                             [session.SessionManager.create_from_bundle, {}],
-                             [session.SessionManager.create_with_extra_labware,
-                              {"extra_labware": {}}]
-                         ])
-def test_http_protocol_sessions_disabled(session_manager, protocol,
-                                         create_func, extra_kwargs):
+@pytest.mark.parametrize(
+    argnames="create_func,extra_kwargs",
+    argvalues=[
+        [session.SessionManager.create, {}],
+        [session.SessionManager.create_from_bundle, {}],
+        [session.SessionManager.create_with_extra_labware, {"extra_labware": {}}],
+    ],
+)
+def test_http_protocol_sessions_disabled(
+    session_manager, protocol, create_func, extra_kwargs
+):
     """Test that we can create a session if enableHttpProtocolSessions is
     disabled."""
     with patch.object(session.Session, "build_and_prep") as mock_build:
         with patch("opentrons.api.util.enable_http_protocol_sessions") as m:
             m.return_value = False
-            create_func(session_manager,
-                        name='<blank>',
-                        contents=protocol.text, **extra_kwargs)
+            create_func(
+                session_manager, name="<blank>", contents=protocol.text, **extra_kwargs
+            )
             mock_build.assert_called_once()
 
 
-@pytest.mark.parametrize(argnames="create_func,extra_kwargs",
-                         argvalues=[
-                             [session.SessionManager.create, {}],
-                             [session.SessionManager.create_from_bundle, {}],
-                             [session.SessionManager.create_with_extra_labware,
-                              {"extra_labware": {}}]
-                         ])
-async def test_http_protocol_sessions_enabled(session_manager, protocol,
-                                              create_func, extra_kwargs):
+@pytest.mark.parametrize(
+    argnames="create_func,extra_kwargs",
+    argvalues=[
+        [session.SessionManager.create, {}],
+        [session.SessionManager.create_from_bundle, {}],
+        [session.SessionManager.create_with_extra_labware, {"extra_labware": {}}],
+    ],
+)
+async def test_http_protocol_sessions_enabled(
+    session_manager, protocol, create_func, extra_kwargs
+):
     """Test that we cannot create a session if enableHttpProtocolSessions is
     enabled."""
     with patch.object(session.Session, "build_and_prep"):
         with patch("opentrons.api.util.enable_http_protocol_sessions") as m:
             m.return_value = True
             with pytest.raises(
-                    RuntimeError,
-                    match="Please disable the 'Enable Experimental HTTP "
-                          "Protocol Sessions' advanced setting for this robot "
-                          "if you'd like to upload protocols from the "
-                          "Opentrons App"):
-                session_manager.create(name='<blank>', contents=protocol.text)
+                RuntimeError,
+                match="Please disable the 'Enable Experimental HTTP "
+                "Protocol Sessions' advanced setting for this robot "
+                "if you'd like to upload protocols from the "
+                "Opentrons App",
+            ):
+                session_manager.create(name="<blank>", contents=protocol.text)

--- a/api/tests/opentrons/broker/test_broker.py
+++ b/api/tests/opentrons/broker/test_broker.py
@@ -1,31 +1,28 @@
 from opentrons.commands.publisher import CommandPublisher, publish
 
 
-def my_command(arg1, meta=None, arg2='', arg3=''):
+def my_command(arg1, meta=None, arg2="", arg3=""):
     return {
-        'name': 'command',
-        'payload': {
-            'description': meta.format(arg1=arg1, arg2=arg2, arg3=arg3)
-        }
+        "name": "command",
+        "payload": {"description": meta.format(arg1=arg1, arg2=arg2, arg3=arg3)},
     }
 
 
 class FakeClass(CommandPublisher):
-
     def __init__(self):
         super().__init__(None)
 
-    @publish.both(command=my_command, meta='{arg1} {arg2} {arg3}')
-    def A(self, arg1, arg2, arg3='foo'):
+    @publish.both(command=my_command, meta="{arg1} {arg2} {arg3}")
+    def A(self, arg1, arg2, arg3="foo"):
         self.B(0)
         return 100
 
-    @publish.both(command=my_command, meta='{arg1} {arg2} {arg3}')
-    def C(self, arg1, arg2, arg3='bar'):
+    @publish.both(command=my_command, meta="{arg1} {arg2} {arg3}")
+    def C(self, arg1, arg2, arg3="bar"):
         self.B(0)
         return 100
 
-    @publish.both(command=my_command, meta='{arg1}')
+    @publish.both(command=my_command, meta="{arg1}")
     def B(self, arg1):
         return None
 
@@ -36,32 +33,33 @@ def test_add_listener():
     fake_obj = FakeClass()
 
     def on_notify(message):
-        assert message['name'] == 'command'
-        payload = message['payload']
-        description = payload['description']
+        assert message["name"] == "command"
+        payload = message["payload"]
+        description = payload["description"]
 
-        if message['$'] == 'before':
+        if message["$"] == "before":
             stack.append(message)
-            calls.append({'level': len(stack), 'description': description})
+            calls.append({"level": len(stack), "description": description})
         else:
             stack.pop()
 
-    unsubscribe = fake_obj.broker.subscribe('command', on_notify)
+    unsubscribe = fake_obj.broker.subscribe("command", on_notify)
 
     fake_obj.A(0, 1)
     fake_obj.B(2)
     fake_obj.C(3, 4)
 
     expected = [
-        {'level': 1, 'description': '0 1 foo'},
-        {'level': 2, 'description': '0'},
-        {'level': 1, 'description': '2'},
-        {'level': 1, 'description': '3 4 bar'},
-        {'level': 2, 'description': '0'}]
+        {"level": 1, "description": "0 1 foo"},
+        {"level": 2, "description": "0"},
+        {"level": 1, "description": "2"},
+        {"level": 1, "description": "3 4 bar"},
+        {"level": 2, "description": "0"},
+    ]
 
     assert calls == expected
 
     unsubscribe()
     fake_obj.A(0, 2)
 
-    assert calls == expected, 'No calls expected after unsubscribe()'
+    assert calls == expected, "No calls expected after unsubscribe()"

--- a/api/tests/opentrons/calibration_storage/test_migration.py
+++ b/api/tests/opentrons/calibration_storage/test_migration.py
@@ -1,49 +1,55 @@
 import pytest
 from unittest.mock import MagicMock
 
-from opentrons.calibration_storage import (
-    get, file_operators as io, migration)
+from opentrons.calibration_storage import get, file_operators as io, migration
 
 OLD_FORMAT = {
-    'opentrons/opentrons_96_tiprack_10ul/1': {
-        'id': 'fakeid1',
-        'slot': 'fakeid1',
-        'module': {}},
-    'opentrons/corning_96_wellplate_360ul_flat/1': {
-        'id': 'fakeid2',
-        'slot': 'fakeid2',
-        'module': {}},
-    'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1': {
-        'id': 'fakeid3',
-        'slot': 'fakeid3temperatureModuleV2',
-        'module': {'temperatureModuleV2': '1-temperatureModuleV2'}}
-        }
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+        "id": "fakeid1",
+        "slot": "fakeid1",
+        "module": {},
+    },
+    "opentrons/corning_96_wellplate_360ul_flat/1": {
+        "id": "fakeid2",
+        "slot": "fakeid2",
+        "module": {},
+    },
+    "opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1": {
+        "id": "fakeid3",
+        "slot": "fakeid3temperatureModuleV2",
+        "module": {"temperatureModuleV2": "1-temperatureModuleV2"},
+    },
+}
 
 NEW_FORMAT = {
-    'version': 1,
-    'data': {
-        'fakeid1': {
-            'uri': 'opentrons/opentrons_96_tiprack_10ul/1',
-            'slot': 'fakeid1',
-            'module': {}},
-        'fakeid2': {
-            'uri': 'opentrons/corning_96_wellplate_360ul_flat/1',
-            'slot': 'fakeid2',
-            'module': {}},
-        'fakeid3temperatureModuleV2': {
-            'uri': 'opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1',
-            'slot': 'fakeid3temperatureModuleV2',
-            'module': {
-                'parent': 'temperatureModuleV2',
-                'fullParent': '1-temperatureModuleV2'}}
-    }
+    "version": 1,
+    "data": {
+        "fakeid1": {
+            "uri": "opentrons/opentrons_96_tiprack_10ul/1",
+            "slot": "fakeid1",
+            "module": {},
+        },
+        "fakeid2": {
+            "uri": "opentrons/corning_96_wellplate_360ul_flat/1",
+            "slot": "fakeid2",
+            "module": {},
+        },
+        "fakeid3temperatureModuleV2": {
+            "uri": "opentrons/opentrons_96_aluminumblock_pcr_strip_200ul/1",
+            "slot": "fakeid3temperatureModuleV2",
+            "module": {
+                "parent": "temperatureModuleV2",
+                "fullParent": "1-temperatureModuleV2",
+            },
+        },
+    },
 }
 
 
 @pytest.fixture
 def setup(labware_offset_tempdir):
     offset_dir = labware_offset_tempdir
-    index_path = offset_dir / 'index.json'
+    index_path = offset_dir / "index.json"
     io.save_to_file(index_path, OLD_FORMAT)
     return index_path
 

--- a/api/tests/opentrons/commands/test_protocol_commands.py
+++ b/api/tests/opentrons/commands/test_protocol_commands.py
@@ -4,10 +4,10 @@ from opentrons.commands import protocol_commands
 
 @pytest.mark.parametrize(
     argnames="seconds,"
-             "minutes,"
-             "expected_seconds,"
-             "expected_minutes,"
-             "expected_text",
+    "minutes,"
+    "expected_seconds,"
+    "expected_minutes,"
+    "expected_text",
     argvalues=[
         [10, 0, 10, 0, "Delaying for 0 minutes and 10.0 seconds"],
         [10, 9, 10, 9, "Delaying for 9 minutes and 10.0 seconds"],
@@ -18,22 +18,17 @@ from opentrons.commands import protocol_commands
         [0.998, 0, 0.998, 0, "Delaying for 0 minutes and 0.998 seconds"],
         [0.9998, 0, 0.9998, 0, "Delaying for 0 minutes and 1.0 seconds"],
         [1.0001, 0, 1.0001, 0, "Delaying for 0 minutes and 1.0 seconds"],
-    ]
+    ],
 )
-def test_delay(seconds,
-               minutes,
-               expected_seconds,
-               expected_minutes,
-               expected_text
-               ):
+def test_delay(seconds, minutes, expected_seconds, expected_minutes, expected_text):
     command = protocol_commands.delay(seconds, minutes)
-    name = command['name']
-    payload = command['payload']
+    name = command["name"]
+    payload = command["payload"]
 
-    assert name == 'command.DELAY'
-    assert payload['seconds'] == expected_seconds
-    assert payload['minutes'] == expected_minutes
-    assert payload['text'] == expected_text
+    assert name == "command.DELAY"
+    assert payload["seconds"] == expected_seconds
+    assert payload["minutes"] == expected_minutes
+    assert payload["text"] == expected_text
 
 
 def test_delay_with_message():

--- a/api/tests/opentrons/commands/test_tree.py
+++ b/api/tests/opentrons/commands/test_tree.py
@@ -2,54 +2,40 @@ from opentrons.commands.util import from_list
 
 
 def test_command_tree():
-    commands = from_list([
-        {'level': 0, 'description': 'A', 'id': 0},
-        {'level': 0, 'description': 'B', 'id': 1},
-        {'level': 0, 'description': 'C', 'id': 2}
-    ])
+    commands = from_list(
+        [
+            {"level": 0, "description": "A", "id": 0},
+            {"level": 0, "description": "B", "id": 1},
+            {"level": 0, "description": "C", "id": 2},
+        ]
+    )
 
     assert commands == [
-        {
-            'description': 'A',
-            'id': 0,
-            'children': []
-        },
-        {
-            'description': 'B',
-            'id': 1,
-            'children': []
-        },
-        {
-            'description': 'C',
-            'id': 2,
-            'children': []
-        },
+        {"description": "A", "id": 0, "children": []},
+        {"description": "B", "id": 1, "children": []},
+        {"description": "C", "id": 2, "children": []},
     ]
 
-    commands = from_list([
-        {'level': 0, 'description': 'A', 'id': 0},
-        {'level': 1, 'description': 'B', 'id': 1},
-        {'level': 2, 'description': 'C', 'id': 2},
-        {'level': 0, 'description': 'D', 'id': 3},
-    ])
+    commands = from_list(
+        [
+            {"level": 0, "description": "A", "id": 0},
+            {"level": 1, "description": "B", "id": 1},
+            {"level": 2, "description": "C", "id": 2},
+            {"level": 0, "description": "D", "id": 3},
+        ]
+    )
 
     assert commands == [
         {
-            'description': 'A',
-            'id': 0,
-            'children': [{
-                    'description': 'B',
-                    'id': 1,
-                    'children': [{
-                                'description': 'C',
-                                'id': 2,
-                                'children': []
-                            }]
-                    }]
+            "description": "A",
+            "id": 0,
+            "children": [
+                {
+                    "description": "B",
+                    "id": 1,
+                    "children": [{"description": "C", "id": 2, "children": []}],
+                }
+            ],
         },
-        {
-            'description': 'D',
-            'id': 3,
-            'children': []
-        }
+        {"description": "D", "id": 3, "children": []},
     ]

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -17,8 +17,8 @@ def mock_settings_version():
 @pytest.fixture
 def mock_settings(mock_settings_values, mock_settings_version):
     return advanced_settings.SettingsData(
-        settings_map=mock_settings_values,
-        version=mock_settings_version)
+        settings_map=mock_settings_values, version=mock_settings_version
+    )
 
 
 @pytest.fixture
@@ -49,66 +49,61 @@ def test_get_advanced_setting_not_found(clear_cache, mock_read_settings_file):
     assert advanced_settings.get_adv_setting("unknown") is None
 
 
-def test_get_advanced_setting_found(clear_cache,
-                                    mock_read_settings_file,
-                                    mock_settings_values):
+def test_get_advanced_setting_found(
+    clear_cache, mock_read_settings_file, mock_settings_values
+):
     for k, v in mock_settings_values.items():
         s = advanced_settings.get_adv_setting(k)
         assert s.value == v
-        assert s.definition == \
-            advanced_settings.settings_by_id[k]
+        assert s.definition == advanced_settings.settings_by_id[k]
 
 
-def test_get_all_adv_settings(clear_cache,
-                              mock_read_settings_file,
-                              mock_settings_values):
+def test_get_all_adv_settings(
+    clear_cache, mock_read_settings_file, mock_settings_values
+):
     s = advanced_settings.get_all_adv_settings()
     assert s.keys() == mock_settings_values.keys()
     for k, v in s.items():
         assert v.value == mock_settings_values[k]
-        assert v.definition == \
-            advanced_settings.settings_by_id[k]
+        assert v.definition == advanced_settings.settings_by_id[k]
 
 
-def test_get_all_adv_settings_empty(clear_cache,
-                                    mock_read_settings_file):
-    mock_read_settings_file.return_value = \
-        advanced_settings.SettingsData({}, 1)
+def test_get_all_adv_settings_empty(clear_cache, mock_read_settings_file):
+    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
     s = advanced_settings.get_all_adv_settings()
     assert s == {}
 
 
-async def test_set_adv_setting(loop,
-                               mock_read_settings_file,
-                               mock_settings_values,
-                               mock_write_settings_file,
-                               mock_settings_version,
-                               restore_restart_required):
+async def test_set_adv_setting(
+    loop,
+    mock_read_settings_file,
+    mock_settings_values,
+    mock_write_settings_file,
+    mock_settings_version,
+    restore_restart_required,
+):
     for k, v in mock_settings_values.items():
         # Toggle the advanced setting
         await advanced_settings.set_adv_setting(k, not v)
         mock_write_settings_file.assert_called_with(
             # Only the current key is toggled
-            {nk: nv if nk != k else not v
-             for nk, nv in mock_settings_values.items()},
+            {nk: nv if nk != k else not v for nk, nv in mock_settings_values.items()},
             mock_settings_version,
-            CONFIG['feature_flags_file']
+            CONFIG["feature_flags_file"],
         )
 
 
-async def test_set_adv_setting_unknown(loop,
-                                       mock_read_settings_file,
-                                       mock_write_settings_file):
-    mock_read_settings_file.return_value = \
-        advanced_settings.SettingsData({}, 1)
+async def test_set_adv_setting_unknown(
+    loop, mock_read_settings_file, mock_write_settings_file
+):
+    mock_read_settings_file.return_value = advanced_settings.SettingsData({}, 1)
     with pytest.raises(ValueError, match="is not recognized"):
         await advanced_settings.set_adv_setting("no", False)
 
 
-async def test_get_all_adv_settings_lru_cache(loop,
-                                              clear_cache,
-                                              mock_read_settings_file,
-                                              mock_write_settings_file):
+async def test_get_all_adv_settings_lru_cache(
+    loop, clear_cache, mock_read_settings_file, mock_write_settings_file
+):
     # Cache should not be used.
     advanced_settings.get_all_adv_settings()
     mock_read_settings_file.assert_called_once()
@@ -118,7 +113,7 @@ async def test_get_all_adv_settings_lru_cache(loop,
     mock_read_settings_file.assert_not_called()
     mock_read_settings_file.reset_mock()
     # Updating will invalidate cache
-    await advanced_settings.set_adv_setting('calibrateToBottom', True)
+    await advanced_settings.set_adv_setting("calibrateToBottom", True)
     mock_read_settings_file.reset_mock()
     # Cache should not be used
     advanced_settings.get_all_adv_settings()
@@ -129,101 +124,99 @@ async def test_get_all_adv_settings_lru_cache(loop,
     mock_read_settings_file.assert_not_called()
 
 
-async def test_on_change_called(loop,
-                                mock_read_settings_file,
-                                mock_settings_values,
-                                mock_write_settings_file,
-                                restore_restart_required):
-    _id = 'calibrateToBottom'
-    with patch(
-        "opentrons.config.advanced_settings.SettingDefinition.on_change"
-    ) as m:
+async def test_on_change_called(
+    loop,
+    mock_read_settings_file,
+    mock_settings_values,
+    mock_write_settings_file,
+    restore_restart_required,
+):
+    _id = "calibrateToBottom"
+    with patch("opentrons.config.advanced_settings.SettingDefinition.on_change") as m:
+
         async def on_change(v):
             pass
+
         m.side_effect = on_change
         await advanced_settings.set_adv_setting(_id, True)
         m.assert_called_once_with(True)
 
 
-async def test_restart_required(loop, restore_restart_required,
-                                mock_read_settings_file,
-                                mock_write_settings_file,
-                                mock_settings_version):
-    _id = 'restart_required'
+async def test_restart_required(
+    loop,
+    restore_restart_required,
+    mock_read_settings_file,
+    mock_write_settings_file,
+    mock_settings_version,
+):
+    _id = "restart_required"
     # Mock out the available settings
     available_settings = [
         advanced_settings.SettingDefinition(
-            _id=_id,
-            title='',
-            description='',
-            restart_required=True)
+            _id=_id, title="", description="", restart_required=True
+        )
     ]
     with patch.object(advanced_settings, "settings", new=available_settings):
         # Mock out the settings_by_id
         available_settings_by_id = {s.id: s for s in available_settings}
-        with patch.object(advanced_settings, "settings_by_id",
-                          new=available_settings_by_id):
-            mock_read_settings_file.return_value = \
-                advanced_settings.SettingsData(
-                    settings_map={_id: None},
-                    version=mock_settings_version
-                )
+        with patch.object(
+            advanced_settings, "settings_by_id", new=available_settings_by_id
+        ):
+            mock_read_settings_file.return_value = advanced_settings.SettingsData(
+                settings_map={_id: None}, version=mock_settings_version
+            )
 
             assert advanced_settings.is_restart_required() is False
             await advanced_settings.set_adv_setting(_id, True)
             assert advanced_settings.is_restart_required() is True
 
 
-def test_get_setting_use_env_overload(mock_read_settings_file,
-                                      mock_settings_values):
-    with patch("os.environ",
-               new={
-                   "OT_API_FF_calibrateToBottom": "TRUE"
-               }):
+def test_get_setting_use_env_overload(mock_read_settings_file, mock_settings_values):
+    with patch("os.environ", new={"OT_API_FF_calibrateToBottom": "TRUE"}):
         v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
-        assert v is not mock_settings_values['calibrateToBottom']
+        assert v is not mock_settings_values["calibrateToBottom"]
 
 
-def test_get_setting_with_env_overload(mock_read_settings_file,
-                                       mock_settings_values):
-    with patch("os.environ",
-               new={}):
+def test_get_setting_with_env_overload(mock_read_settings_file, mock_settings_values):
+    with patch("os.environ", new={}):
         v = advanced_settings.get_setting_with_env_overload("calibrateToBottom")
-        assert v is mock_settings_values['calibrateToBottom']
+        assert v is mock_settings_values["calibrateToBottom"]
 
 
-@pytest.mark.parametrize(argnames=["v", "expected_level"],
-                         argvalues=[
-                             [True, "emerg"],
-                             [False, "info"],
-])
-async def test_disable_log_integration_side_effect(loop,
-                                                   v,
-                                                   expected_level):
-    with patch("opentrons.config.advanced_settings.log_control") \
-            as mock_log_control:
+@pytest.mark.parametrize(
+    argnames=["v", "expected_level"],
+    argvalues=[
+        [True, "emerg"],
+        [False, "info"],
+    ],
+)
+async def test_disable_log_integration_side_effect(loop, v, expected_level):
+    with patch("opentrons.config.advanced_settings.log_control") as mock_log_control:
+
         async def set_syslog_level(level):
             return 0, "", ""
 
         mock_log_control.set_syslog_level.side_effect = set_syslog_level
-        with patch("opentrons.config.advanced_settings.ARCHITECTURE",
-                   new=advanced_settings.ARCHITECTURE.BUILDROOT):
+        with patch(
+            "opentrons.config.advanced_settings.ARCHITECTURE",
+            new=advanced_settings.ARCHITECTURE.BUILDROOT,
+        ):
             s = advanced_settings.DisableLogIntegrationSettingDefinition()
             await s.on_change(v)
-            mock_log_control.set_syslog_level.assert_called_once_with(
-                expected_level
-            )
+            mock_log_control.set_syslog_level.assert_called_once_with(expected_level)
 
 
 async def test_disable_log_integration_side_effect_error(loop):
-    with patch("opentrons.config.advanced_settings.log_control") \
-            as mock_log_control:
+    with patch("opentrons.config.advanced_settings.log_control") as mock_log_control:
+
         async def set_syslog_level(level):
             return 1, "", ""
 
         mock_log_control.set_syslog_level.side_effect = set_syslog_level
-        with patch("opentrons.config.advanced_settings.ARCHITECTURE",
-                   new=advanced_settings.ARCHITECTURE.BUILDROOT):
+        with patch(
+            "opentrons.config.advanced_settings.ARCHITECTURE",
+            new=advanced_settings.ARCHITECTURE.BUILDROOT,
+        ):
             s = advanced_settings.DisableLogIntegrationSettingDefinition()
             with pytest.raises(advanced_settings.SettingException):
                 await s.on_change(True)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -13,16 +13,16 @@ def migrated_file_version() -> int:
 @pytest.fixture
 def default_file_settings() -> Dict[str, Optional[bool]]:
     return {
-        'shortFixedTrash': None,
-        'calibrateToBottom': None,
-        'deckCalibrationDots': None,
-        'disableHomeOnBoot': None,
-        'useOldAspirationFunctions': None,
-        'disableLogAggregation': None,
-        'enableDoorSafetySwitch': None,
-        'enableHttpProtocolSessions': None,
-        'enableProtocolEngine': None,
-        'disableFastProtocolUpload': None,
+        "shortFixedTrash": None,
+        "calibrateToBottom": None,
+        "deckCalibrationDots": None,
+        "disableHomeOnBoot": None,
+        "useOldAspirationFunctions": None,
+        "disableLogAggregation": None,
+        "enableDoorSafetySwitch": None,
+        "enableHttpProtocolSessions": None,
+        "enableProtocolEngine": None,
+        "disableFastProtocolUpload": None,
     }
 
 
@@ -34,104 +34,110 @@ def empty_settings():
 @pytest.fixture
 def version_less():
     return {
-        'shortFixedTrash': True,
-        'calibrateToBottom': True,
-        'deckCalibrationDots': True,
-        'disableHomeOnBoot': True,
-        'useOldAspirationFunctions': True,
+        "shortFixedTrash": True,
+        "calibrateToBottom": True,
+        "deckCalibrationDots": True,
+        "disableHomeOnBoot": True,
+        "useOldAspirationFunctions": True,
     }
 
 
 @pytest.fixture
 def v1_config():
     return {
-        '_version': 1,
-        'shortFixedTrash': True,
-        'calibrateToBottom': True,
-        'deckCalibrationDots': True,
-        'disableHomeOnBoot': True,
-        'useProtocolApi2': None,
-        'useOldAspirationFunctions': True,
+        "_version": 1,
+        "shortFixedTrash": True,
+        "calibrateToBottom": True,
+        "deckCalibrationDots": True,
+        "disableHomeOnBoot": True,
+        "useProtocolApi2": None,
+        "useOldAspirationFunctions": True,
     }
 
 
 @pytest.fixture
 def v2_config(v1_config):
     r = v1_config.copy()
-    r.update({
-        '_version': 2,
-        'disableLogAggregation': True,
-    })
+    r.update(
+        {
+            "_version": 2,
+            "disableLogAggregation": True,
+        }
+    )
     return r
 
 
 @pytest.fixture
 def v3_config(v2_config):
     r = v2_config.copy()
-    r.update({
-        '_version': 3,
-        'enableApi1BackCompat': False
-    })
+    r.update({"_version": 3, "enableApi1BackCompat": False})
     return r
 
 
 @pytest.fixture
 def v4_config(v3_config):
     r = v3_config.copy()
-    r.update({
-        '_version': 4,
-        'useV1HttpApi': False
-    })
+    r.update({"_version": 4, "useV1HttpApi": False})
     return r
 
 
 @pytest.fixture
 def v5_config(v4_config):
     r = v4_config.copy()
-    r.update({
-        '_version': 5,
-        'enableDoorSafetySwitch': True,
-    })
+    r.update(
+        {
+            "_version": 5,
+            "enableDoorSafetySwitch": True,
+        }
+    )
     return r
 
 
 @pytest.fixture
 def v6_config(v5_config):
     r = v5_config.copy()
-    r.update({
-        '_version': 6,
-        'enableTipLengthCalibration': True,
-    })
+    r.update(
+        {
+            "_version": 6,
+            "enableTipLengthCalibration": True,
+        }
+    )
     return r
 
 
 @pytest.fixture
 def v7_config(v6_config):
     r = v6_config.copy()
-    r.update({
-        '_version': 7,
-        'enableHttpProtocolSessions': True,
-    })
+    r.update(
+        {
+            "_version": 7,
+            "enableHttpProtocolSessions": True,
+        }
+    )
     return r
 
 
 @pytest.fixture
 def v8_config(v7_config):
     r = v7_config.copy()
-    r.update({
-        '_version': 8,
-        'enableFastProtocolUpload': True,
-    })
+    r.update(
+        {
+            "_version": 8,
+            "enableFastProtocolUpload": True,
+        }
+    )
     return r
 
 
 @pytest.fixture
 def v9_config(v8_config):
     r = v8_config.copy()
-    r.update({
-        '_version': 9,
-        'enableProtocolEngine': True,
-    })
+    r.update(
+        {
+            "_version": 9,
+            "enableProtocolEngine": True,
+        }
+    )
     return r
 
 
@@ -143,10 +149,12 @@ def v10_config(v9_config):
     r.pop("useV1HttpApi")
     r.pop("enableTipLengthCalibration")
     r.pop("enableFastProtocolUpload")
-    r.update({
-        '_version': 10,
-        'disableFastProtocolUpload': True,
-    })
+    r.update(
+        {
+            "_version": 10,
+            "disableFastProtocolUpload": True,
+        }
+    )
     return r
 
 
@@ -165,73 +173,77 @@ def v10_config(v9_config):
         lazy_fixture("v8_config"),
         lazy_fixture("v9_config"),
         lazy_fixture("v10_config"),
-    ]
+    ],
 )
 def old_settings(request):
     return request.param
 
 
-def test_migrations(
-        old_settings, migrated_file_version, default_file_settings):
+def test_migrations(old_settings, migrated_file_version, default_file_settings):
     settings, version = _migrate(old_settings)
 
     expected = default_file_settings.copy()
-    expected.update({
-        k: v
-        for k, v in old_settings.items()
-        if k != '_version' and k in default_file_settings
-    })
+    expected.update(
+        {
+            k: v
+            for k, v in old_settings.items()
+            if k != "_version" and k in default_file_settings
+        }
+    )
 
     assert version == migrated_file_version
     assert settings == expected
 
 
-def test_migrates_versionless_old_config(
-        migrated_file_version, default_file_settings):
-    settings, version = _migrate({
-        'short-fixed-trash': False,
-        'calibrate-to-bottom': False,
-        'dots-deck-type': True,
-        'disable-home-on-boot': False,
-    })
+def test_migrates_versionless_old_config(migrated_file_version, default_file_settings):
+    settings, version = _migrate(
+        {
+            "short-fixed-trash": False,
+            "calibrate-to-bottom": False,
+            "dots-deck-type": True,
+            "disable-home-on-boot": False,
+        }
+    )
 
     expected = default_file_settings.copy()
-    expected.update({
-        'shortFixedTrash': None,
-        'calibrateToBottom': None,
-        'deckCalibrationDots': True,
-        'disableHomeOnBoot': None,
-    })
+    expected.update(
+        {
+            "shortFixedTrash": None,
+            "calibrateToBottom": None,
+            "deckCalibrationDots": True,
+            "disableHomeOnBoot": None,
+        }
+    )
 
     assert version == migrated_file_version
     assert settings == expected
 
 
 def test_ignores_invalid_keys(migrated_file_version, default_file_settings):
-    settings, version = _migrate({
-        'split-labware-def': True,
-        'splitLabwareDefinitions': True,
-    })
+    settings, version = _migrate(
+        {
+            "split-labware-def": True,
+            "splitLabwareDefinitions": True,
+        }
+    )
 
     assert version == migrated_file_version
     assert settings == default_file_settings
 
 
 def test_ensures_config():
-    assert _ensure({
-        '_version': 3,
-        'shortFixedTrash': False,
-        'disableLogAggregation': True
-    }) == {
-        '_version': 3,
-        'shortFixedTrash': False,
-        'calibrateToBottom': None,
-        'deckCalibrationDots': None,
-        'disableHomeOnBoot': None,
-        'useOldAspirationFunctions': None,
-        'disableLogAggregation': True,
-        'enableDoorSafetySwitch': None,
-        'enableHttpProtocolSessions': None,
-        'enableProtocolEngine': None,
-        'disableFastProtocolUpload': None,
+    assert _ensure(
+        {"_version": 3, "shortFixedTrash": False, "disableLogAggregation": True}
+    ) == {
+        "_version": 3,
+        "shortFixedTrash": False,
+        "calibrateToBottom": None,
+        "deckCalibrationDots": None,
+        "disableHomeOnBoot": None,
+        "useOldAspirationFunctions": None,
+        "disableLogAggregation": True,
+        "enableDoorSafetySwitch": None,
+        "enableHttpProtocolSessions": None,
+        "enableProtocolEngine": None,
+        "disableFastProtocolUpload": None,
     }

--- a/api/tests/opentrons/config/test_pipette_config.py
+++ b/api/tests/opentrons/config/test_pipette_config.py
@@ -9,8 +9,7 @@ from opentrons.config import pipette_config, feature_flags as ff, CONFIG
 from opentrons_shared_data import load_shared_data
 
 
-defs = json.loads(
-    load_shared_data("pipette/definitions/pipetteModelSpecs.json"))
+defs = json.loads(load_shared_data("pipette/definitions/pipetteModelSpecs.json"))
 
 
 def check_sequences_close(first, second):
@@ -22,40 +21,49 @@ def check_sequences_close(first, second):
         assert f == pytest.approx(s)
 
 
-@pytest.mark.parametrize('pipette_model',
-                         [c for c in pipette_config.config_models if not
-                          (c.startswith('p1000')
-                           or c.startswith('p300_multi')
-                           or c.endswith('1.5')
-                           or c.endswith('1.6')
-                           or 'v2' in c)])
+@pytest.mark.parametrize(
+    "pipette_model",
+    [
+        c
+        for c in pipette_config.config_models
+        if not (
+            c.startswith("p1000")
+            or c.startswith("p300_multi")
+            or c.endswith("1.5")
+            or c.endswith("1.6")
+            or "v2" in c
+        )
+    ],
+)
 def test_versioned_aspiration(pipette_model, monkeypatch):
 
-    monkeypatch.setattr(ff, 'use_old_aspiration_functions',
-                        lambda: True)
+    monkeypatch.setattr(ff, "use_old_aspiration_functions", lambda: True)
     was = pipette_config.load(pipette_model)
     check_sequences_close(
-        was.ul_per_mm['aspirate'],
-        defs['config'][pipette_model]['ulPerMm'][0]['aspirate'])
+        was.ul_per_mm["aspirate"],
+        defs["config"][pipette_model]["ulPerMm"][0]["aspirate"],
+    )
     check_sequences_close(
-        was.ul_per_mm['dispense'],
-        defs['config'][pipette_model]['ulPerMm'][0]['dispense'])
+        was.ul_per_mm["dispense"],
+        defs["config"][pipette_model]["ulPerMm"][0]["dispense"],
+    )
 
-    monkeypatch.setattr(ff, 'use_old_aspiration_functions',
-                        lambda: False)
+    monkeypatch.setattr(ff, "use_old_aspiration_functions", lambda: False)
     now = pipette_config.load(pipette_model)
     check_sequences_close(
-        now.ul_per_mm['aspirate'],
-        defs['config'][pipette_model]['ulPerMm'][-1]['aspirate'])
+        now.ul_per_mm["aspirate"],
+        defs["config"][pipette_model]["ulPerMm"][-1]["aspirate"],
+    )
     check_sequences_close(
-        now.ul_per_mm['dispense'],
-        defs['config'][pipette_model]['ulPerMm'][-1]['dispense'])
-    assert now.ul_per_mm['aspirate'] != was.ul_per_mm['aspirate']
+        now.ul_per_mm["dispense"],
+        defs["config"][pipette_model]["ulPerMm"][-1]["dispense"],
+    )
+    assert now.ul_per_mm["aspirate"] != was.ul_per_mm["aspirate"]
 
 
 # TODO:
 # TODO: dispense agree
-@pytest.mark.parametrize('pipette_model', pipette_config.config_models)
+@pytest.mark.parametrize("pipette_model", pipette_config.config_models)
 def test_ul_per_mm_continuous(pipette_model):
     """
     For each model of pipette, for each boundary between pieces of the
@@ -71,19 +79,19 @@ def test_ul_per_mm_continuous(pipette_model):
     https://en.wikipedia.org/wiki/Intermediate_value_theorem
     """
     config = pipette_config.load(pipette_model)
-    aspirate = config.ul_per_mm['aspirate']
-    dispense = config.ul_per_mm['dispense']
+    aspirate = config.ul_per_mm["aspirate"]
+    dispense = config.ul_per_mm["dispense"]
     min_vol = 0.000001  # sufficiently small starting volume
     for lno in range(len(aspirate) - 1):
         line = aspirate[lno]
         curr_max_vol = line[0]
         # find a halfway point roughly between max and min volume for a given
         # piecewise sequence of a pipette function
-        half_max_vol = (curr_max_vol-min_vol)/2 + min_vol
+        half_max_vol = (curr_max_vol - min_vol) / 2 + min_vol
 
-        min_ul_per_mm = line[1]*min_vol + line[2]
-        mid_ul_per_mm = line[1]*half_max_vol + line[2]
-        max_ul_per_mm = line[1]*curr_max_vol + line[2]
+        min_ul_per_mm = line[1] * min_vol + line[2]
+        mid_ul_per_mm = line[1] * half_max_vol + line[2]
+        max_ul_per_mm = line[1] * curr_max_vol + line[2]
 
         lower_mm = min_ul_per_mm / min_vol
         higher_mm = max_ul_per_mm / curr_max_vol
@@ -99,104 +107,96 @@ def test_ul_per_mm_continuous(pipette_model):
     aspirate_seq = aspirate[len(aspirate) - 1]
     dispense_seq = dispense[len(dispense) - 1]
     pip_max_vol = config.max_volume
-    aspirate_mm = (aspirate_seq[1]*pip_max_vol + aspirate_seq[2]) / pip_max_vol
-    dispense_mm = (dispense_seq[1]*pip_max_vol + dispense_seq[2]) / pip_max_vol
+    aspirate_mm = (aspirate_seq[1] * pip_max_vol + aspirate_seq[2]) / pip_max_vol
+    dispense_mm = (dispense_seq[1] * pip_max_vol + dispense_seq[2]) / pip_max_vol
     # for many of the older pipettes, the aspirate and dispense values are
     # not the same.
     assert isclose(round(aspirate_mm), round(dispense_mm))
 
 
 def test_override_load(ot_config_tempdir):
-    cdir = CONFIG['pipette_config_overrides_dir']
+    cdir = CONFIG["pipette_config_overrides_dir"]
 
     existing_overrides = {
-        'pickUpCurrent': {'value': 1231.213},
-        'dropTipSpeed': {'value': 121},
-        'quirks': {'dropTipShake': True}
+        "pickUpCurrent": {"value": 1231.213},
+        "dropTipSpeed": {"value": 121},
+        "quirks": {"dropTipShake": True},
     }
 
-    existing_id = 'ohoahflaseh08102qa'
-    with (cdir/f'{existing_id}.json').open('w') as ovf:
+    existing_id = "ohoahflaseh08102qa"
+    with (cdir / f"{existing_id}.json").open("w") as ovf:
         json.dump(existing_overrides, ovf)
 
-    pconf = pipette_config.load('p300_multi_v1.4', existing_id)
+    pconf = pipette_config.load("p300_multi_v1.4", existing_id)
 
-    assert pconf.pick_up_current == \
-        existing_overrides['pickUpCurrent']['value']
-    assert pconf.drop_tip_speed == existing_overrides['dropTipSpeed']['value']
-    assert pconf.quirks == ['dropTipShake']
+    assert pconf.pick_up_current == existing_overrides["pickUpCurrent"]["value"]
+    assert pconf.drop_tip_speed == existing_overrides["dropTipSpeed"]["value"]
+    assert pconf.quirks == ["dropTipShake"]
 
-    new_id = '0djaisoa921jas'
-    new_pconf = pipette_config.load('p300_multi_v1.4', new_id)
+    new_id = "0djaisoa921jas"
+    new_pconf = pipette_config.load("p300_multi_v1.4", new_id)
 
     assert new_pconf != pconf
 
-    unspecced = pipette_config.load('p300_multi_v1.4')
+    unspecced = pipette_config.load("p300_multi_v1.4")
     assert unspecced == new_pconf
 
 
 def test_override_save(ot_config_tempdir):
-    cdir = CONFIG['pipette_config_overrides_dir']
+    cdir = CONFIG["pipette_config_overrides_dir"]
 
-    overrides = {
-        'pickUpCurrent': 1231.213,
-        'dropTipSpeed': 121,
-        'dropTipShake': False
-    }
+    overrides = {"pickUpCurrent": 1231.213, "dropTipSpeed": 121, "dropTipShake": False}
 
-    new_id = 'aoa2109j09cj2a'
-    model = 'p300_multi_v1'
+    new_id = "aoa2109j09cj2a"
+    model = "p300_multi_v1"
 
-    old_pconf = pipette_config.load('p300_multi_v1.4', new_id)
+    old_pconf = pipette_config.load("p300_multi_v1.4", new_id)
 
-    assert old_pconf.quirks == ['dropTipShake']
+    assert old_pconf.quirks == ["dropTipShake"]
 
     pipette_config.save_overrides(new_id, overrides, model)
 
-    assert (cdir/f'{new_id}.json').is_file()
+    assert (cdir / f"{new_id}.json").is_file()
 
     loaded = pipette_config.load_overrides(new_id)
 
-    assert loaded['pickUpCurrent']['value'] == \
-        overrides['pickUpCurrent']
-    assert loaded['dropTipSpeed']['value'] == \
-        overrides['dropTipSpeed']
+    assert loaded["pickUpCurrent"]["value"] == overrides["pickUpCurrent"]
+    assert loaded["dropTipSpeed"]["value"] == overrides["dropTipSpeed"]
 
-    new_pconf = pipette_config.load('p300_multi_v1.4', new_id)
+    new_pconf = pipette_config.load("p300_multi_v1.4", new_id)
     assert new_pconf.quirks == []
 
 
 @pytest.fixture
 def new_id_for_save() -> str:
     """Fixture to provide a pipette id then delete it's generated file."""
-    r = 'aoa2109j09cj2a'
+    r = "aoa2109j09cj2a"
     yield r
 
-    (CONFIG['pipette_config_overrides_dir'] / f'{r}.json').unlink()
+    (CONFIG["pipette_config_overrides_dir"] / f"{r}.json").unlink()
 
 
 def test_mutable_configs_only(monkeypatch, new_id_for_save):
     # Test that only set mutable configs are populated in this dictionary
 
     monkeypatch.setattr(
-        pipette_config, 'MUTABLE_CONFIGS', ['tipLength', 'plungerCurrent'])
+        pipette_config, "MUTABLE_CONFIGS", ["tipLength", "plungerCurrent"]
+    )
 
-    model = 'p300_multi_v1'
+    model = "p300_multi_v1"
 
     pipette_config.save_overrides(new_id_for_save, {}, model)
 
     config = pipette_config.list_mutable_configs(new_id_for_save)
     # instead of dealing with unordered lists, convert to set and check whether
     # these lists have a difference between them
-    difference = set(list(config.keys())) - \
-        set(pipette_config.MUTABLE_CONFIGS)
+    difference = set(list(config.keys())) - set(pipette_config.MUTABLE_CONFIGS)
     # ensure empty
     assert bool(difference) is False
 
 
 def test_mutable_configs_unknown_pipette_id():
-    with patch("opentrons.config.pipette_config.known_pipettes",
-               return_val={}):
+    with patch("opentrons.config.pipette_config.known_pipettes", return_val={}):
         config = pipette_config.list_mutable_configs("a")
         assert config == {}
 
@@ -204,56 +204,57 @@ def test_mutable_configs_unknown_pipette_id():
 @pytest.fixture
 def mock_pipette_config_model():
     model = {
-        'fieldName': {
+        "fieldName": {
             "min": 1,
             "max": 2,
         },
-        "quirks": {
-            "quirk1": True,
-            "quirk2": True
-        }
+        "quirks": {"quirk1": True, "quirk2": True},
     }
     # Patch VALID_QUIRKS to reflect quirks in the mock pipette config model
-    with patch.object(pipette_config, "VALID_QUIRKS", new=list(model['quirks'].keys())):
+    with patch.object(pipette_config, "VALID_QUIRKS", new=list(model["quirks"].keys())):
         yield model
 
 
-@pytest.mark.parametrize(argnames=["override_field", "expected_error"],
-                         argvalues=[
-                            [{'unknown': 123}, 'Unknown field'],
-                            [{'unknown': True}, 'Unknown field'],
-                            [{'unknown': None}, 'Unknown field'],
-                            [{'quirk1': 321}, 'is invalid for'],
-                            [{'fieldName': "hello"}, 'is invalid for'],
-                            [{'fieldName': 0}, 'out of range'],
-                            [{'fieldName': 5}, 'out of range'],
-                            [{'fieldName': True}, 'is invalid for'],
-                         ])
-def test_validate_overrides_fail(override_field,
-                                 expected_error,
-                                 mock_pipette_config_model):
+@pytest.mark.parametrize(
+    argnames=["override_field", "expected_error"],
+    argvalues=[
+        [{"unknown": 123}, "Unknown field"],
+        [{"unknown": True}, "Unknown field"],
+        [{"unknown": None}, "Unknown field"],
+        [{"quirk1": 321}, "is invalid for"],
+        [{"fieldName": "hello"}, "is invalid for"],
+        [{"fieldName": 0}, "out of range"],
+        [{"fieldName": 5}, "out of range"],
+        [{"fieldName": True}, "is invalid for"],
+    ],
+)
+def test_validate_overrides_fail(
+    override_field, expected_error, mock_pipette_config_model
+):
     with pytest.raises(ValueError, match=expected_error):
-        pipette_config.validate_overrides(override_field,
-                                          mock_pipette_config_model)
+        pipette_config.validate_overrides(override_field, mock_pipette_config_model)
 
 
-@pytest.mark.parametrize(argnames=["override_field"],
-                         argvalues=[
-                            [{'quirk1': False}],
-                            [{'quirk1': None}],
-                            [{'fieldName': None}],
-                            [{'fieldName': 1}],
-                            [{'fieldName': 2}],
-                         ])
-def test_validate_overrides_pass(override_field,
-                                 mock_pipette_config_model):
-    assert pipette_config.validate_overrides(override_field,
-                                             mock_pipette_config_model) is None
+@pytest.mark.parametrize(
+    argnames=["override_field"],
+    argvalues=[
+        [{"quirk1": False}],
+        [{"quirk1": None}],
+        [{"fieldName": None}],
+        [{"fieldName": 1}],
+        [{"fieldName": 2}],
+    ],
+)
+def test_validate_overrides_pass(override_field, mock_pipette_config_model):
+    assert (
+        pipette_config.validate_overrides(override_field, mock_pipette_config_model)
+        is None
+    )
 
 
 @pytest.fixture
 async def attached_pipettes(hardware, request):
-    """ Fixture the robot to have attached pipettes
+    """Fixture the robot to have attached pipettes
 
     Mark the node with
     'attach_left_model': model_name for left (default: p300_single_v1)
@@ -264,70 +265,67 @@ async def attached_pipettes(hardware, request):
     Returns the model by mount style dict of
     {'left': {'name': str, 'model': str, 'id': str}, 'right'...}
     """
+
     def marker_with_default(marker: str, default: str) -> str:
         return request.node.get_closest_marker(marker) or default
-    left_mod = marker_with_default('attach_left_model', 'p300_multi_v1')
-    left_name = left_mod.split('_v')[0]
-    right_mod = marker_with_default('attach_right_model', 'p50_multi_v1')
-    right_name = right_mod.split('_v')[0]
-    left_id = marker_with_default('attach_left_id', 'abc123')
-    right_id = marker_with_default('attach_right_id', 'abcd123')
+
+    left_mod = marker_with_default("attach_left_model", "p300_multi_v1")
+    left_name = left_mod.split("_v")[0]
+    right_mod = marker_with_default("attach_right_model", "p50_multi_v1")
+    right_name = right_mod.split("_v")[0]
+    left_id = marker_with_default("attach_left_id", "abc123")
+    right_id = marker_with_default("attach_right_id", "abcd123")
     hardware._backend._attached_instruments = {
-        types.Mount.RIGHT: {
-            'model': right_mod, 'id': right_id, 'name': right_name
-        },
-        types.Mount.LEFT: {
-            'model': left_mod, 'id': left_id, 'name': left_name
-            }
+        types.Mount.RIGHT: {"model": right_mod, "id": right_id, "name": right_name},
+        types.Mount.LEFT: {"model": left_mod, "id": left_id, "name": left_name},
     }
     await hardware.cache_instruments()
-    yield {k.name.lower(): v for k, v in
-           hardware._backend._attached_instruments.items()}
+    yield {
+        k.name.lower(): v for k, v in hardware._backend._attached_instruments.items()
+    }
 
     # Delete created config files
-    (CONFIG['pipette_config_overrides_dir'] / 'abc123.json').unlink()
-    (CONFIG['pipette_config_overrides_dir'] / 'abcd123.json').unlink()
+    (CONFIG["pipette_config_overrides_dir"] / "abc123.json").unlink()
+    (CONFIG["pipette_config_overrides_dir"] / "abcd123.json").unlink()
 
 
 async def test_override(attached_pipettes):
     # This test will check that setting modified pipette configs
     # works as expected
-    changes = {
-        'pickUpCurrent': 1
-    }
+    changes = {"pickUpCurrent": 1}
 
-    test_id = attached_pipettes['left']['id']
+    test_id = attached_pipettes["left"]["id"]
     # Check data has not been changed yet
     c, _ = pipette_config.load_config_dict(test_id)
-    assert c['pickUpCurrent'] == \
-        pipette_config.list_mutable_configs(
-            pipette_id=test_id)['pickUpCurrent']
+    assert (
+        c["pickUpCurrent"]
+        == pipette_config.list_mutable_configs(pipette_id=test_id)["pickUpCurrent"]
+    )
 
     # Check that data is changed and matches the changes specified
     pipette_config.override(pipette_id=test_id, fields=changes)
 
     c, _ = pipette_config.load_config_dict(test_id)
-    assert c['pickUpCurrent']['value'] == changes['pickUpCurrent']
+    assert c["pickUpCurrent"]["value"] == changes["pickUpCurrent"]
 
     # Check that None reverts a setting to default
-    changes2 = {
-        'pickUpCurrent': None
-    }
+    changes2 = {"pickUpCurrent": None}
     # Check that data is changed and matches the changes specified
     pipette_config.override(pipette_id=test_id, fields=changes2)
 
     c, _ = pipette_config.load_config_dict(test_id)
-    assert c['pickUpCurrent']['value'] == \
-        pipette_config.list_mutable_configs(
-            pipette_id=test_id)['pickUpCurrent']['default']
+    assert (
+        c["pickUpCurrent"]["value"]
+        == pipette_config.list_mutable_configs(pipette_id=test_id)["pickUpCurrent"][
+            "default"
+        ]
+    )
 
 
 async def test_incorrect_modify_pipette_settings(attached_pipettes):
-    out_of_range = {
-        'pickUpCurrent': 1000
-    }
-    with pytest.raises(ValueError,
-                       match='pickUpCurrent out of range with 1000'):
+    out_of_range = {"pickUpCurrent": 1000}
+    with pytest.raises(ValueError, match="pickUpCurrent out of range with 1000"):
         # check over max fails
-        pipette_config.override(pipette_id=attached_pipettes['left']['id'],
-                                fields=out_of_range)
+        pipette_config.override(
+            pipette_id=attached_pipettes["left"]["id"], fields=out_of_range
+        )

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -23,33 +23,35 @@ def mock_labware():
 
 @pytest.fixture
 def mock_reset_pipette_offset():
-    with patch('opentrons.config.reset.reset_pipette_offset') as m:
+    with patch("opentrons.config.reset.reset_pipette_offset") as m:
         yield m
 
 
 @pytest.fixture
 def mock_reset_deck_calibration():
-    with patch('opentrons.config.reset.reset_deck_calibration') as m:
+    with patch("opentrons.config.reset.reset_deck_calibration") as m:
         yield m
 
 
 @pytest.fixture
 def mock_reset_tip_length_calibrations():
-    with patch('opentrons.config.reset.reset_tip_length_calibrations') as m:
+    with patch("opentrons.config.reset.reset_tip_length_calibrations") as m:
         yield m
 
 
 @pytest.fixture
 def mock_cal_storage_delete():
-    with patch('opentrons.config.reset.delete', autospec=True) as m:
+    with patch("opentrons.config.reset.delete", autospec=True) as m:
         yield m
 
 
-def test_reset_empty_set(mock_reset_boot_scripts,
-                         mock_reset_labware_calibration,
-                         mock_reset_pipette_offset,
-                         mock_reset_deck_calibration,
-                         mock_reset_tip_length_calibrations):
+def test_reset_empty_set(
+    mock_reset_boot_scripts,
+    mock_reset_labware_calibration,
+    mock_reset_pipette_offset,
+    mock_reset_deck_calibration,
+    mock_reset_tip_length_calibrations,
+):
     reset.reset(set())
     mock_reset_labware_calibration.assert_not_called()
     mock_reset_boot_scripts.assert_not_called()
@@ -58,16 +60,22 @@ def test_reset_empty_set(mock_reset_boot_scripts,
     mock_reset_tip_length_calibrations.assert_not_called()
 
 
-def test_reset_all_set(mock_reset_boot_scripts,
-                       mock_reset_labware_calibration,
-                       mock_reset_pipette_offset,
-                       mock_reset_deck_calibration,
-                       mock_reset_tip_length_calibrations):
-    reset.reset({reset.ResetOptionId.boot_scripts,
-                 reset.ResetOptionId.labware_calibration,
-                 reset.ResetOptionId.deck_calibration,
-                 reset.ResetOptionId.pipette_offset,
-                 reset.ResetOptionId.tip_length_calibrations})
+def test_reset_all_set(
+    mock_reset_boot_scripts,
+    mock_reset_labware_calibration,
+    mock_reset_pipette_offset,
+    mock_reset_deck_calibration,
+    mock_reset_tip_length_calibrations,
+):
+    reset.reset(
+        {
+            reset.ResetOptionId.boot_scripts,
+            reset.ResetOptionId.labware_calibration,
+            reset.ResetOptionId.deck_calibration,
+            reset.ResetOptionId.pipette_offset,
+            reset.ResetOptionId.tip_length_calibrations,
+        }
+    )
     mock_reset_labware_calibration.assert_called_once()
     mock_reset_boot_scripts.assert_called_once()
     mock_reset_pipette_offset.assert_called_once()
@@ -84,18 +92,15 @@ def test_labware_calibration_reset(mock_labware):
 def test_deck_calibration_reset(mock_cal_storage_delete):
     reset.reset_deck_calibration()
     mock_cal_storage_delete.delete_robot_deck_attitude.assert_called_once()
-    mock_cal_storage_delete.clear_pipette_offset_calibrations\
-                           .assert_called_once()
+    mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()
 
 
 def test_tip_length_calibrations_reset(mock_cal_storage_delete):
     reset.reset_tip_length_calibrations()
     mock_cal_storage_delete.clear_tip_length_calibration.assert_called_once()
-    mock_cal_storage_delete.clear_pipette_offset_calibrations\
-                           .assert_called_once()
+    mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()
 
 
 def test_pipette_offset_reset(mock_cal_storage_delete):
     reset.reset_pipette_offset()
-    mock_cal_storage_delete.clear_pipette_offset_calibrations\
-                           .assert_called_once()
+    mock_cal_storage_delete.clear_pipette_offset_calibrations.assert_called_once()

--- a/api/tests/opentrons/config/test_robots_config.py
+++ b/api/tests/opentrons/config/test_robots_config.py
@@ -7,84 +7,92 @@ from opentrons.config import CONFIG, robot_configs
 from opentrons.hardware_control.types import BoardRevision
 
 legacy_dummy_settings = {
-    'name': 'Rosalind Franklin',
-    'version': 42,
-    'steps_per_mm': 'M92 X80.00 Y80.00 Z400 A400 B768 C768',
-    'gantry_steps_per_mm': {
-        'X': 80.00, 'Y': 80.00, 'Z': 400, 'A': 400},
-    'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
-    'z_retract_distance': 2,
-    'tip_length': 999,
-    'left_mount_offset': [-34, 0, 0],
-    'serial_speed': 888,
-    'default_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'low_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'high_current': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'default_pipette_configs': {
-        'homePosition': 220, 'maxTravel': 30, 'stepsPerMM': 768},
-    'log_level': 'NADA',
+    "name": "Rosalind Franklin",
+    "version": 42,
+    "steps_per_mm": "M92 X80.00 Y80.00 Z400 A400 B768 C768",
+    "gantry_steps_per_mm": {"X": 80.00, "Y": 80.00, "Z": 400, "A": 400},
+    "acceleration": {"X": 3, "Y": 2, "Z": 15, "A": 15, "B": 2, "C": 2},
+    "z_retract_distance": 2,
+    "tip_length": 999,
+    "left_mount_offset": [-34, 0, 0],
+    "serial_speed": 888,
+    "default_current": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "low_current": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "high_current": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "default_max_speed": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "default_pipette_configs": {
+        "homePosition": 220,
+        "maxTravel": 30,
+        "stepsPerMM": 768,
+    },
+    "log_level": "NADA",
 }
 
 
 migrated_dummy_settings = {
-    'name': 'Rosalind Franklin',
-    'version': 4,
-    'gantry_steps_per_mm': {'X': 80.0, 'Y': 80.0, 'Z': 400.0, 'A': 400.0},
-    'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
-    'z_retract_distance': 2,
-    'left_mount_offset': [-34, 0, 0],
-    'serial_speed': 888,
-    'default_current': {
-        'default': {'X': 1.25, 'Y': 1.25, 'Z': 0.5, 'A': 0.5, 'B': 0.05, 'C': 0.05},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "name": "Rosalind Franklin",
+    "version": 4,
+    "gantry_steps_per_mm": {"X": 80.0, "Y": 80.0, "Z": 400.0, "A": 400.0},
+    "acceleration": {"X": 3, "Y": 2, "Z": 15, "A": 15, "B": 2, "C": 2},
+    "z_retract_distance": 2,
+    "left_mount_offset": [-34, 0, 0],
+    "serial_speed": 888,
+    "default_current": {
+        "default": {"X": 1.25, "Y": 1.25, "Z": 0.5, "A": 0.5, "B": 0.05, "C": 0.05},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'low_current': {
-        'default': {'X': 0.7, 'Y': 0.7, 'Z': 0.1, 'A': 0.1, 'B': 0.05, 'C': 0.05},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "low_current": {
+        "default": {"X": 0.7, "Y": 0.7, "Z": 0.1, "A": 0.1, "B": 0.05, "C": 0.05},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'high_current': {
-        'default': {'X': 1.25, 'Y': 1.25, 'Z': 0.5, 'A': 0.5, 'B': 0.05, 'C': 0.05},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "high_current": {
+        "default": {"X": 1.25, "Y": 1.25, "Z": 0.5, "A": 0.5, "B": 0.05, "C": 0.05},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'default_pipette_configs': {
-        'homePosition': 220, 'maxTravel': 30, 'stepsPerMM': 768},
-    'log_level': 'NADA',
+    "default_max_speed": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "default_pipette_configs": {
+        "homePosition": 220,
+        "maxTravel": 30,
+        "stepsPerMM": 768,
+    },
+    "log_level": "NADA",
 }
 
 
 new_dummy_settings = {
-    'name': 'Marie Curie',
-    'version': 4,
-    'gantry_steps_per_mm': {'X': 80.0, 'Y': 80.0, 'Z': 400.0, 'A': 400.0},
-    'acceleration': {'X': 3, 'Y': 2, 'Z': 15, 'A': 15, 'B': 2, 'C': 2},
-    'z_retract_distance': 2,
-    'left_mount_offset': [-34, 0, 0],
-    'serial_speed': 888,
-    'default_current': {
-        'default': {'X': 1.25, 'Y': 1.25, 'Z': 0.8, 'A': 0.8, 'B': 0.05, 'C': 0.05},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "name": "Marie Curie",
+    "version": 4,
+    "gantry_steps_per_mm": {"X": 80.0, "Y": 80.0, "Z": 400.0, "A": 400.0},
+    "acceleration": {"X": 3, "Y": 2, "Z": 15, "A": 15, "B": 2, "C": 2},
+    "z_retract_distance": 2,
+    "left_mount_offset": [-34, 0, 0],
+    "serial_speed": 888,
+    "default_current": {
+        "default": {"X": 1.25, "Y": 1.25, "Z": 0.8, "A": 0.8, "B": 0.05, "C": 0.05},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'low_current': {
-        'default': {'X': 0.7, 'Y': 0.7, 'Z': 0.7, 'A': 0.7, 'B': 0.7, 'C': 0.7},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "low_current": {
+        "default": {"X": 0.7, "Y": 0.7, "Z": 0.7, "A": 0.7, "B": 0.7, "C": 0.7},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'high_current': {
-        'default': {'X': 0.7, 'Y': 0.7, 'Z': 0.7, 'A': 0.7, 'B': 0.7, 'C': 0.7},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
+    "high_current": {
+        "default": {"X": 0.7, "Y": 0.7, "Z": 0.7, "A": 0.7, "B": 0.7, "C": 0.7},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
     },
-    'default_max_speed': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-    'default_pipette_configs': {
-        'homePosition': 220, 'maxTravel': 30, 'stepsPerMM': 768},
-    'log_level': 'NADA',
+    "default_max_speed": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+    "default_pipette_configs": {
+        "homePosition": 220,
+        "maxTravel": 30,
+        "stepsPerMM": 768,
+    },
+    "log_level": "NADA",
 }
 
 
 def test_load_corrupt_json():
-    filename = os.path.join(os.path.dirname(__file__), 'bad_config.json')
-    with open(filename, 'w') as file:
-        file.write('')  # empty config file
+    filename = os.path.join(os.path.dirname(__file__), "bad_config.json")
+    with open(filename, "w") as file:
+        file.write("")  # empty config file
     new_setting = robot_configs._load_json(filename)
     c = robot_configs.build_config(new_setting)
     assert c.version == 4
@@ -104,11 +112,9 @@ def test_dictify_roundtrip():
 
 
 def test_load_legacy_gantry_cal():
-    filename = CONFIG['deck_calibration_file']
-    with open(filename, 'w') as file:
-        deck_cal = {
-            'gantry_calibration': [[0, 0, 0, 0]]
-        }
+    filename = CONFIG["deck_calibration_file"]
+    with open(filename, "w") as file:
+        deck_cal = {"gantry_calibration": [[0, 0, 0, 0]]}
         json.dump(deck_cal, file)
 
     result_1 = robot_configs.get_legacy_gantry_calibration()
@@ -120,35 +126,38 @@ def test_load_legacy_gantry_cal():
 
 
 def test_load_currents():
-    legacy = {'X': 2.0, 'Y': 0.5, 'Z': 0.2, 'A': 0.1, 'B': 0.5, 'C': 0.7}
+    legacy = {"X": 2.0, "Y": 0.5, "Z": 0.2, "A": 0.1, "B": 0.5, "C": 0.7}
     default = {
-        'default': {'X': 0.1, 'Y': 0.3, 'Z': 0.1, 'A': 0.2, 'B': 0.1, 'C': 0.2},
-        'B': {'X': 0.2, 'Y': 0.1, 'Z': 0.5, 'A': 0.6, 'B': 0.7, 'C': 0.8},
-        '2.1': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 7}}
-    default_different_vals = {
-        'default': {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6},
-        '2.1': {'X': 0, 'Y': 1, 'Z': 2, 'A': 3, 'B': 4, 'C': 5}
+        "default": {"X": 0.1, "Y": 0.3, "Z": 0.1, "A": 0.2, "B": 0.1, "C": 0.2},
+        "B": {"X": 0.2, "Y": 0.1, "Z": 0.5, "A": 0.6, "B": 0.7, "C": 0.8},
+        "2.1": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 7},
     }
-    from_legacy = {
-        'default': default['default'],
-        'B': default['B'],
-        '2.1': legacy}
-    assert robot_configs._build_hw_versioned_current_dict(
-        legacy, default) == from_legacy
-    assert robot_configs._build_hw_versioned_current_dict(
-        default_different_vals, default) == default_different_vals
-    assert robot_configs._build_hw_versioned_current_dict(
-        None, default) == default
+    default_different_vals = {
+        "default": {"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6},
+        "2.1": {"X": 0, "Y": 1, "Z": 2, "A": 3, "B": 4, "C": 5},
+    }
+    from_legacy = {"default": default["default"], "B": default["B"], "2.1": legacy}
+    assert (
+        robot_configs._build_hw_versioned_current_dict(legacy, default) == from_legacy
+    )
+    assert (
+        robot_configs._build_hw_versioned_current_dict(default_different_vals, default)
+        == default_different_vals
+    )
+    assert robot_configs._build_hw_versioned_current_dict(None, default) == default
 
 
 @pytest.mark.parametrize(
-    'current_dict,board_rev,result',
+    "current_dict,board_rev,result",
     [
-        ({'default': {'X': 1}, '2.1': {'X': 2}}, BoardRevision.OG, {'X': 2}),
-        ({'default': {'X': 1}, 'A': {'X': 2}}, BoardRevision.OG,  {'X': 1}),
-        ({'default': {'X': 1}, 'A': {'X': 2}, '2.1': {'X': 3}},
-         BoardRevision.A, {'X': 2})
-    ]
+        ({"default": {"X": 1}, "2.1": {"X": 2}}, BoardRevision.OG, {"X": 2}),
+        ({"default": {"X": 1}, "A": {"X": 2}}, BoardRevision.OG, {"X": 1}),
+        (
+            {"default": {"X": 1}, "A": {"X": 2}, "2.1": {"X": 3}},
+            BoardRevision.A,
+            {"X": 2},
+        ),
+    ],
 )
 def test_current_for_revision(current_dict, board_rev, result):
     assert robot_configs.current_for_revision(current_dict, board_rev) == result

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -3,10 +3,10 @@
 # from logging.config import dictConfig
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 from opentrons.protocol_api.labware import Labware
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 
 try:
     import aionotify
@@ -33,19 +33,16 @@ from opentrons.protocol_api import ProtocolContext
 from opentrons.types import Mount, Location, Point
 
 
-Session = namedtuple(
-    'Session',
-    ['server', 'socket', 'token', 'call'])
+Session = namedtuple("Session", ["server", "socket", "token", "call"])
 
-Protocol = namedtuple(
-    'Protocol',
-    ['text', 'filename', 'filelike'])
+Protocol = namedtuple("Protocol", ["text", "filename", "filelike"])
 
 
 @pytest.fixture(autouse=True)
 def asyncio_loop_exception_handler(loop):
     def exception_handler(loop, context):
         pytest.fail(str(context))
+
     loop.set_exception_handler(exception_handler)
     yield
     loop.set_exception_handler(None)
@@ -53,9 +50,7 @@ def asyncio_loop_exception_handler(loop):
 
 def state(topic, state):
     def _match(item):
-        return \
-            item['topic'] == topic and \
-            item['payload'].state == state
+        return item["topic"] == topic and item["payload"].state == state
 
     return _match
 
@@ -64,33 +59,30 @@ def log_by_axis(log, axis):
     from functools import reduce
 
     def reducer(e1, e2):
-        return {
-            axis: e1[axis] + [round(e2[axis])]
-            for axis in axis
-        }
+        return {axis: e1[axis] + [round(e2[axis])] for axis in axis}
 
     return reduce(reducer, log, {axis: [] for axis in axis})
 
 
 @pytest.fixture
 def ot_config_tempdir(tmpdir):
-    os.environ['OT_API_CONFIG_DIR'] = str(tmpdir)
+    os.environ["OT_API_CONFIG_DIR"] = str(tmpdir)
     config.reload()
 
     yield tmpdir
 
-    del os.environ['OT_API_CONFIG_DIR']
+    del os.environ["OT_API_CONFIG_DIR"]
     config.reload()
 
 
 @pytest.fixture
 def labware_offset_tempdir(ot_config_tempdir):
-    yield config.get_opentrons_path('labware_calibration_offsets_dir_v2')
+    yield config.get_opentrons_path("labware_calibration_offsets_dir_v2")
 
 
 @pytest.fixture(autouse=True)
 def clear_feature_flags():
-    ff_file = config.CONFIG['feature_flags_file']
+    ff_file = config.CONFIG["feature_flags_file"]
     if os.path.exists(ff_file):
         os.remove(ff_file)
     yield
@@ -100,51 +92,48 @@ def clear_feature_flags():
 
 @pytest.fixture
 def wifi_keys_tempdir():
-    old_wifi_keys = config.CONFIG['wifi_keys_dir']
+    old_wifi_keys = config.CONFIG["wifi_keys_dir"]
     with tempfile.TemporaryDirectory() as td:
-        config.CONFIG['wifi_keys_dir'] = pathlib.Path(td)
+        config.CONFIG["wifi_keys_dir"] = pathlib.Path(td)
         yield td
-        config.CONFIG['wifi_keys_dir'] = old_wifi_keys
+        config.CONFIG["wifi_keys_dir"] = old_wifi_keys
 
 
 @pytest.fixture
 def is_robot(monkeypatch):
-    monkeypatch.setattr(config, 'IS_ROBOT', True)
+    monkeypatch.setattr(config, "IS_ROBOT", True)
     yield
-    monkeypatch.setattr(config, 'IS_ROBOT', False)
+    monkeypatch.setattr(config, "IS_ROBOT", False)
 
 
 # -------feature flag fixtures-------------
 @pytest.fixture
 async def calibrate_bottom_flag():
-    await config.advanced_settings.set_adv_setting('calibrateToBottom', True)
+    await config.advanced_settings.set_adv_setting("calibrateToBottom", True)
     yield
-    await config.advanced_settings.set_adv_setting('calibrateToBottom', False)
+    await config.advanced_settings.set_adv_setting("calibrateToBottom", False)
 
 
 @pytest.fixture
 async def short_trash_flag():
-    await config.advanced_settings.set_adv_setting('shortFixedTrash', True)
+    await config.advanced_settings.set_adv_setting("shortFixedTrash", True)
     yield
-    await config.advanced_settings.set_adv_setting('shortFixedTrash', False)
+    await config.advanced_settings.set_adv_setting("shortFixedTrash", False)
 
 
 @pytest.fixture
 async def old_aspiration(monkeypatch):
-    await config.advanced_settings.set_adv_setting(
-        'useOldAspirationFunctions', True)
+    await config.advanced_settings.set_adv_setting("useOldAspirationFunctions", True)
     yield
-    await config.advanced_settings.set_adv_setting(
-        'useOldAspirationFunctions', False)
+    await config.advanced_settings.set_adv_setting("useOldAspirationFunctions", False)
 
 
 @pytest.fixture
 async def enable_door_safety_switch():
-    await config.advanced_settings.set_adv_setting(
-        'enableDoorSafetySwitch', True)
+    await config.advanced_settings.set_adv_setting("enableDoorSafetySwitch", True)
     yield
-    await config.advanced_settings.set_adv_setting(
-        'enableDoorSafetySwitch', False)
+    await config.advanced_settings.set_adv_setting("enableDoorSafetySwitch", False)
+
 
 # -----end feature flag fixtures-----------
 
@@ -152,14 +141,14 @@ async def enable_door_safety_switch():
 @pytest.fixture(params=["testosaur_v2.py"])
 def protocol(request):
     try:
-        root = request.getfixturevalue('protocol_file')
+        root = request.getfixturevalue("protocol_file")
     except Exception:
         root = request.param
 
-    filename = os.path.join(os.path.dirname(__file__), 'data', root)
+    filename = os.path.join(os.path.dirname(__file__), "data", root)
 
     file = open(filename)
-    text = ''.join(list(file))
+    text = "".join(list(file))
     file.seek(0)
 
     yield Protocol(text=text, filename=filename, filelike=file)
@@ -175,13 +164,12 @@ def session_manager(main_router):
 @pytest.fixture
 def virtual_smoothie_env(monkeypatch):
     # TODO (ben 20180426): move this to the .env file
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
+    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "true")
     yield
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "false")
 
 
-@pytest.mark.skipif(aionotify is None,
-                    reason="requires inotify (linux only)")
+@pytest.mark.skipif(aionotify is None, reason="requires inotify (linux only)")
 @pytest.fixture
 async def hardware(request, loop, virtual_smoothie_env):
     hw_sim = ThreadManager(API.build_hardware_simulator)
@@ -198,9 +186,8 @@ async def hardware(request, loop, virtual_smoothie_env):
 def main_router(loop, virtual_smoothie_env, hardware):
     router = MainRouter(hardware=hardware, loop=loop, lock=ThreadedAsyncLock())
     router.wait_until = partial(
-        wait_until,
-        notifications=router.notifications,
-        loop=loop)
+        wait_until, notifications=router.notifications, loop=loop
+    )
     yield router
 
 
@@ -211,7 +198,7 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
 
         if pending:
             [task.cancel() for task in pending]
-            raise TimeoutError('Notifications: {0}'.format(result))
+            raise TimeoutError("Notifications: {0}".format(result))
 
         result += [done.pop().result()]
 
@@ -222,31 +209,26 @@ async def wait_until(matcher, notifications, timeout=1, loop=None):
 @pytest.fixture
 async def ctx(loop, hardware) -> ProtocolContext:
     return ProtocolContext(
-        implementation=ProtocolContextImplementation(hardware=hardware),
-        loop=loop
+        implementation=ProtocolContextImplementation(hardware=hardware), loop=loop
     )
 
 
 def data_dir() -> str:
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
 def build_v2_model(h, lw_name, loop):
     ctx = ProtocolContext(
-        implementation=ProtocolContextImplementation(hardware=h),
-        loop=loop)
+        implementation=ProtocolContextImplementation(hardware=h), loop=loop
+    )
 
-    loop.run_until_complete(h.cache_instruments(
-        {Mount.RIGHT: 'p300_single'}))
-    tiprack = ctx.load_labware(
-        'opentrons_96_tiprack_300ul', '2')
-    pip = ctx.load_instrument('p300_single', 'right',
-                              tip_racks=[tiprack])
+    loop.run_until_complete(h.cache_instruments({Mount.RIGHT: "p300_single"}))
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", "2")
+    pip = ctx.load_instrument("p300_single", "right", tip_racks=[tiprack])
     instrument = models.Instrument(pip, [], ctx)
-    plate = ctx.load_labware(
-        lw_name or 'corning_96_wellplate_360ul_flat', 1)
+    plate = ctx.load_labware(lw_name or "corning_96_wellplate_360ul_flat", 1)
     container = models.Container(plate, [], context=ctx)
-    return namedtuple('model', 'robot instrument container')(
+    return namedtuple("model", "robot instrument container")(
         robot=h,
         instrument=instrument,
         container=container,
@@ -259,7 +241,7 @@ def model(request, hardware, loop):
     # to have a different labware loaded as .container. If not passed,
     # defaults to the version-appropriate way to do 96 flat
     try:
-        lw_name = request.getfixturevalue('labware_name')
+        lw_name = request.getfixturevalue("labware_name")
     except Exception:
         lw_name = None
 
@@ -273,8 +255,8 @@ def smoothie(monkeypatch):
     from opentrons.drivers.smoothie_drivers import SmoothieDriver
     from opentrons.config import robot_configs
 
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'true')
-    driver = SmoothieDriver(robot_configs.load(), SimulatingGPIOCharDev('simulated'))
+    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "true")
+    driver = SmoothieDriver(robot_configs.load(), SimulatingGPIOCharDev("simulated"))
     driver.connect()
     yield driver
     try:
@@ -282,17 +264,18 @@ def smoothie(monkeypatch):
     except AttributeError:
         # if the test disconnected
         pass
-    monkeypatch.setenv('ENABLE_VIRTUAL_SMOOTHIE', 'false')
+    monkeypatch.setenv("ENABLE_VIRTUAL_SMOOTHIE", "false")
 
 
 @pytest.fixture
 def hardware_controller_lockfile():
-    old_lockfile = config.CONFIG['hardware_controller_lockfile']
+    old_lockfile = config.CONFIG["hardware_controller_lockfile"]
     with tempfile.TemporaryDirectory() as td:
-        config.CONFIG['hardware_controller_lockfile']\
-            = pathlib.Path(td)/'hardware.lock'
+        config.CONFIG["hardware_controller_lockfile"] = (
+            pathlib.Path(td) / "hardware.lock"
+        )
         yield td
-        config.CONFIG['hardware_controller_lockfile'] = old_lockfile
+        config.CONFIG["hardware_controller_lockfile"] = old_lockfile
 
 
 @pytest.fixture
@@ -303,15 +286,16 @@ def running_on_pi():
     config.IS_ROBOT = oldpi
 
 
-@pytest.mark.skipif(not hc.Controller,
-                    reason='hardware controller not available '
-                           '(probably windows)')
+@pytest.mark.skipif(
+    not hc.Controller, reason="hardware controller not available " "(probably windows)"
+)
 @pytest.fixture
 def cntrlr_mock_connect(monkeypatch):
     async def mock_connect(obj, port=None):
         return
-    monkeypatch.setattr(hc.Controller, 'connect', mock_connect)
-    monkeypatch.setattr(hc.Controller, 'fw_version', 'virtual')
+
+    monkeypatch.setattr(hc.Controller, "connect", mock_connect)
+    monkeypatch.setattr(hc.Controller, "fw_version", "virtual")
 
 
 @pytest.fixture
@@ -323,10 +307,21 @@ async def hardware_api(loop, is_robot):
 @pytest.fixture
 def get_labware_fixture():
     def _get_labware_fixture(fixture_name):
-        with open((pathlib.Path(__file__).parent/'..'/'..'/'..'/'shared-data' /
-                   'labware' / 'fixtures'/'2'/f'{fixture_name}.json'), 'rb'
-                  ) as f:
-            return json.loads(f.read().decode('utf-8'))
+        with open(
+            (
+                pathlib.Path(__file__).parent
+                / ".."
+                / ".."
+                / ".."
+                / "shared-data"
+                / "labware"
+                / "fixtures"
+                / "2"
+                / f"{fixture_name}.json"
+            ),
+            "rb",
+        ) as f:
+            return json.loads(f.read().decode("utf-8"))
 
     return _get_labware_fixture
 
@@ -334,10 +329,19 @@ def get_labware_fixture():
 @pytest.fixture
 def get_json_protocol_fixture():
     def _get_json_protocol_fixture(fixture_version, fixture_name, decode=True):
-        with open(pathlib.Path(__file__).parent /
-                  '..'/'..'/'..'/'shared-data'/'protocol'/'fixtures' /
-                  fixture_version/f'{fixture_name}.json', 'rb') as f:
-            contents = f.read().decode('utf-8')
+        with open(
+            pathlib.Path(__file__).parent
+            / ".."
+            / ".."
+            / ".."
+            / "shared-data"
+            / "protocol"
+            / "fixtures"
+            / fixture_version
+            / f"{fixture_name}.json",
+            "rb",
+        ) as f:
+            contents = f.read().decode("utf-8")
             if decode:
                 return json.loads(contents)
             else:
@@ -349,10 +353,20 @@ def get_json_protocol_fixture():
 @pytest.fixture
 def get_module_fixture():
     def _get_module_fixture(fixture_name):
-        with open(pathlib.Path(__file__).parent
-                  / '..' / '..' / '..' / 'shared-data' / 'module' / 'fixtures'
-                  / '2' / f'{fixture_name}.json', 'rb') as f:
-            return json.loads(f.read().decode('utf-8'))
+        with open(
+            pathlib.Path(__file__).parent
+            / ".."
+            / ".."
+            / ".."
+            / "shared-data"
+            / "module"
+            / "fixtures"
+            / "2"
+            / f"{fixture_name}.json",
+            "rb",
+        ) as f:
+            return json.loads(f.read().decode("utf-8"))
+
     return _get_module_fixture
 
 
@@ -360,11 +374,19 @@ def get_module_fixture():
 def get_bundle_fixture():
     def get_std_labware(loadName, version=1):
         with open(
-            pathlib.Path(__file__).parent / '..' / '..' / '..' /
-            'shared-data' / 'labware' / 'definitions' / '2' /
-            loadName / f'{version}.json', 'rb'
+            pathlib.Path(__file__).parent
+            / ".."
+            / ".."
+            / ".."
+            / "shared-data"
+            / "labware"
+            / "definitions"
+            / "2"
+            / loadName
+            / f"{version}.json",
+            "rb",
         ) as f:
-            labware_def = json.loads(f.read().decode('utf-8'))
+            labware_def = json.loads(f.read().decode("utf-8"))
         return labware_def
 
     def _get_bundle_protocol_fixture(fixture_name):
@@ -376,94 +398,94 @@ def get_bundle_fixture():
         their assertions.
         """
         fixture_dir = (
-            pathlib.Path(__file__).parent / 'protocols' /
-            'fixtures' / 'bundled_protocols' / fixture_name)
+            pathlib.Path(__file__).parent
+            / "protocols"
+            / "fixtures"
+            / "bundled_protocols"
+            / fixture_name
+        )
 
-        result = {'filename': f'{fixture_name}.zip',
-                  'source_dir': fixture_dir}
+        result = {"filename": f"{fixture_name}.zip", "source_dir": fixture_dir}
 
-        fixed_trash_def = get_std_labware('opentrons_1_trash_1100ml_fixed')
+        fixed_trash_def = get_std_labware("opentrons_1_trash_1100ml_fixed")
 
-        empty_protocol = 'def run(context):\n    pass'
+        empty_protocol = "def run(context):\n    pass"
 
-        if fixture_name == 'simple_bundle':
-            with open(fixture_dir / 'protocol.py', 'r') as f:
-                result['contents'] = f.read()
-            with open(fixture_dir / 'data.txt', 'rb') as f:
-                result['bundled_data'] = {'data.txt': f.read()}
-            with open(fixture_dir / 'custom_labware.json', 'r') as f:
+        if fixture_name == "simple_bundle":
+            with open(fixture_dir / "protocol.py", "r") as f:
+                result["contents"] = f.read()
+            with open(fixture_dir / "data.txt", "rb") as f:
+                result["bundled_data"] = {"data.txt": f.read()}
+            with open(fixture_dir / "custom_labware.json", "r") as f:
                 custom_labware = json.load(f)
 
-            tiprack_def = get_std_labware('opentrons_96_tiprack_10ul')
-            result['bundled_labware'] = {
-                'opentrons/opentrons_1_trash_1100ml_fixed/1': fixed_trash_def,
-                'custom_beta/custom_labware/1': custom_labware,
-                'opentrons/opentrons_96_tiprack_10ul/1': tiprack_def}
-            result['bundled_python'] = {}
+            tiprack_def = get_std_labware("opentrons_96_tiprack_10ul")
+            result["bundled_labware"] = {
+                "opentrons/opentrons_1_trash_1100ml_fixed/1": fixed_trash_def,
+                "custom_beta/custom_labware/1": custom_labware,
+                "opentrons/opentrons_96_tiprack_10ul/1": tiprack_def,
+            }
+            result["bundled_python"] = {}
 
             # NOTE: this is copy-pasted from the .py fixture file
-            result['metadata'] = {'author': 'MISTER FIXTURE',
-                                  'apiLevel': '2.0'}
+            result["metadata"] = {"author": "MISTER FIXTURE", "apiLevel": "2.0"}
 
             # make binary zipfile
             binary_zipfile = io.BytesIO()
-            with zipfile.ZipFile(binary_zipfile, 'w') as z:
-                z.writestr('labware/custom_labware.json',
-                           json.dumps(custom_labware))
-                z.writestr('labware/tiprack.json', json.dumps(tiprack_def))
-                z.writestr('labware/fixed_trash.json',
-                           json.dumps(fixed_trash_def))
-                z.writestr('protocol.ot2.py', result['contents'])
-                z.writestr('data/data.txt',
-                           result['bundled_data']['data.txt'])
+            with zipfile.ZipFile(binary_zipfile, "w") as z:
+                z.writestr("labware/custom_labware.json", json.dumps(custom_labware))
+                z.writestr("labware/tiprack.json", json.dumps(tiprack_def))
+                z.writestr("labware/fixed_trash.json", json.dumps(fixed_trash_def))
+                z.writestr("protocol.ot2.py", result["contents"])
+                z.writestr("data/data.txt", result["bundled_data"]["data.txt"])
             binary_zipfile.seek(0)
-            result['binary_zipfile'] = binary_zipfile.read()
+            result["binary_zipfile"] = binary_zipfile.read()
             binary_zipfile.seek(0)
-            result['filelike'] = binary_zipfile
+            result["filelike"] = binary_zipfile
 
-        elif fixture_name == 'no_root_files_bundle':
+        elif fixture_name == "no_root_files_bundle":
             binary_zipfile = io.BytesIO()
-            with zipfile.ZipFile(binary_zipfile, 'w') as z:
-                z.writestr('inner_dir/protocol.ot2.py', empty_protocol)
+            with zipfile.ZipFile(binary_zipfile, "w") as z:
+                z.writestr("inner_dir/protocol.ot2.py", empty_protocol)
             binary_zipfile.seek(0)
-            result['binary_zipfile'] = binary_zipfile.read()
+            result["binary_zipfile"] = binary_zipfile.read()
             binary_zipfile.seek(0)
-            result['filelike'] = binary_zipfile
-        elif fixture_name == 'no_entrypoint_protocol_bundle':
+            result["filelike"] = binary_zipfile
+        elif fixture_name == "no_entrypoint_protocol_bundle":
             binary_zipfile = io.BytesIO()
-            with zipfile.ZipFile(binary_zipfile, 'w') as z:
-                z.writestr('rando_pyfile_name.py', empty_protocol)
+            with zipfile.ZipFile(binary_zipfile, "w") as z:
+                z.writestr("rando_pyfile_name.py", empty_protocol)
             binary_zipfile.seek(0)
-            result['binary_zipfile'] = binary_zipfile.read()
+            result["binary_zipfile"] = binary_zipfile.read()
             binary_zipfile.seek(0)
-            result['filelike'] = binary_zipfile
-        elif fixture_name == 'conflicting_labware_bundle':
+            result["filelike"] = binary_zipfile
+        elif fixture_name == "conflicting_labware_bundle":
             binary_zipfile = io.BytesIO()
-            with zipfile.ZipFile(binary_zipfile, 'w') as z:
-                plate_def = get_std_labware('biorad_96_wellplate_200ul_pcr')
-                z.writestr('protocol.ot2.py', empty_protocol)
-                z.writestr(
-                    'labware/fixed_trash.json', json.dumps(fixed_trash_def))
-                z.writestr('labware/plate.json', json.dumps(plate_def))
-                z.writestr('labware/same_plate.json', json.dumps(plate_def))
+            with zipfile.ZipFile(binary_zipfile, "w") as z:
+                plate_def = get_std_labware("biorad_96_wellplate_200ul_pcr")
+                z.writestr("protocol.ot2.py", empty_protocol)
+                z.writestr("labware/fixed_trash.json", json.dumps(fixed_trash_def))
+                z.writestr("labware/plate.json", json.dumps(plate_def))
+                z.writestr("labware/same_plate.json", json.dumps(plate_def))
             binary_zipfile.seek(0)
-            result['binary_zipfile'] = binary_zipfile.read()
+            result["binary_zipfile"] = binary_zipfile.read()
             binary_zipfile.seek(0)
-            result['filelike'] = binary_zipfile
-        elif fixture_name == 'missing_labware_bundle':
+            result["filelike"] = binary_zipfile
+        elif fixture_name == "missing_labware_bundle":
             # parsing should fail b/c this bundle lacks labware defs.
-            with open(fixture_dir / 'protocol.py', 'r') as f:
+            with open(fixture_dir / "protocol.py", "r") as f:
                 protocol_contents = f.read()
             binary_zipfile = io.BytesIO()
-            with zipfile.ZipFile(binary_zipfile, 'w') as z:
-                z.writestr('protocol.ot2.py', protocol_contents)
+            with zipfile.ZipFile(binary_zipfile, "w") as z:
+                z.writestr("protocol.ot2.py", protocol_contents)
             binary_zipfile.seek(0)
-            result['binary_zipfile'] = binary_zipfile.read()
+            result["binary_zipfile"] = binary_zipfile.read()
             binary_zipfile.seek(0)
-            result['filelike'] = binary_zipfile
+            result["filelike"] = binary_zipfile
         else:
-            raise ValueError(f'get_bundle_fixture has no case to handle '
-                             f'fixture "{fixture_name}"')
+            raise ValueError(
+                f"get_bundle_fixture has no case to handle " f'fixture "{fixture_name}"'
+            )
         return result
 
     return _get_bundle_protocol_fixture
@@ -476,52 +498,41 @@ def minimal_labware_def() -> dict:
             "displayName": "minimal labware",
             "displayCategory": "other",
             "displayVolumeUnits": "mL",
-
         },
-        "cornerOffsetFromSlot": {
-            "x": 10,
-            "y": 10,
-            "z": 5
-        },
+        "cornerOffsetFromSlot": {"x": 10, "y": 10, "z": 5},
         "parameters": {
             "isTiprack": False,
             "loadName": "minimal_labware_def",
             "isMagneticModuleCompatible": True,
-            "format": "irregular"
+            "format": "irregular",
         },
         "ordering": [["A1"], ["A2"]],
         "wells": {
             "A1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "shape": "circular",
             },
             "A2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 10,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
-            }
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 10,
+                "y": 0,
+                "z": 0,
+                "shape": "circular",
+            },
         },
-        "dimensions": {
-            "xDimension": 1.0,
-            "yDimension": 2.0,
-            "zDimension": 3.0
-        },
+        "dimensions": {"xDimension": 1.0, "yDimension": 2.0, "zDimension": 3.0},
         "groups": [],
-        "brand": {
-            "brand": "opentrons"
-        },
+        "brand": {"brand": "opentrons"},
         "version": 1,
         "schemaVersion": 2,
-        "namespace": "opentronstest"
+        "namespace": "opentronstest",
     }
 
 
@@ -533,102 +544,90 @@ def minimal_labware_def2() -> dict:
             "displayCategory": "other",
             "displayVolumeUnits": "mL",
         },
-        "cornerOffsetFromSlot": {
-                "x": 10,
-                "y": 10,
-                "z": 5
-        },
+        "cornerOffsetFromSlot": {"x": 10, "y": 10, "z": 5},
         "parameters": {
             "isTiprack": False,
             "loadName": "minimal_labware_def",
             "isMagneticModuleCompatible": True,
-            "format": "irregular"
+            "format": "irregular",
         },
         "ordering": [["A1", "B1", "C1"], ["A2", "B2", "C2"]],
         "wells": {
             "A1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 18,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 18,
+                "z": 0,
+                "shape": "circular",
             },
             "B1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 9,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 9,
+                "z": 0,
+                "shape": "circular",
             },
             "C1": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 0,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "shape": "circular",
             },
             "A2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 18,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 18,
+                "z": 0,
+                "shape": "circular",
             },
             "B2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 9,
-              "z": 0,
-              "shape": "circular"
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 9,
+                "z": 0,
+                "shape": "circular",
             },
             "C2": {
-              "depth": 40,
-              "totalLiquidVolume": 100,
-              "diameter": 30,
-              "x": 9,
-              "y": 0,
-              "z": 0,
-              "shape": "circular"
-            }
+                "depth": 40,
+                "totalLiquidVolume": 100,
+                "diameter": 30,
+                "x": 9,
+                "y": 0,
+                "z": 0,
+                "shape": "circular",
+            },
         },
         "groups": [],
-        "dimensions": {
-            "xDimension": 1.0,
-            "yDimension": 2.0,
-            "zDimension": 3.0
-        },
+        "dimensions": {"xDimension": 1.0, "yDimension": 2.0, "zDimension": 3.0},
         "schemaVersion": 2,
         "version": 1,
         "namespace": "dummy_namespace",
-        "brand": {
-            "brand": "opentrons"
-        },
+        "brand": {"brand": "opentrons"},
     }
 
 
 @pytest.fixture
 def min_lw_impl(minimal_labware_def) -> LabwareImplementation:
     return LabwareImplementation(
-            definition=minimal_labware_def,
-            parent=Location(Point(0, 0, 0), 'deck')
+        definition=minimal_labware_def, parent=Location(Point(0, 0, 0), "deck")
     )
 
 
 @pytest.fixture
 def min_lw2_impl(minimal_labware_def2) -> LabwareImplementation:
     return LabwareImplementation(
-        definition=minimal_labware_def2,
-        parent=Location(Point(0, 0, 0), 'deck')
+        definition=minimal_labware_def2, parent=Location(Point(0, 0, 0), "deck")
     )
 
 

--- a/api/tests/opentrons/data/bug_aspirate_tip.py
+++ b/api/tests/opentrons/data/bug_aspirate_tip.py
@@ -2,10 +2,10 @@ from opentrons import protocol_api
 
 # metadata
 metadata = {
-    'protocolName': 'Bug 7552',
-    'author': 'Name <email@address.com>',
-    'description': 'Simulation allows aspirating and dispensing on a tip rack',
-    'apiLevel': '2.11'
+    "protocolName": "Bug 7552",
+    "author": "Name <email@address.com>",
+    "description": "Simulation allows aspirating and dispensing on a tip rack",
+    "apiLevel": "2.11",
 }
 
 
@@ -13,10 +13,10 @@ metadata = {
 # where to look for autocomplete suggestions
 def run(protocol: protocol_api.ProtocolContext):
     # labware
-    plate = protocol.load_labware('geb_96_tiprack_10ul', 4)
+    plate = protocol.load_labware("geb_96_tiprack_10ul", 4)
 
     # pipettes
-    pipette = protocol.load_instrument('p300_single', 'left', tip_racks=[plate])
+    pipette = protocol.load_instrument("p300_single", "left", tip_racks=[plate])
 
     # commands
-    pipette.transfer(5, plate.wells_by_name()['A1'], plate.wells_by_name()['B1'])
+    pipette.transfer(5, plate.wells_by_name()["A1"], plate.wells_by_name()["B1"])

--- a/api/tests/opentrons/data/g_code_validation_protocols/2_modules_1s_1m_v2.py
+++ b/api/tests/opentrons/data/g_code_validation_protocols/2_modules_1s_1m_v2.py
@@ -4,19 +4,19 @@ metadata = {"apiLevel": "2.7"}
 
 def run(ctx):
     ctx.home()
-    trough = ctx.load_labware('usascientific_12_reservoir_22ml', 2)
-    tiprack = ctx.load_labware_by_name('opentrons_96_tiprack_20ul', 3)
-    tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', 6)
+    trough = ctx.load_labware("usascientific_12_reservoir_22ml", 2)
+    tiprack = ctx.load_labware_by_name("opentrons_96_tiprack_20ul", 3)
+    tiprack1 = ctx.load_labware_by_name("opentrons_96_tiprack_300ul", 6)
 
-    magdeck = ctx.load_module('magneticModuleV2', 1)
-    magdeck_plate = magdeck.load_labware('nest_96_wellplate_2ml_deep')
+    magdeck = ctx.load_module("magneticModuleV2", 1)
+    magdeck_plate = magdeck.load_labware("nest_96_wellplate_2ml_deep")
 
-    tempdeck = ctx.load_module('Temperature Module', 4)
-    temp_plate = tempdeck.load_labware('opentrons_24_aluminumblock_nest_2ml_snapcap')
+    tempdeck = ctx.load_module("Temperature Module", 4)
+    temp_plate = tempdeck.load_labware("opentrons_24_aluminumblock_nest_2ml_snapcap")
 
     # pipettes
-    pip1 = ctx.load_instrument('p300_single_gen2', 'left', tip_racks=[tiprack1])
-    pip2 = ctx.load_instrument('p20_multi_gen2', 'right', tip_racks=[tiprack])
+    pip1 = ctx.load_instrument("p300_single_gen2", "left", tip_racks=[tiprack1])
+    pip2 = ctx.load_instrument("p20_multi_gen2", "right", tip_racks=[tiprack])
 
     # Temperature Module Testing
     tempdeck.set_temperature(20)
@@ -27,7 +27,7 @@ def run(ctx):
     tempdeck.set_temperature(30)
     ctx.comment(f"temp target {tempdeck.target}")
     ctx.comment(f"temp current {tempdeck.temperature}")
-    pip2.transfer(10, trough.wells('A1'), temp_plate.wells('A1'))
+    pip2.transfer(10, trough.wells("A1"), temp_plate.wells("A1"))
 
     # Magnetic Module Testing
     magdeck.engage(height=10)
@@ -35,8 +35,8 @@ def run(ctx):
     magdeck.disengage()
     ctx.comment(f"mag status {magdeck.status}")
     magdeck.engage()
-    pip1.transfer(10, trough.wells('A1'), magdeck_plate.wells('A1'))
-    pip2.transfer(10, trough.wells('A1'), magdeck_plate.wells('A1'))
+    pip1.transfer(10, trough.wells("A1"), magdeck_plate.wells("A1"))
+    pip2.transfer(10, trough.wells("A1"), magdeck_plate.wells("A1"))
     magdeck.disengage()
 
     # #run time = 6 minutes 1 second

--- a/api/tests/opentrons/data/g_code_validation_protocols/2_single_channel_v2.py
+++ b/api/tests/opentrons/data/g_code_validation_protocols/2_single_channel_v2.py
@@ -5,41 +5,41 @@ metadata = {"apiLevel": "2.11"}
 def run(ctx):
     ctx.home()
 
-    tiprack1 = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', '1')
-    tiprack2 = ctx.load_labware_by_name('opentrons_96_tiprack_300ul', '2')
-    tiprack3 = ctx.load_labware('opentrons_96_filtertiprack_20ul', '3')
-    tiprack4 = ctx.load_labware('opentrons_96_tiprack_20ul', '4')
+    tiprack1 = ctx.load_labware_by_name("opentrons_96_tiprack_300ul", "1")
+    tiprack2 = ctx.load_labware_by_name("opentrons_96_tiprack_300ul", "2")
+    tiprack3 = ctx.load_labware("opentrons_96_filtertiprack_20ul", "3")
+    tiprack4 = ctx.load_labware("opentrons_96_tiprack_20ul", "4")
 
-    plate1 = ctx.load_labware('corning_96_wellplate_360ul_flat', '7')
-    plate2 = ctx.load_labware('corning_96_wellplate_360ul_flat', '8')
+    plate1 = ctx.load_labware("corning_96_wellplate_360ul_flat", "7")
+    plate2 = ctx.load_labware("corning_96_wellplate_360ul_flat", "8")
     pip = ctx.load_instrument(
-        'p20_single_gen2', mount='left', tip_racks=[tiprack3, tiprack4]
+        "p20_single_gen2", mount="left", tip_racks=[tiprack3, tiprack4]
     )
     pip2 = ctx.load_instrument(
-        'p300_single_gen2', mount='right', tip_racks=[tiprack1, tiprack2]
+        "p300_single_gen2", mount="right", tip_racks=[tiprack1, tiprack2]
     )
     pip.transfer(
         10,
-        plate1.wells('A1'),
+        plate1.wells("A1"),
         [
             plate2[well].top()
-            for well in ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1']
-        ]
+            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
+        ],
     )
     pip2.transfer(
         50,
-        plate1.wells('A2'),
+        plate1.wells("A2"),
         [
             plate2[well].bottom()
-            for well in ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1']
-        ]
+            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
+        ],
     )
     # mix behavior
     pip.transfer(
         50,
-        plate1.wells('A3'),
+        plate1.wells("A3"),
         [
             plate2[well].top()
-            for well in ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1']
-        ]
+            for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
+        ],
     )

--- a/api/tests/opentrons/data/g_code_validation_protocols/smoothie_protocol.py
+++ b/api/tests/opentrons/data/g_code_validation_protocols/smoothie_protocol.py
@@ -2,17 +2,17 @@
 from opentrons import types
 
 metadata = {
-    'protocolName': 'Smoothie Testing',
-    'author': 'Derek Maggio',
-    'apiLevel': '2.0',
+    "protocolName": "Smoothie Testing",
+    "author": "Derek Maggio",
+    "apiLevel": "2.0",
 }
 
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    right = ctx.load_instrument('p20_single_gen2', types.Mount.RIGHT, [tr])
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    right = ctx.load_instrument("p20_single_gen2", types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/data/g_code_validation_protocols/swift_smoke.py
+++ b/api/tests/opentrons/data/g_code_validation_protocols/swift_smoke.py
@@ -9,51 +9,56 @@ def run(protocol_context):
     protocol_context.home()
 
     # Labware Setup
-    rt_reagents = protocol_context.load_labware(
-        'nest_12_reservoir_15ml', '2')
+    rt_reagents = protocol_context.load_labware("nest_12_reservoir_15ml", "2")
 
-    p20rack = protocol_context.load_labware('opentrons_96_tiprack_300ul', '3')
+    p20rack = protocol_context.load_labware("opentrons_96_tiprack_300ul", "3")
 
-    p300racks = [protocol_context.load_labware(
-        'opentrons_96_tiprack_20ul', slot) for slot in ['5', '6', ]]
+    p300racks = [
+        protocol_context.load_labware("opentrons_96_tiprack_20ul", slot)
+        for slot in [
+            "5",
+            "6",
+        ]
+    ]
     # Pipette Setup
-    p20 = protocol_context.load_instrument('p20_single_gen2', 'left',
-                                           tip_racks=p300racks)
-    p300 = protocol_context.load_instrument('p300_multi', 'right', tip_racks=[p20rack])
+    p20 = protocol_context.load_instrument(
+        "p20_single_gen2", "left", tip_racks=p300racks
+    )
+    p300 = protocol_context.load_instrument("p300_multi", "right", tip_racks=[p20rack])
 
     # Module Setup
-    magdeck = protocol_context.load_module('magneticModuleV2', '1')
-    mag_plate = magdeck.load_labware('nest_96_wellplate_2ml_deep')
+    magdeck = protocol_context.load_module("magneticModuleV2", "1")
+    mag_plate = magdeck.load_labware("nest_96_wellplate_2ml_deep")
 
-    tempdeck = protocol_context.load_module('temperatureModuleV2', '4')
+    tempdeck = protocol_context.load_module("temperatureModuleV2", "4")
     cool_reagents = tempdeck.load_labware(
-        'opentrons_24_aluminumblock_generic_2ml_screwcap')
+        "opentrons_24_aluminumblock_generic_2ml_screwcap"
+    )
 
-    thermocycler = protocol_context.load_module('thermocycler')
-    reaction_plate = thermocycler.load_labware(
-        'nest_96_wellplate_100ul_pcr_full_skirt')
+    thermocycler = protocol_context.load_module("thermocycler")
+    reaction_plate = thermocycler.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
 
     # Reagent Setup
-    enzymatic_prep_mm = cool_reagents.wells_by_name()['A1']
-    ligation_mm = cool_reagents.wells_by_name()['A2']
-    pcr_mm = cool_reagents.wells_by_name()['A3']
-    beads = rt_reagents.wells_by_name()['A2']
-    ethanol = rt_reagents.wells_by_name()['A3']
-    te = rt_reagents.wells_by_name()['A4']
-    waste = rt_reagents.wells_by_name()['A12']
+    enzymatic_prep_mm = cool_reagents.wells_by_name()["A1"]
+    ligation_mm = cool_reagents.wells_by_name()["A2"]
+    pcr_mm = cool_reagents.wells_by_name()["A3"]
+    beads = rt_reagents.wells_by_name()["A2"]
+    ethanol = rt_reagents.wells_by_name()["A3"]
+    te = rt_reagents.wells_by_name()["A4"]
+    waste = rt_reagents.wells_by_name()["A12"]
 
     # number of samples
     sample_num = 8
 
     # Destination of input DNA samples and samples on the magnetic module
     tc_samples = reaction_plate.columns_by_name()
-    enzymatic_prep_samples = tc_samples['2']
-    pcr_prep_samples = tc_samples['3']
-    purified_samples = tc_samples['4']
+    enzymatic_prep_samples = tc_samples["2"]
+    pcr_prep_samples = tc_samples["3"]
+    purified_samples = tc_samples["4"]
 
     # mag_samples = mag_plate.wells()[:sample_num]
     mag_column = mag_plate.columns_by_name()
-    mag_samples = mag_column['2']
+    mag_samples = mag_column["2"]
 
     p20.flow_rate.aspirate = 150
     p20.flow_rate.dispense = 300
@@ -234,8 +239,10 @@ def run(protocol_context):
     """PCR Prep"""
     # Transfer Dual Indexes to the sample
     # Primer screw tubes are shallow !!!!
-    primers = [well for well in cool_reagents.wells(
-        'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'C1', 'C2')][:sample_num]
+    primers = [
+        well
+        for well in cool_reagents.wells("B1", "B2", "B3", "B4", "B5", "B6", "C1", "C2")
+    ][:sample_num]
     for primer, well in zip(primers, pcr_prep_samples):
         p20.pick_up_tip()
         p20.aspirate(5, primer.top(-25))
@@ -271,12 +278,20 @@ def run(protocol_context):
     # PLATE_TEMP_HOLD_5 = (72, 300)
     PLATE_TEMP_POST = 4
     NUM_CYCLES = 5
-    CYCLED_STEPS = [{'temperature': PLATE_TEMP_HOLD_2[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_2[1]},
-                    {'temperature': PLATE_TEMP_HOLD_3[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_3[1]},
-                    {'temperature': PLATE_TEMP_HOLD_4[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_4[1]}]
+    CYCLED_STEPS = [
+        {
+            "temperature": PLATE_TEMP_HOLD_2[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_2[1],
+        },
+        {
+            "temperature": PLATE_TEMP_HOLD_3[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_3[1],
+        },
+        {
+            "temperature": PLATE_TEMP_HOLD_4[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_4[1],
+        },
+    ]
 
     # Set PRE temp
     thermocycler.set_block_temperature(PLATE_TEMP_PRE)
@@ -284,8 +299,9 @@ def run(protocol_context):
     thermocycler.set_lid_temperature(105)
     thermocycler.close_lid()
     # Set HOLD1 temp
-    thermocycler.set_block_temperature(PLATE_TEMP_HOLD_1[0],
-                                       hold_time_seconds=PLATE_TEMP_HOLD_1[1])
+    thermocycler.set_block_temperature(
+        PLATE_TEMP_HOLD_1[0], hold_time_seconds=PLATE_TEMP_HOLD_1[1]
+    )
     # Loop HOLD2 - HOLD4 temps NUM_CYCLES times
     thermocycler.execute_profile(steps=CYCLED_STEPS, repetitions=NUM_CYCLES)
     # Set POST temp
@@ -293,7 +309,7 @@ def run(protocol_context):
     thermocycler.open_lid()
 
     # PCR purification
-    mag_samples = mag_column['3']
+    mag_samples = mag_column["3"]
 
     # Transfer samples to the Magnetic Module
     p300.flow_rate.aspirate = 10
@@ -420,5 +436,6 @@ def run(protocol_context):
     # Disengage MagDeck for PCR purification protocol
     tempdeck.deactivate()
     magdeck.disengage()
+
 
 # run time = 36 minutes

--- a/api/tests/opentrons/data/g_code_validation_protocols/swift_turbo.py
+++ b/api/tests/opentrons/data/g_code_validation_protocols/swift_turbo.py
@@ -9,51 +9,57 @@ def run(protocol_context):
     protocol_context.home()
 
     # Labware Setup
-    rt_reagents = protocol_context.load_labware(
-        'nest_12_reservoir_15ml', '2')
+    rt_reagents = protocol_context.load_labware("nest_12_reservoir_15ml", "2")
 
-    p20rack = protocol_context.load_labware('opentrons_96_tiprack_20ul', '4')
+    p20rack = protocol_context.load_labware("opentrons_96_tiprack_20ul", "4")
 
-    p300racks = [protocol_context.load_labware(
-        'opentrons_96_tiprack_300ul', slot) for slot in ['5', '1', ]]
+    p300racks = [
+        protocol_context.load_labware("opentrons_96_tiprack_300ul", slot)
+        for slot in [
+            "5",
+            "1",
+        ]
+    ]
     # Pipette Setup
-    p20 = protocol_context.load_instrument('p20_single_gen2', 'left',
-                                           tip_racks=[p20rack])
-    p300 = protocol_context.load_instrument('p300_multi_gen2', 'right',
-                                            tip_racks=p300racks)
+    p20 = protocol_context.load_instrument(
+        "p20_single_gen2", "left", tip_racks=[p20rack]
+    )
+    p300 = protocol_context.load_instrument(
+        "p300_multi_gen2", "right", tip_racks=p300racks
+    )
     # Module Setup
-    magdeck = protocol_context.load_module('magneticModuleV2', '6')
-    mag_plate = magdeck.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
+    magdeck = protocol_context.load_module("magneticModuleV2", "6")
+    mag_plate = magdeck.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
 
-    tempdeck = protocol_context.load_module('temperatureModuleV2', '3')
+    tempdeck = protocol_context.load_module("temperatureModuleV2", "3")
     cool_reagents = tempdeck.load_labware(
-        'opentrons_24_aluminumblock_generic_2ml_screwcap')
+        "opentrons_24_aluminumblock_generic_2ml_screwcap"
+    )
 
-    thermocycler = protocol_context.load_module('thermocycler')
-    reaction_plate = thermocycler.load_labware(
-        'nest_96_wellplate_100ul_pcr_full_skirt')
+    thermocycler = protocol_context.load_module("thermocycler")
+    reaction_plate = thermocycler.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
 
     # Reagent Setup
-    enzymatic_prep_mm = cool_reagents.wells_by_name()['A1']
-    ligation_mm = cool_reagents.wells_by_name()['A2']
-    pcr_mm = cool_reagents.wells_by_name()['A3']
-    beads = rt_reagents.wells_by_name()['A2']
-    ethanol = rt_reagents.wells_by_name()['A3']
-    te = rt_reagents.wells_by_name()['A4']
-    waste = rt_reagents.wells_by_name()['A12']
+    enzymatic_prep_mm = cool_reagents.wells_by_name()["A1"]
+    ligation_mm = cool_reagents.wells_by_name()["A2"]
+    pcr_mm = cool_reagents.wells_by_name()["A3"]
+    beads = rt_reagents.wells_by_name()["A2"]
+    ethanol = rt_reagents.wells_by_name()["A3"]
+    te = rt_reagents.wells_by_name()["A4"]
+    waste = rt_reagents.wells_by_name()["A12"]
 
     # number of samples
     sample_num = 8
 
     # Destination of input DNA samples and samples on the magnetic module
     tc_samples = reaction_plate.columns_by_name()
-    enzymatic_prep_samples = tc_samples['2']
-    pcr_prep_samples = tc_samples['3']
-    purified_samples = tc_samples['4']
+    enzymatic_prep_samples = tc_samples["2"]
+    pcr_prep_samples = tc_samples["3"]
+    purified_samples = tc_samples["4"]
 
     # mag_samples = mag_plate.wells()[:sample_num]
     mag_column = mag_plate.columns_by_name()
-    mag_samples = mag_column['2']
+    mag_samples = mag_column["2"]
 
     p20.flow_rate.aspirate = 150
     p20.flow_rate.dispense = 300
@@ -234,8 +240,10 @@ def run(protocol_context):
     """PCR Prep"""
     # Transfer Dual Indexes to the sample
     # Primer screw tubes are shallow !!!!
-    primers = [well for well in cool_reagents.wells(
-        'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'C1', 'C2')][:sample_num]
+    primers = [
+        well
+        for well in cool_reagents.wells("B1", "B2", "B3", "B4", "B5", "B6", "C1", "C2")
+    ][:sample_num]
     for primer, well in zip(primers, pcr_prep_samples):
         p20.pick_up_tip()
         p20.aspirate(5, primer.top(-25))
@@ -271,12 +279,20 @@ def run(protocol_context):
     # PLATE_TEMP_HOLD_5 = (72, 300)
     PLATE_TEMP_POST = 4
     NUM_CYCLES = 5
-    CYCLED_STEPS = [{'temperature': PLATE_TEMP_HOLD_2[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_2[1]},
-                    {'temperature': PLATE_TEMP_HOLD_3[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_3[1]},
-                    {'temperature': PLATE_TEMP_HOLD_4[0],
-                     'hold_time_seconds': PLATE_TEMP_HOLD_4[1]}]
+    CYCLED_STEPS = [
+        {
+            "temperature": PLATE_TEMP_HOLD_2[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_2[1],
+        },
+        {
+            "temperature": PLATE_TEMP_HOLD_3[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_3[1],
+        },
+        {
+            "temperature": PLATE_TEMP_HOLD_4[0],
+            "hold_time_seconds": PLATE_TEMP_HOLD_4[1],
+        },
+    ]
 
     # Set PRE temp
     thermocycler.set_block_temperature(PLATE_TEMP_PRE)
@@ -284,8 +300,9 @@ def run(protocol_context):
     thermocycler.set_lid_temperature(105)
     thermocycler.close_lid()
     # Set HOLD1 temp
-    thermocycler.set_block_temperature(PLATE_TEMP_HOLD_1[0],
-                                       hold_time_seconds=PLATE_TEMP_HOLD_1[1])
+    thermocycler.set_block_temperature(
+        PLATE_TEMP_HOLD_1[0], hold_time_seconds=PLATE_TEMP_HOLD_1[1]
+    )
     # Loop HOLD2 - HOLD4 temps NUM_CYCLES times
     thermocycler.execute_profile(steps=CYCLED_STEPS, repetitions=NUM_CYCLES)
     # Set POST temp
@@ -293,7 +310,7 @@ def run(protocol_context):
     thermocycler.open_lid()
 
     # PCR purification
-    mag_samples = mag_column['3']
+    mag_samples = mag_column["3"]
 
     # Transfer samples to the Magnetic Module
     p300.flow_rate.aspirate = 10
@@ -354,9 +371,9 @@ def run(protocol_context):
     p300.dispense(180, mag_samples[0].top(-2))
     p300.blow_out()
     p300.air_gap(5)
-    #p300.drop_tip()
+    # p300.drop_tip()
     # protocol_context.delay(seconds=30)
-    #p300.pick_up_tip()
+    # p300.pick_up_tip()
     p300.aspirate(190, mag_samples[0])
     p300.air_gap(5)
     p300.dispense(190, waste)

--- a/api/tests/opentrons/data/mad_mag_v2.py
+++ b/api/tests/opentrons/data/mad_mag_v2.py
@@ -1,20 +1,20 @@
 from opentrons import types
 
 metadata = {
-    'protocolName': 'Mad Mag',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'A Magnetic Module Test',
-    'source': 'Opentrons Repository',
-    'apiLevel': '2.2'
+    "protocolName": "Mad Mag",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": "A Magnetic Module Test",
+    "source": "Opentrons Repository",
+    "apiLevel": "2.2",
 }
 
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    mm = ctx.load_module('magnetic module', 4)
-    lw = mm.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
-    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    mm = ctx.load_module("magnetic module", 4)
+    lw = mm.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
+    right = ctx.load_instrument("p300_single_gen2", types.Mount.RIGHT, [tr])
 
     mm.disengage()
 

--- a/api/tests/opentrons/data/python_v2_custom_lw.py
+++ b/api/tests/opentrons/data/python_v2_custom_lw.py
@@ -1,19 +1,19 @@
 from opentrons import types
 
 metadata = {
-    'protocolName': 'Testosaur (custom labware)',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'A variant on "Dinosaur" for testing custom labware',
-    'source': 'Opentrons Repository',
-    'apiLevel': '2.0'
+    "protocolName": "Testosaur (custom labware)",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'A variant on "Dinosaur" for testing custom labware',
+    "source": "Opentrons Repository",
+    "apiLevel": "2.0",
 }
 
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
-    lw = ctx.load_labware('fixture_96_plate', 2, namespace='fixture')
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    right = ctx.load_instrument("p300_single_gen2", types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware("fixture_96_plate", 2, namespace="fixture")
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/data/smoke.py
+++ b/api/tests/opentrons/data/smoke.py
@@ -1,19 +1,16 @@
 from opentrons import containers, instruments
 
 metadata = {
-    'protocolName': 'Smoke',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'Simple protocol to test the server',
-    'source': 'Opentrons Repository'
+    "protocolName": "Smoke",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": "Simple protocol to test the server",
+    "source": "Opentrons Repository",
 }
 
-tiprack = containers.load('tiprack-200ul', '8')
-plate = containers.load('96-PCR-flat', '5')
+tiprack = containers.load("tiprack-200ul", "8")
+plate = containers.load("96-PCR-flat", "5")
 
-pipette = instruments.P300_Single(
-    tip_racks=[tiprack],
-    mount="right"
-)
+pipette = instruments.P300_Single(tip_racks=[tiprack], mount="right")
 
 pipette.pick_up_tip()
 pipette.aspirate(plate[0])

--- a/api/tests/opentrons/data/test_simulate.py
+++ b/api/tests/opentrons/data/test_simulate.py
@@ -1,20 +1,20 @@
 from opentrons import types
 
 metadata = {
-    'protocolName': 'Test Simulate',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'Testing "simulate"',
-    'source': 'Opentrons Repository',
-    'apiLevel': '2.0',
+    "protocolName": "Test Simulate",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'Testing "simulate"',
+    "source": "Opentrons Repository",
+    "apiLevel": "2.0",
 }
 
 
 def run(ctx):
     ctx.comment(str(ctx.api_version))
     ctx.home()
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    right = ctx.load_instrument('p300_single', types.Mount.RIGHT, [tr])
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    right = ctx.load_instrument("p300_single", types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/data/testosaur-gen2-v2.py
+++ b/api/tests/opentrons/data/testosaur-gen2-v2.py
@@ -1,19 +1,19 @@
 from opentrons import types
 
 metadata = {
-    'protocolName': 'Testosaur',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'A variant on "Dinosaur" for testing',
-    'source': 'Opentrons Repository',
-    'apiLevel': '2.3'
+    "protocolName": "Testosaur",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'A variant on "Dinosaur" for testing',
+    "source": "Opentrons Repository",
+    "apiLevel": "2.3",
 }
 
 
 def run(ctx):
     ctx.home()
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    right = ctx.load_instrument('p300_single_gen2', types.Mount.RIGHT, [tr])
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    right = ctx.load_instrument("p300_single_gen2", types.Mount.RIGHT, [tr])
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
     right.pick_up_tip()
     right.aspirate(10, lw.wells()[0].bottom())
     right.dispense(10, lw.wells()[1].bottom())

--- a/api/tests/opentrons/data/testosaur.py
+++ b/api/tests/opentrons/data/testosaur.py
@@ -1,26 +1,20 @@
 from opentrons import instruments, containers
 
 metadata = {
-    'protocolName': 'Testosaur',
-    'author': 'Opentrons <engineering@opentrons.com>',
-    'description': 'A variant on "Dinosaur" for testing',
-    'source': 'Opentrons Repository'
+    "protocolName": "Testosaur",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'A variant on "Dinosaur" for testing',
+    "source": "Opentrons Repository",
 }
 
-p200rack = containers.load('tiprack-200ul', '5', 'tiprack')
+p200rack = containers.load("tiprack-200ul", "5", "tiprack")
 
 # create a p200 pipette on robot axis B
-p300 = instruments.P300_Single(
-    mount="right",
-    tip_racks=[p200rack])
+p300 = instruments.P300_Single(mount="right", tip_racks=[p200rack])
 
 p300.pick_up_tip()
 
-conts = [
-    containers.load('96-PCR-flat', slot)
-    for slot
-    in ('8', '11')
-]
+conts = [containers.load("96-PCR-flat", slot) for slot in ("8", "11")]
 
 # Uncomment these to test precision
 # p300.move_to(robot.deck['11'])

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -20,8 +20,8 @@ def mock_write_timeout_prop() -> PropertyMock:
 
 @pytest.fixture
 def mock_serial(
-        mock_timeout_prop: PropertyMock,
-        mock_write_timeout_prop: PropertyMock) -> MagicMock:
+    mock_timeout_prop: PropertyMock, mock_write_timeout_prop: PropertyMock
+) -> MagicMock:
     """Mock Serial"""
     m = MagicMock(spec=Serial)
     type(m).timeout = mock_timeout_prop
@@ -31,8 +31,8 @@ def mock_serial(
 
 @pytest.fixture
 async def subject(
-        loop: asyncio.AbstractEventLoop,
-        mock_serial: MagicMock) -> AsyncSerial:
+    loop: asyncio.AbstractEventLoop, mock_serial: MagicMock
+) -> AsyncSerial:
     """The test subject."""
     return AsyncSerial(serial=mock_serial, executor=ThreadPoolExecutor(), loop=loop)
 
@@ -42,19 +42,24 @@ async def subject(
     argvalues=[
         [None, 5],
         [5, 6],
-    ]
+    ],
 )
 async def test_write_timeout_override(
-        subject: AsyncSerial,
-        mock_write_timeout_prop: PropertyMock,
-        default: Optional[int], override: Optional[int]):
+    subject: AsyncSerial,
+    mock_write_timeout_prop: PropertyMock,
+    default: Optional[int],
+    override: Optional[int],
+):
     """It should override the timeout and return to default after the call."""
     mock_write_timeout_prop.return_value = default
     await subject.write(b"", override)
 
     # Three calls: read, override, reset default.
-    assert mock_write_timeout_prop.call_args_list ==\
-           [call(), call(override), call(default)]
+    assert mock_write_timeout_prop.call_args_list == [
+        call(),
+        call(override),
+        call(default),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -62,19 +67,20 @@ async def test_write_timeout_override(
     argvalues=[
         [None, 5],
         [5, 6],
-    ]
+    ],
 )
 async def test_read_timeout_override(
-        subject: AsyncSerial,
-        mock_timeout_prop: PropertyMock,
-        default: Optional[int], override: Optional[int]):
+    subject: AsyncSerial,
+    mock_timeout_prop: PropertyMock,
+    default: Optional[int],
+    override: Optional[int],
+):
     """It should override the timeout and return to default after the call."""
     mock_timeout_prop.return_value = default
     await subject.read_until(b"", override)
 
     # Three calls: read, override, reset default.
-    assert mock_timeout_prop.call_args_list == \
-           [call(), call(override), call(default)]
+    assert mock_timeout_prop.call_args_list == [call(), call(override), call(default)]
 
 
 @pytest.mark.parametrize(
@@ -83,12 +89,14 @@ async def test_read_timeout_override(
         [5, 5],
         [5, None],
         [None, None],
-    ]
+    ],
 )
 async def test_write_timeout_dont_override(
-        subject: AsyncSerial,
-        mock_write_timeout_prop: PropertyMock,
-        default: Optional[int], override: Optional[int]):
+    subject: AsyncSerial,
+    mock_write_timeout_prop: PropertyMock,
+    default: Optional[int],
+    override: Optional[int],
+):
     """It should not override the timeout if not necessary."""
     mock_write_timeout_prop.return_value = default
     await subject.write(b"", override)
@@ -102,12 +110,14 @@ async def test_write_timeout_dont_override(
         [5, 5],
         [5, None],
         [None, None],
-    ]
+    ],
 )
 async def test_read_timeout_dont_override(
-        subject: AsyncSerial,
-        mock_timeout_prop: PropertyMock,
-        default: Optional[int], override: Optional[int]):
+    subject: AsyncSerial,
+    mock_timeout_prop: PropertyMock,
+    default: Optional[int],
+    override: Optional[int],
+):
     """It should not override the timeout if not necessary."""
     mock_timeout_prop.return_value = default
     await subject.read_until(b"", override)

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -4,11 +4,12 @@ import pytest
 from mock import AsyncMock, call
 
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
-from opentrons.drivers.asyncio.communication.serial_connection import (
-    SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
+from opentrons.drivers.asyncio.communication import (
+    NoResponse,
+    AlarmResponse,
+    ErrorResponse,
 )
-from opentrons.drivers.asyncio.communication import NoResponse, AlarmResponse, \
-    ErrorResponse
 
 
 @pytest.fixture
@@ -30,12 +31,12 @@ def subject(mock_serial_port: AsyncMock, ack: str) -> SerialConnection:
         ack=ack,
         name="name",
         port="port",
-        retry_wait_time_seconds=0
+        retry_wait_time_seconds=0,
     )
 
 
 async def test_send_command(
-        mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
 ) -> None:
     """It should send a command."""
     serial_response = "response data " + ack
@@ -50,7 +51,7 @@ async def test_send_command(
 
 
 async def test_send_command_with_retry(
-        mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
 ) -> None:
     """It should retry sending after a read failure."""
     serial_response = "response data " + ack
@@ -59,14 +60,18 @@ async def test_send_command_with_retry(
     await subject.send_data(data="send data", retries=1)
 
     mock_serial_port.write.assert_has_calls(
-        calls=[call(data=b"send data"), call(data=b"send data")])
+        calls=[call(data=b"send data"), call(data=b"send data")]
+    )
     mock_serial_port.read_until.assert_has_calls(
-        calls=[call(match=ack.encode(), timeout=None),
-               call(match=ack.encode(), timeout=None)])
+        calls=[
+            call(match=ack.encode(), timeout=None),
+            call(match=ack.encode(), timeout=None),
+        ]
+    )
 
 
 async def test_send_command_with_retry_exhausted(
-        mock_serial_port: AsyncMock, subject: SerialConnection
+    mock_serial_port: AsyncMock, subject: SerialConnection
 ) -> None:
     """It should raise after retries exhausted."""
     mock_serial_port.read_until.side_effect = (b"", b"", b"")
@@ -76,9 +81,8 @@ async def test_send_command_with_retry_exhausted(
 
 
 async def test_send_command_response(
-        mock_serial_port: AsyncMock,
-        subject: SerialConnection,
-        ack: str) -> None:
+    mock_serial_port: AsyncMock, subject: SerialConnection, ack: str
+) -> None:
     """It should return response without the ack and stripped."""
     response_data = "response data"
     serial_response = f" {response_data}  {ack}"
@@ -98,20 +102,17 @@ async def test_send_command_response(
         ["alarm", AlarmResponse],
         ["ALARM", AlarmResponse],
         ["This is an Alarm", AlarmResponse],
-    ]
+    ],
 )
 def test_raise_on_error(
-        subject: SerialConnection,
-        response: str,
-        exception_type: Type[Exception]
+    subject: SerialConnection, response: str, exception_type: Type[Exception]
 ) -> None:
     """It should raise an exception on error/alarm responses."""
     with pytest.raises(expected_exception=exception_type, match=response):
         subject.raise_on_error(response)
 
 
-async def test_on_retry(mock_serial_port: AsyncMock,
-                        subject: SerialConnection) -> None:
+async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialConnection) -> None:
     """It should try to re-open connection."""
     await subject.on_retry()
 

--- a/api/tests/opentrons/drivers/mag_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/mag_deck/test_driver.py
@@ -1,10 +1,11 @@
 from mock import AsyncMock
 import pytest
 
-from opentrons.drivers.asyncio.communication.serial_connection import \
-    SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
 from opentrons.drivers.mag_deck.driver import (
-    MagDeckDriver, MAG_DECK_COMMAND_TERMINATOR, GCODE_ROUNDING_PRECISION
+    MagDeckDriver,
+    MAG_DECK_COMMAND_TERMINATOR,
+    GCODE_ROUNDING_PRECISION,
 )
 from opentrons.drivers.command_builder import CommandBuilder
 
@@ -24,9 +25,9 @@ async def test_home(driver: MagDeckDriver, connection: AsyncMock) -> None:
     """It should send a home command"""
     await driver.home()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="G28.2")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="G28.2"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
@@ -35,9 +36,9 @@ async def test_probe_plate(driver: MagDeckDriver, connection: AsyncMock) -> None
     """It should send a probe plate command"""
     await driver.probe_plate()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="G38.2")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="G38.2"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
@@ -48,9 +49,9 @@ async def test_get_plate_height(driver: MagDeckDriver, connection: AsyncMock) ->
 
     response = await driver.get_plate_height()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M836")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="M836"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
@@ -63,9 +64,9 @@ async def test_get_mag_position(driver: MagDeckDriver, connection: AsyncMock) ->
 
     response = await driver.get_mag_position()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M114.2")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="M114.2"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
@@ -76,13 +77,13 @@ async def test_move(driver: MagDeckDriver, connection: AsyncMock) -> None:
     """It should send a move command"""
     await driver.move(321.2214)
 
-    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
-        gcode="G0"
-    ).add_float(prefix="Z", value=321.2214, precision=GCODE_ROUNDING_PRECISION)
-
-    connection.send_command.assert_called_once_with(
-        command=expected, retries=3
+    expected = (
+        CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR)
+        .add_gcode(gcode="G0")
+        .add_float(prefix="Z", value=321.2214, precision=GCODE_ROUNDING_PRECISION)
     )
+
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
 async def test_get_device_info(driver: MagDeckDriver, connection: AsyncMock) -> None:
@@ -91,9 +92,9 @@ async def test_get_device_info(driver: MagDeckDriver, connection: AsyncMock) -> 
 
     response = await driver.get_device_info()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M115")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="M115"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
@@ -101,12 +102,13 @@ async def test_get_device_info(driver: MagDeckDriver, connection: AsyncMock) -> 
 
 
 async def test_enter_programming_mode(
-        driver: MagDeckDriver, connection: AsyncMock) -> None:
+    driver: MagDeckDriver, connection: AsyncMock
+) -> None:
     """It should send an enter programming mode command"""
     await driver.enter_programming_mode()
 
-    expected = CommandBuilder(
-        terminator=MAG_DECK_COMMAND_TERMINATOR
-    ).add_gcode(gcode="dfu")
+    expected = CommandBuilder(terminator=MAG_DECK_COMMAND_TERMINATOR).add_gcode(
+        gcode="dfu"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)

--- a/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
+++ b/api/tests/opentrons/drivers/rpi_drivers/test_usb.py
@@ -7,50 +7,49 @@ from opentrons.drivers.rpi_drivers.usb import USBBus
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 fake_bus_og = [
-    '/sys/bus/usb/devices/usb1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.0/tty/ttyAMA0/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/0003:046D:C52B.0017/hidraw/hidraw0/dev',  # noqa: E501
-    '/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/usbmisc/hiddev0/dev'
+    "/sys/bus/usb/devices/usb1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.0/tty/ttyAMA0/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/0003:046D:C52B.0017/hidraw/hidraw0/dev",  # noqa: E501
+    "/sys/bus/usb/devices/usb1/1-1/1-1.5/1-1.5:1.2/usbmisc/hiddev0/dev",
 ]
 
 filtered_ports_og = [
-    '1-1.3/1-1.3:1.0/tty/ttyACM1/dev',
-    '1-1.5/1-1.5:1.0/tty/ttyAMA0/dev',
-    '1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev',
-    '1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev'
+    "1-1.3/1-1.3:1.0/tty/ttyACM1/dev",
+    "1-1.5/1-1.5:1.0/tty/ttyAMA0/dev",
+    "1-1.5/1-1.5/1-1.5.1/1-1.5.1:1.0/tty/ttyAMA1/dev",
+    "1-1.5/1-1.5/1-1.5.3/1-1.5.3:1.0/tty/ttyACM2/dev",
 ]
 
 fake_bus_refresh = [
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev',
-    '/sys/bus/usb/devices/usb1/1-1/1-1.1/dev',
-    '/sys/bus/usb/devices/usb1/1-1/dev'
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev",
+    "/sys/bus/usb/devices/usb1/1-1/1-1.1/dev",
+    "/sys/bus/usb/devices/usb1/1-1/dev",
 ]
 
 filtered_port_refresh = [
-    '1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev',
-    '1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev'
+    "1-1.3/1-1.3.1/1-1.3.1:1.0/tty/ttyACM1/dev",
+    "1-1.3/1-1.3.2/1-1.3.2:1.0/tty/ttyACM0/dev",
 ]
 
 
 @pytest.fixture
 def usb_bus() -> USBBus:
-
     @staticmethod
     def fake_read_bus():
         return fake_bus_og
 
-    with patch.object(USBBus, 'read_bus', fake_read_bus):
+    with patch.object(USBBus, "read_bus", fake_read_bus):
         yield USBBus(BoardRevision.OG)
 
 
@@ -65,7 +64,7 @@ def usb_revision(request) -> USBBus:
         else:
             return fake_bus_refresh
 
-    with patch.object(USBBus, 'read_bus', fake_read_bus):
+    with patch.object(USBBus, "read_bus", fake_read_bus):
         yield USBBus(revision)
 
 
@@ -74,39 +73,34 @@ def test_usb_list_output(usb_revision) -> None:
         filtered = filtered_ports_og
     else:
         filtered = filtered_port_refresh
-    expected_ports = [
-        USBPort.build(p, usb_revision._board_revision)
-        for p in filtered]
+    expected_ports = [USBPort.build(p, usb_revision._board_revision) for p in filtered]
     assert usb_revision.usb_dev == expected_ports
     regular_port = expected_ports[0]
 
     if usb_revision._board_revision == BoardRevision.OG:
-        assert regular_port.name == '1-1.3'
+        assert regular_port.name == "1-1.3"
         assert regular_port.hub is None
         assert regular_port.port_number == 1
         assert regular_port.sub_names == []
 
         hub_port = expected_ports[2]
-        assert hub_port.name == '1-1.5.1'
+        assert hub_port.name == "1-1.5.1"
         assert hub_port.hub == 2
         assert hub_port.port_number == 1
         assert hub_port.sub_names == []
     else:
         regular_port2 = expected_ports[1]
-        assert regular_port.name == '1-1.3.1'
+        assert regular_port.name == "1-1.3.1"
         assert regular_port.hub is None
         assert regular_port.port_number == 1
 
-        assert regular_port2.name == '1-1.3.2'
+        assert regular_port2.name == "1-1.3.2"
         assert regular_port2.hub is None
         assert regular_port2.port_number == 2
 
 
 def test_find_device(usb_bus: USBBus) -> None:
-    device_paths = [
-        '/tty/ttyACM1/dev',
-        '/tty/ttyAMA1/dev',
-        '/tty/ttyAMA0/dev']
+    device_paths = ["/tty/ttyACM1/dev", "/tty/ttyAMA1/dev", "/tty/ttyAMA0/dev"]
     for dp in device_paths:
         port = usb_bus.find_port(dp)
         assert port in usb_bus.usb_dev
@@ -117,35 +111,33 @@ def test_unplug_device(usb_bus: USBBus) -> None:
 
     copy_bus = copy.copy(fake_bus_og)
     copy_ports = copy.copy(filtered_ports_og)
-    u = '/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev'
+    u = "/sys/bus/usb/devices/usb1/1-1/1-1.3/1-1.3:1.0/tty/ttyACM1/dev"
     copy_bus.remove(u)
-    copy_ports.remove('1-1.3/1-1.3:1.0/tty/ttyACM1/dev')
+    copy_ports.remove("1-1.3/1-1.3:1.0/tty/ttyACM1/dev")
 
     usb_bus.read_bus = MagicMock(return_value=copy_bus)
     usb_bus.sort_ports()
 
-    expected_ports = [
-        USBPort.build(p, usb_bus._board_revision)
-        for p in copy_ports]
+    expected_ports = [USBPort.build(p, usb_bus._board_revision) for p in copy_ports]
     assert usb_bus.usb_dev == expected_ports
 
 
 def test_sorted_usb_bus(usb_bus: USBBus) -> None:
-    expected_sorted = {'1-1.3', '1-1.5.1', '1-1.5.3', '1-1.5'}
+    expected_sorted = {"1-1.3", "1-1.5.1", "1-1.5.3", "1-1.5"}
     assert usb_bus.sorted_ports == expected_sorted
 
 
 def test_modify_module_list(usb_bus: USBBus):
-    usb_bus.read_symlink = MagicMock(return_value='ttyACM1')
-    mod_at_port_list = [ModuleAtPort(
-        name='temperature module',
-        port='dev/ot_module_temperature_module')]
+    usb_bus.read_symlink = MagicMock(return_value="ttyACM1")
+    mod_at_port_list = [
+        ModuleAtPort(name="temperature module", port="dev/ot_module_temperature_module")
+    ]
     updated_list = usb_bus.match_virtual_ports(mod_at_port_list)
     assert updated_list[0].usb_port == usb_bus.usb_dev[0]
 
-    usb_bus.read_symlink = MagicMock(return_value='ttyACM2')
-    mod_at_port_list = [ModuleAtPort(
-        name='magnetic module',
-        port='dev/ot_module_magnetic_module')]
+    usb_bus.read_symlink = MagicMock(return_value="ttyACM2")
+    mod_at_port_list = [
+        ModuleAtPort(name="magnetic module", port="dev/ot_module_magnetic_module")
+    ]
     updated_list = usb_bus.match_virtual_ports(mod_at_port_list)
     assert updated_list[0].usb_port == usb_bus.usb_dev[3]

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_connection.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_connection.py
@@ -3,8 +3,7 @@ from mock import AsyncMock
 from opentrons.drivers.asyncio.communication import AsyncSerial
 from opentrons.drivers.smoothie_drivers.connection import SmoothieConnection
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.smoothie_drivers.constants import \
-    SMOOTHIE_COMMAND_TERMINATOR
+from opentrons.drivers.smoothie_drivers.constants import SMOOTHIE_COMMAND_TERMINATOR
 
 
 @pytest.fixture
@@ -17,27 +16,28 @@ def mock_serial_connection() -> AsyncMock:
 def subject(mock_serial_connection: AsyncMock) -> SmoothieConnection:
     """The test subject."""
     return SmoothieConnection(
-        serial=mock_serial_connection, port="", ack="\r\n", name="",
-        retry_wait_time_seconds=0
+        serial=mock_serial_connection,
+        port="",
+        ack="\r\n",
+        name="",
+        retry_wait_time_seconds=0,
     )
 
 
 @pytest.fixture
 def command() -> CommandBuilder:
     """A command fixture"""
-    return CommandBuilder(
-        terminator=SMOOTHIE_COMMAND_TERMINATOR
-    ).add_gcode(
-        "M123"
-    ).add_int(
-        "F", 2
+    return (
+        CommandBuilder(terminator=SMOOTHIE_COMMAND_TERMINATOR)
+        .add_gcode("M123")
+        .add_int("F", 2)
     )
 
 
 async def test_command_sender_sanitized_response(
-        subject: SmoothieConnection,
-        mock_serial_connection: AsyncMock,
-        command: CommandBuilder
+    subject: SmoothieConnection,
+    mock_serial_connection: AsyncMock,
+    command: CommandBuilder,
 ) -> None:
     """It should return sanitized result."""
     sanitized_body = "a"
@@ -58,29 +58,28 @@ async def test_command_sender_sanitized_response(
         ["G28.2B G1", "G1G28.2BG1", ""],
         # Remove command and whitespace from response
         ["\r\nG52\r\n\r\n", "\r\nG52\r\n\r\n", ""],
-        ["\r\nG52\r\n\r\nsome-data\r\nok\r\n",
-         "\r\nG52\r\n\r\nsome-data\r\nok\r\nTESTS-RULE",
-         "TESTS-RULE"
-         ],
-        ["\r\nG52\r\n\r\nsome-data\r\nok\r\n",
-         "G52\r\n\r\nsome-data\r\nokT\r\nESTS-RULE",
-         "TESTS-RULE"],
+        [
+            "\r\nG52\r\n\r\nsome-data\r\nok\r\n",
+            "\r\nG52\r\n\r\nsome-data\r\nok\r\nTESTS-RULE",
+            "TESTS-RULE",
+        ],
+        [
+            "\r\nG52\r\n\r\nsome-data\r\nok\r\n",
+            "G52\r\n\r\nsome-data\r\nokT\r\nESTS-RULE",
+            "TESTS-RULE",
+        ],
         # L is not a command echo but a token
-        ["M371 L \r\n\r\n",
-         "L:703130",
-         "L:703130"],
+        ["M371 L \r\n\r\n", "L:703130", "L:703130"],
         # R is not a command echo but a token
-        ["M3 R \r\n\r\n",
-         "M3R:703130",
-         "R:703130"],
-        ["M369 L \r\n\r\n",
-         "M369 L \r\n\r\nL:5032304D56323032303230303432323036000000000000000000000000000000",  # noqa: E501
-         "L:5032304D56323032303230303432323036000000000000000000000000000000"]
-    ]
+        ["M3 R \r\n\r\n", "M3R:703130", "R:703130"],
+        [
+            "M369 L \r\n\r\n",
+            "M369 L \r\n\r\nL:5032304D56323032303230303432323036000000000000000000000000000000",  # noqa: E501
+            "L:5032304D56323032303230303432323036000000000000000000000000000000",
+        ],
+    ],
 )
-def test_remove_serial_echo(
-        cmd: str, resp: str, expected: str):
+def test_remove_serial_echo(cmd: str, resp: str, expected: str):
     """It should remove unwanted characters only."""
-    res = SmoothieConnection._remove_unwanted_characters(
-        cmd, resp)
+    res = SmoothieConnection._remove_unwanted_characters(cmd, resp)
     assert res == expected

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_driver.py
@@ -5,10 +5,11 @@ from opentrons.drivers import utils
 from opentrons.drivers.asyncio.communication import AlarmResponse
 from mock import AsyncMock
 import pytest
-from opentrons.drivers.smoothie_drivers.connection import \
-    SmoothieConnection
-from opentrons.drivers.smoothie_drivers.constants import HOMED_POSITION, \
-    Y_BOUND_OVERRIDE
+from opentrons.drivers.smoothie_drivers.connection import SmoothieConnection
+from opentrons.drivers.smoothie_drivers.constants import (
+    HOMED_POSITION,
+    Y_BOUND_OVERRIDE,
+)
 from opentrons.drivers.rpi_drivers.gpio_simulator import SimulatingGPIOCharDev
 
 from opentrons.drivers.smoothie_drivers import driver_3_0, constants
@@ -32,69 +33,54 @@ def smoothie(mock_connection: AsyncMock, sim_gpio) -> driver_3_0.SmoothieDriver:
     from opentrons.config import robot_configs
 
     d = driver_3_0.SmoothieDriver(
-        connection=mock_connection,
-        config=robot_configs.load(),
-        gpio_chardev=sim_gpio
+        connection=mock_connection, config=robot_configs.load(), gpio_chardev=sim_gpio
     )
     yield d
 
 
 def position(x, y, z, a, b, c):
-    return {axis: value for axis, value in zip('XYZABC', [x, y, z, a, b, c])}
+    return {axis: value for axis, value in zip("XYZABC", [x, y, z, a, b, c])}
 
 
-async def test_update_position(smoothie: driver_3_0.SmoothieDriver,
-                               mock_connection: AsyncMock) -> None:
+async def test_update_position(
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+) -> None:
     """It should update the position."""
-    mock_connection.send_command.return_value =\
-        'ok MCS: X:1.0000 Y:2.0000 Z:3.0000 A:4.5000 B:0.0000 C:0.0000'
+    mock_connection.send_command.return_value = (
+        "ok MCS: X:1.0000 Y:2.0000 Z:3.0000 A:4.5000 B:0.0000 C:0.0000"
+    )
 
     await smoothie.update_position()
-    expected = {
-        'X': 1,
-        'Y': 2,
-        'Z': 3,
-        'A': 4.5,
-        'B': 0,
-        'C': 0
-    }
+    expected = {"X": 1, "Y": 2, "Z": 3, "A": 4.5, "B": 0, "C": 0}
     assert smoothie.position == expected
 
 
 async def test_update_position_retry(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ) -> None:
     """It should retry after a parse error."""
     mock_connection.send_command.side_effect = [
         # first attempt to read, we get bad data
-        'ok MCS: X:0.0000 Y:MISTAKE Z:0.0000 A:0.0000 B:0.0000 C:0.0000',
-        'ok',
+        "ok MCS: X:0.0000 Y:MISTAKE Z:0.0000 A:0.0000 B:0.0000 C:0.0000",
+        "ok",
         # following attempts to read, we get good data
-        'ok MCS: X:0.0000 Y:321.00 Z:0.0000 A:0.0000 B:0.0000 C:0.0000',
-        'ok',
+        "ok MCS: X:0.0000 Y:321.00 Z:0.0000 A:0.0000 B:0.0000 C:0.0000",
+        "ok",
     ]
 
     await smoothie.update_position()
-    expected = {
-        'X': 0,
-        'Y': 321.00,
-        'Z': 0,
-        'A': 0,
-        'B': 0,
-        'C': 0
-    }
+    expected = {"X": 0, "Y": 321.00, "Z": 0, "A": 0, "B": 0, "C": 0}
     assert smoothie.position == expected
 
 
 def test_active_dwelling_current_push_pop(smoothie):
-    assert smoothie._active_current_settings != \
-           smoothie._dwelling_current_settings
+    assert smoothie._active_current_settings != smoothie._dwelling_current_settings
 
     old_active_currents = deepcopy(smoothie._active_current_settings)
     old_dwelling_currents = deepcopy(smoothie._dwelling_current_settings)
 
     smoothie.push_active_current()
-    smoothie.set_active_current({'X': 2.0, 'Y': 2.0, 'Z': 2.0, 'A': 2.0})
+    smoothie.set_active_current({"X": 2.0, "Y": 2.0, "Z": 2.0, "A": 2.0})
     smoothie.pop_active_current()
 
     assert smoothie._active_current_settings == old_active_currents
@@ -105,76 +91,84 @@ async def test_functional(smoothie: driver_3_0.SmoothieDriver):
     smoothie.simulating = True
     assert smoothie.position == position(0, 0, 0, 0, 0, 0)
 
-    await smoothie.move({'X': 0, 'Y': 1, 'Z': 2, 'A': 3, 'B': 4, 'C': 5})
+    await smoothie.move({"X": 0, "Y": 1, "Z": 2, "A": 3, "B": 4, "C": 5})
     assert smoothie.position == position(0, 1, 2, 3, 4, 5)
 
-    await smoothie.move({'X': 1, 'Z': 3, 'C': 6})
+    await smoothie.move({"X": 1, "Z": 3, "C": 6})
     assert smoothie.position == position(1, 1, 3, 3, 4, 6)
 
-    await smoothie.home(axis='abc', disabled='')
+    await smoothie.home(axis="abc", disabled="")
     assert smoothie.position == position(
-        1, 1, 3,
-        smoothie.homed_position['A'],
-        smoothie.homed_position['B'],
-        smoothie.homed_position['C'])
+        1,
+        1,
+        3,
+        smoothie.homed_position["A"],
+        smoothie.homed_position["B"],
+        smoothie.homed_position["C"],
+    )
 
-    await smoothie.home(disabled='')
+    await smoothie.home(disabled="")
     assert smoothie.position == smoothie.homed_position
 
 
 async def test_read_pipette_v13(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ):
-    mock_connection.send_command.return_value =\
-        'L:' + utils.string_to_hex("p300_single_v13")
-    res = await smoothie.read_pipette_model('left')
-    assert res == 'p300_single_v1.3'
+    mock_connection.send_command.return_value = "L:" + utils.string_to_hex(
+        "p300_single_v13"
+    )
+    res = await smoothie.read_pipette_model("left")
+    assert res == "p300_single_v1.3"
 
 
 async def test_switch_state(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ):
-    smoothie_switch_res = 'X_max:0 Y_max:0 Z_max:0 A_max:0 B_max:0 C_max:0' \
-                          ' _pins ' \
-                          '(XL)2.01:0 (YL)2.01:0 (ZL)2.01:0 ' \
-                          '(AL)2.01:0 (BL)2.01:0 (CL)2.01:0 Probe: 0\r\n'
+    smoothie_switch_res = (
+        "X_max:0 Y_max:0 Z_max:0 A_max:0 B_max:0 C_max:0"
+        " _pins "
+        "(XL)2.01:0 (YL)2.01:0 (ZL)2.01:0 "
+        "(AL)2.01:0 (BL)2.01:0 (CL)2.01:0 Probe: 0\r\n"
+    )
 
     mock_connection.send_command.return_value = smoothie_switch_res
 
     expected = {
-        'X': False,
-        'Y': False,
-        'Z': False,
-        'A': False,
-        'B': False,
-        'C': False,
-        'Probe': False
+        "X": False,
+        "Y": False,
+        "Z": False,
+        "A": False,
+        "B": False,
+        "C": False,
+        "Probe": False,
     }
     r = await smoothie.switch_state()
     assert r == expected
 
-    smoothie_switch_res = 'X_max:0 Y_max:0 Z_max:0 A_max:1 B_max:0 C_max:0' \
-                          ' _pins ' \
-                          '(XL)2.01:0 (YL)2.01:0 (ZL)2.01:0 ' \
-                          '(AL)2.01:0 (BL)2.01:0 (CL)2.01:0 Probe: 1\r\n'
+    smoothie_switch_res = (
+        "X_max:0 Y_max:0 Z_max:0 A_max:1 B_max:0 C_max:0"
+        " _pins "
+        "(XL)2.01:0 (YL)2.01:0 (ZL)2.01:0 "
+        "(AL)2.01:0 (BL)2.01:0 (CL)2.01:0 Probe: 1\r\n"
+    )
 
     mock_connection.send_command.return_value = smoothie_switch_res
 
     expected = {
-        'X': False,
-        'Y': False,
-        'Z': False,
-        'A': True,
-        'B': False,
-        'C': False,
-        'Probe': True
+        "X": False,
+        "Y": False,
+        "Z": False,
+        "A": True,
+        "B": False,
+        "C": False,
+        "Probe": True,
     }
     r = await smoothie.switch_state()
     assert r == expected
 
 
 async def test_clear_limit_switch(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ):
     """
     This functions as a contract test around recovery from a limit-switch hit.
@@ -190,9 +184,9 @@ async def test_clear_limit_switch(
         if constants.GCODE.MOVE in command:
             raise AlarmResponse(port="", response="ALARM: Hard limit +C")
         elif constants.GCODE.CURRENT_POSITION in command:
-            return 'ok M114.2 X:10 Y:20 Z:30 A:40 B:50 C:60'
+            return "ok M114.2 X:10 Y:20 Z:30 A:40 B:50 C:60"
         elif constants.GCODE.HOMING_STATUS in command:
-            return 'X:1 Y:1 Z:1 A:1 B:1 C:1'
+            return "X:1 Y:1 Z:1 A:1 B:1 C:1"
         else:
             return "ok"
 
@@ -200,39 +194,39 @@ async def test_clear_limit_switch(
 
     # This will cause a limit-switch error and not back off
     with pytest.raises(driver_3_0.SmoothieError):
-        await smoothie.move({'C': 100})
+        await smoothie.move({"C": 100})
 
     assert [c.strip() for c in cmd_list] == [
         # attempt to move and fail
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 C100.3 G0 C100',
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 C100.3 G0 C100",
         # recover from failure
-        'M999',
-        'M400',
-        'G28.6',
-        'M400',
+        "M999",
+        "M400",
+        "G28.6",
+        "M400",
         # set current for homing the failed axis (C)
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G28.2 C',
-        'M400',
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G28.2 C",
+        "M400",
         # set current back to idling after home
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
         # update position
-        'M114.2',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
+        "M114.2",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
     ]
 
 
 async def test_unstick_axes(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ):
     cmd_list = []
 
     def write_mock(command, retries, timeout):
         cmd_list.append(command.build())
         if constants.GCODE.LIMIT_SWITCH_STATUS in command:
-            return 'X_max:0 Y_max:0 Z_max:0 A_max:0 B_max:0 C_max:0 Probe: 0 \r\n'
+            return "X_max:0 Y_max:0 Z_max:0 A_max:0 B_max:0 C_max:0 Probe: 0 \r\n"
         else:
             return "ok"
 
@@ -241,16 +235,16 @@ async def test_unstick_axes(
     await smoothie.unstick_axes(axes="ABCXYZ", distance=2, speed=3)
 
     assert [c.strip() for c in cmd_list] == [
-        'M203.1 A3 B3 C3 X3 Y3 Z3',
-        'M400',
-        'M119',
-        'M400',
-        'M907 A0.5 B0.05 C0.05 X1.25 Y1.25 Z0.5 G4 P0.005 G0 A-2 B-2 C-2 X-2 Y-2 Z-2',
-        'M400',
-        'M907 A0.5 B0.05 C0.05 X1.25 Y1.25 Z0.5 G4 P0.005',
-        'M400',
-        'M203.1 A125 B40 C40 X600 Y400 Z125',
-        'M400',
+        "M203.1 A3 B3 C3 X3 Y3 Z3",
+        "M400",
+        "M119",
+        "M400",
+        "M907 A0.5 B0.05 C0.05 X1.25 Y1.25 Z0.5 G4 P0.005 G0 A-2 B-2 C-2 X-2 Y-2 Z-2",
+        "M400",
+        "M907 A0.5 B0.05 C0.05 X1.25 Y1.25 Z0.5 G4 P0.005",
+        "M400",
+        "M203.1 A125 B40 C40 X600 Y400 Z125",
+        "M400",
     ]
 
 
@@ -261,13 +255,18 @@ async def test_unstick_axes(
         [{k: False for k in "XYZABC"}, "XA", "XA"],
         [{k: False for k in "XYZABC"}, "XY", "XY"],
         [{k: False for k in "XYZABC"}, "XYZABC", "XYZABC"],
-        [{"A": True, "B": False, "C": True,
-          "X": False, "Y": True, "Z": False}, "XYZABC", "XZB"],
-    ]
+        [
+            {"A": True, "B": False, "C": True, "X": False, "Y": True, "Z": False},
+            "XYZABC",
+            "XZB",
+        ],
+    ],
 )
 async def test_home_flagged_axes(
-        smoothie: driver_3_0.SmoothieDriver, home_flags: Dict[str, bool],
-        axis_string: str, expected: str
+    smoothie: driver_3_0.SmoothieDriver,
+    home_flags: Dict[str, bool],
+    axis_string: str,
+    expected: str,
 ) -> None:
     """It should only home un-homed axes."""
     smoothie.home = AsyncMock()
@@ -283,9 +282,8 @@ async def test_home_flagged_axes(
     argvalues=[
         [{k: True for k in "XYZABC"}, "A"],
         [{k: True for k in "XYZABC"}, "XYZABC"],
-        [{"A": True, "B": False, "C": True,
-          "X": False, "Y": True, "Z": False}, "ACY"],
-    ]
+        [{"A": True, "B": False, "C": True, "X": False, "Y": True, "Z": False}, "ACY"],
+    ],
 )
 async def test_home_flagged_axes_no_call(
     smoothie: driver_3_0.SmoothieDriver, home_flags: Dict[str, bool], axis_string: str
@@ -300,39 +298,32 @@ async def test_home_flagged_axes_no_call(
 
 
 async def test_update_homed_flags_retry(
-        smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
+    smoothie: driver_3_0.SmoothieDriver, mock_connection: AsyncMock
 ) -> None:
     """It should retry."""
     mock_connection.is_open.return_value = True
 
     # Set all to false
-    await smoothie.update_homed_flags({
-        k: False for k in "ABCXYZ"
-    })
+    await smoothie.update_homed_flags({k: False for k in "ABCXYZ"})
 
     # First response is error then all axes homed
     mock_connection.send_command.side_effect = [
         # first attempt to read, we get bad data
-        'ok AX:1 BBY:0 Z:0 A:0 B:0 C:0',
-        'ok',
-        'ok X:1 Y:1 Z:1 A:1 B:1 C:1',
-        'ok',
+        "ok AX:1 BBY:0 Z:0 A:0 B:0 C:0",
+        "ok",
+        "ok X:1 Y:1 Z:1 A:1 B:1 C:1",
+        "ok",
     ]
 
     await smoothie.update_homed_flags()
 
-    assert smoothie.homed_flags == {
-        k: True for k in "ABCXYZ"
-    }
+    assert smoothie.homed_flags == {k: True for k in "ABCXYZ"}
 
 
-def test_axis_bounds(
-        smoothie: driver_3_0.SmoothieDriver
-) -> None:
+def test_axis_bounds(smoothie: driver_3_0.SmoothieDriver) -> None:
     """It should override Y."""
     bounds = smoothie.axis_bounds
 
     assert bounds == {
-        k: (v if k != 'Y' else Y_BOUND_OVERRIDE)
-        for k, v in HOMED_POSITION.items()
+        k: (v if k != "Y" else Y_BOUND_OVERRIDE) for k, v in HOMED_POSITION.items()
     }

--- a/api/tests/opentrons/drivers/smoothie_drivers/test_parse_utils.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/test_parse_utils.py
@@ -5,15 +5,15 @@ from opentrons.drivers.utils import ParseError
 
 
 def test_parse_position_response():
-    good_data = 'ok M114.2 X:10 Y:20 Z:30 A:40 B:50 C:60'
+    good_data = "ok M114.2 X:10 Y:20 Z:30 A:40 B:50 C:60"
     res = parse_utils.parse_position_response(good_data)
     expected = {
-        'X': 10,
-        'Y': 20,
-        'Z': 30,
-        'A': 40,
-        'B': 50,
-        'C': 60,
+        "X": 10,
+        "Y": 20,
+        "Z": 30,
+        "A": 40,
+        "B": 50,
+        "C": 60,
     }
     assert res == expected
 
@@ -23,8 +23,8 @@ def test_parse_position_response():
     argvalues=[
         [""],
         ["ok M114.2 X:10 Y:20: Z:30A:40 B:50 C:60"],
-        ['ok M114.2 X:10 Y:20: Z:30 A:40 B:50']
-    ]
+        ["ok M114.2 X:10 Y:20: Z:30 A:40 B:50"],
+    ],
 )
 def test_parse_position_response_error(data: str):
     with pytest.raises(ParseError):
@@ -32,11 +32,10 @@ def test_parse_position_response_error(data: str):
 
 
 def test_parse_pipette_data():
-    msg = 'TestsRule!!'
-    mount = 'L'
-    good_data = mount + ': ' + utils.string_to_hex(msg)
-    parsed = parse_utils.parse_instrument_data(
-        good_data).get(mount)
+    msg = "TestsRule!!"
+    mount = "L"
+    good_data = mount + ": " + utils.string_to_hex(msg)
+    parsed = parse_utils.parse_instrument_data(good_data).get(mount)
     assert parsed.decode() == msg
 
 
@@ -44,10 +43,10 @@ def test_parse_pipette_data():
     argnames=["data"],
     argvalues=[
         [""],
-        ['X:'],
-        ['X:4049'],
-        ['L:0.212'],
-    ]
+        ["X:"],
+        ["X:4049"],
+        ["L:0.212"],
+    ],
 )
 def test_parse_pipette_data_error(data: str):
     with pytest.raises(ParseError):

--- a/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
+++ b/api/tests/opentrons/drivers/smoothie_drivers/v3_0_0/test_driver_position_cache.py
@@ -1,9 +1,7 @@
 import pytest
 from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
-from opentrons.drivers.smoothie_drivers.constants import (
-    AXES, HOMED_POSITION as HP
-)
+from opentrons.drivers.smoothie_drivers.constants import AXES, HOMED_POSITION as HP
 
 POSITION_ON_BOOT = {axis: 0 for axis in AXES}
 
@@ -17,27 +15,30 @@ async def test_home(smoothie: SmoothieDriver):
     assert smoothie.position == HP
 
 
-@pytest.mark.parametrize("target_movement, expected_new_position", [
-    (
-        {'X': 1, 'Y': 1, 'Z': 1, 'A': 1, 'B': 1, 'C': 1},
-        {'X': 1, 'Y': 1, 'Z': 1, 'A': 1, 'B': 1, 'C': 1}
-    ),
-    (
-        {'X': 10, 'Y': 21, 'A': 1, 'C': 1},
-        {'X': 10, 'Y': 21, 'Z': HP.get('Z'), 'A': 1, 'B': HP.get('B'), 'C': 1}
-    ),
-    (
-        {'Z': 10, 'B': 21, 'C': 1},
-        {
-            'X': HP.get('X'),
-            'Y': HP.get('Y'),
-            'Z': 10,
-            'A': HP.get('A'),
-            'B': 21,
-            'C': 1
-        }
-    )
-])
+@pytest.mark.parametrize(
+    "target_movement, expected_new_position",
+    [
+        (
+            {"X": 1, "Y": 1, "Z": 1, "A": 1, "B": 1, "C": 1},
+            {"X": 1, "Y": 1, "Z": 1, "A": 1, "B": 1, "C": 1},
+        ),
+        (
+            {"X": 10, "Y": 21, "A": 1, "C": 1},
+            {"X": 10, "Y": 21, "Z": HP.get("Z"), "A": 1, "B": HP.get("B"), "C": 1},
+        ),
+        (
+            {"Z": 10, "B": 21, "C": 1},
+            {
+                "X": HP.get("X"),
+                "Y": HP.get("Y"),
+                "Z": 10,
+                "A": HP.get("A"),
+                "B": 21,
+                "C": 1,
+            },
+        ),
+    ],
+)
 async def test_move(target_movement, expected_new_position, smoothie: SmoothieDriver):
     await smoothie.home()
     await smoothie.move(target_movement)

--- a/api/tests/opentrons/drivers/temp_deck/test_driver.py
+++ b/api/tests/opentrons/drivers/temp_deck/test_driver.py
@@ -1,11 +1,11 @@
 from mock import AsyncMock
 import pytest
 
-from opentrons.drivers.asyncio.communication.serial_connection import \
-    SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
 from opentrons.drivers.temp_deck.abstract import Temperature
 from opentrons.drivers.temp_deck.driver import (
-    TempDeckDriver, TEMP_DECK_COMMAND_TERMINATOR
+    TempDeckDriver,
+    TEMP_DECK_COMMAND_TERMINATOR,
 )
 from opentrons.drivers.command_builder import CommandBuilder
 from opentrons.drivers.utils import TEMPDECK_GCODE_ROUNDING_PRECISION
@@ -22,77 +22,62 @@ def driver(connection: AsyncMock) -> TempDeckDriver:
     return TempDeckDriver(connection)
 
 
-async def test_deactivate(
-        driver: TempDeckDriver, connection: AsyncMock) -> None:
+async def test_deactivate(driver: TempDeckDriver, connection: AsyncMock) -> None:
     """It should send a deactivate command"""
     await driver.deactivate()
 
-    expected = CommandBuilder(
-        terminator=TEMP_DECK_COMMAND_TERMINATOR
-    ).add_gcode("M18")
+    expected = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M18")
 
-    connection.send_command.assert_called_once_with(
-        command=expected, retries=3)
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_set_temperature(
-        driver: TempDeckDriver, connection: AsyncMock) -> None:
+async def test_set_temperature(driver: TempDeckDriver, connection: AsyncMock) -> None:
     """It should send a set temperature command"""
     await driver.set_temperature(celsius=123.4444)
 
-    expected = CommandBuilder(
-        terminator=TEMP_DECK_COMMAND_TERMINATOR
-    ).add_gcode(
-        "M104"
-    ).add_float(
-        prefix="S", value=123.4444, precision=TEMPDECK_GCODE_ROUNDING_PRECISION
+    expected = (
+        CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR)
+        .add_gcode("M104")
+        .add_float(
+            prefix="S", value=123.4444, precision=TEMPDECK_GCODE_ROUNDING_PRECISION
+        )
     )
 
-    connection.send_command.assert_called_once_with(
-        command=expected, retries=3)
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_get_temperature(
-        driver: TempDeckDriver, connection: AsyncMock) -> None:
+async def test_get_temperature(driver: TempDeckDriver, connection: AsyncMock) -> None:
     """It should send a get temperature command and parse response"""
-    connection.send_command.return_value = "T:132 C:25 ok\r\nok\r\n"""
+    connection.send_command.return_value = "T:132 C:25 ok\r\nok\r\n" ""
 
     response = await driver.get_temperature()
 
-    expected = CommandBuilder(
-        terminator=TEMP_DECK_COMMAND_TERMINATOR
-    ).add_gcode("M105")
+    expected = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M105")
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
     assert response == Temperature(current=25, target=132)
 
 
-async def test_get_device_info(
-        driver: TempDeckDriver, connection: AsyncMock) -> None:
+async def test_get_device_info(driver: TempDeckDriver, connection: AsyncMock) -> None:
     """It should send a get device info command and parse response"""
     connection.send_command.return_value = "serial:s model:m version:v"
 
     response = await driver.get_device_info()
 
-    expected = CommandBuilder(
-        terminator=TEMP_DECK_COMMAND_TERMINATOR
-    ).add_gcode("M115")
+    expected = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("M115")
 
-    connection.send_command.assert_called_once_with(
-        command=expected, retries=3
-    )
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
     assert response == {"serial": "s", "model": "m", "version": "v"}
 
 
 async def test_enter_programming_mode(
-        driver: TempDeckDriver, connection: AsyncMock) -> None:
+    driver: TempDeckDriver, connection: AsyncMock
+) -> None:
     """It should send an enter programming mode command"""
     await driver.enter_programming_mode()
 
-    expected = CommandBuilder(
-        terminator=TEMP_DECK_COMMAND_TERMINATOR
-    ).add_gcode("dfu")
+    expected = CommandBuilder(terminator=TEMP_DECK_COMMAND_TERMINATOR).add_gcode("dfu")
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)

--- a/api/tests/opentrons/drivers/test_command_builder.py
+++ b/api/tests/opentrons/drivers/test_command_builder.py
@@ -17,64 +17,60 @@ def test_builder_create_command_with_terminator() -> None:
         [1.2342, 3, 1.234],
         [1.2342, None, 1.2342],
         [1.2342, 0, 1.0],
-    ]
+    ],
 )
 def test_builder_create_command_add_float(
-        value: float, precision: Optional[int], expected_float: float) -> None:
+    value: float, precision: Optional[int], expected_float: float
+) -> None:
     """It should create a command with a floating point value."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
-    assert builder.add_float(
-        prefix='Z', value=value, precision=precision
-    ).build() == f"Z{expected_float} terminator"
+    assert (
+        builder.add_float(prefix="Z", value=value, precision=precision).build()
+        == f"Z{expected_float} terminator"
+    )
 
 
 def test_builder_create_command_add_int() -> None:
     """It should create a command with an integer point value."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
-    assert builder.add_int(
-        prefix='Z', value=15
-    ).build() == f"Z15 {terminator}"
+    assert builder.add_int(prefix="Z", value=15).build() == f"Z15 {terminator}"
 
 
 def test_builder_create_command_add_gcode() -> None:
     """It should create a command with a GCODE."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
-    assert builder.add_gcode(
-        gcode='G321'
-    ).build() == f"G321 {terminator}"
+    assert builder.add_gcode(gcode="G321").build() == f"G321 {terminator}"
 
 
 def test_builder_create_command_add_builder() -> None:
     """It should create a command words in another builder."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
-    assert builder.add_gcode(
-        gcode='G321'
-    ).build() == f"G321 {terminator}"
+    assert builder.add_gcode(gcode="G321").build() == f"G321 {terminator}"
 
     builder2 = CommandBuilder(terminator=terminator)
-    assert builder2.add_builder(
-        builder=builder
-    ).add_gcode(
-        gcode="G123"
-    ).add_builder(
-        builder=builder
-    ).build() == f"G321 G123 G321 {terminator}"
+    assert (
+        builder2.add_builder(builder=builder)
+        .add_gcode(gcode="G123")
+        .add_builder(builder=builder)
+        .build()
+        == f"G321 G123 G321 {terminator}"
+    )
 
 
 def test_builder_chain() -> None:
     """It should create a command using chaining."""
     terminator = "terminator"
     builder = CommandBuilder(terminator=terminator)
-    assert builder.add_gcode(
-        gcode='G321'
-    ).add_float(
-        prefix="X", value=321, precision=3
-    ).add_gcode(
-        gcode="M321"
-    ).add_int(
-        prefix="Z", value=3
-    ).add_gcode("G111").build() == f"G321 X321 M321 Z3 G111 {terminator}"
+    assert (
+        builder.add_gcode(gcode="G321")
+        .add_float(prefix="X", value=321, precision=3)
+        .add_gcode(gcode="M321")
+        .add_int(prefix="Z", value=3)
+        .add_gcode("G111")
+        .build()
+        == f"G321 X321 M321 Z3 G111 {terminator}"
+    )

--- a/api/tests/opentrons/drivers/test_utils.py
+++ b/api/tests/opentrons/drivers/test_utils.py
@@ -5,31 +5,40 @@ from opentrons.drivers.types import Temperature, PlateTemperature
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str', 'expected_result'],
+    argnames=["input_str", "expected_result"],
     argvalues=[
-        ['version:123-2 serial:serial_v model:m',
-         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
-        ['serial:serial_v model:m version:123-2 ',
-         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
-        ['   serial:serial_v model:m    version:123-2   ',
-         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}],
-        ['something:extra serial:serial_v model:m version:123-2',
-         {'version': '123-2', 'serial': 'serial_v', 'model': 'm'}]
-    ]
+        [
+            "version:123-2 serial:serial_v model:m",
+            {"version": "123-2", "serial": "serial_v", "model": "m"},
+        ],
+        [
+            "serial:serial_v model:m version:123-2 ",
+            {"version": "123-2", "serial": "serial_v", "model": "m"},
+        ],
+        [
+            "   serial:serial_v model:m    version:123-2   ",
+            {"version": "123-2", "serial": "serial_v", "model": "m"},
+        ],
+        [
+            "something:extra serial:serial_v model:m version:123-2",
+            {"version": "123-2", "serial": "serial_v", "model": "m"},
+        ],
+    ],
 )
 def test_parse_device_information_success(
-        input_str: str, expected_result: Dict[str, str]) -> None:
+    input_str: str, expected_result: Dict[str, str]
+) -> None:
     """Test parse device information."""
     assert utils.parse_device_information(input_str) == expected_result
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str'],
+    argnames=["input_str"],
     argvalues=[
-        ['version:123 serial:serial_v'],
-        ['version:123 serialg:serial_v model:123'],
-        [''],
-    ]
+        ["version:123 serial:serial_v"],
+        ["version:123 serialg:serial_v model:123"],
+        [""],
+    ],
 )
 def test_parse_device_information_failure(input_str: str) -> None:
     """Test parse device information."""
@@ -38,32 +47,29 @@ def test_parse_device_information_failure(input_str: str) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str', 'expected_result'],
+    argnames=["input_str", "expected_result"],
     argvalues=[
-        ['T:none C:123.4',
-         Temperature(target=None, current=123.4)],
-        ['T:123.566 C:123.446',
-         Temperature(target=123.57, current=123.45)],
-        ['T:-123.566 C:-123.446',
-         Temperature(target=-123.57, current=-123.45)],
-        ['a:3 T:2. C:3 H:0 G:1',
-         Temperature(target=2, current=3)],
-    ]
+        ["T:none C:123.4", Temperature(target=None, current=123.4)],
+        ["T:123.566 C:123.446", Temperature(target=123.57, current=123.45)],
+        ["T:-123.566 C:-123.446", Temperature(target=-123.57, current=-123.45)],
+        ["a:3 T:2. C:3 H:0 G:1", Temperature(target=2, current=3)],
+    ],
 )
 def test_parse_temperature_response_success(
-        input_str: str, expected_result: Temperature) -> None:
+    input_str: str, expected_result: Temperature
+) -> None:
     """It should parse temperature response."""
     assert utils.parse_temperature_response(input_str, 2) == expected_result
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str'],
+    argnames=["input_str"],
     argvalues=[
-        ['T:not_a_float C:123'],
-        ['T:none C:none'],
-        ['C:not_a_float T:123'],
-        [''],
-    ]
+        ["T:not_a_float C:123"],
+        ["T:none C:none"],
+        ["C:not_a_float T:123"],
+        [""],
+    ],
 )
 def test_parse_temperature_response_failure(input_str: str) -> None:
     """It should fail to parse temperature response."""
@@ -72,33 +78,35 @@ def test_parse_temperature_response_failure(input_str: str) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str', 'expected_result'],
+    argnames=["input_str", "expected_result"],
     argvalues=[
-        ['T:none C:0 H:none',
-         PlateTemperature(target=None, current=0, hold=None)],
-        ['T:321.4 C:45 H:123.222',
-         PlateTemperature(target=321.4, current=45, hold=123.22)],
-        ['T:-44.2442 C:-22.233 H:0',
-         PlateTemperature(target=-44.24, current=-22.23, hold=0)],
-        ['a:3 T:2. C:3 H:0 G:1',
-         PlateTemperature(target=2, current=3, hold=0)],
-    ]
+        ["T:none C:0 H:none", PlateTemperature(target=None, current=0, hold=None)],
+        [
+            "T:321.4 C:45 H:123.222",
+            PlateTemperature(target=321.4, current=45, hold=123.22),
+        ],
+        [
+            "T:-44.2442 C:-22.233 H:0",
+            PlateTemperature(target=-44.24, current=-22.23, hold=0),
+        ],
+        ["a:3 T:2. C:3 H:0 G:1", PlateTemperature(target=2, current=3, hold=0)],
+    ],
 )
 def test_parse_plate_temperature_response_success(
-        input_str: str, expected_result: PlateTemperature
+    input_str: str, expected_result: PlateTemperature
 ) -> None:
     """It should parse plate temperature response"""
     assert utils.parse_plate_temperature_response(input_str, 2) == expected_result
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str'],
+    argnames=["input_str"],
     argvalues=[
-        ['T:not_a_float C:123 H:321'],
-        ['C:not_a_float T:123 H:321'],
-        ['H:not_a_float C:123 T:321'],
-        [''],
-    ]
+        ["T:not_a_float C:123 H:321"],
+        ["C:not_a_float T:123 H:321"],
+        ["H:not_a_float C:123 T:321"],
+        [""],
+    ],
 )
 def test_parse_plate_temperature_response_failure(input_str: str) -> None:
     """It should fail to parse plate temperature response"""
@@ -107,13 +115,13 @@ def test_parse_plate_temperature_response_failure(input_str: str) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=['input_str', 'min_length', "expected"],
+    argnames=["input_str", "min_length", "expected"],
     argvalues=[
         ["", 0, ""],
         ["", 1, "0"],
         ["abcd", 12, "616263640000"],
         ["abcd", 5, "61626364"],
-    ]
+    ],
 )
 def test_string_to_hex(input_str: str, min_length: int, expected: str) -> None:
     """It should convert string to hex with padding to reach min_length."""

--- a/api/tests/opentrons/drivers/thermocycler/test_driver.py
+++ b/api/tests/opentrons/drivers/thermocycler/test_driver.py
@@ -2,13 +2,10 @@ from typing import Optional
 
 import pytest
 from mock import AsyncMock
-from opentrons.drivers.asyncio.communication.serial_connection import \
-    SerialConnection
+from opentrons.drivers.asyncio.communication.serial_connection import SerialConnection
 from opentrons.drivers.thermocycler import driver
 from opentrons.drivers.command_builder import CommandBuilder
-from opentrons.drivers.types import (
-    Temperature, PlateTemperature, ThermocyclerLidStatus
-)
+from opentrons.drivers.types import Temperature, PlateTemperature, ThermocyclerLidStatus
 from opentrons.drivers.utils import TC_GCODE_ROUNDING_PRECISION
 
 
@@ -23,40 +20,43 @@ def subject(connection: AsyncMock) -> driver.ThermocyclerDriver:
     return driver.ThermocyclerDriver(connection)
 
 
-async def test_open_lid(subject: driver.ThermocyclerDriver,
-                        connection: AsyncMock) -> None:
+async def test_open_lid(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send an open lid command."""
     await subject.open_lid()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M126")
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M126"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_close_lid(subject: driver.ThermocyclerDriver,
-                         connection: AsyncMock) -> None:
+async def test_close_lid(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a close lid command."""
     await subject.close_lid()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M127")
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M127"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_get_lid_status(subject: driver.ThermocyclerDriver,
-                              connection: AsyncMock) -> None:
+async def test_get_lid_status(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a get lid status command and parse response."""
-    connection.send_command.return_value = 'Lid:open\r\nok\r\nok\r\n'
+    connection.send_command.return_value = "Lid:open\r\nok\r\nok\r\n"
 
     response = await subject.get_lid_status()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M119")
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M119"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
     assert response == ThermocyclerLidStatus.OPEN
@@ -67,37 +67,38 @@ async def test_get_lid_status(subject: driver.ThermocyclerDriver,
     argvalues=[
         [driver.LID_TARGET_MIN + 5, driver.LID_TARGET_MIN + 5],
         [driver.LID_TARGET_MIN - 5, driver.LID_TARGET_MIN],
-        [driver.LID_TARGET_MAX + 5, driver.LID_TARGET_MAX]
-    ]
+        [driver.LID_TARGET_MAX + 5, driver.LID_TARGET_MAX],
+    ],
 )
-async def test_set_lid_temp(subject: driver.ThermocyclerDriver,
-                            connection: AsyncMock,
-                            requested_temp: float,
-                            actual_temp: float) -> None:
+async def test_set_lid_temp(
+    subject: driver.ThermocyclerDriver,
+    connection: AsyncMock,
+    requested_temp: float,
+    actual_temp: float,
+) -> None:
     """It should send a set lid temperature command honoring the min/max."""
     await subject.set_lid_temperature(temp=requested_temp)
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
-        gcode="M140"
-    ).add_float(
-        prefix="S", value=actual_temp, precision=TC_GCODE_ROUNDING_PRECISION
+    expected = (
+        CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR)
+        .add_gcode(gcode="M140")
+        .add_float(prefix="S", value=actual_temp, precision=TC_GCODE_ROUNDING_PRECISION)
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_get_lid_temp(subject: driver.ThermocyclerDriver,
-                            connection: AsyncMock) -> None:
+async def test_get_lid_temp(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a get lid temperate command and parse response."""
     connection.send_command.return_value = "T:100.000 C:22.041\r\nok\r\nok\r\n'"
 
     response = await subject.get_lid_temperature()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(gcode="M141")
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
+        gcode="M141"
+    )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
     assert response == Temperature(target=100, current=22.04)
@@ -112,114 +113,107 @@ async def test_get_lid_temp(subject: driver.ThermocyclerDriver,
         [50, None, 32, "S50 V32"],
         [-5, 2, 32, "S0 H2 V32"],
         [102, 2, 32, "S99 H2 V32"],
-    ]
+    ],
 )
 async def test_set_plate_temp(
-        subject: driver.ThermocyclerDriver, connection: AsyncMock,
-        temp: float, hold_time: Optional[float], volume: Optional[float],
-        expected_body: str) -> None:
+    subject: driver.ThermocyclerDriver,
+    connection: AsyncMock,
+    temp: float,
+    hold_time: Optional[float],
+    volume: Optional[float],
+    expected_body: str,
+) -> None:
     """It should send a set plate temperature command."""
     await subject.set_plate_temperature(temp=temp, hold_time=hold_time, volume=volume)
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
-        gcode="M104"
-    ).add_element(
-        element=expected_body
+    expected = (
+        CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR)
+        .add_gcode(gcode="M104")
+        .add_element(element=expected_body)
     )
 
-    connection.send_command.assert_called_once_with(
-        command=expected, retries=3)
+    connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_get_plate_temp(subject: driver.ThermocyclerDriver,
-                              connection: AsyncMock) -> None:
+async def test_get_plate_temp(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a command to get the plate temperature and parse the response."""
     connection.send_command.return_value = "T:30.000 C:23.317 H:120\r\nok\r\nok\r\n"
 
     response = await subject.get_plate_temperature()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M105"
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
-    assert response == PlateTemperature(
-        target=30, current=23.32, hold=120
-    )
+    assert response == PlateTemperature(target=30, current=23.32, hold=120)
 
 
-async def test_set_ramp_rate(subject: driver.ThermocyclerDriver,
-                             connection: AsyncMock) -> None:
+async def test_set_ramp_rate(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a set ramp rate command."""
     await subject.set_ramp_rate(ramp_rate=22)
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
-        gcode="M566"
-    ).add_float(
-        prefix="S", value=22, precision=TC_GCODE_ROUNDING_PRECISION
+    expected = (
+        CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR)
+        .add_gcode(gcode="M566")
+        .add_float(prefix="S", value=22, precision=TC_GCODE_ROUNDING_PRECISION)
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_deactivate_all(subject: driver.ThermocyclerDriver,
-                              connection: AsyncMock) -> None:
+async def test_deactivate_all(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a deactivate all command."""
     await subject.deactivate_all()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M18"
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_deactivate_lid(subject: driver.ThermocyclerDriver,
-                              connection: AsyncMock) -> None:
+async def test_deactivate_lid(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a deactivate lid command."""
     await subject.deactivate_lid()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M108"
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_deactivate_block(subject: driver.ThermocyclerDriver,
-                                connection: AsyncMock) -> None:
+async def test_deactivate_block(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a deactivate block command."""
     await subject.deactivate_block()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M14"
     )
 
     connection.send_command.assert_called_once_with(command=expected, retries=3)
 
 
-async def test_device_info(subject: driver.ThermocyclerDriver,
-                           connection: AsyncMock) -> None:
+async def test_device_info(
+    subject: driver.ThermocyclerDriver, connection: AsyncMock
+) -> None:
     """It should send a get device info command and parse response."""
     connection.send_command.return_value = "serial:s model:m version:v"
 
     device_info = await subject.get_device_info()
 
-    expected = CommandBuilder(
-        terminator=driver.TC_COMMAND_TERMINATOR
-    ).add_gcode(
+    expected = CommandBuilder(terminator=driver.TC_COMMAND_TERMINATOR).add_gcode(
         gcode="M115"
     )
 

--- a/api/tests/opentrons/hardware_control/emulation/test_parser.py
+++ b/api/tests/opentrons/hardware_control/emulation/test_parser.py
@@ -13,67 +13,56 @@ def parser() -> Parser:
     argnames=["line", "expected"],
     argvalues=[
         ["", []],
-        ["G2", [
-            Command(
-                gcode="G2",
-                body="",
-                params={}
-            )
-        ]],
-        ["   M123.32 with some trailing nonesense   ", [
-            Command(
-                gcode="M123.32",
-                body="with some trailing nonesense",
-                params={}
-            )
-        ]],
-        ["G123 V2 X0", [
-            Command(
-                gcode="G123",
-                body="V2 X0",
-                params={"V": 2.0, "X": 0.0})
-        ]],
-        ["dfuversionM12.3G2", [
-            Command(
-                gcode="dfu",
-                body="",
-                params={}),
-            Command(
-                gcode="version",
-                body="",
-                params={}),
-            Command(
-                gcode="M12.3",
-                body="",
-                params={}),
-            Command(
-                gcode="G2",
-                body="",
-                params={})
-        ]],
+        ["G2", [Command(gcode="G2", body="", params={})]],
+        [
+            "   M123.32 with some trailing nonesense   ",
+            [Command(gcode="M123.32", body="with some trailing nonesense", params={})],
+        ],
+        [
+            "G123 V2 X0",
+            [Command(gcode="G123", body="V2 X0", params={"V": 2.0, "X": 0.0})],
+        ],
+        [
+            "dfuversionM12.3G2",
+            [
+                Command(gcode="dfu", body="", params={}),
+                Command(gcode="version", body="", params={}),
+                Command(gcode="M12.3", body="", params={}),
+                Command(gcode="G2", body="", params={}),
+            ],
+        ],
         # Substring check. Don't confuse G1 with G123 or G123 with G123.2
-        ["G123G123.2G1", [
-            Command(gcode="G123", body="", params={}),
-            Command(gcode="G123.2", body="", params={}),
-            Command(gcode="G1", body="", params={}),
-        ]],
+        [
+            "G123G123.2G1",
+            [
+                Command(gcode="G123", body="", params={}),
+                Command(gcode="G123.2", body="", params={}),
+                Command(gcode="G1", body="", params={}),
+            ],
+        ],
         # Negative numbers, no spaces.
-        ["M123.2 B132C-1D321.2", [
-            Command(
-                gcode="M123.2",
-                body="B132C-1D321.2",
-                params={"B": 132, "C": -1, "D": 321.2}
-            )
-        ]],
+        [
+            "M123.2 B132C-1D321.2",
+            [
+                Command(
+                    gcode="M123.2",
+                    body="B132C-1D321.2",
+                    params={"B": 132, "C": -1, "D": 321.2},
+                )
+            ],
+        ],
         # Just key, no value.
-        ["M123.2 LX R", [
-            Command(
-                gcode="M123.2",
-                body="LX R",
-                params={"L": None, "X": None, "R": None}
-            )
-        ]]
-    ]
+        [
+            "M123.2 LX R",
+            [
+                Command(
+                    gcode="M123.2",
+                    body="LX R",
+                    params={"L": None, "X": None, "R": None},
+                )
+            ],
+        ],
+    ],
 )
 def test_parse_command(parser: Parser, line: str, expected: Sequence[Command]) -> None:
     """It should parse the commands and parameters."""
@@ -84,14 +73,9 @@ def test_parse_command(parser: Parser, line: str, expected: Sequence[Command]) -
 
 @pytest.mark.parametrize(
     argnames=["line"],
-    argvalues=[
-        ["not a gcode G123"],
-        ["X123 G123"],
-        ["   DFU G123"],
-        ["no gcode"]
-    ]
+    argvalues=[["not a gcode G123"], ["X123 G123"], ["   DFU G123"], ["no gcode"]],
 )
 def test_fail_parse(parser: Parser, line: str) -> None:
-    """It should raise an exception """
+    """It should raise an exception"""
     with pytest.raises(ValueError, match="Invalid content"):
         list(parser.parse(line=line))

--- a/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/g_code_program/test_supported_text_modes.py
@@ -2,39 +2,40 @@ import pytest
 
 from opentrons.hardware_control.g_code_parsing.errors import InvalidTextModeError
 from opentrons.hardware_control.g_code_parsing.g_code import GCode
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes,\
-    TextMode,\
-    default_builder,\
-    concise_builder
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+    TextMode,
+    default_builder,
+    concise_builder,
+)
 
 
 @pytest.fixture
 def concise_mode() -> TextMode:
-    return SupportedTextModes.get_text_mode('Concise')
+    return SupportedTextModes.get_text_mode("Concise")
 
 
 @pytest.fixture
 def default_mode() -> TextMode:
-    return SupportedTextModes.get_text_mode('Default')
+    return SupportedTextModes.get_text_mode("Default")
 
 
 @pytest.fixture
 def g_code() -> GCode:
     return GCode.from_raw_code(
-        'M92 X80.0 Y80.0 Z400 A400',
-        'smoothie',
-        'X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:955.000000 '
-        'C:768.000000 \r\nok\r\nok\r\n'
+        "M92 X80.0 Y80.0 Z400 A400",
+        "smoothie",
+        "X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:955.000000 "
+        "C:768.000000 \r\nok\r\nok\r\n",
     )[0]
 
 
 @pytest.mark.parametrize(
-    'input_mode,name,builder_function',
+    "input_mode,name,builder_function",
     [
-        [SupportedTextModes.CONCISE.value, 'Concise', concise_builder],
-        [SupportedTextModes.DEFAULT.value, 'Default', default_builder]
-    ]
+        [SupportedTextModes.CONCISE.value, "Concise", concise_builder],
+        [SupportedTextModes.DEFAULT.value, "Default", default_builder],
+    ],
 )
 def test_mode_lookup(input_mode, name, builder_function):
     assert SupportedTextModes.get_text_mode(input_mode).name == name
@@ -42,57 +43,62 @@ def test_mode_lookup(input_mode, name, builder_function):
 
 
 @pytest.mark.parametrize(
-    'input_mode,name,builder_function',
+    "input_mode,name,builder_function",
     [
-        [SupportedTextModes.CONCISE, 'Concise', concise_builder],
-        [SupportedTextModes.DEFAULT, 'Default', default_builder]
-    ]
+        [SupportedTextModes.CONCISE, "Concise", concise_builder],
+        [SupportedTextModes.DEFAULT, "Default", default_builder],
+    ],
 )
 def test_mode_lookup_by_enum(input_mode, name, builder_function):
     assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).name == name
-    assert SupportedTextModes.get_text_mode_by_enum_value(input_mode).builder\
-           == builder_function
+    assert (
+        SupportedTextModes.get_text_mode_by_enum_value(input_mode).builder
+        == builder_function
+    )
 
 
 def test_invalid_mode_name():
     with pytest.raises(InvalidTextModeError):
-        SupportedTextModes.get_text_mode('INVALID MODE')
+        SupportedTextModes.get_text_mode("INVALID MODE")
 
 
 def test_concise_mode(concise_mode, g_code):
-    expected = 'smoothie: M92 X80.0 Y80.0 Z400.0 A400.0 -> ' \
-               'Setting the following axes steps per mm: ' \
-               'X-Axis: 80.0 steps per mm ' \
-               'Y-Axis: 80.0 steps per mm ' \
-               'Z-Axis: 400.0 steps per mm ' \
-               'A-Axis: 400.0 steps per mm -> ' \
-               'Current set steps per mm: ' \
-               'X Axis: 80.000000 ' \
-               'Y Axis: 80.000000 ' \
-               'Z Axis: 400.000000 ' \
-               'A Axis: 400.000000 ' \
-               'B Axis: 955.000000 ' \
-               'C Axis: 768.000000' \
-
+    expected = (
+        "smoothie: M92 X80.0 Y80.0 Z400.0 A400.0 -> "
+        "Setting the following axes steps per mm: "
+        "X-Axis: 80.0 steps per mm "
+        "Y-Axis: 80.0 steps per mm "
+        "Z-Axis: 400.0 steps per mm "
+        "A-Axis: 400.0 steps per mm -> "
+        "Current set steps per mm: "
+        "X Axis: 80.000000 "
+        "Y Axis: 80.000000 "
+        "Z Axis: 400.000000 "
+        "A Axis: 400.000000 "
+        "B Axis: 955.000000 "
+        "C Axis: 768.000000"
+    )
 
     assert concise_mode.builder(g_code) == expected
 
 
 def test_default_mode(default_mode, g_code):
-    expected = 'Device: smoothie' \
-               '\nCode: M92 X80.0 Y80.0 Z400.0 A400.0' \
-               '\nExplanation: Setting the following axes steps per mm:' \
-               '\n\tX-Axis: 80.0 steps per mm' \
-               '\n\tY-Axis: 80.0 steps per mm' \
-               '\n\tZ-Axis: 400.0 steps per mm' \
-               '\n\tA-Axis: 400.0 steps per mm' \
-               '\nResponse: Current set steps per mm:'\
-               '\n\tX Axis: 80.000000' \
-               '\n\tY Axis: 80.000000' \
-               '\n\tZ Axis: 400.000000' \
-               '\n\tA Axis: 400.000000' \
-               '\n\tB Axis: 955.000000' \
-               '\n\tC Axis: 768.000000' \
-               '\n-----------------------------------------'
+    expected = (
+        "Device: smoothie"
+        "\nCode: M92 X80.0 Y80.0 Z400.0 A400.0"
+        "\nExplanation: Setting the following axes steps per mm:"
+        "\n\tX-Axis: 80.0 steps per mm"
+        "\n\tY-Axis: 80.0 steps per mm"
+        "\n\tZ-Axis: 400.0 steps per mm"
+        "\n\tA-Axis: 400.0 steps per mm"
+        "\nResponse: Current set steps per mm:"
+        "\n\tX Axis: 80.000000"
+        "\n\tY Axis: 80.000000"
+        "\n\tZ Axis: 400.000000"
+        "\n\tA Axis: 400.000000"
+        "\n\tB Axis: 955.000000"
+        "\n\tC Axis: 768.000000"
+        "\n-----------------------------------------"
+    )
 
     assert default_mode.builder(g_code) == expected

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_cli.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_cli.py
@@ -3,98 +3,95 @@ import os
 import pytest
 
 from typing import List
-from opentrons.hardware_control.emulation.settings import \
-    SmoothieSettings
-from opentrons.hardware_control.g_code_parsing.cli import \
-    GCodeCLI, RunCommand, DiffCommand
+from opentrons.hardware_control.emulation.settings import SmoothieSettings
+from opentrons.hardware_control.g_code_parsing.cli import (
+    GCodeCLI,
+    RunCommand,
+    DiffCommand,
+)
 from opentrons.hardware_control.g_code_parsing.errors import UnparsableCLICommandError
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+)
 from tests.opentrons.conftest import data_dir
 
 
 VALIDATION_PROTOCOL_PATH = os.path.join(
-    data_dir(), 'g_code_validation_protocols', 'smoothie_protocol.py'
+    data_dir(), "g_code_validation_protocols", "smoothie_protocol.py"
 )
 DEFAULT_LEFT_PIPETTE = SmoothieSettings().left
 DEFAULT_RIGHT_PIPETTE = SmoothieSettings().right
 
-DIFF_FILE_PATH_1 = os.path.join(tempfile.gettempdir(), 'file_1.txt')
-DIFF_FILE_PATH_2 = os.path.join(tempfile.gettempdir(), 'file_2.txt')
+DIFF_FILE_PATH_1 = os.path.join(tempfile.gettempdir(), "file_1.txt")
+DIFF_FILE_PATH_2 = os.path.join(tempfile.gettempdir(), "file_2.txt")
 
 
 @pytest.fixture
 def setup_same_files():
-    with open(DIFF_FILE_PATH_1, 'w') as file_1, open(DIFF_FILE_PATH_2, 'w') as file_2:
-        file_1.write('Hello World')
-        file_2.write('Hello World')
+    with open(DIFF_FILE_PATH_1, "w") as file_1, open(DIFF_FILE_PATH_2, "w") as file_2:
+        file_1.write("Hello World")
+        file_2.write("Hello World")
 
 
 @pytest.fixture
 def setup_different_files():
-    with open(DIFF_FILE_PATH_1, 'w') as file_1, open(DIFF_FILE_PATH_2, 'w') as file_2:
-        file_1.write('Hello World')
-        file_2.write('Hello')
+    with open(DIFF_FILE_PATH_1, "w") as file_1, open(DIFF_FILE_PATH_2, "w") as file_2:
+        file_1.write("Hello World")
+        file_2.write("Hello")
 
 
 def run_cli_inputs():
     return [
-        ['run', VALIDATION_PROTOCOL_PATH],
-        ['run', VALIDATION_PROTOCOL_PATH, '--text-mode', 'Default'],
+        ["run", VALIDATION_PROTOCOL_PATH],
+        ["run", VALIDATION_PROTOCOL_PATH, "--text-mode", "Default"],
         [
-            'run',
+            "run",
             VALIDATION_PROTOCOL_PATH,
-            '--left-pipette',
-            '{"model": "p20_single_v2.0", "id": "P20SV202020070101"}'
+            "--left-pipette",
+            '{"model": "p20_single_v2.0", "id": "P20SV202020070101"}',
         ],
         [
-            'run',
+            "run",
             VALIDATION_PROTOCOL_PATH,
-            '--right-pipette',
-            '{"model": "p20_multi_v2.0", "id": "P3HMV202020041605"}'
+            "--right-pipette",
+            '{"model": "p20_multi_v2.0", "id": "P3HMV202020041605"}',
         ],
     ]
 
 
 def diff_cli_input():
-    return [
-        ['diff', DIFF_FILE_PATH_1, DIFF_FILE_PATH_2]
-    ]
+    return [["diff", DIFF_FILE_PATH_1, DIFF_FILE_PATH_2]]
 
 
 def run_expected_args():
     return [
         {
-            'command': 'run',
-            'protocol_file_path': VALIDATION_PROTOCOL_PATH,
-            'text_mode': SupportedTextModes.CONCISE.value,
-            'left_pipette': DEFAULT_LEFT_PIPETTE,
-            'right_pipette': DEFAULT_RIGHT_PIPETTE
-
+            "command": "run",
+            "protocol_file_path": VALIDATION_PROTOCOL_PATH,
+            "text_mode": SupportedTextModes.CONCISE.value,
+            "left_pipette": DEFAULT_LEFT_PIPETTE,
+            "right_pipette": DEFAULT_RIGHT_PIPETTE,
         },
         {
-            'command': 'run',
-            'protocol_file_path': VALIDATION_PROTOCOL_PATH,
-            'text_mode': SupportedTextModes.DEFAULT.value,
-            'left_pipette': DEFAULT_LEFT_PIPETTE,
-            'right_pipette': DEFAULT_RIGHT_PIPETTE
-
+            "command": "run",
+            "protocol_file_path": VALIDATION_PROTOCOL_PATH,
+            "text_mode": SupportedTextModes.DEFAULT.value,
+            "left_pipette": DEFAULT_LEFT_PIPETTE,
+            "right_pipette": DEFAULT_RIGHT_PIPETTE,
         },
         {
-            'command': 'run',
-            'protocol_file_path': VALIDATION_PROTOCOL_PATH,
-            'text_mode': SupportedTextModes.CONCISE.value,
-            'left_pipette': DEFAULT_RIGHT_PIPETTE,
-            'right_pipette': DEFAULT_RIGHT_PIPETTE
-
+            "command": "run",
+            "protocol_file_path": VALIDATION_PROTOCOL_PATH,
+            "text_mode": SupportedTextModes.CONCISE.value,
+            "left_pipette": DEFAULT_RIGHT_PIPETTE,
+            "right_pipette": DEFAULT_RIGHT_PIPETTE,
         },
         {
-            'command': 'run',
-            'protocol_file_path': VALIDATION_PROTOCOL_PATH,
-            'text_mode': SupportedTextModes.CONCISE.value,
-            'left_pipette': DEFAULT_LEFT_PIPETTE,
-            'right_pipette': DEFAULT_LEFT_PIPETTE
-
+            "command": "run",
+            "protocol_file_path": VALIDATION_PROTOCOL_PATH,
+            "text_mode": SupportedTextModes.CONCISE.value,
+            "left_pipette": DEFAULT_LEFT_PIPETTE,
+            "right_pipette": DEFAULT_LEFT_PIPETTE,
         },
     ]
 
@@ -102,10 +99,10 @@ def run_expected_args():
 def diff_expected_args():
     return [
         {
-            'command': 'diff',
-            'error_on_different_files': False,
-            'file_path_1': DIFF_FILE_PATH_1,
-            'file_path_2': DIFF_FILE_PATH_2
+            "command": "diff",
+            "error_on_different_files": False,
+            "file_path_1": DIFF_FILE_PATH_1,
+            "file_path_2": DIFF_FILE_PATH_2,
         }
     ]
 
@@ -116,36 +113,31 @@ def run_expected_commands() -> List[RunCommand]:
             protocol_file_path=VALIDATION_PROTOCOL_PATH,
             text_mode=SupportedTextModes.CONCISE.value,
             left_pipette_config=DEFAULT_LEFT_PIPETTE,
-            right_pipette_config=DEFAULT_RIGHT_PIPETTE
+            right_pipette_config=DEFAULT_RIGHT_PIPETTE,
         ),
         RunCommand(
             protocol_file_path=VALIDATION_PROTOCOL_PATH,
             text_mode=SupportedTextModes.DEFAULT.value,
             left_pipette_config=DEFAULT_LEFT_PIPETTE,
-            right_pipette_config=DEFAULT_RIGHT_PIPETTE
+            right_pipette_config=DEFAULT_RIGHT_PIPETTE,
         ),
         RunCommand(
             protocol_file_path=VALIDATION_PROTOCOL_PATH,
             text_mode=SupportedTextModes.CONCISE.value,
             left_pipette_config=DEFAULT_RIGHT_PIPETTE,
-            right_pipette_config=DEFAULT_RIGHT_PIPETTE
+            right_pipette_config=DEFAULT_RIGHT_PIPETTE,
         ),
         RunCommand(
             protocol_file_path=VALIDATION_PROTOCOL_PATH,
             text_mode=SupportedTextModes.CONCISE.value,
             left_pipette_config=DEFAULT_LEFT_PIPETTE,
-            right_pipette_config=DEFAULT_LEFT_PIPETTE
+            right_pipette_config=DEFAULT_LEFT_PIPETTE,
         ),
     ]
 
 
 def diff_expected_command():
-    return [
-        DiffCommand(
-            file_path_1=DIFF_FILE_PATH_1,
-            file_path_2=DIFF_FILE_PATH_2
-        )
-    ]
+    return [DiffCommand(file_path_1=DIFF_FILE_PATH_1, file_path_2=DIFF_FILE_PATH_2)]
 
 
 @pytest.fixture
@@ -154,53 +146,43 @@ def run_command() -> RunCommand:
         protocol_file_path=VALIDATION_PROTOCOL_PATH,
         text_mode=SupportedTextModes.CONCISE.value,
         left_pipette_config=DEFAULT_RIGHT_PIPETTE,
-        right_pipette_config=DEFAULT_RIGHT_PIPETTE
+        right_pipette_config=DEFAULT_RIGHT_PIPETTE,
     )
 
 
 @pytest.fixture
 def same_file_content_diff_command(setup_same_files) -> DiffCommand:
-    return DiffCommand(
-        file_path_1=DIFF_FILE_PATH_1,
-        file_path_2=DIFF_FILE_PATH_2
-    )
+    return DiffCommand(file_path_1=DIFF_FILE_PATH_1, file_path_2=DIFF_FILE_PATH_2)
 
 
 @pytest.fixture
 def different_file_content_diff_command(setup_different_files) -> DiffCommand:
-    return DiffCommand(
-        file_path_1=DIFF_FILE_PATH_1,
-        file_path_2=DIFF_FILE_PATH_2
-    )
+    return DiffCommand(file_path_1=DIFF_FILE_PATH_1, file_path_2=DIFF_FILE_PATH_2)
 
 
 @pytest.mark.parametrize(
-    'input_list,args',
-    list(zip(run_cli_inputs(), run_expected_args()))
+    "input_list,args", list(zip(run_cli_inputs(), run_expected_args()))
 )
 def test_run_arg_parse(input_list, args):
     assert GCodeCLI.parse_args(input_list) == args
 
 
 @pytest.mark.parametrize(
-    'input_list,command',
-    list(zip(run_cli_inputs(), run_expected_commands()))
+    "input_list,command", list(zip(run_cli_inputs(), run_expected_commands()))
 )
 def test_run_command_vals(input_list, command):
     assert GCodeCLI.to_command(GCodeCLI.parse_args(input_list)) == command
 
 
 @pytest.mark.parametrize(
-    'diff_input_args,args',
-    list(zip(diff_cli_input(), diff_expected_args()))
+    "diff_input_args,args", list(zip(diff_cli_input(), diff_expected_args()))
 )
 def test_diff_arg_parse(diff_input_args, args):
     assert GCodeCLI.parse_args(diff_input_args) == args
 
 
 @pytest.mark.parametrize(
-    'diff_input_args,command',
-    list(zip(diff_cli_input(), diff_expected_command()))
+    "diff_input_args,command", list(zip(diff_cli_input(), diff_expected_command()))
 )
 def test_diff_command_vals(diff_input_args, command):
     assert GCodeCLI.to_command(GCodeCLI.parse_args(diff_input_args)) == command
@@ -212,16 +194,19 @@ def test_run_command(run_command):
 
 
 def test_same_file_content_diff_command(same_file_content_diff_command):
-    assert same_file_content_diff_command.execute() == \
-           "No difference between compared strings"
+    assert (
+        same_file_content_diff_command.execute()
+        == "No difference between compared strings"
+    )
 
 
 def test_different_file_content_diff_command(different_file_content_diff_command):
-    assert different_file_content_diff_command.execute() == \
-        '<span>Hello</span>' \
+    assert (
+        different_file_content_diff_command.execute() == "<span>Hello</span>"
         '<del style="background:#ffe6e6;font-size:large;font-weight:bold;"> World</del>'
+    )
 
 
 def test_unparsable_cli_command_error():
     with pytest.raises(UnparsableCLICommandError):
-        GCodeCLI.to_command({'command': 'bad'})
+        GCodeCLI.to_command({"command": "bad"})

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code.py
@@ -1,6 +1,7 @@
 import pytest
-from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.\
-    g_code_functionality_def_base import Explanation
+from opentrons.hardware_control.g_code_parsing.g_code_functionality_defs.g_code_functionality_def_base import (  # noqa: E501
+    Explanation,
+)
 from opentrons.hardware_control.g_code_parsing.g_code import GCode
 from opentrons.hardware_control.g_code_parsing.errors import UnparsableGCodeError
 from typing import List, Dict
@@ -10,198 +11,130 @@ def smoothie_g_codes() -> List[GCode]:
     raw_codes = [
         # FORMAT
         # [GCODE, RESPONSE]
-
         # Home
-        ['G28.2 ABCXYZ', 'ok\r\nok\r\n'],  # Test 0
-        ['G28.2 X', 'ok\r\nok\r\n'],  # Test 1
-        ['G28.2 Y', 'ok\r\nok\r\n'],  # Test 2
-        ['G28.2 Z', 'ok\r\nok\r\n'],  # Test 3
-        ['G28.2 A', 'ok\r\nok\r\n'],  # Test 4
-        ['G28.2 B', 'ok\r\nok\r\n'],  # Test 5
-        ['G28.2 C', 'ok\r\nok\r\n'],  # Test 6
-
+        ["G28.2 ABCXYZ", "ok\r\nok\r\n"],  # Test 0
+        ["G28.2 X", "ok\r\nok\r\n"],  # Test 1
+        ["G28.2 Y", "ok\r\nok\r\n"],  # Test 2
+        ["G28.2 Z", "ok\r\nok\r\n"],  # Test 3
+        ["G28.2 A", "ok\r\nok\r\n"],  # Test 4
+        ["G28.2 B", "ok\r\nok\r\n"],  # Test 5
+        ["G28.2 C", "ok\r\nok\r\n"],  # Test 6
         # Move
-        ['G0 X113.38 Y11.24', 'ok\r\nok\r\n'],  # Test 7
-        ['G0 A132.6', 'ok\r\nok\r\n'],  # Test 8
-        ['G0 C-8.5', 'ok\r\nok\r\n'],  # Test 9
-
+        ["G0 X113.38 Y11.24", "ok\r\nok\r\n"],  # Test 7
+        ["G0 A132.6", "ok\r\nok\r\n"],  # Test 8
+        ["G0 C-8.5", "ok\r\nok\r\n"],  # Test 9
         # Set Speed
-        ['G0 F5.0004', 'ok\r\nok\r\n'],  # Test 10
-
+        ["G0 F5.0004", "ok\r\nok\r\n"],  # Test 10
         # Wait
-        ['M400', 'ok\r\nok\r\n'],  # Test 11
-
+        ["M400", "ok\r\nok\r\n"],  # Test 11
         # Set Current
-        ['M907 A0.1 B0.3 C0.05 X0.3 Y0.3 Z0.1', ''],  # Test 12
-
+        ["M907 A0.1 B0.3 C0.05 X0.3 Y0.3 Z0.1", ""],  # Test 12
         # Dwell
-        ['G4 P555', 'ok\r\nok\r\n'],  # Test 13
-
+        ["G4 P555", "ok\r\nok\r\n"],  # Test 13
         # Get Current Position
         [  # Test 14
-            'M114.2',
-            'M114.2\r\n\r\nok MCS: A:218.0 B:0.0 C:0.0 X:418.0 Y:-3.0 Z:218.0'
+            "M114.2",
+            "M114.2\r\n\r\nok MCS: A:218.0 B:0.0 C:0.0 X:418.0 Y:-3.0 Z:218.0",
         ],
-
         # Get Limit Switch Status
-        ['M119', 'Lid:closed'],  # Test 15
-
+        ["M119", "Lid:closed"],  # Test 15
         # Probe
         [  # Test 16
-            'G38.2 F420Y-40.0',
-            'G38.2 F420Y-40.0\r\n\r\n[PRB:296.825,292.663,218.000:1]\nok\r\nok\r\n'
+            "G38.2 F420Y-40.0",
+            "G38.2 F420Y-40.0\r\n\r\n[PRB:296.825,292.663,218.000:1]\nok\r\nok\r\n",
         ],
-
         # Absolute Mode
-        ['G90', ''],  # Test 17
-
+        ["G90", ""],  # Test 17
         # Relative Mode
-        ['G91', ''],  # Test 18
-
+        ["G91", ""],  # Test 18
         # Reset from Error
-        ['M999', 'ok\r\nok\r\n'],  # Test 19
-
+        ["M999", "ok\r\nok\r\n"],  # Test 19
         # Push Speed
         # TODO: Get Example
-        ['M120', ''],  # Test 20
-
+        ["M120", ""],  # Test 20
         # Pop Speed
         # TODO: Get Example
-        ['M121', ''],  # Test 21
-
+        ["M121", ""],  # Test 21
         # Steps per mm
         [  # Test 22
-            'M92 X80.0 Y80.0 Z400 A400',
-            'X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:955.000000 '
-            'C:768.000000 \r\nok\r\nok\r\n'
+            "M92 X80.0 Y80.0 Z400 A400",
+            "X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:955.000000 "
+            "C:768.000000 \r\nok\r\nok\r\n",
         ],
         [  # Test 23
-            'M92 B768',
-            'X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:768.000000 '
-            'C:768.000000'
+            "M92 B768",
+            "X:80.000000 Y:80.000000 Z:400.000000 A:400.000000 B:768.000000 "
+            "C:768.000000",
         ],
-
         # Read Instrument ID
         [  # Test 24
-            'M369 L',
-            'M369 L\r\n\r\nL: 5032305356323032303230303730313031'
-            '000000000000000000000000000000 \r\nok\r\nok\r\n'
+            "M369 L",
+            "M369 L\r\n\r\nL: 5032305356323032303230303730313031"
+            "000000000000000000000000000000 \r\nok\r\nok\r\n",
         ],
-
         # Write Instrument ID
         [  # Test 25
-            'M370 L5032305356323032303230303730313031000000000000000000000000000000',
-            ''
+            "M370 L5032305356323032303230303730313031000000000000000000000000000000",
+            "",
         ],
         # Read Instrument Model
         [  # Test 26
-            'M371 L',
-            'M371 L\r\n\r\nL: 7032305f6d756c74695f76322e3'
-            '0000000000000000000000000000000000000 \r\nok\r\nok\r\n'
+            "M371 L",
+            "M371 L\r\n\r\nL: 7032305f6d756c74695f76322e3"
+            "0000000000000000000000000000000000000 \r\nok\r\nok\r\n",
         ],
-
         # Write Instrument Model
         [  # Test 27
-            'M372 L7032305f6d756c74695f76322e30000000000000000000000000000000000000',
-            ''
+            "M372 L7032305f6d756c74695f76322e30000000000000000000000000000000000000",
+            "",
         ],
-
         # Set Max Speed
-        [  # Test 28
-            'M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n',
-            ''
-        ],
-
+        ["M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n", ""],  # Test 28
         # Disengage Motor
-        [  # Test 29
-            'M18 ZBCA',
-            ''
-        ],
-
+        ["M18 ZBCA", ""],  # Test 29
         # Homing Status
-        [  # Test 30
-            'G28.6',
-            'G28.6 X:0 Y:0 Z:0 A:0 B:0 C:0'
-        ],
-
+        ["G28.6", "G28.6 X:0 Y:0 Z:0 A:0 B:0 C:0"],  # Test 30
         # Acceleration
-        [  # Test 31
-            'M204 S10000 A1500 B200 C200 X3000 Y2000 Z1500 \r\n\r\n',
-            ''
-        ],
-
+        ["M204 S10000 A1500 B200 C200 X3000 Y2000 Z1500 \r\n\r\n", ""],  # Test 31
         # Pipette Home
-        [  # Test 32
-            'M365.0 A172.15',
-            ''
-        ],
-
+        ["M365.0 A172.15", ""],  # Test 32
         # Pipette Max Travel
-        [  # Test 33
-            'M365.1 A60',
-            ''
-        ],
-
+        ["M365.1 A60", ""],  # Test 33
         # Pipette Debounce
-        [  # Test 34
-            'M365.2 B60',
-            ''
-        ],
-
+        ["M365.2 B60", ""],  # Test 34
         # Pipette Retract
-        [  # Test 35
-            'M365.3 A20',
-            ''
-        ],
-
+        ["M365.3 A20", ""],  # Test 35
         # Microstepping B Enable
-        [  # Test 36
-            'M52',
-            ''
-        ],
-
+        ["M52", ""],  # Test 36
         # Microstepping B Disable
-        [  # Test 37
-            'M53',
-            ''
-        ],
-
+        ["M53", ""],  # Test 37
         # Microstepping C Enable
-        [  # Test 38
-            'M54',
-            ''
-        ],
-
+        ["M54", ""],  # Test 38
         # Microstepping C Disable
-        [  # Test 39
-            'M55',
-            ''
-        ],
-
+        ["M55", ""],  # Test 39
         # Read Instrument ID no space
         [  # Test 40
-            'M369 L',
-            'M369 L\r\n\r\nL:5032305356323032303230303730313031'
-            '000000000000000000000000000000 \r\nok\r\nok\r\n'
+            "M369 L",
+            "M369 L\r\n\r\nL:5032305356323032303230303730313031"
+            "000000000000000000000000000000 \r\nok\r\nok\r\n",
         ],
-
         # Read Instrument Model no space
         [  # Test 41
-            'M371 L',
-            'M371 L\r\n\r\nL:7032305f6d756c74695f76322e3'
-            '0000000000000000000000000000000000000 \r\nok\r\nok\r\n'
+            "M371 L",
+            "M371 L\r\n\r\nL:7032305f6d756c74695f76322e3"
+            "0000000000000000000000000000000000000 \r\nok\r\nok\r\n",
         ],
     ]
     g_code_list = [
-        GCode.from_raw_code(code, 'smoothie', response)
-        for code, response in raw_codes
+        GCode.from_raw_code(code, "smoothie", response) for code, response in raw_codes
     ]
 
     for g_code in g_code_list:
         if len(g_code) > 1:
-            g_codes = ', '.join([code.g_code for code in g_code])
-            raise Exception('Hey, you forgot to put a comma between the G-Codes for '
-                            f'{g_codes}')
+            g_codes = ", ".join([code.g_code for code in g_code])
+            raise Exception(
+                "Hey, you forgot to put a comma between the G-Codes for " f"{g_codes}"
+            )
 
     return [code[0] for code in g_code_list]
 
@@ -209,37 +142,32 @@ def smoothie_g_codes() -> List[GCode]:
 def magdeck_g_codes() -> List[GCode]:
     raw_codes = [
         # Test 42
-        ['G28.2', 'ok\r\nok\r\n'],
-
+        ["G28.2", "ok\r\nok\r\n"],
         # Test 43
-        ['G0 Z10.12', 'ok\r\nok\r\n'],
-
+        ["G0 Z10.12", "ok\r\nok\r\n"],
         # Test 44
-        ['M114.2', 'Z:12.34\r\nok\r\nok\r\n'],
-
+        ["M114.2", "Z:12.34\r\nok\r\nok\r\n"],
         # Test 45
-        ['G38.2', 'ok\r\nok\r\n'],
-
+        ["G38.2", "ok\r\nok\r\n"],
         # Test 46
-        ['M836', 'height:12.34\r\nok\r\nok\r\n'],
-
+        ["M836", "height:12.34\r\nok\r\nok\r\n"],
         # Test 47
         [
-            'M115', 'serial:MDV0118052801 model:mag_deck_v1 '
-            'version:edge-11aa22b\r\nok\r\nok\r\n'
+            "M115",
+            "serial:MDV0118052801 model:mag_deck_v1 "
+            "version:edge-11aa22b\r\nok\r\nok\r\n",
         ],
-
     ]
     g_code_list = [
-        GCode.from_raw_code(code, 'magdeck', response)
-        for code, response in raw_codes
+        GCode.from_raw_code(code, "magdeck", response) for code, response in raw_codes
     ]
 
     for g_code in g_code_list:
         if len(g_code) > 1:
-            g_codes = ', '.join(code.g_code for code in g_code)
-            raise Exception('Hey, you forgot to put a comma between the G-Codes for '
-                            f'{g_codes}')
+            g_codes = ", ".join(code.g_code for code in g_code)
+            raise Exception(
+                "Hey, you forgot to put a comma between the G-Codes for " f"{g_codes}"
+            )
 
     return [code[0] for code in g_code_list]
 
@@ -247,36 +175,33 @@ def magdeck_g_codes() -> List[GCode]:
 def tempdeck_g_codes() -> List[GCode]:
     raw_codes = [
         # Test 48
-        ['M18', 'ok\r\nok\r\n'],
-
+        ["M18", "ok\r\nok\r\n"],
         # Test 49
-        ['M104 S99.6 P0.4 I0.2 D0.3', 'ok\r\nok\r\n'],
-
+        ["M104 S99.6 P0.4 I0.2 D0.3", "ok\r\nok\r\n"],
         # Test 50
-        ['M104 S102.5', '\r\nok\r\nok\r\n'],
-
+        ["M104 S102.5", "\r\nok\r\nok\r\n"],
         # Test 51
-        ['M105', 'T:86.500 C:66.223\r\nok\r\nok\r\n'],
-
+        ["M105", "T:86.500 C:66.223\r\nok\r\nok\r\n"],
         # Test 52
-        ['M105', 'T:none C:45.32\r\nok\r\nok\r\n'],
-
+        ["M105", "T:none C:45.32\r\nok\r\nok\r\n"],
         # Test 53
         [
-            'M115', 'serial:TDV0118052801 model:temp_deck_v1 '
-            'version:edge-11aa22b\r\nok\r\nok\r\n'
+            "M115",
+            "serial:TDV0118052801 model:temp_deck_v1 "
+            "version:edge-11aa22b\r\nok\r\nok\r\n",
         ],
     ]
     g_code_list = [
-        GCode.from_raw_code(code, 'tempdeck', response)
-        for code, response in raw_codes
+        GCode.from_raw_code(code, "tempdeck", response) for code, response in raw_codes
     ]
 
     for g_code in g_code_list:
         if len(g_code) > 1:
-            tempdeck_g_codes = ', '.join([code.g_code for code in g_code])
-            raise Exception('Hey, you forgot to put a comma between the G-Codes for '
-                            f'{tempdeck_g_codes}')
+            tempdeck_g_codes = ", ".join([code.g_code for code in g_code])
+            raise Exception(
+                "Hey, you forgot to put a comma between the G-Codes for "
+                f"{tempdeck_g_codes}"
+            )
 
     return [code[0] for code in g_code_list]
 
@@ -284,87 +209,66 @@ def tempdeck_g_codes() -> List[GCode]:
 def thermocycler_g_codes() -> List[GCode]:
     raw_codes = [
         # Test 54
-        ['M119', 'Lid:open\r\nok\r\nok\r\n'],
+        ["M119", "Lid:open\r\nok\r\nok\r\n"],
         # Test 55
-        ['M119', 'Lid:closed\r\nok\r\nok\r\n'],
+        ["M119", "Lid:closed\r\nok\r\nok\r\n"],
         # Test 56
         [
-            'M115',
-            'serial:TCV0220191127A01 model:v02 '
-            'version:v1.0.0-13-ge948da5\r\nok\r\nok\r\n'
+            "M115",
+            "serial:TCV0220191127A01 model:v02 "
+            "version:v1.0.0-13-ge948da5\r\nok\r\nok\r\n",
         ],
         # Test 57
-        [
-            'M105',
-            'T:none C:22.173 H:none Total_H:none At_target?:0\r\nok\r\nok\r\n'
-        ],
+        ["M105", "T:none C:22.173 H:none Total_H:none At_target?:0\r\nok\r\nok\r\n"],
         # Test 58
         [
-            'M105',
-            'T:89.9 C:22.173 H:360.3 Total_H:400.5 At_target?:false\r\nok\r\nok\r\n'
+            "M105",
+            "T:89.9 C:22.173 H:360.3 Total_H:400.5 At_target?:false\r\nok\r\nok\r\n",
         ],
         # Test 59
-        [
-            'M105',
-            'T:70.9 C:70.9 H:0.0 Total_H:55.5 At_target?:true\r\nok\r\nok\r\n'
-        ],
+        ["M105", "T:70.9 C:70.9 H:0.0 Total_H:55.5 At_target?:true\r\nok\r\nok\r\n"],
         # Test 60
-        [
-            'M105',
-            'T:55.6 C:46.6 H:45.3 Total_H:150.5 At_target?:ugh\r\nok\r\nok\r\n'
-        ],
+        ["M105", "T:55.6 C:46.6 H:45.3 Total_H:150.5 At_target?:ugh\r\nok\r\nok\r\n"],
         # Test 61
-        [
-            'M105',
-            'T:40.000 C:23.823\r\nok\r\nok\r\n'
-        ],
+        ["M105", "T:40.000 C:23.823\r\nok\r\nok\r\n"],
         # Test 62
-        [
-            'M104 S40.0',
-            'ok\r\nok\r\n'
-        ],
+        ["M104 S40.0", "ok\r\nok\r\n"],
         # Test 63
-        [
-            'M126',
-            'ok\r\nok\r\n'
-        ],
+        ["M126", "ok\r\nok\r\n"],
         # Test 64
-        [
-            'M127',
-            'ok\r\nok\r\n'
-        ],
+        ["M127", "ok\r\nok\r\n"],
         # Test 65
-        ['M140 S85.7', 'ok\r\nok\r\n'],
+        ["M140 S85.7", "ok\r\nok\r\n"],
         # Test 66
-        ['M141', 'T:none C:21.974\r\nok\r\nok\r\n'],
+        ["M141", "T:none C:21.974\r\nok\r\nok\r\n"],
         # Test 67
-        ['M141', 'T:40.0 C:23.700\r\nok\r\nok\r\n'],
+        ["M141", "T:40.0 C:23.700\r\nok\r\nok\r\n"],
         # Test 68
-        ['M566', 'ok\r\nok\r\n'],
+        ["M566", "ok\r\nok\r\n"],
         # Test 69
-        ['M566', 'ERROR:BUSY\r\nok\r\n'],
+        ["M566", "ERROR:BUSY\r\nok\r\n"],
         # Test 70
-        ['M108', 'ok\r\nok\r\n'],
+        ["M108", "ok\r\nok\r\n"],
         # Test 71
-        ['M14', 'ok\r\nok\r\n'],
+        ["M14", "ok\r\nok\r\n"],
         # Test 72
-        ['M18', 'ok\r\nok\r\n'],
+        ["M18", "ok\r\nok\r\n"],
         # Test 73
-        ['M301 P0.2 I0.3 D0.4', 'ERROR:BUSY\r\nok\r\n'],
+        ["M301 P0.2 I0.3 D0.4", "ERROR:BUSY\r\nok\r\n"],
         # Test 74
-        ['M301 P0.2 I0.3 D0.4', 'ok\r\nok\r\n'],
-
+        ["M301 P0.2 I0.3 D0.4", "ok\r\nok\r\n"],
     ]
     g_code_list = [
-        GCode.from_raw_code(code, 'thermocycler', response)
+        GCode.from_raw_code(code, "thermocycler", response)
         for code, response in raw_codes
     ]
 
     for g_code in g_code_list:
         if len(g_code) > 1:
-            g_codes = ', '.join([code.g_code for code in g_code])
-            raise Exception('Hey, you forgot to put a comma between the G-Codes for '
-                            f'{g_codes}')
+            g_codes = ", ".join([code.g_code for code in g_code])
+            raise Exception(
+                "Hey, you forgot to put a comma between the G-Codes for " f"{g_codes}"
+            )
 
     return [code[0] for code in g_code_list]
 
@@ -382,87 +286,84 @@ def all_g_codes() -> List[GCode]:
 def expected_function_name_values() -> List[str]:
     return [
         #  Smoothie
-        'HOME',  # Test 0
-        'HOME',  # Test 1
-        'HOME',  # Test 2
-        'HOME',  # Test 3
-        'HOME',  # Test 4
-        'HOME',  # Test 5
-        'HOME',  # Test 6
-        'MOVE',  # Test 7
-        'MOVE',  # Test 8
-        'MOVE',  # Test 9
-        'SET_SPEED',  # Test 10
-        'WAIT',  # Test 11
-        'SET_CURRENT',  # Test 12
-        'DWELL',  # Test 13
-        'CURRENT_POSITION',  # Test 14
-        'LIMIT_SWITCH_STATUS',  # Test 15
-        'PROBE',  # Test 16
-        'ABSOLUTE_COORDS',  # Test 17
-        'RELATIVE_COORDS',  # Test 18
-        'RESET_FROM_ERROR',  # Test 19
-        'PUSH_SPEED',  # Test 20
-        'POP_SPEED',  # Test 21
-        'STEPS_PER_MM',  # Test 22
-        'STEPS_PER_MM',  # Test 23
-        'READ_INSTRUMENT_ID',  # Test 24
-        'WRITE_INSTRUMENT_ID',  # Test 25
-        'READ_INSTRUMENT_MODEL',  # Test 26
-        'WRITE_INSTRUMENT_MODEL',  # Test 27
-        'SET_MAX_SPEED',  # Test 28
-        'DISENGAGE_MOTOR',  # Test 29
-        'HOMING_STATUS',  # Test 30
-        'ACCELERATION',  # Test 31
-        'PIPETTE_HOME',  # Test 32
-        'PIPETTE_MAX_TRAVEL',  # Test 33
-        'PIPETTE_DEBOUNCE',  # Test 34
-        'PIPETTE_RETRACT',  # Test 35
-        'MICROSTEPPING_B_ENABLE',  # Test 36
-        'MICROSTEPPING_B_DISABLE',  # Test 37
-        'MICROSTEPPING_C_ENABLE',  # Test 38
-        'MICROSTEPPING_C_DISABLE',  # Test 39
-        'READ_INSTRUMENT_ID',  # Test 40
-        'READ_INSTRUMENT_MODEL',  # Test 41
-
+        "HOME",  # Test 0
+        "HOME",  # Test 1
+        "HOME",  # Test 2
+        "HOME",  # Test 3
+        "HOME",  # Test 4
+        "HOME",  # Test 5
+        "HOME",  # Test 6
+        "MOVE",  # Test 7
+        "MOVE",  # Test 8
+        "MOVE",  # Test 9
+        "SET_SPEED",  # Test 10
+        "WAIT",  # Test 11
+        "SET_CURRENT",  # Test 12
+        "DWELL",  # Test 13
+        "CURRENT_POSITION",  # Test 14
+        "LIMIT_SWITCH_STATUS",  # Test 15
+        "PROBE",  # Test 16
+        "ABSOLUTE_COORDS",  # Test 17
+        "RELATIVE_COORDS",  # Test 18
+        "RESET_FROM_ERROR",  # Test 19
+        "PUSH_SPEED",  # Test 20
+        "POP_SPEED",  # Test 21
+        "STEPS_PER_MM",  # Test 22
+        "STEPS_PER_MM",  # Test 23
+        "READ_INSTRUMENT_ID",  # Test 24
+        "WRITE_INSTRUMENT_ID",  # Test 25
+        "READ_INSTRUMENT_MODEL",  # Test 26
+        "WRITE_INSTRUMENT_MODEL",  # Test 27
+        "SET_MAX_SPEED",  # Test 28
+        "DISENGAGE_MOTOR",  # Test 29
+        "HOMING_STATUS",  # Test 30
+        "ACCELERATION",  # Test 31
+        "PIPETTE_HOME",  # Test 32
+        "PIPETTE_MAX_TRAVEL",  # Test 33
+        "PIPETTE_DEBOUNCE",  # Test 34
+        "PIPETTE_RETRACT",  # Test 35
+        "MICROSTEPPING_B_ENABLE",  # Test 36
+        "MICROSTEPPING_B_DISABLE",  # Test 37
+        "MICROSTEPPING_C_ENABLE",  # Test 38
+        "MICROSTEPPING_C_DISABLE",  # Test 39
+        "READ_INSTRUMENT_ID",  # Test 40
+        "READ_INSTRUMENT_MODEL",  # Test 41
         # Magdeck
-        'HOME',  # Test 42
-        'MOVE',  # Test 43
-        'GET_CURRENT_POSITION',  # Test 44
-        'PROBE_PLATE',  # Test 45
-        'GET_PLATE_HEIGHT',  # Test 46
-        'DEVICE_INFO',  # Test 47
-
+        "HOME",  # Test 42
+        "MOVE",  # Test 43
+        "GET_CURRENT_POSITION",  # Test 44
+        "PROBE_PLATE",  # Test 45
+        "GET_PLATE_HEIGHT",  # Test 46
+        "DEVICE_INFO",  # Test 47
         # Tempdeck
-        'DISENGAGE',  # Test 48
-        'SET_TEMP',  # Test 49
-        'SET_TEMP',  # Test 50
-        'GET_TEMP',  # Test 51
-        'GET_TEMP',  # Test 52
-        'DEVICE_INFO',  # Test 53
-
+        "DISENGAGE",  # Test 48
+        "SET_TEMP",  # Test 49
+        "SET_TEMP",  # Test 50
+        "GET_TEMP",  # Test 51
+        "GET_TEMP",  # Test 52
+        "DEVICE_INFO",  # Test 53
         # Thermocycler
-        'GET_LID_STATUS',  # Test 54
-        'GET_LID_STATUS',  # Test 55
-        'DEVICE_INFO',  # Test 56
-        'GET_PLATE_TEMP',  # Test 57
-        'GET_PLATE_TEMP',  # Test 58
-        'GET_PLATE_TEMP',  # Test 59
-        'GET_PLATE_TEMP',  # Test 60
-        'GET_PLATE_TEMP',  # Test 61
-        'SET_PLATE_TEMP',  # Test 62
-        'OPEN_LID',  # Test 63
-        'CLOSE_LID',  # Test 64
-        'SET_LID_TEMP',  # Test 65
-        'GET_LID_TEMP',  # Test 66
-        'GET_LID_TEMP',  # Test 67
-        'SET_RAMP_RATE',  # Test 68
-        'SET_RAMP_RATE',  # Test 69
-        'DEACTIVATE_LID',  # Test 70
-        'DEACTIVATE_BLOCK',  # Test 71
-        'DEACTIVATE_ALL',  # Test 72
-        'EDIT_PID_PARAMS',  # Test 73
-        'EDIT_PID_PARAMS',  # Test 74
+        "GET_LID_STATUS",  # Test 54
+        "GET_LID_STATUS",  # Test 55
+        "DEVICE_INFO",  # Test 56
+        "GET_PLATE_TEMP",  # Test 57
+        "GET_PLATE_TEMP",  # Test 58
+        "GET_PLATE_TEMP",  # Test 59
+        "GET_PLATE_TEMP",  # Test 60
+        "GET_PLATE_TEMP",  # Test 61
+        "SET_PLATE_TEMP",  # Test 62
+        "OPEN_LID",  # Test 63
+        "CLOSE_LID",  # Test 64
+        "SET_LID_TEMP",  # Test 65
+        "GET_LID_TEMP",  # Test 66
+        "GET_LID_TEMP",  # Test 67
+        "SET_RAMP_RATE",  # Test 68
+        "SET_RAMP_RATE",  # Test 69
+        "DEACTIVATE_LID",  # Test 70
+        "DEACTIVATE_BLOCK",  # Test 71
+        "DEACTIVATE_ALL",  # Test 72
+        "EDIT_PID_PARAMS",  # Test 73
+        "EDIT_PID_PARAMS",  # Test 74
     ]
 
 
@@ -470,153 +371,105 @@ def expected_arg_values() -> List[Dict[str, int]]:
     return [
         #  Smoothie
         # Test 0
-        {'A': None, 'B': None, 'C': None, 'X': None, 'Y': None, 'Z': None},
-
+        {"A": None, "B": None, "C": None, "X": None, "Y": None, "Z": None},
         # Test 1
-        {'X': None},
-
+        {"X": None},
         # Test 2
-        {'Y': None},
-
+        {"Y": None},
         # Test 3
-        {'Z': None},
-
+        {"Z": None},
         # Test 4
-        {'A': None},
-
+        {"A": None},
         # Test 5
-        {'B': None},
-
+        {"B": None},
         # Test 6
-        {'C': None},
-
+        {"C": None},
         # Test 7
-        {'X': 113.38, 'Y': 11.24},
-
+        {"X": 113.38, "Y": 11.24},
         # Test 8
-        {'A': 132.6},
-
+        {"A": 132.6},
         # Test 9
-        {'C': -8.5},
-
+        {"C": -8.5},
         # Test 10
-        {'F': 5.0004},
-
+        {"F": 5.0004},
         # Test 11
         {},
-
         # Test 12
-        {'A': 0.1, 'B': 0.3, 'C': 0.05, 'X': 0.3, 'Y': 0.3, 'Z': 0.1},
-
+        {"A": 0.1, "B": 0.3, "C": 0.05, "X": 0.3, "Y": 0.3, "Z": 0.1},
         # Test 13
-        {'P': 555},
-
+        {"P": 555},
         # Test 14
         {},
-
         # Test 15
         {},
-
         # Test 16
-        {'F': 420, 'Y': -40.0},
-
+        {"F": 420, "Y": -40.0},
         # Test 17
         {},
-
         # Test 18
         {},
-
         # Test 19
         {},
-
         # Test 20
         {},
-
         # Test 21
         {},
-
         # Test 22
-        {'X': 80.0, 'Y': 80.0, 'Z': 400, 'A': 400},
-
+        {"X": 80.0, "Y": 80.0, "Z": 400, "A": 400},
         # Test 23
-        {'B': 768.0},
-
+        {"B": 768.0},
         # # TODO: Need to figure out to do with 24, 25, 26, and 27
         # Test 24
-        {'L': None},
-
+        {"L": None},
         # Test 25
-        {'L': '5032305356323032303230303730313031000000000000000000000000000000'},
-
+        {"L": "5032305356323032303230303730313031000000000000000000000000000000"},
         # Test 26
-        {'L': None},
-
+        {"L": None},
         # Test 27
-        {'L': '7032305f6d756c74695f76322e30000000000000000000000000000000000000'},
-
+        {"L": "7032305f6d756c74695f76322e30000000000000000000000000000000000000"},
         # Test 28
-        {'A': 125.0, 'B': 40.0, 'C': 40.0, 'X': 600.0, 'Y': 400.0, 'Z': 125.0},
-
+        {"A": 125.0, "B": 40.0, "C": 40.0, "X": 600.0, "Y": 400.0, "Z": 125.0},
         # Test 29
-        {'Z': None, 'B': None, 'C': None, 'A': None},
-
+        {"Z": None, "B": None, "C": None, "A": None},
         # Test 30
         {},
-
         # Test 31
         {
-            'S': 10000.0,
-            'A': 1500.0,
-            'B': 200.0,
-            'C': 200.0,
-            'X': 3000.0,
-            'Y': 2000.0,
-            'Z': 1500.0
+            "S": 10000.0,
+            "A": 1500.0,
+            "B": 200.0,
+            "C": 200.0,
+            "X": 3000.0,
+            "Y": 2000.0,
+            "Z": 1500.0,
         },
-
         # Test 32
-        {
-            'A': 172.15
-        },
-
+        {"A": 172.15},
         # Test 33
-        {
-            'A': 60.0
-        },
-
+        {"A": 60.0},
         # Test 34
         {
-            'B': 60.0,
+            "B": 60.0,
         },
-
         # Test 35
-        {
-            'A': 20.0
-        },
-
+        {"A": 20.0},
         # Test 36
         {},
-
         # Test 37
         {},
-
         # Test 38
         {},
-
         # Test 39
         {},
-
         # Test 40
-        {'L': None},
-
+        {"L": None},
         # Test 41
-        {'L': None},
-
+        {"L": None},
         # Magdeck
         # Test 42
         {},
         # Test 43
-        {'Z': 10.12},
+        {"Z": 10.12},
         # Test 44
         {},
         # Test 45
@@ -625,21 +478,19 @@ def expected_arg_values() -> List[Dict[str, int]]:
         {},
         # Test 47
         {},
-
         # Tempdeck
         # Test 48
         {},
         # Test 49
-        {'S': 99.6, 'P': 0.4, 'I': 0.2, 'D': 0.3},
+        {"S": 99.6, "P": 0.4, "I": 0.2, "D": 0.3},
         # Test 50
-        {'S': 102.5},
+        {"S": 102.5},
         # Test 51
         {},
         # Test 52
         {},
         # Test 53
         {},
-
         # Thermocycler
         # Test 54
         {},
@@ -658,13 +509,13 @@ def expected_arg_values() -> List[Dict[str, int]]:
         # Test 61
         {},
         # Test 62
-        {'S': 40.0},
+        {"S": 40.0},
         # Test 63
         {},
         # Test 64
         {},
         # Test 65
-        {'S': 85.7},
+        {"S": 85.7},
         # Test 66
         {},
         # Test 67
@@ -680,9 +531,9 @@ def expected_arg_values() -> List[Dict[str, int]]:
         # Test 72
         {},
         # Test 73
-        {'P': 0.2, 'I': 0.3, 'D': 0.4},
+        {"P": 0.2, "I": 0.3, "D": 0.4},
         # Test 74
-        {'P': 0.2, 'I': 0.3, 'D': 0.4},
+        {"P": 0.2, "I": 0.3, "D": 0.4},
     ]
 
 
@@ -690,786 +541,773 @@ def explanations() -> List[Explanation]:
     return [
         #  Smoothie
         Explanation(  # Test 0
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'A': None, 'B': None, 'C': None, 'X': None, 'Y': None,
-                           'Z': None},
-            command_explanation='Homing the following axes: X, Y, Z, A, B, C'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={
+                "A": None,
+                "B": None,
+                "C": None,
+                "X": None,
+                "Y": None,
+                "Z": None,
+            },
+            command_explanation="Homing the following axes: X, Y, Z, A, B, C",
         ),
         Explanation(  # Test 1
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'X': None},
-            command_explanation='Homing the following axes: X'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={"X": None},
+            command_explanation="Homing the following axes: X",
         ),
         Explanation(  # Test 2
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'Y': None},
-            command_explanation='Homing the following axes: Y'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={"Y": None},
+            command_explanation="Homing the following axes: Y",
         ),
         Explanation(  # Test 3
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'Z': None},
-            command_explanation='Homing the following axes: Z'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={"Z": None},
+            command_explanation="Homing the following axes: Z",
         ),
         Explanation(  # Test 4
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'A': None},
-            command_explanation='Homing the following axes: A'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={"A": None},
+            command_explanation="Homing the following axes: A",
         ),
         Explanation(  # Test 5
-            code='G28.2',
-            command_name='HOME',
-            response='',
-            provided_args={'B': None},
-            command_explanation='Homing the following axes: B'
+            code="G28.2",
+            command_name="HOME",
+            response="",
+            provided_args={"B": None},
+            command_explanation="Homing the following axes: B",
         ),
         Explanation(  # Test 6
-            code='G28.2',
-            command_name='HOME',
-            response='',
+            code="G28.2",
+            command_name="HOME",
+            response="",
             provided_args={
-                'C': None,
+                "C": None,
             },
-            command_explanation='Homing the following axes: C'
+            command_explanation="Homing the following axes: C",
         ),
         Explanation(  # Test 7
-            code='G0',
-            command_name='MOVE',
-            response='',
-            provided_args={'X': 113.38, 'Y': 11.24},
-            command_explanation='Moving the robot as follows:\n\t'
-                                'The gantry to 113.38 on the X-Axis\n\t'
-                                'The gantry to 11.24 on the Y-Axis'
+            code="G0",
+            command_name="MOVE",
+            response="",
+            provided_args={"X": 113.38, "Y": 11.24},
+            command_explanation="Moving the robot as follows:\n\t"
+            "The gantry to 113.38 on the X-Axis\n\t"
+            "The gantry to 11.24 on the Y-Axis",
         ),
         Explanation(  # Test 8
-            code='G0',
-            command_name='MOVE',
-            response='',
-            provided_args={'A': 132.6},
-            command_explanation='Moving the robot as follows:\n\t'
-                                'The right pipette arm height to 132.6'
+            code="G0",
+            command_name="MOVE",
+            response="",
+            provided_args={"A": 132.6},
+            command_explanation="Moving the robot as follows:\n\t"
+            "The right pipette arm height to 132.6",
         ),
         Explanation(  # Test 9
-            code='G0',
-            command_name='MOVE',
-            response='',
-            provided_args={'C': -8.5},
-            command_explanation='Moving the robot as follows:\n\t'
-                                'The right pipette suction to -8.5'
+            code="G0",
+            command_name="MOVE",
+            response="",
+            provided_args={"C": -8.5},
+            command_explanation="Moving the robot as follows:\n\t"
+            "The right pipette suction to -8.5",
         ),
         Explanation(  # Test 10
-            code='G0',
-            command_name='SET_SPEED',
-            response='',
-            provided_args={'F': 5.0004},
-            command_explanation='Setting speed to 5.0004'
+            code="G0",
+            command_name="SET_SPEED",
+            response="",
+            provided_args={"F": 5.0004},
+            command_explanation="Setting speed to 5.0004",
         ),
         Explanation(  # Test 11
-            code='M400',
-            command_name='WAIT',
-            response='',
+            code="M400",
+            command_name="WAIT",
+            response="",
             provided_args={},
-            command_explanation='Waiting for motors to stop moving'
+            command_explanation="Waiting for motors to stop moving",
         ),
         Explanation(  # Test 12
-            code='M907',
-            command_name='SET_CURRENT',
-            response='',
-            provided_args={'X': 0.3, 'Y': 0.3, 'Z': 0.1, 'A': 0.1, 'B': 0.3, 'C': 0.05},
-            command_explanation='Setting the current (in amps) to:\n\t'
-                                'X-Axis Motor: 0.3\n\t'
-                                'Y-Axis Motor: 0.3\n\t'
-                                'Z-Axis Motor: 0.1\n\t'
-                                'A-Axis Motor: 0.1\n\t'
-                                'B-Axis Motor: 0.3\n\t'
-                                'C-Axis Motor: 0.05'
+            code="M907",
+            command_name="SET_CURRENT",
+            response="",
+            provided_args={"X": 0.3, "Y": 0.3, "Z": 0.1, "A": 0.1, "B": 0.3, "C": 0.05},
+            command_explanation="Setting the current (in amps) to:\n\t"
+            "X-Axis Motor: 0.3\n\t"
+            "Y-Axis Motor: 0.3\n\t"
+            "Z-Axis Motor: 0.1\n\t"
+            "A-Axis Motor: 0.1\n\t"
+            "B-Axis Motor: 0.3\n\t"
+            "C-Axis Motor: 0.05",
         ),
         Explanation(  # Test 13
-            code='G4',
-            command_name='DWELL',
-            response='',
-            provided_args={'P': 555.0},
-            command_explanation='Pausing movement for 555.0ms'
+            code="G4",
+            command_name="DWELL",
+            response="",
+            provided_args={"P": 555.0},
+            command_explanation="Pausing movement for 555.0ms",
         ),
         Explanation(  # Test 14
-            code='M114.2',
-            command_name='CURRENT_POSITION',
-            response='The current position of the robot is:'
-                     '\n\tA Axis: 218.0'
-                     '\n\tB Axis: 0.0'
-                     '\n\tC Axis: 0.0'
-                     '\n\tX Axis: 418.0'
-                     '\n\tY Axis: -3.0'
-                     '\n\tZ Axis: 218.0',
+            code="M114.2",
+            command_name="CURRENT_POSITION",
+            response="The current position of the robot is:"
+            "\n\tA Axis: 218.0"
+            "\n\tB Axis: 0.0"
+            "\n\tC Axis: 0.0"
+            "\n\tX Axis: 418.0"
+            "\n\tY Axis: -3.0"
+            "\n\tZ Axis: 218.0",
             provided_args={},
-            command_explanation='Getting current position for all axes'
+            command_explanation="Getting current position for all axes",
         ),
         Explanation(  # Test 15
-            code='M119',
-            command_name='LIMIT_SWITCH_STATUS',
-            response='Lid:closed',
+            code="M119",
+            command_name="LIMIT_SWITCH_STATUS",
+            response="Lid:closed",
             provided_args={},
-            command_explanation='Getting the limit switch status'
+            command_explanation="Getting the limit switch status",
         ),
         Explanation(  # Test 16
-            code='G38.2',
-            command_name='PROBE',
-            response='Probed to :'
-                     '\n\tX Axis: 296.825'
-                     '\n\tY Axis: 292.663'
-                     '\n\tZ Axis: 218.000',
-            provided_args={'F': 420, 'Y': -40.0},
-            command_explanation='Probing -40.0 on the Y axis, at a speed of 420.0'
+            code="G38.2",
+            command_name="PROBE",
+            response="Probed to :"
+            "\n\tX Axis: 296.825"
+            "\n\tY Axis: 292.663"
+            "\n\tZ Axis: 218.000",
+            provided_args={"F": 420, "Y": -40.0},
+            command_explanation="Probing -40.0 on the Y axis, at a speed of 420.0",
         ),
         Explanation(  # Test 17
-            code='G90',
-            command_name='ABSOLUTE_COORDS',
-            response='',
+            code="G90",
+            command_name="ABSOLUTE_COORDS",
+            response="",
             provided_args={},
-            command_explanation='Switching to Absolute Coordinate Mode'
+            command_explanation="Switching to Absolute Coordinate Mode",
         ),
         Explanation(  # Test 18
-            code='G91',
-            command_name='RELATIVE_COORDS',
-            response='',
+            code="G91",
+            command_name="RELATIVE_COORDS",
+            response="",
             provided_args={},
-            command_explanation='Switching to Relative Coordinate Mode'
+            command_explanation="Switching to Relative Coordinate Mode",
         ),
         Explanation(  # Test 19
-            code='M999',
-            command_name='RESET_FROM_ERROR',
-            response='',
+            code="M999",
+            command_name="RESET_FROM_ERROR",
+            response="",
             provided_args={},
-            command_explanation='Resetting OT-2 from error state'
+            command_explanation="Resetting OT-2 from error state",
         ),
         Explanation(  # Test 20
-            code='M120',
-            command_name='PUSH_SPEED',
-            response='',
+            code="M120",
+            command_name="PUSH_SPEED",
+            response="",
             provided_args={},
-            command_explanation='Saving current speed so temporary'
-                                ' speed can be set'
+            command_explanation="Saving current speed so temporary" " speed can be set",
         ),
         Explanation(  # Test 21
-            code='M121',
-            command_name='POP_SPEED',
-            response='',
+            code="M121",
+            command_name="POP_SPEED",
+            response="",
             provided_args={},
-            command_explanation='Loading previously saved speed'
+            command_explanation="Loading previously saved speed",
         ),
         Explanation(  # Test 22
-            code='M92',
-            command_name='STEPS_PER_MM',
-            response='Current set steps per mm:'
-                     '\n\tX Axis: 80.000000'
-                     '\n\tY Axis: 80.000000'
-                     '\n\tZ Axis: 400.000000'
-                     '\n\tA Axis: 400.000000'
-                     '\n\tB Axis: 955.000000'
-                     '\n\tC Axis: 768.000000',
-            provided_args={'X': 80.0, 'Y': 80.0, 'Z': 400.0, 'A': 400.0},
-            command_explanation='Setting the following axes steps per'
-                                ' mm:'
-                                '\n\tX-Axis: 80.0 steps per mm'
-                                '\n\tY-Axis: 80.0 steps per mm'
-                                '\n\tZ-Axis: 400.0 steps per mm'
-                                '\n\tA-Axis: 400.0 steps per mm'
+            code="M92",
+            command_name="STEPS_PER_MM",
+            response="Current set steps per mm:"
+            "\n\tX Axis: 80.000000"
+            "\n\tY Axis: 80.000000"
+            "\n\tZ Axis: 400.000000"
+            "\n\tA Axis: 400.000000"
+            "\n\tB Axis: 955.000000"
+            "\n\tC Axis: 768.000000",
+            provided_args={"X": 80.0, "Y": 80.0, "Z": 400.0, "A": 400.0},
+            command_explanation="Setting the following axes steps per"
+            " mm:"
+            "\n\tX-Axis: 80.0 steps per mm"
+            "\n\tY-Axis: 80.0 steps per mm"
+            "\n\tZ-Axis: 400.0 steps per mm"
+            "\n\tA-Axis: 400.0 steps per mm",
         ),
         Explanation(  # Test 23
-            code='M92',
-            command_name='STEPS_PER_MM',
-            response='Current set steps per mm:'
-                     '\n\tX Axis: 80.000000'
-                     '\n\tY Axis: 80.000000'
-                     '\n\tZ Axis: 400.000000'
-                     '\n\tA Axis: 400.000000'
-                     '\n\tB Axis: 768.000000'
-                     '\n\tC Axis: 768.000000',
-            provided_args={'B': 768.0},
-            command_explanation='Setting the following axes steps per'
-                                ' mm:'
-                                '\n\tB-Axis: 768.0 steps per mm'
+            code="M92",
+            command_name="STEPS_PER_MM",
+            response="Current set steps per mm:"
+            "\n\tX Axis: 80.000000"
+            "\n\tY Axis: 80.000000"
+            "\n\tZ Axis: 400.000000"
+            "\n\tA Axis: 400.000000"
+            "\n\tB Axis: 768.000000"
+            "\n\tC Axis: 768.000000",
+            provided_args={"B": 768.0},
+            command_explanation="Setting the following axes steps per"
+            " mm:"
+            "\n\tB-Axis: 768.0 steps per mm",
         ),
         # Test 24
         Explanation(
-            code='M369',
-            command_name='READ_INSTRUMENT_ID',
-            response='Read Instrument ID: P20SV202020070101',
-            provided_args={'L': None},
-            command_explanation='Reading instrument ID for Left pipette'
+            code="M369",
+            command_name="READ_INSTRUMENT_ID",
+            response="Read Instrument ID: P20SV202020070101",
+            provided_args={"L": None},
+            command_explanation="Reading instrument ID for Left pipette",
         ),
         # Test 25
         Explanation(
-            code='M370',
-            command_name='WRITE_INSTRUMENT_ID',
-            response='',
-            provided_args={'L': '5032305356323032303230303730313031'
-                                '000000000000000000000000000000'},
-            command_explanation='Writing instrument ID 50323053563230323032303037303130'
-                                '31000000000000000000000000000000 for Left pipette'
+            code="M370",
+            command_name="WRITE_INSTRUMENT_ID",
+            response="",
+            provided_args={
+                "L": "5032305356323032303230303730313031"
+                "000000000000000000000000000000"
+            },
+            command_explanation="Writing instrument ID 50323053563230323032303037303130"
+            "31000000000000000000000000000000 for Left pipette",
         ),
         # Test 26
         Explanation(
-            code='M371',
-            command_name='READ_INSTRUMENT_MODEL',
-            response='Read Instrument Model: p20_multi_v2.0',
-            provided_args={'L': None},
-            command_explanation='Reading instrument model for Left pipette'
+            code="M371",
+            command_name="READ_INSTRUMENT_MODEL",
+            response="Read Instrument Model: p20_multi_v2.0",
+            provided_args={"L": None},
+            command_explanation="Reading instrument model for Left pipette",
         ),
         # Test 27
         Explanation(
-            code='M372',
-            command_name='WRITE_INSTRUMENT_MODEL',
-            response='',
-            provided_args={'L': '7032305f6d756c74695f76322e'
-                                '30000000000000000000000000000000000000'},
-            command_explanation='Writing instrument model 7032305f6d756c74695f76322e3'
-                                '0000000000000000000000000000000000000 for Left pipette'
+            code="M372",
+            command_name="WRITE_INSTRUMENT_MODEL",
+            response="",
+            provided_args={
+                "L": "7032305f6d756c74695f76322e"
+                "30000000000000000000000000000000000000"
+            },
+            command_explanation="Writing instrument model 7032305f6d756c74695f76322e3"
+            "0000000000000000000000000000000000000 for Left pipette",
         ),
         Explanation(  # Test 28
-            code='M203.1',
-            command_name='SET_MAX_SPEED',
-            response='',
+            code="M203.1",
+            command_name="SET_MAX_SPEED",
+            response="",
             provided_args={
-                'A': 125.0,
-                'B': 40.0,
-                'C': 40.0,
-                'X': 600.0,
-                'Y': 400.0,
-                'Z': 125.0
+                "A": 125.0,
+                "B": 40.0,
+                "C": 40.0,
+                "X": 600.0,
+                "Y": 400.0,
+                "Z": 125.0,
             },
-            command_explanation='Setting the max speed for the following axes:'\
-                                '\n\tX-Axis: 600.0'
-                                '\n\tY-Axis: 400.0'
-                                '\n\tZ-Axis: 125.0'
-                                '\n\tA-Axis: 125.0'
-                                '\n\tB-Axis: 40.0'
-                                '\n\tC-Axis: 40.0'
+            command_explanation="Setting the max speed for the following axes:"
+            "\n\tX-Axis: 600.0"
+            "\n\tY-Axis: 400.0"
+            "\n\tZ-Axis: 125.0"
+            "\n\tA-Axis: 125.0"
+            "\n\tB-Axis: 40.0"
+            "\n\tC-Axis: 40.0",
         ),
         Explanation(  # Test 29
-            code='M18',
-            command_name='DISENGAGE_MOTOR',
-            response='',
-            provided_args={'Z': None, 'B': None, 'C': None, 'A': None},
-            command_explanation='Disengaging motor for the following axes: Z, A, B, C'
+            code="M18",
+            command_name="DISENGAGE_MOTOR",
+            response="",
+            provided_args={"Z": None, "B": None, "C": None, "A": None},
+            command_explanation="Disengaging motor for the following axes: Z, A, B, C",
         ),
         Explanation(  # Test 30
-            code='G28.6',
-            command_name='HOMING_STATUS',
-            response='The homing status of the robot is:'
-                     '\n\tA Axis: 0'
-                     '\n\tB Axis: 0'
-                     '\n\tC Axis: 0'
-                     '\n\tX Axis: 0'
-                     '\n\tY Axis: 0'
-                     '\n\tZ Axis: 0',
+            code="G28.6",
+            command_name="HOMING_STATUS",
+            response="The homing status of the robot is:"
+            "\n\tA Axis: 0"
+            "\n\tB Axis: 0"
+            "\n\tC Axis: 0"
+            "\n\tX Axis: 0"
+            "\n\tY Axis: 0"
+            "\n\tZ Axis: 0",
             provided_args={},
-            command_explanation='Getting homing status for all axes'
-
+            command_explanation="Getting homing status for all axes",
         ),
         Explanation(  # Test 31
-            code='M204',
-            command_name='ACCELERATION',
-            response='',
+            code="M204",
+            command_name="ACCELERATION",
+            response="",
             provided_args={
-                'S': 10000.0,
-                'A': 1500.0,
-                'B': 200.0,
-                'C': 200.0,
-                'X': 3000.0,
-                'Y': 2000.0,
-                'Z': 1500.0
+                "S": 10000.0,
+                "A": 1500.0,
+                "B": 200.0,
+                "C": 200.0,
+                "X": 3000.0,
+                "Y": 2000.0,
+                "Z": 1500.0,
             },
-            command_explanation='Setting acceleration for the following axes:' \
-                                '\n\tDefault: 10000.0'
-                                '\n\tX-Axis: 3000.0'
-                                '\n\tY-Axis: 2000.0'
-                                '\n\tLeft Pipette Arm: 1500.0'
-                                '\n\tRight Pipette Arm: 1500.0'
-                                '\n\tLeft Pipette Suction: 200.0'
-                                '\n\tRight Pipette Suction: 200.0'
+            command_explanation="Setting acceleration for the following axes:"
+            "\n\tDefault: 10000.0"
+            "\n\tX-Axis: 3000.0"
+            "\n\tY-Axis: 2000.0"
+            "\n\tLeft Pipette Arm: 1500.0"
+            "\n\tRight Pipette Arm: 1500.0"
+            "\n\tLeft Pipette Suction: 200.0"
+            "\n\tRight Pipette Suction: 200.0",
         ),
         Explanation(  # Test 32
-            code='M365.0',
-            command_name='PIPETTE_HOME',
-            response='',
-            provided_args={
-                'A': 172.15
-            },
-            command_explanation='Setting the pipette home height for the following '
-                                'axes:'
-                                '\n\tA-Axis: 172.15'
+            code="M365.0",
+            command_name="PIPETTE_HOME",
+            response="",
+            provided_args={"A": 172.15},
+            command_explanation="Setting the pipette home height for the following "
+            "axes:"
+            "\n\tA-Axis: 172.15",
         ),
         Explanation(  # Test 33
-            code='M365.1',
-            command_name='PIPETTE_MAX_TRAVEL',
-            response='',
-            provided_args={
-                'A': 60.0
-            },
-            command_explanation='Setting the pipette max travel height for the '
-                                'following axes:'
-                                '\n\tA-Axis: 60.0'
+            code="M365.1",
+            command_name="PIPETTE_MAX_TRAVEL",
+            response="",
+            provided_args={"A": 60.0},
+            command_explanation="Setting the pipette max travel height for the "
+            "following axes:"
+            "\n\tA-Axis: 60.0",
         ),
         Explanation(  # Test 34
-            code='M365.2',
-            command_name='PIPETTE_DEBOUNCE',
-            response='',
-            provided_args={
-                'B': 60.0
-            },
-            command_explanation='Setting the pipette endstop debounce time for the '
-                                'following axes:'
-                                '\n\tB-Axis: 60.0'
+            code="M365.2",
+            command_name="PIPETTE_DEBOUNCE",
+            response="",
+            provided_args={"B": 60.0},
+            command_explanation="Setting the pipette endstop debounce time for the "
+            "following axes:"
+            "\n\tB-Axis: 60.0",
         ),
         Explanation(  # Test 35
-            code='M365.3',
-            command_name='PIPETTE_RETRACT',
-            response='',
-            provided_args={
-                'A': 20.0
-            },
-            command_explanation='Setting the pipette endstop retract distance for the '
-                                'following axes:'
-                                '\n\tA-Axis: 20.0'
+            code="M365.3",
+            command_name="PIPETTE_RETRACT",
+            response="",
+            provided_args={"A": 20.0},
+            command_explanation="Setting the pipette endstop retract distance for the "
+            "following axes:"
+            "\n\tA-Axis: 20.0",
         ),
         Explanation(  # Test 36
-            code='M52',
-            command_name='MICROSTEPPING_B_ENABLE',
-            response='',
+            code="M52",
+            command_name="MICROSTEPPING_B_ENABLE",
+            response="",
             provided_args={},
-            command_explanation='Enabling microstepping on B-Axis'
+            command_explanation="Enabling microstepping on B-Axis",
         ),
         Explanation(  # Test 37
-            code='M53',
-            command_name='MICROSTEPPING_B_DISABLE',
-            response='',
+            code="M53",
+            command_name="MICROSTEPPING_B_DISABLE",
+            response="",
             provided_args={},
-            command_explanation='Disabling microstepping on B-Axis'
+            command_explanation="Disabling microstepping on B-Axis",
         ),
         Explanation(  # Test 38
-            code='M54',
-            command_name='MICROSTEPPING_C_ENABLE',
-            response='',
+            code="M54",
+            command_name="MICROSTEPPING_C_ENABLE",
+            response="",
             provided_args={},
-            command_explanation='Enabling microstepping on C-Axis'
+            command_explanation="Enabling microstepping on C-Axis",
         ),
         Explanation(  # Test 39
-            code='M55',
-            command_name='MICROSTEPPING_C_DISABLE',
-            response='',
+            code="M55",
+            command_name="MICROSTEPPING_C_DISABLE",
+            response="",
             provided_args={},
-            command_explanation='Disabling microstepping on C-Axis'
+            command_explanation="Disabling microstepping on C-Axis",
         ),
         # Test 40
         Explanation(
-            code='M369',
-            command_name='READ_INSTRUMENT_ID',
-            response='Read Instrument ID: P20SV202020070101',
-            provided_args={'L': None},
-            command_explanation='Reading instrument ID for Left pipette'
+            code="M369",
+            command_name="READ_INSTRUMENT_ID",
+            response="Read Instrument ID: P20SV202020070101",
+            provided_args={"L": None},
+            command_explanation="Reading instrument ID for Left pipette",
         ),
         # Test 41
         Explanation(
-            code='M371',
-            command_name='READ_INSTRUMENT_MODEL',
-            response='Read Instrument Model: p20_multi_v2.0',
-            provided_args={'L': None},
-            command_explanation='Reading instrument model for Left pipette'
+            code="M371",
+            command_name="READ_INSTRUMENT_MODEL",
+            response="Read Instrument Model: p20_multi_v2.0",
+            provided_args={"L": None},
+            command_explanation="Reading instrument model for Left pipette",
         ),
-
         # Magdeck
         # Test 42
         Explanation(
-            code='G28.2',
-            command_name='HOME',
-            response='',
+            code="G28.2",
+            command_name="HOME",
+            response="",
             provided_args={},
-            command_explanation='Homing the magdeck'
+            command_explanation="Homing the magdeck",
         ),
         # Test 43
         Explanation(
-            code='G0',
-            command_name='MOVE',
-            response='',
-            provided_args={'Z': 10.12},
-            command_explanation='Setting magnet height to 10.12mm'
+            code="G0",
+            command_name="MOVE",
+            response="",
+            provided_args={"Z": 10.12},
+            command_explanation="Setting magnet height to 10.12mm",
         ),
         # Test 44
         Explanation(
-            code='M114.2',
-            command_name='GET_CURRENT_POSITION',
-            response='Current height of magnets are 12.34mm',
+            code="M114.2",
+            command_name="GET_CURRENT_POSITION",
+            response="Current height of magnets are 12.34mm",
             provided_args={},
-            command_explanation='Reading current position of magnets'
+            command_explanation="Reading current position of magnets",
         ),
         # Test 45
         Explanation(
-            code='G38.2',
-            command_name='PROBE_PLATE',
-            response='',
+            code="G38.2",
+            command_name="PROBE_PLATE",
+            response="",
             provided_args={},
-            command_explanation='Magdeck probing attached labware to get height in mm'
+            command_explanation="Magdeck probing attached labware to get height in mm",
         ),
         # Test 46
         Explanation(
-            code='M836',
-            command_name='GET_PLATE_HEIGHT',
-            response='Magdeck calculated labware height at 12.34mm',
+            code="M836",
+            command_name="GET_PLATE_HEIGHT",
+            response="Magdeck calculated labware height at 12.34mm",
             provided_args={},
-            command_explanation='Calculating magdeck labware height'
+            command_explanation="Calculating magdeck labware height",
         ),
         # Test 47
         Explanation(
-            code='M115',
-            command_name='DEVICE_INFO',
-            response='Magdeck info:'
-                     '\n\tSerial Number: MDV0118052801'
-                     '\n\tModel: mag_deck_v1'
-                     '\n\tFirmware Version: edge-11aa22b',
+            code="M115",
+            command_name="DEVICE_INFO",
+            response="Magdeck info:"
+            "\n\tSerial Number: MDV0118052801"
+            "\n\tModel: mag_deck_v1"
+            "\n\tFirmware Version: edge-11aa22b",
             provided_args={},
-            command_explanation='Getting magdeck device info'
+            command_explanation="Getting magdeck device info",
         ),
-
         # Tempdeck
         # Test 48
         Explanation(
-            code='M18',
-            command_name='DISENGAGE',
-            response='',
+            code="M18",
+            command_name="DISENGAGE",
+            response="",
             provided_args={},
-            command_explanation='Halting holding temperature. Reducing temperature to '
-                                '55C if it is greater than 55C'
+            command_explanation="Halting holding temperature. Reducing temperature to "
+            "55C if it is greater than 55C",
         ),
         # Test 49
         Explanation(
-            code='M104',
-            command_name='SET_TEMP',
-            response='',
-            provided_args={'S': 99.6, 'P': 0.4, 'I': 0.2, 'D': 0.3},
-            command_explanation='Setting temperature values to the following:'
-                                '\n\tTemperature: 99.6C'
-                                '\n\tKp: 0.4'
-                                '\n\tKi: 0.2'
-                                '\n\tKd: 0.3'
+            code="M104",
+            command_name="SET_TEMP",
+            response="",
+            provided_args={"S": 99.6, "P": 0.4, "I": 0.2, "D": 0.3},
+            command_explanation="Setting temperature values to the following:"
+            "\n\tTemperature: 99.6C"
+            "\n\tKp: 0.4"
+            "\n\tKi: 0.2"
+            "\n\tKd: 0.3",
         ),
         # Test 50
         Explanation(
-            code='M104',
-            command_name='SET_TEMP',
-            response='',
-            provided_args={'S': 102.5},
-            command_explanation='Setting temperature values to the following:'
-                                '\n\tTemperature: 102.5C'
-
+            code="M104",
+            command_name="SET_TEMP",
+            response="",
+            provided_args={"S": 102.5},
+            command_explanation="Setting temperature values to the following:"
+            "\n\tTemperature: 102.5C",
         ),
         # Test 51
         Explanation(
-            code='M105',
-            command_name='GET_TEMP',
-            response='Set temperature is 86.500C. Current temperature is 66.223C',
+            code="M105",
+            command_name="GET_TEMP",
+            response="Set temperature is 86.500C. Current temperature is 66.223C",
             provided_args={},
-            command_explanation='Getting temperature',
+            command_explanation="Getting temperature",
         ),
         # Test 52
         Explanation(
-            code='M105',
-            command_name='GET_TEMP',
-            response='Temp deck is disengaged. Current temperature is 45.32C',
+            code="M105",
+            command_name="GET_TEMP",
+            response="Temp deck is disengaged. Current temperature is 45.32C",
             provided_args={},
-            command_explanation='Getting temperature',
+            command_explanation="Getting temperature",
         ),
         # Test 53
         Explanation(
-            code='M115',
-            command_name='DEVICE_INFO',
-            response='Tempdeck info:'
-                     '\n\tSerial Number: TDV0118052801'
-                     '\n\tModel: temp_deck_v1'
-                     '\n\tFirmware Version: edge-11aa22b',
+            code="M115",
+            command_name="DEVICE_INFO",
+            response="Tempdeck info:"
+            "\n\tSerial Number: TDV0118052801"
+            "\n\tModel: temp_deck_v1"
+            "\n\tFirmware Version: edge-11aa22b",
             provided_args={},
-            command_explanation='Getting tempdeck device info'
+            command_explanation="Getting tempdeck device info",
         ),
-
         # Thermocycler
         # Test 54
         Explanation(
-            code='M119',
-            command_name='GET_LID_STATUS',
-            response='Lid Status: Open',
+            code="M119",
+            command_name="GET_LID_STATUS",
+            response="Lid Status: Open",
             provided_args={},
-            command_explanation='Getting status of thermocycler lid'
+            command_explanation="Getting status of thermocycler lid",
         ),
         # Test 55
         Explanation(
-            code='M119',
-            command_name='GET_LID_STATUS',
-            response='Lid Status: Closed',
+            code="M119",
+            command_name="GET_LID_STATUS",
+            response="Lid Status: Closed",
             provided_args={},
-            command_explanation='Getting status of thermocycler lid',
+            command_explanation="Getting status of thermocycler lid",
         ),
         # Test 56
         Explanation(
-            code='M115',
-            command_name='DEVICE_INFO',
-            response='Thermocycler info:'
-                     '\n\tSerial Number: TCV0220191127A01'
-                     '\n\tModel: v02'
-                     '\n\tFirmware Version: v1.0.0-13-ge948da5',
+            code="M115",
+            command_name="DEVICE_INFO",
+            response="Thermocycler info:"
+            "\n\tSerial Number: TCV0220191127A01"
+            "\n\tModel: v02"
+            "\n\tFirmware Version: v1.0.0-13-ge948da5",
             provided_args={},
-            command_explanation='Getting thermocycler device info'
+            command_explanation="Getting thermocycler device info",
         ),
         # Test 57
         Explanation(
-            code='M105',
-            command_name='GET_PLATE_TEMP',
-            response='Temperature values for thermocycler are as follows:'
-                     '\n\tTarget temperature not set'
-                     '\n\tCurrent temperature is: 22.173C',
+            code="M105",
+            command_name="GET_PLATE_TEMP",
+            response="Temperature values for thermocycler are as follows:"
+            "\n\tTarget temperature not set"
+            "\n\tCurrent temperature is: 22.173C",
             provided_args={},
-            command_explanation='Getting temperature values for thermocycler'
+            command_explanation="Getting temperature values for thermocycler",
         ),
         # Test 58
         Explanation(
-            code='M105',
-            command_name='GET_PLATE_TEMP',
-            response='Temperature values for thermocycler are as follows:'
-                     '\n\tTarget temperature is: 89.9C'
-                     '\n\tCurrent temperature is: 22.173C'
-                     '\n\tRemaining hold time is: 360.3ms'
-                     '\n\tTotal hold time is: 400.5ms'
-                     '\n\tNot at target temperature',
+            code="M105",
+            command_name="GET_PLATE_TEMP",
+            response="Temperature values for thermocycler are as follows:"
+            "\n\tTarget temperature is: 89.9C"
+            "\n\tCurrent temperature is: 22.173C"
+            "\n\tRemaining hold time is: 360.3ms"
+            "\n\tTotal hold time is: 400.5ms"
+            "\n\tNot at target temperature",
             provided_args={},
-            command_explanation='Getting temperature values for thermocycler'
+            command_explanation="Getting temperature values for thermocycler",
         ),
         # Test 59
         Explanation(
-            code='M105',
-            command_name='GET_PLATE_TEMP',
-            response='Temperature values for thermocycler are as follows:'
-                     '\n\tTarget temperature is: 70.9C'
-                     '\n\tCurrent temperature is: 70.9C'
-                     '\n\tRemaining hold time is: 0.0ms'
-                     '\n\tTotal hold time is: 55.5ms'
-                     '\n\tAt target temperature',
+            code="M105",
+            command_name="GET_PLATE_TEMP",
+            response="Temperature values for thermocycler are as follows:"
+            "\n\tTarget temperature is: 70.9C"
+            "\n\tCurrent temperature is: 70.9C"
+            "\n\tRemaining hold time is: 0.0ms"
+            "\n\tTotal hold time is: 55.5ms"
+            "\n\tAt target temperature",
             provided_args={},
-            command_explanation='Getting temperature values for thermocycler'
+            command_explanation="Getting temperature values for thermocycler",
         ),
         # Test 60
         Explanation(
-            code='M105',
-            command_name='GET_PLATE_TEMP',
-            response='Temperature values for thermocycler are as follows:'
-                     '\n\tTarget temperature is: 55.6C'
-                     '\n\tCurrent temperature is: 46.6C'
-                     '\n\tRemaining hold time is: 45.3ms'
-                     '\n\tTotal hold time is: 150.5ms'
-                     '\n\tTarget temperature is unparsable: ugh',
+            code="M105",
+            command_name="GET_PLATE_TEMP",
+            response="Temperature values for thermocycler are as follows:"
+            "\n\tTarget temperature is: 55.6C"
+            "\n\tCurrent temperature is: 46.6C"
+            "\n\tRemaining hold time is: 45.3ms"
+            "\n\tTotal hold time is: 150.5ms"
+            "\n\tTarget temperature is unparsable: ugh",
             provided_args={},
-            command_explanation='Getting temperature values for thermocycler'
+            command_explanation="Getting temperature values for thermocycler",
         ),
         # Test 61
         Explanation(
-            code='M105',
-            command_name='GET_PLATE_TEMP',
-            response='Temperature values for thermocycler are as follows:'
-                     '\n\tTarget temperature is: 40.000C'
-                     '\n\tCurrent temperature is: 23.823C',
+            code="M105",
+            command_name="GET_PLATE_TEMP",
+            response="Temperature values for thermocycler are as follows:"
+            "\n\tTarget temperature is: 40.000C"
+            "\n\tCurrent temperature is: 23.823C",
             provided_args={},
-            command_explanation='Getting temperature values for thermocycler'
+            command_explanation="Getting temperature values for thermocycler",
         ),
         # Test 62
         Explanation(
-            code='M104',
-            command_name='SET_PLATE_TEMP',
-            response='',
-            provided_args={'S': 40.0},
-            command_explanation='Setting thermocycler plate temp to 40.0C'
+            code="M104",
+            command_name="SET_PLATE_TEMP",
+            response="",
+            provided_args={"S": 40.0},
+            command_explanation="Setting thermocycler plate temp to 40.0C",
         ),
         # Test 63
         Explanation(
-            code='M126',
-            command_name='OPEN_LID',
-            response='',
+            code="M126",
+            command_name="OPEN_LID",
+            response="",
             provided_args={},
-            command_explanation='Opening thermocycler lid'
+            command_explanation="Opening thermocycler lid",
         ),
         # Test 64
         Explanation(
-            code='M127',
-            command_name='CLOSE_LID',
-            response='',
+            code="M127",
+            command_name="CLOSE_LID",
+            response="",
             provided_args={},
-            command_explanation='Closing thermocycler lid'
+            command_explanation="Closing thermocycler lid",
         ),
         # Test 65
         Explanation(
-            code='M140',
-            command_name='SET_LID_TEMP',
-            response='',
-            provided_args={'S': 85.7},
-            command_explanation='Setting thermocycler lid temp to 85.7C'
+            code="M140",
+            command_name="SET_LID_TEMP",
+            response="",
+            provided_args={"S": 85.7},
+            command_explanation="Setting thermocycler lid temp to 85.7C",
         ),
         # Test 66
         Explanation(
-            code='M141',
-            command_name='GET_LID_TEMP',
-            response='Temperature for thermocycler lid is not set'
-                     '\nCurrent temperature of lid is 21.974C',
+            code="M141",
+            command_name="GET_LID_TEMP",
+            response="Temperature for thermocycler lid is not set"
+            "\nCurrent temperature of lid is 21.974C",
             provided_args={},
-            command_explanation='Getting temperature for thermocycler lid'
+            command_explanation="Getting temperature for thermocycler lid",
         ),
         # Test 67
         Explanation(
-            code='M141',
-            command_name='GET_LID_TEMP',
-            response='Set temperature for thermocycler lid is 40.0C'
-                     '\nCurrent temperature of lid is 23.700C',
+            code="M141",
+            command_name="GET_LID_TEMP",
+            response="Set temperature for thermocycler lid is 40.0C"
+            "\nCurrent temperature of lid is 23.700C",
             provided_args={},
-            command_explanation='Getting temperature for thermocycler lid'
+            command_explanation="Getting temperature for thermocycler lid",
         ),
         # Test 68
         Explanation(
-            code='M566',
-            command_name='SET_RAMP_RATE',
-            response='',
+            code="M566",
+            command_name="SET_RAMP_RATE",
+            response="",
             provided_args={},
-            command_explanation='Setting thermocycler ramp rate.'
-                                '\nNote: This is an unimplemented feature, '
-                                'setting this does nothing',
+            command_explanation="Setting thermocycler ramp rate."
+            "\nNote: This is an unimplemented feature, "
+            "setting this does nothing",
         ),
         # Test 69
         Explanation(
-            code='M566',
-            command_name='SET_RAMP_RATE',
-            response='',
+            code="M566",
+            command_name="SET_RAMP_RATE",
+            response="",
             provided_args={},
-            command_explanation='Setting thermocycler ramp rate.'
-                                '\nNote: This is an unimplemented feature, '
-                                'setting this does nothing',
+            command_explanation="Setting thermocycler ramp rate."
+            "\nNote: This is an unimplemented feature, "
+            "setting this does nothing",
         ),
         # Test 70
         Explanation(
-            code='M108',
-            command_name='DEACTIVATE_LID',
-            response='',
+            code="M108",
+            command_name="DEACTIVATE_LID",
+            response="",
             provided_args={},
-            command_explanation='Deactivating thermocycler lid'
+            command_explanation="Deactivating thermocycler lid",
         ),
         # Test 71
         Explanation(
-            code='M14',
-            command_name='DEACTIVATE_BLOCK',
-            response='',
+            code="M14",
+            command_name="DEACTIVATE_BLOCK",
+            response="",
             provided_args={},
-            command_explanation='Deactivating thermocycler block'
+            command_explanation="Deactivating thermocycler block",
         ),
         # Test 72
         Explanation(
-            code='M18',
-            command_name='DEACTIVATE_ALL',
-            response='',
+            code="M18",
+            command_name="DEACTIVATE_ALL",
+            response="",
             provided_args={},
-            command_explanation='Deactivating thermocycler block and lid'
+            command_explanation="Deactivating thermocycler block and lid",
         ),
         # Test 73
         Explanation(
-            code='M301',
-            command_name='EDIT_PID_PARAMS',
-            response='Cannot set PID values. Thermocycler busy',
-            provided_args={'P': 0.2, 'I': 0.3, 'D': 0.4},
-            command_explanation='Editing PID values to the following:'
-                                '\n\tKp: 0.2'
-                                '\n\tKi: 0.3'
-                                '\n\tKd: 0.4'
+            code="M301",
+            command_name="EDIT_PID_PARAMS",
+            response="Cannot set PID values. Thermocycler busy",
+            provided_args={"P": 0.2, "I": 0.3, "D": 0.4},
+            command_explanation="Editing PID values to the following:"
+            "\n\tKp: 0.2"
+            "\n\tKi: 0.3"
+            "\n\tKd: 0.4",
         ),
         # Test 74
         Explanation(
-            code='M301',
-            command_name='EDIT_PID_PARAMS',
-            response='Edit successful',
-            provided_args={'P': 0.2, 'I': 0.3, 'D': 0.4},
-            command_explanation='Editing PID values to the following:'
-                                '\n\tKp: 0.2'
-                                '\n\tKi: 0.3'
-                                '\n\tKd: 0.4'
+            code="M301",
+            command_name="EDIT_PID_PARAMS",
+            response="Edit successful",
+            provided_args={"P": 0.2, "I": 0.3, "D": 0.4},
+            command_explanation="Editing PID values to the following:"
+            "\n\tKp: 0.2"
+            "\n\tKi: 0.3"
+            "\n\tKd: 0.4",
         ),
     ]
 
 
 @pytest.mark.parametrize(
-    'parsed_value,expected_value',
-    list(zip(all_g_codes(), expected_function_name_values()))
+    "parsed_value,expected_value",
+    list(zip(all_g_codes(), expected_function_name_values())),
 )
 def test_smoothie_g_code_function_lookup(
-    parsed_value: GCode,
-    expected_value: str
+    parsed_value: GCode, expected_value: str
 ) -> None:
     assert parsed_value.get_gcode_function() == expected_value
 
 
 @pytest.mark.parametrize(
-    'parsed_value,expected_value',
-    list(zip(all_g_codes(), expected_arg_values()))
+    "parsed_value,expected_value", list(zip(all_g_codes(), expected_arg_values()))
 )
-def test_g_code_args(
-    parsed_value: GCode,
-    expected_value: dict
-) -> None:
+def test_g_code_args(parsed_value: GCode, expected_value: dict) -> None:
     assert parsed_value.g_code_args == expected_value
 
 
 @pytest.mark.parametrize(
-    'parsed_value,expected_value',
-    list(zip(all_g_codes(), explanations()))
+    "parsed_value,expected_value", list(zip(all_g_codes(), explanations()))
 )
-def test_explanation(
-    parsed_value: GCode,
-    expected_value: dict
-) -> None:
+def test_explanation(parsed_value: GCode, expected_value: dict) -> None:
     assert parsed_value.get_explanation() == expected_value
 
 
 @pytest.mark.parametrize(
-    'bad_raw_code',
+    "bad_raw_code",
     [
-        'M370 T5032305356323032303230303730313031000000000000000000000000000000',
-        'M372 Q7032305f6d756c74695f76322e30000000000000000000000000000000000000',
-    ]
+        "M370 T5032305356323032303230303730313031000000000000000000000000000000",
+        "M372 Q7032305f6d756c74695f76322e30000000000000000000000000000000000000",
+    ],
 )
 def test_bad_read_write_g_codes(bad_raw_code):
     with pytest.raises(UnparsableGCodeError):
-        GCode.from_raw_code(bad_raw_code, 'smoothie', '')
+        GCode.from_raw_code(bad_raw_code, "smoothie", "")
 
 
 @pytest.mark.parametrize(
-    'raw_code',
+    "raw_code",
     [
-        'M204 S10000.0 A1500.0 B200.0 C200.0 X3000.0 Y2000.0 Z1500.0',
-        'M370 L5032305356323032303230303730313031000000000000000000000000000000',
-        'M400',
-    ]
+        "M204 S10000.0 A1500.0 B200.0 C200.0 X3000.0 Y2000.0 Z1500.0",
+        "M370 L5032305356323032303230303730313031000000000000000000000000000000",
+        "M400",
+    ],
 )
 def test_get_g_code_line(raw_code):
-    assert GCode.from_raw_code(raw_code, 'smoothie', '')[0].g_code_line == raw_code
+    assert GCode.from_raw_code(raw_code, "smoothie", "")[0].g_code_line == raw_code
 
 
 @pytest.mark.parametrize(
-    'raw_code',
+    "raw_code",
     [
-        'M3000 S10000 A1500 B200 C200 X3000 Y2000 Z1500',
-        'G5678',
-    ]
+        "M3000 S10000 A1500 B200 C200 X3000 Y2000 Z1500",
+        "G5678",
+    ],
 )
 def test_unparsable_g_code_error(raw_code):
     with pytest.raises(UnparsableGCodeError):
-        GCode.from_raw_code(raw_code, 'smoothie', '')[0].get_gcode_function()
+        GCode.from_raw_code(raw_code, "smoothie", "")[0].get_gcode_function()

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_differ.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_differ.py
@@ -2,14 +2,16 @@ import pytest
 from textwrap import dedent
 from opentrons.hardware_control.g_code_parsing.g_code_differ import GCodeDiffer
 from opentrons.hardware_control.g_code_parsing.g_code import GCode
-from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import \
-    GCodeProgram
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes
+from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import (
+    GCodeProgram,
+)
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+)
 
 # Naive Strings
-HELLO = 'Hello'
-HELLO_WORLD = 'Hello World'
+HELLO = "Hello"
+HELLO_WORLD = "Hello World"
 
 # G-Codes Only
 G_CODE_1 = dedent(
@@ -31,66 +33,46 @@ G_CODE_2 = dedent(
 @pytest.fixture
 def first_g_code_explanation() -> str:
     g_code_line_1 = GCode.from_raw_code(
-        'G28.2 ABCXYZ',
-        GCode.SMOOTHIE_IDENT,
-        'ok\r\nok\r\n'
+        "G28.2 ABCXYZ", GCode.SMOOTHIE_IDENT, "ok\r\nok\r\n"
     )[0]
     g_code_line_2 = GCode.from_raw_code(
-        'G38.2 F420Y-40.0',
+        "G38.2 F420Y-40.0",
         GCode.SMOOTHIE_IDENT,
-        'G38.2 F420Y-40.0\r\n\r\n[PRB:296.825,292.663,218.000:1]\nok\r\nok\r\n'
+        "G38.2 F420Y-40.0\r\n\r\n[PRB:296.825,292.663,218.000:1]\nok\r\nok\r\n",
     )[0]
     g_code_line_3 = GCode.from_raw_code(
-        'M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n',
-        GCode.SMOOTHIE_IDENT,
-        ''
+        "M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n", GCode.SMOOTHIE_IDENT, ""
     )[0]
     mode = SupportedTextModes.get_text_mode(SupportedTextModes.CONCISE.value)
-    return '\n'.join(
-        [
-            mode.builder(line)
-            for line in [g_code_line_1, g_code_line_2, g_code_line_3]
-        ]
+    return "\n".join(
+        [mode.builder(line) for line in [g_code_line_1, g_code_line_2, g_code_line_3]]
     )
 
 
 @pytest.fixture
 def second_g_code_explanation() -> str:
     g_code_line_1 = GCode.from_raw_code(
-        'G28.2 ABCXYZ',
-        GCode.SMOOTHIE_IDENT,
-        'ok\r\nok\r\n'
+        "G28.2 ABCXYZ", GCode.SMOOTHIE_IDENT, "ok\r\nok\r\n"
     )[0]
     g_code_line_2 = GCode.from_raw_code(
-        'M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n',
-        GCode.SMOOTHIE_IDENT,
-        ''
+        "M203.1 A125 B40 C40 X600 Y400 Z125\r\n\r\n", GCode.SMOOTHIE_IDENT, ""
     )[0]
 
     mode = SupportedTextModes.get_text_mode(SupportedTextModes.CONCISE.value)
-    return '\n'.join(
-        [
-            mode.builder(line)
-            for line in [g_code_line_1, g_code_line_2]
-        ]
-    )
+    return "\n".join([mode.builder(line) for line in [g_code_line_1, g_code_line_2]])
 
 
 @pytest.fixture
 def first_g_code_program() -> GCodeProgram:
     raw_codes = [
-        ['G28.2 ABCXYZ', 'ok\r\nok\r\n'],
-        ['G0 X113.38 Y11.24', 'ok\r\nok\r\n'],
-        ['G4 P555', 'ok\r\nok\r\n'],
-        [
-            'M114.2',
-            'M114.2\r\n\r\nok MCS: A:218.0 B:0.0 C:0.0 X:418.0 Y:-3.0 Z:218.0'
-        ],
+        ["G28.2 ABCXYZ", "ok\r\nok\r\n"],
+        ["G0 X113.38 Y11.24", "ok\r\nok\r\n"],
+        ["G4 P555", "ok\r\nok\r\n"],
+        ["M114.2", "M114.2\r\n\r\nok MCS: A:218.0 B:0.0 C:0.0 X:418.0 Y:-3.0 Z:218.0"],
     ]
 
     g_code_list = [
-        GCode.from_raw_code(code, 'smoothie', response)
-        for code, response in raw_codes
+        GCode.from_raw_code(code, "smoothie", response) for code, response in raw_codes
     ]
 
     program = GCodeProgram()
@@ -101,14 +83,13 @@ def first_g_code_program() -> GCodeProgram:
 @pytest.fixture
 def second_g_code_program() -> GCodeProgram:
     raw_codes = [
-        ['G28.2 ABCXYZ', 'ok\r\nok\r\n'],
-        ['G0 X113.01 Y11.24', 'ok\r\nok\r\n'],
-        ['G4 P555', 'ok\r\nok\r\n'],
+        ["G28.2 ABCXYZ", "ok\r\nok\r\n"],
+        ["G0 X113.01 Y11.24", "ok\r\nok\r\n"],
+        ["G4 P555", "ok\r\nok\r\n"],
     ]
 
     g_code_list = [
-        GCode.from_raw_code(code, 'smoothie', response)
-        for code, response in raw_codes
+        GCode.from_raw_code(code, "smoothie", response) for code, response in raw_codes
     ]
 
     program = GCodeProgram()
@@ -121,9 +102,9 @@ def test_naive_insertion():
     hello = diff[0]
     world = diff[1]
     assert GCodeDiffer.get_diff_type(hello) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(hello) == 'Hello'
+    assert GCodeDiffer.get_diff_content(hello) == "Hello"
     assert GCodeDiffer.get_diff_type(world) == GCodeDiffer.INSERTION_TYPE
-    assert GCodeDiffer.get_diff_content(world) == ' World'
+    assert GCodeDiffer.get_diff_content(world) == " World"
 
 
 def test_naive_deletion():
@@ -131,9 +112,9 @@ def test_naive_deletion():
     hello = diff[0]
     world = diff[1]
     assert GCodeDiffer.get_diff_type(hello) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(hello) == 'Hello'
+    assert GCodeDiffer.get_diff_content(hello) == "Hello"
     assert GCodeDiffer.get_diff_type(world) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(world) == ' World'
+    assert GCodeDiffer.get_diff_content(world) == " World"
 
 
 def test_g_code_insertion():
@@ -143,11 +124,11 @@ def test_g_code_insertion():
     line_3 = diff[2]
 
     assert GCodeDiffer.get_diff_type(line_1) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_1) == 'G28.2 ABC\n'
+    assert GCodeDiffer.get_diff_content(line_1) == "G28.2 ABC\n"
     assert GCodeDiffer.get_diff_type(line_2) == GCodeDiffer.INSERTION_TYPE
-    assert GCodeDiffer.get_diff_content(line_2) == 'M400\n'
+    assert GCodeDiffer.get_diff_content(line_2) == "M400\n"
     assert GCodeDiffer.get_diff_type(line_3) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_3) == 'G0 F5.005'
+    assert GCodeDiffer.get_diff_content(line_3) == "G0 F5.005"
 
 
 def test_g_code_deletion():
@@ -157,16 +138,15 @@ def test_g_code_deletion():
     line_3 = diff[2]
 
     assert GCodeDiffer.get_diff_type(line_1) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_1) == 'G28.2 ABC\n'
+    assert GCodeDiffer.get_diff_content(line_1) == "G28.2 ABC\n"
     assert GCodeDiffer.get_diff_type(line_2) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(line_2) == 'M400\n'
+    assert GCodeDiffer.get_diff_content(line_2) == "M400\n"
     assert GCodeDiffer.get_diff_type(line_3) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_3) == 'G0 F5.005'
+    assert GCodeDiffer.get_diff_content(line_3) == "G0 F5.005"
 
 
 def test_g_code_explanation_insertion(
-        first_g_code_explanation,
-        second_g_code_explanation
+    first_g_code_explanation, second_g_code_explanation
 ):
     diff = GCodeDiffer(second_g_code_explanation, first_g_code_explanation).get_diff()
     line_1 = diff[0]
@@ -174,26 +154,30 @@ def test_g_code_explanation_insertion(
     line_3 = diff[2]
 
     assert GCodeDiffer.get_diff_type(line_1) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_1) == \
-           'smoothie: G28.2 A B C X Y Z -> ' \
-           'Homing the following axes: X, Y, Z, A, B, C ->' \
-           '\nsmoothie: '
+    assert (
+        GCodeDiffer.get_diff_content(line_1) == "smoothie: G28.2 A B C X Y Z -> "
+        "Homing the following axes: X, Y, Z, A, B, C ->"
+        "\nsmoothie: "
+    )
 
     assert GCodeDiffer.get_diff_type(line_2) == GCodeDiffer.INSERTION_TYPE
-    assert GCodeDiffer.get_diff_content(line_2) == \
-           'G38.2 F420.0 Y-40.0 -> Probing -40.0 on the Y axis, at a speed of 420.0 ' \
-           '-> Probed to : X Axis: 296.825 Y Axis: 292.663 Z Axis: 218.000\nsmoothie: '
+    assert (
+        GCodeDiffer.get_diff_content(line_2)
+        == "G38.2 F420.0 Y-40.0 -> Probing -40.0 on the Y axis, at a speed of 420.0 "
+        "-> Probed to : X Axis: 296.825 Y Axis: 292.663 Z Axis: 218.000\nsmoothie: "
+    )
     assert GCodeDiffer.get_diff_type(line_3) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_3) == \
-           'M203.1 A125.0 B40.0 C40.0 X600.0 Y400.0 Z125.0 -> ' \
-           'Setting the max speed for the following axes: ' \
-           'X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 ' \
-           'A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 ->'
+    assert (
+        GCodeDiffer.get_diff_content(line_3)
+        == "M203.1 A125.0 B40.0 C40.0 X600.0 Y400.0 Z125.0 -> "
+        "Setting the max speed for the following axes: "
+        "X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 "
+        "A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 ->"
+    )
 
 
 def test_g_code_explanation_deletion(
-        first_g_code_explanation,
-        second_g_code_explanation
+    first_g_code_explanation, second_g_code_explanation
 ):
     diff = GCodeDiffer(first_g_code_explanation, second_g_code_explanation).get_diff()
     line_1 = diff[0]
@@ -201,20 +185,25 @@ def test_g_code_explanation_deletion(
     line_3 = diff[2]
 
     assert GCodeDiffer.get_diff_type(line_1) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_1) == \
-           'smoothie: G28.2 A B C X Y Z -> ' \
-           'Homing the following axes: X, Y, Z, A, B, C ->' \
-           '\nsmoothie: '
+    assert (
+        GCodeDiffer.get_diff_content(line_1) == "smoothie: G28.2 A B C X Y Z -> "
+        "Homing the following axes: X, Y, Z, A, B, C ->"
+        "\nsmoothie: "
+    )
 
     assert GCodeDiffer.get_diff_type(line_2) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(line_2) == \
-           'G38.2 F420.0 Y-40.0 -> Probing -40.0 on the Y axis, at a speed of 420.0 ' \
-           '-> Probed to : X Axis: 296.825 Y Axis: 292.663 Z Axis: 218.000\nsmoothie: '
+    assert (
+        GCodeDiffer.get_diff_content(line_2)
+        == "G38.2 F420.0 Y-40.0 -> Probing -40.0 on the Y axis, at a speed of 420.0 "
+        "-> Probed to : X Axis: 296.825 Y Axis: 292.663 Z Axis: 218.000\nsmoothie: "
+    )
     assert GCodeDiffer.get_diff_type(line_3) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(line_3) == \
-           'M203.1 A125.0 B40.0 C40.0 X600.0 Y400.0 Z125.0 -> Setting the max speed ' \
-           'for the following axes: X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 ' \
-           'A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 ->'
+    assert (
+        GCodeDiffer.get_diff_content(line_3)
+        == "M203.1 A125.0 B40.0 C40.0 X600.0 Y400.0 Z125.0 -> Setting the max speed "
+        "for the following axes: X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 "
+        "A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 ->"
+    )
 
 
 def test_g_code_program_diff(first_g_code_program, second_g_code_program):
@@ -231,59 +220,66 @@ def test_g_code_program_diff(first_g_code_program, second_g_code_program):
     remove_last_line = diff[7]
 
     assert GCodeDiffer.get_diff_type(line_1) == GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(
-        line_1
-    ) == 'smoothie: G28.2 A B C X Y Z -> ' \
-         'Homing the following axes: X, Y, Z, A, B, C ->' \
-         '\nsmoothie: G0 X113.'
+    assert (
+        GCodeDiffer.get_diff_content(line_1) == "smoothie: G28.2 A B C X Y Z -> "
+        "Homing the following axes: X, Y, Z, A, B, C ->"
+        "\nsmoothie: G0 X113."
+    )
 
     assert GCodeDiffer.get_diff_type(remove_38) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(remove_38) == '38'
+    assert GCodeDiffer.get_diff_content(remove_38) == "38"
 
     assert GCodeDiffer.get_diff_type(add_01) == GCodeDiffer.INSERTION_TYPE
-    assert GCodeDiffer.get_diff_content(add_01) == '01'
+    assert GCodeDiffer.get_diff_content(add_01) == "01"
 
-    assert GCodeDiffer.get_diff_type(beginning_partial_response) == \
-           GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(
-        beginning_partial_response
-    ) == ' Y11.24 -> Moving the robot as follows: The gantry to 113.'
+    assert (
+        GCodeDiffer.get_diff_type(beginning_partial_response)
+        == GCodeDiffer.EQUALITY_TYPE
+    )
+    assert (
+        GCodeDiffer.get_diff_content(beginning_partial_response)
+        == " Y11.24 -> Moving the robot as follows: The gantry to 113."
+    )
 
     assert GCodeDiffer.get_diff_type(remove_response_38) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(remove_response_38) == '38'
+    assert GCodeDiffer.get_diff_content(remove_response_38) == "38"
 
     assert GCodeDiffer.get_diff_type(add_response_01) == GCodeDiffer.INSERTION_TYPE
-    assert GCodeDiffer.get_diff_content(add_response_01) == '01'
+    assert GCodeDiffer.get_diff_content(add_response_01) == "01"
 
-    assert GCodeDiffer.get_diff_type(remaining_partial_response) == \
-           GCodeDiffer.EQUALITY_TYPE
-    assert GCodeDiffer.get_diff_content(
-        remaining_partial_response
-    ) == ' on the X-Axis The gantry to 11.24 on the Y-Axis ->' \
-         '\nsmoothie: G4 P555.0 -> Pausing movement for 555.0ms ->'
+    assert (
+        GCodeDiffer.get_diff_type(remaining_partial_response)
+        == GCodeDiffer.EQUALITY_TYPE
+    )
+    assert (
+        GCodeDiffer.get_diff_content(remaining_partial_response)
+        == " on the X-Axis The gantry to 11.24 on the Y-Axis ->"
+        "\nsmoothie: G4 P555.0 -> Pausing movement for 555.0ms ->"
+    )
 
     assert GCodeDiffer.get_diff_type(remove_last_line) == GCodeDiffer.DELETION_TYPE
-    assert GCodeDiffer.get_diff_content(remove_last_line) == \
-           '\nsmoothie: M114.2 -> Getting current position for all axes -> ' \
-           'The current position of the robot is: A Axis: 218.0 B Axis: 0.0 ' \
-           'C Axis: 0.0 X Axis: 418.0 Y Axis: -3.0 Z Axis: 218.0'
+    assert (
+        GCodeDiffer.get_diff_content(remove_last_line)
+        == "\nsmoothie: M114.2 -> Getting current position for all axes -> "
+        "The current position of the robot is: A Axis: 218.0 B Axis: 0.0 "
+        "C Axis: 0.0 X Axis: 418.0 Y Axis: -3.0 Z Axis: 218.0"
+    )
 
 
-def test_html_diff(
-        first_g_code_explanation,
-        second_g_code_explanation
-):
-    expected_html = '<span>smoothie: G28.2 A B C X Y Z -&gt; ' \
-                    'Homing the following axes: X, Y, Z, A, B, C -&gt;' \
-                    '<br>smoothie: </span>' \
-                    '<del style="background:#ffe6e6;font-size:large;'\
-                    'font-weight:bold;">G38.2 F420.0 Y-40.0 -&gt; ' \
-                    'Probing -40.0 on the Y axis, at a speed of 420.0 ' \
-                    '-&gt; Probed to : X Axis: 296.825 Y Axis: 292.663 ' \
-                    'Z Axis: 218.000<br>smoothie: </del><span>M203.1 A125.0 B40.0 ' \
-                    'C40.0 X600.0 Y400.0 Z125.0 -&gt; Setting the max speed for the ' \
-                    'following axes: X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 ' \
-                    'A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 -&gt;</span>'
+def test_html_diff(first_g_code_explanation, second_g_code_explanation):
+    expected_html = (
+        "<span>smoothie: G28.2 A B C X Y Z -&gt; "
+        "Homing the following axes: X, Y, Z, A, B, C -&gt;"
+        "<br>smoothie: </span>"
+        '<del style="background:#ffe6e6;font-size:large;'
+        'font-weight:bold;">G38.2 F420.0 Y-40.0 -&gt; '
+        "Probing -40.0 on the Y axis, at a speed of 420.0 "
+        "-&gt; Probed to : X Axis: 296.825 Y Axis: 292.663 "
+        "Z Axis: 218.000<br>smoothie: </del><span>M203.1 A125.0 B40.0 "
+        "C40.0 X600.0 Y400.0 Z125.0 -&gt; Setting the max speed for the "
+        "following axes: X-Axis: 600.0 Y-Axis: 400.0 Z-Axis: 125.0 "
+        "A-Axis: 125.0 B-Axis: 40.0 C-Axis: 40.0 -&gt;</span>"
+    )
     diff = GCodeDiffer(first_g_code_explanation, second_g_code_explanation)
     html = diff.get_html_diff()
     assert html == expected_html

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_program.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_g_code_program.py
@@ -1,8 +1,9 @@
 import pytest
 from opentrons.hardware_control.g_code_parsing import g_code_watcher
 from opentrons.hardware_control.g_code_parsing.g_code import GCode
-from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program\
-    import GCodeProgram
+from opentrons.hardware_control.g_code_parsing.g_code_program.g_code_program import (
+    GCodeProgram,
+)
 from opentrons.hardware_control.g_code_parsing.errors import PollingGCodeAdditionError
 
 
@@ -10,23 +11,23 @@ from opentrons.hardware_control.g_code_parsing.errors import PollingGCodeAdditio
 def watcher() -> g_code_watcher.GCodeWatcher:
     def temp_return(self):
         return [
-            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
+            g_code_watcher.WatcherData("M400", "smoothie", "ok\r\nok\r\n"),
             g_code_watcher.WatcherData(
-                'M105', 'tempdeck', 'T:86.500 C:66.223\r\nok\r\nok\r\n'
+                "M105", "tempdeck", "T:86.500 C:66.223\r\nok\r\nok\r\n"
             ),
-            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
+            g_code_watcher.WatcherData("M400", "smoothie", "ok\r\nok\r\n"),
             g_code_watcher.WatcherData(
-                'M119', 'thermocycler', 'Lid:open\r\nok\r\nok\r\n'
-            ),
-            g_code_watcher.WatcherData(
-                'M105', 'thermocycler', 'T:40.000 C:23.823\r\nok\r\nok\r\n'
+                "M119", "thermocycler", "Lid:open\r\nok\r\nok\r\n"
             ),
             g_code_watcher.WatcherData(
-                'M141', 'thermocycler', 'T:40.0 C:23.700\r\nok\r\nok\r\n'
+                "M105", "thermocycler", "T:40.000 C:23.823\r\nok\r\nok\r\n"
             ),
-            g_code_watcher.WatcherData('M400', 'smoothie', 'ok\r\nok\r\n'),
-
+            g_code_watcher.WatcherData(
+                "M141", "thermocycler", "T:40.0 C:23.700\r\nok\r\nok\r\n"
+            ),
+            g_code_watcher.WatcherData("M400", "smoothie", "ok\r\nok\r\n"),
         ]
+
     old_function = g_code_watcher.GCodeWatcher.get_command_list
     g_code_watcher.GCodeWatcher.get_command_list = temp_return
     yield g_code_watcher.GCodeWatcher()
@@ -36,7 +37,7 @@ def watcher() -> g_code_watcher.GCodeWatcher:
 @pytest.fixture
 def polling_command() -> GCode:
     return GCode.from_raw_code(
-        'M141', 'thermocycler', 'T:40.0 C:23.700\r\nok\r\nok\r\n'
+        "M141", "thermocycler", "T:40.0 C:23.700\r\nok\r\nok\r\n"
     )[0]
 
 
@@ -44,7 +45,7 @@ def test_filter_codes(watcher):
     actual_codes = [
         g_code.g_code for g_code in GCodeProgram.from_g_code_watcher(watcher).g_codes
     ]
-    expected_codes = ['M400', 'M400', 'M400']
+    expected_codes = ["M400", "M400", "M400"]
 
     assert actual_codes == expected_codes
 

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_protocol_runner.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_protocol_runner.py
@@ -2,21 +2,25 @@ import pytest
 import os
 from tests.opentrons.conftest import data_dir
 from opentrons.hardware_control.g_code_parsing.protocol_runner import ProtocolRunner
-from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes \
-    import SupportedTextModes
-from opentrons.hardware_control.emulation.settings import \
-    Settings, SmoothieSettings, PipetteSettings
+from opentrons.hardware_control.g_code_parsing.g_code_program.supported_text_modes import (  # noqa: E501
+    SupportedTextModes,
+)
+from opentrons.hardware_control.emulation.settings import (
+    Settings,
+    SmoothieSettings,
+    PipetteSettings,
+)
 
 CONFIG = Settings(
-    host='0.0.0.0',
+    host="0.0.0.0",
     smoothie=SmoothieSettings(
-        left=PipetteSettings(model='p20_single_v2.0', id='P20SV202020070101'),
-        right=PipetteSettings(model='p20_single_v2.0', id='P20SV202020070101')
-    )
+        left=PipetteSettings(model="p20_single_v2.0", id="P20SV202020070101"),
+        right=PipetteSettings(model="p20_single_v2.0", id="P20SV202020070101"),
+    ),
 )
 
 PROTOCOL_PATH = os.path.join(
-    data_dir(), 'g_code_validation_protocols', 'smoothie_protocol.py'
+    data_dir(), "g_code_validation_protocols", "smoothie_protocol.py"
 )
 
 

--- a/api/tests/opentrons/hardware_control/g_code_parsing/test_utils.py
+++ b/api/tests/opentrons/hardware_control/g_code_parsing/test_utils.py
@@ -22,14 +22,14 @@ def input_enum() -> Enum:
 @pytest.fixture
 def expected_dict() -> Dict:
     yield {
-        'G28.2': 'HOME',
-        'G0': 'MOVE',
-        'G4': 'DWELL',
-        'M114.2': 'CURRENT_POSITION',
-        'M119': 'LIMIT_SWITCH_STATUS',
-        'G38.2': 'PROBE',
-        'G90': 'ABSOLUTE_COORDS',
-        'G91': 'RELATIVE_COORDS',
+        "G28.2": "HOME",
+        "G0": "MOVE",
+        "G4": "DWELL",
+        "M114.2": "CURRENT_POSITION",
+        "M119": "LIMIT_SWITCH_STATUS",
+        "G38.2": "PROBE",
+        "G90": "ABSOLUTE_COORDS",
+        "G91": "RELATIVE_COORDS",
     }
 
 

--- a/api/tests/opentrons/hardware_control/integration/conftest.py
+++ b/api/tests/opentrons/hardware_control/integration/conftest.py
@@ -2,23 +2,28 @@ import pytest
 import threading
 import asyncio
 from opentrons.hardware_control.emulation.app import ServerManager
-from opentrons.hardware_control.emulation.settings import Settings, SmoothieSettings, \
-    PipetteSettings
+from opentrons.hardware_control.emulation.settings import (
+    Settings,
+    SmoothieSettings,
+    PipetteSettings,
+)
 
 CONFIG = Settings(
-    host='0.0.0.0',
+    host="0.0.0.0",
     smoothie=SmoothieSettings(
-        left=PipetteSettings(model='p20_multi_v2.0', id='P3HMV202020041605'),
-        right=PipetteSettings(model='p20_single_v2.0', id='P20SV202020070101')
-    )
+        left=PipetteSettings(model="p20_multi_v2.0", id="P3HMV202020041605"),
+        right=PipetteSettings(model="p20_single_v2.0", id="P20SV202020070101"),
+    ),
 )
 
 
 @pytest.fixture(scope="session")
 def emulation_app():
     """Run the emulators"""
+
     def runit():
         asyncio.run(ServerManager().run())
+
     # TODO 20210219
     #  The emulators must be run in a separate thread because our serial
     #  drivers block the main thread. Remove this thread when that is no

--- a/api/tests/opentrons/hardware_control/integration/test_controller.py
+++ b/api/tests/opentrons/hardware_control/integration/test_controller.py
@@ -27,22 +27,18 @@ async def test_get_fw_version(subject: Controller):
 async def test_get_attached_instruments(subject: Controller):
     """It should get the attached instruments."""
     instruments = await subject.get_attached_instruments({})
-    assert instruments[Mount.RIGHT]['id'] == "P20SV202020070101"
-    assert instruments[Mount.RIGHT]['config'].name == "p20_single_gen2"
-    assert instruments[Mount.LEFT]['id'] == "P3HMV202020041605"
-    assert instruments[Mount.LEFT]['config'].name == "p20_multi_gen2"
+    assert instruments[Mount.RIGHT]["id"] == "P20SV202020070101"
+    assert instruments[Mount.RIGHT]["config"].name == "p20_single_gen2"
+    assert instruments[Mount.LEFT]["id"] == "P3HMV202020041605"
+    assert instruments[Mount.LEFT]["config"].name == "p20_multi_gen2"
 
 
 async def test_move(subject: Controller):
     """It should move."""
-    new_position = {
-        "X": 1.0, "Z": 2.0, "Y": 3.0, "A": 4.0, "B": 5.0, "C": 6.0
-    }
+    new_position = {"X": 1.0, "Z": 2.0, "Y": 3.0, "A": 4.0, "B": 5.0, "C": 6.0}
 
     await subject.move(target_position=new_position)
 
     updated_position = await subject.update_position()
 
-    assert updated_position == {
-        "X": 1, "Z": 2, "Y": 3, "A": 4, "B": 5, "C": 6
-    }
+    assert updated_position == {"X": 1, "Z": 2, "Y": 3, "A": 4, "B": 5, "C": 6}

--- a/api/tests/opentrons/hardware_control/integration/test_magdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_magdeck.py
@@ -13,7 +13,7 @@ async def magdeck(loop: asyncio.BaseEventLoop, emulation_app) -> MagDeck:
         port=f"socket://127.0.0.1:{MAGDECK_PORT}",
         execution_manager=AsyncMock(),
         usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="", hub=1),
-        loop=loop
+        loop=loop,
     )
     yield module
     await module.cleanup()
@@ -21,7 +21,9 @@ async def magdeck(loop: asyncio.BaseEventLoop, emulation_app) -> MagDeck:
 
 def test_device_info(magdeck: MagDeck):
     assert magdeck.device_info == {
-        'model': 'mag_deck_v20', 'serial': 'magnetic_emulator', 'version': '2.0.0'
+        "model": "mag_deck_v20",
+        "serial": "magnetic_emulator",
+        "version": "2.0.0",
     }
 
 
@@ -30,17 +32,13 @@ async def test_engage_cycle(magdeck: MagDeck):
     await magdeck.engage(1)
     assert magdeck.current_height == 1
     assert magdeck.live_data == {
-        'data': {
-            'engaged': True, 'height': 1.0
-        },
-        'status': 'engaged'
+        "data": {"engaged": True, "height": 1.0},
+        "status": "engaged",
     }
 
     await magdeck.deactivate()
     assert magdeck.current_height == 0
     assert magdeck.live_data == {
-        'data': {
-            'engaged': False, 'height': 0.0
-        },
-        'status': 'disengaged'
+        "data": {"engaged": False, "height": 0.0},
+        "status": "disengaged",
     }

--- a/api/tests/opentrons/hardware_control/integration/test_smoothie.py
+++ b/api/tests/opentrons/hardware_control/integration/test_smoothie.py
@@ -4,7 +4,10 @@ from opentrons.drivers.types import MoveSplit
 from opentrons.hardware_control.emulation.app import SMOOTHIE_PORT
 
 from opentrons.config.robot_configs import (
-    DEFAULT_GANTRY_STEPS_PER_MM, DEFAULT_PIPETTE_CONFIGS, build_config)
+    DEFAULT_GANTRY_STEPS_PER_MM,
+    DEFAULT_PIPETTE_CONFIGS,
+    build_config,
+)
 from opentrons.drivers.smoothie_drivers import SmoothieDriver
 
 
@@ -12,8 +15,7 @@ from opentrons.drivers.smoothie_drivers import SmoothieDriver
 async def subject(emulation_app) -> SmoothieDriver:
     """Smoothie driver connected to emulator."""
     d = await SmoothieDriver.build(
-        port=f"socket://127.0.0.1:{SMOOTHIE_PORT}",
-        config=build_config({})
+        port=f"socket://127.0.0.1:{SMOOTHIE_PORT}", config=build_config({})
     )
     yield d
     await d.disconnect()
@@ -27,136 +29,128 @@ def spy(subject: SmoothieDriver) -> MagicMock:
     return spy
 
 
-async def test_dwell_and_activate_axes(
-        subject: SmoothieDriver, spy: MagicMock
-):
-    subject.activate_axes('X')
+async def test_dwell_and_activate_axes(subject: SmoothieDriver, spy: MagicMock):
+    subject.activate_axes("X")
     await subject._set_saved_current()
-    subject.dwell_axes('X')
+    subject.dwell_axes("X")
     await subject._set_saved_current()
-    subject.activate_axes('XYBC')
+    subject.activate_axes("XYBC")
     await subject._set_saved_current()
-    subject.dwell_axes('XC')
+    subject.dwell_axes("XC")
     await subject._set_saved_current()
-    subject.dwell_axes('BCY')
+    subject.dwell_axes("BCY")
     await subject._set_saved_current()
     expected = [
-        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.1 G4 P0.005',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
+        "M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.1 G4 P0.005",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
 
     assert command_log == expected
 
 
-async def test_disable_motor(
-        subject: SmoothieDriver, spy: MagicMock
-):
-    await subject.disengage_axis('X')
-    await subject.disengage_axis('XYZ')
-    await subject.disengage_axis('ABCD')
+async def test_disable_motor(subject: SmoothieDriver, spy: MagicMock):
+    await subject.disengage_axis("X")
+    await subject.disengage_axis("XYZ")
+    await subject.disengage_axis("ABCD")
     expected = [
-        'M18 X',
-        'M400',
-        'M18 XYZ',
-        'M400',
-        'M18 ABC',
-        'M400',
+        "M18 X",
+        "M400",
+        "M18 XYZ",
+        "M400",
+        "M18 ABC",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
 
 async def test_plunger_commands(subject: SmoothieDriver, spy: MagicMock):
     await subject.home()
     expected = [
-        'M907 A0.8 B0.05 C0.05 X0.3 Y0.3 Z0.8 G4 P0.005 G28.2 ABCZ',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M203.1 Y50',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90',
-        'M400',
-        'M203.1 X80',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X',
-        'M400',
-        'M203.1 A125 B40 C40 X600 Y400 Z125',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M203.1 Y80',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005 G28.2 Y',
-        'M400',
-        'M203.1 Y8',
-        'M400',
-        'G91 G0 Y-3 G90',
-        'M400',
-        'G28.2 Y',
-        'M400',
-        'G91 G0 Y-3 G90',
-        'M400',
-        'M203.1 A125 B40 C40 X600 Y400 Z125',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M114.2',
-        'M400',
+        "M907 A0.8 B0.05 C0.05 X0.3 Y0.3 Z0.8 G4 P0.005 G28.2 ABCZ",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M203.1 Y50",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90",
+        "M400",
+        "M203.1 X80",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X",
+        "M400",
+        "M203.1 A125 B40 C40 X600 Y400 Z125",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M203.1 Y80",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y1.25 Z0.1 G4 P0.005 G28.2 Y",
+        "M400",
+        "M203.1 Y8",
+        "M400",
+        "G91 G0 Y-3 G90",
+        "M400",
+        "G28.2 Y",
+        "M400",
+        "G91 G0 Y-3 G90",
+        "M400",
+        "M203.1 A125 B40 C40 X600 Y400 Z125",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M114.2",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
     spy.reset_mock()
 
-    await subject.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'A': 3})
+    await subject.move({"X": 0, "Y": 1.123456, "Z": 2, "A": 3})
     expected = [
-        'M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 A3 X0 Y1.123 Z2',
-        'M400',
+        "M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 A3 X0 Y1.123 Z2",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
     spy.reset_mock()
 
-    await subject.move({'B': 2})
+    await subject.move({"B": 2})
     expected = [
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
     spy.reset_mock()
 
-    await subject.move({
-        'X': 10.987654321,
-        'Y': 2.12345678,
-        'Z': 2.5,
-        'A': 3.5,
-        'B': 4.25,
-        'C': 5.55})
+    await subject.move(
+        {"X": 10.987654321, "Y": 2.12345678, "Z": 2.5, "A": 3.5, "B": 4.25, "C": 5.55}
+    )
     expected = [
         # Set active axes high
-        'M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 B4.55 G0 A3.5'
-        ' B4.25 C5.55 X10.988 Y2.123 Z2.5',
-        'M400',
+        "M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 B4.55 G0 A3.5"
+        " B4.25 C5.55 X10.988 Y2.123 Z2.5",
+        "M400",
         # Set plunger current low
-        'M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005',
-        'M400',
+        "M907 A0.8 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
 
@@ -171,51 +165,53 @@ async def test_move_with_split(subject: SmoothieDriver, spy: MagicMock):
                 split_current=1.75,
                 split_speed=1,
                 after_time=1800,
-                fullstep=True),
+                fullstep=True,
+            ),
             "C": MoveSplit(
                 split_distance=1,
                 split_current=1.75,
                 split_speed=1,
                 after_time=1800,
-                fullstep=True)
+                fullstep=True,
+            ),
         }
     )
     subject._steps_per_mm = {"B": 1.0, "C": 1.0}
 
-    await subject.move({'X': 0, 'Y': 1.123456, 'Z': 2, 'C': 3})
+    await subject.move({"X": 0, "Y": 1.123456, "Z": 2, "C": 3})
     expected = [
-        'M55 M92 C0.03125 G4 P0.01 G0 F60 M907 A0.1 B0.05 C1.75 X1.25 Y1.25'
-        ' Z0.8 G4 P0.005',
-        'M400',
-        'G0 C18.0',
-        'M400',
-        'M54 M92 C1.0 G4 P0.01',
-        'M400',
-        'G0 F24000 M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 C3 X0 Y1.123 Z2',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005',
-        'M400',
+        "M55 M92 C0.03125 G4 P0.01 G0 F60 M907 A0.1 B0.05 C1.75 X1.25 Y1.25"
+        " Z0.8 G4 P0.005",
+        "M400",
+        "G0 C18.0",
+        "M400",
+        "M54 M92 C1.0 G4 P0.01",
+        "M400",
+        "G0 F24000 M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005 G0 C3 X0 Y1.123 Z2",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X1.25 Y1.25 Z0.8 G4 P0.005",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
     spy.reset_mock()
 
-    await subject.move({'B': 2})
+    await subject.move({"B": 2})
     expected = [
-        'M53 M92 B0.03125 G4 P0.01 G0 F60 M907 A0.1 B1.75 C0.05 X0.3 Y0.3 Z0.1'
-        ' G4 P0.005',
-        'M400',
-        'G0 B18.0',
-        'M400',
-        'M52 M92 B1.0 G4 P0.01',
-        'M400',
-        'G0 F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
+        "M53 M92 B0.03125 G4 P0.01 G0 F60 M907 A0.1 B1.75 C0.05 X0.3 Y0.3 Z0.1"
+        " G4 P0.005",
+        "M400",
+        "G0 B18.0",
+        "M400",
+        "M52 M92 B1.0 G4 P0.01",
+        "M400",
+        "G0 F24000 M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005 G0 B2",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
 
@@ -223,151 +219,142 @@ async def test_set_active_current(subject: SmoothieDriver, spy: MagicMock):
     await subject.home()
     spy.reset_mock()
 
-    subject.set_active_current(
-        {'X': 2, 'Y': 2, 'Z': 2, 'A': 2, 'B': 2, 'C': 2})
-    subject.set_dwelling_current(
-        {'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
+    subject.set_active_current({"X": 2, "Y": 2, "Z": 2, "A": 2, "B": 2, "C": 2})
+    subject.set_dwelling_current({"X": 0, "Y": 0, "Z": 0, "A": 0, "B": 0, "C": 0})
 
-    await subject.move({'X': 0, 'Y': 0, 'Z': 0, 'A': 0, 'B': 0, 'C': 0})
-    await subject.move({'B': 1, 'C': 1})
-    subject.set_active_current({'B': 0.42, 'C': 0.42})
-    await subject.home('BC')
+    await subject.move({"X": 0, "Y": 0, "Z": 0, "A": 0, "B": 0, "C": 0})
+    await subject.move({"B": 1, "C": 1})
+    subject.set_active_current({"B": 0.42, "C": 0.42})
+    await subject.home("BC")
     expected = [
         # move all
-        'M907 A2 B2 C2 X2 Y2 Z2 G4 P0.005 G0 A0 B0 C0 X0 Y0 Z0',
-        'M400',
-        'M907 A2 B0 C0 X2 Y2 Z2 G4 P0.005',  # disable BC axes
-        'M400',
+        "M907 A2 B2 C2 X2 Y2 Z2 G4 P0.005 G0 A0 B0 C0 X0 Y0 Z0",
+        "M400",
+        "M907 A2 B0 C0 X2 Y2 Z2 G4 P0.005",  # disable BC axes
+        "M400",
         # move BC
-        'M907 A0 B2 C2 X0 Y0 Z0 G4 P0.005 G0 B1.3 C1.3 G0 B1 C1',
-        'M400',
-        'M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005',  # disable BC axes
-        'M400',
-        'M907 A0 B0.42 C0.42 X0 Y0 Z0 G4 P0.005 G28.2 BC',  # home BC
-        'M400',
-        'M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005',  # dwell all axes after home
-        'M400',
-        'M114.2',  # update the position
-        'M400',
+        "M907 A0 B2 C2 X0 Y0 Z0 G4 P0.005 G0 B1.3 C1.3 G0 B1 C1",
+        "M400",
+        "M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005",  # disable BC axes
+        "M400",
+        "M907 A0 B0.42 C0.42 X0 Y0 Z0 G4 P0.005 G28.2 BC",  # home BC
+        "M400",
+        "M907 A0 B0 C0 X0 Y0 Z0 G4 P0.005",  # dwell all axes after home
+        "M400",
+        "M114.2",  # update the position
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
 
 async def test_steps_per_mm(subject: SmoothieDriver, spy: MagicMock):
     expected = {
         **DEFAULT_GANTRY_STEPS_PER_MM,
-        'B': DEFAULT_PIPETTE_CONFIGS['stepsPerMM'],
-        'C': DEFAULT_PIPETTE_CONFIGS['stepsPerMM'],
+        "B": DEFAULT_PIPETTE_CONFIGS["stepsPerMM"],
+        "C": DEFAULT_PIPETTE_CONFIGS["stepsPerMM"],
     }
     assert subject.steps_per_mm == expected
-    await subject.update_steps_per_mm({'Z': 450})
-    expected['Z'] = 450
+    await subject.update_steps_per_mm({"Z": 450})
+    expected["Z"] = 450
     assert subject.steps_per_mm == expected
 
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
-    assert command_log == ['M92 Z450', 'M400']
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
+    assert command_log == ["M92 Z450", "M400"]
 
 
 async def test_pipette_configs(subject: SmoothieDriver, spy: MagicMock):
     res = await subject.update_pipette_config(
-        'Z',
-        {'home': 175, 'debounce': 12, 'max_travel': 13, 'retract': 14}
+        "Z", {"home": 175, "debounce": 12, "max_travel": 13, "retract": 14}
     )
     expected_return = {
-        'Z': {'home': 175, 'debounce': 12, 'max_travel': 13, 'retract': 14}
+        "Z": {"home": 175, "debounce": 12, "max_travel": 13, "retract": 14}
     }
     assert res == expected_return
 
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == [
-        'M365.0 Z175',
-        'M400',
-        'M365.2 O12',
-        'M400',
-        'M365.1 Z13',
-        'M400',
-        'M365.3 Z14',
-        'M400'
+        "M365.0 Z175",
+        "M400",
+        "M365.2 O12",
+        "M400",
+        "M365.1 Z13",
+        "M400",
+        "M365.3 Z14",
+        "M400",
     ]
 
 
 async def test_set_acceleration(subject: SmoothieDriver, spy: MagicMock):
-    await subject.set_acceleration(
-        {'X': 1, 'Y': 2, 'Z': 3, 'A': 4, 'B': 5, 'C': 6})
+    await subject.set_acceleration({"X": 1, "Y": 2, "Z": 3, "A": 4, "B": 5, "C": 6})
     subject.push_acceleration()
     await subject.pop_acceleration()
     await subject.set_acceleration(
-        {'X': 10, 'Y': 20, 'Z': 30, 'A': 40, 'B': 50, 'C': 60})
+        {"X": 10, "Y": 20, "Z": 30, "A": 40, "B": 50, "C": 60}
+    )
     await subject.pop_acceleration()
 
     expected = [
-        'M204 S10000 A4 B5 C6 X1 Y2 Z3',
-        'M400',
-        'M204 S10000 A4 B5 C6 X1 Y2 Z3',
-        'M400',
-        'M204 S10000 A40 B50 C60 X10 Y20 Z30',
-        'M400',
-        'M204 S10000 A4 B5 C6 X1 Y2 Z3',
-        'M400',
+        "M204 S10000 A4 B5 C6 X1 Y2 Z3",
+        "M400",
+        "M204 S10000 A4 B5 C6 X1 Y2 Z3",
+        "M400",
+        "M204 S10000 A40 B50 C60 X10 Y20 Z30",
+        "M400",
+        "M204 S10000 A4 B5 C6 X1 Y2 Z3",
+        "M400",
     ]
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == expected
 
 
 async def test_read_and_write_pipettes(subject: SmoothieDriver, spy: MagicMock):
-    test_id = 'TestsRock!!'
-    test_model = 'TestPipette'
-    await subject.write_pipette_id('left', test_id)
-    read_id = await subject.read_pipette_id('left')
+    test_id = "TestsRock!!"
+    test_model = "TestPipette"
+    await subject.write_pipette_id("left", test_id)
+    read_id = await subject.read_pipette_id("left")
     assert read_id == test_id
 
-    await subject.write_pipette_model('left', test_model)
-    read_model = await subject.read_pipette_model('left')
-    assert read_model == test_model + '_v1'
+    await subject.write_pipette_model("left", test_model)
+    read_model = await subject.read_pipette_model("left")
+    assert read_model == test_model + "_v1"
 
 
 async def test_fast_home(subject: SmoothieDriver, spy: MagicMock):
-    await subject.fast_home(axis='X', safety_margin=12)
+    await subject.fast_home(axis="X", safety_margin=12)
 
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == [
-        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G0 X406.0',
-        'M400',
-        'M203.1 Y50',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X1.25 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90',
-        'M400',
-        'M203.1 X80',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X',
-        'M400',
-        'M203.1 A125 B40 C40 X600 Y400 Z125',
-        'M400',
-        'M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005',
-        'M400',
-        'M114.2',
-        'M400'
+        "M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G0 X406.0",
+        "M400",
+        "M203.1 Y50",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X1.25 Y0.8 Z0.1 G4 P0.005 G91 G0 Y-28 G0 Y10 G90",
+        "M400",
+        "M203.1 X80",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X1.25 Y0.3 Z0.1 G4 P0.005 G28.2 X",
+        "M400",
+        "M203.1 A125 B40 C40 X600 Y400 Z125",
+        "M400",
+        "M907 A0.1 B0.05 C0.05 X0.3 Y0.3 Z0.1 G4 P0.005",
+        "M400",
+        "M114.2",
+        "M400",
     ]
 
 
 async def test_update_homing_flags(subject: SmoothieDriver, spy: MagicMock):
     await subject.update_homed_flags()
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
-    assert command_log == [
-        'G28.6',
-        'M400'
-    ]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
+    assert command_log == ["G28.6", "M400"]
 
 
 async def test_update_pipette_config(subject: SmoothieDriver, spy: MagicMock):
-    await subject.update_pipette_config("X", {
-        'retract': 2,
-        'debounce': 3,
-        'max_travel': 4,
-        'home': 5
-    })
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    await subject.update_pipette_config(
+        "X", {"retract": 2, "debounce": 3, "max_travel": 4, "home": 5}
+    )
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == [
         "M365.3 X2",
         "M400",
@@ -381,7 +368,7 @@ async def test_update_pipette_config(subject: SmoothieDriver, spy: MagicMock):
 
 
 async def test_do_relative_splits_during_home_for(
-        subject: SmoothieDriver, spy: MagicMock
+    subject: SmoothieDriver, spy: MagicMock
 ):
     """Test command structure when a split configuration is present."""
     subject.configure_splits_for(
@@ -391,19 +378,20 @@ async def test_do_relative_splits_during_home_for(
                 split_current=1.75,
                 split_speed=1,
                 after_time=1800,
-                fullstep=True)
+                fullstep=True,
+            )
         }
     )
     subject._steps_per_mm = {"B": 1.0, "C": 1.0}
 
     await subject._do_relative_splits_during_home_for("BC")
 
-    command_log = [x.kwargs['data'].strip() for x in spy.call_args_list]
+    command_log = [x.kwargs["data"].strip() for x in spy.call_args_list]
     assert command_log == [
-        'M53 M55 M92 B0.03125 C0.03125 G4 P0.01 M907 B1.75 G4 P0.005 G0 F60 G91',
-        'M400',
-        'G0 B-1',
-        'M400',
-        'G90 M52 M54 M92 B1.0 C1.0 G4 P0.01 G0 F24000',
-        'M400',
+        "M53 M55 M92 B0.03125 C0.03125 G4 P0.01 M907 B1.75 G4 P0.005 G0 F60 G91",
+        "M400",
+        "G0 B-1",
+        "M400",
+        "G90 M52 M54 M92 B1.0 C1.0 G4 P0.01 G0 F24000",
+        "M400",
     ]

--- a/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/integration/test_tempdeck.py
@@ -13,10 +13,9 @@ async def tempdeck(loop: asyncio.BaseEventLoop, emulation_app) -> TempDeck:
     module = await TempDeck.build(
         port=f"socket://127.0.0.1:{TEMPDECK_PORT}",
         execution_manager=execution_manager,
-        usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="",
-                         hub=1),
+        usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="", hub=1),
         loop=loop,
-        polling_frequency=0.01
+        polling_frequency=0.01,
     )
     yield module
     await execution_manager.cancel()
@@ -25,28 +24,25 @@ async def tempdeck(loop: asyncio.BaseEventLoop, emulation_app) -> TempDeck:
 
 def test_device_info(tempdeck) -> None:
     """It should have the device info."""
-    assert {'model': 'temp_deck_v20', 'serial': 'temperature_emulator',
-            'version': 'v2.0.1'} == tempdeck.device_info
+    assert {
+        "model": "temp_deck_v20",
+        "serial": "temperature_emulator",
+        "version": "v2.0.1",
+    } == tempdeck.device_info
 
 
 async def test_set_temperature(tempdeck) -> None:
     """It should set the temperature and return when target is reached."""
     await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
-        'status': "idle",
-        'data': {
-            'currentTemp': 0,
-            'targetTemp': None
-        }
+        "status": "idle",
+        "data": {"currentTemp": 0, "targetTemp": None},
     }
 
     await tempdeck.set_temperature(10)
     assert tempdeck.live_data == {
-        'status': "holding at target",
-        'data': {
-            'currentTemp': 10,
-            'targetTemp': 10
-        }
+        "status": "holding at target",
+        "data": {"currentTemp": 10, "targetTemp": 10},
     }
 
 
@@ -60,21 +56,15 @@ async def test_start_set_temperature_cool(tempdeck) -> None:
     # Wait for poll
     await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
-        'status': "cooling",
-        'data': {
-            'currentTemp': current,
-            'targetTemp': new_temp
-        }
+        "status": "cooling",
+        "data": {"currentTemp": current, "targetTemp": new_temp},
     }
 
     # Wait for temperature to be reached
     await tempdeck.await_temperature(awaiting_temperature=new_temp)
     assert tempdeck.live_data == {
-        'status': "holding at target",
-        'data': {
-            'currentTemp': new_temp,
-            'targetTemp': new_temp
-        }
+        "status": "holding at target",
+        "data": {"currentTemp": new_temp, "targetTemp": new_temp},
     }
 
 
@@ -88,21 +78,15 @@ async def test_start_set_temperature_heat(tempdeck) -> None:
     # Wait for poll
     await tempdeck.wait_next_poll()
     assert tempdeck.live_data == {
-        'status': "heating",
-        'data': {
-            'currentTemp': current,
-            'targetTemp': new_temp
-        }
+        "status": "heating",
+        "data": {"currentTemp": current, "targetTemp": new_temp},
     }
 
     # Wait for temperature to be reached
     await tempdeck.await_temperature(awaiting_temperature=new_temp)
     assert tempdeck.live_data == {
-        'status': "holding at target",
-        'data': {
-            'currentTemp': new_temp,
-            'targetTemp': new_temp
-        }
+        "status": "holding at target",
+        "data": {"currentTemp": new_temp, "targetTemp": new_temp},
     }
 
 
@@ -113,9 +97,6 @@ async def test_deactivate(tempdeck) -> None:
     # Wait for temperature to be reached
     await tempdeck.await_temperature(awaiting_temperature=23)
     assert tempdeck.live_data == {
-        'status': "idle",
-        'data': {
-            'currentTemp': 23,
-            'targetTemp': None
-        }
+        "status": "idle",
+        "data": {"currentTemp": 23, "targetTemp": None},
     }

--- a/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/integration/test_thermocycler.py
@@ -8,18 +8,15 @@ from opentrons.hardware_control.modules import Thermocycler
 
 
 @pytest.fixture
-async def thermocycler(
-        loop: asyncio.BaseEventLoop,
-        emulation_app) -> Thermocycler:
+async def thermocycler(loop: asyncio.BaseEventLoop, emulation_app) -> Thermocycler:
     """Thermocycler fixture."""
     execution_manager = ExecutionManager(loop)
     module = await Thermocycler.build(
         port=f"socket://127.0.0.1:{THERMOCYCLER_PORT}",
         execution_manager=execution_manager,
-        usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="",
-                         hub=1),
+        usb_port=USBPort(name="", port_number=1, sub_names=[], device_path="", hub=1),
         loop=loop,
-        polling_frequency=0.01
+        polling_frequency=0.01,
     )
     yield module
     await execution_manager.cancel()
@@ -28,8 +25,11 @@ async def thermocycler(
 
 def test_device_info(thermocycler: Thermocycler):
     """It should have device info."""
-    assert {'model': 'v02', 'serial': 'thermocycler_emulator',
-            'version': 'v1.1.0'} == thermocycler.device_info
+    assert {
+        "model": "v02",
+        "serial": "thermocycler_emulator",
+        "version": "v1.1.0",
+    } == thermocycler.device_info
 
 
 async def test_lid_status(thermocycler: Thermocycler):
@@ -85,10 +85,12 @@ async def test_cycle_temperatures(thermocycler: Thermocycler):
             "temperature": 70.0,
         },
         {
-            "temperature": 60.0, "hold_time_minutes": 1.0,
+            "temperature": 60.0,
+            "hold_time_minutes": 1.0,
         },
         {
-            "temperature": 50.0, "hold_time_seconds": 22.0,
+            "temperature": 50.0,
+            "hold_time_seconds": 22.0,
         },
     ]
     await thermocycler.cycle_temperatures(steps, repetitions=2)

--- a/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_magdeck.py
@@ -7,60 +7,77 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 @pytest.fixture
 def usb_port():
     return USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_sim_magdeck0')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_sim_magdeck0",
+    )
 
 
 async def test_sim_initialization(loop, usb_port):
-    mag = await modules.build(port='/dev/ot_module_sim_magdeck0',
-                              usb_port=usb_port,
-                              which='magdeck',
-                              simulating=True,
-                              interrupt_callback=lambda x: None,
-                              loop=loop,
-                              execution_manager=ExecutionManager(loop=loop))
+    mag = await modules.build(
+        port="/dev/ot_module_sim_magdeck0",
+        usb_port=usb_port,
+        which="magdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
     assert isinstance(mag, modules.AbstractModule)
 
 
 async def test_sim_data(loop, usb_port):
-    mag = await modules.build(port='/dev/ot_module_sim_magdeck0',
-                              usb_port=usb_port,
-                              which='magdeck',
-                              simulating=True,
-                              interrupt_callback=lambda x: None,
-                              loop=loop,
-                              execution_manager=ExecutionManager(loop=loop))
-    assert mag.status == 'disengaged'
-    assert mag.device_info['serial'] == 'dummySerialMD'
+    mag = await modules.build(
+        port="/dev/ot_module_sim_magdeck0",
+        usb_port=usb_port,
+        which="magdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
+    assert mag.status == "disengaged"
+    assert mag.device_info["serial"] == "dummySerialMD"
     # return v1 when sim_model is not passed
-    assert mag.device_info['model'] == 'mag_deck_v1.1'
-    assert mag.device_info['version'] == 'dummyVersionMD'
-    assert mag.live_data['status'] == mag.status
-    assert 'data' in mag.live_data
+    assert mag.device_info["model"] == "mag_deck_v1.1"
+    assert mag.device_info["version"] == "dummyVersionMD"
+    assert mag.live_data["status"] == mag.status
+    assert "data" in mag.live_data
 
 
 async def test_sim_state_update(loop, usb_port):
-    mag = await modules.build(port='/dev/ot_module_sim_magdeck0',
-                              usb_port=usb_port,
-                              which='magdeck',
-                              simulating=True,
-                              interrupt_callback=lambda x: None,
-                              loop=loop,
-                              execution_manager=ExecutionManager(loop=loop))
+    mag = await modules.build(
+        port="/dev/ot_module_sim_magdeck0",
+        usb_port=usb_port,
+        which="magdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
     await mag.calibrate()
-    assert mag.status == 'disengaged'
+    assert mag.status == "disengaged"
     await mag.engage(2)
-    assert mag.status == 'engaged'
+    assert mag.status == "engaged"
     await mag.deactivate()
-    assert mag.status == 'disengaged'
+    assert mag.status == "disengaged"
 
 
 async def test_revision_model_parsing(loop, usb_port):
-    mag = await modules.build('', 'magdeck', True, usb_port, lambda x: None, loop=loop,
-                              execution_manager=ExecutionManager(loop=loop))
-    mag._device_info['model'] = 'mag_deck_v1.1'
-    assert mag.model() == 'magneticModuleV1'
-    mag._device_info['model'] = 'mag_deck_v20'
-    assert mag.model() == 'magneticModuleV2'
-    del mag._device_info['model']
-    assert mag.model() == 'magneticModuleV1'
+    mag = await modules.build(
+        "",
+        "magdeck",
+        True,
+        usb_port,
+        lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
+    mag._device_info["model"] = "mag_deck_v1.1"
+    assert mag.model() == "magneticModuleV1"
+    mag._device_info["model"] = "mag_deck_v20"
+    assert mag.model() == "magneticModuleV2"
+    del mag._device_info["model"]
+    assert mag.model() == "magneticModuleV1"

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -8,80 +8,86 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 @pytest.fixture
 def usb_port():
     return USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_sim_tempdeck0')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_sim_tempdeck0",
+    )
 
 
 async def test_sim_initialization(loop, usb_port):
-    temp = await modules.build(port='/dev/ot_module_sim_tempdeck0',
-                               usb_port=usb_port,
-                               which='tempdeck',
-                               simulating=True,
-                               interrupt_callback=lambda x: None,
-                               loop=loop,
-                               execution_manager=ExecutionManager(loop=loop))
+    temp = await modules.build(
+        port="/dev/ot_module_sim_tempdeck0",
+        usb_port=usb_port,
+        which="tempdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
     assert isinstance(temp, modules.AbstractModule)
 
 
 async def test_sim_state(loop, usb_port):
     temp = await modules.TempDeck.build(
-        port='/dev/ot_module_sim_tempdeck0',
+        port="/dev/ot_module_sim_tempdeck0",
         usb_port=usb_port,
         simulating=True,
         interrupt_callback=lambda x: None,
         loop=loop,
-        execution_manager=ExecutionManager(loop=loop)
+        execution_manager=ExecutionManager(loop=loop),
     )
     await temp.wait_next_poll()
     assert temp.temperature == 0
     assert temp.target is None
-    assert temp.status == 'idle'
-    assert temp.live_data['status'] == temp.status
-    assert temp.live_data['data']['currentTemp'] == temp.temperature
-    assert temp.live_data['data']['targetTemp'] == temp.target
+    assert temp.status == "idle"
+    assert temp.live_data["status"] == temp.status
+    assert temp.live_data["data"]["currentTemp"] == temp.temperature
+    assert temp.live_data["data"]["targetTemp"] == temp.target
     status = temp.device_info
-    assert status['serial'] == 'dummySerialTD'
+    assert status["serial"] == "dummySerialTD"
     # return v1 if sim_model is not passed
-    assert status['model'] == 'temp_deck_v1.1'
-    assert status['version'] == 'dummyVersionTD'
+    assert status["model"] == "temp_deck_v1.1"
+    assert status["version"] == "dummyVersionTD"
 
 
 async def test_sim_update(loop, usb_port):
     temp = await modules.TempDeck.build(
-        port='/dev/ot_module_sim_tempdeck0',
+        port="/dev/ot_module_sim_tempdeck0",
         usb_port=usb_port,
         simulating=True,
         interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
-        polling_frequency=0
+        polling_frequency=0,
     )
     await temp.set_temperature(10)
     assert temp.temperature == 10
     assert temp.target == 10
-    assert temp.status == 'holding at target'
+    assert temp.status == "holding at target"
     await temp.deactivate()
     await temp.wait_next_poll()
     assert temp.temperature == 23
     assert temp.target is None
-    assert temp.status == 'idle'
+    assert temp.status == "idle"
 
 
 async def test_revision_model_parsing(loop, usb_port):
     mag = await modules.TempDeck.build(
-        port='',
+        port="",
         simulating=True,
         usb_port=usb_port,
         interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
-        polling_frequency=0
+        polling_frequency=0,
     )
-    mag._device_info['model'] = 'temp_deck_v20'
-    assert mag.model() == 'temperatureModuleV2'
-    mag._device_info['model'] = 'temp_deck_v4.0'
-    assert mag.model() == 'temperatureModuleV1'
-    del mag._device_info['model']
-    assert mag.model() == 'temperatureModuleV1'
-    mag._device_info['model'] = 'temp_deck_v1.1'
-    assert mag.model() == 'temperatureModuleV1'
+    mag._device_info["model"] = "temp_deck_v20"
+    assert mag.model() == "temperatureModuleV2"
+    mag._device_info["model"] = "temp_deck_v4.0"
+    assert mag.model() == "temperatureModuleV1"
+    del mag._device_info["model"]
+    assert mag.model() == "temperatureModuleV1"
+    mag._device_info["model"] = "temp_deck_v1.1"
+    assert mag.model() == "temperatureModuleV1"

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -9,92 +9,103 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 @pytest.fixture
 def usb_port() -> USBPort:
     return USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_sim_thermocycler0')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_sim_thermocycler0",
+    )
 
 
 async def test_sim_initialization(loop, usb_port):
-    therm = await modules.build(port='/dev/ot_module_sim_thermocycler0',
-                                usb_port=usb_port,
-                                which='thermocycler',
-                                simulating=True,
-                                interrupt_callback=lambda x: None,
-                                loop=loop,
-                                execution_manager=ExecutionManager(loop=loop))
+    therm = await modules.build(
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        which="thermocycler",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
     assert isinstance(therm, modules.AbstractModule)
 
 
 async def test_lid(loop, usb_port):
-    therm = await modules.build(port='/dev/ot_module_sim_thermocycler0',
-                                usb_port=usb_port,
-                                which='thermocycler',
-                                simulating=True,
-                                interrupt_callback=lambda x: None,
-                                loop=loop,
-                                execution_manager=ExecutionManager(loop=loop))
+    therm = await modules.build(
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        which="thermocycler",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
     await therm.open()
     await therm.wait_next_poll()
-    assert therm.lid_status == 'open'
+    assert therm.lid_status == "open"
 
     await therm.close()
     await therm.wait_next_poll()
-    assert therm.lid_status == 'closed'
+    assert therm.lid_status == "closed"
 
     await therm.close()
     await therm.wait_next_poll()
-    assert therm.lid_status == 'closed'
+    assert therm.lid_status == "closed"
 
     await therm.open()
     await therm.wait_next_poll()
-    assert therm.lid_status == 'open'
+    assert therm.lid_status == "open"
 
 
 async def test_sim_state(loop, usb_port):
-    therm = await modules.build(port='/dev/ot_module_sim_thermocycler0',
-                                usb_port=usb_port,
-                                which='thermocycler',
-                                simulating=True,
-                                interrupt_callback=lambda x: None,
-                                loop=loop,
-                                execution_manager=ExecutionManager(loop=loop))
+    therm = await modules.build(
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        which="thermocycler",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
     assert therm.temperature is None
     assert therm.target is None
-    assert therm.status == 'error'
-    assert therm.live_data['status'] == therm.status
-    assert therm.live_data['data']['currentTemp'] == therm.temperature
-    assert therm.live_data['data']['targetTemp'] == therm.target
+    assert therm.status == "error"
+    assert therm.live_data["status"] == therm.status
+    assert therm.live_data["data"]["currentTemp"] == therm.temperature
+    assert therm.live_data["data"]["targetTemp"] == therm.target
     status = therm.device_info
-    assert status['serial'] == 'dummySerialTC'
-    assert status['model'] == 'dummyModelTC'
-    assert status['version'] == 'dummyVersionTC'
+    assert status["serial"] == "dummySerialTC"
+    assert status["model"] == "dummyModelTC"
+    assert status["version"] == "dummyVersionTC"
 
 
 async def test_sim_update(loop, usb_port):
-    therm = await modules.build(port='/dev/ot_module_sim_thermocycler0',
-                                usb_port=usb_port,
-                                which='thermocycler',
-                                simulating=True,
-                                interrupt_callback=lambda x: None,
-                                loop=loop,
-                                execution_manager=ExecutionManager(loop=loop))
+    therm = await modules.build(
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        which="thermocycler",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
-    await therm.set_temperature(temperature=10,
-                                hold_time_seconds=None,
-                                hold_time_minutes=None,
-                                volume=50)
+    await therm.set_temperature(
+        temperature=10, hold_time_seconds=None, hold_time_minutes=None, volume=50
+    )
     await therm.wait_next_poll()
     assert therm.temperature == 10
     assert therm.target == 10
-    assert therm.status == 'holding at target'
+    assert therm.status == "holding at target"
     # await asyncio.wait_for(therm.wait_for_temp(), timeout=0.2)
     await therm.deactivate_block()
     await therm.wait_next_poll()
     assert therm.temperature == 23
     assert therm.target is None
-    assert therm.status == 'idle'
+    assert therm.status == "idle"
 
     await therm.set_lid_temperature(temperature=80)
     assert therm.lid_temp == 80
@@ -115,7 +126,7 @@ async def test_sim_update(loop, usb_port):
     await therm.wait_next_poll()
     assert therm.temperature == 23
     assert therm.target is None
-    assert therm.status == 'idle'
+    assert therm.status == "idle"
     assert therm.lid_temp == 23
     assert therm.lid_target is None
 
@@ -132,7 +143,7 @@ def set_plate_temp_spy(simulator: SimulatingDriver) -> mock.AsyncMock:
 
 @pytest.fixture
 def simulator_set_plate_spy(
-        simulator: SimulatingDriver, set_plate_temp_spy: mock.AsyncMock
+    simulator: SimulatingDriver, set_plate_temp_spy: mock.AsyncMock
 ) -> SimulatingDriver:
     """Fixture that attaches spy to simulator."""
     simulator.set_plate_temperature = set_plate_temp_spy
@@ -141,78 +152,63 @@ def simulator_set_plate_spy(
 
 @pytest.fixture
 async def set_temperature_subject(
-        loop, usb_port: USBPort, simulator_set_plate_spy: SimulatingDriver
+    loop, usb_port: USBPort, simulator_set_plate_spy: SimulatingDriver
 ) -> modules.Thermocycler:
     """Fixture that spys on set_plate_temperature"""
     hw_tc = modules.Thermocycler(
-        port='/dev/ot_module_sim_thermocycler0',
+        port="/dev/ot_module_sim_thermocycler0",
         usb_port=usb_port,
         interrupt_callback=lambda x: None,
         loop=loop,
         execution_manager=ExecutionManager(loop=loop),
         driver=simulator_set_plate_spy,
         device_info={},
-        polling_interval_sec=0.001
+        polling_interval_sec=0.001,
     )
     return hw_tc
 
 
 async def test_set_temperature_with_volume(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
     """It should call set_plate_temperature with volume param"""
-    await set_temperature_subject.set_temperature(
-        30, volume=35
-    )
-    set_plate_temp_spy.assert_called_once_with(
-        temp=30, hold_time=0, volume=35
-    )
+    await set_temperature_subject.set_temperature(30, volume=35)
+    set_plate_temp_spy.assert_called_once_with(temp=30, hold_time=0, volume=35)
 
 
 async def test_set_temperature_mixed_hold(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
     """It should call set_plate_temperature with total second count computed from
     mix of seconds and minutes."""
     await set_temperature_subject.set_temperature(
         30, hold_time_seconds=20, hold_time_minutes=1
     )
-    set_plate_temp_spy.assert_called_once_with(
-        temp=30, hold_time=80, volume=None
-    )
+    set_plate_temp_spy.assert_called_once_with(temp=30, hold_time=80, volume=None)
 
 
 async def test_set_temperature_just_seconds_hold(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
-    """"It should call set_plate_temperature with total second count computed from
+    """ "It should call set_plate_temperature with total second count computed from
     just seconds."""
     await set_temperature_subject.set_temperature(20, hold_time_seconds=30)
-    set_plate_temp_spy.assert_called_once_with(
-        temp=20, hold_time=30, volume=None
-    )
+    set_plate_temp_spy.assert_called_once_with(temp=20, hold_time=30, volume=None)
 
 
 async def test_set_temperature_just_minutes_hold(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
-    """"It should call set_plate_temperature with total second count computed from
+    """ "It should call set_plate_temperature with total second count computed from
     just minutes."""
     await set_temperature_subject.set_temperature(40, hold_time_minutes=5.5)
-    set_plate_temp_spy.assert_called_once_with(
-        temp=40, hold_time=330, volume=None
-    )
+    set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=330, volume=None)
 
 
 async def test_set_temperature_fuzzy(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
-    """"It should call set_plate_temperature with passed in hold time when under
+    """ "It should call set_plate_temperature with passed in hold time when under
     fuzzy seconds."""
     # Test hold_time < _hold_time_fuzzy_seconds. Here we know
     # that wait_for_hold will be called with the direct hold
@@ -220,44 +216,34 @@ async def test_set_temperature_fuzzy(
     set_temperature_subject._wait_for_hold = mock.AsyncMock()
     await set_temperature_subject.set_temperature(40, hold_time_seconds=2)
     set_temperature_subject._wait_for_hold.assert_called_once_with(2)
-    set_plate_temp_spy.assert_called_once_with(
-        temp=40, hold_time=2, volume=None
-    )
+    set_plate_temp_spy.assert_called_once_with(temp=40, hold_time=2, volume=None)
 
 
 async def test_cycle_temperature(
-        set_temperature_subject: modules.Thermocycler,
-        set_plate_temp_spy: mock.AsyncMock
+    set_temperature_subject: modules.Thermocycler, set_plate_temp_spy: mock.AsyncMock
 ):
     """It should send a series of set_plate_temperature commands from
-     a configuration."""
+    a configuration."""
     await set_temperature_subject.cycle_temperatures(
         steps=[
+            {"temperature": 42, "hold_time_seconds": 30},
+            {"temperature": 50, "hold_time_minutes": 1},
+            {"temperature": 60, "hold_time_seconds": 30, "hold_time_minutes": 2},
             {
-                'temperature': 42, 'hold_time_seconds': 30
-            }, {
-                'temperature': 50, 'hold_time_minutes': 1
-            }, {
-                'temperature': 60, 'hold_time_seconds': 30, 'hold_time_minutes': 2
-            }, {
-                'temperature': 70,
+                "temperature": 70,
             },
         ],
         repetitions=5,
         volume=123,
     )
 
-    assert set_plate_temp_spy.call_args_list == [
-        mock.call(
-            temp=42, hold_time=30, volume=123
-        ),
-        mock.call(
-            temp=50, hold_time=60, volume=123
-        ),
-        mock.call(
-            temp=60, hold_time=150, volume=123
-        ),
-        mock.call(
-            temp=70, hold_time=0, volume=123
-        )
-    ] * 5
+    assert (
+        set_plate_temp_spy.call_args_list
+        == [
+            mock.call(temp=42, hold_time=30, volume=123),
+            mock.call(temp=50, hold_time=60, volume=123),
+            mock.call(temp=60, hold_time=150, volume=123),
+            mock.call(temp=70, hold_time=0, volume=123),
+        ]
+        * 5
+    )

--- a/api/tests/opentrons/hardware_control/modules/test_lid_temp_status.py
+++ b/api/tests/opentrons/hardware_control/modules/test_lid_temp_status.py
@@ -1,7 +1,6 @@
 import pytest
 from opentrons.drivers.types import Temperature
-from opentrons.hardware_control.modules.lid_temp_status import \
-    LidTemperatureStatus
+from opentrons.hardware_control.modules.lid_temp_status import LidTemperatureStatus
 from opentrons.hardware_control.modules.types import TemperatureStatus
 
 
@@ -13,22 +12,41 @@ from opentrons.hardware_control.modules.types import TemperatureStatus
         # At target
         [Temperature(current=50, target=50), TemperatureStatus.HOLDING],
         # Close enough to target
-        [Temperature(current=50 + LidTemperatureStatus.TEMP_THRESHOLD / 2,
-                     target=50), TemperatureStatus.HOLDING],
-        [Temperature(current=50 - LidTemperatureStatus.TEMP_THRESHOLD / 2,
-                     target=50), TemperatureStatus.HOLDING],
-        [Temperature(current=50 + LidTemperatureStatus.TEMP_THRESHOLD,
-                     target=50), TemperatureStatus.HOLDING],
-        [Temperature(current=50 - LidTemperatureStatus.TEMP_THRESHOLD,
-                     target=50), TemperatureStatus.HOLDING],
+        [
+            Temperature(
+                current=50 + LidTemperatureStatus.TEMP_THRESHOLD / 2, target=50
+            ),
+            TemperatureStatus.HOLDING,
+        ],
+        [
+            Temperature(
+                current=50 - LidTemperatureStatus.TEMP_THRESHOLD / 2, target=50
+            ),
+            TemperatureStatus.HOLDING,
+        ],
+        [
+            Temperature(current=50 + LidTemperatureStatus.TEMP_THRESHOLD, target=50),
+            TemperatureStatus.HOLDING,
+        ],
+        [
+            Temperature(current=50 - LidTemperatureStatus.TEMP_THRESHOLD, target=50),
+            TemperatureStatus.HOLDING,
+        ],
         # Above target
-        [Temperature(current=50 + (LidTemperatureStatus.TEMP_THRESHOLD + 1),
-                     target=50), TemperatureStatus.IDLE],
+        [
+            Temperature(
+                current=50 + (LidTemperatureStatus.TEMP_THRESHOLD + 1), target=50
+            ),
+            TemperatureStatus.IDLE,
+        ],
         # Below target
-        [Temperature(current=50 - (LidTemperatureStatus.TEMP_THRESHOLD + 1),
-                     target=50), TemperatureStatus.HEATING]
-
-    ]
+        [
+            Temperature(
+                current=50 - (LidTemperatureStatus.TEMP_THRESHOLD + 1), target=50
+            ),
+            TemperatureStatus.HEATING,
+        ],
+    ],
 )
 def test_lid_temp_status(temp: Temperature, expected: TemperatureStatus) -> None:
     """It should set the status correctly based on temperature reading."""

--- a/api/tests/opentrons/hardware_control/modules/test_plate_temp_status.py
+++ b/api/tests/opentrons/hardware_control/modules/test_plate_temp_status.py
@@ -2,8 +2,7 @@ from typing import List
 
 import pytest
 from opentrons.drivers.types import Temperature, PlateTemperature
-from opentrons.hardware_control.modules.plate_temp_status import \
-    PlateTemperatureStatus
+from opentrons.hardware_control.modules.plate_temp_status import PlateTemperatureStatus
 from opentrons.hardware_control.modules.types import TemperatureStatus
 
 TEMP_DIFF_ABOVE_THRESHOLD = PlateTemperatureStatus.TEMP_THRESHOLD * 2
@@ -12,46 +11,64 @@ TEMP_DIFF_BELOW_THRESHOLD = PlateTemperatureStatus.TEMP_THRESHOLD / 2
 
 MIN_SAMPLES_FOR_HOLD = PlateTemperatureStatus.MIN_SAMPLES_UNDER_THRESHOLD
 
-ONE_TOO_FEW_SAMPLES = (MIN_SAMPLES_FOR_HOLD - 1)
+ONE_TOO_FEW_SAMPLES = MIN_SAMPLES_FOR_HOLD - 1
 
 
 @pytest.mark.parametrize(
     argnames=["temps", "expected"],
     argvalues=[
         # No temperature readings
-        [[],
-         TemperatureStatus.ERROR],
+        [[], TemperatureStatus.ERROR],
         # One too few readings
-        [[Temperature(current=50, target=None)] * ONE_TOO_FEW_SAMPLES,
-         TemperatureStatus.IDLE],
+        [
+            [Temperature(current=50, target=None)] * ONE_TOO_FEW_SAMPLES,
+            TemperatureStatus.IDLE,
+        ],
         # No target
-        [[Temperature(current=50, target=None)] * MIN_SAMPLES_FOR_HOLD,
-         TemperatureStatus.IDLE],
+        [
+            [Temperature(current=50, target=None)] * MIN_SAMPLES_FOR_HOLD,
+            TemperatureStatus.IDLE,
+        ],
         # All readings at target temperature
-        [[Temperature(current=50, target=50)] * MIN_SAMPLES_FOR_HOLD,
-         TemperatureStatus.HOLDING],
+        [
+            [Temperature(current=50, target=50)] * MIN_SAMPLES_FOR_HOLD,
+            TemperatureStatus.HOLDING,
+        ],
         # All are close enough. Half the buffer a bit above and half a bit below.
-        [[Temperature(current=50 + TEMP_DIFF_BELOW_THRESHOLD,  target=50),
-          Temperature(current=50 - TEMP_DIFF_BELOW_THRESHOLD, target=50)] * int(MIN_SAMPLES_FOR_HOLD / 2),  # noqa: E501
-         TemperatureStatus.HOLDING],
+        [
+            [
+                Temperature(current=50 + TEMP_DIFF_BELOW_THRESHOLD, target=50),
+                Temperature(current=50 - TEMP_DIFF_BELOW_THRESHOLD, target=50),
+            ]
+            * int(MIN_SAMPLES_FOR_HOLD / 2),
+            TemperatureStatus.HOLDING,
+        ],
         # One reading above target
-        [[Temperature(current=50 + TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
-         TemperatureStatus.COOLING],
+        [
+            [Temperature(current=50 + TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
+            TemperatureStatus.COOLING,
+        ],
         # One reading below target
-        [[Temperature(current=50 - TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
-         TemperatureStatus.HEATING],
+        [
+            [Temperature(current=50 - TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
+            TemperatureStatus.HEATING,
+        ],
         # All samples are the same but one that is above threshold
-        [[Temperature(current=50, target=50)] * ONE_TOO_FEW_SAMPLES +
-         [Temperature(current=50 + TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
-         TemperatureStatus.COOLING],
+        [
+            [Temperature(current=50, target=50)] * ONE_TOO_FEW_SAMPLES
+            + [Temperature(current=50 + TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
+            TemperatureStatus.COOLING,
+        ],
         # All samples are the same but one that is below threshold
-        [[Temperature(current=50, target=50)] * ONE_TOO_FEW_SAMPLES +
-         [Temperature(current=50 - TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
-         TemperatureStatus.HEATING],
-    ]
+        [
+            [Temperature(current=50, target=50)] * ONE_TOO_FEW_SAMPLES
+            + [Temperature(current=50 - TEMP_DIFF_ABOVE_THRESHOLD, target=50)],
+            TemperatureStatus.HEATING,
+        ],
+    ],
 )
 def test_plate_temp_status(
-        temps: List[PlateTemperature], expected: TemperatureStatus
+    temps: List[PlateTemperature], expected: TemperatureStatus
 ) -> None:
     """It should set the status correctly based on temperature readings."""
     status = PlateTemperatureStatus()

--- a/api/tests/opentrons/hardware_control/test_adapters.py
+++ b/api/tests/opentrons/hardware_control/test_adapters.py
@@ -5,7 +5,6 @@ from opentrons.hardware_control import API, ThreadManager
 async def test_synch_adapter():
     thread_manager = ThreadManager(API.build_hardware_simulator)
     synch = thread_manager.sync
-    synch.cache_instruments({Mount.LEFT: 'p10_single'})
-    assert synch.attached_instruments[Mount.LEFT]['name']\
-                .startswith('p10_single')
+    synch.cache_instruments({Mount.LEFT: "p10_single"})
+    assert synch.attached_instruments[Mount.LEFT]["name"].startswith("p10_single")
     thread_manager.clean_up()

--- a/api/tests/opentrons/hardware_control/test_api_helpers.py
+++ b/api/tests/opentrons/hardware_control/test_api_helpers.py
@@ -1,5 +1,8 @@
 from opentrons.calibration_storage.types import (
-    DeckCalibration, SourceType, CalibrationStatus)
+    DeckCalibration,
+    SourceType,
+    CalibrationStatus,
+)
 from opentrons.hardware_control.util import DeckTransformState
 from opentrons.hardware_control.robot_calibration import RobotCalibration
 
@@ -9,9 +12,10 @@ async def test_validating_attitude(hardware):
     inrange_matrix = [[1, 0, 1], [0, 1, 2], [0, 0, 1]]
     deck_cal = DeckCalibration(
         attitude=inrange_matrix,
-        last_modified='sometime',
+        last_modified="sometime",
         source=SourceType.user,
-        status=CalibrationStatus())
+        status=CalibrationStatus(),
+    )
 
     hardware.set_robot_calibration(RobotCalibration(deck_calibration=deck_cal))
 

--- a/api/tests/opentrons/hardware_control/test_calibration_functions.py
+++ b/api/tests/opentrons/hardware_control/test_calibration_functions.py
@@ -8,64 +8,67 @@ from opentrons.types import Mount
 
 
 def test_migrate_affine_xy_to_attitude():
-    affine = [[1.0, 2.0, 3.0, 4.0],
-              [5.0, 6.0, 7.0, 8.0],
-              [9.0, 10.0, 11.0, 12.0],
-              [13.0, 14.0, 15.0, 16.0]]
+    affine = [
+        [1.0, 2.0, 3.0, 4.0],
+        [5.0, 6.0, 7.0, 8.0],
+        [9.0, 10.0, 11.0, 12.0],
+        [13.0, 14.0, 15.0, 16.0],
+    ]
 
-    expected = [[1.0, 2.0, 3.0],
-                [5.0, 6.0, 7.0],
-                [0.0, 0.0, 1.0]]
+    expected = [[1.0, 2.0, 3.0], [5.0, 6.0, 7.0], [0.0, 0.0, 1.0]]
 
     result = robot_calibration.migrate_affine_xy_to_attitude(affine)
     assert result == expected
 
 
 def test_save_calibration(ot_config_tempdir):
-    pathway = config.get_opentrons_path(
-        'robot_calibration_dir') / 'deck_calibration.json'
-    pip_id = 'fakePip'
-    lw_hash = 'fakeHash'
+    pathway = (
+        config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+    )
+    pip_id = "fakePip"
+    lw_hash = "fakeHash"
     e = ((1, 1, 3), (2, 2, 2), (1, 2, 1))
     a = ((1.1, 3.1, 1.1), (2.1, 2.1, 2.2), (1.1, 2.1, 1.1))
     transform = [[0.975, 0.05, 0.0], [-1.025, 1.05, 0.0], [0.0, 0.0, 1.0]]
     expected = {
-        'attitude': transform,
-        'pipette_calibrated_with': pip_id,
-        'last_modified': None,
-        'tiprack': lw_hash,
-        'source': 'user',
-        'status': {'markedBad': False},
+        "attitude": transform,
+        "pipette_calibrated_with": pip_id,
+        "last_modified": None,
+        "tiprack": lw_hash,
+        "source": "user",
+        "status": {"markedBad": False},
     }
     robot_calibration.save_attitude_matrix(e, a, pip_id, lw_hash)
     data = io.read_cal_file(pathway)
-    data['last_modified'] = None
+    data["last_modified"] = None
     assert data == expected
 
 
 def test_load_calibration(ot_config_tempdir):
-    pathway = config.get_opentrons_path(
-        'robot_calibration_dir') / 'deck_calibration.json'
+    pathway = (
+        config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+    )
     data = {
-        'attitude': [[1, 0, 1], [0, 1, -.5], [0, 0, 1]],
-        'pipette_calibrated_with': 'fake',
-        'last_modified': utc_now(),
-        'tiprack': 'hash'
+        "attitude": [[1, 0, 1], [0, 1, -0.5], [0, 0, 1]],
+        "pipette_calibrated_with": "fake",
+        "last_modified": utc_now(),
+        "tiprack": "hash",
     }
     io.save_to_file(pathway, data)
     obj = robot_calibration.load_attitude_matrix()
-    transform = [[1, 0, 1], [0, 1, -.5], [0, 0, 1]]
+    transform = [[1, 0, 1], [0, 1, -0.5], [0, 0, 1]]
     assert np.allclose(obj.attitude, transform)
 
 
 def test_load_malformed_calibration(ot_config_tempdir):
-    pathway = config.get_opentrons_path(
-        'robot_calibration_dir') / 'deck_calibration.json'
+    pathway = (
+        config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+    )
     data = {
-        'atsadasitude': [[1, 0, 1], [0, 1, -.5], [0, 0, 1]],
-        'last_modified': utc_now(),
-        'tiprack': 'hash',
-        'statu': [1, 2, 3],
+        "atsadasitude": [[1, 0, 1], [0, 1, -0.5], [0, 0, 1]],
+        "last_modified": utc_now(),
+        "tiprack": "hash",
+        "statu": [1, 2, 3],
     }
     io.save_to_file(pathway, data)
     obj = robot_calibration.load_attitude_matrix()
@@ -73,24 +76,23 @@ def test_load_malformed_calibration(ot_config_tempdir):
 
 
 def test_load_json(ot_config_tempdir):
-    path = config.get_opentrons_path('robot_calibration_dir')/'deck_calibration.json'
-    path.write_text('{')
+    path = config.get_opentrons_path("robot_calibration_dir") / "deck_calibration.json"
+    path.write_text("{")
     obj = robot_calibration.load_attitude_matrix()
     assert obj.attitude == [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
 
 def test_load_pipette_offset(ot_config_tempdir):
-    pip_id = 'fakePip'
+    pip_id = "fakePip"
     mount = Mount.LEFT
-    pip_dir = config.get_opentrons_path(
-        'pipette_calibration_dir') / 'left'
+    pip_dir = config.get_opentrons_path("pipette_calibration_dir") / "left"
     pip_dir.mkdir(parents=True, exist_ok=True)
-    pathway = pip_dir/'fakePip.json'
+    pathway = pip_dir / "fakePip.json"
     data = {
-        'offset': [1, 2, 3],
-        'tiprack': 'hash',
-        'uri': 'opentrons/opentrons_96_tiprack_10ul/1',
-        'last_modified': utc_now()
+        "offset": [1, 2, 3],
+        "tiprack": "hash",
+        "uri": "opentrons/opentrons_96_tiprack_10ul/1",
+        "last_modified": utc_now(),
     }
     io.save_to_file(pathway, data)
     obj = robot_calibration.load_pipette_offset(pip_id, mount)
@@ -99,9 +101,9 @@ def test_load_pipette_offset(ot_config_tempdir):
 
 
 def test_load_bad_pipette_offset(ot_config_tempdir):
-    path = config.get_opentrons_path('pipette_calibration_dir')/'left'
+    path = config.get_opentrons_path("pipette_calibration_dir") / "left"
     path.mkdir(parents=True, exist_ok=True)
-    calpath = path / 'fakePip.json'
-    calpath.write_text('{')
-    obj = robot_calibration.load_pipette_offset('fakePip', Mount.LEFT)
+    calpath = path / "fakePip.json"
+    calpath.write_text("{")
+    obj = robot_calibration.load_pipette_offset("fakePip", Mount.LEFT)
     assert obj.offset == [0, 0, 0]

--- a/api/tests/opentrons/hardware_control/test_execution_manager.py
+++ b/api/tests/opentrons/hardware_control/test_execution_manager.py
@@ -1,7 +1,10 @@
 import asyncio
 import pytest
-from opentrons.hardware_control import (ExecutionManager, ExecutionState,
-                                        ExecutionCancelledError)
+from opentrons.hardware_control import (
+    ExecutionManager,
+    ExecutionState,
+    ExecutionCancelledError,
+)
 
 
 async def test_state_machine(loop):
@@ -45,6 +48,7 @@ async def test_cancel_tasks(loop):
     Test that an execution manager cancels all un-protected
     running asyncio Tasks when cancel is called
     """
+
     async def fake_task():
         while True:
             await asyncio.sleep(1)

--- a/api/tests/opentrons/hardware_control/test_gpio.py
+++ b/api/tests/opentrons/hardware_control/test_gpio.py
@@ -10,15 +10,18 @@ async def test_gpio_setup(loop, monkeypatch):
     # Test without DTOVERLAY path
     # Board revision should be defaulted to 2.1
     backend = await hc.Controller.build(config=None)
-    assert str(backend.board_revision) == '2.1'
+    assert str(backend.board_revision) == "2.1"
 
 
 @pytest.mark.parametrize(
-    'revision,a_current',
-    [(hc.types.BoardRevision.OG, 0.8),
-     (hc.types.BoardRevision.A, 0.5),
-     (hc.types.BoardRevision.B, 0.5),
-     (hc.types.BoardRevision.C, 0.5)])
+    "revision,a_current",
+    [
+        (hc.types.BoardRevision.OG, 0.8),
+        (hc.types.BoardRevision.A, 0.5),
+        (hc.types.BoardRevision.B, 0.5),
+        (hc.types.BoardRevision.C, 0.5),
+    ],
+)
 async def test_current_setting(monkeypatch, revision, a_current):
     mock_gpio = MagicMock(spec=SimulatingGPIOCharDev)
 
@@ -28,7 +31,7 @@ async def test_current_setting(monkeypatch, revision, a_current):
     mock_gpio.setup.side_effect = fake_side_effect
     mock_gpio.board_rev = revision
     mock_build = MagicMock(spec=controller.build_gpio_chardev, return_value=mock_gpio)
-    monkeypatch.setattr(controller, 'build_gpio_chardev', mock_build)
+    monkeypatch.setattr(controller, "build_gpio_chardev", mock_build)
     backend = await hc.Controller.build(config=None)
     assert backend.board_revision == revision
-    assert backend._smoothie_driver._active_current_settings.now['A'] == a_current
+    assert backend._smoothie_driver._active_current_settings.now["A"] == a_current

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest import mock
+
 try:
     import aionotify
 except (OSError, ModuleNotFoundError):
@@ -12,24 +13,24 @@ from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control.dev_types import PipetteDict
 
 
-LEFT_PIPETTE_PREFIX = 'p10_single'
-LEFT_PIPETTE_MODEL = '{}_v1'.format(LEFT_PIPETTE_PREFIX)
-LEFT_PIPETTE_ID = 'testy'
+LEFT_PIPETTE_PREFIX = "p10_single"
+LEFT_PIPETTE_MODEL = "{}_v1".format(LEFT_PIPETTE_PREFIX)
+LEFT_PIPETTE_ID = "testy"
 
 
 @pytest.fixture
 def dummy_instruments():
     dummy_instruments_attached = {
         types.Mount.LEFT: {
-            'model': LEFT_PIPETTE_MODEL,
-            'id': LEFT_PIPETTE_ID,
-            'name': LEFT_PIPETTE_PREFIX,
+            "model": LEFT_PIPETTE_MODEL,
+            "id": LEFT_PIPETTE_ID,
+            "name": LEFT_PIPETTE_PREFIX,
         },
         types.Mount.RIGHT: {
-            'model': None,
-            'id': None,
-            'name': None,
-        }
+            "model": None,
+            "id": None,
+            "name": None,
+        },
     }
     return dummy_instruments_attached
 
@@ -38,102 +39,103 @@ def dummy_instruments():
 def dummy_backwards_compatibility():
     dummy_instruments_attached = {
         types.Mount.LEFT: {
-            'model': 'p20_single_v2.0',
-            'id': LEFT_PIPETTE_ID,
-            'name': 'p20_single_gen2'
+            "model": "p20_single_v2.0",
+            "id": LEFT_PIPETTE_ID,
+            "name": "p20_single_gen2",
         },
         types.Mount.RIGHT: {
-            'model': 'p300_single_v2.0',
-            'id': LEFT_PIPETTE_ID + '2',
-            'name': 'p300_single_gen2',
-        }
+            "model": "p300_single_v2.0",
+            "id": LEFT_PIPETTE_ID + "2",
+            "name": "p300_single_gen2",
+        },
     }
     return dummy_instruments_attached
 
 
 async def test_cache_instruments(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments,
-        loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.cache_instruments()
     attached = hw_api.attached_instruments
-    typeguard.check_type(
-        'left mount dict', attached[types.Mount.LEFT],
-        PipetteDict)
+    typeguard.check_type("left mount dict", attached[types.Mount.LEFT], PipetteDict)
 
 
 async def test_mismatch_fails(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments,
-        loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     requested_instr = {
-        types.Mount.LEFT: 'p20_single_gen2', types.Mount.RIGHT: 'p300_single'}
+        types.Mount.LEFT: "p20_single_gen2",
+        types.Mount.RIGHT: "p300_single",
+    }
     with pytest.raises(RuntimeError):
         await hw_api.cache_instruments(requested_instr)
 
 
 async def test_backwards_compatibility(dummy_backwards_compatibility, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_backwards_compatibility,
-        loop=loop)
-    requested_instr = {
-        types.Mount.LEFT: 'p10_single',
-        types.Mount.RIGHT: 'p300_single'}
+        attached_instruments=dummy_backwards_compatibility, loop=loop
+    )
+    requested_instr = {types.Mount.LEFT: "p10_single", types.Mount.RIGHT: "p300_single"}
     volumes = {
-        types.Mount.LEFT: {'min': 1, 'max': 10},
-        types.Mount.RIGHT: {'min': 30, 'max': 300}
+        types.Mount.LEFT: {"min": 1, "max": 10},
+        types.Mount.RIGHT: {"min": 30, "max": 300},
     }
     await hw_api.cache_instruments(requested_instr)
     attached = hw_api.attached_instruments
 
     for mount, name in requested_instr.items():
-        assert attached[mount]['name']\
-            == dummy_backwards_compatibility[mount]['name']
-        assert attached[mount]['min_volume'] == volumes[mount]['min']
-        assert attached[mount]['max_volume'] == volumes[mount]['max']
+        assert attached[mount]["name"] == dummy_backwards_compatibility[mount]["name"]
+        assert attached[mount]["min_volume"] == volumes[mount]["min"]
+        assert attached[mount]["max_volume"] == volumes[mount]["max"]
 
 
-@pytest.mark.skipif(aionotify is None,
-                    reason='inotify not available')
-async def test_cache_instruments_hc(monkeypatch, dummy_instruments,
-                                    hardware_controller_lockfile,
-                                    running_on_pi, cntrlr_mock_connect, loop):
+@pytest.mark.skipif(aionotify is None, reason="inotify not available")
+async def test_cache_instruments_hc(
+    monkeypatch,
+    dummy_instruments,
+    hardware_controller_lockfile,
+    running_on_pi,
+    cntrlr_mock_connect,
+    loop,
+):
     hw_api_cntrlr = await hc.API.build_hardware_controller(loop=loop)
 
     async def mock_driver_model(mount):
-        attached_pipette = {'left': LEFT_PIPETTE_MODEL, 'right': None}
+        attached_pipette = {"left": LEFT_PIPETTE_MODEL, "right": None}
         return attached_pipette[mount]
 
     async def mock_driver_id(mount):
-        attached_pipette = {'left': LEFT_PIPETTE_ID, 'right': None}
+        attached_pipette = {"left": LEFT_PIPETTE_ID, "right": None}
         return attached_pipette[mount]
 
-    monkeypatch.setattr(hw_api_cntrlr._backend._smoothie_driver,
-                        'read_pipette_model', mock_driver_model)
-    monkeypatch.setattr(hw_api_cntrlr._backend._smoothie_driver,
-                        'read_pipette_id', mock_driver_id)
+    monkeypatch.setattr(
+        hw_api_cntrlr._backend._smoothie_driver, "read_pipette_model", mock_driver_model
+    )
+    monkeypatch.setattr(
+        hw_api_cntrlr._backend._smoothie_driver, "read_pipette_id", mock_driver_id
+    )
 
     await hw_api_cntrlr.cache_instruments()
     attached = hw_api_cntrlr.attached_instruments
-    typeguard.check_type('left mount dict default',
-                         attached[types.Mount.LEFT],
-                         PipetteDict)
+    typeguard.check_type(
+        "left mount dict default", attached[types.Mount.LEFT], PipetteDict
+    )
 
     # If we pass a conflicting expectation we should get an error
     with pytest.raises(RuntimeError):
-        await hw_api_cntrlr.cache_instruments({types.Mount.LEFT: 'p300_multi'})
+        await hw_api_cntrlr.cache_instruments({types.Mount.LEFT: "p300_multi"})
 
     # If we pass a matching expects it should work
-    await hw_api_cntrlr.cache_instruments(
-        {types.Mount.LEFT: LEFT_PIPETTE_PREFIX})
+    await hw_api_cntrlr.cache_instruments({types.Mount.LEFT: LEFT_PIPETTE_PREFIX})
     attached = hw_api_cntrlr.attached_instruments
-    typeguard.check_type('left mount dict after expects',
-                         attached[types.Mount.LEFT],
-                         PipetteDict)
+    typeguard.check_type(
+        "left mount dict after expects", attached[types.Mount.LEFT], PipetteDict
+    )
 
 
 async def test_cache_instruments_sim(loop, dummy_instruments):
-
     def fake_func1(value):
         return value
 
@@ -149,8 +151,7 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
 
     await sim.cache_instruments()
     attached = sim.attached_instruments
-    assert attached == {
-        types.Mount.LEFT: {}, types.Mount.RIGHT: {}}
+    assert attached == {types.Mount.LEFT: {}, types.Mount.RIGHT: {}}
     sim._backend._smoothie_driver.update_steps_per_mm.assert_not_called()
     sim._backend._smoothie_driver.update_pipette_config.assert_not_called()
     sim._backend._smoothie_driver.set_dwelling_current.assert_not_called()
@@ -160,71 +161,69 @@ async def test_cache_instruments_sim(loop, dummy_instruments):
     # When we expect instruments, we should get what we expect since nothing
     # was specified at init time
     await sim.cache_instruments(
-        {types.Mount.LEFT: 'p10_single',
-         types.Mount.RIGHT: 'p300_single_gen2'})
+        {types.Mount.LEFT: "p10_single", types.Mount.RIGHT: "p300_single_gen2"}
+    )
     attached = sim.attached_instruments
-    assert attached[types.Mount.LEFT]['model']\
-        == 'p10_single_v1'
-    assert attached[types.Mount.LEFT]['name']\
-        == 'p10_single'
+    assert attached[types.Mount.LEFT]["model"] == "p10_single_v1"
+    assert attached[types.Mount.LEFT]["name"] == "p10_single"
 
-    steps_mm_calls = [mock.call({'B': 768}), mock.call({'C': 3200})]
+    steps_mm_calls = [mock.call({"B": 768}), mock.call({"C": 3200})]
     pip_config_calls = [
-        mock.call('Z', {'home': 220}),
-        mock.call('A', {'home': 172.15}),
-        mock.call('B', {'max_travel': 30}),
-        mock.call('C', {'max_travel': 60})]
-    current_calls = [mock.call({'B': 0.05}), mock.call({'C': 0.05})]
+        mock.call("Z", {"home": 220}),
+        mock.call("A", {"home": 172.15}),
+        mock.call("B", {"max_travel": 30}),
+        mock.call("C", {"max_travel": 60}),
+    ]
+    current_calls = [mock.call({"B": 0.05}), mock.call({"C": 0.05})]
     sim._backend._smoothie_driver.update_steps_per_mm.assert_has_calls(
-        steps_mm_calls, any_order=True)
+        steps_mm_calls, any_order=True
+    )
     sim._backend._smoothie_driver.update_pipette_config.assert_has_calls(
-        pip_config_calls, any_order=True)
+        pip_config_calls, any_order=True
+    )
 
     await sim.cache_instruments(
-        {types.Mount.LEFT: 'p10_single',
-         types.Mount.RIGHT: 'p300_multi_gen2'})
-    current_calls = [mock.call({'B': 0.05}), mock.call({'C': 0.3})]
+        {types.Mount.LEFT: "p10_single", types.Mount.RIGHT: "p300_multi_gen2"}
+    )
+    current_calls = [mock.call({"B": 0.05}), mock.call({"C": 0.3})]
     sim._backend._smoothie_driver.set_dwelling_current.assert_has_calls(
-        current_calls, any_order=True)
+        current_calls, any_order=True
+    )
     # If we use prefixes, that should work too
-    await sim.cache_instruments({types.Mount.RIGHT: 'p300_single'})
+    await sim.cache_instruments({types.Mount.RIGHT: "p300_single"})
     attached = sim.attached_instruments
-    assert attached[types.Mount.RIGHT]['model']\
-        == 'p300_single_v1'
-    assert attached[types.Mount.RIGHT]['name']\
-        == 'p300_single'
+    assert attached[types.Mount.RIGHT]["model"] == "p300_single_v1"
+    assert attached[types.Mount.RIGHT]["name"] == "p300_single"
     # If we specify instruments at init time, we should get them without
     # passing an expectation
-    sim = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments)
+    sim = await hc.API.build_hardware_simulator(attached_instruments=dummy_instruments)
     await sim.cache_instruments()
     attached = sim.attached_instruments
-    typeguard.check_type(
-        'after config',
-        attached[types.Mount.LEFT],
-        PipetteDict
-    )
+    typeguard.check_type("after config", attached[types.Mount.LEFT], PipetteDict)
 
     # If we specify conflicting expectations and init arguments we should
     # get a RuntimeError
     with pytest.raises(RuntimeError):
-        await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
+        await sim.cache_instruments({types.Mount.LEFT: "p300_multi"})
     # Unless we specifically told the simulator to not strictly enforce
     # correspondence between expectations and preconfiguration
     sim = await hc.API.build_hardware_simulator(
         attached_instruments=dummy_instruments,
-        loop=loop, strict_attached_instruments=False)
-    await sim.cache_instruments({types.Mount.LEFT: 'p300_multi'})
+        loop=loop,
+        strict_attached_instruments=False,
+    )
+    await sim.cache_instruments({types.Mount.LEFT: "p300_multi"})
 
     with pytest.raises(RuntimeError):
         # If you pass something that isn't a pipette name it absolutely
         # should not work
-        await sim.cache_instruments({types.Mount.LEFT: 'p10_sing'})
+        await sim.cache_instruments({types.Mount.LEFT: "p10_sing"})
 
 
 async def test_prep_aspirate(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -243,7 +242,8 @@ async def test_prep_aspirate(dummy_instruments, loop):
 
 async def test_aspirate_new(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -261,7 +261,8 @@ async def test_aspirate_new(dummy_instruments, loop):
 
 async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -279,7 +280,8 @@ async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
 
 async def test_dispense(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
 
     await hw_api.cache_instruments()
@@ -295,18 +297,17 @@ async def test_dispense(dummy_instruments, loop):
     dispense_1 = 3.0
     await hw_api.dispense(mount, dispense_1)
     plunger_pos_1 = 10.810573
-    assert (await hw_api.current_position(mount))[Axis.B]\
-        == plunger_pos_1
+    assert (await hw_api.current_position(mount))[Axis.B] == plunger_pos_1
 
     await hw_api.dispense(mount, rate=2)
     plunger_pos_2 = 2
-    assert (await hw_api.current_position(mount))[Axis.B]\
-        == plunger_pos_2
+    assert (await hw_api.current_position(mount))[Axis.B] == plunger_pos_2
 
 
 async def test_no_pipette(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.cache_instruments()
     aspirate_ul = 3.0
     aspirate_rate = 2
@@ -317,17 +318,20 @@ async def test_no_pipette(dummy_instruments, loop):
 
 async def test_pick_up_tip(dummy_instruments, loop, is_robot):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
     tip_position = types.Point(12.13, 9, 150)
-    target_position = {Axis.X: 46.13,   # Left mount offset
-                       Axis.Y: 9,
-                       Axis.Z: 218,     # Z retracts after pick_up
-                       Axis.A: 218,
-                       Axis.B: 2,
-                       Axis.C: 19}
+    target_position = {
+        Axis.X: 46.13,  # Left mount offset
+        Axis.Y: 9,
+        Axis.Z: 218,  # Z retracts after pick_up
+        Axis.A: 218,
+        Axis.B: 2,
+        Axis.C: 19,
+    }
     await hw_api.move_to(mount, tip_position)
 
     # Note: pick_up_tip without a tip_length argument requires the pipette on
@@ -342,7 +346,8 @@ async def test_pick_up_tip(dummy_instruments, loop, is_robot):
 
 async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
@@ -357,24 +362,24 @@ async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch):
         return fut
 
     mock_move_plunger.side_effect = instant_future
-    monkeypatch.setattr(hw_api, '_move_plunger', mock_move_plunger)
+    monkeypatch.setattr(hw_api, "_move_plunger", mock_move_plunger)
     pip = hw_api._attached_instruments[mount]
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 2, 'aspirate'),
-        speed=hw_api._plunger_speed(
-            pip, pip.config.aspirate_flow_rate, 'aspirate')
+        hw_api._plunger_position(pip, 2, "aspirate"),
+        speed=hw_api._plunger_speed(pip, pip.config.aspirate_flow_rate, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 4, 'aspirate'),
+        hw_api._plunger_position(pip, 4, "aspirate"),
         speed=hw_api._plunger_speed(
-            pip, pip.config.aspirate_flow_rate * 0.5, 'aspirate')
+            pip, pip.config.aspirate_flow_rate * 0.5, "aspirate"
+        ),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_flow_rate(mount, aspirate=1)
@@ -382,39 +387,36 @@ async def test_aspirate_flow_rate(dummy_instruments, loop, monkeypatch):
     await hw_api.aspirate(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 6, 'aspirate'),
-        speed=hw_api._plunger_speed(pip, 2, 'aspirate')
+        hw_api._plunger_position(pip, 6, "aspirate"),
+        speed=hw_api._plunger_speed(pip, 2, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 8, 'aspirate'),
-        speed=hw_api._plunger_speed(pip, 1, 'aspirate')
+        hw_api._plunger_position(pip, 8, "aspirate"),
+        speed=hw_api._plunger_speed(pip, 1, "aspirate"),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_pipette_speed(mount, aspirate=10)
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 1)
     assert mock_move_plunger.called_with(
-        mount,
-        hw_api._plunger_position(pip, 8, 'aspirate'),
-        speed=10
+        mount, hw_api._plunger_position(pip, 8, "aspirate"), speed=10
     )
     mock_move_plunger.reset_mock()
     await hw_api.prepare_for_aspirate(types.Mount.LEFT)
     await hw_api.aspirate(types.Mount.LEFT, 1, rate=0.5)
     assert mock_move_plunger.called_with(
-        mount,
-        hw_api._plunger_position(pip, 8, 'aspirate'),
-        speed=5
+        mount, hw_api._plunger_position(pip, 8, "aspirate"), speed=5
     )
 
 
 async def test_dispense_flow_rate(dummy_instruments, loop, monkeypatch):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
@@ -431,58 +433,55 @@ async def test_dispense_flow_rate(dummy_instruments, loop, monkeypatch):
         return fut
 
     mock_move_plunger.side_effect = instant_future
-    monkeypatch.setattr(hw_api, '_move_plunger', mock_move_plunger)
+    monkeypatch.setattr(hw_api, "_move_plunger", mock_move_plunger)
     pip = hw_api._attached_instruments[mount]
     await hw_api.dispense(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 8, 'dispense'),
-        speed=hw_api._plunger_speed(
-            pip, pip.config.dispense_flow_rate, 'dispense')
+        hw_api._plunger_position(pip, 8, "dispense"),
+        speed=hw_api._plunger_speed(pip, pip.config.dispense_flow_rate, "dispense"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 6, 'dispense'),
+        hw_api._plunger_position(pip, 6, "dispense"),
         speed=hw_api._plunger_speed(
-            pip, pip.config.dispense_flow_rate * 0.5, 'dispense')
+            pip, pip.config.dispense_flow_rate * 0.5, "dispense"
+        ),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_flow_rate(mount, dispense=3)
     await hw_api.dispense(types.Mount.LEFT, 2)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 4, 'dispense'),
-        speed=hw_api._plunger_speed(pip, 3, 'dispense')
+        hw_api._plunger_position(pip, 4, "dispense"),
+        speed=hw_api._plunger_speed(pip, 3, "dispense"),
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 2, rate=0.5)
     assert mock_move_plunger.called_with(
         mount,
-        hw_api._plunger_position(pip, 2, 'dispense'),
-        speed=hw_api._plunger_speed(pip, 1.5, 'dispense')
+        hw_api._plunger_position(pip, 2, "dispense"),
+        speed=hw_api._plunger_speed(pip, 1.5, "dispense"),
     )
     mock_move_plunger.reset_mock()
     hw_api.set_pipette_speed(mount, dispense=10)
     await hw_api.dispense(types.Mount.LEFT, 1)
     assert mock_move_plunger.called_with(
-        mount,
-        hw_api._plunger_position(pip, 1, 'dispense'),
-        speed=10
+        mount, hw_api._plunger_position(pip, 1, "dispense"), speed=10
     )
     mock_move_plunger.reset_mock()
     await hw_api.dispense(types.Mount.LEFT, 1, rate=0.5)
     assert mock_move_plunger.called_with(
-        mount,
-        hw_api._plunger_position(pip, 0, 'dispense'),
-        speed=5
+        mount, hw_api._plunger_position(pip, 0, "dispense"), speed=5
     )
 
 
 async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = types.Mount.LEFT
     await hw_api.home()
     await hw_api.cache_instruments()
@@ -497,7 +496,7 @@ async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
         return fut
 
     mock_move_plunger.side_effect = instant_future
-    monkeypatch.setattr(hw_api, '_move_plunger', mock_move_plunger)
+    monkeypatch.setattr(hw_api, "_move_plunger", mock_move_plunger)
     pip = hw_api._attached_instruments[mount]
 
     await hw_api.prepare_for_aspirate(mount)
@@ -507,8 +506,7 @@ async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
     assert mock_move_plunger.called_with(
         mount,
         pip.config.blow_out,
-        speed=hw_api._plunger_speed(
-            pip, pip.config.blow_out_flow_rate, 'dispense')
+        speed=hw_api._plunger_speed(pip, pip.config.blow_out_flow_rate, "dispense"),
     )
     mock_move_plunger.reset_mock()
 
@@ -518,9 +516,7 @@ async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
     mock_move_plunger.reset_mock()
     await hw_api.blow_out(types.Mount.LEFT)
     assert mock_move_plunger.called_with(
-        mount,
-        pip.config.blow_out,
-        speed=hw_api._plunger_speed(pip, 2, 'dispense')
+        mount, pip.config.blow_out, speed=hw_api._plunger_speed(pip, 2, "dispense")
     )
     mock_move_plunger.reset_mock()
 
@@ -529,20 +525,16 @@ async def test_blowout_flow_rate(dummy_instruments, loop, monkeypatch):
     await hw_api.aspirate(types.Mount.LEFT, 10)
     mock_move_plunger.reset_mock()
     await hw_api.blow_out(types.Mount.LEFT)
-    assert mock_move_plunger.called_with(
-        mount,
-        pip.config.blow_out,
-        speed=15
-    )
+    assert mock_move_plunger.called_with(mount, pip.config.blow_out, speed=15)
 
 
 async def test_reset_instruments(dummy_instruments, loop, monkeypatch):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     hw_api.set_flow_rate(types.Mount.LEFT, 20)
     # gut check
-    assert hw_api.attached_instruments[types.Mount.LEFT]['aspirate_flow_rate']\
-        == 20
+    assert hw_api.attached_instruments[types.Mount.LEFT]["aspirate_flow_rate"] == 20
     old_l = hw_api._attached_instruments[types.Mount.LEFT]
     old_r = hw_api._attached_instruments[types.Mount.RIGHT]
     hw_api.reset_instrument(types.Mount.LEFT)
@@ -550,11 +542,9 @@ async def test_reset_instruments(dummy_instruments, loop, monkeypatch):
     assert not (old_l is hw_api._attached_instruments[types.Mount.LEFT])
     assert old_r is hw_api._attached_instruments[types.Mount.RIGHT]
     # after the reset, the left should be more or less the same
-    assert old_l.pipette_id\
-        == hw_api._attached_instruments[types.Mount.LEFT].pipette_id
+    assert old_l.pipette_id == hw_api._attached_instruments[types.Mount.LEFT].pipette_id
     # but non-default configs should be changed
-    assert hw_api.attached_instruments[types.Mount.LEFT]['aspirate_flow_rate']\
-        != 20
+    assert hw_api.attached_instruments[types.Mount.LEFT]["aspirate_flow_rate"] != 20
     old_l = hw_api._attached_instruments[types.Mount.LEFT]
     old_r = hw_api._attached_instruments[types.Mount.RIGHT]
 

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -5,16 +5,19 @@ import pytest
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import ModuleAtPort
 from opentrons.hardware_control.modules.types import (
-    BundledFirmware, MagneticModuleModel, ModuleType)
+    BundledFirmware,
+    MagneticModuleModel,
+    ModuleType,
+)
 from opentrons.hardware_control.modules import tempdeck, magdeck
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
 async def test_get_modules_simulating():
     import opentrons.hardware_control as hardware_control
-    mods = ['tempdeck', 'magdeck', 'thermocycler']
-    api = await hardware_control.API.build_hardware_simulator(
-                        attached_modules=mods)
+
+    mods = ["tempdeck", "magdeck", "thermocycler"]
+    api = await hardware_control.API.build_hardware_simulator(attached_modules=mods)
     await asyncio.sleep(0.05)
     from_api = api.attached_modules
     assert sorted([mod.name() for mod in from_api]) == sorted(mods)
@@ -22,35 +25,39 @@ async def test_get_modules_simulating():
 
 async def test_module_caching():
     import opentrons.hardware_control as hardware_control
-    mod_names = ['tempdeck']
+
+    mod_names = ["tempdeck"]
     api = await hardware_control.API.build_hardware_simulator(
-        attached_modules=mod_names)
+        attached_modules=mod_names
+    )
     await asyncio.sleep(0.05)
 
     # Check that we can add and remove modules and the caching keeps up
     found_mods = api.attached_modules
-    assert found_mods[0].name() == 'tempdeck'
+    assert found_mods[0].name() == "tempdeck"
     await api._backend.module_controls.register_modules(
-        new_mods_at_ports=[ModuleAtPort(port='/dev/ot_module_sim_magdeck1',
-                                        name='magdeck')
-                           ])
+        new_mods_at_ports=[
+            ModuleAtPort(port="/dev/ot_module_sim_magdeck1", name="magdeck")
+        ]
+    )
     with_magdeck = api.attached_modules.copy()
     assert len(with_magdeck) == 2
     assert with_magdeck[0] is found_mods[0]
     await api._backend.module_controls.register_modules(
         removed_mods_at_ports=[
-            ModuleAtPort(port='/dev/ot_module_sim_tempdeck0',
-                         name='tempdeck')
-        ])
+            ModuleAtPort(port="/dev/ot_module_sim_tempdeck0", name="tempdeck")
+        ]
+    )
     only_magdeck = api.attached_modules.copy()
     assert only_magdeck[0] is with_magdeck[1]
 
     # Check that two modules of the same kind on different ports are
     # distinct
     await api._backend.module_controls.register_modules(
-        new_mods_at_ports=[ModuleAtPort(port='/dev/ot_module_sim_magdeck2',
-                                        name='magdeck')
-                           ])
+        new_mods_at_ports=[
+            ModuleAtPort(port="/dev/ot_module_sim_magdeck2", name="magdeck")
+        ]
+    )
     two_magdecks = api.attached_modules
     assert len(two_magdecks) == 2
     assert two_magdecks[0] is with_magdeck[1]
@@ -59,15 +66,14 @@ async def test_module_caching():
 
 async def test_filtering_modules():
     import opentrons.hardware_control as hardware_control
-    mods = [
-        'tempdeck', 'tempdeck', 'magdeck',
-        'magdeck', 'thermocycler']
-    api = await hardware_control.API.build_hardware_simulator(
-                        attached_modules=mods)
+
+    mods = ["tempdeck", "tempdeck", "magdeck", "magdeck", "thermocycler"]
+    api = await hardware_control.API.build_hardware_simulator(attached_modules=mods)
     await asyncio.sleep(0.05)
 
     filtered_modules, _ = await api.find_modules(
-        MagneticModuleModel.MAGNETIC_V1, ModuleType.MAGNETIC)
+        MagneticModuleModel.MAGNETIC_V1, ModuleType.MAGNETIC
+    )
     assert len(filtered_modules) == 2
     assert filtered_modules == api.attached_modules[2:4]
 
@@ -81,154 +87,157 @@ async def test_module_update_integration(monkeypatch, loop):
         return f
 
     bootloader_kwargs = {
-        'stdout': asyncio.subprocess.PIPE,
-        'stderr': asyncio.subprocess.PIPE,
-        'loop': loop,
+        "stdout": asyncio.subprocess.PIPE,
+        "stderr": asyncio.subprocess.PIPE,
+        "loop": loop,
     }
 
     # test temperature module update with avrdude bootloader
     usb_port = USBPort(
-        name='', sub_names=[], hub=None,
-        port_number=None, device_path='/dev/ot_module_sim_tempdeck0')
+        name="",
+        sub_names=[],
+        hub=None,
+        port_number=None,
+        device_path="/dev/ot_module_sim_tempdeck0",
+    )
 
     tempdeck = await modules.build(
-            port='/dev/ot_module_sim_tempdeck0',
-            usb_port=usb_port,
-            which='tempdeck',
-            simulating=True,
-            interrupt_callback=lambda x: None,
-            loop=loop,
-            execution_manager=ExecutionManager(loop=loop),
-            sim_model='temperatureModuleV2')
+        port="/dev/ot_module_sim_tempdeck0",
+        usb_port=usb_port,
+        which="tempdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+        sim_model="temperatureModuleV2",
+    )
 
     upload_via_avrdude_mock = mock.Mock(
-        return_value=(async_return((True, 'avrdude bootloader worked'))))
-    monkeypatch.setattr(modules.update,
-                        'upload_via_avrdude',
-                        upload_via_avrdude_mock)
+        return_value=(async_return((True, "avrdude bootloader worked")))
+    )
+    monkeypatch.setattr(modules.update, "upload_via_avrdude", upload_via_avrdude_mock)
 
     async def mock_find_avrdude_bootloader_port():
-        return 'ot_module_avrdude_bootloader1'
+        return "ot_module_avrdude_bootloader1"
 
-    monkeypatch.setattr(modules.update,
-                        'find_bootloader_port',
-                        mock_find_avrdude_bootloader_port)
+    monkeypatch.setattr(
+        modules.update, "find_bootloader_port", mock_find_avrdude_bootloader_port
+    )
 
-    await modules.update_firmware(tempdeck, 'fake_fw_file_path', loop)
+    await modules.update_firmware(tempdeck, "fake_fw_file_path", loop)
     upload_via_avrdude_mock.assert_called_once_with(
-        'ot_module_avrdude_bootloader1',
-        'fake_fw_file_path',
-        bootloader_kwargs
+        "ot_module_avrdude_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
     upload_via_avrdude_mock.reset_mock()
 
     # test magnetic module update with avrdude bootloader
 
     magdeck = await modules.build(
-            port='/dev/ot_module_sim_magdeck0',
-            usb_port=usb_port,
-            which='magdeck',
-            simulating=True,
-            interrupt_callback=lambda x: None,
-            loop=loop,
-            execution_manager=ExecutionManager(loop=loop))
+        port="/dev/ot_module_sim_magdeck0",
+        usb_port=usb_port,
+        which="magdeck",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
-    await modules.update_firmware(magdeck, 'fake_fw_file_path', loop)
+    await modules.update_firmware(magdeck, "fake_fw_file_path", loop)
     upload_via_avrdude_mock.assert_called_once_with(
-        'ot_module_avrdude_bootloader1',
-        'fake_fw_file_path',
-        bootloader_kwargs
+        "ot_module_avrdude_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
 
     # test thermocycler module update with bossa bootloader
 
     thermocycler = await modules.build(
-            port='/dev/ot_module_sim_thermocycler0',
-            usb_port=usb_port,
-            which='thermocycler',
-            simulating=True,
-            interrupt_callback=lambda x: None,
-            loop=loop,
-            execution_manager=ExecutionManager(loop=loop))
+        port="/dev/ot_module_sim_thermocycler0",
+        usb_port=usb_port,
+        which="thermocycler",
+        simulating=True,
+        interrupt_callback=lambda x: None,
+        loop=loop,
+        execution_manager=ExecutionManager(loop=loop),
+    )
 
     upload_via_bossa_mock = mock.Mock(
-        return_value=(async_return((True, 'bossa bootloader worked'))))
-    monkeypatch.setattr(modules.update,
-                        'upload_via_bossa',
-                        upload_via_bossa_mock)
+        return_value=(async_return((True, "bossa bootloader worked")))
+    )
+    monkeypatch.setattr(modules.update, "upload_via_bossa", upload_via_bossa_mock)
 
     async def mock_find_bossa_bootloader_port():
-        return 'ot_module_bossa_bootloader1'
+        return "ot_module_bossa_bootloader1"
 
-    monkeypatch.setattr(modules.update,
-                        'find_bootloader_port',
-                        mock_find_bossa_bootloader_port)
+    monkeypatch.setattr(
+        modules.update, "find_bootloader_port", mock_find_bossa_bootloader_port
+    )
 
-    await modules.update_firmware(thermocycler,
-                                  'fake_fw_file_path',
-                                  loop)
+    await modules.update_firmware(thermocycler, "fake_fw_file_path", loop)
     upload_via_bossa_mock.assert_called_once_with(
-        'ot_module_bossa_bootloader1',
-        'fake_fw_file_path',
-        bootloader_kwargs
+        "ot_module_bossa_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
 
 
 async def test_get_bundled_fw(monkeypatch, tmpdir):
     from opentrons.hardware_control import modules
 
-    dummy_td_file = Path(tmpdir) / 'temperature-module@v1.2.3.hex'
+    dummy_td_file = Path(tmpdir) / "temperature-module@v1.2.3.hex"
     dummy_td_file.write_text("hello")
 
-    dummy_md_file = Path(tmpdir) / 'magnetic-module@v3.2.1.hex'
+    dummy_md_file = Path(tmpdir) / "magnetic-module@v3.2.1.hex"
     dummy_md_file.write_text("hello")
 
-    dummy_tc_file = Path(tmpdir) / 'thermocycler@v0.1.2.bin'
+    dummy_tc_file = Path(tmpdir) / "thermocycler@v0.1.2.bin"
     dummy_tc_file.write_text("hello")
 
-    dummy_bogus_file = Path(tmpdir) / 'thermoshaker@v6.6.6.bin'
+    dummy_bogus_file = Path(tmpdir) / "thermoshaker@v6.6.6.bin"
     dummy_bogus_file.write_text("hello")
 
-    monkeypatch.setattr(modules.mod_abc, 'ROBOT_FIRMWARE_DIR', Path(tmpdir))
-    monkeypatch.setattr(modules.mod_abc, 'IS_ROBOT', True)
+    monkeypatch.setattr(modules.mod_abc, "ROBOT_FIRMWARE_DIR", Path(tmpdir))
+    monkeypatch.setattr(modules.mod_abc, "IS_ROBOT", True)
 
     from opentrons.hardware_control import API
-    mods = ['tempdeck', 'magdeck', 'thermocycler']
+
+    mods = ["tempdeck", "magdeck", "thermocycler"]
     api = await API.build_hardware_simulator(attached_modules=mods)
     await asyncio.sleep(0.05)
 
     assert api.attached_modules[0].bundled_fw == BundledFirmware(
-        version='1.2.3', path=dummy_td_file)
+        version="1.2.3", path=dummy_td_file
+    )
     assert api.attached_modules[1].bundled_fw == BundledFirmware(
-        version='3.2.1', path=dummy_md_file)
+        version="3.2.1", path=dummy_md_file
+    )
     assert api.attached_modules[2].bundled_fw == BundledFirmware(
-        version='0.1.2', path=dummy_tc_file)
+        version="0.1.2", path=dummy_tc_file
+    )
 
 
 @pytest.mark.parametrize(
-    'revision,model',
+    "revision,model",
     [
-        ('mag_deck_v1.1', 'magneticModuleV1'),
-        ('mag_deck_v20', 'magneticModuleV2'),
-        ('', 'magneticModuleV1'),
-        ('asdasdadvasdasd', 'magneticModuleV1'),
-        (None, 'magneticModuleV1')
-    ])
+        ("mag_deck_v1.1", "magneticModuleV1"),
+        ("mag_deck_v20", "magneticModuleV2"),
+        ("", "magneticModuleV1"),
+        ("asdasdadvasdasd", "magneticModuleV1"),
+        (None, "magneticModuleV1"),
+    ],
+)
 def test_magnetic_module_revision_parsing(revision, model):
     assert magdeck.MagDeck._model_from_revision(revision) == model
 
 
 @pytest.mark.parametrize(
-    'revision,model',
+    "revision,model",
     [
-        ('temp_deck_v1.1', 'temperatureModuleV1'),
-        ('temp_deck_v3.0', 'temperatureModuleV1'),
-        ('temp_deck_v4.0', 'temperatureModuleV1'),
-        ('temp_deck_v15', 'temperatureModuleV1'),
-        ('temp_deck_v20', 'temperatureModuleV2'),
-        ('', 'temperatureModuleV1'),
-        ('v', 'temperatureModuleV1'),
-        (None, 'temperatureModuleV1')
-    ])
+        ("temp_deck_v1.1", "temperatureModuleV1"),
+        ("temp_deck_v3.0", "temperatureModuleV1"),
+        ("temp_deck_v4.0", "temperatureModuleV1"),
+        ("temp_deck_v15", "temperatureModuleV1"),
+        ("temp_deck_v20", "temperatureModuleV2"),
+        ("", "temperatureModuleV1"),
+        ("v", "temperatureModuleV1"),
+        (None, "temperatureModuleV1"),
+    ],
+)
 def test_temperature_module_revision_parsing(revision, model):
     assert tempdeck.TempDeck._model_from_revision(revision) == model

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -3,9 +3,16 @@ import pytest
 from opentrons import types
 from opentrons import hardware_control as hc
 from opentrons.calibration_storage.types import (
-    DeckCalibration, SourceType, CalibrationStatus)
+    DeckCalibration,
+    SourceType,
+    CalibrationStatus,
+)
 from opentrons.hardware_control.types import (
-    Axis, CriticalPoint, OutOfBoundsMove, MotionChecks)
+    Axis,
+    CriticalPoint,
+    OutOfBoundsMove,
+    MotionChecks,
+)
 from opentrons.hardware_control.robot_calibration import RobotCalibration
 
 
@@ -25,35 +32,41 @@ async def test_home_specific_sim(hardware_api, monkeypatch, is_robot):
     hardware_api._last_moved_mount = None
     await hardware_api.move_rel(types.Mount.LEFT, types.Point(0, 0, -20))
     await hardware_api.home([Axis.Z, Axis.C])
-    assert hardware_api._current_position == {Axis.X: 0,
-                                              Axis.Y: 10,
-                                              Axis.Z: 218,
-                                              Axis.A: -10,
-                                              Axis.B: 19,
-                                              Axis.C: 19}
+    assert hardware_api._current_position == {
+        Axis.X: 0,
+        Axis.Y: 10,
+        Axis.Z: 218,
+        Axis.A: -10,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
 
 
 async def test_retract(hardware_api):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 10, 20))
     await hardware_api.retract(types.Mount.RIGHT, 10)
-    assert hardware_api._current_position == {Axis.X: 0,
-                                              Axis.Y: 10,
-                                              Axis.Z: 218,
-                                              Axis.A: 218,
-                                              Axis.B: 19,
-                                              Axis.C: 19}
+    assert hardware_api._current_position == {
+        Axis.X: 0,
+        Axis.Y: 10,
+        Axis.Z: 218,
+        Axis.A: 218,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
 
 
 async def test_move(hardware_api, is_robot):
     abs_position = types.Point(30, 20, 10)
     mount = types.Mount.RIGHT
-    target_position1 = {Axis.X: 30,
-                        Axis.Y: 20,
-                        Axis.Z: 218,
-                        Axis.A: -20,
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_position1 = {
+        Axis.X: 30,
+        Axis.Y: 20,
+        Axis.Z: 218,
+        Axis.A: -20,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     await hardware_api.home()
     await hardware_api.move_to(mount, abs_position)
     assert hardware_api._current_position == target_position1
@@ -63,90 +76,96 @@ async def test_move(hardware_api, is_robot):
     # applied again
     rel_position = types.Point(30, 20, -10)
     mount2 = types.Mount.LEFT
-    target_position2 = {Axis.X: 60,
-                        Axis.Y: 40,
-                        Axis.Z: 208,
-                        Axis.A: 218,  # The other instrument is retracted
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_position2 = {
+        Axis.X: 60,
+        Axis.Y: 40,
+        Axis.Z: 208,
+        Axis.A: 218,  # The other instrument is retracted
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     await hardware_api.move_rel(mount2, rel_position)
     assert hardware_api._current_position == target_position2
 
 
 async def test_move_extras_passed_through(hardware_api, monkeypatch):
     mock_be_move = mock.AsyncMock()
-    monkeypatch.setattr(hardware_api._backend, 'move', mock_be_move)
+    monkeypatch.setattr(hardware_api._backend, "move", mock_be_move)
     await hardware_api.home()
-    await hardware_api.move_to(types.Mount.RIGHT,
-                               types.Point(0, 0, 0))
-    assert mock_be_move.call_args_list[0][1]['speed'] is None
-    assert mock_be_move.call_args_list[0][1]['axis_max_speeds'] == {}
+    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
+    assert mock_be_move.call_args_list[0][1]["speed"] is None
+    assert mock_be_move.call_args_list[0][1]["axis_max_speeds"] == {}
     mock_be_move.reset_mock()
-    await hardware_api.move_to(types.Mount.RIGHT,
-                               types.Point(1, 1, 1),
-                               speed=30,
-                               max_speeds={Axis.X: 10})
-    assert mock_be_move.call_args_list[0][1]['speed'] == 30
-    assert mock_be_move.call_args_list[0][1]['axis_max_speeds'] == {'X': 10}
+    await hardware_api.move_to(
+        types.Mount.RIGHT, types.Point(1, 1, 1), speed=30, max_speeds={Axis.X: 10}
+    )
+    assert mock_be_move.call_args_list[0][1]["speed"] == 30
+    assert mock_be_move.call_args_list[0][1]["axis_max_speeds"] == {"X": 10}
     mock_be_move.reset_mock()
-    await hardware_api.move_rel(types.Mount.LEFT,
-                                types.Point(1, 1, 1),
-                                speed=40,
-                                max_speeds={Axis.Y: 20})
-    assert mock_be_move.call_args_list[0][1]['speed'] == 40
-    assert mock_be_move.call_args_list[0][1]['axis_max_speeds'] == {'Y': 20}
+    await hardware_api.move_rel(
+        types.Mount.LEFT, types.Point(1, 1, 1), speed=40, max_speeds={Axis.Y: 20}
+    )
+    assert mock_be_move.call_args_list[0][1]["speed"] == 40
+    assert mock_be_move.call_args_list[0][1]["axis_max_speeds"] == {"Y": 20}
 
 
-async def test_mount_offset_applied(
-        hardware_api, is_robot):
+async def test_mount_offset_applied(hardware_api, is_robot):
     await hardware_api.home()
     abs_position = types.Point(30, 20, 10)
     mount = types.Mount.LEFT
-    target_position = {Axis.X: 64,
-                       Axis.Y: 20,
-                       Axis.Z: -20,
-                       Axis.A: 218,
-                       Axis.B: 19,
-                       Axis.C: 19}
+    target_position = {
+        Axis.X: 64,
+        Axis.Y: 20,
+        Axis.Z: -20,
+        Axis.A: 218,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     await hardware_api.move_to(mount, abs_position)
     assert hardware_api._current_position == target_position
 
 
 async def test_critical_point_applied(hardware_api, monkeypatch, is_robot):
     await hardware_api.home()
-    hardware_api._backend._attached_instruments\
-        = {types.Mount.LEFT: {'model': None, 'id': None},
-           types.Mount.RIGHT: {'model': 'p10_single_v1', 'id': 'testyness'}}
+    hardware_api._backend._attached_instruments = {
+        types.Mount.LEFT: {"model": None, "id": None},
+        types.Mount.RIGHT: {"model": "p10_single_v1", "id": "testyness"},
+    }
     await hardware_api.cache_instruments()
     # Our critical point is now the tip of the nozzle
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
-    target_no_offset = {Axis.X: 0,
-                        Axis.Y: 0,
-                        Axis.Z: 218,
-                        Axis.A: -12,  # from pipette-config.json nozzle offset
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_no_offset = {
+        Axis.X: 0,
+        Axis.Y: 0,
+        Axis.Z: 218,
+        Axis.A: -12,  # from pipette-config.json nozzle offset
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     assert hardware_api._current_position == target_no_offset
-    target = {Axis.X: 0,
-              Axis.Y: 0,
-              Axis.A: 0,
-              Axis.C: 19}
+    target = {Axis.X: 0, Axis.Y: 0, Axis.A: 0, Axis.C: 19}
     assert await hardware_api.current_position(types.Mount.RIGHT) == target
     p10_tip_length = 33
     # Specifiying critical point overrides as mount should not use nozzle
     # offset
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0),
-                               critical_point=CriticalPoint.MOUNT)
-    assert hardware_api._current_position == {Axis.X: 0.0, Axis.Y: 0.0,
-                                              Axis.Z: 218,
-                                              Axis.A: -30,
-                                              Axis.B: 19, Axis.C: 19}
+    await hardware_api.move_to(
+        types.Mount.RIGHT, types.Point(0, 0, 0), critical_point=CriticalPoint.MOUNT
+    )
+    assert hardware_api._current_position == {
+        Axis.X: 0.0,
+        Axis.Y: 0.0,
+        Axis.Z: 218,
+        Axis.A: -30,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     assert await hardware_api.current_position(
-        types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT)\
-        == {Axis.X: 0.0, Axis.Y: 0.0, Axis.A: 0, Axis.C: 19}
+        types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT
+    ) == {Axis.X: 0.0, Axis.Y: 0.0, Axis.A: 0, Axis.C: 19}
     # Specifying the critical point as nozzle should have the same behavior
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0),
-                               critical_point=CriticalPoint.NOZZLE)
+    await hardware_api.move_to(
+        types.Mount.RIGHT, types.Point(0, 0, 0), critical_point=CriticalPoint.NOZZLE
+    )
     assert hardware_api._current_position == target_no_offset
     await hardware_api.pick_up_tip(types.Mount.RIGHT, p10_tip_length)
     # Now the current position (with offset applied) should change
@@ -178,41 +197,46 @@ async def test_critical_point_applied(hardware_api, monkeypatch, is_robot):
     assert await hardware_api.current_position(types.Mount.RIGHT) == target
 
 
-async def test_new_critical_point_applied(
-        hardware_api, monkeypatch, is_robot):
+async def test_new_critical_point_applied(hardware_api, monkeypatch, is_robot):
     await hardware_api.home()
-    hardware_api._backend._attached_instruments\
-        = {types.Mount.LEFT: {'model': None, 'id': None},
-           types.Mount.RIGHT: {'model': 'p10_single_v1', 'id': 'testyness'}}
+    hardware_api._backend._attached_instruments = {
+        types.Mount.LEFT: {"model": None, "id": None},
+        types.Mount.RIGHT: {"model": "p10_single_v1", "id": "testyness"},
+    }
     await hardware_api.cache_instruments()
     # Our critical point is now the tip of the nozzle
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
-    target_no_offset = {Axis.X: 0,
-                        Axis.Y: 0,
-                        Axis.Z: 218,
-                        Axis.A: -12,  # from pipette-config.json model offset
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_no_offset = {
+        Axis.X: 0,
+        Axis.Y: 0,
+        Axis.Z: 218,
+        Axis.A: -12,  # from pipette-config.json model offset
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     assert hardware_api._current_position == target_no_offset
-    target = {Axis.X: 0,
-              Axis.Y: 0,
-              Axis.A: 0,
-              Axis.C: 19}
+    target = {Axis.X: 0, Axis.Y: 0, Axis.A: 0, Axis.C: 19}
     assert await hardware_api.current_position(types.Mount.RIGHT) == target
     p10_tip_length = 33
     # Specifiying critical point overrides as mount should not use model offset
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0),
-                               critical_point=CriticalPoint.MOUNT)
-    assert hardware_api._current_position == {Axis.X: 0.0, Axis.Y: 0.0,
-                                              Axis.Z: 218,
-                                              Axis.A: -30,
-                                              Axis.B: 19, Axis.C: 19}
+    await hardware_api.move_to(
+        types.Mount.RIGHT, types.Point(0, 0, 0), critical_point=CriticalPoint.MOUNT
+    )
+    assert hardware_api._current_position == {
+        Axis.X: 0.0,
+        Axis.Y: 0.0,
+        Axis.Z: 218,
+        Axis.A: -30,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     assert await hardware_api.current_position(
-        types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT)\
-        == {Axis.X: 0.0, Axis.Y: 0.0, Axis.A: 0, Axis.C: 19}
+        types.Mount.RIGHT, critical_point=CriticalPoint.MOUNT
+    ) == {Axis.X: 0.0, Axis.Y: 0.0, Axis.A: 0, Axis.C: 19}
     # Specifying the critical point as nozzle should have the same behavior
-    await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0),
-                               critical_point=CriticalPoint.NOZZLE)
+    await hardware_api.move_to(
+        types.Mount.RIGHT, types.Point(0, 0, 0), critical_point=CriticalPoint.NOZZLE
+    )
     assert hardware_api._current_position == target_no_offset
     await hardware_api.pick_up_tip(types.Mount.RIGHT, p10_tip_length)
     # Now the current position (with offset applied) should change
@@ -244,72 +268,64 @@ async def test_new_critical_point_applied(
     assert await hardware_api.current_position(types.Mount.RIGHT) == target
 
 
-async def test_attitude_deck_cal_applied(
-        monkeypatch, loop):
-    new_gantry_cal = [
-        [1.0047, -0.0046, 0.0],
-        [0.0011, 1.0038, 0.0],
-        [0.0, 0.0, 1.0]]
+async def test_attitude_deck_cal_applied(monkeypatch, loop):
+    new_gantry_cal = [[1.0047, -0.0046, 0.0], [0.0011, 1.0038, 0.0], [0.0, 0.0, 1.0]]
     called_with = None
 
-    async def mock_move(position, speed=None, home_flagged_axes=True,
-                        axis_max_speeds=None):
+    async def mock_move(
+        position, speed=None, home_flagged_axes=True, axis_max_speeds=None
+    ):
         nonlocal called_with
         called_with = position
 
     hardware_api = await hc.API.build_hardware_simulator(loop=loop)
-    monkeypatch.setattr(hardware_api._backend, 'move', mock_move)
+    monkeypatch.setattr(hardware_api._backend, "move", mock_move)
     deck_cal = RobotCalibration(
         deck_calibration=DeckCalibration(
-            attitude=new_gantry_cal,
-            source=SourceType.user,
-            status=CalibrationStatus()))
+            attitude=new_gantry_cal, source=SourceType.user, status=CalibrationStatus()
+        )
+    )
     hardware_api.set_robot_calibration(deck_cal)
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
-    assert called_with['X'] == 0.0
-    assert called_with['Y'] == 0.0
-    assert called_with['A'] == -30.0
+    assert called_with["X"] == 0.0
+    assert called_with["Y"] == 0.0
+    assert called_with["A"] == -30.0
     # Check that mount offset is also applied
     await hardware_api.move_to(types.Mount.LEFT, types.Point(0, 0, 0))
-    assert round(called_with['X'], 2) == 34.16
-    assert round(called_with['Y'], 2) == 0.04
-    assert round(called_with['Z'], 2) == -30.0
+    assert round(called_with["X"], 2) == 34.16
+    assert round(called_with["Y"], 2) == 0.04
+    assert round(called_with["Z"], 2) == -30.0
 
 
-async def test_other_mount_retracted(
-        hardware_api, is_robot):
+async def test_other_mount_retracted(hardware_api, is_robot):
     await hardware_api.home()
     await hardware_api.move_to(types.Mount.RIGHT, types.Point(0, 0, 0))
-    assert await hardware_api.gantry_position(types.Mount.RIGHT)\
-        == types.Point(0, 0, 0)
+    assert await hardware_api.gantry_position(types.Mount.RIGHT) == types.Point(0, 0, 0)
     await hardware_api.move_to(types.Mount.LEFT, types.Point(20, 20, 0))
-    assert await hardware_api.gantry_position(types.Mount.RIGHT) \
-        == types.Point(54, 20, 248)
+    assert await hardware_api.gantry_position(types.Mount.RIGHT) == types.Point(
+        54, 20, 248
+    )
 
 
-async def test_shake_during_pick_up(
-        hardware_api, monkeypatch):
+async def test_shake_during_pick_up(hardware_api, monkeypatch):
     await hardware_api.home()
-    hardware_api._backend._attached_instruments\
-        = {types.Mount.LEFT: {'model': None, 'id': None},
-           types.Mount.RIGHT: {'model': 'p1000_single_v2.0',
-                               'id': 'testyness'}}
+    hardware_api._backend._attached_instruments = {
+        types.Mount.LEFT: {"model": None, "id": None},
+        types.Mount.RIGHT: {"model": "p1000_single_v2.0", "id": "testyness"},
+    }
     await hardware_api.cache_instruments()
 
-    shake_tips_pick_up = mock.Mock(
-        side_effect=hardware_api._shake_off_tips_pick_up)
-    monkeypatch.setattr(hardware_api, '_shake_off_tips_pick_up',
-                        shake_tips_pick_up)
+    shake_tips_pick_up = mock.Mock(side_effect=hardware_api._shake_off_tips_pick_up)
+    monkeypatch.setattr(hardware_api, "_shake_off_tips_pick_up", shake_tips_pick_up)
 
     # Test double shake for after pick up tips
     await hardware_api.pick_up_tip(types.Mount.RIGHT, 50)
-    shake_tip_calls = [mock.call(types.Mount.RIGHT),
-                       mock.call(types.Mount.RIGHT)]
+    shake_tip_calls = [mock.call(types.Mount.RIGHT), mock.call(types.Mount.RIGHT)]
     shake_tips_pick_up.assert_has_calls(shake_tip_calls)
 
     move_rel = mock.Mock(side_effect=hardware_api.move_rel)
-    monkeypatch.setattr(hardware_api, 'move_rel', move_rel)
+    monkeypatch.setattr(hardware_api, "move_rel", move_rel)
 
     # Test shakes in X and Y direction with 0.3 mm shake tip distance
     shake_tips_pick_up.reset_mock()
@@ -321,32 +337,30 @@ async def test_shake_during_pick_up(
         mock.call(types.Mount.RIGHT, types.Point(0, -0.3, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0, 0.6, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(0, -0.3, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20))]
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+    ]
     move_rel.assert_has_calls(move_rel_calls)
 
 
-async def test_shake_during_drop(
-        hardware_api, monkeypatch):
+async def test_shake_during_drop(hardware_api, monkeypatch):
     await hardware_api.home()
-    hardware_api._backend._attached_instruments\
-        = {types.Mount.LEFT: {'model': None, 'id': None},
-           types.Mount.RIGHT: {'model': 'p1000_single_v1.5',
-                               'id': 'testyness'}}
+    hardware_api._backend._attached_instruments = {
+        types.Mount.LEFT: {"model": None, "id": None},
+        types.Mount.RIGHT: {"model": "p1000_single_v1.5", "id": "testyness"},
+    }
     await hardware_api.cache_instruments()
     await hardware_api.add_tip(types.Mount.RIGHT, 50.0)
     hardware_api.set_current_tiprack_diameter(types.Mount.RIGHT, 30.0)
 
-    shake_tips_drop = mock.Mock(
-        side_effect=hardware_api._shake_off_tips_drop)
-    monkeypatch.setattr(hardware_api, '_shake_off_tips_drop',
-                        shake_tips_drop)
+    shake_tips_drop = mock.Mock(side_effect=hardware_api._shake_off_tips_drop)
+    monkeypatch.setattr(hardware_api, "_shake_off_tips_drop", shake_tips_drop)
 
     # Test single shake after drop tip
     await hardware_api.drop_tip(types.Mount.RIGHT)
     shake_tips_drop.assert_called_once_with(types.Mount.RIGHT, 30)
 
     move_rel = mock.Mock(side_effect=hardware_api.move_rel)
-    monkeypatch.setattr(hardware_api, 'move_rel', move_rel)
+    monkeypatch.setattr(hardware_api, "move_rel", move_rel)
 
     # Test drop tip shake with 25% of tiprack well diameter
     # between upper (2.25 mm) and lower limit (1.0 mm)
@@ -356,7 +370,8 @@ async def test_shake_during_drop(
         mock.call(types.Mount.RIGHT, types.Point(-2, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-2, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20))]
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+    ]
     move_rel.assert_has_calls(move_rel_calls)
 
     # Test drop tip shake with 25% of tiprack well diameter
@@ -367,7 +382,8 @@ async def test_shake_during_drop(
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(4.5, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-2.25, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20))]
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+    ]
     move_rel.assert_has_calls(move_rel_calls)
 
     # Test drop tip shake with 25% of tiprack well diameter
@@ -378,13 +394,13 @@ async def test_shake_during_drop(
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(2, 0, 0), speed=50),
         mock.call(types.Mount.RIGHT, types.Point(-1, 0, 0), speed=50),
-        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20))]
+        mock.call(types.Mount.RIGHT, types.Point(0, 0, 20)),
+    ]
     move_rel.assert_has_calls(move_rel_calls)
 
 
-async def test_move_rel_bounds(
-        hardware_api):
+async def test_move_rel_bounds(hardware_api):
     with pytest.raises(OutOfBoundsMove):
         await hardware_api.move_rel(
-            types.Mount.RIGHT, types.Point(0, 0, 2000),
-            check_bounds=MotionChecks.HIGH)
+            types.Mount.RIGHT, types.Point(0, 0, 2000), check_bounds=MotionChecks.HIGH
+        )

--- a/api/tests/opentrons/hardware_control/test_paired_pipettes.py
+++ b/api/tests/opentrons/hardware_control/test_paired_pipettes.py
@@ -11,47 +11,47 @@ from opentrons.config import pipette_config as pc
 def dummy_instruments():
     dummy_instruments_attached = {
         types.Mount.LEFT: {
-            'model': 'p300_single_v2.0',
-            'id': 'fake',
-            'name': 'p300_single_gen2'
+            "model": "p300_single_v2.0",
+            "id": "fake",
+            "name": "p300_single_gen2",
         },
         types.Mount.RIGHT: {
-            'model': 'p20_single_v2.0',
-            'id': 'fake2',
-            'name': 'p20_single_gen2',
-        }
+            "model": "p20_single_v2.0",
+            "id": "fake2",
+            "name": "p20_single_gen2",
+        },
     }
     return dummy_instruments_attached
 
 
 async def test_move_z_axis(hardware_api, monkeypatch):
     mock_be_move = mock.AsyncMock()
-    monkeypatch.setattr(hardware_api._backend, 'move', mock_be_move)
+    monkeypatch.setattr(hardware_api._backend, "move", mock_be_move)
     mount = PipettePair.PRIMARY_RIGHT
     await hardware_api.home()
-    await hardware_api.move_to(mount,
-                               types.Point(0, 0, 0))
-    expected = {'X': 0.0, 'Y': 0.0, 'A': -30.0, 'Z': -30.0}
+    await hardware_api.move_to(mount, types.Point(0, 0, 0))
+    expected = {"X": 0.0, "Y": 0.0, "A": -30.0, "Z": -30.0}
     assert mock_be_move.call_args_list[0][0][0] == expected
     mock_be_move.reset_mock()
 
     mount = PipettePair.PRIMARY_LEFT
     await hardware_api.home()
-    await hardware_api.move_to(mount,
-                               types.Point(0, 0, 0))
-    expected = {'X': 34.0, 'Y': 0.0, 'A': -30.0, 'Z': -30.0}
+    await hardware_api.move_to(mount, types.Point(0, 0, 0))
+    expected = {"X": 34.0, "Y": 0.0, "A": -30.0, "Z": -30.0}
     assert mock_be_move.call_args_list[0][0][0] == expected
 
 
 async def test_move_gantry(hardware_api, is_robot):
     abs_position = types.Point(30, 20, 10)
     mount = PipettePair.PRIMARY_RIGHT
-    target_position1 = {Axis.X: 30,
-                        Axis.Y: 20,
-                        Axis.Z: -20,
-                        Axis.A: -20,
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_position1 = {
+        Axis.X: 30,
+        Axis.Y: 20,
+        Axis.Z: -20,
+        Axis.A: -20,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     await hardware_api.home()
     await hardware_api.move_to(mount, abs_position)
     assert hardware_api._current_position == target_position1
@@ -60,12 +60,14 @@ async def test_move_gantry(hardware_api, is_robot):
     # same time in the z.
     rel_position = types.Point(30, 20, -10)
     mount2 = PipettePair.PRIMARY_LEFT
-    target_position2 = {Axis.X: 60,
-                        Axis.Y: 40,
-                        Axis.Z: -30,
-                        Axis.A: -30,
-                        Axis.B: 19,
-                        Axis.C: 19}
+    target_position2 = {
+        Axis.X: 60,
+        Axis.Y: 40,
+        Axis.Z: -30,
+        Axis.A: -30,
+        Axis.B: 19,
+        Axis.C: 19,
+    }
     await hardware_api.move_rel(mount2, rel_position)
     assert hardware_api._current_position == target_position2
 
@@ -75,33 +77,33 @@ async def test_move_currents(smoothie, monkeypatch, loop):
     hardware_api = await hc.API.build_hardware_controller(loop=loop)
     mock_active_axes = mock.Mock()
     monkeypatch.setattr(
-        hardware_api._backend._smoothie_driver,
-        'activate_axes',
-        mock_active_axes)
+        hardware_api._backend._smoothie_driver, "activate_axes", mock_active_axes
+    )
 
     mount = PipettePair.PRIMARY_RIGHT
     await hardware_api.home()
     mock_active_axes.reset_mock()
-    await hardware_api.move_to(mount,
-                               types.Point(0, 0, 0))
-    expected_call_list = [mock.call('XYAZ')]
+    await hardware_api.move_to(mount, types.Point(0, 0, 0))
+    expected_call_list = [mock.call("XYAZ")]
     assert mock_active_axes.call_args_list == expected_call_list
 
 
-async def test_pick_up_tip(
-        dummy_instruments, loop, is_robot):
+async def test_pick_up_tip(dummy_instruments, loop, is_robot):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = PipettePair.PRIMARY_RIGHT
     await hw_api.home()
     await hw_api.cache_instruments()
     tip_position = types.Point(12.13, 9, 150)
-    target_position = {Axis.X: 12.13,
-                       Axis.Y: 9.0,
-                       Axis.Z: 218.0,     # Z retracts after pick_up
-                       Axis.A: 218.0,
-                       Axis.B: -14.5,
-                       Axis.C: -8.5}
+    target_position = {
+        Axis.X: 12.13,
+        Axis.Y: 9.0,
+        Axis.Z: 218.0,  # Z retracts after pick_up
+        Axis.A: 218.0,
+        Axis.B: -14.5,
+        Axis.C: -8.5,
+    }
     await hw_api.move_to(mount, tip_position)
 
     # Note: pick_up_tip without a tip_length argument requires the pipette on
@@ -117,10 +119,10 @@ async def test_pick_up_tip(
     assert hw_api._current_position == target_position
 
 
-async def test_drop_tip(
-        dummy_instruments, loop, is_robot):
+async def test_drop_tip(dummy_instruments, loop, is_robot):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     mount = PipettePair.PRIMARY_RIGHT
     await hw_api.home()
     await hw_api.cache_instruments()
@@ -137,10 +139,10 @@ async def test_drop_tip(
     assert hw_api._attached_instruments[mount.secondary].current_volume == 0
 
 
-async def test_prep_aspirate(
-        dummy_instruments, loop):
+async def test_prep_aspirate(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -159,7 +161,8 @@ async def test_prep_aspirate(
 
 async def test_aspirate_new(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -180,7 +183,8 @@ async def test_aspirate_new(dummy_instruments, loop):
 
 async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
     await hw_api.cache_instruments()
 
@@ -201,7 +205,8 @@ async def test_aspirate_old(dummy_instruments, loop, old_aspiration):
 
 async def test_dispense(dummy_instruments, loop):
     hw_api = await hc.API.build_hardware_simulator(
-        attached_instruments=dummy_instruments, loop=loop)
+        attached_instruments=dummy_instruments, loop=loop
+    )
     await hw_api.home()
 
     await hw_api.cache_instruments()
@@ -231,22 +236,25 @@ async def test_dispense(dummy_instruments, loop):
     assert pos2[Axis.C] == plunger_right_2
 
 
-async def test_tip_action_currents(
-        dummy_instruments, smoothie, monkeypatch, loop):
+async def test_tip_action_currents(dummy_instruments, smoothie, monkeypatch, loop):
     smoothie.simulating = False
     hardware_api = await hc.API.build_hardware_controller(loop=loop)
     mock_active_current = mock.Mock()
     monkeypatch.setattr(
         hardware_api._backend._smoothie_driver,
-        'set_active_current',
-        mock_active_current)
+        "set_active_current",
+        mock_active_current,
+    )
 
     async def fake_attached(stuff):
-        return {mount: {'config': pc.load(value['model']),
-                        'id': value['id']}
-                for mount, value in dummy_instruments.items()}
+        return {
+            mount: {"config": pc.load(value["model"]), "id": value["id"]}
+            for mount, value in dummy_instruments.items()
+        }
+
     monkeypatch.setattr(
-        hardware_api._backend, 'get_attached_instruments', fake_attached)
+        hardware_api._backend, "get_attached_instruments", fake_attached
+    )
 
     mount = PipettePair.PRIMARY_RIGHT
     await hardware_api.home()
@@ -257,19 +265,19 @@ async def test_tip_action_currents(
     await hardware_api.pick_up_tip(mount, tip_length)
 
     expected_call_list = [
-        mock.call({'C': 1.0, 'B': 1.0}),
-        mock.call({'A': 0.1, 'Z': 0.125}),
-        mock.call({
-            'X': 1.25, 'Y': 1.25, 'Z': 0.8,
-            'A': 0.8, 'B': 0.05, 'C': 0.05})]
+        mock.call({"C": 1.0, "B": 1.0}),
+        mock.call({"A": 0.1, "Z": 0.125}),
+        mock.call({"X": 1.25, "Y": 1.25, "Z": 0.8, "A": 0.8, "B": 0.05, "C": 0.05}),
+    ]
     assert mock_active_current.call_args_list == expected_call_list
     mock_active_current.reset_mock()
 
     await hardware_api.drop_tip(mount)
 
     expected_call_list = [
-        mock.call({'C': 1.0, 'B': 1.0}),
-        mock.call({'C': 1.0, 'B': 1.25}),
-        mock.call({'C': 1.0, 'B': 1.0}),
-        mock.call({'C': 1.0, 'B': 1.0})]
+        mock.call({"C": 1.0, "B": 1.0}),
+        mock.call({"C": 1.0, "B": 1.25}),
+        mock.call({"C": 1.0, "B": 1.0}),
+        mock.call({"C": 1.0, "B": 1.0}),
+    ]
     assert mock_active_current.call_args_list == expected_call_list

--- a/api/tests/opentrons/hardware_control/test_pause_manager.py
+++ b/api/tests/opentrons/hardware_control/test_pause_manager.py
@@ -1,7 +1,6 @@
 import pytest
 from opentrons.hardware_control import PauseManager
-from opentrons.hardware_control.types import (DoorState, PauseType,
-                                              PauseResumeError)
+from opentrons.hardware_control.types import DoorState, PauseType, PauseResumeError
 
 
 def test_pause_and_delay_separation():

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -7,13 +7,12 @@ from opentrons.config import pipette_config
 PIP_CAL = cal_types.PipetteOffsetByPipetteMount(
     offset=[0, 0, 0],
     source=cal_types.SourceType.user,
-    status=cal_types.CalibrationStatus())
+    status=cal_types.CalibrationStatus(),
+)
 
 
 def test_tip_tracking():
-    pip = pipette.Pipette(pipette_config.load('p10_single_v1'),
-                          PIP_CAL,
-                          'testID')
+    pip = pipette.Pipette(pipette_config.load("p10_single_v1"), PIP_CAL, "testID")
     with pytest.raises(AssertionError):
         pip.remove_tip()
     assert not pip.has_tip
@@ -28,12 +27,10 @@ def test_tip_tracking():
         pip.remove_tip()
 
 
-@pytest.mark.parametrize('model', pipette_config.config_models)
+@pytest.mark.parametrize("model", pipette_config.config_models)
 def test_critical_points_nozzle_offset(model):
     loaded = pipette_config.load(model)
-    pip = pipette.Pipette(loaded,
-                          PIP_CAL,
-                          'testID')
+    pip = pipette.Pipette(loaded, PIP_CAL, "testID")
     # default pipette offset is[0, 0, 0], only nozzle offset would be used
     # to determine critical point
     nozzle_offset = Point(*loaded.nozzle_offset)
@@ -42,8 +39,7 @@ def test_critical_points_nozzle_offset(model):
     assert pip.critical_point(types.CriticalPoint.TIP) == nozzle_offset
     tip_length = 25.0
     pip.add_tip(tip_length)
-    new = nozzle_offset._replace(
-        z=nozzle_offset.z - tip_length)
+    new = nozzle_offset._replace(z=nozzle_offset.z - tip_length)
     assert pip.critical_point() == new
     assert pip.critical_point(types.CriticalPoint.NOZZLE) == nozzle_offset
     assert pip.critical_point(types.CriticalPoint.TIP) == new
@@ -53,17 +49,16 @@ def test_critical_points_nozzle_offset(model):
     assert pip.critical_point(types.CriticalPoint.TIP) == nozzle_offset
 
 
-@pytest.mark.parametrize('model', pipette_config.config_models)
+@pytest.mark.parametrize("model", pipette_config.config_models)
 def test_critical_points_pipette_offset(model):
     loaded = pipette_config.load(model)
     # set pipette offset calibration
     pip_cal = cal_types.PipetteOffsetByPipetteMount(
         offset=[10, 10, 10],
         source=cal_types.SourceType.user,
-        status=cal_types.CalibrationStatus())
-    pip = pipette.Pipette(loaded,
-                          pip_cal,
-                          'testID')
+        status=cal_types.CalibrationStatus(),
+    )
+    pip = pipette.Pipette(loaded, pip_cal, "testID")
     # pipette offset + nozzle offset to determine critical point
     offsets = Point(*pip_cal.offset) + Point(*pip.nozzle_offset)
     assert pip.critical_point() == offsets
@@ -71,8 +66,7 @@ def test_critical_points_pipette_offset(model):
     assert pip.critical_point(types.CriticalPoint.TIP) == offsets
     tip_length = 25.0
     pip.add_tip(tip_length)
-    new = offsets._replace(
-        z=offsets.z - tip_length)
+    new = offsets._replace(z=offsets.z - tip_length)
     assert pip.critical_point() == new
     assert pip.critical_point(types.CriticalPoint.NOZZLE) == offsets
     assert pip.critical_point(types.CriticalPoint.TIP) == new
@@ -82,12 +76,10 @@ def test_critical_points_pipette_offset(model):
     assert pip.critical_point(types.CriticalPoint.TIP) == offsets
 
 
-@pytest.mark.parametrize('config_model', pipette_config.config_models)
+@pytest.mark.parametrize("config_model", pipette_config.config_models)
 def test_volume_tracking(config_model):
     loaded = pipette_config.load(config_model)
-    pip = pipette.Pipette(loaded,
-                          PIP_CAL,
-                          'testID')
+    pip = pipette.Pipette(loaded, PIP_CAL, "testID")
     assert pip.current_volume == 0.0
     assert pip.available_volume == loaded.max_volume
     assert pip.ok_to_add_volume(loaded.max_volume - 0.1)
@@ -108,15 +100,13 @@ def test_volume_tracking(config_model):
     assert pip.current_volume == loaded.max_volume
 
 
-@pytest.mark.parametrize('config_model', pipette_config.config_models)
+@pytest.mark.parametrize("config_model", pipette_config.config_models)
 def test_config_update(config_model):
     loaded = pipette_config.load(config_model)
-    pip = pipette.Pipette(loaded,
-                          PIP_CAL,
-                          'testID')
-    sample_plunger_pos = {'top': 19.5}
-    pip.update_config_item('top', sample_plunger_pos.get('top'))
-    assert pip.config.top == sample_plunger_pos.get('top')
+    pip = pipette.Pipette(loaded, PIP_CAL, "testID")
+    sample_plunger_pos = {"top": 19.5}
+    pip.update_config_item("top", sample_plunger_pos.get("top"))
+    assert pip.config.top == sample_plunger_pos.get("top")
 
 
 def test_smoothie_config_update(monkeypatch):
@@ -124,42 +114,31 @@ def test_smoothie_config_update(monkeypatch):
         assert config == config
 
 
-@pytest.mark.parametrize('config_model', pipette_config.config_models)
+@pytest.mark.parametrize("config_model", pipette_config.config_models)
 def test_tip_overlap(config_model):
     loaded = pipette_config.load(config_model)
-    pip = pipette.Pipette(loaded,
-                          PIP_CAL,
-                          'testId')
-    assert pip.config.tip_overlap\
-        == pipette_config.configs[config_model]['tipOverlap']
+    pip = pipette.Pipette(loaded, PIP_CAL, "testId")
+    assert pip.config.tip_overlap == pipette_config.configs[config_model]["tipOverlap"]
 
 
 def test_flow_rate_setting():
-    pip = pipette.Pipette(pipette_config.load('p300_single_v2.0'),
-                          PIP_CAL,
-                          'testId')
+    pip = pipette.Pipette(pipette_config.load("p300_single_v2.0"), PIP_CAL, "testId")
     # pipettes should load settings from config at init time
-    assert pip.aspirate_flow_rate\
-        == pip.config.default_aspirate_flow_rates['2.0']
-    assert pip.dispense_flow_rate\
-        == pip.config.default_dispense_flow_rates['2.0']
-    assert pip.blow_out_flow_rate\
-        == pip.config.default_blow_out_flow_rates['2.0']
+    assert pip.aspirate_flow_rate == pip.config.default_aspirate_flow_rates["2.0"]
+    assert pip.dispense_flow_rate == pip.config.default_dispense_flow_rates["2.0"]
+    assert pip.blow_out_flow_rate == pip.config.default_blow_out_flow_rates["2.0"]
     # changing flow rates with normal property access shouldn't touch
     # config or other flow rates
     config = pip.config
     pip.aspirate_flow_rate = 2
     assert pip.aspirate_flow_rate == 2
-    assert pip.dispense_flow_rate\
-        == pip.config.default_dispense_flow_rates['2.0']
-    assert pip.blow_out_flow_rate\
-        == pip.config.default_blow_out_flow_rates['2.0']
+    assert pip.dispense_flow_rate == pip.config.default_dispense_flow_rates["2.0"]
+    assert pip.blow_out_flow_rate == pip.config.default_blow_out_flow_rates["2.0"]
     assert pip.config is config
     pip.dispense_flow_rate = 3
     assert pip.aspirate_flow_rate == 2
     assert pip.dispense_flow_rate == 3
-    assert pip.blow_out_flow_rate\
-        == pip.config.default_blow_out_flow_rates['2.0']
+    assert pip.blow_out_flow_rate == pip.config.default_blow_out_flow_rates["2.0"]
     assert pip.config is config
     pip.blow_out_flow_rate = 4
     assert pip.aspirate_flow_rate == 2

--- a/api/tests/opentrons/hardware_control/test_poller.py
+++ b/api/tests/opentrons/hardware_control/test_poller.py
@@ -1,7 +1,5 @@
 from mock import AsyncMock, MagicMock
-from opentrons.hardware_control.poller import (
-    Poller, Listener, Reader
-)
+from opentrons.hardware_control.poller import Poller, Listener, Reader
 
 
 async def test_poll_error() -> None:
@@ -15,7 +13,7 @@ async def test_poll_error() -> None:
     reader.read.side_effect = raiser
     listener = MagicMock(spec=Listener)
 
-    p: Poller[int] = Poller(interval_seconds=.01, reader=reader, listener=listener)
+    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
     await p.stop_and_wait()
 
     listener.on_error.assert_called_once_with(exc)
@@ -28,7 +26,7 @@ async def test_notify() -> None:
     reader.read.return_value = 23
     listener = MagicMock(spec=Listener)
 
-    p: Poller[int] = Poller(interval_seconds=.01, reader=reader, listener=listener)
+    p: Poller[int] = Poller(interval_seconds=0.01, reader=reader, listener=listener)
     await p.stop_and_wait()
 
     listener.on_poll.assert_called_once_with(23)

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -8,88 +8,87 @@ from opentrons.types import Mount
 
 async def test_with_magdeck(loop):
     setup = simulator_setup.SimulatorSetup(
-        attached_modules={'magdeck': [
-            simulator_setup.ModuleCall('engage', kwargs={'height': 3})]
-        })
+        attached_modules={
+            "magdeck": [simulator_setup.ModuleCall("engage", kwargs={"height": 3})]
+        }
+    )
     simulator = await simulator_setup.create_simulator(setup)
 
     assert type(simulator.attached_modules[0]) == MagDeck
     assert simulator.attached_modules[0].live_data == {
-        'data': {
-            'engaged': True,
-            'height': 3
-        },
-        'status': 'engaged'
+        "data": {"engaged": True, "height": 3},
+        "status": "engaged",
     }
 
 
 async def test_with_thermocycler(loop):
     setup = simulator_setup.SimulatorSetup(
-        attached_modules={'thermocycler': [
-            simulator_setup.ModuleCall('set_temperature',
-                                       kwargs={
-                                           'temperature': 3,
-                                           'hold_time_seconds': 1,
-                                           'hold_time_minutes': 2,
-                                           'volume': 5
-                                       })
-        ]})
+        attached_modules={
+            "thermocycler": [
+                simulator_setup.ModuleCall(
+                    "set_temperature",
+                    kwargs={
+                        "temperature": 3,
+                        "hold_time_seconds": 1,
+                        "hold_time_minutes": 2,
+                        "volume": 5,
+                    },
+                )
+            ]
+        }
+    )
     simulator = await simulator_setup.create_simulator(setup)
 
     assert type(simulator.attached_modules[0]) == Thermocycler
     assert simulator.attached_modules[0].live_data == {
-        'data': {'currentCycleIndex': None,
-                 'currentStepIndex': None,
-                 'currentTemp': 3,
-                 'holdTime': 121,
-                 'lid': 'open',
-                 'lidTarget': None,
-                 'lidTemp': 23,
-                 'rampRate': None,
-                 'targetTemp': 3,
-                 'totalCycleCount': None,
-                 'totalStepCount': None},
-        'status': 'heating'
-        }
+        "data": {
+            "currentCycleIndex": None,
+            "currentStepIndex": None,
+            "currentTemp": 3,
+            "holdTime": 121,
+            "lid": "open",
+            "lidTarget": None,
+            "lidTemp": 23,
+            "rampRate": None,
+            "targetTemp": 3,
+            "totalCycleCount": None,
+            "totalStepCount": None,
+        },
+        "status": "heating",
+    }
 
 
 async def test_with_tempdeck(loop):
     setup = simulator_setup.SimulatorSetup(
-        attached_modules={'tempdeck': [
-            simulator_setup.ModuleCall('set_temperature',
-                                       kwargs={'celsius': 23})
-        ]})
+        attached_modules={
+            "tempdeck": [
+                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 23})
+            ]
+        }
+    )
     simulator = await simulator_setup.create_simulator(setup)
 
     assert type(simulator.attached_modules[0]) == TempDeck
     assert simulator.attached_modules[0].live_data == {
-        'data': {
-            'currentTemp': 23,
-            'targetTemp': 23
-        },
-        'status': 'holding at target'
+        "data": {"currentTemp": 23, "targetTemp": 23},
+        "status": "holding at target",
     }
 
 
 def test_persistance(tmpdir):
     sim = simulator_setup.SimulatorSetup(
         attached_instruments={
-            Mount.LEFT: {'max_volume': 300},
-            Mount.RIGHT: {'id': 'some id'},
+            Mount.LEFT: {"max_volume": 300},
+            Mount.RIGHT: {"id": "some id"},
         },
         attached_modules={
-            'magdeck': [
-                simulator_setup.ModuleCall('engage',
-                                           kwargs={'height': 3})
+            "magdeck": [simulator_setup.ModuleCall("engage", kwargs={"height": 3})],
+            "tempdeck": [
+                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 23}),
+                simulator_setup.ModuleCall("set_temperature", kwargs={"celsius": 24}),
             ],
-            'tempdeck': [
-                simulator_setup.ModuleCall('set_temperature',
-                                           kwargs={'celsius': 23}),
-                simulator_setup.ModuleCall('set_temperature',
-                                           kwargs={'celsius': 24})
-            ]
         },
-        config=robot_configs.build_config({})
+        config=robot_configs.build_config({}),
     )
     file = Path(tmpdir) / "sim_setup.json"
     simulator_setup.save_simulator_setup(sim, file)

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -3,8 +3,10 @@ import asyncio
 import pytest
 import weakref
 from opentrons.hardware_control.modules import ModuleAtPort
-from opentrons.hardware_control.thread_manager import ThreadManagerException,\
-    ThreadManager
+from opentrons.hardware_control.thread_manager import (
+    ThreadManagerException,
+    ThreadManager,
+)
 from opentrons.hardware_control.api import API
 
 
@@ -13,18 +15,21 @@ def test_build_fail_raises_exception():
     Test that a builder that raises an exception raises
     a ThreadManagerException
     """
+
     def f():
         raise Exception()
+
     with pytest.raises(ThreadManagerException):
         ThreadManager(f)
 
 
 def test_module_cache_add_entry():
-    """ Test that _cached_modules updates correctly."""
+    """Test that _cached_modules updates correctly."""
 
-    mod_names = ['tempdeck']
-    thread_manager = ThreadManager(API.build_hardware_simulator,
-                                   attached_modules=mod_names)
+    mod_names = ["tempdeck"]
+    thread_manager = ThreadManager(
+        API.build_hardware_simulator, attached_modules=mod_names
+    )
 
     # Test that module gets added to the cache
     mods = thread_manager.attached_modules
@@ -41,10 +46,11 @@ def test_module_cache_add_entry():
 
 
 async def test_module_cache_remove_entry():
-    """Test that module entry gets removed from cache when module detaches. """
-    mod_names = ['tempdeck', 'magdeck']
-    thread_manager = ThreadManager(API.build_hardware_simulator,
-                                   attached_modules=mod_names)
+    """Test that module entry gets removed from cache when module detaches."""
+    mod_names = ["tempdeck", "magdeck"]
+    thread_manager = ThreadManager(
+        API.build_hardware_simulator, attached_modules=mod_names
+    )
 
     mods_before = thread_manager.attached_modules
     assert len(mods_before) == 2
@@ -55,11 +61,10 @@ async def test_module_cache_remove_entry():
     future = asyncio.run_coroutine_threadsafe(
         thread_manager._backend.module_controls.register_modules(
             removed_mods_at_ports=[
-                ModuleAtPort(port='/dev/ot_module_sim_tempdeck0',
-                             name='tempdeck')
+                ModuleAtPort(port="/dev/ot_module_sim_tempdeck0", name="tempdeck")
             ]
         ),
-        loop
+        loop,
     )
     future.result()
     mods_after = thread_manager.attached_modules

--- a/api/tests/opentrons/hardware_control/test_types.py
+++ b/api/tests/opentrons/hardware_control/test_types.py
@@ -3,22 +3,17 @@ from opentrons.hardware_control import types
 
 
 def test_create_aionotify_event():
-
     class FakeEnum(enum.Enum):
         CREATE = enum.auto()
         DELETE = enum.auto()
         MODIFY = enum.auto()
 
-    enum_list = [
-        FakeEnum.CREATE,
-        FakeEnum.DELETE,
-        FakeEnum.MODIFY]
+    enum_list = [FakeEnum.CREATE, FakeEnum.DELETE, FakeEnum.MODIFY]
 
-    new_event =\
-        types.AionotifyEvent.build('fake event', enum_list)
+    new_event = types.AionotifyEvent.build("fake event", enum_list)
 
     assert new_event.flags.CREATE
     assert new_event.flags.DELETE
     assert new_event.flags.MODIFY
 
-    assert new_event.name == 'fake event'
+    assert new_event.name == "fake event"

--- a/api/tests/opentrons/hardware_control/test_util.py
+++ b/api/tests/opentrons/hardware_control/test_util.py
@@ -2,7 +2,11 @@ from typing import List
 
 from opentrons.hardware_control.util import plan_arc, check_motion_bounds
 from opentrons.hardware_control.types import (
-    CriticalPoint, MotionChecks, OutOfBoundsMove, Axis)
+    CriticalPoint,
+    MotionChecks,
+    OutOfBoundsMove,
+    Axis,
+)
 from opentrons.types import Point
 
 
@@ -10,7 +14,7 @@ import pytest
 
 
 def check_arc_basic(arc: List[Point], from_pt: Point, to_pt: Point):
-    """ Check the tests that should always be true for different-well moves
+    """Check the tests that should always be true for different-well moves
     - we should always go only up, then only xy, then only down
     - we should have three moves
     """
@@ -30,23 +34,22 @@ def check_arc_basic(arc: List[Point], from_pt: Point, to_pt: Point):
 
 
 @pytest.mark.parametrize(
-    argnames=['from_pt', 'to_pt', 'z_height'],
+    argnames=["from_pt", "to_pt", "z_height"],
     argvalues=[
         [Point(10, 20, 30), Point(10, 30, 30), 100],
         [Point(10, 20, 30), Point(10, 30, 40), 100],
         [Point(10, 20, 40), Point(10, 30, 30), 40],
-        [Point(10, 20, 30), Point(10, 30, 40), 40]])
+        [Point(10, 20, 30), Point(10, 30, 40), 40],
+    ],
+)
 def test_basic_arcs(from_pt, to_pt, z_height):
-    check_arc_basic([a[0] for a in plan_arc(from_pt, to_pt, z_height)],
-                    from_pt, to_pt)
+    check_arc_basic([a[0] for a in plan_arc(from_pt, to_pt, z_height)], from_pt, to_pt)
 
 
 def test_arc_with_waypoint():
     from_pt = Point(20, 20, 40)
     to_pt = Point(0, 0, 10)
-    arc = plan_arc(from_pt, to_pt,
-                   50,
-                   extra_waypoints=[(5, 10), (20, 30)])
+    arc = plan_arc(from_pt, to_pt, 50, extra_waypoints=[(5, 10), (20, 30)])
     check_arc_basic([a[0] for a in arc], from_pt, to_pt)
     assert arc[1][0].x == 5
     assert arc[1][0].y == 10
@@ -73,24 +76,25 @@ def test_cp_blending():
 
 
 @pytest.mark.parametrize(
-    'xformed,deck,bounds,check,catch,phrase',
+    "xformed,deck,bounds,check,catch,phrase",
     [
         # acceptable moves, iterating through checks
-        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ''),
-        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ''),
-        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ''),
+        ({Axis.X: 2}, {Axis.X: -15}, {Axis.X: (1, 4)}, MotionChecks.NONE, False, ""),
+        ({Axis.X: 2}, {Axis.X: -10}, {Axis.X: (1, 4)}, MotionChecks.LOW, False, ""),
+        ({Axis.X: 2}, {Axis.X: 0}, {Axis.X: (1, 4)}, MotionChecks.HIGH, False, ""),
+        ({Axis.X: 2}, {Axis.X: 10}, {Axis.X: (1, 4)}, MotionChecks.BOTH, False, ""),
         # unacceptable low, with and without checking
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, 'low'),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ''),
-        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'low'),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ""),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, True, "low"),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, False, ""),
+        ({Axis.Z: 1}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, "low"),
         # unacceptable high, with and without checking
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ''),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ''),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, 'high'),
-        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, 'high')
-    ])
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.NONE, False, ""),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.LOW, False, ""),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.HIGH, True, "high"),
+        ({Axis.Z: 5}, {Axis.Z: 3}, {Axis.Z: (2, 4)}, MotionChecks.BOTH, True, "high"),
+    ],
+)
 def test_check_motion_bounds(xformed, deck, bounds, check, catch, phrase):
     if catch:
         with pytest.raises(OutOfBoundsMove, match=phrase):

--- a/api/tests/opentrons/protocol_api/test_accessor_fn.py
+++ b/api/tests/opentrons/protocol_api/test_accessor_fn.py
@@ -2,18 +2,17 @@ from opentrons.types import Point
 
 
 def test_labware_init(min_lw_impl, minimal_labware_def):
-    ordering = [well for col in minimal_labware_def['ordering']
-                for well in col]
+    ordering = [well for col in minimal_labware_def["ordering"] for well in col]
     assert min_lw_impl._ordering == ordering
-    assert min_lw_impl._well_definition == minimal_labware_def['wells']
+    assert min_lw_impl._well_definition == minimal_labware_def["wells"]
     assert min_lw_impl.get_geometry()._offset == Point(x=10, y=10, z=5)
 
 
 def test_wells_accessor(min_lw, min_lw_impl, minimal_labware_def):
-    depth1 = minimal_labware_def['wells']['A1']['depth']
-    depth2 = minimal_labware_def['wells']['A2']['depth']
-    x = minimal_labware_def['wells']['A2']['x']
-    y = minimal_labware_def['wells']['A2']['y']
+    depth1 = minimal_labware_def["wells"]["A1"]["depth"]
+    depth2 = minimal_labware_def["wells"]["A2"]["depth"]
+    x = minimal_labware_def["wells"]["A2"]["x"]
+    y = minimal_labware_def["wells"]["A2"]["y"]
     offset = min_lw_impl.get_geometry()._offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
@@ -22,15 +21,15 @@ def test_wells_accessor(min_lw, min_lw_impl, minimal_labware_def):
 
 
 def test_wells_name_accessor(min_lw, min_lw_impl, minimal_labware_def):
-    depth1 = minimal_labware_def['wells']['A1']['depth']
-    depth2 = minimal_labware_def['wells']['A2']['depth']
-    x = minimal_labware_def['wells']['A2']['x']
-    y = minimal_labware_def['wells']['A2']['y']
+    depth1 = minimal_labware_def["wells"]["A1"]["depth"]
+    depth2 = minimal_labware_def["wells"]["A2"]["depth"]
+    x = minimal_labware_def["wells"]["A2"]["x"]
+    y = minimal_labware_def["wells"]["A2"]["y"]
     offset = min_lw_impl.get_geometry().offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert min_lw.wells_by_name()['A1'].geometry._position == a1
-    assert min_lw.wells_by_name()['A2'].geometry._position == a2
+    assert min_lw.wells_by_name()["A1"].geometry._position == a1
+    assert min_lw.wells_by_name()["A2"].geometry._position == a2
 
 
 def test_deprecated_index_accessors(min_lw):
@@ -40,24 +39,24 @@ def test_deprecated_index_accessors(min_lw):
 
 
 def test_dict_accessor(min_lw, min_lw_impl, minimal_labware_def):
-    depth1 = minimal_labware_def['wells']['A1']['depth']
-    depth2 = minimal_labware_def['wells']['A2']['depth']
-    x = minimal_labware_def['wells']['A2']['x']
-    y = minimal_labware_def['wells']['A2']['y']
+    depth1 = minimal_labware_def["wells"]["A1"]["depth"]
+    depth2 = minimal_labware_def["wells"]["A2"]["depth"]
+    x = minimal_labware_def["wells"]["A2"]["x"]
+    y = minimal_labware_def["wells"]["A2"]["y"]
     offset = min_lw_impl.get_geometry().offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert min_lw['A1'].geometry._position == a1
-    assert min_lw['A2'].geometry._position == a2
+    assert min_lw["A1"].geometry._position == a1
+    assert min_lw["A2"].geometry._position == a2
 
 
 def test_rows_accessor(min_lw2_impl, min_lw2, minimal_labware_def2):
-    depth1 = minimal_labware_def2['wells']['A1']['depth']
-    x1 = minimal_labware_def2['wells']['A1']['x']
-    y1 = minimal_labware_def2['wells']['A1']['y']
-    depth2 = minimal_labware_def2['wells']['B2']['depth']
-    x2 = minimal_labware_def2['wells']['B2']['x']
-    y2 = minimal_labware_def2['wells']['B2']['y']
+    depth1 = minimal_labware_def2["wells"]["A1"]["depth"]
+    x1 = minimal_labware_def2["wells"]["A1"]["x"]
+    y1 = minimal_labware_def2["wells"]["A1"]["y"]
+    depth2 = minimal_labware_def2["wells"]["B2"]["depth"]
+    x2 = minimal_labware_def2["wells"]["B2"]["x"]
+    y2 = minimal_labware_def2["wells"]["B2"]["y"]
     offset = min_lw2_impl.get_geometry().offset
     a1 = Point(x=offset[0] + x1, y=offset[1] + y1, z=offset[2] + depth1)
     b2 = Point(x=offset[0] + x2, y=offset[1] + y2, z=offset[2] + depth2)
@@ -66,24 +65,24 @@ def test_rows_accessor(min_lw2_impl, min_lw2, minimal_labware_def2):
 
 
 def test_row_name_accessor(min_lw2_impl, min_lw2, minimal_labware_def2):
-    depth1 = minimal_labware_def2['wells']['A1']['depth']
-    x1 = minimal_labware_def2['wells']['A1']['x']
-    y1 = minimal_labware_def2['wells']['A1']['y']
-    depth2 = minimal_labware_def2['wells']['B2']['depth']
-    x2 = minimal_labware_def2['wells']['B2']['x']
-    y2 = minimal_labware_def2['wells']['B2']['y']
+    depth1 = minimal_labware_def2["wells"]["A1"]["depth"]
+    x1 = minimal_labware_def2["wells"]["A1"]["x"]
+    y1 = minimal_labware_def2["wells"]["A1"]["y"]
+    depth2 = minimal_labware_def2["wells"]["B2"]["depth"]
+    x2 = minimal_labware_def2["wells"]["B2"]["x"]
+    y2 = minimal_labware_def2["wells"]["B2"]["y"]
     offset = min_lw2_impl.get_geometry().offset
     a1 = Point(x=offset[0] + x1, y=offset[1] + y1, z=offset[2] + depth1)
     b2 = Point(x=offset[0] + x2, y=offset[1] + y2, z=offset[2] + depth2)
-    assert min_lw2.rows_by_name()['A'][0].geometry._position == a1
-    assert min_lw2.rows_by_name()['B'][1].geometry._position == b2
+    assert min_lw2.rows_by_name()["A"][0].geometry._position == a1
+    assert min_lw2.rows_by_name()["B"][1].geometry._position == b2
 
 
 def test_cols_accessor(min_lw_impl, min_lw, minimal_labware_def):
-    depth1 = minimal_labware_def['wells']['A1']['depth']
-    depth2 = minimal_labware_def['wells']['A2']['depth']
-    x = minimal_labware_def['wells']['A2']['x']
-    y = minimal_labware_def['wells']['A2']['y']
+    depth1 = minimal_labware_def["wells"]["A1"]["depth"]
+    depth2 = minimal_labware_def["wells"]["A2"]["depth"]
+    x = minimal_labware_def["wells"]["A2"]["x"]
+    y = minimal_labware_def["wells"]["A2"]["y"]
     offset = min_lw_impl.get_geometry().offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
@@ -92,12 +91,12 @@ def test_cols_accessor(min_lw_impl, min_lw, minimal_labware_def):
 
 
 def test_col_name_accessor(min_lw, min_lw_impl, minimal_labware_def):
-    depth1 = minimal_labware_def['wells']['A1']['depth']
-    depth2 = minimal_labware_def['wells']['A2']['depth']
-    x = minimal_labware_def['wells']['A2']['x']
-    y = minimal_labware_def['wells']['A2']['y']
+    depth1 = minimal_labware_def["wells"]["A1"]["depth"]
+    depth2 = minimal_labware_def["wells"]["A2"]["depth"]
+    x = minimal_labware_def["wells"]["A2"]["x"]
+    y = minimal_labware_def["wells"]["A2"]["y"]
     offset = min_lw_impl.get_geometry().offset
     a1 = Point(x=offset[0], y=offset[1], z=offset[2] + depth1)
     a2 = Point(x=offset[0] + x, y=offset[1] + y, z=offset[2] + depth2)
-    assert min_lw.columns_by_name()['1'][0].geometry._position == a1
-    assert min_lw.columns_by_name()['2'][0].geometry._position == a2
+    assert min_lw.columns_by_name()["1"][0].geometry._position == a1
+    assert min_lw.columns_by_name()["2"][0].geometry._position == a2

--- a/api/tests/opentrons/protocol_api/test_context.py
+++ b/api/tests/opentrons/protocol_api/test_context.py
@@ -6,59 +6,68 @@ from unittest import mock
 import opentrons.protocol_api as papi
 import opentrons.protocols.api_support as papi_support
 import opentrons.protocols.geometry as papi_geometry
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
-from opentrons.protocols.context.simulator.protocol_context import \
-    ProtocolContextSimulation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.protocols.context.simulator.protocol_context import (
+    ProtocolContextSimulation,
+)
 from opentrons_shared_data import load_shared_data
 from opentrons.types import Mount, Point, Location, TransferTipPolicy
-from opentrons.hardware_control import API, NoTipAttachedError, \
-    SynchronousAdapter
+from opentrons.hardware_control import API, NoTipAttachedError, SynchronousAdapter
 from opentrons.hardware_control.pipette import Pipette
 from opentrons.hardware_control.types import Axis
 from opentrons.protocol_api import paired_instrument_context as paired
 from opentrons.protocols.advanced_control import transfers as tf
 from opentrons.config.pipette_config import config_names
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.calibration_storage import (
-    get, modify, delete, types as cs_types)
+from opentrons.calibration_storage import get, modify, delete, types as cs_types
 
 import pytest
 
 
 def set_version_added(attr, mp, version):
-    """ helper to mock versionadded for an attr
+    """helper to mock versionadded for an attr
 
     attr is the attr
     mp is a monkeypatch fixture
     version is an APIVersion
     """
+
     def get_wrapped(attr):
-        if hasattr(attr, '__wrapped__'):
+        if hasattr(attr, "__wrapped__"):
             return get_wrapped(attr.__wrapped__)
         return attr
 
-    if hasattr(attr, 'fget'):
+    if hasattr(attr, "fget"):
         # this is a property probably
         orig = get_wrapped(attr.fget)
     else:
         orig = get_wrapped(attr)
-    mp.setattr(orig, '__opentrons_version_added', version)
+    mp.setattr(orig, "__opentrons_version_added", version)
     return attr
 
 
 @pytest.fixture
 def get_labware_def(monkeypatch):
-    def dummy_load(labware_name, namespace=None, version=None,
-                   bundled_defs=None, extra_defs=None, api_level=None):
+    def dummy_load(
+        labware_name,
+        namespace=None,
+        version=None,
+        bundled_defs=None,
+        extra_defs=None,
+        api_level=None,
+    ):
         # TODO: Ian 2019-05-30 use fixtures not real defs
         labware_def = json.loads(
-            load_shared_data(f'labware/definitions/2/{labware_name}/1.json'))
+            load_shared_data(f"labware/definitions/2/{labware_name}/1.json")
+        )
         return labware_def
-    monkeypatch.setattr(papi.labware, 'get_labware_definition', dummy_load)
+
+    monkeypatch.setattr(papi.labware, "get_labware_definition", dummy_load)
 
 
-@pytest.mark.parametrize('name', config_names)
+@pytest.mark.parametrize("name", config_names)
 def test_load_instrument(name, ctx):
     assert ctx.loaded_instruments == {}
     loaded = ctx.load_instrument(name, Mount.LEFT, replace=True)
@@ -72,17 +81,15 @@ def test_load_instrument(name, ctx):
 async def test_motion(ctx, hardware):
     ctx.connect(hardware)
     ctx.home()
-    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
-    old_pos = await hardware.current_position(
-        instr._implementation.get_mount())
+    instr = ctx.load_instrument("p10_single", Mount.RIGHT)
+    old_pos = await hardware.current_position(instr._implementation.get_mount())
     instr.home()
     assert instr.move_to(Location(Point(0, 0, 0), None)) is instr
     old_pos[Axis.X] = 0
     old_pos[Axis.Y] = 0
     old_pos[Axis.A] = 0
     old_pos[Axis.C] = 2
-    assert await hardware.current_position(
-        instr._implementation.get_mount()) == old_pos
+    assert await hardware.current_position(instr._implementation.get_mount()) == old_pos
 
 
 async def test_max_speeds(ctx, monkeypatch, hardware):
@@ -90,49 +97,53 @@ async def test_max_speeds(ctx, monkeypatch, hardware):
     ctx.home()
     mock_move = mock.Mock()
     monkeypatch.setattr(
-        ctx._implementation.get_hardware().hardware, 'move_to', mock_move)
-    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+        ctx._implementation.get_hardware().hardware, "move_to", mock_move
+    )
+    instr = ctx.load_instrument("p10_single", Mount.RIGHT)
     instr.move_to(Location(Point(0, 0, 0), None))
-    assert all(
-        kwargs['max_speeds'] == {}
-        for args, kwargs in mock_move.call_args_list)
+    assert all(kwargs["max_speeds"] == {} for args, kwargs in mock_move.call_args_list)
 
     mock_move.reset_mock()
-    ctx.max_speeds['x'] = 10
+    ctx.max_speeds["x"] = 10
     instr.move_to(Location(Point(0, 0, 1), None))
     assert all(
-        kwargs['max_speeds'] == {Axis.X: 10}
-        for args, kwargs in mock_move.call_args_list)
+        kwargs["max_speeds"] == {Axis.X: 10}
+        for args, kwargs in mock_move.call_args_list
+    )
 
     mock_move.reset_mock()
-    ctx.max_speeds['x'] = None
+    ctx.max_speeds["x"] = None
     instr.move_to(Location(Point(1, 0, 1), None))
-    assert all(
-        kwargs['max_speeds'] == {}
-        for args, kwargs in mock_move.call_args_list)
+    assert all(kwargs["max_speeds"] == {} for args, kwargs in mock_move.call_args_list)
 
 
 async def test_location_cache(ctx, monkeypatch, get_labware_def, hardware):
     ctx.connect(hardware)
 
-    right = ctx.load_instrument('p10_single', Mount.RIGHT)
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
+    right = ctx.load_instrument("p10_single", Mount.RIGHT)
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
     ctx.home()
 
     test_args = None
 
-    def fake_plan_move(from_loc, to_loc, deck,
-                       well_z_margin=None,
-                       lw_z_margin=None,
-                       force_direct=False,
-                       minimum_z_height=None):
+    def fake_plan_move(
+        from_loc,
+        to_loc,
+        deck,
+        well_z_margin=None,
+        lw_z_margin=None,
+        force_direct=False,
+        minimum_z_height=None,
+    ):
         nonlocal test_args
         test_args = (from_loc, to_loc, deck, well_z_margin, lw_z_margin)
-        return [(Point(0, 1, 10), None),
-                (Point(1, 2, 10), None),
-                (Point(1, 2, 3), None)]
+        return [
+            (Point(0, 1, 10), None),
+            (Point(1, 2, 10), None),
+            (Point(1, 2, 3), None),
+        ]
 
-    monkeypatch.setattr(papi_geometry.planning, 'plan_moves', fake_plan_move)
+    monkeypatch.setattr(papi_geometry.planning, "plan_moves", fake_plan_move)
     # When we move without a cache, the from location should be the gantry
     # position
     right.move_to(lw.wells()[0].top())
@@ -151,8 +162,8 @@ async def test_location_cache_two_pipettes(ctx, get_labware_def, hardware):
     """It should be invalidated when next movement is a different pipette
     than the cached location."""
     ctx.home()
-    left = ctx.load_instrument('p10_single', Mount.LEFT)
-    right = ctx.load_instrument('p10_single', Mount.RIGHT)
+    left = ctx.load_instrument("p10_single", Mount.LEFT)
+    right = ctx.load_instrument("p10_single", Mount.RIGHT)
 
     left_loc = Location(point=Point(1, 2, 3), labware="1")
     right_loc = Location(point=Point(3, 4, 5), labware="2")
@@ -170,14 +181,13 @@ async def test_location_cache_two_pipettes(ctx, get_labware_def, hardware):
 
 
 async def test_location_cache_two_pipettes_fails_pre_2_10(
-        ctx,
-        get_labware_def, hardware
+    ctx, get_labware_def, hardware
 ):
     """It should reuse location cache even if cached location was set by
     move of a different pipette."""
     ctx.home()
-    left = ctx.load_instrument('p10_single', Mount.LEFT)
-    right = ctx.load_instrument('p10_single', Mount.RIGHT)
+    left = ctx.load_instrument("p10_single", Mount.LEFT)
+    right = ctx.load_instrument("p10_single", Mount.RIGHT)
     left._implementation._api_version = APIVersion(2, 9)
     right._implementation._api_version = APIVersion(2, 9)
 
@@ -197,8 +207,8 @@ async def test_location_cache_two_pipettes_fails_pre_2_10(
 async def test_move_uses_arc(ctx, monkeypatch, get_labware_def, hardware):
     ctx.connect(hardware)
     ctx.home()
-    right = ctx.load_instrument('p10_single', Mount.RIGHT)
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
+    right = ctx.load_instrument("p10_single", Mount.RIGHT)
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
     ctx.home()
 
     targets = []
@@ -206,7 +216,8 @@ async def test_move_uses_arc(ctx, monkeypatch, get_labware_def, hardware):
     async def fake_move(self, mount, target_pos, **kwargs):
         nonlocal targets
         targets.append((mount, target_pos, kwargs))
-    monkeypatch.setattr(API, 'move_to', fake_move)
+
+    monkeypatch.setattr(API, "move_to", fake_move)
 
     right.move_to(lw.wells()[0].top())
     assert len(targets) == 3
@@ -215,32 +226,32 @@ async def test_move_uses_arc(ctx, monkeypatch, get_labware_def, hardware):
 
 
 def test_pipette_info(ctx):
-    right = ctx.load_instrument('p300_multi', Mount.RIGHT)
-    left = ctx.load_instrument('p1000_single', Mount.LEFT)
-    assert right.type == 'multi'
+    right = ctx.load_instrument("p300_multi", Mount.RIGHT)
+    left = ctx.load_instrument("p1000_single", Mount.LEFT)
+    assert right.type == "multi"
     hardware = ctx._implementation.get_hardware().hardware
-    name = hardware.attached_instruments[Mount.RIGHT]['name']
-    model = hardware.attached_instruments[Mount.RIGHT]['model']
+    name = hardware.attached_instruments[Mount.RIGHT]["name"]
+    model = hardware.attached_instruments[Mount.RIGHT]["model"]
     assert right.name == name
     assert right.model == model
-    assert left.type == 'single'
-    name = hardware.attached_instruments[Mount.LEFT]['name']
-    model = hardware.attached_instruments[Mount.LEFT]['model']
+    assert left.type == "single"
+    name = hardware.attached_instruments[Mount.LEFT]["name"]
+    model = hardware.attached_instruments[Mount.LEFT]["model"]
     assert left.name == name
     assert left.model == model
 
 
 def test_pipette_pairing(ctx):
-    right = ctx.load_instrument('p300_multi', Mount.RIGHT)
-    left = ctx.load_instrument('p300_multi', Mount.LEFT)
+    right = ctx.load_instrument("p300_multi", Mount.RIGHT)
+    left = ctx.load_instrument("p300_multi", Mount.LEFT)
 
     paired_object = right.pair_with(left)
     assert isinstance(paired_object, paired.PairedInstrumentContext)
 
 
 def test_pipette_pairing_unsupported_instrument(ctx):
-    right = ctx.load_instrument('p300_multi', Mount.RIGHT)
-    left = ctx.load_instrument('p300_multi_gen2', Mount.LEFT)
+    right = ctx.load_instrument("p300_multi", Mount.RIGHT)
+    left = ctx.load_instrument("p300_multi_gen2", Mount.LEFT)
 
     with pytest.raises(paired.UnsupportedInstrumentPairingError):
         right.pair_with(left)
@@ -248,22 +259,23 @@ def test_pipette_pairing_unsupported_instrument(ctx):
 
 def test_pick_up_and_drop_tip(ctx, get_labware_def):
     ctx.home()
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     tip_length = tiprack.tip_length
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
+    instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware._attached_instruments[mount]  # noqa: E501
+    pipette: Pipette = (
+        ctx._implementation.get_hardware().hardware._attached_instruments[mount]
+    )
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
-    target_location = tiprack['A1'].top()
+    target_location = tiprack["A1"].top()
 
     instr.pick_up_tip(target_location)
     assert not tiprack.wells()[0].has_tip
-    overlap = instr.hw_pipette['tip_overlap'][tiprack.uri]
-    new_offset = nozzle_offset - Point(0, 0,
-                                       tip_length - overlap)
+    overlap = instr.hw_pipette["tip_overlap"][tiprack.uri]
+    new_offset = nozzle_offset - Point(0, 0, tip_length - overlap)
     assert pipette.critical_point() == new_offset
     assert pipette.has_tip
 
@@ -279,20 +291,22 @@ def test_return_tip_old_version(loop, get_labware_def):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(api_version=api_version),
         loop=loop,
-        api_version=api_version
+        api_version=api_version,
     )
     ctx.home()
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
+    instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware._attached_instruments[mount]  # noqa: E501
+    pipette: Pipette = (
+        ctx._implementation.get_hardware().hardware._attached_instruments[mount]
+    )
 
-    target_location = tiprack['A1'].top()
+    target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
     assert not tiprack.wells()[0].has_tip
     assert pipette.has_tip
@@ -308,17 +322,19 @@ def test_return_tip_old_version(loop, get_labware_def):
 
 def test_return_tip(ctx, get_labware_def):
     ctx.home()
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
+    instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
 
     with pytest.raises(TypeError):
         instr.return_tip()
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware._attached_instruments[mount]  # noqa: E501
+    pipette: Pipette = (
+        ctx._implementation.get_hardware().hardware._attached_instruments[mount]
+    )
 
-    target_location = tiprack['A1'].top()
+    target_location = tiprack["A1"].top()
     instr.pick_up_tip(target_location)
     assert not tiprack.wells()[0].has_tip
     assert pipette.has_tip
@@ -335,12 +351,14 @@ def test_return_tip(ctx, get_labware_def):
 def test_use_filter_tips(ctx, get_labware_def):
     ctx.home()
 
-    tiprack = ctx.load_labware_by_name('opentrons_96_filtertiprack_200ul', 2)
+    tiprack = ctx.load_labware_by_name("opentrons_96_filtertiprack_200ul", 2)
 
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument('p300_single', mount, tip_racks=[tiprack])
-    pipette: Pipette = ctx._implementation.get_hardware().hardware._attached_instruments[mount]  # noqa: E501
+    instr = ctx.load_instrument("p300_single", mount, tip_racks=[tiprack])
+    pipette: Pipette = (
+        ctx._implementation.get_hardware().hardware._attached_instruments[mount]
+    )
 
     assert pipette.available_volume == pipette.config.max_volume
 
@@ -348,13 +366,11 @@ def test_use_filter_tips(ctx, get_labware_def):
     assert pipette.available_volume < pipette.config.max_volume
 
 
-@pytest.mark.parametrize('pipette_model',
-                         ['p10_single', 'p20_single_gen2'])
+@pytest.mark.parametrize("pipette_model", ["p10_single", "p20_single_gen2"])
 @pytest.mark.parametrize(
-    'tiprack_kind',
-    ['opentrons_96_tiprack_10ul', 'eppendorf_96_tiprack_10ul_eptips'])
-def test_pick_up_tip_no_location(ctx, get_labware_def,
-                                 pipette_model, tiprack_kind):
+    "tiprack_kind", ["opentrons_96_tiprack_10ul", "eppendorf_96_tiprack_10ul_eptips"]
+)
+def test_pick_up_tip_no_location(ctx, get_labware_def, pipette_model, tiprack_kind):
     ctx.home()
 
     tiprack1 = ctx.load_labware(tiprack_kind, 1)
@@ -366,21 +382,20 @@ def test_pick_up_tip_no_location(ctx, get_labware_def,
 
     mount = Mount.LEFT
 
-    instr = ctx.load_instrument(
-        pipette_model, mount, tip_racks=[tiprack1, tiprack2])
+    instr = ctx.load_instrument(pipette_model, mount, tip_racks=[tiprack1, tiprack2])
 
-    pipette: Pipette = ctx._implementation.get_hardware().hardware._attached_instruments[mount]  # noqa: E501
+    pipette: Pipette = (
+        ctx._implementation.get_hardware().hardware._attached_instruments[mount]
+    )
     nozzle_offset = Point(*pipette.config.nozzle_offset)
     assert pipette.critical_point() == nozzle_offset
 
     instr.pick_up_tip()
 
-    assert 'picking up tip' in ','.join([cmd.lower()
-                                         for cmd in ctx.commands()])
+    assert "picking up tip" in ",".join([cmd.lower() for cmd in ctx.commands()])
     assert not tiprack1.wells()[0].has_tip
-    overlap = instr.hw_pipette['tip_overlap'][tiprack1.uri]
-    new_offset = nozzle_offset - Point(0, 0,
-                                       tip_length1 - overlap)
+    overlap = instr.hw_pipette["tip_overlap"][tiprack1.uri]
+    new_offset = nozzle_offset - Point(0, 0, tip_length1 - overlap)
     assert pipette.critical_point() == new_offset
 
     # TODO: remove argument and verify once trash container is added
@@ -403,36 +418,39 @@ def test_instrument_trash(ctx, get_labware_def):
     ctx.home()
 
     mount = Mount.LEFT
-    instr = ctx.load_instrument('p300_single', mount)
+    instr = ctx.load_instrument("p300_single", mount)
 
-    assert instr.trash_container.name == 'opentrons_1_trash_1100ml_fixed'
+    assert instr.trash_container.name == "opentrons_1_trash_1100ml_fixed"
 
-    new_trash = ctx.load_labware('usascientific_12_reservoir_22ml', 2)
+    new_trash = ctx.load_labware("usascientific_12_reservoir_22ml", 2)
     instr.trash_container = new_trash
 
-    assert instr.trash_container.name == 'usascientific_12_reservoir_22ml'
+    assert instr.trash_container.name == "usascientific_12_reservoir_22ml"
 
 
 def test_aspirate(ctx, get_labware_def, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_10ul', 2)
-    instr = ctx.load_instrument(
-        'p10_single', Mount.RIGHT, tip_racks=[tiprack])
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_10ul", 2)
+    instr = ctx.load_instrument("p10_single", Mount.RIGHT, tip_racks=[tiprack])
 
     fake_hw_aspirate = mock.Mock()
     fake_move = mock.Mock()
-    monkeypatch.setattr(API, 'aspirate', fake_hw_aspirate)
-    monkeypatch.setattr(API, 'move_to', fake_move)
+    monkeypatch.setattr(API, "aspirate", fake_hw_aspirate)
+    monkeypatch.setattr(API, "move_to", fake_move)
 
     instr.pick_up_tip()
     instr.aspirate(2.0, lw.wells()[0].bottom())
-    assert 'aspirating' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "aspirating" in ",".join([cmd.lower() for cmd in ctx.commands()])
 
     fake_hw_aspirate.assert_called_once_with(Mount.RIGHT, 2.0, 1.0)
-    assert fake_move.call_args_list[-1] ==\
-        mock.call(Mount.RIGHT, lw.wells()[0].bottom().point,
-                  critical_point=None, speed=400, max_speeds={})
+    assert fake_move.call_args_list[-1] == mock.call(
+        Mount.RIGHT,
+        lw.wells()[0].bottom().point,
+        critical_point=None,
+        speed=400,
+        max_speeds={},
+    )
     fake_move.reset_mock()
     fake_hw_aspirate.reset_mock()
     instr.well_bottom_clearance.aspirate = 1.0
@@ -440,15 +458,12 @@ def test_aspirate(ctx, get_labware_def, monkeypatch):
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
     assert len(fake_move.call_args_list) == 1
-    assert fake_move.call_args_list[0] ==\
-        mock.call(
-            Mount.RIGHT, dest_point, critical_point=None, speed=400,
-            max_speeds={})
+    assert fake_move.call_args_list[0] == mock.call(
+        Mount.RIGHT, dest_point, critical_point=None, speed=400, max_speeds={}
+    )
     fake_move.reset_mock()
     hardware = ctx._implementation.get_hardware().hardware
-    hardware._obj_to_adapt._attached_instruments[
-        Mount.RIGHT
-    ]._current_volume = 1
+    hardware._obj_to_adapt._attached_instruments[Mount.RIGHT]._current_volume = 1
 
     instr.aspirate(2.0)
     fake_move.assert_not_called()
@@ -458,20 +473,22 @@ def test_aspirate(ctx, get_labware_def, monkeypatch):
     instr.aspirate(2.0)
     assert len(fake_move.call_args_list) == 2
     # reset plunger at the top of the well after blowout
-    assert fake_move.call_args_list[0] ==\
-        mock.call(
-            Mount.RIGHT, dest_lw.as_well().top().point, critical_point=None,
-            speed=400, max_speeds={})
-    assert fake_move.call_args_list[1] ==\
-        mock.call(
-            Mount.RIGHT, dest_point, critical_point=None,
-            speed=400, max_speeds={})
+    assert fake_move.call_args_list[0] == mock.call(
+        Mount.RIGHT,
+        dest_lw.as_well().top().point,
+        critical_point=None,
+        speed=400,
+        max_speeds={},
+    )
+    assert fake_move.call_args_list[1] == mock.call(
+        Mount.RIGHT, dest_point, critical_point=None, speed=400, max_speeds={}
+    )
 
 
 def test_dispense(ctx, get_labware_def, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
-    instr = ctx.load_instrument('p10_single', Mount.RIGHT)
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
+    instr = ctx.load_instrument("p10_single", Mount.RIGHT)
 
     disp_called_with = None
 
@@ -485,25 +502,27 @@ def test_dispense(ctx, get_labware_def, monkeypatch):
         nonlocal move_called_with
         move_called_with = (mount, loc, kwargs)
 
-    monkeypatch.setattr(API, 'dispense', fake_hw_dispense)
-    monkeypatch.setattr(API, 'move_to', fake_move)
+    monkeypatch.setattr(API, "dispense", fake_hw_dispense)
+    monkeypatch.setattr(API, "move_to", fake_move)
 
     instr.dispense(2.0, lw.wells()[0].bottom())
-    assert 'dispensing' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "dispensing" in ",".join([cmd.lower() for cmd in ctx.commands()])
     assert disp_called_with == (Mount.RIGHT, 2.0, 1.0)
-    assert move_called_with == (Mount.RIGHT, lw.wells()[0].bottom().point,
-                                {'critical_point': None,
-                                 'speed': 400,
-                                 'max_speeds': {}})
+    assert move_called_with == (
+        Mount.RIGHT,
+        lw.wells()[0].bottom().point,
+        {"critical_point": None, "speed": 400, "max_speeds": {}},
+    )
 
     instr.well_bottom_clearance.dispense = 2.0
     instr.dispense(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 2.0)
-    assert move_called_with == (Mount.RIGHT, dest_point,
-                                {'critical_point': None,
-                                 'speed': 400,
-                                 'max_speeds': {}})
+    assert move_called_with == (
+        Mount.RIGHT,
+        dest_point,
+        {"critical_point": None, "speed": 400, "max_speeds": {}},
+    )
 
     move_called_with = None
     instr.dispense(2.0)
@@ -513,10 +532,9 @@ def test_dispense(ctx, get_labware_def, monkeypatch):
 def test_prevent_liquid_handling_without_tip(ctx):
     ctx.home()
 
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', '1')
-    plate = ctx.load_labware('corning_384_wellplate_112ul_flat', '2')
-    pipR = ctx.load_instrument('p300_single', Mount.RIGHT,
-                               tip_racks=[tr])
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", "1")
+    plate = ctx.load_labware("corning_384_wellplate_112ul_flat", "2")
+    pipR = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tr])
 
     with pytest.raises(NoTipAttachedError):
         pipR.aspirate(100, plate.wells()[0])
@@ -533,12 +551,10 @@ def test_prevent_liquid_handling_without_tip(ctx):
 def test_starting_tip_and_reset_tipracks(ctx, get_labware_def, monkeypatch):
     ctx.home()
 
-    tr = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    tr_2 = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
-    pipL = ctx.load_instrument('p300_single', Mount.LEFT,
-                               tip_racks=[tr, tr_2])
-    pipR = ctx.load_instrument('p300_single', Mount.RIGHT,
-                               tip_racks=[tr, tr_2])
+    tr = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    tr_2 = ctx.load_labware("opentrons_96_tiprack_300ul", 2)
+    pipL = ctx.load_instrument("p300_single", Mount.LEFT, tip_racks=[tr, tr_2])
+    pipR = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tr, tr_2])
 
     pipL.starting_tip = tr.wells()[2]
     pipL.pick_up_tip()
@@ -562,11 +578,9 @@ def test_starting_tip_and_reset_tipracks(ctx, get_labware_def, monkeypatch):
 
 def test_mix(ctx, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
 
     instr.pick_up_tip()
     mix_steps = []
@@ -576,27 +590,29 @@ def test_mix(ctx, monkeypatch):
     def fake_aspirate(vol=None, loc=None, rate=None):
         nonlocal aspirate_called_with
         nonlocal mix_steps
-        aspirate_called_with = ('aspirate', vol, loc, rate)
+        aspirate_called_with = ("aspirate", vol, loc, rate)
         mix_steps.append(aspirate_called_with)
 
     def fake_dispense(vol=None, loc=None, rate=None):
         nonlocal dispense_called_with
         nonlocal mix_steps
-        dispense_called_with = ('dispense', vol, loc, rate)
+        dispense_called_with = ("dispense", vol, loc, rate)
         mix_steps.append(dispense_called_with)
 
-    monkeypatch.setattr(instr, 'aspirate', fake_aspirate)
-    monkeypatch.setattr(instr, 'dispense', fake_dispense)
+    monkeypatch.setattr(instr, "aspirate", fake_aspirate)
+    monkeypatch.setattr(instr, "dispense", fake_dispense)
 
     repetitions = 2
     volume = 5
     location = lw.wells()[0]
     rate = 2
     instr.mix(repetitions, volume, location, rate)
-    expected_mix_steps = [('aspirate', volume, location, 2),
-                          ('dispense', volume, None, 2),
-                          ('aspirate', volume, None, 2),
-                          ('dispense', volume, None, 2)]
+    expected_mix_steps = [
+        ("aspirate", volume, location, 2),
+        ("dispense", volume, None, 2),
+        ("aspirate", volume, None, 2),
+        ("dispense", volume, None, 2),
+    ]
 
     assert mix_steps == expected_mix_steps
 
@@ -606,32 +622,33 @@ def test_touch_tip_default_args(loop, monkeypatch):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(api_version=api_version),
         loop=loop,
-        api_version=api_version
+        api_version=api_version,
     )
     ctx.home()
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
 
     instr.pick_up_tip()
     total_hw_moves = []
 
-    async def fake_hw_move(self, mount, abs_position, speed=None,
-                           critical_point=None, max_speeds=None):
+    async def fake_hw_move(
+        self, mount, abs_position, speed=None, critical_point=None, max_speeds=None
+    ):
         nonlocal total_hw_moves
         total_hw_moves.append((abs_position, speed))
 
     instr.aspirate(10, lw.wells()[0])
-    monkeypatch.setattr(API, 'move_to', fake_hw_move)
+    monkeypatch.setattr(API, "move_to", fake_hw_move)
     instr.touch_tip()
-    z_offset = Point(0, 0, 1)   # default z offset of 1mm
-    speed = 60                  # default speed
-    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
+    z_offset = Point(0, 0, 1)  # default z offset of 1mm
+    speed = 60  # default speed
+    edges = [
+        lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset,
+    ]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
     # Check that the old api version initial well move has the same z height
@@ -643,30 +660,31 @@ def test_touch_tip_default_args(loop, monkeypatch):
 
 def test_touch_tip_new_default_args(ctx, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
 
     instr.pick_up_tip()
     total_hw_moves = []
 
-    async def fake_hw_move(self, mount, abs_position, speed=None,
-                           critical_point=None, max_speeds=None):
+    async def fake_hw_move(
+        self, mount, abs_position, speed=None, critical_point=None, max_speeds=None
+    ):
         nonlocal total_hw_moves
         total_hw_moves.append((abs_position, speed))
 
     instr.aspirate(10, lw.wells()[0])
-    monkeypatch.setattr(API, 'move_to', fake_hw_move)
+    monkeypatch.setattr(API, "move_to", fake_hw_move)
     instr.touch_tip()
-    z_offset = Point(0, 0, 1)   # default z offset of 1mm
-    speed = 60                  # default speed
-    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
+    z_offset = Point(0, 0, 1)  # default z offset of 1mm
+    speed = 60  # default speed
+    edges = [
+        lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset,
+    ]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 
@@ -679,25 +697,22 @@ def test_touch_tip_new_default_args(ctx, monkeypatch):
 
 def test_touch_tip_disabled(ctx, monkeypatch, get_labware_fixture):
     ctx.home()
-    trough1 = get_labware_fixture('fixture_12_trough')
-    trough_lw = ctx.load_labware_from_definition(trough1, '1')
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    trough1 = get_labware_fixture("fixture_12_trough")
+    trough_lw = ctx.load_labware_from_definition(trough1, "1")
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
     instr.pick_up_tip()
     move_mock = mock.Mock()
-    monkeypatch.setattr(API, 'move_to', move_mock)
-    instr.touch_tip(trough_lw['A1'])
+    monkeypatch.setattr(API, "move_to", move_mock)
+    instr.touch_tip(trough_lw["A1"])
     move_mock.assert_not_called()
 
 
 def test_blow_out(ctx, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
 
     move_location = None
     instr.pick_up_tip()
@@ -707,7 +722,7 @@ def test_blow_out(ctx, monkeypatch):
         nonlocal move_location
         move_location = loc
 
-    monkeypatch.setattr(instr, 'move_to', fake_move)
+    monkeypatch.setattr(instr, "move_to", fake_move)
 
     instr.blow_out()
     # pipette should not move, if no location is passed
@@ -725,11 +740,10 @@ def test_blow_out(ctx, monkeypatch):
 
 
 def test_transfer_options(ctx, monkeypatch):
-    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
+    lw1 = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 1)
+    lw2 = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
 
     ctx.home()
     transfer_options = None
@@ -738,10 +752,16 @@ def test_transfer_options(ctx, monkeypatch):
         nonlocal transfer_options
         transfer_options = xfer_plan._options
 
-    monkeypatch.setattr(instr, '_execute_transfer', fake_execute_transfer)
-    instr.transfer(10, lw1.columns()[0], lw2.columns()[0],
-                   new_tip='always', mix_before=(2, 10),
-                   mix_after=(3, 20), blow_out=True)
+    monkeypatch.setattr(instr, "_execute_transfer", fake_execute_transfer)
+    instr.transfer(
+        10,
+        lw1.columns()[0],
+        lw2.columns()[0],
+        new_tip="always",
+        mix_before=(2, 10),
+        mix_after=(3, 20),
+        blow_out=True,
+    )
     expected_xfer_options1 = tf.TransferOptions(
         transfer=tf.Transfer(
             new_tip=TransferTipPolicy.ALWAYS,
@@ -756,26 +776,28 @@ def test_transfer_options(ctx, monkeypatch):
         ),
         pick_up_tip=tf.PickUpTipOpts(),
         mix=tf.Mix(
-            mix_before=tf.MixOpts(repetitions=2,
-                                  volume=10,
-                                  rate=None),
-            mix_after=tf.MixOpts(repetitions=3,
-                                 volume=20,
-                                 rate=None)
+            mix_before=tf.MixOpts(repetitions=2, volume=10, rate=None),
+            mix_after=tf.MixOpts(repetitions=3, volume=20, rate=None),
         ),
         blow_out=tf.BlowOutOpts(),
         touch_tip=tf.TouchTipOpts(),
         aspirate=tf.AspirateOpts(),
-        dispense=tf.DispenseOpts()
+        dispense=tf.DispenseOpts(),
     )
     assert transfer_options == expected_xfer_options1
 
     instr.pick_up_tip()
-    instr.distribute(50, lw1.rows()[0][0], lw2.columns()[0],
-                     new_tip='never', touch_tip=True, trash=False,
-                     disposal_volume=10,
-                     mix_before=(2, 30),
-                     mix_after=(3, 20))
+    instr.distribute(
+        50,
+        lw1.rows()[0][0],
+        lw2.columns()[0],
+        new_tip="never",
+        touch_tip=True,
+        trash=False,
+        disposal_volume=10,
+        mix_before=(2, 30),
+        mix_after=(3, 20),
+    )
     instr.drop_tip()
     expected_xfer_options2 = tf.TransferOptions(
         transfer=tf.Transfer(
@@ -787,23 +809,23 @@ def test_transfer_options(ctx, monkeypatch):
             mix_strategy=tf.MixStrategy.BEFORE,
             drop_tip_strategy=tf.DropTipStrategy.RETURN,
             blow_out_strategy=tf.BlowOutStrategy.NONE,
-            touch_tip_strategy=tf.TouchTipStrategy.ALWAYS
+            touch_tip_strategy=tf.TouchTipStrategy.ALWAYS,
         ),
         pick_up_tip=tf.PickUpTipOpts(),
-        mix=tf.Mix(mix_before=tf.MixOpts(repetitions=2,
-                                         volume=30,
-                                         rate=None),
-                   mix_after=tf.MixOpts()),
+        mix=tf.Mix(
+            mix_before=tf.MixOpts(repetitions=2, volume=30, rate=None),
+            mix_after=tf.MixOpts(),
+        ),
         blow_out=tf.BlowOutOpts(),
         touch_tip=tf.TouchTipOpts(),
         aspirate=tf.AspirateOpts(),
-        dispense=tf.DispenseOpts()
+        dispense=tf.DispenseOpts(),
     )
     assert transfer_options == expected_xfer_options2
-    with pytest.raises(ValueError, match='air_gap.*'):
-        instr.transfer(300, lw1['A1'], lw2['A1'], air_gap=300)
-    with pytest.raises(ValueError, match='air_gap.*'):
-        instr.transfer(300, lw1['A1'], lw2['A1'], air_gap=10000)
+    with pytest.raises(ValueError, match="air_gap.*"):
+        instr.transfer(300, lw1["A1"], lw2["A1"], air_gap=300)
+    with pytest.raises(ValueError, match="air_gap.*"):
+        instr.transfer(300, lw1["A1"], lw2["A1"], air_gap=10000)
 
 
 def test_flow_rate(ctx, monkeypatch):
@@ -813,10 +835,10 @@ def test_flow_rate(ctx, monkeypatch):
         old_sfm(mount, aspirate=None, dispense=None, blow_out=None)
 
     set_flow_rate = mock.Mock(side_effect=pass_on)
-    monkeypatch.setattr(ctx._implementation.get_hardware().hardware,
-                        'set_flow_rate',
-                        set_flow_rate)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT)
+    monkeypatch.setattr(
+        ctx._implementation.get_hardware().hardware, "set_flow_rate", set_flow_rate
+    )
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT)
 
     ctx.home()
     instr.flow_rate.aspirate = 1
@@ -839,10 +861,10 @@ def test_pipette_speed(ctx, monkeypatch):
         old_sfm(aspirate=None, dispense=None, blow_out=None)
 
     set_speed = mock.Mock(side_effect=pass_on)
-    monkeypatch.setattr(ctx._implementation.get_hardware().hardware,
-                        'set_pipette_speed',
-                        set_speed)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT)
+    monkeypatch.setattr(
+        ctx._implementation.get_hardware().hardware, "set_pipette_speed", set_speed
+    )
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT)
 
     ctx.home()
     instr.speed.aspirate = 1
@@ -858,30 +880,29 @@ def test_pipette_speed(ctx, monkeypatch):
 
 def test_loaded_labwares(ctx):
     assert ctx.loaded_labwares == {12: ctx.fixed_trash}
-    lw1 = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    lw2 = ctx.load_labware('opentrons_96_tiprack_300ul', 8)
-    ctx.load_module('tempdeck', 4)
-    mod2 = ctx.load_module('magdeck', 5)
-    mod_lw = mod2.load_labware('biorad_96_wellplate_200ul_pcr')
+    lw1 = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    lw2 = ctx.load_labware("opentrons_96_tiprack_300ul", 8)
+    ctx.load_module("tempdeck", 4)
+    mod2 = ctx.load_module("magdeck", 5)
+    mod_lw = mod2.load_labware("biorad_96_wellplate_200ul_pcr")
     assert ctx.loaded_labwares[3] == lw1
     assert ctx.loaded_labwares[8] == lw2
     assert ctx.loaded_labwares[5] == mod_lw
-    assert sorted(ctx.loaded_labwares.keys())\
-        == sorted([3, 5, 8, 12])
+    assert sorted(ctx.loaded_labwares.keys()) == sorted([3, 5, 8, 12])
 
 
 def test_loaded_modules(ctx, monkeypatch):
     assert ctx.loaded_modules == {}
     from collections import OrderedDict
 
-    mag1 = ctx.load_module('magnetic module gen2', 1)
-    mag2 = ctx.load_module('magnetic module', 2)
-    temp1 = ctx.load_module('temperature module', 3)
-    temp2 = ctx.load_module('temperature module', 4)
+    mag1 = ctx.load_module("magnetic module gen2", 1)
+    mag2 = ctx.load_module("magnetic module", 2)
+    temp1 = ctx.load_module("temperature module", 3)
+    temp2 = ctx.load_module("temperature module", 4)
 
     expected_load_order = OrderedDict(
-        {int(mod.geometry.parent): mod
-         for mod in [mag1, mag2, temp1, temp2]})
+        {int(mod.geometry.parent): mod for mod in [mag1, mag2, temp1, temp2]}
+    )
 
     assert ctx.loaded_modules == expected_load_order
     assert ctx.loaded_modules[1] == mag1
@@ -894,10 +915,10 @@ def test_order_of_module_load(loop, hardware):
     import opentrons.hardware_control as hardware_control
     import opentrons.protocol_api as protocol_api
 
-    mods = [
-        'tempdeck', 'thermocycler', 'tempdeck']
+    mods = ["tempdeck", "thermocycler", "tempdeck"]
     thread_manager = hardware_control.ThreadManager(
-        hardware_control.API.build_hardware_simulator, attached_modules=mods)
+        hardware_control.API.build_hardware_simulator, attached_modules=mods
+    )
     fake_hardware = thread_manager.sync
 
     attached_modules = fake_hardware.attached_modules
@@ -905,12 +926,12 @@ def test_order_of_module_load(loop, hardware):
     hw_temp2 = attached_modules[2]
 
     ctx1 = protocol_api.ProtocolContext(
-        implementation=ProtocolContextImplementation(hardware=hardware),
-        loop=loop)
+        implementation=ProtocolContextImplementation(hardware=hardware), loop=loop
+    )
     with ctx1.temp_connect(fake_hardware) as c:
-        temp1 = c.load_module('tempdeck', 4)
-        c.load_module('thermocycler')
-        temp2 = c.load_module('tempdeck', 1)
+        temp1 = c.load_module("tempdeck", 4)
+        c.load_module("thermocycler")
+        temp2 = c.load_module("tempdeck", 1)
         async_temp1 = temp1._module._obj_to_adapt
         async_temp2 = temp2._module._obj_to_adapt
 
@@ -921,13 +942,13 @@ def test_order_of_module_load(loop, hardware):
     # hardware modules regardless of the slot it
     # was loaded into
     ctx2 = protocol_api.ProtocolContext(
-        implementation=ProtocolContextImplementation(hardware=hardware),
-        loop=loop)
+        implementation=ProtocolContextImplementation(hardware=hardware), loop=loop
+    )
 
     with ctx2.temp_connect(fake_hardware) as c:
-        c.load_module('thermocycler')
-        temp1 = c.load_module('tempdeck', 1)
-        temp2 = c.load_module('tempdeck', 4)
+        c.load_module("thermocycler")
+        temp1 = c.load_module("tempdeck", 1)
+        temp2 = c.load_module("tempdeck", 4)
 
         async_temp1 = temp1._module._obj_to_adapt
         async_temp2 = temp2._module._obj_to_adapt
@@ -936,45 +957,45 @@ def test_order_of_module_load(loop, hardware):
 
 
 def test_tip_length_for(ctx, monkeypatch):
-    instr = ctx.load_instrument('p20_single_gen2', 'left')
-    tiprack = ctx.load_labware('geb_96_tiprack_10ul', '1')
-    assert instr._tip_length_for(tiprack)\
-        == (tiprack._implementation.get_definition()['parameters']['tipLength']
-            - instr.hw_pipette['tip_overlap']
-            ['opentrons/geb_96_tiprack_10ul/1'])
+    instr = ctx.load_instrument("p20_single_gen2", "left")
+    tiprack = ctx.load_labware("geb_96_tiprack_10ul", "1")
+    assert instr._tip_length_for(tiprack) == (
+        tiprack._implementation.get_definition()["parameters"]["tipLength"]
+        - instr.hw_pipette["tip_overlap"]["opentrons/geb_96_tiprack_10ul/1"]
+    )
 
 
 def test_tip_length_for_caldata(ctx, monkeypatch):
-    instr = ctx.load_instrument('p20_single_gen2', 'left')
-    tiprack = ctx.load_labware('geb_96_tiprack_10ul', '1')
+    instr = ctx.load_instrument("p20_single_gen2", "left")
+    tiprack = ctx.load_labware("geb_96_tiprack_10ul", "1")
     mock_tip_length = mock.Mock()
-    mock_tip_length.return_value =\
-        cs_types.TipLengthCalibration(
-            tip_length=2,
-            pipette='fake id',
-            tiprack='fake_hash',
-            last_modified='some time',
-            source=cs_types.SourceType.user,
-            status=cs_types.CalibrationStatus(markedBad=False),
-            uri='opentrons/geb_96_tiprack_10ul/1')
-    monkeypatch.setattr(get, 'load_tip_length_calibration', mock_tip_length)
+    mock_tip_length.return_value = cs_types.TipLengthCalibration(
+        tip_length=2,
+        pipette="fake id",
+        tiprack="fake_hash",
+        last_modified="some time",
+        source=cs_types.SourceType.user,
+        status=cs_types.CalibrationStatus(markedBad=False),
+        uri="opentrons/geb_96_tiprack_10ul/1",
+    )
+    monkeypatch.setattr(get, "load_tip_length_calibration", mock_tip_length)
     assert instr._tip_length_for(tiprack) == 2
     mock_tip_length.side_effect = cs_types.TipLengthCalNotFound
     assert instr._tip_length_for(tiprack) == (
-        tiprack._implementation.get_definition()['parameters']['tipLength']
-        - instr.hw_pipette['tip_overlap']
-        ['opentrons/geb_96_tiprack_10ul/1'])
+        tiprack._implementation.get_definition()["parameters"]["tipLength"]
+        - instr.hw_pipette["tip_overlap"]["opentrons/geb_96_tiprack_10ul/1"]
+    )
 
 
 def test_tip_length_for_load_caldata(ctx):
-    instr = ctx.load_instrument('p20_single_gen2', 'left')
-    tiprack = ctx.load_labware('geb_96_tiprack_10ul', '1')
-    pip_id = instr.hw_pipette['pipette_id']
+    instr = ctx.load_instrument("p20_single_gen2", "left")
+    tiprack = ctx.load_labware("geb_96_tiprack_10ul", "1")
+    pip_id = instr.hw_pipette["pipette_id"]
     fake_tip_length = 31
 
     test_data = modify.create_tip_length_data(
-        tiprack._implementation.get_definition(),
-        fake_tip_length)
+        tiprack._implementation.get_definition(), fake_tip_length
+    )
     modify.save_tip_length_calibration(pip_id, test_data)
 
     assert instr._tip_length_for(tiprack) == fake_tip_length
@@ -982,136 +1003,127 @@ def test_tip_length_for_load_caldata(ctx):
 
 
 def test_bundled_labware(loop, get_labware_fixture, hardware):
-    fixture_96_plate = get_labware_fixture('fixture_96_plate')
-    bundled_labware = {
-        'fixture/fixture_96_plate/1': fixture_96_plate
-    }
+    fixture_96_plate = get_labware_fixture("fixture_96_plate")
+    bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
 
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
-            hardware=hardware,
-            bundled_labware=bundled_labware),
-        loop=loop
+            hardware=hardware, bundled_labware=bundled_labware
+        ),
+        loop=loop,
     )
 
-    lw1 = ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
+    lw1 = ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
     assert ctx.loaded_labwares[3] == lw1
-    assert ctx.loaded_labwares[3]._implementation.get_definition() ==\
-        fixture_96_plate
+    assert ctx.loaded_labwares[3]._implementation.get_definition() == fixture_96_plate
 
 
 def test_bundled_labware_missing(loop, get_labware_fixture, hardware):
     bundled_labware = {}
     with pytest.raises(
-        RuntimeError,
-        match='No labware found in bundle with load name fixture_96_plate'
+        RuntimeError, match="No labware found in bundle with load name fixture_96_plate"
     ):
         ctx = papi.ProtocolContext(
             implementation=ProtocolContextImplementation(
-                bundled_labware=bundled_labware,
-                hardware=hardware
+                bundled_labware=bundled_labware, hardware=hardware
             ),
-            loop=loop)
-        ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
-
-    fixture_96_plate = get_labware_fixture('fixture_96_plate')
-    bundled_labware = {
-        'fixture/fixture_96_plate/1': fixture_96_plate
-    }
-    with pytest.raises(
-        RuntimeError,
-        match='No labware found in bundle with load name fixture_96_plate'
-    ):
-        ctx = papi.ProtocolContext(
-            implementation=ProtocolContextImplementation(
-                bundled_labware={},
-                extra_labware=bundled_labware,
-                hardware=hardware
-            ),
-            loop=loop
+            loop=loop,
         )
-        ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
+        ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
+
+    fixture_96_plate = get_labware_fixture("fixture_96_plate")
+    bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
+    with pytest.raises(
+        RuntimeError, match="No labware found in bundle with load name fixture_96_plate"
+    ):
+        ctx = papi.ProtocolContext(
+            implementation=ProtocolContextImplementation(
+                bundled_labware={}, extra_labware=bundled_labware, hardware=hardware
+            ),
+            loop=loop,
+        )
+        ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
 
 
 def test_bundled_data(loop, hardware):
-    bundled_data = {'foo': b'1,2,3'}
+    bundled_data = {"foo": b"1,2,3"}
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
-            bundled_data=bundled_data,
-            hardware=hardware
+            bundled_data=bundled_data, hardware=hardware
         ),
-        loop=loop
+        loop=loop,
     )
     assert ctx.bundled_data == bundled_data
 
 
 def test_extra_labware(loop, get_labware_fixture, hardware):
-    fixture_96_plate = get_labware_fixture('fixture_96_plate')
-    bundled_labware = {
-        'fixture/fixture_96_plate/1': fixture_96_plate
-    }
+    fixture_96_plate = get_labware_fixture("fixture_96_plate")
+    bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
             extra_labware=bundled_labware, hardware=hardware
         ),
-        loop=loop
+        loop=loop,
     )
 
-    ls1 = ctx.load_labware('fixture_96_plate', 3, namespace='fixture')
+    ls1 = ctx.load_labware("fixture_96_plate", 3, namespace="fixture")
     assert ctx.loaded_labwares[3] == ls1
-    assert ctx.loaded_labwares[3]._implementation.get_definition() ==\
-        fixture_96_plate
+    assert ctx.loaded_labwares[3]._implementation.get_definition() == fixture_96_plate
 
 
 def test_api_version_checking(hardware):
-    minor_over = (papi.MAX_SUPPORTED_VERSION.major,
-                  papi.MAX_SUPPORTED_VERSION.minor + 1)
+    minor_over = (
+        papi.MAX_SUPPORTED_VERSION.major,
+        papi.MAX_SUPPORTED_VERSION.minor + 1,
+    )
     with pytest.raises(RuntimeError):
-        papi.ProtocolContext(api_version=minor_over,
-                             implementation=ProtocolContextImplementation(
-                                 hardware=hardware
-                             ))
+        papi.ProtocolContext(
+            api_version=minor_over,
+            implementation=ProtocolContextImplementation(hardware=hardware),
+        )
 
-    major_over = (papi.MAX_SUPPORTED_VERSION.major + 1,
-                  papi.MAX_SUPPORTED_VERSION.minor)
+    major_over = (
+        papi.MAX_SUPPORTED_VERSION.major + 1,
+        papi.MAX_SUPPORTED_VERSION.minor,
+    )
     with pytest.raises(RuntimeError):
-        papi.ProtocolContext(api_version=major_over,
-                             implementation=ProtocolContextImplementation(
-                                 hardware=hardware
-                             ))
+        papi.ProtocolContext(
+            api_version=major_over,
+            implementation=ProtocolContextImplementation(hardware=hardware),
+        )
 
 
 def test_api_per_call_checking(monkeypatch, hardware):
     implementation = ProtocolContextImplementation(hardware=hardware)
 
-    ctx = papi.ProtocolContext(implementation=implementation,
-                               api_version=APIVersion(1, 9))
+    ctx = papi.ProtocolContext(
+        implementation=implementation, api_version=APIVersion(1, 9)
+    )
     assert ctx.deck  # 1.9 < 2.0, but api version 1 is excepted from checking
     monkeypatch.setattr(
-        papi.protocol_context, 'MAX_SUPPORTED_VERSION',
-        APIVersion(2, 1))
-    ctx = papi.ProtocolContext(implementation=implementation,
-                               api_version=APIVersion(2, 1))
+        papi.protocol_context, "MAX_SUPPORTED_VERSION", APIVersion(2, 1)
+    )
+    ctx = papi.ProtocolContext(
+        implementation=implementation, api_version=APIVersion(2, 1)
+    )
     # versions > 2.0 are ok
     assert ctx.deck
     # pretend disconnect() was only added in 2.1
-    set_version_added(
-        papi.ProtocolContext.disconnect, monkeypatch, APIVersion(2, 1))
-    ctx = papi.ProtocolContext(implementation=implementation,
-                               api_version=APIVersion(2, 0))
+    set_version_added(papi.ProtocolContext.disconnect, monkeypatch, APIVersion(2, 1))
+    ctx = papi.ProtocolContext(
+        implementation=implementation, api_version=APIVersion(2, 0)
+    )
     with pytest.raises(papi_support.util.APIVersionError):
         ctx.disconnect()
 
 
 def test_home_plunger(monkeypatch, hardware):
     ctx = papi.ProtocolContext(
-        implementation=ProtocolContextImplementation(
-            hardware=hardware
-        ),
-        api_version=APIVersion(2, 0)
+        implementation=ProtocolContextImplementation(hardware=hardware),
+        api_version=APIVersion(2, 0),
     )
     ctx.home()
-    instr = ctx.load_instrument('p1000_single', 'left')
+    instr = ctx.load_instrument("p1000_single", "left")
     instr.home_plunger()
 
 
@@ -1119,9 +1131,9 @@ def test_move_to_with_thermocycler(ctx):
     def raiser(*args, **kwargs):
         raise RuntimeError("Cannot")
 
-    mod = ctx.load_module('thermocycler')
+    mod = ctx.load_module("thermocycler")
     mod.flag_unsafe_move = mock.MagicMock(side_effect=raiser)
-    instr = ctx.load_instrument('p1000_single', 'left')
+    instr = ctx.load_instrument("p1000_single", "left")
     with pytest.raises(RuntimeError, match="Cannot"):
         instr.move_to(Location(Point(0, 0, 0), None))
 
@@ -1131,7 +1143,8 @@ def test_move_to_with_thermocycler(ctx):
     argvalues=[
         [ProtocolContextImplementation],
         [ProtocolContextSimulation],
-    ])
+    ],
+)
 def test_temp_connect(implementation_class, hardware):
     """Test that temp_connect can be used to assign hardware controller to
     protocol implementation."""
@@ -1140,17 +1153,19 @@ def test_temp_connect(implementation_class, hardware):
     wrappable_hardware = mock.MagicMock()
     # Must mock result of get_attached_instrument for temp_connect to work.
     wrappable_hardware.get_attached_instrument.return_value = {
-        'default_aspirate_flow_rates': {'2.0': 100},
-        'default_dispense_flow_rates': {'2.0': 100},
-        'default_blow_out_flow_rates': {'2.0': 100}
+        "default_aspirate_flow_rates": {"2.0": 100},
+        "default_dispense_flow_rates": {"2.0": 100},
+        "default_blow_out_flow_rates": {"2.0": 100},
     }
 
     # Create the SynchronousAdapter wrapping the wrappable_hardware.
     temp_hardware = SynchronousAdapter(wrappable_hardware)
 
-    ctx = papi.ProtocolContext(implementation=implementation_class(hardware=hardware),
-                               api_version=APIVersion(2, 0))
-    instr = ctx.load_instrument('p1000_single', 'left')
+    ctx = papi.ProtocolContext(
+        implementation=implementation_class(hardware=hardware),
+        api_version=APIVersion(2, 0),
+    )
+    instr = ctx.load_instrument("p1000_single", "left")
 
     with ctx.temp_connect(temp_hardware):
         instr.home()

--- a/api/tests/opentrons/protocol_api/test_instrument.py
+++ b/api/tests/opentrons/protocol_api/test_instrument.py
@@ -3,8 +3,9 @@ import pytest
 from unittest import mock
 import opentrons.protocol_api as papi
 from opentrons.protocols.advanced_control import transfers
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 from opentrons.types import Mount
 from opentrons.protocols.api_support.types import APIVersion
 
@@ -14,115 +15,101 @@ def make_context_and_labware(hardware):
     def _make_context_and_labware(api_version):
         ctx = papi.ProtocolContext(
             implementation=ProtocolContextImplementation(
-                hardware=hardware,
-                api_version=api_version
+                hardware=hardware, api_version=api_version
             ),
-            api_version=api_version
+            api_version=api_version,
         )
-        lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
-        instr = ctx.load_instrument('p300_single', Mount.RIGHT)
+        lw1 = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 1)
+        instr = ctx.load_instrument("p300_single", Mount.RIGHT)
 
-        return {'ctx': ctx, 'instr': instr, 'lw1': lw1}
+        return {"ctx": ctx, "instr": instr, "lw1": lw1}
 
     return _make_context_and_labware
 
 
 @pytest.mark.parametrize(
-    'liquid_handling_command',
-    ['transfer', 'consolidate', 'distribute'])
+    "liquid_handling_command", ["transfer", "consolidate", "distribute"]
+)
 def test_blowout_location_unsupported_version(
-        make_context_and_labware, liquid_handling_command):
+    make_context_and_labware, liquid_handling_command
+):
     # not supported in versions below 2.8
     context_and_labware = make_context_and_labware(APIVersion(2, 7))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
+    context_and_labware["ctx"].home()
+    lw1 = context_and_labware["lw1"]
+    instr = context_and_labware["instr"]
     with pytest.raises(
-            ValueError,
-            match='Cannot specify blowout location when using api version ' +
-            'below 2.8, current version is 2.7'):
+        ValueError,
+        match="Cannot specify blowout location when using api version "
+        + "below 2.8, current version is 2.7",
+    ):
         getattr(instr, liquid_handling_command)(
-            100,
-            lw1['A1'],
-            lw1['A2'],
-            blowout_location='should not matter')
+            100, lw1["A1"], lw1["A2"], blowout_location="should not matter"
+        )
 
 
 @pytest.mark.parametrize(
-    argnames='liquid_handling_command,'
-             'blowout_location,'
-             'expected_error_match,',
+    argnames="liquid_handling_command," "blowout_location," "expected_error_match,",
     argvalues=[
+        ["transfer", "some invalid location", "blowout location should be either"],
         [
-            'transfer',
-            'some invalid location',
-            'blowout location should be either'
+            "consolidate",
+            "source well",
+            "blowout location for consolidate cannot be source well",
         ],
         [
-            'consolidate',
-            'source well',
-            'blowout location for consolidate cannot be source well'
+            "distribute",
+            "destination well",
+            "blowout location for distribute cannot be destination well",
         ],
-        [
-            'distribute',
-            'destination well',
-            'blowout location for distribute cannot be destination well'
-        ],
-    ]
+    ],
 )
 def test_blowout_location_invalid(
-        make_context_and_labware,
-        liquid_handling_command,
-        blowout_location,
-        expected_error_match):
+    make_context_and_labware,
+    liquid_handling_command,
+    blowout_location,
+    expected_error_match,
+):
     context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
+    context_and_labware["ctx"].home()
+    lw1 = context_and_labware["lw1"]
+    instr = context_and_labware["instr"]
     with pytest.raises(ValueError, match=expected_error_match):
 
         getattr(instr, liquid_handling_command)(
-            100,
-            lw1['A1'],
-            lw1['A2'],
-            blowout_location=blowout_location)
+            100, lw1["A1"], lw1["A2"], blowout_location=blowout_location
+        )
 
 
 @pytest.mark.parametrize(
-    argnames='liquid_handling_command,'
-             'blowout_location,'
-             'expected_strat,',
+    argnames="liquid_handling_command," "blowout_location," "expected_strat,",
     argvalues=[
-        ['transfer', 'destination well', transfers.BlowOutStrategy.DEST],
-        ['transfer', 'source well', transfers.BlowOutStrategy.SOURCE],
-        ['transfer', 'trash', transfers.BlowOutStrategy.TRASH],
-        ['consolidate', 'destination well', transfers.BlowOutStrategy.DEST],
-        ['consolidate', 'trash', transfers.BlowOutStrategy.TRASH],
-        ['distribute', 'source well', transfers.BlowOutStrategy.SOURCE],
-        ['distribute', 'trash', transfers.BlowOutStrategy.TRASH],
-    ]
+        ["transfer", "destination well", transfers.BlowOutStrategy.DEST],
+        ["transfer", "source well", transfers.BlowOutStrategy.SOURCE],
+        ["transfer", "trash", transfers.BlowOutStrategy.TRASH],
+        ["consolidate", "destination well", transfers.BlowOutStrategy.DEST],
+        ["consolidate", "trash", transfers.BlowOutStrategy.TRASH],
+        ["distribute", "source well", transfers.BlowOutStrategy.SOURCE],
+        ["distribute", "trash", transfers.BlowOutStrategy.TRASH],
+    ],
 )
 def test_valid_blowout_location(
-        make_context_and_labware,
-        liquid_handling_command,
-        blowout_location,
-        expected_strat):
+    make_context_and_labware, liquid_handling_command, blowout_location, expected_strat
+):
     context_and_labware = make_context_and_labware(APIVersion(2, 8))
-    context_and_labware['ctx'].home()
-    lw1 = context_and_labware['lw1']
-    instr = context_and_labware['instr']
+    context_and_labware["ctx"].home()
+    lw1 = context_and_labware["lw1"]
+    instr = context_and_labware["instr"]
 
-    with mock.patch.object(
-            papi.InstrumentContext, '_execute_transfer') as patch:
+    with mock.patch.object(papi.InstrumentContext, "_execute_transfer") as patch:
         getattr(instr, liquid_handling_command)(
             100,
-            lw1['A2'],
-            [lw1['A1'], lw1['B1']],
+            lw1["A2"],
+            [lw1["A1"], lw1["B1"]],
             blow_out=True,
             blowout_location=blowout_location,
-            new_tip='never'
+            new_tip="never",
         )
-        blowout_strat = patch.call_args[0][0]._options.transfer \
-            .blow_out_strategy
+        blowout_strat = patch.call_args[0][0]._options.transfer.blow_out_strategy
 
         assert blowout_strat == expected_strat

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -2,44 +2,44 @@ import json
 
 import pytest
 
-from opentrons.protocol_api import (
-    labware, MAX_SUPPORTED_VERSION)
+from opentrons.protocol_api import labware, MAX_SUPPORTED_VERSION
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.protocols.labware.definition import _get_parent_identifier
 
 from opentrons_shared_data import load_shared_data
-from opentrons.calibration_storage import (
-    helpers, get, delete, file_operators)
+from opentrons.calibration_storage import helpers, get, delete, file_operators
 from opentrons.types import Point, Location
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.geometry.module_geometry import (
-    ModuleGeometry, MagneticModuleModel, ModuleType)
+    ModuleGeometry,
+    MagneticModuleModel,
+    ModuleType,
+)
 
 test_data = {
-    'circular_well_json': {
-        'shape': 'circular',
-        'depth': 40,
-        'totalLiquidVolume': 100,
-        'diameter': 30,
-        'x': 40,
-        'y': 50,
-        'z': 3
+    "circular_well_json": {
+        "shape": "circular",
+        "depth": 40,
+        "totalLiquidVolume": 100,
+        "diameter": 30,
+        "x": 40,
+        "y": 50,
+        "z": 3,
     },
-    'rectangular_well_json': {
-        'shape': 'rectangular',
-        'depth': 20,
-        'totalLiquidVolume': 200,
-        'xDimension': 120,
-        'yDimension': 50,
-        'x': 45,
-        'y': 10,
-        'z': 22
-    }
+    "rectangular_well_json": {
+        "shape": "rectangular",
+        "depth": 20,
+        "totalLiquidVolume": 200,
+        "xDimension": 120,
+        "yDimension": 50,
+        "x": 45,
+        "y": 10,
+        "z": 22,
+    },
 }
 
 
@@ -47,16 +47,15 @@ test_data = {
 def set_up_index_file(labware_offset_tempdir):
     deck = Deck()
     labware_list = [
-        'nest_96_wellplate_2ml_deep',
-        'corning_384_wellplate_112ul_flat',
-        'geb_96_tiprack_1000ul',
-        'nest_12_reservoir_15ml']
+        "nest_96_wellplate_2ml_deep",
+        "corning_384_wellplate_112ul_flat",
+        "geb_96_tiprack_1000ul",
+        "nest_12_reservoir_15ml",
+    ]
     for idx, name in enumerate(labware_list):
-        parent = deck.position_for(idx+1)
+        parent = deck.position_for(idx + 1)
         definition = labware.get_labware_definition(name)
-        lw = labware.Labware(
-            implementation=LabwareImplementation(definition, parent)
-        )
+        lw = labware.Labware(implementation=LabwareImplementation(definition, parent))
         labware.save_calibration(lw, Point(0, 0, 0))
 
     return labware_list
@@ -64,108 +63,114 @@ def set_up_index_file(labware_offset_tempdir):
 
 def test_well_init():
     slot = Location(Point(1, 2, 3), 1)
-    well_name = 'circular_well_json'
+    well_name = "circular_well_json"
     has_tip = False
     well1 = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well_name],
-                                       parent_point=slot.point,
-                                       parent_object=slot.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well_name],
+                parent_point=slot.point,
+                parent_object=slot.labware,
+            ),
             display_name=well_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
-    assert well1.geometry.diameter == test_data[well_name]['diameter']
+    assert well1.geometry.diameter == test_data[well_name]["diameter"]
     assert well1.geometry._length is None
     assert well1.geometry._width is None
 
-    well2_name = 'rectangular_well_json'
+    well2_name = "rectangular_well_json"
     well2 = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well2_name],
-                                       parent_point=slot.point,
-                                       parent_object=slot.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well2_name],
+                parent_point=slot.point,
+                parent_object=slot.labware,
+            ),
             display_name=well2_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
     assert well2.geometry.diameter is None
-    assert well2.geometry._length == test_data[well2_name]['xDimension']
-    assert well2.geometry._width == test_data[well2_name]['yDimension']
+    assert well2.geometry._length == test_data[well2_name]["xDimension"]
+    assert well2.geometry._width == test_data[well2_name]["yDimension"]
 
 
 def test_top():
     slot = Location(Point(4, 5, 6), 1)
-    well_name = 'circular_well_json'
+    well_name = "circular_well_json"
     has_tip = False
     well = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well_name],
-                                       parent_point=slot.point,
-                                       parent_object=slot.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well_name],
+                parent_point=slot.point,
+                parent_object=slot.labware,
+            ),
             display_name=well_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
     well_data = test_data[well_name]
-    expected_x = well_data['x'] + slot.point.x
-    expected_y = well_data['y'] + slot.point.y
-    expected_z = well_data['z'] + well_data['depth'] + slot.point.z
-    assert well.top() == Location(Point(expected_x, expected_y, expected_z),
-                                  well)
+    expected_x = well_data["x"] + slot.point.x
+    expected_y = well_data["y"] + slot.point.y
+    expected_z = well_data["z"] + well_data["depth"] + slot.point.z
+    assert well.top() == Location(Point(expected_x, expected_y, expected_z), well)
 
 
 def test_bottom():
     slot = Location(Point(7, 8, 9), 1)
-    well_name = 'rectangular_well_json'
+    well_name = "rectangular_well_json"
     has_tip = False
     well = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well_name],
-                                       parent_point=slot.point,
-                                       parent_object=slot.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well_name],
+                parent_point=slot.point,
+                parent_object=slot.labware,
+            ),
             display_name=well_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
     well_data = test_data[well_name]
-    expected_x = well_data['x'] + slot.point.x
-    expected_y = well_data['y'] + slot.point.y
-    expected_z = well_data['z'] + slot.point.z
-    assert well.bottom() == Location(Point(expected_x, expected_y, expected_z),
-                                     well)
+    expected_x = well_data["x"] + slot.point.x
+    expected_y = well_data["y"] + slot.point.y
+    expected_z = well_data["z"] + slot.point.z
+    assert well.bottom() == Location(Point(expected_x, expected_y, expected_z), well)
 
 
 def test_from_center_cartesian():
     slot1 = Location(Point(10, 11, 12), 1)
-    well_name = 'circular_well_json'
+    well_name = "circular_well_json"
     has_tip = False
     well1 = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well_name],
-                                       parent_point=slot1.point,
-                                       parent_object=slot1.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well_name],
+                parent_point=slot1.point,
+                parent_object=slot1.labware,
+            ),
             display_name=well_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
 
     percent1_x = 1
     percent1_y = 1
     percent1_z = -0.5
-    point1 = well1.from_center_cartesian(percent1_x,
-                                         percent1_y,
-                                         percent1_z)
+    point1 = well1.from_center_cartesian(percent1_x, percent1_y, percent1_z)
 
     # slot.x + well.x + 1 * well.diamter/2
     expected_x = 10 + 40 + 15
@@ -179,25 +184,25 @@ def test_from_center_cartesian():
     assert point1.z == expected_z
 
     slot2 = Location(Point(13, 14, 15), 1)
-    well2_name = 'rectangular_well_json'
+    well2_name = "rectangular_well_json"
     has_tip = False
     well2 = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry(well_props=test_data[well2_name],
-                                       parent_point=slot2.point,
-                                       parent_object=slot2.labware),
+            well_geometry=WellGeometry(
+                well_props=test_data[well2_name],
+                parent_point=slot2.point,
+                parent_object=slot2.labware,
+            ),
             display_name=well2_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
     percent2_x = -0.25
     percent2_y = 0.1
     percent2_z = 0.9
-    point2 = well2.geometry.from_center_cartesian(percent2_x,
-                                                  percent2_y,
-                                                  percent2_z)
+    point2 = well2.geometry.from_center_cartesian(percent2_x, percent2_y, percent2_z)
 
     # slot.x + well.x - 0.25 * well.length/2
     expected_x = 13 + 45 - 15
@@ -213,7 +218,7 @@ def test_from_center_cartesian():
 
 @pytest.fixture
 def corning_96_wellplate_360ul_flat_def():
-    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_name = "corning_96_wellplate_360ul_flat"
     return labware.get_labware_definition(labware_name)
 
 
@@ -222,7 +227,8 @@ def corning_96_wellplate_360ul_flat(corning_96_wellplate_360ul_flat_def):
     return labware.Labware(
         implementation=LabwareImplementation(
             definition=corning_96_wellplate_360ul_flat_def,
-            parent=Location(Point(0, 0, 0), 'Test Slot'))
+            parent=Location(Point(0, 0, 0), "Test Slot"),
+        )
     )
 
 
@@ -237,7 +243,8 @@ def opentrons_96_tiprack_300ul(opentrons_96_tiprack_300ul_def):
     return labware.Labware(
         implementation=LabwareImplementation(
             definition=opentrons_96_tiprack_300ul_def,
-            parent=Location(Point(0, 0, 0), 'Test Slot'))
+            parent=Location(Point(0, 0, 0), "Test Slot"),
+        )
     )
 
 
@@ -248,38 +255,41 @@ def test_back_compat(corning_96_wellplate_360ul_flat):
     # because dimensional parameters could be subject to modification through
     # calibration, whereas here we are testing for "identity" in a way that is
     # related to the combination of well name, labware name, and slot name
-    well_a1_name = repr(lw.wells_by_name()['A1'])
-    well_b2_name = repr(lw.wells_by_name()['B2'])
-    well_c3_name = repr(lw.wells_by_name()['C3'])
+    well_a1_name = repr(lw.wells_by_name()["A1"])
+    well_b2_name = repr(lw.wells_by_name()["B2"])
+    well_c3_name = repr(lw.wells_by_name()["C3"])
 
     w2 = lw.well(0)
     assert repr(w2) == well_a1_name
 
-    w3 = lw.well('A1')
+    w3 = lw.well("A1")
     assert repr(w3) == well_a1_name
 
-    w4 = lw.wells('B2')
+    w4 = lw.wells("B2")
     assert repr(w4[0]) == well_b2_name
 
     w5 = lw.wells(9, 21, 25, 27)
     assert len(w5) == 4
     assert repr(w5[0]) == well_b2_name
 
-    w6 = lw.wells('A1', 'B2', 'C3')
-    assert all([
-        repr(well[0]) == well[1]
-        for well in zip(w6, [well_a1_name, well_b2_name, well_c3_name])])
+    w6 = lw.wells("A1", "B2", "C3")
+    assert all(
+        [
+            repr(well[0]) == well[1]
+            for well in zip(w6, [well_a1_name, well_b2_name, well_c3_name])
+        ]
+    )
 
-    w7 = lw.rows('A')
+    w7 = lw.rows("A")
     assert len(w7) == 1
     assert repr(w7[0][0]) == well_a1_name
 
-    w8 = lw.rows('A', 'C')
+    w8 = lw.rows("A", "C")
     assert len(w8) == 2
     assert repr(w8[0][0]) == well_a1_name
     assert repr(w8[1][2]) == well_c3_name
 
-    w11 = lw.columns('2', '3', '6')
+    w11 = lw.columns("2", "3", "6")
     assert len(w11) == 3
     assert repr(w11[1][2]) == well_c3_name
 
@@ -287,7 +297,7 @@ def test_back_compat(corning_96_wellplate_360ul_flat):
 def test_well_parent(corning_96_wellplate_360ul_flat):
     lw = corning_96_wellplate_360ul_flat
     parent = Location(Point(7, 8, 9), lw)
-    well_name = 'circular_well_json'
+    well_name = "circular_well_json"
     has_tip = True
     well = labware.Well(
         api_level=MAX_SUPPORTED_VERSION,
@@ -295,12 +305,12 @@ def test_well_parent(corning_96_wellplate_360ul_flat):
             well_geometry=WellGeometry(
                 well_props=test_data[well_name],
                 parent_point=parent.point,
-                parent_object=parent.labware.as_labware()._implementation
+                parent_object=parent.labware.as_labware()._implementation,
             ),
             display_name=well_name,
             has_tip=has_tip,
-            name="A1"
-        )
+            name="A1",
+        ),
     )
     assert well.parent == lw
     assert well.top().labware.object == well
@@ -311,8 +321,7 @@ def test_well_parent(corning_96_wellplate_360ul_flat):
     assert well.center().labware.parent.object == lw
 
 
-def test_tip_tracking_init(corning_96_wellplate_360ul_flat,
-                           opentrons_96_tiprack_300ul):
+def test_tip_tracking_init(corning_96_wellplate_360ul_flat, opentrons_96_tiprack_300ul):
     tiprack = opentrons_96_tiprack_300ul
     assert tiprack.is_tiprack
     for well in tiprack.wells():
@@ -360,8 +369,7 @@ def test_use_tips(opentrons_96_tiprack_300ul):
         assert well.has_tip
 
 
-def test_select_next_tip(opentrons_96_tiprack_300ul,
-                         opentrons_96_tiprack_300ul_def):
+def test_select_next_tip(opentrons_96_tiprack_300ul, opentrons_96_tiprack_300ul_def):
     tiprack = opentrons_96_tiprack_300ul
     well_list = tiprack.wells()
 
@@ -414,9 +422,9 @@ def test_select_next_tip(opentrons_96_tiprack_300ul,
     early_tr = labware.Labware(
         implementation=LabwareImplementation(
             definition=opentrons_96_tiprack_300ul_def,
-            parent=Location(Point(0, 0, 0), 'Test Slot')
+            parent=Location(Point(0, 0, 0), "Test Slot"),
         ),
-        api_level=APIVersion(2, 1)
+        api_level=APIVersion(2, 1),
     )
     early_tr.use_tips(well_list[0])
     with pytest.raises(AssertionError):
@@ -463,77 +471,79 @@ def test_return_tips(opentrons_96_tiprack_300ul):
     assert not tiprack.wells()[8].has_tip
 
 
-@pytest.mark.parametrize(
-    'v1_module_name', ['tempdeck', 'magdeck', 'thermocycler'])
+@pytest.mark.parametrize("v1_module_name", ["tempdeck", "magdeck", "thermocycler"])
 def test_module_load_v1(v1_module_name):
-    module_defs = json.loads(
-        load_shared_data('module/definitions/1.json'))
+    module_defs = json.loads(load_shared_data("module/definitions/1.json"))
     model = module_geometry.resolve_module_model(v1_module_name)
-    mod = module_geometry.load_module(
-        model, Location(Point(0, 0, 0), 'test'))
+    mod = module_geometry.load_module(model, Location(Point(0, 0, 0), "test"))
     mod_def = module_defs[v1_module_name]
-    offset = Point(mod_def['labwareOffset']['x'],
-                   mod_def['labwareOffset']['y'],
-                   mod_def['labwareOffset']['z'])
-    high_z = mod_def['dimensions']['bareOverallHeight']
+    offset = Point(
+        mod_def["labwareOffset"]["x"],
+        mod_def["labwareOffset"]["y"],
+        mod_def["labwareOffset"]["z"],
+    )
+    high_z = mod_def["dimensions"]["bareOverallHeight"]
     assert mod.highest_z == high_z
     assert mod.location.point == offset
-    mod = module_geometry.load_module(
-        model, Location(Point(1, 2, 3), 'test'))
+    mod = module_geometry.load_module(model, Location(Point(1, 2, 3), "test"))
     assert mod.highest_z == high_z + 3
     assert mod.location.point == (offset + Point(1, 2, 3))
     mod2 = module_geometry.load_module_from_definition(
         module_defs[v1_module_name],
-        Location(Point(3, 2, 1), 'test2'),
-        module_geometry.ThermocyclerConfiguration.FULL)
+        Location(Point(3, 2, 1), "test2"),
+        module_geometry.ThermocyclerConfiguration.FULL,
+    )
     assert mod2.highest_z == high_z + 1
     assert mod2.location.point == (offset + Point(3, 2, 1))
 
 
 @pytest.mark.parametrize(
-    'module_model',
+    "module_model",
     list(module_geometry.MagneticModuleModel)
     + list(module_geometry.TemperatureModuleModel)
-    + list(module_geometry.ThermocyclerModuleModel))
+    + list(module_geometry.ThermocyclerModuleModel),
+)
 def test_module_load_v2(module_model):
-    mod = module_geometry.load_module(
-        module_model, Location(Point(0, 0, 0), '3'))
-    mod_def = module_geometry._load_module_definition(MAX_SUPPORTED_VERSION,
-                                                      module_model)
-    high_z = mod_def['dimensions']['bareOverallHeight']
+    mod = module_geometry.load_module(module_model, Location(Point(0, 0, 0), "3"))
+    mod_def = module_geometry._load_module_definition(
+        MAX_SUPPORTED_VERSION, module_model
+    )
+    high_z = mod_def["dimensions"]["bareOverallHeight"]
     assert mod.highest_z == high_z
 
 
 @pytest.mark.parametrize(
-    'module_name', [
-        'tempdeck',
-        'magdeck',
-        'temperature module',
-        'temperature module gen2',
-        'thermocycler',
-        'thermocycler module',
-        'magnetic module',
-        'magnetic module gen2',
-        'magneticModuleV1',
-        'magneticModuleV2',
-        'temperatureModuleV1',
-        'temperatureModuleV2',
-        'thermocyclerModuleV1'
-        ])
+    "module_name",
+    [
+        "tempdeck",
+        "magdeck",
+        "temperature module",
+        "temperature module gen2",
+        "thermocycler",
+        "thermocycler module",
+        "magnetic module",
+        "magnetic module gen2",
+        "magneticModuleV1",
+        "magneticModuleV2",
+        "temperatureModuleV1",
+        "temperatureModuleV2",
+        "thermocyclerModuleV1",
+    ],
+)
 def test_module_load_labware(module_name):
-    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_name = "corning_96_wellplate_360ul_flat"
     labware_def = labware.get_labware_definition(labware_name)
     model = module_geometry.resolve_module_model(module_name)
-    mod = module_geometry.load_module(
-        model, Location(Point(0, 0, 0), 'test'))
+    mod = module_geometry.load_module(model, Location(Point(0, 0, 0), "test"))
     old_z = mod.highest_z
     lw = labware.load_from_definition(labware_def, mod.location)
     mod.add_labware(lw)
     assert mod.labware == lw
-    assert mod.highest_z ==\
-        (mod.location.point.z
-         + labware_def['dimensions']['zDimension']
-         + mod._over_labware)
+    assert mod.highest_z == (
+        mod.location.point.z
+        + labware_def["dimensions"]["zDimension"]
+        + mod._over_labware
+    )
     with pytest.raises(AssertionError):
         mod.add_labware(lw)
     mod.reset_labware()
@@ -542,98 +552,93 @@ def test_module_load_labware(module_name):
 
 
 def test_tiprack_list():
-    labware_name = 'opentrons_96_tiprack_300ul'
+    labware_name = "opentrons_96_tiprack_300ul"
     labware_def = labware.get_labware_definition(labware_name)
     tiprack = labware.Labware(
-        implementation=LabwareImplementation(labware_def,
-                                             Location(Point(0, 0, 0),
-                                                      'Test Slot'
-                                                      )
-                                             )
+        implementation=LabwareImplementation(
+            labware_def, Location(Point(0, 0, 0), "Test Slot")
+        )
     )
     tiprack_2 = labware.Labware(
-        implementation=LabwareImplementation(labware_def,
-                                             Location(Point(0, 0, 0),
-                                                      'Test Slot'
-                                                      )
-                                             )
+        implementation=LabwareImplementation(
+            labware_def, Location(Point(0, 0, 0), "Test Slot")
+        )
     )
 
-    assert labware.select_tiprack_from_list(
-        [tiprack], 1) == (tiprack, tiprack['A1'])
+    assert labware.select_tiprack_from_list([tiprack], 1) == (tiprack, tiprack["A1"])
 
-    assert labware.select_tiprack_from_list(
-        [tiprack], 1, tiprack.wells()[1]) == (tiprack, tiprack['B1'])
+    assert labware.select_tiprack_from_list([tiprack], 1, tiprack.wells()[1]) == (
+        tiprack,
+        tiprack["B1"],
+    )
 
-    tiprack['C1'].has_tip = False
-    assert labware.select_tiprack_from_list(
-        [tiprack], 1, tiprack.wells()[2]) == (tiprack, tiprack['D1'])
+    tiprack["C1"].has_tip = False
+    assert labware.select_tiprack_from_list([tiprack], 1, tiprack.wells()[2]) == (
+        tiprack,
+        tiprack["D1"],
+    )
 
-    tiprack['H12'].has_tip = False
-    tiprack_2['A1'].has_tip = False
+    tiprack["H12"].has_tip = False
+    tiprack_2["A1"].has_tip = False
     assert labware.select_tiprack_from_list(
-        [tiprack, tiprack_2], 1, tiprack.wells()[95]) == (
-            tiprack_2, tiprack_2['B1'])
+        [tiprack, tiprack_2], 1, tiprack.wells()[95]
+    ) == (tiprack_2, tiprack_2["B1"])
 
     with pytest.raises(labware.OutOfTipsError):
-        labware.select_tiprack_from_list(
-            [tiprack], 1, tiprack.wells()[95])
+        labware.select_tiprack_from_list([tiprack], 1, tiprack.wells()[95])
 
 
 def test_uris():
-    details = ('opentrons', 'opentrons_96_tiprack_300ul', '1')
-    uri = 'opentrons/opentrons_96_tiprack_300ul/1'
+    details = ("opentrons", "opentrons_96_tiprack_300ul", "1")
+    uri = "opentrons/opentrons_96_tiprack_300ul/1"
     assert helpers.uri_from_details(*details) == uri
     defn = labware.get_labware_definition(details[1], details[0], details[2])
     assert helpers.uri_from_definition(defn) == uri
     lw = labware.Labware(
-        implementation=LabwareImplementation(defn,
-                                             Location(Point(0, 0, 0),
-                                                      'Test Slot')
-                                             )
+        implementation=LabwareImplementation(
+            defn, Location(Point(0, 0, 0), "Test Slot")
+        )
     )
     assert lw.uri == uri
 
 
 @pytest.mark.parametrize(
-    'labware_name', [
-        'nest_96_wellplate_2ml_deep',
-        'corning_384_wellplate_112ul_flat',
-        'geb_96_tiprack_1000ul',
-        'nest_12_reservoir_15ml'])
+    "labware_name",
+    [
+        "nest_96_wellplate_2ml_deep",
+        "corning_384_wellplate_112ul_flat",
+        "geb_96_tiprack_1000ul",
+        "nest_12_reservoir_15ml",
+    ],
+)
 def test_add_index_file(labware_name, labware_offset_tempdir):
     deck = Deck()
     parent = deck.position_for(1)
     definition = labware.get_labware_definition(labware_name)
-    lw = labware.Labware(
-        implementation=LabwareImplementation(definition, parent))
+    lw = labware.Labware(implementation=LabwareImplementation(definition, parent))
     labware_hash = helpers.hash_labware_def(definition)
     labware.save_calibration(lw, Point(0, 0, 0))
 
     lw_uri = helpers.uri_from_definition(definition)
 
     str_parent = _get_parent_identifier(lw._implementation)
-    slot = '1'
+    slot = "1"
     if str_parent:
-        mod_dict = {str_parent: f'{slot}-{str_parent}'}
+        mod_dict = {str_parent: f"{slot}-{str_parent}"}
     else:
         mod_dict = {}
-    full_id = f'{labware_hash}{str_parent}'
-    blob = {
-            "uri": f'{lw_uri}',
-            "slot": full_id,
-            "module": mod_dict
-        }
+    full_id = f"{labware_hash}{str_parent}"
+    blob = {"uri": f"{lw_uri}", "slot": full_id, "module": mod_dict}
 
-    lw_path = labware_offset_tempdir / 'index.json'
+    lw_path = labware_offset_tempdir / "index.json"
     info = file_operators.read_cal_file(lw_path)
-    assert info['data'][full_id] == blob
+    assert info["data"][full_id] == blob
 
 
 def test_delete_one_calibration(set_up_index_file):
-    lw_to_delete = 'nest_96_wellplate_2ml_deep'
+    lw_to_delete = "nest_96_wellplate_2ml_deep"
     all_cals = get.get_all_calibrations()
-    id_saved = ''
+    id_saved = ""
 
     def get_load_names(all_cals):
         nonlocal id_saved
@@ -659,46 +664,54 @@ def test_delete_one_calibration(set_up_index_file):
 
 
 def test_get_parent_identifier():
-    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_name = "corning_96_wellplate_360ul_flat"
     labware_def = labware.get_labware_definition(labware_name)
     lw = labware.Labware(
-        implementation=LabwareImplementation(labware_def,
-                                             Location(Point(0, 0, 0),
-                                                      'Test Slot'))
+        implementation=LabwareImplementation(
+            labware_def, Location(Point(0, 0, 0), "Test Slot")
+        )
     )
     # slots have no parent identifier
-    assert _get_parent_identifier(lw._implementation) == ''
+    assert _get_parent_identifier(lw._implementation) == ""
     # modules do
-    mmg = ModuleGeometry('my magdeck',
-                         MagneticModuleModel.MAGNETIC_V1,
-                         ModuleType.MAGNETIC,
-                         Point(0, 0, 0), 10, 10, Location(Point(1, 2, 3), '3'),
-                         APIVersion(2, 4))
+    mmg = ModuleGeometry(
+        "my magdeck",
+        MagneticModuleModel.MAGNETIC_V1,
+        ModuleType.MAGNETIC,
+        Point(0, 0, 0),
+        10,
+        10,
+        Location(Point(1, 2, 3), "3"),
+        APIVersion(2, 4),
+    )
     lw = labware.Labware(
         implementation=LabwareImplementation(labware_def, mmg.location)
     )
-    assert _get_parent_identifier(lw._implementation)\
+    assert (
+        _get_parent_identifier(lw._implementation)
         == MagneticModuleModel.MAGNETIC_V1.value
+    )
 
 
 def test_labware_hash_func_same_implementation(minimal_labware_def):
     """Test that multiple Labware objects with same implementation and version
     have the same __hash__"""
-    impl = LabwareImplementation(minimal_labware_def,
-                                 Location(Point(0, 0, 0),
-                                          'Test Slot'))
-    s = set(labware.Labware(implementation=impl,
-                            api_level=APIVersion(2, 3)) for i in range(10))
+    impl = LabwareImplementation(
+        minimal_labware_def, Location(Point(0, 0, 0), "Test Slot")
+    )
+    s = set(
+        labware.Labware(implementation=impl, api_level=APIVersion(2, 3))
+        for i in range(10)
+    )
     assert len(s) == 1
 
 
-def test_labware_hash_func_same_implementation_different_version(
-        minimal_labware_def):
+def test_labware_hash_func_same_implementation_different_version(minimal_labware_def):
     """Test that multiple Labware objects with same implementation yet
     different version have different __hash__"""
-    impl = LabwareImplementation(minimal_labware_def,
-                                 Location(Point(0, 0, 0),
-                                          'Test Slot'))
+    impl = LabwareImplementation(
+        minimal_labware_def, Location(Point(0, 0, 0), "Test Slot")
+    )
 
     l1 = labware.Labware(implementation=impl, api_level=APIVersion(2, 3))
     l2 = labware.Labware(implementation=impl, api_level=APIVersion(2, 4))
@@ -706,16 +719,15 @@ def test_labware_hash_func_same_implementation_different_version(
     assert len({l1, l2}) == 2
 
 
-def test_labware_hash_func_diff_implementation_same_version(
-        minimal_labware_def):
+def test_labware_hash_func_diff_implementation_same_version(minimal_labware_def):
     """Test that multiple Labware objects with different implementation yet
     sane version have different __hash__"""
-    impl1 = LabwareImplementation(minimal_labware_def,
-                                  Location(Point(0, 0, 0),
-                                           'Test Slot'))
-    impl2 = LabwareImplementation(minimal_labware_def,
-                                  Location(Point(0, 0, 0),
-                                           'Test Slot2'))
+    impl1 = LabwareImplementation(
+        minimal_labware_def, Location(Point(0, 0, 0), "Test Slot")
+    )
+    impl2 = LabwareImplementation(
+        minimal_labware_def, Location(Point(0, 0, 0), "Test Slot2")
+    )
 
     l1 = labware.Labware(implementation=impl1, api_level=APIVersion(2, 3))
     l2 = labware.Labware(implementation=impl2, api_level=APIVersion(2, 3))

--- a/api/tests/opentrons/protocol_api/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api/test_labware_load.py
@@ -2,39 +2,36 @@ import pytest
 from opentrons import protocol_api as papi, types
 
 
-labware_name = 'corning_96_wellplate_360ul_flat'
+labware_name = "corning_96_wellplate_360ul_flat"
 
 
 def test_load_to_slot(ctx):
-    labware = ctx.load_labware(labware_name, '1')
-    assert labware._implementation.get_geometry().offset == \
-           types.Point(0, 0, 0)
+    labware = ctx.load_labware(labware_name, "1")
+    assert labware._implementation.get_geometry().offset == types.Point(0, 0, 0)
     other = ctx.load_labware(labware_name, 2)
-    assert other._implementation.get_geometry().offset ==\
-           types.Point(132.5, 0, 0)
+    assert other._implementation.get_geometry().offset == types.Point(132.5, 0, 0)
 
 
 def test_loaded(ctx):
-    labware = ctx.load_labware(labware_name, '1')
+    labware = ctx.load_labware(labware_name, "1")
     assert ctx.loaded_labwares[1] == labware
 
 
 def test_get_incorrect_definition_by_name():
     with pytest.raises(FileNotFoundError):
-        papi.labware.get_labware_definition('fake_labware')
+        papi.labware.get_labware_definition("fake_labware")
 
 
 def test_get_mixed_case_labware_def():
-    dfn = papi.labware.get_labware_definition(
-        'COrnIng_96_wElLplaTE_360UL_Flat')
-    assert dfn['parameters']['loadName'] == labware_name
+    dfn = papi.labware.get_labware_definition("COrnIng_96_wElLplaTE_360UL_Flat")
+    assert dfn["parameters"]["loadName"] == labware_name
 
 
 def test_load_label(ctx):
-    labware = ctx.load_labware(labware_name, '1', 'my cool labware')
-    assert 'my cool labware' in str(labware)
+    labware = ctx.load_labware(labware_name, "1", "my cool labware")
+    assert "my cool labware" in str(labware)
 
 
 def test_deprecated_load(ctx):
-    labware = ctx.load_labware_by_name(labware_name, '1', 'my cool labware')
-    assert 'my cool labware' in str(labware)
+    labware = ctx.load_labware_by_name(labware_name, "1", "my cool labware")
+    assert "my cool labware" in str(labware)

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -5,11 +5,17 @@ import mock
 from opentrons.hardware_control.modules.magdeck import OFFSET_TO_LABWARE_BOTTOM
 import opentrons.protocol_api as papi
 import opentrons.protocols.geometry as papi_geometry
-from opentrons.hardware_control.modules.types import ModuleModel, ModuleType, \
-    TemperatureModuleModel, MagneticModuleModel, ThermocyclerModuleModel
+from opentrons.hardware_control.modules.types import (
+    ModuleModel,
+    ModuleType,
+    TemperatureModuleModel,
+    MagneticModuleModel,
+    ThermocyclerModuleModel,
+)
 from opentrons.protocol_api import ProtocolContext
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 from opentrons_shared_data import load_shared_data
 from opentrons.types import Point, Location
 
@@ -26,16 +32,19 @@ def mock_module_controller() -> mock.MagicMock:
 
 @pytest.fixture
 def ctx_with_tempdeck(
-        mock_hardware: mock.MagicMock, mock_module_controller: mock.MagicMock
+    mock_hardware: mock.MagicMock, mock_module_controller: mock.MagicMock
 ) -> ProtocolContext:
     """Context fixture with a mock temp deck."""
     mock_module_controller.model.return_value = "temperatureModuleV2"
 
     def find_modules(resolved_model: ModuleModel, resolved_type: ModuleType):
-        if resolved_model == TemperatureModuleModel.TEMPERATURE_V1\
-                and resolved_type == ModuleType.TEMPERATURE:
+        if (
+            resolved_model == TemperatureModuleModel.TEMPERATURE_V1
+            and resolved_type == ModuleType.TEMPERATURE
+        ):
             return [mock_module_controller], None
         return []
+
     mock_hardware.find_modules.side_effect = find_modules
     return ProtocolContext(
         implementation=ProtocolContextImplementation(hardware=mock_hardware),
@@ -44,16 +53,19 @@ def ctx_with_tempdeck(
 
 @pytest.fixture
 def ctx_with_magdeck(
-        mock_hardware: mock.AsyncMock, mock_module_controller: mock.MagicMock
+    mock_hardware: mock.AsyncMock, mock_module_controller: mock.MagicMock
 ) -> ProtocolContext:
     """Context fixture with a mock mag deck."""
     mock_module_controller.model.return_value = "magneticModuleV1"
 
     def find_modules(resolved_model: ModuleModel, resolved_type: ModuleType):
-        if resolved_model == MagneticModuleModel.MAGNETIC_V1 and\
-                resolved_type == ModuleType.MAGNETIC:
+        if (
+            resolved_model == MagneticModuleModel.MAGNETIC_V1
+            and resolved_type == ModuleType.MAGNETIC
+        ):
             return [mock_module_controller], None
         return []
+
     mock_hardware.find_modules.side_effect = find_modules
     return ProtocolContext(
         implementation=ProtocolContextImplementation(hardware=mock_hardware),
@@ -62,16 +74,19 @@ def ctx_with_magdeck(
 
 @pytest.fixture
 def ctx_with_thermocycler(
-        mock_hardware: mock.AsyncMock, mock_module_controller: mock.MagicMock
+    mock_hardware: mock.AsyncMock, mock_module_controller: mock.MagicMock
 ) -> ProtocolContext:
     """Context fixture with a mock thermocycler."""
     mock_module_controller.model.return_value = "thermocyclerModuleV1"
 
     def find_modules(resolved_model: ModuleModel, resolved_type: ModuleType):
-        if resolved_model == ThermocyclerModuleModel.THERMOCYCLER_V1 and \
-                resolved_type == ModuleType.THERMOCYCLER:
+        if (
+            resolved_model == ThermocyclerModuleModel.THERMOCYCLER_V1
+            and resolved_type == ModuleType.THERMOCYCLER
+        ):
             return [mock_module_controller], None
         return []
+
     mock_hardware.find_modules.side_effect = find_modules
     return ProtocolContext(
         implementation=ProtocolContextImplementation(hardware=mock_hardware),
@@ -80,54 +95,56 @@ def ctx_with_thermocycler(
 
 def test_load_module(ctx_with_tempdeck):
     ctx_with_tempdeck.home()
-    mod = ctx_with_tempdeck.load_module('tempdeck', 1)
+    mod = ctx_with_tempdeck.load_module("tempdeck", 1)
     assert isinstance(mod, papi.TemperatureModuleContext)
 
 
 def test_load_module_default_slot(ctx_with_thermocycler):
     ctx_with_thermocycler.home()
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     assert isinstance(mod, papi.ThermocyclerContext)
 
 
 def test_no_slot_module_error(ctx_with_magdeck):
     ctx_with_magdeck.home()
     with pytest.raises(AssertionError):
-        assert ctx_with_magdeck.load_module('magdeck')
+        assert ctx_with_magdeck.load_module("magdeck")
 
 
 def test_invalid_slot_module_error(ctx_with_thermocycler):
     ctx_with_thermocycler.home()
     with pytest.raises(AssertionError):
-        assert ctx_with_thermocycler.load_module('thermocycler', 1)
+        assert ctx_with_thermocycler.load_module("thermocycler", 1)
 
 
 def test_bad_slot_module_error(ctx_with_tempdeck):
     ctx_with_tempdeck.home()
     with pytest.raises(ValueError):
-        assert ctx_with_tempdeck.load_module('thermocycler', 42)
+        assert ctx_with_tempdeck.load_module("thermocycler", 42)
 
 
 def test_incorrect_module_error(ctx_with_tempdeck):
     ctx_with_tempdeck.home()
     with pytest.raises(ValueError):
-        assert ctx_with_tempdeck.load_module('the cool module', 1)
+        assert ctx_with_tempdeck.load_module("the cool module", 1)
 
 
 @pytest.mark.parametrize(
-    'loadname,klass,model',
-    [('tempdeck', papi.TemperatureModuleContext, 'temperatureModuleV1'),
-     ('temperature module',
-      papi.TemperatureModuleContext,
-      'temperatureModuleV1'),
-     ('temperature module gen2',
-      papi.TemperatureModuleContext,
-      'temperatureModuleV2'),
-     ('magdeck', papi.MagneticModuleContext, 'magneticModuleV1'),
-     ('magnetic module', papi.MagneticModuleContext, 'magneticModuleV1'),
-     ('magnetic module gen2', papi.MagneticModuleContext, 'magneticModuleV2'),
-     ('thermocycler', papi.ThermocyclerContext, 'thermocyclerModuleV1'),
-     ('thermocycler module', papi.ThermocyclerContext, 'thermocyclerModuleV1')]
+    "loadname,klass,model",
+    [
+        ("tempdeck", papi.TemperatureModuleContext, "temperatureModuleV1"),
+        ("temperature module", papi.TemperatureModuleContext, "temperatureModuleV1"),
+        (
+            "temperature module gen2",
+            papi.TemperatureModuleContext,
+            "temperatureModuleV2",
+        ),
+        ("magdeck", papi.MagneticModuleContext, "magneticModuleV1"),
+        ("magnetic module", papi.MagneticModuleContext, "magneticModuleV1"),
+        ("magnetic module gen2", papi.MagneticModuleContext, "magneticModuleV2"),
+        ("thermocycler", papi.ThermocyclerContext, "thermocyclerModuleV1"),
+        ("thermocycler module", papi.ThermocyclerContext, "thermocyclerModuleV1"),
+    ],
 )
 def test_load_simulating_module(ctx, loadname, klass, model):
     # Check that a known module will not throw an error if
@@ -140,54 +157,56 @@ def test_load_simulating_module(ctx, loadname, klass, model):
 
 
 def test_tempdeck(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     assert ctx_with_tempdeck.deck[1] == mod._geometry
 
 
 def test_tempdeck_target(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     m = mock.PropertyMock(return_value=0x1337)
     type(mock_module_controller).target = m
     assert mod.target == 0x1337
 
 
 def test_tempdeck_set_temperature(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     mod.set_temperature(20)
-    assert 'setting temperature' in ','.join(
-        cmd.lower() for cmd in ctx_with_tempdeck.commands())
+    assert "setting temperature" in ",".join(
+        cmd.lower() for cmd in ctx_with_tempdeck.commands()
+    )
     mock_module_controller.set_temperature.assert_called_once_with(20)
 
 
 def test_tempdeck_temperature(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
-    m = mock.PropertyMock(return_value=0xdead)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
+    m = mock.PropertyMock(return_value=0xDEAD)
     type(mock_module_controller).temperature = m
-    assert mod.temperature == 0xdead
+    assert mod.temperature == 0xDEAD
 
 
 def test_tempdeck_deactivate(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     mod.deactivate()
-    assert 'deactivating temperature' in ','.join(
-        cmd.lower() for cmd in ctx_with_tempdeck.commands())
+    assert "deactivating temperature" in ",".join(
+        cmd.lower() for cmd in ctx_with_tempdeck.commands()
+    )
     mock_module_controller.deactivate.assert_called_once()
 
 
 def test_tempdeck_status(ctx_with_tempdeck, mock_module_controller):
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     m = mock.PropertyMock(return_value="some status")
     type(mock_module_controller).status = m
     assert mod.status == "some status"
 
 
 def test_magdeck(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     assert ctx_with_magdeck.deck[1] == mod._geometry
 
 
 def test_magdeck_status(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     m = mock.PropertyMock(return_value="disengaged")
     type(mock_module_controller).status = m
     assert mod.status == "disengaged"
@@ -195,225 +214,246 @@ def test_magdeck_status(ctx_with_magdeck, mock_module_controller):
 
 def test_magdeck_engage_no_height_no_labware(ctx_with_magdeck, mock_module_controller):
     """It should raise an error."""
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     with pytest.raises(ValueError):
         mod.engage()
 
 
 def test_magdeck_engage_with_height(ctx_with_magdeck, mock_module_controller):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     mod.engage(height=2)
-    assert 'engaging magnetic' in ','.join(
-        cmd.lower() for cmd in ctx_with_magdeck.commands())
+    assert "engaging magnetic" in ",".join(
+        cmd.lower() for cmd in ctx_with_magdeck.commands()
+    )
     mock_module_controller.engage.assert_called_once_with(2)
 
 
-def test_magdeck_engage_with_height_from_base(
-        ctx_with_magdeck, mock_module_controller
-):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+def test_magdeck_engage_with_height_from_base(ctx_with_magdeck, mock_module_controller):
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     mod.engage(height_from_base=2)
     mock_module_controller.engage.assert_called_once_with(7)
 
 
-def test_magdeck_disengage(
-        ctx_with_magdeck, mock_module_controller
-):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+def test_magdeck_disengage(ctx_with_magdeck, mock_module_controller):
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     mod.disengage()
-    assert 'disengaging magnetic' in ','.join(
-        cmd.lower() for cmd in ctx_with_magdeck.commands())
+    assert "disengaging magnetic" in ",".join(
+        cmd.lower() for cmd in ctx_with_magdeck.commands()
+    )
     mock_module_controller.deactivate.assert_called_once_with()
 
 
-def test_magdeck_calibrate(
-        ctx_with_magdeck, mock_module_controller
-):
-    mod = ctx_with_magdeck.load_module('Magnetic Module', 1)
+def test_magdeck_calibrate(ctx_with_magdeck, mock_module_controller):
+    mod = ctx_with_magdeck.load_module("Magnetic Module", 1)
     mod.calibrate()
-    assert 'calibrating magnetic' in ','.join(
-        cmd.lower() for cmd in ctx_with_magdeck.commands())
+    assert "calibrating magnetic" in ",".join(
+        cmd.lower() for cmd in ctx_with_magdeck.commands()
+    )
     mock_module_controller.calibrate.assert_called_once()
 
 
 def test_thermocycler(ctx_with_thermocycler, mock_module_controller):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     assert ctx_with_thermocycler.deck[7] == mod._geometry
 
 
 def test_thermocycler_lid_status(ctx_with_thermocycler, mock_module_controller):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     m = mock.PropertyMock(return_value="open")
     type(mock_module_controller).lid_status = m
-    assert mod.lid_position == 'open'
+    assert mod.lid_position == "open"
 
 
-def test_thermocycler_lid(
-        ctx_with_thermocycler, mock_module_controller
-):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+def test_thermocycler_lid(ctx_with_thermocycler, mock_module_controller):
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     # Open should work if the lid is open (no status change)
     mock_module_controller.open.return_value = "open"
     mod.open_lid()
-    assert 'opening thermocycler lid' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+    assert "opening thermocycler lid" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.open.assert_called_once()
-    assert mod._geometry.lid_status == 'open'
+    assert mod._geometry.lid_status == "open"
     assert mod._geometry.highest_z == 98.0
 
     mock_module_controller.close.return_value = "closed"
     mod.close_lid()
-    assert 'closing thermocycler lid' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+    assert "closing thermocycler lid" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.close.assert_called_once()
-    assert mod._geometry.lid_status == 'closed'
+    assert mod._geometry.lid_status == "closed"
     assert mod._geometry.highest_z == 98.0  # ignore 37.7mm lid for now
 
 
 def test_thermocycler_set_lid_temperature(
-        ctx_with_thermocycler, mock_module_controller
+    ctx_with_thermocycler, mock_module_controller
 ):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     mod.set_lid_temperature(123)
     mock_module_controller.set_lid_temperature.assert_called_once_with(123)
 
 
 def test_thermocycler_temp_default_ramp_rate(
-        ctx_with_thermocycler, mock_module_controller
+    ctx_with_thermocycler, mock_module_controller
 ):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
 
     # Test default ramp rate
     mod.set_block_temperature(20, hold_time_seconds=5.0, hold_time_minutes=1.0)
-    assert 'setting thermocycler' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+    assert "setting thermocycler" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.set_temperature.assert_called_once_with(
-        temperature=20, hold_time_seconds=5.0, hold_time_minutes=1.0,
-        ramp_rate=None, volume=None,
+        temperature=20,
+        hold_time_seconds=5.0,
+        hold_time_minutes=1.0,
+        ramp_rate=None,
+        volume=None,
     )
 
 
 def test_thermocycler_temp_specific_ramp_rate(
-        ctx_with_thermocycler, mock_module_controller
+    ctx_with_thermocycler, mock_module_controller
 ):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     # Test specified ramp rate
     mod.set_block_temperature(41.3, hold_time_seconds=25.5, ramp_rate=2.0)
-    assert 'setting thermocycler' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+    assert "setting thermocycler" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.set_temperature.assert_called_once_with(
-        temperature=41.3, hold_time_seconds=25.5, hold_time_minutes=None,
-        ramp_rate=2.0, volume=None,
+        temperature=41.3,
+        hold_time_seconds=25.5,
+        hold_time_minutes=None,
+        ramp_rate=2.0,
+        volume=None,
     )
 
 
-def test_thermocycler_temp_infinite_hold(
-        ctx_with_thermocycler, mock_module_controller
-):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+def test_thermocycler_temp_infinite_hold(ctx_with_thermocycler, mock_module_controller):
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     # Test infinite hold and volume
     mod.set_block_temperature(13.2, block_max_volume=123)
-    assert 'setting thermocycler' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+    assert "setting thermocycler" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.set_temperature.assert_called_once_with(
-        temperature=13.2, hold_time_seconds=None, hold_time_minutes=None,
-        ramp_rate=None, volume=123,
+        temperature=13.2,
+        hold_time_seconds=None,
+        hold_time_minutes=None,
+        ramp_rate=None,
+        volume=123,
     )
 
 
 def test_thermocycler_profile_invalid_repetitions(
-        ctx_with_thermocycler, mock_module_controller
+    ctx_with_thermocycler, mock_module_controller
 ):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
 
     with pytest.raises(ValueError, match="positive integer"):
         mod.execute_profile(
-            steps=[{'temperature': 10, 'hold_time_seconds': 30},
-                   {'temperature': 30, 'hold_time_seconds': 90}],
-            repetitions=-1)
+            steps=[
+                {"temperature": 10, "hold_time_seconds": 30},
+                {"temperature": 30, "hold_time_seconds": 90},
+            ],
+            repetitions=-1,
+        )
 
 
 def test_thermocycler_profile_no_temperature(
-        ctx_with_thermocycler, mock_module_controller
+    ctx_with_thermocycler, mock_module_controller
 ):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     with pytest.raises(ValueError, match="temperature must be defined"):
         mod.execute_profile(
-            steps=[{'temperature': 10, 'hold_time_seconds': 30},
-                   {'hold_time_seconds': 90}],
-            repetitions=5)
+            steps=[
+                {"temperature": 10, "hold_time_seconds": 30},
+                {"hold_time_seconds": 90},
+            ],
+            repetitions=5,
+        )
 
 
-def test_thermocycler_profile_no_hold(
-        ctx_with_thermocycler, mock_module_controller
-):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
+def test_thermocycler_profile_no_hold(ctx_with_thermocycler, mock_module_controller):
+    mod = ctx_with_thermocycler.load_module("thermocycler")
     with pytest.raises(
-            ValueError, match="either hold_time_minutes or hold_time_seconds"
+        ValueError, match="either hold_time_minutes or hold_time_seconds"
     ):
         mod.execute_profile(
-            steps=[{'temperature': 10, 'hold_time_seconds': 30},
-                   {'temperature': 30}],
-            repetitions=5)
+            steps=[{"temperature": 10, "hold_time_seconds": 30}, {"temperature": 30}],
+            repetitions=5,
+        )
 
 
-def test_thermocycler_profile(
-        ctx_with_thermocycler, mock_module_controller
-):
-    mod = ctx_with_thermocycler.load_module('thermocycler')
-    mod.execute_profile(steps=[{'temperature': 10, 'hold_time_seconds': 30},
-                               {'temperature': 30, 'hold_time_seconds': 90}],
-                        repetitions=5,
-                        block_max_volume=123)
-    assert 'thermocycler starting' in ','.join(
-        cmd.lower() for cmd in ctx_with_thermocycler.commands())
+def test_thermocycler_profile(ctx_with_thermocycler, mock_module_controller):
+    mod = ctx_with_thermocycler.load_module("thermocycler")
+    mod.execute_profile(
+        steps=[
+            {"temperature": 10, "hold_time_seconds": 30},
+            {"temperature": 30, "hold_time_seconds": 90},
+        ],
+        repetitions=5,
+        block_max_volume=123,
+    )
+    assert "thermocycler starting" in ",".join(
+        cmd.lower() for cmd in ctx_with_thermocycler.commands()
+    )
     mock_module_controller.cycle_temperatures.assert_called_once_with(
-        steps=[{'temperature': 10, 'hold_time_seconds': 30},
-               {'temperature': 30, 'hold_time_seconds': 90}],
+        steps=[
+            {"temperature": 10, "hold_time_seconds": 30},
+            {"temperature": 30, "hold_time_seconds": 90},
+        ],
         repetitions=5,
         volume=123,
     )
 
 
 def test_module_load_labware(ctx_with_tempdeck):
-    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_name = "corning_96_wellplate_360ul_flat"
     # TODO Ian 2019-05-29 load fixtures, not real defs
     labware_def = json.loads(
-        load_shared_data(f'labware/definitions/2/{labware_name}/1.json'))
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+        load_shared_data(f"labware/definitions/2/{labware_name}/1.json")
+    )
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     assert mod.labware is None
     lw = mod.load_labware(labware_name)
-    lw_offset = Point(labware_def['cornerOffsetFromSlot']['x'],
-                      labware_def['cornerOffsetFromSlot']['y'],
-                      labware_def['cornerOffsetFromSlot']['z'])
-    assert lw._implementation.get_geometry().offset ==\
-           lw_offset + mod._geometry.location.point
+    lw_offset = Point(
+        labware_def["cornerOffsetFromSlot"]["x"],
+        labware_def["cornerOffsetFromSlot"]["y"],
+        labware_def["cornerOffsetFromSlot"]["z"],
+    )
+    assert (
+        lw._implementation.get_geometry().offset
+        == lw_offset + mod._geometry.location.point
+    )
     assert lw.name == labware_name
 
 
 def test_module_load_labware_with_label(ctx_with_tempdeck):
-    labware_name = 'corning_96_wellplate_360ul_flat'
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
-    lw = mod.load_labware(labware_name, label='my cool labware')
-    assert lw.name == 'my cool labware'
+    labware_name = "corning_96_wellplate_360ul_flat"
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
+    lw = mod.load_labware(labware_name, label="my cool labware")
+    assert lw.name == "my cool labware"
 
 
 def test_module_load_invalid_labware(ctx_with_tempdeck):
-    labware_name = 'corning_96_wellplate_360ul_flat'
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    labware_name = "corning_96_wellplate_360ul_flat"
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     # wrong version number
     with pytest.raises(FileNotFoundError):
-        mod.load_labware(labware_name, namespace='opentrons', version=100)
+        mod.load_labware(labware_name, namespace="opentrons", version=100)
     # wrong namespace
     with pytest.raises(FileNotFoundError):
-        mod.load_labware(labware_name, namespace='fake namespace', version=1)
+        mod.load_labware(labware_name, namespace="fake namespace", version=1)
     # valid info
-    assert mod.load_labware(labware_name, namespace='opentrons', version=1)
+    assert mod.load_labware(labware_name, namespace="opentrons", version=1)
 
 
 def test_deprecated_module_load_labware_by_name(ctx_with_tempdeck):
     """It should call load labware"""
-    mod = ctx_with_tempdeck.load_module('Temperature Module', 1)
+    mod = ctx_with_tempdeck.load_module("Temperature Module", 1)
     mod.load_labware = mock.MagicMock()
     mod.load_labware_by_name(
         name="a module", namespace="ns", label="a label", version=2
@@ -423,10 +463,11 @@ def test_deprecated_module_load_labware_by_name(ctx_with_tempdeck):
 
 async def test_magdeck_gen1_labware_props(ctx):
     # TODO Ian 2019-05-29 load fixtures, not real defs
-    labware_name = 'biorad_96_wellplate_200ul_pcr'
+    labware_name = "biorad_96_wellplate_200ul_pcr"
     labware_def = json.loads(
-        load_shared_data(f'labware/definitions/2/{labware_name}/1.json'))
-    mod = ctx.load_module('magdeck', 1)
+        load_shared_data(f"labware/definitions/2/{labware_name}/1.json")
+    )
+    mod = ctx.load_module("magdeck", 1)
     assert mod.labware is None
     mod.engage(height=45)
     assert mod._module.current_height == 45
@@ -434,7 +475,7 @@ async def test_magdeck_gen1_labware_props(ctx):
         mod.engage(height=45.1)  # max engage height for gen1 is 45 mm
     mod.load_labware(labware_name)
     mod.engage()
-    lw_offset = labware_def['parameters']['magneticModuleEngageHeight']
+    lw_offset = labware_def["parameters"]["magneticModuleEngageHeight"]
     assert await mod._module._driver.get_plate_height() == lw_offset
     mod.disengage()
     mod.engage(offset=2)
@@ -443,7 +484,7 @@ async def test_magdeck_gen1_labware_props(ctx):
     mod.engage(height=3)
     assert await mod._module._driver.get_plate_height() == 3
     mod._geometry.reset_labware()
-    labware_name = 'corning_96_wellplate_360ul_flat'
+    labware_name = "corning_96_wellplate_360ul_flat"
     mod.load_labware(labware_name)
     with pytest.raises(ValueError):
         mod.engage()
@@ -454,12 +495,14 @@ async def test_magdeck_gen1_labware_props(ctx):
     mod.engage(height=0)
     assert await mod._module._driver.get_plate_height() == 0
     mod.engage(height_from_base=2)
-    assert await mod._module._driver.get_plate_height() == 2 +\
-        OFFSET_TO_LABWARE_BOTTOM[mod._module.model()]
+    assert (
+        await mod._module._driver.get_plate_height()
+        == 2 + OFFSET_TO_LABWARE_BOTTOM[mod._module.model()]
+    )
 
 
 def test_magdeck_gen2_labware_props(ctx):
-    mod = ctx.load_module('magnetic module gen2', 1)
+    mod = ctx.load_module("magnetic module gen2", 1)
     mod.engage(height=25)
     assert mod._module.current_height == 25
     with pytest.raises(ValueError):
@@ -469,38 +512,37 @@ def test_magdeck_gen2_labware_props(ctx):
 
 
 def test_module_compatibility(get_module_fixture, monkeypatch):
-
     def load_fixtures(model):
         return get_module_fixture(model.value)
 
     monkeypatch.setattr(
-        papi_geometry.module_geometry, '_load_v2_module_def', load_fixtures)
+        papi_geometry.module_geometry, "_load_v2_module_def", load_fixtures
+    )
 
     class DummyEnum:
         def __init__(self, value: str):
             self.value = value
 
-        def __eq__(self, other: 'DummyEnum') -> bool:
+        def __eq__(self, other: "DummyEnum") -> bool:
             return self.value == other.value
 
     assert not papi_geometry.module_geometry.models_compatible(
-        DummyEnum('incompatibleGenerationV1'),
-        DummyEnum('incompatibleGenerationV2'))
+        DummyEnum("incompatibleGenerationV1"), DummyEnum("incompatibleGenerationV2")
+    )
     assert papi_geometry.module_geometry.models_compatible(
-        DummyEnum('incompatibleGenerationV2'),
-        DummyEnum('incompatibleGenerationV2'))
+        DummyEnum("incompatibleGenerationV2"), DummyEnum("incompatibleGenerationV2")
+    )
     assert papi_geometry.module_geometry.models_compatible(
-        DummyEnum('compatibleGenerationV1'),
-        DummyEnum('compatibleGenerationV1'))
+        DummyEnum("compatibleGenerationV1"), DummyEnum("compatibleGenerationV1")
+    )
     assert not papi_geometry.module_geometry.models_compatible(
-        DummyEnum('compatibleGenerationV1'),
-        DummyEnum('incompatibleGenerationV1')
+        DummyEnum("compatibleGenerationV1"), DummyEnum("incompatibleGenerationV1")
     )
 
 
 def test_thermocycler_semi_plate_configuration(ctx):
-    labware_name = 'nest_96_wellplate_100ul_pcr_full_skirt'
-    mod = ctx.load_module('thermocycler', configuration='semi')
+    labware_name = "nest_96_wellplate_100ul_pcr_full_skirt"
+    mod = ctx.load_module("thermocycler", configuration="semi")
     assert mod._geometry.labware_offset == Point(-23.28, 82.56, 97.8)
 
     tc_labware = mod.load_labware(labware_name)
@@ -516,9 +558,8 @@ def test_thermocycler_semi_plate_configuration(ctx):
 def test_thermocycler_flag_unsafe_move(ctx_with_thermocycler, mock_module_controller):
     """Flag unsafe should raise if the lid is open and source or target is
     the labware on thermocycler."""
-    mod = ctx_with_thermocycler.load_module('thermocycler',
-                                            configuration='semi')
-    labware_name = 'nest_96_wellplate_100ul_pcr_full_skirt'
+    mod = ctx_with_thermocycler.load_module("thermocycler", configuration="semi")
+    labware_name = "nest_96_wellplate_100ul_pcr_full_skirt"
     tc_labware = mod.load_labware(labware_name)
 
     with_tc_labware = Location(None, tc_labware)
@@ -527,9 +568,7 @@ def test_thermocycler_flag_unsafe_move(ctx_with_thermocycler, mock_module_contro
     m = mock.PropertyMock(return_value="closed")
     type(mock_module_controller).lid_status = m
 
-    with pytest.raises(RuntimeError,
-                       match="Cannot move to labware"):
+    with pytest.raises(RuntimeError, match="Cannot move to labware"):
         mod.flag_unsafe_move(with_tc_labware, without_tc_labware)
-    with pytest.raises(RuntimeError,
-                       match="Cannot move to labware"):
+    with pytest.raises(RuntimeError, match="Cannot move to labware"):
         mod.flag_unsafe_move(without_tc_labware, with_tc_labware)

--- a/api/tests/opentrons/protocol_api/test_offsets.py
+++ b/api/tests/opentrons/protocol_api/test_offsets.py
@@ -11,32 +11,26 @@ from opentrons.calibration_storage import (
     helpers,
     delete,
     encoder_decoder as ed,
-    types as cs_types)
+    types as cs_types,
+)
 from opentrons.protocol_api import labware
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.protocols.labware.definition import _get_labware_path
 from opentrons.types import Point, Location
 from opentrons.util.helpers import utc_now
 
-MOCK_HASH = 'mock_hash'
-PIPETTE_ID = 'pipette_id'
-URI = 'custom/minimal_labware_def/1'
+MOCK_HASH = "mock_hash"
+PIPETTE_ID = "pipette_id"
+URI = "custom/minimal_labware_def/1"
 
 minimalLabwareDef = {
-    "metadata": {
-        "displayName": "minimal labware"
-    },
-    "cornerOffsetFromSlot": {
-        "x": 10,
-        "y": 10,
-        "z": 5
-    },
+    "metadata": {"displayName": "minimal labware"},
+    "cornerOffsetFromSlot": {"x": 10, "y": 10, "z": 5},
     "parameters": {
         "isTiprack": True,
         "tipLength": 55.3,
         "tipOverlap": 2.8,
-        "loadName": "minimal_labware_def"
+        "loadName": "minimal_labware_def",
     },
     "ordering": [["A1"], ["A2"]],
     "wells": {
@@ -47,7 +41,7 @@ minimalLabwareDef = {
             "x": 0,
             "y": 0,
             "z": 0,
-            "shape": "circular"
+            "shape": "circular",
         },
         "A2": {
             "depth": 40,
@@ -56,33 +50,27 @@ minimalLabwareDef = {
             "x": 10,
             "y": 0,
             "z": 0,
-            "shape": "circular"
-        }
+            "shape": "circular",
+        },
     },
-    "dimensions": {
-        "xDimension": 1.0,
-        "yDimension": 2.0,
-        "zDimension": 3.0
-    },
+    "dimensions": {"xDimension": 1.0, "yDimension": 2.0, "zDimension": 3.0},
     "namespace": "custom",
-    "version": 1
+    "version": 1,
 }
 
 
 def path(calibration_name):
     return config.get_opentrons_path(
-        'labware_calibration_offsets_dir_v2') \
-        / '{}.json'.format(calibration_name)
+        "labware_calibration_offsets_dir_v2"
+    ) / "{}.json".format(calibration_name)
 
 
 def tlc_path(pip_id):
-    return config.get_tip_length_cal_path() \
-        / '{}.json'.format(pip_id)
+    return config.get_tip_length_cal_path() / "{}.json".format(pip_id)
 
 
 def custom_tiprack_path(uri):
-    return config.get_custom_tiprack_def_path() \
-        / '{}.json'.format(uri)
+    return config.get_custom_tiprack_def_path() / "{}.json".format(uri)
 
 
 def mock_hash_labware(labware_def):
@@ -123,7 +111,7 @@ def clear_tlc_calibration(monkeypatch):
         pass
     yield
     try:
-        os.remove(tlc_path('index'))
+        os.remove(tlc_path("index"))
     except FileNotFoundError:
         pass
 
@@ -132,15 +120,10 @@ def test_save_labware_calibration(monkeypatch, clear_calibration):
     # Test the save calibration file
     assert not os.path.exists(path(MOCK_HASH))
 
-    impl = LabwareImplementation(
-        minimalLabwareDef,
-        Location(Point(0, 0, 0), 'deck'))
+    impl = LabwareImplementation(minimalLabwareDef, Location(Point(0, 0, 0), "deck"))
     impl.set_calibration = Mock()
 
-    monkeypatch.setattr(
-        helpers,
-        'hash_labware_def', mock_hash_labware
-    )
+    monkeypatch.setattr(helpers, "hash_labware_def", mock_hash_labware)
 
     test_labware = labware.Labware(impl)
 
@@ -152,7 +135,7 @@ def test_save_labware_calibration(monkeypatch, clear_calibration):
 
 def test_json_datetime_encoder():
     fake_time = utc_now()
-    original = {'mock_hash': {'tipLength': 25.0, 'lastModified': fake_time}}
+    original = {"mock_hash": {"tipLength": 25.0, "lastModified": fake_time}}
 
     encoded = json.dumps(original, cls=ed.DateTimeEncoder)
     decoded = json.loads(encoded, cls=ed.DateTimeDecoder)
@@ -163,64 +146,55 @@ def test_create_tip_length_calibration_data(monkeypatch, clear_custom_tiprack_di
 
     fake_time = utc_now()
 
-    monkeypatch.setattr(modify, 'utc_now', lambda: fake_time)
+    monkeypatch.setattr(modify, "utc_now", lambda: fake_time)
 
-    monkeypatch.setattr(
-        helpers,
-        'hash_labware_def', mock_hash_labware)
+    monkeypatch.setattr(helpers, "hash_labware_def", mock_hash_labware)
 
     tip_length = 22.0
     expected_data = {
         MOCK_HASH: {
-            'tipLength': tip_length,
-            'lastModified': fake_time,
-            'source': cs_types.SourceType.user,
-            'status': {'markedBad': False},
-            'uri': URI
+            "tipLength": tip_length,
+            "lastModified": fake_time,
+            "source": cs_types.SourceType.user,
+            "status": {"markedBad": False},
+            "uri": URI,
         }
     }
     assert not os.path.exists(custom_tiprack_path(URI))
-    result = modify.create_tip_length_data(
-        minimalLabwareDef, tip_length)
+    result = modify.create_tip_length_data(minimalLabwareDef, tip_length)
     assert result == expected_data
     assert os.path.exists(custom_tiprack_path(URI))
 
 
-def test_save_tip_length_calibration_data(monkeypatch,
-                                          clear_tlc_calibration):
+def test_save_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
     assert not os.path.exists(tlc_path(PIPETTE_ID))
 
-    test_data = {
-        MOCK_HASH: {
-            'tipLength': 22.0,
-            'lastModified': 1
-        }
-    }
+    test_data = {MOCK_HASH: {"tipLength": 22.0, "lastModified": 1}}
     modify.save_tip_length_calibration(PIPETTE_ID, test_data)
     assert os.path.exists(tlc_path(PIPETTE_ID))
     # test an index file is also created
-    assert os.path.exists(tlc_path('index'))
+    assert os.path.exists(tlc_path("index"))
 
 
 def test_add_index_file(monkeypatch, clear_tlc_calibration):
-
     def get_result():
-        with open(tlc_path('index')) as f:
+        with open(tlc_path("index")) as f:
             result = json.load(f)
         return result
 
-    modify._append_to_index_tip_length_file('pip_1', 'lw_1')
-    assert get_result() == {'lw_1': ['pip_1']}
+    modify._append_to_index_tip_length_file("pip_1", "lw_1")
+    assert get_result() == {"lw_1": ["pip_1"]}
 
-    modify._append_to_index_tip_length_file('pip_2', 'lw_1')
-    assert get_result() == {'lw_1': ['pip_1', 'pip_2']}
+    modify._append_to_index_tip_length_file("pip_2", "lw_1")
+    assert get_result() == {"lw_1": ["pip_1", "pip_2"]}
 
-    modify._append_to_index_tip_length_file('pip_2', 'lw_2')
-    assert get_result() == {'lw_1': ['pip_1', 'pip_2'], 'lw_2': ['pip_2']}
+    modify._append_to_index_tip_length_file("pip_2", "lw_2")
+    assert get_result() == {"lw_1": ["pip_1", "pip_2"], "lw_2": ["pip_2"]}
 
 
 def test_load_nonexistent_tip_length_calibration_data(
-        monkeypatch, clear_tlc_calibration):
+    monkeypatch, clear_tlc_calibration
+):
     assert not os.path.exists(tlc_path(PIPETTE_ID))
 
     # file does not exist (FileNotFoundError)
@@ -229,13 +203,8 @@ def test_load_nonexistent_tip_length_calibration_data(
 
     # labware hash not in calibration file (KeyError)
     calpath = config.get_tip_length_cal_path()
-    with open(calpath / f'{PIPETTE_ID}.json', 'w') as offset_file:
-        test_offset = {
-            'FAKE_HASH': {
-                'tipLength': 22.0,
-                'lastModified': 1
-            }
-        }
+    with open(calpath / f"{PIPETTE_ID}.json", "w") as offset_file:
+        test_offset = {"FAKE_HASH": {"tipLength": 22.0, "lastModified": 1}}
         json.dump(test_offset, offset_file)
     with pytest.raises(cs_types.TipLengthCalNotFound):
         get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef)
@@ -244,42 +213,33 @@ def test_load_nonexistent_tip_length_calibration_data(
 def test_load_tip_length_calibration_data(monkeypatch, clear_tlc_calibration):
     assert not os.path.exists(tlc_path(PIPETTE_ID))
 
-    monkeypatch.setattr(
-        helpers,
-        'hash_labware_def', mock_hash_labware)
+    monkeypatch.setattr(helpers, "hash_labware_def", mock_hash_labware)
 
     tip_length = 22.0
-    test_data = modify.create_tip_length_data(
-        minimalLabwareDef, tip_length)
+    test_data = modify.create_tip_length_data(minimalLabwareDef, tip_length)
     modify.save_tip_length_calibration(PIPETTE_ID, test_data)
-    result = get.load_tip_length_calibration(
-        PIPETTE_ID, minimalLabwareDef)
+    result = get.load_tip_length_calibration(PIPETTE_ID, minimalLabwareDef)
     expected = cs_types.TipLengthCalibration(
         tip_length=tip_length,
         pipette=PIPETTE_ID,
         source=cs_types.SourceType.user,
         status=cs_types.CalibrationStatus(markedBad=False),
         tiprack=MOCK_HASH,
-        uri='custom/minimal_labware_def/1',
-        last_modified=test_data[MOCK_HASH]['lastModified']
+        uri="custom/minimal_labware_def/1",
+        last_modified=test_data[MOCK_HASH]["lastModified"],
     )
     assert result == expected
 
 
 def test_clear_tip_length_calibration_data(monkeypatch):
     calpath = config.get_tip_length_cal_path()
-    with open(calpath / f'{PIPETTE_ID}.json', 'w') as offset_file:
-        test_offset = {
-            MOCK_HASH: {
-                'tipLength': 22.0,
-                'lastModified': 1
-            }
-        }
+    with open(calpath / f"{PIPETTE_ID}.json", "w") as offset_file:
+        test_offset = {MOCK_HASH: {"tipLength": 22.0, "lastModified": 1}}
         json.dump(test_offset, offset_file)
 
-    assert len([f for f in os.listdir(calpath) if f.endswith('.json')]) > 0
+    assert len([f for f in os.listdir(calpath) if f.endswith(".json")]) > 0
     delete.clear_tip_length_calibration()
-    assert len([f for f in os.listdir(calpath) if f.endswith('.json')]) == 0
+    assert len([f for f in os.listdir(calpath) if f.endswith(".json")]) == 0
 
 
 def test_schema_shape(monkeypatch, clear_calibration):
@@ -300,25 +260,17 @@ def test_schema_shape(monkeypatch, clear_calibration):
     mock.__class__ = datetime.datetime
 
     test_labware = labware.Labware(
-        LabwareImplementation(minimalLabwareDef,
-                              Location(Point(0, 0, 0), 'deck'))
+        LabwareImplementation(minimalLabwareDef, Location(Point(0, 0, 0), "deck"))
     )
 
-    monkeypatch.setattr(
-        helpers,
-        'hash_labware_def', mock_hash_labware
-    )
+    monkeypatch.setattr(helpers, "hash_labware_def", mock_hash_labware)
 
     expected = {"default": {"offset": [1, 1, 1], "lastModified": fake_time}}
 
     def fake_helper_data(path, delta):
         return expected
 
-    monkeypatch.setattr(
-        modify,
-        '_helper_offset_data_format',
-        fake_helper_data
-    )
+    monkeypatch.setattr(modify, "_helper_offset_data_format", fake_helper_data)
 
     labware.save_calibration(test_labware, Point(1, 1, 1))
     with open(path(MOCK_HASH)) as f:
@@ -328,16 +280,10 @@ def test_schema_shape(monkeypatch, clear_calibration):
 
 def test_load_calibration(monkeypatch, clear_calibration):
 
-    monkeypatch.setattr(
-        helpers,
-        'hash_labware_def', mock_hash_labware
-    )
+    monkeypatch.setattr(helpers, "hash_labware_def", mock_hash_labware)
 
     test_labware = labware.Labware(
-        LabwareImplementation(
-            minimalLabwareDef,
-            Location(Point(0, 0, 0), 'deck')
-        )
+        LabwareImplementation(minimalLabwareDef, Location(Point(0, 0, 0), "deck"))
     )
 
     test_offset = Point(1, 1, 1)
@@ -350,8 +296,7 @@ def test_load_calibration(monkeypatch, clear_calibration):
     test_labware.tip_length = 46.8
     lookup_path = _get_labware_path(test_labware._implementation)
     calibration_point = get.get_labware_calibration(
-        lookup_path,
-        test_labware._implementation.get_definition()
+        lookup_path, test_labware._implementation.get_definition()
     )
     assert calibration_point == test_offset
 
@@ -359,33 +304,25 @@ def test_load_calibration(monkeypatch, clear_calibration):
 def test_wells_rebuilt_with_offset():
     test_labware = labware.Labware(
         implementation=LabwareImplementation(
-            minimalLabwareDef,
-            Location(Point(0, 0, 0), 'deck')
+            minimalLabwareDef, Location(Point(0, 0, 0), "deck")
         )
     )
     old_wells = test_labware.wells()
-    assert test_labware._implementation.get_geometry().offset ==\
-        Point(10, 10, 5)
-    assert test_labware._implementation.get_calibrated_offset() ==\
-        Point(10, 10, 5)
+    assert test_labware._implementation.get_geometry().offset == Point(10, 10, 5)
+    assert test_labware._implementation.get_calibrated_offset() == Point(10, 10, 5)
     labware.save_calibration(test_labware, Point(2, 2, 2))
     new_wells = test_labware.wells()
     assert old_wells[0] != new_wells[0]
-    assert test_labware._implementation.get_geometry().offset ==\
-        Point(10, 10, 5)
-    assert test_labware._implementation.get_calibrated_offset() ==\
-        Point(12, 12, 7)
+    assert test_labware._implementation.get_geometry().offset == Point(10, 10, 5)
+    assert test_labware._implementation.get_calibrated_offset() == Point(12, 12, 7)
 
 
 def test_clear_calibrations():
-    calpath = config.get_opentrons_path('labware_calibration_offsets_dir_v2')
-    with open(calpath / '1.json', 'w') as offset_file:
+    calpath = config.get_opentrons_path("labware_calibration_offsets_dir_v2")
+    with open(calpath / "1.json", "w") as offset_file:
         test_offset = {
-            "default": {
-                "offset": [1, 2, 3],
-                "lastModified": 1
-            },
-            "tipLength": 1.2
+            "default": {"offset": [1, 2, 3], "lastModified": 1},
+            "tipLength": 1.2,
         }
         json.dump(test_offset, offset_file)
 
@@ -401,12 +338,11 @@ def testhash_labware_def():
     def2 = {"metadata": {"a": 123}, "importantStuff": [1.1, 0.000033, 1 / 3]}
 
     # identity preserved across json serialization+deserialization
-    assert helpers.hash_labware_def(def1a) == \
-        helpers.hash_labware_def(
-            json.loads(json.dumps(def1a, separators=(',', ':'))))
+    assert helpers.hash_labware_def(def1a) == helpers.hash_labware_def(
+        json.loads(json.dumps(def1a, separators=(",", ":")))
+    )
     # 2 instances of same def should match
-    assert helpers.hash_labware_def(def1a) == \
-        helpers.hash_labware_def(def1aa)
+    assert helpers.hash_labware_def(def1a) == helpers.hash_labware_def(def1aa)
     # metadata ignored
     assert helpers.hash_labware_def(def1a) == helpers.hash_labware_def(def1b)
     # different data should not match

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -10,13 +10,13 @@ from opentrons.hardware_control.pipette import Pipette
 @pytest.fixture
 def set_up_paired_instrument(ctx):
     ctx.home()
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
-    tiprack2 = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
-    tiprack3 = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
+    tiprack2 = ctx.load_labware("opentrons_96_tiprack_300ul", 2)
+    tiprack3 = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
     right = ctx.load_instrument(
-        'p300_multi', Mount.RIGHT, tip_racks=[tiprack, tiprack2])
-    left = ctx.load_instrument(
-        'p300_multi', Mount.LEFT, tip_racks=[tiprack2, tiprack3])
+        "p300_multi", Mount.RIGHT, tip_racks=[tiprack, tiprack2]
+    )
+    left = ctx.load_instrument("p300_multi", Mount.LEFT, tip_racks=[tiprack2, tiprack3])
 
     return right.pair_with(left), [tiprack, tiprack2, tiprack3]
 
@@ -49,35 +49,31 @@ def test_pick_up_and_drop_tip_with_tipracks(set_up_paired_instrument):
 def test_incompatible_pickup_location(set_up_paired_instrument):
     paired, tipracks = set_up_paired_instrument
     with pytest.raises(pc.PipettePairPickUpTipError):
-        paired.pick_up_tip(tipracks[2].columns_by_name()['12'][0])
+        paired.pick_up_tip(tipracks[2].columns_by_name()["12"][0])
 
 
 def test_pick_up_and_drop_tip_no_tipracks(ctx):
     ctx.home()
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 1)
     tip_length = tiprack.tip_length
-    right = ctx.load_instrument('p300_multi', Mount.RIGHT)
-    left = ctx.load_instrument('p300_multi', Mount.LEFT)
+    right = ctx.load_instrument("p300_multi", Mount.RIGHT)
+    left = ctx.load_instrument("p300_multi", Mount.LEFT)
 
     paired = right.pair_with(left)
     hardware = ctx._implementation.get_hardware().hardware
-    r_pip: Pipette =\
-        hardware._attached_instruments[Mount.RIGHT]
-    l_pip: Pipette =\
-        hardware._attached_instruments[Mount.LEFT]
+    r_pip: Pipette = hardware._attached_instruments[Mount.RIGHT]
+    l_pip: Pipette = hardware._attached_instruments[Mount.LEFT]
     nozzle_offset = Point(*r_pip.config.nozzle_offset)
     assert r_pip.critical_point() == nozzle_offset
     assert l_pip.critical_point() == nozzle_offset
-    target_location = tiprack['A1'].top()
+    target_location = tiprack["A1"].top()
 
     paired.pick_up_tip(target_location)
-    assert 'picking up tip' in ','.join(
-        [cmd.lower() for cmd in ctx.commands()])
+    assert "picking up tip" in ",".join([cmd.lower() for cmd in ctx.commands()])
     assert not tiprack.wells()[0].has_tip
     assert not tiprack.columns()[4][0].has_tip
-    overlap = right.hw_pipette['tip_overlap'][tiprack.uri]
-    new_offset = nozzle_offset - Point(0, 0,
-                                       tip_length-overlap)
+    overlap = right.hw_pipette["tip_overlap"][tiprack.uri]
+    new_offset = nozzle_offset - Point(0, 0, tip_length - overlap)
     assert r_pip.critical_point() == new_offset
     assert l_pip.critical_point() == new_offset
     assert r_pip.has_tip
@@ -85,7 +81,7 @@ def test_pick_up_and_drop_tip_no_tipracks(ctx):
 
     ctx.clear_commands()
     paired.drop_tip()
-    assert 'dropping tip' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "dropping tip" in ",".join([cmd.lower() for cmd in ctx.commands()])
     assert not r_pip.has_tip
     assert not l_pip.has_tip
 
@@ -102,22 +98,25 @@ def test_return_tip(set_up_paired_instrument):
 
 def test_aspirate(set_up_paired_instrument, monkeypatch, ctx):
     paired, _ = set_up_paired_instrument
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 4)
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 4)
 
     fake_hw_aspirate = mock.Mock()
     fake_move = mock.Mock()
-    monkeypatch.setattr(API, 'aspirate', fake_hw_aspirate)
-    monkeypatch.setattr(API, 'move_to', fake_move)
+    monkeypatch.setattr(API, "aspirate", fake_hw_aspirate)
+    monkeypatch.setattr(API, "move_to", fake_move)
 
     paired.pick_up_tip()
     paired.aspirate(2.0, lw.wells()[0].bottom())
 
-    assert 'aspirating' in ','.join([cmd.lower() for cmd in ctx.commands()])
-    fake_hw_aspirate.assert_called_once_with(
-        paired._pair_policy, 2.0, 1.0)
-    assert fake_move.call_args_list[-1] ==\
-        mock.call(paired._pair_policy, lw.wells()[0].bottom().point,
-                  critical_point=None, speed=400, max_speeds={})
+    assert "aspirating" in ",".join([cmd.lower() for cmd in ctx.commands()])
+    fake_hw_aspirate.assert_called_once_with(paired._pair_policy, 2.0, 1.0)
+    assert fake_move.call_args_list[-1] == mock.call(
+        paired._pair_policy,
+        lw.wells()[0].bottom().point,
+        critical_point=None,
+        speed=400,
+        max_speeds={},
+    )
     fake_move.reset_mock()
     fake_hw_aspirate.reset_mock()
     paired.well_bottom_clearance.aspirate = 1.0
@@ -125,15 +124,12 @@ def test_aspirate(set_up_paired_instrument, monkeypatch, ctx):
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 1.0)
     assert len(fake_move.call_args_list) == 1
-    assert fake_move.call_args_list[0] ==\
-        mock.call(
-            paired._pair_policy, dest_point, critical_point=None,
-            speed=400, max_speeds={})
+    assert fake_move.call_args_list[0] == mock.call(
+        paired._pair_policy, dest_point, critical_point=None, speed=400, max_speeds={}
+    )
     fake_move.reset_mock()
     hardware = ctx._implementation.get_hardware().hardware
-    hardware._obj_to_adapt._attached_instruments[
-        Mount.RIGHT
-    ]._current_volume = 1
+    hardware._obj_to_adapt._attached_instruments[Mount.RIGHT]._current_volume = 1
 
     paired.aspirate(2.0)
     fake_move.assert_not_called()
@@ -143,19 +139,21 @@ def test_aspirate(set_up_paired_instrument, monkeypatch, ctx):
     paired.aspirate(2.0)
     assert len(fake_move.call_args_list) == 2
     # reset plunger at the top of the well after blowout
-    assert fake_move.call_args_list[0] ==\
-        mock.call(
-            paired._pair_policy, dest_lw.as_well().top().point,
-            critical_point=None, speed=400, max_speeds={})
-    assert fake_move.call_args_list[1] ==\
-        mock.call(
-            paired._pair_policy, dest_point, critical_point=None,
-            speed=400, max_speeds={})
+    assert fake_move.call_args_list[0] == mock.call(
+        paired._pair_policy,
+        dest_lw.as_well().top().point,
+        critical_point=None,
+        speed=400,
+        max_speeds={},
+    )
+    assert fake_move.call_args_list[1] == mock.call(
+        paired._pair_policy, dest_point, critical_point=None, speed=400, max_speeds={}
+    )
 
 
 def test_dispense(set_up_paired_instrument, monkeypatch, ctx):
     paired, _ = set_up_paired_instrument
-    lw = ctx.load_labware('corning_96_wellplate_360ul_flat', 4)
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", 4)
 
     disp_called_with = None
 
@@ -169,26 +167,27 @@ def test_dispense(set_up_paired_instrument, monkeypatch, ctx):
         nonlocal move_called_with
         move_called_with = (mount, loc, kwargs)
 
-    monkeypatch.setattr(API, 'dispense', fake_hw_dispense)
-    monkeypatch.setattr(API, 'move_to', fake_move)
+    monkeypatch.setattr(API, "dispense", fake_hw_dispense)
+    monkeypatch.setattr(API, "move_to", fake_move)
     paired.pick_up_tip()
     paired.dispense(2.0, lw.wells()[0].bottom())
-    assert 'dispensing' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "dispensing" in ",".join([cmd.lower() for cmd in ctx.commands()])
     assert disp_called_with == (paired._pair_policy, 2.0, 1.0)
-    assert move_called_with == (paired._pair_policy,
-                                lw.wells()[0].bottom().point,
-                                {'critical_point': None,
-                                 'speed': 400,
-                                 'max_speeds': {}})
+    assert move_called_with == (
+        paired._pair_policy,
+        lw.wells()[0].bottom().point,
+        {"critical_point": None, "speed": 400, "max_speeds": {}},
+    )
 
     paired.well_bottom_clearance.dispense = 2.0
     paired.dispense(2.0, lw.wells()[0])
     dest_point, dest_lw = lw.wells()[0].bottom()
     dest_point = dest_point._replace(z=dest_point.z + 2.0)
-    assert move_called_with == (paired._pair_policy, dest_point,
-                                {'critical_point': None,
-                                 'speed': 400,
-                                 'max_speeds': {}})
+    assert move_called_with == (
+        paired._pair_policy,
+        dest_point,
+        {"critical_point": None, "speed": 400, "max_speeds": {}},
+    )
 
     move_called_with = None
     paired.dispense(2.0)
@@ -197,8 +196,7 @@ def test_dispense(set_up_paired_instrument, monkeypatch, ctx):
 
 def test_mix(set_up_paired_instrument, monkeypatch, ctx):
     paired, _ = set_up_paired_instrument
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 4)
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 4)
 
     paired.pick_up_tip()
     mix_steps = []
@@ -208,36 +206,37 @@ def test_mix(set_up_paired_instrument, monkeypatch, ctx):
     def fake_aspirate(vol=None, loc=None, rate=None):
         nonlocal aspirate_called_with
         nonlocal mix_steps
-        aspirate_called_with = ('aspirate', vol, loc, rate)
+        aspirate_called_with = ("aspirate", vol, loc, rate)
         mix_steps.append(aspirate_called_with)
 
     def fake_dispense(vol=None, loc=None, rate=None):
         nonlocal dispense_called_with
         nonlocal mix_steps
-        dispense_called_with = ('dispense', vol, loc, rate)
+        dispense_called_with = ("dispense", vol, loc, rate)
         mix_steps.append(dispense_called_with)
 
-    monkeypatch.setattr(paired, 'aspirate', fake_aspirate)
-    monkeypatch.setattr(paired, 'dispense', fake_dispense)
+    monkeypatch.setattr(paired, "aspirate", fake_aspirate)
+    monkeypatch.setattr(paired, "dispense", fake_dispense)
 
     repetitions = 2
     volume = 5
     location = lw.wells()[0]
     rate = 2
     paired.mix(repetitions, volume, location, rate)
-    assert 'mixing' in ','.join([cmd.lower() for cmd in ctx.commands()])
-    expected_mix_steps = [('aspirate', volume, location, 2),
-                          ('dispense', volume, None, 2),
-                          ('aspirate', volume, None, 2),
-                          ('dispense', volume, None, 2)]
+    assert "mixing" in ",".join([cmd.lower() for cmd in ctx.commands()])
+    expected_mix_steps = [
+        ("aspirate", volume, location, 2),
+        ("dispense", volume, None, 2),
+        ("aspirate", volume, None, 2),
+        ("dispense", volume, None, 2),
+    ]
 
     assert mix_steps == expected_mix_steps
 
 
 def test_blow_out(set_up_paired_instrument, monkeypatch, ctx):
     paired, _ = set_up_paired_instrument
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 4)
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 4)
 
     move_location = None
     paired.pick_up_tip()
@@ -247,10 +246,10 @@ def test_blow_out(set_up_paired_instrument, monkeypatch, ctx):
         nonlocal move_location
         move_location = loc
 
-    monkeypatch.setattr(paired.paired_instrument_obj, 'move_to', fake_move)
+    monkeypatch.setattr(paired.paired_instrument_obj, "move_to", fake_move)
 
     paired.blow_out()
-    assert 'blowing out' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "blowing out" in ",".join([cmd.lower() for cmd in ctx.commands()])
     # pipette should not move, if no location is passed
     assert move_location is None
 
@@ -269,17 +268,15 @@ def test_air_gap(set_up_paired_instrument, monkeypatch, ctx):
     paired, _ = set_up_paired_instrument
 
     hardware = ctx._implementation.get_hardware().hardware
-    r_pip: Pipette =\
-        hardware._attached_instruments[Mount.RIGHT]
-    l_pip: Pipette =\
-        hardware._attached_instruments[Mount.LEFT]
+    r_pip: Pipette = hardware._attached_instruments[Mount.RIGHT]
+    l_pip: Pipette = hardware._attached_instruments[Mount.LEFT]
 
     paired.pick_up_tip()
     assert r_pip.current_volume == 0
     assert l_pip.current_volume == 0
     paired.air_gap(20)
 
-    assert 'air gap' in ','.join([cmd.lower() for cmd in ctx.commands()])
+    assert "air gap" in ",".join([cmd.lower() for cmd in ctx.commands()])
 
     assert r_pip.current_volume == 20
     assert l_pip.current_volume == 20
@@ -291,50 +288,48 @@ def test_air_gap(set_up_paired_instrument, monkeypatch, ctx):
     paired.drop_tip()
 
     aspirate_mock = mock.Mock()
-    monkeypatch.setattr(API, 'aspirate', aspirate_mock)
+    monkeypatch.setattr(API, "aspirate", aspirate_mock)
 
     paired.pick_up_tip()
     paired.air_gap(20)
 
-    assert aspirate_mock.call_args_list ==\
-        [mock.call(paired._pair_policy, 20, 1.0)]
+    assert aspirate_mock.call_args_list == [mock.call(paired._pair_policy, 20, 1.0)]
     aspirate_mock.reset_mock()
     paired.air_gap()
-    assert aspirate_mock.call_args_list ==\
-        [mock.call(paired._pair_policy, None, 1.0)]
+    assert aspirate_mock.call_args_list == [mock.call(paired._pair_policy, None, 1.0)]
 
 
 def test_touch_tip_new_default_args(ctx, monkeypatch):
     ctx.home()
-    lw = ctx.load_labware(
-        'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap', 1)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    right = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
-    left = ctx.load_instrument('p300_single', Mount.LEFT,
-                               tip_racks=[tiprack])
+    lw = ctx.load_labware("opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap", 1)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    right = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
+    left = ctx.load_instrument("p300_single", Mount.LEFT, tip_racks=[tiprack])
 
     paired = left.pair_with(right)
 
     paired.pick_up_tip()
     total_hw_moves = []
 
-    async def fake_hw_move(self, mount, abs_position, speed=None,
-                           critical_point=None, max_speeds=None):
+    async def fake_hw_move(
+        self, mount, abs_position, speed=None, critical_point=None, max_speeds=None
+    ):
         nonlocal total_hw_moves
         total_hw_moves.append((abs_position, speed))
 
     paired.aspirate(10, lw.wells()[0])
-    monkeypatch.setattr(API, 'move_to', fake_hw_move)
+    monkeypatch.setattr(API, "move_to", fake_hw_move)
     paired.touch_tip()
-    assert 'touching tip' in ','.join([cmd.lower() for cmd in ctx.commands()])
-    z_offset = Point(0, 0, 1)   # default z offset of 1mm
-    speed = 60                  # default speed
-    edges = [lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
-             lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset]
+    assert "touching tip" in ",".join([cmd.lower() for cmd in ctx.commands()])
+    z_offset = Point(0, 0, 1)  # default z offset of 1mm
+    speed = 60  # default speed
+    edges = [
+        lw.wells()[0].from_center_cartesian(1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(-1, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, 0, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, 1, 1) - z_offset,
+        lw.wells()[0].from_center_cartesian(0, -1, 1) - z_offset,
+    ]
     for i in range(1, 5):
         assert total_hw_moves[i] == (edges[i - 1], speed)
 
@@ -347,17 +342,15 @@ def test_touch_tip_new_default_args(ctx, monkeypatch):
 
 def test_touch_tip_disabled(ctx, monkeypatch, get_labware_fixture):
     ctx.home()
-    trough1 = get_labware_fixture('fixture_12_trough')
-    trough_lw = ctx.load_labware_from_definition(trough1, '1')
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    right = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
-    left = ctx.load_instrument('p300_single', Mount.LEFT,
-                               tip_racks=[tiprack])
+    trough1 = get_labware_fixture("fixture_12_trough")
+    trough_lw = ctx.load_labware_from_definition(trough1, "1")
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    right = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
+    left = ctx.load_instrument("p300_single", Mount.LEFT, tip_racks=[tiprack])
 
     paired = left.pair_with(right)
     paired.pick_up_tip()
     move_mock = mock.Mock()
-    monkeypatch.setattr(API, 'move_to', move_mock)
-    paired.touch_tip(trough_lw['A1'])
+    monkeypatch.setattr(API, "move_to", move_mock)
+    paired.touch_tip(trough_lw["A1"])
     move_mock.assert_not_called()

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -1,8 +1,9 @@
 """ Test the Transfer class and its functions """
 import pytest
 import opentrons.protocol_api as papi
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
 from opentrons.types import Mount, TransferTipPolicy
 from opentrons.protocols.advanced_control import transfers as tx
 from opentrons.protocols.api_support.types import APIVersion
@@ -10,17 +11,21 @@ from opentrons.protocols.api_support.types import APIVersion
 
 @pytest.fixture
 def _instr_labware(ctx):
-    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', 2)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    tiprack2 = ctx.load_labware('opentrons_96_tiprack_300ul', 4)
-    instr = ctx.load_instrument('p300_single', Mount.RIGHT,
-                                tip_racks=[tiprack])
-    instr_multi = ctx.load_instrument(
-        'p300_multi', Mount.LEFT, tip_racks=[tiprack2])
+    lw1 = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 1)
+    lw2 = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    tiprack2 = ctx.load_labware("opentrons_96_tiprack_300ul", 4)
+    instr = ctx.load_instrument("p300_single", Mount.RIGHT, tip_racks=[tiprack])
+    instr_multi = ctx.load_instrument("p300_multi", Mount.LEFT, tip_racks=[tiprack2])
 
-    return {'ctx': ctx, 'instr': instr, 'lw1': lw1, 'lw2': lw2,
-            'tiprack': tiprack, 'instr_multi': instr_multi}
+    return {
+        "ctx": ctx,
+        "instr": instr,
+        "lw1": lw1,
+        "lw2": lw2,
+        "tiprack": tiprack,
+        "instr_multi": instr_multi,
+    }
 
 
 # +++++++ Test Helper Functions ++++++++++
@@ -36,372 +41,349 @@ def test_check_if_zero():
 def test_default_transfers(_instr_labware):
     # Transfer 100ml from row1 of labware1 to row1 of labware2: first with
     #  new_tip = ONCE, then with new_tip = NEVER
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     # ========== Transfer ===========
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0], lw2.columns()[0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer')
+        100,
+        lw1.columns()[0],
+        lw2.columns()[0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][5], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][5], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][6], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][6], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][7], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][7], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][5], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][5], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][6], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][6], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][7], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][7], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
     # ========== Distribute ===========
     dist_plan = tx.TransferPlan(
-        50, lw1.columns()[0][0], lw2.columns()[0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute')
+        50,
+        lw1.columns()[0][0],
+        lw2.columns()[0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+    )
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
-    exp2 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][5], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][6], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [50, lw2.columns()[0][7], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp2 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [300, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][5], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][6], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [50, lw2.columns()[0][7], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert dist_plan_list == exp2
 
     # ========== Consolidate ===========
     consd_plan = tx.TransferPlan(
-        50, lw1.columns()[0], lw2.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='consolidate')
+        50,
+        lw1.columns()[0],
+        lw2.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="consolidate",
+    )
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
-    exp3 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][5], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw2.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][6], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [50, lw1.columns()[0][7], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp3 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][5], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][6], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [50, lw1.columns()[0][7], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert consd_plan_list == exp3
 
 
 def test_uneven_transfers(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     options = tx.TransferOptions()
     options = options._replace(
-        transfer=options.transfer._replace(
-            new_tip=TransferTipPolicy.NEVER))
+        transfer=options.transfer._replace(new_tip=TransferTipPolicy.NEVER)
+    )
 
     # ========== One-to-Many ==========
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0][0], lw2.columns()[1][:4],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer', options=options)
+        100,
+        lw1.columns()[0][0],
+        lw2.columns()[1][:4],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     one_to_many_plan_list = []
     for step in xfer_plan:
         one_to_many_plan_list.append(step)
-    exp1 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][1], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][2], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][3], 1.0],
-            'kwargs': {}}]
+    exp1 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][1], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][2], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][3], 1.0], "kwargs": {}},
+    ]
     assert one_to_many_plan_list == exp1
 
     # ========== Few-to-Many ==========
     xfer_plan = tx.TransferPlan(
-        [100, 90, 80, 70], lw1.columns()[0][:2], lw2.columns()[1][:4],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer', options=options)
+        [100, 90, 80, 70],
+        lw1.columns()[0][:2],
+        lw2.columns()[1][:4],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     few_to_many_plan_list = []
     for step in xfer_plan:
         few_to_many_plan_list.append(step)
-    exp2 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [90, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [90, lw2.columns()[1][1], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [80, lw1.columns()[0][1], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [80, lw2.columns()[1][2], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [70, lw1.columns()[0][1], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [70, lw2.columns()[1][3], 1.0],
-            'kwargs': {}}]
+    exp2 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [90, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [90, lw2.columns()[1][1], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [80, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [80, lw2.columns()[1][2], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [70, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.columns()[1][3], 1.0], "kwargs": {}},
+    ]
     assert few_to_many_plan_list == exp2
 
     # ========== Many-to-One ==========
     xfer_plan = tx.TransferPlan(
-        [100, 90, 80, 70], lw1.columns()[0][:4], lw2.columns()[1][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer', options=options)
+        [100, 90, 80, 70],
+        lw1.columns()[0][:4],
+        lw2.columns()[1][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     many_to_one_plan_list = []
     for step in xfer_plan:
         many_to_one_plan_list.append(step)
-    exp3 = [{'method': 'aspirate', 'args': [100, lw1.columns()[0][0], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[1][0], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [90, lw1.columns()[0][1], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [90, lw2.columns()[1][0], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [80, lw1.columns()[0][2], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [80, lw2.columns()[1][0], 1.0],
-            'kwargs': {}},
-            {'method': 'aspirate', 'args': [70, lw1.columns()[0][3], 1.0],
-            'kwargs': {}},
-            {'method': 'dispense', 'args': [70, lw2.columns()[1][0], 1.0],
-            'kwargs': {}}]
+    exp3 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [90, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [90, lw2.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [80, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [80, lw2.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [70, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.columns()[1][0], 1.0], "kwargs": {}},
+    ]
     assert many_to_one_plan_list == exp3
 
 
 def test_location_wells(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
     aspirate_loc = lw1.wells()[0].top()
     # Test single-channel transfer with locations
-    list_of_locs = [
-        well.bottom(5) for col in lw2.columns()[0:11] for well in col]
+    list_of_locs = [well.bottom(5) for col in lw2.columns()[0:11] for well in col]
 
     xfer_plan = tx.TransferPlan(
         30,
         aspirate_loc,
         list_of_locs,
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer')
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+    )
     idx_dest = 0
     for step in xfer_plan:
-        if step['method'] == 'aspirate':
-            assert step['args'][1].point == aspirate_loc.point
-        elif step['method'] == 'dispense':
-            assert step['args'][1].point\
-                    == list_of_locs[idx_dest].point
+        if step["method"] == "aspirate":
+            assert step["args"][1].point == aspirate_loc.point
+        elif step["method"] == "dispense":
+            assert step["args"][1].point == list_of_locs[idx_dest].point
             idx_dest += 1
 
-    multi_locs = [
-        col[0].bottom(5) for col in lw2.columns()[0:11]]
+    multi_locs = [col[0].bottom(5) for col in lw2.columns()[0:11]]
     # Test multi-channel transfer with locations
     xfer_plan = tx.TransferPlan(
         30,
         aspirate_loc,
         multi_locs,
-        _instr_labware['instr_multi'],
-        max_volume=_instr_labware['instr_multi'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer')
+        _instr_labware["instr_multi"],
+        max_volume=_instr_labware["instr_multi"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+    )
 
     idx_dest = 0
     for step in xfer_plan:
-        if step['method'] == 'aspirate':
-            assert step['args'][1].point == aspirate_loc.point
-        elif step['method'] == 'dispense':
-            assert step['args'][1].point\
-                    == multi_locs[idx_dest].point
+        if step["method"] == "aspirate":
+            assert step["args"][1].point == aspirate_loc.point
+        elif step["method"] == "dispense":
+            assert step["args"][1].point == multi_locs[idx_dest].point
             idx_dest += 1
 
 
 def test_no_new_tip(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     options = tx.TransferOptions()
     options = options._replace(
-        transfer=options.transfer._replace(
-            new_tip=TransferTipPolicy.NEVER))
+        transfer=options.transfer._replace(new_tip=TransferTipPolicy.NEVER)
+    )
     # ========== Transfer ==========
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0], lw2.columns()[0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        100,
+        lw1.columns()[0],
+        lw2.columns()[0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     for step in xfer_plan:
-        assert step['method'] != 'pick_up_tip'
-        assert step['method'] != 'drop_tip'
+        assert step["method"] != "pick_up_tip"
+        assert step["method"] != "drop_tip"
 
     # ========== Distribute ===========
     dist_plan = tx.TransferPlan(
-        30, lw1.columns()[0][0], lw2.columns()[0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute',
-        options=options)
+        30,
+        lw1.columns()[0][0],
+        lw2.columns()[0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+        options=options,
+    )
     for step in dist_plan:
-        assert step['method'] != 'pick_up_tip'
-        assert step['method'] != 'drop_tip'
+        assert step["method"] != "pick_up_tip"
+        assert step["method"] != "drop_tip"
 
     # ========== Consolidate ===========
     consd_plan = tx.TransferPlan(
-        40, lw1.columns()[0], lw2.rows()[0][1],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        40,
+        lw1.columns()[0],
+        lw2.rows()[0][1],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     for step in consd_plan:
-        assert step['method'] != 'pick_up_tip'
-        assert step['method'] != 'drop_tip'
+        assert step["method"] != "pick_up_tip"
+        assert step["method"] != "drop_tip"
 
 
 def test_new_tip_always(_instr_labware, monkeypatch):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
-    tiprack = _instr_labware['tiprack']
-    i_ctx = _instr_labware['instr']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
+    tiprack = _instr_labware["tiprack"]
+    i_ctx = _instr_labware["instr"]
 
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            new_tip=TransferTipPolicy.ALWAYS,
-            drop_tip_strategy=tx.DropTipStrategy.TRASH))
+            new_tip=TransferTipPolicy.ALWAYS, drop_tip_strategy=tx.DropTipStrategy.TRASH
+        )
+    )
 
     xfer_plan = tx.TransferPlan(
         100,
-        lw1.columns()[0][1:5], lw2.columns()[0][1:5],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        lw1.columns()[0][1:5],
+        lw2.columns()[0][1:5],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][1], 1.0],
-             'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[0][1], 1.0],
-             'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
-            {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][2], 1.0],
-             'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[0][2], 1.0],
-             'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
-            {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][3], 1.0],
-             'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[0][3], 1.0],
-             'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}},
-            {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate', 'args': [100, lw1.columns()[0][4], 1.0],
-             'kwargs': {}},
-            {'method': 'dispense', 'args': [100, lw2.columns()[0][4], 1.0],
-             'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
     for cmd in xfer_plan_list:
-        getattr(i_ctx, cmd['method'])(*cmd['args'], **cmd['kwargs'])
+        getattr(i_ctx, cmd["method"])(*cmd["args"], **cmd["kwargs"])
     assert tiprack.next_tip() == tiprack.columns()[0][4]
 
 
 def test_transfer_w_touchtip_blowout(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     # ========== Transfer ==========
     options = tx.TransferOptions()
@@ -409,359 +391,343 @@ def test_transfer_w_touchtip_blowout(_instr_labware):
         transfer=options.transfer._replace(
             touch_tip_strategy=tx.TouchTipStrategy.ALWAYS,
             blow_out_strategy=tx.BlowOutStrategy.TRASH,
-            new_tip=TransferTipPolicy.NEVER))
+            new_tip=TransferTipPolicy.NEVER,
+        )
+    )
 
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0][:3], lw2.rows()[0][:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        100,
+        lw1.columns()[0][:3],
+        lw2.rows()[0][:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'aspirate',
-             'args': [100, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [_instr_labware['instr'].trash_container.wells()[0]],
-             'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [_instr_labware['instr'].trash_container.wells()[0]],
-             'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [_instr_labware['instr'].trash_container.wells()[0]],
-             'kwargs': {}}]
+    exp1 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {
+            "method": "blow_out",
+            "args": [_instr_labware["instr"].trash_container.wells()[0]],
+            "kwargs": {},
+        },
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {
+            "method": "blow_out",
+            "args": [_instr_labware["instr"].trash_container.wells()[0]],
+            "kwargs": {},
+        },
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {
+            "method": "blow_out",
+            "args": [_instr_labware["instr"].trash_container.wells()[0]],
+            "kwargs": {},
+        },
+    ]
     assert xfer_plan_list == exp1
 
     # ========== Distribute ==========
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            disposal_volume=_instr_labware['instr'].min_volume,
+            disposal_volume=_instr_labware["instr"].min_volume,
             touch_tip_strategy=tx.TouchTipStrategy.ALWAYS,
-            new_tip=TransferTipPolicy.NEVER))
+            new_tip=TransferTipPolicy.NEVER,
+        )
+    )
 
     dist_plan = tx.TransferPlan(
-        30, lw1.columns()[0][0], lw2.rows()[0][:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute',
-        options=options)
+        30,
+        lw1.columns()[0][0],
+        lw2.rows()[0][:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+        options=options,
+    )
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
-    exp2 = [{'method': 'aspirate',
-             'args': [120, lw1.columns()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [30, lw2.rows()[0][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [30, lw2.rows()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [30, lw2.rows()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [_instr_labware['instr'].trash_container.wells()[0]],
-             'kwargs': {}}]
+    exp2 = [
+        {"method": "aspirate", "args": [120, lw1.columns()[0][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2.rows()[0][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2.rows()[0][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2.rows()[0][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {
+            "method": "blow_out",
+            "args": [_instr_labware["instr"].trash_container.wells()[0]],
+            "kwargs": {},
+        },
+    ]
     assert dist_plan_list == exp2
 
 
 def test_transfer_w_airgap_blowout(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            air_gap=10, blow_out_strategy=tx.BlowOutStrategy.DEST,
-            new_tip=TransferTipPolicy.NEVER))
+            air_gap=10,
+            blow_out_strategy=tx.BlowOutStrategy.DEST,
+            new_tip=TransferTipPolicy.NEVER,
+        )
+    )
 
     # ========== Transfer ==========
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        100,
+        lw1.columns()[0][1:5],
+        lw2.rows()[0][1:5],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'aspirate',
-             'args': [100, lw1.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'air_gap',
-             'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [110, lw2.rows()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [lw2.rows()[0][1]], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'air_gap',
-             'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [110, lw2.rows()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [lw2.rows()[0][2]], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'air_gap',
-             'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [110, lw2.rows()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'blow_out',
-             'args': [lw2.rows()[0][3]], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'air_gap',
-             'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [110, lw2.rows()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'blow_out', 'args': [lw2.rows()[0][4]], 'kwargs': {}}]
+    exp1 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [110, lw2.rows()[0][1], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[0][1]], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [110, lw2.rows()[0][2], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[0][2]], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [110, lw2.rows()[0][3], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[0][3]], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [110, lw2.rows()[0][4], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[0][4]], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
     # ========== Distribute ==========
     dist_plan = tx.TransferPlan(
-        60, lw1.columns()[1][0], lw2.rows()[1][1:6],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute',
-        options=options)
+        60,
+        lw1.columns()[1][0],
+        lw2.rows()[1][1:6],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+        options=options,
+    )
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
-    exp2 = [{'method': 'aspirate',
-             'args': [240, lw1.columns()[1][0], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [70, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [70, lw2.rows()[1][2], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [70, lw2.rows()[1][3], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [70, lw2.rows()[1][4], 1.0], 'kwargs': {}},
-            {'method': 'blow_out', 'args': [lw2.rows()[1][4]], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][0], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [70, lw2.rows()[1][5], 1.0], 'kwargs': {}},
-            {'method': 'blow_out', 'args': [lw2.rows()[1][5]], 'kwargs': {}}]
+    exp2 = [
+        {"method": "aspirate", "args": [240, lw1.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.rows()[1][2], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.rows()[1][3], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.rows()[1][4], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[1][4]], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [70, lw2.rows()[1][5], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[1][5]], "kwargs": {}},
+    ]
     assert dist_plan_list == exp2
 
     # ========== Consolidate ==========
     consd_plan = tx.TransferPlan(
-        60, lw1.columns()[1], lw2.rows()[1][1],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='consolidate',
-        options=options)
+        60,
+        lw1.columns()[1],
+        lw2.rows()[1][1],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="consolidate",
+        options=options,
+    )
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
-    exp3 = [{'method': 'aspirate',
-             'args': [60, lw1.columns()[1][0], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][2], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][3], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [280, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'blow_out', 'args': [lw2.rows()[1][1]], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][4], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][5], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][6], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][7], 1.0], 'kwargs': {}},
-            {'method': 'air_gap', 'args': [10], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [280, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'blow_out', 'args': [lw2.rows()[1][1]], 'kwargs': {}}]
+    exp3 = [
+        {"method": "aspirate", "args": [60, lw1.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][1], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][2], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][3], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [280, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[1][1]], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][4], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][5], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][6], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][7], 1.0], "kwargs": {}},
+        {"method": "air_gap", "args": [10], "kwargs": {}},
+        {"method": "dispense", "args": [280, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2.rows()[1][1]], "kwargs": {}},
+    ]
     assert consd_plan_list == exp3
 
 
 def test_touchtip_mix(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
             new_tip=TransferTipPolicy.NEVER,
             touch_tip_strategy=tx.TouchTipStrategy.ALWAYS,
-            mix_strategy=tx.MixStrategy.AFTER))
+            mix_strategy=tx.MixStrategy.AFTER,
+        )
+    )
 
     # ========== Transfer ==========
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0][1:5], lw2.rows()[0][1:5],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        100,
+        lw1.columns()[0][1:5],
+        lw2.rows()[0][1:5],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'aspirate',
-             'args': [100, lw1.columns()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[0][1]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[0][2]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[0][3]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][4], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[0][4]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][1], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[0][1]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][2], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[0][2]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][3], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][3], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[0][3]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][4], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][4], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[0][4]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
     # ========== Distribute ==========
     dist_plan = tx.TransferPlan(
-        60, lw1.columns()[1][0], lw2.rows()[1][1:6],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute',
-        options=options)
+        60,
+        lw1.columns()[1][0],
+        lw2.rows()[1][1:6],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+        options=options,
+    )
     dist_plan_list = []
     for step in dist_plan:
         dist_plan_list.append(step)
-    exp2 = [{'method': 'aspirate',
-             'args': [300, lw1.columns()[1][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [60, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [60, lw2.rows()[1][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [60, lw2.rows()[1][3], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [60, lw2.rows()[1][4], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [60, lw2.rows()[1][5], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[1][5]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}}]
+    exp2 = [
+        {"method": "aspirate", "args": [300, lw1.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw2.rows()[1][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw2.rows()[1][3], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw2.rows()[1][4], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw2.rows()[1][5], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[1][5]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+    ]
 
     assert dist_plan_list == exp2
 
     # ========== Consolidate ==========
     consd_plan = tx.TransferPlan(
-        60, lw1.columns()[1], lw2.rows()[1][1],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='consolidate',
-        options=options)
+        60,
+        lw1.columns()[1],
+        lw2.rows()[1][1],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="consolidate",
+        options=options,
+    )
     consd_plan_list = []
     for step in consd_plan:
         consd_plan_list.append(step)
-    exp3 = [{'method': 'aspirate',
-             'args': [60, lw1.columns()[1][0], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][2], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][3], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][4], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[1][1]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][5], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][6], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [60, lw1.columns()[1][7], 1.0], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [180, lw2.rows()[1][1], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'location': lw2.rows()[1][1]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {}}]
+    exp3 = [
+        {"method": "aspirate", "args": [60, lw1.columns()[1][0], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][1], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][2], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][3], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][4], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[1][1]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][5], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][6], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [60, lw1.columns()[1][7], 1.0], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+        {"method": "dispense", "args": [180, lw2.rows()[1][1], 1.0], "kwargs": {}},
+        {"method": "mix", "args": [], "kwargs": {"location": lw2.rows()[1][1]}},
+        {"method": "touch_tip", "args": [], "kwargs": {}},
+    ]
     assert consd_plan_list == exp3
 
 
 def test_all_options(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     options = tx.TransferOptions()
     options = options._replace(
@@ -769,187 +735,313 @@ def test_all_options(_instr_labware):
             new_tip=TransferTipPolicy.ONCE,
             drop_tip_strategy=tx.DropTipStrategy.RETURN,
             touch_tip_strategy=tx.TouchTipStrategy.ALWAYS,
-            mix_strategy=tx.MixStrategy.AFTER),
-        pick_up_tip=options.pick_up_tip._replace(
-            presses=4,
-            increment=2),
-        touch_tip=options.touch_tip._replace(
-            speed=1.6),
+            mix_strategy=tx.MixStrategy.AFTER,
+        ),
+        pick_up_tip=options.pick_up_tip._replace(presses=4, increment=2),
+        touch_tip=options.touch_tip._replace(speed=1.6),
         mix=options.mix._replace(
-            mix_after=options.mix.mix_after._replace(
-                repetitions=2)),
-        blow_out=options.blow_out._replace(
-            location=lw2.columns()[10][0]),
-        aspirate=options.aspirate._replace(
-            rate=1.5))
+            mix_after=options.mix.mix_after._replace(repetitions=2)
+        ),
+        blow_out=options.blow_out._replace(location=lw2.columns()[10][0]),
+        aspirate=options.aspirate._replace(rate=1.5),
+    )
 
     xfer_plan = tx.TransferPlan(
-        100, lw1.columns()[0][1:4], lw2.rows()[0][1:4],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer',
-        options=options)
+        100,
+        lw1.columns()[0][1:4],
+        lw2.rows()[0][1:4],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+        options=options,
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip',
-             'args': [], 'kwargs': {'presses': 4, 'increment': 2}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][1], 1.5], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][1], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'repetitions': 2, 'location': lw2.rows()[0][1]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][2], 1.5], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][2], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'repetitions': 2, 'location': lw2.rows()[0][2]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'aspirate',
-             'args': [100, lw1.columns()[0][3], 1.5], 'kwargs': {}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'dispense',
-             'args': [100, lw2.rows()[0][3], 1.0], 'kwargs': {}},
-            {'method': 'mix', 'args': [], 'kwargs': {
-                'repetitions': 2, 'location': lw2.rows()[0][3]}},
-            {'method': 'touch_tip', 'args': [], 'kwargs': {'speed': 1.6}},
-            {'method': 'return_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {"presses": 4, "increment": 2}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][1], 1.5], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][1], 1.0], "kwargs": {}},
+        {
+            "method": "mix",
+            "args": [],
+            "kwargs": {"repetitions": 2, "location": lw2.rows()[0][1]},
+        },
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][2], 1.5], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][2], 1.0], "kwargs": {}},
+        {
+            "method": "mix",
+            "args": [],
+            "kwargs": {"repetitions": 2, "location": lw2.rows()[0][2]},
+        },
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "aspirate", "args": [100, lw1.columns()[0][3], 1.5], "kwargs": {}},
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "dispense", "args": [100, lw2.rows()[0][3], 1.0], "kwargs": {}},
+        {
+            "method": "mix",
+            "args": [],
+            "kwargs": {"repetitions": 2, "location": lw2.rows()[0][3]},
+        },
+        {"method": "touch_tip", "args": [], "kwargs": {"speed": 1.6}},
+        {"method": "return_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
 
 def test_oversized_distribute(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     xfer_plan = tx.TransferPlan(
-        700, lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='distribute')
+        700,
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="distribute",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {
+            "method": "aspirate",
+            "args": [300, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [300, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
 
 def test_oversized_consolidate(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     xfer_plan = tx.TransferPlan(
-        700, lw2.rows()[0][1:3],
-        lw1.wells_by_index()['A1'],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='consolidate')
+        700,
+        lw2.rows()[0][1:3],
+        lw1.wells_by_index()["A1"],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="consolidate",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {
+            "method": "aspirate",
+            "args": [300, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [300, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
 
 def test_oversized_transfer(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
 
     xfer_plan = tx.TransferPlan(
-        700, lw2.rows()[0][1:3], lw1.columns()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
-        api_version=_instr_labware['ctx'].api_version,
-        mode='transfer')
+        700,
+        lw2.rows()[0][1:3],
+        lw1.columns()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
+        api_version=_instr_labware["ctx"].api_version,
+        mode="transfer",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw1.wells_by_index()['B1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['B1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['B1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [300, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [300, lw1.wells_by_index()['C1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['C1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw2.wells_by_index()['A3'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw1.wells_by_index()['C1'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {
+            "method": "aspirate",
+            "args": [300, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw1.wells_by_index()["B1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["B1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["B1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [300, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [300, lw1.wells_by_index()["C1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["C1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "aspirate",
+            "args": [200, lw2.wells_by_index()["A3"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [200, lw1.wells_by_index()["C1"], 1.0],
+            "kwargs": {},
+        },
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
 
@@ -959,44 +1051,57 @@ def test_multichannel_transfer_old_version(loop, hardware):
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(hardware=hardware),
         loop=loop,
-        api_version=APIVersion(2, 1)
+        api_version=APIVersion(2, 1),
     )
-    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware('corning_384_wellplate_112ul_flat', 2)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr_multi = ctx.load_instrument(
-        'p300_multi', Mount.LEFT, tip_racks=[tiprack])
+    lw1 = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 1)
+    lw2 = ctx.load_labware("corning_384_wellplate_112ul_flat", 2)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr_multi = ctx.load_instrument("p300_multi", Mount.LEFT, tip_racks=[tiprack])
 
     xfer_plan = tx.TransferPlan(
-            100, lw1.rows()[0][0], [lw2.rows()[0][1], lw2.rows()[1][1]],
-            instr_multi,
-            max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version,
-            mode='distribute')
+        100,
+        lw1.rows()[0][0],
+        [lw2.rows()[0][1], lw2.rows()[1][1]],
+        instr_multi,
+        max_volume=instr_multi.hw_pipette["working_volume"],
+        api_version=ctx.api_version,
+        mode="distribute",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.wells_by_name()['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2.wells_by_index()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {
+            "method": "aspirate",
+            "args": [100, lw1.wells_by_name()["A1"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [100, lw2.wells_by_index()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
     # target without row limit
     with pytest.raises(IndexError):
         xfer_plan = tx.TransferPlan(
-            100, lw1.rows()[0][1], lw2.rows()[1][1],
+            100,
+            lw1.rows()[0][1],
+            lw2.rows()[1][1],
             instr_multi,
-            max_volume=instr_multi.hw_pipette['working_volume'],
+            max_volume=instr_multi.hw_pipette["working_volume"],
             api_version=ctx.api_version,
             # todo(mm, 2021-03-17): This test intends to test mode='transfer',
             # but it's always accidentally tested mode='consolidate' because of
             # a quirk in how TransferPlan used to guess the mode when not
             # explicitly specified. If this is changed to mode='transfer' now,
             # it raises ZeroDivisionError instead of IndexError. Bug #7516.
-            mode='consolidate')
+            mode="consolidate",
+        )
         xfer_plan_list = []
         for step in xfer_plan:
             xfer_plan_list.append(step)
@@ -1006,43 +1111,55 @@ def test_multichannel_transfer_locs(loop, hardware):
     api_version = APIVersion(2, 2)
     ctx = papi.ProtocolContext(
         implementation=ProtocolContextImplementation(
-            api_version=api_version,
-            hardware=hardware
+            api_version=api_version, hardware=hardware
         ),
         loop=loop,
-        api_version=api_version
+        api_version=api_version,
     )
-    lw1 = ctx.load_labware('biorad_96_wellplate_200ul_pcr', 1)
-    lw2 = ctx.load_labware('corning_384_wellplate_112ul_flat', 2)
-    tiprack = ctx.load_labware('opentrons_96_tiprack_300ul', 3)
-    instr_multi = ctx.load_instrument(
-        'p300_multi', Mount.LEFT, tip_racks=[tiprack])
+    lw1 = ctx.load_labware("biorad_96_wellplate_200ul_pcr", 1)
+    lw2 = ctx.load_labware("corning_384_wellplate_112ul_flat", 2)
+    tiprack = ctx.load_labware("opentrons_96_tiprack_300ul", 3)
+    instr_multi = ctx.load_instrument("p300_multi", Mount.LEFT, tip_racks=[tiprack])
 
     # targets within row limit
     xfer_plan = tx.TransferPlan(
-            100, lw1.rows()[0][1], lw2.rows()[1][1],
-            instr_multi,
-            max_volume=instr_multi.hw_pipette['working_volume'],
-            api_version=ctx.api_version,
-            mode='transfer')
+        100,
+        lw1.rows()[0][1],
+        lw2.rows()[1][1],
+        instr_multi,
+        max_volume=instr_multi.hw_pipette["working_volume"],
+        api_version=ctx.api_version,
+        mode="transfer",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
-    exp1 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1.wells_by_name()['A2'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-            'args': [100, lw2.wells_by_index()['B2'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp1 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {
+            "method": "aspirate",
+            "args": [100, lw1.wells_by_name()["A2"], 1.0],
+            "kwargs": {},
+        },
+        {
+            "method": "dispense",
+            "args": [100, lw2.wells_by_index()["B2"], 1.0],
+            "kwargs": {},
+        },
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     assert xfer_plan_list == exp1
 
     # targets outside of row limit will be skipped
     xfer_plan = tx.TransferPlan(
-        100, lw1.rows()[0][1], [lw2.rows()[1][1], lw2.rows()[2][1]],
+        100,
+        lw1.rows()[0][1],
+        [lw2.rows()[1][1], lw2.rows()[2][1]],
         instr_multi,
-        max_volume=instr_multi.hw_pipette['working_volume'],
+        max_volume=instr_multi.hw_pipette["working_volume"],
         api_version=ctx.api_version,
-        mode='transfer')
+        mode="transfer",
+    )
     xfer_plan_list = []
     for step in xfer_plan:
         xfer_plan_list.append(step)
@@ -1051,105 +1168,128 @@ def test_multichannel_transfer_locs(loop, hardware):
     # no valid source or targets, raise error
     with pytest.raises(RuntimeError):
         assert tx.TransferPlan(
-            100, lw1.rows()[0][1], lw2.rows()[2][1],
+            100,
+            lw1.rows()[0][1],
+            lw2.rows()[2][1],
             instr_multi,
-            max_volume=instr_multi.hw_pipette['working_volume'],
+            max_volume=instr_multi.hw_pipette["working_volume"],
             api_version=ctx.api_version,
-            mode='transfer')
+            mode="transfer",
+        )
 
 
 def test_zero_volume_results_in_no_transfer(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
-    API_VERSION = _instr_labware['ctx'].api_version
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
+    API_VERSION = _instr_labware["ctx"].api_version
 
-    exp_no_vol = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-                  {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+    exp_no_vol = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
 
     # ========== Transfer ===========
     xfer_plan = tx.TransferPlan(
-        0, lw1.columns()[0], lw2.columns()[0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        0,
+        lw1.columns()[0],
+        lw2.columns()[0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='transfer')
+        mode="transfer",
+    )
     for step, expected in zip(xfer_plan, exp_no_vol):
         assert step == expected
 
     xfer_plan = tx.TransferPlan(
-        [100, 0, 200], lw1.wells()[0:3], lw2.wells()[0:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        [100, 0, 200],
+        lw1.wells()[0:3],
+        lw2.wells()[0:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='transfer')
-    exp2 = [{'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [100, lw2['A1'], 1.0], 'kwargs': {}},
-            {'method': 'aspirate',
-             'args': [200, lw1['C1'], 1.0], 'kwargs': {}},
-            {'method': 'dispense',
-             'args': [200, lw2['C1'], 1.0], 'kwargs': {}},
-            {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        mode="transfer",
+    )
+    exp2 = [
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["C1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [200, lw2["C1"], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(xfer_plan, exp2):
         assert step == expected
 
     # ========== Distribute ===========
     dist_plan = tx.TransferPlan(
-        0, lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        0,
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='distribute')
+        mode="distribute",
+    )
     for step, expected in zip(dist_plan, exp_no_vol):
         assert step == expected
 
     dist_plan = tx.TransferPlan(
-        [100, 0], lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        [100, 0],
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='distribute')
+        mode="distribute",
+    )
     exp3 = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [100, lw2['A2'], 1.0], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2["A2"], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(dist_plan, exp3):
         assert step == expected
 
     # ========== Consolidate ===========
     consd_plan = tx.TransferPlan(
-        0, lw1.columns()[0], lw2.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        0,
+        lw1.columns()[0],
+        lw2.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='consolidate')
+        mode="consolidate",
+    )
     for step, expected in zip(consd_plan, exp_no_vol):
         assert step == expected
 
     cons_list = [100, 200, 300, 200, 0, 0, 100, 200]
     consd_plan = tx.TransferPlan(
-        cons_list, lw1.columns()[0], lw2.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        cons_list,
+        lw1.columns()[0],
+        lw2.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='consolidate')
+        mode="consolidate",
+    )
     exp4 = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['B1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [300, lw1['C1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['D1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [100, lw1['G1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['H1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [200, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["B1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [300, lw1["C1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["D1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["G1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["H1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [200, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(consd_plan, exp4):
         assert step == expected
 
@@ -1159,131 +1299,155 @@ def test_zero_volume_causes_transfer_of_disposal_vol(_instr_labware):
     # with zero volumes in which case the volume aspirated/dispensed
     # was the min volume + disposal volume if a zero volume was
     # specified.
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
     API_VERSION = APIVersion(2, 6)
-    blow_out = _instr_labware['instr'].trash_container.wells()[0]
+    blow_out = _instr_labware["instr"].trash_container.wells()[0]
 
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            disposal_volume=_instr_labware['instr'].min_volume))
+            disposal_volume=_instr_labware["instr"].min_volume
+        )
+    )
 
     # ========== Distribute ===========
     dist_plan = tx.TransferPlan(
-        0, lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        0,
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='distribute',
-        options=options)
+        mode="distribute",
+        options=options,
+    )
 
     exp_no_vol = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [0, lw2['A2'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [0, lw2['A3'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [blow_out], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [0, lw2["A2"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [0, lw2["A3"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [blow_out], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(dist_plan, exp_no_vol):
         assert step == expected
 
     dist_plan = tx.TransferPlan(
-        [100, 0], lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        [100, 0],
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='distribute',
-        options=options)
+        mode="distribute",
+        options=options,
+    )
     exp = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [130, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [100, lw2['A2'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [0, lw2['A3'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [blow_out], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [130, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [100, lw2["A2"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [0, lw2["A3"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [blow_out], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(dist_plan, exp):
         assert step == expected
 
     # ========== Consolidate ===========
     consd_plan = tx.TransferPlan(
-        0, lw1.columns()[0], lw2.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        0,
+        lw1.columns()[0],
+        lw2.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='consolidate')
+        mode="consolidate",
+    )
     exp_no_vol = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['B1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['C1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['D1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['E1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['F1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['G1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['H1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [0, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["B1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["C1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["D1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["E1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["F1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["G1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["H1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [0, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(consd_plan, exp_no_vol):
         assert step == expected
 
     cons_list = [100, 200, 300, 200, 0, 0, 100, 200]
     consd_plan = tx.TransferPlan(
-        cons_list, lw1.columns()[0], lw2.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        cons_list,
+        lw1.columns()[0],
+        lw2.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='consolidate')
+        mode="consolidate",
+    )
     exp2 = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [100, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['B1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [300, lw1['C1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['D1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['E1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [0, lw1['F1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [100, lw1['G1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [300, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [200, lw1['H1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [200, lw2['A1'], 1.0], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["B1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [300, lw1["C1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["D1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["E1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [0, lw1["F1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [100, lw1["G1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [300, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [200, lw1["H1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [200, lw2["A1"], 1.0], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(consd_plan, exp2):
         assert step == expected
 
 
 def test_blowout_to_source(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
     API_VERSION = APIVersion(2, 6)
 
     # ========== Transfer ===========
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            disposal_volume=_instr_labware['instr'].min_volume,
-            blow_out_strategy=tx.BlowOutStrategy.SOURCE))
+            disposal_volume=_instr_labware["instr"].min_volume,
+            blow_out_strategy=tx.BlowOutStrategy.SOURCE,
+        )
+    )
 
     xfer_plan = tx.TransferPlan(
-        30, [lw1['A1'], lw1['A2']], [lw2['B1'], lw2['B2']],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        30,
+        [lw1["A1"], lw1["A2"]],
+        [lw2["B1"], lw2["B2"]],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='transfer',
-        options=options)
+        mode="transfer",
+        options=options,
+    )
 
     exp = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['B1'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw1['A1']], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw1['A2'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['B2'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw1['A2']], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["B1"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw1["A1"]], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw1["A2"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["B2"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw1["A2"]], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(xfer_plan, exp):
         assert step == expected
 
@@ -1291,81 +1455,97 @@ def test_blowout_to_source(_instr_labware):
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            disposal_volume=_instr_labware['instr'].min_volume,
-            blow_out_strategy=tx.BlowOutStrategy.SOURCE))
+            disposal_volume=_instr_labware["instr"].min_volume,
+            blow_out_strategy=tx.BlowOutStrategy.SOURCE,
+        )
+    )
 
     dist_plan = tx.TransferPlan(
-        30, lw1.columns()[0][0], lw2.rows()[0][1:3],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        30,
+        lw1.columns()[0][0],
+        lw2.rows()[0][1:3],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='distribute',
-        options=options)
+        mode="distribute",
+        options=options,
+    )
 
     exp = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [90, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['A2'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['A3'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw1['A1']], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [90, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["A2"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["A3"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw1["A1"]], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(dist_plan, exp):
         assert step == expected
 
 
 def test_blowout_to_dest(_instr_labware):
-    _instr_labware['ctx'].home()
-    lw1 = _instr_labware['lw1']
-    lw2 = _instr_labware['lw2']
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
     API_VERSION = APIVersion(2, 6)
 
     # ========== Transfer ===========
     options = tx.TransferOptions()
     options = options._replace(
         transfer=options.transfer._replace(
-            disposal_volume=_instr_labware['instr'].min_volume,
-            blow_out_strategy=tx.BlowOutStrategy.DEST))
+            disposal_volume=_instr_labware["instr"].min_volume,
+            blow_out_strategy=tx.BlowOutStrategy.DEST,
+        )
+    )
 
     xfer_plan = tx.TransferPlan(
-        30, [lw1['A1'], lw1['A2']], [lw2['B1'], lw2['B2']],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        30,
+        [lw1["A1"], lw1["A2"]],
+        [lw2["B1"], lw2["B2"]],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='transfer',
-        options=options)
+        mode="transfer",
+        options=options,
+    )
 
     exp = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['B1'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw2['B1']], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw1['A2'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [30, lw2['B2'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw2['B2']], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["B1"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2["B1"]], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw1["A2"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [30, lw2["B2"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw2["B2"]], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(xfer_plan, exp):
         assert step == expected
 
     # ========== Consolidate ===========
     options = tx.TransferOptions()
     options = options._replace(
-        transfer=options.transfer._replace(
-            blow_out_strategy=tx.BlowOutStrategy.DEST))
+        transfer=options.transfer._replace(blow_out_strategy=tx.BlowOutStrategy.DEST)
+    )
 
     consd_plan = tx.TransferPlan(
-        30, lw2.rows()[0][1:3], lw1.columns()[0][0],
-        _instr_labware['instr'],
-        max_volume=_instr_labware['instr'].hw_pipette['working_volume'],
+        30,
+        lw2.rows()[0][1:3],
+        lw1.columns()[0][0],
+        _instr_labware["instr"],
+        max_volume=_instr_labware["instr"].hw_pipette["working_volume"],
         api_version=API_VERSION,
-        mode='consolidate',
-        options=options)
+        mode="consolidate",
+        options=options,
+    )
 
     exp = [
-        {'method': 'pick_up_tip', 'args': [], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw2['A2'], 1.0], 'kwargs': {}},
-        {'method': 'aspirate', 'args': [30, lw2['A3'], 1.0], 'kwargs': {}},
-        {'method': 'dispense', 'args': [60, lw1['A1'], 1.0], 'kwargs': {}},
-        {'method': 'blow_out', 'args': [lw1['A1']], 'kwargs': {}},
-        {'method': 'drop_tip', 'args': [], 'kwargs': {}}]
+        {"method": "pick_up_tip", "args": [], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw2["A2"], 1.0], "kwargs": {}},
+        {"method": "aspirate", "args": [30, lw2["A3"], 1.0], "kwargs": {}},
+        {"method": "dispense", "args": [60, lw1["A1"], 1.0], "kwargs": {}},
+        {"method": "blow_out", "args": [lw1["A1"]], "kwargs": {}},
+        {"method": "drop_tip", "args": [], "kwargs": {}},
+    ]
     for step, expected in zip(consd_plan, exp):
         assert step == expected

--- a/api/tests/opentrons/protocols/api_support/test_instrument.py
+++ b/api/tests/opentrons/protocols/api_support/test_instrument.py
@@ -2,28 +2,30 @@ from unittest import mock
 
 import pytest
 from opentrons.protocol_api.labware import Well
-from opentrons.protocols.api_support.instrument import determine_drop_target, \
-    validate_can_aspirate, \
-    validate_can_dispense
+from opentrons.protocols.api_support.instrument import (
+    determine_drop_target,
+    validate_can_aspirate,
+    validate_can_dispense,
+)
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Point
 
 
-@pytest.mark.parametrize(argnames=["api_version", "expected_point"],
-                         argvalues=[
-                             # Above version_breakpoint:
-                             #  subtract return_height (0.5) * tip_length (1)
-                             #  from z (15)
-                             [APIVersion(2, 3), Point(10, 10, 14.5)],
-                             # Below version_breakpoint:
-                             #  add 10 to bottom (10)
-                             [APIVersion(2, 0), Point(10, 10, 20)],
-                         ])
-def test_determine_drop_target(
-        api_version,
-        expected_point):
+@pytest.mark.parametrize(
+    argnames=["api_version", "expected_point"],
+    argvalues=[
+        # Above version_breakpoint:
+        #  subtract return_height (0.5) * tip_length (1)
+        #  from z (15)
+        [APIVersion(2, 3), Point(10, 10, 14.5)],
+        # Below version_breakpoint:
+        #  add 10 to bottom (10)
+        [APIVersion(2, 0), Point(10, 10, 20)],
+    ],
+)
+def test_determine_drop_target(api_version, expected_point):
     lw_mock = mock.MagicMock()
     lw_mock.is_tiprack = mock.MagicMock(return_value=True)
     lw_mock.get_tip_length = mock.MagicMock(return_value=1)
@@ -31,21 +33,22 @@ def test_determine_drop_target(
         well_implementation=WellImplementation(
             well_geometry=WellGeometry(
                 well_props={
-                    'shape': 'circular',
-                    'depth': 5,
-                    'totalLiquidVolume': 0,
-                    'x': 10,
-                    'y': 10,
-                    'z': 10,
-                    'diameter': 5,
+                    "shape": "circular",
+                    "depth": 5,
+                    "totalLiquidVolume": 0,
+                    "x": 10,
+                    "y": 10,
+                    "z": 10,
+                    "diameter": 5,
                 },
                 parent_point=Point(0, 0, 0),
-                parent_object=lw_mock),
+                parent_object=lw_mock,
+            ),
             display_name="",
             has_tip=False,
             name="A1",
         ),
-        api_level=api_version
+        api_level=api_version,
     )
     r = determine_drop_target(api_version, well, 0.5)
     assert r.labware.object == well
@@ -53,17 +56,17 @@ def test_determine_drop_target(
 
 
 def test_validate_can_aspirate(ctx):
-    well_plate = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
-    tip_rack = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
+    well_plate = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
+    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 2)
     # test type `Location`
     validate_can_aspirate(well_plate.wells()[0].top())
     with pytest.raises(RuntimeError):
-        validate_can_aspirate(tip_rack.wells_by_name()['A1'].top())
+        validate_can_aspirate(tip_rack.wells_by_name()["A1"].top())
 
 
 def test_validate_can_dispense(ctx):
-    well_plate = ctx.load_labware('corning_96_wellplate_360ul_flat', 1)
-    tip_rack = ctx.load_labware('opentrons_96_tiprack_300ul', 2)
+    well_plate = ctx.load_labware("corning_96_wellplate_360ul_flat", 1)
+    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 2)
     validate_can_dispense(well_plate.wells()[0].top())
     with pytest.raises(RuntimeError):
-        validate_can_dispense(tip_rack.wells_by_name()['A1'].top())
+        validate_can_dispense(tip_rack.wells_by_name()["A1"].top())

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -3,8 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from opentrons.protocol_api import labware
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons.protocols.api_support.labware_like import (
-    LabwareLike, LabwareLikeType)
+from opentrons.protocols.api_support.labware_like import LabwareLike, LabwareLikeType
 from opentrons.protocols.geometry import module_geometry
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.types import Location
@@ -13,14 +12,13 @@ from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
 @pytest.fixture(scope="session")
 def trough_definition() -> LabwareDefinition:
-    return labware.get_labware_definition('usascientific_12_reservoir_22ml')
+    return labware.get_labware_definition("usascientific_12_reservoir_22ml")
 
 
 @pytest.fixture(scope="session")
 def trough(trough_definition):
     deck = Deck()
-    return labware.load_from_definition(
-        trough_definition, deck.position_for(1))
+    return labware.load_from_definition(trough_definition, deck.position_for(1))
 
 
 @pytest.fixture(scope="session")
@@ -28,8 +26,9 @@ def module(trough):
     deck = Deck()
     mod = module_geometry.load_module(
         module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for('6'),
-        MAX_SUPPORTED_VERSION)
+        deck.position_for("6"),
+        MAX_SUPPORTED_VERSION,
+    )
     return mod
 
 
@@ -50,7 +49,7 @@ def test_labware(trough, mod_trough, module):
 
 
 def test_well(trough):
-    well = trough['A1']
+    well = trough["A1"]
     ll = LabwareLike(well)
     assert ll.has_parent is True
     assert ll.parent.object == trough
@@ -69,10 +68,10 @@ def test_module(module):
 
 
 def test_slot():
-    ll = LabwareLike('1')
+    ll = LabwareLike("1")
     assert ll.has_parent is False
     assert ll.parent.object is None
-    assert ll.object == '1'
+    assert ll.object == "1"
     assert ll.object_type == LabwareLikeType.SLOT
 
 
@@ -86,27 +85,28 @@ def test_empty():
 
 def test_module_parent(trough, module, mod_trough):
     assert LabwareLike(mod_trough).module_parent() == module
-    assert LabwareLike(mod_trough['A1']).module_parent() == module
+    assert LabwareLike(mod_trough["A1"]).module_parent() == module
     assert LabwareLike(module).module_parent() == module
     assert LabwareLike(trough).module_parent() is None
-    assert LabwareLike('1').module_parent() is None
+    assert LabwareLike("1").module_parent() is None
 
 
 def test_first_parent(trough, module, mod_trough):
-    assert LabwareLike(trough).first_parent() == '1'
-    assert LabwareLike(trough['A2']).first_parent() == '1'
+    assert LabwareLike(trough).first_parent() == "1"
+    assert LabwareLike(trough["A2"]).first_parent() == "1"
     assert LabwareLike(None).first_parent() is None
-    assert LabwareLike('6').first_parent() == '6'
+    assert LabwareLike("6").first_parent() == "6"
 
-    assert LabwareLike(mod_trough['A5']).first_parent() == '6'
-    assert LabwareLike(mod_trough).first_parent() == '6'
-    assert LabwareLike(module).first_parent() == '6'
+    assert LabwareLike(mod_trough["A5"]).first_parent() == "6"
+    assert LabwareLike(mod_trough).first_parent() == "6"
+    assert LabwareLike(module).first_parent() == "6"
 
     # Set up recursion cycle test.
     mock_labware_geometry = MagicMock()
     mock_labware_geometry.parent = Location(point=None, labware=mod_trough)
     mod_trough._implementation.get_geometry = MagicMock(
-        return_value=mock_labware_geometry)
+        return_value=mock_labware_geometry
+    )
 
     with pytest.raises(RuntimeError):
         # make sure we catch cycles

--- a/api/tests/opentrons/protocols/api_support/test_tip_tracker.py
+++ b/api/tests/opentrons/protocols/api_support/test_tip_tracker.py
@@ -8,31 +8,21 @@ from opentrons.protocols.api_support.well_grid import WellGrid
 
 @pytest.fixture()
 def names_96_well() -> List[str]:
-    names = (
-        (
-            f'{c}{r}' for c in (chr(65 + i) for i in range(8))
-        ) for r in range(1, 13)
-    )
+    names = ((f"{c}{r}" for c in (chr(65 + i) for i in range(8))) for r in range(1, 13))
     return [name for column in names for name in column]
 
 
 @pytest.fixture()
 def wells(names_96_well) -> List[WellImplementation]:
     return [
-        WellImplementation(
-            well_geometry=None,
-            display_name=n,
-            has_tip=True,
-            name=n
-        ) for n in names_96_well
+        WellImplementation(well_geometry=None, display_name=n, has_tip=True, name=n)
+        for n in names_96_well
     ]
 
 
 @pytest.fixture()
 def well_grid(names_96_well, wells) -> WellGrid:
-    return WellGrid(
-        wells
-    )
+    return WellGrid(wells)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocols/api_support/test_util.py
+++ b/api/tests/opentrons/protocols/api_support/test_util.py
@@ -1,13 +1,16 @@
 import pytest
 
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.types import Point, Location, Mount
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocol_api.labware import Labware, get_labware_definition
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocols.api_support.util import (
-    HardwareManager, AxisMaxSpeeds, build_edges, _find_value_for_api_version)
+    HardwareManager,
+    AxisMaxSpeeds,
+    build_edges,
+    _find_value_for_api_version,
+)
 from opentrons.hardware_control import API, adapters, types, ThreadManager
 
 
@@ -47,141 +50,157 @@ def test_max_speeds_userdict():
     assert dict(defaults) == {}
 
     with pytest.raises(KeyError):
-        defaults['asdas'] = 2
+        defaults["asdas"] = 2
 
     with pytest.raises(AssertionError):
-        defaults['x'] = -1
+        defaults["x"] = -1
 
     with pytest.raises(AssertionError):
-        defaults['y'] = 'ggg'
+        defaults["y"] = "ggg"
 
     with pytest.raises(KeyError):
-        defaults['b'] = 2
+        defaults["b"] = 2
 
     with pytest.raises(KeyError):
-        defaults['c'] = 3
+        defaults["c"] = 3
 
-    defaults['x'] = 2
+    defaults["x"] = 2
     defaults[types.Axis.A] = 20
 
-    assert defaults['X'] == 2
-    assert defaults['x'] == 2
+    assert defaults["X"] == 2
+    assert defaults["x"] == 2
     assert defaults[types.Axis.X] == 2
 
-    assert defaults['A'] == 20
-    assert defaults['a'] == 20
+    assert defaults["A"] == 20
+    assert defaults["a"] == 20
     assert defaults[types.Axis.A] == 20
 
-    assert sorted(list(defaults.keys()))\
-        == sorted(['X', 'A'])
-    assert 'X' in defaults.keys()
+    assert sorted(list(defaults.keys())) == sorted(["X", "A"])
+    assert "X" in defaults.keys()
 
-    del defaults['A']
-    assert 'A' not in defaults
+    del defaults["A"]
+    assert "A" not in defaults
 
-    defaults['x'] = None
-    assert 'x' not in defaults
+    defaults["x"] = None
+    assert "x" not in defaults
 
 
 def test_build_edges():
-    lw_def = get_labware_definition('corning_96_wellplate_360ul_flat')
+    lw_def = get_labware_definition("corning_96_wellplate_360ul_flat")
     test_lw = Labware(
-        implementation=LabwareImplementation(lw_def,
-                                             Location(Point(0, 0, 0), None)))
+        implementation=LabwareImplementation(lw_def, Location(Point(0, 0, 0), None))
+    )
     off = Point(0, 0, 1.0)
     deck = Deck()
     old_correct_edges = [
-        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
-    res = build_edges(
-        test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 2))
+    res = build_edges(test_lw["A1"], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 2))
     assert res == old_correct_edges
 
     new_correct_edges = [
-        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
-    res2 = build_edges(
-        test_lw['A1'], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 4))
+    res2 = build_edges(test_lw["A1"], 1.0, Mount.RIGHT, deck, version=APIVersion(2, 4))
     assert res2 == new_correct_edges
 
 
 def test_build_edges_left_pipette(ctx):
-    test_lw = ctx.load_labware('corning_96_wellplate_360ul_flat', '2')
-    test_lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', '6')
-    mod = ctx.load_module('magnetic module', '3')
-    mod.load_labware('corning_96_wellplate_360ul_flat')
+    test_lw = ctx.load_labware("corning_96_wellplate_360ul_flat", "2")
+    test_lw2 = ctx.load_labware("corning_96_wellplate_360ul_flat", "6")
+    mod = ctx.load_module("magnetic module", "3")
+    mod.load_labware("corning_96_wellplate_360ul_flat")
     off = Point(0, 0, 1.0)
     left_pip_edges = [
-        test_lw['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw["A12"].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw["A12"].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw["A12"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw["A12"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 3 results in modified edge list
     res = build_edges(
-        test_lw['A12'], 1.0, Mount.LEFT,
-        ctx._implementation.get_deck(), version=APIVersion(2, 4))
+        test_lw["A12"],
+        1.0,
+        Mount.LEFT,
+        ctx._implementation.get_deck(),
+        version=APIVersion(2, 4),
+    )
     assert res == left_pip_edges
 
     left_pip_edges = [
-        test_lw2['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in modified edge list
     res2 = build_edges(
-        test_lw2['A12'], 1.0, Mount.LEFT,
-        ctx._implementation.get_deck(), version=APIVersion(2, 4))
+        test_lw2["A12"],
+        1.0,
+        Mount.LEFT,
+        ctx._implementation.get_deck(),
+        version=APIVersion(2, 4),
+    )
     assert res2 == left_pip_edges
 
 
 def test_build_edges_right_pipette(ctx):
-    test_lw = ctx.load_labware('corning_96_wellplate_360ul_flat', '2')
-    test_lw2 = ctx.load_labware('corning_96_wellplate_360ul_flat', '6')
-    mod = ctx.load_module('magnetic module', '1')
-    mod.load_labware('corning_96_wellplate_360ul_flat')
+    test_lw = ctx.load_labware("corning_96_wellplate_360ul_flat", "2")
+    test_lw2 = ctx.load_labware("corning_96_wellplate_360ul_flat", "6")
+    mod = ctx.load_module("magnetic module", "1")
+    mod.load_labware("corning_96_wellplate_360ul_flat")
     off = Point(0, 0, 1.0)
     right_pip_edges = [
-        test_lw['A1'].from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw['A1'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw["A1"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that module in slot 1 results in modified edge list
     res = build_edges(
-        test_lw['A1'], 1.0, Mount.RIGHT,
-        ctx._implementation._deck_layout, version=APIVersion(2, 4))
+        test_lw["A1"],
+        1.0,
+        Mount.RIGHT,
+        ctx._implementation._deck_layout,
+        version=APIVersion(2, 4),
+    )
     assert res == right_pip_edges
 
     right_pip_edges = [
-        test_lw2['A12'].from_center_cartesian(x=1.0, y=0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=-1.0, y=0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=1.0, z=1) + off,
-        test_lw2['A12'].from_center_cartesian(x=0, y=-1.0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=1.0, y=0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=-1.0, y=0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=1.0, z=1) + off,
+        test_lw2["A12"].from_center_cartesian(x=0, y=-1.0, z=1) + off,
     ]
     # Test that labware in slot 6 results in unmodified edge list
     res2 = build_edges(
-        test_lw2['A12'], 1.0, Mount.RIGHT,
-        ctx._implementation.get_deck(), version=APIVersion(2, 4))
+        test_lw2["A12"],
+        1.0,
+        Mount.RIGHT,
+        ctx._implementation.get_deck(),
+        version=APIVersion(2, 4),
+    )
     assert res2 == right_pip_edges
 
 
-@pytest.mark.parametrize('data,level,desired', [
-    ({'2.0': 5}, APIVersion(2, 0), 5),
-    ({'2.0': 5}, APIVersion(2, 5), 5),
-    ({'2.6': 4, '2.0': 5}, APIVersion(2, 1), 5),
-    ({'2.6': 4, '2.0': 5}, APIVersion(2, 6), 4),
-    ({'2.0': 5, '2.6': 4}, APIVersion(2, 3), 5),
-    ({'2.0': 5, '2.6': 4}, APIVersion(2, 6), 4)
-])
+@pytest.mark.parametrize(
+    "data,level,desired",
+    [
+        ({"2.0": 5}, APIVersion(2, 0), 5),
+        ({"2.0": 5}, APIVersion(2, 5), 5),
+        ({"2.6": 4, "2.0": 5}, APIVersion(2, 1), 5),
+        ({"2.6": 4, "2.0": 5}, APIVersion(2, 6), 4),
+        ({"2.0": 5, "2.6": 4}, APIVersion(2, 3), 5),
+        ({"2.0": 5, "2.6": 4}, APIVersion(2, 6), 4),
+    ],
+)
 def test_find_value_for_api_version(data, level, desired):
     assert _find_value_for_api_version(level, data) == desired

--- a/api/tests/opentrons/protocols/api_support/test_well_grid.py
+++ b/api/tests/opentrons/protocols/api_support/test_well_grid.py
@@ -7,19 +7,32 @@ from opentrons.protocols.context.well import WellImplementation
 NONE: list = []
 ONE_VAL = ["A1"]
 NORMAL = [
-    "A1", "B1", "C1",
-    "A2", "B2", "C2",
-    "A3", "B3", "C3",
-    "A4", "B4", "C4",
-  ]
-CRAZY_SHAPE = [
-    "A1", "B1", "C1",
-    "B2", "C2",
+    "A1",
+    "B1",
+    "C1",
+    "A2",
+    "B2",
+    "C2",
+    "A3",
     "B3",
-    "A4", "C4", "D4",
+    "C3",
+    "A4",
+    "B4",
+    "C4",
+]
+CRAZY_SHAPE = [
+    "A1",
+    "B1",
+    "C1",
+    "B2",
+    "C2",
+    "B3",
+    "A4",
+    "C4",
+    "D4",
 ]
 TWELVE_BY_TWELVE_GRID = [
-    [f'{c}{r}' for c in [chr(65 + i) for i in range(12)]] for r in range(1, 13)
+    [f"{c}{r}" for c in [chr(65 + i) for i in range(12)]] for r in range(1, 13)
 ]
 # Flatten to a list of well names
 TWELVE_BY_TWELVE = [n for x in TWELVE_BY_TWELVE_GRID for n in x]
@@ -28,23 +41,25 @@ TWELVE_BY_TWELVE = [n for x in TWELVE_BY_TWELVE_GRID for n in x]
 def wells_from_names(names: List[str]) -> List[WellImplementation]:
     return [
         WellImplementation(
-            well_geometry=None,
-            display_name=None,
-            has_tip=None,
-            name=name
-        ) for name in names]
+            well_geometry=None, display_name=None, has_tip=None, name=name
+        )
+        for name in names
+    ]
 
 
 @pytest.mark.parametrize(
     argnames=["names", "expected"],
     argvalues=[
         [NONE, []],
-        [ONE_VAL, ['A']],
-        [NORMAL, ['A', 'B', 'C']],
-        [CRAZY_SHAPE, ['A', 'B', 'C', 'D']],
-        [TWELVE_BY_TWELVE, ['A', 'B', 'C', 'D', 'E', 'F',
-                            'G', 'H', 'I', 'J', 'K', 'L']]
-    ])
+        [ONE_VAL, ["A"]],
+        [NORMAL, ["A", "B", "C"]],
+        [CRAZY_SHAPE, ["A", "B", "C", "D"]],
+        [
+            TWELVE_BY_TWELVE,
+            ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"],
+        ],
+    ],
+)
 def test_row_headers(names, expected):
     assert WellGrid(wells_from_names(names)).row_headers() == expected
 
@@ -53,23 +68,24 @@ def test_row_headers(names, expected):
     argnames=["names", "expected"],
     argvalues=[
         [NONE, {}],
-        [ONE_VAL, {'A': [0]}],
-        [NORMAL, {
-            "A": [0, 3, 6, 9],
-            "B": [1, 4, 7, 10],
-            "C": [2, 5, 8, 11],
-        }],
-        [CRAZY_SHAPE, {
-            "A": [0, 6],
-            "B": [1, 3, 5],
-            "C": [2, 4, 7],
-            "D": [8]}],
-    ])
+        [ONE_VAL, {"A": [0]}],
+        [
+            NORMAL,
+            {
+                "A": [0, 3, 6, 9],
+                "B": [1, 4, 7, 10],
+                "C": [2, 5, 8, 11],
+            },
+        ],
+        [CRAZY_SHAPE, {"A": [0, 6], "B": [1, 3, 5], "C": [2, 4, 7], "D": [8]}],
+    ],
+)
 def test_row_dict(names, expected):
     wells = wells_from_names(names)
     grid = WellGrid(wells)
-    assert grid.get_row_dict() == {k: [wells[i] for i in v]
-                                   for k, v in expected.items()}
+    assert grid.get_row_dict() == {
+        k: [wells[i] for i in v] for k, v in expected.items()
+    }
 
 
 @pytest.mark.parametrize(
@@ -77,17 +93,25 @@ def test_row_dict(names, expected):
     argvalues=[
         [NONE, []],
         [ONE_VAL, [[0]]],
-        [NORMAL, [
-            [0, 3, 6, 9],
-            [1, 4, 7, 10],
-            [2, 5, 8, 11],
-        ]],
-        [CRAZY_SHAPE, [
-            [0, 6],
-            [1, 3, 5],
-            [2, 4, 7],
-            [8],
-        ]]])
+        [
+            NORMAL,
+            [
+                [0, 3, 6, 9],
+                [1, 4, 7, 10],
+                [2, 5, 8, 11],
+            ],
+        ],
+        [
+            CRAZY_SHAPE,
+            [
+                [0, 6],
+                [1, 3, 5],
+                [2, 4, 7],
+                [8],
+            ],
+        ],
+    ],
+)
 def test_rows(names, expected):
     wells = wells_from_names(names)
     grid = WellGrid(wells)
@@ -98,12 +122,15 @@ def test_rows(names, expected):
     argnames=["names", "expected"],
     argvalues=[
         [NONE, []],
-        [ONE_VAL, ['1']],
-        [NORMAL, ['1', '2', '3', '4']],
-        [CRAZY_SHAPE, ['1', '2', '3', '4']],
-        [TWELVE_BY_TWELVE, ['1', '2', '3', '4', '5', '6',
-                            '7', '8', '9', '10', '11', '12']]
-        ])
+        [ONE_VAL, ["1"]],
+        [NORMAL, ["1", "2", "3", "4"]],
+        [CRAZY_SHAPE, ["1", "2", "3", "4"]],
+        [
+            TWELVE_BY_TWELVE,
+            ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
+        ],
+    ],
+)
 def test_column_headers(names, expected):
     wells = wells_from_names(names)
     grid = WellGrid(wells)
@@ -114,20 +141,19 @@ def test_column_headers(names, expected):
     argnames=["names", "expected"],
     argvalues=[
         [NONE, {}],
-        [ONE_VAL, {'1': [0]}],
-        [NORMAL, {
-            '1': [0, 1, 2],
-            '2': [3, 4, 5],
-            '3': [6, 7, 8],
-            '4': [9, 10, 11],
-        }],
-        [CRAZY_SHAPE, {
-            '1': [0, 1, 2],
-            '2': [3, 4],
-            '3': [5],
-            '4': [6, 7, 8]
-        }]
-    ])
+        [ONE_VAL, {"1": [0]}],
+        [
+            NORMAL,
+            {
+                "1": [0, 1, 2],
+                "2": [3, 4, 5],
+                "3": [6, 7, 8],
+                "4": [9, 10, 11],
+            },
+        ],
+        [CRAZY_SHAPE, {"1": [0, 1, 2], "2": [3, 4], "3": [5], "4": [6, 7, 8]}],
+    ],
+)
 def test_column_dict(names, expected):
     wells = wells_from_names(names)
     grid = WellGrid(wells)
@@ -141,30 +167,27 @@ def test_column_dict(names, expected):
     argvalues=[
         [NONE, []],
         [ONE_VAL, [[0]]],
-        [NORMAL, [
-            [0, 1, 2],
-            [3, 4, 5],
-            [6, 7, 8],
-            [9, 10, 11],
-        ]],
-        [CRAZY_SHAPE, [
-            [0, 1, 2],
-            [3, 4],
-            [5],
-            [6, 7, 8]
-        ]]
-    ])
+        [
+            NORMAL,
+            [
+                [0, 1, 2],
+                [3, 4, 5],
+                [6, 7, 8],
+                [9, 10, 11],
+            ],
+        ],
+        [CRAZY_SHAPE, [[0, 1, 2], [3, 4], [5], [6, 7, 8]]],
+    ],
+)
 def test_columns(names, expected):
     wells = wells_from_names(names)
     grid = WellGrid(wells)
     assert grid.get_columns() == [[wells[i] for i in r] for r in expected]
 
 
-@pytest.mark.parametrize(argnames=["column", "expected"],
-                         argvalues=[
-                             ["2", [3, 4, 5]],
-                             ["1000", []]
-                         ])
+@pytest.mark.parametrize(
+    argnames=["column", "expected"], argvalues=[["2", [3, 4, 5]], ["1000", []]]
+)
 def test_column(column, expected):
     names = NORMAL
     wells = wells_from_names(names)
@@ -172,11 +195,9 @@ def test_column(column, expected):
     assert grid.get_column(column) == [wells[i] for i in expected]
 
 
-@pytest.mark.parametrize(argnames=["row", "expected"],
-                         argvalues=[
-                             ["B", [1, 4, 7, 10]],
-                             ["X", []]
-                         ])
+@pytest.mark.parametrize(
+    argnames=["row", "expected"], argvalues=[["B", [1, 4, 7, 10]], ["X", []]]
+)
 def test_row(row, expected):
     names = NORMAL
     wells = wells_from_names(names)

--- a/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_instrument_context.py
@@ -5,15 +5,16 @@ from pytest_lazyfixture import lazy_fixture
 from opentrons.hardware_control import NoTipAttachedError
 from opentrons.hardware_control.types import TipAttachedError
 from opentrons.protocols.context.labware import AbstractLabware
-from opentrons.protocols.context.protocol_api.labware import \
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons import types, ThreadManager
 from opentrons.protocols.context.instrument import AbstractInstrument
-from opentrons.protocols.context.protocol_api.protocol_context import \
-    ProtocolContextImplementation
-from opentrons.protocols.context.simulator.instrument_context import \
-    InstrumentContextSimulation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.protocols.context.simulator.instrument_context import (
+    InstrumentContextSimulation,
+)
 
 
 @pytest.fixture
@@ -24,21 +25,25 @@ def protocol_context(hardware: ThreadManager) -> ProtocolContextImplementation:
 
 @pytest.fixture
 def instrument_context(
-        protocol_context: ProtocolContextImplementation) -> AbstractInstrument:
+    protocol_context: ProtocolContextImplementation,
+) -> AbstractInstrument:
     """Instrument context backed by hardware simulator."""
     return protocol_context.load_instrument(
-        'p300_single_gen2', types.Mount.RIGHT, replace=False
+        "p300_single_gen2", types.Mount.RIGHT, replace=False
     )
 
 
 @pytest.fixture
-def simulating_context(protocol_context: ProtocolContextImplementation,
-                       instrument_context: AbstractInstrument) -> AbstractInstrument:
+def simulating_context(
+    protocol_context: ProtocolContextImplementation,
+    instrument_context: AbstractInstrument,
+) -> AbstractInstrument:
     """A simulating instrument context."""
     return InstrumentContextSimulation(
         protocol_interface=protocol_context,
         pipette_dict=instrument_context.get_pipette(),
-        mount=types.Mount.RIGHT, instrument_name='p300_single_gen2'
+        mount=types.Mount.RIGHT,
+        instrument_name="p300_single_gen2",
     )
 
 
@@ -51,15 +56,16 @@ def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
     )
 
 
-@pytest.fixture(params=[lazy_fixture("instrument_context"),
-                        lazy_fixture("simulating_context")
-                        ])
+@pytest.fixture(
+    params=[lazy_fixture("instrument_context"), lazy_fixture("simulating_context")]
+)
 def subject(request) -> AbstractInstrument:
     return request.param
 
 
-def test_same_pipette(instrument_context: AbstractInstrument,
-                      simulating_context: AbstractInstrument) -> None:
+def test_same_pipette(
+    instrument_context: AbstractInstrument, simulating_context: AbstractInstrument
+) -> None:
     """It should have the same pipette as hardware backed instrument context."""
     assert instrument_context.get_pipette() == simulating_context.get_pipette()
 
@@ -72,8 +78,7 @@ def test_aspirate_no_tip(subject: AbstractInstrument) -> None:
 
 def test_prepare_to_aspirate_no_tip(subject: AbstractInstrument) -> None:
     """It should raise an error if a tip is not attached."""
-    with pytest.raises(NoTipAttachedError,
-                       match="Cannot perform PREPARE_ASPIRATE"):
+    with pytest.raises(NoTipAttachedError, match="Cannot perform PREPARE_ASPIRATE"):
         subject.prepare_for_aspirate()
 
 
@@ -95,25 +100,30 @@ def test_blow_out_no_tip(subject: AbstractInstrument) -> None:
         subject.blow_out()
 
 
-def test_pick_up_tip_no_tip(subject: AbstractInstrument,
-                            labware: AbstractLabware) -> None:
+def test_pick_up_tip_no_tip(
+    subject: AbstractInstrument, labware: AbstractLabware
+) -> None:
     """It should raise an error if a tip is already attached."""
     subject.home()
-    subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1, presses=None,
-                        increment=None)
+    subject.pick_up_tip(
+        well=labware.get_wells()[0], tip_length=1, presses=None, increment=None
+    )
     with pytest.raises(TipAttachedError):
-        subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1,
-                            presses=None,
-                            increment=None)
+        subject.pick_up_tip(
+            well=labware.get_wells()[0], tip_length=1, presses=None, increment=None
+        )
 
 
-def test_aspirate_too_much(subject: AbstractInstrument,
-                           labware: AbstractLabware) -> None:
+def test_aspirate_too_much(
+    subject: AbstractInstrument, labware: AbstractLabware
+) -> None:
     """It should raise an error if try to aspirate more than possible."""
     subject.home()
-    subject.pick_up_tip(well=labware.get_wells()[0], tip_length=1, presses=None,
-                        increment=None)
+    subject.pick_up_tip(
+        well=labware.get_wells()[0], tip_length=1, presses=None, increment=None
+    )
     subject.prepare_for_aspirate()
-    with pytest.raises(AssertionError,
-                       match="Cannot aspirate more than pipette max volume"):
+    with pytest.raises(
+        AssertionError, match="Cannot aspirate more than pipette max volume"
+    ):
         subject.aspirate(subject.get_max_volume() + 1, rate=1)

--- a/api/tests/opentrons/protocols/context/test_well.py
+++ b/api/tests/opentrons/protocols/context/test_well.py
@@ -2,14 +2,16 @@ import pytest
 from opentrons.protocols.context.well import WellImplementation
 
 
-@pytest.mark.parametrize(argnames=["name", "row", "col"],
-                         argvalues=[
-                             ["A1", "A", "1"],
-                             ["A10", "A", "10"],
-                             ["Z100", "Z", "100"],
-                             ["A0", "A", "0"],
-                             ["B0100", "B", "0100"]
-                         ])
+@pytest.mark.parametrize(
+    argnames=["name", "row", "col"],
+    argvalues=[
+        ["A1", "A", "1"],
+        ["A10", "A", "10"],
+        ["Z100", "Z", "100"],
+        ["A0", "A", "0"],
+        ["B0100", "B", "0100"],
+    ],
+)
 def test_row_column(name, row, col):
     w = WellImplementation(None, None, None, name=name)
     assert w.get_name() == name
@@ -17,12 +19,14 @@ def test_row_column(name, row, col):
     assert w.get_column_name() == col
 
 
-@pytest.mark.parametrize(argnames=["name"],
-                         argvalues=[
-                             ["a1"],
-                             ["Aa1"],
-                             ["A 1"],
-                         ])
+@pytest.mark.parametrize(
+    argnames=["name"],
+    argvalues=[
+        ["a1"],
+        ["Aa1"],
+        ["A 1"],
+    ],
+)
 def test_row_column_fail(name):
     with pytest.raises(AssertionError, match=f"could not match '{name}'"):
         WellImplementation(None, None, None, name=name)

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v3.py
@@ -1,6 +1,5 @@
 from opentrons.protocols.geometry.well_geometry import WellGeometry
-from opentrons.protocols.context.protocol_api.labware import\
-    LabwareImplementation
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 from opentrons.protocols.context.well import WellImplementation
 
 from unittest import mock
@@ -10,35 +9,55 @@ from opentrons.types import Location, Point
 from opentrons.protocols.parse import parse
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import (
-    ProtocolContext, InstrumentContext, labware, MAX_SUPPORTED_VERSION)
+    ProtocolContext,
+    InstrumentContext,
+    labware,
+    MAX_SUPPORTED_VERSION,
+)
 from opentrons.protocols.execution import execute
 from opentrons.protocols.execution.execute_json_v3 import (
-    _aspirate, _dispense, _delay, _drop_tip, _blowout, dispatch_json,
-    _pick_up_tip, _touch_tip, _air_gap, _move_to_slot,
-    load_labware_from_json_defs, _get_well, _set_flow_rate,
-    _get_location_with_offset, load_pipettes_from_json)
+    _aspirate,
+    _dispense,
+    _delay,
+    _drop_tip,
+    _blowout,
+    dispatch_json,
+    _pick_up_tip,
+    _touch_tip,
+    _air_gap,
+    _move_to_slot,
+    load_labware_from_json_defs,
+    _get_well,
+    _set_flow_rate,
+    _get_location_with_offset,
+    load_pipettes_from_json,
+)
 
 
 def test_load_pipettes_from_json():
     def fake_pipette(name, mount):
         return (name, mount)
+
     ctx = mock.create_autospec(ProtocolContext)
     ctx.load_instrument = fake_pipette
-    protocol = {'pipettes': {
-        'aID': {'mount': 'left', 'name': 'a'},
-        'bID': {'mount': 'right', 'name': 'b'}}}
+    protocol = {
+        "pipettes": {
+            "aID": {"mount": "left", "name": "a"},
+            "bID": {"mount": "right", "name": "b"},
+        }
+    }
     result = load_pipettes_from_json(ctx, protocol)
-    assert result == {'aID': ('a', 'left'), 'bID': ('b', 'right')}
+    assert result == {"aID": ("a", "left"), "bID": ("b", "right")}
 
 
 def test_get_well(minimal_labware_def2):
-    deck = Location(Point(0, 0, 0), 'deck')
-    well_name = 'A2'
+    deck = Location(Point(0, 0, 0), "deck")
+    well_name = "A2"
     some_labware = labware.Labware(
         implementation=LabwareImplementation(minimal_labware_def2, deck)
     )
-    loaded_labware = {'someLabwareId': some_labware}
-    params = {'labware': 'someLabwareId', 'well': well_name}
+    loaded_labware = {"someLabwareId": some_labware}
+    params = {"labware": "someLabwareId", "well": well_name}
     result = _get_well(loaded_labware, params)
     assert result == some_labware[well_name]
 
@@ -48,7 +67,7 @@ def test_set_flow_rate():
     pipette.flow_rate.aspirate = 1
     pipette.flow_rate.dispense = 2
     pipette.flow_rate.blow_out = 3
-    params = {'flowRate': 42}
+    params = {"flowRate": 42}
 
     _set_flow_rate(pipette, params)
     assert pipette.flow_rate.aspirate == 42
@@ -57,68 +76,61 @@ def test_set_flow_rate():
 
 
 def test_load_labware_from_json_defs(ctx, get_labware_fixture):
-    custom_trough_def = get_labware_fixture('fixture_12_trough')
+    custom_trough_def = get_labware_fixture("fixture_12_trough")
     data = {
-        "labwareDefinitions": {
-            "someTroughDef": custom_trough_def
-        },
+        "labwareDefinitions": {"someTroughDef": custom_trough_def},
         "labware": {
             "sourcePlateId": {
                 "slot": "10",
                 "definitionId": "someTroughDef",
-                "displayName": "Source (Buffer)"
+                "displayName": "Source (Buffer)",
             },
-            "destPlateId": {
-                "slot": "11",
-                "definitionId": "someTroughDef"
-            },
-        }
+            "destPlateId": {"slot": "11", "definitionId": "someTroughDef"},
+        },
     }
     loaded_labware = load_labware_from_json_defs(ctx, data)
 
     # objects in loaded_labware should be same objs as labware objs in the deck
-    assert loaded_labware['sourcePlateId'] == ctx.loaded_labwares[10]
+    assert loaded_labware["sourcePlateId"] == ctx.loaded_labwares[10]
     # use the displayName from protocol's labware.labwareId.displayName
-    assert 'Source (Buffer)' in str(loaded_labware['sourcePlateId'])
-    assert loaded_labware['destPlateId'] == ctx.loaded_labwares[11]
+    assert "Source (Buffer)" in str(loaded_labware["sourcePlateId"])
+    assert loaded_labware["destPlateId"] == ctx.loaded_labwares[11]
     # use the metadata.displayName from embedded def
-    assert (custom_trough_def['metadata']['displayName'] in
-            str(loaded_labware['destPlateId']))
+    assert custom_trough_def["metadata"]["displayName"] in str(
+        loaded_labware["destPlateId"]
+    )
 
 
 def test_get_location_with_offset(min_lw2):
-    loaded_labware = {'someLabwareId': min_lw2}
-    params = {'offsetFromBottomMm': 3,
-              'labware': 'someLabwareId', 'well': 'A2'}
+    loaded_labware = {"someLabwareId": min_lw2}
+    params = {"offsetFromBottomMm": 3, "labware": "someLabwareId", "well": "A2"}
     result = _get_location_with_offset(loaded_labware, params)
-    assert result == Location(Point(19, 28, 8), min_lw2['A2'])
+    assert result == Location(Point(19, 28, 8), min_lw2["A2"])
 
 
 def test_get_location_with_offset_fixed_trash(minimal_labware_def2):
-    deck = Location(Point(0, 0, 0), 'deck')
+    deck = Location(Point(0, 0, 0), "deck")
     trash_labware_def = deepcopy(minimal_labware_def2)
-    trash_labware_def['parameters']['quirks'] = ["fixedTrash"]
+    trash_labware_def["parameters"]["quirks"] = ["fixedTrash"]
     trash_labware = labware.Labware(
         implementation=LabwareImplementation(trash_labware_def, deck)
     )
 
-    loaded_labware = {'someLabwareId': trash_labware}
-    params = {'offsetFromBottomMm': 3,
-              'labware': 'someLabwareId', 'well': 'A1'}
+    loaded_labware = {"someLabwareId": trash_labware}
+    params = {"offsetFromBottomMm": 3, "labware": "someLabwareId", "well": "A1"}
 
     result = _get_location_with_offset(loaded_labware, params)
 
-    assert result == Location(Point(10, 28, 45), trash_labware['A1'])
+    assert result == Location(Point(10, 28, 45), trash_labware["A1"])
 
 
 @pytest.mark.parametrize(
-    'params, expected',
+    "params, expected",
     [
-        ({'wait': True, 'message': 'm'},
-         [mock.call.pause(msg='m')]),
-        ({'wait': 123, 'message': 'm'}, [
-         mock.call.delay(seconds=123, msg='m')])
-    ])
+        ({"wait": True, "message": "m"}, [mock.call.pause(msg="m")]),
+        ({"wait": 123, "message": "m"}, [mock.call.delay(seconds=123, msg="m")]),
+    ],
+)
 def test_delay(params, expected):
     mock_context = mock.MagicMock()
     _delay(mock_context, params)
@@ -131,51 +143,55 @@ def test_blowout():
     m.pipette_mock = mock.create_autospec(InstrumentContext)
     m.mock_set_flow_rate = mock.MagicMock()
 
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': m.pipette_mock}
-    well = 'theWell'
-    loaded_labware = {'someLabwareId': {'someWell': well}}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": m.pipette_mock}
+    well = "theWell"
+    loaded_labware = {"someLabwareId": {"someWell": well}}
 
-    flow_rate_patch = \
-        'opentrons.protocols.execution.execute_json_v3._set_flow_rate'
+    flow_rate_patch = "opentrons.protocols.execution.execute_json_v3._set_flow_rate"
     with mock.patch(flow_rate_patch, new=m.mock_set_flow_rate):
         _blowout(instruments, loaded_labware, params)
 
     assert m.mock_calls == [
         mock.call.mock_set_flow_rate(m.pipette_mock, params),
-        mock.call.pipette_mock.blow_out(well)
+        mock.call.pipette_mock.blow_out(well),
     ]
 
 
 def test_pick_up_tip():
     pipette_mock = mock.create_autospec(InstrumentContext)
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': pipette_mock}
-    well = 'theWell'
-    loaded_labware = {'someLabwareId': {'someWell': well}}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": pipette_mock}
+    well = "theWell"
+    loaded_labware = {"someLabwareId": {"someWell": well}}
 
     _pick_up_tip(instruments, loaded_labware, params)
 
-    assert pipette_mock.mock_calls == [
-        mock.call.pick_up_tip(well)
-    ]
+    assert pipette_mock.mock_calls == [mock.call.pick_up_tip(well)]
 
 
 def test_drop_tip():
     pipette_mock = mock.create_autospec(InstrumentContext)
 
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': pipette_mock}
-    well = 'theWell'
-    loaded_labware = {'someLabwareId': {'someWell': well}}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": pipette_mock}
+    well = "theWell"
+    loaded_labware = {"someLabwareId": {"someWell": well}}
     _drop_tip(instruments, loaded_labware, params)
 
-    assert pipette_mock.mock_calls == [
-        mock.call.drop_tip(well)
-    ]
+    assert pipette_mock.mock_calls == [mock.call.drop_tip(well)]
 
 
 def test_air_gap(minimal_labware_def2):
@@ -183,25 +199,30 @@ def test_air_gap(minimal_labware_def2):
     m.pipette_mock = mock.create_autospec(InstrumentContext)
     m.mock_set_flow_rate = mock.MagicMock()
 
-    deck = Location(Point(0, 0, 0), 'deck')
-    well_name = 'A2'
+    deck = Location(Point(0, 0, 0), "deck")
+    well_name = "A2"
     some_labware = labware.Labware(
         implementation=LabwareImplementation(minimal_labware_def2, deck)
     )
-    loaded_labware = {'someLabwareId': some_labware}
-    params = {'labware': 'someLabwareId', 'well': well_name}
+    loaded_labware = {"someLabwareId": some_labware}
+    params = {"labware": "someLabwareId", "well": well_name}
 
-    params = {'pipette': 'somePipetteId', 'volume': 42,
-              'labware': 'someLabwareId', 'well': well_name,
-              'offsetFromBottomMm': 12}
+    params = {
+        "pipette": "somePipetteId",
+        "volume": 42,
+        "labware": "someLabwareId",
+        "well": well_name,
+        "offsetFromBottomMm": 12,
+    }
 
-    instruments = {'somePipetteId': m.pipette_mock}
+    instruments = {"somePipetteId": m.pipette_mock}
 
-    loaded_labware = {'someLabwareId': some_labware}
+    loaded_labware = {"someLabwareId": some_labware}
 
     with mock.patch(
-            'opentrons.protocols.execution.execute_json_v3._set_flow_rate',
-            new=m.mock_set_flow_rate):
+        "opentrons.protocols.execution.execute_json_v3._set_flow_rate",
+        new=m.mock_set_flow_rate,
+    ):
         _air_gap(instruments, loaded_labware, params)
 
     # NOTE: air_gap `height` arg is mm from well top,
@@ -209,9 +230,9 @@ def test_air_gap(minimal_labware_def2):
     assert m.mock_calls == [
         mock.call.mock_set_flow_rate(m.pipette_mock, params),
         mock.call.pipette_mock.move_to(
-            Location(point=Point(x=19, y=28, z=17.0),
-                     labware=some_labware[well_name])),
-        mock.call.pipette_mock.air_gap(42, 12 - 40)
+            Location(point=Point(x=19, y=28, z=17.0), labware=some_labware[well_name])
+        ),
+        mock.call.pipette_mock.air_gap(42, 12 - 40),
     ]
 
 
@@ -219,26 +240,32 @@ def test_aspirate():
     m = mock.MagicMock()
     m.pipette_mock = mock.create_autospec(InstrumentContext)
     m.mock_get_location_with_offset = mock.MagicMock(
-        return_value=mock.sentinel.location)
+        return_value=mock.sentinel.location
+    )
     m.mock_set_flow_rate = mock.MagicMock()
 
-    params = {'pipette': 'somePipetteId', 'volume': 42,
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': m.pipette_mock}
+    params = {
+        "pipette": "somePipetteId",
+        "volume": 42,
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": m.pipette_mock}
 
     with mock.patch(
-            'opentrons.protocols.execution.execute_json_v3._get_location_with_offset',
-            new=m.mock_get_location_with_offset):
+        "opentrons.protocols.execution.execute_json_v3._get_location_with_offset",
+        new=m.mock_get_location_with_offset,
+    ):
         with mock.patch(
-                'opentrons.protocols.execution.execute_json_v3._set_flow_rate',
-                new=m.mock_set_flow_rate):
+            "opentrons.protocols.execution.execute_json_v3._set_flow_rate",
+            new=m.mock_set_flow_rate,
+        ):
             _aspirate(instruments, mock.sentinel.loaded_labware, params)
 
     assert m.mock_calls == [
-        mock.call.mock_get_location_with_offset(
-            mock.sentinel.loaded_labware, params),
+        mock.call.mock_get_location_with_offset(mock.sentinel.loaded_labware, params),
         mock.call.mock_set_flow_rate(m.pipette_mock, params),
-        mock.call.pipette_mock.aspirate(42, mock.sentinel.location)
+        mock.call.pipette_mock.aspirate(42, mock.sentinel.location),
     ]
 
 
@@ -246,84 +273,97 @@ def test_dispense():
     m = mock.MagicMock()
     m.pipette_mock = mock.create_autospec(InstrumentContext)
     m.mock_get_location_with_offset = mock.MagicMock(
-        return_value=mock.sentinel.location)
+        return_value=mock.sentinel.location
+    )
     m.mock_set_flow_rate = mock.MagicMock()
 
-    params = {'pipette': 'somePipetteId', 'volume': 42,
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': m.pipette_mock}
+    params = {
+        "pipette": "somePipetteId",
+        "volume": 42,
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": m.pipette_mock}
 
     with mock.patch(
-        'opentrons.protocols.execution.execute_json_v3._get_location_with_offset',
-            new=m.mock_get_location_with_offset):
+        "opentrons.protocols.execution.execute_json_v3._get_location_with_offset",
+        new=m.mock_get_location_with_offset,
+    ):
         with mock.patch(
-            'opentrons.protocols.execution.execute_json_v3._set_flow_rate',
-                new=m.mock_set_flow_rate):
+            "opentrons.protocols.execution.execute_json_v3._set_flow_rate",
+            new=m.mock_set_flow_rate,
+        ):
             _dispense(instruments, mock.sentinel.loaded_labware, params)
 
     assert m.mock_calls == [
-        mock.call.mock_get_location_with_offset(
-            mock.sentinel.loaded_labware, params),
+        mock.call.mock_get_location_with_offset(mock.sentinel.loaded_labware, params),
         mock.call.mock_set_flow_rate(m.pipette_mock, params),
-        mock.call.pipette_mock.dispense(42, mock.sentinel.location)
+        mock.call.pipette_mock.dispense(42, mock.sentinel.location),
     ]
 
 
 def test_touch_tip():
-    location = Location(Point(1, 2, 3), 'deck')
+    location = Location(Point(1, 2, 3), "deck")
     well = labware.Well(
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry({
-                'shape': 'circular',
-                'depth': 40,
-                'totalLiquidVolume': 100,
-                'diameter': 30,
-                'x': 40,
-                'y': 50,
-                'z': 3},
+            well_geometry=WellGeometry(
+                {
+                    "shape": "circular",
+                    "depth": 40,
+                    "totalLiquidVolume": 100,
+                    "diameter": 30,
+                    "x": 40,
+                    "y": 50,
+                    "z": 3,
+                },
                 parent_point=Point(10, 20, 30),
-                parent_object=1
+                parent_object=1,
             ),
             has_tip=False,
-            display_name='some well',
-            name="A2"
+            display_name="some well",
+            name="A2",
         ),
-        api_level=MAX_SUPPORTED_VERSION
+        api_level=MAX_SUPPORTED_VERSION,
     )
 
-    pipette_mock = mock.create_autospec(InstrumentContext, name='pipette_mock')
+    pipette_mock = mock.create_autospec(InstrumentContext, name="pipette_mock")
     mock_get_location_with_offset = mock.MagicMock(
-        return_value=location, name='mock_get_location_with_offset')
-    mock_get_well = mock.MagicMock(
-        return_value=well, name='mock_get_well')
-    mock_set_flow_rate = mock.MagicMock(name='mock_set_flow_rate')
+        return_value=location, name="mock_get_location_with_offset"
+    )
+    mock_get_well = mock.MagicMock(return_value=well, name="mock_get_well")
+    mock_set_flow_rate = mock.MagicMock(name="mock_set_flow_rate")
 
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId', 'well': 'someWell'}
-    instruments = {'somePipetteId': pipette_mock}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
+    instruments = {"somePipetteId": pipette_mock}
 
     with mock.patch(
-        'opentrons.protocols.execution.execute_json_v3._get_location_with_offset',
-            new=mock_get_location_with_offset):
+        "opentrons.protocols.execution.execute_json_v3._get_location_with_offset",
+        new=mock_get_location_with_offset,
+    ):
         with mock.patch(
-            'opentrons.protocols.execution.execute_json_v3._get_well',
-                new=mock_get_well):
+            "opentrons.protocols.execution.execute_json_v3._get_well", new=mock_get_well
+        ):
             with mock.patch(
-                'opentrons.protocols.execution.execute_json_v3._set_flow_rate',
-                    new=mock_set_flow_rate):
+                "opentrons.protocols.execution.execute_json_v3._set_flow_rate",
+                new=mock_set_flow_rate,
+            ):
                 _touch_tip(instruments, mock.sentinel.loaded_labware, params)
 
     # note: for this fn, order of calls doesn't matter b/c
     # we don't have stateful stuff like flow_rate
     mock_get_location_with_offset.assert_called_once_with(
-        mock.sentinel.loaded_labware, params)
+        mock.sentinel.loaded_labware, params
+    )
     mock_get_well.assert_called_once_with(mock.sentinel.loaded_labware, params)
-    assert pipette_mock.mock_calls == [
-        mock.call.touch_tip(well, v_offset=-70.0)]
+    assert pipette_mock.mock_calls == [mock.call.touch_tip(well, v_offset=-70.0)]
 
 
 def test_move_to_slot():
-    slot_position = Location(Point(1, 2, 3), 'deck')
+    slot_position = Location(Point(1, 2, 3), "deck")
     mock_context = mock.Mock()
 
     mock_deck = mock.MagicMock(spec=Deck)
@@ -333,20 +373,25 @@ def test_move_to_slot():
     mock_context.deck = mock_deck
     pipette_mock = mock.create_autospec(InstrumentContext)
 
-    instruments = {'somePipetteId': pipette_mock}
+    instruments = {"somePipetteId": pipette_mock}
 
-    params = {'pipette': 'somePipetteId', 'slot': '4',
-              'offset': {'x': 10, 'y': 11, 'z': 12},
-              'forceDirect': mock.sentinel.force_direct,
-              'minimumZHeight': mock.sentinel.minimum_z_height}
+    params = {
+        "pipette": "somePipetteId",
+        "slot": "4",
+        "offset": {"x": 10, "y": 11, "z": 12},
+        "forceDirect": mock.sentinel.force_direct,
+        "minimumZHeight": mock.sentinel.minimum_z_height,
+    }
 
     _move_to_slot(mock_context, instruments, params)
 
     assert pipette_mock.mock_calls == [
         mock.call.move_to(
-            Location(Point(11, 13, 15), 'deck'),
+            Location(Point(11, 13, 15), "deck"),
             force_direct=mock.sentinel.force_direct,
-            minimum_z_height=mock.sentinel.minimum_z_height)]
+            minimum_z_height=mock.sentinel.minimum_z_height,
+        )
+    ]
 
 
 def test_dispatch_json():
@@ -359,57 +404,59 @@ def test_dispatch_json():
         "aspirate": m._aspirate,
         "dispense": m._dispense,
         "touchTip": m._touch_tip,
-        "moveToSlot": m._move_to_slot
+        "moveToSlot": m._move_to_slot,
     }
 
     with mock.patch(
-        'opentrons.protocols.execution.execute_json_v3.dispatcher_map',
-            new=mock_dispatcher_map):
-        protocol_data = {'commands': [
-            {'command': 'delay', 'params': 'delay_params'},
-            {'command': 'blowout', 'params': 'blowout_params'},
-            {'command': 'pickUpTip', 'params': 'pickUpTip_params'},
-            {'command': 'dropTip', 'params': 'dropTip_params'},
-            {'command': 'aspirate', 'params': 'aspirate_params'},
-            {'command': 'dispense', 'params': 'dispense_params'},
-            {'command': 'touchTip', 'params': 'touchTip_params'},
-            {'command': 'moveToSlot', 'params': 'moveToSlot_params'},
-        ]}
+        "opentrons.protocols.execution.execute_json_v3.dispatcher_map",
+        new=mock_dispatcher_map,
+    ):
+        protocol_data = {
+            "commands": [
+                {"command": "delay", "params": "delay_params"},
+                {"command": "blowout", "params": "blowout_params"},
+                {"command": "pickUpTip", "params": "pickUpTip_params"},
+                {"command": "dropTip", "params": "dropTip_params"},
+                {"command": "aspirate", "params": "aspirate_params"},
+                {"command": "dispense", "params": "dispense_params"},
+                {"command": "touchTip", "params": "touchTip_params"},
+                {"command": "moveToSlot", "params": "moveToSlot_params"},
+            ]
+        }
         context = mock.sentinel.context
         instruments = mock.sentinel.instruments
         loaded_labware = mock.sentinel.loaded_labware
-        dispatch_json(
-            context, protocol_data, instruments, loaded_labware)
+        dispatch_json(context, protocol_data, instruments, loaded_labware)
 
         assert m.mock_calls == [
-            mock.call._delay(context, 'delay_params'),
-            mock.call._blowout(instruments, loaded_labware, 'blowout_params'),
-            mock.call._pick_up_tip(
-                instruments, loaded_labware, 'pickUpTip_params'),
-            mock.call._drop_tip(instruments, loaded_labware, 'dropTip_params'),
-            mock.call._aspirate(
-                instruments, loaded_labware, 'aspirate_params'),
-            mock.call._dispense(
-                instruments, loaded_labware, 'dispense_params'),
-            mock.call._touch_tip(
-                instruments, loaded_labware, 'touchTip_params'),
-            mock.call._move_to_slot(context, instruments, 'moveToSlot_params')
+            mock.call._delay(context, "delay_params"),
+            mock.call._blowout(instruments, loaded_labware, "blowout_params"),
+            mock.call._pick_up_tip(instruments, loaded_labware, "pickUpTip_params"),
+            mock.call._drop_tip(instruments, loaded_labware, "dropTip_params"),
+            mock.call._aspirate(instruments, loaded_labware, "aspirate_params"),
+            mock.call._dispense(instruments, loaded_labware, "dispense_params"),
+            mock.call._touch_tip(instruments, loaded_labware, "touchTip_params"),
+            mock.call._move_to_slot(context, instruments, "moveToSlot_params"),
         ]
 
 
 def test_dispatch_json_invalid_command():
-    protocol_data = {'commands': [
-        {'command': 'no_such_command', 'params': 'foo'},
-    ]}
+    protocol_data = {
+        "commands": [
+            {"command": "no_such_command", "params": "foo"},
+        ]
+    }
     with pytest.raises(RuntimeError):
         dispatch_json(
-            context=None, protocol_data=protocol_data, instruments=None,
-            loaded_labware=None)
+            context=None,
+            protocol_data=protocol_data,
+            instruments=None,
+            loaded_labware=None,
+        )
 
 
 def test_papi_execute_json_v3(monkeypatch, ctx, get_json_protocol_fixture):
-    protocol_data = get_json_protocol_fixture(
-        '3', 'testAllAtomicSingleV3', False)
+    protocol_data = get_json_protocol_fixture("3", "testAllAtomicSingleV3", False)
     protocol = parse(protocol_data, None)
     ctx.home()
     # Check that we end up executing the protocol ok

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v4.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v4.py
@@ -2,7 +2,10 @@ from unittest import mock
 import pytest
 from opentrons.protocols.parse import parse
 from opentrons.protocols.execution.execute_json_v4 import (
-    dispatch_json, _engage_magnet, _disengage_magnet, load_modules_from_json,
+    dispatch_json,
+    _engage_magnet,
+    _disengage_magnet,
+    load_modules_from_json,
     _temperature_module_set_temp,
     _temperature_module_deactivate,
     _temperature_module_await_temp,
@@ -15,17 +18,21 @@ from opentrons.protocols.execution.execute_json_v4 import (
     _thermocycler_run_profile,
     assert_no_async_tc_behavior,
     assert_tc_commands_do_not_use_unimplemented_params,
-    TC_SPANNING_SLOT)
+    TC_SPANNING_SLOT,
+)
 import opentrons.protocols.execution.execute_json_v4 as v4
 from opentrons.protocol_api import (
-    MagneticModuleContext, TemperatureModuleContext, ThermocyclerContext,
-    ProtocolContext)
+    MagneticModuleContext,
+    TemperatureModuleContext,
+    ThermocyclerContext,
+    ProtocolContext,
+)
 from opentrons.protocols.execution import execute
 from opentrons_shared_data.protocol.constants import (
     JsonPipetteCommand as JPC,
     JsonMagneticModuleCommand as JMMC,
     JsonTemperatureModuleCommand as JTMC,
-    JsonThermocyclerCommand as JTHC
+    JsonThermocyclerCommand as JTHC,
 )
 
 
@@ -53,10 +60,8 @@ def pipette_command_map(mockObj):
 @pytest.fixture
 def magnetic_module_command_map(mockObj):
     mock_magnetic_module_command_map = {
-        JMMC.magneticModuleEngageMagnet.value:
-        mockObj._engage_magnet,
-        JMMC.magneticModuleDisengageMagnet.value:
-        mockObj._disengage_magnet,
+        JMMC.magneticModuleEngageMagnet.value: mockObj._engage_magnet,
+        JMMC.magneticModuleDisengageMagnet.value: mockObj._disengage_magnet,
     }
 
     return mock_magnetic_module_command_map
@@ -65,12 +70,9 @@ def magnetic_module_command_map(mockObj):
 @pytest.fixture
 def temperature_module_command_map(mockObj):
     mock_temperature_module_command_map = {
-        JTMC.temperatureModuleSetTargetTemperature.value:
-        mockObj._temperature_module_set_temp,
-        JTMC.temperatureModuleDeactivate.value:
-        mockObj._temperature_module_deactivate,
-        JTMC.temperatureModuleAwaitTemperature.value:
-        mockObj._temperature_module_await_temp
+        JTMC.temperatureModuleSetTargetTemperature.value: mockObj._temperature_module_set_temp,  # noqa: E501
+        JTMC.temperatureModuleDeactivate.value: mockObj._temperature_module_deactivate,
+        JTMC.temperatureModuleAwaitTemperature.value: mockObj._temperature_module_await_temp,  # noqa: E501
     }
     return mock_temperature_module_command_map
 
@@ -78,184 +80,157 @@ def temperature_module_command_map(mockObj):
 @pytest.fixture
 def thermocycler_module_command_map(mockObj):
     mock_thermocycler_module_command_map = {
-        JTHC.thermocyclerCloseLid.value:
-            mockObj._thermocycler_close_lid,
-        JTHC.thermocyclerOpenLid.value:
-            mockObj._thermocycler_open_lid,
-        JTHC.thermocyclerDeactivateBlock.value:
-            mockObj._thermocycler_deactivate_block,
-        JTHC.thermocyclerDeactivateLid.value:
-            mockObj._thermocycler_deactivate_lid,
-        JTHC.thermocyclerSetTargetBlockTemperature.value:
-            mockObj._thermocycler_set_block_temperature,
-        JTHC.thermocyclerSetTargetLidTemperature.value:
-            mockObj._thermocycler_set_lid_temperature,
-        JTHC.thermocyclerRunProfile.value:
-            mockObj._thermocycler_run_profile,
+        JTHC.thermocyclerCloseLid.value: mockObj._thermocycler_close_lid,
+        JTHC.thermocyclerOpenLid.value: mockObj._thermocycler_open_lid,
+        JTHC.thermocyclerDeactivateBlock.value: mockObj._thermocycler_deactivate_block,
+        JTHC.thermocyclerDeactivateLid.value: mockObj._thermocycler_deactivate_lid,
+        JTHC.thermocyclerSetTargetBlockTemperature.value: mockObj._thermocycler_set_block_temperature,  # noqa: E501
+        JTHC.thermocyclerSetTargetLidTemperature.value: mockObj._thermocycler_set_lid_temperature,  # noqa: E501
+        JTHC.thermocyclerRunProfile.value: mockObj._thermocycler_run_profile,
         # NOTE: the thermocyclerAwaitX commands are expected to always
         # follow a corresponding SetX command, which is implemented as
         # blocking. Then nothing needs to be done for awaitX commands.
-        JTHC.thermocyclerAwaitBlockTemperature.value: \
-            mockObj.tc_do_nothing,
-        JTHC.thermocyclerAwaitLidTemperature.value: \
-            mockObj.tc_do_nothing,
-        JTHC.thermocyclerAwaitProfileComplete.value: \
-            mockObj.tc_do_nothing
+        JTHC.thermocyclerAwaitBlockTemperature.value: mockObj.tc_do_nothing,
+        JTHC.thermocyclerAwaitLidTemperature.value: mockObj.tc_do_nothing,
+        JTHC.thermocyclerAwaitProfileComplete.value: mockObj.tc_do_nothing,
     }
     return mock_thermocycler_module_command_map
 
 
 def test_load_modules_from_json():
     def fake_module(model, slot=None):
-        return 'mock_module_ctx_' + model
+        return "mock_module_ctx_" + model
+
     ctx = mock.create_autospec(ProtocolContext)
     ctx.load_module.side_effect = fake_module
-    protocol = {'modules': {
-        'aID': {'slot': '1', 'model': 'magneticModuleV1'},
-        'bID': {'slot': '4', 'model': 'temperatureModuleV2'},
-        'cID': {
-            'slot': TC_SPANNING_SLOT,
-            'model': 'thermocyclerModuleV1'}
-    }}
+    protocol = {
+        "modules": {
+            "aID": {"slot": "1", "model": "magneticModuleV1"},
+            "bID": {"slot": "4", "model": "temperatureModuleV2"},
+            "cID": {"slot": TC_SPANNING_SLOT, "model": "thermocyclerModuleV1"},
+        }
+    }
     result = load_modules_from_json(ctx, protocol)
 
     # load_module should be called in a deterministic order
     assert ctx.mock_calls == [
-        mock.call.load_module('magneticModuleV1', '1'),
-        mock.call.load_module('temperatureModuleV2', '4'),
-        mock.call.load_module('thermocyclerModuleV1')
+        mock.call.load_module("magneticModuleV1", "1"),
+        mock.call.load_module("temperatureModuleV2", "4"),
+        mock.call.load_module("thermocyclerModuleV1"),
     ]
 
     # resulting dict should have ModuleContext objects (from calling
     # load_module) as its values
-    assert result == {'aID': 'mock_module_ctx_magneticModuleV1',
-                      'bID': 'mock_module_ctx_temperatureModuleV2',
-                      'cID': 'mock_module_ctx_thermocyclerModuleV1'}
+    assert result == {
+        "aID": "mock_module_ctx_magneticModuleV1",
+        "bID": "mock_module_ctx_temperatureModuleV2",
+        "cID": "mock_module_ctx_thermocyclerModuleV1",
+    }
 
 
 def test_engage_magnet():
     module_mock = mock.create_autospec(MagneticModuleContext)
-    params = {'module': 'someModuleId', 'engageHeight': 4.2, }
+    params = {
+        "module": "someModuleId",
+        "engageHeight": 4.2,
+    }
     _engage_magnet(module_mock, params)
 
-    assert module_mock.mock_calls == [
-        mock.call.engage(height_from_base=4.2)
-    ]
+    assert module_mock.mock_calls == [mock.call.engage(height_from_base=4.2)]
 
 
 def test_disengage_magnet():
     module_mock = mock.create_autospec(MagneticModuleContext)
-    params = {'module': 'someModuleId'}
+    params = {"module": "someModuleId"}
     _disengage_magnet(module_mock, params)
 
-    assert module_mock.mock_calls == [
-        mock.call.disengage()
-    ]
+    assert module_mock.mock_calls == [mock.call.disengage()]
 
 
 def test_temperature_module_set_temp():
     module_mock = mock.create_autospec(TemperatureModuleContext)
-    params = {'module': 'someModuleId', 'temperature': 42.5}
+    params = {"module": "someModuleId", "temperature": 42.5}
     _temperature_module_set_temp(module_mock, params)
 
-    assert module_mock.mock_calls == [
-        mock.call.start_set_temperature(42.5)
-    ]
+    assert module_mock.mock_calls == [mock.call.start_set_temperature(42.5)]
 
 
 def test_temperature_module_deactivate():
     module_mock = mock.create_autospec(TemperatureModuleContext)
-    params = {'module': 'someModuleId'}
+    params = {"module": "someModuleId"}
     _temperature_module_deactivate(module_mock, params)
 
-    assert module_mock.mock_calls == [
-        mock.call.deactivate()
-    ]
+    assert module_mock.mock_calls == [mock.call.deactivate()]
 
 
 def test_temperature_module_await_temp():
     module_mock = mock.create_autospec(TemperatureModuleContext)
-    params = {'module': 'someModuleId', 'temperature': 12.3}
+    params = {"module": "someModuleId", "temperature": 12.3}
     _temperature_module_await_temp(module_mock, params)
 
-    assert module_mock.mock_calls == [
-        mock.call.await_temperature(12.3)
-    ]
+    assert module_mock.mock_calls == [mock.call.await_temperature(12.3)]
 
 
 def test_thermocycler_close_lid():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"module": "someModuleId"}
     _thermocycler_close_lid(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.close_lid()
-    ]
+    assert module_mock.mock_calls == [mock.call.close_lid()]
 
 
 def test_thermocycler_open_lid():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"module": "someModuleId"}
     _thermocycler_open_lid(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.open_lid()
-    ]
+    assert module_mock.mock_calls == [mock.call.open_lid()]
 
 
 def test_thermocycler_deactivate_block():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"module": "someModuleId"}
     _thermocycler_deactivate_block(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.deactivate_block()
-    ]
+    assert module_mock.mock_calls == [mock.call.deactivate_block()]
 
 
 def test_thermocycler_deactivate_lid():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"module": "someModuleId"}
     _thermocycler_deactivate_lid(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.deactivate_lid()
-    ]
+    assert module_mock.mock_calls == [mock.call.deactivate_lid()]
 
 
 def test_thermocycler_set_block_temperature():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"temperature": 42, "module": "someModuleId"}
     _thermocycler_set_block_temperature(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.set_block_temperature(42)
-    ]
+    assert module_mock.mock_calls == [mock.call.set_block_temperature(42)]
 
 
 def test_thermocycler_set_lid_temperature():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {"module": "someModuleId", "temperature": 42}
     _thermocycler_set_lid_temperature(module_mock, params)
-    assert module_mock.mock_calls == [
-        mock.call.set_lid_temperature(42)
-    ]
+    assert module_mock.mock_calls == [mock.call.set_lid_temperature(42)]
 
 
 def test_thermocycler_run_profile():
     module_mock = mock.create_autospec(ThermocyclerContext)
     params = {
         "profile": [
-            {'temperature': 55, 'holdTime': 90},
-            {'temperature': 65, 'holdTime': 30}
+            {"temperature": 55, "holdTime": 90},
+            {"temperature": 65, "holdTime": 30},
         ],
         "module": "someModuleId",
-        "volume": 98
+        "volume": 98,
     }
 
     steps = [
-        {'temperature': 55, 'hold_time_seconds': 90},
-        {'temperature': 65, 'hold_time_seconds': 30}
+        {"temperature": 55, "hold_time_seconds": 90},
+        {"temperature": 65, "hold_time_seconds": 30},
     ]
     _thermocycler_run_profile(module_mock, params)
     assert module_mock.mock_calls == [
-        mock.call.execute_profile(
-            steps=steps, block_max_volume=98, repetitions=1)
+        mock.call.execute_profile(steps=steps, block_max_volume=98, repetitions=1)
     ]
 
 
@@ -265,109 +240,109 @@ def test_dispatch_json(
     magnetic_module_command_map,
     temperature_module_command_map,
     thermocycler_module_command_map,
-    mockObj
+    mockObj,
 ):
 
-    monkeypatch.setattr(v4, '_delay', mockObj)
-    monkeypatch.setattr(v4, '_move_to_slot', mockObj)
+    monkeypatch.setattr(v4, "_delay", mockObj)
+    monkeypatch.setattr(v4, "_move_to_slot", mockObj)
 
-    magnetic_module_id = 'magnetic_module_id'
-    temperature_module_id = 'temperature_module_id'
-    thermocycler_module_id = 'thermocycler_module_id'
+    magnetic_module_id = "magnetic_module_id"
+    temperature_module_id = "temperature_module_id"
+    thermocycler_module_id = "thermocycler_module_id"
 
     mock_magnetic_module = mock.create_autospec(MagneticModuleContext)
     mock_temperature_module = mock.create_autospec(TemperatureModuleContext)
     mock_thermocycler_module = mock.create_autospec(ThermocyclerContext)
 
-    protocol_data = {'commands': [
-        # Pipette
-        {'command': 'delay', 'params': 'delay_params'},
-        {'command': 'blowout', 'params': 'blowout_params'},
-        {'command': 'pickUpTip', 'params': 'pickUpTip_params'},
-        {'command': 'dropTip', 'params': 'dropTip_params'},
-        {'command': 'aspirate', 'params': 'aspirate_params'},
-        {'command': 'dispense', 'params': 'dispense_params'},
-        {'command': 'touchTip', 'params': 'touchTip_params'},
-        {'command': 'moveToSlot', 'params': 'moveToSlot_params'},
-        # Magnetic Module
-        {'command': 'magneticModule/engageMagnet',
-            'params': {'module': magnetic_module_id}},
-        {'command': 'magneticModule/disengageMagnet',
-            'params': {'module': magnetic_module_id}},
-        # Temperature Module
-        {'command': 'temperatureModule/setTargetTemperature',
-            'params': {'module': temperature_module_id}},
-        {'command': 'temperatureModule/deactivate',
-            'params': {'module': temperature_module_id}},
-        {'command': 'temperatureModule/awaitTemperature',
-            'params': {'module': temperature_module_id}},
-        # Thermocycler
-        {
-            "command": "thermocycler/setTargetBlockTemperature",
-            "params": {
-                "module": thermocycler_module_id,
-                "temperature": 55
-            }
-        },
-        {
-            "command": "thermocycler/awaitBlockTemperature",
-            "params": {
-                "module": thermocycler_module_id,
-                "temperature": 55
-            }
-        },
-        {
-            "command": "thermocycler/setTargetLidTemperature",
-            "params": {
-                "module": thermocycler_module_id,
-                "temperature": 60
-            }
-        },
-        {
-            "command": "thermocycler/awaitLidTemperature",
-            "params": {
-                "module": thermocycler_module_id,
-                "temperature": 60
-            }
-        },
-        {
-            "command": "thermocycler/closeLid",
-            "params": {"module": thermocycler_module_id}
-        },
-        {
-            "command": "thermocycler/openLid",
-            "params": {"module": thermocycler_module_id}
-        },
-        {
-            "command": "thermocycler/deactivateBlock",
-            "params": {"module": thermocycler_module_id}
-        },
-        {
-            "command": "thermocycler/deactivateLid",
-            "params": {"module": thermocycler_module_id}
-        },
-        {
-            "command": "thermocycler/closeLid",
-            "params": {"module": thermocycler_module_id}
-        },
-        {
-            "command": "thermocycler/runProfile",
-            "params": {
-                "module": thermocycler_module_id,
-                "profile": [
-                    {"temperature": 70, "holdTime": 60},
-                    {"temperature": 40, "holdTime": 30},
-                    {"temperature": 72, "holdTime": 60},
-                    {"temperature": 38, "holdTime": 30}
-                ],
-                "volume": 123
-            }
-        },
-        {
-            "command": "thermocycler/awaitProfileComplete",
-            "params": {"module": thermocycler_module_id}
-        }
-    ]}
+    protocol_data = {
+        "commands": [
+            # Pipette
+            {"command": "delay", "params": "delay_params"},
+            {"command": "blowout", "params": "blowout_params"},
+            {"command": "pickUpTip", "params": "pickUpTip_params"},
+            {"command": "dropTip", "params": "dropTip_params"},
+            {"command": "aspirate", "params": "aspirate_params"},
+            {"command": "dispense", "params": "dispense_params"},
+            {"command": "touchTip", "params": "touchTip_params"},
+            {"command": "moveToSlot", "params": "moveToSlot_params"},
+            # Magnetic Module
+            {
+                "command": "magneticModule/engageMagnet",
+                "params": {"module": magnetic_module_id},
+            },
+            {
+                "command": "magneticModule/disengageMagnet",
+                "params": {"module": magnetic_module_id},
+            },
+            # Temperature Module
+            {
+                "command": "temperatureModule/setTargetTemperature",
+                "params": {"module": temperature_module_id},
+            },
+            {
+                "command": "temperatureModule/deactivate",
+                "params": {"module": temperature_module_id},
+            },
+            {
+                "command": "temperatureModule/awaitTemperature",
+                "params": {"module": temperature_module_id},
+            },
+            # Thermocycler
+            {
+                "command": "thermocycler/setTargetBlockTemperature",
+                "params": {"module": thermocycler_module_id, "temperature": 55},
+            },
+            {
+                "command": "thermocycler/awaitBlockTemperature",
+                "params": {"module": thermocycler_module_id, "temperature": 55},
+            },
+            {
+                "command": "thermocycler/setTargetLidTemperature",
+                "params": {"module": thermocycler_module_id, "temperature": 60},
+            },
+            {
+                "command": "thermocycler/awaitLidTemperature",
+                "params": {"module": thermocycler_module_id, "temperature": 60},
+            },
+            {
+                "command": "thermocycler/closeLid",
+                "params": {"module": thermocycler_module_id},
+            },
+            {
+                "command": "thermocycler/openLid",
+                "params": {"module": thermocycler_module_id},
+            },
+            {
+                "command": "thermocycler/deactivateBlock",
+                "params": {"module": thermocycler_module_id},
+            },
+            {
+                "command": "thermocycler/deactivateLid",
+                "params": {"module": thermocycler_module_id},
+            },
+            {
+                "command": "thermocycler/closeLid",
+                "params": {"module": thermocycler_module_id},
+            },
+            {
+                "command": "thermocycler/runProfile",
+                "params": {
+                    "module": thermocycler_module_id,
+                    "profile": [
+                        {"temperature": 70, "holdTime": 60},
+                        {"temperature": 40, "holdTime": 30},
+                        {"temperature": 72, "holdTime": 60},
+                        {"temperature": 38, "holdTime": 30},
+                    ],
+                    "volume": 123,
+                },
+            },
+            {
+                "command": "thermocycler/awaitProfileComplete",
+                "params": {"module": thermocycler_module_id},
+            },
+        ]
+    }
 
     context = mock.sentinel.context
     instruments = mock.sentinel.instruments
@@ -376,7 +351,7 @@ def test_dispatch_json(
     modules = {
         magnetic_module_id: mock_magnetic_module,
         temperature_module_id: mock_temperature_module,
-        thermocycler_module_id: mock_thermocycler_module
+        thermocycler_module_id: mock_thermocycler_module,
     }
 
     dispatch_json(
@@ -388,92 +363,86 @@ def test_dispatch_json(
         pipette_command_map,
         magnetic_module_command_map,
         temperature_module_command_map,
-        thermocycler_module_command_map
+        thermocycler_module_command_map,
     )
 
     assert mockObj.mock_calls == [
         # Pipette
-        mock.call._delay(context, 'delay_params'),
-        mock.call._blowout(instruments, loaded_labware, 'blowout_params'),
-        mock.call._pick_up_tip(
-            instruments, loaded_labware, 'pickUpTip_params'),
-        mock.call._drop_tip(instruments, loaded_labware, 'dropTip_params'),
-        mock.call._aspirate(
-            instruments, loaded_labware, 'aspirate_params'),
-        mock.call._dispense(
-            instruments, loaded_labware, 'dispense_params'),
-        mock.call._touch_tip(
-            instruments, loaded_labware, 'touchTip_params'),
-        mock.call._move_to_slot(context, instruments, 'moveToSlot_params'),
+        mock.call._delay(context, "delay_params"),
+        mock.call._blowout(instruments, loaded_labware, "blowout_params"),
+        mock.call._pick_up_tip(instruments, loaded_labware, "pickUpTip_params"),
+        mock.call._drop_tip(instruments, loaded_labware, "dropTip_params"),
+        mock.call._aspirate(instruments, loaded_labware, "aspirate_params"),
+        mock.call._dispense(instruments, loaded_labware, "dispense_params"),
+        mock.call._touch_tip(instruments, loaded_labware, "touchTip_params"),
+        mock.call._move_to_slot(context, instruments, "moveToSlot_params"),
         # Magnetic module
-        mock.call._engage_magnet(
-            mock_magnetic_module, {'module': magnetic_module_id}
-        ),
+        mock.call._engage_magnet(mock_magnetic_module, {"module": magnetic_module_id}),
         mock.call._disengage_magnet(
-            mock_magnetic_module, {'module': magnetic_module_id}
+            mock_magnetic_module, {"module": magnetic_module_id}
         ),
         # Temperature module
         mock.call._temperature_module_set_temp(
-            mock_temperature_module, {'module': temperature_module_id}
+            mock_temperature_module, {"module": temperature_module_id}
         ),
         mock.call._temperature_module_deactivate(
-            mock_temperature_module, {'module': temperature_module_id}
+            mock_temperature_module, {"module": temperature_module_id}
         ),
         mock.call._temperature_module_await_temp(
-            mock_temperature_module, {'module': temperature_module_id}
+            mock_temperature_module, {"module": temperature_module_id}
         ),
         # Thermocycler
         mock.call._thermocycler_set_block_temperature(
             mock_thermocycler_module,
-            {'module': thermocycler_module_id, 'temperature': 55}
+            {"module": thermocycler_module_id, "temperature": 55},
         ),
         # await block temp = do nothing (corresponding set is blocking)
         mock.call.tc_do_nothing(
             mock_thermocycler_module,
-            {'module': thermocycler_module_id, 'temperature': 55}
+            {"module": thermocycler_module_id, "temperature": 55},
         ),
         mock.call._thermocycler_set_lid_temperature(
             mock_thermocycler_module,
-            {'module': thermocycler_module_id, 'temperature': 60}
+            {"module": thermocycler_module_id, "temperature": 60},
         ),
         # await lid temp = do nothing (corresponding set is blocking)
         mock.call.tc_do_nothing(
             mock_thermocycler_module,
-            {'module': thermocycler_module_id, 'temperature': 60}
+            {"module": thermocycler_module_id, "temperature": 60},
         ),
         mock.call._thermocycler_close_lid(
-            mock_thermocycler_module, {'module': thermocycler_module_id}
+            mock_thermocycler_module, {"module": thermocycler_module_id}
         ),
         mock.call._thermocycler_open_lid(
-            mock_thermocycler_module, {'module': thermocycler_module_id}
+            mock_thermocycler_module, {"module": thermocycler_module_id}
         ),
         mock.call._thermocycler_deactivate_block(
-            mock_thermocycler_module, {'module': thermocycler_module_id}
+            mock_thermocycler_module, {"module": thermocycler_module_id}
         ),
         mock.call._thermocycler_deactivate_lid(
-            mock_thermocycler_module, {'module': thermocycler_module_id}
+            mock_thermocycler_module, {"module": thermocycler_module_id}
         ),
         mock.call._thermocycler_close_lid(
-            mock_thermocycler_module, {'module': thermocycler_module_id}
+            mock_thermocycler_module, {"module": thermocycler_module_id}
         ),
         mock.call._thermocycler_run_profile(
-            mock_thermocycler_module, {
+            mock_thermocycler_module,
+            {
                 "module": thermocycler_module_id,
                 "profile": [
                     {"temperature": 70, "holdTime": 60},
                     {"temperature": 40, "holdTime": 30},
                     {"temperature": 72, "holdTime": 60},
-                    {"temperature": 38, "holdTime": 30}
+                    {"temperature": 38, "holdTime": 30},
                 ],
-                "volume": 123
-            }
+                "volume": 123,
+            },
         ),
         # await profile complete = do nothing
         # (corresponding set is blocking)
         mock.call.tc_do_nothing(
-            mock_thermocycler_module,
-            {'module': thermocycler_module_id}
-        )
+            mock_thermocycler_module, {"module": thermocycler_module_id}
+        ),
     ]
 
 
@@ -481,11 +450,13 @@ def test_dispatch_json_invalid_command(
     pipette_command_map,
     magnetic_module_command_map,
     temperature_module_command_map,
-    thermocycler_module_command_map
+    thermocycler_module_command_map,
 ):
-    protocol_data = {'commands': [
-        {'command': 'no_such_command', 'params': 'foo'},
-    ]}
+    protocol_data = {
+        "commands": [
+            {"command": "no_such_command", "params": "foo"},
+        ]
+    }
     with pytest.raises(RuntimeError):
         dispatch_json(
             context=None,
@@ -496,13 +467,12 @@ def test_dispatch_json_invalid_command(
             pipette_command_map=pipette_command_map,
             magnetic_module_command_map=magnetic_module_command_map,
             temperature_module_command_map=temperature_module_command_map,
-            thermocycler_module_command_map=thermocycler_module_command_map
+            thermocycler_module_command_map=thermocycler_module_command_map,
         )
 
 
 def test_papi_execute_json_v4(monkeypatch, ctx, get_json_protocol_fixture):
-    protocol_data = get_json_protocol_fixture(
-        '4', 'testModulesProtocol', False)
+    protocol_data = get_json_protocol_fixture("4", "testModulesProtocol", False)
     protocol = parse(protocol_data, None)
     ctx.home()
     # Check that we end up executing the protocol ok
@@ -510,30 +480,29 @@ def test_papi_execute_json_v4(monkeypatch, ctx, get_json_protocol_fixture):
 
 
 def test_assert_no_async_tc_behavior():
-    setBlock = {
-        "command": "thermocycler/setTargetBlockTemperature"}
-    awaitBlock = {
-        "command": "thermocycler/awaitBlockTemperature"}
-    setLid = {
-        "command": "thermocycler/setTargetLidTemperature"}
-    awaitLid = {
-        "command": "thermocycler/awaitLidTemperature"}
-    runProfile = {
-        "command": "thermocycler/runProfile"}
-    awaitProfile = {
-        "command": "thermocycler/awaitProfileComplete"}
+    setBlock = {"command": "thermocycler/setTargetBlockTemperature"}
+    awaitBlock = {"command": "thermocycler/awaitBlockTemperature"}
+    setLid = {"command": "thermocycler/setTargetLidTemperature"}
+    awaitLid = {"command": "thermocycler/awaitLidTemperature"}
+    runProfile = {"command": "thermocycler/runProfile"}
+    awaitProfile = {"command": "thermocycler/awaitProfileComplete"}
     anything = {"command": "foo"}  # stand-in for some other command
 
     # no error
-    assert_no_async_tc_behavior([
-        anything,
-        setBlock, awaitBlock,
-        anything,
-        setLid, awaitLid,
-        anything,
-        runProfile, awaitProfile,
-        anything
-    ])
+    assert_no_async_tc_behavior(
+        [
+            anything,
+            setBlock,
+            awaitBlock,
+            anything,
+            setLid,
+            awaitLid,
+            anything,
+            runProfile,
+            awaitProfile,
+            anything,
+        ]
+    )
 
     assert_no_async_tc_behavior([anything, anything])
 
@@ -543,15 +512,11 @@ def test_assert_no_async_tc_behavior():
         # Should raise if anything except the corresponding await
         # follows a "setter" command
         with pytest.raises(RuntimeError):
-            assert_no_async_tc_behavior([
-                setter, anything
-            ])
+            assert_no_async_tc_behavior([setter, anything])
 
         # Should raise if setter is the last command in the array
         with pytest.raises(RuntimeError):
-            assert_no_async_tc_behavior([
-                anything, setter
-            ])
+            assert_no_async_tc_behavior([anything, setter])
 
     awaiters = [awaitBlock, awaitLid, awaitProfile]
 
@@ -559,26 +524,21 @@ def test_assert_no_async_tc_behavior():
         # Should raise if anything except the corresponding set
         # precedes the await
         with pytest.raises(RuntimeError):
-            assert_no_async_tc_behavior([
-                anything, awaiter
-            ])
+            assert_no_async_tc_behavior([anything, awaiter])
 
         # Should raise if awaiter is the first command in the array
         with pytest.raises(RuntimeError):
-            assert_no_async_tc_behavior([
-                awaiter, anything
-            ])
+            assert_no_async_tc_behavior([awaiter, anything])
 
 
 def test_assert_tc_commands_do_not_use_unimplemented_params():
     # should not throw for arbitrary commands
-    assert_tc_commands_do_not_use_unimplemented_params([
-        {'command': 'foo', 'params': {}}])
+    assert_tc_commands_do_not_use_unimplemented_params(
+        [{"command": "foo", "params": {}}]
+    )
 
     fail_cases = [
-        [{
-            'command': 'thermocycler/setTargetBlockTemperature',
-            'params': {'volume': 0}}]
+        [{"command": "thermocycler/setTargetBlockTemperature", "params": {"volume": 0}}]
     ]
     for cmds in fail_cases:
         with pytest.raises(RuntimeError):

--- a/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_json_v5.py
@@ -3,103 +3,104 @@ from unittest import mock
 from opentrons.protocols.geometry.well_geometry import WellGeometry
 from opentrons.protocols.context.well import WellImplementation
 from opentrons.types import Point
-from opentrons.protocol_api import InstrumentContext, \
-    labware, MAX_SUPPORTED_VERSION
+from opentrons.protocol_api import InstrumentContext, labware, MAX_SUPPORTED_VERSION
 from opentrons.protocols.execution.execute_json_v5 import _move_to_well
 
 
 def test_move_to_well_with_optional_params():
     pipette_mock = mock.create_autospec(InstrumentContext)
-    instruments = {'somePipetteId': pipette_mock}
+    instruments = {"somePipetteId": pipette_mock}
 
     well = labware.Well(
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry({
-                'shape': 'circular',
-                'depth': 40,
-                'totalLiquidVolume': 100,
-                'diameter': 30,
-                'x': 40,
-                'y': 50,
-                'z': 3},
+            well_geometry=WellGeometry(
+                {
+                    "shape": "circular",
+                    "depth": 40,
+                    "totalLiquidVolume": 100,
+                    "diameter": 30,
+                    "x": 40,
+                    "y": 50,
+                    "z": 3,
+                },
                 parent_point=Point(10, 20, 30),
-                parent_object=1
+                parent_object=1,
             ),
             has_tip=False,
-            display_name='some well',
-            name="A2"
+            display_name="some well",
+            name="A2",
         ),
-        api_level=MAX_SUPPORTED_VERSION)
+        api_level=MAX_SUPPORTED_VERSION,
+    )
 
-    mock_get_well = mock.MagicMock(
-        return_value=well, name='mock_get_well')
+    mock_get_well = mock.MagicMock(return_value=well, name="mock_get_well")
 
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId',
-              'well': 'someWell',
-              'offset': {'x': 10, 'y': 11, 'z': 12},
-              'forceDirect': mock.sentinel.force_direct,
-              'minimumZHeight': mock.sentinel.minimum_z_height}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+        "offset": {"x": 10, "y": 11, "z": 12},
+        "forceDirect": mock.sentinel.force_direct,
+        "minimumZHeight": mock.sentinel.minimum_z_height,
+    }
 
     with mock.patch(
-            'opentrons.protocols.execution.execute_json_v5._get_well',
-            new=mock_get_well):
-        _move_to_well(
-            instruments, mock.sentinel.loaded_labware, params)
+        "opentrons.protocols.execution.execute_json_v5._get_well", new=mock_get_well
+    ):
+        _move_to_well(instruments, mock.sentinel.loaded_labware, params)
 
     assert pipette_mock.mock_calls == [
         mock.call.move_to(
             well.bottom().move(Point(10, 11, 12)),
             force_direct=mock.sentinel.force_direct,
-            minimum_z_height=mock.sentinel.minimum_z_height)]
-
-    assert mock_get_well.mock_calls == [
-        mock.call(mock.sentinel.loaded_labware, params)
+            minimum_z_height=mock.sentinel.minimum_z_height,
+        )
     ]
+
+    assert mock_get_well.mock_calls == [mock.call(mock.sentinel.loaded_labware, params)]
 
 
 def test_move_to_well_without_optional_params():
     pipette_mock = mock.create_autospec(InstrumentContext)
-    instruments = {'somePipetteId': pipette_mock}
+    instruments = {"somePipetteId": pipette_mock}
 
     well = labware.Well(
         well_implementation=WellImplementation(
-            well_geometry=WellGeometry({
-                'shape': 'circular',
-                'depth': 40,
-                'totalLiquidVolume': 100,
-                'diameter': 30,
-                'x': 40,
-                'y': 50,
-                'z': 3},
+            well_geometry=WellGeometry(
+                {
+                    "shape": "circular",
+                    "depth": 40,
+                    "totalLiquidVolume": 100,
+                    "diameter": 30,
+                    "x": 40,
+                    "y": 50,
+                    "z": 3,
+                },
                 parent_point=Point(10, 20, 30),
-                parent_object=1
+                parent_object=1,
             ),
             has_tip=False,
-            display_name='some well',
-            name="A2"
+            display_name="some well",
+            name="A2",
         ),
-        api_level=MAX_SUPPORTED_VERSION)
+        api_level=MAX_SUPPORTED_VERSION,
+    )
 
-    mock_get_well = mock.MagicMock(
-        return_value=well, name='mock_get_well')
+    mock_get_well = mock.MagicMock(return_value=well, name="mock_get_well")
 
-    params = {'pipette': 'somePipetteId',
-              'labware': 'someLabwareId',
-              'well': 'someWell'}
+    params = {
+        "pipette": "somePipetteId",
+        "labware": "someLabwareId",
+        "well": "someWell",
+    }
 
     with mock.patch(
-            'opentrons.protocols.execution.execute_json_v5._get_well',
-            new=mock_get_well):
-        _move_to_well(
-            instruments, mock.sentinel.loaded_labware, params)
+        "opentrons.protocols.execution.execute_json_v5._get_well", new=mock_get_well
+    ):
+        _move_to_well(instruments, mock.sentinel.loaded_labware, params)
 
     assert pipette_mock.mock_calls == [
-        mock.call.move_to(
-            well.bottom(),
-            force_direct=None,
-            minimum_z_height=None)]
-
-    assert mock_get_well.mock_calls == [
-        mock.call(mock.sentinel.loaded_labware, params)
+        mock.call.move_to(well.bottom(), force_direct=None, minimum_z_height=None)
     ]
+
+    assert mock_get_well.mock_calls == [mock.call(mock.sentinel.loaded_labware, params)]

--- a/api/tests/opentrons/protocols/execution/test_execute_python.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_python.py
@@ -35,46 +35,48 @@ def test_api2_runfunc():
     execute_python._runfunc_ok(starargs)
 
 
-@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py"])
 def test_execute_ok(protocol, protocol_file, ctx):
     proto = parse(protocol.text, protocol.filename)
     execute.run_protocol(proto, context=ctx)
 
 
 def test_bad_protocol(ctx):
-    no_args = parse('''
+    no_args = parse(
+        """
 metadata={"apiLevel": "2.0"}
 def run():
     pass
-''')
+"""
+    )
     with pytest.raises(execute_python.MalformedProtocolError) as e:
         execute.run_protocol(no_args, context=ctx)
         assert "Function 'run()' does not take any parameters" in str(e.value)
 
-    many_args = parse('''
+    many_args = parse(
+        """
 metadata={"apiLevel": "2.0"}
 def run(a, b):
     pass
-''')
+"""
+    )
     with pytest.raises(execute_python.MalformedProtocolError) as e:
         execute.run_protocol(many_args, context=ctx)
         assert "must be called with more than one argument" in str(e.value)
 
 
 def test_proto_with_exception(ctx):
-    exc_in_root = '''metadata={"apiLevel": "2.0"}
+    exc_in_root = """metadata={"apiLevel": "2.0"}
 
 def run(ctx):
     raise Exception("hi")
-'''
+"""
     protocol = parse(exc_in_root)
     with pytest.raises(execute_python.ExceptionInProtocolError) as e:
-        execute.run_protocol(
-            protocol,
-            context=ctx)
-    assert 'Exception [line 4]: hi' in str(e.value)
+        execute.run_protocol(protocol, context=ctx)
+    assert "Exception [line 4]: hi" in str(e.value)
 
-    nested_exc = '''
+    nested_exc = """
 import ast
 
 def this_throws():
@@ -84,11 +86,9 @@ def run(ctx):
     this_throws()
 
 metadata={"apiLevel": "2.0"};
-'''
+"""
     protocol = parse(nested_exc)
     with pytest.raises(execute_python.ExceptionInProtocolError) as e:
-        execute.run_protocol(
-            protocol,
-            context=ctx)
-    assert '[line 5]' in str(e.value)
-    assert 'Exception [line 5]: hi' in str(e.value)
+        execute.run_protocol(protocol, context=ctx)
+    assert "[line 5]" in str(e.value)
+    assert "Exception [line 5]: hi" in str(e.value)

--- a/api/tests/opentrons/protocols/fixtures/bundled_protocols/missing_labware_bundle/protocol.py
+++ b/api/tests/opentrons/protocols/fixtures/bundled_protocols/missing_labware_bundle/protocol.py
@@ -1,9 +1,9 @@
 def run(protocol_context):
-    tip_rack = protocol_context.load_labware('opentrons_96_tiprack_10ul', '3')
-    plate = protocol_context.load_labware(
-        'biorad_96_wellplate_200ul_pcr', '1')
+    tip_rack = protocol_context.load_labware("opentrons_96_tiprack_10ul", "3")
+    plate = protocol_context.load_labware("biorad_96_wellplate_200ul_pcr", "1")
 
-    pipette = protocol_context.load_instrument('p10_single', 'left',
-                                               tip_racks=[tip_rack])
+    pipette = protocol_context.load_instrument(
+        "p10_single", "left", tip_racks=[tip_rack]
+    )
 
-    pipette.transfer(5, plate.wells('A1'), plate.wells('B1'))
+    pipette.transfer(5, plate.wells("A1"), plate.wells("B1"))

--- a/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
+++ b/api/tests/opentrons/protocols/fixtures/bundled_protocols/simple_bundle/protocol.py
@@ -1,17 +1,18 @@
-metadata = {'author': 'MISTER FIXTURE',
-            'apiLevel': '2.0'}
+metadata = {"author": "MISTER FIXTURE", "apiLevel": "2.0"}
 
 
 def run(protocol_context):
-    tip_rack = protocol_context.load_labware('opentrons_96_tiprack_10ul', '3')
+    tip_rack = protocol_context.load_labware("opentrons_96_tiprack_10ul", "3")
     plate = protocol_context.load_labware(
-        'custom_labware', '1', namespace='custom_beta')
+        "custom_labware", "1", namespace="custom_beta"
+    )
 
-    pipette = protocol_context.load_instrument('p10_single', 'left',
-                                               tip_racks=[tip_rack])
+    pipette = protocol_context.load_instrument(
+        "p10_single", "left", tip_racks=[tip_rack]
+    )
 
-    csv_data = protocol_context.bundled_data['data.txt'].decode('utf-8')
+    csv_data = protocol_context.bundled_data["data.txt"].decode("utf-8")
 
-    for volume in csv_data.split(','):
+    for volume in csv_data.split(","):
         v = float(volume.strip())
-        pipette.transfer(v, plate.wells('A1'), plate.wells('A4'))
+        pipette.transfer(v, plate.wells("A1"), plate.wells("A4"))

--- a/api/tests/opentrons/protocols/geometry/test_geometry.py
+++ b/api/tests/opentrons/protocols/geometry/test_geometry.py
@@ -2,16 +2,19 @@ import pytest
 
 from opentrons.types import Location, Point
 from opentrons.protocols.geometry.planning import (
-    plan_moves, safe_height, should_dodge_thermocycler)
+    plan_moves,
+    safe_height,
+    should_dodge_thermocycler,
+)
 from opentrons.protocols.geometry.deck import Deck
 from opentrons.protocol_api import labware
 from opentrons.protocols.geometry import module_geometry
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
-tall_lw_name = 'opentrons_96_tiprack_1000ul'
-labware_name = 'corning_96_wellplate_360ul_flat'
-trough_name = 'usascientific_12_reservoir_22ml'
+tall_lw_name = "opentrons_96_tiprack_1000ul"
+labware_name = "corning_96_wellplate_360ul_flat"
+trough_name = "usascientific_12_reservoir_22ml"
 P300M_GEN2_MAX_HEIGHT = 155.75
 
 
@@ -25,38 +28,40 @@ def test_slot_names():
             assert slot in d
             d[slot] = lw
             with pytest.raises(ValueError):
-                d[slot] = 'not this time boyo'
+                d[slot] = "not this time boyo"
             del d[slot]
             assert slot in d
             assert d[slot] is None
             mod = module_geometry.load_module(
                 module_geometry.TemperatureModuleModel.TEMPERATURE_V1,
-                d.position_for(slot))
+                d.position_for(slot),
+            )
             d[slot] = mod
             assert mod == d[slot]
 
-    assert 'hasasdaia' not in d
+    assert "hasasdaia" not in d
     with pytest.raises(ValueError):
-        d['ahgoasia'] = 'nope'
+        d["ahgoasia"] = "nope"
 
 
 def test_slot_collisions():
     d = Deck()
-    mod_slot = '7'
+    mod_slot = "7"
     mod = module_geometry.load_module(
         module_geometry.ThermocyclerModuleModel.THERMOCYCLER_V1,
-        d.position_for(mod_slot))
+        d.position_for(mod_slot),
+    )
     d[mod_slot] = mod
     with pytest.raises(ValueError):
-        d['7'] = 'not this time boyo'
+        d["7"] = "not this time boyo"
     with pytest.raises(ValueError):
-        d['8'] = 'nor this time boyo'
+        d["8"] = "nor this time boyo"
     with pytest.raises(ValueError):
-        d['10'] = 'or even this time boyo'
+        d["10"] = "or even this time boyo"
     with pytest.raises(ValueError):
-        d['11'] = 'def not this time though'
+        d["11"] = "def not this time though"
 
-    lw_slot = '4'
+    lw_slot = "4"
     lw = labware.load(labware_name, d.position_for(lw_slot))
     d[lw_slot] = lw
 
@@ -73,8 +78,8 @@ def test_highest_z():
     del deck[1]
     assert deck.highest_z == fixed_trash.highest_z
     mod = module_geometry.load_module(
-        module_geometry.TemperatureModuleModel.TEMPERATURE_V1,
-        deck.position_for(8))
+        module_geometry.TemperatureModuleModel.TEMPERATURE_V1, deck.position_for(8)
+    )
     deck[8] = mod
     assert deck.highest_z == mod.highest_z
     lw = labware.load(labware_name, mod.location)
@@ -84,7 +89,7 @@ def test_highest_z():
 
 
 def check_arc_basic(arc, from_loc, to_loc):
-    """ Check the tests that should always be true for different-well moves
+    """Check the tests that should always be true for different-well moves
     - we should always go only up, then only xy, then only down
     - we should have three moves
     """
@@ -102,13 +107,19 @@ def test_direct_moves():
     lw1 = labware.load(labware_name, deck.position_for(1))
 
     same_place = plan_moves(
-        lw1.wells()[0].top(), lw1.wells()[0].top(), deck,
-        instr_max_height=P300M_GEN2_MAX_HEIGHT)
+        lw1.wells()[0].top(),
+        lw1.wells()[0].top(),
+        deck,
+        instr_max_height=P300M_GEN2_MAX_HEIGHT,
+    )
     assert same_place == [(lw1.wells()[0].top().point, None)]
 
     same_well = plan_moves(
-        lw1.wells()[0].top(), lw1.wells()[0].bottom(), deck,
-        instr_max_height=P300M_GEN2_MAX_HEIGHT)
+        lw1.wells()[0].top(),
+        lw1.wells()[0].bottom(),
+        deck,
+        instr_max_height=P300M_GEN2_MAX_HEIGHT,
+    )
     assert same_well == [(lw1.wells()[0].bottom().point, None)]
 
 
@@ -120,23 +131,28 @@ def test_basic_arc():
     deck[2] = lw2
 
     # same-labware moves should use the smaller safe z
-    same_lw = plan_moves(lw1.wells()[0].top(),
-                         lw1.wells()[8].bottom(),
-                         deck,
-                         P300M_GEN2_MAX_HEIGHT,
-                         5.0, 10.0)
+    same_lw = plan_moves(
+        lw1.wells()[0].top(),
+        lw1.wells()[8].bottom(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+    )
     check_arc_basic(same_lw, lw1.wells()[0].top(), lw1.wells()[8].bottom())
     assert same_lw[0][0].z == lw1.wells()[0].top().point.z + 5.0
 
     # different-labware moves, or moves with no labware attached,
     # should use the larger safe z and the global z
-    different_lw = plan_moves(lw1.wells()[0].top(),
-                              lw2.wells()[0].bottom(),
-                              deck,
-                              P300M_GEN2_MAX_HEIGHT,
-                              5.0, 10.0)
-    check_arc_basic(different_lw,
-                    lw1.wells()[0].top(), lw2.wells()[0].bottom())
+    different_lw = plan_moves(
+        lw1.wells()[0].top(),
+        lw2.wells()[0].bottom(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+    )
+    check_arc_basic(different_lw, lw1.wells()[0].top(), lw2.wells()[0].bottom())
     assert different_lw[0][0].z == deck.highest_z + 10.0
 
 
@@ -145,19 +161,27 @@ def test_force_direct():
     lw1 = labware.load(labware_name, deck.position_for(1))
     lw2 = labware.load(labware_name, deck.position_for(2))
     # same-labware moves should move direct
-    same_lw = plan_moves(lw1.wells()[0].top(),
-                         lw1.wells()[8].bottom(),
-                         deck,
-                         P300M_GEN2_MAX_HEIGHT,
-                         5.0, 10.0, force_direct=True)
+    same_lw = plan_moves(
+        lw1.wells()[0].top(),
+        lw1.wells()[8].bottom(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+        force_direct=True,
+    )
     assert same_lw == [(lw1.wells()[8].bottom().point, None)]
 
     # different-labware moves should move direct
-    different_lw = plan_moves(lw1.wells()[0].top(),
-                              lw2.wells()[0].bottom(),
-                              deck,
-                              P300M_GEN2_MAX_HEIGHT,
-                              5.0, 10.0, force_direct=True)
+    different_lw = plan_moves(
+        lw1.wells()[0].top(),
+        lw2.wells()[0].bottom(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+        force_direct=True,
+    )
     assert different_lw == [(lw2.wells()[0].bottom().point, None)]
 
 
@@ -172,28 +196,32 @@ def test_no_labware_loc(labware_offset_tempdir):
     # Various flavors of locations without labware should work
     no_lw = Location(point=lw1.wells()[0].top().point, labware=None)
 
-    no_from = plan_moves(no_lw, lw2.wells()[0].bottom(), deck,
-                         P300M_GEN2_MAX_HEIGHT, 5.0, 10.0)
+    no_from = plan_moves(
+        no_lw, lw2.wells()[0].bottom(), deck, P300M_GEN2_MAX_HEIGHT, 5.0, 10.0
+    )
     check_arc_basic(no_from, no_lw, lw2.wells()[0].bottom())
     assert no_from[0][0].z == deck.highest_z + 10.0
 
-    no_to = plan_moves(lw1.wells()[0].bottom(), no_lw, deck,
-                       P300M_GEN2_MAX_HEIGHT, 5.0, 10.0)
+    no_to = plan_moves(
+        lw1.wells()[0].bottom(), no_lw, deck, P300M_GEN2_MAX_HEIGHT, 5.0, 10.0
+    )
     check_arc_basic(no_to, lw1.wells()[0].bottom(), no_lw)
     assert no_from[0][0].z == deck.highest_z + 10.0
 
     no_well = Location(point=lw1.wells()[0].top().point, labware=lw1)
 
-    no_from_well = plan_moves(no_well, lw1.wells()[1].top(), deck,
-                              P300M_GEN2_MAX_HEIGHT, 5.0, 10.0)
+    no_from_well = plan_moves(
+        no_well, lw1.wells()[1].top(), deck, P300M_GEN2_MAX_HEIGHT, 5.0, 10.0
+    )
     check_arc_basic(no_from_well, no_well, lw1.wells()[1].top())
 
     no_from_well_height = no_from_well[0][0].z
-    lw_height_expected = labware_def['dimensions']['zDimension'] + 5.0
+    lw_height_expected = labware_def["dimensions"]["zDimension"] + 5.0
     assert no_from_well_height == lw_height_expected
 
-    no_to_well = plan_moves(lw1.wells()[1].top(), no_well, deck,
-                            P300M_GEN2_MAX_HEIGHT, 5.0, 10.0)
+    no_to_well = plan_moves(
+        lw1.wells()[1].top(), no_well, deck, P300M_GEN2_MAX_HEIGHT, 5.0, 10.0
+    )
     check_arc_basic(no_to_well, lw1.wells()[1].top(), no_well)
     no_to_well_height = no_to_well[0][0].z
     assert no_to_well_height == lw_height_expected
@@ -215,8 +243,7 @@ def test_arc_tall_point():
     assert from_tall[0][0].z == tall_z
 
     no_well = Location(point=tall_top.point, labware=lw1)
-    from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
-                              5.0, 10.0)
+    from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck, 5.0, 10.0)
     check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom())
 
 
@@ -229,22 +256,34 @@ def test_arc_lower_minimum_z_height():
     tall_point = old_top.point._replace(z=tall_z)
     tall_top = Location(point=tall_point, labware=old_top.labware)
     to_tall = plan_moves(
-        lw1.wells()[2].top(), tall_top, deck,
-        P300M_GEN2_MAX_HEIGHT, 5.0, 10.0, False,
-        minimum_z_height=minimum_z_height)
+        lw1.wells()[2].top(),
+        tall_top,
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+        False,
+        minimum_z_height=minimum_z_height,
+    )
     check_arc_basic(to_tall, lw1.wells()[2].top(), tall_top)
     assert to_tall[0][0].z == tall_z
 
     from_tall = plan_moves(
-        tall_top, lw1.wells()[3].top(), deck,
-        P300M_GEN2_MAX_HEIGHT, 5.0, 10.0,
-        minimum_z_height=minimum_z_height)
+        tall_top,
+        lw1.wells()[3].top(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+        5.0,
+        10.0,
+        minimum_z_height=minimum_z_height,
+    )
     check_arc_basic(from_tall, tall_top, lw1.wells()[3].top())
     assert from_tall[0][0].z == tall_z
 
     no_well = Location(point=tall_top.point, labware=lw1)
-    from_tall_lw = plan_moves(no_well, lw1.wells()[4].bottom(), deck,
-                              P300M_GEN2_MAX_HEIGHT, 5.0, 10.0)
+    from_tall_lw = plan_moves(
+        no_well, lw1.wells()[4].bottom(), deck, P300M_GEN2_MAX_HEIGHT, 5.0, 10.0
+    )
     check_arc_basic(from_tall_lw, no_well, lw1.wells()[4].bottom())
 
 
@@ -256,8 +295,9 @@ def test_direct_minimum_z_height():
     zmo = 150
     # This would normally be a direct move since it’s inside the same well,
     # but we want to check that we override it into an arc
-    moves = plan_moves(from_loc, to_loc, deck, P300M_GEN2_MAX_HEIGHT,
-                       minimum_z_height=zmo)
+    moves = plan_moves(
+        from_loc, to_loc, deck, P300M_GEN2_MAX_HEIGHT, minimum_z_height=zmo
+    )
     assert len(moves) == 3
     assert moves[0][0].z == zmo  # equals zmo b/c 150 is max of all safe z's
     check_arc_basic(moves, from_loc, to_loc)
@@ -269,34 +309,38 @@ def test_direct_cp():
     lw1 = labware.load(labware_name, deck.position_for(2))
     # when moving from no origin location to a centered labware we should
     # start in default cp
-    from_nothing = plan_moves(Location(Point(50, 50, 50), None),
-                              trough.wells()[0].top(),
-                              deck, P300M_GEN2_MAX_HEIGHT)
-    check_arc_basic(from_nothing, Location(Point(50, 50, 50), None),
-                    trough.wells()[0].top())
+    from_nothing = plan_moves(
+        Location(Point(50, 50, 50), None),
+        trough.wells()[0].top(),
+        deck,
+        P300M_GEN2_MAX_HEIGHT,
+    )
+    check_arc_basic(
+        from_nothing, Location(Point(50, 50, 50), None), trough.wells()[0].top()
+    )
     assert from_nothing[0][1] is None
     assert from_nothing[1][1] == CriticalPoint.XY_CENTER
     assert from_nothing[2][1] == CriticalPoint.XY_CENTER
     # when moving from an origin with a centered labware to a dest with a
     # centered labware we should stay in centered the entire time, whether
     # arc
-    from_centered_arc = plan_moves(trough.wells()[0].top(),
-                                   trough.wells()[1].top(),
-                                   deck, P300M_GEN2_MAX_HEIGHT)
-    check_arc_basic(from_centered_arc,
-                    trough.wells()[0].top(), trough.wells()[1].top())
+    from_centered_arc = plan_moves(
+        trough.wells()[0].top(), trough.wells()[1].top(), deck, P300M_GEN2_MAX_HEIGHT
+    )
+    check_arc_basic(from_centered_arc, trough.wells()[0].top(), trough.wells()[1].top())
     assert from_centered_arc[0][1] == CriticalPoint.XY_CENTER
     assert from_centered_arc[1][1] == CriticalPoint.XY_CENTER
     assert from_centered_arc[2][1] == CriticalPoint.XY_CENTER
     # or direct
-    from_centered_direct = plan_moves(trough.wells()[0].top(),
-                                      trough.wells()[1].bottom(),
-                                      deck, P300M_GEN2_MAX_HEIGHT)
+    from_centered_direct = plan_moves(
+        trough.wells()[0].top(), trough.wells()[1].bottom(), deck, P300M_GEN2_MAX_HEIGHT
+    )
     assert from_centered_direct[0][1] == CriticalPoint.XY_CENTER
     # when moving from centered to normal, only the first move should be
     # centered
-    to_normal = plan_moves(trough.wells()[0].top(), lw1.wells()[0].top(), deck,
-                           P300M_GEN2_MAX_HEIGHT)
+    to_normal = plan_moves(
+        trough.wells()[0].top(), lw1.wells()[0].top(), deck, P300M_GEN2_MAX_HEIGHT
+    )
     check_arc_basic(to_normal, trough.wells()[0].top(), lw1.wells()[0].top())
     assert to_normal[0][1] == CriticalPoint.XY_CENTER
     assert to_normal[1][1] is None
@@ -307,24 +351,28 @@ def test_gen2_module_transforms():
     deck = Deck()
     tmod = module_geometry.load_module(
         module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for('1'),
-        MAX_SUPPORTED_VERSION)
+        deck.position_for("1"),
+        MAX_SUPPORTED_VERSION,
+    )
     assert tmod.labware_offset == Point(-1.45, -0.15, 80.09)
     tmod2 = module_geometry.load_module(
         module_geometry.TemperatureModuleModel.TEMPERATURE_V2,
-        deck.position_for('3'),
-        MAX_SUPPORTED_VERSION)
+        deck.position_for("3"),
+        MAX_SUPPORTED_VERSION,
+    )
     assert tmod2.labware_offset == Point(1.15, -0.15, 80.09)
 
     mmod = module_geometry.load_module(
         module_geometry.MagneticModuleModel.MAGNETIC_V2,
-        deck.position_for('1'),
-        MAX_SUPPORTED_VERSION)
+        deck.position_for("1"),
+        MAX_SUPPORTED_VERSION,
+    )
     assert mmod.labware_offset == Point(-1.175, -0.125, 82.25)
     mmod2 = module_geometry.load_module(
         module_geometry.MagneticModuleModel.MAGNETIC_V2,
-        deck.position_for('3'),
-        MAX_SUPPORTED_VERSION)
+        deck.position_for("3"),
+        MAX_SUPPORTED_VERSION,
+    )
     assert mmod2.labware_offset == Point(1.425, -0.125, 82.25)
 
 
@@ -346,7 +394,8 @@ def test_instr_max_height():
         deck=deck,
         instr_max_height=round(instr_max_height, 2),
         well_z_margin=5.0,
-        lw_z_margin=10.0)
+        lw_z_margin=10.0,
+    )
     assert height == round(instr_max_height, 2)
 
     # if the highest deck height is > 10 mm below the max instrument
@@ -358,9 +407,9 @@ def test_instr_max_height():
         deck=deck,
         instr_max_height=round(instr_max_height, 2),
         well_z_margin=5.0,
-        lw_z_margin=10.0)
-    assert height2 ==\
-        round(fixed_trash.wells()[0].top().point.z, 2) + 10.0
+        lw_z_margin=10.0,
+    )
+    assert height2 == round(fixed_trash.wells()[0].top().point.z, 2) + 10.0
 
     # it fails if the highest deck height is less than 1 mm below
     # the max instr achievable height
@@ -372,31 +421,32 @@ def test_instr_max_height():
             deck=deck,
             instr_max_height=round(instr_max_height, 2),
             well_z_margin=5.0,
-            lw_z_margin=10.0)
+            lw_z_margin=10.0,
+        )
 
 
 def test_should_dodge():
     deck = Deck()
     # with no tc loaded, doesn't matter what the positions are
     assert not should_dodge_thermocycler(
-        deck, deck.position_for(4), deck.position_for(9))
+        deck, deck.position_for(4), deck.position_for(9)
+    )
     deck[7] = module_geometry.load_module(
-        module_geometry.ThermocyclerModuleModel.THERMOCYCLER_V1,
-        deck.position_for(7))
+        module_geometry.ThermocyclerModuleModel.THERMOCYCLER_V1, deck.position_for(7)
+    )
     # with a tc loaded, some positions should require dodging
-    assert should_dodge_thermocycler(
-        deck, deck.position_for(12), deck.position_for(1))
-    assert should_dodge_thermocycler(
-        deck, deck.position_for(9), deck.position_for(4))
+    assert should_dodge_thermocycler(deck, deck.position_for(12), deck.position_for(1))
+    assert should_dodge_thermocycler(deck, deck.position_for(9), deck.position_for(4))
     # but ones that weren't explicitly marked shouldn't
     assert not should_dodge_thermocycler(
-        deck, deck.position_for(1), deck.position_for(2))
+        deck, deck.position_for(1), deck.position_for(2)
+    )
     # including a situation where we might have some messed up locations
     # with no parent
     assert not should_dodge_thermocycler(
         deck,
         Location(point=deck.position_for(1).point, labware=None),
-        deck.position_for(12)
+        deck.position_for(12),
     )
 
 
@@ -408,11 +458,11 @@ def test_labware_in_next_slot():
     deck[4] = trough
     deck[1] = trough2
     deck[3] = trough3
-    assert deck.right_of('3') is None
-    assert deck.left_of('2') is trough2
-    assert deck.right_of('2') is trough3
+    assert deck.right_of("3") is None
+    assert deck.left_of("2") is trough2
+    assert deck.right_of("2") is trough3
 
-    assert deck.right_of('9') is None
+    assert deck.right_of("9") is None
 
 
 def test_get_non_fixture_slots():
@@ -420,5 +470,4 @@ def test_get_non_fixture_slots():
     trough = labware.load(trough_name, deck.position_for(4))
     deck[4] = trough
 
-    assert deck.get_non_fixture_slots() == [1, 2, 3, 4, 5, 6,
-                                            7, 8, 9, 10, 11]
+    assert deck.get_non_fixture_slots() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/api/tests/opentrons/protocols/models/test_json_protocol.py
+++ b/api/tests/opentrons/protocols/models/test_json_protocol.py
@@ -3,19 +3,20 @@ from opentrons.protocols.models import json_protocol
 
 
 @pytest.mark.parametrize(
-    argnames=['version', 'name'],
+    argnames=["version", "name"],
     argvalues=[
         ["5", "simpleV5"],
         ["4", "simpleV4"],
         ["4", "testModulesProtocol"],
         ["3", "simple"],
         ["3", "testAllAtomicSingleV3"],
-    ]
+    ],
 )
 def test_json_protocol_model(get_json_protocol_fixture, version: str, name: str):
     """It should be parsed and validated correctly."""
     fx = get_json_protocol_fixture(
-        fixture_version=version, fixture_name=name, decode=True)
+        fixture_version=version, fixture_name=name, decode=True
+    )
 
     # Create the model
     d = json_protocol.Model.parse_obj(fx)

--- a/api/tests/opentrons/protocols/test_bundle.py
+++ b/api/tests/opentrons/protocols/test_bundle.py
@@ -7,38 +7,37 @@ from opentrons.protocols import bundle
 
 
 def test_parse_bundle_no_root_files(get_bundle_fixture):
-    fixture = get_bundle_fixture('no_root_files_bundle')
-    with pytest.raises(RuntimeError,
-                       match='No files found in ZIP file\'s root directory'):
-        buf = io.BytesIO(fixture['binary_zipfile'])
+    fixture = get_bundle_fixture("no_root_files_bundle")
+    with pytest.raises(
+        RuntimeError, match="No files found in ZIP file's root directory"
+    ):
+        buf = io.BytesIO(fixture["binary_zipfile"])
         buf.seek(0)
         zf = zipfile.ZipFile(buf)
         bundle.extract_bundle(zf)
 
 
 def test_parse_bundle_no_entrypoint_protocol(get_bundle_fixture):
-    fixture = get_bundle_fixture('no_entrypoint_protocol_bundle')
-    with pytest.raises(RuntimeError,
-                       match='Bundled protocol should have a'):
-        buf = io.BytesIO(fixture['binary_zipfile'])
+    fixture = get_bundle_fixture("no_entrypoint_protocol_bundle")
+    with pytest.raises(RuntimeError, match="Bundled protocol should have a"):
+        buf = io.BytesIO(fixture["binary_zipfile"])
         buf.seek(0)
         zf = zipfile.ZipFile(buf)
         bundle.extract_bundle(zf)
 
 
 def test_parse_bundle_conflicting_labware(get_bundle_fixture):
-    fixture = get_bundle_fixture('conflicting_labware_bundle')
-    with pytest.raises(RuntimeError,
-                       match='Conflicting labware in bundle'):
-        buf = io.BytesIO(fixture['binary_zipfile'])
+    fixture = get_bundle_fixture("conflicting_labware_bundle")
+    with pytest.raises(RuntimeError, match="Conflicting labware in bundle"):
+        buf = io.BytesIO(fixture["binary_zipfile"])
         buf.seek(0)
         zf = zipfile.ZipFile(buf)
         bundle.extract_bundle(zf)
 
 
 def test_write_bundle(get_bundle_fixture):
-    fixture = get_bundle_fixture('simple_bundle')
-    buf = io.BytesIO(fixture['binary_zipfile'])
+    fixture = get_bundle_fixture("simple_bundle")
+    buf = io.BytesIO(fixture["binary_zipfile"])
     buf.seek(0)
     zf = zipfile.ZipFile(buf)
     original_contents = bundle.extract_bundle(zf)

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -10,19 +10,19 @@ from opentrons.protocols.parse import (
     parse,
     API_VERSION_FOR_JSON_V5_AND_BELOW,
     MAX_SUPPORTED_JSON_SCHEMA_VERSION,
-    version_from_metadata)
-from opentrons.protocols.types import (JsonProtocol,
-                                       PythonProtocol,
-                                       MalformedProtocolError,
-                                       ApiDeprecationError)
+    version_from_metadata,
+)
+from opentrons.protocols.types import (
+    JsonProtocol,
+    PythonProtocol,
+    MalformedProtocolError,
+    ApiDeprecationError,
+)
 from opentrons.protocols.api_support.types import APIVersion
 
 
 def test_extract_metadata():
-    expected = {
-        'hello': 'world',
-        'what?': 'no'
-    }
+    expected = {"hello": "world", "what?": "no"}
 
     prot = """
 this = 0
@@ -40,28 +40,38 @@ metadata['hello'] = 'moon'
 fakedata['what?'] = 'ham'
 """
 
-    parsed = ast.parse(prot, filename='testy', mode='exec')
+    parsed = ast.parse(prot, filename="testy", mode="exec")
     metadata = extract_metadata(parsed)
     assert metadata == expected
 
 
 infer_version_cases = [
-    ("""
+    (
+        """
 from opentrons import instruments
 
 p = instruments.P10_Single(mount='right')
-""", APIVersion(1, 0)),
-    ("""
+""",
+        APIVersion(1, 0),
+    ),
+    (
+        """
 import opentrons.instruments
 
 p = instruments.P10_Single(mount='right')
-""", APIVersion(1, 0)),
-    ("""
+""",
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import instruments as instr
 
 p = instr.P10_Single(mount='right')
-""", APIVersion(1, 0)),
-    ("""
+""",
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import instruments
 
 metadata = {
@@ -69,8 +79,11 @@ metadata = {
   }
 
 p = instruments.P10_Single(mount='right')
-""", APIVersion(1, 0)),
-    ("""
+""",
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import types
 
 metadata = {
@@ -79,8 +92,11 @@ metadata = {
 
 def run(ctx):
     right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
-""", APIVersion(2, 0)),
-    ("""
+""",
+        APIVersion(2, 0),
+    ),
+    (
+        """
 from opentrons import types
 
 metadata = {
@@ -89,8 +105,11 @@ metadata = {
 
 def run(ctx):
     right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
-""", APIVersion(1, 0)),
-    ("""
+""",
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import types
 
 metadata = {
@@ -99,29 +118,43 @@ metadata = {
 
 def run(ctx):
     right = ctx.load_instrument('p300_single', types.Mount.RIGHT)
-""", APIVersion(2, 0)),
-    ("""
+""",
+        APIVersion(2, 0),
+    ),
+    (
+        """
 from opentrons import labware, instruments
 
 p = instruments.P10_Single(mount='right')
-    """, APIVersion(1, 0)),
-    ("""
+    """,
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import types, containers
-    """, APIVersion(1, 0)),
-    ("""
+    """,
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import types, instruments
 
 p = instruments.P10_Single(mount='right')
-    """, APIVersion(1, 0)),
-    ("""
+    """,
+        APIVersion(1, 0),
+    ),
+    (
+        """
 from opentrons import instruments as instr
 
 p = instr.P300_Single('right')
-    """, APIVersion(1, 0))
+    """,
+        APIVersion(1, 0),
+    ),
 ]
 
 
-@pytest.mark.parametrize('proto,version', infer_version_cases)
+@pytest.mark.parametrize("proto,version", infer_version_cases)
 def test_get_version(proto, version):
     if version == APIVersion(1, 0):
         with pytest.raises(ApiDeprecationError):
@@ -132,86 +165,87 @@ def test_get_version(proto, version):
 
 
 test_valid_metadata = [
-    ({'apiLevel': '1'}, APIVersion(1, 0)),
-    ({'apiLevel': '1.0'}, APIVersion(1, 0)),
-    ({'apiLevel': '1.2'}, APIVersion(1, 2)),
-    ({'apiLevel': '2.0'}, APIVersion(2, 0)),
-    ({'apiLevel': '2.6'}, APIVersion(2, 6)),
-    ({'apiLevel': '10.23123151'}, APIVersion(10, 23123151))
+    ({"apiLevel": "1"}, APIVersion(1, 0)),
+    ({"apiLevel": "1.0"}, APIVersion(1, 0)),
+    ({"apiLevel": "1.2"}, APIVersion(1, 2)),
+    ({"apiLevel": "2.0"}, APIVersion(2, 0)),
+    ({"apiLevel": "2.6"}, APIVersion(2, 6)),
+    ({"apiLevel": "10.23123151"}, APIVersion(10, 23123151)),
 ]
 
 
 test_invalid_metadata = [
     ({}, KeyError),
-    ({'sasdaf': 'asdaf'}, KeyError),
-    ({'apiLevel': '2'}, ValueError),
-    ({'apiLevel': '2.0.0'}, ValueError),
-    ({'apiLevel': 'asda'}, ValueError)
+    ({"sasdaf": "asdaf"}, KeyError),
+    ({"apiLevel": "2"}, ValueError),
+    ({"apiLevel": "2.0.0"}, ValueError),
+    ({"apiLevel": "asda"}, ValueError),
 ]
 
 
-@pytest.mark.parametrize('metadata,version', test_valid_metadata)
+@pytest.mark.parametrize("metadata,version", test_valid_metadata)
 def test_valid_version_from_metadata(metadata, version):
     assert version_from_metadata(metadata) == version
 
 
-@pytest.mark.parametrize('metadata,exc', test_invalid_metadata)
+@pytest.mark.parametrize("metadata,exc", test_invalid_metadata)
 def test_invalid_version_from_metadata(metadata, exc):
     with pytest.raises(exc):
         version_from_metadata(metadata)
 
 
 def test_get_protocol_schema_version():
-    assert _get_protocol_schema_version({'protocol-schema': '1.0.0'}) == 1
-    assert _get_protocol_schema_version({'protocol-schema': '2.0.0'}) == 2
-    assert _get_protocol_schema_version({'schemaVersion': 123}) == 123
+    assert _get_protocol_schema_version({"protocol-schema": "1.0.0"}) == 1
+    assert _get_protocol_schema_version({"protocol-schema": "2.0.0"}) == 2
+    assert _get_protocol_schema_version({"schemaVersion": 123}) == 123
 
     # schemaVersion has precedence over legacy 'protocol-schema'
-    assert _get_protocol_schema_version({
-        'protocol-schema': '2.0.0',
-        'schemaVersion': 123}) == 123
+    assert (
+        _get_protocol_schema_version({"protocol-schema": "2.0.0", "schemaVersion": 123})
+        == 123
+    )
 
     with pytest.raises(RuntimeError):
-        _get_protocol_schema_version({'schemaVersion': None})
+        _get_protocol_schema_version({"schemaVersion": None})
     with pytest.raises(RuntimeError):
         _get_protocol_schema_version({})
     with pytest.raises(RuntimeError):
-        _get_protocol_schema_version({'protocol-schema': '1.2.3'})
+        _get_protocol_schema_version({"protocol-schema": "1.2.3"})
 
 
 def test_validate_json(get_json_protocol_fixture, get_labware_fixture):
     # valid data that has no schema should fail
-    with pytest.raises(RuntimeError, match='deprecated'):
-        validate_json({'protocol-schema': '1.0.0'})
-    with pytest.raises(RuntimeError, match='Please update your OT-2 App' +
-                       ' ' +
-                       'and robot server to the latest version and try again'):
-        validate_json({'schemaVersion': str(
-            MAX_SUPPORTED_JSON_SCHEMA_VERSION + 1)})
-    labware = get_labware_fixture('fixture_12_trough_v2')
-    with pytest.raises(RuntimeError, match='labware'):
+    with pytest.raises(RuntimeError, match="deprecated"):
+        validate_json({"protocol-schema": "1.0.0"})
+    with pytest.raises(
+        RuntimeError,
+        match="Please update your OT-2 App"
+        + " "
+        + "and robot server to the latest version and try again",
+    ):
+        validate_json({"schemaVersion": str(MAX_SUPPORTED_JSON_SCHEMA_VERSION + 1)})
+    labware = get_labware_fixture("fixture_12_trough_v2")
+    with pytest.raises(RuntimeError, match="labware"):
         validate_json(labware)
-    with pytest.raises(RuntimeError, match='corrupted'):
-        validate_json({'schemaVersion': '3'})
+    with pytest.raises(RuntimeError, match="corrupted"):
+        validate_json({"schemaVersion": "3"})
 
-    v3 = get_json_protocol_fixture('3', 'testAllAtomicSingleV3')
+    v3 = get_json_protocol_fixture("3", "testAllAtomicSingleV3")
     assert validate_json(v3)[0] == 3
 
-    v4 = get_json_protocol_fixture('4', 'testModulesProtocol')
+    v4 = get_json_protocol_fixture("4", "testModulesProtocol")
     assert validate_json(v4)[0] == 4
 
 
-@pytest.mark.parametrize('protocol_file',
-                         ['testosaur_v2.py'])
-@pytest.mark.parametrize('protocol_text_kind', ['str', 'bytes'])
-@pytest.mark.parametrize('filename', ['real', 'none'])
-def test_parse_python_details(
-        protocol, protocol_text_kind, filename, protocol_file):
-    if protocol_text_kind == 'bytes':
-        text = protocol.text.encode('utf-8')
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py"])
+@pytest.mark.parametrize("protocol_text_kind", ["str", "bytes"])
+@pytest.mark.parametrize("filename", ["real", "none"])
+def test_parse_python_details(protocol, protocol_text_kind, filename, protocol_file):
+    if protocol_text_kind == "bytes":
+        text = protocol.text.encode("utf-8")
     else:
         text = protocol.text
-    if filename == 'real':
+    if filename == "real":
         fake_fname = protocol.filename
     else:
         fake_fname = None
@@ -219,43 +253,41 @@ def test_parse_python_details(
     assert isinstance(parsed, PythonProtocol)
     assert parsed.text == protocol.text
     assert isinstance(parsed.text, str)
-    fname = fake_fname if fake_fname else '<protocol>'
+    fname = fake_fname if fake_fname else "<protocol>"
     assert parsed.filename == fname
     assert parsed.api_level == APIVersion(2, 0)
     assert parsed.metadata == {
-        'protocolName': 'Testosaur',
-        'author': 'Opentrons <engineering@opentrons.com>',
-        'description': 'A variant on "Dinosaur" for testing',
-        'source': 'Opentrons Repository',
-        'apiLevel': '2.0'
+        "protocolName": "Testosaur",
+        "author": "Opentrons <engineering@opentrons.com>",
+        "description": 'A variant on "Dinosaur" for testing',
+        "source": "Opentrons Repository",
+        "apiLevel": "2.0",
     }
-    assert parsed.contents == compile(
-        protocol.text,
-        filename=fname,
-        mode='exec')
+    assert parsed.contents == compile(protocol.text, filename=fname, mode="exec")
 
 
-@pytest.mark.parametrize('protocol_details',
-                         [('3', 'simple'), ('3', 'testAllAtomicSingleV3')])
-@pytest.mark.parametrize('protocol_text_kind', ['str', 'bytes'])
-@pytest.mark.parametrize('filename', ['real', 'none'])
-def test_parse_json_details(get_json_protocol_fixture,
-                            protocol_details, protocol_text_kind, filename):
-    protocol = get_json_protocol_fixture(*protocol_details,
-                                         decode=False)
-    if protocol_text_kind == 'text':
+@pytest.mark.parametrize(
+    "protocol_details", [("3", "simple"), ("3", "testAllAtomicSingleV3")]
+)
+@pytest.mark.parametrize("protocol_text_kind", ["str", "bytes"])
+@pytest.mark.parametrize("filename", ["real", "none"])
+def test_parse_json_details(
+    get_json_protocol_fixture, protocol_details, protocol_text_kind, filename
+):
+    protocol = get_json_protocol_fixture(*protocol_details, decode=False)
+    if protocol_text_kind == "text":
         protocol_text = protocol
     else:
-        protocol_text = protocol.encode('utf-8')
-    if filename == 'real':
-        fname = 'simple.json'
+        protocol_text = protocol.encode("utf-8")
+    if filename == "real":
+        fname = "simple.json"
     else:
         fname = None
     parsed = parse(protocol_text, fname)
     assert isinstance(parsed, JsonProtocol)
     assert parsed.filename == fname
     assert parsed.contents == json.loads(protocol)
-    assert parsed.metadata == parsed.contents['metadata']
+    assert parsed.metadata == parsed.contents["metadata"]
     assert parsed.schema_version == int(protocol_details[0])
     # TODO(IL, 2020-10-07): if schema v6 declares its own api_level,
     # then those v6 fixtures will need to be asserted differently
@@ -263,56 +295,58 @@ def test_parse_json_details(get_json_protocol_fixture,
 
 
 def test_parse_bundle_details(get_bundle_fixture):
-    fixture = get_bundle_fixture('simple_bundle')
-    filename = fixture['filename']
+    fixture = get_bundle_fixture("simple_bundle")
+    filename = fixture["filename"]
 
-    parsed = parse(fixture['binary_zipfile'], filename)
+    parsed = parse(fixture["binary_zipfile"], filename)
 
     assert isinstance(parsed, PythonProtocol)
-    assert parsed.filename == 'protocol.ot2.py'
-    assert parsed.bundled_labware == fixture['bundled_labware']
-    assert parsed.bundled_python == fixture['bundled_python']
-    assert parsed.bundled_data == fixture['bundled_data']
-    assert parsed.metadata == fixture['metadata']
+    assert parsed.filename == "protocol.ot2.py"
+    assert parsed.bundled_labware == fixture["bundled_labware"]
+    assert parsed.bundled_python == fixture["bundled_python"]
+    assert parsed.bundled_data == fixture["bundled_data"]
+    assert parsed.metadata == fixture["metadata"]
     assert parsed.api_level == APIVersion(2, 0)
 
 
-@pytest.mark.parametrize('protocol_file',
-                         ['testosaur_v2.py'])
-def test_extra_contents(
-        get_labware_fixture, protocol_file, protocol):
-    fixture_96_plate = get_labware_fixture('fixture_96_plate')
-    bundled_labware = {
-        'fixture/fixture_96_plate/1': fixture_96_plate
-    }
-    extra_data = {'hi': b'there'}
-    parsed = parse(protocol.text, 'testosaur_v2.py',
-                   extra_labware=bundled_labware,
-                   extra_data=extra_data)
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py"])
+def test_extra_contents(get_labware_fixture, protocol_file, protocol):
+    fixture_96_plate = get_labware_fixture("fixture_96_plate")
+    bundled_labware = {"fixture/fixture_96_plate/1": fixture_96_plate}
+    extra_data = {"hi": b"there"}
+    parsed = parse(
+        protocol.text,
+        "testosaur_v2.py",
+        extra_labware=bundled_labware,
+        extra_data=extra_data,
+    )
     assert parsed.extra_labware == bundled_labware
     assert parsed.bundled_data == extra_data
 
 
-@pytest.mark.parametrize('bad_protocol', [
-    '''
+@pytest.mark.parametrize(
+    "bad_protocol",
+    [
+        """
 metadata={"apiLevel": "2.0"}
 def run(ctx): pass
 def run(ctx): pass
-''',
-    '''
+""",
+        """
 metadata = {"apiLevel": "2.0"}
 
 print('hi')
-''',
-    '''
+""",
+        """
 metadata = {"apiLevel": "2.0"}
 def run(ctx):
   pass
 
 def run(blahblah):
   pass
-'''
-])
+""",
+    ],
+)
 def test_bad_structure(bad_protocol):
     with pytest.raises(MalformedProtocolError):
         parse(bad_protocol)

--- a/api/tests/opentrons/system/test_nmcli.py
+++ b/api/tests/opentrons/system/test_nmcli.py
@@ -5,46 +5,51 @@ from opentrons.system import nmcli
 
 def test_parse_colonsep():
     assert nmcli._parse_colonsep_response(
-        'dank mimos\\: slow zone:100:yes:wpa2\n'
-        'some other network:20:no:wep\n'
-        'blah:4:yes:none\n')\
-        == [['dank mimos: slow zone', '100', 'yes', 'wpa2'],
-            ['some other network', '20', 'no', 'wep'],
-            ['blah', '4', 'yes', 'none']]
+        "dank mimos\\: slow zone:100:yes:wpa2\n"
+        "some other network:20:no:wep\n"
+        "blah:4:yes:none\n"
+    ) == [
+        ["dank mimos: slow zone", "100", "yes", "wpa2"],
+        ["some other network", "20", "no", "wep"],
+        ["blah", "4", "yes", "none"],
+    ]
 
 
 def test_sanitize_args():
-    cmd = ['nmcli',
-           'connection', 'add', 'wifi.ssid', 'Opentrons',
-           'wifi-sec.psk', 'test-password',
-           'wifi-sec.key-mgmt', 'wpa2-psk']
+    cmd = [
+        "nmcli",
+        "connection",
+        "add",
+        "wifi.ssid",
+        "Opentrons",
+        "wifi-sec.psk",
+        "test-password",
+        "wifi-sec.key-mgmt",
+        "wpa2-psk",
+    ]
     sanitized = nmcli.sanitize_args(cmd)
     # Check preconditions
-    assert 'test-password' in cmd
+    assert "test-password" in cmd
     # Check output
-    assert 'test-password' not in sanitized
+    assert "test-password" not in sanitized
 
-    cmd2 = ['nmcli',
-            'connection', 'modify',
-            '+wifi-sec.psk', 'test-password']
+    cmd2 = ["nmcli", "connection", "modify", "+wifi-sec.psk", "test-password"]
     sanitized = nmcli.sanitize_args(cmd2)
-    assert 'test-password' in cmd2
-    assert 'test-password' not in sanitized
+    assert "test-password" in cmd2
+    assert "test-password" not in sanitized
 
 
 def test_output_transformations():
-    fields = ['name', 'type', 'autorun', 'active', 'iface', 'state']
-    should_have = [['static-eth0',
-                    '802-3-ethernet',
-                    'yes', 'yes', 'eth0', 'activated'],
-                   ['wifi-wlan0',
-                    '802-11-wireless',
-                    'yes', 'no', 'wlan0', '--']]
+    fields = ["name", "type", "autorun", "active", "iface", "state"]
+    should_have = [
+        ["static-eth0", "802-3-ethernet", "yes", "yes", "eth0", "activated"],
+        ["wifi-wlan0", "802-11-wireless", "yes", "no", "wlan0", "--"],
+    ]
     # This test input is taken from the result of
     # nmcli -t -f name,type,autoconnect,active,device,state connection show
-    test_input = '''static-eth0:802-3-ethernet:yes:yes:eth0:activated
+    test_input = """static-eth0:802-3-ethernet:yes:yes:eth0:activated
 wifi-wlan0:802-11-wireless:yes:no:wlan0:--
-'''
+"""
     # No transforms: correctly parse fields
     split = nmcli._dict_from_terse_tabular(fields, test_input)
     assert len(split) == 2
@@ -54,47 +59,80 @@ wifi-wlan0:802-11-wireless:yes:no:wlan0:--
         assert outp[1] == list(outp[0].values())
 
     # Transforms for some but not all keys
-    transforms = {'name': lambda s: s.upper(),
-                  'active': lambda s: s == 'yes'}
+    transforms = {"name": lambda s: s.upper(), "active": lambda s: s == "yes"}
     split = nmcli._dict_from_terse_tabular(fields, test_input, transforms)
-    assert split[0]['name'] == should_have[0][0].upper()
-    assert split[1]['name'] == should_have[1][0].upper()
-    assert split[0]['active'] is True
-    assert split[1]['active'] is False
+    assert split[0]["name"] == should_have[0][0].upper()
+    assert split[1]["name"] == should_have[1][0].upper()
+    assert split[0]["active"] is True
+    assert split[1]["active"] is False
 
 
 async def test_available_ssids(monkeypatch):
-    mock_nmcli_output = '''mock_wpa2:90:no:WPA2
+    mock_nmcli_output = """mock_wpa2:90:no:WPA2
 mock_no_security:80:no:
 mock_enterprise:70:no:WPA1 WPA2 802.1X
 mock_connected:60:yes:WPA2
 mock_bad_security:50:no:foobar
---:40:no:'''
+--:40:no:"""
 
     expected_cmds = iter(
-        (['device', 'wifi', 'rescan'],
-         ['--terse', '--fields',
-          'ssid,signal,active,security', 'device', 'wifi', 'list']))
+        (
+            ["device", "wifi", "rescan"],
+            [
+                "--terse",
+                "--fields",
+                "ssid,signal,active,security",
+                "device",
+                "wifi",
+                "list",
+            ],
+        )
+    )
 
     expected = [
-        {'ssid': 'mock_wpa2', 'signal': 90, 'active': False,
-            'security': 'WPA2', 'securityType': 'wpa-psk'},
-        {'ssid': 'mock_no_security', 'signal': 80, 'active': False,
-            'security': '', 'securityType': 'none'},
-        {'ssid': 'mock_enterprise', 'signal': 70, 'active': False,
-            'security': 'WPA1 WPA2 802.1X', 'securityType': 'wpa-eap'},
-        {'ssid': 'mock_connected', 'signal': 60, 'active': True,
-            'security': 'WPA2', 'securityType': 'wpa-psk'},
-        {'ssid': 'mock_bad_security', 'signal': 50, 'active': False,
-            'security': 'foobar', 'securityType': 'unsupported'}
+        {
+            "ssid": "mock_wpa2",
+            "signal": 90,
+            "active": False,
+            "security": "WPA2",
+            "securityType": "wpa-psk",
+        },
+        {
+            "ssid": "mock_no_security",
+            "signal": 80,
+            "active": False,
+            "security": "",
+            "securityType": "none",
+        },
+        {
+            "ssid": "mock_enterprise",
+            "signal": 70,
+            "active": False,
+            "security": "WPA1 WPA2 802.1X",
+            "securityType": "wpa-eap",
+        },
+        {
+            "ssid": "mock_connected",
+            "signal": 60,
+            "active": True,
+            "security": "WPA2",
+            "securityType": "wpa-psk",
+        },
+        {
+            "ssid": "mock_bad_security",
+            "signal": 50,
+            "active": False,
+            "security": "foobar",
+            "securityType": "unsupported",
+        }
         # note entry for 'ssid': '--' is expected to be filterd out
     ]
 
     async def mock_call(cmd, suppress_err=False):
         assert cmd == next(expected_cmds)
-        return mock_nmcli_output, ''
+        return mock_nmcli_output, ""
 
-    monkeypatch.setattr(nmcli, '_call', mock_call)
+    monkeypatch.setattr(nmcli, "_call", mock_call)
     result = await nmcli.available_ssids()
     assert result == expected
 
@@ -102,53 +140,53 @@ mock_bad_security:50:no:foobar
 async def test_networking_status(loop, monkeypatch):
     async def mock_call(cmd):
         # Command: `nmcli networking connectivity`
-        if 'connectivity' in cmd:
-            res = 'full'
-        elif 'wlan0' in cmd:
-            res = '''GENERAL.HWADDR:B8:27:EB:5F:A6:89
+        if "connectivity" in cmd:
+            res = "full"
+        elif "wlan0" in cmd:
+            res = """GENERAL.HWADDR:B8:27:EB:5F:A6:89
 IP4.ADDRESS[1]:--
 IP4.GATEWAY:--
 GENERAL.TYPE:wifi
-GENERAL.STATE:30 (disconnected)'''
-        elif 'eth0' in cmd:
-            res = '''GENERAL.HWADDR:B8:27:EB:39:C0:9A
+GENERAL.STATE:30 (disconnected)"""
+        elif "eth0" in cmd:
+            res = """GENERAL.HWADDR:B8:27:EB:39:C0:9A
 IP4.ADDRESS[1]:169.254.229.173/16
 GENERAL.TYPE:ethernet
-GENERAL.STATE:100 (connected)'''
+GENERAL.STATE:100 (connected)"""
         else:
-            res = 'incorrect nmcli call'
+            res = "incorrect nmcli call"
 
-        return res, ''
+        return res, ""
 
-    monkeypatch.setattr(nmcli, '_call', mock_call)
+    monkeypatch.setattr(nmcli, "_call", mock_call)
 
-    assert await nmcli.is_connected() == 'full'
+    assert await nmcli.is_connected() == "full"
     assert await nmcli.iface_info(nmcli.NETWORK_IFACES.WIFI) == {
         # test "--" gets mapped to None
-        'ipAddress': None,
-        'macAddress': 'B8:27:EB:5F:A6:89',
+        "ipAddress": None,
+        "macAddress": "B8:27:EB:5F:A6:89",
         # test "--" gets mapped to None
-        'gatewayAddress': None,
-        'state': 'disconnected',
-        'type': 'wifi'
+        "gatewayAddress": None,
+        "state": "disconnected",
+        "type": "wifi",
     }
 
     assert await nmcli.iface_info(nmcli.NETWORK_IFACES.ETH_LL) == {
-        'ipAddress': '169.254.229.173/16',
-        'macAddress': 'B8:27:EB:39:C0:9A',
+        "ipAddress": "169.254.229.173/16",
+        "macAddress": "B8:27:EB:39:C0:9A",
         # test missing output gets mapped to None
-        'gatewayAddress': None,
-        'state': 'connected',
-        'type': 'ethernet'
+        "gatewayAddress": None,
+        "state": "connected",
+        "type": "ethernet",
     }
 
     async def mock_call(cmd):
-        if 'connectivity' in cmd:
-            return 'full', ''
+        if "connectivity" in cmd:
+            return "full", ""
         else:
-            return '', 'this is a dummy error'
+            return "", "this is a dummy error"
 
-    monkeypatch.setattr(nmcli, '_call', mock_call)
-    assert await nmcli.is_connected() == 'full'
-    with pytest.raises(ValueError, match='this is a dummy error'):
+    monkeypatch.setattr(nmcli, "_call", mock_call)
+    assert await nmcli.is_connected() == "full"
+    with pytest.raises(ValueError, match="this is a dummy error"):
         await nmcli.iface_info(nmcli.NETWORK_IFACES.WIFI)

--- a/api/tests/opentrons/system/test_wifi.py
+++ b/api/tests/opentrons/system/test_wifi.py
@@ -7,39 +7,51 @@ from opentrons.system import wifi
 
 
 def test_check_eap_config(wifi_keys_tempdir):
-    wifi_key_id = '88188cafcf'
+    wifi_key_id = "88188cafcf"
     os.mkdir(os.path.join(wifi_keys_tempdir, wifi_key_id))
-    with open(os.path.join(wifi_keys_tempdir,
-                           wifi_key_id,
-                           'test.pem'), 'w') as f:
-        f.write('what a terrible key')
+    with open(os.path.join(wifi_keys_tempdir, wifi_key_id, "test.pem"), "w") as f:
+        f.write("what a terrible key")
     # Bad eap types should fail
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi.eap_check_config({'eapType': 'afaosdasd'})
+        wifi.eap_check_config({"eapType": "afaosdasd"})
     # Valid (if short) arguments should work
-    wifi.eap_check_config({'eapType': 'peap/eap-mschapv2',
-                           'identity': 'test@hi.com',
-                           'password': 'passwd'})
+    wifi.eap_check_config(
+        {
+            "eapType": "peap/eap-mschapv2",
+            "identity": "test@hi.com",
+            "password": "passwd",
+        }
+    )
     # Extra args should fail
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi.eap_check_config({'eapType': 'tls',
-                               'identity': 'test@example.com',
-                               'privateKey': wifi_key_id,
-                               'clientCert': wifi_key_id,
-                               'phase2CaCertf': 'foo'})
+        wifi.eap_check_config(
+            {
+                "eapType": "tls",
+                "identity": "test@example.com",
+                "privateKey": wifi_key_id,
+                "clientCert": wifi_key_id,
+                "phase2CaCertf": "foo",
+            }
+        )
     # Filenames should be rewritten
-    rewritten = wifi.eap_check_config({'eapType': 'ttls/eap-md5',
-                                       'identity': 'hello@example.com',
-                                       'password': 'hi',
-                                       'caCert': wifi_key_id})
-    assert rewritten['caCert'] == os.path.join(wifi_keys_tempdir,
-                                               wifi_key_id,
-                                               'test.pem')
+    rewritten = wifi.eap_check_config(
+        {
+            "eapType": "ttls/eap-md5",
+            "identity": "hello@example.com",
+            "password": "hi",
+            "caCert": wifi_key_id,
+        }
+    )
+    assert rewritten["caCert"] == os.path.join(
+        wifi_keys_tempdir, wifi_key_id, "test.pem"
+    )
     # A config should be returned with the same keys
-    config = {'eapType': 'ttls/eap-tls',
-              'identity': "test@hello.com",
-              'phase2ClientCert': wifi_key_id,
-              'phase2PrivateKey': wifi_key_id}
+    config = {
+        "eapType": "ttls/eap-tls",
+        "identity": "test@hello.com",
+        "phase2ClientCert": wifi_key_id,
+        "phase2PrivateKey": wifi_key_id,
+    }
     out = wifi.eap_check_config(config)
     for key in config.keys():
         assert key in out
@@ -48,71 +60,94 @@ def test_check_eap_config(wifi_keys_tempdir):
 def test_eap_check_option():
     # Required arguments that are not specified should raise
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'test-opt', 'required': True,
-                                   'displayName': 'Test Option'},
-                                  {'eapType': 'test'})
+        wifi._eap_check_option_ok(
+            {"name": "test-opt", "required": True, "displayName": "Test Option"},
+            {"eapType": "test"},
+        )
     # Non-required arguments that are not specified should not raise
-    wifi._eap_check_option_ok({'name': 'test-1',
-                               'required': False,
-                               'type': 'string',
-                               'displayName': 'Test Option'},
-                              {'eapType': 'test'})
+    wifi._eap_check_option_ok(
+        {
+            "name": "test-1",
+            "required": False,
+            "type": "string",
+            "displayName": "Test Option",
+        },
+        {"eapType": "test"},
+    )
 
     # Check type mismatch detection pos and neg
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'identity',
-                                   'displayName': 'Username',
-                                   'required': True,
-                                   'type': 'string'},
-                                  {'identity': 2,
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'identity',
-                               'required': True,
-                               'displayName': 'Username',
-                               'type': 'string'},
-                              {'identity': 'hi',
-                               'eapType': 'test'})
+        wifi._eap_check_option_ok(
+            {
+                "name": "identity",
+                "displayName": "Username",
+                "required": True,
+                "type": "string",
+            },
+            {"identity": 2, "eapType": "test"},
+        )
+    wifi._eap_check_option_ok(
+        {
+            "name": "identity",
+            "required": True,
+            "displayName": "Username",
+            "type": "string",
+        },
+        {"identity": "hi", "eapType": "test"},
+    )
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'password',
-                                   'required': True,
-                                   'displayName': 'Password',
-                                   'type': 'password'},
-                                  {'password': [2, 3],
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'password',
-                               'required': True,
-                               'displayName': 'password',
-                               'type': 'password'},
-                              {'password': 'secret',
-                               'eapType': 'test'})
+        wifi._eap_check_option_ok(
+            {
+                "name": "password",
+                "required": True,
+                "displayName": "Password",
+                "type": "password",
+            },
+            {"password": [2, 3], "eapType": "test"},
+        )
+    wifi._eap_check_option_ok(
+        {
+            "name": "password",
+            "required": True,
+            "displayName": "password",
+            "type": "password",
+        },
+        {"password": "secret", "eapType": "test"},
+    )
     with pytest.raises(wifi.ConfigureArgsError):
-        wifi._eap_check_option_ok({'name': 'phase2CaCert',
-                                   'displayName': 'some file who cares',
-                                   'required': True,
-                                   'type': 'file'},
-                                  {'phase2CaCert': 2,
-                                   'eapType': 'test'})
-    wifi._eap_check_option_ok({'name': 'phase2CaCert',
-                               'required': True,
-                               'displayName': 'hello',
-                               'type': 'file'},
-                              {'phase2CaCert': '82141cceaf',
-                               'eapType': 'test'})
+        wifi._eap_check_option_ok(
+            {
+                "name": "phase2CaCert",
+                "displayName": "some file who cares",
+                "required": True,
+                "type": "file",
+            },
+            {"phase2CaCert": 2, "eapType": "test"},
+        )
+    wifi._eap_check_option_ok(
+        {
+            "name": "phase2CaCert",
+            "required": True,
+            "displayName": "hello",
+            "type": "file",
+        },
+        {"phase2CaCert": "82141cceaf", "eapType": "test"},
+    )
 
 
 async def test_list_keys(loop, wifi_keys_tempdir):
-    dummy_names = ['ad12d1df199bc912', 'cbdda8124128cf', '812410990c5412']
+    dummy_names = ["ad12d1df199bc912", "cbdda8124128cf", "812410990c5412"]
     for dn in dummy_names:
         os.mkdir(os.path.join(wifi_keys_tempdir, dn))
-        with open(os.path.join(wifi_keys_tempdir, dn, 'test.pem'), 'w') as file:
-            file.write('hi')
+        with open(os.path.join(wifi_keys_tempdir, dn, "test.pem"), "w") as file:
+            file.write("hi")
 
     keys = list(wifi.list_keys())
     assert len(keys) == 3
     for dn in dummy_names:
         for keyfile in keys:
             if keyfile.directory == dn:
-                assert keyfile.file == 'test.pem'
+                assert keyfile.file == "test.pem"
                 break
         else:
             raise KeyError(dn)
@@ -125,36 +160,34 @@ async def test_key_lifecycle(loop, wifi_keys_tempdir):
 
         results = {}
         # We should be able to add multiple keys
-        for fn in ['test1.pem', 'test2.pem', 'test3.pem']:
+        for fn in ["test1.pem", "test2.pem", "test3.pem"]:
             path = os.path.join(source_td, fn)
-            with open(path, 'w') as f:
+            with open(path, "w") as f:
                 f.write(str(random.getrandbits(2048)))
 
-            with open(path, 'rb') as f:
+            with open(path, "rb") as f:
                 add_response = wifi.add_key(fn, f.read())
                 assert add_response.created is True
                 assert add_response.key.file == fn
                 results[fn] = add_response
 
         # We should not be able to upload a duplicate
-        with open(os.path.join(source_td, 'test1.pem'), 'rb') as f:
-            add_response = wifi.add_key('test1.pem', f.read())
+        with open(os.path.join(source_td, "test1.pem"), "rb") as f:
+            add_response = wifi.add_key("test1.pem", f.read())
             assert add_response.created is False
 
         # We should be able to see them all
         list_resp = list(wifi.list_keys())
         assert len(list_resp) == 3
         for elem in list_resp:
-            assert elem.directory in {r.key.directory
-                                      for r in results.values()}
+            assert elem.directory in {r.key.directory for r in results.values()}
 
         for fn, data in results.items():
             del_resp = wifi.remove_key(data.key.directory)
             assert del_resp == fn
 
             del_list_resp = list(wifi.list_keys())
-            assert data.key.directory not in {k.directory
-                                              for k in del_list_resp}
+            assert data.key.directory not in {k.directory for k in del_list_resp}
 
-        dup_del_resp = wifi.remove_key(results['test1.pem'].key.directory)
+        dup_del_resp = wifi.remove_key(results["test1.pem"].key.directory)
         assert dup_del_resp is None

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -21,47 +21,47 @@ def mock_get_attached_instr(monkeypatch, virtual_smoothie_env):
     async def dummy_delay(self, duration_s):
         pass
 
-    monkeypatch.setattr(controller.Controller,
-                        'get_attached_instruments',
-                        gai_mock)
-    monkeypatch.setattr(api.API, 'delay', dummy_delay)
-    gai_mock.return_value = {types.Mount.RIGHT: {'model': None, 'id': None},
-                             types.Mount.LEFT: {'model': None, 'id': None}}
+    monkeypatch.setattr(controller.Controller, "get_attached_instruments", gai_mock)
+    monkeypatch.setattr(api.API, "delay", dummy_delay)
+    gai_mock.return_value = {
+        types.Mount.RIGHT: {"model": None, "id": None},
+        types.Mount.LEFT: {"model": None, "id": None},
+    }
     return gai_mock
 
 
-@pytest.mark.parametrize('protocol_file', ['testosaur_v2.py'])
-def test_execute_function_apiv2(protocol,
-                                protocol_file,
-                                monkeypatch,
-                                virtual_smoothie_env,
-                                mock_get_attached_instr):
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py"])
+def test_execute_function_apiv2(
+    protocol, protocol_file, monkeypatch, virtual_smoothie_env, mock_get_attached_instr
+):
 
-    mock_get_attached_instr.return_value[types.Mount.LEFT]\
-        = {'config': load('p10_single_v1.5'), 'id': 'testid'}
-    mock_get_attached_instr.return_value[types.Mount.RIGHT]\
-        = {'config': load('p300_single_v1.5'), 'id': 'testid2'}
+    mock_get_attached_instr.return_value[types.Mount.LEFT] = {
+        "config": load("p10_single_v1.5"),
+        "id": "testid",
+    }
+    mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
+        "config": load("p300_single_v1.5"),
+        "id": "testid2",
+    }
     entries = []
 
     def emit_runlog(entry):
         nonlocal entries
         entries.append(entry)
 
-    execute.execute(
-        protocol.filelike, 'testosaur_v2.py', emit_runlog=emit_runlog)
-    assert [item['payload']['text'] for item in entries
-            if item['$'] == 'before'] == [
-        'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa: E501,
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa: E501,
-        'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
-        ]
+    execute.execute(protocol.filelike, "testosaur_v2.py", emit_runlog=emit_runlog)
+    assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
+        "Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",
+        "Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec",  # noqa: E501,
+        "Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec",  # noqa: E501,
+        "Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1",
+    ]
 
 
-def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
-                                        virtual_smoothie_env,
-                                        mock_get_attached_instr):
-    jp = get_json_protocol_fixture('3', 'simple', False)
+def test_execute_function_json_v3_apiv2(
+    get_json_protocol_fixture, virtual_smoothie_env, mock_get_attached_instr
+):
+    jp = get_json_protocol_fixture("3", "simple", False)
     filelike = io.StringIO(jp)
     entries = []
 
@@ -70,25 +70,26 @@ def test_execute_function_json_v3_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'config': load('p10_single_v1.5'), 'id': 'testid'}
-    execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
-    assert [item['payload']['text'] for item in entries
-            if item['$'] == 'before'] == [
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
-        'Delaying for 0 minutes and 42.0 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
-        'Touching tip',
-        'Blowing out at B1 of Dest Plate on 3',
-        'Moving to 5',
-        'Dropping tip into A1 of Trash on 12'
+        "config": load("p10_single_v1.5"),
+        "id": "testid",
+    }
+    execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
+    assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1",
+        "Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec",
+        "Delaying for 0 minutes and 42.0 seconds",
+        "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
+        "Touching tip",
+        "Blowing out at B1 of Dest Plate on 3",
+        "Moving to 5",
+        "Dropping tip into A1 of Trash on 12",
     ]
 
 
-def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
-                                        virtual_smoothie_env,
-                                        mock_get_attached_instr):
-    jp = get_json_protocol_fixture('4', 'simpleV4', False)
+def test_execute_function_json_v4_apiv2(
+    get_json_protocol_fixture, virtual_smoothie_env, mock_get_attached_instr
+):
+    jp = get_json_protocol_fixture("4", "simpleV4", False)
     filelike = io.StringIO(jp)
     entries = []
 
@@ -97,25 +98,26 @@ def test_execute_function_json_v4_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'config': load('p10_single_v1.5'), 'id': 'testid'}
-    execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
-    assert [item['payload']['text'] for item in entries
-            if item['$'] == 'before'] == [
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
-        'Delaying for 0 minutes and 42.0 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
-        'Touching tip',
-        'Blowing out at B1 of Dest Plate on 3',
-        'Moving to 5',
-        'Dropping tip into A1 of Trash on 12'
+        "config": load("p10_single_v1.5"),
+        "id": "testid",
+    }
+    execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
+    assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1",
+        "Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec",
+        "Delaying for 0 minutes and 42.0 seconds",
+        "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
+        "Touching tip",
+        "Blowing out at B1 of Dest Plate on 3",
+        "Moving to 5",
+        "Dropping tip into A1 of Trash on 12",
     ]
 
 
-def test_execute_function_json_v5_apiv2(get_json_protocol_fixture,
-                                        virtual_smoothie_env,
-                                        mock_get_attached_instr):
-    jp = get_json_protocol_fixture('5', 'simpleV5', False)
+def test_execute_function_json_v5_apiv2(
+    get_json_protocol_fixture, virtual_smoothie_env, mock_get_attached_instr
+):
+    jp = get_json_protocol_fixture("5", "simpleV5", False)
     filelike = io.StringIO(jp)
     entries = []
 
@@ -124,27 +126,28 @@ def test_execute_function_json_v5_apiv2(get_json_protocol_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'config': load('p10_single_v1.5'), 'id': 'testid'}
-    execute.execute(filelike, 'simple.json', emit_runlog=emit_runlog)
-    assert [item['payload']['text'] for item in entries
-            if item['$'] == 'before'] == [
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
-        'Delaying for 0 minutes and 42.0 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
-        'Touching tip',
-        'Blowing out at B1 of Dest Plate on 3',
-        'Moving to 5',
-        'Moving to B2 of Dest Plate on 3',
-        'Moving to B2 of Dest Plate on 3',
-        'Dropping tip into A1 of Trash on 12'
+        "config": load("p10_single_v1.5"),
+        "id": "testid",
+    }
+    execute.execute(filelike, "simple.json", emit_runlog=emit_runlog)
+    assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1",
+        "Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec",
+        "Delaying for 0 minutes and 42.0 seconds",
+        "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
+        "Touching tip",
+        "Blowing out at B1 of Dest Plate on 3",
+        "Moving to 5",
+        "Moving to B2 of Dest Plate on 3",
+        "Moving to B2 of Dest Plate on 3",
+        "Dropping tip into A1 of Trash on 12",
     ]
 
 
-def test_execute_function_bundle_apiv2(get_bundle_fixture,
-                                       virtual_smoothie_env,
-                                       mock_get_attached_instr):
-    bundle = get_bundle_fixture('simple_bundle')
+def test_execute_function_bundle_apiv2(
+    get_bundle_fixture, virtual_smoothie_env, mock_get_attached_instr
+):
+    bundle = get_bundle_fixture("simple_bundle")
     entries = []
 
     def emit_runlog(entry):
@@ -152,38 +155,36 @@ def test_execute_function_bundle_apiv2(get_bundle_fixture,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.LEFT] = {
-        'config': load('p10_single_v1.5'), 'id': 'testid'}
-    execute.execute(
-        bundle['filelike'], 'simple_bundle.zip', emit_runlog=emit_runlog)
-    assert [item['payload']['text']
-            for item in entries if item['$'] == 'before'] == [
-        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
-        "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at" \
-        " 5.0 uL/sec",
-        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12'
-        ]
+        "config": load("p10_single_v1.5"),
+        "id": "testid",
+    }
+    execute.execute(bundle["filelike"], "simple_bundle.zip", emit_runlog=emit_runlog)
+    assert [item["payload"]["text"] for item in entries if item["$"] == "before"] == [
+        "Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at" " 5.0 uL/sec",
+        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+        "Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
+        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+        "Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
+        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+    ]
 
 
-@pytest.mark.parametrize('protocol_file', ['python_v2_custom_lw.py'])
-def test_execute_extra_labware(protocol, protocol_file, monkeypatch,
-                               virtual_smoothie_env, mock_get_attached_instr):
-    fixturedir = HERE / '..' / '..' / '..' /\
-        'shared-data' / 'labware' / 'fixtures' / '2'
+@pytest.mark.parametrize("protocol_file", ["python_v2_custom_lw.py"])
+def test_execute_extra_labware(
+    protocol, protocol_file, monkeypatch, virtual_smoothie_env, mock_get_attached_instr
+):
+    fixturedir = (
+        HERE / ".." / ".." / ".." / "shared-data" / "labware" / "fixtures" / "2"
+    )
     entries = []
 
     def emit_runlog(entry):
@@ -191,43 +192,45 @@ def test_execute_extra_labware(protocol, protocol_file, monkeypatch,
         entries.append(entry)
 
     mock_get_attached_instr.return_value[types.Mount.RIGHT] = {
-        'config': load('p300_single_v2.0'), 'id': 'testid'}
+        "config": load("p300_single_v2.0"),
+        "id": "testid",
+    }
     # make sure we can load labware explicitly
     # make sure we don't have an exception from not finding the labware
-    execute.execute(protocol.filelike, 'custom_labware.py',
-                    emit_runlog=emit_runlog,
-                    custom_labware_paths=[str(fixturedir)])
+    execute.execute(
+        protocol.filelike,
+        "custom_labware.py",
+        emit_runlog=emit_runlog,
+        custom_labware_paths=[str(fixturedir)],
+    )
     # instead of 4 in simulate because we get before and after
     assert len(entries) == 8
 
     protocol.filelike.seek(0)
     # make sure we don't get autoload behavior when not on a robot
-    with pytest.raises(ExceptionInProtocolError,
-                       match='.*FileNotFoundError.*'):
-        execute.execute(protocol.filelike, 'custom_labware.py')
-    no_lw = execute.get_protocol_api('2.0')
+    with pytest.raises(ExceptionInProtocolError, match=".*FileNotFoundError.*"):
+        execute.execute(protocol.filelike, "custom_labware.py")
+    no_lw = execute.get_protocol_api("2.0")
     assert not no_lw._implementation._extra_labware
     protocol.filelike.seek(0)
-    monkeypatch.setattr(execute, 'IS_ROBOT', True)
-    monkeypatch.setattr(execute, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
-                        fixturedir)
+    monkeypatch.setattr(execute, "IS_ROBOT", True)
+    monkeypatch.setattr(execute, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
     # make sure we don't have an exception from not finding the labware
     entries = []
-    execute.execute(protocol.filelike, 'custom_labware.py',
-                    emit_runlog=emit_runlog)
+    execute.execute(protocol.filelike, "custom_labware.py", emit_runlog=emit_runlog)
     # instead of 4 in simulate because we get before and after
     assert len(entries) == 8
 
     # make sure the extra labware loaded by default is right
-    ctx = execute.get_protocol_api('2.0')
-    assert len(ctx._implementation._extra_labware.keys()) ==\
-           len(os.listdir(fixturedir))
+    ctx = execute.get_protocol_api("2.0")
+    assert len(ctx._implementation._extra_labware.keys()) == len(os.listdir(fixturedir))
 
-    assert ctx.load_labware('fixture_12_trough', 1, namespace='fixture')
+    assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 
     # if there is no labware dir, make sure everything still works
-    monkeypatch.setattr(execute, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
-                        HERE / 'nosuchdirectory')
-    ctx = execute.get_protocol_api('2.0')
+    monkeypatch.setattr(
+        execute, "JUPYTER_NOTEBOOK_LABWARE_DIR", HERE / "nosuchdirectory"
+    )
+    ctx = execute.get_protocol_api("2.0")
     with pytest.raises(FileNotFoundError):
-        ctx.load_labware("fixture_12_trough", 1, namespace='fixture')
+        ctx.load_labware("fixture_12_trough", 1, namespace="fixture")

--- a/api/tests/opentrons/test_init.py
+++ b/api/tests/opentrons/test_init.py
@@ -4,9 +4,9 @@ from pathlib import Path
 def test_find_smoothie_file(monkeypatch, tmpdir):
     import opentrons
 
-    dummy_file = Path(tmpdir) / 'smoothie-edge-2cac98asda.hex'
+    dummy_file = Path(tmpdir) / "smoothie-edge-2cac98asda.hex"
     dummy_file.write_text("hello")
-    monkeypatch.setattr(opentrons, 'ROBOT_FIRMWARE_DIR', Path(tmpdir))
+    monkeypatch.setattr(opentrons, "ROBOT_FIRMWARE_DIR", Path(tmpdir))
 
-    monkeypatch.setattr(opentrons, 'IS_ROBOT', True)
-    assert opentrons._find_smoothie_file() == (dummy_file, 'edge-2cac98asda')
+    monkeypatch.setattr(opentrons, "IS_ROBOT", True)
+    assert opentrons._find_smoothie_file() == (dummy_file, "edge-2cac98asda")

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -12,114 +12,107 @@ from opentrons.protocols.execution.errors import ExceptionInProtocolError
 HERE = Path(__file__).parent
 
 
-@pytest.mark.parametrize('protocol_file', ['test_simulate.py'])
-def test_simulate_function_apiv2(protocol,
-                                 protocol_file,
-                                 monkeypatch):
-    monkeypatch.setenv('OT_API_FF_allowBundleCreation', '1')
-    runlog, bundle = simulate.simulate(
-        protocol.filelike, 'test_simulate.py')
+@pytest.mark.parametrize("protocol_file", ["test_simulate.py"])
+def test_simulate_function_apiv2(protocol, protocol_file, monkeypatch):
+    monkeypatch.setenv("OT_API_FF_allowBundleCreation", "1")
+    runlog, bundle = simulate.simulate(protocol.filelike, "test_simulate.py")
     assert isinstance(bundle, protocols.types.BundleContents)
-    assert [item['payload']['text'] for item in runlog] == [
-        '2.0',
-        'Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1',
-        'Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec',  # noqa: E501,
-        'Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec',  # noqa: E501,
-        'Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1'
-        ]
+    assert [item["payload"]["text"] for item in runlog] == [
+        "2.0",
+        "Picking up tip from A1 of Opentrons 96 Tip Rack 300 µL on 1",
+        "Aspirating 10.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 150.0 uL/sec",  # noqa: E501,
+        "Dispensing 10.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 300.0 uL/sec",  # noqa: E501,
+        "Dropping tip into H12 of Opentrons 96 Tip Rack 300 µL on 1",
+    ]
 
 
 def test_simulate_function_json_apiv2(get_json_protocol_fixture):
-    jp = get_json_protocol_fixture('3', 'simple', False)
+    jp = get_json_protocol_fixture("3", "simple", False)
     filelike = io.StringIO(jp)
-    runlog, bundle = simulate.simulate(filelike, 'simple.json')
+    runlog, bundle = simulate.simulate(filelike, "simple.json")
     assert bundle is None
-    assert [item['payload']['text'] for item in runlog] == [
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1',
-        'Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec',
-        'Delaying for 0 minutes and 42.0 seconds',
-        'Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec',
-        'Touching tip',
-        'Blowing out at B1 of Dest Plate on 3',
-        'Moving to 5',
-        'Dropping tip into A1 of Trash on 12'
+    assert [item["payload"]["text"] for item in runlog] == [
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1",
+        "Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec",
+        "Delaying for 0 minutes and 42.0 seconds",
+        "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
+        "Touching tip",
+        "Blowing out at B1 of Dest Plate on 3",
+        "Moving to 5",
+        "Dropping tip into A1 of Trash on 12",
     ]
 
 
 def test_simulate_function_bundle_apiv2(get_bundle_fixture):
-    bundle = get_bundle_fixture('simple_bundle')
-    runlog, bundle = simulate.simulate(
-        bundle['filelike'], 'simple_bundle.zip')
+    bundle = get_bundle_fixture("simple_bundle")
+    runlog, bundle = simulate.simulate(bundle["filelike"], "simple_bundle.zip")
     assert bundle is None
-    assert [item['payload']['text'] for item in runlog] == [
-        'Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12',
-        'Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1',  # noqa: E501
-        'Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3',
-        'Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec',
-        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" \
-        " 10.0 uL/sec",
-        'Dropping tip into A1 of Opentrons Fixed Trash on 12'
-        ]
+    assert [item["payload"]["text"] for item in runlog] == [
+        "Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from A1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
+        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+        "Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
+        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+        "Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",  # noqa: E501
+        "Picking up tip from C1 of Opentrons 96 Tip Rack 10 µL on 3",
+        "Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
+        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at" " 10.0 uL/sec",
+        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
+    ]
 
 
-@pytest.mark.parametrize('protocol_file', ['testosaur.py'])
+@pytest.mark.parametrize("protocol_file", ["testosaur.py"])
 def test_simulate_function_v1(protocol, protocol_file):
     with pytest.raises(ApiDeprecationError):
-        simulate.simulate(protocol.filelike, 'testosaur.py')
+        simulate.simulate(protocol.filelike, "testosaur.py")
 
 
-@pytest.mark.parametrize('protocol_file', ['python_v2_custom_lw.py'])
+@pytest.mark.parametrize("protocol_file", ["python_v2_custom_lw.py"])
 def test_simulate_extra_labware(protocol, protocol_file, monkeypatch):
-    fixturedir = HERE / '..' / '..' / '..' /\
-        'shared-data' / 'labware' / 'fixtures' / '2'
+    fixturedir = (
+        HERE / ".." / ".." / ".." / "shared-data" / "labware" / "fixtures" / "2"
+    )
     # make sure we can load labware explicitly
     # make sure we don't have an exception from not finding the labware
-    runlog, _ = simulate.simulate(protocol.filelike, 'custom_labware.py',
-                                  custom_labware_paths=[str(fixturedir)])
+    runlog, _ = simulate.simulate(
+        protocol.filelike, "custom_labware.py", custom_labware_paths=[str(fixturedir)]
+    )
     assert len(runlog) == 4
 
     protocol.filelike.seek(0)
     # make sure we don't get autoload behavior when not on a robot
-    with pytest.raises(ExceptionInProtocolError,
-                       match='.*FileNotFoundError.*'):
-        simulate.simulate(protocol.filelike, 'custom_labware.py')
-    no_lw = simulate.get_protocol_api('2.0')
+    with pytest.raises(ExceptionInProtocolError, match=".*FileNotFoundError.*"):
+        simulate.simulate(protocol.filelike, "custom_labware.py")
+    no_lw = simulate.get_protocol_api("2.0")
     assert not no_lw._implementation._extra_labware
     protocol.filelike.seek(0)
-    monkeypatch.setattr(simulate, 'IS_ROBOT', True)
-    monkeypatch.setattr(simulate, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
-                        fixturedir)
+    monkeypatch.setattr(simulate, "IS_ROBOT", True)
+    monkeypatch.setattr(simulate, "JUPYTER_NOTEBOOK_LABWARE_DIR", fixturedir)
     # make sure we don't have an exception from not finding the labware
-    runlog, _ = simulate.simulate(protocol.filelike, 'custom_labware.py')
+    runlog, _ = simulate.simulate(protocol.filelike, "custom_labware.py")
     assert len(runlog) == 4
 
     # make sure the extra labware loaded by default is right
-    ctx = simulate.get_protocol_api('2.0')
-    assert len(ctx._implementation._extra_labware.keys()) == \
-           len(os.listdir(fixturedir))
+    ctx = simulate.get_protocol_api("2.0")
+    assert len(ctx._implementation._extra_labware.keys()) == len(os.listdir(fixturedir))
 
-    assert ctx.load_labware('fixture_12_trough', 1, namespace='fixture')
+    assert ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 
     # if there is no labware dir, make sure everything still works
-    monkeypatch.setattr(simulate, 'JUPYTER_NOTEBOOK_LABWARE_DIR',
-                        HERE / 'nosuchdirectory')
-    ctx = simulate.get_protocol_api('2.0')
+    monkeypatch.setattr(
+        simulate, "JUPYTER_NOTEBOOK_LABWARE_DIR", HERE / "nosuchdirectory"
+    )
+    ctx = simulate.get_protocol_api("2.0")
     with pytest.raises(FileNotFoundError):
-        ctx.load_labware("fixture_12_trough", 1, namespace='fixture')
+        ctx.load_labware("fixture_12_trough", 1, namespace="fixture")
 
 
-@pytest.mark.parametrize('protocol_file', ['bug_aspirate_tip.py'])
+@pytest.mark.parametrize("protocol_file", ["bug_aspirate_tip.py"])
 def test_simulate_aspirate_tip(protocol, protocol_file, monkeypatch):
     with pytest.raises(ExceptionInProtocolError):
-        simulate.simulate(protocol.filelike, 'bug_aspirate_tip.py')
+        simulate.simulate(protocol.filelike, "bug_aspirate_tip.py")

--- a/api/tests/opentrons/test_types.py
+++ b/api/tests/opentrons/test_types.py
@@ -26,19 +26,22 @@ def test_point_rmul():
 def test_location_repr_labware(min_lw):
     """It should represent labware as Labware"""
     loc = Location(point=Point(x=1.1, y=2.1, z=3.5), labware=min_lw)
-    assert f'{loc}' ==\
-           "Location(point=Point(x=1.1, y=2.1, z=3.5), labware=minimal labware on deck)"
+    assert (
+        f"{loc}"
+        == "Location(point=Point(x=1.1, y=2.1, z=3.5), labware=minimal labware on deck)"
+    )
 
 
 def test_location_repr_well(min_lw):
     """It should represent labware as Well"""
     loc = Location(point=Point(x=1, y=2, z=3), labware=min_lw.wells()[0])
-    assert f'{loc}' == \
-           "Location(point=Point(x=1, y=2, z=3), labware=A1 of minimal labware on deck)"
+    assert (
+        f"{loc}"
+        == "Location(point=Point(x=1, y=2, z=3), labware=A1 of minimal labware on deck)"
+    )
 
 
 def test_location_repr_slot():
     """It should represent labware as a slot"""
     loc = Location(point=Point(x=-1, y=2, z=3), labware="1")
-    assert f'{loc}' == \
-           "Location(point=Point(x=-1, y=2, z=3), labware=1)"
+    assert f"{loc}" == "Location(point=Point(x=-1, y=2, z=3), labware=1)"

--- a/api/tests/opentrons/tools/test_pipette_memory.py
+++ b/api/tests/opentrons/tools/test_pipette_memory.py
@@ -69,30 +69,30 @@ async def test_check_previous_data(mock_driver: AsyncMock) -> None:
 
 
 pipette_barcode_to_model = {
-    'P10S20180101A01': 'p10_single_v1',
-    'P10M20180101A01': 'p10_multi_v1',
-    'P50S180101A01': 'p50_single_v1',
-    'P50M20180101B01': 'p50_multi_v1',
-    'P300S20180101A01': 'p300_single_v1',
-    'P300M20180101A01': 'p300_multi_v1',
-    'P1000S20180101A01': 'p1000_single_v1',
-    'P10SV1318010101': 'p10_single_v1.3',
-    'P10MV1318010102': 'p10_multi_v1.3',
-    'P50SV1318010103': 'p50_single_v1.3',
-    'P50MV1318010104': 'p50_multi_v1.3',
-    'P3HSV1318010105': 'p300_single_v1.3',
-    'P3HMV1318010106': 'p300_multi_v1.3',
-    'P1KSV1318010107': 'p1000_single_v1.3',
-    'P10SV1418010101': 'p10_single_v1.4',
-    'P10MV1418010102': 'p10_multi_v1.4',
-    'P50SV1418010103': 'p50_single_v1.4',
-    'P50MV1418010104': 'p50_multi_v1.4',
-    'P3HSV1418010105': 'p300_single_v1.4',
-    'P3HMV1418010106': 'p300_multi_v1.4',
-    'P1KSV1418010107': 'p1000_single_v1.4',
-    'P20MV2120120204': 'p20_multi_v2.1',
-    'P1KSV2218010107': 'p1000_single_v2.2',
-    'P20SV2220020501': 'p20_single_v2.2',
+    "P10S20180101A01": "p10_single_v1",
+    "P10M20180101A01": "p10_multi_v1",
+    "P50S180101A01": "p50_single_v1",
+    "P50M20180101B01": "p50_multi_v1",
+    "P300S20180101A01": "p300_single_v1",
+    "P300M20180101A01": "p300_multi_v1",
+    "P1000S20180101A01": "p1000_single_v1",
+    "P10SV1318010101": "p10_single_v1.3",
+    "P10MV1318010102": "p10_multi_v1.3",
+    "P50SV1318010103": "p50_single_v1.3",
+    "P50MV1318010104": "p50_multi_v1.3",
+    "P3HSV1318010105": "p300_single_v1.3",
+    "P3HMV1318010106": "p300_multi_v1.3",
+    "P1KSV1318010107": "p1000_single_v1.3",
+    "P10SV1418010101": "p10_single_v1.4",
+    "P10MV1418010102": "p10_multi_v1.4",
+    "P50SV1418010103": "p50_single_v1.4",
+    "P50MV1418010104": "p50_multi_v1.4",
+    "P3HSV1418010105": "p300_single_v1.4",
+    "P3HMV1418010106": "p300_multi_v1.4",
+    "P1KSV1418010107": "p1000_single_v1.4",
+    "P20MV2120120204": "p20_multi_v2.1",
+    "P1KSV2218010107": "p1000_single_v2.2",
+    "P20SV2220020501": "p20_single_v2.2",
 }
 
 
@@ -101,10 +101,10 @@ def test_parse_model_from_barcode():
         assert write_pipette_memory._parse_model_from_barcode(barcode) == model
 
     with pytest.raises(Exception):
-        write_pipette_memory._parse_model_from_barcode('P1HSV1318010101')
+        write_pipette_memory._parse_model_from_barcode("P1HSV1318010101")
 
     with pytest.raises(Exception):
-        write_pipette_memory._parse_model_from_barcode('P1KSV1218010101')
+        write_pipette_memory._parse_model_from_barcode("P1KSV1218010101")
 
     with pytest.raises(Exception):
-        write_pipette_memory._parse_model_from_barcode('aP300S20180101A01')
+        write_pipette_memory._parse_model_from_barcode("aP300S20180101A01")

--- a/api/tests/opentrons/util/test_entrypoint_utils.py
+++ b/api/tests/opentrons/util/test_entrypoint_utils.py
@@ -2,54 +2,65 @@ import json
 import os
 import pathlib
 
-from opentrons.util.entrypoint_util import (labware_from_paths,
-                                            datafiles_from_paths)
+from opentrons.util.entrypoint_util import labware_from_paths, datafiles_from_paths
 
 
 def test_labware_from_paths(tmpdir, get_labware_fixture):
-    os.mkdir(os.path.join(tmpdir, 'path-1'))
-    os.mkdir(os.path.join(tmpdir, 'path-2'))
-    lw1 = get_labware_fixture('fixture_96_plate')
-    lw2 = get_labware_fixture('fixture_24_tuberack')
-    lw3 = get_labware_fixture('fixture_irregular_example_1')
-    with open(os.path.join(tmpdir, 'path-1', 'labware1.json'), 'w') as lwtemp:
+    os.mkdir(os.path.join(tmpdir, "path-1"))
+    os.mkdir(os.path.join(tmpdir, "path-2"))
+    lw1 = get_labware_fixture("fixture_96_plate")
+    lw2 = get_labware_fixture("fixture_24_tuberack")
+    lw3 = get_labware_fixture("fixture_irregular_example_1")
+    with open(os.path.join(tmpdir, "path-1", "labware1.json"), "w") as lwtemp:
         json.dump(lw1, lwtemp)
-    with open(os.path.join(tmpdir, 'path-1', 'labware2.json'), 'w') as lwtemp:
+    with open(os.path.join(tmpdir, "path-1", "labware2.json"), "w") as lwtemp:
         json.dump(lw2, lwtemp)
-    with open(os.path.join(tmpdir, 'path-2', 'labware3.json'), 'w') as lwtemp:
+    with open(os.path.join(tmpdir, "path-2", "labware3.json"), "w") as lwtemp:
         json.dump(lw3, lwtemp)
-    with open(os.path.join(tmpdir, 'path-2', 'invalid.json'), 'w') as lwtemp:
-        lwtemp.write('asdjkashdkajvka')
-    with open(os.path.join(tmpdir, 'path-2', 'notevenjson'), 'w') as lwtemp:
-        lwtemp.write('bgbbabcba')
+    with open(os.path.join(tmpdir, "path-2", "invalid.json"), "w") as lwtemp:
+        lwtemp.write("asdjkashdkajvka")
+    with open(os.path.join(tmpdir, "path-2", "notevenjson"), "w") as lwtemp:
+        lwtemp.write("bgbbabcba")
 
-    res = labware_from_paths([os.path.realpath(os.path.join(tmpdir, 'path-1')),
-                              pathlib.Path(os.path.join(tmpdir, 'path-2'))])
-    assert sorted(res) == sorted({
-        'fixture/fixture_96_plate/1': lw1,
-        'fixture/fixture_24_tuberack/1': lw2,
-        'fixture/fixture_irregular_example_1/1': lw2})
+    res = labware_from_paths(
+        [
+            os.path.realpath(os.path.join(tmpdir, "path-1")),
+            pathlib.Path(os.path.join(tmpdir, "path-2")),
+        ]
+    )
+    assert sorted(res) == sorted(
+        {
+            "fixture/fixture_96_plate/1": lw1,
+            "fixture/fixture_24_tuberack/1": lw2,
+            "fixture/fixture_irregular_example_1/1": lw2,
+        }
+    )
 
 
 def test_datafiles_from_paths(tmpdir):
-    os.mkdir(os.path.join(tmpdir, 'path-1'))
-    os.mkdir(os.path.join(tmpdir, 'path-2'))
-    with open(os.path.join(tmpdir, 'path-1', 'test3'), 'wb') as f:
-        f.write('oh hey there checkitout'.encode('utf-8'))
-    with open(os.path.join(tmpdir, 'path-2', 'test2'), 'wb') as f:
-        f.write('oh man this isnt even utf8'.encode('utf-16'))
-    with open(os.path.join(tmpdir, 'path-2', 'test1'), 'wb') as f:
+    os.mkdir(os.path.join(tmpdir, "path-1"))
+    os.mkdir(os.path.join(tmpdir, "path-2"))
+    with open(os.path.join(tmpdir, "path-1", "test3"), "wb") as f:
+        f.write("oh hey there checkitout".encode("utf-8"))
+    with open(os.path.join(tmpdir, "path-2", "test2"), "wb") as f:
+        f.write("oh man this isnt even utf8".encode("utf-16"))
+    with open(os.path.join(tmpdir, "path-2", "test1"), "wb") as f:
         f.write("wait theres a second file???".encode())
-    with open(os.path.join(tmpdir, 'test-file'), 'wb') as f:
+    with open(os.path.join(tmpdir, "test-file"), "wb") as f:
         f.write("this isnt even in a directory".encode())
 
-    res = datafiles_from_paths([
-        os.path.join(tmpdir, 'path-1'),
-        pathlib.Path(os.path.join(tmpdir, 'path-2')),
-        os.path.join(tmpdir, 'test-file')])
-    assert sorted(res) == sorted({
-        'test3': 'oh hey there checkitout'.encode('utf-8'),
-        'test2': 'oh man this isnt even utf8'.encode('utf-16'),
-        'test1': 'wait theres a second file???'.encode(),
-        'test-file': "this isnt even in a directory".encode()
-    })
+    res = datafiles_from_paths(
+        [
+            os.path.join(tmpdir, "path-1"),
+            pathlib.Path(os.path.join(tmpdir, "path-2")),
+            os.path.join(tmpdir, "test-file"),
+        ]
+    )
+    assert sorted(res) == sorted(
+        {
+            "test3": "oh hey there checkitout".encode("utf-8"),
+            "test2": "oh man this isnt even utf8".encode("utf-16"),
+            "test1": "wait theres a second file???".encode(),
+            "test-file": "this isnt even in a directory".encode(),
+        }
+    )

--- a/api/tests/opentrons/util/test_helpers.py
+++ b/api/tests/opentrons/util/test_helpers.py
@@ -6,38 +6,36 @@ from opentrons.util import helpers
 @pytest.fixture
 def deep_dict():
     return {
-        'a': 1,
-        'b': [1, 2, 3],
-        'c': {
-            'a': [4, 5, 6],
-            'b': {
-                'd': 4
-            },
+        "a": 1,
+        "b": [1, 2, 3],
+        "c": {
+            "a": [4, 5, 6],
+            "b": {"d": 4},
         },
-        'd': [
-            {'a': [7, 8, 9]}
-        ]
+        "d": [{"a": [7, 8, 9]}],
     }
 
 
-@pytest.mark.parametrize(argnames="key,expected_result",
-                         argvalues=[
-                             # Success cases
-                             [['a'], 1],
-                             [['b', 2], 3],
-                             [['c', 'a', 1], 5],
-                             [['c', 'b', 'd'], 4],
-                             [['d', 0, 'a', 2], 9],
-                             [('b',), [1, 2, 3]],
-                             # Failure cases
-                             [None, None],
-                             [[], None],
-                             # Index out of range
-                             [['b', 22], None],
-                             # String index
-                             [['b', "23"], None],
-                             # key error
-                             [["e"], None],
-                         ])
+@pytest.mark.parametrize(
+    argnames="key,expected_result",
+    argvalues=[
+        # Success cases
+        [["a"], 1],
+        [["b", 2], 3],
+        [["c", "a", 1], 5],
+        [["c", "b", "d"], 4],
+        [["d", 0, "a", 2], 9],
+        [("b",), [1, 2, 3]],
+        # Failure cases
+        [None, None],
+        [[], None],
+        # Index out of range
+        [["b", 22], None],
+        # String index
+        [["b", "23"], None],
+        # key error
+        [["e"], None],
+    ],
+)
 def test_deep_get(deep_dict, key, expected_result):
     assert helpers.deep_get(deep_dict, key) == expected_result

--- a/api/tests/opentrons/util/test_linal.py
+++ b/api/tests/opentrons/util/test_linal.py
@@ -8,19 +8,19 @@ def test_solve():
     theta = pi / 3.0  # 60 deg
     scale = 2.0
 
-    expected = [
-        [cos(0), sin(0)],
-        [cos(pi / 2), sin(pi / 2)],
-        [cos(pi), sin(pi)]]
+    expected = [[cos(0), sin(0)], [cos(pi / 2), sin(pi / 2)], [cos(pi), sin(pi)]]
 
     actual = [
         [cos(theta) * scale + 0.5, sin(theta) * scale + 0.25],
         [cos(theta + pi / 2) * scale + 0.5, sin(theta + pi / 2) * scale + 0.25],
-        [cos(theta + pi) * scale + 0.5, sin(theta + pi) * scale + 0.25]]
+        [cos(theta + pi) * scale + 0.5, sin(theta + pi) * scale + 0.25],
+    ]
 
     X = solve(expected, actual)
 
-    expected = np.array([cos(theta + pi / 2) * scale + 0.5, sin(theta + pi / 2) * scale + 0.25, 1])   # noqa: E501
+    expected = np.array(
+        [cos(theta + pi / 2) * scale + 0.5, sin(theta + pi / 2) * scale + 0.25, 1]
+    )
     result = np.dot(X, np.array([[0], [1], [1]])).transpose()
 
     return np.isclose(expected, result).all()
@@ -31,16 +31,9 @@ def test_add_z():
     y = 10
     z = 20
 
-    xy_array = np.array([
-        [1, 0, x],
-        [0, 1, y],
-        [0, 0, 1]])
+    xy_array = np.array([[1, 0, x], [0, 1, y], [0, 0, 1]])
 
-    expected = np.array([
-        [1, 0, 0, x],
-        [0, 1, 0, y],
-        [0, 0, 1, z],
-        [0, 0, 0, 1]])
+    expected = np.array([[1, 0, 0, x], [0, 1, 0, y], [0, 0, 1, z], [0, 0, 0, 1]])
 
     result = add_z(xy_array, z)
     assert (result == expected).all()
@@ -58,13 +51,11 @@ def test_apply_transform():
     a = (
         (1 + x_delta, 1 + y_delta, 1.1),
         (2 + x_delta, 2 + y_delta, 2.2),
-        (1 + x_delta, 2 + y_delta, 1.1))
+        (1 + x_delta, 2 + y_delta, 1.1),
+    )
     transform = solve_attitude(e, a)
 
-    expected = (
-        round(x - x_delta, 2),
-        round(y - y_delta, 2),
-        round(z))
+    expected = (round(x - x_delta, 2), round(y - y_delta, 2), round(z))
 
     result = apply_transform(inv(transform), (1, 2, 3))
     assert np.isclose(result, expected, atol=0.1).all()


### PR DESCRIPTION
## Overview

This PR rips the Black bandaid off of the `api` project and formats all Python files with Black. Going to say this closes #7629, even with `shared-data`, `update-server`, and `notify-server` still floating around. That can be an exercise for whomever wants to do that while working on those projects; most active dev from CPX is focused on `api` and `robot-server` for the time being.

## Changelog

- See title

## Review requests

This should be a style-only change, so give the code a skim and maybe run a smoke test, if you have time.

## Risk assessment

Very low, if Black did its job and all tests are passsing
