### PR TITLE
style(robot-server): make moves towards strict mode mypy typechecking

### DIFF
--- a/robot-server/mypy.ini
+++ b/robot-server/mypy.ini
@@ -1,9 +1,44 @@
 [mypy]
 plugins = pydantic.mypy,decoy.mypy
-check_untyped_defs = True
-ignore_missing_imports = False
 show_error_codes = True
 exclude = tests/(robot|service)
+
+# TODO(mc, 2021-10-02): replace the the following flags
+# with `strict = True` when able
+
+warn_unused_configs = True
+disallow_subclassing_any = True
+check_untyped_defs = True
+warn_redundant_casts = True
+strict_equality = True
+warn_unused_ignores = True
+
+# TODO(mc, 2021-10-02): fix ~25 anys in generics
+# disallow_any_generics = True
+
+# TODO(mc, 2021-10-02): fix ~150 untyped call errors
+# disallow_untyped_calls = True
+
+# TODO(mc, 2021-10-02): fix ~200 untyped def errors
+# disallow_untyped_defs = True
+
+# TODO(mc, 2021-10-02): fix ~80 incomplete def errors
+# disallow_incomplete_defs = True
+
+# TODO(mc, 2021-10-02): fix ~5 untyped decorators
+# disallow_untyped_decorators = True
+
+# TODO(mc, 2021-10-02): fix ~35 implicit optionals
+# no_implicit_optional = True
+
+# TODO(mc, 2021-10-02): fix ~30 any returns
+# warn_return_any = True
+
+# TODO(mc, 2021-10-02): fix ~250 implicit re-export errors, some in FastAPI
+# FastAPI errors can be resolved by upgrading FastAPI
+# no_implicit_reexport = True
+
+# end strict mode flags
 
 [pydantic-mypy]
 init_forbid_extra = True

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -132,7 +132,7 @@ class RequiredLabware(BaseModel):
     @classmethod
     def from_lw(cls, lw: labware.Labware, slot: typing.Optional[DeckLocation] = None):
         if not slot:
-            slot = lw.parent  # type: ignore[assignment]
+            slot = lw.parent
         lw_def = lw._implementation.get_definition()
         return cls(
             # TODO(mc, 2020-09-17): DeckLocation does not match

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -192,7 +192,7 @@ class PipetteOffsetCalibrationUserFlow:
 
     def get_pipette(self) -> AttachedPipette:
         # TODO(mc, 2020-09-17): s/tip_length/tipLength
-        return AttachedPipette(  # type: ignore[call-arg]
+        return AttachedPipette(
             model=self._hw_pipette.model,
             name=self._hw_pipette.name,
             tipLength=self._hw_pipette.config.tip_length,

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -149,11 +149,7 @@ async def get_all_labware_calibrations(
         )
     calibrations = _format_calibrations(all_calibrations)
 
-    # TODO(mc, 2020-09-17): the type of all_calibrations does not match
-    # what MultipleCalibrationsResponse expects for data
-    return lw_models.MultipleCalibrationsResponse(
-        data=calibrations  # type: ignore[arg-type]
-    )
+    return lw_models.MultipleCalibrationsResponse(data=calibrations)
 
 
 @router.get(
@@ -178,11 +174,8 @@ async def get_specific_labware_calibration(
         )
 
     formatted_calibrations = _format_calibrations([calibration])
-    # TODO(mc, 2020-09-17): type of formatted_calibrations[0] does not match
-    # what SingleCalibrationResponse expects for data
-    return lw_models.SingleCalibrationResponse(
-        data=formatted_calibrations[0]
-    )  # type: ignore[arg-type]
+
+    return lw_models.SingleCalibrationResponse(data=formatted_calibrations[0])
 
 
 @router.delete(

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -27,7 +27,7 @@ async def post_identify(
     seconds: int = Query(..., description="Time to blink the lights for"),
     hardware: ThreadManager = Depends(get_hardware),
 ) -> V1BasicResponse:
-    identify = hardware.identify  # type: ignore
+    identify = hardware.identify
     asyncio.ensure_future(identify(seconds))
     return V1BasicResponse(message="identifying")
 
@@ -100,8 +100,8 @@ async def post_home_robot(
             mount = robot_home_target.mount
             target = robot_home_target.target
 
-            home = hardware.home  # type: ignore
-            home_plunger = hardware.home_plunger  # type: ignore
+            home = hardware.home
+            home_plunger = hardware.home_plunger
 
             if target == control.HomeTarget.pipette and mount:
                 await home([Axis.by_mount(Mount[mount.upper()])])
@@ -128,7 +128,7 @@ async def post_home_robot(
 async def get_robot_light_state(
     hardware: ThreadManager = Depends(get_hardware),
 ) -> control.RobotLightState:
-    light_state = hardware.get_lights()  # type: ignore
+    light_state = hardware.get_lights()
     return control.RobotLightState(on=light_state.get("rails", False))
 
 
@@ -141,13 +141,13 @@ async def post_robot_light_state(
     robot_light_state: control.RobotLightState,
     hardware: ThreadManager = Depends(get_hardware),
 ) -> control.RobotLightState:
-    await hardware.set_lights(rails=robot_light_state.on)  # type: ignore
+    await hardware.set_lights(rails=robot_light_state.on)
     return robot_light_state
 
 
 async def _do_move(hardware: ThreadManager, robot_move_target: control.RobotMoveTarget):
     """Perform the move"""
-    await hardware.cache_instruments()  # type: ignore
+    await hardware.cache_instruments()
 
     critical_point = None
     if robot_move_target.target == control.MotionTarget.mount:
@@ -157,10 +157,10 @@ async def _do_move(hardware: ThreadManager, robot_move_target: control.RobotMove
     target_pos = Point(*robot_move_target.point)
 
     # Reset z position
-    await hardware.home_z()  # type: ignore
+    await hardware.home_z()
 
-    gantry_position = hardware.gantry_position  # type: ignore
-    move_to = hardware.move_to  # type: ignore
+    gantry_position = hardware.gantry_position
+    move_to = hardware.move_to
 
     pos = await gantry_position(mount, critical_point=critical_point)
     # Move to requested x, y and current z position

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -27,7 +27,7 @@ router = APIRouter()
     response_model=Modules,
 )
 async def get_modules(hardware: ThreadManager = Depends(get_hardware)) -> Modules:
-    attached_modules = hardware.attached_modules  # type: ignore
+    attached_modules = hardware.attached_modules
     module_data = [
         Module(
             name=mod.name(),  # TODO: legacy, remove
@@ -66,7 +66,7 @@ async def get_module_serial(
 ) -> ModuleSerial:
     res = None
 
-    attached_modules = hardware.attached_modules  # type: ignore
+    attached_modules = hardware.attached_modules
     matching_module = find_matching_module(serial, attached_modules)
     if matching_module and hasattr(matching_module, "live_data"):
         res = matching_module.live_data
@@ -105,7 +105,7 @@ async def post_serial_command(
     hardware: ThreadManager = Depends(get_hardware),
 ) -> SerialCommandResponse:
     """Send a command on device identified by serial"""
-    attached_modules = hardware.attached_modules  # type: ignore
+    attached_modules = hardware.attached_modules
     if not attached_modules:
         raise LegacyErrorResponse(message="No connected modules").as_error(
             status.HTTP_404_NOT_FOUND
@@ -159,7 +159,7 @@ async def post_serial_update(
     hardware: ThreadManager = Depends(get_hardware),
 ) -> V1BasicResponse:
     """Update module firmware"""
-    attached_modules = hardware.attached_modules  # type: ignore
+    attached_modules = hardware.attached_modules
     matching_module = find_matching_module(serial, attached_modules)
 
     if not matching_module:

--- a/robot-server/robot_server/service/legacy/routers/motors.py
+++ b/robot-server/robot_server/service/legacy/routers/motors.py
@@ -25,7 +25,7 @@ async def get_engaged_motors(
     hardware: ThreadManager = Depends(get_hardware),
 ) -> model.EngagedMotors:  # type: ignore
     try:
-        engaged_axes = hardware.engaged_axes  # type: ignore
+        engaged_axes = hardware.engaged_axes
         axes_dict = {
             str(k).lower(): model.EngagedMotor(enabled=v)
             for k, v in engaged_axes.items()
@@ -47,5 +47,5 @@ async def post_disengage_motors(
 ) -> V1BasicResponse:
 
     input_axes = [Axis[ax.upper()] for ax in axes.axes]
-    await hardware.disengage_axes(input_axes)  # type: ignore
+    await hardware.disengage_axes(input_axes)
     return V1BasicResponse(message="Disengaged axes: {}".format(", ".join(axes.axes)))

--- a/robot-server/robot_server/service/legacy/routers/pipettes.py
+++ b/robot-server/robot_server/service/legacy/routers/pipettes.py
@@ -46,9 +46,9 @@ async def get_pipettes(
     mount will report `'model': null`
     """
     if refresh is True:
-        await hardware.cache_instruments()  # type: ignore
+        await hardware.cache_instruments()
 
-    attached = hardware.attached_instruments  # type: ignore
+    attached = hardware.attached_instruments
 
     def make_pipette(mount, o):
         return pipettes.AttachedPipette(

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -123,8 +123,8 @@ async def post_log_level_local(
     for logger_name in ("opentrons", "robot_server", "uvicorn"):
         logging.getLogger(logger_name).setLevel(level.level_id)
     # Update and save settings
-    await hardware.update_config(log_level=level_name)  # type: ignore
-    robot_configs.save_robot_settings(hardware.config)  # type: ignore
+    await hardware.update_config(log_level=level_name)
+    robot_configs.save_robot_settings(hardware.config)
 
     return V1BasicResponse(message=f"log_level set to {level}")
 

--- a/robot-server/tests/sessions/router/test_commands_router.py
+++ b/robot-server/tests/sessions/router/test_commands_router.py
@@ -73,9 +73,7 @@ async def test_get_session_commands(
             session_store=matchers.Anything(),
             engine_store=matchers.Anything(),
         ),
-    ).then_return(
-        ResponseModel(data=session_response)  # type: ignore[arg-type]
-    )
+    ).then_return(ResponseModel(data=session_response))
 
     response = await async_client.get("/sessions/session-id/commands")
 


### PR DESCRIPTION
## Overview

This PR makes moves towards getting the `robot-server` to a place where we can use `mypy --strict`.

## Changelog

- Manually copy in all strict-mode settings into `robot-server/mypy.ini`
    - These settings can only be found by running `mypy --help`, because mypy is fun™️ 
- Enable strict mode options that do not cause new errors to be reported
- Remove unused `type: ignore` comments

## Review requests

- [ ] Verify comment / formatting changes only

## Risk assessment

Very low
