### PR TITLE
chore(robot-server): update dist name in makefile

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -11,7 +11,7 @@ SRC_PATH = robot_server
 # Find the version of the wheel from package.json using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the wheel.
-wheel_file = dist/$(call python_get_wheelname,robot-server,robotserver,$(BUILD_NUMBER))
+wheel_file = dist/$(call python_get_wheelname,robot-server,robot_server,$(BUILD_NUMBER))
 
 
 # These variables can be overriden when make is invoked to customize the


### PR DESCRIPTION
# Overview

We changed the robot server's dist name from `robotserver` to `robot_server` in #8228. This PR updates the robot server's makefile to be compatible with this change.

# Changelog

- Updated `robot-server/Makefile`

# Review requests

- Check that a `make push` from `robot-server` succeeds

# Risk assessment

Very low. Only affects robot-server's `make push`.