### PR TITLE
refactor(duration-estimation): Api protocol timer refactors use deck

### DIFF
--- a/api/src/opentrons/protocols/duration/estimator.py
+++ b/api/src/opentrons/protocols/duration/estimator.py
@@ -517,6 +517,16 @@ class DurationEstimator:
 
     @staticmethod
     def rate_high(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a high temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if temp0 >= TEMP_MOD_HIGH_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_HIGH_AND_ABOVE
@@ -532,6 +542,16 @@ class DurationEstimator:
 
     @staticmethod
     def rate_mid(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a medium temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if TEMP_MOD_LOW_THRESH <= temp0 <= TEMP_MOD_HIGH_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_LOW_TO_HIGH
@@ -549,6 +569,16 @@ class DurationEstimator:
     # How to handle temperatures where one of them is low temp
     @staticmethod
     def rate_low(temp0: float, temp1: float) -> float:
+        """
+        Calculate temp deck temperature change to a low temperature.
+
+        Args:
+            temp0: Current
+            temp1: Target
+
+        Returns:
+            Duration in seconds.
+        """
         val = 0.0
         if temp0 <= TEMP_MOD_LOW_THRESH:
             val = abs(temp1 - temp0) / TEMP_MOD_RATE_ZERO_TO_LOW

--- a/api/tests/opentrons/protocols/duration/test_estimator.py
+++ b/api/tests/opentrons/protocols/duration/test_estimator.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from opentrons.commands import types
@@ -14,6 +15,8 @@ from opentrons.protocols.duration.estimator import (
     THERMO_HIGH_THRESH,
     THERMO_LOW_THRESH,
 )
+from opentrons.protocols.geometry.deck import Deck
+from opentrons.types import Location, Point
 
 
 @pytest.fixture
@@ -34,7 +37,7 @@ def test_ignore_before(subject: DurationEstimator):
         payload=types.DelayCommandPayload(minutes=1, seconds=1)
     )
     message["$"] = "before"
-    message["name"] = "command.DELAY"
+    message["name"] = types.DELAY
     subject.on_message(message)
     assert subject.get_total_duration() == 0
 
@@ -45,7 +48,8 @@ def test_pick_up_tip(subject: DurationEstimator, mock_instrument: MagicMock):
     # Movement in same slot
     subject._last_deckslot = "1"
     message = types.PickUpTipCommand(
-        payload=types.PickUpTipCommandPayload(location="1", instrument=mock_instrument))
+        payload=types.PickUpTipCommandPayload(location="1", instrument=mock_instrument)
+    )
     message["$"] = "after"
     message["name"] = types.PICK_UP_TIP
     subject.on_message(message)
@@ -58,7 +62,8 @@ def test_drop_tip(subject: DurationEstimator, mock_instrument: MagicMock):
     # Movement in same slot
     subject._last_deckslot = "1"
     message = types.DropTipCommand(
-        payload=types.DropTipCommandPayload(location="1", instrument=mock_instrument))
+        payload=types.DropTipCommandPayload(location="1", instrument=mock_instrument)
+    )
     message["$"] = "after"
     message["name"] = types.DROP_TIP
     subject.on_message(message)
@@ -92,6 +97,56 @@ def test_delay(subject: DurationEstimator):
     message["name"] = types.DELAY
     subject.on_message(message)
     assert subject.get_total_duration() == 61
+
+
+@pytest.fixture
+def mock_deck() -> MagicMock:
+    """A mock deck fixture"""
+
+    def position_for(slot):
+        # zero based
+        s = int(slot) - 1
+        row = int(s / 3)
+        col = int(s % 3)
+        return Location(point=Point(x=col * 10, y=row * 100), labware=None)
+
+    m = MagicMock(spec=Deck)
+    m.position_for.side_effect = position_for
+    return m
+
+
+@pytest.mark.parametrize(
+    argnames=["current_slot", "previous_slot", "speed", "expected_duration"],
+    argvalues=[
+        # Within same slot
+        ["12", "12", 1, 0.5],
+        # Same row sqrt(10**2) / 2
+        ["1", "2", 2, 5],
+        # Same col sqrt(100**2) / 2
+        ["1", "4", 2, 50],
+        # Extremes
+        ["1", "12", 2, np.sqrt(20 ** 2 + 300 ** 2) / 2],
+        # Same row sqrt(10**2) / 2
+        ["3", "2", 2, 5],
+        # Same col sqrt(100**2) / 2
+        ["5", "2", 2, 50],
+        # Extremes
+        ["12", "1", 2, np.sqrt(20 ** 2 + 300 ** 2) / 2],
+    ],
+)
+def test_calc_deck_movement_time(
+    subject: DurationEstimator,
+    mock_deck: MagicMock,
+    current_slot: str,
+    previous_slot: str,
+    speed: float,
+    expected_duration: float,
+):
+    """It should calculate deck movement correctly."""
+    assert (
+        subject.calc_deck_movement_time(mock_deck, current_slot, previous_slot, speed)
+        == expected_duration
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Use the `Deck` class for slot dimensions in `calc_deck_movement_time`.

Type `DurationEstimator_last_deckslot` as a `str` and initialize it at Trash. The `previous_slot` arg to `calc_deck_movement_time` is also typed as `str`. Can lose the check for `previous_slot` is `None`.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

None
