### PR TITLE
fix(fastsim): set_defaults for FlowRates in InstrumentContextSimulation

### DIFF
--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -39,7 +39,6 @@ class InstrumentContextImplementation(AbstractInstrument):
         api_version: Optional[APIVersion] = None,
     ):
         """ "Constructor"""
-        # TODO AL 20201110 - Remove need for api_version in this module
         self._api_version = api_version or MAX_SUPPORTED_VERSION
         self._protocol_interface = protocol_interface
         self._mount = mount

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -1,9 +1,10 @@
 import typing
 
-from opentrons import types
+from opentrons import types, APIVersion
 from opentrons.hardware_control import NoTipAttachedError, TipAttachedError
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.types import HardwareAction
+from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clearances
 from opentrons.protocols.geometry import planning
@@ -22,6 +23,7 @@ class InstrumentContextSimulation(AbstractInstrument):
         mount: types.Mount,
         instrument_name: str,
         default_speed: float = 400.0,
+        api_version: typing.Optional[APIVersion] = None,
     ):
         """Constructor."""
         self._protocol_interface = protocol_interface
@@ -29,7 +31,9 @@ class InstrumentContextSimulation(AbstractInstrument):
         self._pipette_dict = pipette_dict
         self._instrument_name = instrument_name
         self._default_speed = default_speed
+        self._api_version = api_version or MAX_SUPPORTED_VERSION
         self._flow_rate = FlowRates(self)
+        self._flow_rate.set_defaults(api_level=self._api_version)
         self._plunger_speeds = PlungerSpeeds(self)
         # Cache the maximum instrument height
         self._instrument_max_height = (

--- a/api/src/opentrons/protocols/context/simulator/protocol_context.py
+++ b/api/src/opentrons/protocols/context/simulator/protocol_context.py
@@ -40,6 +40,7 @@ class ProtocolContextSimulation(ProtocolContextImplementation):
             pipette_dict=self._hw_manager.hardware.get_attached_instruments()[mount],
             mount=mount,
             instrument_name=instrument_name,
+            api_version=self._api_version,
         )
         self._instruments[mount] = new_instr
         self._log.info(f"Instrument {new_instr} loaded")


### PR DESCRIPTION
# Overview

Default flow rates are not correct when using fast simulation. 

closes #8272 

# Changelog

set default flow rates based on api_version in `InstrumentContextSimulation`

# Review requests


# Risk assessment

None