### PR TITLE
refactor(protocol-engine): add public LoadedLabware/LoadedPipette models

### DIFF
--- a/api/src/opentrons/protocol_api_experimental/labware.py
+++ b/api/src/opentrons/protocol_api_experimental/labware.py
@@ -71,7 +71,7 @@ class Labware:  # noqa: D101
         deck slot. Otherwise, the labware is on a module, and the object
         returned will be a :py:class:`ModuleContext`.
         """
-        parent = self._engine_client.state.labware.get_labware_location(
+        parent = self._engine_client.state.labware.get_location(
             labware_id=self._labware_id
         )
         return str(parent.slot)
@@ -215,10 +215,8 @@ class Labware:  # noqa: D101
 
     def _definition(self) -> LabwareDefinition:
         if self._lw_definition is None:
-            self._lw_definition = (
-                self._engine_client.state.labware.get_labware_definition(
-                    labware_id=self.labware_id
-                )
+            self._lw_definition = self._engine_client.state.labware.get_definition(
+                labware_id=self.labware_id
             )
         return self._lw_definition
 

--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -9,13 +9,15 @@ from .create_protocol_engine import create_protocol_engine
 from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError
 from .commands import Command, CommandRequest, CommandStatus, CommandType
-from .state import State, StateView, LabwareData, PipetteData
+from .state import State, StateView
 from .types import (
-    DeckLocation,
+    CalibrationOffset,
     DeckSlotLocation,
     Dimensions,
     EngineStatus,
     LabwareLocation,
+    LoadedLabware,
+    LoadedPipette,
     PipetteName,
     WellLocation,
     WellOrigin,
@@ -35,14 +37,14 @@ __all__ = [
     # state interfaces and models
     "State",
     "StateView",
-    "LabwareData",
-    "PipetteData",
-    # type definitions and other value models
-    "DeckLocation",
+    # public value interfaces and models
+    "CalibrationOffset",
     "DeckSlotLocation",
     "Dimensions",
     "EngineStatus",
     "LabwareLocation",
+    "LoadedLabware",
+    "LoadedPipette",
     "PipetteName",
     "WellLocation",
     "WellOrigin",

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -1,12 +1,12 @@
 """Load labware command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import Optional, Tuple, Type
+from typing import Optional, Type
 from typing_extensions import Literal
 
 from opentrons.protocols.models import LabwareDefinition
 
-from opentrons.protocol_engine.types import LabwareLocation
+from ..types import LabwareLocation, CalibrationOffset
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandRequest
 
 LoadLabwareCommandType = Literal["loadLabware"]
@@ -49,7 +49,7 @@ class LoadLabwareResult(BaseModel):
         ...,
         description="The full definition data for this labware.",
     )
-    calibration: Tuple[float, float, float] = Field(
+    calibration: CalibrationOffset = Field(
         ...,
         description="Calibration offset data for this labware at load time.",
     )
@@ -69,11 +69,12 @@ class LoadLabwareImplementation(
             location=data.location,
             labware_id=data.labwareId,
         )
+        x_offset, y_offset, z_offset = loaded_labware.calibration
 
         return LoadLabwareResult(
             labwareId=loaded_labware.labware_id,
             definition=loaded_labware.definition,
-            calibration=loaded_labware.calibration,
+            calibration=CalibrationOffset(x=x_offset, y=y_offset, z=z_offset),
         )
 
 

--- a/api/src/opentrons/protocol_engine/execution/__init__.py
+++ b/api/src/opentrons/protocol_engine/execution/__init__.py
@@ -3,7 +3,7 @@
 from .create_queue_worker import create_queue_worker
 from .command_executor import CommandExecutor
 from .queue_worker import QueueWorker
-from .equipment import EquipmentHandler, LoadedLabware, LoadedPipette
+from .equipment import EquipmentHandler, LoadedLabwareData, LoadedPipetteData
 from .movement import MovementHandler
 from .pipetting import PipettingHandler
 from .run_control import RunControlHandler
@@ -13,8 +13,8 @@ __all__ = [
     "CommandExecutor",
     "QueueWorker",
     "EquipmentHandler",
-    "LoadedLabware",
-    "LoadedPipette",
+    "LoadedLabwareData",
+    "LoadedPipetteData",
     "MovementHandler",
     "PipettingHandler",
     "RunControlHandler",

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -14,7 +14,7 @@ from ..types import LabwareLocation, PipetteName
 
 
 @dataclass(frozen=True)
-class LoadedLabware:
+class LoadedLabwareData:
     """The result of a load labware procedure."""
 
     labware_id: str
@@ -23,7 +23,7 @@ class LoadedLabware:
 
 
 @dataclass(frozen=True)
-class LoadedPipette:
+class LoadedPipetteData:
     """The result of a load pipette procedure."""
 
     pipette_id: str
@@ -57,7 +57,7 @@ class EquipmentHandler:
         version: int,
         location: LabwareLocation,
         labware_id: Optional[str],
-    ) -> LoadedLabware:
+    ) -> LoadedLabwareData:
         """Load labware by assigning an identifier and pulling required data.
 
         Args:
@@ -69,7 +69,7 @@ class EquipmentHandler:
                 identifier will be generated.
 
         Returns:
-            A LoadedLabware object.
+            A LoadedLabwareData object.
         """
         labware_id = labware_id if labware_id else self._model_utils.generate_id()
 
@@ -94,7 +94,7 @@ class EquipmentHandler:
             location=location,
         )
 
-        return LoadedLabware(
+        return LoadedLabwareData(
             labware_id=labware_id,
             definition=definition,
             calibration=calibration,
@@ -105,7 +105,7 @@ class EquipmentHandler:
         pipette_name: PipetteName,
         mount: MountType,
         pipette_id: Optional[str],
-    ) -> LoadedPipette:
+    ) -> LoadedPipetteData:
         """Ensure the requested pipette is attached.
 
         Args:
@@ -115,16 +115,14 @@ class EquipmentHandler:
                 identifier will be generated.
 
         Returns:
-            A LoadedPipette object.
+            A LoadedPipetteData object.
         """
         other_mount = mount.other_mount()
-        other_pipette = self._state_store.pipettes.get_pipette_data_by_mount(
-            other_mount,
-        )
+        other_pipette = self._state_store.pipettes.get_by_mount(other_mount)
 
         cache_request = {mount.to_hw_mount(): pipette_name}
         if other_pipette is not None:
-            cache_request[other_mount.to_hw_mount()] = other_pipette.pipette_name
+            cache_request[other_mount.to_hw_mount()] = other_pipette.pipetteName
 
         # TODO(mc, 2020-10-18): calling `cache_instruments` mirrors the
         # behavior of protocol_context.load_instrument, and is used here as a
@@ -137,4 +135,4 @@ class EquipmentHandler:
 
         pipette_id = pipette_id or self._model_utils.generate_id()
 
-        return LoadedPipette(pipette_id=pipette_id)
+        return LoadedPipetteData(pipette_id=pipette_id)

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -2,8 +2,8 @@
 from typing import Optional
 from opentrons.hardware_control.api import API as HardwareAPI
 
-from ..types import DeckLocation, WellLocation
-from ..state import StateStore
+from ..types import WellLocation
+from ..state import StateStore, CurrentWell
 
 
 class MovementHandler:
@@ -27,13 +27,13 @@ class MovementHandler:
         labware_id: str,
         well_name: str,
         well_location: Optional[WellLocation] = None,
-        current_location: Optional[DeckLocation] = None,
+        current_well: Optional[CurrentWell] = None,
     ) -> None:
         """Move to a specific well."""
         # get the pipette's mount and current critical point, if applicable
         pipette_location = self._state_store.motion.get_pipette_location(
             pipette_id=pipette_id,
-            current_location=current_location,
+            current_well=current_well,
         )
 
         hw_mount = pipette_location.mount.to_hw_mount()
@@ -55,7 +55,7 @@ class MovementHandler:
             origin=origin,
             origin_cp=origin_cp,
             max_travel_z=max_travel_z,
-            current_location=current_location,
+            current_well=current_well,
         )
 
         # move through the waypoints

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -1,8 +1,8 @@
 """Pipetting command handling."""
 from opentrons.hardware_control.api import API as HardwareAPI
 
-from ..state import StateStore
-from ..types import DeckLocation, WellLocation, WellOrigin
+from ..state import StateStore, CurrentWell
+from ..types import WellLocation, WellOrigin
 from .movement import MovementHandler
 
 
@@ -124,7 +124,7 @@ class PipettingHandler:
             pipette_config=hw_pipette.config,
         )
 
-        current_location = None
+        current_well = None
 
         if not ready_to_aspirate:
             await self._movement_handler.move_to_well(
@@ -138,7 +138,7 @@ class PipettingHandler:
 
             # set our current deck location to the well now that we've made
             # an intermediate move for the "prepare for aspirate" step
-            current_location = DeckLocation(
+            current_well = CurrentWell(
                 pipette_id=pipette_id,
                 labware_id=labware_id,
                 well_name=well_name,
@@ -149,7 +149,7 @@ class PipettingHandler:
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
-            current_location=current_location,
+            current_well=current_well,
         )
 
         await self._hardware_api.aspirate(mount=hw_pipette.mount, volume=volume)

--- a/api/src/opentrons/protocol_engine/state/__init__.py
+++ b/api/src/opentrons/protocol_engine/state/__init__.py
@@ -3,8 +3,8 @@
 from .create_state_store import create_state_store
 from .state import State, StateStore, StateView
 from .commands import CommandState, CommandView
-from .labware import LabwareState, LabwareView, LabwareData
-from .pipettes import PipetteState, PipetteView, PipetteData, HardwarePipette
+from .labware import LabwareState, LabwareView
+from .pipettes import PipetteState, PipetteView, HardwarePipette, CurrentWell
 from .geometry import GeometryView, TipGeometry
 from .motion import MotionView, PipetteLocationData
 from .actions import Action, PlayAction, PauseAction, StopAction, UpdateCommandAction
@@ -22,12 +22,11 @@ __all__ = [
     # labware state
     "LabwareState",
     "LabwareView",
-    "LabwareData",
     # pipette state
     "PipetteState",
     "PipetteView",
-    "PipetteData",
     "HardwarePipette",
+    "CurrentWell",
     # computed geometry state
     "GeometryView",
     "TipGeometry",

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -1,11 +1,10 @@
-"""Base protocol engine types and interfaces."""
+"""Public protocol engine value types and models."""
 from enum import Enum
 from dataclasses import dataclass
 from pydantic import BaseModel
 from typing import Union, Tuple
-from typing_extensions import final
 
-from opentrons.types import DeckSlotName
+from opentrons.types import MountType, DeckSlotName
 
 
 class EngineStatus(str, Enum):
@@ -31,7 +30,6 @@ LabwareLocation = Union[DeckSlotLocation]
 """Union of all legal labware locations."""
 
 
-@final
 class WellOrigin(str, Enum):
     """Origin of WellLocation offset."""
 
@@ -46,23 +44,17 @@ class WellLocation(BaseModel):
     offset: Tuple[float, float, float] = (0, 0, 0)
 
 
-class DeckLocation(BaseModel):
-    """A symbolic reference to a location on the deck.
-
-    Specified as the pipette, labware, and well. A `DeckLocation` may be
-    combined with a `WellLocation` to produce an absolute position in deck
-    coordinates.
-    """
-
-    pipette_id: str
-    labware_id: str
-    well_name: str
-
-
-@final
 @dataclass(frozen=True)
 class Dimensions:
     """Dimensions of an object in deck-space."""
+
+    x: float
+    y: float
+    z: float
+
+
+class CalibrationOffset(BaseModel):
+    """Calibration offset from nomimal to actual position."""
 
     x: float
     y: float
@@ -86,3 +78,20 @@ class PipetteName(str, Enum):
     P300_MULTI_GEN2 = "p300_multi_gen2"
     P1000_SINGLE = "p1000_single"
     P1000_SINGLE_GEN2 = "p1000_single_gen2"
+
+
+class LoadedPipette(BaseModel):
+    """A pipette that has been loaded."""
+
+    id: str
+    pipetteName: PipetteName
+    mount: MountType
+
+
+class LoadedLabware(BaseModel):
+    """A labware that has been loaded."""
+
+    id: str
+    loadName: str
+    definitionUri: str
+    location: LabwareLocation

--- a/api/tests/opentrons/protocol_api_experimental/test_labware.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_labware.py
@@ -66,7 +66,7 @@ def test_labware_deck_slot_parent(
 ) -> None:
     """It should return a deck slot name if labware is loaded on the deck."""
     decoy.when(
-        engine_client.state.labware.get_labware_location(labware_id="labware-id")
+        engine_client.state.labware.get_location(labware_id="labware-id")
     ).then_return(DeckSlotLocation(slot=DeckSlotName.SLOT_5))
 
     assert subject.parent == "5"
@@ -124,7 +124,7 @@ def test_labware_parameters(
 ) -> None:
     """It should return the labware definition's parameters."""
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
     assert subject.parameters == labware_definition.parameters
 
@@ -137,7 +137,7 @@ def test_labware_magdeck_engage_height_not_compatible(
 ) -> None:
     """It should return None for magdeck engage height if not in definition."""
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
 
     assert subject.magdeck_engage_height is None
@@ -152,7 +152,7 @@ def test_labware_magdeck_engage_height(
     """It should return magdeck engage height from definition."""
     labware_definition.parameters.magneticModuleEngageHeight = 101.0
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
 
     assert subject.magdeck_engage_height == 101.0
@@ -166,7 +166,7 @@ def test_labware_is_not_tiprack(
 ) -> None:
     """It should return False if not tiprack."""
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
     assert subject.is_tiprack is False
 
@@ -180,7 +180,7 @@ def test_labware_tip_length(
     """It should return tip length if present in the definition."""
     labware_definition.parameters.tipLength = 42.0
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
     assert subject.tip_length == 42.0
 
@@ -193,7 +193,7 @@ def test_labware_no_tip_length(
 ) -> None:
     """It should raise a LabwareIsNotTiprackError if tip length is not present."""
     decoy.when(
-        engine_client.state.labware.get_labware_definition(labware_id="labware-id")
+        engine_client.state.labware.get_definition(labware_id="labware-id")
     ).then_return(labware_definition)
     with pytest.raises(errors.LabwareIsNotTipRackError):
         subject.tip_length

--- a/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_experimental/test_protocol_context.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 from opentrons_shared_data.labware import dev_types
 
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine import commands
+from opentrons.protocol_engine import CalibrationOffset, commands
 from opentrons.protocol_engine.clients import SyncClient
 
 from opentrons.protocol_api_experimental.types import (
@@ -142,7 +142,7 @@ def test_load_labware(
         commands.LoadLabwareResult(
             labwareId="abc123",
             definition=LabwareDefinition.parse_obj(minimal_labware_def),
-            calibration=(1, 2, 3),
+            calibration=CalibrationOffset(x=1, y=2, z=3),
         )
     )
 
@@ -174,7 +174,7 @@ def test_load_labware_default_namespace_and_version(
         commands.LoadLabwareResult(
             labwareId="abc123",
             definition=minimal_labware_def,
-            calibration=(1, 2, 3),
+            calibration=CalibrationOffset(x=1, y=2, z=3),
         )
     )
 

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -15,7 +15,7 @@ from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_engine import DeckSlotLocation, PipetteName, commands
 from opentrons.protocol_engine.clients import SyncClient, AbstractSyncTransport
-from opentrons.protocol_engine.types import WellOrigin, WellLocation
+from opentrons.protocol_engine.types import CalibrationOffset, WellOrigin, WellLocation
 
 
 @pytest.fixture
@@ -50,7 +50,7 @@ def stubbed_load_labware_result(
     result = commands.LoadLabwareResult(
         labwareId="abc123",
         definition=tip_rack_def,
-        calibration=(1, 2, 3),
+        calibration=CalibrationOffset(x=1, y=2, z=3),
     )
 
     decoy.when(transport.execute_command(request=request)).then_return(result)

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -3,9 +3,9 @@ from decoy import Decoy
 
 from opentrons.types import DeckSlotName
 from opentrons.protocols.models import LabwareDefinition
-from opentrons.protocol_engine.types import DeckSlotLocation
+from opentrons.protocol_engine.types import CalibrationOffset, DeckSlotLocation
 from opentrons.protocol_engine.execution import (
-    LoadedLabware,
+    LoadedLabwareData,
     EquipmentHandler,
     MovementHandler,
     PipettingHandler,
@@ -50,7 +50,7 @@ async def test_load_labware_implementation(
             labware_id=None,
         )
     ).then_return(
-        LoadedLabware(
+        LoadedLabwareData(
             labware_id="labware-id",
             definition=well_plate_def,
             calibration=(1, 2, 3),
@@ -62,5 +62,5 @@ async def test_load_labware_implementation(
     assert result == LoadLabwareResult(
         labwareId="labware-id",
         definition=well_plate_def,
-        calibration=(1, 2, 3),
+        calibration=CalibrationOffset(x=1, y=2, z=3),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -5,7 +5,7 @@ from opentrons.types import MountType
 from opentrons.protocol_engine.types import PipetteName
 
 from opentrons.protocol_engine.execution import (
-    LoadedPipette,
+    LoadedPipetteData,
     EquipmentHandler,
     MovementHandler,
     PipettingHandler,
@@ -45,7 +45,7 @@ async def test_load_pipette_implementation(
             mount=MountType.LEFT,
             pipette_id="some id",
         )
-    ).then_return(LoadedPipette(pipette_id="pipette-id"))
+    ).then_return(LoadedPipetteData(pipette_id="pipette-id"))
 
     result = await subject.execute(data)
 

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -7,8 +7,8 @@ from opentrons.hardware_control.api import API as HardwareAPI
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons.motion_planning import Waypoint
 
-from opentrons.protocol_engine import DeckLocation, WellLocation, WellOrigin
-from opentrons.protocol_engine.state import StateStore, PipetteLocationData
+from opentrons.protocol_engine import WellLocation, WellOrigin
+from opentrons.protocol_engine.state import StateStore, PipetteLocationData, CurrentWell
 from opentrons.protocol_engine.execution.movement import MovementHandler
 
 
@@ -42,7 +42,7 @@ async def test_move_to_well(
     decoy.when(
         state_store.motion.get_pipette_location(
             pipette_id="pipette-id",
-            current_location=None,
+            current_well=None,
         )
     ).then_return(
         PipetteLocationData(
@@ -71,7 +71,7 @@ async def test_move_to_well(
             labware_id="labware-id",
             well_name="B2",
             well_location=well_location,
-            current_location=None,
+            current_well=None,
         )
     ).then_return(
         [Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER), Waypoint(Point(4, 5, 6))]
@@ -105,14 +105,16 @@ async def test_move_to_well_from_starting_location(
     """It should be able to move to a well from a start location."""
     well_location = WellLocation(origin=WellOrigin.BOTTOM, offset=(0, 0, 1))
 
-    current_location = DeckLocation(
-        pipette_id="pipette-id", labware_id="labware-id", well_name="B2"
+    current_well = CurrentWell(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="B2",
     )
 
     decoy.when(
         state_store.motion.get_pipette_location(
             pipette_id="pipette-id",
-            current_location=current_location,
+            current_well=current_well,
         )
     ).then_return(
         PipetteLocationData(
@@ -134,7 +136,7 @@ async def test_move_to_well_from_starting_location(
 
     decoy.when(
         state_store.motion.get_movement_waypoints(
-            current_location=current_location,
+            current_well=current_well,
             origin=Point(1, 2, 5),
             origin_cp=CriticalPoint.XY_CENTER,
             max_travel_z=42.0,
@@ -150,7 +152,7 @@ async def test_move_to_well_from_starting_location(
         labware_id="labware-id",
         well_name="B2",
         well_location=well_location,
-        current_location=current_location,
+        current_well=current_well,
     )
 
     decoy.verify(

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -8,8 +8,13 @@ from opentrons.types import Mount
 from opentrons.hardware_control.api import API as HardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict
 
-from opentrons.protocol_engine import DeckLocation, WellLocation, WellOrigin
-from opentrons.protocol_engine.state import StateStore, TipGeometry, HardwarePipette
+from opentrons.protocol_engine import WellLocation, WellOrigin
+from opentrons.protocol_engine.state import (
+    StateStore,
+    TipGeometry,
+    HardwarePipette,
+    CurrentWell,
+)
 from opentrons.protocol_engine.execution.movement import MovementHandler
 from opentrons.protocol_engine.execution.pipetting import PipettingHandler
 
@@ -234,7 +239,7 @@ async def test_handle_aspirate_request_without_prep(
             labware_id="labware-id",
             well_name="C6",
             well_location=well_location,
-            current_location=None,
+            current_well=None,
         ),
         await hardware_api.aspirate(
             mount=Mount.LEFT,
@@ -296,8 +301,10 @@ async def test_handle_aspirate_request_with_prep(
             labware_id="labware-id",
             well_name="C6",
             well_location=well_location,
-            current_location=DeckLocation(
-                pipette_id="pipette-id", labware_id="labware-id", well_name="C6"
+            current_well=CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="C6",
             ),
         ),
         await hardware_api.aspirate(mount=Mount.LEFT, volume=25),

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -1,12 +1,17 @@
 """Command factories to use in tests as data fixtures."""
 from datetime import datetime
 from pydantic import BaseModel
-from typing import Optional, Tuple, cast
+from typing import Optional, cast
 
 from opentrons.types import MountType
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import commands as cmd
-from opentrons.protocol_engine.types import PipetteName, WellLocation, LabwareLocation
+from opentrons.protocol_engine.types import (
+    CalibrationOffset,
+    PipetteName,
+    WellLocation,
+    LabwareLocation,
+)
 
 
 def create_pending_command(
@@ -87,7 +92,7 @@ def create_load_labware_command(
     labware_id: str,
     location: LabwareLocation,
     definition: LabwareDefinition,
-    calibration: Tuple[float, float, float],
+    calibration: CalibrationOffset,
 ) -> cmd.LoadLabware:
     """Create a completed LoadLabware command."""
     data = cmd.LoadLabwareData(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -10,8 +10,14 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.types import Point, DeckSlotName
 
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.types import DeckSlotLocation, WellLocation, WellOrigin
-from opentrons.protocol_engine.state.labware import LabwareView, LabwareData
+from opentrons.protocol_engine.types import (
+    CalibrationOffset,
+    DeckSlotLocation,
+    LoadedLabware,
+    WellLocation,
+    WellOrigin,
+)
+from opentrons.protocol_engine.state.labware import LabwareView
 from opentrons.protocol_engine.state.geometry import GeometryView
 
 
@@ -29,14 +35,13 @@ def test_get_labware_parent_position(
     subject: GeometryView,
 ) -> None:
     """It should return a deck slot position for labware in a deck slot."""
-    labware_data = LabwareData(
-        uri=uri_from_details(namespace="a", load_name="b", version=1),
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="b",
+        definitionUri=uri_from_details(namespace="a", load_name="b", version=1),
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
     )
-    decoy.when(labware_view.get_labware_data_by_id("labware-id")).then_return(
-        labware_data
-    )
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
         Point(1, 2, 3)
     )
@@ -54,23 +59,15 @@ def test_get_labware_origin_position(
     subject: GeometryView,
 ) -> None:
     """It should return a deck slot position with the labware's offset as its origin."""
-    uri = uri_from_details(
-        namespace=well_plate_def.namespace,
-        load_name=well_plate_def.parameters.loadName,
-        version=well_plate_def.version,
-    )
-    labware_data = LabwareData(
-        uri=uri,
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="defintion-uri",
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
     )
 
-    decoy.when(labware_view.get_labware_data_by_id("labware-id")).then_return(
-        labware_data
-    )
-
-    decoy.when(labware_view.get_definition_by_uri(uri)).then_return(well_plate_def)
-
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
         Point(1, 2, 3)
     )
@@ -96,32 +93,27 @@ def test_get_labware_highest_z(
     subject: GeometryView,
 ) -> None:
     """It should get the absolute location of a labware's highest Z point."""
-    uri = uri_from_details(
-        namespace=well_plate_def.namespace,
-        load_name=well_plate_def.parameters.loadName,
-        version=well_plate_def.version,
-    )
-    labware_data = LabwareData(
-        uri=uri,
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
     )
-
-    decoy.when(labware_view.get_labware_data_by_id("labware-id")).then_return(
-        labware_data
-    )
-
-    decoy.when(labware_view.get_definition_by_uri(uri)).then_return(well_plate_def)
-
     slot_pos = Point(1, 2, 3)
+    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
 
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_calibration_offset("labware-id")).then_return(
+        calibration_offset
+    )
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
         slot_pos
     )
 
     highest_z = subject.get_labware_highest_z("labware-id")
 
-    assert highest_z == (well_plate_def.dimensions.zDimension + slot_pos[2] + 3)
+    assert highest_z == (well_plate_def.dimensions.zDimension + 3 + 3)
 
 
 def test_get_all_labware_highest_z(
@@ -133,50 +125,39 @@ def test_get_all_labware_highest_z(
     subject: GeometryView,
 ) -> None:
     """It should get the highest Z amongst all labware."""
-    plate_data = LabwareData(
-        uri=uri_from_details(
-            namespace=well_plate_def.namespace,
-            load_name=well_plate_def.parameters.loadName,
-            version=well_plate_def.version,
-        ),
+    plate = LoadedLabware(
+        id="plate-id",
+        loadName="plate-load-name",
+        definitionUri="plate-definition-uri",
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
     )
-    reservoir_data = LabwareData(
-        uri=uri_from_details(
-            namespace=reservoir_def.namespace,
-            load_name=reservoir_def.parameters.loadName,
-            version=reservoir_def.version,
-        ),
+    reservoir = LoadedLabware(
+        id="reservoir-id",
+        loadName="reservoir-load-name",
+        definitionUri="reservoir-definition-uri",
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
-        calibration=(1, -2, 3),
     )
 
-    decoy.when(labware_view.get_labware_data_by_id("plate-id")).then_return(plate_data)
+    plate_offset = CalibrationOffset(x=1, y=-2, z=3)
+    reservoir_offset = CalibrationOffset(x=1, y=-2, z=3)
 
-    decoy.when(labware_view.get_labware_data_by_id("reservoir-id")).then_return(
-        reservoir_data
+    decoy.when(labware_view.get_all()).then_return([plate, reservoir])
+    decoy.when(labware_view.get("plate-id")).then_return(plate)
+    decoy.when(labware_view.get("reservoir-id")).then_return(reservoir)
+
+    decoy.when(labware_view.get_definition("plate-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_definition("reservoir-id")).then_return(reservoir_def)
+
+    decoy.when(labware_view.get_calibration_offset("plate-id")).then_return(
+        plate_offset
     )
-
-    decoy.when(labware_view.get_definition_by_uri(plate_data.uri)).then_return(
-        well_plate_def
-    )
-
-    decoy.when(labware_view.get_definition_by_uri(reservoir_data.uri)).then_return(
-        reservoir_def
-    )
-
-    decoy.when(labware_view.get_all_labware()).then_return(
-        [
-            ("plate-id", plate_data),
-            ("reservoir-id", reservoir_data),
-        ]
+    decoy.when(labware_view.get_calibration_offset("reservoir-id")).then_return(
+        reservoir_offset
     )
 
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
         Point(1, 2, 3)
     )
-
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
         Point(4, 5, 6)
     )
@@ -196,28 +177,25 @@ def test_get_labware_position(
     subject: GeometryView,
 ) -> None:
     """It should return the slot position plus calibrated offset."""
-    labware_data = LabwareData(
-        uri=uri_from_details(
-            namespace=well_plate_def.namespace,
-            load_name=well_plate_def.parameters.loadName,
-            version=well_plate_def.version,
-        ),
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
         location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
-        calibration=(1, -2, 3),
     )
+    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
 
-    decoy.when(labware_view.get_labware_data_by_id("abc")).then_return(labware_data)
-
-    decoy.when(labware_view.get_definition_by_uri(labware_data.uri)).then_return(
-        well_plate_def
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_calibration_offset("labware-id")).then_return(
+        calibration_offset
     )
-
     decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
         slot_pos
     )
 
-    position = subject.get_labware_position(labware_id="abc")
+    position = subject.get_labware_position(labware_id="labware-id")
 
     assert position == Point(
         x=slot_pos[0] + well_plate_def.cornerOffsetFromSlot.x + 1,
@@ -234,35 +212,31 @@ def test_get_well_position(
     subject: GeometryView,
 ) -> None:
     """It should be able to get the position of a well top in a labware."""
-    labware_data = LabwareData(
-        uri=uri_from_details(
-            namespace=well_plate_def.namespace,
-            load_name=well_plate_def.parameters.loadName,
-            version=well_plate_def.version,
-        ),
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
     )
-    well_def = well_plate_def.wells["B2"]
+    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    well_def = well_plate_def.wells["B2"]
 
-    decoy.when(labware_view.get_definition_by_uri(labware_data.uri)).then_return(
-        well_plate_def
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_calibration_offset("labware-id")).then_return(
+        calibration_offset
     )
-
-    decoy.when(labware_view.get_labware_data_by_id("plate-id")).then_return(
-        labware_data
-    )
-
-    decoy.when(labware_view.get_well_definition("plate-id", "B2")).then_return(well_def)
-
-    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
+    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
         slot_pos
     )
+    decoy.when(labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
+    )
 
-    point = subject.get_well_position("plate-id", "B2")
+    result = subject.get_well_position("labware-id", "B2")
 
-    assert point == Point(
+    assert result == Point(
         x=slot_pos[0] + 1 + well_def.x,
         y=slot_pos[1] - 2 + well_def.y,
         z=slot_pos[2] + 3 + well_def.z + well_def.depth,
@@ -277,37 +251,35 @@ def test_get_well_position_with_top_offset(
     subject: GeometryView,
 ) -> None:
     """It should be able to get the position of a well top in a labware."""
-    labware_data = LabwareData(
-        uri=uri_from_details(
-            namespace=well_plate_def.namespace,
-            load_name=well_plate_def.parameters.loadName,
-            version=well_plate_def.version,
-        ),
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
     )
-    well_def = well_plate_def.wells["B2"]
+    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    well_def = well_plate_def.wells["B2"]
 
-    decoy.when(labware_view.get_definition_by_uri(labware_data.uri)).then_return(
-        well_plate_def
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_calibration_offset("labware-id")).then_return(
+        calibration_offset
     )
-
-    decoy.when(labware_view.get_labware_data_by_id("plate-id")).then_return(
-        labware_data
-    )
-
-    decoy.when(labware_view.get_well_definition("plate-id", "B2")).then_return(well_def)
-
-    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
+    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
         slot_pos
     )
-
-    point = subject.get_well_position(
-        "plate-id", "B2", WellLocation(origin=WellOrigin.TOP, offset=(1, 2, 3))
+    decoy.when(labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
     )
 
-    assert point == Point(
+    result = subject.get_well_position(
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=WellLocation(origin=WellOrigin.TOP, offset=(1, 2, 3)),
+    )
+
+    assert result == Point(
         x=slot_pos[0] + 1 + well_def.x + 1,
         y=slot_pos[1] - 2 + well_def.y + 2,
         z=slot_pos[2] + 3 + well_def.z + well_def.depth + 3,
@@ -321,38 +293,36 @@ def test_get_well_position_with_bottom_offset(
     labware_view: LabwareView,
     subject: GeometryView,
 ) -> None:
-    """It should be able to get the position of a well top in a labware."""
-    labware_data = LabwareData(
-        uri=uri_from_details(
-            namespace=well_plate_def.namespace,
-            load_name=well_plate_def.parameters.loadName,
-            version=well_plate_def.version,
-        ),
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_3),
-        calibration=(1, -2, 3),
+    """It should be able to get the position of a well bottom in a labware."""
+    labware_data = LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="definition-uri",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_4),
     )
-    well_def = well_plate_def.wells["B2"]
+    calibration_offset = CalibrationOffset(x=1, y=-2, z=3)
     slot_pos = Point(4, 5, 6)
+    well_def = well_plate_def.wells["B2"]
 
-    decoy.when(labware_view.get_definition_by_uri(labware_data.uri)).then_return(
-        well_plate_def
+    decoy.when(labware_view.get("labware-id")).then_return(labware_data)
+    decoy.when(labware_view.get_definition("labware-id")).then_return(well_plate_def)
+    decoy.when(labware_view.get_calibration_offset("labware-id")).then_return(
+        calibration_offset
     )
-
-    decoy.when(labware_view.get_labware_data_by_id("plate-id")).then_return(
-        labware_data
-    )
-
-    decoy.when(labware_view.get_well_definition("plate-id", "B2")).then_return(well_def)
-
-    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_3)).then_return(
+    decoy.when(labware_view.get_slot_position(DeckSlotName.SLOT_4)).then_return(
         slot_pos
     )
-
-    point = subject.get_well_position(
-        "plate-id", "B2", WellLocation(origin=WellOrigin.BOTTOM, offset=(3, 2, 1))
+    decoy.when(labware_view.get_well_definition("labware-id", "B2")).then_return(
+        well_def
     )
 
-    assert point == Point(
+    result = subject.get_well_position(
+        labware_id="labware-id",
+        well_name="B2",
+        well_location=WellLocation(origin=WellOrigin.BOTTOM, offset=(3, 2, 1)),
+    )
+
+    assert result == Point(
         x=slot_pos[0] + 1 + well_def.x + 3,
         y=slot_pos[1] - 2 + well_def.y + 2,
         z=slot_pos[2] + 3 + well_def.z + 1,
@@ -482,7 +452,7 @@ def test_get_tip_drop_location_with_trash(
     pipette_config: PipetteDict = cast(PipetteDict, {"return_tip_height": 0.7})
 
     decoy.when(
-        labware_view.get_labware_has_quirk(labware_id="labware-id", quirk="fixedTrash")
+        labware_view.get_has_quirk(labware_id="labware-id", quirk="fixedTrash")
     ).then_return(True)
 
     location = subject.get_tip_drop_location(

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -8,23 +8,56 @@ from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName, Point
 
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.types import DeckSlotLocation, Dimensions
-from opentrons.protocol_engine.state.labware import (
-    LabwareState,
-    LabwareView,
-    LabwareData,
+from opentrons.protocol_engine.types import (
+    CalibrationOffset,
+    DeckSlotLocation,
+    Dimensions,
+    LoadedLabware,
+)
+
+from opentrons.protocol_engine.state.labware import LabwareState, LabwareView
+
+
+plate = LoadedLabware(
+    id="plate-id",
+    loadName="plate-load-name",
+    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    definitionUri="some-plate-uri",
+)
+
+reservoir = LoadedLabware(
+    id="reservoir-id",
+    loadName="reservoir-load-name",
+    location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
+    definitionUri="some-reservoir-uri",
+)
+
+tube_rack = LoadedLabware(
+    id="tube-rack-id",
+    loadName="tube-rack-load-name",
+    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    definitionUri="some-tube-rack-uri",
+)
+
+tip_rack = LoadedLabware(
+    id="tip-rack-id",
+    loadName="tip-rack-load-name",
+    location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    definitionUri="some-tip-rack-uri",
 )
 
 
 def get_labware_view(
-    labware_by_id: Optional[Dict[str, LabwareData]] = None,
-    labware_definitions_by_uri: Optional[Dict[str, LabwareDefinition]] = None,
+    labware_by_id: Optional[Dict[str, LoadedLabware]] = None,
+    calibrations_by_id: Optional[Dict[str, CalibrationOffset]] = None,
+    definitions_by_uri: Optional[Dict[str, LabwareDefinition]] = None,
     deck_definition: Optional[DeckDefinitionV2] = None,
 ) -> LabwareView:
     """Get a labware view test subject."""
     state = LabwareState(
         labware_by_id=labware_by_id or {},
-        labware_definitions_by_uri=labware_definitions_by_uri or {},
+        calibrations_by_id=calibrations_by_id or {},
+        definitions_by_uri=definitions_by_uri or {},
         deck_definition=deck_definition or cast(DeckDefinitionV2, {"fake": True}),
     )
 
@@ -36,42 +69,24 @@ def test_get_labware_data_bad_id() -> None:
     subject = get_labware_view()
 
     with pytest.raises(errors.LabwareDoesNotExistError):
-        subject.get_labware_data_by_id("asdfghjkl")
+        subject.get("asdfghjkl")
 
 
 def test_get_labware_data_by_id() -> None:
     """It should retrieve labware data from the state."""
-    subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-definition-uri"),
-                calibration=(1, 2, 3),
-            )
-        }
-    )
+    subject = get_labware_view(labware_by_id={"plate-id": plate})
 
-    assert subject.get_labware_data_by_id("plate-id") == LabwareData(
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-        uri=cast(LabwareUri, "some-definition-uri"),
-        calibration=(1, 2, 3),
-    )
+    assert subject.get("plate-id") == plate
 
 
 def test_get_labware_definition(well_plate_def: LabwareDefinition) -> None:
     """It should get a labware's definition from the state."""
     subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-definition-uri"),
-                calibration=(1, 2, 3),
-            )
-        },
-        labware_definitions_by_uri={"some-definition-uri": well_plate_def},
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
     )
 
-    assert subject.get_labware_definition("plate-id") == well_plate_def
+    assert subject.get_definition("plate-id") == well_plate_def
 
 
 def test_get_labware_definition_bad_id() -> None:
@@ -89,74 +104,47 @@ def test_get_all_labware(
     """It should return all labware."""
     subject = get_labware_view(
         labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-definition-uri"),
-                calibration=(1, 2, 3),
-            ),
-            "reservoir-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-                uri=cast(LabwareUri, "other-definition-uri"),
-                calibration=(4, 5, 6),
-            ),
+            "plate-id": plate,
+            "reservoir-id": reservoir,
         }
     )
 
-    all_labware = subject.get_all_labware()
+    all_labware = subject.get_all()
 
-    assert all_labware == [
-        ("plate-id", subject.get_labware_data_by_id("plate-id")),
-        ("reservoir-id", subject.get_labware_data_by_id("reservoir-id")),
-    ]
+    assert all_labware == [plate, reservoir]
 
 
 def test_get_labware_location() -> None:
     """It should return labware location."""
-    subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-definition-uri"),
-                calibration=(1, 2, 3),
-            )
-        }
-    )
+    subject = get_labware_view(labware_by_id={"plate-id": plate})
 
-    result = subject.get_labware_location("plate-id")
+    result = subject.get_location("plate-id")
 
     assert result == DeckSlotLocation(slot=DeckSlotName.SLOT_1)
 
 
-def test_get_labware_has_quirk(
+def test_get_has_quirk(
     well_plate_def: LabwareDefinition,
     reservoir_def: LabwareDefinition,
 ) -> None:
     """It should return whether a labware by ID has a given quirk."""
     subject = get_labware_view(
         labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-            "reservoir-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-                uri=cast(LabwareUri, "some-reservoir-uri"),
-                calibration=(4, 5, 6),
-            ),
+            "plate-id": plate,
+            "reservoir-id": reservoir,
         },
-        labware_definitions_by_uri={
+        definitions_by_uri={
             "some-plate-uri": well_plate_def,
             "some-reservoir-uri": reservoir_def,
         },
     )
 
-    well_plate_has_center_quirk = subject.get_labware_has_quirk(
+    well_plate_has_center_quirk = subject.get_has_quirk(
         labware_id="plate-id",
         quirk="centerMultichannelOnWells",
     )
 
-    reservoir_has_center_quirk = subject.get_labware_has_quirk(
+    reservoir_has_center_quirk = subject.get_has_quirk(
         labware_id="reservoir-id",
         quirk="centerMultichannelOnWells",
     )
@@ -172,18 +160,10 @@ def test_quirks(
     """It should return a labware's quirks."""
     subject = get_labware_view(
         labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-            "reservoir-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-                uri=cast(LabwareUri, "some-reservoir-uri"),
-                calibration=(4, 5, 6),
-            ),
+            "plate-id": plate,
+            "reservoir-id": reservoir,
         },
-        labware_definitions_by_uri={
+        definitions_by_uri={
             "some-plate-uri": well_plate_def,
             "some-reservoir-uri": reservoir_def,
         },
@@ -199,14 +179,8 @@ def test_quirks(
 def test_get_well_definition_bad_id(well_plate_def: LabwareDefinition) -> None:
     """get_well_definition should raise if well name doesn't exist."""
     subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-plate-uri": well_plate_def},
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
     )
 
     with pytest.raises(errors.WellDoesNotExistError):
@@ -216,14 +190,8 @@ def test_get_well_definition_bad_id(well_plate_def: LabwareDefinition) -> None:
 def test_get_well_definition(well_plate_def: LabwareDefinition) -> None:
     """It should return a well definition by well ID."""
     subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-plate-uri": well_plate_def},
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
     )
 
     expected_well_def = well_plate_def.wells["B2"]
@@ -235,51 +203,36 @@ def test_get_well_definition(well_plate_def: LabwareDefinition) -> None:
 def test_get_wells(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return a list of wells from definition."""
     subject = get_labware_view(
-        labware_by_id={
-            "tuberack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tuberack-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-tuberack-uri": falcon_tuberack_def},
+        labware_by_id={"tube-rack-id": tube_rack},
+        definitions_by_uri={"some-tube-rack-uri": falcon_tuberack_def},
     )
+
     expected_wells = ["A1", "B1", "A2", "B2", "A3", "B3"]
-    result = subject.get_wells(labware_id="tuberack-id")
+    result = subject.get_wells(labware_id="tube-rack-id")
     assert result == expected_wells
 
 
 def test_get_well_columns(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return wells as dict of list of columns."""
     subject = get_labware_view(
-        labware_by_id={
-            "tuberack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tuberack-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-tuberack-uri": falcon_tuberack_def},
+        labware_by_id={"tube-rack-id": tube_rack},
+        definitions_by_uri={"some-tube-rack-uri": falcon_tuberack_def},
     )
+
     expected_columns = {"1": ["A1", "B1"], "2": ["A2", "B2"], "3": ["A3", "B3"]}
-    result = subject.get_well_columns(labware_id="tuberack-id")
+    result = subject.get_well_columns(labware_id="tube-rack-id")
     assert result == expected_columns
 
 
 def test_get_well_rows(falcon_tuberack_def: LabwareDefinition) -> None:
     """It should return wells as dict of list of rows."""
     subject = get_labware_view(
-        labware_by_id={
-            "tuberack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tuberack-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-tuberack-uri": falcon_tuberack_def},
+        labware_by_id={"tube-rack-id": tube_rack},
+        definitions_by_uri={"some-tube-rack-uri": falcon_tuberack_def},
     )
+
     expected_rows = {"A": ["A1", "A2", "A3"], "B": ["B1", "B2", "B3"]}
-    result = subject.get_well_rows(labware_id="tuberack-id")
+    result = subject.get_well_rows(labware_id="tube-rack-id")
     assert result == expected_rows
 
 
@@ -288,14 +241,8 @@ def test_get_tip_length_raises_with_non_tip_rack(
 ) -> None:
     """It should raise if you try to get the tip length of a regular labware."""
     subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-plate-uri": well_plate_def},
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
     )
 
     with pytest.raises(errors.LabwareIsNotTipRackError):
@@ -307,14 +254,8 @@ def test_get_tip_length_gets_length_from_definition(
 ) -> None:
     """It should return the tip length from the definition."""
     subject = get_labware_view(
-        labware_by_id={
-            "tip-rack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tip-rack-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-tip-rack-uri": tip_rack_def},
+        labware_by_id={"tip-rack-id": tip_rack},
+        definitions_by_uri={"some-tip-rack-uri": tip_rack_def},
     )
 
     length = subject.get_tip_length("tip-rack-id")
@@ -323,15 +264,16 @@ def test_get_tip_length_gets_length_from_definition(
 
 def test_get_labware_uri_from_definition(tip_rack_def: LabwareDefinition) -> None:
     """It should return the labware's definition URI."""
+    tip_rack = LoadedLabware(
+        id="tip-rack-id",
+        loadName="tip-rack-load-name",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+        definitionUri="some-tip-rack-uri",
+    )
+
     subject = get_labware_view(
-        labware_by_id={
-            "tip-rack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tip-rack-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-tip-rack-uri": tip_rack_def},
+        labware_by_id={"tip-rack-id": tip_rack},
+        definitions_by_uri={"some-tip-rack-uri": tip_rack_def},
     )
 
     result = subject.get_definition_uri(labware_id="tip-rack-id")
@@ -344,18 +286,10 @@ def test_is_tiprack(
     """It should determine if labware is a tip rack."""
     subject = get_labware_view(
         labware_by_id={
-            "tip-rack-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-tip-rack-uri"),
-                calibration=(1, 2, 3),
-            ),
-            "reservoir-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-                uri=cast(LabwareUri, "some-reservoir-uri"),
-                calibration=(4, 5, 6),
-            ),
+            "tip-rack-id": tip_rack,
+            "reservoir-id": reservoir,
         },
-        labware_definitions_by_uri={
+        definitions_by_uri={
             "some-tip-rack-uri": tip_rack_def,
             "some-reservoir-uri": reservoir_def,
         },
@@ -368,14 +302,8 @@ def test_is_tiprack(
 def test_get_load_name(reservoir_def: LabwareDefinition) -> None:
     """It should return the load name."""
     subject = get_labware_view(
-        labware_by_id={
-            "reservoir-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_2),
-                uri=cast(LabwareUri, "some-reservoir-uri"),
-                calibration=(4, 5, 6),
-            ),
-        },
-        labware_definitions_by_uri={"some-reservoir-uri": reservoir_def},
+        labware_by_id={"reservoir-id": reservoir},
+        definitions_by_uri={"some-reservoir-uri": reservoir_def},
     )
 
     result = subject.get_load_name("reservoir-id")
@@ -386,14 +314,8 @@ def test_get_load_name(reservoir_def: LabwareDefinition) -> None:
 def test_get_dimensions(well_plate_def: LabwareDefinition) -> None:
     """It should compute the dimensions of a labware."""
     subject = get_labware_view(
-        labware_by_id={
-            "plate-id": LabwareData(
-                location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                uri=cast(LabwareUri, "some-plate-uri"),
-                calibration=(1, 2, 3),
-            ),
-        },
-        labware_definitions_by_uri={"some-plate-uri": well_plate_def},
+        labware_by_id={"plate-id": plate},
+        definitions_by_uri={"some-plate-uri": well_plate_def},
     )
 
     result = subject.get_dimensions(labware_id="plate-id")
@@ -442,3 +364,16 @@ def test_get_slot_position(standard_deck_def: DeckDefinitionV2) -> None:
     result = subject.get_slot_position(DeckSlotName.SLOT_3)
 
     assert result == Point(x=slot_pos[0], y=slot_pos[1], z=slot_pos[2])
+
+
+def test_get_calibration_offset() -> None:
+    """It should get a labware's calibrated offset."""
+    offset = CalibrationOffset(x=1, y=2, z=3)
+    subject = get_labware_view(calibrations_by_id={"labware-id": offset})
+
+    result = subject.get_calibration_offset("labware-id")
+
+    assert result == offset
+
+    with pytest.raises(errors.LabwareDoesNotExistError):
+        subject.get_calibration_offset("wrong-id")

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -9,18 +9,17 @@ from opentrons.hardware_control.types import CriticalPoint
 from opentrons.protocols.geometry.planning import MoveType, get_waypoints
 
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.state import PipetteData, PipetteLocationData
-from opentrons.protocol_engine.state.labware import LabwareView
-from opentrons.protocol_engine.state.pipettes import PipetteView
-from opentrons.protocol_engine.state.geometry import GeometryView
-from opentrons.protocol_engine.state.motion import MotionView
-
 from opentrons.protocol_engine.types import (
-    DeckLocation,
     WellLocation,
     WellOrigin,
     PipetteName,
+    LoadedPipette,
 )
+from opentrons.protocol_engine.state import PipetteLocationData
+from opentrons.protocol_engine.state.labware import LabwareView
+from opentrons.protocol_engine.state.pipettes import PipetteView, CurrentWell
+from opentrons.protocol_engine.state.geometry import GeometryView
+from opentrons.protocol_engine.state.motion import MotionView
 
 
 @pytest.fixture
@@ -43,12 +42,13 @@ def test_get_pipette_location_with_no_current_location(
     subject: MotionView,
 ) -> None:
     """It should return mount and critical_point=None if no location."""
-    decoy.when(pipette_view.get_current_deck_location()).then_return(None)
+    decoy.when(pipette_view.get_current_well()).then_return(None)
 
-    decoy.when(pipette_view.get_pipette_data_by_id("pipette-id")).then_return(
-        PipetteData(
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
             mount=MountType.LEFT,
-            pipette_name=PipetteName.P300_SINGLE,
+            pipetteName=PipetteName.P300_SINGLE,
         )
     )
 
@@ -64,19 +64,20 @@ def test_get_pipette_location_with_current_location_with_quirks(
     subject: MotionView,
 ) -> None:
     """It should return cp=XY_CENTER if location labware has center quirk."""
-    decoy.when(pipette_view.get_current_deck_location()).then_return(
-        DeckLocation(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
+    decoy.when(pipette_view.get_current_well()).then_return(
+        CurrentWell(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
     )
 
-    decoy.when(pipette_view.get_pipette_data_by_id("pipette-id")).then_return(
-        PipetteData(
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
             mount=MountType.RIGHT,
-            pipette_name=PipetteName.P300_SINGLE,
+            pipetteName=PipetteName.P300_SINGLE,
         )
     )
 
     decoy.when(
-        labware_view.get_labware_has_quirk(
+        labware_view.get_has_quirk(
             "reservoir-id",
             "centerMultichannelOnWells",
         )
@@ -97,23 +98,24 @@ def test_get_pipette_location_with_current_location_different_pipette(
     subject: MotionView,
 ) -> None:
     """It should return mount and cp=None if location used other pipette."""
-    decoy.when(pipette_view.get_current_deck_location()).then_return(
-        DeckLocation(
+    decoy.when(pipette_view.get_current_well()).then_return(
+        CurrentWell(
             pipette_id="other-pipette-id",
             labware_id="reservoir-id",
             well_name="A1",
         )
     )
 
-    decoy.when(pipette_view.get_pipette_data_by_id("pipette-id")).then_return(
-        PipetteData(
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
             mount=MountType.LEFT,
-            pipette_name=PipetteName.P300_SINGLE,
+            pipetteName=PipetteName.P300_SINGLE,
         )
     )
 
     decoy.when(
-        labware_view.get_labware_has_quirk(
+        labware_view.get_has_quirk(
             "reservoir-id",
             "centerMultichannelOnWells",
         )
@@ -134,21 +136,22 @@ def test_get_pipette_location_override_current_location(
     subject: MotionView,
 ) -> None:
     """It should calculate pipette location from a passed in deck location."""
-    current_location = DeckLocation(
+    current_well = CurrentWell(
         pipette_id="pipette-id",
         labware_id="reservoir-id",
         well_name="A1",
     )
 
-    decoy.when(pipette_view.get_pipette_data_by_id("pipette-id")).then_return(
-        PipetteData(
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
             mount=MountType.RIGHT,
-            pipette_name=PipetteName.P300_SINGLE,
+            pipetteName=PipetteName.P300_SINGLE,
         )
     )
 
     decoy.when(
-        labware_view.get_labware_has_quirk(
+        labware_view.get_has_quirk(
             "reservoir-id",
             "centerMultichannelOnWells",
         )
@@ -156,7 +159,7 @@ def test_get_pipette_location_override_current_location(
 
     result = subject.get_pipette_location(
         pipette_id="pipette-id",
-        current_location=current_location,
+        current_well=current_well,
     )
 
     assert result == PipetteLocationData(
@@ -178,7 +181,7 @@ class WaypointSpec:
     origin: Point = field(default_factory=lambda: Point(1, 2, 3))
     dest: Point = field(default_factory=lambda: Point(4, 5, 6))
     origin_cp: Optional[CriticalPoint] = None
-    location: Optional[DeckLocation] = None
+    location: Optional[CurrentWell] = None
     expected_dest_cp: Optional[CriticalPoint] = None
     has_center_multichannel_quirk: bool = False
     labware_z: Optional[float] = None
@@ -199,7 +202,7 @@ class WaypointSpec:
         ),
         WaypointSpec(
             name="General arc if moving from other labware",
-            location=DeckLocation(
+            location=CurrentWell(
                 pipette_id="pipette-id",
                 labware_id="other-labware-id",
                 well_name="A1",
@@ -209,7 +212,7 @@ class WaypointSpec:
         ),
         WaypointSpec(
             name="In-labware arc if moving to same labware",
-            location=DeckLocation(
+            location=CurrentWell(
                 pipette_id="pipette-id",
                 labware_id="labware-id",
                 well_name="B2",
@@ -219,7 +222,7 @@ class WaypointSpec:
         ),
         WaypointSpec(
             name="General arc if moving to same labware with different pipette",
-            location=DeckLocation(
+            location=CurrentWell(
                 pipette_id="other-pipette-id",
                 labware_id="labware-id",
                 well_name="A1",
@@ -229,7 +232,7 @@ class WaypointSpec:
         ),
         WaypointSpec(
             name="Direct movement from well to same well",
-            location=DeckLocation(
+            location=CurrentWell(
                 pipette_id="pipette-id",
                 labware_id="labware-id",
                 well_name="A1",
@@ -263,7 +266,7 @@ def test_get_movement_waypoints(
 ) -> None:
     """It should calculate the correct set of waypoints for a move."""
     decoy.when(
-        labware_view.get_labware_has_quirk(
+        labware_view.get_has_quirk(
             spec.labware_id,
             "centerMultichannelOnWells",
         )
@@ -294,7 +297,7 @@ def test_get_movement_waypoints(
         )
     ).then_return(spec.dest)
 
-    decoy.when(pipette_view.get_current_deck_location()).then_return(spec.location)
+    decoy.when(pipette_view.get_current_well()).then_return(spec.location)
 
     result = subject.get_movement_waypoints(
         pipette_id=spec.pipette_id,
@@ -327,7 +330,7 @@ def test_get_movement_waypoints_raises(
     subject: MotionView,
 ) -> None:
     """It should raise FailedToPlanMoveError if get_waypoints raises."""
-    decoy.when(pipette_view.get_current_deck_location()).then_return(None)
+    decoy.when(pipette_view.get_current_well()).then_return(None)
     decoy.when(geometry_view.get_well_position("labware-id", "A1", None)).then_return(
         Point(4, 5, 6)
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -3,12 +3,12 @@ import pytest
 
 from opentrons.types import MountType
 from opentrons.protocol_engine import commands as cmd
-from opentrons.protocol_engine.types import PipetteName, DeckLocation
+from opentrons.protocol_engine.types import PipetteName, LoadedPipette
 from opentrons.protocol_engine.state.actions import UpdateCommandAction
 from opentrons.protocol_engine.state.pipettes import (
     PipetteStore,
     PipetteState,
-    PipetteData,
+    CurrentWell,
 )
 
 from .command_fixtures import (
@@ -34,7 +34,7 @@ def test_sets_initial_state(subject: PipetteStore) -> None:
     assert result == PipetteState(
         pipettes_by_id={},
         aspirated_volume_by_id={},
-        current_location=None,
+        current_well=None,
     )
 
 
@@ -50,8 +50,9 @@ def test_handles_load_pipette(subject: PipetteStore) -> None:
 
     result = subject.state
 
-    assert result.pipettes_by_id["pipette-id"] == PipetteData(
-        pipette_name=PipetteName.P300_SINGLE,
+    assert result.pipettes_by_id["pipette-id"] == LoadedPipette(
+        id="pipette-id",
+        pipetteName=PipetteName.P300_SINGLE,
         mount=MountType.LEFT,
     )
     assert result.aspirated_volume_by_id["pipette-id"] == 0
@@ -120,7 +121,7 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
                 well_name="aspirate-well-name",
                 volume=1337,
             ),
-            DeckLocation(
+            CurrentWell(
                 pipette_id="aspirate-pipette-id",
                 labware_id="aspirate-labware-id",
                 well_name="aspirate-well-name",
@@ -133,7 +134,7 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
                 well_name="dispense-well-name",
                 volume=1337,
             ),
-            DeckLocation(
+            CurrentWell(
                 pipette_id="dispense-pipette-id",
                 labware_id="dispense-labware-id",
                 well_name="dispense-well-name",
@@ -145,7 +146,7 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
                 labware_id="pick-up-tip-labware-id",
                 well_name="pick-up-tip-well-name",
             ),
-            DeckLocation(
+            CurrentWell(
                 pipette_id="pick-up-tip-pipette-id",
                 labware_id="pick-up-tip-labware-id",
                 well_name="pick-up-tip-well-name",
@@ -157,7 +158,7 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
                 labware_id="drop-tip-labware-id",
                 well_name="drop-tip-well-name",
             ),
-            DeckLocation(
+            CurrentWell(
                 pipette_id="drop-tip-pipette-id",
                 labware_id="drop-tip-labware-id",
                 well_name="drop-tip-well-name",
@@ -169,7 +170,7 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
                 labware_id="move-to-well-labware-id",
                 well_name="move-to-well-well-name",
             ),
-            DeckLocation(
+            CurrentWell(
                 pipette_id="move-to-well-pipette-id",
                 labware_id="move-to-well-labware-id",
                 well_name="move-to-well-well-name",
@@ -177,9 +178,9 @@ def test_pipette_volume_subtracts_dispense(subject: PipetteStore) -> None:
         ),
     ),
 )
-def test_movement_commands_update_current_location(
+def test_movement_commands_update_current_well(
     command: cmd.Command,
-    expected_location: DeckLocation,
+    expected_location: CurrentWell,
     subject: PipetteStore,
 ) -> None:
     """It should save the last used pipette, labware, and well for movement commands."""
@@ -192,4 +193,4 @@ def test_movement_commands_update_current_location(
     subject.handle_action(UpdateCommandAction(command=load_pipette_command))
     subject.handle_action(UpdateCommandAction(command=command))
 
-    assert subject.state.current_location == expected_location
+    assert subject.state.current_well == expected_location

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -5,26 +5,25 @@ from typing import cast, Dict, Optional
 from opentrons.types import MountType, Mount as HwMount
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.protocol_engine import errors
-from opentrons.protocol_engine.types import DeckLocation, PipetteName
-
+from opentrons.protocol_engine.types import PipetteName, LoadedPipette
 from opentrons.protocol_engine.state.pipettes import (
     PipetteState,
     PipetteView,
-    PipetteData,
+    CurrentWell,
     HardwarePipette,
 )
 
 
 def get_pipette_view(
-    pipettes_by_id: Optional[Dict[str, PipetteData]] = None,
+    pipettes_by_id: Optional[Dict[str, LoadedPipette]] = None,
     aspirated_volume_by_id: Dict[str, float] = None,
-    current_location: Optional[DeckLocation] = None,
+    current_well: Optional[CurrentWell] = None,
 ) -> PipetteView:
     """Get a pipette view test subject with the specified state."""
     state = PipetteState(
         pipettes_by_id=pipettes_by_id or {},
         aspirated_volume_by_id=aspirated_volume_by_id or {},
-        current_location=current_location,
+        current_well=current_well,
     )
 
     return PipetteView(state=state)
@@ -35,28 +34,29 @@ def test_initial_pipette_data_by_id() -> None:
     subject = get_pipette_view()
 
     with pytest.raises(errors.PipetteDoesNotExistError):
-        subject.get_pipette_data_by_id("asdfghjkl")
+        subject.get("asdfghjkl")
 
 
 def test_initial_pipette_data_by_mount() -> None:
     """It should return None if mount isn't present."""
     subject = get_pipette_view()
 
-    assert subject.get_pipette_data_by_mount(MountType.LEFT) is None
-    assert subject.get_pipette_data_by_mount(MountType.RIGHT) is None
+    assert subject.get_by_mount(MountType.LEFT) is None
+    assert subject.get_by_mount(MountType.RIGHT) is None
 
 
 def test_get_pipette_data() -> None:
     """It should get pipette data by ID and mount from the state."""
-    pipette_data = PipetteData(
-        pipette_name=PipetteName.P300_SINGLE,
+    pipette_data = LoadedPipette(
+        id="pipette-id",
+        pipetteName=PipetteName.P300_SINGLE,
         mount=MountType.LEFT,
     )
 
     subject = get_pipette_view(pipettes_by_id={"pipette-id": pipette_data})
 
-    result_by_id = subject.get_pipette_data_by_id("pipette-id")
-    result_by_mount = subject.get_pipette_data_by_mount(MountType.LEFT)
+    result_by_id = subject.get("pipette-id")
+    result_by_mount = subject.get_by_mount(MountType.LEFT)
 
     assert result_by_id == pipette_data
     assert result_by_mount == pipette_data
@@ -72,13 +72,15 @@ def test_get_hardware_pipette() -> None:
 
     subject = get_pipette_view(
         pipettes_by_id={
-            "left-id": PipetteData(
+            "left-id": LoadedPipette(
+                id="left-id",
                 mount=MountType.LEFT,
-                pipette_name=PipetteName.P300_SINGLE,
+                pipetteName=PipetteName.P300_SINGLE,
             ),
-            "right-id": PipetteData(
+            "right-id": LoadedPipette(
+                id="right-id",
                 mount=MountType.RIGHT,
-                pipette_name=PipetteName.P300_MULTI,
+                pipetteName=PipetteName.P300_MULTI,
             ),
         }
     )
@@ -111,9 +113,10 @@ def test_get_hardware_pipette_raises_with_name_mismatch() -> None:
 
     subject = get_pipette_view(
         pipettes_by_id={
-            "pipette-id": PipetteData(
+            "pipette-id": LoadedPipette(
+                id="pipette-id",
                 mount=MountType.LEFT,
-                pipette_name=PipetteName.P300_SINGLE,
+                pipetteName=PipetteName.P300_SINGLE,
             ),
         }
     )
@@ -146,9 +149,10 @@ def test_pipette_is_ready_to_aspirate_if_has_volume() -> None:
 
     subject = get_pipette_view(
         pipettes_by_id={
-            "pipette-id": PipetteData(
+            "pipette-id": LoadedPipette(
+                id="pipette-id",
                 mount=MountType.LEFT,
-                pipette_name=PipetteName.P300_SINGLE,
+                pipetteName=PipetteName.P300_SINGLE,
             ),
         },
         aspirated_volume_by_id={"pipette-id": 42},
@@ -167,9 +171,10 @@ def test_pipette_is_ready_to_aspirate_if_no_volume_and_hc_says_ready() -> None:
 
     subject = get_pipette_view(
         pipettes_by_id={
-            "pipette-id": PipetteData(
+            "pipette-id": LoadedPipette(
+                id="pipette-id",
                 mount=MountType.LEFT,
-                pipette_name=PipetteName.P300_SINGLE,
+                pipetteName=PipetteName.P300_SINGLE,
             ),
         },
         aspirated_volume_by_id={"pipette-id": 0},
@@ -189,9 +194,10 @@ def test_pipette_not_ready_to_aspirate() -> None:
 
     subject = get_pipette_view(
         pipettes_by_id={
-            "pipette-id": PipetteData(
+            "pipette-id": LoadedPipette(
+                id="pipette-id",
                 mount=MountType.LEFT,
-                pipette_name=PipetteName.P300_SINGLE,
+                pipetteName=PipetteName.P300_SINGLE,
             ),
         },
         aspirated_volume_by_id={"pipette-id": 0},

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -7,8 +7,7 @@ from opentrons.hardware_control import API as HardwareAPI
 from opentrons.protocols.geometry.deck import FIXED_TRASH_ID
 
 from opentrons.protocol_engine import ProtocolEngine, create_protocol_engine
-from opentrons.protocol_engine.types import DeckSlotLocation
-from opentrons.protocol_engine.state import LabwareData
+from opentrons.protocol_engine.types import DeckSlotLocation, LoadedLabware
 
 
 async def test_create_engine_initializes_state_with_deck_geometry(
@@ -22,12 +21,15 @@ async def test_create_engine_initializes_state_with_deck_geometry(
 
     assert isinstance(engine, ProtocolEngine)
     assert state.labware.get_deck_definition() == standard_deck_def
-    assert state.labware.get_labware_data_by_id(FIXED_TRASH_ID) == LabwareData(
-        location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
-        uri=uri_from_details(
-            load_name=fixed_trash_def.parameters.loadName,
-            namespace=fixed_trash_def.namespace,
-            version=fixed_trash_def.version,
-        ),
-        calibration=(0, 0, 0),
-    )
+    assert state.labware.get_all() == [
+        LoadedLabware(
+            id=FIXED_TRASH_ID,
+            loadName=fixed_trash_def.parameters.loadName,
+            definitionUri=uri_from_details(
+                load_name=fixed_trash_def.parameters.loadName,
+                namespace=fixed_trash_def.namespace,
+                version=fixed_trash_def.version,
+            ),
+            location=DeckSlotLocation(slot=DeckSlotName.FIXED_TRASH),
+        )
+    ]

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
@@ -12,13 +12,12 @@ from pathlib import Path
 from datetime import datetime
 from decoy import matchers
 
-from opentrons_shared_data.pipette.dev_types import LabwareUri
 from opentrons.types import MountType
 from opentrons.protocol_api_experimental import DeckSlotName
 
 from opentrons.protocol_engine import (
-    LabwareData,
-    PipetteData,
+    LoadedLabware,
+    LoadedPipette,
     PipetteName,
     DeckSlotLocation,
     commands,
@@ -39,28 +38,25 @@ async def test_protocol_runner_with_python(python_protocol_file: Path) -> None:
 
     subject = await create_simulating_runner()
     commands_result = await subject.run(protocol_file)
-    pipettes_result = subject.engine.state_view.pipettes.get_all_pipettes()
-    labware_result = subject.engine.state_view.labware.get_all_labware()
+    pipettes_result = subject.engine.state_view.pipettes.get_all()
+    labware_result = subject.engine.state_view.labware.get_all()
 
     pipette_id_captor = matchers.Captor()
     labware_id_captor = matchers.Captor()
 
-    expected_pipette_entry = (
-        pipette_id_captor,
-        PipetteData(pipette_name=PipetteName.P300_SINGLE, mount=MountType.LEFT),
+    expected_pipette = LoadedPipette.construct(
+        id=pipette_id_captor, pipetteName=PipetteName.P300_SINGLE, mount=MountType.LEFT
     )
 
-    expected_labware_entry = (
-        labware_id_captor,
-        LabwareData(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-            uri=LabwareUri("opentrons/opentrons_96_tiprack_300ul/1"),
-            calibration=(matchers.IsA(float), matchers.IsA(float), matchers.IsA(float)),
-        ),
+    expected_labware = LoadedLabware.construct(
+        id=labware_id_captor,
+        loadName="opentrons_96_tiprack_300ul",
+        definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
     )
 
-    assert expected_pipette_entry in pipettes_result
-    assert expected_labware_entry in labware_result
+    assert expected_pipette in pipettes_result
+    assert expected_labware in labware_result
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),
@@ -88,25 +84,24 @@ async def test_protocol_runner_with_json(json_protocol_file: Path) -> None:
 
     subject = await create_simulating_runner()
     commands_result = await subject.run(protocol_file)
-    pipettes_result = subject.engine.state_view.pipettes.get_all_pipettes()
-    labware_result = subject.engine.state_view.labware.get_all_labware()
+    pipettes_result = subject.engine.state_view.pipettes.get_all()
+    labware_result = subject.engine.state_view.labware.get_all()
 
-    expected_pipette_entry = (
-        "pipette-id",
-        PipetteData(pipette_name=PipetteName.P300_SINGLE, mount=MountType.LEFT),
+    expected_pipette = LoadedPipette(
+        id="pipette-id",
+        pipetteName=PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
     )
 
-    expected_labware_entry = (
-        "labware-id",
-        LabwareData(
-            location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-            uri=LabwareUri("opentrons/opentrons_96_tiprack_300ul/1"),
-            calibration=(matchers.IsA(float), matchers.IsA(float), matchers.IsA(float)),
-        ),
+    expected_labware = LoadedLabware(
+        id="labware-id",
+        loadName="opentrons_96_tiprack_300ul",
+        definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
     )
 
-    assert expected_pipette_entry in pipettes_result
-    assert expected_labware_entry in labware_result
+    assert expected_pipette in pipettes_result
+    assert expected_labware in labware_result
 
     expected_command = commands.PickUpTip.construct(
         id=matchers.IsA(str),

--- a/api/tests/opentrons/protocol_runner/test_python_context_creator.py
+++ b/api/tests/opentrons/protocol_runner/test_python_context_creator.py
@@ -50,7 +50,7 @@ async def test_wires_protocol_context_to_engine(
         ),
     )
 
-    labware_location = protocol_engine.state_view.labware.get_labware_location(
+    labware_location = protocol_engine.state_view.labware.get_location(
         labware_id=result.labware_id
     )
 

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -80,7 +80,7 @@ command_analysis_specs: List[CommandAnalysisSpec] = [
                 result=pe_commands.LoadLabwareResult.construct(
                     labwareId="labware-id",
                     definition=cast(LabwareDefinition, {}),
-                    calibration=(1, 2, 3),
+                    calibration=pe_types.CalibrationOffset(x=1, y=2, z=3),
                 ),
             )
         ],


### PR DESCRIPTION
## Overview

This PR takes over for the API portion of closed PR #8069. It adds public `LoadedLabware` and `LoadedPipette` models to the protocol engine for future use by the `Session` and `ProtocolAnalysis` responses.

## Changelog

- Add public LoadedPipette and LoadedLabware models to protocol engine state
- Rename various methods and interfaces to handle the new public models as well as adhere to newer conventions established when we made the `Command` models public

| old and busted | new hotness |
| --- | --- |
| `labware.get_labware_data_by_id` | `labware.get` |
| `labware.get_all_labware` | `labware.get_all` |
| `labware.get_labware_definition` | `labware.get_definition` |
| `labware.get_labware_location` | `labware.get_location` |
| `labware.get_labware_has_quirk` | `labware.get_has_quirk` |
| `pipettes.get_pipette_data_by_id` | `pipettes.get` |
| `pipettes.get_all_pipettes` | `pipettes.get_all` |
| `pipettes.get_current_deck_location` | `pipettes.get_current_well` |
| `DeckLocation` dataclass | `CurrentWell` dataclass |
| `Tuple` calibration vector | `CalibrationOffset` pydantic model |

## Review requests

Code only review. This PR does not introduce any behavioral changes, and is easier to test in the followup PR that actually uses these models in robot-server HTTP responses

## Risk assessment

Low, feature flagged