### PR TITLE
fix(fastsim): fast sim fails when using InstrumentContext.pair_with function

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -42,6 +42,8 @@ AdvancedLiquidHandling = Union[
     Well, types.Location, List[Union[Well, types.Location]], List[List[Well]]
 ]
 
+logger = logging.getLogger(__name__)
+
 
 class InstrumentContext(CommandPublisher):
     """A context for a specific pipette or instrument.
@@ -66,7 +68,6 @@ class InstrumentContext(CommandPublisher):
         implementation: AbstractInstrument,
         ctx: ProtocolContext,
         broker: Broker,
-        log_parent: logging.Logger,
         at_version: APIVersion,
         tip_racks: List[Labware] = None,
         trash: Optional[Labware] = None,
@@ -76,12 +77,11 @@ class InstrumentContext(CommandPublisher):
         self._api_version = at_version
         self._implementation = implementation
         self._ctx = ctx
-        self._log = log_parent.getChild(repr(self))
 
         self._tip_racks = tip_racks or list()
         for tip_rack in self.tip_racks:
             assert tip_rack.is_tiprack
-            validate_tiprack(self.name, tip_rack, self._log)
+            validate_tiprack(self.name, tip_rack, logger)
         if trash is None:
             self.trash_container = self._ctx.fixed_trash
         else:
@@ -169,7 +169,7 @@ class InstrumentContext(CommandPublisher):
             ``instr.aspirate(location=wellplate['A1'])``
 
         """
-        self._log.debug(
+        logger.debug(
             "aspirate {} from {} at {}".format(
                 volume, location if location else "current position", rate
             )
@@ -210,7 +210,7 @@ class InstrumentContext(CommandPublisher):
                 else:
                     # TODO(seth,2019/7/29): This should be a warning exposed
                     #  via rpc to the runapp
-                    self._log.warning(
+                    logger.warning(
                         "When aspirate is called on something other than a "
                         "well relative position, we can't move to the top of"
                         " the well to prepare for aspiration. This might "
@@ -298,7 +298,7 @@ class InstrumentContext(CommandPublisher):
             ``instr.dispense(location=wellplate['A1'])``
 
         """
-        self._log.debug(
+        logger.debug(
             "dispense {} from {} at {}".format(
                 volume, location if location else "current position", rate
             )
@@ -403,7 +403,7 @@ class InstrumentContext(CommandPublisher):
             ``location`` unless you use keywords.
 
         """
-        self._log.debug(
+        logger.debug(
             "mixing {}uL with {} repetitions in {} at rate={}".format(
                 volume, repetitions, location if location else "current position", rate
             )
@@ -473,7 +473,7 @@ class InstrumentContext(CommandPublisher):
 
         if isinstance(location, Well):
             if location.parent.is_tiprack:
-                self._log.warning(
+                logger.warning(
                     "Blow_out being performed on a tiprack. "
                     "Please re-check your code"
                 )
@@ -588,10 +588,10 @@ class InstrumentContext(CommandPublisher):
 
         if well.is_well:
             if "touchTipDisabled" in well.quirks_from_any_parent():
-                self._log.info(f"Ignoring touch tip on labware {well}")
+                logger.info(f"Ignoring touch tip on labware {well}")
                 return self
             if well.parent.as_labware().is_tiprack:
-                self._log.warning(
+                logger.warning(
                     "Touch_tip being performed on a tiprack. "
                     "Please re-check your code"
                 )
@@ -679,7 +679,7 @@ class InstrumentContext(CommandPublisher):
             See the ``home_after`` parameter in :py:obj:`drop_tip`.
         """
         if not self._implementation.has_tip():
-            self._log.warning("Pipette has no tip to return")
+            logger.warning("Pipette has no tip to return")
         loc = self._last_tip_picked_up_from
         if not isinstance(loc, Well):
             raise TypeError(
@@ -765,7 +765,7 @@ class InstrumentContext(CommandPublisher):
             )
 
         assert tiprack.is_tiprack, "{} is not a tiprack".format(str(tiprack))
-        validate_tiprack(self.name, tiprack, self._log)
+        validate_tiprack(self.name, tiprack, logger)
         do_publish(
             self.broker,
             cmds.pick_up_tip,
@@ -942,7 +942,7 @@ class InstrumentContext(CommandPublisher):
                 # Similarly to :py:meth:`return_tips`, the failure case here
                 # just means the tip can't be reused, so don't actually stop
                 # the protocol
-                self._log.exception(f"Could not return tip to {target}")
+                logger.exception(f"Could not return tip to {target}")
         self._last_tip_picked_up_from = None
         return self
 
@@ -995,7 +995,7 @@ class InstrumentContext(CommandPublisher):
                        minimum volume of the pipette
         :returns: This instance
         """
-        self._log.debug("Distributing {} from {} to {}".format(volume, source, dest))
+        logger.debug("Distributing {} from {} to {}".format(volume, source, dest))
         kwargs["mode"] = "distribute"
         kwargs["disposal_volume"] = kwargs.get("disposal_volume", self.min_volume)
         kwargs["mix_after"] = (0, 0)
@@ -1027,7 +1027,7 @@ class InstrumentContext(CommandPublisher):
                        and ``disposal_volume`` is ignored and set to 0.
         :returns: This instance
         """
-        self._log.debug("Consolidate {} from {} to {}".format(volume, source, dest))
+        logger.debug("Consolidate {} from {} to {}".format(volume, source, dest))
         kwargs["mode"] = "consolidate"
         kwargs["mix_before"] = (0, 0)
         kwargs["disposal_volume"] = 0
@@ -1142,7 +1142,7 @@ class InstrumentContext(CommandPublisher):
 
         :returns: This instance
         """
-        self._log.debug("Transfer {} from {} to {}".format(volume, source, dest))
+        logger.debug("Transfer {} from {} to {}".format(volume, source, dest))
 
         blowout_location = kwargs.get("blowout_location")
         validate_blowout_location(self.api_version, "transfer", blowout_location)
@@ -1598,7 +1598,7 @@ class InstrumentContext(CommandPublisher):
             pair_policy=PipettePair.of_mount(self._implementation.get_mount()),
             api_version=self.api_version,
             trash=self.trash_container,
-            log_parent=self._log,
+            log_parent=logger,
         )
 
     def _tip_length_for(self, tiprack: Labware) -> float:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1593,10 +1593,10 @@ class InstrumentContext(CommandPublisher):
         return PairedInstrumentContext(
             primary_instrument=self,
             secondary_instrument=instrument,
+            implementation=self._implementation.pair_with(instrument._implementation),
             ctx=self._ctx,
             pair_policy=PipettePair.of_mount(self._implementation.get_mount()),
             api_version=self.api_version,
-            hardware_manager=self._ctx._implementation.get_hardware(),
             trash=self.trash_container,
             log_parent=self._log,
         )

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, Union
+from typing import Generic, List, Optional, TYPE_CHECKING, TypeVar, Union, cast
 
 from opentrons import types
 from opentrons.hardware_control import modules
@@ -474,17 +474,9 @@ class ThermocyclerContext(ModuleContext[ThermocyclerGeometry]):
             instr.move_to(types.Location(safe_point, None), force_direct=True)
 
     def flag_unsafe_move(self, to_loc: types.Location, from_loc: types.Location):
-        to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
-        from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
-        if (
-            self.labware is not None
-            and (self.labware == to_lw or self.labware == from_lw)
-            and self.lid_position != "open"
-        ):
-            raise RuntimeError(
-                "Cannot move to labware loaded in Thermocycler"
-                " when lid is not fully open."
-            )
+        cast(ThermocyclerGeometry, self.geometry).flag_unsafe_move(
+            to_loc, from_loc, self.lid_position
+        )
 
     @publish.both(command=cmds.thermocycler_open)
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -9,7 +9,7 @@ from opentrons import types, hardware_control as hc
 from opentrons.commands import paired_commands as cmds
 from opentrons.commands.publisher import CommandPublisher, publish_paired, publish
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.context.protocol_api.paired_instrument import PairedInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
 
 from opentrons.protocols.api_support.util import (
     requires_version,
@@ -50,10 +50,10 @@ class PairedInstrumentContext(CommandPublisher):
         self,
         primary_instrument: InstrumentContext,
         secondary_instrument: InstrumentContext,
+        implementation: AbstractPairedInstrument,
         ctx: ProtocolContext,
         pair_policy: hc_types.PipettePair,
         api_version: APIVersion,
-        hardware_manager: HardwareManager,
         trash: Labware,
         log_parent: logging.Logger,
     ) -> None:
@@ -77,14 +77,7 @@ class PairedInstrumentContext(CommandPublisher):
         )
 
         self.trash_container = trash
-        self.paired_instrument_obj = PairedInstrument(
-            primary_instrument,
-            secondary_instrument,
-            pair_policy,
-            ctx,
-            hardware_manager,
-            self._log,
-        )
+        self.paired_instrument_obj = implementation
 
     @property  # type: ignore
     @requires_version(2, 7)

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -76,7 +76,7 @@ class PairedInstrumentContext(CommandPublisher):
         )
         self._ctx = ctx
         self.trash_container = trash
-        self.paired_instrument_obj = implementation
+        self._implementation = implementation
 
     @property  # type: ignore
     @requires_version(2, 7)
@@ -255,7 +255,7 @@ class PairedInstrumentContext(CommandPublisher):
         publish_paired(
             self.broker, cmds.paired_pick_up_tip, "before", None, instruments, targets
         )
-        self.paired_instrument_obj.pick_up_tip(
+        self._implementation.pick_up_tip(
             target, secondary_target, tiprack, presses, increment, tip_length
         )
         self._last_tip_picked_up_from = target
@@ -353,7 +353,7 @@ class PairedInstrumentContext(CommandPublisher):
         publish_paired(
             self.broker, cmds.paired_drop_tip, "before", None, instruments, targets
         )
-        self.paired_instrument_obj.drop_tip(target, home_after)
+        self._implementation.drop_tip(target, home_after)
         publish_paired(
             self.broker, cmds.paired_drop_tip, "after", self, instruments, targets
         )
@@ -417,7 +417,6 @@ class PairedInstrumentContext(CommandPublisher):
             )
         )
 
-        # checked_location: Optional[types.Location] = None
         if isinstance(location, Well):
             point, well = location.bottom()
             checked_location = types.Location(
@@ -464,7 +463,7 @@ class PairedInstrumentContext(CommandPublisher):
             rate,
         )
 
-        self.paired_instrument_obj.aspirate(
+        self._implementation.aspirate(
             volume=c_vol, location=checked_location, rate=rate
         )
 
@@ -588,7 +587,7 @@ class PairedInstrumentContext(CommandPublisher):
             rate,
         )
 
-        self.paired_instrument_obj.dispense(
+        self._implementation.dispense(
             volume=c_vol, location=checked_location, rate=rate
         )
 
@@ -656,8 +655,8 @@ class PairedInstrumentContext(CommandPublisher):
         if not loc or not loc.labware.is_well:
             raise RuntimeError("No previous Well cached to perform air gap")
         target = loc.labware.as_well().top(height)
-        self.paired_instrument_obj.move_to(target)
-        self.paired_instrument_obj.aspirate(volume=c_vol, location=loc, rate=1.0)
+        self._implementation.move_to(target)
+        self._implementation.aspirate(volume=c_vol, location=loc, rate=1.0)
         return self
 
     @requires_version(2, 7)
@@ -716,7 +715,7 @@ class PairedInstrumentContext(CommandPublisher):
         publish_paired(
             self.broker, cmds.paired_blow_out, "before", None, instruments, locations
         )
-        self.paired_instrument_obj.blow_out(loc)
+        self._implementation.blow_out(loc)
         publish_paired(
             self.broker, cmds.paired_blow_out, "after", self, instruments, locations
         )
@@ -875,7 +874,7 @@ class PairedInstrumentContext(CommandPublisher):
                 0, 0, v_offset
             )
             to_loc = types.Location(move_with_z_offset, well)
-            self.paired_instrument_obj.move_to(to_loc)
+            self._implementation.move_to(to_loc)
         else:
             # If location is a not a valid well, raise a type error
             raise TypeError(f"location should be a Well, but it is {location}")
@@ -897,9 +896,7 @@ class PairedInstrumentContext(CommandPublisher):
         publish_paired(
             self.broker, cmds.paired_touch_tip, "before", None, instruments, locations
         )
-        self.paired_instrument_obj.touch_tip(
-            well.as_well(), radius, v_offset, checked_speed
-        )
+        self._implementation.touch_tip(well.as_well(), radius, v_offset, checked_speed)
         publish_paired(
             self.broker, cmds.paired_touch_tip, "after", self, instruments, locations
         )
@@ -958,9 +955,7 @@ class PairedInstrumentContext(CommandPublisher):
         publish_paired(
             self.broker, cmds.paired_move_to, "before", None, instruments, locations
         )
-        self.paired_instrument_obj.move_to(
-            location, force_direct, minimum_z_height, speed
-        )
+        self._implementation.move_to(location, force_direct, minimum_z_height, speed)
         publish_paired(
             self.broker, cmds.paired_move_to, "after", None, instruments, locations
         )

--- a/api/src/opentrons/protocol_api/paired_instrument_context.py
+++ b/api/src/opentrons/protocol_api/paired_instrument_context.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
     from .protocol_context import ProtocolContext
     from .instrument_context import InstrumentContext
     from opentrons.hardware_control import types as hc_types
-    from opentrons.protocols.api_support.util import HardwareManager
 
 
 SBS_96_WELL_SPACING = 4

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -392,9 +392,7 @@ class ProtocolContext(CommandPublisher):
         .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
-        logger.warning(
-            "load_labware_by_name is deprecated. Use load_labware instead."
-        )
+        logger.warning("load_labware_by_name is deprecated. Use load_labware instead.")
         return self.load_labware(load_name, location, label, namespace, version)
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -49,7 +49,7 @@ from opentrons.protocols.api_support.util import (
 if TYPE_CHECKING:
     from opentrons_shared_data.labware.dev_types import LabwareDefinition
 
-MODULE_LOG = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 ModuleTypes = Union[
     "TemperatureModuleContext", "MagneticModuleContext", "ThermocyclerContext"
@@ -106,7 +106,6 @@ class ProtocolContext(CommandPublisher):
         }
         self._modules: List[ModuleContext] = []
 
-        self._log = MODULE_LOG.getChild(self.__class__.__name__)
         self._commands: List[str] = []
         self._unsubscribe_commands: Optional[Callable[[], None]] = None
         self.clear_commands()
@@ -140,7 +139,7 @@ class ProtocolContext(CommandPublisher):
     def _hw_manager(self):
         # TODO (lc 01-05-2021) remove this once we have a more
         # user facing hardware control http api.
-        self._log.warning(
+        logger.warning(
             "This function will be deprecated in later versions."
             "Please use with caution."
         )
@@ -393,7 +392,7 @@ class ProtocolContext(CommandPublisher):
         .. deprecated:: 2.0
             Use :py:meth:`load_labware` instead.
         """
-        MODULE_LOG.warning(
+        logger.warning(
             "load_labware_by_name is deprecated. Use load_labware instead."
         )
         return self.load_labware(load_name, location, label, namespace, version)
@@ -561,7 +560,7 @@ class ProtocolContext(CommandPublisher):
                 "mount should be either an instance of opentrons.types.Mount"
                 " or a string, but is {}.".format(mount)
             )
-        self._log.info(
+        logger.info(
             "Trying to load {} on {} mount".format(
                 instrument_name, checked_mount.name.lower()
             )
@@ -577,7 +576,6 @@ class ProtocolContext(CommandPublisher):
             implementation=impl,
             at_version=self.api_version,
             tip_racks=tip_racks,
-            log_parent=self._log,
         )
         self._instruments[checked_mount] = new_instr
         return new_instr
@@ -664,7 +662,7 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 0)
     def home(self):
         """Homes the robot."""
-        self._log.debug("home")
+        logger.debug("home")
         self._implementation.home()
 
     @property

--- a/api/src/opentrons/protocols/context/instrument.py
+++ b/api/src/opentrons/protocols/context/instrument.py
@@ -8,8 +8,7 @@ import typing
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
-from opentrons.protocols.context.paired_instrument import \
-    AbstractPairedInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
 from opentrons.protocols.context.well import WellImplementation
 
 
@@ -163,5 +162,7 @@ class AbstractInstrument(ABC):
         ...
 
     @abstractmethod
-    def pair_with(self, other_instrument: AbstractInstrument) -> AbstractPairedInstrument:
+    def pair_with(
+        self, other_instrument: AbstractInstrument
+    ) -> AbstractPairedInstrument:
         ...

--- a/api/src/opentrons/protocols/context/instrument.py
+++ b/api/src/opentrons/protocols/context/instrument.py
@@ -8,6 +8,8 @@ import typing
 from opentrons import types
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocols.api_support.util import Clearances, PlungerSpeeds, FlowRates
+from opentrons.protocols.context.paired_instrument import \
+    AbstractPairedInstrument
 from opentrons.protocols.context.well import WellImplementation
 
 
@@ -158,4 +160,8 @@ class AbstractInstrument(ABC):
         dispense: typing.Optional[float] = None,
         blow_out: typing.Optional[float] = None,
     ) -> None:
+        ...
+
+    @abstractmethod
+    def pair_with(self, other_instrument: AbstractInstrument) -> AbstractPairedInstrument:
         ...

--- a/api/src/opentrons/protocols/context/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/paired_instrument.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Callable, Tuple
+from typing import Optional
 
 from opentrons import types
 from opentrons.protocol_api.labware import Labware, Well
@@ -37,16 +37,14 @@ class AbstractPairedInstrument(ABC):
     @abstractmethod
     def aspirate(
         self,
-        volume: Optional[float],
-        location: Optional[types.Location] = None,
-        rate: Optional[float] = 1.0,
-    ) -> Tuple[types.Location, Callable]:
+        volume: float,
+        location: types.Location,
+        rate: float,
+    ) -> None:
         ...
 
     @abstractmethod
-    def dispense(
-        self, volume: Optional[float], location: Optional[types.Location], rate: float
-    ) -> Tuple[types.Location, Callable]:
+    def dispense(self, volume: float, location: types.Location, rate: float) -> None:
         ...
 
     @abstractmethod
@@ -54,11 +52,7 @@ class AbstractPairedInstrument(ABC):
         ...
 
     @abstractmethod
-    def air_gap(self, volume: Optional[float], height: float) -> None:
-        ...
-
-    @abstractmethod
     def touch_tip(
-        self, location: Optional[Well], radius: float, v_offset: float, speed: float
+        self, well: Well, radius: float, v_offset: float, speed: float
     ) -> None:
         ...

--- a/api/src/opentrons/protocols/context/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/paired_instrument.py
@@ -8,7 +8,6 @@ from opentrons.protocol_api.labware import Labware, Well
 
 
 class AbstractPairedInstrument(ABC):
-
     @abstractmethod
     def pick_up_tip(
         self,

--- a/api/src/opentrons/protocols/context/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/paired_instrument.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, Callable, Tuple
+
+from opentrons import types
+from opentrons.protocol_api.labware import Labware, Well
+
+
+class AbstractPairedInstrument(ABC):
+
+    @abstractmethod
+    def pick_up_tip(
+        self,
+        target: Well,
+        secondary_target: Well,
+        tiprack: Labware,
+        presses: Optional[int],
+        increment: Optional[float],
+        tip_length: float,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def drop_tip(self, target: types.Location, home_after: bool) -> None:
+        ...
+
+    @abstractmethod
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool = False,
+        minimum_z_height: Optional[float] = None,
+        speed: Optional[float] = None,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def aspirate(
+        self,
+        volume: Optional[float],
+        location: Optional[types.Location] = None,
+        rate: Optional[float] = 1.0,
+    ) -> Tuple[types.Location, Callable]:
+        ...
+
+    @abstractmethod
+    def dispense(
+        self, volume: Optional[float], location: Optional[types.Location], rate: float
+    ) -> Tuple[types.Location, Callable]:
+        ...
+
+    @abstractmethod
+    def blow_out(self, location: types.Location) -> None:
+        ...
+
+    @abstractmethod
+    def air_gap(self, volume: Optional[float], height: float) -> None:
+        ...
+
+    @abstractmethod
+    def touch_tip(
+        self, location: Optional[Well], radius: float, v_offset: float, speed: float
+    ) -> None:
+        ...

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 from opentrons import types
@@ -22,9 +21,6 @@ from opentrons.protocols.geometry import planning
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.context.well import WellImplementation
-
-
-LLLL = logging.getLogger(__name__)
 
 
 class InstrumentContextImplementation(AbstractInstrument):
@@ -314,5 +310,4 @@ class InstrumentContextImplementation(AbstractInstrument):
             ctx=self._protocol_interface,
             pair_policy=PipettePair.of_mount(self.get_mount()),
             hardware_manager=self._protocol_interface.get_hardware(),
-            log_parent=LLLL
         )

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from opentrons import types
@@ -21,6 +22,9 @@ from opentrons.protocols.geometry import planning
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.context.well import WellImplementation
+
+
+LLLL = logging.getLogger(__name__)
 
 
 class InstrumentContextImplementation(AbstractInstrument):
@@ -310,5 +314,5 @@ class InstrumentContextImplementation(AbstractInstrument):
             ctx=self._protocol_interface,
             pair_policy=PipettePair.of_mount(self.get_mount()),
             hardware_manager=self._protocol_interface.get_hardware(),
-            log_parent=None
+            log_parent=LLLL
         )

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from opentrons import types
+from opentrons.hardware_control.types import PipettePair
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.hardware_control import CriticalPoint
 from opentrons.hardware_control.dev_types import PipetteDict
@@ -12,6 +13,10 @@ from opentrons.protocols.api_support.util import (
     FlowRates,
     PlungerSpeeds,
 )
+from opentrons.protocols.context.paired_instrument import \
+    AbstractPairedInstrument
+from opentrons.protocols.context.protocol_api.paired_instrument import \
+    PairedInstrument
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
@@ -295,4 +300,15 @@ class InstrumentContextImplementation(AbstractInstrument):
             aspirate=aspirate,
             dispense=dispense,
             blow_out=blow_out,
+        )
+
+    def pair_with(self, other_instrument: AbstractInstrument) -> AbstractPairedInstrument:
+        """Create an AbstractPairedInstrument"""
+        return PairedInstrument(
+            primary_instrument=self,
+            secondary_instrument=other_instrument,
+            ctx=self._protocol_interface,
+            pair_policy=PipettePair.of_mount(self.get_mount()),
+            hardware_manager=self._protocol_interface.get_hardware(),
+            log_parent=None
         )

--- a/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/instrument_context.py
@@ -13,10 +13,8 @@ from opentrons.protocols.api_support.util import (
     FlowRates,
     PlungerSpeeds,
 )
-from opentrons.protocols.context.paired_instrument import \
-    AbstractPairedInstrument
-from opentrons.protocols.context.protocol_api.paired_instrument import \
-    PairedInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
+from opentrons.protocols.context.protocol_api.paired_instrument import PairedInstrument
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
@@ -302,7 +300,9 @@ class InstrumentContextImplementation(AbstractInstrument):
             blow_out=blow_out,
         )
 
-    def pair_with(self, other_instrument: AbstractInstrument) -> AbstractPairedInstrument:
+    def pair_with(
+        self, other_instrument: AbstractInstrument
+    ) -> AbstractPairedInstrument:
         """Create an AbstractPairedInstrument"""
         return PairedInstrument(
             primary_instrument=self,

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -19,6 +19,8 @@ from opentrons.protocols.api_support.util import build_edges
 if TYPE_CHECKING:
     from opentrons.hardware_control import types as hc_types
     from opentrons.protocols.api_support.util import HardwareManager
+    
+logger = logging.getLogger(__name__)
 
 
 class PairedInstrument(AbstractPairedInstrument):
@@ -29,14 +31,12 @@ class PairedInstrument(AbstractPairedInstrument):
         pair_policy: hc_types.PipettePair,
         ctx: AbstractProtocol,
         hardware_manager: HardwareManager,
-        log_parent: logging.Logger,
     ):
         self.p_instrument = primary_instrument
         self.s_instrument = secondary_instrument
         self._pair_policy = pair_policy
         self._ctx = ctx
         self._hw_manager = hardware_manager
-        self._log = log_parent.getChild(repr(self))
 
         self._last_location: Union[Labware, Well, None] = None
 
@@ -114,7 +114,7 @@ class PairedInstrument(AbstractPairedInstrument):
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
         )
-        self._log.debug("move_to: {}->{} via:\n\t{}".format(from_loc, location, moves))
+        logger.debug("move_to: {}->{} via:\n\t{}".format(from_loc, location, moves))
         try:
             for move in moves:
                 self._hw_manager.hardware.move_to(
@@ -161,7 +161,7 @@ class PairedInstrument(AbstractPairedInstrument):
                 else:
                     # TODO(seth,2019/7/29): This should be a warning exposed
                     #  via rpc to the runapp
-                    self._log.warning(
+                    logger.warning(
                         "When aspirate is called on something other than a "
                         "well relative position, we can't move to the top of"
                         " the well to prepare for aspiration. This might "
@@ -237,10 +237,10 @@ class PairedInstrument(AbstractPairedInstrument):
 
         if well.is_well:
             if "touchTipDisabled" in well.quirks_from_any_parent():
-                self._log.info(f"Ignoring touch tip on labware {well}")
+                logger.info(f"Ignoring touch tip on labware {well}")
                 return self
             if well.parent.as_labware().is_tiprack:
-                self._log.warning(
+                logger.warning(
                     "Touch_tip being performed on a tiprack. "
                     "Please re-check your code"
                 )

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional, cast
 from opentrons import types
 from opentrons.hardware_control.modules import Thermocycler
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.protocol_api.module_contexts import ThermocyclerContext
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.context.instrument import AbstractInstrument

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -81,7 +81,7 @@ class PairedInstrument(AbstractPairedInstrument):
         if not speed:
             speed = self.p_instrument.get_default_speed()
 
-        last_location = self._ctx.location_cache
+        last_location = self._ctx.get_last_location()
         if last_location:
             from_lw = last_location.labware
         else:
@@ -125,10 +125,10 @@ class PairedInstrument(AbstractPairedInstrument):
                     max_speeds=self._ctx.get_max_speeds().data,
                 )
         except Exception:
-            self._ctx.location_cache = None
+            self._ctx.set_last_location(None)
             raise
         else:
-            self._ctx.location_cache = location
+            self._ctx.set_last_location(location)
         return self
 
     def aspirate(
@@ -230,7 +230,7 @@ class PairedInstrument(AbstractPairedInstrument):
             if not self._ctx.get_last_location():
                 raise RuntimeError("No valid current location cache present")
             else:
-                well = self._ctx.location_cache.labware  # type: ignore
+                well = self._ctx.get_last_location().labware  # type: ignore
                 # type checked below
         else:
             well = LabwareLike(location)

--- a/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/protocol_api/paired_instrument.py
@@ -10,8 +10,7 @@ from opentrons.protocol_api.module_contexts import ThermocyclerContext
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.context.instrument import AbstractInstrument
-from opentrons.protocols.context.paired_instrument import \
-    AbstractPairedInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.api_support.util import build_edges
@@ -19,7 +18,7 @@ from opentrons.protocols.api_support.util import build_edges
 if TYPE_CHECKING:
     from opentrons.hardware_control import types as hc_types
     from opentrons.protocols.api_support.util import HardwareManager
-    
+
 logger = logging.getLogger(__name__)
 
 

--- a/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocols/context/protocol_api/protocol_context.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from opentrons.hardware_control.modules import AbstractModule
 
 
-MODULE_LOG = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 SHORT_TRASH_DECK = "ot2_short_trash"
 STANDARD_DECK = "ot2_standard"
@@ -82,7 +82,6 @@ class ProtocolContextImplementation(AbstractProtocol):
         self._modules: List[LoadModuleResult] = []
 
         self._hw_manager = HardwareManager(hardware)
-        self._log = MODULE_LOG.getChild(self.__class__.__name__)
 
         self._bundled_labware = bundled_labware
         self._extra_labware = extra_labware or {}
@@ -260,7 +259,7 @@ class ProtocolContextImplementation(AbstractProtocol):
             default_speed=400.0,
         )
         self._instruments[mount] = new_instr
-        self._log.info("Instrument {} loaded".format(new_instr))
+        logger.info("Instrument {} loaded".format(new_instr))
         return new_instr
 
     def get_loaded_instruments(self) -> InstrumentDict:

--- a/api/src/opentrons/protocols/context/simulator/instrument_context.py
+++ b/api/src/opentrons/protocols/context/simulator/instrument_context.py
@@ -7,6 +7,10 @@ from opentrons.hardware_control.types import HardwareAction
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.labware_like import LabwareLike
 from opentrons.protocols.api_support.util import FlowRates, PlungerSpeeds, Clearances
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
+from opentrons.protocols.context.simulator.paired_instrument import (
+    PairedInstrumentSimulation,
+)
 from opentrons.protocols.geometry import planning
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol import AbstractProtocol
@@ -206,3 +210,12 @@ class InstrumentContextSimulation(AbstractInstrument):
         """Raise TipAttachedError if tip."""
         if self.has_tip():
             raise TipAttachedError(f"Cannot {action} with a tip attached")
+
+    def pair_with(
+        self, other_instrument: AbstractInstrument
+    ) -> AbstractPairedInstrument:
+        return PairedInstrumentSimulation(
+            primary_instrument=self,
+            secondary_instrument=other_instrument,
+            ctx=self._protocol_interface,
+        )

--- a/api/src/opentrons/protocols/context/simulator/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/simulator/paired_instrument.py
@@ -1,0 +1,95 @@
+from typing import Optional, Tuple, Callable
+
+from opentrons import types
+from opentrons.protocol_api.labware import Well, Labware
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
+from opentrons.protocols.context.protocol import AbstractProtocol
+
+
+class PairedInstrumentSimulation(AbstractPairedInstrument):
+    def __init__(
+        self,
+        primary_instrument: AbstractInstrument,
+        secondary_instrument: AbstractInstrument,
+        ctx: AbstractProtocol,
+    ):
+        self._primary = primary_instrument
+        self._secondary = secondary_instrument
+        self._protocol_interface = ctx
+
+    def pick_up_tip(
+        self,
+        target: Well,
+        secondary_target: Well,
+        tiprack: Labware,
+        presses: Optional[int],
+        increment: Optional[float],
+        tip_length: float,
+    ) -> None:
+        self.move_to(target.top())
+
+        self._primary.pick_up_tip(
+            well=target._impl,
+            tip_length=tip_length,
+            presses=presses,
+            increment=increment,
+        )
+        self._secondary.pick_up_tip(
+            well=secondary_target._impl,
+            tip_length=tip_length,
+            presses=presses,
+            increment=increment,
+        )
+
+        tiprack.use_tips(target, self._primary.get_channels())
+        tiprack.use_tips(secondary_target, self._secondary.get_channels())
+
+    def drop_tip(self, target: types.Location, home_after: bool) -> None:
+        self._primary.drop_tip(home_after=home_after)
+        self._secondary.drop_tip(home_after=home_after)
+
+    def move_to(
+        self,
+        location: types.Location,
+        force_direct: bool = False,
+        minimum_z_height: Optional[float] = None,
+        speed: Optional[float] = None,
+    ) -> None:
+        self._protocol_interface.set_last_location(location)
+
+    def aspirate(
+        self,
+        volume: Optional[float],
+        location: Optional[types.Location] = None,
+        rate: Optional[float] = 1.0,
+    ) -> Tuple[types.Location, Callable]:
+        location = location or self._protocol_interface.get_last_location()
+
+        def _aspirate():
+            self._primary.aspirate(volume, rate)
+            self._secondary.aspirate(volume, rate)
+
+        return location, _aspirate
+
+    def dispense(
+        self, volume: Optional[float], location: Optional[types.Location], rate: float
+    ) -> Tuple[types.Location, Callable]:
+        location = location or self._protocol_interface.get_last_location()
+
+        def _aspirate():
+            self._primary.dispense(volume, rate)
+            self._secondary.dispense(volume, rate)
+
+        return location, _aspirate
+
+    def blow_out(self, location: types.Location) -> None:
+        pass
+
+    def air_gap(self, volume: Optional[float], height: float) -> None:
+        pass
+
+    def touch_tip(
+        self, location: Optional[Well], radius: float, v_offset: float, speed: float
+    ) -> None:
+        pass

--- a/api/src/opentrons/protocols/context/simulator/paired_instrument.py
+++ b/api/src/opentrons/protocols/context/simulator/paired_instrument.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Callable
+from typing import Optional
 
 from opentrons import types
 from opentrons.protocol_api.labware import Well, Labware
@@ -60,36 +60,22 @@ class PairedInstrumentSimulation(AbstractPairedInstrument):
 
     def aspirate(
         self,
-        volume: Optional[float],
-        location: Optional[types.Location] = None,
-        rate: Optional[float] = 1.0,
-    ) -> Tuple[types.Location, Callable]:
-        location = location or self._protocol_interface.get_last_location()
+        volume: float,
+        location: types.Location,
+        rate: float,
+    ) -> None:
+        self._primary.aspirate(volume, rate)
+        self._secondary.aspirate(volume, rate)
 
-        def _aspirate():
-            self._primary.aspirate(volume, rate)
-            self._secondary.aspirate(volume, rate)
-
-        return location, _aspirate
-
-    def dispense(
-        self, volume: Optional[float], location: Optional[types.Location], rate: float
-    ) -> Tuple[types.Location, Callable]:
-        location = location or self._protocol_interface.get_last_location()
-
-        def _aspirate():
-            self._primary.dispense(volume, rate)
-            self._secondary.dispense(volume, rate)
-
-        return location, _aspirate
+    def dispense(self, volume: float, location: types.Location, rate: float) -> None:
+        self._primary.dispense(volume, rate)
+        self._secondary.dispense(volume, rate)
 
     def blow_out(self, location: types.Location) -> None:
-        pass
-
-    def air_gap(self, volume: Optional[float], height: float) -> None:
-        pass
+        self._primary.blow_out()
+        self._secondary.blow_out()
 
     def touch_tip(
-        self, location: Optional[Well], radius: float, v_offset: float, speed: float
+        self, well: Well, radius: float, v_offset: float, speed: float
     ) -> None:
         pass

--- a/api/src/opentrons/protocols/context/simulator/protocol_context.py
+++ b/api/src/opentrons/protocols/context/simulator/protocol_context.py
@@ -1,3 +1,5 @@
+import logging
+
 from opentrons import types
 from opentrons.protocols.context.instrument import AbstractInstrument
 from opentrons.protocols.context.protocol_api.protocol_context import (
@@ -6,6 +8,9 @@ from opentrons.protocols.context.protocol_api.protocol_context import (
 from opentrons.protocols.context.simulator.instrument_context import (
     InstrumentContextSimulation,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProtocolContextSimulation(ProtocolContextImplementation):
@@ -43,5 +48,5 @@ class ProtocolContextSimulation(ProtocolContextImplementation):
             api_version=self._api_version,
         )
         self._instruments[mount] = new_instr
-        self._log.info(f"Instrument {new_instr} loaded")
+        logger.info(f"Instrument {new_instr} loaded")
         return new_instr

--- a/api/src/opentrons/protocols/geometry/module_geometry.py
+++ b/api/src/opentrons/protocols/geometry/module_geometry.py
@@ -13,6 +13,7 @@ from typing import Mapping, Optional, Union, TYPE_CHECKING
 
 import numpy as np  # type: ignore
 import jsonschema  # type: ignore
+from opentrons import types
 from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
 
 from opentrons_shared_data import module
@@ -304,6 +305,24 @@ class ThermocyclerGeometry(ModuleGeometry):
         else:
             self._labware = labware
         return self._labware
+
+    def flag_unsafe_move(
+        self,
+        to_loc: types.Location,
+        from_loc: types.Location,
+        lid_position: Optional[str],
+    ):
+        to_lw, to_well = to_loc.labware.get_parent_labware_and_well()
+        from_lw, from_well = from_loc.labware.get_parent_labware_and_well()
+        if (
+            self.labware is not None
+            and (self.labware == to_lw or self.labware == from_lw)
+            and lid_position != "open"
+        ):
+            raise RuntimeError(
+                "Cannot move to labware loaded in Thermocycler"
+                " when lid is not fully open."
+            )
 
 
 def _load_from_v1(

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -246,7 +246,7 @@ def test_blow_out(set_up_paired_instrument, monkeypatch, ctx):
         nonlocal move_location
         move_location = loc
 
-    monkeypatch.setattr(paired.paired_instrument_obj, "move_to", fake_move)
+    monkeypatch.setattr(paired._implementation, "move_to", fake_move)
 
     paired.blow_out()
     assert "blowing out" in ",".join([cmd.lower() for cmd in ctx.commands()])

--- a/api/tests/opentrons/protocol_api/test_paired_context.py
+++ b/api/tests/opentrons/protocol_api/test_paired_context.py
@@ -296,7 +296,7 @@ def test_air_gap(set_up_paired_instrument, monkeypatch, ctx):
     assert aspirate_mock.call_args_list == [mock.call(paired._pair_policy, 20, 1.0)]
     aspirate_mock.reset_mock()
     paired.air_gap()
-    assert aspirate_mock.call_args_list == [mock.call(paired._pair_policy, None, 1.0)]
+    assert aspirate_mock.call_args_list == [mock.call(paired._pair_policy, 300, 1.0)]
 
 
 def test_touch_tip_new_default_args(ctx, monkeypatch):

--- a/api/tests/opentrons/protocols/context/simulator/conftest.py
+++ b/api/tests/opentrons/protocols/context/simulator/conftest.py
@@ -1,0 +1,113 @@
+import pytest
+from opentrons import ThreadManager, types
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.labware import AbstractLabware
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
+from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.protocols.context.simulator.instrument_context import (
+    InstrumentContextSimulation,
+)
+from opentrons.protocols.context.simulator.protocol_context import (
+    ProtocolContextSimulation,
+)
+from opentrons_shared_data.labware.dev_types import LabwareDefinition
+
+
+@pytest.fixture
+def protocol_context(hardware: ThreadManager) -> ProtocolContextImplementation:
+    """Protocol context implementation fixture."""
+    return ProtocolContextImplementation(hardware=hardware)
+
+
+@pytest.fixture
+def simulating_protocol_context(hardware: ThreadManager) -> ProtocolContextSimulation:
+    """Protocol context simulation fixture."""
+    return ProtocolContextSimulation(hardware=hardware)
+
+
+@pytest.fixture
+def instrument_context(
+    protocol_context: ProtocolContextImplementation,
+) -> AbstractInstrument:
+    """Instrument context backed by hardware simulator."""
+    return protocol_context.load_instrument(
+        "p300_single_gen2", types.Mount.RIGHT, replace=False
+    )
+
+
+@pytest.fixture
+def second_instrument_context(
+    protocol_context: ProtocolContextImplementation,
+) -> AbstractInstrument:
+    """Instrument context backed by hardware simulator."""
+    return protocol_context.load_instrument(
+        "p300_single_gen2", types.Mount.LEFT, replace=False
+    )
+
+
+@pytest.fixture
+def simulating_instrument_context(
+    protocol_context: ProtocolContextImplementation,
+    instrument_context: AbstractInstrument,
+) -> AbstractInstrument:
+    """A simulating instrument context."""
+    return InstrumentContextSimulation(
+        protocol_interface=protocol_context,
+        pipette_dict=instrument_context.get_pipette(),
+        mount=types.Mount.RIGHT,
+        instrument_name="p300_single_gen2",
+    )
+
+
+@pytest.fixture
+def second_simulating_instrument_context(
+    protocol_context: ProtocolContextImplementation,
+    second_instrument_context: AbstractInstrument,
+) -> AbstractInstrument:
+    """A simulating instrument context."""
+    return InstrumentContextSimulation(
+        protocol_interface=protocol_context,
+        pipette_dict=second_instrument_context.get_pipette(),
+        mount=types.Mount.LEFT,
+        instrument_name="p300_single_gen2",
+    )
+
+
+@pytest.fixture
+def paired_instrument(
+    instrument_context: AbstractInstrument,
+    second_instrument_context: AbstractInstrument,
+) -> AbstractPairedInstrument:
+    """A paired instrument."""
+    instrument_context.home()
+    return instrument_context.pair_with(second_instrument_context)
+
+
+@pytest.fixture
+def simulating_paired_instrument(
+    simulating_instrument_context: AbstractInstrument,
+    second_simulating_instrument_context: AbstractInstrument,
+) -> AbstractPairedInstrument:
+    """A simulating paired instrument."""
+    return simulating_instrument_context.pair_with(second_simulating_instrument_context)
+
+
+@pytest.fixture
+def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
+    """Labware fixture."""
+    return LabwareImplementation(
+        definition=minimal_labware_def,
+        parent=types.Location(types.Point(0, 0, 0), "1"),
+    )
+
+
+@pytest.fixture
+def second_labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
+    """Labware fixture."""
+    return LabwareImplementation(
+        definition=minimal_labware_def,
+        parent=types.Location(types.Point(0, 0, 0), "5"),
+    )

--- a/api/tests/opentrons/protocols/context/simulator/test_paired_instrument.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_paired_instrument.py
@@ -1,0 +1,129 @@
+"""Test paired instrument simulation."""
+import pytest
+from unittest.mock import MagicMock
+
+from opentrons.protocol_api import ProtocolContext
+from opentrons.protocol_api.labware import Well, Labware
+from opentrons.protocols.context.instrument import AbstractInstrument
+from opentrons.protocols.context.paired_instrument import AbstractPairedInstrument
+from opentrons.protocols.context.protocol_api.protocol_context import (
+    ProtocolContextImplementation,
+)
+from opentrons.types import Location, Point
+from pytest_lazyfixture import lazy_fixture
+
+from opentrons.hardware_control import NoTipAttachedError
+from opentrons.hardware_control.types import TipAttachedError
+from opentrons.protocols.context.labware import AbstractLabware
+
+
+@pytest.fixture(
+    params=[
+        lazy_fixture("paired_instrument"),
+        lazy_fixture("simulating_paired_instrument"),
+    ]
+)
+def subject(request) -> AbstractPairedInstrument:
+    return request.param
+
+
+def test_aspirate_no_tip(
+    subject: AbstractPairedInstrument, labware: AbstractLabware
+) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(
+        NoTipAttachedError, match="Cannot perform .+ without a tip attached"
+    ):
+        loc = Location(Point(0, 0, 0), Well(labware.get_wells()[0]))
+        subject.aspirate(location=loc, volume=1, rate=1)
+
+
+def test_dispense_no_tip(
+    subject: AbstractPairedInstrument, labware: AbstractLabware
+) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform DISPENSE"):
+        loc = Location(Point(0, 0, 0), Well(labware.get_wells()[0]))
+        subject.dispense(location=loc, volume=1, rate=1)
+
+
+def test_drop_tip_no_tip(
+    subject: AbstractPairedInstrument, labware: AbstractLabware
+) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform DROPTIP"):
+        loc = Location(Point(0, 0, 0), Labware(labware))
+        subject.drop_tip(target=loc, home_after=False)
+
+
+def test_blow_out_no_tip(
+    subject: AbstractPairedInstrument, labware: AbstractLabware
+) -> None:
+    """It should raise an error if a tip is not attached."""
+    with pytest.raises(NoTipAttachedError, match="Cannot perform BLOWOUT"):
+        loc = Location(Point(0, 0, 0), Well(labware.get_wells()[0]))
+        subject.blow_out(location=loc)
+
+
+def test_pick_up_tip_no_tip(
+    subject: AbstractPairedInstrument, labware: AbstractLabware
+) -> None:
+    """It should raise an error if a tip is already attached."""
+    mock_tip_rack = MagicMock()
+    subject.pick_up_tip(
+        target=Well(labware.get_wells()[0]),
+        secondary_target=Well(labware.get_wells()[1]),
+        tip_length=1,
+        presses=None,
+        increment=None,
+        tiprack=mock_tip_rack,
+    )
+    with pytest.raises(TipAttachedError):
+        subject.pick_up_tip(
+            target=Well(labware.get_wells()[0]),
+            secondary_target=Well(labware.get_wells()[1]),
+            tip_length=1,
+            presses=None,
+            increment=None,
+            tiprack=mock_tip_rack,
+        )
+
+
+def test_aspirate_too_much(
+    subject: AbstractPairedInstrument,
+    labware: AbstractLabware,
+    instrument_context: AbstractInstrument,
+) -> None:
+    """It should raise an error if try to aspirate more than possible."""
+    mock_tip_rack = MagicMock()
+    subject.pick_up_tip(
+        target=Well(labware.get_wells()[0]),
+        secondary_target=Well(labware.get_wells()[1]),
+        tip_length=1,
+        presses=None,
+        increment=None,
+        tiprack=mock_tip_rack,
+    )
+    with pytest.raises(
+        AssertionError, match="Cannot aspirate more than pipette max volume"
+    ):
+        loc = Location(Point(0, 0, 0), Well(labware.get_wells()[0]))
+        subject.aspirate(
+            location=loc, volume=instrument_context.get_max_volume() + 1, rate=1
+        )
+
+
+def test_unsafe_thermocycler_move(
+    subject: AbstractPairedInstrument,
+    protocol_context: ProtocolContextImplementation,
+) -> None:
+    """It should raise an error due to an unsafe move."""
+    ctx = ProtocolContext(implementation=protocol_context)
+    m = ctx.load_module("thermocycler", configuration="semi", location="7")
+    tc_labware = m.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")
+    m.close_lid()
+
+    with pytest.raises(
+        RuntimeError, match="Cannot move to labware loaded in Thermocycler"
+    ):
+        subject.move_to(location=Location(Point(0, 0, 0), tc_labware))

--- a/api/tests/opentrons/protocols/context/simulator/test_protocol_context.py
+++ b/api/tests/opentrons/protocols/context/simulator/test_protocol_context.py
@@ -4,36 +4,7 @@ from opentrons.protocols.context.protocol import AbstractProtocol
 from pytest_lazyfixture import lazy_fixture
 
 from opentrons.protocols.context.labware import AbstractLabware
-from opentrons.protocols.context.protocol_api.labware import LabwareImplementation
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons import types, ThreadManager
-from opentrons.protocols.context.protocol_api.protocol_context import (
-    ProtocolContextImplementation,
-)
-from opentrons.protocols.context.simulator.protocol_context import (
-    ProtocolContextSimulation,
-)
-
-
-@pytest.fixture
-def protocol_context(hardware: ThreadManager) -> ProtocolContextImplementation:
-    """Protocol context implementation fixture."""
-    return ProtocolContextImplementation(hardware=hardware)
-
-
-@pytest.fixture
-def simulating_protocol_context(hardware: ThreadManager) -> ProtocolContextSimulation:
-    """Protocol context simulation fixture."""
-    return ProtocolContextSimulation(hardware=hardware)
-
-
-@pytest.fixture
-def labware(minimal_labware_def: LabwareDefinition) -> AbstractLabware:
-    """Labware fixture."""
-    return LabwareImplementation(
-        definition=minimal_labware_def,
-        parent=types.Location(types.Point(0, 0, 0), "1"),
-    )
+from opentrons import types
 
 
 @pytest.fixture(


### PR DESCRIPTION
# Overview

The paired pipette feature was completely neglected by the fast simulation refactor. This PR aims to remedy that by having `PairedInstrumentContext` initialized with an `AbstractPairedInstrument`. For normal cases, we will use `PairedInstrument` just like now. But for fast simulation, we will use an `AbstractPairedInstrument` that does not communicate with the hardware controller at all.

This is a way bigger PR than I'd hoped. But I couldn't think of an easier solution.

closes #8222 

# Changelog

- Create `AbstractPairedInstrument` 
- Have `PairedInstrument` inherit from `AbstractPairedInstrument`
- Create `AbstractInstrument.pair_with` in order to specialize in `InstrumentContextSimulation`.
- `AbstractPairedInstrument` is supplied to `PairedInstrumentContext`'s constructor.
- Created `PairedInstrumentSimulation` for fast simulation
- Moved a lot of location validation out of `PairedInstrument` into `PairedInstrumentContext` so the validation happens for  fastsim too.
- Added tests to validate that same errors are raised in simulation and in fast simulation.
- Fixed the flag unsafe move checking in move_to

# Review requests

Does pipette pairing still work?

I tested by comparing the simulator outputs of user supplied protocol using fast and slow simulation.  The only differences were some of the timings.

# Risk assessment

High in that it impacts a documented feature of our protocol api. **It is however a very rarely used feature.** 