### PR TITLE
refactor(robot-server): pull sessions/analysis equipment from engine

### DIFF
--- a/api/src/opentrons/protocol_runner/__init__.py
+++ b/api/src/opentrons/protocol_runner/__init__.py
@@ -3,12 +3,13 @@
 The main export of this module is the ProtocolRunner class. See
 protocol_runner.py for more details.
 """
-from .protocol_runner import ProtocolRunner
+from .protocol_runner import ProtocolRunner, ProtocolRunData
 from .protocol_file import ProtocolFile, ProtocolFileType
 from .create_simulating_runner import create_simulating_runner
 
 __all__ = [
     "ProtocolRunner",
+    "ProtocolRunData",
     "ProtocolFile",
     "ProtocolFileType",
     "create_simulating_runner",

--- a/api/src/opentrons/protocol_runner/python_executor.py
+++ b/api/src/opentrons/protocol_runner/python_executor.py
@@ -10,23 +10,16 @@ from .python_file_reader import PythonProtocol
 class PythonExecutor:
     """Execute a given PythonProtocol's run method with a ProtocolContext."""
 
-    def __init__(self) -> None:
-        """Initialize the executor with a thread pool.
-
-        A PythonExecutor uses its own ThreadPoolExecutor (rather than the default)
-        to avoid thread pool exhaustion from tying up protocol execution.
-        """
-        self._loop = asyncio.get_running_loop()
-        # fixme(mm, 2021-08-09): This class should be a context manager and call
-        # self._thread_pool.shutdown(). Currently, I think we leak threads.
-        self._thread_pool = ThreadPoolExecutor(max_workers=1)
-
-    async def execute(self, protocol: PythonProtocol, context: ProtocolContext) -> None:
+    @staticmethod
+    async def execute(protocol: PythonProtocol, context: ProtocolContext) -> None:
         """Execute a PythonProtocol using the given ProtocolContext.
 
         Runs the protocol asynchronously in a child thread.
         """
-        await self._loop.run_in_executor(
-            executor=self._thread_pool,
-            func=partial(protocol.run, context),
-        )
+        loop = asyncio.get_running_loop()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            await loop.run_in_executor(
+                executor=executor,
+                func=partial(protocol.run, context),
+            )

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner_smoke.py
@@ -16,10 +16,10 @@ from opentrons.types import MountType
 from opentrons.protocol_api_experimental import DeckSlotName
 
 from opentrons.protocol_engine import (
+    DeckSlotLocation,
     LoadedLabware,
     LoadedPipette,
     PipetteName,
-    DeckSlotLocation,
     commands,
 )
 from opentrons.protocol_runner import (
@@ -37,22 +37,25 @@ async def test_protocol_runner_with_python(python_protocol_file: Path) -> None:
     )
 
     subject = await create_simulating_runner()
-    commands_result = await subject.run(protocol_file)
-    pipettes_result = subject.engine.state_view.pipettes.get_all()
-    labware_result = subject.engine.state_view.labware.get_all()
+    result = await subject.run(protocol_file)
+    commands_result = result.commands
+    pipettes_result = result.pipettes
+    labware_result = result.labware
 
     pipette_id_captor = matchers.Captor()
     labware_id_captor = matchers.Captor()
 
     expected_pipette = LoadedPipette.construct(
-        id=pipette_id_captor, pipetteName=PipetteName.P300_SINGLE, mount=MountType.LEFT
+        id=pipette_id_captor,
+        pipetteName=PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
     )
 
     expected_labware = LoadedLabware.construct(
         id=labware_id_captor,
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
     )
 
     assert expected_pipette in pipettes_result
@@ -83,9 +86,10 @@ async def test_protocol_runner_with_json(json_protocol_file: Path) -> None:
     )
 
     subject = await create_simulating_runner()
-    commands_result = await subject.run(protocol_file)
-    pipettes_result = subject.engine.state_view.pipettes.get_all()
-    labware_result = subject.engine.state_view.labware.get_all()
+    result = await subject.run(protocol_file)
+    commands_result = result.commands
+    pipettes_result = result.pipettes
+    labware_result = result.labware
 
     expected_pipette = LoadedPipette(
         id="pipette-id",
@@ -95,9 +99,9 @@ async def test_protocol_runner_with_json(json_protocol_file: Path) -> None:
 
     expected_labware = LoadedLabware(
         id="labware-id",
+        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
         loadName="opentrons_96_tiprack_300ul",
         definitionUri="opentrons/opentrons_96_tiprack_300ul/1",
-        location=DeckSlotLocation(slot=DeckSlotName.SLOT_1),
     )
 
     assert expected_pipette in pipettes_result

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -5,12 +5,7 @@ from pydantic import BaseModel, Field
 from typing import List, Union
 from typing_extensions import Literal
 
-from opentrons.types import MountType
-from opentrons.protocol_engine import (
-    Command as EngineCommand,
-    PipetteName,
-    LabwareLocation,
-)
+from opentrons.protocol_engine import Command, LoadedLabware, LoadedPipette
 
 
 class AnalysisStatus(str, Enum):
@@ -52,23 +47,6 @@ class PendingAnalysis(AnalysisSummary):
     status: Literal[AnalysisStatus.PENDING] = AnalysisStatus.PENDING
 
 
-class AnalysisPipette(BaseModel):
-    """A pipette that the protocol is expected to use, based on the analysis."""
-
-    id: str
-    pipetteName: PipetteName
-    mount: MountType
-
-
-class AnalysisLabware(BaseModel):
-    """A labware that the protocol is expected to use, based on the analysis."""
-
-    id: str
-    loadName: str
-    definitionUri: str
-    location: LabwareLocation
-
-
 class CompletedAnalysis(AnalysisSummary):
     """A completed protocol run analysis.
 
@@ -95,15 +73,15 @@ class CompletedAnalysis(AnalysisSummary):
         ...,
         description="Whether the protocol is expected to run successfully",
     )
-    pipettes: List[AnalysisPipette] = Field(
+    pipettes: List[LoadedPipette] = Field(
         ...,
         description="Pipettes used by the protocol",
     )
-    labware: List[AnalysisLabware] = Field(
+    labware: List[LoadedLabware] = Field(
         ...,
         description="Labware used by the protocol",
     )
-    commands: List[EngineCommand] = Field(
+    commands: List[Command] = Field(
         ...,
         description="The protocol commands the run is expected to produce",
     )

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -1,16 +1,18 @@
 """Protocol analysis storage."""
 from typing import Dict, List, Set, Sequence
 
-from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons.protocol_engine import commands as pe_commands
+from opentrons.protocol_engine import (
+    Command,
+    CommandStatus,
+    LoadedPipette,
+    LoadedLabware,
+)
 
 from .analysis_models import (
     ProtocolAnalysis,
     PendingAnalysis,
     CompletedAnalysis,
     AnalysisResult,
-    AnalysisLabware,
-    AnalysisPipette,
 )
 
 
@@ -35,41 +37,18 @@ class AnalysisStore:
     def update(
         self,
         analysis_id: str,
-        commands: Sequence[pe_commands.Command],
+        commands: Sequence[Command],
+        labware: Sequence[LoadedLabware],
+        pipettes: Sequence[LoadedPipette],
         errors: Sequence[Exception],
     ) -> None:
         """Update analysis results in the store."""
-        labware = []
-        pipettes = []
         # TODO(mc, 2021-08-25): return error details objects, not strings
         error_messages = [str(e) for e in errors]
 
-        for c in commands:
-            if isinstance(c, pe_commands.LoadLabware) and c.result is not None:
-                labware.append(
-                    AnalysisLabware(
-                        id=c.result.labwareId,
-                        loadName=c.data.loadName,
-                        definitionUri=uri_from_details(
-                            load_name=c.data.loadName,
-                            namespace=c.data.namespace,
-                            version=c.data.version,
-                        ),
-                        location=c.data.location,
-                    )
-                )
-            elif isinstance(c, pe_commands.LoadPipette) and c.result is not None:
-                pipettes.append(
-                    AnalysisPipette(
-                        id=c.result.pipetteId,
-                        pipetteName=c.data.pipetteName,
-                        mount=c.data.mount,
-                    )
-                )
-
         if len(error_messages) > 0:
             result = AnalysisResult.ERROR
-        elif any(c.status == pe_commands.CommandStatus.FAILED for c in commands):
+        elif any(c.status == CommandStatus.FAILED for c in commands):
             result = AnalysisResult.NOT_OK
         else:
             result = AnalysisResult.OK
@@ -78,9 +57,9 @@ class AnalysisStore:
             id=analysis_id,
             result=result,
             commands=list(commands),
+            labware=list(labware),
+            pipettes=list(pipettes),
             errors=error_messages,
-            labware=labware,
-            pipettes=pipettes,
         )
 
     def get_by_protocol(self, protocol_id: str) -> List[ProtocolAnalysis]:

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -1,6 +1,6 @@
 """Protocol analysis module."""
-from typing import Sequence
-from opentrons.protocol_engine import Command as ProtocolCommand
+from typing import List
+from opentrons.protocol_engine import Command, LoadedLabware, LoadedPipette
 from opentrons.protocol_runner import ProtocolRunner
 
 from .protocol_store import ProtocolResource
@@ -25,16 +25,23 @@ class ProtocolAnalyzer:
         analysis_id: str,
     ) -> None:
         """Analyze a given protocol, storing the analysis when complete."""
-        commands: Sequence[ProtocolCommand] = []
-        errors: Sequence[Exception] = []
+        commands: List[Command] = []
+        labware: List[LoadedLabware] = []
+        pipettes: List[LoadedPipette] = []
+        errors: List[Exception] = []
 
         try:
-            commands = await self._protocol_runner.run(protocol_resource)
+            result = await self._protocol_runner.run(protocol_resource)
+            commands = result.commands
+            labware = result.labware
+            pipettes = result.pipettes
         except Exception as e:
             errors = [e]
 
         self._analysis_store.update(
             analysis_id=analysis_id,
             commands=commands,
+            labware=labware,
+            pipettes=pipettes,
             errors=errors,
         )

--- a/robot-server/robot_server/sessions/router/base_router.py
+++ b/robot-server/robot_server/sessions/router/base_router.py
@@ -112,12 +112,13 @@ async def create_session(
         raise SessionAlreadyActive(detail=str(e)).as_error(status.HTTP_409_CONFLICT)
 
     session_store.upsert(session=session)
-    commands = engine_store.engine.state_view.commands.get_all()
-    engine_status = engine_store.engine.state_view.commands.get_status()
+
     data = session_view.as_response(
         session=session,
-        commands=commands,
-        engine_status=engine_status,
+        commands=engine_store.engine.state_view.commands.get_all(),
+        pipettes=engine_store.engine.state_view.pipettes.get_all(),
+        labware=engine_store.engine.state_view.labware.get_all(),
+        engine_status=engine_store.engine.state_view.commands.get_status(),
     )
 
     return ResponseModel(data=data)
@@ -146,13 +147,14 @@ async def get_sessions(
 
     for session in session_store.get_all():
         # TODO(mc, 2021-06-23): add multi-engine support
-        commands = engine_store.engine.state_view.commands.get_all()
-        engine_status = engine_store.engine.state_view.commands.get_status()
         session_data = session_view.as_response(
             session=session,
-            commands=commands,
-            engine_status=engine_status,
+            commands=engine_store.engine.state_view.commands.get_all(),
+            pipettes=engine_store.engine.state_view.pipettes.get_all(),
+            labware=engine_store.engine.state_view.labware.get_all(),
+            engine_status=engine_store.engine.state_view.commands.get_status(),
         )
+
         data.append(session_data)
 
     return MultiResponseModel(data=data)
@@ -187,12 +189,12 @@ async def get_session(
     except SessionNotFoundError as e:
         raise SessionNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND)
 
-    commands = engine_store.engine.state_view.commands.get_all()
-    engine_status = engine_store.engine.state_view.commands.get_status()
     data = session_view.as_response(
         session=session,
-        commands=commands,
-        engine_status=engine_status,
+        commands=engine_store.engine.state_view.commands.get_all(),
+        pipettes=engine_store.engine.state_view.pipettes.get_all(),
+        labware=engine_store.engine.state_view.labware.get_all(),
+        engine_status=engine_store.engine.state_view.commands.get_status(),
     )
 
     return ResponseModel(data=data)

--- a/robot-server/robot_server/sessions/session_models.py
+++ b/robot-server/robot_server/sessions/session_models.py
@@ -9,6 +9,8 @@ from opentrons.protocol_engine import (
     CommandStatus,
     CommandType,
     EngineStatus as SessionStatus,
+    LoadedPipette,
+    LoadedLabware,
 )
 from robot_server.service.json_api import ResourceModel
 from .action_models import SessionAction
@@ -61,6 +63,14 @@ class AbstractSession(ResourceModel):
     commands: List[SessionCommandSummary] = Field(
         ...,
         description="Protocol commands queued, running, or executed for the session.",
+    )
+    pipettes: List[LoadedPipette] = Field(
+        ...,
+        description="Pipettes that have been loaded into the session.",
+    )
+    labware: List[LoadedLabware] = Field(
+        ...,
+        description="Labware that has been loaded into the session.",
     )
 
 

--- a/robot-server/robot_server/sessions/session_view.py
+++ b/robot-server/robot_server/sessions/session_view.py
@@ -120,10 +120,10 @@ class SessionView:
         }
 
         if isinstance(create_data, BasicSessionCreateData):
-            return BasicSession.construct(**response_fields)
+            return BasicSession(**response_fields)
 
         if isinstance(create_data, ProtocolSessionCreateData):
             response_fields["createParams"] = create_data.createParams
-            return ProtocolSession.construct(**response_fields)
+            return ProtocolSession(**response_fields)
 
         raise ValueError(f"Invalid session resource {session}")

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -1,17 +1,14 @@
 """Tests for the AnalysisStore interface."""
 import pytest
 from datetime import datetime
-from typing import List, NamedTuple, Sequence, cast
+from typing import List, NamedTuple, Sequence
 
 from opentrons.types import MountType, DeckSlotName
-from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import commands as pe_commands, types as pe_types
 
 from robot_server.protocols.analysis_store import AnalysisStore
 from robot_server.protocols.analysis_models import (
     AnalysisResult,
-    AnalysisPipette,
-    AnalysisLabware,
     PendingAnalysis,
     CompletedAnalysis,
 )
@@ -39,7 +36,13 @@ def test_add_errored_analysis() -> None:
     error = RuntimeError("oh no!")
 
     result = subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
-    subject.update(analysis_id="analysis-id", commands=[], errors=[error])
+    subject.update(
+        analysis_id="analysis-id",
+        commands=[],
+        labware=[],
+        pipettes=[],
+        errors=[error],
+    )
 
     result = subject.get_by_protocol("protocol-id")
 
@@ -55,87 +58,76 @@ def test_add_errored_analysis() -> None:
     ]
 
 
+def test_add_analysis_equipment() -> None:
+    """It should add labware and pipettes to the stored analysis."""
+    labware = pe_types.LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="namespace/load-name/42",
+        location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    )
+
+    pipette = pe_types.LoadedPipette(
+        id="pipette-id",
+        pipetteName=pe_types.PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
+    subject = AnalysisStore()
+    subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
+    subject.update(
+        analysis_id="analysis-id",
+        labware=[labware],
+        pipettes=[pipette],
+        commands=[],
+        errors=[],
+    )
+
+    result = subject.get_by_protocol("protocol-id")
+
+    assert result == [
+        CompletedAnalysis(
+            id="analysis-id",
+            result=AnalysisResult.OK,
+            labware=[labware],
+            pipettes=[pipette],
+            commands=[],
+            errors=[],
+        )
+    ]
+
+
 class CommandAnalysisSpec(NamedTuple):
     """Spec data for command parsing tests."""
 
     commands: Sequence[pe_commands.Command]
     expected_result: AnalysisResult
-    expected_labware: List[AnalysisLabware]
-    expected_pipettes: List[AnalysisPipette]
 
 
 command_analysis_specs: List[CommandAnalysisSpec] = [
     CommandAnalysisSpec(
         commands=[
-            pe_commands.LoadLabware(
-                id="load-labware-1",
+            pe_commands.Pause(
+                id="pause-1",
                 status=pe_commands.CommandStatus.SUCCEEDED,
                 createdAt=datetime(year=2021, month=1, day=1),
-                data=pe_commands.LoadLabwareData(
-                    location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                    loadName="load-name",
-                    namespace="namespace",
-                    version=42,
-                ),
-                result=pe_commands.LoadLabwareResult.construct(
-                    labwareId="labware-id",
-                    definition=cast(LabwareDefinition, {}),
-                    calibration=pe_types.CalibrationOffset(x=1, y=2, z=3),
-                ),
+                data=pe_commands.PauseData(message="hello world"),
+                result=pe_commands.PauseResult(),
             )
         ],
         expected_result=AnalysisResult.OK,
-        expected_labware=[
-            AnalysisLabware(
-                id="labware-id",
-                loadName="load-name",
-                definitionUri="namespace/load-name/42",
-                location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-            )
-        ],
-        expected_pipettes=[],
     ),
     CommandAnalysisSpec(
         commands=[
-            pe_commands.LoadPipette(
-                id="load-pipette-1",
-                status=pe_commands.CommandStatus.SUCCEEDED,
-                createdAt=datetime(year=2021, month=1, day=1),
-                data=pe_commands.LoadPipetteData(
-                    pipetteName=pe_types.PipetteName.P300_SINGLE,
-                    mount=MountType.LEFT,
-                ),
-                result=pe_commands.LoadPipetteResult(pipetteId="pipette-id"),
-            )
-        ],
-        expected_result=AnalysisResult.OK,
-        expected_labware=[],
-        expected_pipettes=[
-            AnalysisPipette(
-                id="pipette-id",
-                pipetteName=pe_types.PipetteName.P300_SINGLE,
-                mount=MountType.LEFT,
-            )
-        ],
-    ),
-    CommandAnalysisSpec(
-        commands=[
-            pe_commands.LoadLabware(
-                id="load-labware-1",
+            pe_commands.Pause(
+                id="pause-1",
                 status=pe_commands.CommandStatus.FAILED,
                 createdAt=datetime(year=2021, month=1, day=1),
-                data=pe_commands.LoadLabwareData(
-                    location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
-                    loadName="load-name",
-                    namespace="namespace",
-                    version=42,
-                ),
+                data=pe_commands.PauseData(message="hello world"),
                 error="Oh no!",
             )
         ],
         expected_result=AnalysisResult.NOT_OK,
-        expected_labware=[],
-        expected_pipettes=[],
     ),
 ]
 
@@ -144,23 +136,18 @@ command_analysis_specs: List[CommandAnalysisSpec] = [
 def test_add_parses_labware_commands(
     commands: Sequence[pe_commands.Command],
     expected_result: AnalysisResult,
-    expected_labware: List[AnalysisLabware],
-    expected_pipettes: List[AnalysisPipette],
 ) -> None:
     """It should be able to parse the commands list for analysis results."""
     subject = AnalysisStore()
 
     subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
-    subject.update(analysis_id="analysis-id", commands=commands, errors=[])
-    result = subject.get_by_protocol("protocol-id")
+    subject.update(
+        analysis_id="analysis-id",
+        commands=commands,
+        labware=[],
+        pipettes=[],
+        errors=[],
+    )
+    res = subject.get_by_protocol("protocol-id")[0].result  # type: ignore[union-attr]
 
-    assert result == [
-        CompletedAnalysis(
-            id="analysis-id",
-            result=expected_result,
-            labware=expected_labware,
-            pipettes=expected_pipettes,
-            commands=list(commands),
-            errors=[],
-        )
-    ]
+    assert res == expected_result

--- a/robot-server/tests/sessions/router/test_base_router.py
+++ b/robot-server/tests/sessions/router/test_base_router.py
@@ -6,10 +6,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
-from tests.helpers import verify_response
+from opentrons.types import DeckSlotName, MountType
+from opentrons.protocol_engine import commands as pe_commands, types as pe_types
 
 from robot_server.service.task_runner import TaskRunner
-
 from robot_server.protocols import (
     ProtocolStore,
     ProtocolResource,
@@ -22,6 +22,7 @@ from robot_server.sessions.session_view import SessionView, BasicSessionCreateDa
 
 from robot_server.sessions.session_models import (
     SessionStatus,
+    SessionCommandSummary,
     BasicSession,
     ProtocolSession,
     ProtocolSessionCreateData,
@@ -41,6 +42,8 @@ from robot_server.sessions.router.base_router import (
     SessionNotFound,
     SessionAlreadyActive,
 )
+
+from tests.helpers import verify_response
 
 
 @pytest.fixture(autouse=True)
@@ -72,10 +75,13 @@ async def test_create_session(
         status=SessionStatus.READY_TO_RUN,
         actions=[],
         commands=[],
+        pipettes=[],
+        labware=[],
     )
 
     decoy.when(engine_store.engine.state_view.commands.get_all()).then_return([])
-
+    decoy.when(engine_store.engine.state_view.pipettes.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.labware.get_all()).then_return([])
     decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(
         SessionStatus.READY_TO_RUN
     )
@@ -92,6 +98,8 @@ async def test_create_session(
         session_view.as_response(
             session=session,
             commands=[],
+            pipettes=[],
+            labware=[],
             engine_status=SessionStatus.READY_TO_RUN,
         ),
     ).then_return(expected_response)
@@ -142,6 +150,8 @@ async def test_create_protocol_session(
         createParams=ProtocolSessionCreateParams(protocolId="protocol-id"),
         actions=[],
         commands=[],
+        pipettes=[],
+        labware=[],
     )
 
     decoy.when(protocol_store.get(protocol_id="protocol-id")).then_return(
@@ -159,6 +169,8 @@ async def test_create_protocol_session(
     ).then_return(session)
 
     decoy.when(engine_store.engine.state_view.commands.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.pipettes.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.labware.get_all()).then_return([])
     decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(
         SessionStatus.READY_TO_RUN
     )
@@ -167,6 +179,8 @@ async def test_create_protocol_session(
         session_view.as_response(
             session=session,
             commands=[],
+            pipettes=[],
+            labware=[],
             engine_status=SessionStatus.READY_TO_RUN,
         ),
     ).then_return(expected_response)
@@ -274,17 +288,48 @@ def test_get_session(
         created_at=created_at,
         actions=[],
     )
+
+    command = pe_commands.Pause(
+        id="command-id",
+        status=pe_commands.CommandStatus.QUEUED,
+        createdAt=datetime(year=2021, month=1, day=1),
+        data=pe_commands.PauseData(message="hello world"),
+    )
+
+    labware = pe_types.LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="namespace/load-name/42",
+        location=pe_types.DeckSlotLocation(slot=DeckSlotName.SLOT_1),
+    )
+
+    pipette = pe_types.LoadedPipette(
+        id="pipette-id",
+        pipetteName=pe_types.PipetteName.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
     expected_response = BasicSession(
         id="session-id",
         createdAt=created_at,
         status=SessionStatus.READY_TO_RUN,
         actions=[],
-        commands=[],
+        commands=[
+            SessionCommandSummary(
+                id=command.id,
+                commandType=command.commandType,
+                status=command.status,
+            ),
+        ],
+        pipettes=[pipette],
+        labware=[labware],
     )
 
     decoy.when(session_store.get(session_id="session-id")).then_return(session)
 
-    decoy.when(engine_store.engine.state_view.commands.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.commands.get_all()).then_return([command])
+    decoy.when(engine_store.engine.state_view.pipettes.get_all()).then_return([pipette])
+    decoy.when(engine_store.engine.state_view.labware.get_all()).then_return([labware])
     decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(
         SessionStatus.READY_TO_RUN
     )
@@ -292,7 +337,9 @@ def test_get_session(
     decoy.when(
         session_view.as_response(
             session=session,
-            commands=[],
+            commands=[command],
+            pipettes=[pipette],
+            labware=[labware],
             engine_status=SessionStatus.READY_TO_RUN,
         ),
     ).then_return(expected_response)
@@ -358,11 +405,15 @@ def test_get_sessions_not_empty(
         status=SessionStatus.SUCCEEDED,
         actions=[],
         commands=[],
+        pipettes=[],
+        labware=[],
     )
 
     decoy.when(session_store.get_all()).then_return([session_1])
 
     decoy.when(engine_store.engine.state_view.commands.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.pipettes.get_all()).then_return([])
+    decoy.when(engine_store.engine.state_view.labware.get_all()).then_return([])
     decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(
         SessionStatus.SUCCEEDED
     )
@@ -371,6 +422,8 @@ def test_get_sessions_not_empty(
         session_view.as_response(
             session=session_1,
             commands=[],
+            pipettes=[],
+            labware=[],
             engine_status=SessionStatus.SUCCEEDED,
         ),
     ).then_return(response_1)

--- a/robot-server/tests/sessions/router/test_commands_router.py
+++ b/robot-server/tests/sessions/router/test_commands_router.py
@@ -64,6 +64,8 @@ async def test_get_session_commands(
         status=SessionStatus.RUNNING,
         actions=[],
         commands=[command_summary],
+        pipettes=[],
+        labware=[],
     )
 
     decoy.when(


### PR DESCRIPTION
## Overview

This PR closes #8069 by using the `LoadedPipette` and `LoadedLabware` models added by #8319 to the `/sessions` router for session responses and the `/protocols` router for protocol analysis responses.

## Review requests

For smoke testing: either a simulating server or a real robot is sufficient

1. Run robot server with `enableProtocolEngine` feature flag on
2. `POST` a protocol - verify pipettes and labware in analysis results
3. `POST` and run a session - verify pipettes and labware in session once the load commands have run

## Risk assessment

Low, feature flagged