### PR TITLE
chore(robot-server): update dist name in rule too

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -70,7 +70,7 @@ clean:
 teardown:
 	$(pipenv) --rm
 
-dist/robotserver-%-py2.py3-none-any.whl: setup.py $(ot_sources)
+dist/robot_server-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 	$(clean_cmd)
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -70,7 +70,7 @@ clean:
 teardown:
 	$(pipenv) --rm
 
-dist/robot_server-%-py2.py3-none-any.whl: setup.py $(ot_sources)
+$(wheel_file): setup.py $(ot_sources)
 	$(clean_cmd)
 	$(python) setup.py $(wheel_opts) bdist_wheel
 	$(SHX) rm -rf build


### PR DESCRIPTION
Follow up for #8276 

# Changelog

`dist/robotserver-%-py2.py3-none-any.whl` -> `dist/robot_server-%-py2.py3-none-any.whl`

The wheel file name is also used as a makefile rule that builds the package wheel. But this rule isn't being called directly, and instead is supposed to be called upon after expansion of `$(wheel_file)`, which is called by the `wheel` rule. So now, even if the `dist/robotserver..` rule was mismatched, there was no error being thrown because the `wheel` rule simply expanded `$(wheel_file)` and left it at that.

Then if you already had a previously built wheel file with the correct name (which you most likely would), `make push` would simply `scp` that file to the robot, not knowing that it's a stale file.

# Review requests

Test that `make wheel` and `make push` actually build the wheel when you make a change to any of the source files.

# Risk assessment

Low. Just dev stuff
